### PR TITLE
feat(install): bun-link detection + seedEntry on specs

### DIFF
--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { install } from "../commands/install.ts";
-import { upsertService } from "../services-manifest.ts";
+import { findService, upsertService } from "../services-manifest.ts";
 
 function makeTempPath(): { path: string; cleanup: () => void } {
   const dir = mkdtempSync(join(tmpdir(), "pcli-install-"));
@@ -21,6 +21,7 @@ describe("install", () => {
       const code = await install("mystery", {
         runner: async () => 0,
         manifestPath: path,
+        isLinked: () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(1);
@@ -30,7 +31,7 @@ describe("install", () => {
     }
   });
 
-  test("runs bun add -g then init, warns when manifest stays empty", async () => {
+  test("runs bun add -g then init; seeds manifest when service didn't write one", async () => {
     const { path, cleanup } = makeTempPath();
     try {
       const calls: string[][] = [];
@@ -41,18 +42,22 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        isLinked: () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
       expect(calls[0]).toEqual(["bun", "add", "-g", "@openparachute/vault"]);
       expect(calls[1]).toEqual(["parachute-vault", "init"]);
-      expect(logs.join("\n")).toMatch(/no services\.json entry/);
+      expect(logs.join("\n")).toMatch(/Seeded services\.json entry for parachute-vault/);
+      const seeded = findService("parachute-vault", path);
+      expect(seeded?.port).toBe(1940);
+      expect(seeded?.version).toBe("0.0.0-linked");
     } finally {
       cleanup();
     }
   });
 
-  test("confirms registration when manifest entry exists after init", async () => {
+  test("confirms registration when manifest entry exists after init (no seeding)", async () => {
     const { path, cleanup } = makeTempPath();
     try {
       const logs: string[] = [];
@@ -73,10 +78,14 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        isLinked: () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
       expect(logs.join("\n")).toMatch(/registered on port 1940/);
+      expect(logs.join("\n")).not.toMatch(/Seeded/);
+      const entry = findService("parachute-vault", path);
+      expect(entry?.version).toBe("0.2.4");
     } finally {
       cleanup();
     }
@@ -92,6 +101,7 @@ describe("install", () => {
           return 42;
         },
         manifestPath: path,
+        isLinked: () => false,
         log: () => {},
       });
       expect(code).toBe(42);
@@ -102,7 +112,7 @@ describe("install", () => {
   });
 
   test("warns when manifest entry lands outside the canonical port range", async () => {
-    // Notes historically wrote 5173 (Vite's dev default). Canonical is
+    // Historically notes wrote 5173 (Vite's dev default). Canonical is
     // 1939–1949; warn so integrators know their service could conflict with
     // other software on the box, but don't block — forks may intentionally
     // deviate.
@@ -126,6 +136,7 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        isLinked: () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -157,6 +168,7 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        isLinked: () => false,
         log: (l) => logs.push(l),
       });
       expect(logs.join("\n")).not.toMatch(/outside the canonical/);
@@ -165,21 +177,90 @@ describe("install", () => {
     }
   });
 
-  test("skips init when spec has none", async () => {
+  test("skips init when spec has none (scribe)", async () => {
     const { path, cleanup } = makeTempPath();
     try {
       const calls: string[][] = [];
+      const logs: string[] = [];
       const code = await install("scribe", {
         runner: async (cmd) => {
           calls.push([...cmd]);
           return 0;
         },
         manifestPath: path,
-        log: () => {},
+        isLinked: () => false,
+        log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
       expect(calls).toHaveLength(1);
       expect(calls[0]).toEqual(["bun", "add", "-g", "@openparachute/scribe"]);
+      // scribe has no init, so seedEntry fires — no authoritative entry to defer to.
+      const seeded = findService("parachute-scribe", path);
+      expect(seeded?.port).toBe(1943);
+      expect(logs.join("\n")).toMatch(/Seeded services\.json entry for parachute-scribe/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("skips `bun add -g` when the package is already bun-linked", async () => {
+    // The scribe motivator: package isn't published to npm yet, so `bun add -g`
+    // 404s. If bun link already points the global node_modules at a local
+    // checkout, detect that and proceed to init + seeding.
+    const { path, cleanup } = makeTempPath();
+    try {
+      const calls: string[][] = [];
+      const logs: string[] = [];
+      const code = await install("scribe", {
+        runner: async (cmd) => {
+          calls.push([...cmd]);
+          return 0;
+        },
+        manifestPath: path,
+        isLinked: (pkg) => pkg === "@openparachute/scribe",
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(calls).toHaveLength(0);
+      expect(logs.join("\n")).toMatch(/already linked globally/);
+      const seeded = findService("parachute-scribe", path);
+      expect(seeded?.port).toBe(1943);
+      expect(seeded?.paths).toEqual(["/scribe"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("linked vault still runs init and defers to init's manifest write", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const calls: string[][] = [];
+      const logs: string[] = [];
+      const code = await install("vault", {
+        runner: async (cmd) => {
+          calls.push([...cmd]);
+          if (cmd[0] === "parachute-vault") {
+            upsertService(
+              {
+                name: "parachute-vault",
+                port: 1940,
+                paths: ["/vault/default"],
+                health: "/vault/default/health",
+                version: "0.3.0",
+              },
+              path,
+            );
+          }
+          return 0;
+        },
+        manifestPath: path,
+        isLinked: () => true,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(calls).toEqual([["parachute-vault", "init"]]);
+      expect(logs.join("\n")).not.toMatch(/Seeded/);
+      expect(findService("parachute-vault", path)?.version).toBe("0.3.0");
     } finally {
       cleanup();
     }

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,3 +1,6 @@
+import { lstatSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import {
   CANONICAL_PORT_MAX,
@@ -6,7 +9,7 @@ import {
   isCanonicalPort,
   knownServices,
 } from "../service-spec.ts";
-import { findService } from "../services-manifest.ts";
+import { findService, upsertService } from "../services-manifest.ts";
 import { migrateNotice } from "./migrate.ts";
 
 export type Runner = (cmd: readonly string[]) => Promise<number>;
@@ -17,11 +20,38 @@ export interface InstallOpts {
   configDir?: string;
   now?: () => Date;
   log?: (line: string) => void;
+  /**
+   * True when the package is already globally linked (via `bun link`) so
+   * `bun add -g` would be redundant — or worse, fail with a 404 for a
+   * package that isn't published to npm yet (the scribe case on 2026-04-19).
+   * Defaults to a symlink check against bun's global node_modules prefix.
+   */
+  isLinked?: (pkg: string) => boolean;
 }
 
 async function defaultRunner(cmd: readonly string[]): Promise<number> {
   const proc = Bun.spawn([...cmd], { stdio: ["inherit", "inherit", "inherit"] });
   return await proc.exited;
+}
+
+function bunGlobalPrefixes(): string[] {
+  const prefixes: string[] = [];
+  const fromEnv = process.env.BUN_INSTALL;
+  if (fromEnv) prefixes.push(join(fromEnv, "install", "global", "node_modules"));
+  prefixes.push(join(homedir(), ".bun", "install", "global", "node_modules"));
+  return prefixes;
+}
+
+function defaultIsLinked(pkg: string): boolean {
+  for (const prefix of bunGlobalPrefixes()) {
+    const path = join(prefix, ...pkg.split("/"));
+    try {
+      if (lstatSync(path).isSymbolicLink()) return true;
+    } catch {
+      // Not present at this prefix; try the next.
+    }
+  }
+  return false;
 }
 
 export async function install(service: string, opts: InstallOpts = {}): Promise<number> {
@@ -30,6 +60,7 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
   const configDir = opts.configDir ?? CONFIG_DIR;
   const now = opts.now ?? (() => new Date());
   const log = opts.log ?? ((line) => console.log(line));
+  const isLinked = opts.isLinked ?? defaultIsLinked;
 
   const spec = getSpec(service);
   if (!spec) {
@@ -38,11 +69,15 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
     return 1;
   }
 
-  log(`Installing ${spec.package}…`);
-  const addCode = await runner(["bun", "add", "-g", spec.package]);
-  if (addCode !== 0) {
-    log(`bun add -g ${spec.package} failed (exit ${addCode})`);
-    return addCode;
+  if (isLinked(spec.package)) {
+    log(`${spec.package} is already linked globally (bun link) — skipping bun add.`);
+  } else {
+    log(`Installing ${spec.package}…`);
+    const addCode = await runner(["bun", "add", "-g", spec.package]);
+    if (addCode !== 0) {
+      log(`bun add -g ${spec.package} failed (exit ${addCode})`);
+      return addCode;
+    }
   }
 
   if (spec.init) {
@@ -54,7 +89,15 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
     }
   }
 
-  const entry = findService(spec.manifestName, manifestPath);
+  let entry = findService(spec.manifestName, manifestPath);
+  if (!entry && spec.seedEntry) {
+    entry = spec.seedEntry();
+    upsertService(entry, manifestPath);
+    log(
+      `Seeded services.json entry for ${spec.manifestName} (placeholder; service's own boot will overwrite).`,
+    );
+  }
+
   if (!entry) {
     log(
       `Installed, but no services.json entry for "${spec.manifestName}" yet. Run \`parachute status\` after the service has started.`,

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -65,9 +65,29 @@ export interface ServiceSpec {
    * shouldn't be managed by `parachute start`.
    */
   readonly startCmd?: (entry: ServiceEntry) => readonly string[] | undefined;
+  /**
+   * Canonical initial services.json entry used when the service hasn't
+   * written its own entry yet. Fires post-install only if `findService`
+   * returns undefined — normal npm installs hit this almost never (the
+   * service's init or first boot writes the authoritative entry first).
+   *
+   * Main use case: `bun link` local-dev installs where the service hasn't
+   * run yet but `parachute expose` / `parachute start` need an entry to
+   * plan against. First service boot overwrites the seed with its own
+   * authoritative version.
+   */
+  readonly seedEntry?: () => ServiceEntry;
 }
 
 const NOTES_SERVE_PATH = fileURLToPath(new URL("./notes-serve.ts", import.meta.url));
+
+/**
+ * Seed entries land in services.json as placeholder rows when a freshly
+ * installed service hasn't written its own. Version `"0.0.0-linked"`
+ * telegraphs the state: the row is a stopgap, and the service's first boot
+ * will overwrite with its own authoritative write.
+ */
+const SEED_VERSION = "0.0.0-linked";
 
 export const SERVICE_SPECS: Record<string, ServiceSpec> = {
   vault: {
@@ -75,21 +95,49 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
     manifestName: "parachute-vault",
     init: ["parachute-vault", "init"],
     startCmd: () => ["parachute-vault", "serve"],
+    seedEntry: () => ({
+      name: "parachute-vault",
+      port: 1940,
+      paths: ["/vault/default"],
+      health: "/vault/default/health",
+      version: SEED_VERSION,
+    }),
   },
   notes: {
     package: "@openparachute/notes",
     manifestName: "parachute-notes",
     startCmd: (entry) => ["bun", NOTES_SERVE_PATH, "--port", String(entry.port)],
+    seedEntry: () => ({
+      name: "parachute-notes",
+      port: 1942,
+      paths: ["/notes"],
+      health: "/notes/health",
+      version: SEED_VERSION,
+    }),
   },
   scribe: {
     package: "@openparachute/scribe",
     manifestName: "parachute-scribe",
     startCmd: () => ["parachute-scribe", "serve"],
+    seedEntry: () => ({
+      name: "parachute-scribe",
+      port: 1943,
+      paths: ["/scribe"],
+      health: "/scribe/health",
+      version: SEED_VERSION,
+    }),
   },
   channel: {
     package: "@openparachute/channel",
     manifestName: "parachute-channel",
     startCmd: () => ["parachute-channel", "daemon"],
+    seedEntry: () => ({
+      name: "parachute-channel",
+      port: 1941,
+      paths: ["/channel"],
+      health: "/channel/health",
+      version: SEED_VERSION,
+    }),
   },
 };
 


### PR DESCRIPTION
## Why

Aaron hit this trying to install scribe: `parachute install scribe` runs `bun add -g @openparachute/scribe`, which 404s because scribe isn't published to npm yet. The local workaround — `bun link` from a checkout — exposes a second gap: services.json stays empty until the service boots for the first time, so `parachute expose` and `parachute start` have nothing to plan against in the meantime.

This PR closes both.

## Changes

**Link detection.** Install checks bun's global `node_modules/<pkg>` for a symlink before calling `bun add -g`. If present, we skip the npm fetch and proceed to init + manifest. `BUN_INSTALL` env respected, `~/.bun/install/global/node_modules` as fallback. `isLinked` is an injected opt so tests don't depend on real filesystem state.

**`seedEntry` on specs.** Each `ServiceSpec` gains an optional `seedEntry: () => ServiceEntry`. After install, if `findService` returns undefined and the spec has a `seedEntry`, we write a placeholder row using canonical port-table values and `version: "0.0.0-linked"`. First real boot overwrites. Normal npm installs almost never hit this — init or first boot already populated the row. The bun-link path needs it.

Single source of truth for the seeded values: each spec owns its own canonical shape (name, port, paths, health).

## Test plan

- [x] `bun test` — 160/160 pass, 9 install tests (was 7) including linked-skip and scribe-seed
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check .` — clean
- [ ] Manual: `bun link` scribe locally, run `parachute install scribe`, confirm bun add is skipped and services.json gets a scribe row on port 1943