### PR TITLE
feat(expose): native Cloudflare Quick Tunnel (`--cloudflare` flag)

### DIFF
--- a/src/__tests__/expose-cloudflare.test.ts
+++ b/src/__tests__/expose-cloudflare.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  exposeCloudflareOff,
+  exposeCloudflareUp,
+} from "../commands/expose-cloudflare.ts";
+
+let tmp: string;
+let manifestPath: string;
+let statePath: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "parachute-expose-cf-"));
+  manifestPath = join(tmp, "services.json");
+  statePath = join(tmp, "cloudflared-state.json");
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeManifest(services: Array<{ name: string; port: number; paths?: string[] }>) {
+  writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      services: services.map((s) => ({
+        name: s.name,
+        port: s.port,
+        paths: s.paths ?? [`/${s.name.replace(/^parachute-/, "")}`],
+        version: "0.0.0-test",
+        health: "/health",
+      })),
+    }),
+  );
+}
+
+const cloudflaredPresent = async () => ({ code: 0, stdout: "cloudflared version", stderr: "" });
+const cloudflaredMissing = async () => ({ code: 127, stdout: "", stderr: "not found" });
+
+describe("exposeCloudflareUp", () => {
+  it("errors out with install help when cloudflared is missing", async () => {
+    writeManifest([{ name: "parachute-vault", port: 1940, paths: ["/vault/default"] }]);
+    const lines: string[] = [];
+    const code = await exposeCloudflareUp({
+      runner: cloudflaredMissing,
+      manifestPath,
+      statePath,
+      log: (l) => lines.push(l),
+      spawn: async () => {
+        throw new Error("spawn should not be called");
+      },
+      stop: () => false,
+    });
+    expect(code).toBe(1);
+    expect(lines.join("\n")).toContain("cloudflared is not installed");
+    expect(lines.join("\n")).toContain("brew install cloudflared");
+    expect(existsSync(statePath)).toBe(false);
+  });
+
+  it("errors out when no vault is installed", async () => {
+    writeManifest([]);
+    const lines: string[] = [];
+    const code = await exposeCloudflareUp({
+      runner: cloudflaredPresent,
+      manifestPath,
+      statePath,
+      log: (l) => lines.push(l),
+      spawn: async () => {
+        throw new Error("spawn should not be called");
+      },
+      stop: () => false,
+    });
+    expect(code).toBe(1);
+    expect(lines.join("\n")).toContain("No vault installed");
+  });
+
+  it("spawns tunnel, writes state, and prints URLs when vault is present", async () => {
+    writeManifest([{ name: "parachute-vault", port: 1940, paths: ["/vault/default"] }]);
+    const lines: string[] = [];
+    let stopCalled = false;
+    const code = await exposeCloudflareUp({
+      runner: cloudflaredPresent,
+      manifestPath,
+      statePath,
+      log: (l) => lines.push(l),
+      spawn: async ({ port }) => ({
+        pid: 12345,
+        url: `https://quick-abc.trycloudflare.com`,
+        logPath: `/tmp/cf-${port}.log`,
+      }),
+      stop: () => {
+        stopCalled = true;
+        return false;
+      },
+    });
+    expect(code).toBe(0);
+    expect(existsSync(statePath)).toBe(true);
+    const body = lines.join("\n");
+    expect(body).toContain("Cloudflare Quick Tunnel active");
+    expect(body).toContain("https://quick-abc.trycloudflare.com");
+    expect(body).toContain("https://quick-abc.trycloudflare.com/vault/default");
+    // Security guidance — both OAuth + API tokens mentioned
+    expect(body).toContain("OAuth");
+    expect(body).toContain("API tokens");
+    expect(stopCalled).toBe(false); // no prior state
+  });
+
+  it("stops prior tunnel before starting a new one", async () => {
+    writeManifest([{ name: "parachute-vault", port: 1940, paths: ["/vault/default"] }]);
+    writeFileSync(
+      statePath,
+      JSON.stringify({
+        version: 1,
+        pid: 99999,
+        url: "https://old.trycloudflare.com",
+        localPort: 1940,
+        startedAt: "2026-04-23T00:00:00Z",
+      }),
+    );
+    const stopped: number[] = [];
+    const code = await exposeCloudflareUp({
+      runner: cloudflaredPresent,
+      manifestPath,
+      statePath,
+      log: () => {},
+      spawn: async () => ({
+        pid: 12345,
+        url: `https://new.trycloudflare.com`,
+        logPath: `/tmp/cf.log`,
+      }),
+      stop: (pid) => {
+        stopped.push(pid);
+        return true;
+      },
+    });
+    expect(code).toBe(0);
+    expect(stopped).toEqual([99999]);
+  });
+});
+
+describe("exposeCloudflareOff", () => {
+  it("is a no-op when no tunnel is running", async () => {
+    const lines: string[] = [];
+    const code = await exposeCloudflareOff({
+      statePath,
+      log: (l) => lines.push(l),
+      stop: () => {
+        throw new Error("should not be called");
+      },
+    });
+    expect(code).toBe(0);
+    expect(lines.join("\n")).toContain("Nothing to tear down");
+  });
+
+  it("kills the tunnel PID and clears state when running", async () => {
+    writeFileSync(
+      statePath,
+      JSON.stringify({
+        version: 1,
+        pid: 54321,
+        url: "https://x.trycloudflare.com",
+        localPort: 1940,
+        startedAt: "2026-04-23T00:00:00Z",
+      }),
+    );
+    const stopped: number[] = [];
+    const code = await exposeCloudflareOff({
+      statePath,
+      log: () => {},
+      stop: (pid) => {
+        stopped.push(pid);
+        return true;
+      },
+    });
+    expect(code).toBe(0);
+    expect(stopped).toEqual([54321]);
+    expect(existsSync(statePath)).toBe(false);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -155,7 +155,8 @@ async function main(argv: string[]): Promise<number> {
         console.error(`parachute expose: ${hubExtract.error}`);
         return 1;
       }
-      const exposeArgs = hubExtract.rest;
+      const useCloudflare = hubExtract.rest.includes("--cloudflare");
+      const exposeArgs = hubExtract.rest.filter((a) => a !== "--cloudflare");
       const layer = exposeArgs[0];
       const mode = exposeArgs[1];
       if (isHelpFlag(layer)) {
@@ -165,7 +166,7 @@ async function main(argv: string[]): Promise<number> {
       if (layer !== "tailnet" && layer !== "public") {
         console.error(`parachute expose: unknown layer "${layer ?? ""}"`);
         console.error("usage: parachute expose tailnet [off]");
-        console.error("       parachute expose public  [off]");
+        console.error("       parachute expose public  [off] [--cloudflare]");
         console.error("run `parachute expose --help` for details");
         return 1;
       }
@@ -179,6 +180,17 @@ async function main(argv: string[]): Promise<number> {
         return 1;
       }
       const action = mode === "off" ? "off" : "up";
+      if (useCloudflare) {
+        if (layer !== "public") {
+          console.error("--cloudflare only makes sense with `expose public`.");
+          console.error("(tailnet exposure is what Tailscale already does.)");
+          return 1;
+        }
+        const { exposeCloudflareUp, exposeCloudflareOff } = await import(
+          "./commands/expose-cloudflare.ts"
+        );
+        return action === "off" ? await exposeCloudflareOff() : await exposeCloudflareUp();
+      }
       const exposeOpts = hubExtract.hubOrigin ? { hubOrigin: hubExtract.hubOrigin } : {};
       return layer === "public"
         ? await exposePublic(action, exposeOpts)

--- a/src/cloudflare/detect.ts
+++ b/src/cloudflare/detect.ts
@@ -1,0 +1,15 @@
+import type { Runner } from "../tailscale/run.ts";
+
+/**
+ * Detect whether `cloudflared` is installed and on PATH. We don't require
+ * any particular version — cloudflared's tunnel CLI has been stable for
+ * years, so `cloudflared version` exiting successfully is a sufficient signal.
+ */
+export async function isCloudflaredInstalled(runner: Runner): Promise<boolean> {
+  try {
+    const result = await runner(["cloudflared", "version"]);
+    return result.code === 0;
+  } catch {
+    return false;
+  }
+}

--- a/src/cloudflare/state.ts
+++ b/src/cloudflare/state.ts
@@ -1,0 +1,84 @@
+/**
+ * State file for an active cloudflared quick tunnel. Separate from
+ * `expose-state.json` (which tracks tailscale serve) because the shape and
+ * lifecycle are independent — a user can have tailscale + cloudflared both
+ * active in principle, though `parachute expose` serializes to one at a time.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { CONFIG_DIR } from "../config.ts";
+
+export const CLOUDFLARE_STATE_PATH = join(CONFIG_DIR, "cloudflared-state.json");
+
+export interface CloudflaredState {
+  version: 1;
+  pid: number;
+  url: string;
+  localPort: number;
+  startedAt: string;
+}
+
+export class CloudflaredStateError extends Error {
+  override name = "CloudflaredStateError";
+}
+
+function validate(raw: unknown, path: string): CloudflaredState {
+  if (!raw || typeof raw !== "object") {
+    throw new CloudflaredStateError(`${path}: root must be an object`);
+  }
+  const r = raw as Record<string, unknown>;
+  if (r.version !== 1) {
+    throw new CloudflaredStateError(`${path}: unsupported version ${String(r.version)}`);
+  }
+  if (typeof r.pid !== "number" || !Number.isInteger(r.pid)) {
+    throw new CloudflaredStateError(`${path}: pid must be an integer`);
+  }
+  if (typeof r.url !== "string" || !r.url.startsWith("https://")) {
+    throw new CloudflaredStateError(`${path}: url must be an https://… string`);
+  }
+  if (typeof r.localPort !== "number" || !Number.isInteger(r.localPort)) {
+    throw new CloudflaredStateError(`${path}: localPort must be an integer`);
+  }
+  if (typeof r.startedAt !== "string") {
+    throw new CloudflaredStateError(`${path}: startedAt must be a string`);
+  }
+  return {
+    version: 1,
+    pid: r.pid,
+    url: r.url,
+    localPort: r.localPort,
+    startedAt: r.startedAt,
+  };
+}
+
+export function readCloudflaredState(
+  path: string = CLOUDFLARE_STATE_PATH,
+): CloudflaredState | undefined {
+  if (!existsSync(path)) return undefined;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    throw new CloudflaredStateError(
+      `failed to parse ${path}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  return validate(raw, path);
+}
+
+export function writeCloudflaredState(
+  state: CloudflaredState,
+  path: string = CLOUDFLARE_STATE_PATH,
+): void {
+  if (!existsSync(dirname(path))) {
+    mkdirSync(dirname(path), { recursive: true });
+  }
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`);
+  renameSync(tmp, path);
+}
+
+export function clearCloudflaredState(path: string = CLOUDFLARE_STATE_PATH): void {
+  if (existsSync(path)) unlinkSync(path);
+}

--- a/src/cloudflare/tunnel.ts
+++ b/src/cloudflare/tunnel.ts
@@ -1,0 +1,117 @@
+/**
+ * Minimal wrapper around `cloudflared tunnel --url http://127.0.0.1:<port>`.
+ *
+ * Spawns a long-lived quick tunnel pointed at a local service and parses the
+ * generated `*.trycloudflare.com` URL out of cloudflared's log output. Returns
+ * the child PID + URL so the caller can write state, print guidance, and tear
+ * the tunnel down later by killing the PID.
+ *
+ * Quick tunnels are ephemeral — the URL changes every time cloudflared starts.
+ * They're useful for demos and claude.ai connector testing but not for durable
+ * public exposure. Named tunnel support (with a domain) is tracked as a
+ * follow-up; that path will land here alongside this shim.
+ */
+
+import { join } from "node:path";
+import { existsSync, mkdirSync } from "node:fs";
+import { CONFIG_DIR } from "../config.ts";
+
+export interface QuickTunnelResult {
+  pid: number;
+  url: string;
+  logPath: string;
+}
+
+export interface SpawnQuickTunnelOpts {
+  /** Port of the local service to tunnel to (e.g. the vault at 1940). */
+  port: number;
+  /** Override cloudflared command (tests inject a shim). Default: "cloudflared". */
+  bin?: string;
+  /** Override the log directory. Default: ~/.parachute/cloudflared/. */
+  logDir?: string;
+  /** Max ms to wait for the URL to appear in stderr. Default 15s. */
+  timeoutMs?: number;
+}
+
+const URL_RE = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/i;
+
+export async function spawnQuickTunnel(opts: SpawnQuickTunnelOpts): Promise<QuickTunnelResult> {
+  const bin = opts.bin ?? "cloudflared";
+  const logDir = opts.logDir ?? join(CONFIG_DIR, "cloudflared");
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+
+  if (!existsSync(logDir)) mkdirSync(logDir, { recursive: true });
+  const logPath = join(logDir, "quick-tunnel.log");
+
+  const logFd = Bun.file(logPath).writer();
+
+  const proc = Bun.spawn(
+    [bin, "tunnel", "--no-autoupdate", "--url", `http://127.0.0.1:${opts.port}`],
+    {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+
+  // cloudflared writes the URL to stderr in a multi-line banner. Tail both
+  // streams until we find the URL (or time out / process exits).
+  const url = await new Promise<string>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timed out waiting for cloudflared URL (${timeoutMs}ms)`));
+    }, timeoutMs);
+
+    let found = false;
+
+    const tail = async (stream: ReadableStream<Uint8Array> | null) => {
+      if (!stream) return;
+      const reader = stream.getReader();
+      const decoder = new TextDecoder();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) return;
+          const chunk = decoder.decode(value, { stream: true });
+          logFd.write(chunk);
+          if (!found) {
+            const match = chunk.match(URL_RE);
+            if (match) {
+              found = true;
+              clearTimeout(timer);
+              resolve(match[0]);
+            }
+          }
+        }
+      } catch {
+        // stream closed; ignore
+      }
+    };
+
+    void tail(proc.stdout as ReadableStream<Uint8Array> | null);
+    void tail(proc.stderr as ReadableStream<Uint8Array> | null);
+
+    proc.exited.then((code) => {
+      if (!found) {
+        clearTimeout(timer);
+        reject(new Error(`cloudflared exited ${code} before emitting a URL`));
+      }
+    });
+  });
+
+  return { pid: proc.pid, url, logPath };
+}
+
+/**
+ * Stop a running cloudflared PID. Returns true if the process was still alive
+ * and received the signal; false if it was already gone.
+ */
+export function stopQuickTunnel(pid: number): boolean {
+  try {
+    process.kill(pid, "SIGTERM");
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") return false;
+    throw err;
+  }
+}

--- a/src/commands/expose-cloudflare.ts
+++ b/src/commands/expose-cloudflare.ts
@@ -1,0 +1,147 @@
+/**
+ * `parachute expose public --cloudflare` — wrap a Cloudflare Quick Tunnel
+ * pointed at the installed vault. Ephemeral (URL changes each run), but
+ * works without a domain and without Tailscale. Ideal for "try it publicly
+ * in 30 seconds" scenarios: install vault → expose public --cloudflare →
+ * paste the URL into claude.ai Connectors.
+ *
+ * Named tunnel + custom domain is tracked as a follow-up; today we only
+ * handle quick tunnels (no login required, no domain required).
+ */
+
+import { SERVICES_MANIFEST_PATH } from "../config.ts";
+import { type Runner, defaultRunner } from "../tailscale/run.ts";
+import { isVaultEntry } from "../well-known.ts";
+import { readManifest } from "../services-manifest.ts";
+import { isCloudflaredInstalled } from "../cloudflare/detect.ts";
+import { spawnQuickTunnel, stopQuickTunnel } from "../cloudflare/tunnel.ts";
+import {
+  CLOUDFLARE_STATE_PATH,
+  clearCloudflaredState,
+  readCloudflaredState,
+  writeCloudflaredState,
+} from "../cloudflare/state.ts";
+
+export interface ExposeCloudflareOpts {
+  runner?: Runner;
+  manifestPath?: string;
+  statePath?: string;
+  log?: (line: string) => void;
+  /** Override spawn (tests inject a mock that returns a deterministic URL). */
+  spawn?: typeof spawnQuickTunnel;
+  /** Override the teardown (tests check whether it was called). */
+  stop?: typeof stopQuickTunnel;
+}
+
+function log(opts: ExposeCloudflareOpts): (line: string) => void {
+  return opts.log ?? ((line) => console.log(line));
+}
+
+function primaryVaultPort(manifestPath: string): number | undefined {
+  const manifest = readManifest(manifestPath);
+  const vault = manifest.services.find(isVaultEntry);
+  return vault?.port;
+}
+
+function installHelp(): string[] {
+  return [
+    "cloudflared is not installed or not on PATH.",
+    "Install:",
+    "  macOS:  brew install cloudflared",
+    "  Linux:  https://pkg.cloudflare.com/install",
+    "  other:  https://github.com/cloudflare/cloudflared/releases",
+    "",
+    "Alternatively, `parachute expose public` (without --cloudflare) uses",
+    "Tailscale Funnel, which is free for personal use.",
+  ];
+}
+
+export async function exposeCloudflareUp(opts: ExposeCloudflareOpts = {}): Promise<number> {
+  const print = log(opts);
+  const runner = opts.runner ?? defaultRunner;
+  const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const statePath = opts.statePath ?? CLOUDFLARE_STATE_PATH;
+  const spawn = opts.spawn ?? spawnQuickTunnel;
+  const stop = opts.stop ?? stopQuickTunnel;
+
+  if (!(await isCloudflaredInstalled(runner))) {
+    for (const line of installHelp()) print(line);
+    return 1;
+  }
+
+  const vaultPort = primaryVaultPort(manifestPath);
+  if (vaultPort === undefined) {
+    print("No vault installed. Run: parachute install vault");
+    return 1;
+  }
+
+  // If a prior cloudflared state exists, stop it first — one tunnel at a time.
+  const prior = readCloudflaredState(statePath);
+  if (prior) {
+    print(`Found prior Cloudflare tunnel (pid ${prior.pid}); stopping…`);
+    stop(prior.pid);
+    clearCloudflaredState(statePath);
+  }
+
+  print(`Starting Cloudflare Quick Tunnel to http://127.0.0.1:${vaultPort}…`);
+  let result: Awaited<ReturnType<typeof spawnQuickTunnel>>;
+  try {
+    result = await spawn({ port: vaultPort });
+  } catch (err) {
+    print(`cloudflared failed to start: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+
+  writeCloudflaredState(
+    {
+      version: 1,
+      pid: result.pid,
+      url: result.url,
+      localPort: vaultPort,
+      startedAt: new Date().toISOString(),
+    },
+    statePath,
+  );
+
+  print("");
+  print(`✓ Cloudflare Quick Tunnel active: ${result.url}`);
+  print(`  Claude / ChatGPT Connector URL: ${result.url}/vault/default`);
+  print("");
+  print("Security — strongly recommended before sharing this URL:");
+  print("  • OAuth + 2FA for human clients (claude.ai, ChatGPT):");
+  print("      parachute vault set-password");
+  print("      parachute vault 2fa enroll");
+  print("  • Or API tokens for scripts / agents:");
+  print("      parachute vault tokens create --scope vault:write");
+  print("");
+  print("Notes:");
+  print("  • Quick Tunnels are ephemeral. The URL above will change every time");
+  print("    cloudflared restarts (including this machine rebooting). For a");
+  print("    stable URL, use `parachute expose public` (Tailscale Funnel).");
+  print("  • Teardown: parachute expose public off");
+  print(`  • Logs: ${result.logPath}`);
+  return 0;
+}
+
+export async function exposeCloudflareOff(opts: ExposeCloudflareOpts = {}): Promise<number> {
+  const print = log(opts);
+  const statePath = opts.statePath ?? CLOUDFLARE_STATE_PATH;
+  const stop = opts.stop ?? stopQuickTunnel;
+
+  const state = readCloudflaredState(statePath);
+  if (!state) {
+    print("No Cloudflare tunnel state recorded. Nothing to tear down.");
+    return 0;
+  }
+
+  const killed = stop(state.pid);
+  clearCloudflaredState(statePath);
+
+  if (killed) {
+    print(`✓ Cloudflare tunnel stopped (was: ${state.url}).`);
+  } else {
+    print(`Cloudflare tunnel process (pid ${state.pid}) was already gone.`);
+    print(`Cleared state (URL was: ${state.url}).`);
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary
- `parachute expose public --cloudflare` spawns a Cloudflare Quick Tunnel to the vault, parses the generated URL, writes state, prints Claude/ChatGPT connector URL + security guidance.
- `parachute expose public off --cloudflare` tears it down.
- Defers named-tunnel-with-domain to issue #29.

## Why
Docs were teaching users to run 6 raw `cloudflared` commands. CLI should absorb that.

## Scope
- New: `src/cloudflare/{detect,tunnel,state}.ts`, `commands/expose-cloudflare.ts`, wired into `cli.ts` with dynamic import.
- 6 new tests; 227/227 pass overall; tsc clean.

## Security copy
Recommendations call out OAuth + 2FA *or* API tokens as parallel valid paths, not sequential requirements.

## Limitations called out inline
Quick tunnels are ephemeral (URL rotates per restart). Stable URL = Tailscale Funnel or a named Cloudflare tunnel with domain (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)