### PR TITLE
feat(auth): introduce `parachute auth` namespace for ecosystem identity

### DIFF
--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { type Runner, auth, authHelp } from "../commands/auth.ts";
+
+function makeRunner(result: number | (() => Promise<number>) = 0): {
+  runner: Runner;
+  calls: Array<readonly string[]>;
+} {
+  const calls: Array<readonly string[]> = [];
+  const runner: Runner = {
+    async run(cmd) {
+      calls.push(cmd);
+      return typeof result === "function" ? await result() : result;
+    },
+  };
+  return { runner, calls };
+}
+
+describe("parachute auth", () => {
+  test("set-password forwards to parachute-vault set-password", async () => {
+    const { runner, calls } = makeRunner(0);
+    const code = await auth(["set-password"], runner);
+    expect(code).toBe(0);
+    expect(calls).toEqual([["parachute-vault", "set-password"]]);
+  });
+
+  test("set-password --clear forwards the flag", async () => {
+    const { runner, calls } = makeRunner(0);
+    const code = await auth(["set-password", "--clear"], runner);
+    expect(code).toBe(0);
+    expect(calls).toEqual([["parachute-vault", "set-password", "--clear"]]);
+  });
+
+  test("2fa enroll forwards to parachute-vault 2fa enroll", async () => {
+    const { runner, calls } = makeRunner(0);
+    const code = await auth(["2fa", "enroll"], runner);
+    expect(code).toBe(0);
+    expect(calls).toEqual([["parachute-vault", "2fa", "enroll"]]);
+  });
+
+  test("2fa enroll --some-flag forwards every arg after the subcommand", async () => {
+    const { runner, calls } = makeRunner(0);
+    const code = await auth(["2fa", "enroll", "--some-flag", "value"], runner);
+    expect(code).toBe(0);
+    expect(calls).toEqual([["parachute-vault", "2fa", "enroll", "--some-flag", "value"]]);
+  });
+
+  test("exit code from parachute-vault is propagated", async () => {
+    const { runner } = makeRunner(3);
+    const code = await auth(["2fa", "status"], runner);
+    expect(code).toBe(3);
+  });
+
+  test("ENOENT surfaces install hint and exit 127", async () => {
+    const runner: Runner = {
+      async run() {
+        throw new Error("ENOENT: spawn parachute-vault");
+      },
+    };
+    const code = await auth(["set-password"], runner);
+    expect(code).toBe(127);
+  });
+
+  test("bogus subcommand exits 1 without spawning vault", async () => {
+    const { runner, calls } = makeRunner(0);
+    const code = await auth(["whoami"], runner);
+    expect(code).toBe(1);
+    expect(calls).toEqual([]);
+  });
+
+  test("no args prints help and exits 0 without spawning vault", async () => {
+    const { runner, calls } = makeRunner(0);
+    const code = await auth([], runner);
+    expect(code).toBe(0);
+    expect(calls).toEqual([]);
+  });
+
+  test("--help and help both route to the same help surface", async () => {
+    const { runner, calls } = makeRunner(0);
+    expect(await auth(["--help"], runner)).toBe(0);
+    expect(await auth(["-h"], runner)).toBe(0);
+    expect(await auth(["help"], runner)).toBe(0);
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("authHelp", () => {
+  const h = authHelp();
+
+  test("lists every blessed subcommand", () => {
+    expect(h).toContain("parachute auth set-password");
+    expect(h).toContain("--clear");
+    expect(h).toContain("parachute auth 2fa status");
+    expect(h).toContain("parachute auth 2fa enroll");
+    expect(h).toContain("parachute auth 2fa disable");
+    expect(h).toContain("parachute auth 2fa backup-codes");
+  });
+
+  test("mentions the vault-install hint", () => {
+    expect(h).toContain("parachute install vault");
+  });
+});

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -39,6 +39,7 @@ describe("cli", () => {
     expect(code).toBe(0);
     expect(stdout).toMatch(/parachute install/);
     expect(stdout).toMatch(/parachute status/);
+    expect(stdout).toMatch(/parachute auth/);
     expect(stdout).toMatch(/parachute vault/);
     expect(stdout).toMatch(/expose tailnet/);
     expect(stdout).toMatch(/expose public/);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@
  */
 
 import pkg from "../package.json" with { type: "json" };
+import { auth } from "./commands/auth.ts";
 import { exposePublic, exposeTailnet } from "./commands/expose.ts";
 import { install } from "./commands/install.ts";
 import { logs, restart, start, stop } from "./commands/lifecycle.ts";
@@ -197,6 +198,9 @@ async function main(argv: string[]): Promise<number> {
       }
       return await migrate({ dryRun, yes });
     }
+
+    case "auth":
+      return await auth(rest);
 
     case "vault":
       // `parachute vault` with no args forwards --help to parachute-vault so

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,0 +1,69 @@
+/**
+ * `parachute auth` — ecosystem-level identity commands.
+ *
+ * Identity (password + 2FA) is an ecosystem concern now that the hub owns
+ * OAuth issuance (Phase 0). The *implementation* still lives in
+ * parachute-vault — these commands are thin shell-forwards to the vault
+ * binary so beta users learn the blessed namespace from day one.
+ *
+ * Vault keeps its own `set-password` / `2fa` commands for back-compat.
+ */
+
+export interface Runner {
+  run(cmd: readonly string[]): Promise<number>;
+}
+
+export const defaultRunner: Runner = {
+  async run(cmd) {
+    const proc = Bun.spawn([...cmd], { stdio: ["inherit", "inherit", "inherit"] });
+    return await proc.exited;
+  },
+};
+
+const AUTH_SUBCOMMANDS = new Set(["set-password", "2fa"]);
+
+export function authHelp(): string {
+  return `parachute auth — ecosystem identity commands (password + two-factor authentication)
+
+Usage:
+  parachute auth set-password         Set or change the owner password
+  parachute auth set-password --clear Remove the owner password
+  parachute auth 2fa status           Show 2FA state
+  parachute auth 2fa enroll           Enable TOTP 2FA (QR + backup codes)
+  parachute auth 2fa disable          Disable 2FA (requires password)
+  parachute auth 2fa backup-codes     Regenerate backup codes
+
+All subcommands forward to \`parachute-vault\` which implements the storage
+and crypto. If you see "not found on PATH", install vault first:
+
+  parachute install vault
+`;
+}
+
+export async function auth(
+  args: readonly string[],
+  runner: Runner = defaultRunner,
+): Promise<number> {
+  const sub = args[0];
+  if (sub === undefined || sub === "--help" || sub === "-h" || sub === "help") {
+    console.log(authHelp());
+    return 0;
+  }
+  if (!AUTH_SUBCOMMANDS.has(sub)) {
+    console.error(`parachute auth: unknown subcommand "${sub}"`);
+    console.error("run `parachute auth --help` for usage");
+    return 1;
+  }
+  try {
+    return await runner.run(["parachute-vault", ...args]);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.toLowerCase().includes("enoent") || msg.toLowerCase().includes("not found")) {
+      console.error("parachute-vault not found on PATH.");
+      console.error("Install it with: parachute install vault");
+      return 127;
+    }
+    console.error(`failed to run parachute-vault: ${msg}`);
+    return 1;
+  }
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -16,6 +16,7 @@ Usage:
   parachute expose tailnet [off]    HTTPS across your tailnet
   parachute expose public  [off]    HTTPS on the public internet (Funnel)
   parachute migrate [--dry-run]     archive legacy files at ecosystem root
+  parachute auth <cmd>              identity (set password, manage 2FA)
   parachute vault <args...>         vault-specific ops (tokens, 2fa, config, init,
                                     etc.) — forwards to parachute-vault.
                                     For lifecycle, use \`parachute start|stop|restart|logs vault\`.


### PR DESCRIPTION
## Why

Phase 0 (just merged) made the **hub** the OAuth issuer — identity is an ecosystem concern now, not a vault concern. But the *commands* to manage identity still lived under `parachute-vault`:

```
parachute-vault set-password
parachute-vault 2fa enroll
...
```

That's backwards — and it matters right now because Aaron's launch blog post + beta email ship this week. Whatever names those docs use are the names users will learn. Moving these to `parachute auth ...` pre-launch is free; moving them after is expensive.

When third-party modules arrive post-launch, `parachute auth` is also the natural namespace for all ecosystem-identity ops (whoami/login/logout later).

## What

New `parachute auth` command group. Pure dispatch — no auth logic in the CLI. Each subcommand forwards to the existing `parachute-vault` implementation via `Bun.spawn`, same pattern as `parachute vault <args>`.

| Command                                  | Forwards to                                   |
|------------------------------------------|-----------------------------------------------|
| `parachute auth set-password`            | `parachute-vault set-password`                |
| `parachute auth set-password --clear`    | `parachute-vault set-password --clear`        |
| `parachute auth 2fa status`              | `parachute-vault 2fa status`                  |
| `parachute auth 2fa enroll`              | `parachute-vault 2fa enroll`                  |
| `parachute auth 2fa disable`             | `parachute-vault 2fa disable`                 |
| `parachute auth 2fa backup-codes`        | `parachute-vault 2fa backup-codes`            |

Everything after the subcommand forwards verbatim — vault can evolve flag surfaces (--clear, --format=qr, etc.) without the CLI needing to know.

### Help text

Top-level `parachute --help` gets:
```
parachute auth <cmd>              identity (set password, manage 2FA)
```

`parachute auth` with no subcommand prints the full subcommand list (matches the shape team-lead specified).

Unknown subcommand → exit 1 with pointer to `--help`. No spawn attempted.

## Design notes

- **Runner seam**: the dispatcher takes a `Runner` interface (`run(cmd) → Promise<number>`). Default implementation shells out; tests inject a spy. Keeps unit tests fast and assertion-friendly — no shelling out to a binary that may or may not exist on the test host.
- **ENOENT mapping**: if `parachute-vault` isn't on PATH, exit 127 with the same install hint the vault-dispatch uses.
- **Vault-side**: unchanged here. Team-lead dispatched a parallel PR to vault steward marking `set-password` and `2fa` as "implementation — prefer `parachute auth ...`" in vault's help, matching the Advanced/Standalone split pattern.

## Out of scope

- No `whoami` / `login` / `logout` — post-launch when there's actually an ecosystem session to query.
- No auth logic in the CLI itself — all crypto + storage stays in vault.
- No changes to vault's CLI (handled in the parallel PR).

## Test plan

- [x] `bun test` — 169 passing, including 11 new `auth.test.ts` assertions
  - set-password forwards
  - --clear flag propagates
  - 2fa enroll forwards
  - arbitrary trailing flags propagate
  - exit code from vault propagates
  - ENOENT → 127 with install hint
  - bogus subcommand → 1, no spawn
  - empty args → prints help, no spawn
  - --help / -h / help all route to help
  - authHelp lists every subcommand
  - authHelp mentions install hint
- [x] `bunx tsc --noEmit`
- [x] `bunx biome check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)