### PR TITLE
PR 5: well-known canonical schema — vaults array + multi-tenant shape

### DIFF
--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -91,7 +91,12 @@ describe("expose tailnet up", () => {
 
       expect(existsSync(h.wellKnownPath)).toBe(true);
       const wk = JSON.parse(await Bun.file(h.wellKnownPath).text());
-      expect(wk.vault?.url).toBe("https://parachute.taildf9ce2.ts.net/");
+      expect(wk.vaults).toHaveLength(1);
+      expect(wk.vaults[0]).toEqual({
+        name: "default",
+        url: "https://parachute.taildf9ce2.ts.net/",
+        version: "0.2.4",
+      });
       expect(wk.notes?.url).toBe("https://parachute.taildf9ce2.ts.net/notes");
 
       const state = readExposeState(h.statePath);

--- a/src/__tests__/well-known.test.ts
+++ b/src/__tests__/well-known.test.ts
@@ -3,13 +3,19 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ServiceEntry } from "../services-manifest.ts";
-import { buildWellKnown, shortName, writeWellKnownFile } from "../well-known.ts";
+import {
+  buildWellKnown,
+  isVaultEntry,
+  shortName,
+  vaultInstanceName,
+  writeWellKnownFile,
+} from "../well-known.ts";
 
 const vault: ServiceEntry = {
   name: "parachute-vault",
   port: 1940,
-  paths: ["/"],
-  health: "/health",
+  paths: ["/vault/default"],
+  health: "/vault/default/health",
   version: "0.2.4",
 };
 
@@ -29,23 +35,104 @@ const scribe: ServiceEntry = {
   version: "0.1.0",
 };
 
-describe("well-known document", () => {
-  test("shortName strips parachute- prefix", () => {
+describe("shortName", () => {
+  test("strips parachute- prefix", () => {
     expect(shortName("parachute-vault")).toBe("vault");
     expect(shortName("parachute-notes")).toBe("notes");
     expect(shortName("custom-service")).toBe("custom-service");
   });
+});
 
-  test("builds map keyed by short name with absolute URLs", () => {
+describe("isVaultEntry", () => {
+  test("matches bare parachute-vault", () => {
+    expect(isVaultEntry(vault)).toBe(true);
+  });
+
+  test("matches prefixed vault instances", () => {
+    expect(isVaultEntry({ ...vault, name: "parachute-vault-work" })).toBe(true);
+    expect(isVaultEntry({ ...vault, name: "parachute-vault-personal" })).toBe(true);
+  });
+
+  test("rejects non-vault services", () => {
+    expect(isVaultEntry(notes)).toBe(false);
+    expect(isVaultEntry(scribe)).toBe(false);
+  });
+
+  test("does not match an unrelated name that merely starts with parachute-vaultish", () => {
+    expect(isVaultEntry({ ...vault, name: "parachute-vaultkeeper" })).toBe(false);
+  });
+});
+
+describe("vaultInstanceName", () => {
+  test("prefers /vault/<name> path segment", () => {
+    expect(vaultInstanceName({ ...vault, paths: ["/vault/work"] })).toBe("work");
+    expect(vaultInstanceName({ ...vault, paths: ["/vault/default"] })).toBe("default");
+  });
+
+  test("falls back to manifest-name suffix when path is non-vault", () => {
+    expect(vaultInstanceName({ ...vault, name: "parachute-vault-personal", paths: ["/"] })).toBe(
+      "personal",
+    );
+  });
+
+  test("defaults to 'default' when nothing else matches", () => {
+    expect(vaultInstanceName({ ...vault, paths: ["/"] })).toBe("default");
+    expect(vaultInstanceName({ ...vault, paths: [] })).toBe("default");
+  });
+
+  test("path wins over name suffix", () => {
+    expect(
+      vaultInstanceName({
+        ...vault,
+        name: "parachute-vault-work",
+        paths: ["/vault/override"],
+      }),
+    ).toBe("override");
+  });
+});
+
+describe("buildWellKnown", () => {
+  test("vaults is always an array, other services are flat entries", () => {
     const doc = buildWellKnown({
       services: [vault, notes, scribe],
       canonicalOrigin: "https://parachute.taildf9ce2.ts.net",
     });
     expect(doc).toEqual({
-      vault: { url: "https://parachute.taildf9ce2.ts.net/", version: "0.2.4" },
+      vaults: [
+        {
+          name: "default",
+          url: "https://parachute.taildf9ce2.ts.net/vault/default",
+          version: "0.2.4",
+        },
+      ],
       notes: { url: "https://parachute.taildf9ce2.ts.net/notes", version: "0.0.1" },
       scribe: { url: "https://parachute.taildf9ce2.ts.net/scribe", version: "0.1.0" },
     });
+  });
+
+  test("vaults array is present even when no vault is installed", () => {
+    const doc = buildWellKnown({
+      services: [notes],
+      canonicalOrigin: "https://x.example",
+    });
+    expect(doc.vaults).toEqual([]);
+    expect(doc.notes).toEqual({ url: "https://x.example/notes", version: "0.0.1" });
+  });
+
+  test("multiple vault instances all land in the vaults array", () => {
+    const work: ServiceEntry = {
+      ...vault,
+      name: "parachute-vault-work",
+      paths: ["/vault/work"],
+      port: 1941,
+      version: "0.2.4",
+    };
+    const doc = buildWellKnown({
+      services: [vault, work],
+      canonicalOrigin: "https://x.example",
+    });
+    expect(doc.vaults).toHaveLength(2);
+    expect(doc.vaults.map((v) => v.name).sort()).toEqual(["default", "work"]);
   });
 
   test("handles canonicalOrigin with trailing slash", () => {
@@ -53,7 +140,7 @@ describe("well-known document", () => {
       services: [vault],
       canonicalOrigin: "https://parachute.taildf9ce2.ts.net/",
     });
-    expect(doc.vault?.url).toBe("https://parachute.taildf9ce2.ts.net/");
+    expect(doc.vaults[0]?.url).toBe("https://parachute.taildf9ce2.ts.net/vault/default");
   });
 
   test("falls back to / for empty paths", () => {
@@ -62,10 +149,12 @@ describe("well-known document", () => {
       services: [entry],
       canonicalOrigin: "https://x.example",
     });
-    expect(doc.vault?.url).toBe("https://x.example/");
+    expect(doc.vaults[0]?.url).toBe("https://x.example/");
   });
+});
 
-  test("writeWellKnownFile writes pretty JSON and creates dir", () => {
+describe("writeWellKnownFile", () => {
+  test("writes pretty JSON and creates nested directories", () => {
     const dir = mkdtempSync(join(tmpdir(), "pcli-wk-"));
     try {
       const path = join(dir, "nested", "parachute.json");

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -3,20 +3,70 @@ import { dirname, join } from "node:path";
 import { CONFIG_DIR } from "./config.ts";
 import type { ServiceEntry } from "./services-manifest.ts";
 
-export interface WellKnownService {
+export interface WellKnownServiceEntry {
   url: string;
   version: string;
 }
 
-export type WellKnownDocument = Record<string, WellKnownService>;
+export interface WellKnownVaultEntry {
+  name: string;
+  url: string;
+  version: string;
+}
+
+/**
+ * Canonical `/.well-known/parachute.json` shape.
+ *
+ * `vaults` is always an array — even for the single-default-vault case —
+ * because vault is the only multi-tenant service in the ecosystem. Other
+ * services are single-entry objects keyed by their short name.
+ *
+ * Example (launch-grade):
+ * {
+ *   "vaults": [{ "name": "default", "url": "https://host/vault/default", "version": "0.2.4" }],
+ *   "notes":  { "url": "https://host/notes",  "version": "0.3.0" },
+ *   "scribe": { "url": "https://host/scribe", "version": "0.1.0" }
+ * }
+ */
+export type WellKnownDocument = {
+  vaults: WellKnownVaultEntry[];
+} & { [shortName: string]: WellKnownVaultEntry[] | WellKnownServiceEntry | undefined };
 
 export const WELL_KNOWN_DIR = join(CONFIG_DIR, "well-known");
 export const WELL_KNOWN_PATH = join(WELL_KNOWN_DIR, "parachute.json");
 export const WELL_KNOWN_MOUNT = "/.well-known/parachute.json";
 
+const VAULT_MANIFEST_PREFIX = "parachute-vault";
+
 /** Strip the conventional `parachute-` prefix for the well-known document's keys. */
 export function shortName(manifestName: string): string {
   return manifestName.replace(/^parachute-/, "");
+}
+
+/**
+ * True when this manifest entry is a vault instance. Any name that starts
+ * with `parachute-vault` counts, so post-multi-tenancy names like
+ * `parachute-vault-work` also route to the vaults array.
+ */
+export function isVaultEntry(entry: ServiceEntry): boolean {
+  return entry.name === VAULT_MANIFEST_PREFIX || entry.name.startsWith(`${VAULT_MANIFEST_PREFIX}-`);
+}
+
+/**
+ * Derive a vault instance name. Prefer a `/vault/<name>` path segment; fall
+ * back to the manifest-name suffix (`parachute-vault-work` → `work`); last
+ * resort is "default".
+ */
+export function vaultInstanceName(entry: ServiceEntry): string {
+  const path = entry.paths[0];
+  if (path) {
+    const match = path.match(/^\/vault\/([^/]+)/);
+    if (match?.[1]) return match[1];
+  }
+  if (entry.name.startsWith(`${VAULT_MANIFEST_PREFIX}-`)) {
+    return entry.name.slice(VAULT_MANIFEST_PREFIX.length + 1);
+  }
+  return "default";
 }
 
 export interface BuildWellKnownOpts {
@@ -26,12 +76,15 @@ export interface BuildWellKnownOpts {
 
 export function buildWellKnown(opts: BuildWellKnownOpts): WellKnownDocument {
   const base = opts.canonicalOrigin.replace(/\/$/, "");
-  const doc: WellKnownDocument = {};
+  const doc: WellKnownDocument = { vaults: [] };
   for (const s of opts.services) {
-    const key = shortName(s.name);
     const path = s.paths[0] ?? "/";
     const url = new URL(path, `${base}/`).toString();
-    doc[key] = { url, version: s.version };
+    if (isVaultEntry(s)) {
+      doc.vaults.push({ name: vaultInstanceName(s), url, version: s.version });
+    } else {
+      doc[shortName(s.name)] = { url, version: s.version };
+    }
   }
   return doc;
 }


### PR DESCRIPTION
## Why

Vault is the one service in the ecosystem that's multi-tenant — today there's one default vault, but multi-vault is an inevitable next step. The `/.well-known/parachute.json` document needs to lock that shape in *before* launch so consumers (notes, scribe, channel, parachute-daily, future web clients) don't have to reshape their read code the first time a second vault appears.

This PR pins the canonical shape:

```json
{
  "vaults": [
    { "name": "default", "url": "https://host/vault/default", "version": "0.2.4" }
  ],
  "notes":  { "url": "https://host/notes",  "version": "0.3.0" },
  "scribe": { "url": "https://host/scribe", "version": "0.1.0" }
}
```

`vaults` is always an array, even for the single-default-vault case. Non-vault services stay as flat entries keyed by shortname — they're single-instance and keeping them flat avoids every consumer having to loop over a one-element array.

## Design rationale

- **Vault detection is by manifest-name prefix**, not by magic config. Anything named `parachute-vault` or `parachute-vault-*` routes into the `vaults[]` array. Post-multi-tenancy, a `parachute-vault-work` manifest entry needs no special handling.
- **Instance name derivation has a three-tier fallback**: path segment `/vault/<name>` wins first (matches vault PR 7's new base-path shape), then the manifest-name suffix (`parachute-vault-work` → `work`), last resort `"default"`. Path wins over name so an operator who renames a path can rename an instance without editing package names.
- **`vaults: []` is always present**, even when no vault is installed. Consumers can iterate unconditionally instead of guarding on key presence.

## Implementation notes

`buildWellKnown` now routes each service entry through `isVaultEntry` and either pushes to `doc.vaults[]` or writes a flat `doc[shortname]`. The `WellKnownDocument` type carries `vaults: WellKnownVaultEntry[]` as a first-class field plus an index signature for the flat entries.

Tests cover: vault detection (bare + prefixed + negative), instance-name derivation (path, suffix, default, path-wins-over-suffix), and the full document shape with empty-vault and multi-vault cases.

## Test plan

- [x] `bun test` — 74/74 pass
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [ ] Paired with vault's `paths: ["/vault/default"]` write (vault coordination — already flagged to vault tentacle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)