### PR TITLE
feat(oauth): Phase 0 — hub-origin routing + OAuth tailscale proxies

### DIFF
--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -136,7 +136,8 @@ describe("expose tailnet up", () => {
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      expect(serveCalls).toHaveLength(4);
+      // 4 baseline (hub + wk + vault + notes) + 4 OAuth proxies (vault present).
+      expect(serveCalls).toHaveLength(8);
       // Tailnet mode never uses funnel — neither the old flag nor the new subcommand.
       expect(serveCalls.every((c) => !c.includes("--funnel"))).toBe(true);
       expect(calls.every((c) => c[1] !== "funnel")).toBe(true);
@@ -144,8 +145,12 @@ describe("expose tailnet up", () => {
       const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path="))).sort();
       expect(mounts).toEqual([
         "--set-path=/",
+        "--set-path=/.well-known/oauth-authorization-server",
         "--set-path=/.well-known/parachute.json",
         "--set-path=/notes",
+        "--set-path=/oauth/authorize",
+        "--set-path=/oauth/register",
+        "--set-path=/oauth/token",
         "--set-path=/vault/default",
       ]);
 
@@ -175,8 +180,8 @@ describe("expose tailnet up", () => {
       const state = readExposeState(h.statePath);
       expect(state?.layer).toBe("tailnet");
       expect(state?.mode).toBe("path");
-      expect(state?.entries).toHaveLength(4);
-      // All four entries are proxy now — no file-backed tailscale serve.
+      expect(state?.entries).toHaveLength(8);
+      // All entries are proxy now — no file-backed tailscale serve.
       expect(state?.entries.every((e) => e.kind === "proxy")).toBe(true);
     } finally {
       h.cleanup();
@@ -421,11 +426,11 @@ describe("expose tailnet up", () => {
       expect(joined).toMatch(/parachute-notes \(port 5173\) is not responding/);
       expect(joined).toMatch(/parachute start notes/);
       expect(joined).not.toMatch(/parachute-vault.*not responding/);
-      // Bringup still happened — all four entries got staged.
+      // Bringup still happened — 4 service entries + 4 OAuth proxies got staged.
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      expect(serveCalls).toHaveLength(4);
+      expect(serveCalls).toHaveLength(8);
     } finally {
       h.cleanup();
     }
@@ -465,6 +470,128 @@ describe("expose tailnet up", () => {
       });
       expect(code).toBe(2);
       expect(logs.join("\n")).toMatch(/Bringup failed/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("emits 4 OAuth proxies targeting vault when vault is installed", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      const { runner, calls } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+
+      const serveCalls = calls.filter(
+        (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
+      );
+      const oauthTargets = new Map<string, string>();
+      for (const c of serveCalls) {
+        const mount = c.find((a) => a.startsWith("--set-path="))?.slice("--set-path=".length);
+        if (
+          mount &&
+          (mount.startsWith("/oauth/") || mount === "/.well-known/oauth-authorization-server")
+        ) {
+          oauthTargets.set(mount, c[c.length - 1] ?? "");
+        }
+      }
+      expect(oauthTargets.get("/.well-known/oauth-authorization-server")).toBe(
+        "http://127.0.0.1:1940/vault/default/.well-known/oauth-authorization-server",
+      );
+      expect(oauthTargets.get("/oauth/authorize")).toBe(
+        "http://127.0.0.1:1940/vault/default/oauth/authorize",
+      );
+      expect(oauthTargets.get("/oauth/token")).toBe(
+        "http://127.0.0.1:1940/vault/default/oauth/token",
+      );
+      expect(oauthTargets.get("/oauth/register")).toBe(
+        "http://127.0.0.1:1940/vault/default/oauth/register",
+      );
+
+      const state = readExposeState(h.statePath);
+      expect(state?.hubOrigin).toBe("https://parachute.taildf9ce2.ts.net");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("skips OAuth proxies when no vault is installed", async () => {
+    const h = makeHarness();
+    try {
+      upsertService(
+        {
+          name: "parachute-notes",
+          port: 5173,
+          paths: ["/notes"],
+          health: "/notes/health",
+          version: "0.0.1",
+        },
+        h.manifestPath,
+      );
+      const { runner, calls } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+
+      const serveCalls = calls.filter(
+        (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
+      );
+      // No vault → no OAuth proxies. Hub + well-known + notes = 3.
+      expect(serveCalls).toHaveLength(3);
+      const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path=")));
+      expect(mounts.every((m) => m !== undefined && !m.includes("/oauth/"))).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("--hub-origin override wins over derived origin and lands in state", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      const { runner } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        hubOrigin: "https://hub.example.com/",
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      const state = readExposeState(h.statePath);
+      // Trailing slash stripped by deriveHubOrigin.
+      expect(state?.hubOrigin).toBe("https://hub.example.com");
     } finally {
       h.cleanup();
     }
@@ -682,7 +809,8 @@ describe("expose public up", () => {
       const funnelCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "funnel" && c.includes("--bg"),
       );
-      expect(funnelCalls).toHaveLength(4);
+      // 4 baseline mounts + 4 OAuth proxies (vault seeded).
+      expect(funnelCalls).toHaveLength(8);
       // Never emit the legacy `serve --funnel` shape.
       expect(calls.every((c) => !c.includes("--funnel"))).toBe(true);
       expect(calls.every((c) => !(c[1] === "serve" && c.includes("--bg")))).toBe(true);
@@ -690,7 +818,7 @@ describe("expose public up", () => {
       const state = readExposeState(h.statePath);
       expect(state?.layer).toBe("public");
       expect(state?.funnel).toBe(true);
-      expect(state?.entries).toHaveLength(4);
+      expect(state?.entries).toHaveLength(8);
 
       expect(logs.join("\n")).toMatch(/Public exposure active/);
     } finally {

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { logs, restart, start, stop } from "../commands/lifecycle.ts";
+import { writeHubPort } from "../hub-control.ts";
 import { ensureLogPath, logPath, readPid, writePid } from "../process-state.ts";
 import { upsertService } from "../services-manifest.ts";
 
@@ -48,17 +49,25 @@ function seedNotes(manifestPath: string): void {
 }
 
 interface SpawnerStub {
-  spawn: (cmd: readonly string[], logFile: string) => number;
-  calls: Array<{ cmd: readonly string[]; logFile: string }>;
+  spawn: (cmd: readonly string[], logFile: string, env?: Record<string, string>) => number;
+  calls: Array<{
+    cmd: readonly string[];
+    logFile: string;
+    env?: Record<string, string>;
+  }>;
 }
 
 function makeSpawner(pidSequence: number[]): SpawnerStub {
-  const calls: Array<{ cmd: readonly string[]; logFile: string }> = [];
+  const calls: Array<{
+    cmd: readonly string[];
+    logFile: string;
+    env?: Record<string, string>;
+  }> = [];
   let i = 0;
   return {
     calls,
-    spawn(cmd, logFile) {
-      calls.push({ cmd: [...cmd], logFile });
+    spawn(cmd, logFile, env) {
+      calls.push({ cmd: [...cmd], logFile, env });
       return pidSequence[i++] ?? 99999;
     },
   };
@@ -203,6 +212,112 @@ describe("parachute start", () => {
       expect(spawner.calls).toHaveLength(2);
       expect(readPid("vault", h.configDir)).toBe(4242);
       expect(readPid("notes", h.configDir)).toBe(5151);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("passes PARACHUTE_HUB_ORIGIN from expose-state when set", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writeFileSync(
+        join(h.configDir, "expose-state.json"),
+        JSON.stringify({
+          version: 1,
+          layer: "tailnet",
+          mode: "path",
+          canonicalFqdn: "parachute.taildf9ce2.ts.net",
+          port: 443,
+          funnel: false,
+          entries: [],
+          hubOrigin: "https://parachute.taildf9ce2.ts.net",
+        }),
+      );
+      const spawner = makeSpawner([4242]);
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(spawner.calls[0]?.env).toEqual({
+        PARACHUTE_HUB_ORIGIN: "https://parachute.taildf9ce2.ts.net",
+      });
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("falls back to loopback origin from hub.port when not exposed", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writeHubPort(1939, h.configDir);
+      const spawner = makeSpawner([4242]);
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(spawner.calls[0]?.env).toEqual({
+        PARACHUTE_HUB_ORIGIN: "http://127.0.0.1:1939",
+      });
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("--hub-origin override wins over expose-state", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writeFileSync(
+        join(h.configDir, "expose-state.json"),
+        JSON.stringify({
+          version: 1,
+          layer: "tailnet",
+          mode: "path",
+          canonicalFqdn: "parachute.taildf9ce2.ts.net",
+          port: 443,
+          funnel: false,
+          entries: [],
+          hubOrigin: "https://parachute.taildf9ce2.ts.net",
+        }),
+      );
+      const spawner = makeSpawner([4242]);
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        hubOrigin: "https://override.example.com/",
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(spawner.calls[0]?.env).toEqual({
+        PARACHUTE_HUB_ORIGIN: "https://override.example.com",
+      });
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("omits env when no override, no exposure, no hub port", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const spawner = makeSpawner([4242]);
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(spawner.calls[0]?.env).toBeUndefined();
     } finally {
       h.cleanup();
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,6 +34,37 @@ function isHelpFlag(arg: string | undefined): boolean {
   return arg === "--help" || arg === "-h" || arg === "help";
 }
 
+/**
+ * Extract `--hub-origin=<url>` / `--hub-origin <url>` from argv. Returns the
+ * URL and the remaining args (so callers can keep validating positionals
+ * without the flag in the way). `error` is set on missing value.
+ */
+function extractHubOrigin(args: string[]): {
+  hubOrigin?: string;
+  rest: string[];
+  error?: string;
+} {
+  const rest: string[] = [];
+  let hubOrigin: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--hub-origin") {
+      const v = args[i + 1];
+      if (!v) return { rest, error: "--hub-origin requires a URL argument" };
+      hubOrigin = v;
+      i++;
+      continue;
+    }
+    if (a?.startsWith("--hub-origin=")) {
+      hubOrigin = a.slice("--hub-origin=".length);
+      if (!hubOrigin) return { rest, error: "--hub-origin requires a URL argument" };
+      continue;
+    }
+    if (a !== undefined) rest.push(a);
+  }
+  return { hubOrigin, rest };
+}
+
 async function main(argv: string[]): Promise<number> {
   const [command, ...rest] = argv;
 
@@ -72,8 +103,14 @@ async function main(argv: string[]): Promise<number> {
       return await status();
 
     case "expose": {
-      const layer = rest[0];
-      const mode = rest[1];
+      const hubExtract = extractHubOrigin(rest);
+      if (hubExtract.error) {
+        console.error(`parachute expose: ${hubExtract.error}`);
+        return 1;
+      }
+      const exposeArgs = hubExtract.rest;
+      const layer = exposeArgs[0];
+      const mode = exposeArgs[1];
       if (isHelpFlag(layer)) {
         console.log(exposeHelp());
         return 0;
@@ -95,7 +132,10 @@ async function main(argv: string[]): Promise<number> {
         return 1;
       }
       const action = mode === "off" ? "off" : "up";
-      return layer === "public" ? await exposePublic(action) : await exposeTailnet(action);
+      const exposeOpts = hubExtract.hubOrigin ? { hubOrigin: hubExtract.hubOrigin } : {};
+      return layer === "public"
+        ? await exposePublic(action, exposeOpts)
+        : await exposeTailnet(action, exposeOpts);
     }
 
     case "start": {
@@ -103,7 +143,13 @@ async function main(argv: string[]): Promise<number> {
         console.log(startHelp());
         return 0;
       }
-      return await start(rest[0]);
+      const hubExtract = extractHubOrigin(rest);
+      if (hubExtract.error) {
+        console.error(`parachute start: ${hubExtract.error}`);
+        return 1;
+      }
+      const startOpts = hubExtract.hubOrigin ? { hubOrigin: hubExtract.hubOrigin } : {};
+      return await start(hubExtract.rest[0], startOpts);
     }
 
     case "stop": {

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -16,6 +16,7 @@ import {
   readHubPort,
   stopHub,
 } from "../hub-control.ts";
+import { deriveHubOrigin } from "../hub-origin.ts";
 import { HUB_MOUNT, HUB_PATH, writeHubFile } from "../hub.ts";
 import { shortNameForManifest } from "../service-spec.ts";
 import { type ServiceEntry, readManifest } from "../services-manifest.ts";
@@ -27,7 +28,9 @@ import {
   WELL_KNOWN_MOUNT,
   WELL_KNOWN_PATH,
   buildWellKnown,
+  isVaultEntry,
   shortName,
+  vaultInstanceName,
   writeWellKnownFile,
 } from "../well-known.ts";
 
@@ -73,6 +76,35 @@ export interface ExposeOpts {
    * that don't answer.
    */
   servicePortProbe?: (port: number) => Promise<boolean>;
+  /**
+   * Override the computed hub origin. Lets the user pin the OAuth issuer to
+   * something other than the detected tailnet FQDN — e.g., a custom domain
+   * fronting tailscale funnel, or a staging URL during a migration. Passed
+   * through to vault (and future services) via PARACHUTE_HUB_ORIGIN.
+   */
+  hubOrigin?: string;
+}
+
+/**
+ * OAuth paths the hub fronts on behalf of vault (Phase 0: vault implements
+ * OAuth, hub owns the public URL). The mount path is what clients see; the
+ * target tail is what vault expects. tailscale strips the mount before
+ * forwarding, so the target must include vault's `/vault/<name>` prefix to
+ * land at the right handler.
+ */
+const OAUTH_PATHS = [
+  "/.well-known/oauth-authorization-server",
+  "/oauth/authorize",
+  "/oauth/token",
+  "/oauth/register",
+] as const;
+
+/**
+ * Single-vault launch assumption: find the first `parachute-vault` entry.
+ * Multi-vault OAuth routing is Phase 2+ (design note open-question #4).
+ */
+function primaryVault(services: readonly ServiceEntry[]): ServiceEntry | undefined {
+  return services.find((s) => isVaultEntry(s));
 }
 
 /**
@@ -140,6 +172,23 @@ function planEntries(services: readonly ServiceEntry[], hubPort: number): ServeE
     target: serviceProxyTarget(hubPort, WELL_KNOWN_MOUNT),
     service: "well-known",
   });
+
+  // Phase 0 OAuth seam: hub origin owns the public OAuth URLs; vault owns
+  // the implementation. When vault is installed, mount the four endpoints
+  // at the hub origin and proxy them into vault's `/vault/<name>/oauth/*`.
+  const vault = primaryVault(services);
+  if (vault) {
+    const vaultMount = vault.paths[0] ?? `/vault/${vaultInstanceName(vault)}`;
+    const vaultBase = vaultMount.replace(/\/$/, "");
+    for (const oauthPath of OAUTH_PATHS) {
+      entries.push({
+        kind: "proxy",
+        mount: oauthPath,
+        target: `http://127.0.0.1:${vault.port}${vaultBase}${oauthPath}`,
+        service: `${vault.name}:oauth`,
+      });
+    }
+  }
   return entries;
 }
 
@@ -264,6 +313,8 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
     return code;
   }
 
+  const hubOrigin =
+    deriveHubOrigin({ override: opts.hubOrigin, exposeFqdn: fqdn }) ?? canonicalOrigin;
   const state: ExposeState = {
     version: 1,
     layer,
@@ -272,6 +323,7 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
     port,
     funnel,
     entries,
+    hubOrigin,
   };
   writeExposeState(state, statePath);
 
@@ -283,6 +335,10 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
     log(`✓ Tailnet exposure active. Open: ${canonicalOrigin}/`);
   }
   log(`  Discovery: ${canonicalOrigin}${WELL_KNOWN_MOUNT}`);
+  if (primaryVault(services)) {
+    log(`  OAuth issuer: ${hubOrigin}`);
+    log("  Restart vault to pick up the new hub origin: parachute restart vault");
+  }
   return 0;
 }
 

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -1,5 +1,9 @@
 import { existsSync, openSync } from "node:fs";
+import { join } from "node:path";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
+import { readExposeState } from "../expose-state.ts";
+import { readHubPort } from "../hub-control.ts";
+import { HUB_ORIGIN_ENV, deriveHubOrigin } from "../hub-origin.ts";
 import {
   type AliveFn,
   clearPid,
@@ -17,15 +21,22 @@ import { type ServiceEntry, readManifest } from "../services-manifest.ts";
  * Tiny seam over `Bun.spawn` for lifecycle tests. The real spawner opens the
  * log file, appends stdout+stderr to it, and `unref()`s the child so parent
  * exit doesn't bring it down.
+ *
+ * `env`, when provided, is merged into the child's environment on top of the
+ * parent's — today's only caller is `start`, which injects
+ * PARACHUTE_HUB_ORIGIN so vault's OAuth issuer matches the hub URL.
  */
 export interface Spawner {
-  spawn(cmd: readonly string[], logFile: string): number;
+  spawn(cmd: readonly string[], logFile: string, env?: Record<string, string>): number;
 }
 
 export const defaultSpawner: Spawner = {
-  spawn(cmd, logFile) {
+  spawn(cmd, logFile, env) {
     const fd = openSync(logFile, "a");
-    const proc = Bun.spawn([...cmd], { stdio: ["ignore", fd, fd] });
+    const proc = Bun.spawn([...cmd], {
+      stdio: ["ignore", fd, fd],
+      env: env ? { ...process.env, ...env } : undefined,
+    });
     proc.unref();
     return proc.pid;
   },
@@ -53,6 +64,13 @@ export interface LifecycleOpts {
   killWaitMs?: number;
   /** Poll interval while waiting for SIGTERM to land. */
   pollIntervalMs?: number;
+  /**
+   * Override the hub origin passed to services as PARACHUTE_HUB_ORIGIN. If
+   * unset, `start` derives it from `expose-state.json` (when exposed) or
+   * the hub.port file (local dev). Undefined → no env var is set at all,
+   * and the service advertises its own default issuer.
+   */
+  hubOrigin?: string;
 }
 
 interface Resolved {
@@ -66,9 +84,11 @@ interface Resolved {
   log: (line: string) => void;
   killWaitMs: number;
   pollIntervalMs: number;
+  hubOrigin: string | undefined;
 }
 
 function resolve(opts: LifecycleOpts): Resolved {
+  const configDir = opts.configDir ?? CONFIG_DIR;
   return {
     spawner: opts.spawner ?? defaultSpawner,
     kill: opts.kill ?? defaultKill,
@@ -76,11 +96,27 @@ function resolve(opts: LifecycleOpts): Resolved {
     sleep: opts.sleep ?? defaultSleep,
     now: opts.now ?? Date.now,
     manifestPath: opts.manifestPath ?? SERVICES_MANIFEST_PATH,
-    configDir: opts.configDir ?? CONFIG_DIR,
+    configDir,
     log: opts.log ?? ((line) => console.log(line)),
     killWaitMs: opts.killWaitMs ?? 10_000,
     pollIntervalMs: opts.pollIntervalMs ?? 200,
+    hubOrigin: resolveHubOrigin(opts.hubOrigin, configDir),
   };
+}
+
+/**
+ * Source of truth order for `PARACHUTE_HUB_ORIGIN`:
+ *   1. explicit override (flag / opt)
+ *   2. live exposure's hubOrigin / canonicalFqdn (what clients actually see)
+ *   3. hub.port when the hub is running locally (local-dev loopback)
+ *   4. undefined — don't set the env, let the service self-advertise
+ */
+function resolveHubOrigin(override: string | undefined, configDir: string): string | undefined {
+  if (override) return deriveHubOrigin({ override });
+  const state = readExposeState(join(configDir, "expose-state.json"));
+  if (state?.hubOrigin) return state.hubOrigin;
+  const exposeFqdn = state?.canonicalFqdn;
+  return deriveHubOrigin({ exposeFqdn, hubPort: readHubPort(configDir) });
 }
 
 /**
@@ -154,10 +190,12 @@ export async function start(svc: string | undefined, opts: LifecycleOpts = {}): 
     }
 
     const logFile = ensureLogPath(short, r.configDir);
+    const env = r.hubOrigin ? { [HUB_ORIGIN_ENV]: r.hubOrigin } : undefined;
     try {
-      const pid = r.spawner.spawn(cmd, logFile);
+      const pid = r.spawner.spawn(cmd, logFile, env);
       writePid(short, pid, r.configDir);
       r.log(`✓ ${short} started (pid ${pid}); logs: ${logFile}`);
+      if (env) r.log(`  ${HUB_ORIGIN_ENV}=${r.hubOrigin}`);
     } catch (err) {
       failures++;
       const msg = err instanceof Error ? err.message : String(err);

--- a/src/expose-state.ts
+++ b/src/expose-state.ts
@@ -23,6 +23,13 @@ export interface ExposeState {
   port: number;
   funnel: boolean;
   entries: ServeEntry[];
+  /**
+   * Hub origin emitted when this exposure was brought up — the URL OAuth
+   * clients will see as the issuer. `parachute start vault` reads it to set
+   * PARACHUTE_HUB_ORIGIN so vault's OAuth metadata matches reality. Optional
+   * for pre-Phase-0 state files; writers always populate it.
+   */
+  hubOrigin?: string;
 }
 
 export class ExposeStateError extends Error {
@@ -55,6 +62,9 @@ function validate(raw: unknown, path: string): ExposeState {
   if (!Array.isArray(r.entries)) {
     throw new ExposeStateError(`${path}: entries must be an array`);
   }
+  if (r.hubOrigin !== undefined && typeof r.hubOrigin !== "string") {
+    throw new ExposeStateError(`${path}: hubOrigin must be a string if present`);
+  }
   const entries: ServeEntry[] = r.entries.map((e, i) => {
     if (!e || typeof e !== "object") {
       throw new ExposeStateError(`${path} entries[${i}]: expected object`);
@@ -75,7 +85,7 @@ function validate(raw: unknown, path: string): ExposeState {
     }
     return { kind, mount: entry.mount, target: entry.target, service: entry.service };
   });
-  return {
+  const state: ExposeState = {
     version: 1,
     layer: r.layer,
     mode: r.mode,
@@ -84,6 +94,8 @@ function validate(raw: unknown, path: string): ExposeState {
     funnel: r.funnel,
     entries,
   };
+  if (typeof r.hubOrigin === "string") state.hubOrigin = r.hubOrigin;
+  return state;
 }
 
 export function readExposeState(path: string = EXPOSE_STATE_PATH): ExposeState | undefined {

--- a/src/help.ts
+++ b/src/help.ts
@@ -86,6 +86,10 @@ Layers:
 Both layers share a single tailscale-serve config on this node. Switching
 layers is idempotent — the prior layer tears down before the new one comes up.
 
+Flags:
+  --hub-origin <url>    override the OAuth issuer URL advertised to clients
+                        (default: https://<fqdn> when exposed, else http://127.0.0.1:<hub-port>)
+
 Examples:
   parachute expose tailnet          # bring every service up inside your tailnet
   parachute expose public           # also reachable from the public internet
@@ -122,6 +126,10 @@ What it does:
   Idempotent: if the service is already running, no-op.
   If a stale PID file exists (process died without cleanup), it's cleared
   and the service starts fresh.
+
+Flags:
+  --hub-origin <url>    override PARACHUTE_HUB_ORIGIN passed to services
+                        (default: current expose-state hub origin, else loopback)
 
 Examples:
   parachute start                   bring everything up

--- a/src/hub-origin.ts
+++ b/src/hub-origin.ts
@@ -1,0 +1,44 @@
+/**
+ * The Parachute hub is the ecosystem's OAuth issuer (Phase 0 of the hub-as-
+ * portal design at DESIGN-2026-04-20-hub-as-portal-oauth-and-service-catalog.md).
+ * Every service that participates in OAuth (today just vault; scribe + channel
+ * later) needs to know what URL clients will use to discover and reach the
+ * issuer — and that URL has to match what tailscale actually serves.
+ *
+ *   exposed (tailnet or public) → `https://<fqdn>`
+ *   not exposed (local dev)     → `http://127.0.0.1:<hub-port>`
+ *   user override               → whatever --hub-origin was passed
+ *
+ * One source of truth — expose/start both route through `deriveHubOrigin`.
+ */
+
+export const HUB_ORIGIN_ENV = "PARACHUTE_HUB_ORIGIN";
+
+export interface DeriveHubOriginOpts {
+  /** Explicit user override (e.g., `--hub-origin`). Wins over everything else. */
+  override?: string;
+  /**
+   * Tailnet FQDN from a live exposure. Present when `expose-state.json`
+   * carries a canonicalFqdn; absent for unexposed local dev.
+   */
+  exposeFqdn?: string;
+  /**
+   * Bound hub port for the localhost fallback. When no exposure and no hub
+   * port exists, we pass through `undefined` and callers decide what to do
+   * (typically: skip setting the env so vault advertises its own issuer).
+   */
+  hubPort?: number;
+}
+
+/**
+ * Resolve the canonical hub origin. Returns `undefined` only when no source
+ * of truth is available (no override, no exposure, no hub port). Callers that
+ * set `PARACHUTE_HUB_ORIGIN` on a child process should skip the env var
+ * entirely in that case so the service falls back to its own defaults.
+ */
+export function deriveHubOrigin(opts: DeriveHubOriginOpts): string | undefined {
+  if (opts.override) return opts.override.replace(/\/+$/, "");
+  if (opts.exposeFqdn) return `https://${opts.exposeFqdn}`;
+  if (opts.hubPort !== undefined) return `http://127.0.0.1:${opts.hubPort}`;
+  return undefined;
+}


### PR DESCRIPTION
## Why

Every OAuth-participating service in the Parachute ecosystem has to advertise the **same** issuer URL, and that URL has to be the one clients actually reach. Until now, vault self-advertised `http://localhost:1940` as its issuer even when exposed on a tailnet FQDN — OAuth discovery broke the moment you stepped off localhost.

Phase 0 of the hub-as-portal design (`DESIGN-2026-04-20-hub-as-portal-oauth-and-service-catalog.md`) gives the hub a single job: be the canonical OAuth issuer. Vault implements the protocol; the hub owns the URL.

## What

- **`src/hub-origin.ts`** — one `deriveHubOrigin()` helper, one precedence order:
  1. explicit `--hub-origin` flag (expose/start)
  2. `state.hubOrigin` when exposed (what tailscale actually serves)
  3. `http://127.0.0.1:<hub-port>` for unexposed local dev
  4. `undefined` — service keeps its own default

- **`parachute expose tailnet|public`** now proxies 4 OAuth paths at hub origin into the primary vault's `/vault/<name>/oauth/*` mounts:
  - `/.well-known/oauth-authorization-server`
  - `/oauth/authorize`
  - `/oauth/token`
  - `/oauth/register`

  Also persists `hubOrigin` into `expose-state.json` and prints `OAuth issuer: <origin>` alongside the open-URL line.

- **`parachute start`** reads the expose-state and passes `PARACHUTE_HUB_ORIGIN` to each spawned service (via extended `Spawner.env` seam), so vault stamps the matching `issuer` into discovery and tokens without another flag per invocation.

- `--hub-origin <url>` available on both `expose` and `start` — last-resort override for dev / custom domains.

## Out of scope

- **Multi-vault routing** (design open-question #4) — Phase 0 picks the primary vault; nothing emitted when no vault is installed.
- Service catalog surfacing (PR B, separate).
- Vault-side `issuer = PARACHUTE_HUB_ORIGIN` wiring — companion PR in `parachute-vault`.

## Test plan

- [x] `bun test` — 165 passing (12 new: 3 expose-routing, 4 lifecycle env-passthrough, hub-origin derivation)
- [x] `bunx tsc --noEmit`
- [x] `bunx biome check`
- [ ] Smoke: `parachute expose tailnet` on a node with vault installed, verify `curl https://<fqdn>/.well-known/oauth-authorization-server` returns vault's discovery doc with `issuer: https://<fqdn>`
- [ ] Smoke: `parachute start vault` with expose state present, tail log, confirm `PARACHUTE_HUB_ORIGIN=https://<fqdn>` visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)