### PR TITLE
Bump to 0.2.0 for launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "parachute — the top-level CLI for the Parachute ecosystem.",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Ready for `bun publish`. See commit for the material changes.