### PR TITLE
feat(expose,install): safe-by-default exposure + vault↔scribe auto-wire

### DIFF
--- a/src/__tests__/auto-wire.test.ts
+++ b/src/__tests__/auto-wire.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SCRIBE_AUTH_ENV_KEY, autoWireScribeAuth } from "../auto-wire.ts";
+
+function makeHarness(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-autowire-"));
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe("autoWireScribeAuth", () => {
+  test("first call: writes new token to both vault .env and scribe config.json", async () => {
+    const h = makeHarness();
+    try {
+      const logs: string[] = [];
+      const result = autoWireScribeAuth({
+        configDir: h.dir,
+        randomToken: () => "deadbeef00".repeat(6),
+        log: (l) => logs.push(l),
+      });
+      expect(result.generated).toBe(true);
+      expect(result.token).toBe("deadbeef00".repeat(6));
+
+      const envText = readFileSync(join(h.dir, "vault", ".env"), "utf8");
+      expect(envText).toBe(`${SCRIBE_AUTH_ENV_KEY}=${result.token}\n`);
+
+      const scribeCfg = JSON.parse(readFileSync(join(h.dir, "scribe", "config.json"), "utf8"));
+      expect(scribeCfg).toEqual({ auth: { required_token: result.token } });
+
+      expect(logs.join("\n")).toMatch(/Auto-wired shared secret for vault → scribe/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("idempotent: pre-existing SCRIBE_AUTH_TOKEN in vault .env is preserved", async () => {
+    const h = makeHarness();
+    try {
+      // Seed a prior wire (or operator-set value). The helper must not
+      // regenerate on repeat install — churning the token would break a
+      // running vault worker that already has the old one in its process env.
+      const envPath = join(h.dir, "vault", ".env");
+      const seed = "seeded-token-abc123";
+      mkdirSync(join(h.dir, "vault"), { recursive: true });
+      writeFileSync(envPath, `FOO=bar\n${SCRIBE_AUTH_ENV_KEY}=${seed}\nOTHER=baz\n`);
+
+      const result = autoWireScribeAuth({
+        configDir: h.dir,
+        // If randomToken is ever called, test would notice — result.token
+        // would change, assertion fails.
+        randomToken: () => "should-not-be-used",
+        log: () => {},
+      });
+      expect(result.generated).toBe(false);
+      expect(result.token).toBe(seed);
+
+      // vault .env unchanged — other keys intact, token unchanged.
+      const envText = readFileSync(envPath, "utf8");
+      expect(envText).toContain("FOO=bar");
+      expect(envText).toContain(`${SCRIBE_AUTH_ENV_KEY}=${seed}`);
+      expect(envText).toContain("OTHER=baz");
+      // And scribe config.json gets the seeded value (so drift between the
+      // two sides repairs on repeat install).
+      const scribeCfg = JSON.parse(readFileSync(join(h.dir, "scribe", "config.json"), "utf8"));
+      expect(scribeCfg.auth.required_token).toBe(seed);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("appends SCRIBE_AUTH_TOKEN without clobbering other vault .env keys", async () => {
+    const h = makeHarness();
+    try {
+      const envPath = join(h.dir, "vault", ".env");
+      mkdirSync(join(h.dir, "vault"), { recursive: true });
+      writeFileSync(envPath, "VAULT_SECRET=xyz\nLOG_LEVEL=debug\n");
+
+      autoWireScribeAuth({
+        configDir: h.dir,
+        randomToken: () => "fresh-token-123",
+        log: () => {},
+      });
+
+      const envText = readFileSync(envPath, "utf8");
+      expect(envText).toContain("VAULT_SECRET=xyz");
+      expect(envText).toContain("LOG_LEVEL=debug");
+      expect(envText).toContain(`${SCRIBE_AUTH_ENV_KEY}=fresh-token-123`);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("merges into existing scribe config.json, preserving other keys", async () => {
+    const h = makeHarness();
+    try {
+      // Simulate a scribe with its own config already on disk (e.g., user
+      // set a whisper model) — auto-wire must add `auth.required_token`
+      // without nuking the rest.
+      const scribeCfgPath = join(h.dir, "scribe", "config.json");
+      mkdirSync(join(h.dir, "scribe"), { recursive: true });
+      writeFileSync(
+        scribeCfgPath,
+        JSON.stringify({ whisper: { model: "medium.en" }, auth: { other: "kept" } }, null, 2),
+      );
+
+      autoWireScribeAuth({
+        configDir: h.dir,
+        randomToken: () => "tok",
+        log: () => {},
+      });
+
+      const cfg = JSON.parse(readFileSync(scribeCfgPath, "utf8"));
+      expect(cfg.whisper.model).toBe("medium.en");
+      expect(cfg.auth.other).toBe("kept");
+      expect(cfg.auth.required_token).toBe("tok");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("handles quoted token values in vault .env (preserves the raw value)", async () => {
+    // Operators sometimes quote .env values. Parse the quotes off so the
+    // token we write to scribe config.json matches what vault actually reads.
+    const h = makeHarness();
+    try {
+      const envPath = join(h.dir, "vault", ".env");
+      mkdirSync(join(h.dir, "vault"), { recursive: true });
+      writeFileSync(envPath, `${SCRIBE_AUTH_ENV_KEY}="quoted-value"\n`);
+
+      const result = autoWireScribeAuth({
+        configDir: h.dir,
+        randomToken: () => "should-not-be-used",
+        log: () => {},
+      });
+      expect(result.generated).toBe(false);
+      expect(result.token).toBe("quoted-value");
+
+      const cfg = JSON.parse(readFileSync(join(h.dir, "scribe", "config.json"), "utf8"));
+      expect(cfg.auth.required_token).toBe("quoted-value");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("creates vault/ and scribe/ dirs if missing", async () => {
+    const h = makeHarness();
+    try {
+      // Fresh config dir — no per-service subdirs yet. Helper must create
+      // them (matches how the rest of the CLI creates dirs on demand).
+      expect(existsSync(join(h.dir, "vault"))).toBe(false);
+      expect(existsSync(join(h.dir, "scribe"))).toBe(false);
+      autoWireScribeAuth({
+        configDir: h.dir,
+        randomToken: () => "tok",
+        log: () => {},
+      });
+      expect(existsSync(join(h.dir, "vault", ".env"))).toBe(true);
+      expect(existsSync(join(h.dir, "scribe", "config.json"))).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -1010,3 +1010,248 @@ describe("expose public off", () => {
     }
   });
 });
+
+describe("expose publicExposure filter", () => {
+  // Launch-blocker: services without auth should never be mounted on
+  // tailnet/funnel. The filter reads `publicExposure` from each entry (or
+  // derives a safe default from the service spec) and withholds non-"allowed"
+  // services from the tailscale serve plan.
+  test("explicit loopback keeps the service off the serve plan", async () => {
+    const h = makeHarness();
+    try {
+      // Vault is mounted as usual; scribe declares loopback and is withheld.
+      upsertService(
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.2.4",
+          publicExposure: "allowed",
+        },
+        h.manifestPath,
+      );
+      upsertService(
+        {
+          name: "parachute-scribe",
+          port: 1943,
+          paths: ["/scribe"],
+          health: "/scribe/health",
+          version: "0.1.0",
+          publicExposure: "loopback",
+        },
+        h.manifestPath,
+      );
+      const { runner, calls } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const logs: string[] = [];
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+
+      const serveCalls = calls.filter(
+        (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
+      );
+      const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path=")));
+      // Vault + its 4 OAuth proxies + hub + well-known — but no /scribe.
+      expect(mounts).toContain("--set-path=/vault/default");
+      expect(mounts).not.toContain("--set-path=/scribe");
+
+      // Operator-visible notice explaining the withhold.
+      expect(logs.join("\n")).toMatch(
+        /parachute-scribe is loopback-only — loopback-only by service declaration/,
+      );
+
+      // State file reflects the reduced plan so teardown doesn't trip on
+      // entries that were never brought up.
+      const state = readExposeState(h.statePath);
+      expect(state?.entries.some((e) => e.mount === "/scribe")).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("explicit auth-required behaves like loopback at launch", async () => {
+    // auth-required is the future-looking declaration for a service that
+    // wants auth but hasn't confirmed it's configured. Today the CLI treats
+    // it identically to loopback — still no funnel/tailnet exposure.
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath); // vault + notes, both allowed by default
+      upsertService(
+        {
+          name: "parachute-channel",
+          port: 1941,
+          paths: ["/channel"],
+          health: "/channel/health",
+          version: "0.1.0",
+          publicExposure: "auth-required",
+        },
+        h.manifestPath,
+      );
+      const { runner, calls } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const logs: string[] = [];
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      const mounts = calls
+        .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
+        .map((c) => c.find((a) => a.startsWith("--set-path=")));
+      expect(mounts).not.toContain("--set-path=/channel");
+      expect(logs.join("\n")).toMatch(/parachute-channel is loopback-only — auth-required/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("missing publicExposure + spec kind=api, hasAuth=false → loopback default (scribe)", async () => {
+    // Scribe today has no auth gate; its ServiceSpec says so (kind: "api",
+    // hasAuth: false). With publicExposure absent we should still withhold.
+    // This is the safe-by-default case for services that haven't yet been
+    // updated to declare their exposure.
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      upsertService(
+        {
+          name: "parachute-scribe",
+          port: 1943,
+          paths: ["/scribe"],
+          health: "/scribe/health",
+          version: "0.1.0",
+          // publicExposure intentionally absent — exercises spec-derived default
+        },
+        h.manifestPath,
+      );
+      const { runner, calls } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const logs: string[] = [];
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      const mounts = calls
+        .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
+        .map((c) => c.find((a) => a.startsWith("--set-path=")));
+      expect(mounts).not.toContain("--set-path=/scribe");
+      // Reason text points operators at the missing auth gate.
+      expect(logs.join("\n")).toMatch(
+        /parachute-scribe is loopback-only — auth-required: service has no auth gate/,
+      );
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("missing publicExposure on a known auth'd api service (vault) still exposes", async () => {
+    // vault's ServiceSpec has hasAuth: true, so the absence of publicExposure
+    // should not hide it — the back-compat path for every vault entry written
+    // before this field existed.
+    const h = makeHarness();
+    try {
+      upsertService(
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.2.4",
+        },
+        h.manifestPath,
+      );
+      const { runner, calls } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      const mounts = calls
+        .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
+        .map((c) => c.find((a) => a.startsWith("--set-path=")));
+      expect(mounts).toContain("--set-path=/vault/default");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("unknown third-party service without publicExposure defaults to allowed", async () => {
+    // A service not in SERVICE_SPECS has no kind/hasAuth signal. We err on
+    // the side of preserving current behavior (back-compat) so operators'
+    // existing exposures don't silently stop working on upgrade. If the
+    // third-party wants to opt out, they can write publicExposure: "loopback"
+    // into their services.json entry.
+    const h = makeHarness();
+    try {
+      upsertService(
+        {
+          name: "parachute-rando",
+          port: 1947,
+          paths: ["/rando"],
+          health: "/rando/health",
+          version: "0.0.1",
+        },
+        h.manifestPath,
+      );
+      const { runner, calls } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      const mounts = calls
+        .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
+        .map((c) => c.find((a) => a.startsWith("--set-path=")));
+      expect(mounts).toContain("--set-path=/rando");
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { install } from "../commands/install.ts";
@@ -350,6 +350,188 @@ describe("install", () => {
       expect(calls).toEqual([["parachute-vault", "init"]]);
       expect(logs.join("\n")).not.toMatch(/Seeded/);
       expect(findService("parachute-vault", path)?.version).toBe("0.3.0");
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Auto-wire: when `parachute install` lands a service that completes the
+  // vault↔scribe pair, generate a shared secret and persist to both sides.
+  // Covered in detail by auto-wire.test.ts; these tests assert the install
+  // command actually invokes the helper at the right moment.
+  test("installing scribe with vault already present auto-wires the shared secret", async () => {
+    const { path, cleanup } = makeTempPath();
+    const configDir = join(path, "..");
+    try {
+      // Pretend vault was installed previously — entry already in services.json.
+      upsertService(
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.2.4",
+        },
+        path,
+      );
+      const logs: string[] = [];
+      const code = await install("scribe", {
+        runner: async () => 0,
+        manifestPath: path,
+        configDir,
+        isLinked: () => false,
+        log: (l) => logs.push(l),
+        randomToken: () => "test-token-value",
+      });
+      expect(code).toBe(0);
+
+      const envPath = join(configDir, "vault", ".env");
+      const scribeCfgPath = join(configDir, "scribe", "config.json");
+      expect(existsSync(envPath)).toBe(true);
+      expect(existsSync(scribeCfgPath)).toBe(true);
+
+      const envText = readFileSync(envPath, "utf8");
+      expect(envText).toContain("SCRIBE_AUTH_TOKEN=test-token-value");
+      const cfg = JSON.parse(readFileSync(scribeCfgPath, "utf8"));
+      expect(cfg.auth.required_token).toBe("test-token-value");
+
+      expect(logs.join("\n")).toMatch(/Auto-wired shared secret for vault → scribe/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("installing scribe without vault does NOT auto-wire (nothing to wire against)", async () => {
+    const { path, cleanup } = makeTempPath();
+    const configDir = join(path, "..");
+    try {
+      const logs: string[] = [];
+      const code = await install("scribe", {
+        runner: async () => 0,
+        manifestPath: path,
+        configDir,
+        isLinked: () => false,
+        log: (l) => logs.push(l),
+        randomToken: () => "should-not-fire",
+      });
+      expect(code).toBe(0);
+      // No vault/.env, no scribe/config.json written by auto-wire.
+      expect(existsSync(join(configDir, "vault", ".env"))).toBe(false);
+      expect(existsSync(join(configDir, "scribe", "config.json"))).toBe(false);
+      expect(logs.join("\n")).not.toMatch(/Auto-wired shared secret/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("installing vault with scribe already present auto-wires (either-order)", async () => {
+    const { path, cleanup } = makeTempPath();
+    const configDir = join(path, "..");
+    try {
+      upsertService(
+        {
+          name: "parachute-scribe",
+          port: 1943,
+          paths: ["/scribe"],
+          health: "/scribe/health",
+          version: "0.1.0",
+        },
+        path,
+      );
+      const code = await install("vault", {
+        runner: async () => 0,
+        manifestPath: path,
+        configDir,
+        isLinked: () => false,
+        log: () => {},
+        randomToken: () => "install-vault-side-token",
+      });
+      expect(code).toBe(0);
+      const envText = readFileSync(join(configDir, "vault", ".env"), "utf8");
+      expect(envText).toContain("SCRIBE_AUTH_TOKEN=install-vault-side-token");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("repeat install preserves an existing SCRIBE_AUTH_TOKEN (idempotent)", async () => {
+    const { path, cleanup } = makeTempPath();
+    const configDir = join(path, "..");
+    try {
+      upsertService(
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.2.4",
+        },
+        path,
+      );
+      // First install: mints a token.
+      await install("scribe", {
+        runner: async () => 0,
+        manifestPath: path,
+        configDir,
+        isLinked: () => false,
+        log: () => {},
+        randomToken: () => "first-token",
+      });
+      // Second install: must preserve the first token — churning it would
+      // break an already-running vault worker that's holding the old one.
+      await install("scribe", {
+        runner: async () => 0,
+        manifestPath: path,
+        configDir,
+        isLinked: () => false,
+        log: () => {},
+        randomToken: () => "should-not-replace",
+      });
+      const envText = readFileSync(join(configDir, "vault", ".env"), "utf8");
+      expect(envText).toContain("SCRIBE_AUTH_TOKEN=first-token");
+      expect(envText).not.toContain("should-not-replace");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("installing notes doesn't trigger auto-wire even if vault + scribe are present", async () => {
+    // Defense: auto-wire should only fire from the scribe or vault install
+    // path. A parallel install of a different service shouldn't touch the
+    // shared-secret files.
+    const { path, cleanup } = makeTempPath();
+    const configDir = join(path, "..");
+    try {
+      upsertService(
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.2.4",
+        },
+        path,
+      );
+      upsertService(
+        {
+          name: "parachute-scribe",
+          port: 1943,
+          paths: ["/scribe"],
+          health: "/scribe/health",
+          version: "0.1.0",
+        },
+        path,
+      );
+      await install("notes", {
+        runner: async () => 0,
+        manifestPath: path,
+        configDir,
+        isLinked: () => false,
+        log: () => {},
+        randomToken: () => "should-not-fire",
+      });
+      expect(existsSync(join(configDir, "vault", ".env"))).toBe(false);
+      expect(existsSync(join(configDir, "scribe", "config.json"))).toBe(false);
     } finally {
       cleanup();
     }

--- a/src/auto-wire.ts
+++ b/src/auto-wire.ts
@@ -1,0 +1,137 @@
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/**
+ * Cross-service auto-wiring for shared secrets.
+ *
+ * Vault's transcription worker authenticates to scribe over loopback using a
+ * shared bearer token. On install, when both services are present, we mint
+ * one and write it to both sides so the operator never has to. Missing either
+ * service → no-op; token already present in vault's .env → preserved.
+ *
+ * Storage locations (convention, matches what each service reads at boot):
+ *   ~/.parachute/vault/.env        SCRIBE_AUTH_TOKEN=<value>
+ *   ~/.parachute/scribe/config.json  { "auth": { "required_token": "<value>" } }
+ *
+ * Idempotency rule: we don't regenerate if vault's .env already carries the
+ * var. This preserves operator-set overrides and keeps repeat installs from
+ * churning the token (which would break an already-running vault worker).
+ */
+
+export const SCRIBE_AUTH_ENV_KEY = "SCRIBE_AUTH_TOKEN";
+
+export interface AutoWireOpts {
+  configDir: string;
+  /** Override for tests; must return a hex string of any reasonable length. */
+  randomToken?: () => string;
+  log?: (line: string) => void;
+  /**
+   * Guard: if either service isn't installed, skip silently. The install
+   * command owns this check (it reads services.json); the helper itself
+   * trusts the caller and just writes.
+   */
+}
+
+export interface AutoWireResult {
+  /** True when a token was written this call (vs. preserved from a prior wire). */
+  generated: boolean;
+  /** The token value, whether newly minted or pre-existing. */
+  token: string;
+  vaultEnvPath: string;
+  scribeConfigPath: string;
+}
+
+function defaultRandomToken(): string {
+  // 32 bytes = 256 bits, hex-encoded. Matches the brief; width plenty for an
+  // HMAC-grade shared secret without pulling in base64url concerns.
+  return randomBytes(32).toString("hex");
+}
+
+function readVaultEnv(path: string): { lines: string[]; existingToken: string | undefined } {
+  if (!existsSync(path)) return { lines: [], existingToken: undefined };
+  const content = readFileSync(path, "utf8");
+  const lines = content.length === 0 ? [] : content.split("\n");
+  // Drop a trailing empty string from a file that ends in "\n" so we don't
+  // double up newlines when we round-trip.
+  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  let existing: string | undefined;
+  for (const line of lines) {
+    if (line.startsWith(`${SCRIBE_AUTH_ENV_KEY}=`)) {
+      existing = line.slice(SCRIBE_AUTH_ENV_KEY.length + 1);
+      // Strip surrounding quotes if present — common .env style.
+      if (
+        existing.length >= 2 &&
+        ((existing.startsWith('"') && existing.endsWith('"')) ||
+          (existing.startsWith("'") && existing.endsWith("'")))
+      ) {
+        existing = existing.slice(1, -1);
+      }
+      break;
+    }
+  }
+  return { lines, existingToken: existing };
+}
+
+function writeVaultEnv(path: string, lines: string[], token: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const rendered = [...lines, `${SCRIBE_AUTH_ENV_KEY}=${token}`].join("\n");
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, `${rendered}\n`);
+  renameSync(tmp, path);
+}
+
+function writeScribeConfig(path: string, token: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  let current: Record<string, unknown> = {};
+  if (existsSync(path)) {
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf8"));
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        current = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Malformed config — overwrite. Auto-wire owns this file's auth block;
+      // repairing a user-broken JSON is not our job.
+    }
+  }
+  const existingAuth =
+    typeof current.auth === "object" && current.auth !== null && !Array.isArray(current.auth)
+      ? (current.auth as Record<string, unknown>)
+      : {};
+  const next = {
+    ...current,
+    auth: { ...existingAuth, required_token: token },
+  };
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, `${JSON.stringify(next, null, 2)}\n`);
+  renameSync(tmp, path);
+}
+
+/**
+ * Mint (or preserve) a shared secret and persist it to vault and scribe.
+ * Caller has already confirmed both services are installed.
+ */
+export function autoWireScribeAuth(opts: AutoWireOpts): AutoWireResult {
+  const random = opts.randomToken ?? defaultRandomToken;
+  const log = opts.log ?? (() => {});
+  const vaultEnvPath = join(opts.configDir, "vault", ".env");
+  const scribeConfigPath = join(opts.configDir, "scribe", "config.json");
+
+  const { lines, existingToken } = readVaultEnv(vaultEnvPath);
+  if (existingToken !== undefined && existingToken.length > 0) {
+    // Preserve whatever is already there — operator-set or previously wired.
+    // Still re-assert scribe's copy in case the two drifted.
+    writeScribeConfig(scribeConfigPath, existingToken);
+    log(`${SCRIBE_AUTH_ENV_KEY} already set in vault .env — preserved. Synced scribe config.json.`);
+    return { generated: false, token: existingToken, vaultEnvPath, scribeConfigPath };
+  }
+
+  const token = random();
+  writeVaultEnv(vaultEnvPath, lines, token);
+  writeScribeConfig(scribeConfigPath, token);
+  log(
+    `Auto-wired shared secret for vault → scribe transcription. Stored in ${vaultEnvPath} and ${scribeConfigPath}.`,
+  );
+  return { generated: true, token, vaultEnvPath, scribeConfigPath };
+}

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -18,7 +18,7 @@ import {
 } from "../hub-control.ts";
 import { deriveHubOrigin } from "../hub-origin.ts";
 import { HUB_MOUNT, HUB_PATH, writeHubFile } from "../hub.ts";
-import { shortNameForManifest } from "../service-spec.ts";
+import { effectivePublicExposure, shortNameForManifest } from "../service-spec.ts";
 import { type ServiceEntry, readManifest } from "../services-manifest.ts";
 import { type ServeEntry, bringupCommand, teardownCommand } from "../tailscale/commands.ts";
 import { getFqdn, isTailscaleInstalled } from "../tailscale/detect.ts";
@@ -128,6 +128,42 @@ function remapLegacyRoot(
     );
     return { ...s, paths: [remapped, ...s.paths.slice(1)] };
   });
+}
+
+/**
+ * Partition services into ones that will be mounted on the layer versus ones
+ * that stay loopback-only. "allowed" services go on the serve plan; every
+ * other effective exposure state (explicit loopback, explicit auth-required,
+ * spec-default auth-required) is withheld. Hidden services still appear in
+ * services.json so on-box callers reach them at http://127.0.0.1:<port>.
+ */
+interface ExposurePartition {
+  exposed: ServiceEntry[];
+  hidden: Array<{ entry: ServiceEntry; reason: string }>;
+}
+
+function partitionByExposure(services: readonly ServiceEntry[]): ExposurePartition {
+  const exposed: ServiceEntry[] = [];
+  const hidden: Array<{ entry: ServiceEntry; reason: string }> = [];
+  for (const s of services) {
+    const eff = effectivePublicExposure(s);
+    if (eff === "allowed") {
+      exposed.push(s);
+      continue;
+    }
+    // Explicit declaration tells the user exactly what the service asked for;
+    // a spec-derived default points at the usual cause (no auth configured).
+    let reason: string;
+    if (s.publicExposure === "loopback") {
+      reason = "loopback-only by service declaration";
+    } else if (s.publicExposure === "auth-required") {
+      reason = "auth-required: service reports auth is not yet configured";
+    } else {
+      reason = "auth-required: service has no auth gate — set the service's auth token to expose";
+    }
+    hidden.push({ entry: s, reason });
+  }
+  return { exposed, hidden };
 }
 
 /**
@@ -253,7 +289,12 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
     }
   }
 
-  const services = remapLegacyRoot(manifest.services, log);
+  const allServices = remapLegacyRoot(manifest.services, log);
+  // Split out loopback/auth-required services before planning the serve routes.
+  // Hidden services keep their /127.0.0.1:<port> accessibility for on-box
+  // callers (e.g., vault's transcription-worker dialing scribe); they just
+  // don't land on tailnet/funnel.
+  const { exposed: services, hidden } = partitionByExposure(allServices);
 
   /**
    * Probe each service port before wiring tailscale up. A service that's
@@ -304,6 +345,9 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
   for (const e of entries) {
     const suffix = e.kind === "proxy" ? `→ ${e.target}  (${e.service})` : `→ ${e.target}`;
     log(`  ${e.mount.padEnd(30, " ")} ${suffix}`);
+  }
+  for (const { entry: hiddenSvc, reason } of hidden) {
+    log(`  (${hiddenSvc.name} is loopback-only — ${reason})`);
   }
 
   const cmds = entries.map((e) => bringupCommand(e, { port, funnel }));

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,6 +1,7 @@
 import { lstatSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { autoWireScribeAuth } from "../auto-wire.ts";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import {
   CANONICAL_PORT_MAX,
@@ -34,6 +35,11 @@ export interface InstallOpts {
    * package is bun-linked locally, the tag is moot.
    */
   tag?: string;
+  /**
+   * Override the random-token source for the vault↔scribe auto-wire.
+   * Tests pass a deterministic string; production uses crypto.randomBytes.
+   */
+  randomToken?: () => string;
 }
 
 async function defaultRunner(cmd: readonly string[]): Promise<number> {
@@ -116,6 +122,19 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
       log(
         `⚠ port ${entry.port} is outside the canonical Parachute range (${CANONICAL_PORT_MIN}–${CANONICAL_PORT_MAX}); may conflict with other software.`,
       );
+    }
+  }
+
+  // Auto-wire the vault↔scribe shared secret when both services end up
+  // installed. Fires from either install order (scribe then vault, or vault
+  // then scribe). Idempotent — preserves any pre-existing token in vault .env.
+  if (spec.manifestName === "parachute-vault" || spec.manifestName === "parachute-scribe") {
+    const vaultPresent = !!findService("parachute-vault", manifestPath);
+    const scribePresent = !!findService("parachute-scribe", manifestPath);
+    if (vaultPresent && scribePresent) {
+      const autoWireOpts: Parameters<typeof autoWireScribeAuth>[0] = { configDir, log };
+      if (opts.randomToken) autoWireOpts.randomToken = opts.randomToken;
+      autoWireScribeAuth(autoWireOpts);
     }
   }
 

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -51,6 +51,16 @@ export function isCanonicalPort(port: number): boolean {
   return port >= CANONICAL_PORT_MIN && port <= CANONICAL_PORT_MAX;
 }
 
+/**
+ * Broad shape of a service. Matches the hub's card-kind taxonomy.
+ *   "frontend"  a user-facing UI (notes). Safe to expose by default.
+ *   "api"       a programmatic surface (vault, channel, scribe). Whether
+ *               it's safe to expose depends on `hasAuth`.
+ *   "tool"      like "api" but specifically MCP-shaped / agent-callable.
+ *               Treated the same as "api" for exposure defaults.
+ */
+export type ServiceKind = "api" | "tool" | "frontend";
+
 export interface ServiceSpec {
   readonly package: string;
   readonly manifestName: string;
@@ -77,6 +87,19 @@ export interface ServiceSpec {
    * authoritative version.
    */
   readonly seedEntry?: () => ServiceEntry;
+  /**
+   * Declares the service's broad shape. Drives exposure defaults: api/tool
+   * services without auth fall back to `publicExposure: "auth-required"`
+   * (treated as loopback at launch); frontends default to "allowed".
+   */
+  readonly kind?: ServiceKind;
+  /**
+   * Does the service gate its endpoints behind auth today? Used together with
+   * `kind` to pick a safe default when the services.json entry omits
+   * `publicExposure`. True for vault/channel (owner-authenticated);
+   * conservatively false for scribe until its auth-gate ships.
+   */
+  readonly hasAuth?: boolean;
 }
 
 const NOTES_SERVE_PATH = fileURLToPath(new URL("./notes-serve.ts", import.meta.url));
@@ -95,6 +118,8 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
     manifestName: "parachute-vault",
     init: ["parachute-vault", "init"],
     startCmd: () => ["parachute-vault", "serve"],
+    kind: "api",
+    hasAuth: true,
     seedEntry: () => ({
       name: "parachute-vault",
       port: 1940,
@@ -107,6 +132,7 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
     package: "@openparachute/notes",
     manifestName: "parachute-notes",
     startCmd: (entry) => ["bun", NOTES_SERVE_PATH, "--port", String(entry.port)],
+    kind: "frontend",
     seedEntry: () => ({
       name: "parachute-notes",
       port: 1942,
@@ -119,6 +145,11 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
     package: "@openparachute/scribe",
     manifestName: "parachute-scribe",
     startCmd: () => ["parachute-scribe", "serve"],
+    // No auth gate today. Scribe's launch PR adds optional SCRIBE_AUTH_TOKEN;
+    // once it lands and scribe writes `publicExposure: "allowed"` when a token
+    // is configured, that explicit declaration overrides this default.
+    kind: "api",
+    hasAuth: false,
     seedEntry: () => ({
       name: "parachute-scribe",
       port: 1943,
@@ -131,6 +162,8 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
     package: "@openparachute/channel",
     manifestName: "parachute-channel",
     startCmd: () => ["parachute-channel", "daemon"],
+    kind: "api",
+    hasAuth: true,
     seedEntry: () => ({
       name: "parachute-channel",
       port: 1941,
@@ -140,6 +173,26 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
     }),
   },
 };
+
+/**
+ * Effective publicExposure for a service, given what's on its services.json
+ * entry. Explicit wins. If absent, derive from the spec: known api/tool
+ * services without declared auth fall back to "auth-required" (treated as
+ * loopback at launch); everything else defaults to "allowed" — so vault,
+ * notes, channel and unknown third-party services continue to be exposed
+ * without needing to opt in.
+ */
+export function effectivePublicExposure(
+  entry: ServiceEntry,
+): "allowed" | "loopback" | "auth-required" {
+  if (entry.publicExposure !== undefined) return entry.publicExposure;
+  const short = shortNameForManifest(entry.name);
+  const spec = short !== undefined ? SERVICE_SPECS[short] : undefined;
+  if (spec && (spec.kind === "api" || spec.kind === "tool") && spec.hasAuth === false) {
+    return "auth-required";
+  }
+  return "allowed";
+}
 
 export function knownServices(): string[] {
   return Object.keys(SERVICE_SPECS);

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -2,6 +2,26 @@ import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "
 import { dirname } from "node:path";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
 
+/**
+ * Whether the service is safe to mount on public-facing expose layers.
+ *
+ *   "allowed"       mount on every layer (tailnet + public). Use when the
+ *                   service gates its own endpoints with auth.
+ *   "loopback"      never mount on tailnet/funnel — only reachable at
+ *                   http://127.0.0.1:<port>. For internal services that
+ *                   shouldn't leave the box.
+ *   "auth-required" the service wants auth but isn't guaranteed to have it
+ *                   configured (e.g., scribe without SCRIBE_AUTH_TOKEN set).
+ *                   At launch this is treated the same as "loopback"; future
+ *                   work can flip to "allowed" once the service reports its
+ *                   auth state over `/.parachute/info`.
+ *
+ * Absent field: the CLI derives a safe default from the service's ServiceSpec
+ * (known api/tool services without declared auth → "auth-required"; everything
+ * else → "allowed"). Unknown services default to "allowed" for back-compat.
+ */
+export type PublicExposure = "allowed" | "loopback" | "auth-required";
+
 export interface ServiceEntry {
   name: string;
   port: number;
@@ -12,6 +32,8 @@ export interface ServiceEntry {
   displayName?: string;
   /** One-line subtitle for the hub page card. */
   tagline?: string;
+  /** Opt-in or opt-out of public-facing expose layers. See PublicExposure. */
+  publicExposure?: PublicExposure;
 }
 
 export interface ServicesManifest {
@@ -51,15 +73,27 @@ function validateEntry(raw: unknown, where: string): ServiceEntry {
   }
   const displayName = e.displayName;
   const tagline = e.tagline;
+  const publicExposure = e.publicExposure;
   if (displayName !== undefined && typeof displayName !== "string") {
     throw new ServicesManifestError(`${where}: "displayName" must be a string if present`);
   }
   if (tagline !== undefined && typeof tagline !== "string") {
     throw new ServicesManifestError(`${where}: "tagline" must be a string if present`);
   }
+  if (
+    publicExposure !== undefined &&
+    publicExposure !== "allowed" &&
+    publicExposure !== "loopback" &&
+    publicExposure !== "auth-required"
+  ) {
+    throw new ServicesManifestError(
+      `${where}: "publicExposure" must be "allowed" | "loopback" | "auth-required" if present`,
+    );
+  }
   const entry: ServiceEntry = { name, port, paths: paths as string[], health, version };
   if (displayName !== undefined) entry.displayName = displayName;
   if (tagline !== undefined) entry.tagline = tagline;
+  if (publicExposure !== undefined) entry.publicExposure = publicExposure as PublicExposure;
   return entry;
 }
 


### PR DESCRIPTION
## Why

Launch-blocker prep for the scribe auth rollout. Today every service in `services.json` gets mounted on tailnet/funnel unconditionally. Scribe ships without an auth gate for first launch — so that path would hand the world a freely-callable transcription API as soon as someone runs `parachute expose`. The fix has two halves that only work together:

1. **The CLI must refuse** to mount services that declare they're not safe for public layers.
2. **Vault and scribe need a shared secret** (so vault's transcription worker can call scribe over loopback) without the operator having to hand-mint one.

Companion to scribe's `SCRIBE_AUTH_TOKEN` PR + vault's bearer-header PR. Three repos, compose at merge.

## What

### Expose safety

- `ServiceEntry.publicExposure?: "allowed" | "loopback" | "auth-required"` — services opt in/out explicitly.
- `effectivePublicExposure(entry)` derives a safe default when the field is absent: known api/tool services with `hasAuth: false` fall back to `"auth-required"`; everything else (vault, notes, channel, unknown third-party) stays `"allowed"` so back-compat is preserved.
- `ServiceSpec` gains `kind?: "api" | "tool" | "frontend"` + `hasAuth?: boolean`. Filled in for the four known services.
- `exposeUp` partitions services before planning tailscale serve entries; hidden services stay in services.json so on-box callers reach them at `127.0.0.1:<port>`.
- Output tells the operator exactly what got withheld and why:
  ```
    (parachute-scribe is loopback-only — auth-required: service has no auth gate — set the service's auth token to expose)
  ```

### Auto-wire

- New `src/auto-wire.ts` mints a 256-bit hex secret, writes `SCRIBE_AUTH_TOKEN=...` to `~/.parachute/vault/.env`, and merges it into `~/.parachute/scribe/config.json` under `auth.required_token`.
- Called from `parachute install` when the pair completes — works in either install order (scribe-then-vault or vault-then-scribe).
- Idempotent: if vault's `.env` already carries `SCRIBE_AUTH_TOKEN`, we preserve it (churning it would break a running vault worker that's holding the old value in its process env) and re-sync scribe's copy in case they drifted.
- Injectable random seam for deterministic tests; `crypto.randomBytes(32)` in production.

## Scope choices (flag for reviewer)

- **Picked install-time over start-time** for auto-wire. Install already seeds services.json and writes per-service config; start is a per-session signal that shouldn't mutate on-disk state. Team-lead called out both shapes; install felt more honest.
- **"auth-required" = "loopback" at launch.** Keeps the door open for a future state where services report auth configuration over `/.parachute/info`, but we don't need that yet. Docs the distinction in the `PublicExposure` JSDoc.
- **Absent field defaults to "allowed" for unknown services.** A third-party service not in `SERVICE_SPECS` has no kind signal; failing closed would silently break existing exposures on upgrade. They can opt out via explicit `publicExposure: "loopback"`.

## Test plan

- [x] `bun test` — 205 pass (+16 new: 5 expose filter, 6 auto-wire unit, 5 install integration)
- [x] `bunx tsc --noEmit`
- [x] `bunx biome check`
- [ ] Smoke once scribe + vault PRs land: `parachute install vault` then `parachute install scribe` on a fresh box → verify `.env` + `config.json` written, `parachute expose tailnet` shows scribe as loopback-only, then set `SCRIBE_AUTH_TOKEN` + re-declare `publicExposure: "allowed"` via scribe's PR → scribe mounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)