### PR TITLE
hotfix: route public mode through `tailscale funnel` subcommand (1.82+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install, inspect, and expose Parachute services with one command. Each service (
 bun add -g @openparachute/cli
 ```
 
-Prereqs: [Bun](https://bun.sh), and — for `parachute expose` — [Tailscale](https://tailscale.com/download) installed and `tailscale up` run at least once.
+Prereqs: [Bun](https://bun.sh), and — for `parachute expose` — [Tailscale](https://tailscale.com/download) **1.82 or newer** installed and `tailscale up` run at least once. (1.82 is when `tailscale funnel` was split out into its own subcommand; the CLI targets the modern shape only.)
 
 ## First 5 minutes
 
@@ -78,9 +78,9 @@ Each additive; each can be turned off without affecting the layer below.
 
 - **Local** — services on loopback. Zero config. Browsers treat `localhost` as a secure context, so OAuth, PKCE, and Web Crypto all just work out of the box.
 - **Tailnet** — `parachute expose tailnet` wraps `tailscale serve` for every registered service. HTTPS via Tailscale's MagicDNS cert. Only machines on your tailnet can reach the URL.
-- **Public** — `parachute expose public` adds `--funnel` to each handler so the same URLs become reachable from the public internet. At launch, Funnel is the only supported backend; Caddy + your-own-domain and cloudflared tunnels are planned post-launch.
+- **Public** — `parachute expose public` routes each handler through `tailscale funnel` so the same URLs become reachable from the public internet. At launch, Funnel is the only supported backend; Caddy + your-own-domain and cloudflared tunnels are planned post-launch.
 
-Under the hood, tailnet and public share a single `tailscale serve` config. The CLI records which layer is live so that `expose <other-layer> off` is a no-op rather than a surprise teardown of the active layer.
+Under the hood, tailnet mode uses `tailscale serve` and public mode uses `tailscale funnel`; both write into the same node-level serve config. The CLI records which layer is live so that `expose <other-layer> off` is a no-op rather than a surprise teardown of the active layer.
 
 ## Path-routing (and why)
 

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -133,7 +133,9 @@ describe("expose tailnet up", () => {
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
       expect(serveCalls).toHaveLength(4);
+      // Tailnet mode never uses funnel — neither the old flag nor the new subcommand.
       expect(serveCalls.every((c) => !c.includes("--funnel"))).toBe(true);
+      expect(calls.every((c) => c[1] !== "funnel")).toBe(true);
 
       const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path="))).sort();
       expect(mounts).toEqual([
@@ -604,7 +606,7 @@ describe("expose tailnet off", () => {
 });
 
 describe("expose public up", () => {
-  test("adds --funnel to every serve command and records layer=public", async () => {
+  test("routes every bringup through `tailscale funnel` and records layer=public", async () => {
     const h = makeHarness();
     try {
       seedServices(h.manifestPath);
@@ -624,11 +626,15 @@ describe("expose public up", () => {
       });
       expect(code).toBe(0);
 
-      const serveCalls = calls.filter(
-        (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
+      // Modern tailscale (1.82+) rejects `serve --funnel`; public mode must use
+      // the `funnel` subcommand instead.
+      const funnelCalls = calls.filter(
+        (c) => c[0] === "tailscale" && c[1] === "funnel" && c.includes("--bg"),
       );
-      expect(serveCalls).toHaveLength(4);
-      expect(serveCalls.every((c) => c.includes("--funnel"))).toBe(true);
+      expect(funnelCalls).toHaveLength(4);
+      // Never emit the legacy `serve --funnel` shape.
+      expect(calls.every((c) => !c.includes("--funnel"))).toBe(true);
+      expect(calls.every((c) => !(c[1] === "serve" && c.includes("--bg")))).toBe(true);
 
       const state = readExposeState(h.statePath);
       expect(state?.layer).toBe("public");
@@ -636,6 +642,53 @@ describe("expose public up", () => {
       expect(state?.entries).toHaveLength(4);
 
       expect(logs.join("\n")).toMatch(/Public exposure active/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("switching from public to tailnet tears prior state down via `tailscale funnel … off`", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      writeExposeState(
+        {
+          version: 1,
+          layer: "public",
+          mode: "path",
+          canonicalFqdn: "parachute.taildf9ce2.ts.net",
+          port: 443,
+          funnel: true,
+          entries: [
+            {
+              kind: "proxy",
+              mount: "/vault/default",
+              target: "http://127.0.0.1:1940/vault/default",
+              service: "parachute-vault",
+            },
+          ],
+        },
+        h.statePath,
+      );
+      const { runner, calls } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      // Prior was public → teardown must use `tailscale funnel … off`,
+      // not `tailscale serve … off` (which wouldn't drop the funnel entry on 1.82+).
+      const offs = calls.filter((c) => c[c.length - 1] === "off");
+      expect(offs).toHaveLength(1);
+      expect(offs[0]?.[1]).toBe("funnel");
     } finally {
       h.cleanup();
     }
@@ -689,7 +742,7 @@ describe("expose public up", () => {
 });
 
 describe("expose public off", () => {
-  test("tears down public exposure and clears state", async () => {
+  test("tears down public exposure via `tailscale funnel … off` and clears state", async () => {
     const h = makeHarness();
     try {
       writeExposeState(
@@ -723,7 +776,10 @@ describe("expose public off", () => {
         log: () => {},
       });
       expect(code).toBe(0);
-      expect(calls.every((c) => c[c.length - 1] === "off")).toBe(true);
+      // Public teardown must use the funnel subcommand, matching bringup.
+      const offCalls = calls.filter((c) => c[c.length - 1] === "off");
+      expect(offCalls.length).toBeGreaterThan(0);
+      expect(offCalls.every((c) => c[1] === "funnel")).toBe(true);
       expect(existsSync(h.statePath)).toBe(false);
     } finally {
       h.cleanup();

--- a/src/__tests__/hub-control.test.ts
+++ b/src/__tests__/hub-control.test.ts
@@ -179,6 +179,30 @@ describe("ensureHubRunning", () => {
     }
   });
 
+  test("skips reserved service ports during fallback", async () => {
+    // Hub defaults start at 1939 and walk up. Vault claims 1940, so without
+    // reservation the hub would steal it when vault isn't yet bound. Reserved
+    // ports must be skipped over during fallback.
+    const h = makeHarness();
+    try {
+      const spawner = makeSpawner(3333);
+      const result = await ensureHubRunning({
+        configDir: h.configDir,
+        wellKnownDir: h.wellKnownDir,
+        spawner,
+        alive: () => true,
+        probe: probeTaken(new Set([1939])), // default port is held
+        reservedPorts: [1940], // vault's reservation
+        readyWaitMs: 0,
+      });
+      // 1939 is taken, 1940 is reserved → we get 1941.
+      expect(result.port).toBe(1941);
+      expect(readHubPort(h.configDir)).toBe(1941);
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("honors startPort override", async () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/tailscale-commands.test.ts
+++ b/src/__tests__/tailscale-commands.test.ts
@@ -56,12 +56,13 @@ describe("tailscale commands", () => {
     ]);
   });
 
-  test("bringup adds --funnel when funnel=true", () => {
+  test("bringup uses `tailscale funnel` subcommand when funnel=true", () => {
+    // Modern tailscale (1.82+) split funnel out of serve. Public mode must
+    // route through `tailscale funnel`, not `tailscale serve --funnel`.
     expect(bringupCommand(proxyEntry, { funnel: true })).toEqual([
       "tailscale",
-      "serve",
+      "funnel",
       "--bg",
-      "--funnel",
       "--https=443",
       "--set-path=/",
       "http://127.0.0.1:1940",
@@ -92,6 +93,18 @@ describe("tailscale commands", () => {
       "serve",
       "--https=443",
       "--set-path=/.well-known/parachute.json",
+      "off",
+    ]);
+  });
+
+  test("teardown routes through `tailscale funnel` when funnel=true", () => {
+    // Same subcommand split applies to teardown — `serve … off` doesn't
+    // remove a funnel-mounted entry on 1.82+.
+    expect(teardownCommand(proxyEntry, { funnel: true })).toEqual([
+      "tailscale",
+      "funnel",
+      "--https=443",
+      "--set-path=/",
       "off",
     ]);
   });

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -185,7 +185,9 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
   if (prior && prior.entries.length > 0) {
     const priorLabel = layerLabel(prior.layer);
     log(`Found prior ${priorLabel} exposure; tearing down ${prior.entries.length} entries first…`);
-    const teardownCmds = prior.entries.map((e) => teardownCommand(e, { port: prior.port }));
+    const teardownCmds = prior.entries.map((e) =>
+      teardownCommand(e, { port: prior.port, funnel: prior.funnel }),
+    );
     const code = await runEach(runner, teardownCmds, log);
     if (code !== 0) {
       log("Teardown of prior state failed; aborting.");
@@ -210,6 +212,7 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
     hubPort = existing;
   } else {
     const hub = await ensureHubRunning({
+      reservedPorts: services.map((s) => s.port),
       ...(opts.hubEnsureOpts ?? {}),
       configDir,
       wellKnownDir,
@@ -277,7 +280,9 @@ export async function exposeOff(layer: ExposeLayer, opts: ExposeOpts = {}): Prom
   }
 
   log(`Tearing down ${state.entries.length} ${layerLabel(layer)} serve entries…`);
-  const cmds = state.entries.map((e) => teardownCommand(e, { port: state.port }));
+  const cmds = state.entries.map((e) =>
+    teardownCommand(e, { port: state.port, funnel: state.funnel }),
+  );
   const code = await runEach(runner, cmds, log);
   if (code !== 0) {
     log("Teardown failed. State file left in place so you can retry.");

--- a/src/hub-control.ts
+++ b/src/hub-control.ts
@@ -109,6 +109,13 @@ export interface EnsureHubOpts {
   startPort?: number;
   /** How many ports to try before giving up (default 20). */
   fallbackRange?: number;
+  /**
+   * Ports to skip during fallback — typically service ports from services.json
+   * so the hub doesn't steal a port a registered service will bind later.
+   * Probed ports that happen to be listening still fail the probe on their own;
+   * this guards the case where the service isn't running yet.
+   */
+  reservedPorts?: Iterable<number>;
   /** How long to wait after spawn before claiming readiness. Short — tests set to 0. */
   readyWaitMs?: number;
   log?: (line: string) => void;
@@ -130,6 +137,7 @@ export async function ensureHubRunning(opts: EnsureHubOpts = {}): Promise<Ensure
   const sleep = opts.sleep ?? defaultSleep;
   const startPort = opts.startPort ?? HUB_DEFAULT_PORT;
   const fallbackRange = opts.fallbackRange ?? HUB_PORT_FALLBACK_RANGE;
+  const reservedPorts = new Set(opts.reservedPorts ?? []);
   const readyWaitMs = opts.readyWaitMs ?? 150;
   const log = opts.log ?? (() => {});
 
@@ -145,6 +153,7 @@ export async function ensureHubRunning(opts: EnsureHubOpts = {}): Promise<Ensure
   let chosenPort: number | undefined;
   for (let i = 0; i < fallbackRange; i++) {
     const candidate = startPort + i;
+    if (reservedPorts.has(candidate)) continue;
     if (await probe(candidate)) {
       chosenPort = candidate;
       break;

--- a/src/tailscale/commands.ts
+++ b/src/tailscale/commands.ts
@@ -10,17 +10,32 @@ export interface BringupOpts {
   port?: number;
 }
 
+/**
+ * Funnel was a flag on `tailscale serve` through ~1.80; from 1.82 onward
+ * it's a separate `tailscale funnel` subcommand with the same syntax minus
+ * the `--funnel` flag. Modern tailscale (1.82+) rejects `serve --funnel`
+ * outright: "flag provided but not defined: -funnel". Pick the subcommand
+ * up-front; we don't support the pre-split syntax.
+ */
+function serveVerb(funnel: boolean): string {
+  return funnel ? "funnel" : "serve";
+}
+
 export function bringupCommand(entry: ServeEntry, opts: BringupOpts = {}): string[] {
   const port = opts.port ?? 443;
-  const cmd = ["tailscale", "serve", "--bg"];
-  if (opts.funnel) cmd.push("--funnel");
-  cmd.push(`--https=${port}`);
-  cmd.push(`--set-path=${entry.mount}`);
-  cmd.push(entry.target);
-  return cmd;
+  const funnel = opts.funnel === true;
+  return [
+    "tailscale",
+    serveVerb(funnel),
+    "--bg",
+    `--https=${port}`,
+    `--set-path=${entry.mount}`,
+    entry.target,
+  ];
 }
 
 export function teardownCommand(entry: ServeEntry, opts: BringupOpts = {}): string[] {
   const port = opts.port ?? 443;
-  return ["tailscale", "serve", `--https=${port}`, `--set-path=${entry.mount}`, "off"];
+  const funnel = opts.funnel === true;
+  return ["tailscale", serveVerb(funnel), `--https=${port}`, `--set-path=${entry.mount}`, "off"];
 }


### PR DESCRIPTION
## Why

Launch blocker — `parachute expose public` is broken on every current Tailscale install.

Tailscale 1.82 (Dec 2024) split `funnel` out of `serve` into its own subcommand with the same syntax minus the `--funnel` flag. Modern tailscaled rejects the pre-split form outright:

```
flag provided but not defined: -funnel
```

We were emitting `tailscale serve --bg --funnel --https=443 …` on public bringup — that fails, and the stale state it leaves behind (see known issues below) compounds the problem.

This routes public mode through the `tailscale funnel` subcommand for both bringup **and** teardown. Tailnet mode is unchanged. Both subcommands write into the same node-level serve config, so teardown has to use the matching verb — `serve … off` will not remove a funnel-mounted entry on 1.82+, which is why `expose-state.json` already tracks `funnel: boolean` and we pass it through on teardown paths (including the layer-switch teardown that fires when you flip from public to tailnet).

## Also in this PR

**Hub port fallback skips service-reserved ports.** The hub defaults to 1939 and walks up on collision. Vault claims 1940 but only binds it when running — during the narrow window where vault is registered but not yet bound, the hub was eligible to steal it. `ensureHubRunning` now takes a `reservedPorts` list (sourced from `services.json` ports) and skips over those candidates during fallback.

**README.** Prereq bumped to Tailscale 1.82+, with a one-line note on why. Public-layer description updated to name `tailscale funnel` directly.

## Test coverage

- `tailscale-commands.test.ts` — bringup/teardown emit `tailscale funnel …` (no `--funnel` flag) when `funnel: true`
- `expose.test.ts` — public up emits funnel subcommand calls, asserts no `--funnel` flag and no `serve --bg` in the public path; public off uses funnel subcommand; switching public → tailnet tears the prior funnel state down via `tailscale funnel … off`
- `hub-control.test.ts` — new "skips reserved service ports during fallback" test (1939 taken, 1940 reserved → hub lands on 1941)

138 tests pass, typecheck clean, lint clean.

## Known issue — not addressed this round

If a `public` bringup fails midway (e.g. Funnel quota hit, network blip), `expose-state.json` can end up recording a layer that was never fully stood up. Subsequent `expose … off` then tries to tear down entries tailscaled never registered, which logs scary-looking errors even though the node state is already clean. We should either (a) only write the state file after bringup succeeds, or (b) make teardown tolerant of "no such entry" responses. Worth a follow-up PR; not a launch blocker.

## Launch

Targeted for Wed 2026-04-23. Aaron is live-testing on a 1.82+ node — this should unblock that path immediately on merge.