### PR TITLE
Add parachute migrate — sweep ecosystem-root cruft

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ parachute start vault
 
 An at-login auto-start mode (`parachute start --boot`) is on the post-launch roadmap.
 
+### Migrating from pre-CLI installs
+
+If you've been running Parachute services by hand for a while, `~/.parachute/` may contain files from before the per-service restructure — top-level `daily.db`, `server.yaml`, a stray `logs/` directory, and so on. `parachute install` will print a one-line notice when it sees anything like that; run `parachute migrate` to sweep them:
+
+```sh
+parachute migrate --dry-run       # see the plan
+parachute migrate                 # interactive (prompts before moving)
+parachute migrate --yes           # unattended
+```
+
+Anything swept goes to `~/.parachute/.archive-<YYYY-MM-DD>/` with its original name — nothing is deleted. Recognized entries (per-service dirs, `services.json`, `expose-state.json`, `well-known/`) are left in place, and so is anything starting with a dot (so `.env` and prior `.archive-*` dirs are safe).
+
 ## Three layers of addressability
 
 Each additive; each can be turned off without affecting the layer below.
@@ -231,6 +243,7 @@ parachute restart [service]       stop + start
 parachute logs <service> [-f]     print/tail service logs
 parachute expose tailnet [off]    HTTPS across your tailnet
 parachute expose public  [off]    HTTPS on the public internet (Funnel)
+parachute migrate [--dry-run]     archive legacy files at ecosystem root
 parachute vault <args...>         dispatch to parachute-vault
 ```
 

--- a/src/__tests__/migrate.test.ts
+++ b/src/__tests__/migrate.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { migrate, migrateNotice, planArchive, safelistEntries } from "../commands/migrate.ts";
+
+interface Harness {
+  configDir: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-migrate-"));
+  return { configDir: dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+function touch(path: string, content = ""): void {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, content);
+}
+
+const APRIL_19 = new Date("2026-04-19T12:00:00Z");
+const APRIL_20 = new Date("2026-04-20T09:00:00Z");
+
+function seedSafelist(configDir: string): void {
+  // Realistic safelist items so we can assert they stay put across every test.
+  mkdirSync(join(configDir, "vault"), { recursive: true });
+  touch(join(configDir, "vault", "config.json"), "{}");
+  mkdirSync(join(configDir, "hub", "run"), { recursive: true });
+  mkdirSync(join(configDir, "well-known"), { recursive: true });
+  touch(join(configDir, "services.json"), '{"services":[]}');
+  touch(join(configDir, "expose-state.json"), "{}");
+}
+
+describe("safelistEntries", () => {
+  test("covers service dirs, hub, state files, and well-known", () => {
+    const s = safelistEntries();
+    // Service dirs from SERVICE_SPECS
+    expect(s.has("vault")).toBe(true);
+    expect(s.has("notes")).toBe(true);
+    expect(s.has("scribe")).toBe(true);
+    expect(s.has("channel")).toBe(true);
+    // Internal
+    expect(s.has("hub")).toBe(true);
+    // CLI state
+    expect(s.has("services.json")).toBe(true);
+    expect(s.has("expose-state.json")).toBe(true);
+    expect(s.has("well-known")).toBe(true);
+  });
+});
+
+describe("planArchive", () => {
+  test("clean ecosystem root produces an empty plan", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      const plan = planArchive(h.configDir, APRIL_19);
+      expect(plan.items).toEqual([]);
+      expect(plan.totalBytes).toBe(0);
+      expect(plan.archiveDirName).toBe(".archive-2026-04-19");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("pre-restructure cruft is identified and sized", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      touch(join(h.configDir, "daily.db"), "X".repeat(100));
+      touch(join(h.configDir, "daily.db-shm"), "S");
+      touch(join(h.configDir, "server.yaml"), "port: 1940\n");
+      mkdirSync(join(h.configDir, "logs"), { recursive: true });
+      touch(join(h.configDir, "logs", "old.log"), "old-entry\n");
+      touch(join(h.configDir, "random-note.txt"), "mystery content");
+
+      const plan = planArchive(h.configDir, APRIL_19);
+      const names = plan.items.map((i) => i.name).sort();
+      expect(names).toEqual(["daily.db", "daily.db-shm", "logs", "random-note.txt", "server.yaml"]);
+      expect(plan.totalBytes).toBeGreaterThan(100);
+      // known-cruft annotation is attached
+      expect(plan.items.find((i) => i.name === "daily.db")?.annotation).toMatch(/daily/i);
+      expect(plan.items.find((i) => i.name === "logs")?.annotation).toMatch(/logs/i);
+      // unknown files get no annotation
+      expect(plan.items.find((i) => i.name === "random-note.txt")?.annotation).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("dotfiles at root are left alone", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      touch(join(h.configDir, ".env"), "SECRET=x");
+      touch(join(h.configDir, ".DS_Store"), "");
+      mkdirSync(join(h.configDir, ".archive-2026-04-01"), { recursive: true });
+      touch(join(h.configDir, ".archive-2026-04-01", "daily.db"), "Y");
+
+      const plan = planArchive(h.configDir, APRIL_19);
+      expect(plan.items).toEqual([]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("directory sizes are summed recursively", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      const nested = join(h.configDir, "old-tree", "a", "b");
+      mkdirSync(nested, { recursive: true });
+      touch(join(nested, "inner.dat"), "Z".repeat(500));
+      touch(join(h.configDir, "old-tree", "top.dat"), "Q".repeat(300));
+
+      const plan = planArchive(h.configDir, APRIL_19);
+      const oldTree = plan.items.find((i) => i.name === "old-tree");
+      expect(oldTree).toBeDefined();
+      expect(oldTree?.kind).toBe("dir");
+      expect(oldTree?.bytes).toBe(800);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("migrate", () => {
+  test("no-op on a clean root with exit 0", async () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      const logs: string[] = [];
+      const code = await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: (l) => logs.push(l),
+        prompt: async () => {
+          throw new Error("prompt must not be called");
+        },
+      });
+      expect(code).toBe(0);
+      expect(logs.join("\n")).toMatch(/nothing to archive/i);
+      expect(existsSync(join(h.configDir, ".archive-2026-04-19"))).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("dry-run prints plan, makes no changes, no prompt", async () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      touch(join(h.configDir, "daily.db"), "X");
+      touch(join(h.configDir, "random"), "Y");
+
+      const logs: string[] = [];
+      const code = await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: (l) => logs.push(l),
+        prompt: async () => {
+          throw new Error("prompt must not be called");
+        },
+        dryRun: true,
+      });
+      expect(code).toBe(0);
+      expect(logs.join("\n")).toMatch(/dry-run/i);
+      expect(existsSync(join(h.configDir, "daily.db"))).toBe(true);
+      expect(existsSync(join(h.configDir, "random"))).toBe(true);
+      expect(existsSync(join(h.configDir, ".archive-2026-04-19"))).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("--yes archives without prompting, safelist untouched", async () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      touch(join(h.configDir, "daily.db"), "X".repeat(50));
+      touch(join(h.configDir, "server.yaml"), "port: 1\n");
+      mkdirSync(join(h.configDir, "logs"), { recursive: true });
+      touch(join(h.configDir, "logs", "a.log"), "a");
+
+      const logs: string[] = [];
+      const code = await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: (l) => logs.push(l),
+        prompt: async () => {
+          throw new Error("prompt must not be called");
+        },
+        yes: true,
+      });
+      expect(code).toBe(0);
+      const archive = join(h.configDir, ".archive-2026-04-19");
+      expect(existsSync(archive)).toBe(true);
+      expect(existsSync(join(archive, "daily.db"))).toBe(true);
+      expect(existsSync(join(archive, "server.yaml"))).toBe(true);
+      expect(existsSync(join(archive, "logs", "a.log"))).toBe(true);
+      // safelist still in place
+      expect(existsSync(join(h.configDir, "vault", "config.json"))).toBe(true);
+      expect(existsSync(join(h.configDir, "services.json"))).toBe(true);
+      expect(existsSync(join(h.configDir, "well-known"))).toBe(true);
+      expect(existsSync(join(h.configDir, "hub"))).toBe(true);
+      // originals gone
+      expect(existsSync(join(h.configDir, "daily.db"))).toBe(false);
+      expect(existsSync(join(h.configDir, "server.yaml"))).toBe(false);
+      expect(existsSync(join(h.configDir, "logs"))).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("prompt 'n' aborts with exit 1, no changes", async () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      touch(join(h.configDir, "daily.db"), "X");
+      const logs: string[] = [];
+      const code = await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: (l) => logs.push(l),
+        prompt: async () => "n",
+      });
+      expect(code).toBe(1);
+      expect(logs.join("\n")).toMatch(/aborted/i);
+      expect(existsSync(join(h.configDir, "daily.db"))).toBe(true);
+      expect(existsSync(join(h.configDir, ".archive-2026-04-19"))).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("prompt 'y' (and 'yes') proceeds", async () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      touch(join(h.configDir, "cruft.txt"), "Z");
+      const code = await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: () => {},
+        prompt: async () => "y",
+      });
+      expect(code).toBe(0);
+      expect(existsSync(join(h.configDir, ".archive-2026-04-19", "cruft.txt"))).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("re-run same day reuses the same .archive-<date>/", async () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      touch(join(h.configDir, "first.txt"), "1");
+      await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: () => {},
+        yes: true,
+      });
+      // Add more cruft and sweep again the same day
+      touch(join(h.configDir, "second.txt"), "2");
+      await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: () => {},
+        yes: true,
+      });
+      const archive = join(h.configDir, ".archive-2026-04-19");
+      expect(existsSync(join(archive, "first.txt"))).toBe(true);
+      expect(existsSync(join(archive, "second.txt"))).toBe(true);
+      // Only one archive dir at root
+      const archiveDirs = readdirSync(h.configDir).filter((n) => n.startsWith(".archive-"));
+      expect(archiveDirs).toEqual([".archive-2026-04-19"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("different day creates a second archive dir; prior one is left alone", async () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      touch(join(h.configDir, "day1.txt"), "1");
+      await migrate({ configDir: h.configDir, now: () => APRIL_19, log: () => {}, yes: true });
+      touch(join(h.configDir, "day2.txt"), "2");
+      await migrate({ configDir: h.configDir, now: () => APRIL_20, log: () => {}, yes: true });
+      expect(existsSync(join(h.configDir, ".archive-2026-04-19", "day1.txt"))).toBe(true);
+      expect(existsSync(join(h.configDir, ".archive-2026-04-20", "day2.txt"))).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("conflicting name in today's archive gets a .dup suffix", async () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      // Pre-existing archive with a same-name entry.
+      mkdirSync(join(h.configDir, ".archive-2026-04-19"), { recursive: true });
+      touch(join(h.configDir, ".archive-2026-04-19", "notes.md"), "old");
+      // New cruft with the same name.
+      touch(join(h.configDir, "notes.md"), "new");
+      await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: () => {},
+        yes: true,
+      });
+      const archive = join(h.configDir, ".archive-2026-04-19");
+      const contents = readdirSync(archive);
+      expect(contents).toContain("notes.md");
+      expect(contents.some((n) => n.startsWith("notes.md.dup-"))).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("migrateNotice", () => {
+  test("undefined when nothing to archive", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      expect(migrateNotice(h.configDir, APRIL_19)).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("returns a single line with the count when cruft exists", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      touch(join(h.configDir, "daily.db"), "x");
+      touch(join(h.configDir, "stray"), "y");
+      const notice = migrateNotice(h.configDir, APRIL_19);
+      expect(notice).toBeDefined();
+      expect(notice).toMatch(/parachute migrate/);
+      expect(notice).toMatch(/2 unrecognized/);
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import pkg from "../package.json" with { type: "json" };
 import { exposePublic, exposeTailnet } from "./commands/expose.ts";
 import { install } from "./commands/install.ts";
 import { logs, restart, start, stop } from "./commands/lifecycle.ts";
+import { migrate } from "./commands/migrate.ts";
 import { status } from "./commands/status.ts";
 import { dispatchVault } from "./commands/vault.ts";
 import { ExposeStateError } from "./expose-state.ts";
@@ -17,6 +18,7 @@ import {
   exposeHelp,
   installHelp,
   logsHelp,
+  migrateHelp,
   restartHelp,
   startHelp,
   statusHelp,
@@ -133,6 +135,22 @@ async function main(argv: string[]): Promise<number> {
       }
       const follow = rest.includes("-f") || rest.includes("--follow");
       return await logs(svc, { follow });
+    }
+
+    case "migrate": {
+      if (isHelpFlag(rest[0])) {
+        console.log(migrateHelp());
+        return 0;
+      }
+      const dryRun = rest.includes("--dry-run");
+      const yes = rest.includes("--yes") || rest.includes("-y");
+      const unknown = rest.find((a) => a !== "--dry-run" && a !== "--yes" && a !== "-y");
+      if (unknown !== undefined) {
+        console.error(`parachute migrate: unknown argument "${unknown}"`);
+        console.error("usage: parachute migrate [--dry-run] [--yes]");
+        return 1;
+      }
+      return await migrate({ dryRun, yes });
     }
 
     case "vault":

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,12 +1,15 @@
-import { SERVICES_MANIFEST_PATH } from "../config.ts";
+import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import { getSpec, knownServices } from "../service-spec.ts";
 import { findService } from "../services-manifest.ts";
+import { migrateNotice } from "./migrate.ts";
 
 export type Runner = (cmd: readonly string[]) => Promise<number>;
 
 export interface InstallOpts {
   runner?: Runner;
   manifestPath?: string;
+  configDir?: string;
+  now?: () => Date;
   log?: (line: string) => void;
 }
 
@@ -18,6 +21,8 @@ async function defaultRunner(cmd: readonly string[]): Promise<number> {
 export async function install(service: string, opts: InstallOpts = {}): Promise<number> {
   const runner = opts.runner ?? defaultRunner;
   const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const configDir = opts.configDir ?? CONFIG_DIR;
+  const now = opts.now ?? (() => new Date());
   const log = opts.log ?? ((line) => console.log(line));
 
   const spec = getSpec(service);
@@ -51,5 +56,9 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
   } else {
     log(`✓ ${spec.manifestName} registered on port ${entry.port}`);
   }
+
+  const notice = migrateNotice(configDir, now());
+  if (notice) log(notice);
+
   return 0;
 }

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,0 +1,231 @@
+import { existsSync, mkdirSync, readdirSync, renameSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { createInterface } from "node:readline/promises";
+import { CONFIG_DIR } from "../config.ts";
+import { knownServices } from "../service-spec.ts";
+
+/**
+ * `parachute migrate` — sweep unrecognized entries at the ecosystem root
+ * (`~/.parachute/`) into a dated archive directory so pre-restructure cruft
+ * doesn't confuse beta installs.
+ *
+ * Archive, never delete: moved under `.archive-<YYYY-MM-DD>/` so anything
+ * swept is recoverable. Dotfiles and the recognized top-level entries
+ * (service dirs, services.json, expose-state.json, well-known/) are left
+ * alone. Content *inside* service dirs is owned by that service's own
+ * migration.
+ */
+
+export const ARCHIVE_PREFIX = ".archive-";
+
+/**
+ * Top-level names we keep in place. Service dirs derive from
+ * `knownServices()` so adding a service doesn't require touching migrate;
+ * `hub` is added explicitly since it's an internal-only lifecycle dir not
+ * in SERVICE_SPECS.
+ */
+export function safelistEntries(): Set<string> {
+  return new Set<string>([
+    ...knownServices(),
+    "hub",
+    "services.json",
+    "expose-state.json",
+    "well-known",
+  ]);
+}
+
+/**
+ * Friendly labels for entries we've seen in the wild. Matched by exact name
+ * or (for sqlite companion files) by prefix. Purely cosmetic — drives the
+ * annotation column in the plan printout.
+ */
+const KNOWN_CRUFT: Array<{ match: (name: string) => boolean; label: string }> = [
+  {
+    match: (n) => n === "daily.db" || n.startsWith("daily.db-"),
+    label: "legacy parachute-daily state",
+  },
+  { match: (n) => n === "server.yaml", label: "legacy server config" },
+  { match: (n) => n === "channel.log" || n === "channel.err", label: "legacy channel logs" },
+  { match: (n) => n === "channel.start.sh", label: "legacy channel launcher" },
+  { match: (n) => n === "logs", label: "vestigial top-level logs dir" },
+  {
+    match: (n) => n === "tokens.db" || n.startsWith("tokens.db-"),
+    label: "legacy top-level tokens db",
+  },
+];
+
+function annotationFor(name: string): string | undefined {
+  for (const rule of KNOWN_CRUFT) if (rule.match(name)) return rule.label;
+  return undefined;
+}
+
+export interface ArchiveItem {
+  name: string;
+  absPath: string;
+  kind: "file" | "dir";
+  bytes: number;
+  annotation?: string;
+}
+
+export interface ArchivePlan {
+  archiveDirName: string;
+  archiveDir: string;
+  items: ArchiveItem[];
+  totalBytes: number;
+}
+
+function sizeOf(path: string): number {
+  const st = statSync(path);
+  if (!st.isDirectory()) return st.size;
+  let total = 0;
+  for (const entry of readdirSync(path, { withFileTypes: true })) {
+    total += sizeOf(join(path, entry.name));
+  }
+  return total;
+}
+
+function archiveDirName(now: Date): string {
+  return `${ARCHIVE_PREFIX}${now.toISOString().slice(0, 10)}`;
+}
+
+/**
+ * Inspect the ecosystem root and build a plan. Pure-ish: reads filesystem
+ * but never mutates. Returns zero-length items when nothing is archivable.
+ *
+ * Rule: skip anything starting with "." (dotfiles are the user's — `.env`,
+ * `.DS_Store`, prior `.archive-*` dirs, etc.) and anything in the safelist.
+ */
+export function planArchive(configDir: string, now: Date): ArchivePlan {
+  const dirName = archiveDirName(now);
+  const archiveDir = join(configDir, dirName);
+  const plan: ArchivePlan = {
+    archiveDirName: dirName,
+    archiveDir,
+    items: [],
+    totalBytes: 0,
+  };
+  if (!existsSync(configDir)) return plan;
+
+  const safelist = safelistEntries();
+  const entries = readdirSync(configDir, { withFileTypes: true }).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) continue;
+    if (safelist.has(entry.name)) continue;
+    const abs = join(configDir, entry.name);
+    const bytes = sizeOf(abs);
+    plan.items.push({
+      name: entry.name,
+      absPath: abs,
+      kind: entry.isDirectory() ? "dir" : "file",
+      bytes,
+      annotation: annotationFor(entry.name),
+    });
+    plan.totalBytes += bytes;
+  }
+  return plan;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB"];
+  let v = bytes / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i += 1;
+  }
+  return `${v.toFixed(1)} ${units[i]}`;
+}
+
+function formatPlan(plan: ArchivePlan): string[] {
+  const lines: string[] = [];
+  lines.push(
+    `Will archive: ${plan.items.length} item${plan.items.length === 1 ? "" : "s"} (${formatBytes(plan.totalBytes)}) → ${plan.archiveDirName}/`,
+  );
+  for (const item of plan.items) {
+    const kindMark = item.kind === "dir" ? "/" : "";
+    const note = item.annotation ? `  — ${item.annotation}` : "";
+    lines.push(`  ${item.name}${kindMark}  (${formatBytes(item.bytes)})${note}`);
+  }
+  return lines;
+}
+
+/**
+ * Pick a destination name inside the archive dir. If a prior sweep the same
+ * day already archived the same name, suffix with `.dup-<epoch-ms>` so we
+ * never clobber. Rare in practice.
+ */
+function resolveDest(archiveDir: string, name: string, now: Date): string {
+  const target = join(archiveDir, name);
+  if (!existsSync(target)) return target;
+  return join(archiveDir, `${name}.dup-${now.getTime()}`);
+}
+
+export async function defaultPrompt(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await rl.question(question);
+  rl.close();
+  return answer;
+}
+
+export interface MigrateOpts {
+  configDir?: string;
+  now?: () => Date;
+  log?: (line: string) => void;
+  prompt?: (question: string) => Promise<string>;
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+export async function migrate(opts: MigrateOpts = {}): Promise<number> {
+  const configDir = opts.configDir ?? CONFIG_DIR;
+  const now = (opts.now ?? (() => new Date()))();
+  const log = opts.log ?? ((line) => console.log(line));
+  const prompt = opts.prompt ?? defaultPrompt;
+  const dryRun = opts.dryRun ?? false;
+  const yes = opts.yes ?? false;
+
+  const plan = planArchive(configDir, now);
+  if (plan.items.length === 0) {
+    log(`Nothing to archive. ${configDir} is already clean.`);
+    return 0;
+  }
+
+  for (const line of formatPlan(plan)) log(line);
+
+  if (dryRun) {
+    log("(dry-run — no changes made)");
+    return 0;
+  }
+
+  if (!yes) {
+    const answer = (await prompt("Proceed? [y/N] ")).trim().toLowerCase();
+    if (answer !== "y" && answer !== "yes") {
+      log("Aborted.");
+      return 1;
+    }
+  }
+
+  mkdirSync(plan.archiveDir, { recursive: true });
+  for (const item of plan.items) {
+    const dest = resolveDest(plan.archiveDir, item.name, now);
+    renameSync(item.absPath, dest);
+  }
+  log(
+    `✓ Archived ${plan.items.length} item${plan.items.length === 1 ? "" : "s"} to ${plan.archiveDirName}/`,
+  );
+  return 0;
+}
+
+/**
+ * One-line notice for contexts where migrate is *not* what the user
+ * asked for (e.g., after `parachute install`). Returns undefined when
+ * there's nothing archivable so callers can branch on truthy/falsy.
+ */
+export function migrateNotice(configDir: string, now: Date): string | undefined {
+  const plan = planArchive(configDir, now);
+  if (plan.items.length === 0) return undefined;
+  return `parachute migrate: ${plan.items.length} unrecognized entr${plan.items.length === 1 ? "y" : "ies"} at ecosystem root — run 'parachute migrate' to archive.`;
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -15,6 +15,7 @@ Usage:
   parachute logs <service> [-f]     print service logs; -f to tail
   parachute expose tailnet [off]    HTTPS across your tailnet
   parachute expose public  [off]    HTTPS on the public internet (Funnel)
+  parachute migrate [--dry-run]     archive legacy files at ecosystem root
   parachute vault <args...>         dispatch to parachute-vault
 
 Flags:
@@ -177,6 +178,34 @@ Log file:
   ~/.parachute/<service>/logs/<service>.log
 
 If no log file exists yet, prints a hint to \`parachute start <service>\`.
+`;
+}
+
+export function migrateHelp(): string {
+  return `parachute migrate — archive legacy files at the ecosystem root
+
+Usage:
+  parachute migrate [--dry-run] [--yes]
+
+What it does:
+  Scans ~/.parachute/ for files and directories that don't belong to the
+  post-restructure layout. Recognized entries — per-service dirs
+  (vault/, notes/, scribe/, channel/, hub/), services.json,
+  expose-state.json, well-known/ — stay in place. Anything else (plus
+  known legacy cruft like daily.db, server.yaml) is moved under
+  ~/.parachute/.archive-<YYYY-MM-DD>/, never deleted.
+
+  Dotfiles at the root (.env, .DS_Store, prior .archive-* dirs) are left
+  alone.
+
+Flags:
+  --dry-run     print the plan; make no changes
+  --yes, -y     skip the confirmation prompt
+
+Examples:
+  parachute migrate --dry-run       see what would move, without touching anything
+  parachute migrate                 interactive sweep (prompts before acting)
+  parachute migrate --yes           sweep without prompting
 `;
 }
 


### PR DESCRIPTION
## Why

Pre-launch cleanup. `~/.parachute/` is the ecosystem root; after the per-service restructure it should only contain per-service dirs (`vault/`, `notes/`, `scribe/`, `channel/`, `hub/`), CLI state (`services.json`, `expose-state.json`), and `well-known/`. Aaron's real machine has accumulated top-level files from before the restructure (`daily.db`, `server.yaml`, a stray `logs/` dir, `channel.log`, `tokens.db*`) that we want to sweep before beta grows. Rather than delete, archive to `~/.parachute/.archive-<YYYY-MM-DD>/` — reversible, recoverable, low-risk.

Pairs with concurrent vault + scribe internal-hygiene PRs. Either ordering of this and the vault PR works: if vault pulls `tokens.db*` into `vault/` first, this migrate just won't see them; if this sweeps them first, vault's boot will start with fresh tokens. Not worth blocking on ordering.

## What

- `parachute migrate` (`src/commands/migrate.ts`): scans the root, builds a plan, prompts (unless `--yes`), moves unrecognized entries to `.archive-<YYYY-MM-DD>/`.
- `--dry-run` prints the plan without touching anything.
- Safelist derived from `knownServices()` plus `hub`, the two state files, and `well-known/`, so adding a new service doesn't require editing migrate.
- Dotfiles at the root are always left alone — safer default; `.env`, prior `.archive-*`, `.DS_Store` stay.
- Content *inside* service dirs is each service's own migration to do. Migrate never crosses that boundary.
- Known-cruft labels (`daily.db — legacy parachute-daily state`, etc.) so the plan is readable.
- Same-day re-run reuses the same `.archive-<date>/`; conflicting names get a `.dup-<ms>` suffix.
- `parachute install` prints a one-line notice when anything is archivable, so the first install on an older machine surfaces the need without doing it implicitly.

## Test plan

- [x] `bun test` — 150 pass, 0 fail (with clean `PARACHUTE_HOME`)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Manual smoke: seeded tmp dir with `daily.db`, `server.yaml`, `logs/`, `.env`, `services.json`, `vault/` — `--dry-run` prints plan, `--yes` archives cruft, safelist + `.env` untouched.
- [ ] Aaron runs `parachute migrate --dry-run` on his real `~/.parachute/` and confirms the plan looks right before letting it sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)