### PR TITLE
PR 1: package scaffold + services.json ABI + install/status

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "organizeImports": { "enabled": true },
+  "files": {
+    "ignore": ["dist", "node_modules", "coverage"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "all",
+      "semicolons": "always"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "style": {
+        "noNonNullAssertion": "off",
+        "useImportType": "error"
+      },
+      "suspicious": {
+        "noExplicitAny": "warn"
+      }
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,45 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@openparachute/cli",
+      "devDependencies": {
+        "@biomejs/biome": "^1.9.4",
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@1.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@openparachute/cli",
+  "version": "0.1.0",
+  "description": "parachute — the top-level CLI for the Parachute ecosystem.",
+  "license": "AGPL-3.0",
+  "type": "module",
+  "module": "src/cli.ts",
+  "bin": {
+    "parachute": "src/cli.ts"
+  },
+  "files": ["src", "README.md", "LICENSE"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ParachuteComputer/parachute-cli.git"
+  },
+  "scripts": {
+    "start": "bun src/cli.ts",
+    "test": "bun test",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "format": "biome format --write .",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+const CLI = join(import.meta.dir, "..", "cli.ts");
+
+async function runCli(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["bun", CLI, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, HOME: "/tmp/parachute-cli-nonexistent-home" },
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { code, stdout, stderr };
+}
+
+describe("cli", () => {
+  test("--version prints version from package.json", async () => {
+    const { code, stdout } = await runCli(["--version"]);
+    expect(code).toBe(0);
+    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  test("--help lists commands", async () => {
+    const { code, stdout } = await runCli(["--help"]);
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/parachute install/);
+    expect(stdout).toMatch(/parachute status/);
+    expect(stdout).toMatch(/parachute vault/);
+  });
+
+  test("no args prints help", async () => {
+    const { code, stdout } = await runCli([]);
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/Usage:/);
+  });
+
+  test("install with no service name exits 1", async () => {
+    const { code, stderr } = await runCli(["install"]);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/usage: parachute install/);
+  });
+
+  test("unknown command exits 1", async () => {
+    const { code, stderr } = await runCli(["wat"]);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/unknown command/);
+  });
+});

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { install } from "../commands/install.ts";
+import { upsertService } from "../services-manifest.ts";
+
+function makeTempPath(): { path: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-install-"));
+  return {
+    path: join(dir, "services.json"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("install", () => {
+  test("rejects unknown service with exit 1", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      const code = await install("mystery", {
+        runner: async () => 0,
+        manifestPath: path,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(1);
+      expect(logs.join("\n")).toMatch(/unknown service/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("runs bun add -g then init, warns when manifest stays empty", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const calls: string[][] = [];
+      const logs: string[] = [];
+      const code = await install("vault", {
+        runner: async (cmd) => {
+          calls.push([...cmd]);
+          return 0;
+        },
+        manifestPath: path,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(calls[0]).toEqual(["bun", "add", "-g", "@openparachute/vault"]);
+      expect(calls[1]).toEqual(["parachute-vault", "init"]);
+      expect(logs.join("\n")).toMatch(/no services\.json entry/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("confirms registration when manifest entry exists after init", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      const code = await install("vault", {
+        runner: async (cmd) => {
+          if (cmd[0] === "parachute-vault") {
+            upsertService(
+              {
+                name: "parachute-vault",
+                port: 1940,
+                paths: ["/"],
+                health: "/health",
+                version: "0.2.4",
+              },
+              path,
+            );
+          }
+          return 0;
+        },
+        manifestPath: path,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(logs.join("\n")).toMatch(/registered on port 1940/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("propagates non-zero exit from bun add", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const calls: string[][] = [];
+      const code = await install("vault", {
+        runner: async (cmd) => {
+          calls.push([...cmd]);
+          return 42;
+        },
+        manifestPath: path,
+        log: () => {},
+      });
+      expect(code).toBe(42);
+      expect(calls).toHaveLength(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("skips init when spec has none", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const calls: string[][] = [];
+      const code = await install("scribe", {
+        runner: async (cmd) => {
+          calls.push([...cmd]);
+          return 0;
+        },
+        manifestPath: path,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(["bun", "add", "-g", "@openparachute/scribe"]);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/__tests__/services-manifest.test.ts
+++ b/src/__tests__/services-manifest.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type ServiceEntry,
+  ServicesManifestError,
+  findService,
+  readManifest,
+  removeService,
+  upsertService,
+  writeManifest,
+} from "../services-manifest.ts";
+
+function makeTempPath(): { path: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-"));
+  const path = join(dir, "services.json");
+  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+const vault: ServiceEntry = {
+  name: "parachute-vault",
+  port: 1940,
+  paths: ["/"],
+  health: "/health",
+  version: "0.2.4",
+};
+
+const notes: ServiceEntry = {
+  name: "parachute-notes",
+  port: 5173,
+  paths: ["/notes"],
+  health: "/notes/health",
+  version: "0.0.1",
+};
+
+describe("services-manifest", () => {
+  test("readManifest returns empty when file missing", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      expect(readManifest(path)).toEqual({ services: [] });
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("writeManifest + readManifest round-trip", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writeManifest({ services: [vault] }, path);
+      expect(readManifest(path)).toEqual({ services: [vault] });
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("upsertService adds a new entry", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const m = upsertService(vault, path);
+      expect(m.services).toHaveLength(1);
+      expect(m.services[0]).toEqual(vault);
+      expect(readManifest(path)).toEqual(m);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("upsertService updates by name, never duplicates", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      upsertService(vault, path);
+      upsertService({ ...vault, version: "0.3.0", port: 1941 }, path);
+      const m = readManifest(path);
+      expect(m.services).toHaveLength(1);
+      expect(m.services[0]?.version).toBe("0.3.0");
+      expect(m.services[0]?.port).toBe(1941);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("upsertService preserves other services", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      upsertService(vault, path);
+      upsertService(notes, path);
+      const m = readManifest(path);
+      expect(m.services).toHaveLength(2);
+      expect(m.services.map((s) => s.name).sort()).toEqual(["parachute-notes", "parachute-vault"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("removeService drops entry by name", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      upsertService(vault, path);
+      upsertService(notes, path);
+      removeService("parachute-vault", path);
+      const m = readManifest(path);
+      expect(m.services).toHaveLength(1);
+      expect(m.services[0]?.name).toBe("parachute-notes");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("findService returns entry or undefined", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      upsertService(vault, path);
+      expect(findService("parachute-vault", path)).toEqual(vault);
+      expect(findService("parachute-none", path)).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("readManifest throws on invalid JSON", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writeFileSync(path, "{ not json");
+      expect(() => readManifest(path)).toThrow(ServicesManifestError);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("readManifest throws on malformed entry", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writeFileSync(path, JSON.stringify({ services: [{ name: "x" }] }));
+      expect(() => readManifest(path)).toThrow(/port/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("upsertService validates entry", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      expect(() => upsertService({ ...vault, port: 99999 } as ServiceEntry, path)).toThrow(
+        ServicesManifestError,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/__tests__/status.test.ts
+++ b/src/__tests__/status.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { status } from "../commands/status.ts";
+import { upsertService } from "../services-manifest.ts";
+
+function makeTempPath(): { path: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-status-"));
+  return {
+    path: join(dir, "services.json"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("status", () => {
+  test("empty manifest prints hint and exits 0", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const lines: string[] = [];
+      const code = await status({
+        manifestPath: path,
+        fetchImpl: async () => new Response(null, { status: 200 }),
+        print: (l) => lines.push(l),
+      });
+      expect(code).toBe(0);
+      expect(lines.join("\n")).toMatch(/No services installed/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("all-healthy returns 0 and prints table", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.2.4" },
+        path,
+      );
+      upsertService(
+        {
+          name: "parachute-scribe",
+          port: 3200,
+          paths: ["/scribe"],
+          health: "/scribe/health",
+          version: "0.1.0",
+        },
+        path,
+      );
+      const seen: string[] = [];
+      const lines: string[] = [];
+      const code = await status({
+        manifestPath: path,
+        fetchImpl: async (url) => {
+          seen.push(String(url));
+          return new Response(null, { status: 200 });
+        },
+        print: (l) => lines.push(l),
+      });
+      expect(code).toBe(0);
+      expect(seen).toContain("http://localhost:1940/health");
+      expect(seen).toContain("http://localhost:3200/scribe/health");
+      expect(lines[0]).toMatch(/SERVICE/);
+      expect(lines.some((l) => l.includes("parachute-vault"))).toBe(true);
+      expect(lines.some((l) => l.includes("ok"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("any-failing returns 1", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.2.4" },
+        path,
+      );
+      const lines: string[] = [];
+      const code = await status({
+        manifestPath: path,
+        fetchImpl: async () => {
+          throw new Error("ECONNREFUSED");
+        },
+        print: (l) => lines.push(l),
+      });
+      expect(code).toBe(1);
+      expect(lines.some((l) => l.includes("ECONNREFUSED"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("http non-2xx counts as unhealthy with status code", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.2.4" },
+        path,
+      );
+      const lines: string[] = [];
+      const code = await status({
+        manifestPath: path,
+        fetchImpl: async () => new Response(null, { status: 503 }),
+        print: (l) => lines.push(l),
+      });
+      expect(code).toBe(1);
+      expect(lines.some((l) => l.includes("http 503"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env bun
+
+/**
+ * parachute — the top-level CLI for the Parachute ecosystem.
+ *
+ * Usage:
+ *   parachute install <service>     install a Parachute service
+ *   parachute status                read services manifest, probe localhost
+ *   parachute vault <args...>       dispatch to parachute-vault
+ *   parachute --version
+ *   parachute --help
+ */
+
+import pkg from "../package.json" with { type: "json" };
+import { install } from "./commands/install.ts";
+import { status } from "./commands/status.ts";
+import { dispatchVault } from "./commands/vault.ts";
+import { knownServices } from "./service-spec.ts";
+
+function usage(): void {
+  const services = knownServices().join(" | ");
+  console.log(`parachute ${pkg.version} — top-level CLI for the Parachute ecosystem
+
+Usage:
+  parachute install <service>       install and register a service
+                                    services: ${services}
+  parachute status                  show installed services and health
+  parachute vault <args...>         dispatch to parachute-vault
+
+Flags:
+  --help, -h                        show this help
+  --version, -v                     print version
+
+Coming soon:
+  parachute expose tailnet [off]    HTTPS across your tailnet  (PR 2)
+  parachute expose public  [off]    HTTPS on the public internet (PR 3)
+`);
+}
+
+async function main(argv: string[]): Promise<number> {
+  const [command, ...rest] = argv;
+
+  switch (command) {
+    case undefined:
+    case "help":
+    case "--help":
+    case "-h":
+      usage();
+      return 0;
+
+    case "--version":
+    case "-v":
+      console.log(pkg.version);
+      return 0;
+
+    case "install": {
+      const service = rest[0];
+      if (!service) {
+        console.error("usage: parachute install <service>");
+        console.error(`services: ${knownServices().join(", ")}`);
+        return 1;
+      }
+      return await install(service);
+    }
+
+    case "status":
+      return await status();
+
+    case "vault":
+      return await dispatchVault(rest);
+
+    default:
+      console.error(`parachute: unknown command "${command}"`);
+      console.error("run `parachute --help` for usage");
+      return 1;
+  }
+}
+
+const code = await main(process.argv.slice(2));
+process.exit(code);

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,0 +1,55 @@
+import { SERVICES_MANIFEST_PATH } from "../config.ts";
+import { getSpec, knownServices } from "../service-spec.ts";
+import { findService } from "../services-manifest.ts";
+
+export type Runner = (cmd: readonly string[]) => Promise<number>;
+
+export interface InstallOpts {
+  runner?: Runner;
+  manifestPath?: string;
+  log?: (line: string) => void;
+}
+
+async function defaultRunner(cmd: readonly string[]): Promise<number> {
+  const proc = Bun.spawn([...cmd], { stdio: ["inherit", "inherit", "inherit"] });
+  return await proc.exited;
+}
+
+export async function install(service: string, opts: InstallOpts = {}): Promise<number> {
+  const runner = opts.runner ?? defaultRunner;
+  const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const log = opts.log ?? ((line) => console.log(line));
+
+  const spec = getSpec(service);
+  if (!spec) {
+    log(`unknown service: "${service}"`);
+    log(`known services: ${knownServices().join(", ")}`);
+    return 1;
+  }
+
+  log(`Installing ${spec.package}…`);
+  const addCode = await runner(["bun", "add", "-g", spec.package]);
+  if (addCode !== 0) {
+    log(`bun add -g ${spec.package} failed (exit ${addCode})`);
+    return addCode;
+  }
+
+  if (spec.init) {
+    log(`Running ${spec.init.join(" ")}…`);
+    const initCode = await runner(spec.init);
+    if (initCode !== 0) {
+      log(`${spec.init.join(" ")} exited ${initCode}`);
+      return initCode;
+    }
+  }
+
+  const entry = findService(spec.manifestName, manifestPath);
+  if (!entry) {
+    log(
+      `Installed, but no services.json entry for "${spec.manifestName}" yet. Run \`parachute status\` after the service has started.`,
+    );
+  } else {
+    log(`✓ ${spec.manifestName} registered on port ${entry.port}`);
+  }
+  return 0;
+}

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,0 +1,92 @@
+import { SERVICES_MANIFEST_PATH } from "../config.ts";
+import { type ServiceEntry, readManifest } from "../services-manifest.ts";
+
+export type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
+
+export interface StatusOpts {
+  manifestPath?: string;
+  fetchImpl?: FetchFn;
+  print?: (line: string) => void;
+  timeoutMs?: number;
+}
+
+export interface ProbeResult {
+  entry: ServiceEntry;
+  healthy: boolean;
+  statusCode?: number;
+  error?: string;
+  latencyMs: number;
+}
+
+export async function probe(
+  entry: ServiceEntry,
+  fetchImpl: FetchFn,
+  timeoutMs: number,
+): Promise<ProbeResult> {
+  const url = `http://localhost:${entry.port}${entry.health}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const start = performance.now();
+  try {
+    const res = await fetchImpl(url, { signal: controller.signal });
+    const latencyMs = Math.round(performance.now() - start);
+    return {
+      entry,
+      healthy: res.ok,
+      statusCode: res.status,
+      latencyMs,
+    };
+  } catch (err) {
+    const latencyMs = Math.round(performance.now() - start);
+    return {
+      entry,
+      healthy: false,
+      error: err instanceof Error ? err.message : String(err),
+      latencyMs,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function formatRow(cells: string[], widths: number[]): string {
+  return cells
+    .map((c, i) => c.padEnd(widths[i] ?? 0, " "))
+    .join("  ")
+    .trimEnd();
+}
+
+export async function status(opts: StatusOpts = {}): Promise<number> {
+  const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const print = opts.print ?? ((line) => console.log(line));
+  const timeoutMs = opts.timeoutMs ?? 1500;
+
+  const manifest = readManifest(manifestPath);
+  if (manifest.services.length === 0) {
+    print("No services installed yet.");
+    print("Try: parachute install vault");
+    return 0;
+  }
+
+  const probes = await Promise.all(manifest.services.map((e) => probe(e, fetchImpl, timeoutMs)));
+
+  const header = ["SERVICE", "PORT", "VERSION", "STATUS", "LATENCY"];
+  const rows = probes.map((p) => {
+    const status = p.healthy
+      ? "ok"
+      : p.statusCode !== undefined
+        ? `http ${p.statusCode}`
+        : (p.error ?? "down");
+    return [p.entry.name, String(p.entry.port), p.entry.version, status, `${p.latencyMs}ms`];
+  });
+
+  const widths = header.map((_, i) =>
+    Math.max(header[i]?.length ?? 0, ...rows.map((r) => r[i]?.length ?? 0)),
+  );
+
+  print(formatRow(header, widths));
+  for (const r of rows) print(formatRow(r, widths));
+
+  return probes.every((p) => p.healthy) ? 0 : 1;
+}

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -1,0 +1,17 @@
+export async function dispatchVault(args: readonly string[]): Promise<number> {
+  try {
+    const proc = Bun.spawn(["parachute-vault", ...args], {
+      stdio: ["inherit", "inherit", "inherit"],
+    });
+    return await proc.exited;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.toLowerCase().includes("enoent") || msg.toLowerCase().includes("not found")) {
+      console.error("parachute-vault not found on PATH.");
+      console.error("Install it with: parachute install vault");
+      return 127;
+    }
+    console.error(`failed to run parachute-vault: ${msg}`);
+    return 1;
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,5 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const CONFIG_DIR = join(homedir(), ".parachute");
+export const SERVICES_MANIFEST_PATH = join(CONFIG_DIR, "services.json");

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -1,0 +1,33 @@
+export interface ServiceSpec {
+  readonly package: string;
+  readonly manifestName: string;
+  readonly init?: readonly string[];
+}
+
+export const SERVICE_SPECS: Record<string, ServiceSpec> = {
+  vault: {
+    package: "@openparachute/vault",
+    manifestName: "parachute-vault",
+    init: ["parachute-vault", "init"],
+  },
+  notes: {
+    package: "@openparachute/notes",
+    manifestName: "parachute-notes",
+  },
+  scribe: {
+    package: "@openparachute/scribe",
+    manifestName: "parachute-scribe",
+  },
+  channel: {
+    package: "@openparachute/channel",
+    manifestName: "parachute-channel",
+  },
+};
+
+export function knownServices(): string[] {
+  return Object.keys(SERVICE_SPECS);
+}
+
+export function getSpec(service: string): ServiceSpec | undefined {
+  return SERVICE_SPECS[service];
+}

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -1,0 +1,122 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { SERVICES_MANIFEST_PATH } from "./config.ts";
+
+export interface ServiceEntry {
+  name: string;
+  port: number;
+  paths: string[];
+  health: string;
+  version: string;
+}
+
+export interface ServicesManifest {
+  services: ServiceEntry[];
+}
+
+export class ServicesManifestError extends Error {
+  override name = "ServicesManifestError";
+}
+
+const EMPTY: ServicesManifest = { services: [] };
+
+function validateEntry(raw: unknown, where: string): ServiceEntry {
+  if (!raw || typeof raw !== "object") {
+    throw new ServicesManifestError(`${where}: expected object, got ${typeof raw}`);
+  }
+  const e = raw as Record<string, unknown>;
+  const name = e.name;
+  const port = e.port;
+  const paths = e.paths;
+  const health = e.health;
+  const version = e.version;
+  if (typeof name !== "string" || name.length === 0) {
+    throw new ServicesManifestError(`${where}: "name" must be a non-empty string`);
+  }
+  if (typeof port !== "number" || !Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new ServicesManifestError(`${where}: "port" must be an integer 1..65535`);
+  }
+  if (!Array.isArray(paths) || paths.some((p) => typeof p !== "string")) {
+    throw new ServicesManifestError(`${where}: "paths" must be an array of strings`);
+  }
+  if (typeof health !== "string" || !health.startsWith("/")) {
+    throw new ServicesManifestError(`${where}: "health" must be a path starting with "/"`);
+  }
+  if (typeof version !== "string") {
+    throw new ServicesManifestError(`${where}: "version" must be a string`);
+  }
+  return { name, port, paths: paths as string[], health, version };
+}
+
+function validateManifest(raw: unknown, where: string): ServicesManifest {
+  if (!raw || typeof raw !== "object") {
+    throw new ServicesManifestError(`${where}: root must be an object`);
+  }
+  const services = (raw as Record<string, unknown>).services;
+  if (!Array.isArray(services)) {
+    throw new ServicesManifestError(`${where}: "services" must be an array`);
+  }
+  return {
+    services: services.map((s, i) => validateEntry(s, `${where} services[${i}]`)),
+  };
+}
+
+export function readManifest(path: string = SERVICES_MANIFEST_PATH): ServicesManifest {
+  if (!existsSync(path)) return { services: [] };
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    throw new ServicesManifestError(
+      `failed to parse ${path}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  return validateManifest(raw, path);
+}
+
+export function writeManifest(
+  manifest: ServicesManifest,
+  path: string = SERVICES_MANIFEST_PATH,
+): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, `${JSON.stringify(manifest, null, 2)}\n`);
+  renameSync(tmp, path);
+}
+
+export function upsertService(
+  entry: ServiceEntry,
+  path: string = SERVICES_MANIFEST_PATH,
+): ServicesManifest {
+  validateEntry(entry, "entry");
+  const current = existsSync(path) ? readManifest(path) : structuredClone(EMPTY);
+  const idx = current.services.findIndex((s) => s.name === entry.name);
+  if (idx >= 0) {
+    current.services[idx] = entry;
+  } else {
+    current.services.push(entry);
+  }
+  writeManifest(current, path);
+  return current;
+}
+
+export function removeService(
+  name: string,
+  path: string = SERVICES_MANIFEST_PATH,
+): ServicesManifest {
+  if (!existsSync(path)) return structuredClone(EMPTY);
+  const current = readManifest(path);
+  const next: ServicesManifest = {
+    services: current.services.filter((s) => s.name !== name),
+  };
+  writeManifest(next, path);
+  return next;
+}
+
+export function findService(
+  name: string,
+  path: string = SERVICES_MANIFEST_PATH,
+): ServiceEntry | undefined {
+  if (!existsSync(path)) return undefined;
+  return readManifest(path).services.find((s) => s.name === name);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "allowJs": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Why

This is the first PR for `parachute-cli` — the top-level command for the Parachute ecosystem. It establishes the package + the services.json contract that each service will conform to, plus the two commands that can ship on day one without any other moving pieces: `install` and `status`. It also lands the `parachute vault *` dispatch shim so existing `parachute init`/`parachute serve` users can keep their muscle memory while the vault tentacle's `parachute` → `parachute-vault` binary rename lands.

This is the foundation for PRs 2 (`expose tailnet`) and 3 (`expose public --funnel`), both of which read this same manifest.

## Scope

- `@openparachute/cli` package, Bun-native, TypeScript-strict, no bundler. `bin: { parachute: "src/cli.ts" }` with a `#!/usr/bin/env bun` shebang.
- **`src/services-manifest.ts`** — schema + strict read validation + upsert/remove/find helpers + atomic write (tempfile+rename). Format: `{ services: [{ name, port, paths, health, version }] }`. Upsert-by-name only, never replace-whole-file.
- **`src/service-spec.ts`** — CLI-side mapping from user-facing service name (`vault`) to package (`@openparachute/vault`), expected manifest name (`parachute-vault`), and optional init command.
- **`src/commands/install.ts`** — runs `bun add -g @openparachute/<service>`, chains the service's init command if defined, verifies the manifest entry appeared. Takes an injectable runner for testability.
- **`src/commands/status.ts`** — reads the manifest, probes each `http://localhost:<port><health>` with a 1.5s timeout, prints a padded table. Exit code reflects overall health.
- **`src/commands/vault.ts`** — dispatches `parachute vault <args…>` to the `parachute-vault` binary via `Bun.spawn` with stdio inherited. Friendly error if the binary isn't on PATH.
- **`src/cli.ts`** — top-level arg dispatcher; `expose` surfaces as "coming in PR 2 / PR 3".

## Design calls worth naming

- **Strict manifest validation on read.** Services writing malformed entries surface loud (typed `ServicesManifestError`) rather than silently rendering a broken `status` table.
- **Atomic write** via tempfile+rename so two services writing at once don't produce a truncated file.
- **Hard-coded service spec table** for launch. No PATH-discovery of `parachute-*` binaries — that was a different CLI shape (see the archived `openparachute-cli`). This CLI is an ecosystem-aware coordinator, not a generic dispatcher.
- **Injected dependencies for tests.** `install({ runner })` and `status({ fetchImpl, manifestPath })` so tests never spawn real processes or hit real ports.
- **Expose stubbed in help text**, not implemented. Scope boundary.

## Gates

- [x] `bun test` — 24 pass, 0 fail
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] Smoke: `bun src/cli.ts --version`, `--help`, `status` (empty manifest)

## Coordination

- **Vault tentacle** is renaming its binary `parachute` → `parachute-vault` in parallel. This PR's vault-dispatch targets the renamed binary. Until the rename lands, `parachute vault …` will error with the "install it with: parachute install vault" hint — acceptable during the handoff window.
- **Services.json schema** is defined here; vault / notes / scribe each conform on their side. The launch-grade schema is intentionally tiny — additive fields can land without CLI changes.

## Not in this PR

- `parachute expose tailnet [off]` — PR 2
- `parachute expose public [--funnel]` — PR 3
- Caddy / cloudflared modes — post-launch
- README rewrite with install walkthrough — PR 4
- npm publishing — separate conversation with Aaron

🤖 Generated with [Claude Code](https://claude.com/claude-code)