### PR TITLE
PR 4: launch polish — README, per-subcommand help, friendly errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 `parachute` — the top-level command for the [Parachute](https://parachute.computer) ecosystem.
 
-Install, inspect, and expose Parachute services with one command. Each service (vault, notes, scribe, channel, …) remains a standalone package; this CLI is the coordinator.
-
-## Status
-
-Pre-alpha, in development.
+Install, inspect, and expose Parachute services with one command. Each service (vault, notes, scribe, channel, …) stays a standalone package; this CLI is the coordinator.
 
 ## Install
 
@@ -14,32 +10,159 @@ Pre-alpha, in development.
 bun add -g @openparachute/cli
 ```
 
-Then:
+Prereqs: [Bun](https://bun.sh), and — for `parachute expose` — [Tailscale](https://tailscale.com/download) installed and `tailscale up` run at least once.
+
+## First 5 minutes
 
 ```sh
+# 1. Install the CLI (one line)
+bun add -g @openparachute/cli
+
+# 2. Install a service (runs `bun add -g @openparachute/vault` + `parachute-vault init`)
 parachute install vault
-parachute install notes
-parachute vault init          # still works — dispatches to parachute-vault
-parachute status              # what's running, where
-parachute expose tailnet      # HTTPS across your tailnet
-parachute expose public       # HTTPS to the public internet
+
+# 3. Check it landed — reads ~/.parachute/services.json, probes health
+parachute status
+# SERVICE          PORT  VERSION  STATUS  LATENCY
+# parachute-vault  1940  0.2.4    ok      2ms
+
+# 4. Expose across your tailnet (HTTPS via Tailscale MagicDNS)
+parachute expose tailnet
+# ✓ Tailnet exposure active. Open: https://parachute.<tailnet>.ts.net/
+
+# 5. Go public (Tailscale Funnel — same URL, now reachable from the internet)
+parachute expose public
+# ✓ Public exposure active (Funnel). Open: https://parachute.<tailnet>.ts.net/
 ```
 
-## How it works
-
-Each Parachute service writes a manifest entry to `~/.parachute/services.json` on install. The CLI reads that manifest to generate the right config for `parachute status`, `parachute expose tailnet`, and `parachute expose public`.
-
-Cross-service discovery travels through `/.well-known/parachute.json` at the canonical origin — Parachute Notes and any future clients probe it to find the vault (and anything else).
+Tear down with `parachute expose tailnet off` or `parachute expose public off`. Layers are independent — `off` only affects the layer you name.
 
 ## Three layers of addressability
 
 Each additive; each can be turned off without affecting the layer below.
 
-- **Local** — services on loopback. Zero config. Browsers treat `localhost` as a secure context, so OAuth + PKCE + crypto-subtle all just work.
-- **Tailnet** — `parachute expose tailnet` wraps `tailscale serve` for each installed service, HTTPS via Tailscale's MagicDNS cert.
-- **Public** — `parachute expose public` supports three modes: Tailscale Funnel (default), Caddy + your own domain, cloudflared tunnel + your own domain.
+- **Local** — services on loopback. Zero config. Browsers treat `localhost` as a secure context, so OAuth, PKCE, and Web Crypto all just work out of the box.
+- **Tailnet** — `parachute expose tailnet` wraps `tailscale serve` for every registered service. HTTPS via Tailscale's MagicDNS cert. Only machines on your tailnet can reach the URL.
+- **Public** — `parachute expose public` adds `--funnel` to each handler so the same URLs become reachable from the public internet. At launch, Funnel is the only supported backend; Caddy + your-own-domain and cloudflared tunnels are planned post-launch.
 
-See [the decision note](https://github.com/ParachuteComputer/parachute-vault) for the full design rationale.
+Under the hood, tailnet and public share a single `tailscale serve` config. The CLI records which layer is live so that `expose <other-layer> off` is a no-op rather than a surprise teardown of the active layer.
+
+## Path-routing (and why)
+
+Every service mounts under a path on a single canonical hostname:
+
+```
+https://parachute.<tailnet>.ts.net/           → parachute-vault
+https://parachute.<tailnet>.ts.net/notes      → parachute-notes
+https://parachute.<tailnet>.ts.net/scribe     → parachute-scribe
+https://parachute.<tailnet>.ts.net/.well-known/parachute.json   ← discovery
+```
+
+The `/.well-known/parachute.json` document maps short names to absolute URLs so clients can discover each other without knowing install-local ports:
+
+```json
+{
+  "vault":  { "url": "https://parachute.taildf9ce2.ts.net/",       "version": "0.2.4" },
+  "notes":  { "url": "https://parachute.taildf9ce2.ts.net/notes",  "version": "0.0.1" }
+}
+```
+
+Why path-routing and not subdomain-per-service? Two reasons:
+
+1. **Tailscale Funnel HTTPS is capped at three ports per node** (443, 8443, 10000). Pinning every service to 443 behind a path means you can install any number of services without ever hitting that cap.
+2. **Subdomain-per-service requires the Tailscale Services feature** (virtual-IP advertisement per service), which is more than a MagicDNS wildcard — it needs admin-side setup that's out of scope for a one-command install. When it's a launch-grade path, we'll add `parachute expose tailnet --mode subdomain`.
+
+Funnel has bandwidth quotas on Tailscale's free tier. See [tailscale.com/kb/1223/funnel](https://tailscale.com/kb/1223/funnel) for current limits; for heavy traffic, the post-launch Caddy / cloudflared modes will be the answer.
+
+## How services register
+
+Each Parachute service writes a manifest entry to `~/.parachute/services.json` on install. The CLI reads that manifest to drive `parachute status`, `parachute expose tailnet`, and `parachute expose public`.
+
+```json
+{
+  "services": [
+    {
+      "name":    "parachute-vault",
+      "port":    1940,
+      "paths":   ["/"],
+      "health":  "/health",
+      "version": "0.2.4"
+    }
+  ]
+}
+```
+
+The schema is a bit-for-bit contract shared between the CLI and every service. Services own their write side; the CLI owns the read + exposure side.
+
+If you want the CLI (and every service you install) to use a config directory other than `~/.parachute`, set `PARACHUTE_HOME`:
+
+```sh
+export PARACHUTE_HOME=/some/other/path
+```
+
+## Already have parachute-vault installed?
+
+Install the CLI and `parachute vault ...` forwards to your existing `parachute-vault` binary:
+
+```sh
+bun add -g @openparachute/cli
+parachute vault init     # dispatches to parachute-vault init
+parachute vault --help   # dispatches to parachute-vault --help
+```
+
+Nothing about your existing vault moves or needs reconfiguring.
+
+## Smoke walkthrough (post-install)
+
+Copy-paste to verify the whole chain. Everything here is idempotent.
+
+```sh
+# Install
+bun add -g @openparachute/cli
+
+# Verify CLI
+parachute --version
+parachute --help
+
+# Install a service
+parachute install vault
+
+# Manifest should now exist
+cat ~/.parachute/services.json
+
+# Status should show vault as healthy
+parachute status
+
+# Expose across your tailnet (requires tailscale + `tailscale up`)
+parachute expose tailnet
+
+# Open the URL printed above in a browser on any tailnet peer.
+# Also confirm the discovery document:
+curl -s https://parachute.<tailnet>.ts.net/.well-known/parachute.json | jq .
+
+# Flip to public (Funnel)
+parachute expose public
+# Open the same URL in a browser NOT on your tailnet — phone on cell, say.
+
+# Tear down
+parachute expose public off
+```
+
+## Subcommand reference
+
+Run `parachute --help` for the top-level list, and `parachute <subcommand> --help` for details on any individual command.
+
+```
+parachute install <service>       install and register a service
+parachute status                  show installed services and health
+parachute expose tailnet [off]    HTTPS across your tailnet
+parachute expose public  [off]    HTTPS on the public internet (Funnel)
+parachute vault <args...>         dispatch to parachute-vault
+```
+
+## Status
+
+Pre-alpha. API surface is stabilizing but not frozen.
 
 ## License
 

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const CLI = join(import.meta.dir, "..", "cli.ts");
 
-async function runCli(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+async function runCli(
+  args: string[],
+  env: Record<string, string> = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
   const proc = Bun.spawn(["bun", CLI, ...args], {
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...process.env, HOME: "/tmp/parachute-cli-nonexistent-home" },
+    env: {
+      ...process.env,
+      HOME: "/tmp/parachute-cli-nonexistent-home",
+      PARACHUTE_HOME: "/tmp/parachute-cli-nonexistent-home",
+      ...env,
+    },
   });
   const [stdout, stderr, code] = await Promise.all([
     new Response(proc.stdout).text(),
@@ -57,5 +67,65 @@ describe("cli", () => {
     const { code, stderr } = await runCli(["wat"]);
     expect(code).toBe(1);
     expect(stderr).toMatch(/unknown command/);
+  });
+});
+
+describe("cli per-subcommand help", () => {
+  test("install --help shows install usage", async () => {
+    const { code, stdout } = await runCli(["install", "--help"]);
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/parachute install/);
+    expect(stdout).toMatch(/bun add -g/);
+  });
+
+  test("install -h also works", async () => {
+    const { code, stdout } = await runCli(["install", "-h"]);
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/parachute install/);
+  });
+
+  test("status --help shows status usage", async () => {
+    const { code, stdout } = await runCli(["status", "--help"]);
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/parachute status/);
+    expect(stdout).toMatch(/Exit codes/);
+  });
+
+  test("expose --help shows both layers and Funnel notes", async () => {
+    const { code, stdout } = await runCli(["expose", "--help"]);
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/expose tailnet/);
+    expect(stdout).toMatch(/expose public/);
+    expect(stdout).toMatch(/Funnel/);
+    expect(stdout).toMatch(/443/);
+  });
+
+  test("expose tailnet --help shows full expose help", async () => {
+    const { code, stdout } = await runCli(["expose", "tailnet", "--help"]);
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/expose tailnet/);
+  });
+
+  test("vault with no args shows dispatch help", async () => {
+    const { code, stdout } = await runCli(["vault"]);
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/parachute vault/);
+    expect(stdout).toMatch(/parachute install vault/);
+  });
+});
+
+describe("cli friendly errors", () => {
+  test("malformed services.json prints friendly error not stack trace", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pcli-bad-"));
+    try {
+      writeFileSync(join(dir, "services.json"), "this is not json{");
+      const { code, stderr } = await runCli(["status"], { PARACHUTE_HOME: dir });
+      expect(code).toBe(1);
+      expect(stderr).toMatch(/services\.json is malformed/);
+      expect(stderr).not.toMatch(/at process\./);
+      expect(stderr).not.toMatch(/Error:.*at \//);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,12 +3,7 @@
 /**
  * parachute — the top-level CLI for the Parachute ecosystem.
  *
- * Usage:
- *   parachute install <service>     install a Parachute service
- *   parachute status                read services manifest, probe localhost
- *   parachute vault <args...>       dispatch to parachute-vault
- *   parachute --version
- *   parachute --help
+ * Run `parachute --help` or `parachute <subcommand> --help` for usage.
  */
 
 import pkg from "../package.json" with { type: "json" };
@@ -16,24 +11,14 @@ import { exposePublic, exposeTailnet } from "./commands/expose.ts";
 import { install } from "./commands/install.ts";
 import { status } from "./commands/status.ts";
 import { dispatchVault } from "./commands/vault.ts";
+import { ExposeStateError } from "./expose-state.ts";
+import { exposeHelp, installHelp, statusHelp, topLevelHelp, vaultHelp } from "./help.ts";
 import { knownServices } from "./service-spec.ts";
+import { ServicesManifestError } from "./services-manifest.ts";
+import { TailscaleError } from "./tailscale/run.ts";
 
-function usage(): void {
-  const services = knownServices().join(" | ");
-  console.log(`parachute ${pkg.version} — top-level CLI for the Parachute ecosystem
-
-Usage:
-  parachute install <service>       install and register a service
-                                    services: ${services}
-  parachute status                  show installed services and health
-  parachute expose tailnet [off]    HTTPS across your tailnet
-  parachute expose public  [off]    HTTPS on the public internet (Funnel)
-  parachute vault <args...>         dispatch to parachute-vault
-
-Flags:
-  --help, -h                        show this help
-  --version, -v                     print version
-`);
+function isHelpFlag(arg: string | undefined): boolean {
+  return arg === "--help" || arg === "-h" || arg === "help";
 }
 
 async function main(argv: string[]): Promise<number> {
@@ -44,7 +29,7 @@ async function main(argv: string[]): Promise<number> {
     case "help":
     case "--help":
     case "-h":
-      usage();
+      console.log(topLevelHelp());
       return 0;
 
     case "--version":
@@ -53,6 +38,10 @@ async function main(argv: string[]): Promise<number> {
       return 0;
 
     case "install": {
+      if (isHelpFlag(rest[0])) {
+        console.log(installHelp());
+        return 0;
+      }
       const service = rest[0];
       if (!service) {
         console.error("usage: parachute install <service>");
@@ -63,16 +52,29 @@ async function main(argv: string[]): Promise<number> {
     }
 
     case "status":
+      if (isHelpFlag(rest[0])) {
+        console.log(statusHelp());
+        return 0;
+      }
       return await status();
 
     case "expose": {
       const layer = rest[0];
       const mode = rest[1];
+      if (isHelpFlag(layer)) {
+        console.log(exposeHelp());
+        return 0;
+      }
       if (layer !== "tailnet" && layer !== "public") {
         console.error(`parachute expose: unknown layer "${layer ?? ""}"`);
         console.error("usage: parachute expose tailnet [off]");
         console.error("       parachute expose public  [off]");
+        console.error("run `parachute expose --help` for details");
         return 1;
+      }
+      if (isHelpFlag(mode)) {
+        console.log(exposeHelp());
+        return 0;
       }
       if (mode !== undefined && mode !== "off") {
         console.error(`parachute expose ${layer}: unknown argument "${mode}"`);
@@ -84,6 +86,13 @@ async function main(argv: string[]): Promise<number> {
     }
 
     case "vault":
+      // `parachute vault` alone shows CLI's dispatch help (usage hint).
+      // `parachute vault <anything>` forwards verbatim — including --help,
+      // which goes to parachute-vault itself so the user sees vault's own help.
+      if (rest.length === 0) {
+        console.log(vaultHelp());
+        return 0;
+      }
       return await dispatchVault(rest);
 
     default:
@@ -93,5 +102,27 @@ async function main(argv: string[]): Promise<number> {
   }
 }
 
-const code = await main(process.argv.slice(2));
+async function run(argv: string[]): Promise<number> {
+  try {
+    return await main(argv);
+  } catch (err) {
+    if (err instanceof ServicesManifestError) {
+      console.error(`services.json is malformed: ${err.message}`);
+      console.error("Fix or remove the file, then re-run.");
+      return 1;
+    }
+    if (err instanceof ExposeStateError) {
+      console.error(`expose-state.json is malformed: ${err.message}`);
+      console.error("If you're stuck, delete ~/.parachute/expose-state.json and re-run.");
+      return 1;
+    }
+    if (err instanceof TailscaleError) {
+      console.error(`tailscale command failed: ${err.message}`);
+      return 1;
+    }
+    throw err;
+  }
+}
+
+const code = await run(process.argv.slice(2));
 process.exit(code);

--- a/src/help.ts
+++ b/src/help.ts
@@ -1,0 +1,113 @@
+import pkg from "../package.json" with { type: "json" };
+import { knownServices } from "./service-spec.ts";
+
+export function topLevelHelp(): string {
+  const services = knownServices().join(" | ");
+  return `parachute ${pkg.version} — top-level CLI for the Parachute ecosystem
+
+Usage:
+  parachute install <service>       install and register a service
+                                    services: ${services}
+  parachute status                  show installed services and health
+  parachute expose tailnet [off]    HTTPS across your tailnet
+  parachute expose public  [off]    HTTPS on the public internet (Funnel)
+  parachute vault <args...>         dispatch to parachute-vault
+
+Flags:
+  --help, -h                        show this help (also per-subcommand: \`parachute <cmd> --help\`)
+  --version, -v                     print version
+`;
+}
+
+export function installHelp(): string {
+  return `parachute install — install and register a Parachute service
+
+Usage:
+  parachute install <service>
+
+Services:
+  ${knownServices().join(", ")}
+
+What it does:
+  1. bun add -g @openparachute/<service>
+  2. run any service-specific init (e.g. \`parachute-vault init\`)
+  3. verify the service registered itself in ~/.parachute/services.json
+
+Examples:
+  parachute install vault           # installs + runs \`parachute-vault init\`
+  parachute install notes           # installs notes (no init required)
+`;
+}
+
+export function statusHelp(): string {
+  return `parachute status — show installed services and their health
+
+Usage:
+  parachute status
+
+What it does:
+  Reads ~/.parachute/services.json and probes \`http://localhost:<port><health>\`
+  for every registered service.
+
+Exit codes:
+  0   all services healthy (or no services installed yet)
+  1   one or more services unhealthy
+
+Example:
+  $ parachute status
+  SERVICE          PORT  VERSION  STATUS  LATENCY
+  parachute-vault  1940  0.2.4    ok      2ms
+`;
+}
+
+export function exposeHelp(): string {
+  return `parachute expose — route your services behind HTTPS on a network layer
+
+Usage:
+  parachute expose tailnet [off]
+  parachute expose public  [off]
+
+Layers:
+  tailnet    HTTPS across your tailnet (tailscale serve)
+  public     HTTPS on the public internet (Tailscale Funnel)
+
+Both layers share a single tailscale-serve config on this node. Switching
+layers is idempotent — the prior layer tears down before the new one comes up.
+
+Examples:
+  parachute expose tailnet          # bring every service up inside your tailnet
+  parachute expose public           # also reachable from the public internet
+  parachute expose tailnet off      # tear down tailnet exposure
+  parachute expose public off       # tear down public exposure
+
+Constraints (public layer / Funnel):
+  - Funnel supports HTTPS only on ports 443 / 8443 / 10000 per node.
+    We pin to 443 and path-route (vault at /, notes at /notes, …) so this
+    cap never becomes a constraint no matter how many services you install.
+  - Funnel has bandwidth caps on Tailscale's free tier.
+    See https://tailscale.com/kb/1223/funnel for current limits.
+  - Subdomain-per-service (vault.<fqdn>, notes.<fqdn>, …) requires the
+    Tailscale Services feature and is not supported in this release.
+
+Coming soon:
+  parachute expose public --mode caddy        use your own domain + Caddy
+  parachute expose public --mode cloudflared  use your own domain + cloudflared
+`;
+}
+
+export function vaultHelp(): string {
+  return `parachute vault — dispatch to parachute-vault
+
+Usage:
+  parachute vault <args...>
+
+Everything after \`parachute vault\` is forwarded verbatim to the installed
+parachute-vault binary. If you get "not found on PATH", install it with:
+
+  parachute install vault
+
+Examples:
+  parachute vault init              # same as running \`parachute-vault init\`
+  parachute vault --help            # forwards --help to parachute-vault
+`;
+}


### PR DESCRIPTION
## Why

The prior README was a skeleton; subcommand help was one monolithic blob. For launch, a reader should be able to paste a 5-minute walkthrough and get vault + notes + expose running on their own tailnet and Funnel without reading the code.

## README

- **First 5 minutes** walkthrough — install CLI → install vault → status → expose tailnet → expose public. Copy-paste runnable.
- **Three-layers framing** (local / tailnet / public) with one short paragraph each + why path-routing is the default.
- **Funnel constraints** called out: three-port cap (why it doesn't bite us), bandwidth quotas on the free tier with a link to [tailscale.com/kb/1223/funnel](https://tailscale.com/kb/1223/funnel) for current limits.
- **Manifest schema** example + `$PARACHUTE_HOME`.
- **Migration note** for existing `parachute-vault` users — one `bun add -g @openparachute/cli` unlocks `parachute vault *` dispatch; nothing needs reconfiguring.
- **Smoke walkthrough** section (curl the well-known, phone-on-cell public-layer test).

## Per-subcommand help (new `src/help.ts`)

`parachute <subcommand> --help` now prints a section tailored to that subcommand — usage line, short explanation, 2-3 examples. Covers install, status, expose (with Funnel notes + coming-soon caddy/cloudflared).

- `parachute vault <anything>` forwards verbatim, including `--help`, so `parachute vault --help` reaches vault's own help text.
- `parachute vault` (no args) shows CLI's dispatch help since it's a usage hint, not a pass-through.

## Friendly errors

Top-level `run()` wrapper catches typed error classes and prints a one-line message pointing at the fix:
- `ServicesManifestError` → "services.json is malformed: … / Fix or remove the file, then re-run."
- `ExposeStateError` → "expose-state.json is malformed: … / If you're stuck, delete ~/.parachute/expose-state.json and re-run."
- `TailscaleError` → "tailscale command failed: …"

Everything else still bubbles up with a stack trace (bug, not expected-error).

## Tests

64/64 passing (was 57). New:
- Each subcommand help prints the right section (6 tests).
- Malformed `services.json` → exit 1, friendly message, **no stack trace**.
- Test harness hardened to isolate `$PARACHUTE_HOME` so host env can't leak into the sandbox.

## Explicitly out of scope (per brief)

- `parachute expose public --mode caddy`
- `parachute expose public --mode cloudflared`
- Interactive wizards
- npm publish flow

## Test plan

- [x] `bun test` — 64/64 pass
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] Smoke all help outputs (`parachute --help`, `parachute <subcommand> --help`) — sections render correctly
- [ ] Live walkthrough (Aaron): paste the README's "First 5 minutes" block on a fresh machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)