### PR TITLE
PR 3: parachute expose public [off] (Funnel)

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -30,6 +30,15 @@ describe("cli", () => {
     expect(stdout).toMatch(/parachute install/);
     expect(stdout).toMatch(/parachute status/);
     expect(stdout).toMatch(/parachute vault/);
+    expect(stdout).toMatch(/expose tailnet/);
+    expect(stdout).toMatch(/expose public/);
+  });
+
+  test("expose with unknown layer exits 1", async () => {
+    const { code, stderr } = await runCli(["expose", "wat"]);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/unknown layer/);
+    expect(stderr).toMatch(/expose public/);
   });
 
   test("no args prints help", async () => {

--- a/src/__tests__/expose-state.test.ts
+++ b/src/__tests__/expose-state.test.ts
@@ -20,6 +20,7 @@ function makeTempPath(): { path: string; cleanup: () => void } {
 
 const sample: ExposeState = {
   version: 1,
+  layer: "tailnet",
   mode: "path",
   canonicalFqdn: "parachute.taildf9ce2.ts.net",
   port: 443,

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { exposeTailnetOff, exposeTailnetUp } from "../commands/expose.ts";
+import { exposePublic, exposeTailnet } from "../commands/expose.ts";
 import { readExposeState, writeExposeState } from "../expose-state.ts";
 import { upsertService } from "../services-manifest.ts";
 import type { Runner } from "../tailscale/run.ts";
@@ -67,7 +67,7 @@ describe("expose tailnet up", () => {
       seedServices(h.manifestPath);
       const { runner, calls } = makeRunner();
       const logs: string[] = [];
-      const code = await exposeTailnetUp({
+      const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
@@ -80,6 +80,7 @@ describe("expose tailnet up", () => {
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
       expect(serveCalls).toHaveLength(3);
+      expect(serveCalls.every((c) => !c.includes("--funnel"))).toBe(true);
 
       const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path="))).sort();
       expect(mounts).toEqual([
@@ -94,6 +95,7 @@ describe("expose tailnet up", () => {
       expect(wk.notes?.url).toBe("https://parachute.taildf9ce2.ts.net/notes");
 
       const state = readExposeState(h.statePath);
+      expect(state?.layer).toBe("tailnet");
       expect(state?.canonicalFqdn).toBe("parachute.taildf9ce2.ts.net");
       expect(state?.mode).toBe("path");
       expect(state?.entries).toHaveLength(3);
@@ -108,7 +110,7 @@ describe("expose tailnet up", () => {
     try {
       const { runner } = makeRunner();
       const logs: string[] = [];
-      const code = await exposeTailnetUp({
+      const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
@@ -130,7 +132,7 @@ describe("expose tailnet up", () => {
         throw new Error("spawn tailscale ENOENT");
       };
       const logs: string[] = [];
-      const code = await exposeTailnetUp({
+      const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
@@ -151,6 +153,7 @@ describe("expose tailnet up", () => {
       writeExposeState(
         {
           version: 1,
+          layer: "tailnet",
           mode: "path",
           canonicalFqdn: "parachute.taildf9ce2.ts.net",
           port: 443,
@@ -167,7 +170,7 @@ describe("expose tailnet up", () => {
         h.statePath,
       );
       const { runner, calls } = makeRunner();
-      const code = await exposeTailnetUp({
+      const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
@@ -202,7 +205,7 @@ describe("expose tailnet up", () => {
         return { code: 0, stdout: "", stderr: "" };
       };
       const logs: string[] = [];
-      const code = await exposeTailnetUp({
+      const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
@@ -223,7 +226,7 @@ describe("expose tailnet off", () => {
     try {
       const { runner, calls } = makeRunner();
       const logs: string[] = [];
-      const code = await exposeTailnetOff({
+      const code = await exposeTailnet("off", {
         runner,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
@@ -243,6 +246,7 @@ describe("expose tailnet off", () => {
       writeExposeState(
         {
           version: 1,
+          layer: "tailnet",
           mode: "path",
           canonicalFqdn: "parachute.taildf9ce2.ts.net",
           port: 443,
@@ -266,7 +270,7 @@ describe("expose tailnet off", () => {
       );
       await Bun.write(h.wellKnownPath, "{}\n");
       const { runner, calls } = makeRunner();
-      const code = await exposeTailnetOff({
+      const code = await exposeTailnet("off", {
         runner,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
@@ -288,6 +292,7 @@ describe("expose tailnet off", () => {
       writeExposeState(
         {
           version: 1,
+          layer: "tailnet",
           mode: "path",
           canonicalFqdn: "parachute.taildf9ce2.ts.net",
           port: 443,
@@ -305,7 +310,7 @@ describe("expose tailnet off", () => {
       );
       const runner: Runner = async () => ({ code: 5, stdout: "", stderr: "tailscale blew up" });
       const logs: string[] = [];
-      const code = await exposeTailnetOff({
+      const code = await exposeTailnet("off", {
         runner,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
@@ -313,6 +318,198 @@ describe("expose tailnet off", () => {
       });
       expect(code).toBe(5);
       expect(existsSync(h.statePath)).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("tailnet off does not tear down public exposure", async () => {
+    const h = makeHarness();
+    try {
+      writeExposeState(
+        {
+          version: 1,
+          layer: "public",
+          mode: "path",
+          canonicalFqdn: "parachute.taildf9ce2.ts.net",
+          port: 443,
+          funnel: true,
+          entries: [
+            {
+              kind: "proxy",
+              mount: "/",
+              target: "http://127.0.0.1:1940",
+              service: "parachute-vault",
+            },
+          ],
+        },
+        h.statePath,
+      );
+      const { runner, calls } = makeRunner();
+      const logs: string[] = [];
+      const code = await exposeTailnet("off", {
+        runner,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(calls).toHaveLength(0);
+      expect(existsSync(h.statePath)).toBe(true);
+      expect(logs.join("\n")).toMatch(/Current exposure is Public/);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("expose public up", () => {
+  test("adds --funnel to every serve command and records layer=public", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      const { runner, calls } = makeRunner();
+      const logs: string[] = [];
+      const code = await exposePublic("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+
+      const serveCalls = calls.filter(
+        (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
+      );
+      expect(serveCalls).toHaveLength(3);
+      expect(serveCalls.every((c) => c.includes("--funnel"))).toBe(true);
+
+      const state = readExposeState(h.statePath);
+      expect(state?.layer).toBe("public");
+      expect(state?.funnel).toBe(true);
+      expect(state?.entries).toHaveLength(3);
+
+      expect(logs.join("\n")).toMatch(/Public exposure active/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("switching from tailnet to public tears down prior state first", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      writeExposeState(
+        {
+          version: 1,
+          layer: "tailnet",
+          mode: "path",
+          canonicalFqdn: "parachute.taildf9ce2.ts.net",
+          port: 443,
+          funnel: false,
+          entries: [
+            {
+              kind: "proxy",
+              mount: "/",
+              target: "http://127.0.0.1:1940",
+              service: "parachute-vault",
+            },
+          ],
+        },
+        h.statePath,
+      );
+      const { runner, calls } = makeRunner();
+      const code = await exposePublic("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      const offs = calls.filter((c) => c[c.length - 1] === "off");
+      expect(offs).toHaveLength(1);
+      const state = readExposeState(h.statePath);
+      expect(state?.layer).toBe("public");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("expose public off", () => {
+  test("tears down public exposure and clears state", async () => {
+    const h = makeHarness();
+    try {
+      writeExposeState(
+        {
+          version: 1,
+          layer: "public",
+          mode: "path",
+          canonicalFqdn: "parachute.taildf9ce2.ts.net",
+          port: 443,
+          funnel: true,
+          entries: [
+            {
+              kind: "proxy",
+              mount: "/",
+              target: "http://127.0.0.1:1940",
+              service: "parachute-vault",
+            },
+          ],
+        },
+        h.statePath,
+      );
+      const { runner, calls } = makeRunner();
+      const code = await exposePublic("off", {
+        runner,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(calls.every((c) => c[c.length - 1] === "off")).toBe(true);
+      expect(existsSync(h.statePath)).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("public off does not tear down tailnet exposure", async () => {
+    const h = makeHarness();
+    try {
+      writeExposeState(
+        {
+          version: 1,
+          layer: "tailnet",
+          mode: "path",
+          canonicalFqdn: "parachute.taildf9ce2.ts.net",
+          port: 443,
+          funnel: false,
+          entries: [
+            {
+              kind: "proxy",
+              mount: "/",
+              target: "http://127.0.0.1:1940",
+              service: "parachute-vault",
+            },
+          ],
+        },
+        h.statePath,
+      );
+      const { runner, calls } = makeRunner();
+      const logs: string[] = [];
+      const code = await exposePublic("off", {
+        runner,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(calls).toHaveLength(0);
+      expect(existsSync(h.statePath)).toBe(true);
+      expect(logs.join("\n")).toMatch(/Current exposure is Tailnet/);
     } finally {
       h.cleanup();
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@
  */
 
 import pkg from "../package.json" with { type: "json" };
-import { exposeTailnet } from "./commands/expose.ts";
+import { exposePublic, exposeTailnet } from "./commands/expose.ts";
 import { install } from "./commands/install.ts";
 import { status } from "./commands/status.ts";
 import { dispatchVault } from "./commands/vault.ts";
@@ -27,14 +27,12 @@ Usage:
                                     services: ${services}
   parachute status                  show installed services and health
   parachute expose tailnet [off]    HTTPS across your tailnet
+  parachute expose public  [off]    HTTPS on the public internet (Funnel)
   parachute vault <args...>         dispatch to parachute-vault
 
 Flags:
   --help, -h                        show this help
   --version, -v                     print version
-
-Coming soon:
-  parachute expose public [off]     HTTPS on the public internet  (PR 3)
 `);
 }
 
@@ -70,21 +68,19 @@ async function main(argv: string[]): Promise<number> {
     case "expose": {
       const layer = rest[0];
       const mode = rest[1];
-      if (layer !== "tailnet") {
-        if (layer === "public") {
-          console.error("parachute expose public is coming in PR 3.");
-        } else {
-          console.error(`parachute expose: unknown layer "${layer ?? ""}"`);
-          console.error("usage: parachute expose tailnet [off]");
-        }
+      if (layer !== "tailnet" && layer !== "public") {
+        console.error(`parachute expose: unknown layer "${layer ?? ""}"`);
+        console.error("usage: parachute expose tailnet [off]");
+        console.error("       parachute expose public  [off]");
         return 1;
       }
       if (mode !== undefined && mode !== "off") {
-        console.error(`parachute expose tailnet: unknown argument "${mode}"`);
-        console.error("usage: parachute expose tailnet [off]");
+        console.error(`parachute expose ${layer}: unknown argument "${mode}"`);
+        console.error(`usage: parachute expose ${layer} [off]`);
         return 1;
       }
-      return await exposeTailnet(mode === "off" ? "off" : "up");
+      const action = mode === "off" ? "off" : "up";
+      return layer === "public" ? await exposePublic(action) : await exposeTailnet(action);
     }
 
     case "vault":

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -2,6 +2,7 @@ import { existsSync, unlinkSync } from "node:fs";
 import { SERVICES_MANIFEST_PATH } from "../config.ts";
 import {
   EXPOSE_STATE_PATH,
+  type ExposeLayer,
   type ExposeState,
   clearExposeState,
   readExposeState,
@@ -18,7 +19,19 @@ import {
   writeWellKnownFile,
 } from "../well-known.ts";
 
-export interface ExposeTailnetOpts {
+/**
+ * Two exposure layers share a single tailscale serve config on this node.
+ * Public layer adds `--funnel` to each handler; everything else is identical.
+ *
+ * Funnel constraint: Tailscale allows at most three public HTTPS ports per
+ * node (443, 8443, 10000). Path-routing packs every service onto a single
+ * port — that's why we default to one `--https=443` and mount services under
+ * `/vault`, `/notes`, etc. rather than giving each service its own port or
+ * subdomain. Subdomain-per-service requires the Tailscale Services feature
+ * (virtual-IP advertisement) and is deferred.
+ */
+
+export interface ExposeOpts {
   runner?: Runner;
   manifestPath?: string;
   statePath?: string;
@@ -65,13 +78,18 @@ async function runEach(
   return 0;
 }
 
-export async function exposeTailnetUp(opts: ExposeTailnetOpts = {}): Promise<number> {
+function layerLabel(layer: ExposeLayer): string {
+  return layer === "public" ? "Public (Funnel)" : "Tailnet";
+}
+
+export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promise<number> {
   const runner = opts.runner ?? defaultRunner;
   const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
   const statePath = opts.statePath ?? EXPOSE_STATE_PATH;
   const wellKnownFilePath = opts.wellKnownPath ?? WELL_KNOWN_PATH;
   const port = opts.port ?? 443;
   const log = opts.log ?? ((line) => console.log(line));
+  const funnel = layer === "public";
 
   if (!(await isTailscaleInstalled(runner))) {
     log("tailscale is not installed or not on PATH.");
@@ -90,7 +108,8 @@ export async function exposeTailnetUp(opts: ExposeTailnetOpts = {}): Promise<num
 
   const prior = readExposeState(statePath);
   if (prior && prior.entries.length > 0) {
-    log(`Found prior tailnet exposure; tearing down ${prior.entries.length} entries first…`);
+    const priorLabel = layerLabel(prior.layer);
+    log(`Found prior ${priorLabel} exposure; tearing down ${prior.entries.length} entries first…`);
     const teardownCmds = prior.entries.map((e) => teardownCommand(e, { port: prior.port }));
     const code = await runEach(runner, teardownCmds, log);
     if (code !== 0) {
@@ -104,13 +123,13 @@ export async function exposeTailnetUp(opts: ExposeTailnetOpts = {}): Promise<num
   log(`Wrote ${wellKnownFilePath}`);
 
   const entries = planEntries(manifest.services, wellKnownFilePath);
-  log(`Exposing under ${canonicalOrigin} (path-routing, port ${port}):`);
+  log(`Exposing under ${canonicalOrigin} (${layerLabel(layer)}, path-routing, port ${port}):`);
   for (const e of entries) {
     const suffix = e.kind === "proxy" ? `→ ${e.target}  (${e.service})` : `→ ${e.target}`;
     log(`  ${e.mount.padEnd(30, " ")} ${suffix}`);
   }
 
-  const cmds = entries.map((e) => bringupCommand(e, { port }));
+  const cmds = entries.map((e) => bringupCommand(e, { port, funnel }));
   const code = await runEach(runner, cmds, log);
   if (code !== 0) {
     log("Bringup failed; see error above. Prior tailscale state may be partially applied.");
@@ -119,21 +138,27 @@ export async function exposeTailnetUp(opts: ExposeTailnetOpts = {}): Promise<num
 
   const state: ExposeState = {
     version: 1,
+    layer,
     mode: "path",
     canonicalFqdn: fqdn,
     port,
-    funnel: false,
+    funnel,
     entries,
   };
   writeExposeState(state, statePath);
 
   log("");
-  log(`✓ Tailnet exposure active. Open: ${canonicalOrigin}/`);
+  if (layer === "public") {
+    log(`✓ Public exposure active (Funnel). Open: ${canonicalOrigin}/`);
+    log("  This node is reachable from the public internet.");
+  } else {
+    log(`✓ Tailnet exposure active. Open: ${canonicalOrigin}/`);
+  }
   log(`  Discovery: ${canonicalOrigin}${WELL_KNOWN_MOUNT}`);
   return 0;
 }
 
-export async function exposeTailnetOff(opts: ExposeTailnetOpts = {}): Promise<number> {
+export async function exposeOff(layer: ExposeLayer, opts: ExposeOpts = {}): Promise<number> {
   const runner = opts.runner ?? defaultRunner;
   const statePath = opts.statePath ?? EXPOSE_STATE_PATH;
   const wellKnownFilePath = opts.wellKnownPath ?? WELL_KNOWN_PATH;
@@ -141,11 +166,17 @@ export async function exposeTailnetOff(opts: ExposeTailnetOpts = {}): Promise<nu
 
   const state = readExposeState(statePath);
   if (!state || state.entries.length === 0) {
-    log("No tailnet exposure recorded. Nothing to tear down.");
+    log(`No ${layerLabel(layer)} exposure recorded. Nothing to tear down.`);
+    return 0;
+  }
+  if (state.layer !== layer) {
+    log(`No ${layerLabel(layer)} exposure recorded.`);
+    log(`Current exposure is ${layerLabel(state.layer)}.`);
+    log(`Run: parachute expose ${state.layer} off`);
     return 0;
   }
 
-  log(`Tearing down ${state.entries.length} tailnet serve entries…`);
+  log(`Tearing down ${state.entries.length} ${layerLabel(layer)} serve entries…`);
   const cmds = state.entries.map((e) => teardownCommand(e, { port: state.port }));
   const code = await runEach(runner, cmds, log);
   if (code !== 0) {
@@ -157,13 +188,14 @@ export async function exposeTailnetOff(opts: ExposeTailnetOpts = {}): Promise<nu
   if (existsSync(wellKnownFilePath)) {
     unlinkSync(wellKnownFilePath);
   }
-  log("✓ Tailnet exposure removed.");
+  log(`✓ ${layerLabel(layer)} exposure removed.`);
   return 0;
 }
 
-export async function exposeTailnet(
-  action: "up" | "off",
-  opts: ExposeTailnetOpts = {},
-): Promise<number> {
-  return action === "off" ? exposeTailnetOff(opts) : exposeTailnetUp(opts);
+export async function exposeTailnet(action: "up" | "off", opts: ExposeOpts = {}): Promise<number> {
+  return action === "off" ? exposeOff("tailnet", opts) : exposeUp("tailnet", opts);
+}
+
+export async function exposePublic(action: "up" | "off", opts: ExposeOpts = {}): Promise<number> {
+  return action === "off" ? exposeOff("public", opts) : exposeUp("public", opts);
 }

--- a/src/expose-state.ts
+++ b/src/expose-state.ts
@@ -13,9 +13,11 @@ import type { ServeEntry } from "./tailscale/commands.ts";
 export const EXPOSE_STATE_PATH = join(CONFIG_DIR, "expose-state.json");
 
 export type ExposeMode = "path" | "subdomain";
+export type ExposeLayer = "tailnet" | "public";
 
 export interface ExposeState {
   version: 1;
+  layer: ExposeLayer;
   mode: ExposeMode;
   canonicalFqdn: string;
   port: number;
@@ -34,6 +36,9 @@ function validate(raw: unknown, path: string): ExposeState {
   const r = raw as Record<string, unknown>;
   if (r.version !== 1) {
     throw new ExposeStateError(`${path}: unsupported version ${String(r.version)}`);
+  }
+  if (r.layer !== "tailnet" && r.layer !== "public") {
+    throw new ExposeStateError(`${path}: layer must be "tailnet" or "public"`);
   }
   if (r.mode !== "path" && r.mode !== "subdomain") {
     throw new ExposeStateError(`${path}: mode must be "path" or "subdomain"`);
@@ -72,6 +77,7 @@ function validate(raw: unknown, path: string): ExposeState {
   });
   return {
     version: 1,
+    layer: r.layer,
     mode: r.mode,
     canonicalFqdn: r.canonicalFqdn,
     port: r.port,


### PR DESCRIPTION
## Why

Tailnet-only exposure (PR 2) works when Aaron is the only reader. The moment he wants to share a note with someone who isn't on his tailnet, he needs the public internet. `parachute expose public` should flip that on without asking the user about ports, subdomains, or HTTPS certs.

Funnel is the only launch-grade backend here — it ships with tailscale, so there's nothing new to install once you've already done `tailscale up`. caddy and cloudflared backends are deferred post-launch; they're a different scope.

## What changes

- `parachute expose public` — brings every service up behind Tailscale Funnel (`--funnel` on each `tailscale serve` handler).
- `parachute expose public off` — tears down the public exposure, clears state, deletes the well-known file.
- `parachute expose tailnet off` and `parachute expose public off` are now layer-scoped: they refuse to tear down a mismatched layer and point you at the right command. Switching layers (tailnet ⇄ public) transparently tears down the prior state first.

## Design

**Shared serve config.** Tailnet and public layers use the same underlying `tailscale serve` config on this node — the only difference is `--funnel` per handler. `ExposeState` now tracks `layer: "tailnet" | "public"` so teardown never acts on the wrong layer.

**Why path-routing (still) by default.** Funnel is capped at three public HTTPS ports per node (443 / 8443 / 10000). Pinning to `--https=443` and mounting services under `/`, `/notes`, `/scribe`, etc. keeps every install shape within that cap regardless of how many services are registered. Subdomain-per-service requires the Tailscale Services feature (virtual IPs + explicit advertisement) and is deferred — `detectWildcardMagicDNS` is the seam for that future PR.

**Why `exposeUp/Off(layer, opts)` as the core.** Two thin action-wrappers (`exposeTailnet`, `exposePublic`) keep the CLI dispatch symmetric while keeping the shared logic in one place.

## Tests

57/57 passing (was 51). New coverage:
- `expose public` threads `--funnel` through every serve invocation.
- `expose public` + prior tailnet state → tears down tailnet first.
- `expose tailnet off` with public state → prints current layer, leaves state intact.
- `expose public off` with tailnet state → same, inverted.
- CLI dispatch for `expose wat` → exit 1, help mentions both layers.

## Test plan

- [x] `bun test` — 57/57 pass
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun src/cli.ts --help` — shows both exposure layers
- [ ] Live smoke (Aaron): `parachute expose public` on a machine with vault + notes, hit the canonical FQDN from a public browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)