### PR TITLE
Bump to 0.2.0-rc.1 for pre-launch RC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/cli",
-  "version": "0.2.0",
+  "version": "0.2.0-rc.1",
   "description": "parachute — the top-level CLI for the Parachute ecosystem.",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Publish with `bun publish --tag rc`. Plain installs unaffected.