### PR TITLE
PR 6: service lifecycle — start / stop / restart / logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,56 @@ bun add -g @openparachute/cli
 # 2. Install a service (runs `bun add -g @openparachute/vault` + `parachute-vault init`)
 parachute install vault
 
-# 3. Check it landed — reads ~/.parachute/services.json, probes health
-parachute status
-# SERVICE          PORT  VERSION  STATUS  LATENCY
-# parachute-vault  1940  0.2.4    ok      2ms
+# 3. Start the service in the background (PID + logs tracked under ~/.parachute/vault/)
+parachute start vault
 
-# 4. Expose across your tailnet (HTTPS via Tailscale MagicDNS)
+# 4. Check it landed — reads ~/.parachute/services.json, shows process state + probes health
+parachute status
+# SERVICE          PORT  VERSION  PROCESS  PID    UPTIME  HEALTH  LATENCY
+# parachute-vault  1940  0.2.4    running  12345  12s     ok      2ms
+
+# 5. Expose across your tailnet (HTTPS via Tailscale MagicDNS)
 parachute expose tailnet
 # ✓ Tailnet exposure active. Open: https://parachute.<tailnet>.ts.net/
 
-# 5. Go public (Tailscale Funnel — same URL, now reachable from the internet)
+# 6. Go public (Tailscale Funnel — same URL, now reachable from the internet)
 parachute expose public
 # ✓ Public exposure active (Funnel). Open: https://parachute.<tailnet>.ts.net/
 ```
 
 Tear down with `parachute expose tailnet off` or `parachute expose public off`. Layers are independent — `off` only affects the layer you name.
+
+## Service lifecycle
+
+`parachute start`, `stop`, `restart`, and `logs` manage services as background processes — no launchd, no manual `bun serve`, no hunting for PIDs.
+
+```sh
+parachute start               # start every installed service
+parachute start vault         # just one
+parachute stop                # SIGTERM, then SIGKILL after 10s if stuck
+parachute restart vault       # stop + start
+parachute logs vault          # last 200 lines
+parachute logs vault -f       # tail (like `tail -f`)
+```
+
+State lives under `~/.parachute/<service>/`:
+
+- `run/<service>.pid` — child PID; `parachute status` uses this to report running/stopped + uptime
+- `logs/<service>.log` — stdout + stderr (appended)
+
+`parachute start` is idempotent: if the service is already running, it's a no-op. Stale PID files (process died without cleanup) are cleared on the next start. Services whose PID file is absent are treated as *unknown* — status still probes their port, so externally-managed services (e.g. you ran `parachute-vault serve` directly) aren't misreported as stopped.
+
+### Migrating from launchd (pre-launch beta)
+
+If you previously ran vault under launchd, switch to `parachute start`:
+
+```sh
+launchctl unload ~/Library/LaunchAgents/computer.parachute.vault.plist
+rm ~/Library/LaunchAgents/computer.parachute.vault.plist
+parachute start vault
+```
+
+An at-login auto-start mode (`parachute start --boot`) is on the post-launch roadmap.
 
 ## Three layers of addressability
 
@@ -130,8 +165,14 @@ parachute install vault
 # Manifest should now exist
 cat ~/.parachute/services.json
 
-# Status should show vault as healthy
+# Start it in the background
+parachute start vault
+
+# Status should show vault as running + healthy
 parachute status
+
+# Peek at the service's logs
+parachute logs vault
 
 # Expose across your tailnet (requires tailscale + `tailscale up`)
 parachute expose tailnet
@@ -154,7 +195,11 @@ Run `parachute --help` for the top-level list, and `parachute <subcommand> --hel
 
 ```
 parachute install <service>       install and register a service
-parachute status                  show installed services and health
+parachute status                  show installed services, process state, health
+parachute start   [service]       start services in the background
+parachute stop    [service]       stop services (SIGTERM → 10s → SIGKILL)
+parachute restart [service]       stop + start
+parachute logs <service> [-f]     print/tail service logs
 parachute expose tailnet [off]    HTTPS across your tailnet
 parachute expose public  [off]    HTTPS on the public internet (Funnel)
 parachute vault <args...>         dispatch to parachute-vault

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -1,0 +1,387 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { logs, restart, start, stop } from "../commands/lifecycle.ts";
+import { ensureLogPath, logPath, readPid, writePid } from "../process-state.ts";
+import { upsertService } from "../services-manifest.ts";
+
+interface Harness {
+  configDir: string;
+  manifestPath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-life-"));
+  return {
+    configDir: dir,
+    manifestPath: join(dir, "services.json"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+function seedVault(manifestPath: string): void {
+  upsertService(
+    {
+      name: "parachute-vault",
+      port: 1940,
+      paths: ["/vault/default"],
+      health: "/vault/default/health",
+      version: "0.2.4",
+    },
+    manifestPath,
+  );
+}
+
+function seedNotes(manifestPath: string): void {
+  upsertService(
+    {
+      name: "parachute-notes",
+      port: 5173,
+      paths: ["/notes"],
+      health: "/notes/health",
+      version: "0.0.1",
+    },
+    manifestPath,
+  );
+}
+
+interface SpawnerStub {
+  spawn: (cmd: readonly string[], logFile: string) => number;
+  calls: Array<{ cmd: readonly string[]; logFile: string }>;
+}
+
+function makeSpawner(pidSequence: number[]): SpawnerStub {
+  const calls: Array<{ cmd: readonly string[]; logFile: string }> = [];
+  let i = 0;
+  return {
+    calls,
+    spawn(cmd, logFile) {
+      calls.push({ cmd: [...cmd], logFile });
+      return pidSequence[i++] ?? 99999;
+    },
+  };
+}
+
+describe("parachute start", () => {
+  test("errors cleanly when no services installed", async () => {
+    const h = makeHarness();
+    try {
+      const logs: string[] = [];
+      const code = await start(undefined, {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(1);
+      expect(logs.join("\n")).toMatch(/No services installed/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("errors cleanly when targeting an uninstalled service", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const logs: string[] = [];
+      const code = await start("notes", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(1);
+      expect(logs.join("\n")).toMatch(/notes isn't installed/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("spawns vault with parachute-vault serve, writes PID", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const spawner = makeSpawner([4242]);
+      const logs: string[] = [];
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(spawner.calls).toHaveLength(1);
+      expect(spawner.calls[0]?.cmd).toEqual(["parachute-vault", "serve"]);
+      expect(spawner.calls[0]?.logFile).toBe(logPath("vault", h.configDir));
+      expect(readPid("vault", h.configDir)).toBe(4242);
+      expect(logs.join("\n")).toMatch(/vault started \(pid 4242\)/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("notes start command includes configured port and notes-serve shim path", async () => {
+    const h = makeHarness();
+    try {
+      seedNotes(h.manifestPath);
+      const spawner = makeSpawner([5151]);
+      const code = await start("notes", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      const cmd = spawner.calls[0]?.cmd ?? [];
+      expect(cmd[0]).toBe("bun");
+      expect(cmd.at(-2)).toBe("--port");
+      expect(cmd.at(-1)).toBe("5173");
+      expect(cmd.some((a) => a.endsWith("notes-serve.ts"))).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("no-op when already running", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writePid("vault", 4242, h.configDir);
+      const spawner = makeSpawner([9999]);
+      const logs: string[] = [];
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        alive: () => true,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(spawner.calls).toHaveLength(0);
+      expect(logs.join("\n")).toMatch(/already running \(pid 4242\)/);
+      expect(readPid("vault", h.configDir)).toBe(4242);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("clears stale PID file before spawning fresh", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writePid("vault", 4242, h.configDir);
+      const spawner = makeSpawner([7777]);
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        alive: () => false,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(spawner.calls).toHaveLength(1);
+      expect(readPid("vault", h.configDir)).toBe(7777);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("start (no svc) targets every installed + known service", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      seedNotes(h.manifestPath);
+      const spawner = makeSpawner([4242, 5151]);
+      const code = await start(undefined, {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(spawner.calls).toHaveLength(2);
+      expect(readPid("vault", h.configDir)).toBe(4242);
+      expect(readPid("notes", h.configDir)).toBe(5151);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("parachute stop", () => {
+  test("no-op when nothing is running", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const killed: Array<[number, string | number]> = [];
+      const logs: string[] = [];
+      const code = await stop("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        kill: (pid, sig) => killed.push([pid, sig]),
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(killed).toHaveLength(0);
+      expect(logs.join("\n")).toMatch(/wasn't running/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("cleans stale PID file without sending any signal", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writePid("vault", 4242, h.configDir);
+      const killed: Array<[number, string | number]> = [];
+      const code = await stop("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        kill: (pid, sig) => killed.push([pid, sig]),
+        alive: () => false,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(killed).toHaveLength(0);
+      expect(readPid("vault", h.configDir)).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("SIGTERM + clean exit within window clears PID", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writePid("vault", 4242, h.configDir);
+      const killed: Array<[number, string | number]> = [];
+      let aliveCall = 0;
+      const code = await stop("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        kill: (pid, sig) => killed.push([pid, sig]),
+        alive: () => {
+          aliveCall++;
+          return aliveCall === 1;
+        },
+        sleep: async () => {},
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(killed).toEqual([[4242, "SIGTERM"]]);
+      expect(readPid("vault", h.configDir)).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("escalates to SIGKILL when SIGTERM doesn't land", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writePid("vault", 4242, h.configDir);
+      const killed: Array<[number, string | number]> = [];
+      let t = 0;
+      const code = await stop("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        kill: (pid, sig) => killed.push([pid, sig]),
+        alive: () => true,
+        sleep: async () => {},
+        now: () => {
+          // Jump past the kill-wait window so the polling loop exits fast.
+          t += 20_000;
+          return t;
+        },
+        killWaitMs: 10_000,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(killed[0]).toEqual([4242, "SIGTERM"]);
+      expect(killed[killed.length - 1]).toEqual([4242, "SIGKILL"]);
+      expect(readPid("vault", h.configDir)).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("parachute restart", () => {
+  test("stops then starts in sequence", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writePid("vault", 4242, h.configDir);
+      const spawner = makeSpawner([7777]);
+      const killed: Array<[number, string | number]> = [];
+      const code = await restart("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        kill: (pid, sig) => killed.push([pid, sig]),
+        alive: () => false,
+        sleep: async () => {},
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(killed).toHaveLength(0); // stale pid → cleanup without kill
+      expect(spawner.calls).toHaveLength(1);
+      expect(readPid("vault", h.configDir)).toBe(7777);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("parachute logs", () => {
+  test("hint when no log file exists", async () => {
+    const h = makeHarness();
+    try {
+      const lines: string[] = [];
+      const code = await logs("vault", {
+        configDir: h.configDir,
+        log: (l) => lines.push(l),
+      });
+      expect(code).toBe(0);
+      expect(lines.join("\n")).toMatch(/no logs yet/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("prints last N lines in one-shot mode", async () => {
+    const h = makeHarness();
+    try {
+      const p = ensureLogPath("vault", h.configDir);
+      const content = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join("\n");
+      writeFileSync(p, `${content}\n`);
+      const lines: string[] = [];
+      const code = await logs("vault", {
+        configDir: h.configDir,
+        lines: 3,
+        log: (l) => lines.push(l),
+      });
+      expect(code).toBe(0);
+      expect(lines).toEqual(["line 8", "line 9", "line 10"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("unknown service errors cleanly", async () => {
+    const h = makeHarness();
+    try {
+      const lines: string[] = [];
+      const code = await logs("nope", {
+        configDir: h.configDir,
+        log: (l) => lines.push(l),
+      });
+      expect(code).toBe(1);
+      expect(lines.join("\n")).toMatch(/unknown service/);
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/process-state.test.ts
+++ b/src/__tests__/process-state.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  clearPid,
+  defaultAlive,
+  ensureLogPath,
+  formatUptime,
+  logPath,
+  pidPath,
+  processState,
+  readPid,
+  writePid,
+} from "../process-state.ts";
+
+function makeTempConfig(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-proc-"));
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe("process-state paths", () => {
+  test("pidPath / logPath land under <configDir>/<svc>/{run,logs}", () => {
+    expect(pidPath("vault", "/cfg")).toBe("/cfg/vault/run/vault.pid");
+    expect(logPath("notes", "/cfg")).toBe("/cfg/notes/logs/notes.log");
+  });
+});
+
+describe("writePid / readPid / clearPid", () => {
+  test("round-trips through the filesystem", () => {
+    const { dir, cleanup } = makeTempConfig();
+    try {
+      expect(readPid("vault", dir)).toBeUndefined();
+      writePid("vault", 12345, dir);
+      expect(readPid("vault", dir)).toBe(12345);
+      clearPid("vault", dir);
+      expect(readPid("vault", dir)).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("readPid ignores garbage pid files", () => {
+    const { dir, cleanup } = makeTempConfig();
+    try {
+      const p = pidPath("vault", dir);
+      mkdirSync(dirname(p), { recursive: true });
+      writeFileSync(p, "not-a-number\n");
+      expect(readPid("vault", dir)).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("processState", () => {
+  test("no pid file → unknown (externally-managed is possible)", () => {
+    const { dir, cleanup } = makeTempConfig();
+    try {
+      expect(processState("vault", dir).status).toBe("unknown");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("pid file + alive pid → running with pid + startedAt", () => {
+    const { dir, cleanup } = makeTempConfig();
+    try {
+      writePid("vault", 4242, dir);
+      const state = processState("vault", dir, () => true);
+      expect(state.status).toBe("running");
+      expect(state.pid).toBe(4242);
+      expect(state.startedAt).toBeInstanceOf(Date);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("pid file + dead pid → stopped (known-dead, not unknown)", () => {
+    const { dir, cleanup } = makeTempConfig();
+    try {
+      writePid("vault", 4242, dir);
+      const state = processState("vault", dir, () => false);
+      expect(state.status).toBe("stopped");
+      expect(state.pid).toBe(4242);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("defaultAlive", () => {
+  test("current process is alive", () => {
+    expect(defaultAlive(process.pid)).toBe(true);
+  });
+
+  test("absurd pid is not alive", () => {
+    // PIDs above 2^22 don't exist on mainstream OSes.
+    expect(defaultAlive(99_999_999)).toBe(false);
+  });
+});
+
+describe("formatUptime", () => {
+  test("sub-minute → seconds", () => {
+    const now = new Date("2026-04-19T12:00:45Z");
+    const start = new Date("2026-04-19T12:00:00Z");
+    expect(formatUptime(start, now)).toBe("45s");
+  });
+
+  test("sub-hour → minutes", () => {
+    const now = new Date("2026-04-19T12:13:00Z");
+    const start = new Date("2026-04-19T12:00:00Z");
+    expect(formatUptime(start, now)).toBe("13m");
+  });
+
+  test("sub-day → h+m", () => {
+    const now = new Date("2026-04-19T14:13:00Z");
+    const start = new Date("2026-04-19T12:00:00Z");
+    expect(formatUptime(start, now)).toBe("2h 13m");
+  });
+
+  test("multi-day → d+h", () => {
+    const now = new Date("2026-04-23T18:00:00Z");
+    const start = new Date("2026-04-19T12:00:00Z");
+    expect(formatUptime(start, now)).toBe("4d 6h");
+  });
+});
+
+describe("ensureLogPath", () => {
+  test("creates logs dir and returns the log-file path", () => {
+    const { dir, cleanup } = makeTempConfig();
+    try {
+      const p = ensureLogPath("vault", dir);
+      expect(p).toBe(logPath("vault", dir));
+      expect(existsSync(join(dir, "vault", "logs"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/__tests__/status.test.ts
+++ b/src/__tests__/status.test.ts
@@ -3,12 +3,14 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { status } from "../commands/status.ts";
+import { writePid } from "../process-state.ts";
 import { upsertService } from "../services-manifest.ts";
 
-function makeTempPath(): { path: string; cleanup: () => void } {
+function makeTempPath(): { path: string; cleanup: () => void; configDir: string } {
   const dir = mkdtempSync(join(tmpdir(), "pcli-status-"));
   return {
     path: join(dir, "services.json"),
+    configDir: dir,
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
   };
 }
@@ -105,6 +107,83 @@ describe("status", () => {
       });
       expect(code).toBe(1);
       expect(lines.some((l) => l.includes("http 503"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("running process shows pid + uptime and still probes", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.2.4" },
+        path,
+      );
+      writePid("vault", 4242, configDir);
+      const lines: string[] = [];
+      const code = await status({
+        manifestPath: path,
+        configDir,
+        alive: () => true,
+        fetchImpl: async () => new Response(null, { status: 200 }),
+        print: (l) => lines.push(l),
+      });
+      expect(code).toBe(0);
+      expect(lines.some((l) => l.includes("running"))).toBe(true);
+      expect(lines.some((l) => l.includes("4242"))).toBe(true);
+      expect(lines.some((l) => l.includes("ok"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("known-stopped process skips probe and doesn't fail exit", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.2.4" },
+        path,
+      );
+      writePid("vault", 4242, configDir);
+      let probed = false;
+      const lines: string[] = [];
+      const code = await status({
+        manifestPath: path,
+        configDir,
+        alive: () => false,
+        fetchImpl: async () => {
+          probed = true;
+          return new Response(null, { status: 200 });
+        },
+        print: (l) => lines.push(l),
+      });
+      expect(code).toBe(0);
+      expect(probed).toBe(false);
+      expect(lines.some((l) => l.includes("stopped"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("unknown process state (no pid file) still probes — externally managed OK", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.2.4" },
+        path,
+      );
+      let probed = false;
+      const code = await status({
+        manifestPath: path,
+        configDir,
+        fetchImpl: async () => {
+          probed = true;
+          return new Response(null, { status: 200 });
+        },
+        print: () => {},
+      });
+      expect(code).toBe(0);
+      expect(probed).toBe(true);
     } finally {
       cleanup();
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,10 +9,21 @@
 import pkg from "../package.json" with { type: "json" };
 import { exposePublic, exposeTailnet } from "./commands/expose.ts";
 import { install } from "./commands/install.ts";
+import { logs, restart, start, stop } from "./commands/lifecycle.ts";
 import { status } from "./commands/status.ts";
 import { dispatchVault } from "./commands/vault.ts";
 import { ExposeStateError } from "./expose-state.ts";
-import { exposeHelp, installHelp, statusHelp, topLevelHelp, vaultHelp } from "./help.ts";
+import {
+  exposeHelp,
+  installHelp,
+  logsHelp,
+  restartHelp,
+  startHelp,
+  statusHelp,
+  stopHelp,
+  topLevelHelp,
+  vaultHelp,
+} from "./help.ts";
 import { knownServices } from "./service-spec.ts";
 import { ServicesManifestError } from "./services-manifest.ts";
 import { TailscaleError } from "./tailscale/run.ts";
@@ -83,6 +94,45 @@ async function main(argv: string[]): Promise<number> {
       }
       const action = mode === "off" ? "off" : "up";
       return layer === "public" ? await exposePublic(action) : await exposeTailnet(action);
+    }
+
+    case "start": {
+      if (isHelpFlag(rest[0])) {
+        console.log(startHelp());
+        return 0;
+      }
+      return await start(rest[0]);
+    }
+
+    case "stop": {
+      if (isHelpFlag(rest[0])) {
+        console.log(stopHelp());
+        return 0;
+      }
+      return await stop(rest[0]);
+    }
+
+    case "restart": {
+      if (isHelpFlag(rest[0])) {
+        console.log(restartHelp());
+        return 0;
+      }
+      return await restart(rest[0]);
+    }
+
+    case "logs": {
+      if (isHelpFlag(rest[0])) {
+        console.log(logsHelp());
+        return 0;
+      }
+      const svc = rest[0];
+      if (!svc) {
+        console.error("usage: parachute logs <service> [-f]");
+        console.error(`services: ${knownServices().join(", ")}`);
+        return 1;
+      }
+      const follow = rest.includes("-f") || rest.includes("--follow");
+      return await logs(svc, { follow });
     }
 
     case "vault":

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -1,0 +1,276 @@
+import { existsSync, openSync } from "node:fs";
+import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
+import {
+  type AliveFn,
+  clearPid,
+  defaultAlive,
+  ensureLogPath,
+  logPath as logPathFor,
+  processState,
+  readPid,
+  writePid,
+} from "../process-state.ts";
+import { getSpec, knownServices, shortNameForManifest } from "../service-spec.ts";
+import { type ServiceEntry, readManifest } from "../services-manifest.ts";
+
+/**
+ * Tiny seam over `Bun.spawn` for lifecycle tests. The real spawner opens the
+ * log file, appends stdout+stderr to it, and `unref()`s the child so parent
+ * exit doesn't bring it down.
+ */
+export interface Spawner {
+  spawn(cmd: readonly string[], logFile: string): number;
+}
+
+export const defaultSpawner: Spawner = {
+  spawn(cmd, logFile) {
+    const fd = openSync(logFile, "a");
+    const proc = Bun.spawn([...cmd], { stdio: ["ignore", fd, fd] });
+    proc.unref();
+    return proc.pid;
+  },
+};
+
+export type KillFn = (pid: number, signal: NodeJS.Signals | number) => void;
+export type SleepFn = (ms: number) => Promise<void>;
+
+export const defaultKill: KillFn = (pid, signal) => {
+  process.kill(pid, signal);
+};
+
+export const defaultSleep: SleepFn = (ms) => new Promise((r) => setTimeout(r, ms));
+
+export interface LifecycleOpts {
+  spawner?: Spawner;
+  kill?: KillFn;
+  alive?: AliveFn;
+  sleep?: SleepFn;
+  now?: () => number;
+  manifestPath?: string;
+  configDir?: string;
+  log?: (line: string) => void;
+  /** How long stop waits for SIGTERM before escalating to SIGKILL. */
+  killWaitMs?: number;
+  /** Poll interval while waiting for SIGTERM to land. */
+  pollIntervalMs?: number;
+}
+
+interface Resolved {
+  spawner: Spawner;
+  kill: KillFn;
+  alive: AliveFn;
+  sleep: SleepFn;
+  now: () => number;
+  manifestPath: string;
+  configDir: string;
+  log: (line: string) => void;
+  killWaitMs: number;
+  pollIntervalMs: number;
+}
+
+function resolve(opts: LifecycleOpts): Resolved {
+  return {
+    spawner: opts.spawner ?? defaultSpawner,
+    kill: opts.kill ?? defaultKill,
+    alive: opts.alive ?? defaultAlive,
+    sleep: opts.sleep ?? defaultSleep,
+    now: opts.now ?? Date.now,
+    manifestPath: opts.manifestPath ?? SERVICES_MANIFEST_PATH,
+    configDir: opts.configDir ?? CONFIG_DIR,
+    log: opts.log ?? ((line) => console.log(line)),
+    killWaitMs: opts.killWaitMs ?? 10_000,
+    pollIntervalMs: opts.pollIntervalMs ?? 200,
+  };
+}
+
+/**
+ * Services selected by the `[svc]` positional. `undefined` targets every
+ * installed service (looked up via the manifest). Unknown names get a
+ * friendly error up front rather than a confusing spawn failure downstream.
+ */
+function resolveTargets(
+  svc: string | undefined,
+  manifestPath: string,
+): { targets: Array<{ short: string; entry: ServiceEntry }> } | { error: string } {
+  const manifest = readManifest(manifestPath);
+  if (manifest.services.length === 0) {
+    return { error: "No services installed yet. Try: parachute install vault" };
+  }
+
+  if (svc !== undefined) {
+    const spec = getSpec(svc);
+    if (!spec) {
+      return {
+        error: `unknown service "${svc}". known: ${knownServices().join(", ")}`,
+      };
+    }
+    const entry = manifest.services.find((s) => s.name === spec.manifestName);
+    if (!entry) {
+      return {
+        error: `${svc} isn't installed. Run \`parachute install ${svc}\` first.`,
+      };
+    }
+    return { targets: [{ short: svc, entry }] };
+  }
+
+  const targets: Array<{ short: string; entry: ServiceEntry }> = [];
+  for (const entry of manifest.services) {
+    const short = shortNameForManifest(entry.name);
+    if (!short) continue;
+    targets.push({ short, entry });
+  }
+  if (targets.length === 0) {
+    return { error: "No manageable services in services.json." };
+  }
+  return { targets };
+}
+
+export async function start(svc: string | undefined, opts: LifecycleOpts = {}): Promise<number> {
+  const r = resolve(opts);
+  const picked = resolveTargets(svc, r.manifestPath);
+  if ("error" in picked) {
+    r.log(picked.error);
+    return 1;
+  }
+
+  let failures = 0;
+  for (const { short, entry } of picked.targets) {
+    const state = processState(short, r.configDir, r.alive);
+    if (state.status === "running") {
+      r.log(`${short} already running (pid ${state.pid}).`);
+      continue;
+    }
+    if (state.pid !== undefined) {
+      // Stale PID file for a dead process — clear it before we spawn fresh.
+      clearPid(short, r.configDir);
+    }
+
+    const spec = getSpec(short);
+    const cmd = spec?.startCmd?.(entry);
+    if (!cmd || cmd.length === 0) {
+      r.log(`${short}: lifecycle not yet supported for this service.`);
+      failures++;
+      continue;
+    }
+
+    const logFile = ensureLogPath(short, r.configDir);
+    try {
+      const pid = r.spawner.spawn(cmd, logFile);
+      writePid(short, pid, r.configDir);
+      r.log(`✓ ${short} started (pid ${pid}); logs: ${logFile}`);
+    } catch (err) {
+      failures++;
+      const msg = err instanceof Error ? err.message : String(err);
+      r.log(`✗ ${short} failed to start: ${msg}`);
+    }
+  }
+  return failures === 0 ? 0 : 1;
+}
+
+export async function stop(svc: string | undefined, opts: LifecycleOpts = {}): Promise<number> {
+  const r = resolve(opts);
+  const picked = resolveTargets(svc, r.manifestPath);
+  if ("error" in picked) {
+    r.log(picked.error);
+    return 1;
+  }
+
+  let failures = 0;
+  for (const { short } of picked.targets) {
+    const pid = readPid(short, r.configDir);
+    if (pid === undefined) {
+      r.log(`${short} wasn't running.`);
+      continue;
+    }
+    if (!r.alive(pid)) {
+      clearPid(short, r.configDir);
+      r.log(`${short} wasn't running (cleaned stale pid file).`);
+      continue;
+    }
+
+    try {
+      r.kill(pid, "SIGTERM");
+    } catch (err) {
+      failures++;
+      r.log(`✗ ${short}: SIGTERM failed: ${err instanceof Error ? err.message : String(err)}`);
+      continue;
+    }
+
+    const deadline = r.now() + r.killWaitMs;
+    while (r.now() < deadline && r.alive(pid)) {
+      await r.sleep(r.pollIntervalMs);
+    }
+
+    if (r.alive(pid)) {
+      r.log(`${short} didn't exit after ${r.killWaitMs}ms; sending SIGKILL.`);
+      try {
+        r.kill(pid, "SIGKILL");
+      } catch (err) {
+        failures++;
+        r.log(`✗ ${short}: SIGKILL failed: ${err instanceof Error ? err.message : String(err)}`);
+        continue;
+      }
+    }
+
+    clearPid(short, r.configDir);
+    r.log(`✓ ${short} stopped.`);
+  }
+  return failures === 0 ? 0 : 1;
+}
+
+export async function restart(svc: string | undefined, opts: LifecycleOpts = {}): Promise<number> {
+  const stopCode = await stop(svc, opts);
+  if (stopCode !== 0) return stopCode;
+  return await start(svc, opts);
+}
+
+export interface LogsOpts {
+  configDir?: string;
+  log?: (line: string) => void;
+  /** Tail stream — if omitted, uses `tail -n <lines> -f <file>` via spawn. */
+  tailSpawner?: Spawner;
+  /** Number of trailing lines to print (default 200). */
+  lines?: number;
+  follow?: boolean;
+}
+
+export async function logs(svc: string, opts: LogsOpts = {}): Promise<number> {
+  const configDir = opts.configDir ?? CONFIG_DIR;
+  const log = opts.log ?? ((line) => console.log(line));
+  const lines = opts.lines ?? 200;
+  const follow = opts.follow ?? false;
+
+  const spec = getSpec(svc);
+  if (!spec) {
+    log(`unknown service "${svc}". known: ${knownServices().join(", ")}`);
+    return 1;
+  }
+
+  const path = logPathFor(svc, configDir);
+  if (!existsSync(path)) {
+    log(`no logs yet for ${svc}. \`parachute start ${svc}\` to begin.`);
+    return 0;
+  }
+
+  if (follow) {
+    const spawner = opts.tailSpawner ?? {
+      spawn(cmd) {
+        const proc = Bun.spawn([...cmd], { stdio: ["ignore", "inherit", "inherit"] });
+        return proc.pid;
+      },
+    };
+    spawner.spawn(["tail", "-n", String(lines), "-f", path], path);
+    // tail runs until user Ctrl-C; block this process until it exits.
+    // When called from the real CLI, process.exit wraps us; in tests a
+    // stub spawner returns immediately and we fall through.
+    return 0;
+  }
+
+  // Non-follow path: read last N lines synchronously for a clean one-shot.
+  const content = await Bun.file(path).text();
+  const trimmed = content.replace(/\n$/, "");
+  const allLines = trimmed === "" ? [] : trimmed.split("\n");
+  const tail = allLines.slice(-lines);
+  for (const line of tail) log(line);
+  return 0;
+}

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,4 +1,6 @@
-import { SERVICES_MANIFEST_PATH } from "../config.ts";
+import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
+import { type AliveFn, defaultAlive, formatUptime, processState } from "../process-state.ts";
+import { shortNameForManifest } from "../service-spec.ts";
 import { type ServiceEntry, readManifest } from "../services-manifest.ts";
 
 export type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
@@ -8,6 +10,9 @@ export interface StatusOpts {
   fetchImpl?: FetchFn;
   print?: (line: string) => void;
   timeoutMs?: number;
+  configDir?: string;
+  alive?: AliveFn;
+  now?: () => Date;
 }
 
 export interface ProbeResult {
@@ -61,6 +66,9 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
   const fetchImpl = opts.fetchImpl ?? fetch;
   const print = opts.print ?? ((line) => console.log(line));
   const timeoutMs = opts.timeoutMs ?? 1500;
+  const configDir = opts.configDir ?? CONFIG_DIR;
+  const alive = opts.alive ?? defaultAlive;
+  const now = opts.now ?? (() => new Date());
 
   const manifest = readManifest(manifestPath);
   if (manifest.services.length === 0) {
@@ -69,24 +77,86 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
     return 0;
   }
 
-  const probes = await Promise.all(manifest.services.map((e) => probe(e, fetchImpl, timeoutMs)));
+  const nowDate = now();
 
-  const header = ["SERVICE", "PORT", "VERSION", "STATUS", "LATENCY"];
-  const rows = probes.map((p) => {
-    const status = p.healthy
-      ? "ok"
-      : p.statusCode !== undefined
-        ? `http ${p.statusCode}`
-        : (p.error ?? "down");
-    return [p.entry.name, String(p.entry.port), p.entry.version, status, `${p.latencyMs}ms`];
-  });
+  /**
+   * Per-row resolution: look up the short name so we can read PID state,
+   * skip the health probe when the process is known-stopped (ECONNREFUSED
+   * noise isn't informative), and report it as running/stopped + uptime.
+   *
+   * Third-party services we don't know about fall back to probing and show
+   * "-" for process columns.
+   */
+  const rows = await Promise.all(
+    manifest.services.map(async (entry) => {
+      const short = shortNameForManifest(entry.name);
+      const proc = short ? processState(short, configDir, alive) : undefined;
 
-  const widths = header.map((_, i) =>
-    Math.max(header[i]?.length ?? 0, ...rows.map((r) => r[i]?.length ?? 0)),
+      const processLabel =
+        proc?.status === "running" ? "running" : proc?.status === "stopped" ? "stopped" : "-";
+      const pidLabel =
+        proc?.status === "running" && proc.pid !== undefined ? String(proc.pid) : "-";
+      const uptimeLabel =
+        proc?.status === "running" && proc.startedAt ? formatUptime(proc.startedAt, nowDate) : "-";
+
+      // Only skip probe when we know the process is dead (PID file was
+      // present but kill(pid, 0) failed). "unknown" status (no PID file)
+      // still probes — externally-managed services should report health.
+      if (proc?.status === "stopped") {
+        return {
+          entry,
+          processLabel,
+          pidLabel,
+          uptimeLabel,
+          healthLabel: "-",
+          latencyLabel: "-",
+          healthy: false,
+          skipped: true,
+        };
+      }
+
+      const p = await probe(entry, fetchImpl, timeoutMs);
+      const healthLabel = p.healthy
+        ? "ok"
+        : p.statusCode !== undefined
+          ? `http ${p.statusCode}`
+          : (p.error ?? "down");
+      return {
+        entry,
+        processLabel,
+        pidLabel,
+        uptimeLabel,
+        healthLabel,
+        latencyLabel: `${p.latencyMs}ms`,
+        healthy: p.healthy,
+        skipped: false,
+      };
+    }),
   );
 
+  const header = ["SERVICE", "PORT", "VERSION", "PROCESS", "PID", "UPTIME", "HEALTH", "LATENCY"];
+  const textRows = rows.map((r) => [
+    r.entry.name,
+    String(r.entry.port),
+    r.entry.version,
+    r.processLabel,
+    r.pidLabel,
+    r.uptimeLabel,
+    r.healthLabel,
+    r.latencyLabel,
+  ]);
+  const widths = header.map((_, i) =>
+    Math.max(header[i]?.length ?? 0, ...textRows.map((r) => r[i]?.length ?? 0)),
+  );
   print(formatRow(header, widths));
-  for (const r of rows) print(formatRow(r, widths));
+  for (const r of textRows) print(formatRow(r, widths));
 
-  return probes.every((p) => p.healthy) ? 0 : 1;
+  /**
+   * Overall exit: non-zero if any *probed* service is unhealthy. A stopped
+   * service is expected ("I haven't started it yet"), not a failure — users
+   * want `parachute status` to return 0 after a fresh install before they
+   * `parachute start`. Health regressions among running services still 1.
+   */
+  const anyUnhealthy = rows.some((r) => !r.skipped && !r.healthy);
+  return anyUnhealthy ? 1 : 0;
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -8,7 +8,11 @@ export function topLevelHelp(): string {
 Usage:
   parachute install <service>       install and register a service
                                     services: ${services}
-  parachute status                  show installed services and health
+  parachute status                  show installed services, process state, health
+  parachute start   [service]       start all services (or one) in the background
+  parachute stop    [service]       stop all services (or one) — SIGTERM then SIGKILL
+  parachute restart [service]       stop + start
+  parachute logs <service> [-f]     print service logs; -f to tail
   parachute expose tailnet [off]    HTTPS across your tailnet
   parachute expose public  [off]    HTTPS on the public internet (Funnel)
   parachute vault <args...>         dispatch to parachute-vault
@@ -40,23 +44,30 @@ Examples:
 }
 
 export function statusHelp(): string {
-  return `parachute status — show installed services and their health
+  return `parachute status — show installed services, process state, and health
 
 Usage:
   parachute status
 
 What it does:
-  Reads ~/.parachute/services.json and probes \`http://localhost:<port><health>\`
-  for every registered service.
+  Reads ~/.parachute/services.json. For each registered service:
+    - checks PID file at ~/.parachute/<svc>/run/<svc>.pid → running/stopped
+    - probes http://localhost:<port><health> (skipped for known-stopped processes)
+
+  Stopped services show "-" for health and don't count toward the exit
+  code — they're an expected state after fresh install before \`parachute
+  start\`. Running or externally-managed services that fail health checks
+  do exit 1.
 
 Exit codes:
-  0   all services healthy (or no services installed yet)
-  1   one or more services unhealthy
+  0   all probed services healthy (or none running)
+  1   one or more probed services unhealthy
 
 Example:
   $ parachute status
-  SERVICE          PORT  VERSION  STATUS  LATENCY
-  parachute-vault  1940  0.2.4    ok      2ms
+  SERVICE          PORT  VERSION  PROCESS  PID    UPTIME  HEALTH  LATENCY
+  parachute-vault  1940  0.2.4    running  12345  2h 13m  ok      2ms
+  parachute-notes  5173  0.0.1    stopped  -      -       -       -
 `;
 }
 
@@ -92,6 +103,80 @@ Constraints (public layer / Funnel):
 Coming soon:
   parachute expose public --mode caddy        use your own domain + Caddy
   parachute expose public --mode cloudflared  use your own domain + cloudflared
+`;
+}
+
+export function startHelp(): string {
+  return `parachute start — spawn services in the background
+
+Usage:
+  parachute start                   start every installed service
+  parachute start <service>         start just that one
+
+What it does:
+  For each target service, spawns its start command detached, redirects
+  stdout+stderr to ~/.parachute/<service>/logs/<service>.log, and records
+  the child PID at ~/.parachute/<service>/run/<service>.pid.
+
+  Idempotent: if the service is already running, no-op.
+  If a stale PID file exists (process died without cleanup), it's cleared
+  and the service starts fresh.
+
+Examples:
+  parachute start                   bring everything up
+  parachute start vault             just vault
+  parachute logs vault              watch what just started
+
+Start commands by service:
+  vault     parachute-vault serve
+  scribe    parachute-scribe serve
+  channel   parachute-channel daemon
+  notes     bun <cli>/notes-serve.ts --port <configured>
+`;
+}
+
+export function stopHelp(): string {
+  return `parachute stop — stop running services cleanly
+
+Usage:
+  parachute stop                    stop every installed service
+  parachute stop <service>          stop just that one
+
+What it does:
+  Sends SIGTERM, waits up to 10s for a clean exit, then escalates to
+  SIGKILL if the process is still alive. Removes the PID file on success.
+
+  No-op if the service wasn't running.
+
+Examples:
+  parachute stop                    stop everything before sleep
+  parachute stop vault              just vault
+`;
+}
+
+export function restartHelp(): string {
+  return `parachute restart — stop then start
+
+Usage:
+  parachute restart                 restart every installed service
+  parachute restart <service>       restart just that one
+
+What it does:
+  Equivalent to \`parachute stop <svc> && parachute start <svc>\`.
+`;
+}
+
+export function logsHelp(): string {
+  return `parachute logs — print service logs
+
+Usage:
+  parachute logs <service>          print the last 200 lines
+  parachute logs <service> -f       tail the log (like \`tail -f\`)
+
+Log file:
+  ~/.parachute/<service>/logs/<service>.log
+
+If no log file exists yet, prints a hint to \`parachute start <service>\`.
 `;
 }
 

--- a/src/notes-serve.ts
+++ b/src/notes-serve.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env bun
+
+/**
+ * Tiny static-file server for the @openparachute/notes PWA bundle.
+ *
+ * Notes is a SPA — no backend of its own. `parachute start notes` invokes
+ * this shim with the installed `dist/` path so the PWA is served at a
+ * known port and can be reverse-proxied by `parachute expose` alongside
+ * the other services.
+ *
+ * Invoked as:
+ *   bun <this-file> --port <n> [--dist <path>]
+ *
+ * If --dist is omitted, we resolve @openparachute/notes's dist directory
+ * via Bun.resolveSync. If that fails (package not installed globally, or
+ * package doesn't ship dist/), exit 1 with a clear error.
+ */
+
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+function parseArgs(argv: string[]): { port: number; dist?: string } {
+  let port = 5173;
+  let dist: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--port") {
+      const v = argv[++i];
+      if (!v) throw new Error("--port requires a value");
+      const n = Number.parseInt(v, 10);
+      if (!Number.isInteger(n) || n <= 0 || n > 65535) {
+        throw new Error(`--port must be 1..65535, got "${v}"`);
+      }
+      port = n;
+    } else if (a === "--dist") {
+      const v = argv[++i];
+      if (!v) throw new Error("--dist requires a value");
+      dist = resolve(v);
+    } else {
+      throw new Error(`unknown argument: ${a}`);
+    }
+  }
+  return { port, dist };
+}
+
+function resolveNotesDist(): string {
+  const pkgPath = Bun.resolveSync("@openparachute/notes/package.json", process.cwd());
+  const root = dirname(pkgPath);
+  const dist = join(root, "dist");
+  if (!existsSync(dist)) {
+    throw new Error(
+      `@openparachute/notes is installed but has no dist/ directory at ${dist}. The package may not ship a prebuilt bundle — ask the notes maintainer to add a prepublishOnly build step.`,
+    );
+  }
+  return dist;
+}
+
+const { port, dist: distArg } = parseArgs(process.argv.slice(2));
+
+let dist: string;
+try {
+  dist = distArg ?? resolveNotesDist();
+} catch (err) {
+  console.error(`parachute-notes-serve: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+}
+
+const indexHtml = join(dist, "index.html");
+
+Bun.serve({
+  port,
+  fetch(req) {
+    const url = new URL(req.url);
+    const filePath = join(dist, decodeURIComponent(url.pathname));
+    if (!filePath.startsWith(dist)) {
+      return new Response("forbidden", { status: 403 });
+    }
+    const file = Bun.file(filePath);
+    if (existsSync(filePath) && !filePath.endsWith("/")) {
+      return new Response(file);
+    }
+    return new Response(Bun.file(indexHtml), {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  },
+});
+
+console.log(`notes static-serve listening on :${port} (dist=${dist})`);

--- a/src/process-state.ts
+++ b/src/process-state.ts
@@ -1,0 +1,111 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { CONFIG_DIR } from "./config.ts";
+
+/**
+ * Per-service state lives under `<configDir>/<svc>/...`. `svc` is the
+ * short name (`vault`, `notes`, `scribe`, `channel`) so paths stay tidy —
+ * `~/.parachute/vault/run/vault.pid` rather than `parachute-vault/run/…`.
+ *
+ * The single source of truth for whether a service is running is
+ * `pid file present` + `process.kill(pid, 0)` succeeds. A stale PID file
+ * (process died without cleanup) reads as stopped; writers of the PID
+ * file own removing it on clean shutdown.
+ */
+
+export function serviceDir(svc: string, configDir: string = CONFIG_DIR): string {
+  return join(configDir, svc);
+}
+
+export function runDir(svc: string, configDir: string = CONFIG_DIR): string {
+  return join(serviceDir(svc, configDir), "run");
+}
+
+export function logsDir(svc: string, configDir: string = CONFIG_DIR): string {
+  return join(serviceDir(svc, configDir), "logs");
+}
+
+export function pidPath(svc: string, configDir: string = CONFIG_DIR): string {
+  return join(runDir(svc, configDir), `${svc}.pid`);
+}
+
+export function logPath(svc: string, configDir: string = CONFIG_DIR): string {
+  return join(logsDir(svc, configDir), `${svc}.log`);
+}
+
+export function readPid(svc: string, configDir: string = CONFIG_DIR): number | undefined {
+  const p = pidPath(svc, configDir);
+  if (!existsSync(p)) return undefined;
+  const raw = readFileSync(p, "utf8").trim();
+  const n = Number.parseInt(raw, 10);
+  return Number.isInteger(n) && n > 0 ? n : undefined;
+}
+
+export function writePid(svc: string, pid: number, configDir: string = CONFIG_DIR): void {
+  const p = pidPath(svc, configDir);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, `${pid}\n`);
+}
+
+export function clearPid(svc: string, configDir: string = CONFIG_DIR): void {
+  const p = pidPath(svc, configDir);
+  if (existsSync(p)) rmSync(p, { force: true });
+}
+
+export function ensureLogPath(svc: string, configDir: string = CONFIG_DIR): string {
+  const p = logPath(svc, configDir);
+  mkdirSync(dirname(p), { recursive: true });
+  return p;
+}
+
+export type AliveFn = (pid: number) => boolean;
+
+export const defaultAlive: AliveFn = (pid: number) => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Three-state rather than two so we don't lie about services we can't see:
+ *
+ * - `running` — PID file present, `kill(pid, 0)` succeeds.
+ * - `stopped` — PID file present, process gone (stale pidfile, or cleanly shut down).
+ * - `unknown` — no PID file. Service may be externally managed (user ran
+ *   `parachute-vault serve` directly, or legacy launchd-era). Don't claim stopped.
+ */
+export interface ProcessState {
+  status: "running" | "stopped" | "unknown";
+  pid?: number;
+  /** mtime of the PID file — a stand-in for "process start time". */
+  startedAt?: Date;
+}
+
+export function processState(
+  svc: string,
+  configDir: string = CONFIG_DIR,
+  alive: AliveFn = defaultAlive,
+): ProcessState {
+  const pid = readPid(svc, configDir);
+  if (pid === undefined) return { status: "unknown" };
+  if (!alive(pid)) return { status: "stopped", pid };
+  const p = pidPath(svc, configDir);
+  const startedAt = existsSync(p) ? statSync(p).mtime : undefined;
+  return { status: "running", pid, startedAt };
+}
+
+/** Human-friendly uptime like "2h 13m" / "4d 6h" / "45s". */
+export function formatUptime(startedAt: Date, now: Date = new Date()): string {
+  const ms = Math.max(0, now.getTime() - startedAt.getTime());
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ${m % 60}m`;
+  const d = Math.floor(h / 24);
+  return `${d}d ${h % 24}h`;
+}

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -1,26 +1,45 @@
+import { fileURLToPath } from "node:url";
+import type { ServiceEntry } from "./services-manifest.ts";
+
 export interface ServiceSpec {
   readonly package: string;
   readonly manifestName: string;
   readonly init?: readonly string[];
+  /**
+   * Command to spawn for `parachute start <svc>`. Receives the services.json
+   * entry so commands that need per-install data (e.g., the notes static-serve
+   * shim needs the configured port) can pull it from there.
+   *
+   * Returns `undefined` to declare "lifecycle not supported for this service."
+   * That never applies today but leaves a seam for future services that
+   * shouldn't be managed by `parachute start`.
+   */
+  readonly startCmd?: (entry: ServiceEntry) => readonly string[] | undefined;
 }
+
+const NOTES_SERVE_PATH = fileURLToPath(new URL("./notes-serve.ts", import.meta.url));
 
 export const SERVICE_SPECS: Record<string, ServiceSpec> = {
   vault: {
     package: "@openparachute/vault",
     manifestName: "parachute-vault",
     init: ["parachute-vault", "init"],
+    startCmd: () => ["parachute-vault", "serve"],
   },
   notes: {
     package: "@openparachute/notes",
     manifestName: "parachute-notes",
+    startCmd: (entry) => ["bun", NOTES_SERVE_PATH, "--port", String(entry.port)],
   },
   scribe: {
     package: "@openparachute/scribe",
     manifestName: "parachute-scribe",
+    startCmd: () => ["parachute-scribe", "serve"],
   },
   channel: {
     package: "@openparachute/channel",
     manifestName: "parachute-channel",
+    startCmd: () => ["parachute-channel", "daemon"],
   },
 };
 
@@ -30,4 +49,13 @@ export function knownServices(): string[] {
 
 export function getSpec(service: string): ServiceSpec | undefined {
   return SERVICE_SPECS[service];
+}
+
+/** Short name (the key into SERVICE_SPECS) for a given manifest name, e.g.
+ *  `parachute-vault` → `vault`. Returns undefined for unknown manifests. */
+export function shortNameForManifest(manifestName: string): string | undefined {
+  for (const [short, spec] of Object.entries(SERVICE_SPECS)) {
+    if (spec.manifestName === manifestName) return short;
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Why

Running Parachute services day-to-day has been the missing piece between "I installed vault" and "it's part of my workflow." launchd plists added complexity, bare `bun serve` loses track of PIDs, and stopping something meant hunting for a process by port. This PR replaces all of that with a unified CLI-managed lifecycle.

After this lands, the launch story is: **install → start → expose**. No external service manager. No `ps | grep`. No hunt-and-kill.

## What ships

- `parachute start [svc]` — spawn detached, stdout+stderr appended to a log file, PID tracked at `~/.parachute/<svc>/run/<svc>.pid`. Idempotent; stale PID files (process died without cleanup) are cleared automatically before respawning.
- `parachute stop [svc]` — SIGTERM, poll up to 10s for clean exit, escalate to SIGKILL if stuck. Friendly no-op when the service wasn't running.
- `parachute restart [svc]` — stop + start.
- `parachute logs <svc> [-f]` — last 200 lines; `-f` tails via `tail -f`.
- `parachute status` — new PROCESS / PID / UPTIME columns. Stopped processes don't probe and don't fail exit — fresh-install-before-start is expected state, not a fault.

## Design rationale

**Per-service start commands are hardcoded by convention.** Vault → `parachute-vault serve`, scribe → `parachute-scribe serve`, channel → `parachute-channel daemon`, notes → a bundled static-serve shim. Reading `start` from services.json was tempting but adds ABI surface we don't need yet. We can promote to self-declared if a third-party service ever needs it; launch-grade ships with what we know.

**Three process states, not two: `running` / `stopped` / `unknown`.** "Unknown" means no PID file — the service might be externally managed (user ran `parachute-vault serve` themselves, or they're mid-launchd migration). Calling that "stopped" would be a lie. Status still probes unknown processes because the port might be live; it skips the probe only when it knows the process is dead (pid file present but `kill(pid, 0)` failed).

**Notes needs a static-serve shim** since it's a PWA with no backend of its own. `src/notes-serve.ts` resolves `@openparachute/notes/dist` via `Bun.resolveSync` and serves it from `Bun.serve`. If the package doesn't ship `dist/` — an open question that may need a notes-side `prepublishOnly` — the shim exits with an actionable error. Falls through cleanly when it does.

**Fully injectable seams** (`Spawner`, `KillFn`, `AliveFn`, `SleepFn`, `now`). Real implementation uses `Bun.spawn` + `process.kill(pid, 0)`; tests replace all four and drive the SIGTERM-then-SIGKILL escalation path without waiting 10 real seconds or forking real children. The lifecycle test file has 15 tests; all run in milliseconds.

## Migration from launchd

Documented in README; for beta users on launchd:

```sh
launchctl unload ~/Library/LaunchAgents/computer.parachute.vault.plist
rm ~/Library/LaunchAgents/computer.parachute.vault.plist
parachute start vault
```

## Out of scope (parked for post-launch)

- `parachute start --boot` that writes a launchd/systemd unit invoking `parachute start <svc>` at login — bare-process lifecycle first, auto-start later.
- Service-declared start commands in services.json.
- Dependency ordering (vault-first, etc.) — launch starts everything in parallel.
- Health-probe-before-started. `start` records PID and returns; `status` does the health check separately.

## Open question for notes tentacle

Does `@openparachute/notes` ship a prebuilt `dist/` in the published package? If not, the shim exits cleanly with a message asking for a `prepublishOnly` build step. I'll follow up with lens tentacle after this merges.

## Test plan

- [x] `bun test` — 105/105 pass (was 74; +31 new)
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [ ] Smoke: `parachute install vault && parachute start vault && parachute status && parachute logs vault && parachute stop vault` on a real machine
- [ ] Verify child survives parent CLI exit (detached + unref)
- [ ] Verify SIGTERM → SIGKILL escalation with a process that ignores TERM

🤖 Generated with [Claude Code](https://claude.com/claude-code)