### PR TITLE
revert: rename back to notes (front-end name reverted on launch eve)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Parachute CLI
 
-`parachute` — the top-level CLI. Installs services, runs them as background processes, and exposes them over Tailscale. Coordinator, not a service: each Parachute package (`vault`, `lens`, `scribe`, `channel`) stays standalone; this CLI stitches them together.
+`parachute` — the top-level CLI. Installs services, runs them as background processes, and exposes them over Tailscale. Coordinator, not a service: each Parachute package (`vault`, `notes`, `scribe`, `channel`) stays standalone; this CLI stitches them together.
 
 User-facing README is the right intro for operators. This file is for agents and humans working *on* the CLI itself.
 
@@ -24,7 +24,7 @@ The flat shape matters: each command is a self-contained module in `src/commands
 - **`src/hub-server.ts`** — internal Bun server on port 1939. Serves `/` (discovery page) and `/.well-known/parachute.json`. Spawned by `parachute expose`, stopped when the last layer goes away. Tailscale serve can't directly serve files on macOS (sandboxed), so this loopback proxy is the portable shape.
 - **`src/expose-state.ts`** — which layers (tailnet/public) are currently up, persisted to `~/.parachute/expose-state.json`. Lets `expose <layer> off` be precise rather than blowing away everything.
 - **`src/tailscale/`** — thin wrappers around `tailscale serve` / `tailscale funnel`. Shape is pinned to 1.82+ (`funnel` as its own subcommand).
-- **`src/lens-serve.ts`** — tiny Bun static-file server for the @openparachute/lens PWA bundle. Invoked as `bun lens-serve.ts --port <n> [--dist <path>] [--mount <prefix>]`. The `--mount` arg (default `/lens`, derived from `entry.paths[0]` in the service spec) is the path prefix the reverse proxy hands us; the shim strips it before joining with `dist/`. Without the strip, requests for `/lens/sw.js` and `/lens/manifest.webmanifest` get SPA-shelled with `text/html`, the browser never sees them as the SW + manifest, and the PWA install prompt never fires. Pass `--mount ""` (or `--mount /`) when serving at the origin root.
+- **`src/notes-serve.ts`** — tiny Bun static-file server for the @openparachute/notes PWA bundle. Invoked as `bun notes-serve.ts --port <n> [--dist <path>] [--mount <prefix>]`. The `--mount` arg (default `/notes`, derived from `entry.paths[0]` in the service spec) is the path prefix the reverse proxy hands us; the shim strips it before joining with `dist/`. Without the strip, requests for `/notes/sw.js` and `/notes/manifest.webmanifest` get SPA-shelled with `text/html`, the browser never sees them as the SW + manifest, and the PWA install prompt never fires. Pass `--mount ""` (or `--mount /`) when serving at the origin root.
 
 ## Key design decisions
 
@@ -74,7 +74,7 @@ Every PR here is reviewer-gated — no direct-to-main, even for one-line fixes. 
 - Bin name: `parachute`
 - Config root: `~/.parachute/` (override with `PARACHUTE_HOME`)
 - Per-service dirs: `~/.parachute/<short>/` (e.g. `~/.parachute/vault/`)
-- Short names (map to `manifestName` via `SERVICE_SPECS`): `vault`, `lens`, `scribe`, `channel`. `notes` is a transition alias for `lens` on `parachute install` (one release cycle); removed post-launch.
+- Short names (map to `manifestName` via `SERVICE_SPECS`): `vault`, `notes`, `scribe`, `channel`. `lens` is a transition alias for `notes` on `parachute install` (one release cycle, residue from the brief Notes→Lens→Notes round-trip on 2026-04-19/22); removed post-launch.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/cli",
-  "version": "0.2.0-rc.1",
+  "version": "0.2.0-rc.2",
   "description": "parachute — the top-level CLI for the Parachute ecosystem.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -98,10 +98,10 @@ function seedServices(path: string): void {
   );
   upsertService(
     {
-      name: "parachute-lens",
+      name: "parachute-notes",
       port: 5173,
-      paths: ["/lens"],
-      health: "/lens/health",
+      paths: ["/notes"],
+      health: "/notes/health",
       version: "0.0.1",
     },
     path,
@@ -136,7 +136,7 @@ describe("expose tailnet up", () => {
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      // 4 baseline (hub + wk + vault + lens) + 4 OAuth proxies (vault present).
+      // 4 baseline (hub + wk + vault + notes) + 4 OAuth proxies (vault present).
       expect(serveCalls).toHaveLength(8);
       // Tailnet mode never uses funnel — neither the old flag nor the new subcommand.
       expect(serveCalls.every((c) => !c.includes("--funnel"))).toBe(true);
@@ -147,7 +147,7 @@ describe("expose tailnet up", () => {
         "--set-path=/",
         "--set-path=/.well-known/oauth-authorization-server",
         "--set-path=/.well-known/parachute.json",
-        "--set-path=/lens",
+        "--set-path=/notes",
         "--set-path=/oauth/authorize",
         "--set-path=/oauth/register",
         "--set-path=/oauth/token",
@@ -167,8 +167,8 @@ describe("expose tailnet up", () => {
 
       // Service targets also include their mount path to prevent tailscale
       // from stripping the prefix before forwarding to a base-aware backend.
-      const lensCall = serveCalls.find((c) => c.includes("--set-path=/lens"));
-      expect(lensCall?.[lensCall.length - 1]).toBe("http://127.0.0.1:5173/lens");
+      const notesCall = serveCalls.find((c) => c.includes("--set-path=/notes"));
+      expect(notesCall?.[notesCall.length - 1]).toBe("http://127.0.0.1:5173/notes");
       const vaultCall = serveCalls.find((c) => c.includes("--set-path=/vault/default"));
       expect(vaultCall?.[vaultCall.length - 1]).toBe("http://127.0.0.1:1940/vault/default");
 
@@ -219,17 +219,17 @@ describe("expose tailnet up", () => {
   });
 
   test("trailing-slash mount preserves trailing slash in target URL", async () => {
-    // Aaron hit ERR_TOO_MANY_REDIRECTS on /lens/ because tailscale strips
-    // the prefix, Vite (base=/lens) redirects back to /lens/, tailscale
+    // Aaron hit ERR_TOO_MANY_REDIRECTS on /notes/ because tailscale strips
+    // the prefix, Vite (base=/notes) redirects back to /notes/, tailscale
     // strips again, loop. Pinning target = mount byte-for-byte breaks that.
     const h = makeHarness();
     try {
       upsertService(
         {
-          name: "parachute-lens",
+          name: "parachute-notes",
           port: 5173,
-          paths: ["/lens/"],
-          health: "/lens/health",
+          paths: ["/notes/"],
+          health: "/notes/health",
           version: "0.0.1",
         },
         h.manifestPath,
@@ -252,9 +252,9 @@ describe("expose tailnet up", () => {
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      const lensCall = serveCalls.find((c) => c.includes("--set-path=/lens/"));
-      expect(lensCall).toBeDefined();
-      expect(lensCall?.[lensCall.length - 1]).toBe("http://127.0.0.1:5173/lens/");
+      const notesCall = serveCalls.find((c) => c.includes("--set-path=/notes/"));
+      expect(notesCall).toBeDefined();
+      expect(notesCall?.[notesCall.length - 1]).toBe("http://127.0.0.1:5173/notes/");
     } finally {
       h.cleanup();
     }
@@ -417,14 +417,14 @@ describe("expose tailnet up", () => {
         wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         hubEnsureOpts: hubEnsureOpts(spawner),
-        // vault is up; lens is down.
+        // vault is up; notes is down.
         servicePortProbe: async (port) => port === 1940,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
       const joined = logs.join("\n");
-      expect(joined).toMatch(/parachute-lens \(port 5173\) is not responding/);
-      expect(joined).toMatch(/parachute start lens/);
+      expect(joined).toMatch(/parachute-notes \(port 5173\) is not responding/);
+      expect(joined).toMatch(/parachute start notes/);
       expect(joined).not.toMatch(/parachute-vault.*not responding/);
       // Bringup still happened — 4 service entries + 4 OAuth proxies got staged.
       const serveCalls = calls.filter(
@@ -533,10 +533,10 @@ describe("expose tailnet up", () => {
     try {
       upsertService(
         {
-          name: "parachute-lens",
+          name: "parachute-notes",
           port: 5173,
-          paths: ["/lens"],
-          health: "/lens/health",
+          paths: ["/notes"],
+          health: "/notes/health",
           version: "0.0.1",
         },
         h.manifestPath,
@@ -560,7 +560,7 @@ describe("expose tailnet up", () => {
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      // No vault → no OAuth proxies. Hub + well-known + lens = 3.
+      // No vault → no OAuth proxies. Hub + well-known + notes = 3.
       expect(serveCalls).toHaveLength(3);
       const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path=")));
       expect(mounts.every((m) => m !== undefined && !m.includes("/oauth/"))).toBe(true);
@@ -1087,7 +1087,7 @@ describe("expose publicExposure filter", () => {
     // it identically to loopback — still no funnel/tailnet exposure.
     const h = makeHarness();
     try {
-      seedServices(h.manifestPath); // vault + lens, both allowed by default
+      seedServices(h.manifestPath); // vault + notes, both allowed by default
       upsertService(
         {
           name: "parachute-channel",

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -112,22 +112,22 @@ describe("install", () => {
   });
 
   test("warns when manifest entry lands outside the canonical port range", async () => {
-    // Historically lens wrote 5173 (Vite's dev default). Canonical is
-    // 1939–1949; warn so integrators know their service could conflict with
-    // other software on the box, but don't block — forks may intentionally
-    // deviate.
+    // Historically the notes PWA wrote 5173 (Vite's dev default). Canonical
+    // is 1939–1949; warn so integrators know their service could conflict
+    // with other software on the box, but don't block — forks may
+    // intentionally deviate.
     const { path, cleanup } = makeTempPath();
     try {
       const logs: string[] = [];
-      const code = await install("lens", {
+      const code = await install("notes", {
         runner: async (cmd) => {
           if (cmd[0] === "bun") {
             upsertService(
               {
-                name: "parachute-lens",
+                name: "parachute-notes",
                 port: 5173,
-                paths: ["/lens"],
-                health: "/lens/health",
+                paths: ["/notes"],
+                health: "/notes/health",
                 version: "0.0.1",
               },
               path,
@@ -147,14 +147,16 @@ describe("install", () => {
     }
   });
 
-  test("`install notes` aliases to lens with a rename notice", async () => {
-    // Transition alias after the Lens rebrand (2026-04). Accepted for one
-    // release cycle; removed after launch users have re-installed.
+  test("`install lens` aliases to notes with a rename notice", async () => {
+    // Transition alias for the brief Notes→Lens rename (Apr 19) that was
+    // reverted on launch eve (Apr 22). Accepted for one release cycle so
+    // anyone who ran `parachute install lens` during the ~3-day window
+    // keeps working; removed after launch users have re-installed.
     const { path, cleanup } = makeTempPath();
     try {
       const calls: string[][] = [];
       const logs: string[] = [];
-      const code = await install("notes", {
+      const code = await install("lens", {
         runner: async (cmd) => {
           calls.push([...cmd]);
           return 0;
@@ -164,12 +166,10 @@ describe("install", () => {
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
-      expect(logs.join("\n")).toMatch(
-        /"notes" has been renamed to "lens"; installing lens\./,
-      );
+      expect(logs.join("\n")).toMatch(/"lens" has been renamed to "notes"; installing notes\./);
       // Downstream bun-add must use the new package name, not the old.
-      expect(calls[0]).toEqual(["bun", "add", "-g", "@openparachute/lens"]);
-      const seeded = findService("parachute-lens", path);
+      expect(calls[0]).toEqual(["bun", "add", "-g", "@openparachute/notes"]);
+      const seeded = findService("parachute-notes", path);
       expect(seeded?.port).toBe(1942);
     } finally {
       cleanup();
@@ -524,7 +524,7 @@ describe("install", () => {
     }
   });
 
-  test("installing lens doesn't trigger auto-wire even if vault + scribe are present", async () => {
+  test("installing notes doesn't trigger auto-wire even if vault + scribe are present", async () => {
     // Defense: auto-wire should only fire from the scribe or vault install
     // path. A parallel install of a different service shouldn't touch the
     // shared-secret files.
@@ -551,7 +551,7 @@ describe("install", () => {
         },
         path,
       );
-      await install("lens", {
+      await install("notes", {
         runner: async () => 0,
         manifestPath: path,
         configDir,

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -35,13 +35,13 @@ function seedVault(manifestPath: string): void {
   );
 }
 
-function seedLens(manifestPath: string): void {
+function seedNotes(manifestPath: string): void {
   upsertService(
     {
-      name: "parachute-lens",
+      name: "parachute-notes",
       port: 5173,
-      paths: ["/lens"],
-      health: "/lens/health",
+      paths: ["/notes"],
+      health: "/notes/health",
       version: "0.0.1",
     },
     manifestPath,
@@ -95,13 +95,13 @@ describe("parachute start", () => {
     try {
       seedVault(h.manifestPath);
       const logs: string[] = [];
-      const code = await start("lens", {
+      const code = await start("notes", {
         configDir: h.configDir,
         manifestPath: h.manifestPath,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(1);
-      expect(logs.join("\n")).toMatch(/lens isn't installed/);
+      expect(logs.join("\n")).toMatch(/notes isn't installed/);
     } finally {
       h.cleanup();
     }
@@ -130,12 +130,12 @@ describe("parachute start", () => {
     }
   });
 
-  test("lens start command includes configured port and lens-serve shim path", async () => {
+  test("notes start command includes configured port and notes-serve shim path", async () => {
     const h = makeHarness();
     try {
-      seedLens(h.manifestPath);
+      seedNotes(h.manifestPath);
       const spawner = makeSpawner([5151]);
-      const code = await start("lens", {
+      const code = await start("notes", {
         configDir: h.configDir,
         manifestPath: h.manifestPath,
         spawner,
@@ -144,13 +144,13 @@ describe("parachute start", () => {
       expect(code).toBe(0);
       const cmd = spawner.calls[0]?.cmd ?? [];
       expect(cmd[0]).toBe("bun");
-      expect(cmd.some((a) => a.endsWith("lens-serve.ts"))).toBe(true);
+      expect(cmd.some((a) => a.endsWith("notes-serve.ts"))).toBe(true);
       const portIdx = cmd.indexOf("--port");
       expect(portIdx).toBeGreaterThan(-1);
       expect(cmd[portIdx + 1]).toBe("5173");
       const mountIdx = cmd.indexOf("--mount");
       expect(mountIdx).toBeGreaterThan(-1);
-      expect(cmd[mountIdx + 1]).toBe("/lens");
+      expect(cmd[mountIdx + 1]).toBe("/notes");
     } finally {
       h.cleanup();
     }
@@ -204,7 +204,7 @@ describe("parachute start", () => {
     const h = makeHarness();
     try {
       seedVault(h.manifestPath);
-      seedLens(h.manifestPath);
+      seedNotes(h.manifestPath);
       const spawner = makeSpawner([4242, 5151]);
       const code = await start(undefined, {
         configDir: h.configDir,
@@ -215,26 +215,26 @@ describe("parachute start", () => {
       expect(code).toBe(0);
       expect(spawner.calls).toHaveLength(2);
       expect(readPid("vault", h.configDir)).toBe(4242);
-      expect(readPid("lens", h.configDir)).toBe(5151);
+      expect(readPid("notes", h.configDir)).toBe(5151);
     } finally {
       h.cleanup();
     }
   });
 
-  test("legacy parachute-notes manifest entry still starts under the lens spec", async () => {
-    // v0.x users upgraded into the lens rename will still have
-    // `parachute-notes` in services.json until their lens package next
-    // boots and rewrites the row. Without the manifest alias,
+  test("legacy parachute-lens manifest entry still starts under the notes spec", async () => {
+    // Users who installed during the brief Notes→Lens window (Apr 19–22)
+    // will still have `parachute-lens` in services.json until their notes
+    // package next boots and rewrites the row. Without the manifest alias,
     // shortNameForManifest returns undefined, resolveTargets skips the
     // entry, and they get "No manageable services" with no hint.
     const h = makeHarness();
     try {
       upsertService(
         {
-          name: "parachute-notes",
+          name: "parachute-lens",
           port: 5173,
-          paths: ["/notes"],
-          health: "/notes/health",
+          paths: ["/lens"],
+          health: "/lens/health",
           version: "0.0.1",
         },
         h.manifestPath,
@@ -248,8 +248,8 @@ describe("parachute start", () => {
       });
       expect(code).toBe(0);
       expect(spawner.calls).toHaveLength(1);
-      expect(spawner.calls[0]?.cmd.some((a) => a.endsWith("lens-serve.ts"))).toBe(true);
-      expect(readPid("lens", h.configDir)).toBe(5151);
+      expect(spawner.calls[0]?.cmd.some((a) => a.endsWith("notes-serve.ts"))).toBe(true);
+      expect(readPid("notes", h.configDir)).toBe(5151);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/migrate.test.ts
+++ b/src/__tests__/migrate.test.ts
@@ -46,12 +46,13 @@ describe("safelistEntries", () => {
     const s = safelistEntries();
     // Service dirs from SERVICE_SPECS
     expect(s.has("vault")).toBe(true);
-    expect(s.has("lens")).toBe(true);
+    expect(s.has("notes")).toBe(true);
     expect(s.has("scribe")).toBe(true);
     expect(s.has("channel")).toBe(true);
-    // Legacy — kept across the lens rename so existing ~/.parachute/notes/
-    // dirs from pre-rename installs don't get archived on upgrade.
-    expect(s.has("notes")).toBe(true);
+    // Legacy — kept across the Notes→Lens→Notes rename round-trip
+    // (Apr 19 → Apr 22) so existing ~/.parachute/lens/ dirs from the
+    // brief Lens window don't get archived on upgrade.
+    expect(s.has("lens")).toBe(true);
     // Internal
     expect(s.has("hub")).toBe(true);
     // CLI state

--- a/src/__tests__/notes-serve.test.ts
+++ b/src/__tests__/notes-serve.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { lensFetch, normalizeMount } from "../lens-serve.ts";
+import { normalizeMount, notesFetch } from "../notes-serve.ts";
 
 interface Harness {
   dir: string;
@@ -10,10 +10,10 @@ interface Harness {
 }
 
 function makeHarness(): Harness {
-  const dir = mkdtempSync(join(tmpdir(), "pcli-lens-serve-"));
-  writeFileSync(join(dir, "index.html"), "<html><body>lens spa</body></html>");
+  const dir = mkdtempSync(join(tmpdir(), "pcli-notes-serve-"));
+  writeFileSync(join(dir, "index.html"), "<html><body>notes spa</body></html>");
   writeFileSync(join(dir, "sw.js"), "self.addEventListener('install', () => {});");
-  writeFileSync(join(dir, "manifest.webmanifest"), '{"name":"Lens","start_url":"/lens/"}');
+  writeFileSync(join(dir, "manifest.webmanifest"), '{"name":"Notes","start_url":"/notes/"}');
   return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
 }
 
@@ -23,9 +23,9 @@ function req(path: string): Request {
 
 describe("normalizeMount", () => {
   test("strips trailing slashes", () => {
-    expect(normalizeMount("/lens/")).toBe("/lens");
-    expect(normalizeMount("/lens")).toBe("/lens");
-    expect(normalizeMount("/lens///")).toBe("/lens");
+    expect(normalizeMount("/notes/")).toBe("/notes");
+    expect(normalizeMount("/notes")).toBe("/notes");
+    expect(normalizeMount("/notes///")).toBe("/notes");
   });
 
   test("collapses root-equivalents to empty string", () => {
@@ -34,11 +34,11 @@ describe("normalizeMount", () => {
   });
 });
 
-describe("lensFetch with default /lens mount", () => {
-  test("GET /lens/sw.js serves the SW with JS content-type, not text/html", async () => {
+describe("notesFetch with default /notes mount", () => {
+  test("GET /notes/sw.js serves the SW with JS content-type, not text/html", async () => {
     const h = makeHarness();
     try {
-      const res = lensFetch(h.dir, "/lens")(req("/lens/sw.js"));
+      const res = notesFetch(h.dir, "/notes")(req("/notes/sw.js"));
       expect(res.status).toBe(200);
       const ct = res.headers.get("content-type") ?? "";
       expect(ct).not.toContain("text/html");
@@ -49,59 +49,59 @@ describe("lensFetch with default /lens mount", () => {
     }
   });
 
-  test("GET /lens/manifest.webmanifest serves application/manifest+json", async () => {
+  test("GET /notes/manifest.webmanifest serves application/manifest+json", async () => {
     const h = makeHarness();
     try {
-      const res = lensFetch(h.dir, "/lens")(req("/lens/manifest.webmanifest"));
+      const res = notesFetch(h.dir, "/notes")(req("/notes/manifest.webmanifest"));
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("application/manifest+json");
-      expect(await res.text()).toContain('"name":"Lens"');
+      expect(await res.text()).toContain('"name":"Notes"');
     } finally {
       h.cleanup();
     }
   });
 
-  test("GET /lens/ serves the SPA shell", async () => {
+  test("GET /notes/ serves the SPA shell", async () => {
     const h = makeHarness();
     try {
-      const res = lensFetch(h.dir, "/lens")(req("/lens/"));
+      const res = notesFetch(h.dir, "/notes")(req("/notes/"));
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
-      expect(await res.text()).toContain("lens spa");
+      expect(await res.text()).toContain("notes spa");
     } finally {
       h.cleanup();
     }
   });
 
-  test("GET /lens (no trailing slash) serves the SPA shell", async () => {
+  test("GET /notes (no trailing slash) serves the SPA shell", async () => {
     const h = makeHarness();
     try {
-      const res = lensFetch(h.dir, "/lens")(req("/lens"));
+      const res = notesFetch(h.dir, "/notes")(req("/notes"));
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
-      expect(await res.text()).toContain("lens spa");
+      expect(await res.text()).toContain("notes spa");
     } finally {
       h.cleanup();
     }
   });
 
-  test("GET /lens/nonexistent/deep/route falls back to SPA shell", async () => {
+  test("GET /notes/nonexistent/deep/route falls back to SPA shell", async () => {
     const h = makeHarness();
     try {
-      const res = lensFetch(h.dir, "/lens")(req("/lens/nonexistent/deep/route"));
+      const res = notesFetch(h.dir, "/notes")(req("/notes/nonexistent/deep/route"));
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
-      expect(await res.text()).toContain("lens spa");
+      expect(await res.text()).toContain("notes spa");
     } finally {
       h.cleanup();
     }
   });
 
-  test("GET /lensx/foo (mount-prefix collision) is not stripped", async () => {
-    // Guards against startsWith("/lens") matching unrelated /lensx routes.
+  test("GET /notesx/foo (mount-prefix collision) is not stripped", async () => {
+    // Guards against startsWith("/notes") matching unrelated /notesx routes.
     const h = makeHarness();
     try {
-      const res = lensFetch(h.dir, "/lens")(req("/lensx/foo"));
+      const res = notesFetch(h.dir, "/notes")(req("/notesx/foo"));
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
     } finally {
@@ -110,11 +110,11 @@ describe("lensFetch with default /lens mount", () => {
   });
 });
 
-describe("lensFetch with empty mount (root deployment)", () => {
+describe("notesFetch with empty mount (root deployment)", () => {
   test("GET /sw.js serves the SW directly", async () => {
     const h = makeHarness();
     try {
-      const res = lensFetch(h.dir, "")(req("/sw.js"));
+      const res = notesFetch(h.dir, "")(req("/sw.js"));
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type") ?? "").toMatch(/javascript/);
     } finally {
@@ -125,7 +125,7 @@ describe("lensFetch with empty mount (root deployment)", () => {
   test("GET / serves the SPA shell", async () => {
     const h = makeHarness();
     try {
-      const res = lensFetch(h.dir, "")(req("/"));
+      const res = notesFetch(h.dir, "")(req("/"));
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
     } finally {

--- a/src/__tests__/process-state.test.ts
+++ b/src/__tests__/process-state.test.ts
@@ -22,7 +22,7 @@ function makeTempConfig(): { dir: string; cleanup: () => void } {
 describe("process-state paths", () => {
   test("pidPath / logPath land under <configDir>/<svc>/{run,logs}", () => {
     expect(pidPath("vault", "/cfg")).toBe("/cfg/vault/run/vault.pid");
-    expect(logPath("lens", "/cfg")).toBe("/cfg/lens/logs/lens.log");
+    expect(logPath("notes", "/cfg")).toBe("/cfg/notes/logs/notes.log");
   });
 });
 

--- a/src/__tests__/services-manifest.test.ts
+++ b/src/__tests__/services-manifest.test.ts
@@ -26,11 +26,11 @@ const vault: ServiceEntry = {
   version: "0.2.4",
 };
 
-const lens: ServiceEntry = {
-  name: "parachute-lens",
+const notes: ServiceEntry = {
+  name: "parachute-notes",
   port: 5173,
-  paths: ["/lens"],
-  health: "/lens/health",
+  paths: ["/notes"],
+  health: "/notes/health",
   version: "0.0.1",
 };
 
@@ -84,10 +84,10 @@ describe("services-manifest", () => {
     const { path, cleanup } = makeTempPath();
     try {
       upsertService(vault, path);
-      upsertService(lens, path);
+      upsertService(notes, path);
       const m = readManifest(path);
       expect(m.services).toHaveLength(2);
-      expect(m.services.map((s) => s.name).sort()).toEqual(["parachute-lens", "parachute-vault"]);
+      expect(m.services.map((s) => s.name).sort()).toEqual(["parachute-notes", "parachute-vault"]);
     } finally {
       cleanup();
     }
@@ -97,11 +97,11 @@ describe("services-manifest", () => {
     const { path, cleanup } = makeTempPath();
     try {
       upsertService(vault, path);
-      upsertService(lens, path);
+      upsertService(notes, path);
       removeService("parachute-vault", path);
       const m = readManifest(path);
       expect(m.services).toHaveLength(1);
-      expect(m.services[0]?.name).toBe("parachute-lens");
+      expect(m.services[0]?.name).toBe("parachute-notes");
     } finally {
       cleanup();
     }

--- a/src/__tests__/tailscale-commands.test.ts
+++ b/src/__tests__/tailscale-commands.test.ts
@@ -17,9 +17,9 @@ const fileEntry: ServeEntry = {
 
 const subpathEntry: ServeEntry = {
   kind: "proxy",
-  mount: "/lens",
+  mount: "/notes",
   target: "http://127.0.0.1:5173",
-  service: "parachute-lens",
+  service: "parachute-notes",
 };
 
 describe("tailscale commands", () => {
@@ -40,7 +40,7 @@ describe("tailscale commands", () => {
       "serve",
       "--bg",
       "--https=443",
-      "--set-path=/lens",
+      "--set-path=/notes",
       "http://127.0.0.1:5173",
     ]);
   });

--- a/src/__tests__/well-known.test.ts
+++ b/src/__tests__/well-known.test.ts
@@ -19,11 +19,11 @@ const vault: ServiceEntry = {
   version: "0.2.4",
 };
 
-const lens: ServiceEntry = {
-  name: "parachute-lens",
+const notes: ServiceEntry = {
+  name: "parachute-notes",
   port: 5173,
-  paths: ["/lens"],
-  health: "/lens/health",
+  paths: ["/notes"],
+  health: "/notes/health",
   version: "0.0.1",
 };
 
@@ -38,7 +38,7 @@ const scribe: ServiceEntry = {
 describe("shortName", () => {
   test("strips parachute- prefix", () => {
     expect(shortName("parachute-vault")).toBe("vault");
-    expect(shortName("parachute-lens")).toBe("lens");
+    expect(shortName("parachute-notes")).toBe("notes");
     expect(shortName("custom-service")).toBe("custom-service");
   });
 });
@@ -54,7 +54,7 @@ describe("isVaultEntry", () => {
   });
 
   test("rejects non-vault services", () => {
-    expect(isVaultEntry(lens)).toBe(false);
+    expect(isVaultEntry(notes)).toBe(false);
     expect(isVaultEntry(scribe)).toBe(false);
   });
 
@@ -94,7 +94,7 @@ describe("vaultInstanceName", () => {
 describe("buildWellKnown", () => {
   test("vaults is always an array, other services are flat entries, services[] includes all", () => {
     const doc = buildWellKnown({
-      services: [vault, lens, scribe],
+      services: [vault, notes, scribe],
       canonicalOrigin: "https://parachute.taildf9ce2.ts.net",
     });
     expect(doc.vaults).toEqual([
@@ -104,8 +104,8 @@ describe("buildWellKnown", () => {
         version: "0.2.4",
       },
     ]);
-    expect(doc.lens).toEqual({
-      url: "https://parachute.taildf9ce2.ts.net/lens",
+    expect(doc.notes).toEqual({
+      url: "https://parachute.taildf9ce2.ts.net/notes",
       version: "0.0.1",
     });
     expect(doc.scribe).toEqual({
@@ -114,14 +114,14 @@ describe("buildWellKnown", () => {
     });
     expect(doc.services.map((s) => s.name)).toEqual([
       "parachute-vault",
-      "parachute-lens",
+      "parachute-notes",
       "parachute-scribe",
     ]);
   });
 
   test("services[] entries include infoUrl pointing at /.parachute/info", () => {
     const doc = buildWellKnown({
-      services: [vault, lens],
+      services: [vault, notes],
       canonicalOrigin: "https://x.example",
     });
     expect(doc.services).toEqual([
@@ -133,17 +133,17 @@ describe("buildWellKnown", () => {
         infoUrl: "https://x.example/vault/default/.parachute/info",
       },
       {
-        name: "parachute-lens",
-        url: "https://x.example/lens",
-        path: "/lens",
+        name: "parachute-notes",
+        url: "https://x.example/notes",
+        path: "/notes",
         version: "0.0.1",
-        infoUrl: "https://x.example/lens/.parachute/info",
+        infoUrl: "https://x.example/notes/.parachute/info",
       },
     ]);
   });
 
   test("infoUrl for root-mounted service has no double slash", () => {
-    const rootSvc: ServiceEntry = { ...lens, paths: ["/"] };
+    const rootSvc: ServiceEntry = { ...notes, paths: ["/"] };
     const doc = buildWellKnown({
       services: [rootSvc],
       canonicalOrigin: "https://x.example",
@@ -153,12 +153,12 @@ describe("buildWellKnown", () => {
 
   test("vaults array is present even when no vault is installed", () => {
     const doc = buildWellKnown({
-      services: [lens],
+      services: [notes],
       canonicalOrigin: "https://x.example",
     });
     expect(doc.vaults).toEqual([]);
     expect(doc.services).toHaveLength(1);
-    expect(doc.lens).toEqual({ url: "https://x.example/lens", version: "0.0.1" });
+    expect(doc.notes).toEqual({ url: "https://x.example/notes", version: "0.0.1" });
   });
 
   test("multiple vault instances all land in the vaults array", () => {

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -41,7 +41,7 @@ import {
  * Funnel constraint: Tailscale allows at most three public HTTPS ports per
  * node (443, 8443, 10000). Path-routing packs every service onto a single
  * port — that's why we default to one `--https=443` and mount services under
- * `/vault`, `/lens`, etc. rather than giving each service its own port or
+ * `/vault`, `/notes`, etc. rather than giving each service its own port or
  * subdomain. Subdomain-per-service requires the Tailscale Services feature
  * (virtual-IP advertisement) and is deferred.
  *

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -17,13 +17,15 @@ export type Runner = (cmd: readonly string[]) => Promise<number>;
 
 /**
  * Transition aliases for services that were renamed. Accepted for one
- * release cycle with a rename notice, then removed. `notes → lens`
- * landed 2026-04 as part of the Lens rebrand; remove after launch
- * sinks in and `parachute install notes` has stopped appearing in
- * support threads.
+ * release cycle with a rename notice, then removed. `lens → notes`
+ * exists because the frontend was briefly renamed Notes → Lens (Apr 19)
+ * and then reverted (Apr 22) on launch eve. Anyone who ran `parachute
+ * install lens` during the ~3-day window keeps working. Remove after
+ * launch sinks in and `parachute install lens` has stopped appearing
+ * in support threads.
  */
 const SERVICE_ALIASES: Record<string, string> = {
-  notes: "lens",
+  lens: "notes",
 };
 
 export interface InstallOpts {

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -24,14 +24,16 @@ export const ARCHIVE_PREFIX = ".archive-";
  * `hub` is added explicitly since it's an internal-only lifecycle dir not
  * in SERVICE_SPECS.
  *
- * `notes` is kept after the lens rename so existing `~/.parachute/notes/`
- * dirs don't get swept into `.archive-*` on upgrade. Safe to remove once
- * launch users have all had a chance to re-install under the new name.
+ * `lens` is kept across the Notes→Lens→Notes rename round-trip
+ * (Apr 19 → Apr 22): users who installed during the brief Lens window
+ * have `~/.parachute/lens/` dirs that shouldn't get swept into
+ * `.archive-*` on upgrade. Safe to remove once launch users have all
+ * had a chance to re-install under the restored name.
  */
 export function safelistEntries(): Set<string> {
   return new Set<string>([
     ...knownServices(),
-    "notes",
+    "lens",
     "hub",
     "services.json",
     "expose-state.json",

--- a/src/help.ts
+++ b/src/help.ts
@@ -50,13 +50,14 @@ Flags:
 
 Examples:
   parachute install vault           # installs + runs \`parachute-vault init\`
-  parachute install lens            # installs lens (no init required)
+  parachute install notes           # installs notes (no init required)
   parachute install vault --tag rc  # pin to the rc dist-tag for pre-release testing
   parachute install all --tag rc    # bootstrap the whole ecosystem to rc
 
 Aliases:
-  notes → lens                      # accepted for one release cycle after
-                                    # the Lens rebrand; prints a rename notice.
+  lens → notes                      # accepted for one release cycle after
+                                    # the brief Lens rebrand was reverted on
+                                    # 2026-04-22; prints a rename notice.
 `;
 }
 
@@ -84,7 +85,7 @@ Example:
   $ parachute status
   SERVICE          PORT  VERSION  PROCESS  PID    UPTIME  HEALTH  LATENCY
   parachute-vault  1940  0.2.4    running  12345  2h 13m  ok      2ms
-  parachute-lens   5173  0.0.1    stopped  -      -       -       -
+  parachute-notes  5173  0.0.1    stopped  -      -       -       -
 `;
 }
 
@@ -114,11 +115,11 @@ Examples:
 
 Constraints (public layer / Funnel):
   - Funnel supports HTTPS only on ports 443 / 8443 / 10000 per node.
-    We pin to 443 and path-route (vault at /vault/…, lens at /lens, …) so this
+    We pin to 443 and path-route (vault at /vault/…, notes at /notes, …) so this
     cap never becomes a constraint no matter how many services you install.
   - Funnel has bandwidth caps on Tailscale's free tier.
     See https://tailscale.com/kb/1223/funnel for current limits.
-  - Subdomain-per-service (vault.<fqdn>, lens.<fqdn>, …) requires the
+  - Subdomain-per-service (vault.<fqdn>, notes.<fqdn>, …) requires the
     Tailscale Services feature and is not supported in this release.
 
 Coming soon:
@@ -156,7 +157,7 @@ Start commands by service:
   vault     parachute-vault serve
   scribe    parachute-scribe serve
   channel   parachute-channel daemon
-  lens      bun <cli>/lens-serve.ts --port <configured> --mount <paths[0]>
+  notes     bun <cli>/notes-serve.ts --port <configured> --mount <paths[0]>
 `;
 }
 
@@ -214,7 +215,7 @@ Usage:
 What it does:
   Scans ~/.parachute/ for files and directories that don't belong to the
   post-restructure layout. Recognized entries — per-service dirs
-  (vault/, lens/, scribe/, channel/, hub/; legacy notes/ also kept),
+  (vault/, notes/, scribe/, channel/, hub/; legacy lens/ also kept),
   services.json,
   expose-state.json, well-known/ — stay in place. Anything else (plus
   known legacy cruft like daily.db, server.yaml) is moved under

--- a/src/notes-serve.ts
+++ b/src/notes-serve.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env bun
 
 /**
- * Tiny static-file server for the @openparachute/lens PWA bundle.
+ * Tiny static-file server for the @openparachute/notes PWA bundle.
  *
- * Lens is a SPA — no backend of its own. `parachute start lens` invokes
+ * Notes is a SPA — no backend of its own. `parachute start notes` invokes
  * this shim with the installed `dist/` path so the PWA is served at a
  * known port and can be reverse-proxied by `parachute expose` alongside
  * the other services.
@@ -11,15 +11,15 @@
  * Invoked as:
  *   bun <this-file> --port <n> [--dist <path>] [--mount <prefix>]
  *
- * `--mount` (default `/lens`) is the path prefix the reverse proxy hands
+ * `--mount` (default `/notes`) is the path prefix the reverse proxy hands
  * us. We strip it before resolving against `dist/` so a request for
- * `/lens/sw.js` reads `{dist}/sw.js` rather than the nonexistent
- * `{dist}/lens/sw.js`. Without the strip, the SW + .webmanifest both
+ * `/notes/sw.js` reads `{dist}/sw.js` rather than the nonexistent
+ * `{dist}/notes/sw.js`. Without the strip, the SW + .webmanifest both
  * SPA-fall-back to index.html with content-type text/html, and the PWA
  * install prompt never fires. Pass `--mount ""` (or `--mount /`) when the
  * bundle is served at the origin root.
  *
- * If --dist is omitted, we resolve @openparachute/lens's dist directory
+ * If --dist is omitted, we resolve @openparachute/notes's dist directory
  * via Bun.resolveSync. If that fails (package not installed globally, or
  * package doesn't ship dist/), exit 1 with a clear error.
  */
@@ -36,7 +36,7 @@ interface Args {
 function parseArgs(argv: string[]): Args {
   let port = 5173;
   let dist: string | undefined;
-  let mount = "/lens";
+  let mount = "/notes";
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--port") {
@@ -67,13 +67,13 @@ export function normalizeMount(raw: string): string {
   return raw.replace(/\/+$/, "");
 }
 
-function resolveLensDist(): string {
-  const pkgPath = Bun.resolveSync("@openparachute/lens/package.json", process.cwd());
+function resolveNotesDist(): string {
+  const pkgPath = Bun.resolveSync("@openparachute/notes/package.json", process.cwd());
   const root = dirname(pkgPath);
   const dist = join(root, "dist");
   if (!existsSync(dist)) {
     throw new Error(
-      `@openparachute/lens is installed but has no dist/ directory at ${dist}. The package may not ship a prebuilt bundle — ask the lens maintainer to add a prepublishOnly build step.`,
+      `@openparachute/notes is installed but has no dist/ directory at ${dist}. The package may not ship a prebuilt bundle — ask the notes maintainer to add a prepublishOnly build step.`,
     );
   }
   return dist;
@@ -86,7 +86,7 @@ function mimeFor(path: string): string | undefined {
   return undefined;
 }
 
-export function lensFetch(dist: string, mount: string): (req: Request) => Response {
+export function notesFetch(dist: string, mount: string): (req: Request) => Response {
   const indexHtml = join(dist, "index.html");
   const spaShell = () =>
     new Response(Bun.file(indexHtml), {
@@ -120,16 +120,16 @@ if (import.meta.main) {
 
   let dist: string;
   try {
-    dist = distArg ?? resolveLensDist();
+    dist = distArg ?? resolveNotesDist();
   } catch (err) {
-    console.error(`parachute-lens-serve: ${err instanceof Error ? err.message : String(err)}`);
+    console.error(`parachute-notes-serve: ${err instanceof Error ? err.message : String(err)}`);
     process.exit(1);
   }
 
   Bun.serve({
     port,
-    fetch: lensFetch(dist, mount),
+    fetch: notesFetch(dist, mount),
   });
 
-  console.log(`lens static-serve listening on :${port} (dist=${dist}, mount=${mount || "/"})`);
+  console.log(`notes static-serve listening on :${port} (dist=${dist}, mount=${mount || "/"})`);
 }

--- a/src/process-state.ts
+++ b/src/process-state.ts
@@ -4,7 +4,7 @@ import { CONFIG_DIR } from "./config.ts";
 
 /**
  * Per-service state lives under `<configDir>/<svc>/...`. `svc` is the
- * short name (`vault`, `lens`, `scribe`, `channel`) so paths stay tidy —
+ * short name (`vault`, `notes`, `scribe`, `channel`) so paths stay tidy —
  * `~/.parachute/vault/run/vault.pid` rather than `parachute-vault/run/…`.
  *
  * The single source of truth for whether a service is running is

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -8,7 +8,7 @@ import type { ServiceEntry } from "./services-manifest.ts";
  *   1939  parachute-hub      internal static + proxy, CLI-managed
  *   1940  parachute-vault
  *   1941  parachute-channel
- *   1942  parachute-lens     static server over the PWA bundle (formerly parachute-notes)
+ *   1942  parachute-notes    static server over the PWA bundle
  *   1943  parachute-scribe
  *   1944  reserved — pendant
  *   1945  reserved — daily-v2
@@ -37,7 +37,7 @@ export const PORT_RESERVATIONS: readonly PortReservation[] = [
   { port: 1939, name: "parachute-hub", status: "assigned" },
   { port: 1940, name: "parachute-vault", status: "assigned" },
   { port: 1941, name: "parachute-channel", status: "assigned" },
-  { port: 1942, name: "parachute-lens", status: "assigned" },
+  { port: 1942, name: "parachute-notes", status: "assigned" },
   { port: 1943, name: "parachute-scribe", status: "assigned" },
   { port: 1944, name: "pendant", status: "reserved" },
   { port: 1945, name: "daily-v2", status: "reserved" },
@@ -53,7 +53,7 @@ export function isCanonicalPort(port: number): boolean {
 
 /**
  * Broad shape of a service. Matches the hub's card-kind taxonomy.
- *   "frontend"  a user-facing UI (lens). Safe to expose by default.
+ *   "frontend"  a user-facing UI (notes). Safe to expose by default.
  *   "api"       a programmatic surface (vault, channel, scribe). Whether
  *               it's safe to expose depends on `hasAuth`.
  *   "tool"      like "api" but specifically MCP-shaped / agent-callable.
@@ -67,7 +67,7 @@ export interface ServiceSpec {
   readonly init?: readonly string[];
   /**
    * Command to spawn for `parachute start <svc>`. Receives the services.json
-   * entry so commands that need per-install data (e.g., the lens static-serve
+   * entry so commands that need per-install data (e.g., the notes static-serve
    * shim needs the configured port) can pull it from there.
    *
    * Returns `undefined` to declare "lifecycle not supported for this service."
@@ -102,7 +102,7 @@ export interface ServiceSpec {
   readonly hasAuth?: boolean;
 }
 
-const LENS_SERVE_PATH = fileURLToPath(new URL("./lens-serve.ts", import.meta.url));
+const NOTES_SERVE_PATH = fileURLToPath(new URL("./notes-serve.ts", import.meta.url));
 
 /**
  * Seed entries land in services.json as placeholder rows when a freshly
@@ -128,22 +128,22 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
       version: SEED_VERSION,
     }),
   },
-  lens: {
-    // Lens is the product name (formerly "notes"). vault's internal
-    // `/api/notes` endpoint is unchanged — different concept.
-    package: "@openparachute/lens",
-    manifestName: "parachute-lens",
+  notes: {
+    // Frontend product name is "Notes". vault's internal `/api/notes` endpoint
+    // is unrelated — different concept (vault data primitive vs. PWA brand).
+    package: "@openparachute/notes",
+    manifestName: "parachute-notes",
     startCmd: (entry) => {
-      const first = entry.paths[0] ?? "/lens";
+      const first = entry.paths[0] ?? "/notes";
       const mount = first === "/" ? "" : first.replace(/\/+$/, "");
-      return ["bun", LENS_SERVE_PATH, "--port", String(entry.port), "--mount", mount];
+      return ["bun", NOTES_SERVE_PATH, "--port", String(entry.port), "--mount", mount];
     },
     kind: "frontend",
     seedEntry: () => ({
-      name: "parachute-lens",
+      name: "parachute-notes",
       port: 1942,
-      paths: ["/lens"],
-      health: "/lens/health",
+      paths: ["/notes"],
+      health: "/notes/health",
       version: SEED_VERSION,
     }),
   },
@@ -185,7 +185,7 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
  * entry. Explicit wins. If absent, derive from the spec: known api/tool
  * services without declared auth fall back to "auth-required" (treated as
  * loopback at launch); everything else defaults to "allowed" — so vault,
- * lens, channel and unknown third-party services continue to be exposed
+ * notes, channel and unknown third-party services continue to be exposed
  * without needing to opt in.
  */
 export function effectivePublicExposure(
@@ -211,14 +211,18 @@ export function getSpec(service: string): ServiceSpec | undefined {
 /**
  * Legacy manifest names kept so `parachute start` / `stop` / `logs` keep
  * working on an already-installed services.json that still carries the
- * old name. v0.x users who installed before the rename will have
- * `"parachute-notes"` in their manifest until the lens package next
- * boots and rewrites the entry; without this alias, lifecycle commands
- * silently skip those rows. Remove after launch, alongside the
- * `notes → lens` install alias.
+ * old name.
+ *
+ * `parachute-notes` was the original; it became `parachute-lens` for ~3
+ * days during the Lens rebrand window (2026-04-19 → 2026-04-22), then
+ * reverted. Users who installed during that window have `parachute-lens`
+ * in their services.json and need lifecycle commands to keep finding
+ * their install — without this alias, `parachute start/stop/logs/status`
+ * silently skip those rows. Remove after launch, alongside the `lens →
+ * notes` install alias.
  */
 const LEGACY_MANIFEST_ALIASES: Record<string, string> = {
-  "parachute-notes": "lens",
+  "parachute-lens": "notes",
 };
 
 /** Short name (the key into SERVICE_SPECS) for a given manifest name, e.g.

--- a/src/tailscale/detect.ts
+++ b/src/tailscale/detect.ts
@@ -43,7 +43,7 @@ export async function getFqdn(runner: Runner): Promise<string> {
 
 /**
  * Detect whether wildcard MagicDNS is active — i.e. whether subdomains of the
- * current machine (vault.<fqdn>, lens.<fqdn>, …) resolve back to this node.
+ * current machine (vault.<fqdn>, notes.<fqdn>, …) resolve back to this node.
  *
  * Tailscale's standard MagicDNS gives each machine a single hostname and does
  * not auto-resolve arbitrary subdomains; wildcard MagicDNS exists in the

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -36,7 +36,7 @@ export interface WellKnownServicesEntry {
  *     multi-tenant service.
  *   - `services: []` — flat list the hub page iterates. Scales to N frontends
  *     without the consumer needing to know every shortName.
- *   - Top-level flat keys (`lens`, `scribe`, …) — kept for back-compat with
+ *   - Top-level flat keys (`notes`, `scribe`, …) — kept for back-compat with
  *     clients that predate `services[]`.
  */
 export type WellKnownDocument = {


### PR DESCRIPTION
## Summary

Team meeting on launch eve (2026-04-22) reverted the brief Notes→Lens rebrand done three days prior — front-end is "Notes," back-end is "Vault." This rolls back PR #26 on the CLI side while keeping every upgrade path that PR established still working *in reverse*.

## Reverse-rename surface

- `SERVICE_SPECS.notes` is canonical again — package `@openparachute/notes`, manifestName `parachute-notes`, port 1942, mount `/notes`.
- `parachute install lens` aliases to `notes` with a rename notice (was the symmetric `notes → lens`). One release cycle of grace for anyone who installed during the brief Lens window.
- `LEGACY_MANIFEST_ALIASES["parachute-lens"] = "notes"` so any `services.json` row written by a `parachute-lens` boot still resolves through `shortNameForManifest` and gets managed by `start/stop/restart/logs` until the user's notes package next boots and overwrites the row.
- `~/.parachute/lens/` stays on the migrate safelist so left-over per-service dirs from the brief Lens window aren't archived on upgrade.
- `src/lens-serve.ts` → `src/notes-serve.ts` (preserves the PR #27 `--mount` + `.webmanifest` MIME fix verbatim — just renamed end-to-end with the function `notesFetch`, default mount `/notes`).
- `parachute-lens` short-name removed from `PORT_RESERVATIONS`; `parachute-notes` reinstated at port 1942.
- `CLAUDE.md`, `src/help.ts`, comments throughout — all swept.

## Version

`0.2.0-rc.1` → `0.2.0-rc.2`. Aaron republishes `@openparachute/cli@rc` after merge so RC testers re-pull.

## Coordination

Parallel reverts in `parachute-lens` (frontend repo rename) and `parachute.computer` (site copy + launch blog) — coordinated through team-lead.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test` — 221 pass, 0 fail across 18 files
- [x] `bunx biome check` — clean
- [ ] After merge: republish `@openparachute/cli@rc` and re-run `parachute install notes` smoke from a clean machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)