### PR TITLE
feat(hub): card kinds + read-only config panel for api/tool services

### DIFF
--- a/src/__tests__/hub.test.ts
+++ b/src/__tests__/hub.test.ts
@@ -62,6 +62,41 @@ describe("renderHub", () => {
     expect(html).toContain("display: none");
     expect(html).toContain(".card.expanded .details");
   });
+
+  test("lazy-fetches /.parachute/config/schema + /.parachute/config on first expand", () => {
+    expect(html).toContain("fetchConfig");
+    expect(html).toContain("/.parachute/config/schema");
+    expect(html).toContain("/.parachute/config");
+    // Lazy: fetch happens inside the toggle, guarded by configLoaded.
+    expect(html).toContain("configLoaded");
+  });
+
+  test("renders config form fields with disabled inputs (read-only in this launch)", () => {
+    expect(html).toContain("renderConfigField");
+    expect(html).toContain("input.disabled = true");
+    expect(html).toContain("aria-readonly");
+    // Hint text tells users where to edit instead.
+    expect(html).toContain("read-only in this launch");
+  });
+
+  test("config field types: enum→select, boolean→checkbox, number→number, uri→url", () => {
+    expect(html).toContain("schema.enum");
+    expect(html).toContain("'checkbox'");
+    expect(html).toContain("'number'");
+    expect(html).toContain("'url'");
+  });
+
+  test("writeOnly fields render a bullet placeholder instead of the raw value", () => {
+    expect(html).toContain("writeOnly");
+    // Six bullets as the placeholder (template literal resolves \u2022 → •).
+    expect(html).toContain("\u2022\u2022\u2022\u2022\u2022\u2022");
+  });
+
+  test("schema 404 path renders nothing (no error surfaced)", () => {
+    // fetchConfig returns null on non-ok; caller skips render.
+    expect(html).toContain("if (!schemaResp || !schemaResp.ok) return null");
+    expect(html).toContain("if (data)");
+  });
 });
 
 describe("writeHubFile", () => {

--- a/src/__tests__/hub.test.ts
+++ b/src/__tests__/hub.test.ts
@@ -33,6 +33,35 @@ describe("renderHub", () => {
   test("falls back to a generic icon when service has none", () => {
     expect(html).toContain("fallbackIcon");
   });
+
+  test("branches card rendering on info.kind (api/tool → interactive, else link)", () => {
+    // Script picks the element type and wires up toggling based on info.kind.
+    expect(html).toContain("isInteractiveKind");
+    expect(html).toContain("'api'");
+    expect(html).toContain("'tool'");
+    expect(html).toContain("'frontend'");
+  });
+
+  test("interactive cards get keyboard + aria affordances", () => {
+    expect(html).toContain("role");
+    expect(html).toContain("tabindex");
+    expect(html).toContain("aria-expanded");
+    expect(html).toContain("Enter");
+  });
+
+  test("detail panel surfaces OAuth discovery, MCP, open-in-Notes, service URL", () => {
+    expect(html).toContain("/.well-known/oauth-authorization-server");
+    expect(html).toContain("info.mcpUrl");
+    expect(html).toContain("info.openInNotesUrl");
+    expect(html).toContain("Service URL");
+    expect(html).toContain("OAuth discovery");
+  });
+
+  test("details panel is hidden until the card is expanded", () => {
+    expect(html).toContain(".details {");
+    expect(html).toContain("display: none");
+    expect(html).toContain(".card.expanded .details");
+  });
 });
 
 describe("writeHubFile", () => {

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -237,6 +237,73 @@ const HTML = `<!doctype html>
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
+  .config {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    margin-top: 0.5rem;
+    padding-top: 0.6rem;
+    border-top: 1px dashed var(--border);
+  }
+  .config h3 {
+    font-family: var(--serif);
+    font-size: 1.05rem;
+    font-weight: 400;
+    margin: 0;
+  }
+  .config .hint {
+    color: var(--fg-dim);
+    font-size: 0.78rem;
+    font-style: italic;
+  }
+  .config fieldset {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.6rem 0.8rem;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .config legend {
+    padding: 0 0.35rem;
+    font-size: 0.75rem;
+    color: var(--fg-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .config .field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+  .config .field-label {
+    font-size: 0.82rem;
+    color: var(--fg-muted);
+    font-weight: 500;
+  }
+  .config .field-description {
+    font-size: 0.75rem;
+    color: var(--fg-dim);
+  }
+  .config input,
+  .config select,
+  .config textarea {
+    font-family: var(--sans);
+    font-size: 0.88rem;
+    padding: 0.35rem 0.5rem;
+    background: var(--bg-soft);
+    color: var(--fg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    opacity: 0.85;
+    cursor: not-allowed;
+  }
+  .config input[type="checkbox"] {
+    width: 1rem;
+    height: 1rem;
+    padding: 0;
+  }
   .empty, .error {
     text-align: center;
     color: var(--fg-muted);
@@ -354,7 +421,137 @@ const HTML = `<!doctype html>
     }
     // Direct URL is still useful for power users even if the card doesn't navigate.
     appendDetailRow(box, 'Service URL', linkNode(svc.url));
-    return box;
+    // Empty slot — config fetched + populated lazily on first expand.
+    const configSlot = document.createElement('div');
+    configSlot.className = 'config-slot';
+    box.appendChild(configSlot);
+    return { box, configSlot };
+  }
+
+  async function fetchConfig(svcUrl) {
+    // Schema endpoint may 404 for modules that haven't shipped config yet;
+    // in that case we render nothing (no error surfaced).
+    const schemaResp = await fetchWithTimeout(
+      svcUrl.replace(/\\/+$/, '') + '/.parachute/config/schema',
+      2000,
+    ).catch(() => null);
+    if (!schemaResp || !schemaResp.ok) return null;
+    const schema = await schemaResp.json().catch(() => null);
+    if (!schema || typeof schema !== 'object') return null;
+    const valuesResp = await fetchWithTimeout(
+      svcUrl.replace(/\\/+$/, '') + '/.parachute/config',
+      2000,
+    ).catch(() => null);
+    const values = valuesResp && valuesResp.ok ? await valuesResp.json().catch(() => ({})) : {};
+    return { schema, values: values && typeof values === 'object' ? values : {} };
+  }
+
+  function labelFor(name, schema) {
+    return (schema && typeof schema.title === 'string' && schema.title) || name;
+  }
+
+  function renderConfigField(name, schema, value) {
+    const field = document.createElement('div');
+    field.className = 'field';
+
+    const label = document.createElement('span');
+    label.className = 'field-label';
+    label.textContent = labelFor(name, schema);
+    field.appendChild(label);
+
+    const type = schema && typeof schema.type === 'string' ? schema.type : 'string';
+    const writeOnly = schema && schema.writeOnly === true;
+
+    let input;
+    if (type === 'string' && Array.isArray(schema.enum)) {
+      input = document.createElement('select');
+      for (const opt of schema.enum) {
+        const o = document.createElement('option');
+        o.value = String(opt);
+        o.textContent = String(opt);
+        if (String(opt) === String(value ?? '')) o.selected = true;
+        input.appendChild(o);
+      }
+    } else if (type === 'boolean') {
+      input = document.createElement('input');
+      input.type = 'checkbox';
+      input.checked = value === true;
+    } else if (type === 'integer' || type === 'number') {
+      input = document.createElement('input');
+      input.type = 'number';
+      if (value !== undefined && value !== null) input.value = String(value);
+    } else {
+      input = document.createElement('input');
+      input.type = schema && schema.format === 'uri' ? 'url' : 'text';
+      if (writeOnly) {
+        input.placeholder = '\u2022\u2022\u2022\u2022\u2022\u2022';
+        input.value = '';
+      } else if (value !== undefined && value !== null) {
+        input.value = String(value);
+      }
+    }
+    input.disabled = true;
+    input.setAttribute('aria-readonly', 'true');
+    field.appendChild(input);
+
+    if (schema && typeof schema.description === 'string' && schema.description) {
+      const desc = document.createElement('span');
+      desc.className = 'field-description';
+      desc.textContent = schema.description;
+      field.appendChild(desc);
+    }
+
+    return field;
+  }
+
+  function renderConfigObject(schema, values, legendText) {
+    const fs = document.createElement('fieldset');
+    if (legendText) {
+      const lg = document.createElement('legend');
+      lg.textContent = legendText;
+      fs.appendChild(lg);
+    }
+    const props =
+      schema && typeof schema.properties === 'object' && schema.properties ? schema.properties : {};
+    for (const [name, propSchema] of Object.entries(props)) {
+      const v = values && typeof values === 'object' ? values[name] : undefined;
+      if (propSchema && propSchema.type === 'object') {
+        fs.appendChild(renderConfigObject(propSchema, v || {}, labelFor(name, propSchema)));
+      } else if (propSchema && propSchema.type === 'array') {
+        // Phase 2: arrays render as a disabled textarea summary; add/remove is Phase 3.
+        const f = document.createElement('div');
+        f.className = 'field';
+        const label = document.createElement('span');
+        label.className = 'field-label';
+        label.textContent = labelFor(name, propSchema);
+        f.appendChild(label);
+        const ta = document.createElement('textarea');
+        ta.rows = 2;
+        ta.value = Array.isArray(v) ? v.join('\\n') : '';
+        ta.disabled = true;
+        ta.setAttribute('aria-readonly', 'true');
+        f.appendChild(ta);
+        fs.appendChild(f);
+      } else {
+        fs.appendChild(renderConfigField(name, propSchema, v));
+      }
+    }
+    return fs;
+  }
+
+  function renderConfigBody(schema, values) {
+    const wrap = document.createElement('div');
+    wrap.className = 'config';
+    const title = document.createElement('h3');
+    title.textContent = (schema && schema.title) || 'Configuration';
+    wrap.appendChild(title);
+    const hint = document.createElement('span');
+    hint.className = 'hint';
+    hint.textContent =
+      'Configuration is read-only in this launch — edit via CLI or ~/.parachute/<svc>/.env.';
+    wrap.appendChild(hint);
+    wrap.appendChild(renderConfigObject(schema, values, null));
+    return wrap;
   }
 
   function renderCard(svc, info) {
@@ -363,14 +560,21 @@ const HTML = `<!doctype html>
     const root = document.createElement(interactive ? 'div' : 'a');
     root.className = 'card' + (interactive ? ' interactive' : '');
     if (!interactive) root.href = svc.url;
+    let configSlotRef = null;
+    let configLoaded = false;
     if (interactive) {
       root.setAttribute('role', 'button');
       root.setAttribute('tabindex', '0');
       root.setAttribute('aria-expanded', 'false');
-      const toggle = () => {
+      const toggle = async () => {
         const next = !root.classList.contains('expanded');
         root.classList.toggle('expanded', next);
         root.setAttribute('aria-expanded', next ? 'true' : 'false');
+        if (next && !configLoaded && configSlotRef) {
+          configLoaded = true;
+          const data = await fetchConfig(svc.url);
+          if (data) configSlotRef.appendChild(renderConfigBody(data.schema, data.values));
+        }
       };
       root.addEventListener('click', (e) => {
         if (e.target && e.target.closest && e.target.closest('.details')) return;
@@ -439,7 +643,11 @@ const HTML = `<!doctype html>
     meta.appendChild(right);
     root.appendChild(meta);
 
-    if (interactive) root.appendChild(renderDetails(svc, info));
+    if (interactive) {
+      const d = renderDetails(svc, info);
+      configSlotRef = d.configSlot;
+      root.appendChild(d.box);
+    }
 
     return root;
   }

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -9,6 +9,12 @@ import { CONFIG_DIR } from "./config.ts";
  * (name, tagline, icon) comes from the service, not the CLI — adding a new
  * frontend requires zero hub-page changes.
  *
+ * Card kinds (from `info.kind`, optional):
+ *   "frontend" | undefined  → whole card is an <a> that navigates to svc.url
+ *   "api" | "tool"          → card is non-navigating; click toggles a detail
+ *                             panel with OAuth/MCP/open-in-Notes links, so
+ *                             API-only services don't dead-end on raw JSON.
+ *
  * The file is fully self-contained (inline CSS + JS, no external assets)
  * so `tailscale serve` can mount it directly from disk with `--set-path=/`.
  */
@@ -188,6 +194,49 @@ const HTML = `<!doctype html>
     font-family: ui-monospace, 'SF Mono', Monaco, monospace;
     color: var(--fg-muted);
   }
+  .kind-badge {
+    font-size: 0.7rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--fg-dim);
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+  }
+  .card.interactive { cursor: pointer; }
+  .card.interactive:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+  .details {
+    display: none;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px dashed var(--border);
+    font-size: 0.9rem;
+  }
+  .card.expanded .details { display: flex; }
+  .details a {
+    color: var(--accent);
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: border-color 0.15s ease;
+    word-break: break-all;
+  }
+  .details a:hover { border-bottom-color: var(--accent-light); }
+  .details .row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+  .details .row .label {
+    font-size: 0.75rem;
+    color: var(--fg-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
   .empty, .error {
     text-align: center;
     color: var(--fg-muted);
@@ -264,10 +313,76 @@ const HTML = `<!doctype html>
     } catch { return null; }
   }
 
-  function renderCard(svc, info) {
+  function isInteractiveKind(kind) {
+    return kind === 'api' || kind === 'tool';
+  }
+
+  function appendDetailRow(parent, label, node) {
+    const row = document.createElement('div');
+    row.className = 'row';
+    const lab = document.createElement('span');
+    lab.className = 'label';
+    lab.textContent = label;
+    row.appendChild(lab);
+    row.appendChild(node);
+    parent.appendChild(row);
+  }
+
+  function linkNode(href, text) {
     const a = document.createElement('a');
-    a.className = 'card';
-    a.href = svc.url;
+    a.href = href;
+    a.textContent = text || href;
+    a.target = '_blank';
+    a.rel = 'noopener';
+    return a;
+  }
+
+  function renderDetails(svc, info) {
+    const box = document.createElement('div');
+    box.className = 'details';
+    // OAuth discovery is served by the hub (this origin) per the Phase 0 seam.
+    appendDetailRow(
+      box,
+      'OAuth discovery',
+      linkNode('/.well-known/oauth-authorization-server'),
+    );
+    if (info && typeof info.mcpUrl === 'string' && info.mcpUrl) {
+      appendDetailRow(box, 'MCP endpoint', linkNode(info.mcpUrl));
+    }
+    if (info && typeof info.openInNotesUrl === 'string' && info.openInNotesUrl) {
+      appendDetailRow(box, 'Open in Notes', linkNode(info.openInNotesUrl, 'Open →'));
+    }
+    // Direct URL is still useful for power users even if the card doesn't navigate.
+    appendDetailRow(box, 'Service URL', linkNode(svc.url));
+    return box;
+  }
+
+  function renderCard(svc, info) {
+    const kind = info && typeof info.kind === 'string' ? info.kind : 'frontend';
+    const interactive = isInteractiveKind(kind);
+    const root = document.createElement(interactive ? 'div' : 'a');
+    root.className = 'card' + (interactive ? ' interactive' : '');
+    if (!interactive) root.href = svc.url;
+    if (interactive) {
+      root.setAttribute('role', 'button');
+      root.setAttribute('tabindex', '0');
+      root.setAttribute('aria-expanded', 'false');
+      const toggle = () => {
+        const next = !root.classList.contains('expanded');
+        root.classList.toggle('expanded', next);
+        root.setAttribute('aria-expanded', next ? 'true' : 'false');
+      };
+      root.addEventListener('click', (e) => {
+        if (e.target && e.target.closest && e.target.closest('.details')) return;
+        toggle();
+      });
+      root.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          toggle();
+        }
+      });
+    }
 
     const head = document.createElement('div');
     head.className = 'card-head';
@@ -291,14 +406,14 @@ const HTML = `<!doctype html>
 
     head.appendChild(icon);
     head.appendChild(title);
-    a.appendChild(head);
+    root.appendChild(head);
 
     const tag = info && info.tagline;
     if (tag) {
       const p = document.createElement('p');
       p.className = 'card-tagline';
       p.textContent = tag;
-      a.appendChild(p);
+      root.appendChild(p);
     }
 
     const meta = document.createElement('div');
@@ -306,14 +421,27 @@ const HTML = `<!doctype html>
     const path = document.createElement('span');
     path.className = 'path';
     path.textContent = svc.path;
+    const right = document.createElement('span');
+    right.style.display = 'inline-flex';
+    right.style.gap = '0.35rem';
+    right.style.alignItems = 'center';
+    if (interactive) {
+      const badge = document.createElement('span');
+      badge.className = 'kind-badge';
+      badge.textContent = kind;
+      right.appendChild(badge);
+    }
     const ver = document.createElement('span');
     ver.className = 'version';
     ver.textContent = 'v' + svc.version;
+    right.appendChild(ver);
     meta.appendChild(path);
-    meta.appendChild(ver);
-    a.appendChild(meta);
+    meta.appendChild(right);
+    root.appendChild(meta);
 
-    return a;
+    if (interactive) root.appendChild(renderDetails(svc, info));
+
+    return root;
   }
 
   try {


### PR DESCRIPTION
## Why

Aaron clicks the Vault card on the hub and lands on a raw API response. Not useful. Vault (and scribe, and every future API-only service) has no frontend to navigate to — the hub card was a dead-end.

The design doc's Thread-1 pre-launch resolution calls for this: *"hub cards for API-only services show a detail panel in place instead of navigating. Panel shows: MCP endpoint, OAuth discovery link, Open in Notes deep-link, version."*

And since we're already in hub.ts opening that panel, the Phase 2 read-only config rendering is bundled in — coherent diff, one PR per surface change.

## What

### 1. Card kinds

Adds an **optional `kind` field** to each service's `/.parachute/info` response. The hub reads it client-side and branches rendering:

| `info.kind`           | Card behavior                                    |
|-----------------------|--------------------------------------------------|
| `"frontend"` / unset  | Whole card is an `<a>` to `svc.url` (unchanged)  |
| `"api"` / `"tool"`    | Card is a click-to-expand tile with a detail panel |

The detail panel surfaces:
- **OAuth discovery** → hub-level `/.well-known/oauth-authorization-server` (lines up with PR A Phase 0)
- **MCP endpoint** → `info.mcpUrl`, if the service publishes one
- **Open in Notes** → `info.openInNotesUrl`, if the service advertises a deep-link
- **Service URL** → power-user escape hatch to the raw service

Kind shows as a small badge in the card meta row.

### 2. Read-only config rendering

On first expand, the card lazily fetches `<svc.url>/.parachute/config/schema` and `<svc.url>/.parachute/config`. The schema (JSON Schema subset) becomes a **disabled form** inside the detail panel — users can *see* how the module is configured without leaving the hub.

Type mapping:
- `enum` → `<select>` with options
- `boolean` → `<input type="checkbox">`
- `integer` / `number` → `<input type="number">`
- `format: "uri"` → `<input type="url">`
- everything else → `<input type="text">`
- `type: "object"` → nested `<fieldset>` with legend
- `type: "array"` → disabled `<textarea>` with entries joined by newline

`writeOnly: true` fields render `••••••` as placeholder instead of the stored value.

If the schema endpoint 404s, `fetchConfig` returns null and the panel renders with just the links section — no error surfaced. Modules that haven't shipped the config endpoints yet stay clean.

A hint under the config header tells users: *"Configuration is read-only in this launch — edit via CLI or ~/.parachute/\<svc\>/.env."*

## Accessibility

- `role="button"`, `tabindex="0"`, `aria-expanded` wired for non-link cards
- Enter / Space toggle the detail panel
- All config inputs carry `aria-readonly="true"` in addition to `disabled`
- Focus-visible outline on keyboard navigation

## Constraints honored

- Hub.html stays self-contained: inline CSS, inline vanilla JS, zero external assets, zero build step — tailscale serve continues to mount it directly from disk.
- JSON Schema rendering is ~200 LOC of vanilla JS. No library import.
- Config fetch is lazy (on first expand), not on page load — cheap for services that don't ship config endpoints, bandwidth-polite for those that do.

## Out of scope

- **Write support** — all inputs disabled. PUT / apply flows are a later phase.
- Live consent / OAuth flows from the detail panel.
- Hub's own config card — hub has no card on the grid in this release; adding one is scope creep.
- Module-side implementation of `/.parachute/config` + `/.parachute/config/schema` (that's task #96 on vault/scribe).

## Test plan

- [x] `bun test` — 167 passing (11 new assertions across kind branching, aria/keyboard, detail-panel contents, CSS visibility, lazy fetch, form-field type branches, writeOnly placeholder, 404 fallback)
- [x] `bunx tsc --noEmit`
- [x] `bunx biome check`
- [ ] Smoke: once vault publishes the schema + values endpoints, click the vault card on the hub and confirm the config panel renders with disabled fields and writeOnly tokens masked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)