### PR TITLE
feat: port coherence (1939–1949) + expose warns on dead services

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,25 @@ Why path-routing and not subdomain-per-service? Two reasons:
 
 Funnel has bandwidth quotas on Tailscale's free tier. See [tailscale.com/kb/1223/funnel](https://tailscale.com/kb/1223/funnel) for current limits; for heavy traffic, the post-launch Caddy / cloudflared modes will be the answer.
 
+## Ports
+
+Parachute services reserve a block of loopback ports in the canonical range **1939–1949**. One range, one firewall rule, no surprises.
+
+| Port | Service            |
+| ---- | ------------------ |
+| 1939 | parachute-hub (internal proxy + static) |
+| 1940 | parachute-vault    |
+| 1941 | parachute-channel  |
+| 1942 | parachute-notes    |
+| 1943 | parachute-scribe   |
+| 1944 | *reserved — pendant*  |
+| 1945 | *reserved — daily-v2* |
+| 1946–1949 | *reserved* |
+
+The hub pins 1939 — no fallback. If something else is on 1939 when you run `parachute expose`, the command fails with a pointer to `lsof -iTCP:1939` rather than walking up into another service's slot. `parachute install` warns (but doesn't block) if a service's declared port lands outside the canonical range.
+
+`parachute expose` probes every service's port at bringup. A service that isn't responding still gets exposed, but you get a `⚠ parachute-<svc> (port …) is not responding` line so proxied requests never silently 502 without explanation.
+
 ## How services register
 
 Each Parachute service writes a manifest entry to `~/.parachute/services.json` on install. The CLI reads that manifest to drive `parachute status`, `parachute expose tailnet`, and `parachute expose public`.

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -108,6 +108,9 @@ function seedServices(path: string): void {
   );
 }
 
+/** Default probe for tests: every service is up (nobody wants dead-service warnings polluting unrelated assertions). */
+const allServicesUp = async () => true;
+
 describe("expose tailnet up", () => {
   test("mounts hub proxy at /, one proxy per service, plus well-known proxy", async () => {
     const h = makeHarness();
@@ -125,6 +128,7 @@ describe("expose tailnet up", () => {
         wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -194,6 +198,7 @@ describe("expose tailnet up", () => {
         wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
         log: () => {},
       });
       expect(code).toBe(0);
@@ -235,6 +240,7 @@ describe("expose tailnet up", () => {
         wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
         log: () => {},
       });
       expect(code).toBe(0);
@@ -268,6 +274,7 @@ describe("expose tailnet up", () => {
         wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -301,6 +308,7 @@ describe("expose tailnet up", () => {
         wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(1);
@@ -328,6 +336,7 @@ describe("expose tailnet up", () => {
         wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(1);
@@ -371,12 +380,52 @@ describe("expose tailnet up", () => {
         wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
         log: () => {},
       });
       expect(code).toBe(0);
       const offs = calls.filter((c) => c[c.length - 1] === "off");
       expect(offs).toHaveLength(1);
       expect(offs[0]).toContain("--set-path=/old-service");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("warns (but still exposes) when a service port isn't responding", async () => {
+    // Aaron hit this: vault was quietly stopped, `parachute expose tailnet`
+    // happily proxied /vault/default to a dead port, every request 502'd.
+    // Now we probe and warn — but don't fail, so users can stand up layers
+    // before starting services if they want.
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      const { runner, calls } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const logs: string[] = [];
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        // vault is up; notes is down.
+        servicePortProbe: async (port) => port === 1940,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      const joined = logs.join("\n");
+      expect(joined).toMatch(/parachute-notes \(port 5173\) is not responding/);
+      expect(joined).toMatch(/parachute start notes/);
+      expect(joined).not.toMatch(/parachute-vault.*not responding/);
+      // Bringup still happened — all four entries got staged.
+      const serveCalls = calls.filter(
+        (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
+      );
+      expect(serveCalls).toHaveLength(4);
     } finally {
       h.cleanup();
     }
@@ -411,6 +460,7 @@ describe("expose tailnet up", () => {
         wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(2);
@@ -622,6 +672,7 @@ describe("expose public up", () => {
         wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -681,6 +732,7 @@ describe("expose public up", () => {
         wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
         log: () => {},
       });
       expect(code).toBe(0);
@@ -728,6 +780,7 @@ describe("expose public up", () => {
         wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
         log: () => {},
       });
       expect(code).toBe(0);

--- a/src/__tests__/hub-control.test.ts
+++ b/src/__tests__/hub-control.test.ts
@@ -95,7 +95,29 @@ describe("ensureHubRunning", () => {
     }
   });
 
-  test("falls back to next port when default is taken", async () => {
+  test("default fallback is 1 slot: fails when 1939 is taken", async () => {
+    // Canonical layout pins hub to 1939. Walking up would collide with the
+    // next service's slot, so the default is to fail and let the user unblock
+    // the port — not quietly land somewhere else.
+    const h = makeHarness();
+    try {
+      const spawner = makeSpawner(7777);
+      await expect(
+        ensureHubRunning({
+          configDir: h.configDir,
+          wellKnownDir: h.wellKnownDir,
+          spawner,
+          alive: () => true,
+          probe: probeTaken(new Set([1939])),
+          readyWaitMs: 0,
+        }),
+      ).rejects.toThrow(/lsof -iTCP:1939/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("fallback walks up when caller widens the range (debug/tests only)", async () => {
     const h = makeHarness();
     try {
       const spawner = makeSpawner(7777);
@@ -106,6 +128,7 @@ describe("ensureHubRunning", () => {
         alive: () => true,
         probe: probeTaken(new Set([1939, 1940])),
         readyWaitMs: 0,
+        fallbackRange: 5,
       });
       expect(result.port).toBe(1941);
       expect(readHubPort(h.configDir)).toBe(1941);
@@ -173,16 +196,16 @@ describe("ensureHubRunning", () => {
           readyWaitMs: 0,
           fallbackRange: 3,
         }),
-      ).rejects.toThrow(/no free port/);
+      ).rejects.toThrow(/unavailable/);
     } finally {
       h.cleanup();
     }
   });
 
-  test("skips reserved service ports during fallback", async () => {
-    // Hub defaults start at 1939 and walk up. Vault claims 1940, so without
-    // reservation the hub would steal it when vault isn't yet bound. Reserved
-    // ports must be skipped over during fallback.
+  test("skips reserved service ports during fallback (widened range)", async () => {
+    // Fallback is off by default (range=1). When a caller opens it up for
+    // debug, reservedPorts must still be honored so the hub never steals a
+    // registered service's slot even if the service isn't yet bound.
     const h = makeHarness();
     try {
       const spawner = makeSpawner(3333);
@@ -194,6 +217,7 @@ describe("ensureHubRunning", () => {
         probe: probeTaken(new Set([1939])), // default port is held
         reservedPorts: [1940], // vault's reservation
         readyWaitMs: 0,
+        fallbackRange: 5,
       });
       // 1939 is taken, 1940 is reserved → we get 1941.
       expect(result.port).toBe(1941);

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -101,6 +101,70 @@ describe("install", () => {
     }
   });
 
+  test("warns when manifest entry lands outside the canonical port range", async () => {
+    // Notes historically wrote 5173 (Vite's dev default). Canonical is
+    // 1939–1949; warn so integrators know their service could conflict with
+    // other software on the box, but don't block — forks may intentionally
+    // deviate.
+    const { path, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      const code = await install("notes", {
+        runner: async (cmd) => {
+          if (cmd[0] === "bun") {
+            upsertService(
+              {
+                name: "parachute-notes",
+                port: 5173,
+                paths: ["/notes"],
+                health: "/notes/health",
+                version: "0.0.1",
+              },
+              path,
+            );
+          }
+          return 0;
+        },
+        manifestPath: path,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(logs.join("\n")).toMatch(/registered on port 5173/);
+      expect(logs.join("\n")).toMatch(/outside the canonical Parachute range/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("does not warn when manifest port is in the canonical range", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      await install("vault", {
+        runner: async (cmd) => {
+          if (cmd[0] === "parachute-vault") {
+            upsertService(
+              {
+                name: "parachute-vault",
+                port: 1940,
+                paths: ["/vault/default"],
+                health: "/vault/default/health",
+                version: "0.2.4",
+              },
+              path,
+            );
+          }
+          return 0;
+        },
+        manifestPath: path,
+        log: (l) => logs.push(l),
+      });
+      expect(logs.join("\n")).not.toMatch(/outside the canonical/);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("skips init when spec has none", async () => {
     const { path, cleanup } = makeTempPath();
     try {

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -11,11 +11,13 @@ import {
 import {
   type EnsureHubOpts,
   type StopHubOpts,
+  defaultPortProbe,
   ensureHubRunning,
   readHubPort,
   stopHub,
 } from "../hub-control.ts";
 import { HUB_MOUNT, HUB_PATH, writeHubFile } from "../hub.ts";
+import { shortNameForManifest } from "../service-spec.ts";
 import { type ServiceEntry, readManifest } from "../services-manifest.ts";
 import { type ServeEntry, bringupCommand, teardownCommand } from "../tailscale/commands.ts";
 import { getFqdn, isTailscaleInstalled } from "../tailscale/detect.ts";
@@ -64,6 +66,13 @@ export interface ExposeOpts {
   hubStopOpts?: Omit<StopHubOpts, "configDir" | "log">;
   /** Skip spawning the hub server. Tests flip this off to verify it's called. */
   skipHub?: boolean;
+  /**
+   * Probe a port to decide whether a service is responding. Returns true when
+   * something is listening (i.e., bind-probe fails). Primarily a test seam —
+   * the default walks every service port before bringup and warns on any
+   * that don't answer.
+   */
+  servicePortProbe?: (port: number) => Promise<boolean>;
 }
 
 /**
@@ -196,6 +205,24 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
   }
 
   const services = remapLegacyRoot(manifest.services, log);
+
+  /**
+   * Probe each service port before wiring tailscale up. A service that's
+   * quietly stopped would otherwise get proxied for silent 502s. Warn and
+   * continue — users sometimes expose paths ahead of starting a service,
+   * and we don't want probe flakes to block bringup.
+   */
+  const portProbe = opts.servicePortProbe ?? (async (p: number) => !(await defaultPortProbe(p)));
+  const probeResults = await Promise.all(
+    services.map(async (s) => ({ svc: s, up: await portProbe(s.port) })),
+  );
+  for (const { svc, up } of probeResults) {
+    if (up) continue;
+    const short = shortNameForManifest(svc.name) ?? svc.name;
+    log(
+      `⚠ ${svc.name} (port ${svc.port}) is not responding; its path will proxy to a dead port. Run \`parachute start ${short}\`.`,
+    );
+  }
 
   const wellKnownDoc = buildWellKnown({ services, canonicalOrigin });
   writeWellKnownFile(wellKnownDoc, wellKnownFilePath);

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,5 +1,11 @@
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
-import { getSpec, knownServices } from "../service-spec.ts";
+import {
+  CANONICAL_PORT_MAX,
+  CANONICAL_PORT_MIN,
+  getSpec,
+  isCanonicalPort,
+  knownServices,
+} from "../service-spec.ts";
 import { findService } from "../services-manifest.ts";
 import { migrateNotice } from "./migrate.ts";
 
@@ -55,6 +61,11 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
     );
   } else {
     log(`✓ ${spec.manifestName} registered on port ${entry.port}`);
+    if (!isCanonicalPort(entry.port)) {
+      log(
+        `⚠ port ${entry.port} is outside the canonical Parachute range (${CANONICAL_PORT_MIN}–${CANONICAL_PORT_MAX}); may conflict with other software.`,
+      );
+    }
   }
 
   const notice = migrateNotice(configDir, now());

--- a/src/hub-control.ts
+++ b/src/hub-control.ts
@@ -27,7 +27,12 @@ import { WELL_KNOWN_DIR } from "./well-known.ts";
 
 export const HUB_SVC = "hub";
 export const HUB_DEFAULT_PORT = 1939;
-export const HUB_PORT_FALLBACK_RANGE = 20;
+/**
+ * Default fallback range is 1 — the hub binds 1939 or fails. Walking up would
+ * steal another Parachute service's slot from the canonical 1939–1949 range.
+ * Tests and debug tooling can pass a larger `fallbackRange` explicitly.
+ */
+export const HUB_PORT_FALLBACK_RANGE = 1;
 
 const HUB_SERVER_PATH = fileURLToPath(new URL("./hub-server.ts", import.meta.url));
 
@@ -160,8 +165,10 @@ export async function ensureHubRunning(opts: EnsureHubOpts = {}): Promise<Ensure
     }
   }
   if (chosenPort === undefined) {
+    const range =
+      fallbackRange === 1 ? `${startPort}` : `${startPort}..${startPort + fallbackRange - 1}`;
     throw new Error(
-      `hub: no free port in ${startPort}..${startPort + fallbackRange - 1}. Is something already bound to that range?`,
+      `hub: port ${range} unavailable. Run \`lsof -iTCP:${startPort}\` to find what's using it, or pass --hub-port to override.`,
     );
   }
 

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -1,6 +1,56 @@
 import { fileURLToPath } from "node:url";
 import type { ServiceEntry } from "./services-manifest.ts";
 
+/**
+ * Canonical Parachute port range. Every ecosystem service reserves a slot in
+ * 1939–1949; third-party integrators are expected to avoid it.
+ *
+ *   1939  parachute-hub      internal static + proxy, CLI-managed
+ *   1940  parachute-vault
+ *   1941  parachute-channel
+ *   1942  parachute-notes    static server over the PWA bundle
+ *   1943  parachute-scribe
+ *   1944  reserved — pendant
+ *   1945  reserved — daily-v2
+ *   1946–1949  reserved
+ *
+ * Hub pins 1939: `parachute expose` composes hub targets as
+ * `http://127.0.0.1:1939/` and that URL has to be stable across machines for
+ * tailscale serve to proxy it correctly. The hub-port fallback range is 1
+ * (see hub-control.ts) — if something else is on 1939 we fail loudly rather
+ * than walking up into a service's slot.
+ *
+ * Ports outside the range aren't blocked. `parachute install` warns but
+ * proceeds, since forks and non-standard deployments sometimes land on other
+ * ports intentionally.
+ */
+export const CANONICAL_PORT_MIN = 1939;
+export const CANONICAL_PORT_MAX = 1949;
+
+export interface PortReservation {
+  readonly port: number;
+  readonly name: string;
+  readonly status: "assigned" | "reserved";
+}
+
+export const PORT_RESERVATIONS: readonly PortReservation[] = [
+  { port: 1939, name: "parachute-hub", status: "assigned" },
+  { port: 1940, name: "parachute-vault", status: "assigned" },
+  { port: 1941, name: "parachute-channel", status: "assigned" },
+  { port: 1942, name: "parachute-notes", status: "assigned" },
+  { port: 1943, name: "parachute-scribe", status: "assigned" },
+  { port: 1944, name: "pendant", status: "reserved" },
+  { port: 1945, name: "daily-v2", status: "reserved" },
+  { port: 1946, name: "unassigned", status: "reserved" },
+  { port: 1947, name: "unassigned", status: "reserved" },
+  { port: 1948, name: "unassigned", status: "reserved" },
+  { port: 1949, name: "unassigned", status: "reserved" },
+];
+
+export function isCanonicalPort(port: number): boolean {
+  return port >= CANONICAL_PORT_MIN && port <= CANONICAL_PORT_MAX;
+}
+
 export interface ServiceSpec {
   readonly package: string;
   readonly manifestName: string;


### PR DESCRIPTION
## Why

**Ports are a launch-grade integration contract.** Installing Parachute should claim a single, predictable block of loopback ports — one firewall rule, one range to remember, no surprises when the next service ships. This PR canonicalizes that range and enforces it where it matters.

Aaron also hit a phantom bug tonight: vault had been quietly stopped, `parachute expose tailnet` happily proxied `/vault/default` to a dead port, every request 502'd with zero indication from the CLI. This PR makes expose probe-before-wire so that never happens silently again.

## What changes

**1. Canonical port table — `src/service-spec.ts`.** Documents 1939–1949 with explicit assignments, exports `CANONICAL_PORT_MIN/MAX`, `PORT_RESERVATIONS`, and `isCanonicalPort()`:

| Port | Service |
| --- | --- |
| 1939 | parachute-hub (internal) |
| 1940 | parachute-vault |
| 1941 | parachute-channel |
| 1942 | parachute-notes |
| 1943 | parachute-scribe |
| 1944 | *reserved — pendant* |
| 1945 | *reserved — daily-v2* |
| 1946–1949 | *reserved* |

**2. Hub fallback narrowed from 20 → 1.** Hub binds 1939 or fails; walking up would land in another service's slot. Error message points at `lsof -iTCP:1939` + `--hub-port` override for recovery. `reservedPorts` plumbing from #12 stays intact so widened fallback (debug / tests) still honors service reservations.

**3. `parachute install` warns on out-of-range ports.** Registers the service regardless — forks and non-standard deployments sometimes land elsewhere intentionally — but prints `⚠ port <N> is outside the canonical Parachute range (1939–1949); may conflict with other software.` so integrators know. Notes currently lands on Vite's 5173; team-lead is dispatching the notes-side fix to write 1942 separately.

**4. `parachute expose` probes service ports at bringup.** Any service whose port isn't answering gets a warning: `⚠ parachute-<svc> (port …) is not responding; its path will proxy to a dead port. Run \`parachute start <svc>\`.` Continues with exposure anyway (Option A from the brief) — users sometimes stand up exposure before starting services, and a probe flake shouldn't block.

**5. README.** New "Ports" section with the full reservation table, hub-pin explanation, and dead-service probe behavior.

## Notes prod-serving — diagnosed, no change needed

Investigated whether `parachute start notes` was invoking Vite dev. It isn't — it spawns `bun src/notes-serve.ts --port <port>`, a CLI-owned static shim that resolves `@openparachute/notes/dist/` via `Bun.resolveSync`, SPA-fallbacks to `index.html`, and guards against path traversal outside `dist/`. That shim has been in place since the hub work. Confirmed in the diagnosis report and left unchanged.

## Test coverage

- `install.test.ts` — warns when port is outside the canonical range; doesn't warn when in range.
- `hub-control.test.ts` — default fallback is 1 (fails on 1939 collision with the new error message); widened range still honors reservedPorts.
- `expose.test.ts` — dead-service probe emits a per-service warning but still stages all four bringup calls.

158 tests pass, typecheck clean, lint clean.

## Out of scope

- Notes-side port change from 5173 → 1942 (dispatched separately by team-lead).
- npm publish prep.
- Vite dev default (stays 5173 for `bun run dev`; unrelated to CLI-managed starts).