### PR TITLE
hotfix(lens-serve): strip mount prefix and fix .webmanifest MIME

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ The flat shape matters: each command is a self-contained module in `src/commands
 - **`src/hub-server.ts`** — internal Bun server on port 1939. Serves `/` (discovery page) and `/.well-known/parachute.json`. Spawned by `parachute expose`, stopped when the last layer goes away. Tailscale serve can't directly serve files on macOS (sandboxed), so this loopback proxy is the portable shape.
 - **`src/expose-state.ts`** — which layers (tailnet/public) are currently up, persisted to `~/.parachute/expose-state.json`. Lets `expose <layer> off` be precise rather than blowing away everything.
 - **`src/tailscale/`** — thin wrappers around `tailscale serve` / `tailscale funnel`. Shape is pinned to 1.82+ (`funnel` as its own subcommand).
+- **`src/lens-serve.ts`** — tiny Bun static-file server for the @openparachute/lens PWA bundle. Invoked as `bun lens-serve.ts --port <n> [--dist <path>] [--mount <prefix>]`. The `--mount` arg (default `/lens`, derived from `entry.paths[0]` in the service spec) is the path prefix the reverse proxy hands us; the shim strips it before joining with `dist/`. Without the strip, requests for `/lens/sw.js` and `/lens/manifest.webmanifest` get SPA-shelled with `text/html`, the browser never sees them as the SW + manifest, and the PWA install prompt never fires. Pass `--mount ""` (or `--mount /`) when serving at the origin root.
 
 ## Key design decisions
 

--- a/src/__tests__/lens-serve.test.ts
+++ b/src/__tests__/lens-serve.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { lensFetch, normalizeMount } from "../lens-serve.ts";
+
+interface Harness {
+  dir: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-lens-serve-"));
+  writeFileSync(join(dir, "index.html"), "<html><body>lens spa</body></html>");
+  writeFileSync(join(dir, "sw.js"), "self.addEventListener('install', () => {});");
+  writeFileSync(join(dir, "manifest.webmanifest"), '{"name":"Lens","start_url":"/lens/"}');
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+function req(path: string): Request {
+  return new Request(`http://127.0.0.1${path}`);
+}
+
+describe("normalizeMount", () => {
+  test("strips trailing slashes", () => {
+    expect(normalizeMount("/lens/")).toBe("/lens");
+    expect(normalizeMount("/lens")).toBe("/lens");
+    expect(normalizeMount("/lens///")).toBe("/lens");
+  });
+
+  test("collapses root-equivalents to empty string", () => {
+    expect(normalizeMount("")).toBe("");
+    expect(normalizeMount("/")).toBe("");
+  });
+});
+
+describe("lensFetch with default /lens mount", () => {
+  test("GET /lens/sw.js serves the SW with JS content-type, not text/html", async () => {
+    const h = makeHarness();
+    try {
+      const res = lensFetch(h.dir, "/lens")(req("/lens/sw.js"));
+      expect(res.status).toBe(200);
+      const ct = res.headers.get("content-type") ?? "";
+      expect(ct).not.toContain("text/html");
+      expect(ct).toMatch(/javascript/);
+      expect(await res.text()).toContain("addEventListener");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("GET /lens/manifest.webmanifest serves application/manifest+json", async () => {
+    const h = makeHarness();
+    try {
+      const res = lensFetch(h.dir, "/lens")(req("/lens/manifest.webmanifest"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("application/manifest+json");
+      expect(await res.text()).toContain('"name":"Lens"');
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("GET /lens/ serves the SPA shell", async () => {
+    const h = makeHarness();
+    try {
+      const res = lensFetch(h.dir, "/lens")(req("/lens/"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      expect(await res.text()).toContain("lens spa");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("GET /lens (no trailing slash) serves the SPA shell", async () => {
+    const h = makeHarness();
+    try {
+      const res = lensFetch(h.dir, "/lens")(req("/lens"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      expect(await res.text()).toContain("lens spa");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("GET /lens/nonexistent/deep/route falls back to SPA shell", async () => {
+    const h = makeHarness();
+    try {
+      const res = lensFetch(h.dir, "/lens")(req("/lens/nonexistent/deep/route"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      expect(await res.text()).toContain("lens spa");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("GET /lensx/foo (mount-prefix collision) is not stripped", async () => {
+    // Guards against startsWith("/lens") matching unrelated /lensx routes.
+    const h = makeHarness();
+    try {
+      const res = lensFetch(h.dir, "/lens")(req("/lensx/foo"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("lensFetch with empty mount (root deployment)", () => {
+  test("GET /sw.js serves the SW directly", async () => {
+    const h = makeHarness();
+    try {
+      const res = lensFetch(h.dir, "")(req("/sw.js"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type") ?? "").toMatch(/javascript/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("GET / serves the SPA shell", async () => {
+    const h = makeHarness();
+    try {
+      const res = lensFetch(h.dir, "")(req("/"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -144,9 +144,13 @@ describe("parachute start", () => {
       expect(code).toBe(0);
       const cmd = spawner.calls[0]?.cmd ?? [];
       expect(cmd[0]).toBe("bun");
-      expect(cmd.at(-2)).toBe("--port");
-      expect(cmd.at(-1)).toBe("5173");
       expect(cmd.some((a) => a.endsWith("lens-serve.ts"))).toBe(true);
+      const portIdx = cmd.indexOf("--port");
+      expect(portIdx).toBeGreaterThan(-1);
+      expect(cmd[portIdx + 1]).toBe("5173");
+      const mountIdx = cmd.indexOf("--mount");
+      expect(mountIdx).toBeGreaterThan(-1);
+      expect(cmd[mountIdx + 1]).toBe("/lens");
     } finally {
       h.cleanup();
     }

--- a/src/help.ts
+++ b/src/help.ts
@@ -156,7 +156,7 @@ Start commands by service:
   vault     parachute-vault serve
   scribe    parachute-scribe serve
   channel   parachute-channel daemon
-  lens      bun <cli>/lens-serve.ts --port <configured>
+  lens      bun <cli>/lens-serve.ts --port <configured> --mount <paths[0]>
 `;
 }
 

--- a/src/lens-serve.ts
+++ b/src/lens-serve.ts
@@ -9,7 +9,15 @@
  * the other services.
  *
  * Invoked as:
- *   bun <this-file> --port <n> [--dist <path>]
+ *   bun <this-file> --port <n> [--dist <path>] [--mount <prefix>]
+ *
+ * `--mount` (default `/lens`) is the path prefix the reverse proxy hands
+ * us. We strip it before resolving against `dist/` so a request for
+ * `/lens/sw.js` reads `{dist}/sw.js` rather than the nonexistent
+ * `{dist}/lens/sw.js`. Without the strip, the SW + .webmanifest both
+ * SPA-fall-back to index.html with content-type text/html, and the PWA
+ * install prompt never fires. Pass `--mount ""` (or `--mount /`) when the
+ * bundle is served at the origin root.
  *
  * If --dist is omitted, we resolve @openparachute/lens's dist directory
  * via Bun.resolveSync. If that fails (package not installed globally, or
@@ -19,9 +27,16 @@
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
-function parseArgs(argv: string[]): { port: number; dist?: string } {
+interface Args {
+  port: number;
+  dist?: string;
+  mount: string;
+}
+
+function parseArgs(argv: string[]): Args {
   let port = 5173;
   let dist: string | undefined;
+  let mount = "/lens";
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--port") {
@@ -36,11 +51,20 @@ function parseArgs(argv: string[]): { port: number; dist?: string } {
       const v = argv[++i];
       if (!v) throw new Error("--dist requires a value");
       dist = resolve(v);
+    } else if (a === "--mount") {
+      const v = argv[++i];
+      if (v === undefined) throw new Error("--mount requires a value");
+      mount = normalizeMount(v);
     } else {
       throw new Error(`unknown argument: ${a}`);
     }
   }
-  return { port, dist };
+  return { port, dist, mount };
+}
+
+export function normalizeMount(raw: string): string {
+  if (raw === "" || raw === "/") return "";
+  return raw.replace(/\/+$/, "");
 }
 
 function resolveLensDist(): string {
@@ -55,34 +79,57 @@ function resolveLensDist(): string {
   return dist;
 }
 
-const { port, dist: distArg } = parseArgs(process.argv.slice(2));
-
-let dist: string;
-try {
-  dist = distArg ?? resolveLensDist();
-} catch (err) {
-  console.error(`parachute-lens-serve: ${err instanceof Error ? err.message : String(err)}`);
-  process.exit(1);
+function mimeFor(path: string): string | undefined {
+  // Bun.file infers MIME from extension but doesn't know .webmanifest;
+  // without this the PWA install prompt sees text/html and bails.
+  if (path.endsWith(".webmanifest")) return "application/manifest+json";
+  return undefined;
 }
 
-const indexHtml = join(dist, "index.html");
+export function lensFetch(dist: string, mount: string): (req: Request) => Response {
+  const indexHtml = join(dist, "index.html");
+  const spaShell = () =>
+    new Response(Bun.file(indexHtml), {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
 
-Bun.serve({
-  port,
-  fetch(req) {
+  return (req) => {
     const url = new URL(req.url);
-    const filePath = join(dist, decodeURIComponent(url.pathname));
+    let pathname = url.pathname;
+    if (mount && (pathname === mount || pathname.startsWith(`${mount}/`))) {
+      pathname = pathname.slice(mount.length) || "/";
+    }
+    if (pathname === "/" || pathname.endsWith("/")) {
+      return spaShell();
+    }
+    const filePath = join(dist, decodeURIComponent(pathname));
     if (!filePath.startsWith(dist)) {
       return new Response("forbidden", { status: 403 });
     }
-    const file = Bun.file(filePath);
-    if (existsSync(filePath) && !filePath.endsWith("/")) {
-      return new Response(file);
+    if (existsSync(filePath)) {
+      const file = Bun.file(filePath);
+      const mime = mimeFor(filePath);
+      return new Response(file, mime ? { headers: { "content-type": mime } } : undefined);
     }
-    return new Response(Bun.file(indexHtml), {
-      headers: { "content-type": "text/html; charset=utf-8" },
-    });
-  },
-});
+    return spaShell();
+  };
+}
 
-console.log(`lens static-serve listening on :${port} (dist=${dist})`);
+if (import.meta.main) {
+  const { port, dist: distArg, mount } = parseArgs(process.argv.slice(2));
+
+  let dist: string;
+  try {
+    dist = distArg ?? resolveLensDist();
+  } catch (err) {
+    console.error(`parachute-lens-serve: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  Bun.serve({
+    port,
+    fetch: lensFetch(dist, mount),
+  });
+
+  console.log(`lens static-serve listening on :${port} (dist=${dist}, mount=${mount || "/"})`);
+}

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -133,7 +133,11 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
     // `/api/notes` endpoint is unchanged — different concept.
     package: "@openparachute/lens",
     manifestName: "parachute-lens",
-    startCmd: (entry) => ["bun", LENS_SERVE_PATH, "--port", String(entry.port)],
+    startCmd: (entry) => {
+      const first = entry.paths[0] ?? "/lens";
+      const mount = first === "/" ? "" : first.replace(/\/+$/, "");
+      return ["bun", LENS_SERVE_PATH, "--port", String(entry.port), "--mount", mount];
+    },
     kind: "frontend",
     seedEntry: () => ({
       name: "parachute-lens",


### PR DESCRIPTION
## Summary
- Lens PWA install prompt was dead because `lens-serve.ts` joined `url.pathname` directly with `dist/` — `GET /lens/sw.js` → `{dist}/lens/sw.js` (missing) → SPA-fall-back to `index.html` with `content-type: text/html`. Browser never saw the SW as JS or the manifest as a manifest.
- Adds `--mount <prefix>` (default `/lens`, sourced from `entry.paths[0]` in `service-spec.ts`) that gets stripped before resolving against `dist/`.
- Adds a `mimeFor()` override for `.webmanifest` → `application/manifest+json` (Bun.file doesn't know that extension).
- Extracts `lensFetch(dist, mount)` so it's testable, gates `Bun.serve` on `import.meta.main` (matches `hub-server.ts`).

## Why now
Aaron is blocked on PWA install for launch — verified `GET /lens/sw.js` on port 1942 was returning 200 with `text/html` body. Service worker never registered, install prompt never fired, offline mode dead code.

## Manual verification
Ran `bun src/lens-serve.ts --port 19942 --dist <lens-dist> --mount /lens` and curled:

```
sw.js:           status=200 ct=text/javascript;charset=utf-8
manifest:        status=200 ct=application/manifest+json
/lens/:          status=200 ct=text/html; charset=utf-8
missing route:   status=200 ct=text/html; charset=utf-8
no-prefix sw.js: status=200 ct=text/javascript;charset=utf-8
```

(Couldn't repro on the running install at 1942 — Aaron's lens vite dev server is currently bound to that port too and intercepts first. After merge + `parachute restart lens`, the shim will be the only listener.)

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun test` — 221 pass / 0 fail (10 new tests in `src/__tests__/lens-serve.test.ts`, lifecycle test updated for new cmd shape)
- [x] `bunx biome check` clean on changed files
- [x] Manual curl confirms all four launch-critical paths

## Scope discipline
- One PR. `--mount` arg + `.webmanifest` MIME + service-spec wiring + tests + docs only.
- No shim refactor beyond extracting `lensFetch` (needed for testability).
- Path-traversal guard untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)