### PR TITLE
hotfix: preserve mount path in proxy target URLs

### DIFF
--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -144,13 +144,22 @@ describe("expose tailnet up", () => {
       ]);
 
       // Hub + well-known now point at localhost HTTP, not a file path.
+      // Target path mirrors mount exactly so tailscale's strip-then-forward
+      // is a no-op; otherwise SPAs at /<mount>/ redirect-loop.
       const hubCall = serveCalls.find((c) => c.includes("--set-path=/"));
-      expect(hubCall?.[hubCall.length - 1]).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+      expect(hubCall?.[hubCall.length - 1]).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
 
       const wkCall = serveCalls.find((c) => c.includes("--set-path=/.well-known/parachute.json"));
       expect(wkCall?.[wkCall.length - 1]).toMatch(
         /^http:\/\/127\.0\.0\.1:\d+\/\.well-known\/parachute\.json$/,
       );
+
+      // Service targets also include their mount path to prevent tailscale
+      // from stripping the prefix before forwarding to a base-aware backend.
+      const notesCall = serveCalls.find((c) => c.includes("--set-path=/notes"));
+      expect(notesCall?.[notesCall.length - 1]).toBe("http://127.0.0.1:5173/notes");
+      const vaultCall = serveCalls.find((c) => c.includes("--set-path=/vault/default"));
+      expect(vaultCall?.[vaultCall.length - 1]).toBe("http://127.0.0.1:1940/vault/default");
 
       expect(existsSync(h.wellKnownPath)).toBe(true);
       expect(existsSync(h.hubPath)).toBe(true);
@@ -192,6 +201,47 @@ describe("expose tailnet up", () => {
       expect(cmd).toContain("--port");
       expect(cmd).toContain("--well-known-dir");
       expect(cmd).toContain(h.wellKnownDir);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("trailing-slash mount preserves trailing slash in target URL", async () => {
+    // Aaron hit ERR_TOO_MANY_REDIRECTS on /notes/ because tailscale strips
+    // the prefix, Vite (base=/notes) redirects back to /notes/, tailscale
+    // strips again, loop. Pinning target = mount byte-for-byte breaks that.
+    const h = makeHarness();
+    try {
+      upsertService(
+        {
+          name: "parachute-notes",
+          port: 5173,
+          paths: ["/notes/"],
+          health: "/notes/health",
+          version: "0.0.1",
+        },
+        h.manifestPath,
+      );
+      const { runner, calls } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      const serveCalls = calls.filter(
+        (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
+      );
+      const notesCall = serveCalls.find((c) => c.includes("--set-path=/notes/"));
+      expect(notesCall).toBeDefined();
+      expect(notesCall?.[notesCall.length - 1]).toBe("http://127.0.0.1:5173/notes/");
     } finally {
       h.cleanup();
     }

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -89,13 +89,31 @@ function remapLegacyRoot(
   });
 }
 
+/**
+ * Compose the tailscale serve target URL for a service rooted at `mount`.
+ *
+ * `tailscale serve --set-path=<mount> <target>` strips `<mount>` from the
+ * incoming request path before forwarding. So if the backend expects
+ * requests to keep arriving at `<mount>/...` (every SPA with a configured
+ * base path, plus vault's `/vault/<name>/` API root) the target URL must
+ * include the same mount path — otherwise the backend sees requests at `/`,
+ * emits a redirect back to its real base, tailscale strips again, and the
+ * client loops on `ERR_TOO_MANY_REDIRECTS`.
+ *
+ * The rule of thumb is: mount and target path must match byte-for-byte
+ * (including trailing slash state), so tailscale's strip-then-forward is a
+ * no-op and the backend sees the full path it expects.
+ */
+function serviceProxyTarget(port: number, mount: string): string {
+  return `http://127.0.0.1:${port}${mount}`;
+}
+
 function planEntries(services: readonly ServiceEntry[], hubPort: number): ServeEntry[] {
-  const hubTarget = `http://127.0.0.1:${hubPort}`;
   const entries: ServeEntry[] = [];
   entries.push({
     kind: "proxy",
     mount: HUB_MOUNT,
-    target: hubTarget,
+    target: serviceProxyTarget(hubPort, HUB_MOUNT),
     service: "hub",
   });
   for (const s of services) {
@@ -103,14 +121,14 @@ function planEntries(services: readonly ServiceEntry[], hubPort: number): ServeE
     entries.push({
       kind: "proxy",
       mount,
-      target: `http://127.0.0.1:${s.port}`,
+      target: serviceProxyTarget(s.port, mount),
       service: s.name,
     });
   }
   entries.push({
     kind: "proxy",
     mount: WELL_KNOWN_MOUNT,
-    target: `${hubTarget}${WELL_KNOWN_MOUNT}`,
+    target: serviceProxyTarget(hubPort, WELL_KNOWN_MOUNT),
     service: "well-known",
   });
   return entries;


### PR DESCRIPTION
## Why

Companion fix that was supposed to ship with PR #9 but got orphaned by a squash-merge race — it's on `hotfix-hub-proxy` but never reached main. Aaron's `/notes/` redirect loop is still live.

`tailscale serve --set-path=<mount> <target>` strips `<mount>` from the request before forwarding. When the backend has a configured base path (every SPA with a non-root base, plus vault's `/vault/<name>/` API root), it receives requests at `/`, redirects to its real base (`/notes/`), tailscale strips again, browser loops on `ERR_TOO_MANY_REDIRECTS`.

Rule: the target URL's path has to match the mount byte-for-byte — trailing-slash state included — so strip-then-forward is a no-op and the backend gets the path it expects.

## What

- `serviceProxyTarget(port, mount)` helper in `expose.ts` applied to hub `/`, per-service mounts, and the `/.well-known/parachute.json` mount.
- Tests assert each mount shape: catch-all `/`, `/notes`, `/vault/default`, and the trailing-slash variant.

## Test plan

- [x] `bun test src/__tests__/expose.test.ts` — 16 pass
- [ ] Aaron reloads `https://parachute.taildf9ce2.ts.net/notes/` — no more redirect loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)