### PR TITLE
polish: clarify `parachute vault` dispatch boundary

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -106,11 +106,24 @@ describe("cli per-subcommand help", () => {
     expect(stdout).toMatch(/expose tailnet/);
   });
 
-  test("vault with no args shows dispatch help", async () => {
-    const { code, stdout } = await runCli(["vault"]);
-    expect(code).toBe(0);
-    expect(stdout).toMatch(/parachute vault/);
-    expect(stdout).toMatch(/parachute install vault/);
+  test("vault with no args forwards --help to parachute-vault", async () => {
+    // Clear PATH so the dispatcher reliably hits the ENOENT branch — that
+    // proves the CLI is forwarding rather than printing local help. Spawn
+    // bun by absolute path so the outer shell-out isn't affected by PATH=''.
+    const proc = Bun.spawn([process.execPath, CLI, "vault"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        PATH: "",
+        HOME: "/tmp/parachute-cli-nonexistent-home",
+        PARACHUTE_HOME: "/tmp/parachute-cli-nonexistent-home",
+      },
+    });
+    const [stderr, code] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
+    expect(code).toBe(127);
+    expect(stderr).toMatch(/parachute-vault not found on PATH/);
+    expect(stderr).toMatch(/parachute install vault/);
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,6 @@ import {
   statusHelp,
   stopHelp,
   topLevelHelp,
-  vaultHelp,
 } from "./help.ts";
 import { knownServices } from "./service-spec.ts";
 import { ServicesManifestError } from "./services-manifest.ts";
@@ -154,14 +153,10 @@ async function main(argv: string[]): Promise<number> {
     }
 
     case "vault":
-      // `parachute vault` alone shows CLI's dispatch help (usage hint).
-      // `parachute vault <anything>` forwards verbatim — including --help,
-      // which goes to parachute-vault itself so the user sees vault's own help.
-      if (rest.length === 0) {
-        console.log(vaultHelp());
-        return 0;
-      }
-      return await dispatchVault(rest);
+      // `parachute vault` with no args forwards --help to parachute-vault so
+      // users see the actual vault surface, not a CLI-side stub. Anything
+      // after `vault` (including --help) is passed through verbatim.
+      return await dispatchVault(rest.length === 0 ? ["--help"] : rest);
 
     default:
       console.error(`parachute: unknown command "${command}"`);

--- a/src/help.ts
+++ b/src/help.ts
@@ -16,7 +16,9 @@ Usage:
   parachute expose tailnet [off]    HTTPS across your tailnet
   parachute expose public  [off]    HTTPS on the public internet (Funnel)
   parachute migrate [--dry-run]     archive legacy files at ecosystem root
-  parachute vault <args...>         dispatch to parachute-vault
+  parachute vault <args...>         vault-specific ops (tokens, 2fa, config, init,
+                                    etc.) — forwards to parachute-vault.
+                                    For lifecycle, use \`parachute start|stop|restart|logs vault\`.
 
 Flags:
   --help, -h                        show this help (also per-subcommand: \`parachute <cmd> --help\`)
@@ -206,22 +208,5 @@ Examples:
   parachute migrate --dry-run       see what would move, without touching anything
   parachute migrate                 interactive sweep (prompts before acting)
   parachute migrate --yes           sweep without prompting
-`;
-}
-
-export function vaultHelp(): string {
-  return `parachute vault — dispatch to parachute-vault
-
-Usage:
-  parachute vault <args...>
-
-Everything after \`parachute vault\` is forwarded verbatim to the installed
-parachute-vault binary. If you get "not found on PATH", install it with:
-
-  parachute install vault
-
-Examples:
-  parachute vault init              # same as running \`parachute-vault init\`
-  parachute vault --help            # forwards --help to parachute-vault
 `;
 }


### PR DESCRIPTION
## Why

Aaron (and anyone new to the CLI) lands in an awkward spot when typing `parachute vault`:

- The top-level help says `parachute vault <args...>         dispatch to parachute-vault` — technically accurate, but it doesn't tell a user *what* belongs here vs. what belongs in `parachute start vault`. The boundary is load-bearing and it was invisible.
- Bare `parachute vault` printed a CLI-side stub of vault's help, which drifts from whatever vault actually ships and made the wrapper look like it owned the surface.

Pairs with a vault-side help polish team-lead just dispatched; they compose cleanly.

## What

Two small changes, no restructure:

1. **Top-level help** — the `parachute vault` line now names what belongs on the vault side and points explicitly at lifecycle:
   ```
   parachute vault <args...>         vault-specific ops (tokens, 2fa, config, init,
                                     etc.) — forwards to parachute-vault.
                                     For lifecycle, use `parachute start|stop|restart|logs vault`.
   ```

2. **Dispatch** — `parachute vault` with no further args now forwards `--help` to parachute-vault directly. Users see vault's real help, not a wrapper doc. Any further args still pass through verbatim.

Also drops the now-unused `vaultHelp()` export (dead code after #2).

## Test plan

- [x] `bun test` — 158 passing (the old "vault with no args shows dispatch help" test is rewritten to assert forwarding: with `PATH=''`, dispatch hits the ENOENT branch and surfaces `parachute-vault not found on PATH` + the install hint)
- [x] `bunx tsc --noEmit`
- [x] `bunx biome check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)