### PR TITLE
PR 2: parachute expose tailnet [off]

### DIFF
--- a/src/__tests__/expose-state.test.ts
+++ b/src/__tests__/expose-state.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type ExposeState,
+  ExposeStateError,
+  clearExposeState,
+  readExposeState,
+  writeExposeState,
+} from "../expose-state.ts";
+
+function makeTempPath(): { path: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-state-"));
+  return {
+    path: join(dir, "expose-state.json"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+const sample: ExposeState = {
+  version: 1,
+  mode: "path",
+  canonicalFqdn: "parachute.taildf9ce2.ts.net",
+  port: 443,
+  funnel: false,
+  entries: [
+    {
+      kind: "proxy",
+      mount: "/",
+      target: "http://127.0.0.1:1940",
+      service: "parachute-vault",
+    },
+    {
+      kind: "file",
+      mount: "/.well-known/parachute.json",
+      target: "/home/x/.parachute/well-known/parachute.json",
+      service: "well-known",
+    },
+  ],
+};
+
+describe("expose-state", () => {
+  test("readExposeState returns undefined when missing", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      expect(readExposeState(path)).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("write + read round-trip", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writeExposeState(sample, path);
+      expect(readExposeState(path)).toEqual(sample);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("clearExposeState removes the file", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writeExposeState(sample, path);
+      expect(existsSync(path)).toBe(true);
+      clearExposeState(path);
+      expect(existsSync(path)).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("throws on unsupported version", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writeFileSync(path, JSON.stringify({ ...sample, version: 99 }));
+      expect(() => readExposeState(path)).toThrow(/unsupported version/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("throws on malformed entries", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writeFileSync(
+        path,
+        JSON.stringify({
+          ...sample,
+          entries: [{ kind: "proxy", mount: "no-slash", target: "http://x", service: "s" }],
+        }),
+      );
+      expect(() => readExposeState(path)).toThrow(ExposeStateError);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { exposeTailnetOff, exposeTailnetUp } from "../commands/expose.ts";
+import { readExposeState, writeExposeState } from "../expose-state.ts";
+import { upsertService } from "../services-manifest.ts";
+import type { Runner } from "../tailscale/run.ts";
+
+interface Harness {
+  manifestPath: string;
+  statePath: string;
+  wellKnownPath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-expose-"));
+  return {
+    manifestPath: join(dir, "services.json"),
+    statePath: join(dir, "expose-state.json"),
+    wellKnownPath: join(dir, "well-known", "parachute.json"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+function makeRunner(): { runner: Runner; calls: string[][] } {
+  const calls: string[][] = [];
+  const runner: Runner = async (cmd) => {
+    calls.push([...cmd]);
+    if (cmd[0] === "tailscale" && cmd[1] === "version") {
+      return { code: 0, stdout: "1.96.4\n", stderr: "" };
+    }
+    if (cmd[0] === "tailscale" && cmd[1] === "status" && cmd[2] === "--json") {
+      return {
+        code: 0,
+        stdout: JSON.stringify({ Self: { DNSName: "parachute.taildf9ce2.ts.net." } }),
+        stderr: "",
+      };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  };
+  return { runner, calls };
+}
+
+function seedServices(path: string): void {
+  upsertService(
+    { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.2.4" },
+    path,
+  );
+  upsertService(
+    {
+      name: "parachute-notes",
+      port: 5173,
+      paths: ["/notes"],
+      health: "/notes/health",
+      version: "0.0.1",
+    },
+    path,
+  );
+}
+
+describe("expose tailnet up", () => {
+  test("generates one tailscale serve per service plus well-known", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      const { runner, calls } = makeRunner();
+      const logs: string[] = [];
+      const code = await exposeTailnetUp({
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+
+      const serveCalls = calls.filter(
+        (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
+      );
+      expect(serveCalls).toHaveLength(3);
+
+      const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path="))).sort();
+      expect(mounts).toEqual([
+        "--set-path=/",
+        "--set-path=/.well-known/parachute.json",
+        "--set-path=/notes",
+      ]);
+
+      expect(existsSync(h.wellKnownPath)).toBe(true);
+      const wk = JSON.parse(await Bun.file(h.wellKnownPath).text());
+      expect(wk.vault?.url).toBe("https://parachute.taildf9ce2.ts.net/");
+      expect(wk.notes?.url).toBe("https://parachute.taildf9ce2.ts.net/notes");
+
+      const state = readExposeState(h.statePath);
+      expect(state?.canonicalFqdn).toBe("parachute.taildf9ce2.ts.net");
+      expect(state?.mode).toBe("path");
+      expect(state?.entries).toHaveLength(3);
+      expect(state?.funnel).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("empty manifest exits 1 with hint", async () => {
+    const h = makeHarness();
+    try {
+      const { runner } = makeRunner();
+      const logs: string[] = [];
+      const code = await exposeTailnetUp({
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(1);
+      expect(logs.join("\n")).toMatch(/No services installed/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("missing tailscale exits 1 with install hint", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      const runner: Runner = async () => {
+        throw new Error("spawn tailscale ENOENT");
+      };
+      const logs: string[] = [];
+      const code = await exposeTailnetUp({
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(1);
+      expect(logs.join("\n")).toMatch(/tailscale is not installed/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("idempotent re-run: tears down prior state first", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      writeExposeState(
+        {
+          version: 1,
+          mode: "path",
+          canonicalFqdn: "parachute.taildf9ce2.ts.net",
+          port: 443,
+          funnel: false,
+          entries: [
+            {
+              kind: "proxy",
+              mount: "/old-service",
+              target: "http://127.0.0.1:9999",
+              service: "parachute-old",
+            },
+          ],
+        },
+        h.statePath,
+      );
+      const { runner, calls } = makeRunner();
+      const code = await exposeTailnetUp({
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      const offs = calls.filter((c) => c[c.length - 1] === "off");
+      expect(offs).toHaveLength(1);
+      expect(offs[0]).toContain("--set-path=/old-service");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("bringup failure propagates exit code", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      const runner: Runner = async (cmd) => {
+        if (cmd[1] === "version") return { code: 0, stdout: "", stderr: "" };
+        if (cmd[1] === "status") {
+          return {
+            code: 0,
+            stdout: JSON.stringify({ Self: { DNSName: "parachute.taildf9ce2.ts.net." } }),
+            stderr: "",
+          };
+        }
+        if (cmd[1] === "serve" && cmd.includes("--bg")) {
+          return { code: 2, stdout: "", stderr: "port 443 already in use" };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      };
+      const logs: string[] = [];
+      const code = await exposeTailnetUp({
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(2);
+      expect(logs.join("\n")).toMatch(/Bringup failed/);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("expose tailnet off", () => {
+  test("no-op when no prior state", async () => {
+    const h = makeHarness();
+    try {
+      const { runner, calls } = makeRunner();
+      const logs: string[] = [];
+      const code = await exposeTailnetOff({
+        runner,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(calls).toHaveLength(0);
+      expect(logs.join("\n")).toMatch(/Nothing to tear down/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("tears down every tracked entry and clears state", async () => {
+    const h = makeHarness();
+    try {
+      writeExposeState(
+        {
+          version: 1,
+          mode: "path",
+          canonicalFqdn: "parachute.taildf9ce2.ts.net",
+          port: 443,
+          funnel: false,
+          entries: [
+            {
+              kind: "proxy",
+              mount: "/",
+              target: "http://127.0.0.1:1940",
+              service: "parachute-vault",
+            },
+            {
+              kind: "file",
+              mount: "/.well-known/parachute.json",
+              target: h.wellKnownPath,
+              service: "well-known",
+            },
+          ],
+        },
+        h.statePath,
+      );
+      await Bun.write(h.wellKnownPath, "{}\n");
+      const { runner, calls } = makeRunner();
+      const code = await exposeTailnetOff({
+        runner,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(calls.every((c) => c[c.length - 1] === "off")).toBe(true);
+      expect(calls).toHaveLength(2);
+      expect(existsSync(h.statePath)).toBe(false);
+      expect(existsSync(h.wellKnownPath)).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("leaves state in place on teardown failure", async () => {
+    const h = makeHarness();
+    try {
+      writeExposeState(
+        {
+          version: 1,
+          mode: "path",
+          canonicalFqdn: "parachute.taildf9ce2.ts.net",
+          port: 443,
+          funnel: false,
+          entries: [
+            {
+              kind: "proxy",
+              mount: "/",
+              target: "http://127.0.0.1:1940",
+              service: "parachute-vault",
+            },
+          ],
+        },
+        h.statePath,
+      );
+      const runner: Runner = async () => ({ code: 5, stdout: "", stderr: "tailscale blew up" });
+      const logs: string[] = [];
+      const code = await exposeTailnetOff({
+        runner,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(5);
+      expect(existsSync(h.statePath)).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/tailscale-commands.test.ts
+++ b/src/__tests__/tailscale-commands.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { type ServeEntry, bringupCommand, teardownCommand } from "../tailscale/commands.ts";
+
+const proxyEntry: ServeEntry = {
+  kind: "proxy",
+  mount: "/",
+  target: "http://127.0.0.1:1940",
+  service: "parachute-vault",
+};
+
+const fileEntry: ServeEntry = {
+  kind: "file",
+  mount: "/.well-known/parachute.json",
+  target: "/Users/x/.parachute/well-known/parachute.json",
+  service: "well-known",
+};
+
+const subpathEntry: ServeEntry = {
+  kind: "proxy",
+  mount: "/notes",
+  target: "http://127.0.0.1:5173",
+  service: "parachute-notes",
+};
+
+describe("tailscale commands", () => {
+  test("bringup proxy uses https=443 and --set-path", () => {
+    expect(bringupCommand(proxyEntry)).toEqual([
+      "tailscale",
+      "serve",
+      "--bg",
+      "--https=443",
+      "--set-path=/",
+      "http://127.0.0.1:1940",
+    ]);
+  });
+
+  test("bringup preserves subpath mounts", () => {
+    expect(bringupCommand(subpathEntry)).toEqual([
+      "tailscale",
+      "serve",
+      "--bg",
+      "--https=443",
+      "--set-path=/notes",
+      "http://127.0.0.1:5173",
+    ]);
+  });
+
+  test("bringup file entry passes filesystem path as target", () => {
+    expect(bringupCommand(fileEntry)).toEqual([
+      "tailscale",
+      "serve",
+      "--bg",
+      "--https=443",
+      "--set-path=/.well-known/parachute.json",
+      "/Users/x/.parachute/well-known/parachute.json",
+    ]);
+  });
+
+  test("bringup adds --funnel when funnel=true", () => {
+    expect(bringupCommand(proxyEntry, { funnel: true })).toEqual([
+      "tailscale",
+      "serve",
+      "--bg",
+      "--funnel",
+      "--https=443",
+      "--set-path=/",
+      "http://127.0.0.1:1940",
+    ]);
+  });
+
+  test("bringup honors custom port", () => {
+    expect(bringupCommand(proxyEntry, { port: 8443 })).toEqual([
+      "tailscale",
+      "serve",
+      "--bg",
+      "--https=8443",
+      "--set-path=/",
+      "http://127.0.0.1:1940",
+    ]);
+  });
+
+  test("teardown issues off per mount", () => {
+    expect(teardownCommand(proxyEntry)).toEqual([
+      "tailscale",
+      "serve",
+      "--https=443",
+      "--set-path=/",
+      "off",
+    ]);
+    expect(teardownCommand(fileEntry)).toEqual([
+      "tailscale",
+      "serve",
+      "--https=443",
+      "--set-path=/.well-known/parachute.json",
+      "off",
+    ]);
+  });
+});

--- a/src/__tests__/well-known.test.ts
+++ b/src/__tests__/well-known.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ServiceEntry } from "../services-manifest.ts";
+import { buildWellKnown, shortName, writeWellKnownFile } from "../well-known.ts";
+
+const vault: ServiceEntry = {
+  name: "parachute-vault",
+  port: 1940,
+  paths: ["/"],
+  health: "/health",
+  version: "0.2.4",
+};
+
+const notes: ServiceEntry = {
+  name: "parachute-notes",
+  port: 5173,
+  paths: ["/notes"],
+  health: "/notes/health",
+  version: "0.0.1",
+};
+
+const scribe: ServiceEntry = {
+  name: "parachute-scribe",
+  port: 3200,
+  paths: ["/scribe"],
+  health: "/scribe/health",
+  version: "0.1.0",
+};
+
+describe("well-known document", () => {
+  test("shortName strips parachute- prefix", () => {
+    expect(shortName("parachute-vault")).toBe("vault");
+    expect(shortName("parachute-notes")).toBe("notes");
+    expect(shortName("custom-service")).toBe("custom-service");
+  });
+
+  test("builds map keyed by short name with absolute URLs", () => {
+    const doc = buildWellKnown({
+      services: [vault, notes, scribe],
+      canonicalOrigin: "https://parachute.taildf9ce2.ts.net",
+    });
+    expect(doc).toEqual({
+      vault: { url: "https://parachute.taildf9ce2.ts.net/", version: "0.2.4" },
+      notes: { url: "https://parachute.taildf9ce2.ts.net/notes", version: "0.0.1" },
+      scribe: { url: "https://parachute.taildf9ce2.ts.net/scribe", version: "0.1.0" },
+    });
+  });
+
+  test("handles canonicalOrigin with trailing slash", () => {
+    const doc = buildWellKnown({
+      services: [vault],
+      canonicalOrigin: "https://parachute.taildf9ce2.ts.net/",
+    });
+    expect(doc.vault?.url).toBe("https://parachute.taildf9ce2.ts.net/");
+  });
+
+  test("falls back to / for empty paths", () => {
+    const entry: ServiceEntry = { ...vault, paths: [] };
+    const doc = buildWellKnown({
+      services: [entry],
+      canonicalOrigin: "https://x.example",
+    });
+    expect(doc.vault?.url).toBe("https://x.example/");
+  });
+
+  test("writeWellKnownFile writes pretty JSON and creates dir", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pcli-wk-"));
+    try {
+      const path = join(dir, "nested", "parachute.json");
+      const doc = buildWellKnown({
+        services: [vault],
+        canonicalOrigin: "https://x.example",
+      });
+      writeWellKnownFile(doc, path);
+      const round = JSON.parse(readFileSync(path, "utf8"));
+      expect(round).toEqual(doc);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@
  */
 
 import pkg from "../package.json" with { type: "json" };
+import { exposeTailnet } from "./commands/expose.ts";
 import { install } from "./commands/install.ts";
 import { status } from "./commands/status.ts";
 import { dispatchVault } from "./commands/vault.ts";
@@ -25,6 +26,7 @@ Usage:
   parachute install <service>       install and register a service
                                     services: ${services}
   parachute status                  show installed services and health
+  parachute expose tailnet [off]    HTTPS across your tailnet
   parachute vault <args...>         dispatch to parachute-vault
 
 Flags:
@@ -32,8 +34,7 @@ Flags:
   --version, -v                     print version
 
 Coming soon:
-  parachute expose tailnet [off]    HTTPS across your tailnet  (PR 2)
-  parachute expose public  [off]    HTTPS on the public internet (PR 3)
+  parachute expose public [off]     HTTPS on the public internet  (PR 3)
 `);
 }
 
@@ -65,6 +66,26 @@ async function main(argv: string[]): Promise<number> {
 
     case "status":
       return await status();
+
+    case "expose": {
+      const layer = rest[0];
+      const mode = rest[1];
+      if (layer !== "tailnet") {
+        if (layer === "public") {
+          console.error("parachute expose public is coming in PR 3.");
+        } else {
+          console.error(`parachute expose: unknown layer "${layer ?? ""}"`);
+          console.error("usage: parachute expose tailnet [off]");
+        }
+        return 1;
+      }
+      if (mode !== undefined && mode !== "off") {
+        console.error(`parachute expose tailnet: unknown argument "${mode}"`);
+        console.error("usage: parachute expose tailnet [off]");
+        return 1;
+      }
+      return await exposeTailnet(mode === "off" ? "off" : "up");
+    }
 
     case "vault":
       return await dispatchVault(rest);

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -1,0 +1,169 @@
+import { existsSync, unlinkSync } from "node:fs";
+import { SERVICES_MANIFEST_PATH } from "../config.ts";
+import {
+  EXPOSE_STATE_PATH,
+  type ExposeState,
+  clearExposeState,
+  readExposeState,
+  writeExposeState,
+} from "../expose-state.ts";
+import { type ServiceEntry, readManifest } from "../services-manifest.ts";
+import { type ServeEntry, bringupCommand, teardownCommand } from "../tailscale/commands.ts";
+import { getFqdn, isTailscaleInstalled } from "../tailscale/detect.ts";
+import { type Runner, defaultRunner } from "../tailscale/run.ts";
+import {
+  WELL_KNOWN_MOUNT,
+  WELL_KNOWN_PATH,
+  buildWellKnown,
+  writeWellKnownFile,
+} from "../well-known.ts";
+
+export interface ExposeTailnetOpts {
+  runner?: Runner;
+  manifestPath?: string;
+  statePath?: string;
+  wellKnownPath?: string;
+  port?: number;
+  log?: (line: string) => void;
+  /** Override detected FQDN — primarily for tests. */
+  fqdnOverride?: string;
+}
+
+function planEntries(services: readonly ServiceEntry[], wellKnownFilePath: string): ServeEntry[] {
+  const entries: ServeEntry[] = [];
+  for (const s of services) {
+    const mount = s.paths[0] ?? "/";
+    entries.push({
+      kind: "proxy",
+      mount,
+      target: `http://127.0.0.1:${s.port}`,
+      service: s.name,
+    });
+  }
+  entries.push({
+    kind: "file",
+    mount: WELL_KNOWN_MOUNT,
+    target: wellKnownFilePath,
+    service: "well-known",
+  });
+  return entries;
+}
+
+async function runEach(
+  runner: Runner,
+  commands: string[][],
+  log: (line: string) => void,
+): Promise<number> {
+  for (const cmd of commands) {
+    log(`  $ ${cmd.join(" ")}`);
+    const { code, stderr } = await runner(cmd);
+    if (code !== 0) {
+      if (stderr.trim()) log(stderr.trim());
+      return code;
+    }
+  }
+  return 0;
+}
+
+export async function exposeTailnetUp(opts: ExposeTailnetOpts = {}): Promise<number> {
+  const runner = opts.runner ?? defaultRunner;
+  const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const statePath = opts.statePath ?? EXPOSE_STATE_PATH;
+  const wellKnownFilePath = opts.wellKnownPath ?? WELL_KNOWN_PATH;
+  const port = opts.port ?? 443;
+  const log = opts.log ?? ((line) => console.log(line));
+
+  if (!(await isTailscaleInstalled(runner))) {
+    log("tailscale is not installed or not on PATH.");
+    log("Install from https://tailscale.com/download and run `tailscale up`.");
+    return 1;
+  }
+
+  const manifest = readManifest(manifestPath);
+  if (manifest.services.length === 0) {
+    log("No services installed yet. Try: parachute install vault");
+    return 1;
+  }
+
+  const fqdn = opts.fqdnOverride ?? (await getFqdn(runner));
+  const canonicalOrigin = `https://${fqdn}`;
+
+  const prior = readExposeState(statePath);
+  if (prior && prior.entries.length > 0) {
+    log(`Found prior tailnet exposure; tearing down ${prior.entries.length} entries first…`);
+    const teardownCmds = prior.entries.map((e) => teardownCommand(e, { port: prior.port }));
+    const code = await runEach(runner, teardownCmds, log);
+    if (code !== 0) {
+      log("Teardown of prior state failed; aborting.");
+      return code;
+    }
+  }
+
+  const wellKnownDoc = buildWellKnown({ services: manifest.services, canonicalOrigin });
+  writeWellKnownFile(wellKnownDoc, wellKnownFilePath);
+  log(`Wrote ${wellKnownFilePath}`);
+
+  const entries = planEntries(manifest.services, wellKnownFilePath);
+  log(`Exposing under ${canonicalOrigin} (path-routing, port ${port}):`);
+  for (const e of entries) {
+    const suffix = e.kind === "proxy" ? `→ ${e.target}  (${e.service})` : `→ ${e.target}`;
+    log(`  ${e.mount.padEnd(30, " ")} ${suffix}`);
+  }
+
+  const cmds = entries.map((e) => bringupCommand(e, { port }));
+  const code = await runEach(runner, cmds, log);
+  if (code !== 0) {
+    log("Bringup failed; see error above. Prior tailscale state may be partially applied.");
+    return code;
+  }
+
+  const state: ExposeState = {
+    version: 1,
+    mode: "path",
+    canonicalFqdn: fqdn,
+    port,
+    funnel: false,
+    entries,
+  };
+  writeExposeState(state, statePath);
+
+  log("");
+  log(`✓ Tailnet exposure active. Open: ${canonicalOrigin}/`);
+  log(`  Discovery: ${canonicalOrigin}${WELL_KNOWN_MOUNT}`);
+  return 0;
+}
+
+export async function exposeTailnetOff(opts: ExposeTailnetOpts = {}): Promise<number> {
+  const runner = opts.runner ?? defaultRunner;
+  const statePath = opts.statePath ?? EXPOSE_STATE_PATH;
+  const wellKnownFilePath = opts.wellKnownPath ?? WELL_KNOWN_PATH;
+  const log = opts.log ?? ((line) => console.log(line));
+
+  const state = readExposeState(statePath);
+  if (!state || state.entries.length === 0) {
+    log("No tailnet exposure recorded. Nothing to tear down.");
+    return 0;
+  }
+
+  log(`Tearing down ${state.entries.length} tailnet serve entries…`);
+  const cmds = state.entries.map((e) => teardownCommand(e, { port: state.port }));
+  const code = await runEach(runner, cmds, log);
+  if (code !== 0) {
+    log("Teardown failed. State file left in place so you can retry.");
+    return code;
+  }
+
+  clearExposeState(statePath);
+  if (existsSync(wellKnownFilePath)) {
+    unlinkSync(wellKnownFilePath);
+  }
+  log("✓ Tailnet exposure removed.");
+  return 0;
+}
+
+export async function exposeTailnet(
+  action: "up" | "off",
+  opts: ExposeTailnetOpts = {},
+): Promise<number> {
+  return action === "off" ? exposeTailnetOff(opts) : exposeTailnetUp(opts);
+}

--- a/src/expose-state.ts
+++ b/src/expose-state.ts
@@ -1,0 +1,107 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { CONFIG_DIR } from "./config.ts";
+import type { ServeEntry } from "./tailscale/commands.ts";
+
+export const EXPOSE_STATE_PATH = join(CONFIG_DIR, "expose-state.json");
+
+export type ExposeMode = "path" | "subdomain";
+
+export interface ExposeState {
+  version: 1;
+  mode: ExposeMode;
+  canonicalFqdn: string;
+  port: number;
+  funnel: boolean;
+  entries: ServeEntry[];
+}
+
+export class ExposeStateError extends Error {
+  override name = "ExposeStateError";
+}
+
+function validate(raw: unknown, path: string): ExposeState {
+  if (!raw || typeof raw !== "object") {
+    throw new ExposeStateError(`${path}: root must be an object`);
+  }
+  const r = raw as Record<string, unknown>;
+  if (r.version !== 1) {
+    throw new ExposeStateError(`${path}: unsupported version ${String(r.version)}`);
+  }
+  if (r.mode !== "path" && r.mode !== "subdomain") {
+    throw new ExposeStateError(`${path}: mode must be "path" or "subdomain"`);
+  }
+  if (typeof r.canonicalFqdn !== "string" || r.canonicalFqdn.length === 0) {
+    throw new ExposeStateError(`${path}: canonicalFqdn must be a non-empty string`);
+  }
+  if (typeof r.port !== "number" || !Number.isInteger(r.port)) {
+    throw new ExposeStateError(`${path}: port must be an integer`);
+  }
+  if (typeof r.funnel !== "boolean") {
+    throw new ExposeStateError(`${path}: funnel must be a boolean`);
+  }
+  if (!Array.isArray(r.entries)) {
+    throw new ExposeStateError(`${path}: entries must be an array`);
+  }
+  const entries: ServeEntry[] = r.entries.map((e, i) => {
+    if (!e || typeof e !== "object") {
+      throw new ExposeStateError(`${path} entries[${i}]: expected object`);
+    }
+    const entry = e as Record<string, unknown>;
+    const kind = entry.kind;
+    if (kind !== "proxy" && kind !== "file") {
+      throw new ExposeStateError(`${path} entries[${i}]: kind must be "proxy" or "file"`);
+    }
+    if (typeof entry.mount !== "string" || !entry.mount.startsWith("/")) {
+      throw new ExposeStateError(`${path} entries[${i}]: mount must start with "/"`);
+    }
+    if (typeof entry.target !== "string" || entry.target.length === 0) {
+      throw new ExposeStateError(`${path} entries[${i}]: target must be non-empty string`);
+    }
+    if (typeof entry.service !== "string" || entry.service.length === 0) {
+      throw new ExposeStateError(`${path} entries[${i}]: service must be non-empty string`);
+    }
+    return { kind, mount: entry.mount, target: entry.target, service: entry.service };
+  });
+  return {
+    version: 1,
+    mode: r.mode,
+    canonicalFqdn: r.canonicalFqdn,
+    port: r.port,
+    funnel: r.funnel,
+    entries,
+  };
+}
+
+export function readExposeState(path: string = EXPOSE_STATE_PATH): ExposeState | undefined {
+  if (!existsSync(path)) return undefined;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    throw new ExposeStateError(
+      `failed to parse ${path}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  return validate(raw, path);
+}
+
+export function writeExposeState(state: ExposeState, path: string = EXPOSE_STATE_PATH): void {
+  if (!existsSync(dirname(path))) {
+    mkdirSync(dirname(path), { recursive: true });
+  }
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`);
+  renameSync(tmp, path);
+}
+
+export function clearExposeState(path: string = EXPOSE_STATE_PATH): void {
+  if (existsSync(path)) unlinkSync(path);
+}

--- a/src/tailscale/commands.ts
+++ b/src/tailscale/commands.ts
@@ -1,0 +1,26 @@
+export interface ServeEntry {
+  kind: "proxy" | "file";
+  mount: string;
+  target: string;
+  service: string;
+}
+
+export interface BringupOpts {
+  funnel?: boolean;
+  port?: number;
+}
+
+export function bringupCommand(entry: ServeEntry, opts: BringupOpts = {}): string[] {
+  const port = opts.port ?? 443;
+  const cmd = ["tailscale", "serve", "--bg"];
+  if (opts.funnel) cmd.push("--funnel");
+  cmd.push(`--https=${port}`);
+  cmd.push(`--set-path=${entry.mount}`);
+  cmd.push(entry.target);
+  return cmd;
+}
+
+export function teardownCommand(entry: ServeEntry, opts: BringupOpts = {}): string[] {
+  const port = opts.port ?? 443;
+  return ["tailscale", "serve", `--https=${port}`, `--set-path=${entry.mount}`, "off"];
+}

--- a/src/tailscale/detect.ts
+++ b/src/tailscale/detect.ts
@@ -1,0 +1,56 @@
+import type { Runner } from "./run.ts";
+import { TailscaleError } from "./run.ts";
+
+export async function isTailscaleInstalled(runner: Runner): Promise<boolean> {
+  try {
+    const { code } = await runner(["tailscale", "version"]);
+    return code === 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function getFqdn(runner: Runner): Promise<string> {
+  const result = await runner(["tailscale", "status", "--json"]);
+  if (result.code !== 0) {
+    throw new TailscaleError(
+      `tailscale status --json exited ${result.code}: ${result.stderr.trim()}`,
+      ["tailscale", "status", "--json"],
+      result,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (err) {
+    throw new TailscaleError(
+      `failed to parse tailscale status JSON: ${err instanceof Error ? err.message : String(err)}`,
+      ["tailscale", "status", "--json"],
+      result,
+    );
+  }
+  const self = (parsed as { Self?: { DNSName?: unknown } }).Self;
+  const dnsName = self?.DNSName;
+  if (typeof dnsName !== "string" || dnsName.length === 0) {
+    throw new TailscaleError(
+      "tailscale status did not return Self.DNSName — is this machine logged in?",
+      ["tailscale", "status", "--json"],
+      result,
+    );
+  }
+  return dnsName.replace(/\.$/, "");
+}
+
+/**
+ * Detect whether wildcard MagicDNS is active — i.e. whether subdomains of the
+ * current machine (vault.<fqdn>, notes.<fqdn>, …) resolve back to this node.
+ *
+ * Tailscale's standard MagicDNS gives each machine a single hostname and does
+ * not auto-resolve arbitrary subdomains; wildcard MagicDNS exists in the
+ * Services feature but requires explicit advertisement. For launch we return
+ * false (path-routing) and let a later PR add real detection once the
+ * subdomain-per-service path is supported end-to-end.
+ */
+export async function detectWildcardMagicDNS(_runner: Runner): Promise<boolean> {
+  return false;
+}

--- a/src/tailscale/run.ts
+++ b/src/tailscale/run.ts
@@ -1,0 +1,28 @@
+export interface CommandResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type Runner = (cmd: readonly string[]) => Promise<CommandResult>;
+
+export async function defaultRunner(cmd: readonly string[]): Promise<CommandResult> {
+  const proc = Bun.spawn([...cmd], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { code, stdout, stderr };
+}
+
+export class TailscaleError extends Error {
+  override name = "TailscaleError";
+  constructor(
+    message: string,
+    public readonly cmd: readonly string[],
+    public readonly result: CommandResult,
+  ) {
+    super(message);
+  }
+}

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -1,0 +1,47 @@
+import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { CONFIG_DIR } from "./config.ts";
+import type { ServiceEntry } from "./services-manifest.ts";
+
+export interface WellKnownService {
+  url: string;
+  version: string;
+}
+
+export type WellKnownDocument = Record<string, WellKnownService>;
+
+export const WELL_KNOWN_DIR = join(CONFIG_DIR, "well-known");
+export const WELL_KNOWN_PATH = join(WELL_KNOWN_DIR, "parachute.json");
+export const WELL_KNOWN_MOUNT = "/.well-known/parachute.json";
+
+/** Strip the conventional `parachute-` prefix for the well-known document's keys. */
+export function shortName(manifestName: string): string {
+  return manifestName.replace(/^parachute-/, "");
+}
+
+export interface BuildWellKnownOpts {
+  services: readonly ServiceEntry[];
+  canonicalOrigin: string;
+}
+
+export function buildWellKnown(opts: BuildWellKnownOpts): WellKnownDocument {
+  const base = opts.canonicalOrigin.replace(/\/$/, "");
+  const doc: WellKnownDocument = {};
+  for (const s of opts.services) {
+    const key = shortName(s.name);
+    const path = s.paths[0] ?? "/";
+    const url = new URL(path, `${base}/`).toString();
+    doc[key] = { url, version: s.version };
+  }
+  return doc;
+}
+
+export function writeWellKnownFile(doc: WellKnownDocument, path: string = WELL_KNOWN_PATH): string {
+  if (!existsSync(dirname(path))) {
+    mkdirSync(dirname(path), { recursive: true });
+  }
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, `${JSON.stringify(doc, null, 2)}\n`);
+  renameSync(tmp, path);
+  return path;
+}


### PR DESCRIPTION
## Why

Layer 2 of the three-layer exposure model from the decision note: wrap `tailscale serve` for each installed service so the whole Parachute ecosystem is reachable over HTTPS on the tailnet with a single command. Reads the services.json manifest this CLI locked in PR 1 — services stay unaware of exposure. Also emits `/.well-known/parachute.json` as part of the same serve config so Lens/Notes can discover the ecosystem from any origin served by this layer.

This unblocks the self-hosting narrative: after `parachute install` + `parachute expose tailnet`, you have HTTPS on your tailnet with zero manual tailscale-serve commands.

## What the command does

- Verifies `tailscale` is on PATH + returns `Self.DNSName` from `tailscale status --json`
- Reads services.json; refuses to run with an empty manifest
- For each service, generates `tailscale serve --bg --https=443 --set-path=<paths[0]> http://127.0.0.1:<port>`
- Writes `~/.parachute/well-known/parachute.json` (keyed by short name, e.g. `vault` / `notes` / `scribe`) and adds a file-handler serve entry at `/.well-known/parachute.json`
- Records what it put up in `~/.parachute/expose-state.json`
- `off` reads that state and issues one `tailscale serve --https=443 --set-path=<mount> off` per tracked entry, then deletes the state file and the well-known doc

## Design calls

- **Path routing as the default, always.** Real Tailscale "wildcard MagicDNS" per-host subdomains requires the Services feature (virtual IP + explicit advertise), which is a bigger footprint than launch can absorb. `detectWildcardMagicDNS` is stubbed to return `false` so path-routing is what ships. The detection hook exists as a seam so a later PR can wire in real probing without touching callers.
- **Well-known doc as a tailscale-serve file handler, not an HTTP server.** Avoids a long-running static-server process. Serve config reloads the file on each request (Tailscale's serve handles that).
- **Tracked teardown, non-destructive.** State file records *only* what this CLI created. Handlers a user set up manually with `tailscale serve` directly are untouched on `off`. If teardown fails mid-way, state is left in place so a retry picks up the rest.
- **Idempotent re-run.** Running `expose tailnet` a second time tears down prior CLI-owned entries before applying the new set — so editing the manifest + re-running doesn't accumulate stale handlers.
- **Runner injection everywhere.** `Runner = (cmd) => Promise<{code,stdout,stderr}>` is the single seam for tailscale invocation; tests swap in a fake that returns deterministic `status --json`.
- **Funnel flag is already threaded** through `bringupCommand`, unused here — PR 3 turns it on.

## Scope boundary

- Subdomain-per-service is deferred (post-launch). Documented in code.
- `parachute expose public` still errors with "coming in PR 3."
- No warning yet for services whose path collides with a pre-existing user serve handler — polish-grade.

## Gates

- [x] `bun test` — 48 pass, 0 fail (24 new cases)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] Smoke: `--help`, `expose` dispatch errors, `expose tailnet bogus` rejection

## Coordination

- Services just need to write their manifest entry correctly — vault has, notes is on it. No further interface changes in this PR.
- Scribe / channel can wire up services.json whenever; this PR will pick them up on the next `expose tailnet` automatically.

## Not in this PR

- PR 3 — `parachute expose public [--funnel]` (adds `--funnel` on the same serve commands + marks `funnel: true` in state)
- PR 4 — README, per-subcommand help, launch polish
- Subdomain detection / subdomain-per-service mode (post-launch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)