### PR TITLE
rename(notes→lens): CLI-side of the Lens rebrand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Parachute CLI
 
-`parachute` — the top-level CLI. Installs services, runs them as background processes, and exposes them over Tailscale. Coordinator, not a service: each Parachute package (`vault`, `notes`, `scribe`, `channel`) stays standalone; this CLI stitches them together.
+`parachute` — the top-level CLI. Installs services, runs them as background processes, and exposes them over Tailscale. Coordinator, not a service: each Parachute package (`vault`, `lens`, `scribe`, `channel`) stays standalone; this CLI stitches them together.
 
 User-facing README is the right intro for operators. This file is for agents and humans working *on* the CLI itself.
 
@@ -73,7 +73,7 @@ Every PR here is reviewer-gated — no direct-to-main, even for one-line fixes. 
 - Bin name: `parachute`
 - Config root: `~/.parachute/` (override with `PARACHUTE_HOME`)
 - Per-service dirs: `~/.parachute/<short>/` (e.g. `~/.parachute/vault/`)
-- Short names (map to `manifestName` via `SERVICE_SPECS`): `vault`, `notes`, `scribe`, `channel`
+- Short names (map to `manifestName` via `SERVICE_SPECS`): `vault`, `lens`, `scribe`, `channel`. `notes` is a transition alias for `lens` on `parachute install` (one release cycle); removed post-launch.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `parachute` — the top-level command for the [Parachute](https://parachute.computer) ecosystem.
 
-Install, inspect, and expose Parachute services with one command. Each service (vault, notes, scribe, channel, …) stays a standalone package; this CLI is the coordinator.
+Install, inspect, and expose Parachute services with one command. Each service (vault, lens, scribe, channel, …) stays a standalone package; this CLI is the coordinator.
 
 ## Install
 
@@ -101,7 +101,7 @@ Every service mounts under a path on a single canonical hostname. The root `/` i
 ```
 https://parachute.<tailnet>.ts.net/                              → hub (service directory)
 https://parachute.<tailnet>.ts.net/vault/default                 → parachute-vault API
-https://parachute.<tailnet>.ts.net/notes                         → parachute-notes
+https://parachute.<tailnet>.ts.net/lens                          → parachute-lens
 https://parachute.<tailnet>.ts.net/scribe                        → parachute-scribe
 https://parachute.<tailnet>.ts.net/.well-known/parachute.json    ← discovery
 ```
@@ -126,14 +126,14 @@ The `/.well-known/parachute.json` document is an always-present descriptor — f
       "infoUrl": "https://parachute.taildf9ce2.ts.net/vault/default/.parachute/info"
     },
     {
-      "name": "parachute-notes",
-      "url":  "https://parachute.taildf9ce2.ts.net/notes",
-      "path": "/notes",
+      "name": "parachute-lens",
+      "url":  "https://parachute.taildf9ce2.ts.net/lens",
+      "path": "/lens",
       "version": "0.0.1",
-      "infoUrl": "https://parachute.taildf9ce2.ts.net/notes/.parachute/info"
+      "infoUrl": "https://parachute.taildf9ce2.ts.net/lens/.parachute/info"
     }
   ],
-  "notes": { "url": "https://parachute.taildf9ce2.ts.net/notes", "version": "0.0.1" }
+  "lens": { "url": "https://parachute.taildf9ce2.ts.net/lens", "version": "0.0.1" }
 }
 ```
 
@@ -153,7 +153,7 @@ Parachute services reserve a block of loopback ports in the canonical range **19
 | 1939 | parachute-hub (internal proxy + static) |
 | 1940 | parachute-vault    |
 | 1941 | parachute-channel  |
-| 1942 | parachute-notes    |
+| 1942 | parachute-lens     |
 | 1943 | parachute-scribe   |
 | 1944 | *reserved — pendant*  |
 | 1945 | *reserved — daily-v2* |

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -98,10 +98,10 @@ function seedServices(path: string): void {
   );
   upsertService(
     {
-      name: "parachute-notes",
+      name: "parachute-lens",
       port: 5173,
-      paths: ["/notes"],
-      health: "/notes/health",
+      paths: ["/lens"],
+      health: "/lens/health",
       version: "0.0.1",
     },
     path,
@@ -136,7 +136,7 @@ describe("expose tailnet up", () => {
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      // 4 baseline (hub + wk + vault + notes) + 4 OAuth proxies (vault present).
+      // 4 baseline (hub + wk + vault + lens) + 4 OAuth proxies (vault present).
       expect(serveCalls).toHaveLength(8);
       // Tailnet mode never uses funnel — neither the old flag nor the new subcommand.
       expect(serveCalls.every((c) => !c.includes("--funnel"))).toBe(true);
@@ -147,7 +147,7 @@ describe("expose tailnet up", () => {
         "--set-path=/",
         "--set-path=/.well-known/oauth-authorization-server",
         "--set-path=/.well-known/parachute.json",
-        "--set-path=/notes",
+        "--set-path=/lens",
         "--set-path=/oauth/authorize",
         "--set-path=/oauth/register",
         "--set-path=/oauth/token",
@@ -167,8 +167,8 @@ describe("expose tailnet up", () => {
 
       // Service targets also include their mount path to prevent tailscale
       // from stripping the prefix before forwarding to a base-aware backend.
-      const notesCall = serveCalls.find((c) => c.includes("--set-path=/notes"));
-      expect(notesCall?.[notesCall.length - 1]).toBe("http://127.0.0.1:5173/notes");
+      const lensCall = serveCalls.find((c) => c.includes("--set-path=/lens"));
+      expect(lensCall?.[lensCall.length - 1]).toBe("http://127.0.0.1:5173/lens");
       const vaultCall = serveCalls.find((c) => c.includes("--set-path=/vault/default"));
       expect(vaultCall?.[vaultCall.length - 1]).toBe("http://127.0.0.1:1940/vault/default");
 
@@ -219,17 +219,17 @@ describe("expose tailnet up", () => {
   });
 
   test("trailing-slash mount preserves trailing slash in target URL", async () => {
-    // Aaron hit ERR_TOO_MANY_REDIRECTS on /notes/ because tailscale strips
-    // the prefix, Vite (base=/notes) redirects back to /notes/, tailscale
+    // Aaron hit ERR_TOO_MANY_REDIRECTS on /lens/ because tailscale strips
+    // the prefix, Vite (base=/lens) redirects back to /lens/, tailscale
     // strips again, loop. Pinning target = mount byte-for-byte breaks that.
     const h = makeHarness();
     try {
       upsertService(
         {
-          name: "parachute-notes",
+          name: "parachute-lens",
           port: 5173,
-          paths: ["/notes/"],
-          health: "/notes/health",
+          paths: ["/lens/"],
+          health: "/lens/health",
           version: "0.0.1",
         },
         h.manifestPath,
@@ -252,9 +252,9 @@ describe("expose tailnet up", () => {
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      const notesCall = serveCalls.find((c) => c.includes("--set-path=/notes/"));
-      expect(notesCall).toBeDefined();
-      expect(notesCall?.[notesCall.length - 1]).toBe("http://127.0.0.1:5173/notes/");
+      const lensCall = serveCalls.find((c) => c.includes("--set-path=/lens/"));
+      expect(lensCall).toBeDefined();
+      expect(lensCall?.[lensCall.length - 1]).toBe("http://127.0.0.1:5173/lens/");
     } finally {
       h.cleanup();
     }
@@ -417,14 +417,14 @@ describe("expose tailnet up", () => {
         wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         hubEnsureOpts: hubEnsureOpts(spawner),
-        // vault is up; notes is down.
+        // vault is up; lens is down.
         servicePortProbe: async (port) => port === 1940,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
       const joined = logs.join("\n");
-      expect(joined).toMatch(/parachute-notes \(port 5173\) is not responding/);
-      expect(joined).toMatch(/parachute start notes/);
+      expect(joined).toMatch(/parachute-lens \(port 5173\) is not responding/);
+      expect(joined).toMatch(/parachute start lens/);
       expect(joined).not.toMatch(/parachute-vault.*not responding/);
       // Bringup still happened — 4 service entries + 4 OAuth proxies got staged.
       const serveCalls = calls.filter(
@@ -533,10 +533,10 @@ describe("expose tailnet up", () => {
     try {
       upsertService(
         {
-          name: "parachute-notes",
+          name: "parachute-lens",
           port: 5173,
-          paths: ["/notes"],
-          health: "/notes/health",
+          paths: ["/lens"],
+          health: "/lens/health",
           version: "0.0.1",
         },
         h.manifestPath,
@@ -560,7 +560,7 @@ describe("expose tailnet up", () => {
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      // No vault → no OAuth proxies. Hub + well-known + notes = 3.
+      // No vault → no OAuth proxies. Hub + well-known + lens = 3.
       expect(serveCalls).toHaveLength(3);
       const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path=")));
       expect(mounts.every((m) => m !== undefined && !m.includes("/oauth/"))).toBe(true);
@@ -1087,7 +1087,7 @@ describe("expose publicExposure filter", () => {
     // it identically to loopback — still no funnel/tailnet exposure.
     const h = makeHarness();
     try {
-      seedServices(h.manifestPath); // vault + notes, both allowed by default
+      seedServices(h.manifestPath); // vault + lens, both allowed by default
       upsertService(
         {
           name: "parachute-channel",

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -112,22 +112,22 @@ describe("install", () => {
   });
 
   test("warns when manifest entry lands outside the canonical port range", async () => {
-    // Historically notes wrote 5173 (Vite's dev default). Canonical is
+    // Historically lens wrote 5173 (Vite's dev default). Canonical is
     // 1939–1949; warn so integrators know their service could conflict with
     // other software on the box, but don't block — forks may intentionally
     // deviate.
     const { path, cleanup } = makeTempPath();
     try {
       const logs: string[] = [];
-      const code = await install("notes", {
+      const code = await install("lens", {
         runner: async (cmd) => {
           if (cmd[0] === "bun") {
             upsertService(
               {
-                name: "parachute-notes",
+                name: "parachute-lens",
                 port: 5173,
-                paths: ["/notes"],
-                health: "/notes/health",
+                paths: ["/lens"],
+                health: "/lens/health",
                 version: "0.0.1",
               },
               path,
@@ -142,6 +142,35 @@ describe("install", () => {
       expect(code).toBe(0);
       expect(logs.join("\n")).toMatch(/registered on port 5173/);
       expect(logs.join("\n")).toMatch(/outside the canonical Parachute range/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("`install notes` aliases to lens with a rename notice", async () => {
+    // Transition alias after the Lens rebrand (2026-04). Accepted for one
+    // release cycle; removed after launch users have re-installed.
+    const { path, cleanup } = makeTempPath();
+    try {
+      const calls: string[][] = [];
+      const logs: string[] = [];
+      const code = await install("notes", {
+        runner: async (cmd) => {
+          calls.push([...cmd]);
+          return 0;
+        },
+        manifestPath: path,
+        isLinked: () => false,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(logs.join("\n")).toMatch(
+        /"notes" has been renamed to "lens"; installing lens\./,
+      );
+      // Downstream bun-add must use the new package name, not the old.
+      expect(calls[0]).toEqual(["bun", "add", "-g", "@openparachute/lens"]);
+      const seeded = findService("parachute-lens", path);
+      expect(seeded?.port).toBe(1942);
     } finally {
       cleanup();
     }
@@ -495,7 +524,7 @@ describe("install", () => {
     }
   });
 
-  test("installing notes doesn't trigger auto-wire even if vault + scribe are present", async () => {
+  test("installing lens doesn't trigger auto-wire even if vault + scribe are present", async () => {
     // Defense: auto-wire should only fire from the scribe or vault install
     // path. A parallel install of a different service shouldn't touch the
     // shared-secret files.
@@ -522,7 +551,7 @@ describe("install", () => {
         },
         path,
       );
-      await install("notes", {
+      await install("lens", {
         runner: async () => 0,
         manifestPath: path,
         configDir,

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -217,6 +217,40 @@ describe("parachute start", () => {
     }
   });
 
+  test("legacy parachute-notes manifest entry still starts under the lens spec", async () => {
+    // v0.x users upgraded into the lens rename will still have
+    // `parachute-notes` in services.json until their lens package next
+    // boots and rewrites the row. Without the manifest alias,
+    // shortNameForManifest returns undefined, resolveTargets skips the
+    // entry, and they get "No manageable services" with no hint.
+    const h = makeHarness();
+    try {
+      upsertService(
+        {
+          name: "parachute-notes",
+          port: 5173,
+          paths: ["/notes"],
+          health: "/notes/health",
+          version: "0.0.1",
+        },
+        h.manifestPath,
+      );
+      const spawner = makeSpawner([5151]);
+      const code = await start(undefined, {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(spawner.calls).toHaveLength(1);
+      expect(spawner.calls[0]?.cmd.some((a) => a.endsWith("lens-serve.ts"))).toBe(true);
+      expect(readPid("lens", h.configDir)).toBe(5151);
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("passes PARACHUTE_HUB_ORIGIN from expose-state when set", async () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -35,13 +35,13 @@ function seedVault(manifestPath: string): void {
   );
 }
 
-function seedNotes(manifestPath: string): void {
+function seedLens(manifestPath: string): void {
   upsertService(
     {
-      name: "parachute-notes",
+      name: "parachute-lens",
       port: 5173,
-      paths: ["/notes"],
-      health: "/notes/health",
+      paths: ["/lens"],
+      health: "/lens/health",
       version: "0.0.1",
     },
     manifestPath,
@@ -95,13 +95,13 @@ describe("parachute start", () => {
     try {
       seedVault(h.manifestPath);
       const logs: string[] = [];
-      const code = await start("notes", {
+      const code = await start("lens", {
         configDir: h.configDir,
         manifestPath: h.manifestPath,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(1);
-      expect(logs.join("\n")).toMatch(/notes isn't installed/);
+      expect(logs.join("\n")).toMatch(/lens isn't installed/);
     } finally {
       h.cleanup();
     }
@@ -130,12 +130,12 @@ describe("parachute start", () => {
     }
   });
 
-  test("notes start command includes configured port and notes-serve shim path", async () => {
+  test("lens start command includes configured port and lens-serve shim path", async () => {
     const h = makeHarness();
     try {
-      seedNotes(h.manifestPath);
+      seedLens(h.manifestPath);
       const spawner = makeSpawner([5151]);
-      const code = await start("notes", {
+      const code = await start("lens", {
         configDir: h.configDir,
         manifestPath: h.manifestPath,
         spawner,
@@ -146,7 +146,7 @@ describe("parachute start", () => {
       expect(cmd[0]).toBe("bun");
       expect(cmd.at(-2)).toBe("--port");
       expect(cmd.at(-1)).toBe("5173");
-      expect(cmd.some((a) => a.endsWith("notes-serve.ts"))).toBe(true);
+      expect(cmd.some((a) => a.endsWith("lens-serve.ts"))).toBe(true);
     } finally {
       h.cleanup();
     }
@@ -200,7 +200,7 @@ describe("parachute start", () => {
     const h = makeHarness();
     try {
       seedVault(h.manifestPath);
-      seedNotes(h.manifestPath);
+      seedLens(h.manifestPath);
       const spawner = makeSpawner([4242, 5151]);
       const code = await start(undefined, {
         configDir: h.configDir,
@@ -211,7 +211,7 @@ describe("parachute start", () => {
       expect(code).toBe(0);
       expect(spawner.calls).toHaveLength(2);
       expect(readPid("vault", h.configDir)).toBe(4242);
-      expect(readPid("notes", h.configDir)).toBe(5151);
+      expect(readPid("lens", h.configDir)).toBe(5151);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/migrate.test.ts
+++ b/src/__tests__/migrate.test.ts
@@ -46,9 +46,12 @@ describe("safelistEntries", () => {
     const s = safelistEntries();
     // Service dirs from SERVICE_SPECS
     expect(s.has("vault")).toBe(true);
-    expect(s.has("notes")).toBe(true);
+    expect(s.has("lens")).toBe(true);
     expect(s.has("scribe")).toBe(true);
     expect(s.has("channel")).toBe(true);
+    // Legacy — kept across the lens rename so existing ~/.parachute/notes/
+    // dirs from pre-rename installs don't get archived on upgrade.
+    expect(s.has("notes")).toBe(true);
     // Internal
     expect(s.has("hub")).toBe(true);
     // CLI state

--- a/src/__tests__/process-state.test.ts
+++ b/src/__tests__/process-state.test.ts
@@ -22,7 +22,7 @@ function makeTempConfig(): { dir: string; cleanup: () => void } {
 describe("process-state paths", () => {
   test("pidPath / logPath land under <configDir>/<svc>/{run,logs}", () => {
     expect(pidPath("vault", "/cfg")).toBe("/cfg/vault/run/vault.pid");
-    expect(logPath("notes", "/cfg")).toBe("/cfg/notes/logs/notes.log");
+    expect(logPath("lens", "/cfg")).toBe("/cfg/lens/logs/lens.log");
   });
 });
 

--- a/src/__tests__/services-manifest.test.ts
+++ b/src/__tests__/services-manifest.test.ts
@@ -26,11 +26,11 @@ const vault: ServiceEntry = {
   version: "0.2.4",
 };
 
-const notes: ServiceEntry = {
-  name: "parachute-notes",
+const lens: ServiceEntry = {
+  name: "parachute-lens",
   port: 5173,
-  paths: ["/notes"],
-  health: "/notes/health",
+  paths: ["/lens"],
+  health: "/lens/health",
   version: "0.0.1",
 };
 
@@ -84,10 +84,10 @@ describe("services-manifest", () => {
     const { path, cleanup } = makeTempPath();
     try {
       upsertService(vault, path);
-      upsertService(notes, path);
+      upsertService(lens, path);
       const m = readManifest(path);
       expect(m.services).toHaveLength(2);
-      expect(m.services.map((s) => s.name).sort()).toEqual(["parachute-notes", "parachute-vault"]);
+      expect(m.services.map((s) => s.name).sort()).toEqual(["parachute-lens", "parachute-vault"]);
     } finally {
       cleanup();
     }
@@ -97,11 +97,11 @@ describe("services-manifest", () => {
     const { path, cleanup } = makeTempPath();
     try {
       upsertService(vault, path);
-      upsertService(notes, path);
+      upsertService(lens, path);
       removeService("parachute-vault", path);
       const m = readManifest(path);
       expect(m.services).toHaveLength(1);
-      expect(m.services[0]?.name).toBe("parachute-notes");
+      expect(m.services[0]?.name).toBe("parachute-lens");
     } finally {
       cleanup();
     }

--- a/src/__tests__/tailscale-commands.test.ts
+++ b/src/__tests__/tailscale-commands.test.ts
@@ -17,9 +17,9 @@ const fileEntry: ServeEntry = {
 
 const subpathEntry: ServeEntry = {
   kind: "proxy",
-  mount: "/notes",
+  mount: "/lens",
   target: "http://127.0.0.1:5173",
-  service: "parachute-notes",
+  service: "parachute-lens",
 };
 
 describe("tailscale commands", () => {
@@ -40,7 +40,7 @@ describe("tailscale commands", () => {
       "serve",
       "--bg",
       "--https=443",
-      "--set-path=/notes",
+      "--set-path=/lens",
       "http://127.0.0.1:5173",
     ]);
   });

--- a/src/__tests__/well-known.test.ts
+++ b/src/__tests__/well-known.test.ts
@@ -19,11 +19,11 @@ const vault: ServiceEntry = {
   version: "0.2.4",
 };
 
-const notes: ServiceEntry = {
-  name: "parachute-notes",
+const lens: ServiceEntry = {
+  name: "parachute-lens",
   port: 5173,
-  paths: ["/notes"],
-  health: "/notes/health",
+  paths: ["/lens"],
+  health: "/lens/health",
   version: "0.0.1",
 };
 
@@ -38,7 +38,7 @@ const scribe: ServiceEntry = {
 describe("shortName", () => {
   test("strips parachute- prefix", () => {
     expect(shortName("parachute-vault")).toBe("vault");
-    expect(shortName("parachute-notes")).toBe("notes");
+    expect(shortName("parachute-lens")).toBe("lens");
     expect(shortName("custom-service")).toBe("custom-service");
   });
 });
@@ -54,7 +54,7 @@ describe("isVaultEntry", () => {
   });
 
   test("rejects non-vault services", () => {
-    expect(isVaultEntry(notes)).toBe(false);
+    expect(isVaultEntry(lens)).toBe(false);
     expect(isVaultEntry(scribe)).toBe(false);
   });
 
@@ -94,7 +94,7 @@ describe("vaultInstanceName", () => {
 describe("buildWellKnown", () => {
   test("vaults is always an array, other services are flat entries, services[] includes all", () => {
     const doc = buildWellKnown({
-      services: [vault, notes, scribe],
+      services: [vault, lens, scribe],
       canonicalOrigin: "https://parachute.taildf9ce2.ts.net",
     });
     expect(doc.vaults).toEqual([
@@ -104,8 +104,8 @@ describe("buildWellKnown", () => {
         version: "0.2.4",
       },
     ]);
-    expect(doc.notes).toEqual({
-      url: "https://parachute.taildf9ce2.ts.net/notes",
+    expect(doc.lens).toEqual({
+      url: "https://parachute.taildf9ce2.ts.net/lens",
       version: "0.0.1",
     });
     expect(doc.scribe).toEqual({
@@ -114,14 +114,14 @@ describe("buildWellKnown", () => {
     });
     expect(doc.services.map((s) => s.name)).toEqual([
       "parachute-vault",
-      "parachute-notes",
+      "parachute-lens",
       "parachute-scribe",
     ]);
   });
 
   test("services[] entries include infoUrl pointing at /.parachute/info", () => {
     const doc = buildWellKnown({
-      services: [vault, notes],
+      services: [vault, lens],
       canonicalOrigin: "https://x.example",
     });
     expect(doc.services).toEqual([
@@ -133,17 +133,17 @@ describe("buildWellKnown", () => {
         infoUrl: "https://x.example/vault/default/.parachute/info",
       },
       {
-        name: "parachute-notes",
-        url: "https://x.example/notes",
-        path: "/notes",
+        name: "parachute-lens",
+        url: "https://x.example/lens",
+        path: "/lens",
         version: "0.0.1",
-        infoUrl: "https://x.example/notes/.parachute/info",
+        infoUrl: "https://x.example/lens/.parachute/info",
       },
     ]);
   });
 
   test("infoUrl for root-mounted service has no double slash", () => {
-    const rootSvc: ServiceEntry = { ...notes, paths: ["/"] };
+    const rootSvc: ServiceEntry = { ...lens, paths: ["/"] };
     const doc = buildWellKnown({
       services: [rootSvc],
       canonicalOrigin: "https://x.example",
@@ -153,12 +153,12 @@ describe("buildWellKnown", () => {
 
   test("vaults array is present even when no vault is installed", () => {
     const doc = buildWellKnown({
-      services: [notes],
+      services: [lens],
       canonicalOrigin: "https://x.example",
     });
     expect(doc.vaults).toEqual([]);
     expect(doc.services).toHaveLength(1);
-    expect(doc.notes).toEqual({ url: "https://x.example/notes", version: "0.0.1" });
+    expect(doc.lens).toEqual({ url: "https://x.example/lens", version: "0.0.1" });
   });
 
   test("multiple vault instances all land in the vaults array", () => {

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -41,7 +41,7 @@ import {
  * Funnel constraint: Tailscale allows at most three public HTTPS ports per
  * node (443, 8443, 10000). Path-routing packs every service onto a single
  * port — that's why we default to one `--https=443` and mount services under
- * `/vault`, `/notes`, etc. rather than giving each service its own port or
+ * `/vault`, `/lens`, etc. rather than giving each service its own port or
  * subdomain. Subdomain-per-service requires the Tailscale Services feature
  * (virtual-IP advertisement) and is deferred.
  *

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -15,6 +15,17 @@ import { migrateNotice } from "./migrate.ts";
 
 export type Runner = (cmd: readonly string[]) => Promise<number>;
 
+/**
+ * Transition aliases for services that were renamed. Accepted for one
+ * release cycle with a rename notice, then removed. `notes → lens`
+ * landed 2026-04 as part of the Lens rebrand; remove after launch
+ * sinks in and `parachute install notes` has stopped appearing in
+ * support threads.
+ */
+const SERVICE_ALIASES: Record<string, string> = {
+  notes: "lens",
+};
+
 export interface InstallOpts {
   runner?: Runner;
   manifestPath?: string;
@@ -75,9 +86,15 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
   const log = opts.log ?? ((line) => console.log(line));
   const isLinked = opts.isLinked ?? defaultIsLinked;
 
-  const spec = getSpec(service);
+  const aliased = SERVICE_ALIASES[service];
+  if (aliased !== undefined) {
+    log(`"${service}" has been renamed to "${aliased}"; installing ${aliased}.`);
+  }
+  const resolvedService = aliased ?? service;
+
+  const spec = getSpec(resolvedService);
   if (!spec) {
-    log(`unknown service: "${service}"`);
+    log(`unknown service: "${resolvedService}"`);
     log(`known services: ${knownServices().join(", ")}`);
     return 1;
   }

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -23,10 +23,15 @@ export const ARCHIVE_PREFIX = ".archive-";
  * `knownServices()` so adding a service doesn't require touching migrate;
  * `hub` is added explicitly since it's an internal-only lifecycle dir not
  * in SERVICE_SPECS.
+ *
+ * `notes` is kept after the lens rename so existing `~/.parachute/notes/`
+ * dirs don't get swept into `.archive-*` on upgrade. Safe to remove once
+ * launch users have all had a chance to re-install under the new name.
  */
 export function safelistEntries(): Set<string> {
   return new Set<string>([
     ...knownServices(),
+    "notes",
     "hub",
     "services.json",
     "expose-state.json",

--- a/src/help.ts
+++ b/src/help.ts
@@ -50,9 +50,13 @@ Flags:
 
 Examples:
   parachute install vault           # installs + runs \`parachute-vault init\`
-  parachute install notes           # installs notes (no init required)
+  parachute install lens            # installs lens (no init required)
   parachute install vault --tag rc  # pin to the rc dist-tag for pre-release testing
   parachute install all --tag rc    # bootstrap the whole ecosystem to rc
+
+Aliases:
+  notes → lens                      # accepted for one release cycle after
+                                    # the Lens rebrand; prints a rename notice.
 `;
 }
 
@@ -80,7 +84,7 @@ Example:
   $ parachute status
   SERVICE          PORT  VERSION  PROCESS  PID    UPTIME  HEALTH  LATENCY
   parachute-vault  1940  0.2.4    running  12345  2h 13m  ok      2ms
-  parachute-notes  5173  0.0.1    stopped  -      -       -       -
+  parachute-lens   5173  0.0.1    stopped  -      -       -       -
 `;
 }
 
@@ -110,11 +114,11 @@ Examples:
 
 Constraints (public layer / Funnel):
   - Funnel supports HTTPS only on ports 443 / 8443 / 10000 per node.
-    We pin to 443 and path-route (vault at /, notes at /notes, …) so this
+    We pin to 443 and path-route (vault at /vault/…, lens at /lens, …) so this
     cap never becomes a constraint no matter how many services you install.
   - Funnel has bandwidth caps on Tailscale's free tier.
     See https://tailscale.com/kb/1223/funnel for current limits.
-  - Subdomain-per-service (vault.<fqdn>, notes.<fqdn>, …) requires the
+  - Subdomain-per-service (vault.<fqdn>, lens.<fqdn>, …) requires the
     Tailscale Services feature and is not supported in this release.
 
 Coming soon:
@@ -152,7 +156,7 @@ Start commands by service:
   vault     parachute-vault serve
   scribe    parachute-scribe serve
   channel   parachute-channel daemon
-  notes     bun <cli>/notes-serve.ts --port <configured>
+  lens      bun <cli>/lens-serve.ts --port <configured>
 `;
 }
 
@@ -210,7 +214,8 @@ Usage:
 What it does:
   Scans ~/.parachute/ for files and directories that don't belong to the
   post-restructure layout. Recognized entries — per-service dirs
-  (vault/, notes/, scribe/, channel/, hub/), services.json,
+  (vault/, lens/, scribe/, channel/, hub/; legacy notes/ also kept),
+  services.json,
   expose-state.json, well-known/ — stay in place. Anything else (plus
   known legacy cruft like daily.db, server.yaml) is moved under
   ~/.parachute/.archive-<YYYY-MM-DD>/, never deleted.

--- a/src/lens-serve.ts
+++ b/src/lens-serve.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env bun
 
 /**
- * Tiny static-file server for the @openparachute/notes PWA bundle.
+ * Tiny static-file server for the @openparachute/lens PWA bundle.
  *
- * Notes is a SPA — no backend of its own. `parachute start notes` invokes
+ * Lens is a SPA — no backend of its own. `parachute start lens` invokes
  * this shim with the installed `dist/` path so the PWA is served at a
  * known port and can be reverse-proxied by `parachute expose` alongside
  * the other services.
@@ -11,7 +11,7 @@
  * Invoked as:
  *   bun <this-file> --port <n> [--dist <path>]
  *
- * If --dist is omitted, we resolve @openparachute/notes's dist directory
+ * If --dist is omitted, we resolve @openparachute/lens's dist directory
  * via Bun.resolveSync. If that fails (package not installed globally, or
  * package doesn't ship dist/), exit 1 with a clear error.
  */
@@ -43,13 +43,13 @@ function parseArgs(argv: string[]): { port: number; dist?: string } {
   return { port, dist };
 }
 
-function resolveNotesDist(): string {
-  const pkgPath = Bun.resolveSync("@openparachute/notes/package.json", process.cwd());
+function resolveLensDist(): string {
+  const pkgPath = Bun.resolveSync("@openparachute/lens/package.json", process.cwd());
   const root = dirname(pkgPath);
   const dist = join(root, "dist");
   if (!existsSync(dist)) {
     throw new Error(
-      `@openparachute/notes is installed but has no dist/ directory at ${dist}. The package may not ship a prebuilt bundle — ask the notes maintainer to add a prepublishOnly build step.`,
+      `@openparachute/lens is installed but has no dist/ directory at ${dist}. The package may not ship a prebuilt bundle — ask the lens maintainer to add a prepublishOnly build step.`,
     );
   }
   return dist;
@@ -59,9 +59,9 @@ const { port, dist: distArg } = parseArgs(process.argv.slice(2));
 
 let dist: string;
 try {
-  dist = distArg ?? resolveNotesDist();
+  dist = distArg ?? resolveLensDist();
 } catch (err) {
-  console.error(`parachute-notes-serve: ${err instanceof Error ? err.message : String(err)}`);
+  console.error(`parachute-lens-serve: ${err instanceof Error ? err.message : String(err)}`);
   process.exit(1);
 }
 
@@ -85,4 +85,4 @@ Bun.serve({
   },
 });
 
-console.log(`notes static-serve listening on :${port} (dist=${dist})`);
+console.log(`lens static-serve listening on :${port} (dist=${dist})`);

--- a/src/process-state.ts
+++ b/src/process-state.ts
@@ -4,7 +4,7 @@ import { CONFIG_DIR } from "./config.ts";
 
 /**
  * Per-service state lives under `<configDir>/<svc>/...`. `svc` is the
- * short name (`vault`, `notes`, `scribe`, `channel`) so paths stay tidy —
+ * short name (`vault`, `lens`, `scribe`, `channel`) so paths stay tidy —
  * `~/.parachute/vault/run/vault.pid` rather than `parachute-vault/run/…`.
  *
  * The single source of truth for whether a service is running is

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -8,7 +8,7 @@ import type { ServiceEntry } from "./services-manifest.ts";
  *   1939  parachute-hub      internal static + proxy, CLI-managed
  *   1940  parachute-vault
  *   1941  parachute-channel
- *   1942  parachute-notes    static server over the PWA bundle
+ *   1942  parachute-lens     static server over the PWA bundle (formerly parachute-notes)
  *   1943  parachute-scribe
  *   1944  reserved — pendant
  *   1945  reserved — daily-v2
@@ -37,7 +37,7 @@ export const PORT_RESERVATIONS: readonly PortReservation[] = [
   { port: 1939, name: "parachute-hub", status: "assigned" },
   { port: 1940, name: "parachute-vault", status: "assigned" },
   { port: 1941, name: "parachute-channel", status: "assigned" },
-  { port: 1942, name: "parachute-notes", status: "assigned" },
+  { port: 1942, name: "parachute-lens", status: "assigned" },
   { port: 1943, name: "parachute-scribe", status: "assigned" },
   { port: 1944, name: "pendant", status: "reserved" },
   { port: 1945, name: "daily-v2", status: "reserved" },
@@ -53,7 +53,7 @@ export function isCanonicalPort(port: number): boolean {
 
 /**
  * Broad shape of a service. Matches the hub's card-kind taxonomy.
- *   "frontend"  a user-facing UI (notes). Safe to expose by default.
+ *   "frontend"  a user-facing UI (lens). Safe to expose by default.
  *   "api"       a programmatic surface (vault, channel, scribe). Whether
  *               it's safe to expose depends on `hasAuth`.
  *   "tool"      like "api" but specifically MCP-shaped / agent-callable.
@@ -67,7 +67,7 @@ export interface ServiceSpec {
   readonly init?: readonly string[];
   /**
    * Command to spawn for `parachute start <svc>`. Receives the services.json
-   * entry so commands that need per-install data (e.g., the notes static-serve
+   * entry so commands that need per-install data (e.g., the lens static-serve
    * shim needs the configured port) can pull it from there.
    *
    * Returns `undefined` to declare "lifecycle not supported for this service."
@@ -102,7 +102,7 @@ export interface ServiceSpec {
   readonly hasAuth?: boolean;
 }
 
-const NOTES_SERVE_PATH = fileURLToPath(new URL("./notes-serve.ts", import.meta.url));
+const LENS_SERVE_PATH = fileURLToPath(new URL("./lens-serve.ts", import.meta.url));
 
 /**
  * Seed entries land in services.json as placeholder rows when a freshly
@@ -128,16 +128,18 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
       version: SEED_VERSION,
     }),
   },
-  notes: {
-    package: "@openparachute/notes",
-    manifestName: "parachute-notes",
-    startCmd: (entry) => ["bun", NOTES_SERVE_PATH, "--port", String(entry.port)],
+  lens: {
+    // Lens is the product name (formerly "notes"). vault's internal
+    // `/api/notes` endpoint is unchanged — different concept.
+    package: "@openparachute/lens",
+    manifestName: "parachute-lens",
+    startCmd: (entry) => ["bun", LENS_SERVE_PATH, "--port", String(entry.port)],
     kind: "frontend",
     seedEntry: () => ({
-      name: "parachute-notes",
+      name: "parachute-lens",
       port: 1942,
-      paths: ["/notes"],
-      health: "/notes/health",
+      paths: ["/lens"],
+      health: "/lens/health",
       version: SEED_VERSION,
     }),
   },
@@ -179,7 +181,7 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
  * entry. Explicit wins. If absent, derive from the spec: known api/tool
  * services without declared auth fall back to "auth-required" (treated as
  * loopback at launch); everything else defaults to "allowed" — so vault,
- * notes, channel and unknown third-party services continue to be exposed
+ * lens, channel and unknown third-party services continue to be exposed
  * without needing to opt in.
  */
 export function effectivePublicExposure(

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -204,11 +204,24 @@ export function getSpec(service: string): ServiceSpec | undefined {
   return SERVICE_SPECS[service];
 }
 
+/**
+ * Legacy manifest names kept so `parachute start` / `stop` / `logs` keep
+ * working on an already-installed services.json that still carries the
+ * old name. v0.x users who installed before the rename will have
+ * `"parachute-notes"` in their manifest until the lens package next
+ * boots and rewrites the entry; without this alias, lifecycle commands
+ * silently skip those rows. Remove after launch, alongside the
+ * `notes → lens` install alias.
+ */
+const LEGACY_MANIFEST_ALIASES: Record<string, string> = {
+  "parachute-notes": "lens",
+};
+
 /** Short name (the key into SERVICE_SPECS) for a given manifest name, e.g.
  *  `parachute-vault` → `vault`. Returns undefined for unknown manifests. */
 export function shortNameForManifest(manifestName: string): string | undefined {
   for (const [short, spec] of Object.entries(SERVICE_SPECS)) {
     if (spec.manifestName === manifestName) return short;
   }
-  return undefined;
+  return LEGACY_MANIFEST_ALIASES[manifestName];
 }

--- a/src/tailscale/detect.ts
+++ b/src/tailscale/detect.ts
@@ -43,7 +43,7 @@ export async function getFqdn(runner: Runner): Promise<string> {
 
 /**
  * Detect whether wildcard MagicDNS is active — i.e. whether subdomains of the
- * current machine (vault.<fqdn>, notes.<fqdn>, …) resolve back to this node.
+ * current machine (vault.<fqdn>, lens.<fqdn>, …) resolve back to this node.
  *
  * Tailscale's standard MagicDNS gives each machine a single hostname and does
  * not auto-resolve arbitrary subdomains; wildcard MagicDNS exists in the

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -36,7 +36,7 @@ export interface WellKnownServicesEntry {
  *     multi-tenant service.
  *   - `services: []` — flat list the hub page iterates. Scales to N frontends
  *     without the consumer needing to know every shortName.
- *   - Top-level flat keys (`notes`, `scribe`, …) — kept for back-compat with
+ *   - Top-level flat keys (`lens`, `scribe`, …) — kept for back-compat with
  *     clients that predate `services[]`.
  */
 export type WellKnownDocument = {


### PR DESCRIPTION
## Why

`parachute-notes` is shipping as `parachute-lens` for launch. The product has been renamed across the ecosystem (package name `@openparachute/lens`, site, PWA bundle, docs). The CLI is the coordinator that composes URLs, reads services.json, and prints help — every user-facing string it owns has to match the new package or `parachute install lens` breaks with a mismatched manifestName.

## What moves

- `SERVICE_SPECS.notes` → `SERVICE_SPECS.lens`; `package: @openparachute/lens`, `manifestName: parachute-lens`, seed paths `/lens`
- `src/notes-serve.ts` → `src/lens-serve.ts` (function + logs renamed with it)
- `PORT_RESERVATIONS[1942]` entry renamed; `kind: "frontend"` (preserved from #24)
- README, CLAUDE.md, help.ts, docstrings updated

## Transition discipline

- **`parachute install notes`** stays accepted as a soft alias for one release cycle: logs `"notes" has been renamed to "lens"; installing lens.` and installs lens. Scoped to `install` — `start notes` will fail with "unknown service" (users install first, see the notice, then use the new name).
- **`~/.parachute/notes/`** kept on migrate's safelist so existing config dirs survive upgrade. Transition-only; remove after launch settles.

Both aliases documented inline with a "remove after launch" note.

## What I did NOT change

- `vault`'s `/api/notes` endpoint — different concept (vault-internal notes storage), unrelated to the Lens product
- `services-manifest.test.ts` tagline `"Your notes, sovereign"` — user-concept text, not a product name
- `migrate.test.ts` `notes.md` archive fixture — tests the archive-collision path with an arbitrary filename
- `cli.test.ts` "Funnel notes" — English usage

## Gates

- `bun run typecheck` ✓
- `bun test` — 210 pass, 0 fail (up from 194: PR #24 added tests; also added new `install notes` alias test)

## Coordination

Lens steward's next publish will populate services.json authoritatively; the seed entry here is the one-release fallback for `bun link` local-dev. Removing the soft alias and migrate safelist entry is tracked for the post-launch cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)