### PR TITLE
hotfix(migrate): don't follow symlinks when sizing archive plan

### DIFF
--- a/src/__tests__/migrate.test.ts
+++ b/src/__tests__/migrate.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { migrate, migrateNotice, planArchive, safelistEntries } from "../commands/migrate.ts";
@@ -122,6 +131,35 @@ describe("planArchive", () => {
       h.cleanup();
     }
   });
+
+  test("symlinks at root are not followed when sizing", () => {
+    // Regression guard: Dirent.isDirectory() returns true for a symlink to a
+    // directory on macOS/Linux, so the pre-fix planner would descend sizeOf()
+    // into the link's target. A user pointing ~/.parachute/external-backup
+    // at a multi-GB external volume would see absurd byte totals and pay
+    // the cost of walking that tree.
+    const targetHarness = makeHarness();
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      // Populate the target with a much-bigger-than-plausible file so if the
+      // planner does descend, the assertion on bytes=0 would obviously fail.
+      touch(join(targetHarness.configDir, "huge.bin"), "X".repeat(10_000));
+      touch(join(targetHarness.configDir, "more.bin"), "Y".repeat(5_000));
+      const linkPath = join(h.configDir, "external-backup");
+      symlinkSync(targetHarness.configDir, linkPath);
+
+      const plan = planArchive(h.configDir, APRIL_19);
+      const item = plan.items.find((i) => i.name === "external-backup");
+      expect(item).toBeDefined();
+      expect(item?.bytes).toBe(0);
+      expect(item?.kind).toBe("file");
+      expect(plan.totalBytes).toBe(0);
+    } finally {
+      h.cleanup();
+      targetHarness.cleanup();
+    }
+  });
 });
 
 describe("migrate", () => {
@@ -209,6 +247,37 @@ describe("migrate", () => {
       expect(existsSync(join(h.configDir, "logs"))).toBe(false);
     } finally {
       h.cleanup();
+    }
+  });
+
+  test("--yes archives a symlink by moving the link, not the target", async () => {
+    const targetHarness = makeHarness();
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      touch(join(targetHarness.configDir, "huge.bin"), "X".repeat(10_000));
+      const linkPath = join(h.configDir, "external-backup");
+      symlinkSync(targetHarness.configDir, linkPath);
+
+      const code = await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: () => {},
+        prompt: async () => {
+          throw new Error("prompt must not be called");
+        },
+        yes: true,
+      });
+      expect(code).toBe(0);
+      const archivedLink = join(h.configDir, ".archive-2026-04-19", "external-backup");
+      expect(lstatSync(archivedLink).isSymbolicLink()).toBe(true);
+      // Target tree untouched
+      expect(existsSync(join(targetHarness.configDir, "huge.bin"))).toBe(true);
+      // Original link site is empty
+      expect(existsSync(linkPath)).toBe(false);
+    } finally {
+      h.cleanup();
+      targetHarness.cleanup();
     }
   });
 

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -114,6 +114,21 @@ export function planArchive(configDir: string, now: Date): ArchivePlan {
     if (entry.name.startsWith(".")) continue;
     if (safelist.has(entry.name)) continue;
     const abs = join(configDir, entry.name);
+    // Dirent.isDirectory() follows symlinks on macOS/Linux — so a link
+    // pointing at an external tree would get sized via sizeOf() (bogus
+    // byte count, and potentially a slow walk through /mnt/... or similar).
+    // Classify the link itself as a zero-byte "file"; renameSync moves the
+    // link, not the target, which is the behavior we want.
+    if (entry.isSymbolicLink()) {
+      plan.items.push({
+        name: entry.name,
+        absPath: abs,
+        kind: "file",
+        bytes: 0,
+        annotation: annotationFor(entry.name),
+      });
+      continue;
+    }
     const bytes = sizeOf(abs);
     plan.items.push({
       name: entry.name,


### PR DESCRIPTION
## Why

Reviewer audit flagged that `planArchive` classifies a symlink-to-directory at `~/.parachute/` root as `kind: \"dir\"`, because `Dirent.isDirectory()` follows symlinks on macOS and Linux. `sizeOf()` then descends through the link into whatever the target is — could be `/mnt/external/backup` with many gigabytes.

Two failure modes: the plan printout shows nonsense byte totals, and the recursive walk itself is a perf hazard on external storage. The rename is always safe (`renameSync` moves the link, not the target), but the planning stage is broken.

## Fix

`src/commands/migrate.ts` — guard `isSymbolicLink()` before the file/dir branch. Classify the link as `kind: \"file\"` with `bytes: 0` and skip `sizeOf`. Rename still archives the link itself.

## Test plan

- [x] New regression: `planArchive` on a symlink pointing into a populated tree reports `bytes: 0` (fails loudly if sizeOf ever descends again).
- [x] New archive test: `migrate --yes` moves the symlink into the dated archive dir, target tree untouched, original link site gone.
- [x] `bun test` — 160/160 pass
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check .` — clean