### PR TITLE
PR 7: hub page at / + well-known services[] + expose rewire

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 *.log
 *.tsbuildinfo
 bun.lock.backup
+package/

--- a/README.md
+++ b/README.md
@@ -84,21 +84,42 @@ Under the hood, tailnet and public share a single `tailscale serve` config. The 
 
 ## Path-routing (and why)
 
-Every service mounts under a path on a single canonical hostname:
+Every service mounts under a path on a single canonical hostname. The root `/` is a hub page that auto-discovers everything installed on this node:
 
 ```
-https://parachute.<tailnet>.ts.net/           → parachute-vault
-https://parachute.<tailnet>.ts.net/notes      → parachute-notes
-https://parachute.<tailnet>.ts.net/scribe     → parachute-scribe
-https://parachute.<tailnet>.ts.net/.well-known/parachute.json   ← discovery
+https://parachute.<tailnet>.ts.net/                              → hub (service directory)
+https://parachute.<tailnet>.ts.net/vault/default                 → parachute-vault API
+https://parachute.<tailnet>.ts.net/notes                         → parachute-notes
+https://parachute.<tailnet>.ts.net/scribe                        → parachute-scribe
+https://parachute.<tailnet>.ts.net/.well-known/parachute.json    ← discovery
 ```
 
-The `/.well-known/parachute.json` document maps short names to absolute URLs so clients can discover each other without knowing install-local ports:
+The hub page fetches the discovery doc at load, then each service's `/.parachute/info` endpoint for display name, tagline, and icon. Adding a new service is zero CLI code — drop in its manifest entry and the hub picks it up.
+
+The `/.well-known/parachute.json` document is an always-present descriptor — flat `services[]` array that the hub iterates, plus top-level keys for legacy clients:
 
 ```json
 {
-  "vault":  { "url": "https://parachute.taildf9ce2.ts.net/",       "version": "0.2.4" },
-  "notes":  { "url": "https://parachute.taildf9ce2.ts.net/notes",  "version": "0.0.1" }
+  "vaults": [
+    { "name": "default", "url": "https://parachute.taildf9ce2.ts.net/vault/default", "version": "0.2.4" }
+  ],
+  "services": [
+    {
+      "name": "parachute-vault",
+      "url":  "https://parachute.taildf9ce2.ts.net/vault/default",
+      "path": "/vault/default",
+      "version": "0.2.4",
+      "infoUrl": "https://parachute.taildf9ce2.ts.net/vault/default/.parachute/info"
+    },
+    {
+      "name": "parachute-notes",
+      "url":  "https://parachute.taildf9ce2.ts.net/notes",
+      "path": "/notes",
+      "version": "0.0.1",
+      "infoUrl": "https://parachute.taildf9ce2.ts.net/notes/.parachute/info"
+    }
+  ],
+  "notes": { "url": "https://parachute.taildf9ce2.ts.net/notes", "version": "0.0.1" }
 }
 ```
 
@@ -119,15 +140,21 @@ Each Parachute service writes a manifest entry to `~/.parachute/services.json` o
     {
       "name":    "parachute-vault",
       "port":    1940,
-      "paths":   ["/"],
-      "health":  "/health",
+      "paths":   ["/vault/default"],
+      "health":  "/vault/default/health",
       "version": "0.2.4"
     }
   ]
 }
 ```
 
+Optional `displayName` and `tagline` may be added to personalize the hub-page card; if absent, the hub falls back to the short name and the service's own `/.parachute/info` response.
+
 The schema is a bit-for-bit contract shared between the CLI and every service. Services own their write side; the CLI owns the read + exposure side.
+
+### Claiming `/` — legacy manifests
+
+Pre-hub services wrote `paths: ["/"]` (when there was only one service at `/`). On `parachute expose`, any such entry is remapped in-memory to `/<shortname>` with a one-line warning; re-running `parachute install <svc>` updates the on-disk manifest permanently. The hub always owns `/`.
 
 If you want the CLI (and every service you install) to use a config directory other than `~/.parachute`, set `PARACHUTE_HOME`:
 

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -11,6 +11,7 @@ interface Harness {
   manifestPath: string;
   statePath: string;
   wellKnownPath: string;
+  hubPath: string;
   cleanup: () => void;
 }
 
@@ -20,6 +21,7 @@ function makeHarness(): Harness {
     manifestPath: join(dir, "services.json"),
     statePath: join(dir, "expose-state.json"),
     wellKnownPath: join(dir, "well-known", "parachute.json"),
+    hubPath: join(dir, "well-known", "hub.html"),
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
   };
 }
@@ -45,7 +47,13 @@ function makeRunner(): { runner: Runner; calls: string[][] } {
 
 function seedServices(path: string): void {
   upsertService(
-    { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.2.4" },
+    {
+      name: "parachute-vault",
+      port: 1940,
+      paths: ["/vault/default"],
+      health: "/vault/default/health",
+      version: "0.2.4",
+    },
     path,
   );
   upsertService(
@@ -61,7 +69,7 @@ function seedServices(path: string): void {
 }
 
 describe("expose tailnet up", () => {
-  test("generates one tailscale serve per service plus well-known", async () => {
+  test("mounts hub at /, one proxy per service, plus well-known", async () => {
     const h = makeHarness();
     try {
       seedServices(h.manifestPath);
@@ -72,6 +80,7 @@ describe("expose tailnet up", () => {
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -79,7 +88,7 @@ describe("expose tailnet up", () => {
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      expect(serveCalls).toHaveLength(3);
+      expect(serveCalls).toHaveLength(4);
       expect(serveCalls.every((c) => !c.includes("--funnel"))).toBe(true);
 
       const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path="))).sort();
@@ -87,24 +96,67 @@ describe("expose tailnet up", () => {
         "--set-path=/",
         "--set-path=/.well-known/parachute.json",
         "--set-path=/notes",
+        "--set-path=/vault/default",
       ]);
 
+      const hubCall = serveCalls.find((c) => c.includes("--set-path=/"));
+      expect(hubCall?.[hubCall.length - 1]).toBe(h.hubPath);
+
       expect(existsSync(h.wellKnownPath)).toBe(true);
+      expect(existsSync(h.hubPath)).toBe(true);
       const wk = JSON.parse(await Bun.file(h.wellKnownPath).text());
       expect(wk.vaults).toHaveLength(1);
       expect(wk.vaults[0]).toEqual({
         name: "default",
-        url: "https://parachute.taildf9ce2.ts.net/",
+        url: "https://parachute.taildf9ce2.ts.net/vault/default",
         version: "0.2.4",
       });
       expect(wk.notes?.url).toBe("https://parachute.taildf9ce2.ts.net/notes");
+      expect(wk.services).toHaveLength(2);
+      expect(wk.services.map((s: { name: string }) => s.name).sort()).toEqual([
+        "parachute-notes",
+        "parachute-vault",
+      ]);
 
       const state = readExposeState(h.statePath);
       expect(state?.layer).toBe("tailnet");
       expect(state?.canonicalFqdn).toBe("parachute.taildf9ce2.ts.net");
       expect(state?.mode).toBe("path");
-      expect(state?.entries).toHaveLength(3);
+      expect(state?.entries).toHaveLength(4);
       expect(state?.funnel).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("legacy paths:[/] entry is remapped to /<shortname> with warning", async () => {
+    const h = makeHarness();
+    try {
+      upsertService(
+        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.2.4" },
+        h.manifestPath,
+      );
+      const { runner, calls } = makeRunner();
+      const logs: string[] = [];
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+
+      const serveCalls = calls.filter(
+        (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
+      );
+      const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path="))).sort();
+      expect(mounts).toContain("--set-path=/vault");
+      expect(mounts).toContain("--set-path=/");
+      expect(mounts.filter((m) => m === "--set-path=/")).toHaveLength(1);
+
+      expect(logs.join("\n")).toMatch(/parachute-vault claims "\/"; hub page lives there/);
     } finally {
       h.cleanup();
     }
@@ -120,6 +172,7 @@ describe("expose tailnet up", () => {
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(1);
@@ -142,6 +195,7 @@ describe("expose tailnet up", () => {
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(1);
@@ -180,6 +234,7 @@ describe("expose tailnet up", () => {
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
         log: () => {},
       });
       expect(code).toBe(0);
@@ -215,6 +270,7 @@ describe("expose tailnet up", () => {
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(2);
@@ -235,6 +291,7 @@ describe("expose tailnet off", () => {
         runner,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -274,11 +331,13 @@ describe("expose tailnet off", () => {
         h.statePath,
       );
       await Bun.write(h.wellKnownPath, "{}\n");
+      await Bun.write(h.hubPath, "<html/>\n");
       const { runner, calls } = makeRunner();
       const code = await exposeTailnet("off", {
         runner,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
         log: () => {},
       });
       expect(code).toBe(0);
@@ -286,6 +345,7 @@ describe("expose tailnet off", () => {
       expect(calls).toHaveLength(2);
       expect(existsSync(h.statePath)).toBe(false);
       expect(existsSync(h.wellKnownPath)).toBe(false);
+      expect(existsSync(h.hubPath)).toBe(false);
     } finally {
       h.cleanup();
     }
@@ -319,6 +379,7 @@ describe("expose tailnet off", () => {
         runner,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(5);
@@ -356,6 +417,7 @@ describe("expose tailnet off", () => {
         runner,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -380,6 +442,7 @@ describe("expose public up", () => {
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -387,13 +450,13 @@ describe("expose public up", () => {
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      expect(serveCalls).toHaveLength(3);
+      expect(serveCalls).toHaveLength(4);
       expect(serveCalls.every((c) => c.includes("--funnel"))).toBe(true);
 
       const state = readExposeState(h.statePath);
       expect(state?.layer).toBe("public");
       expect(state?.funnel).toBe(true);
-      expect(state?.entries).toHaveLength(3);
+      expect(state?.entries).toHaveLength(4);
 
       expect(logs.join("\n")).toMatch(/Public exposure active/);
     } finally {
@@ -430,6 +493,7 @@ describe("expose public up", () => {
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
         log: () => {},
       });
       expect(code).toBe(0);
@@ -471,6 +535,7 @@ describe("expose public off", () => {
         runner,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
         log: () => {},
       });
       expect(code).toBe(0);
@@ -509,6 +574,7 @@ describe("expose public off", () => {
         runner,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);

--- a/src/__tests__/hub.test.ts
+++ b/src/__tests__/hub.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { renderHub, writeHubFile } from "../hub.ts";
+
+describe("renderHub", () => {
+  const html = renderHub();
+
+  test("is a self-contained HTML document with inline styles and script", () => {
+    expect(html).toStartWith("<!doctype html>");
+    expect(html).toContain("<style>");
+    expect(html).toContain("<script>");
+  });
+
+  test("fetches /.well-known/parachute.json and iterates services[]", () => {
+    expect(html).toContain("/.well-known/parachute.json");
+    expect(html).toContain("doc.services");
+    expect(html).toContain("infoUrl");
+  });
+
+  test("uses parachute.computer sage palette and serif/sans fonts", () => {
+    expect(html).toContain("#4a7c59");
+    expect(html).toContain("#faf8f4");
+    expect(html).toContain("Instrument Serif");
+    expect(html).toContain("DM Sans");
+  });
+
+  test("supports prefers-color-scheme dark", () => {
+    expect(html).toContain("prefers-color-scheme: dark");
+  });
+
+  test("falls back to a generic icon when service has none", () => {
+    expect(html).toContain("fallbackIcon");
+  });
+});
+
+describe("writeHubFile", () => {
+  test("writes the rendered HTML to the given path, creating parent dirs", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pcli-hub-"));
+    try {
+      const path = join(dir, "well-known", "hub.html");
+      const written = writeHubFile(path);
+      expect(written).toBe(path);
+      expect(existsSync(path)).toBe(true);
+      const content = readFileSync(path, "utf8");
+      expect(content).toBe(renderHub());
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/services-manifest.test.ts
+++ b/src/__tests__/services-manifest.test.ts
@@ -148,4 +148,30 @@ describe("services-manifest", () => {
       cleanup();
     }
   });
+
+  test("round-trips optional displayName and tagline", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const full: ServiceEntry = {
+        ...vault,
+        displayName: "Vault",
+        tagline: "Your notes, sovereign",
+      };
+      upsertService(full, path);
+      expect(readManifest(path).services[0]).toEqual(full);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rejects non-string displayName", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      expect(() => upsertService({ ...vault, displayName: 42 as unknown as string }, path)).toThrow(
+        /displayName/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
 });

--- a/src/__tests__/well-known.test.ts
+++ b/src/__tests__/well-known.test.ts
@@ -92,22 +92,63 @@ describe("vaultInstanceName", () => {
 });
 
 describe("buildWellKnown", () => {
-  test("vaults is always an array, other services are flat entries", () => {
+  test("vaults is always an array, other services are flat entries, services[] includes all", () => {
     const doc = buildWellKnown({
       services: [vault, notes, scribe],
       canonicalOrigin: "https://parachute.taildf9ce2.ts.net",
     });
-    expect(doc).toEqual({
-      vaults: [
-        {
-          name: "default",
-          url: "https://parachute.taildf9ce2.ts.net/vault/default",
-          version: "0.2.4",
-        },
-      ],
-      notes: { url: "https://parachute.taildf9ce2.ts.net/notes", version: "0.0.1" },
-      scribe: { url: "https://parachute.taildf9ce2.ts.net/scribe", version: "0.1.0" },
+    expect(doc.vaults).toEqual([
+      {
+        name: "default",
+        url: "https://parachute.taildf9ce2.ts.net/vault/default",
+        version: "0.2.4",
+      },
+    ]);
+    expect(doc.notes).toEqual({
+      url: "https://parachute.taildf9ce2.ts.net/notes",
+      version: "0.0.1",
     });
+    expect(doc.scribe).toEqual({
+      url: "https://parachute.taildf9ce2.ts.net/scribe",
+      version: "0.1.0",
+    });
+    expect(doc.services.map((s) => s.name)).toEqual([
+      "parachute-vault",
+      "parachute-notes",
+      "parachute-scribe",
+    ]);
+  });
+
+  test("services[] entries include infoUrl pointing at /.parachute/info", () => {
+    const doc = buildWellKnown({
+      services: [vault, notes],
+      canonicalOrigin: "https://x.example",
+    });
+    expect(doc.services).toEqual([
+      {
+        name: "parachute-vault",
+        url: "https://x.example/vault/default",
+        path: "/vault/default",
+        version: "0.2.4",
+        infoUrl: "https://x.example/vault/default/.parachute/info",
+      },
+      {
+        name: "parachute-notes",
+        url: "https://x.example/notes",
+        path: "/notes",
+        version: "0.0.1",
+        infoUrl: "https://x.example/notes/.parachute/info",
+      },
+    ]);
+  });
+
+  test("infoUrl for root-mounted service has no double slash", () => {
+    const rootSvc: ServiceEntry = { ...notes, paths: ["/"] };
+    const doc = buildWellKnown({
+      services: [rootSvc],
+      canonicalOrigin: "https://x.example",
+    });
+    expect(doc.services[0]?.infoUrl).toBe("https://x.example/.parachute/info");
   });
 
   test("vaults array is present even when no vault is installed", () => {
@@ -116,6 +157,7 @@ describe("buildWellKnown", () => {
       canonicalOrigin: "https://x.example",
     });
     expect(doc.vaults).toEqual([]);
+    expect(doc.services).toHaveLength(1);
     expect(doc.notes).toEqual({ url: "https://x.example/notes", version: "0.0.1" });
   });
 

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -8,6 +8,7 @@ import {
   readExposeState,
   writeExposeState,
 } from "../expose-state.ts";
+import { HUB_MOUNT, HUB_PATH, writeHubFile } from "../hub.ts";
 import { type ServiceEntry, readManifest } from "../services-manifest.ts";
 import { type ServeEntry, bringupCommand, teardownCommand } from "../tailscale/commands.ts";
 import { getFqdn, isTailscaleInstalled } from "../tailscale/detect.ts";
@@ -16,6 +17,7 @@ import {
   WELL_KNOWN_MOUNT,
   WELL_KNOWN_PATH,
   buildWellKnown,
+  shortName,
   writeWellKnownFile,
 } from "../well-known.ts";
 
@@ -36,16 +38,50 @@ export interface ExposeOpts {
   manifestPath?: string;
   statePath?: string;
   wellKnownPath?: string;
+  hubPath?: string;
   port?: number;
   log?: (line: string) => void;
   /** Override detected FQDN — primarily for tests. */
   fqdnOverride?: string;
 }
 
-function planEntries(services: readonly ServiceEntry[], wellKnownFilePath: string): ServeEntry[] {
+/**
+ * Remap legacy `paths: ["/"]` entries to `/<shortname>` so they don't collide
+ * with the hub page at `/`. Emits a warning per remapped service. This is the
+ * transitional path for services installed before the vault PR that writes
+ * `paths: ["/vault/<default>"]` — once `parachute install` is re-run those
+ * entries update themselves and this branch goes dormant.
+ */
+function remapLegacyRoot(
+  services: readonly ServiceEntry[],
+  log: (line: string) => void,
+): ServiceEntry[] {
+  return services.map((s) => {
+    const first = s.paths[0];
+    if (first !== "/") return s;
+    const sn = shortName(s.name);
+    const remapped = `/${sn}`;
+    log(
+      `note: ${s.name} claims "/"; hub page lives there — exposing at "${remapped}" instead. Re-run \`parachute install ${sn}\` to update services.json.`,
+    );
+    return { ...s, paths: [remapped, ...s.paths.slice(1)] };
+  });
+}
+
+function planEntries(
+  services: readonly ServiceEntry[],
+  wellKnownFilePath: string,
+  hubFilePath: string,
+): ServeEntry[] {
   const entries: ServeEntry[] = [];
+  entries.push({
+    kind: "file",
+    mount: HUB_MOUNT,
+    target: hubFilePath,
+    service: "hub",
+  });
   for (const s of services) {
-    const mount = s.paths[0] ?? "/";
+    const mount = s.paths[0] ?? `/${shortName(s.name)}`;
     entries.push({
       kind: "proxy",
       mount,
@@ -87,6 +123,7 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
   const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
   const statePath = opts.statePath ?? EXPOSE_STATE_PATH;
   const wellKnownFilePath = opts.wellKnownPath ?? WELL_KNOWN_PATH;
+  const hubFilePath = opts.hubPath ?? HUB_PATH;
   const port = opts.port ?? 443;
   const log = opts.log ?? ((line) => console.log(line));
   const funnel = layer === "public";
@@ -118,11 +155,15 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
     }
   }
 
-  const wellKnownDoc = buildWellKnown({ services: manifest.services, canonicalOrigin });
+  const services = remapLegacyRoot(manifest.services, log);
+
+  const wellKnownDoc = buildWellKnown({ services, canonicalOrigin });
   writeWellKnownFile(wellKnownDoc, wellKnownFilePath);
   log(`Wrote ${wellKnownFilePath}`);
+  writeHubFile(hubFilePath);
+  log(`Wrote ${hubFilePath}`);
 
-  const entries = planEntries(manifest.services, wellKnownFilePath);
+  const entries = planEntries(services, wellKnownFilePath, hubFilePath);
   log(`Exposing under ${canonicalOrigin} (${layerLabel(layer)}, path-routing, port ${port}):`);
   for (const e of entries) {
     const suffix = e.kind === "proxy" ? `→ ${e.target}  (${e.service})` : `→ ${e.target}`;
@@ -162,6 +203,7 @@ export async function exposeOff(layer: ExposeLayer, opts: ExposeOpts = {}): Prom
   const runner = opts.runner ?? defaultRunner;
   const statePath = opts.statePath ?? EXPOSE_STATE_PATH;
   const wellKnownFilePath = opts.wellKnownPath ?? WELL_KNOWN_PATH;
+  const hubFilePath = opts.hubPath ?? HUB_PATH;
   const log = opts.log ?? ((line) => console.log(line));
 
   const state = readExposeState(statePath);
@@ -187,6 +229,9 @@ export async function exposeOff(layer: ExposeLayer, opts: ExposeOpts = {}): Prom
   clearExposeState(statePath);
   if (existsSync(wellKnownFilePath)) {
     unlinkSync(wellKnownFilePath);
+  }
+  if (existsSync(hubFilePath)) {
+    unlinkSync(hubFilePath);
   }
   log(`✓ ${layerLabel(layer)} exposure removed.`);
   return 0;

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -1,0 +1,338 @@
+import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { CONFIG_DIR } from "./config.ts";
+
+/**
+ * Hub page served at `/` when the node is exposed. Lists every installed
+ * service via a client-side fetch to `/.well-known/parachute.json` and each
+ * service's own `/.parachute/info`. Everything that needs personalization
+ * (name, tagline, icon) comes from the service, not the CLI — adding a new
+ * frontend requires zero hub-page changes.
+ *
+ * The file is fully self-contained (inline CSS + JS, no external assets)
+ * so `tailscale serve` can mount it directly from disk with `--set-path=/`.
+ */
+
+export const HUB_PATH = join(CONFIG_DIR, "well-known", "hub.html");
+export const HUB_MOUNT = "/";
+
+export function renderHub(): string {
+  return HTML;
+}
+
+export function writeHubFile(path: string = HUB_PATH): string {
+  if (!existsSync(dirname(path))) {
+    mkdirSync(dirname(path), { recursive: true });
+  }
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, HTML);
+  renameSync(tmp, path);
+  return path;
+}
+
+const HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Parachute</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ctext y='26' font-size='26'%3E\u{1FA82}%3C/text%3E%3C/svg%3E" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=DM+Sans:wght@400;500;600&display=swap" />
+<style>
+  :root {
+    --bg: #faf8f4;
+    --bg-soft: #f3f0ea;
+    --fg: #2c2a26;
+    --fg-muted: #6b6860;
+    --fg-dim: #9a9690;
+    --accent: #4a7c59;
+    --accent-soft: rgba(74, 124, 89, 0.08);
+    --accent-hover: #3d6849;
+    --accent-light: #6a9b77;
+    --border: #e4e0d8;
+    --card-bg: #ffffff;
+    --serif: 'Instrument Serif', Georgia, serif;
+    --sans: 'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #1a1917;
+      --bg-soft: #24221f;
+      --fg: #e8e4dc;
+      --fg-muted: #a8a49a;
+      --fg-dim: #6b6860;
+      --accent: #7ab08a;
+      --accent-soft: rgba(122, 176, 138, 0.1);
+      --accent-hover: #8fc49e;
+      --accent-light: #8fc49e;
+      --border: #3a3733;
+      --card-bg: #24221f;
+    }
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--fg);
+    font-family: var(--sans);
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+  }
+  main {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 4rem 1.5rem 6rem;
+  }
+  header {
+    text-align: center;
+    margin-bottom: 3.5rem;
+  }
+  h1 {
+    font-family: var(--serif);
+    font-weight: 400;
+    font-size: clamp(2.75rem, 6vw, 4rem);
+    line-height: 1.05;
+    margin: 0 0 0.75rem;
+    letter-spacing: -0.01em;
+  }
+  .tagline {
+    color: var(--fg-muted);
+    font-size: 1.1rem;
+    margin: 0;
+  }
+  .grid {
+    display: grid;
+    gap: 1.25rem;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  }
+  .card {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.75rem;
+    text-decoration: none;
+    color: inherit;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+    opacity: 0;
+    animation: fadeUp 0.4s ease forwards;
+  }
+  .card:nth-child(1) { animation-delay: 0.02s; }
+  .card:nth-child(2) { animation-delay: 0.06s; }
+  .card:nth-child(3) { animation-delay: 0.1s; }
+  .card:nth-child(4) { animation-delay: 0.14s; }
+  .card:nth-child(5) { animation-delay: 0.18s; }
+  .card:nth-child(n+6) { animation-delay: 0.22s; }
+  .card:hover {
+    border-color: var(--accent-light);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+    transform: translateY(-2px);
+  }
+  .card-head {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .icon {
+    width: 2.25rem;
+    height: 2.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--accent-soft);
+    border-radius: 8px;
+    color: var(--accent);
+    font-size: 1.25rem;
+    flex-shrink: 0;
+    overflow: hidden;
+  }
+  .icon img, .icon svg {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+  .card-title {
+    font-family: var(--serif);
+    font-size: 1.5rem;
+    font-weight: 400;
+    margin: 0;
+    line-height: 1.1;
+  }
+  .card-tagline {
+    color: var(--fg-muted);
+    font-size: 0.95rem;
+    margin: 0;
+    flex-grow: 1;
+  }
+  .card-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 0.25rem;
+    font-size: 0.8rem;
+    color: var(--fg-dim);
+  }
+  .version {
+    font-family: ui-monospace, 'SF Mono', Monaco, monospace;
+    padding: 0.1rem 0.5rem;
+    background: var(--bg-soft);
+    border-radius: 999px;
+    border: 1px solid var(--border);
+  }
+  .path {
+    font-family: ui-monospace, 'SF Mono', Monaco, monospace;
+    color: var(--fg-muted);
+  }
+  .empty, .error {
+    text-align: center;
+    color: var(--fg-muted);
+    padding: 3rem 1rem;
+    border: 1px dashed var(--border);
+    border-radius: 12px;
+  }
+  .empty code, .error code {
+    font-family: ui-monospace, 'SF Mono', Monaco, monospace;
+    background: var(--bg-soft);
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    color: var(--accent);
+  }
+  footer {
+    text-align: center;
+    margin-top: 4rem;
+    color: var(--fg-dim);
+    font-size: 0.85rem;
+  }
+  footer a {
+    color: var(--fg-muted);
+    text-decoration: none;
+    border-bottom: 1px solid var(--border);
+  }
+  footer a:hover {
+    color: var(--accent);
+    border-bottom-color: var(--accent-light);
+  }
+  @keyframes fadeUp {
+    from { opacity: 0; transform: translateY(8px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  @media (max-width: 640px) {
+    main { padding: 2.5rem 1rem 4rem; }
+    .card { padding: 1.5rem; }
+  }
+</style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>Parachute</h1>
+    <p class="tagline">Your personal-computing services.</p>
+  </header>
+  <section id="services" class="grid" aria-live="polite">
+    <div class="empty" id="loading">Loading services\u2026</div>
+  </section>
+  <footer>
+    <a href="/.well-known/parachute.json">discovery</a>
+  </footer>
+</main>
+<script>
+(async () => {
+  const root = document.getElementById('services');
+  const fallbackIcon = \`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="9"/></svg>\`;
+
+  function shortName(manifestName) {
+    return manifestName.replace(/^parachute-/, '');
+  }
+
+  function fetchWithTimeout(url, ms) {
+    const ctl = new AbortController();
+    const t = setTimeout(() => ctl.abort(), ms);
+    return fetch(url, { signal: ctl.signal, credentials: 'omit' })
+      .finally(() => clearTimeout(t));
+  }
+
+  async function loadInfo(infoUrl) {
+    try {
+      const r = await fetchWithTimeout(infoUrl, 2000);
+      if (!r.ok) return null;
+      return await r.json();
+    } catch { return null; }
+  }
+
+  function renderCard(svc, info) {
+    const a = document.createElement('a');
+    a.className = 'card';
+    a.href = svc.url;
+
+    const head = document.createElement('div');
+    head.className = 'card-head';
+
+    const icon = document.createElement('div');
+    icon.className = 'icon';
+    const iconUrl = info && info.icon ? new URL(info.icon, svc.url).toString() : null;
+    if (iconUrl) {
+      const img = document.createElement('img');
+      img.src = iconUrl;
+      img.alt = '';
+      img.onerror = () => { icon.innerHTML = fallbackIcon; };
+      icon.appendChild(img);
+    } else {
+      icon.innerHTML = fallbackIcon;
+    }
+
+    const title = document.createElement('h2');
+    title.className = 'card-title';
+    title.textContent = (info && info.displayName) || shortName(svc.name);
+
+    head.appendChild(icon);
+    head.appendChild(title);
+    a.appendChild(head);
+
+    const tag = info && info.tagline;
+    if (tag) {
+      const p = document.createElement('p');
+      p.className = 'card-tagline';
+      p.textContent = tag;
+      a.appendChild(p);
+    }
+
+    const meta = document.createElement('div');
+    meta.className = 'card-meta';
+    const path = document.createElement('span');
+    path.className = 'path';
+    path.textContent = svc.path;
+    const ver = document.createElement('span');
+    ver.className = 'version';
+    ver.textContent = 'v' + svc.version;
+    meta.appendChild(path);
+    meta.appendChild(ver);
+    a.appendChild(meta);
+
+    return a;
+  }
+
+  try {
+    const wk = await fetch('/.well-known/parachute.json', { credentials: 'omit' });
+    if (!wk.ok) throw new Error('well-known fetch failed: ' + wk.status);
+    const doc = await wk.json();
+    const services = Array.isArray(doc.services) ? doc.services : [];
+    if (services.length === 0) {
+      root.innerHTML = '<div class="empty">No services installed yet. Try <code>parachute install vault</code>.</div>';
+      return;
+    }
+    const infos = await Promise.all(services.map((s) => loadInfo(s.infoUrl)));
+    root.innerHTML = '';
+    services.forEach((svc, i) => root.appendChild(renderCard(svc, infos[i])));
+  } catch (err) {
+    root.innerHTML = '<div class="error">Could not load services: ' + (err && err.message ? err.message : String(err)) + '</div>';
+  }
+})();
+</script>
+</body>
+</html>
+`;

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -8,6 +8,10 @@ export interface ServiceEntry {
   paths: string[];
   health: string;
   version: string;
+  /** Human-readable name for the hub page. Falls back to the short manifest name. */
+  displayName?: string;
+  /** One-line subtitle for the hub page card. */
+  tagline?: string;
 }
 
 export interface ServicesManifest {
@@ -45,7 +49,18 @@ function validateEntry(raw: unknown, where: string): ServiceEntry {
   if (typeof version !== "string") {
     throw new ServicesManifestError(`${where}: "version" must be a string`);
   }
-  return { name, port, paths: paths as string[], health, version };
+  const displayName = e.displayName;
+  const tagline = e.tagline;
+  if (displayName !== undefined && typeof displayName !== "string") {
+    throw new ServicesManifestError(`${where}: "displayName" must be a string if present`);
+  }
+  if (tagline !== undefined && typeof tagline !== "string") {
+    throw new ServicesManifestError(`${where}: "tagline" must be a string if present`);
+  }
+  const entry: ServiceEntry = { name, port, paths: paths as string[], health, version };
+  if (displayName !== undefined) entry.displayName = displayName;
+  if (tagline !== undefined) entry.tagline = tagline;
+  return entry;
 }
 
 function validateManifest(raw: unknown, where: string): ServicesManifest {

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -15,22 +15,40 @@ export interface WellKnownVaultEntry {
 }
 
 /**
+ * Flat service descriptor — one per installed service, used by the hub page
+ * to iterate without having to know every service's shortName ahead of time.
+ * `infoUrl` points at the service's `/.parachute/info` endpoint (relative to
+ * its mount path) which the hub fetches client-side for displayName/tagline.
+ */
+export interface WellKnownServicesEntry {
+  name: string;
+  url: string;
+  path: string;
+  version: string;
+  infoUrl: string;
+}
+
+/**
  * Canonical `/.well-known/parachute.json` shape.
  *
- * `vaults` is always an array — even for the single-default-vault case —
- * because vault is the only multi-tenant service in the ecosystem. Other
- * services are single-entry objects keyed by their short name.
- *
- * Example (launch-grade):
- * {
- *   "vaults": [{ "name": "default", "url": "https://host/vault/default", "version": "0.2.4" }],
- *   "notes":  { "url": "https://host/notes",  "version": "0.3.0" },
- *   "scribe": { "url": "https://host/scribe", "version": "0.1.0" }
- * }
+ * Three parts, all additive so old clients keep working:
+ *   - `vaults: []` — always an array; vault is the ecosystem's only
+ *     multi-tenant service.
+ *   - `services: []` — flat list the hub page iterates. Scales to N frontends
+ *     without the consumer needing to know every shortName.
+ *   - Top-level flat keys (`notes`, `scribe`, …) — kept for back-compat with
+ *     clients that predate `services[]`.
  */
 export type WellKnownDocument = {
   vaults: WellKnownVaultEntry[];
-} & { [shortName: string]: WellKnownVaultEntry[] | WellKnownServiceEntry | undefined };
+  services: WellKnownServicesEntry[];
+} & {
+  [shortName: string]:
+    | WellKnownVaultEntry[]
+    | WellKnownServicesEntry[]
+    | WellKnownServiceEntry
+    | undefined;
+};
 
 export const WELL_KNOWN_DIR = join(CONFIG_DIR, "well-known");
 export const WELL_KNOWN_PATH = join(WELL_KNOWN_DIR, "parachute.json");
@@ -74,12 +92,21 @@ export interface BuildWellKnownOpts {
   canonicalOrigin: string;
 }
 
+/** Join a base origin and a path without double slashes — "/" stays "/". */
+function joinInfoPath(path: string): string {
+  const trimmed = path.replace(/\/$/, "");
+  return `${trimmed}/.parachute/info`;
+}
+
 export function buildWellKnown(opts: BuildWellKnownOpts): WellKnownDocument {
   const base = opts.canonicalOrigin.replace(/\/$/, "");
-  const doc: WellKnownDocument = { vaults: [] };
+  const doc: WellKnownDocument = { vaults: [], services: [] };
   for (const s of opts.services) {
     const path = s.paths[0] ?? "/";
     const url = new URL(path, `${base}/`).toString();
+    const infoPath = joinInfoPath(path);
+    const infoUrl = new URL(infoPath, `${base}/`).toString();
+    doc.services.push({ name: s.name, url, path, version: s.version, infoUrl });
     if (isVaultEntry(s)) {
       doc.vaults.push({ name: vaultInstanceName(s), url, version: s.version });
     } else {


### PR DESCRIPTION
## Why

Root (`/`) was a single frontend squatting on the landing page — fine with one service, but the second frontend forced an awkward "which one owns /" choice. This PR replaces "one squats on /" with **root is a discovery portal; every frontend lives under its own path**, so adding the Nth service takes zero CLI code.

The hub is driven entirely by two contracts that already exist or are trivial extensions:

- `/.well-known/parachute.json` gains a flat `services[]` array — each entry carries `name`, `url`, `path`, `version`, and `infoUrl` so the hub can iterate without knowing every shortName ahead of time. `vaults[]` and the legacy top-level keys stay in place for back-compat.
- Each service's own `/.parachute/info` endpoint (vault's already live, lens PR in flight) supplies display name, tagline, and icon for the card. If a service's info endpoint isn't reachable yet, the card falls back to the short name.

Pairs with concurrent lens and vault PRs that were mentioned in the assignment.

## What changes

- **Hub page** (`src/hub.ts`) — standalone `hub.html` with inline CSS + JS, no external assets beyond Google Fonts. Uses the parachute.computer sage palette (`--accent: #4a7c59`, `--bg: #faf8f4`), Instrument Serif + DM Sans, `prefers-color-scheme: dark`, staggered fade-up animation, responsive grid breaking to single-column at 640px. Fetches `/.well-known/parachute.json`, then per-service `infoUrl` with a 2s timeout; gracefully degrades when a service's info endpoint is absent.
- **Well-known extension** (`src/well-known.ts`) — additive `services[]` array keyed by manifest name; `infoUrl` is `<path>/.parachute/info` with no double slashes for root-mounted services. Existing `vaults[]` and top-level flat keys untouched.
- **Expose rewire** (`src/commands/expose.ts`) — mounts hub.html at `/` via `tailscale serve --set-path=/`. Any manifest entry still claiming `paths: ["/"]` is remapped in-memory to `/<shortname>` with a one-line warning so pre-hub manifests keep working until the user re-runs `parachute install <svc>`. `exposeOff` cleans up hub.html alongside parachute.json.
- **ServiceEntry** (`src/services-manifest.ts`) — optional `displayName` and `tagline` fields with validator support, so services can personalize the hub card directly from services.json rather than relying only on `/.parachute/info`.
- **Housekeeping** — `package/` (bun-pack artifact) added to `.gitignore`.

## Gates

- `bun run lint` — clean (biome, 34 files)
- `bun run tsc --noEmit` — clean
- `bun test` — 116 pass / 0 fail (+8 new across hub, well-known services[], legacy-remap, displayName round-trip)
- Local smoke — hub.html + well-known served via a local Bun.serve; both load as expected at 8.5kb / 200.

## Not included

- The hub's client-side JS isn't exercised by the unit tests — it's HTML-snapshot coverage only. Will want a browser smoke from Aaron once he brings up `parachute expose tailnet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)