### PR TITLE
feat(install): --tag flag for pinning a dist-tag or version

### DIFF
--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -231,6 +231,95 @@ describe("install", () => {
     }
   });
 
+  test("--tag composes `<package>@<tag>` for the bun add call", async () => {
+    // RC testers pin a pre-release channel via dist-tag (e.g. `--tag rc`).
+    // The composed name shows up in logs so the operator knows which channel
+    // they're on — no surprise upgrades when the tag rolls forward.
+    const { path, cleanup } = makeTempPath();
+    try {
+      const calls: string[][] = [];
+      const logs: string[] = [];
+      const code = await install("vault", {
+        runner: async (cmd) => {
+          calls.push([...cmd]);
+          return 0;
+        },
+        manifestPath: path,
+        isLinked: () => false,
+        log: (l) => logs.push(l),
+        tag: "rc",
+      });
+      expect(code).toBe(0);
+      expect(calls[0]).toEqual(["bun", "add", "-g", "@openparachute/vault@rc"]);
+      expect(logs.join("\n")).toMatch(/Installing @openparachute\/vault@rc/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("--tag accepts an exact version string", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const calls: string[][] = [];
+      const code = await install("vault", {
+        runner: async (cmd) => {
+          calls.push([...cmd]);
+          return 0;
+        },
+        manifestPath: path,
+        isLinked: () => false,
+        log: () => {},
+        tag: "0.3.0-rc.1",
+      });
+      expect(code).toBe(0);
+      expect(calls[0]).toEqual(["bun", "add", "-g", "@openparachute/vault@0.3.0-rc.1"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("--tag is moot when the package is already bun-linked", async () => {
+    // The link short-circuit beats the tag — local checkout wins, no fetch.
+    const { path, cleanup } = makeTempPath();
+    try {
+      const calls: string[][] = [];
+      const logs: string[] = [];
+      const code = await install("scribe", {
+        runner: async (cmd) => {
+          calls.push([...cmd]);
+          return 0;
+        },
+        manifestPath: path,
+        isLinked: () => true,
+        log: (l) => logs.push(l),
+        tag: "rc",
+      });
+      expect(code).toBe(0);
+      expect(calls).toHaveLength(0);
+      expect(logs.join("\n")).toMatch(/already linked globally/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("error log on non-zero bun add includes the tagged spec", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      const code = await install("vault", {
+        runner: async () => 1,
+        manifestPath: path,
+        isLinked: () => false,
+        log: (l) => logs.push(l),
+        tag: "rc",
+      });
+      expect(code).toBe(1);
+      expect(logs.join("\n")).toMatch(/bun add -g @openparachute\/vault@rc failed/);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("linked vault still runs init and defers to init's manifest write", async () => {
     const { path, cleanup } = makeTempPath();
     try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -65,6 +65,37 @@ function extractHubOrigin(args: string[]): {
   return { hubOrigin, rest };
 }
 
+/**
+ * Extract `--tag=<value>` / `--tag <value>` from argv. Same shape as
+ * `extractHubOrigin` so the install command can layer the two flags
+ * uniformly. `error` is set on missing value.
+ */
+function extractTag(args: string[]): {
+  tag?: string;
+  rest: string[];
+  error?: string;
+} {
+  const rest: string[] = [];
+  let tag: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--tag") {
+      const v = args[i + 1];
+      if (!v) return { rest, error: "--tag requires a value (dist-tag or version)" };
+      tag = v;
+      i++;
+      continue;
+    }
+    if (a?.startsWith("--tag=")) {
+      tag = a.slice("--tag=".length);
+      if (!tag) return { rest, error: "--tag requires a value (dist-tag or version)" };
+      continue;
+    }
+    if (a !== undefined) rest.push(a);
+  }
+  return { tag, rest };
+}
+
 async function main(argv: string[]): Promise<number> {
   const [command, ...rest] = argv;
 
@@ -86,13 +117,29 @@ async function main(argv: string[]): Promise<number> {
         console.log(installHelp());
         return 0;
       }
-      const service = rest[0];
+      const tagExtract = extractTag(rest);
+      if (tagExtract.error) {
+        console.error(`parachute install: ${tagExtract.error}`);
+        return 1;
+      }
+      const installArgs = tagExtract.rest;
+      const service = installArgs[0];
       if (!service) {
-        console.error("usage: parachute install <service>");
+        console.error("usage: parachute install <service|all> [--tag <name>]");
         console.error(`services: ${knownServices().join(", ")}`);
         return 1;
       }
-      return await install(service);
+      const installOpts = tagExtract.tag ? { tag: tagExtract.tag } : {};
+      if (service === "all") {
+        // Bootstrap the whole ecosystem to one dist-tag — the RC-testing payload.
+        // Bail on first failure so a broken channel doesn't mask a working tag.
+        for (const svc of knownServices()) {
+          const code = await install(svc, installOpts);
+          if (code !== 0) return code;
+        }
+        return 0;
+      }
+      return await install(service, installOpts);
     }
 
     case "status":

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -27,6 +27,13 @@ export interface InstallOpts {
    * Defaults to a symlink check against bun's global node_modules prefix.
    */
   isLinked?: (pkg: string) => boolean;
+  /**
+   * Optional npm dist-tag or exact version to install. When set, the
+   * `bun add -g` call is composed as `<package>@<tag>` so RC testers can
+   * pin a pre-release channel. `isLinked` still short-circuits — if the
+   * package is bun-linked locally, the tag is moot.
+   */
+  tag?: string;
 }
 
 async function defaultRunner(cmd: readonly string[]): Promise<number> {
@@ -72,10 +79,11 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
   if (isLinked(spec.package)) {
     log(`${spec.package} is already linked globally (bun link) — skipping bun add.`);
   } else {
-    log(`Installing ${spec.package}…`);
-    const addCode = await runner(["bun", "add", "-g", spec.package]);
+    const addSpec = opts.tag ? `${spec.package}@${opts.tag}` : spec.package;
+    log(`Installing ${addSpec}…`);
+    const addCode = await runner(["bun", "add", "-g", addSpec]);
     if (addCode !== 0) {
-      log(`bun add -g ${spec.package} failed (exit ${addCode})`);
+      log(`bun add -g ${addSpec} failed (exit ${addCode})`);
       return addCode;
     }
   }

--- a/src/help.ts
+++ b/src/help.ts
@@ -31,19 +31,28 @@ export function installHelp(): string {
   return `parachute install — install and register a Parachute service
 
 Usage:
-  parachute install <service>
+  parachute install <service> [--tag <name>]
+  parachute install all       [--tag <name>]
 
 Services:
   ${knownServices().join(", ")}
+  all                               install every known service in turn
 
 What it does:
-  1. bun add -g @openparachute/<service>
+  1. bun add -g @openparachute/<service>[@<tag>]
   2. run any service-specific init (e.g. \`parachute-vault init\`)
   3. verify the service registered itself in ~/.parachute/services.json
+
+Flags:
+  --tag <name>      npm dist-tag or exact version to install
+                    (e.g. \`--tag rc\` → \`bun add -g @openparachute/vault@rc\`)
+                    Skipped if the package is already \`bun link\`-ed locally.
 
 Examples:
   parachute install vault           # installs + runs \`parachute-vault init\`
   parachute install notes           # installs notes (no init required)
+  parachute install vault --tag rc  # pin to the rc dist-tag for pre-release testing
+  parachute install all --tag rc    # bootstrap the whole ecosystem to rc
 `;
 }
 


### PR DESCRIPTION
## Why

Aaron is publishing the four service packages with an `rc` dist-tag for pre-launch testing. Without a flag, RC testers would have to drop down to `bun add -g @openparachute/vault@rc` per-package and skip the seed/init choreography that `parachute install` does for them — the lifecycle wrapper they came to `parachute install` for goes away exactly when they need it most.

## What

- `parachute install <svc> --tag <name>` composes `bun add -g @openparachute/<svc>@<name>`. The composed name is logged so operators see the channel they actually pinned.
- `parachute install all [--tag <name>]` loops `knownServices()` and bails on first failure, so a single broken channel doesn't mask a working tag elsewhere.
- `--tag` accepts dist-tags (`rc`) or exact versions (`0.3.0-rc.1`) — npm syntax, no shape validation on our side.
- The bun-link short-circuit still wins. If the package is locally linked the tag is moot, matching how the rest of install works.
- All other install logic (init, seedEntry, manifest writes, canonical-port warning) is untouched.

## Test plan

- [x] `bun test` — 4 new tests covering tag composition, exact-version, link-short-circuit-beats-tag, error log includes tagged spec
- [x] `bunx tsc --noEmit`
- [x] `bunx biome check`
- [ ] Smoke: once Aaron publishes RC packages, `parachute install vault --tag rc` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)