### PR TITLE
feat(expose): interactive provider picker for `parachute expose public`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ parachute status
 parachute expose tailnet
 # ✓ Tailnet exposure active. Open: https://parachute.<tailnet>.ts.net/
 
-# 6. Go public (Tailscale Funnel — same URL, now reachable from the internet)
+# 6. Go public — `parachute expose public` in a terminal walks through
+#    provider selection (Tailscale Funnel vs. Cloudflare Tunnel) and
+#    prompts for setup bits as needed. Non-interactive or flag-driven
+#    invocations stay scripted — see `parachute expose --help`.
 parachute expose public
 # ✓ Public exposure active (Funnel). Open: https://parachute.<tailnet>.ts.net/
 ```

--- a/src/__tests__/expose-interactive.test.ts
+++ b/src/__tests__/expose-interactive.test.ts
@@ -611,6 +611,49 @@ describe("exposePublicInteractive — edge cases", () => {
     }
   });
 
+  test("preselect=cloudflare skips picker and prompts only for hostname", async () => {
+    // Simulates `parachute expose public --cloudflare` in a TTY without
+    // --domain: we know the user wants Cloudflare, so no provider picker,
+    // straight to the hostname prompt.
+    const env = makeEnv({ cloudflaredLoggedIn: true });
+    try {
+      const { runner } = fixedRunner({
+        tailscaleInstalled: true,
+        tailscaleLoggedIn: true,
+        tailscaleFunnelCap: true,
+        cloudflaredInstalled: true,
+      });
+      const { prompt, asked } = queuePrompt(["vault.example.com"]);
+      let cloudflareHostname: string | undefined;
+      let tailscaleCalled = false;
+      const code = await exposePublicInteractive({
+        runner,
+        prompt,
+        preselect: "cloudflare",
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: () => {},
+        exposePublicImpl: async () => {
+          tailscaleCalled = true;
+          return 0;
+        },
+        exposeCloudflareUpImpl: async (h) => {
+          cloudflareHostname = h;
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      expect(tailscaleCalled).toBe(false);
+      expect(cloudflareHostname).toBe("vault.example.com");
+      // Only one prompt was asked — the hostname. No provider picker shown.
+      expect(asked).toHaveLength(1);
+      expect(asked[0]?.toLowerCase()).toContain("hostname");
+      expect(readLastProvider(env.lastProviderPath)?.provider).toBe("cloudflare");
+    } finally {
+      env.cleanup();
+    }
+  });
+
   test("invalid provider input reprompts rather than crashing", async () => {
     const env = makeEnv({ cloudflaredLoggedIn: true });
     try {

--- a/src/__tests__/expose-interactive.test.ts
+++ b/src/__tests__/expose-interactive.test.ts
@@ -1,0 +1,644 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { exposePublicInteractive } from "../commands/expose-interactive.ts";
+import { readLastProvider, writeLastProvider } from "../expose-last-provider.ts";
+import type { CommandResult, Runner } from "../tailscale/run.ts";
+
+interface TestEnv {
+  cloudflaredHome: string;
+  lastProviderPath: string;
+  cleanup: () => void;
+}
+
+function makeEnv(opts: { cloudflaredLoggedIn?: boolean } = {}): TestEnv {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-expose-interactive-"));
+  const cloudflaredHome = join(dir, "cloudflared");
+  require("node:fs").mkdirSync(cloudflaredHome, { recursive: true });
+  if (opts.cloudflaredLoggedIn) {
+    writeFileSync(join(cloudflaredHome, "cert.pem"), "---");
+  }
+  return {
+    cloudflaredHome,
+    lastProviderPath: join(dir, "expose-last-provider.json"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+interface FixedRunnerOpts {
+  tailscaleInstalled?: boolean;
+  tailscaleLoggedIn?: boolean;
+  tailscaleFunnelCap?: boolean;
+  cloudflaredInstalled?: boolean;
+}
+
+/**
+ * Returns a runner that answers the detection calls deterministically:
+ *  - `tailscale version` → exit 0 iff tailscaleInstalled
+ *  - `tailscale status --json` → JSON with Self.DNSName (if logged in) and
+ *    Self.CapMap[funnel] (if funnel cap granted)
+ *  - `cloudflared --version` → exit 0 iff cloudflaredInstalled
+ *
+ * Every call is appended to the returned `calls` array.
+ */
+function fixedRunner(opts: FixedRunnerOpts): { runner: Runner; calls: string[][] } {
+  const calls: string[][] = [];
+  const runner: Runner = async (cmd) => {
+    calls.push([...cmd]);
+    const head = cmd.slice(0, 2).join(" ");
+    if (head === "tailscale version") {
+      return opts.tailscaleInstalled
+        ? ({ code: 0, stdout: "1.82.0\n", stderr: "" } as CommandResult)
+        : ({ code: 127, stdout: "", stderr: "not found" } as CommandResult);
+    }
+    if (head === "tailscale status") {
+      const self: Record<string, unknown> = {};
+      if (opts.tailscaleLoggedIn) self.DNSName = "parachute.example.ts.net.";
+      if (opts.tailscaleFunnelCap) self.CapMap = { "https://tailscale.com/cap/funnel": ["*"] };
+      return { code: 0, stdout: JSON.stringify({ Self: self }), stderr: "" } as CommandResult;
+    }
+    if (head === "cloudflared --version") {
+      return opts.cloudflaredInstalled
+        ? ({ code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" } as CommandResult)
+        : ({ code: 127, stdout: "", stderr: "not found" } as CommandResult);
+    }
+    throw new Error(`unexpected runner call: ${cmd.join(" ")}`);
+  };
+  return { runner, calls };
+}
+
+function queuePrompt(answers: string[]): {
+  prompt: (q: string) => Promise<string>;
+  asked: string[];
+} {
+  const asked: string[] = [];
+  let i = 0;
+  return {
+    prompt: async (q) => {
+      asked.push(q);
+      const a = answers[i++];
+      if (a === undefined) throw new Error(`prompt exhausted at question: ${q}`);
+      return a;
+    },
+    asked,
+  };
+}
+
+describe("exposePublicInteractive — both ready", () => {
+  test("picks Tailscale by default when nothing remembered", async () => {
+    const env = makeEnv({ cloudflaredLoggedIn: true });
+    try {
+      const { runner } = fixedRunner({
+        tailscaleInstalled: true,
+        tailscaleLoggedIn: true,
+        tailscaleFunnelCap: true,
+        cloudflaredInstalled: true,
+      });
+      const { prompt } = queuePrompt([""]); // accept default
+      let tailscaleCalled = false;
+      let cloudflareCalled = false;
+      const code = await exposePublicInteractive({
+        runner,
+        prompt,
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: () => {},
+        exposePublicImpl: async () => {
+          tailscaleCalled = true;
+          return 0;
+        },
+        exposeCloudflareUpImpl: async () => {
+          cloudflareCalled = true;
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      expect(tailscaleCalled).toBe(true);
+      expect(cloudflareCalled).toBe(false);
+      expect(readLastProvider(env.lastProviderPath)?.provider).toBe("tailscale");
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("remembers and defaults to the last-used provider", async () => {
+    const env = makeEnv({ cloudflaredLoggedIn: true });
+    writeLastProvider("cloudflare", { path: env.lastProviderPath });
+    try {
+      const { runner } = fixedRunner({
+        tailscaleInstalled: true,
+        tailscaleLoggedIn: true,
+        tailscaleFunnelCap: true,
+        cloudflaredInstalled: true,
+      });
+      // Accept default (blank) at provider prompt, then supply hostname.
+      const { prompt } = queuePrompt(["", "vault.example.com"]);
+      let cloudflareHostname: string | undefined;
+      const code = await exposePublicInteractive({
+        runner,
+        prompt,
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: () => {},
+        exposePublicImpl: async () => 0,
+        exposeCloudflareUpImpl: async (h) => {
+          cloudflareHostname = h;
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      expect(cloudflareHostname).toBe("vault.example.com");
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("explicit '2' selects Cloudflare; hostname prompted and validated", async () => {
+    const env = makeEnv({ cloudflaredLoggedIn: true });
+    try {
+      const { runner } = fixedRunner({
+        tailscaleInstalled: true,
+        tailscaleLoggedIn: true,
+        tailscaleFunnelCap: true,
+        cloudflaredInstalled: true,
+      });
+      const { prompt } = queuePrompt(["2", "not a host", "vault.example.com"]);
+      let cloudflareHostname: string | undefined;
+      const code = await exposePublicInteractive({
+        runner,
+        prompt,
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: () => {},
+        exposePublicImpl: async () => 0,
+        exposeCloudflareUpImpl: async (h) => {
+          cloudflareHostname = h;
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      expect(cloudflareHostname).toBe("vault.example.com");
+      expect(readLastProvider(env.lastProviderPath)?.provider).toBe("cloudflare");
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("'q' aborts cleanly with exit 0 and no downstream calls", async () => {
+    const env = makeEnv({ cloudflaredLoggedIn: true });
+    try {
+      const { runner } = fixedRunner({
+        tailscaleInstalled: true,
+        tailscaleLoggedIn: true,
+        tailscaleFunnelCap: true,
+        cloudflaredInstalled: true,
+      });
+      const { prompt } = queuePrompt(["q"]);
+      let anyCalled = false;
+      const code = await exposePublicInteractive({
+        runner,
+        prompt,
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: () => {},
+        exposePublicImpl: async () => {
+          anyCalled = true;
+          return 0;
+        },
+        exposeCloudflareUpImpl: async () => {
+          anyCalled = true;
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      expect(anyCalled).toBe(false);
+      expect(readLastProvider(env.lastProviderPath)).toBeUndefined();
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("blank hostname at the Cloudflare prompt exits 0 without handoff", async () => {
+    const env = makeEnv({ cloudflaredLoggedIn: true });
+    try {
+      const { runner } = fixedRunner({
+        tailscaleInstalled: true,
+        tailscaleLoggedIn: true,
+        tailscaleFunnelCap: true,
+        cloudflaredInstalled: true,
+      });
+      const { prompt } = queuePrompt(["2", ""]);
+      let cloudflareCalled = false;
+      const code = await exposePublicInteractive({
+        runner,
+        prompt,
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: () => {},
+        exposePublicImpl: async () => 0,
+        exposeCloudflareUpImpl: async () => {
+          cloudflareCalled = true;
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      expect(cloudflareCalled).toBe(false);
+    } finally {
+      env.cleanup();
+    }
+  });
+});
+
+describe("exposePublicInteractive — only one ready", () => {
+  test("tailscale-ready, cloudflare-missing: announces and runs tailscale without prompting", async () => {
+    const env = makeEnv();
+    try {
+      const { runner } = fixedRunner({
+        tailscaleInstalled: true,
+        tailscaleLoggedIn: true,
+        tailscaleFunnelCap: true,
+        cloudflaredInstalled: false,
+      });
+      let prompts = 0;
+      const logs: string[] = [];
+      const code = await exposePublicInteractive({
+        runner,
+        prompt: async () => {
+          prompts++;
+          return "";
+        },
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: (l) => logs.push(l),
+        exposePublicImpl: async () => 0,
+        exposeCloudflareUpImpl: async () => 0,
+      });
+      expect(code).toBe(0);
+      expect(prompts).toBe(0);
+      expect(logs.join("\n")).toContain("Using Tailscale Funnel");
+      expect(readLastProvider(env.lastProviderPath)?.provider).toBe("tailscale");
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("cloudflare-ready, tailscale-missing: announces and prompts hostname", async () => {
+    const env = makeEnv({ cloudflaredLoggedIn: true });
+    try {
+      const { runner } = fixedRunner({
+        tailscaleInstalled: false,
+        cloudflaredInstalled: true,
+      });
+      const { prompt } = queuePrompt(["vault.example.com"]);
+      const logs: string[] = [];
+      let cloudflareHostname: string | undefined;
+      const code = await exposePublicInteractive({
+        runner,
+        prompt,
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: (l) => logs.push(l),
+        exposePublicImpl: async () => 0,
+        exposeCloudflareUpImpl: async (h) => {
+          cloudflareHostname = h;
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      expect(cloudflareHostname).toBe("vault.example.com");
+      expect(logs.join("\n")).toContain("Using Cloudflare Tunnel");
+    } finally {
+      env.cleanup();
+    }
+  });
+});
+
+describe("exposePublicInteractive — neither ready", () => {
+  test("user picks tailscale: prints setup guidance and exits 1", async () => {
+    const env = makeEnv();
+    try {
+      const { runner } = fixedRunner({});
+      const { prompt } = queuePrompt(["1"]);
+      const logs: string[] = [];
+      let tailscaleCalled = false;
+      const code = await exposePublicInteractive({
+        runner,
+        prompt,
+        platform: "darwin",
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: (l) => logs.push(l),
+        exposePublicImpl: async () => {
+          tailscaleCalled = true;
+          return 0;
+        },
+        exposeCloudflareUpImpl: async () => 0,
+      });
+      expect(code).toBe(1);
+      expect(tailscaleCalled).toBe(false);
+      const joined = logs.join("\n");
+      expect(joined).toContain("brew install tailscale");
+      expect(joined).toContain("tailscale up");
+      expect(joined).toContain("login.tailscale.com/admin/acls");
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("user picks tailscale on linux: install hint links to tailscale.com", async () => {
+    const env = makeEnv();
+    try {
+      const { runner } = fixedRunner({});
+      const { prompt } = queuePrompt(["1"]);
+      const logs: string[] = [];
+      const code = await exposePublicInteractive({
+        runner,
+        prompt,
+        platform: "linux",
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: (l) => logs.push(l),
+        exposePublicImpl: async () => 0,
+        exposeCloudflareUpImpl: async () => 0,
+      });
+      expect(code).toBe(1);
+      const joined = logs.join("\n");
+      expect(joined).toContain("tailscale.com/download");
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("user picks cloudflare on macos: brew install confirmed, login runs, hostname then handoff", async () => {
+    const env = makeEnv();
+    try {
+      let cloudflaredInstalled = false;
+      const calls: string[][] = [];
+      const runner: Runner = async (cmd) => {
+        calls.push([...cmd]);
+        const head = cmd.slice(0, 2).join(" ");
+        if (head === "tailscale version") return { code: 127, stdout: "", stderr: "not found" };
+        if (head === "tailscale status") return { code: 0, stdout: "{}", stderr: "" };
+        if (head === "cloudflared --version") {
+          return cloudflaredInstalled
+            ? { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" }
+            : { code: 127, stdout: "", stderr: "not found" };
+        }
+        throw new Error(`unexpected runner call: ${cmd.join(" ")}`);
+      };
+      const interactiveCmds: string[][] = [];
+      const interactiveRunner = async (cmd: readonly string[]) => {
+        interactiveCmds.push([...cmd]);
+        if (cmd[0] === "brew") {
+          cloudflaredInstalled = true;
+          return 0;
+        }
+        if (cmd[0] === "cloudflared") {
+          // Simulate successful login by dropping cert.pem.
+          writeFileSync(join(env.cloudflaredHome, "cert.pem"), "---");
+          return 0;
+        }
+        throw new Error(`unexpected interactive cmd: ${cmd.join(" ")}`);
+      };
+      const { prompt } = queuePrompt(["2", "y", "y", "vault.example.com"]);
+      const logs: string[] = [];
+      let cloudflareHostname: string | undefined;
+      const code = await exposePublicInteractive({
+        runner,
+        interactiveRunner,
+        prompt,
+        platform: "darwin",
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: (l) => logs.push(l),
+        exposePublicImpl: async () => 0,
+        exposeCloudflareUpImpl: async (h) => {
+          cloudflareHostname = h;
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      expect(interactiveCmds[0]).toEqual(["brew", "install", "cloudflared"]);
+      expect(interactiveCmds[1]).toEqual(["cloudflared", "tunnel", "login"]);
+      expect(cloudflareHostname).toBe("vault.example.com");
+      expect(readLastProvider(env.lastProviderPath)?.provider).toBe("cloudflare");
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("user picks cloudflare on linux: prints manual install pointers and exits 1", async () => {
+    const env = makeEnv();
+    try {
+      const { runner } = fixedRunner({});
+      const { prompt } = queuePrompt(["2"]);
+      const logs: string[] = [];
+      let interactiveCalled = false;
+      let cloudflareCalled = false;
+      const code = await exposePublicInteractive({
+        runner,
+        interactiveRunner: async () => {
+          interactiveCalled = true;
+          return 0;
+        },
+        prompt,
+        platform: "linux",
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: (l) => logs.push(l),
+        exposePublicImpl: async () => 0,
+        exposeCloudflareUpImpl: async () => {
+          cloudflareCalled = true;
+          return 0;
+        },
+      });
+      expect(code).toBe(1);
+      expect(interactiveCalled).toBe(false);
+      expect(cloudflareCalled).toBe(false);
+      const joined = logs.join("\n");
+      expect(joined).toMatch(/apt-get|dnf/);
+      expect(joined).toContain(
+        "developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads",
+      );
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("user picks cloudflare on macos but declines brew: exits 1, no install attempted", async () => {
+    const env = makeEnv();
+    try {
+      const { runner } = fixedRunner({});
+      const interactiveCmds: string[][] = [];
+      const { prompt } = queuePrompt(["2", "n"]);
+      const code = await exposePublicInteractive({
+        runner,
+        interactiveRunner: async (cmd) => {
+          interactiveCmds.push([...cmd]);
+          return 0;
+        },
+        prompt,
+        platform: "darwin",
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: () => {},
+        exposePublicImpl: async () => 0,
+        exposeCloudflareUpImpl: async () => 0,
+      });
+      expect(code).toBe(1);
+      expect(interactiveCmds).toHaveLength(0);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("user picks cloudflare on macos, installed but login declined: exits 1", async () => {
+    const env = makeEnv(); // no cert.pem
+    try {
+      const { runner } = fixedRunner({ cloudflaredInstalled: true });
+      const interactiveCmds: string[][] = [];
+      const { prompt } = queuePrompt(["2", "n"]);
+      const code = await exposePublicInteractive({
+        runner,
+        interactiveRunner: async (cmd) => {
+          interactiveCmds.push([...cmd]);
+          return 0;
+        },
+        prompt,
+        platform: "darwin",
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: () => {},
+        exposePublicImpl: async () => 0,
+        exposeCloudflareUpImpl: async () => 0,
+      });
+      expect(code).toBe(1);
+      // No brew install was needed; no login was performed.
+      expect(interactiveCmds).toHaveLength(0);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("quit at neither-ready picker exits 0 with no handoff", async () => {
+    const env = makeEnv();
+    try {
+      const { runner } = fixedRunner({});
+      const { prompt } = queuePrompt(["q"]);
+      let anyCalled = false;
+      const code = await exposePublicInteractive({
+        runner,
+        prompt,
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: () => {},
+        exposePublicImpl: async () => {
+          anyCalled = true;
+          return 0;
+        },
+        exposeCloudflareUpImpl: async () => {
+          anyCalled = true;
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      expect(anyCalled).toBe(false);
+    } finally {
+      env.cleanup();
+    }
+  });
+});
+
+describe("exposePublicInteractive — edge cases", () => {
+  test("tailscale installed+logged-in but Funnel cap missing counts as not ready", async () => {
+    const env = makeEnv({ cloudflaredLoggedIn: true });
+    try {
+      const { runner } = fixedRunner({
+        tailscaleInstalled: true,
+        tailscaleLoggedIn: true,
+        tailscaleFunnelCap: false,
+        cloudflaredInstalled: true,
+      });
+      // Since tailscale isn't "ready", only cloudflare counts as ready → one-ready path.
+      const { prompt } = queuePrompt(["vault.example.com"]);
+      let cloudflareCalled = false;
+      const code = await exposePublicInteractive({
+        runner,
+        prompt,
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: () => {},
+        exposePublicImpl: async () => 0,
+        exposeCloudflareUpImpl: async () => {
+          cloudflareCalled = true;
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      expect(cloudflareCalled).toBe(true);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("passthrough opts flow to the downstream entry points", async () => {
+    const env = makeEnv();
+    try {
+      const { runner } = fixedRunner({
+        tailscaleInstalled: true,
+        tailscaleLoggedIn: true,
+        tailscaleFunnelCap: true,
+      });
+      let receivedExposeOpts: unknown;
+      const code = await exposePublicInteractive({
+        runner,
+        prompt: async () => "",
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: () => {},
+        exposeOpts: { hubOrigin: "https://custom.example" },
+        exposePublicImpl: async (_action, opts) => {
+          receivedExposeOpts = opts;
+          return 0;
+        },
+        exposeCloudflareUpImpl: async () => 0,
+      });
+      expect(code).toBe(0);
+      expect(receivedExposeOpts).toEqual({ hubOrigin: "https://custom.example" });
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("invalid provider input reprompts rather than crashing", async () => {
+    const env = makeEnv({ cloudflaredLoggedIn: true });
+    try {
+      const { runner } = fixedRunner({
+        tailscaleInstalled: true,
+        tailscaleLoggedIn: true,
+        tailscaleFunnelCap: true,
+        cloudflaredInstalled: true,
+      });
+      const { prompt, asked } = queuePrompt(["huh", "7", "1"]);
+      let tailscaleCalled = false;
+      const code = await exposePublicInteractive({
+        runner,
+        prompt,
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        log: () => {},
+        exposePublicImpl: async () => {
+          tailscaleCalled = true;
+          return 0;
+        },
+        exposeCloudflareUpImpl: async () => 0,
+      });
+      expect(code).toBe(0);
+      expect(tailscaleCalled).toBe(true);
+      expect(asked.length).toBeGreaterThanOrEqual(3);
+    } finally {
+      env.cleanup();
+    }
+  });
+});

--- a/src/__tests__/expose-last-provider.test.ts
+++ b/src/__tests__/expose-last-provider.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { clearLastProvider, readLastProvider, writeLastProvider } from "../expose-last-provider.ts";
+
+function makeEnv(): { path: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-last-provider-"));
+  return {
+    path: join(dir, "expose-last-provider.json"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("expose-last-provider", () => {
+  test("returns undefined when file is missing", () => {
+    const env = makeEnv();
+    try {
+      expect(readLastProvider(env.path)).toBeUndefined();
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("round-trips a provider", () => {
+    const env = makeEnv();
+    try {
+      writeLastProvider("cloudflare", {
+        path: env.path,
+        now: () => new Date("2026-04-22T12:34:56Z"),
+      });
+      const record = readLastProvider(env.path);
+      expect(record).toEqual({
+        version: 1,
+        provider: "cloudflare",
+        writtenAt: "2026-04-22T12:34:56.000Z",
+      });
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("atomic write leaves no tmp file behind on success", () => {
+    const env = makeEnv();
+    try {
+      writeLastProvider("tailscale", { path: env.path });
+      const contents = readFileSync(env.path, "utf8");
+      // rename (not raw write) is the atomic path — body has to be valid JSON.
+      expect(() => JSON.parse(contents)).not.toThrow();
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("returns undefined on corrupt JSON rather than throwing", () => {
+    const env = makeEnv();
+    try {
+      writeFileSync(env.path, "{ not: json");
+      expect(readLastProvider(env.path)).toBeUndefined();
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("returns undefined on schema mismatch (wrong provider value)", () => {
+    const env = makeEnv();
+    try {
+      writeFileSync(
+        env.path,
+        JSON.stringify({ version: 1, provider: "aws", writtenAt: "2026-04-22T00:00:00Z" }),
+      );
+      expect(readLastProvider(env.path)).toBeUndefined();
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("returns undefined on unknown version", () => {
+    const env = makeEnv();
+    try {
+      writeFileSync(
+        env.path,
+        JSON.stringify({ version: 99, provider: "tailscale", writtenAt: "2026-04-22T00:00:00Z" }),
+      );
+      expect(readLastProvider(env.path)).toBeUndefined();
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("clearLastProvider removes the file", () => {
+    const env = makeEnv();
+    try {
+      writeLastProvider("tailscale", { path: env.path });
+      expect(readLastProvider(env.path)).toBeDefined();
+      clearLastProvider(env.path);
+      expect(readLastProvider(env.path)).toBeUndefined();
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("overwriting updates the stored provider", () => {
+    const env = makeEnv();
+    try {
+      writeLastProvider("tailscale", { path: env.path });
+      writeLastProvider("cloudflare", { path: env.path });
+      expect(readLastProvider(env.path)?.provider).toBe("cloudflare");
+    } finally {
+      env.cleanup();
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,16 @@ function isHelpFlag(arg: string | undefined): boolean {
 }
 
 /**
+ * Both stdin and stdout must be TTYs before we offer interactive prompts.
+ * Stdin-only TTY would let us read keystrokes but leave prompt text going to
+ * a log file; stdout-only TTY would let us write prompts but never read an
+ * answer. Either asymmetry means the flag-driven path is the safer default.
+ */
+function isTtyInteractive(): boolean {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+/**
  * Extract `--hub-origin=<url>` / `--hub-origin <url>` from argv. Returns the
  * URL and the remaining args (so callers can keep validating positionals
  * without the flag in the way). `error` is set on missing value.
@@ -258,6 +268,17 @@ async function main(argv: string[]): Promise<number> {
       }
 
       const exposeOpts = hubExtract.hubOrigin ? { hubOrigin: hubExtract.hubOrigin } : {};
+
+      // Interactive picker: `parachute expose public` with no provider/domain
+      // flags, running under a TTY on both stdin and stdout, routes through a
+      // guided flow that offers Tailscale vs. Cloudflare, walks provider
+      // setup, and hands back to the flag-driven entry points. Non-TTY or any
+      // scripted use (flags present) keeps today's behavior exactly.
+      if (layer === "public" && action === "up" && isTtyInteractive()) {
+        const { exposePublicInteractive } = await import("./commands/expose-interactive.ts");
+        return await exposePublicInteractive({ exposeOpts });
+      }
+
       return layer === "public"
         ? await exposePublic(action, exposeOpts)
         : await exposeTailnet(action, exposeOpts);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -252,6 +252,15 @@ async function main(argv: string[]): Promise<number> {
           return await exposeCloudflareOff();
         }
         if (!cfExtract.domain) {
+          // Partial flag promotion: the user told us they want Cloudflare but
+          // didn't supply a hostname. In a TTY, prompt only for what's
+          // missing instead of forcing them to retype the whole command. In a
+          // non-TTY (scripts, CI), keep today's hard-error so automation
+          // doesn't block on an invisible prompt.
+          if (isTtyInteractive()) {
+            const { exposePublicInteractive } = await import("./commands/expose-interactive.ts");
+            return await exposePublicInteractive({ preselect: "cloudflare" });
+          }
           console.error("parachute expose public --cloudflare: --domain <hostname> is required.");
           console.error("Example: parachute expose public --cloudflare --domain vault.example.com");
           console.error("");

--- a/src/commands/expose-cloudflare.ts
+++ b/src/commands/expose-cloudflare.ts
@@ -51,7 +51,7 @@ const AUTH_DOC_URL =
  * Cloudflare's own validation catch the rest. Pre-checking against every
  * RFC 1123 corner would be overkill for a CLI flag that the user just typed.
  */
-function isValidHostname(h: string): boolean {
+export function isValidHostname(h: string): boolean {
   if (h.length === 0 || h.length > 253) return false;
   if (!h.includes(".")) return false;
   const labelRe = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/i;

--- a/src/commands/expose-interactive.ts
+++ b/src/commands/expose-interactive.ts
@@ -1,0 +1,388 @@
+/**
+ * `parachute expose public` (no flags, in a TTY) — guided provider picker.
+ *
+ * The same command scripted (`--cloudflare --domain …` or running under a
+ * non-TTY stdin) keeps today's flag-driven behavior unchanged; this module is
+ * only reached via the explicit TTY+no-flags route from `cli.ts`.
+ *
+ * Shape mirrors `expose-cloudflare.ts`: every side-effectful edge (runner,
+ * prompt, platform detection, interactive stdio commands, last-provider
+ * storage) is an injectable seam so the prompt tree is testable end-to-end.
+ */
+
+import { createInterface } from "node:readline/promises";
+import {
+  DEFAULT_CLOUDFLARED_HOME,
+  isCloudflaredInstalled,
+  isCloudflaredLoggedIn,
+} from "../cloudflare/detect.ts";
+import {
+  EXPOSE_LAST_PROVIDER_PATH,
+  type ExposeProvider,
+  readLastProvider,
+  writeLastProvider,
+} from "../expose-last-provider.ts";
+import {
+  hasFunnelCapability,
+  isTailscaleInstalled,
+  isTailscaleLoggedIn,
+} from "../tailscale/detect.ts";
+import { type Runner, defaultRunner } from "../tailscale/run.ts";
+import {
+  type ExposeCloudflareOpts,
+  exposeCloudflareUp,
+  isValidHostname,
+} from "./expose-cloudflare.ts";
+import { type ExposeOpts, exposePublic } from "./expose.ts";
+
+/**
+ * Runs a command with inherited stdio, returning only the exit code. Used for
+ * interactive bits like `brew install cloudflared` and `cloudflared tunnel
+ * login` where we want the user to see the live output (brew progress bar,
+ * the login URL cloudflared prints, etc.).
+ */
+export type InteractiveRunner = (cmd: readonly string[]) => Promise<number>;
+
+const defaultInteractiveRunner: InteractiveRunner = async (cmd) => {
+  const proc = Bun.spawn([...cmd], { stdio: ["inherit", "inherit", "inherit"] });
+  return await proc.exited;
+};
+
+async function defaultPrompt(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return await rl.question(question);
+  } finally {
+    rl.close();
+  }
+}
+
+export interface ExposeInteractiveOpts {
+  runner?: Runner;
+  /** Inherit-stdio runner for brew/cloudflared-login. */
+  interactiveRunner?: InteractiveRunner;
+  prompt?: (question: string) => Promise<string>;
+  cloudflaredHome?: string;
+  platform?: NodeJS.Platform;
+  lastProviderPath?: string;
+  now?: () => Date;
+  log?: (line: string) => void;
+  /** Passthrough opts for the Tailscale Funnel path (`exposePublic`). */
+  exposeOpts?: ExposeOpts;
+  /** Passthrough opts for the Cloudflare path (`exposeCloudflareUp`). */
+  cloudflareOpts?: ExposeCloudflareOpts;
+  /**
+   * Test seams for the downstream entry points — lets us exercise the
+   * interactive branches without standing up a full tailscale/cloudflared
+   * stub stack. Production code never sets these.
+   */
+  exposePublicImpl?: (action: "up" | "off", opts: ExposeOpts) => Promise<number>;
+  exposeCloudflareUpImpl?: (hostname: string, opts: ExposeCloudflareOpts) => Promise<number>;
+}
+
+interface Resolved {
+  runner: Runner;
+  interactiveRunner: InteractiveRunner;
+  prompt: (question: string) => Promise<string>;
+  cloudflaredHome: string;
+  platform: NodeJS.Platform;
+  lastProviderPath: string;
+  now: () => Date;
+  log: (line: string) => void;
+  exposeOpts: ExposeOpts;
+  cloudflareOpts: ExposeCloudflareOpts;
+  exposePublicImpl: (action: "up" | "off", opts: ExposeOpts) => Promise<number>;
+  exposeCloudflareUpImpl: (hostname: string, opts: ExposeCloudflareOpts) => Promise<number>;
+}
+
+function resolve(opts: ExposeInteractiveOpts): Resolved {
+  return {
+    runner: opts.runner ?? defaultRunner,
+    interactiveRunner: opts.interactiveRunner ?? defaultInteractiveRunner,
+    prompt: opts.prompt ?? defaultPrompt,
+    cloudflaredHome: opts.cloudflaredHome ?? DEFAULT_CLOUDFLARED_HOME,
+    platform: opts.platform ?? process.platform,
+    lastProviderPath: opts.lastProviderPath ?? EXPOSE_LAST_PROVIDER_PATH,
+    now: opts.now ?? (() => new Date()),
+    log: opts.log ?? ((line) => console.log(line)),
+    exposeOpts: opts.exposeOpts ?? {},
+    cloudflareOpts: opts.cloudflareOpts ?? {},
+    exposePublicImpl: opts.exposePublicImpl ?? exposePublic,
+    exposeCloudflareUpImpl: opts.exposeCloudflareUpImpl ?? exposeCloudflareUp,
+  };
+}
+
+interface Readiness {
+  tailscaleInstalled: boolean;
+  tailscaleLoggedIn: boolean;
+  tailscaleFunnelCap: boolean;
+  cloudflareInstalled: boolean;
+  cloudflareLoggedIn: boolean;
+}
+
+async function detectReadiness(r: Resolved): Promise<Readiness> {
+  const tailscaleInstalled = await isTailscaleInstalled(r.runner);
+  // Logged-in + funnel-cap only mean something if the binary's there — skip
+  // the follow-on status calls (they'd just fail) when it isn't.
+  const tailscaleLoggedIn = tailscaleInstalled ? await isTailscaleLoggedIn(r.runner) : false;
+  const tailscaleFunnelCap = tailscaleLoggedIn ? await hasFunnelCapability(r.runner) : false;
+
+  const cloudflareInstalled = await isCloudflaredInstalled(r.runner);
+  const cloudflareLoggedIn = cloudflareInstalled ? isCloudflaredLoggedIn(r.cloudflaredHome) : false;
+
+  return {
+    tailscaleInstalled,
+    tailscaleLoggedIn,
+    tailscaleFunnelCap,
+    cloudflareInstalled,
+    cloudflareLoggedIn,
+  };
+}
+
+function isTailscaleReady(r: Readiness): boolean {
+  return r.tailscaleInstalled && r.tailscaleLoggedIn && r.tailscaleFunnelCap;
+}
+
+function isCloudflareReady(r: Readiness): boolean {
+  return r.cloudflareInstalled && r.cloudflareLoggedIn;
+}
+
+type PickResult = ExposeProvider | "quit";
+
+/**
+ * Prompt loop tolerant to blank/whitespace/unexpected input: reprompts on
+ * garbage rather than failing. Empty string picks the default.
+ */
+async function pickProvider(
+  r: Resolved,
+  opts: { defaultProvider: ExposeProvider; context: "both-ready" | "neither-ready" },
+): Promise<PickResult> {
+  const defaultLabel = opts.defaultProvider === "tailscale" ? "[1] default" : "[2] default";
+  const intro =
+    opts.context === "both-ready"
+      ? "Which provider?"
+      : "Neither Tailscale nor Cloudflare is set up. Which would you like to use?";
+  r.log("");
+  r.log(intro);
+  r.log("  [1] Tailscale Funnel  (free, *.ts.net URL, no domain needed)");
+  r.log("  [2] Cloudflare Tunnel (your own domain, Cloudflare DNS)");
+  r.log(`  [q] quit              (default on enter: ${defaultLabel})`);
+
+  // Bounded retries — a stuck prompt (non-TTY stdin that slipped through,
+  // piped `/dev/null`, etc.) shouldn't spin forever.
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const raw = (await r.prompt("> ")).trim().toLowerCase();
+    if (raw === "" || raw === opts.defaultProvider[0]) return opts.defaultProvider;
+    if (raw === "1" || raw === "tailscale") return "tailscale";
+    if (raw === "2" || raw === "cloudflare") return "cloudflare";
+    if (raw === "q" || raw === "quit" || raw === "exit") return "quit";
+    r.log(`Sorry — expected 1, 2, or q (got "${raw}"). Try again.`);
+  }
+  r.log("Too many invalid entries; aborting.");
+  return "quit";
+}
+
+async function promptHostname(r: Resolved): Promise<string | undefined> {
+  r.log("");
+  r.log("Cloudflare needs a hostname under a domain you've added to your Cloudflare account.");
+  r.log('Example: vault.example.com   (apex "example.com" must be a Cloudflare zone)');
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const raw = (await r.prompt("Hostname (or blank to quit): ")).trim();
+    if (raw === "") return undefined;
+    if (isValidHostname(raw)) return raw;
+    r.log(`"${raw}" doesn't look like a hostname. Expected something like vault.example.com.`);
+  }
+  r.log("Too many invalid entries; aborting.");
+  return undefined;
+}
+
+/**
+ * Print guidance for getting Tailscale ready. We do *not* automate any of
+ * this: `tailscale up` requires a browser auth flow, and the Funnel ACL is
+ * an admin-console change scoped to the tailnet — the CLI impersonating
+ * either would be presumptuous. User re-runs after fixing.
+ */
+function printTailscaleSetupGuidance(r: Resolved, readiness: Readiness): void {
+  r.log("");
+  r.log("Tailscale Funnel needs three things:");
+  r.log("");
+  if (!readiness.tailscaleInstalled) {
+    r.log("  1. Install Tailscale:");
+    if (r.platform === "darwin") {
+      r.log("       brew install tailscale");
+    } else {
+      r.log("       https://tailscale.com/download");
+    }
+  } else {
+    r.log("  1. ✓ Tailscale is installed.");
+  }
+  if (!readiness.tailscaleLoggedIn) {
+    r.log("  2. Log this machine into your tailnet:");
+    r.log("       tailscale up");
+  } else {
+    r.log("  2. ✓ This machine is logged in.");
+  }
+  if (!readiness.tailscaleFunnelCap) {
+    r.log("  3. Enable Funnel for this node in your tailnet ACLs:");
+    r.log("       https://login.tailscale.com/admin/acls");
+    r.log("     Add (or merge) this block under the ACL's top-level object:");
+    r.log("");
+    r.log('       "nodeAttrs": [');
+    r.log('         { "target": ["*"], "attr": ["funnel"] }');
+    r.log("       ]");
+    r.log("");
+    r.log("     (Scope `target` tighter — tag:server, a user, etc. — if you prefer.)");
+  } else {
+    r.log("  3. ✓ Funnel is enabled for this node.");
+  }
+  r.log("");
+  r.log("Once those are done, re-run: parachute expose public");
+}
+
+/**
+ * Walks the user through installing and logging in cloudflared. On macOS we
+ * auto-install via brew (with confirmation); on Linux we print manual-install
+ * pointers and bail so the user can pick apt/dnf/tarball. Returns true only
+ * when cloudflared is both present and logged in afterwards.
+ */
+async function guideCloudflareSetup(r: Resolved, readiness: Readiness): Promise<boolean> {
+  let installed = readiness.cloudflareInstalled;
+  let loggedIn = readiness.cloudflareLoggedIn;
+
+  if (!installed) {
+    if (r.platform === "darwin") {
+      r.log("");
+      r.log("Cloudflare Tunnel uses the `cloudflared` binary, which isn't installed yet.");
+      const answer = (await r.prompt("OK to run `brew install cloudflared`? [Y/n] "))
+        .trim()
+        .toLowerCase();
+      if (answer === "n" || answer === "no") {
+        r.log("Skipped auto-install. Install manually, then re-run: parachute expose public");
+        return false;
+      }
+      const code = await r.interactiveRunner(["brew", "install", "cloudflared"]);
+      if (code !== 0) {
+        r.log(`\`brew install cloudflared\` exited ${code}. Fix the error above, then re-run.`);
+        return false;
+      }
+      installed = await isCloudflaredInstalled(r.runner);
+      if (!installed) {
+        r.log("Installation reported success, but `cloudflared` still isn't on PATH.");
+        r.log("Open a fresh shell (so PATH picks up the new binary) and re-run.");
+        return false;
+      }
+    } else {
+      r.log("");
+      r.log("Cloudflare Tunnel uses the `cloudflared` binary, which isn't installed yet.");
+      r.log("Install one way:");
+      r.log("  Debian / Ubuntu:");
+      r.log(
+        "    curl -L https://pkg.cloudflare.com/install.sh | sudo bash && sudo apt-get install -y cloudflared",
+      );
+      r.log("  RHEL / Fedora:");
+      r.log("    sudo dnf install cloudflared");
+      r.log("  Tarball / other:");
+      r.log(
+        "    https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/",
+      );
+      r.log("");
+      r.log("After install, re-run: parachute expose public");
+      return false;
+    }
+  }
+
+  if (!loggedIn) {
+    r.log("");
+    r.log("cloudflared needs to be authenticated with your Cloudflare account first.");
+    r.log("The next step opens a browser so you can pick the domain to use.");
+    const answer = (await r.prompt("Run `cloudflared tunnel login` now? [Y/n] "))
+      .trim()
+      .toLowerCase();
+    if (answer === "n" || answer === "no") {
+      r.log("Skipped login. Run `cloudflared tunnel login` manually, then re-run.");
+      return false;
+    }
+    const code = await r.interactiveRunner(["cloudflared", "tunnel", "login"]);
+    if (code !== 0) {
+      r.log(`\`cloudflared tunnel login\` exited ${code}. Fix the error above, then re-run.`);
+      return false;
+    }
+    loggedIn = isCloudflaredLoggedIn(r.cloudflaredHome);
+    if (!loggedIn) {
+      r.log("Login ran but cert.pem didn't appear in ~/.cloudflared.");
+      r.log("Check the browser flow completed, then re-run: parachute expose public");
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Default provider when both are ready: prefer whatever the user picked last
+ * time, falling back to Tailscale (spec: free + no domain needed — the more
+ * accessible starting point).
+ */
+function defaultProviderFrom(lastPath: string): ExposeProvider {
+  const last = readLastProvider(lastPath);
+  return last?.provider ?? "tailscale";
+}
+
+export async function exposePublicInteractive(opts: ExposeInteractiveOpts = {}): Promise<number> {
+  const r = resolve(opts);
+  const readiness = await detectReadiness(r);
+  const tsReady = isTailscaleReady(readiness);
+  const cfReady = isCloudflareReady(readiness);
+
+  let provider: ExposeProvider;
+  if (tsReady && cfReady) {
+    const picked = await pickProvider(r, {
+      defaultProvider: defaultProviderFrom(r.lastProviderPath),
+      context: "both-ready",
+    });
+    if (picked === "quit") {
+      r.log("Nothing exposed.");
+      return 0;
+    }
+    provider = picked;
+  } else if (tsReady) {
+    r.log("Using Tailscale Funnel (Cloudflare Tunnel is also available with `--cloudflare`).");
+    provider = "tailscale";
+  } else if (cfReady) {
+    r.log("Using Cloudflare Tunnel.");
+    r.log("You'll need your own domain added to your Cloudflare account.");
+    provider = "cloudflare";
+  } else {
+    const picked = await pickProvider(r, {
+      defaultProvider: "tailscale",
+      context: "neither-ready",
+    });
+    if (picked === "quit") {
+      r.log("Nothing exposed.");
+      return 0;
+    }
+    provider = picked;
+  }
+
+  if (provider === "tailscale") {
+    if (!tsReady) {
+      printTailscaleSetupGuidance(r, readiness);
+      return 1;
+    }
+    writeLastProvider("tailscale", { path: r.lastProviderPath, now: r.now });
+    return r.exposePublicImpl("up", r.exposeOpts);
+  }
+
+  // Cloudflare path.
+  if (!cfReady) {
+    const ok = await guideCloudflareSetup(r, readiness);
+    if (!ok) return 1;
+  }
+  const hostname = await promptHostname(r);
+  if (!hostname) {
+    r.log("Nothing exposed.");
+    return 0;
+  }
+  writeLastProvider("cloudflare", { path: r.lastProviderPath, now: r.now });
+  return r.exposeCloudflareUpImpl(hostname, r.cloudflareOpts);
+}

--- a/src/commands/expose-interactive.ts
+++ b/src/commands/expose-interactive.ts
@@ -22,11 +22,7 @@ import {
   readLastProvider,
   writeLastProvider,
 } from "../expose-last-provider.ts";
-import {
-  hasFunnelCapability,
-  isTailscaleInstalled,
-  isTailscaleLoggedIn,
-} from "../tailscale/detect.ts";
+import { getTailscaleStatus, isTailscaleInstalled } from "../tailscale/detect.ts";
 import { type Runner, defaultRunner } from "../tailscale/run.ts";
 import {
   type ExposeCloudflareOpts,
@@ -72,6 +68,13 @@ export interface ExposeInteractiveOpts {
   /** Passthrough opts for the Cloudflare path (`exposeCloudflareUp`). */
   cloudflareOpts?: ExposeCloudflareOpts;
   /**
+   * Skip the provider picker — the caller has already chosen. Used when the
+   * user typed a provider flag but left a required piece out (e.g.
+   * `--cloudflare` without `--domain` in a TTY): we've got their choice, we
+   * just need to prompt for what's missing.
+   */
+  preselect?: ExposeProvider;
+  /**
    * Test seams for the downstream entry points — lets us exercise the
    * interactive branches without standing up a full tailscale/cloudflared
    * stub stack. Production code never sets these.
@@ -91,6 +94,7 @@ interface Resolved {
   log: (line: string) => void;
   exposeOpts: ExposeOpts;
   cloudflareOpts: ExposeCloudflareOpts;
+  preselect: ExposeProvider | undefined;
   exposePublicImpl: (action: "up" | "off", opts: ExposeOpts) => Promise<number>;
   exposeCloudflareUpImpl: (hostname: string, opts: ExposeCloudflareOpts) => Promise<number>;
 }
@@ -107,6 +111,7 @@ function resolve(opts: ExposeInteractiveOpts): Resolved {
     log: opts.log ?? ((line) => console.log(line)),
     exposeOpts: opts.exposeOpts ?? {},
     cloudflareOpts: opts.cloudflareOpts ?? {},
+    preselect: opts.preselect,
     exposePublicImpl: opts.exposePublicImpl ?? exposePublic,
     exposeCloudflareUpImpl: opts.exposeCloudflareUpImpl ?? exposeCloudflareUp,
   };
@@ -122,10 +127,11 @@ interface Readiness {
 
 async function detectReadiness(r: Resolved): Promise<Readiness> {
   const tailscaleInstalled = await isTailscaleInstalled(r.runner);
-  // Logged-in + funnel-cap only mean something if the binary's there — skip
-  // the follow-on status calls (they'd just fail) when it isn't.
-  const tailscaleLoggedIn = tailscaleInstalled ? await isTailscaleLoggedIn(r.runner) : false;
-  const tailscaleFunnelCap = tailscaleLoggedIn ? await hasFunnelCapability(r.runner) : false;
+  // One `tailscale status --json` covers both login state and Funnel cap.
+  // Skipped when the binary's missing — the call would just fail.
+  const { loggedIn: tailscaleLoggedIn, funnelCapable: tailscaleFunnelCap } = tailscaleInstalled
+    ? await getTailscaleStatus(r.runner)
+    : { loggedIn: false, funnelCapable: false };
 
   const cloudflareInstalled = await isCloudflaredInstalled(r.runner);
   const cloudflareLoggedIn = cloudflareInstalled ? isCloudflaredLoggedIn(r.cloudflaredHome) : false;
@@ -335,7 +341,11 @@ export async function exposePublicInteractive(opts: ExposeInteractiveOpts = {}):
   const cfReady = isCloudflareReady(readiness);
 
   let provider: ExposeProvider;
-  if (tsReady && cfReady) {
+  if (r.preselect) {
+    // Caller passed a provider flag but is missing a required piece — skip
+    // the picker entirely and resume at the setup / hostname prompt.
+    provider = r.preselect;
+  } else if (tsReady && cfReady) {
     const picked = await pickProvider(r, {
       defaultProvider: defaultProviderFrom(r.lastProviderPath),
       context: "both-ready",

--- a/src/expose-last-provider.ts
+++ b/src/expose-last-provider.ts
@@ -1,0 +1,71 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { CONFIG_DIR } from "./config.ts";
+
+export const EXPOSE_LAST_PROVIDER_PATH = join(CONFIG_DIR, "expose-last-provider.json");
+
+export type ExposeProvider = "tailscale" | "cloudflare";
+
+export interface ExposeLastProvider {
+  version: 1;
+  provider: ExposeProvider;
+  /** ISO-8601 timestamp of the last selection — debugging only. */
+  writtenAt: string;
+}
+
+/**
+ * Persisted cross-invocation preference — remembers which provider the user
+ * picked last in the interactive flow so we can default to it next time.
+ *
+ * Unlike the live state files (`expose-state.json`, `cloudflared-state.json`)
+ * this is just a preference hint, so missing or corrupt content is not fatal:
+ * we return `undefined` and the caller falls back to its default. A stale file
+ * is never load-bearing — the worst case is a one-keystroke re-pick.
+ */
+export function readLastProvider(
+  path: string = EXPOSE_LAST_PROVIDER_PATH,
+): ExposeLastProvider | undefined {
+  if (!existsSync(path)) return undefined;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return undefined;
+  }
+  if (!raw || typeof raw !== "object") return undefined;
+  const r = raw as Record<string, unknown>;
+  if (r.version !== 1) return undefined;
+  if (r.provider !== "tailscale" && r.provider !== "cloudflare") return undefined;
+  if (typeof r.writtenAt !== "string" || r.writtenAt.length === 0) return undefined;
+  return { version: 1, provider: r.provider, writtenAt: r.writtenAt };
+}
+
+export function writeLastProvider(
+  provider: ExposeProvider,
+  opts: { path?: string; now?: () => Date } = {},
+): void {
+  const path = opts.path ?? EXPOSE_LAST_PROVIDER_PATH;
+  const now = opts.now ?? (() => new Date());
+  if (!existsSync(dirname(path))) {
+    mkdirSync(dirname(path), { recursive: true });
+  }
+  const record: ExposeLastProvider = {
+    version: 1,
+    provider,
+    writtenAt: now().toISOString(),
+  };
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, `${JSON.stringify(record, null, 2)}\n`);
+  renameSync(tmp, path);
+}
+
+export function clearLastProvider(path: string = EXPOSE_LAST_PROVIDER_PATH): void {
+  if (existsSync(path)) unlinkSync(path);
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -98,6 +98,13 @@ Usage:
   parachute expose public  --cloudflare --domain <hostname>
   parachute expose public  off --cloudflare
 
+Interactive:
+  Run in a terminal with no flags, \`parachute expose public\` walks you
+  through provider selection (Tailscale Funnel vs. Cloudflare Tunnel),
+  offers to install missing dependencies on macOS, and prompts for the
+  Cloudflare hostname when needed. Piped / non-TTY invocations keep the
+  scripted behavior: default to Tailscale, flags override.
+
 Layers:
   tailnet    HTTPS across your tailnet (tailscale serve)
   public     HTTPS on the public internet

--- a/src/tailscale/detect.ts
+++ b/src/tailscale/detect.ts
@@ -4,7 +4,7 @@ import { TailscaleError } from "./run.ts";
 /** ACL capability key Tailscale emits on `Self.CapMap` when the node is
  * allowed to run Funnel. Internal-ish surface: the key string is stable in
  * practice but not documented as API. Treat the probe as best-effort (see
- * {@link hasFunnelCapability}). */
+ * {@link getTailscaleStatus}). */
 const FUNNEL_CAP_KEY = "https://tailscale.com/cap/funnel";
 
 export async function isTailscaleInstalled(runner: Runner): Promise<boolean> {
@@ -17,44 +17,43 @@ export async function isTailscaleInstalled(runner: Runner): Promise<boolean> {
 }
 
 /**
- * Returns `true` when `tailscale status --json` responds with a node logged
- * into a tailnet (Self.DNSName is non-empty). False on `Logged out`, `Stopped`,
- * install/PATH errors, or parse failures — callers use this to decide whether
- * to prompt the user to run `tailscale up` before anything else.
- */
-export async function isTailscaleLoggedIn(runner: Runner): Promise<boolean> {
-  try {
-    const result = await runner(["tailscale", "status", "--json"]);
-    if (result.code !== 0) return false;
-    const parsed = JSON.parse(result.stdout) as { Self?: { DNSName?: unknown } };
-    const dnsName = parsed.Self?.DNSName;
-    return typeof dnsName === "string" && dnsName.length > 0;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Best-effort probe for whether this node is allowed to expose Funnel. Reads
- * `Self.CapMap` from `tailscale status --json` and checks for the Funnel
- * capability key.
+ * Consolidated read of `tailscale status --json`, returning everything the
+ * readiness check needs in one subprocess call:
  *
- * Caveat: `CapMap` is a semi-internal field whose shape Tailscale can shift
- * across versions. This probe is not load-bearing — a false negative only
- * means we'll point the user at the admin console when they don't actually
- * need to do anything. The downstream `tailscale funnel` call is the real
- * gate; this just lets us nudge the user earlier in the flow.
+ * - `loggedIn` — Self.DNSName is present and non-empty. False on `Logged out`,
+ *   `Stopped`, install/PATH errors, or parse failures — callers use this to
+ *   decide whether to prompt the user to run `tailscale up` before anything
+ *   else.
+ * - `funnelCapable` — best-effort probe for whether this node is allowed to
+ *   expose Funnel, via `Self.CapMap[{@link FUNNEL_CAP_KEY}]`.
+ *
+ * Caveat on `funnelCapable`: `CapMap` is a semi-internal field whose shape
+ * Tailscale can shift across versions. This probe is not load-bearing — a
+ * false negative only means we'll point the user at the admin console when
+ * they don't actually need to do anything. The downstream `tailscale funnel`
+ * call is the real gate; this just lets us nudge the user earlier in the flow.
+ *
+ * Any error (non-zero exit, parse failure) returns `{ loggedIn: false,
+ * funnelCapable: false }` rather than throwing; the readiness check is an
+ * advisory pre-flight, not a hard gate.
  */
-export async function hasFunnelCapability(runner: Runner): Promise<boolean> {
+export async function getTailscaleStatus(
+  runner: Runner,
+): Promise<{ loggedIn: boolean; funnelCapable: boolean }> {
   try {
     const result = await runner(["tailscale", "status", "--json"]);
-    if (result.code !== 0) return false;
-    const parsed = JSON.parse(result.stdout) as { Self?: { CapMap?: Record<string, unknown> } };
+    if (result.code !== 0) return { loggedIn: false, funnelCapable: false };
+    const parsed = JSON.parse(result.stdout) as {
+      Self?: { DNSName?: unknown; CapMap?: Record<string, unknown> };
+    };
+    const dnsName = parsed.Self?.DNSName;
+    const loggedIn = typeof dnsName === "string" && dnsName.length > 0;
     const capMap = parsed.Self?.CapMap;
-    if (!capMap || typeof capMap !== "object") return false;
-    return FUNNEL_CAP_KEY in capMap;
+    const funnelCapable =
+      loggedIn && !!capMap && typeof capMap === "object" && FUNNEL_CAP_KEY in capMap;
+    return { loggedIn, funnelCapable };
   } catch {
-    return false;
+    return { loggedIn: false, funnelCapable: false };
   }
 }
 

--- a/src/tailscale/detect.ts
+++ b/src/tailscale/detect.ts
@@ -1,10 +1,58 @@
 import type { Runner } from "./run.ts";
 import { TailscaleError } from "./run.ts";
 
+/** ACL capability key Tailscale emits on `Self.CapMap` when the node is
+ * allowed to run Funnel. Internal-ish surface: the key string is stable in
+ * practice but not documented as API. Treat the probe as best-effort (see
+ * {@link hasFunnelCapability}). */
+const FUNNEL_CAP_KEY = "https://tailscale.com/cap/funnel";
+
 export async function isTailscaleInstalled(runner: Runner): Promise<boolean> {
   try {
     const { code } = await runner(["tailscale", "version"]);
     return code === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns `true` when `tailscale status --json` responds with a node logged
+ * into a tailnet (Self.DNSName is non-empty). False on `Logged out`, `Stopped`,
+ * install/PATH errors, or parse failures — callers use this to decide whether
+ * to prompt the user to run `tailscale up` before anything else.
+ */
+export async function isTailscaleLoggedIn(runner: Runner): Promise<boolean> {
+  try {
+    const result = await runner(["tailscale", "status", "--json"]);
+    if (result.code !== 0) return false;
+    const parsed = JSON.parse(result.stdout) as { Self?: { DNSName?: unknown } };
+    const dnsName = parsed.Self?.DNSName;
+    return typeof dnsName === "string" && dnsName.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Best-effort probe for whether this node is allowed to expose Funnel. Reads
+ * `Self.CapMap` from `tailscale status --json` and checks for the Funnel
+ * capability key.
+ *
+ * Caveat: `CapMap` is a semi-internal field whose shape Tailscale can shift
+ * across versions. This probe is not load-bearing — a false negative only
+ * means we'll point the user at the admin console when they don't actually
+ * need to do anything. The downstream `tailscale funnel` call is the real
+ * gate; this just lets us nudge the user earlier in the flow.
+ */
+export async function hasFunnelCapability(runner: Runner): Promise<boolean> {
+  try {
+    const result = await runner(["tailscale", "status", "--json"]);
+    if (result.code !== 0) return false;
+    const parsed = JSON.parse(result.stdout) as { Self?: { CapMap?: Record<string, unknown> } };
+    const capMap = parsed.Self?.CapMap;
+    if (!capMap || typeof capMap !== "object") return false;
+    return FUNNEL_CAP_KEY in capMap;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

Running `parachute expose public` naked in a TTY now walks the user through
provider selection — Tailscale Funnel vs. Cloudflare Tunnel — with detection,
guided setup, and hostname prompting for Cloudflare. Flag-based calls
(`--cloudflare --domain …`) and non-TTY stdin preserve today's behavior.

**WHY:** The flag surface worked for scripts but hid both options behind
memorization. After #31 merged, Aaron flagged: "a lot of this can happen in
the interaction mode. Like, `parachute expose public` should actually bring
you through an interactive thing for this." This PR is **Layer 1** of that
work. Layers 2–4 (post-setup auth preflight, interactive `tokens create`,
smarter `expose public off`) land as separate PRs, serialized.

## What's new

- **`src/commands/expose-interactive.ts`** — the picker. Detects readiness
  per provider:
  - Tailscale: `tailscale` on PATH + logged-in tailnet + Funnel ACL.
  - Cloudflare: `cloudflared` on PATH + `~/.cloudflared/cert.pem`.

  Branches on both-ready / one-ready / neither-ready. macOS gets auto-install
  via `brew install cloudflared` (with explicit `Y/n` confirm) and inline
  `cloudflared tunnel login`; Linux gets manual-install pointers
  (apt/dnf/tarball). Tailscale setup is guided-only — no automation, since
  `tailscale up` is a browser flow and the Funnel ACL is admin-console
  territory.

- **`src/expose-last-provider.ts`** — cross-invocation preference
  `{ version, provider, writtenAt }` that seeds the default when both
  providers are ready. Lenient read: missing/corrupt returns undefined.

- **`src/tailscale/detect.ts`** — new `isTailscaleLoggedIn` +
  `hasFunnelCapability` probes (best-effort). The Funnel-cap check leans on
  `Self.CapMap["https://tailscale.com/cap/funnel"]`, which is
  Tailscale-internal shape — commented so readers don't mistake it for
  load-bearing, since worst case is a false-negative setup nudge.

- **`src/cli.ts`** — routes `expose public up` through the picker only when
  both stdin and stdout are TTYs and no provider flags are set. Non-TTY +
  no flags keeps today's Tailscale default for scripts.

## Design notes

Every side-effectful edge is an injectable seam (runner, prompt,
interactive runner, platform, downstream entry points, last-provider
storage, `now()`). Tests walk every branch of the prompt tree without
standing up a real tailscale/cloudflared stack.

Non-TTY mapping (not explicit in the spec but chosen for minimal blast
radius): `parachute expose public` with no flags on a piped stdin/stdout
keeps today's silent-Tailscale behavior. Anything flag-driven works the
same as before in both modes.

## Test plan

- [x] `bun test` — 287 pass, 0 fail (24 new tests across 2 new files)
- [x] `bun run typecheck` — clean
- [x] `bunx biome check .` — clean
- [ ] Manual smoke on macOS: `parachute expose public` in a terminal with
      neither provider ready (should prompt, offer brew install, etc.)
- [ ] Manual smoke: `parachute expose public --cloudflare --domain X`
      still takes the flag path (no prompts)
- [ ] Manual smoke: `echo '' | parachute expose public` still runs the
      Tailscale path silently (non-TTY back-compat)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>