### PR TITLE
feat(expose): post-setup auth preflight for `expose public`

### DIFF
--- a/src/__tests__/expose-auth-preflight.test.ts
+++ b/src/__tests__/expose-auth-preflight.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from "bun:test";
+import { runAuthPreflight } from "../commands/expose-auth-preflight.ts";
+import type { VaultAuthStatus } from "../vault/auth-status.ts";
+
+interface Harness {
+  logs: string[];
+  prompts: string[];
+  promptAnswers: string[];
+  commands: string[][];
+}
+
+function makeHarness(answers: string[] = []): Harness {
+  return { logs: [], prompts: [], promptAnswers: answers, commands: [] };
+}
+
+function wire(h: Harness) {
+  let i = 0;
+  return {
+    log: (line: string) => h.logs.push(line),
+    prompt: async (q: string) => {
+      h.prompts.push(q);
+      const answer = h.promptAnswers[i++];
+      if (answer === undefined) throw new Error(`prompt exhausted at: ${q}`);
+      return answer;
+    },
+    interactiveRunner: async (cmd: readonly string[]) => {
+      h.commands.push([...cmd]);
+      return 0;
+    },
+  };
+}
+
+function status(partial: Partial<VaultAuthStatus> = {}): VaultAuthStatus {
+  return {
+    hasOwnerPassword: false,
+    hasTotp: false,
+    tokenCount: 0,
+    vaultNames: ["default"],
+    ...partial,
+  };
+}
+
+describe("runAuthPreflight — wide open (no password, no tokens)", () => {
+  test("warns loudly and offers password, 2FA, and token creation", async () => {
+    const h = makeHarness(["y", "n", "n"]); // password yes, 2fa no, token no
+    await runAuthPreflight({ status: status(), ...wire(h) });
+    const joined = h.logs.join("\n");
+    expect(joined).toContain("No owner password and no API tokens");
+    expect(joined).toContain("public internet");
+    expect(h.commands).toHaveLength(1);
+    expect(h.commands[0]).toEqual(["parachute", "auth", "set-password"]);
+  });
+
+  test("user declines every prompt → no subprocesses run", async () => {
+    const h = makeHarness(["", "", ""]); // all Enter = skip
+    await runAuthPreflight({ status: status(), ...wire(h) });
+    expect(h.commands).toHaveLength(0);
+    // Still prompted on all three lines, even though each was declined.
+    expect(h.prompts).toHaveLength(3);
+  });
+
+  test("user accepts all three → all three commands invoked in order", async () => {
+    const h = makeHarness(["y", "y", "y"]);
+    await runAuthPreflight({ status: status(), ...wire(h) });
+    expect(h.commands.map((c) => c.join(" "))).toEqual([
+      "parachute auth set-password",
+      "parachute auth 2fa enroll",
+      "parachute vault tokens create",
+    ]);
+  });
+});
+
+describe("runAuthPreflight — password set, no 2FA", () => {
+  test("short nudge, offers 2FA only", async () => {
+    const h = makeHarness(["y"]);
+    await runAuthPreflight({
+      status: status({ hasOwnerPassword: true, tokenCount: 3 }),
+      ...wire(h),
+    });
+    const joined = h.logs.join("\n");
+    expect(joined).toContain("Owner password is set");
+    expect(joined).toContain("2FA");
+    expect(h.prompts).toHaveLength(1);
+    expect(h.commands).toEqual([["parachute", "auth", "2fa", "enroll"]]);
+  });
+
+  test("user declines → no command runs", async () => {
+    const h = makeHarness([""]);
+    await runAuthPreflight({
+      status: status({ hasOwnerPassword: true, tokenCount: 3 }),
+      ...wire(h),
+    });
+    expect(h.commands).toHaveLength(0);
+  });
+});
+
+describe("runAuthPreflight — tokens exist, no password", () => {
+  test("notes that OAuth is not set up, offers password", async () => {
+    const h = makeHarness(["y"]);
+    await runAuthPreflight({
+      status: status({ hasOwnerPassword: false, tokenCount: 2 }),
+      ...wire(h),
+    });
+    const joined = h.logs.join("\n");
+    expect(joined).toContain("API tokens exist");
+    expect(joined).toContain("no owner password");
+    expect(h.prompts).toHaveLength(1);
+    expect(h.commands).toEqual([["parachute", "auth", "set-password"]]);
+  });
+});
+
+describe("runAuthPreflight — unknown token count (SQLite failed)", () => {
+  test("advises running `tokens list`, no token-dependent prompts", async () => {
+    const h = makeHarness([]);
+    await runAuthPreflight({
+      status: status({ hasOwnerPassword: false, hasTotp: false, tokenCount: null }),
+      ...wire(h),
+    });
+    const joined = h.logs.join("\n");
+    expect(joined).toContain("Couldn't read vault token state");
+    expect(joined).toContain("parachute vault tokens list");
+    // No prompts because we don't offer password/token flow when token
+    // state is unknown (it'd be ambiguous whether we're dealing with the
+    // wide-open or the tokens-only case).
+    expect(h.prompts).toHaveLength(0);
+  });
+
+  test("password set + 2FA absent + tokens unknown → still offers 2FA", async () => {
+    const h = makeHarness([""]); // decline 2FA
+    await runAuthPreflight({
+      status: status({ hasOwnerPassword: true, hasTotp: false, tokenCount: null }),
+      ...wire(h),
+    });
+    expect(h.prompts).toHaveLength(1);
+    expect(h.prompts[0]?.toLowerCase()).toContain("2fa");
+  });
+});
+
+describe("runAuthPreflight — all good", () => {
+  test("single positive line, no prompts", async () => {
+    const h = makeHarness([]);
+    await runAuthPreflight({
+      status: status({ hasOwnerPassword: true, hasTotp: true, tokenCount: 1 }),
+      ...wire(h),
+    });
+    const joined = h.logs.join("\n");
+    expect(joined).toContain("looks good");
+    expect(h.prompts).toHaveLength(0);
+    expect(h.commands).toHaveLength(0);
+  });
+});
+
+describe("runAuthPreflight — subprocess failure handling", () => {
+  test("non-zero exit from auth command doesn't abort the rest of the preflight", async () => {
+    const h = makeHarness(["y", "y", "y"]);
+    // Override the interactive runner to return non-zero on the first call.
+    let first = true;
+    const interactiveRunner = async (cmd: readonly string[]) => {
+      h.commands.push([...cmd]);
+      if (first) {
+        first = false;
+        return 7;
+      }
+      return 0;
+    };
+    await runAuthPreflight({
+      status: status(),
+      log: (l) => h.logs.push(l),
+      prompt: async (q) => {
+        h.prompts.push(q);
+        return h.promptAnswers.shift() ?? "";
+      },
+      interactiveRunner,
+    });
+    // All three commands still attempted, none aborted the flow.
+    expect(h.commands.map((c) => c[0])).toEqual(["parachute", "parachute", "parachute"]);
+    const joined = h.logs.join("\n");
+    expect(joined).toContain("exited 7");
+  });
+});
+
+describe("runAuthPreflight — case-insensitive yes", () => {
+  test('"Y", "YES", and "y" all count as affirmative; anything else is decline', async () => {
+    for (const yes of ["y", "Y", "yes", "YES"]) {
+      const h = makeHarness([yes]);
+      await runAuthPreflight({
+        status: status({ hasOwnerPassword: true, tokenCount: 1 }),
+        ...wire(h),
+      });
+      expect(h.commands).toHaveLength(1);
+    }
+    for (const no of ["", "n", "no", "q", "bogus"]) {
+      const h = makeHarness([no]);
+      await runAuthPreflight({
+        status: status({ hasOwnerPassword: true, tokenCount: 1 }),
+        ...wire(h),
+      });
+      expect(h.commands).toHaveLength(0);
+    }
+  });
+});

--- a/src/__tests__/expose-interactive.test.ts
+++ b/src/__tests__/expose-interactive.test.ts
@@ -6,6 +6,12 @@ import { exposePublicInteractive } from "../commands/expose-interactive.ts";
 import { readLastProvider, writeLastProvider } from "../expose-last-provider.ts";
 import type { CommandResult, Runner } from "../tailscale/run.ts";
 
+// Every test in this file uses injected seams for tailscale/cloudflared; the
+// auth preflight is a separate module with its own test file, so stub it out
+// here to keep these tests focused on the picker logic. Tests that want to
+// assert preflight behavior override this.
+const noopPreflight = async () => {};
+
 interface TestEnv {
   cloudflaredHome: string;
   lastProviderPath: string;
@@ -112,6 +118,7 @@ describe("exposePublicInteractive — both ready", () => {
           cloudflareCalled = true;
           return 0;
         },
+        runAuthPreflightImpl: noopPreflight,
       });
       expect(code).toBe(0);
       expect(tailscaleCalled).toBe(true);
@@ -146,6 +153,7 @@ describe("exposePublicInteractive — both ready", () => {
           cloudflareHostname = h;
           return 0;
         },
+        runAuthPreflightImpl: noopPreflight,
       });
       expect(code).toBe(0);
       expect(cloudflareHostname).toBe("vault.example.com");
@@ -176,6 +184,7 @@ describe("exposePublicInteractive — both ready", () => {
           cloudflareHostname = h;
           return 0;
         },
+        runAuthPreflightImpl: noopPreflight,
       });
       expect(code).toBe(0);
       expect(cloudflareHostname).toBe("vault.example.com");
@@ -273,6 +282,7 @@ describe("exposePublicInteractive — only one ready", () => {
         log: (l) => logs.push(l),
         exposePublicImpl: async () => 0,
         exposeCloudflareUpImpl: async () => 0,
+        runAuthPreflightImpl: noopPreflight,
       });
       expect(code).toBe(0);
       expect(prompts).toBe(0);
@@ -304,6 +314,7 @@ describe("exposePublicInteractive — only one ready", () => {
           cloudflareHostname = h;
           return 0;
         },
+        runAuthPreflightImpl: noopPreflight,
       });
       expect(code).toBe(0);
       expect(cloudflareHostname).toBe("vault.example.com");
@@ -417,6 +428,7 @@ describe("exposePublicInteractive — neither ready", () => {
           cloudflareHostname = h;
           return 0;
         },
+        runAuthPreflightImpl: noopPreflight,
       });
       expect(code).toBe(0);
       expect(interactiveCmds[0]).toEqual(["brew", "install", "cloudflared"]);
@@ -574,6 +586,7 @@ describe("exposePublicInteractive — edge cases", () => {
           cloudflareCalled = true;
           return 0;
         },
+        runAuthPreflightImpl: noopPreflight,
       });
       expect(code).toBe(0);
       expect(cloudflareCalled).toBe(true);
@@ -603,6 +616,7 @@ describe("exposePublicInteractive — edge cases", () => {
           return 0;
         },
         exposeCloudflareUpImpl: async () => 0,
+        runAuthPreflightImpl: noopPreflight,
       });
       expect(code).toBe(0);
       expect(receivedExposeOpts).toEqual({ hubOrigin: "https://custom.example" });
@@ -641,6 +655,7 @@ describe("exposePublicInteractive — edge cases", () => {
           cloudflareHostname = h;
           return 0;
         },
+        runAuthPreflightImpl: noopPreflight,
       });
       expect(code).toBe(0);
       expect(tailscaleCalled).toBe(false);
@@ -676,6 +691,7 @@ describe("exposePublicInteractive — edge cases", () => {
           return 0;
         },
         exposeCloudflareUpImpl: async () => 0,
+        runAuthPreflightImpl: noopPreflight,
       });
       expect(code).toBe(0);
       expect(tailscaleCalled).toBe(true);

--- a/src/__tests__/vault-auth-status.test.ts
+++ b/src/__tests__/vault-auth-status.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readVaultAuthStatus } from "../vault/auth-status.ts";
+
+function makeVaultHome(): { path: string; cleanup: () => void } {
+  const path = mkdtempSync(join(tmpdir(), "pcli-vault-auth-"));
+  return { path, cleanup: () => rmSync(path, { recursive: true, force: true }) };
+}
+
+function writeConfig(vaultHome: string, body: string): void {
+  writeFileSync(join(vaultHome, "config.yaml"), body);
+}
+
+function seedVault(vaultHome: string, name: string, opts: { withDb?: boolean } = {}): string {
+  const dir = join(vaultHome, "data", name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "vault.yaml"), "# placeholder\n");
+  const dbPath = join(dir, "vault.db");
+  if (opts.withDb) writeFileSync(dbPath, ""); // exists but opaque to the fake counter
+  return dbPath;
+}
+
+describe("readVaultAuthStatus — config.yaml parse", () => {
+  test("missing config.yaml → hasOwnerPassword + hasTotp both false", () => {
+    const env = makeVaultHome();
+    try {
+      const status = readVaultAuthStatus({ vaultHome: env.path, countTokens: () => 0 });
+      expect(status.hasOwnerPassword).toBe(false);
+      expect(status.hasTotp).toBe(false);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("both keys present and non-empty → both true", () => {
+    const env = makeVaultHome();
+    try {
+      writeConfig(
+        env.path,
+        [
+          "port: 1940",
+          'owner_password_hash: "$2b$12$somehashhere"',
+          'totp_secret: "JBSWY3DPEHPK3PXP"',
+          "",
+        ].join("\n"),
+      );
+      const status = readVaultAuthStatus({ vaultHome: env.path, countTokens: () => 0 });
+      expect(status.hasOwnerPassword).toBe(true);
+      expect(status.hasTotp).toBe(true);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("empty quoted values are treated as absent (matches vault's readGlobalConfig)", () => {
+    const env = makeVaultHome();
+    try {
+      writeConfig(env.path, ['owner_password_hash: ""', 'totp_secret: ""', ""].join("\n"));
+      const status = readVaultAuthStatus({ vaultHome: env.path, countTokens: () => 0 });
+      expect(status.hasOwnerPassword).toBe(false);
+      expect(status.hasTotp).toBe(false);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("only owner_password_hash present", () => {
+    const env = makeVaultHome();
+    try {
+      writeConfig(env.path, 'owner_password_hash: "$2b$12$abc"\n');
+      const status = readVaultAuthStatus({ vaultHome: env.path, countTokens: () => 0 });
+      expect(status.hasOwnerPassword).toBe(true);
+      expect(status.hasTotp).toBe(false);
+    } finally {
+      env.cleanup();
+    }
+  });
+});
+
+describe("readVaultAuthStatus — vault discovery", () => {
+  test("no data/ dir → vaultNames empty, tokenCount 0", () => {
+    const env = makeVaultHome();
+    try {
+      const status = readVaultAuthStatus({ vaultHome: env.path, countTokens: () => 999 });
+      expect(status.vaultNames).toEqual([]);
+      expect(status.tokenCount).toBe(0);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("directories without vault.yaml are skipped", () => {
+    const env = makeVaultHome();
+    try {
+      // "real" vault
+      seedVault(env.path, "default", { withDb: true });
+      // garbage dir that happens to sit under data/
+      mkdirSync(join(env.path, "data", "stray"), { recursive: true });
+      const status = readVaultAuthStatus({ vaultHome: env.path, countTokens: () => 0 });
+      expect(status.vaultNames).toEqual(["default"]);
+    } finally {
+      env.cleanup();
+    }
+  });
+});
+
+describe("readVaultAuthStatus — token count resilience", () => {
+  test("sums across multiple vaults", () => {
+    const env = makeVaultHome();
+    try {
+      seedVault(env.path, "default", { withDb: true });
+      seedVault(env.path, "work", { withDb: true });
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        countTokens: (dbPath) => (dbPath.includes("/default/") ? 2 : 3),
+      });
+      expect(status.tokenCount).toBe(5);
+      expect(new Set(status.vaultNames)).toEqual(new Set(["default", "work"]));
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("vault.yaml present but vault.db missing → count that vault as 0, keep going", () => {
+    const env = makeVaultHome();
+    try {
+      seedVault(env.path, "default", { withDb: false });
+      seedVault(env.path, "work", { withDb: true });
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        countTokens: (dbPath) => {
+          // Should only be called for the vault whose DB exists.
+          if (dbPath.includes("/default/")) throw new Error("should not open missing DB");
+          return 4;
+        },
+      });
+      expect(status.tokenCount).toBe(4);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("countTokens throws → tokenCount degrades to null (not partial)", () => {
+    const env = makeVaultHome();
+    try {
+      seedVault(env.path, "default", { withDb: true });
+      seedVault(env.path, "work", { withDb: true });
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        countTokens: (dbPath) => {
+          if (dbPath.includes("/work/")) throw new Error("locked");
+          return 2;
+        },
+      });
+      // Even though "default" succeeded with 2, we return null — callers
+      // shouldn't see a misleading partial count.
+      expect(status.tokenCount).toBeNull();
+    } finally {
+      env.cleanup();
+    }
+  });
+});

--- a/src/commands/expose-auth-preflight.ts
+++ b/src/commands/expose-auth-preflight.ts
@@ -1,0 +1,217 @@
+/**
+ * Post-exposure auth nudge. Runs after `parachute expose public` successfully
+ * brings a tunnel up (TTY only). The tunnel is already live; this is purely
+ * advisory — we never error the exposure flow regardless of what the user
+ * chooses. The goal is to catch the "fresh vault, just went public, no
+ * password or tokens set" trap before someone else finds it first.
+ *
+ * Four states we branch on, based on {@link VaultAuthStatus}:
+ *
+ *   - neither password nor tokens: loud warning + offer to set up each.
+ *   - password, no 2FA: shorter "recommend 2FA" nudge.
+ *   - tokens but no password: OAuth isn't set up; offer to add a password.
+ *   - `tokenCount === null`: couldn't read the DB; advisory only, no prompts
+ *     that depend on token state.
+ *   - all set: one-line "looks good" (the quiet path).
+ *
+ * Defaults are always "skip" — Enter declines every prompt. User can always
+ * run `parachute auth …` or `parachute vault tokens create` later.
+ */
+
+import { createInterface } from "node:readline/promises";
+import { type VaultAuthStatus, readVaultAuthStatus } from "../vault/auth-status.ts";
+
+/** `Bun.spawn(..., { stdio: "inherit" })` wrapper. Factored out so tests can
+ *  assert which commands got invoked without running them. */
+export type InteractiveRunner = (cmd: readonly string[]) => Promise<number>;
+
+const defaultInteractiveRunner: InteractiveRunner = async (cmd) => {
+  const proc = Bun.spawn([...cmd], { stdio: ["inherit", "inherit", "inherit"] });
+  return await proc.exited;
+};
+
+async function defaultPrompt(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return await rl.question(question);
+  } finally {
+    rl.close();
+  }
+}
+
+export interface AuthPreflightOpts {
+  /** Supply a pre-computed status to skip the on-disk read (tests). In
+   *  production, leave unset and we'll call {@link readVaultAuthStatus}. */
+  status?: VaultAuthStatus;
+  prompt?: (question: string) => Promise<string>;
+  interactiveRunner?: InteractiveRunner;
+  log?: (line: string) => void;
+  /** Forwarded to {@link readVaultAuthStatus} when `status` is not supplied. */
+  vaultHome?: string;
+}
+
+interface Resolved {
+  status: VaultAuthStatus;
+  prompt: (question: string) => Promise<string>;
+  interactiveRunner: InteractiveRunner;
+  log: (line: string) => void;
+}
+
+function resolve(opts: AuthPreflightOpts): Resolved {
+  return {
+    status: opts.status ?? readVaultAuthStatus({ vaultHome: opts.vaultHome }),
+    prompt: opts.prompt ?? defaultPrompt,
+    interactiveRunner: opts.interactiveRunner ?? defaultInteractiveRunner,
+    log: opts.log ?? ((line) => console.log(line)),
+  };
+}
+
+/**
+ * Prompt the user yes/no with Enter defaulting to "no" (skip). Returns true
+ * only on an affirmative answer. Anything else — blank, "n", garbage — is a
+ * decline; we don't reprompt, because the preflight is explicitly optional
+ * and the user has already done the hard part.
+ */
+async function yesNo(r: Resolved, question: string): Promise<boolean> {
+  const raw = (await r.prompt(`${question} [y/N] `)).trim().toLowerCase();
+  return raw === "y" || raw === "yes";
+}
+
+async function runCmd(r: Resolved, cmd: readonly string[], friendly: string): Promise<void> {
+  r.log("");
+  const code = await r.interactiveRunner(cmd);
+  if (code !== 0) {
+    // Don't blow up the preflight on a sub-command failure — the user can
+    // see the error, and the tunnel is still up. Just log a hint and move on.
+    r.log(
+      `(${friendly} exited ${code} — you can re-run \`${cmd.join(" ")}\` anytime. Continuing.)`,
+    );
+  }
+}
+
+async function offerOwnerPassword(r: Resolved): Promise<void> {
+  if (await yesNo(r, "Set the owner password now?")) {
+    await runCmd(r, ["parachute", "auth", "set-password"], "parachute auth set-password");
+  }
+}
+
+async function offerTotp(r: Resolved): Promise<void> {
+  if (await yesNo(r, "Enable TOTP 2FA now?")) {
+    await runCmd(r, ["parachute", "auth", "2fa", "enroll"], "parachute auth 2fa enroll");
+  }
+}
+
+async function offerTokenCreate(r: Resolved): Promise<void> {
+  if (await yesNo(r, "Create an API token now?")) {
+    await runCmd(r, ["parachute", "vault", "tokens", "create"], "parachute vault tokens create");
+  }
+}
+
+function printDivider(r: Resolved): void {
+  r.log("");
+  r.log("──────────────────────────────────────────────────────────────");
+}
+
+/**
+ * `neither password nor tokens`: the exposure is wide open — anyone who
+ * finds the URL can talk to the vault. The loudest warning we draw.
+ */
+async function handleWideOpen(r: Resolved): Promise<void> {
+  printDivider(r);
+  r.log("⚠  No owner password and no API tokens are configured.");
+  r.log("   The tunnel is reachable from the public internet RIGHT NOW.");
+  r.log("   Anyone with the URL can make requests until you set auth up.");
+  r.log("");
+  r.log("Recommended: set an owner password (enables the browser sign-in flow)");
+  r.log("and/or create an API token (for programmatic clients).");
+  r.log("");
+  await offerOwnerPassword(r);
+  // Offer 2FA regardless of the password step outcome: we can't observe it
+  // from outside the subprocess, and vault itself will reject a 2fa enroll
+  // if there's no password yet, surfacing the real error to the user.
+  await offerTotp(r);
+  await offerTokenCreate(r);
+  printDivider(r);
+}
+
+/**
+ * `password set, no 2FA`: the common case where the user did the obvious
+ * thing but hasn't opted into the stronger factor yet. Short nudge.
+ */
+async function handlePasswordNoTotp(r: Resolved): Promise<void> {
+  r.log("");
+  r.log("✓  Owner password is set.");
+  r.log("   Consider also enabling 2FA for defense-in-depth.");
+  await offerTotp(r);
+}
+
+/**
+ * `tokens exist, no password`: vault is authenticated for API clients but
+ * nobody can sign in through a browser — the hub's OAuth flow is dead in
+ * the water. Offer to fix.
+ */
+async function handleTokensNoPassword(r: Resolved): Promise<void> {
+  r.log("");
+  r.log("ℹ  API tokens exist, but no owner password is set.");
+  r.log("   Browser sign-in (OAuth) won't work until you add one.");
+  await offerOwnerPassword(r);
+}
+
+/**
+ * `tokenCount === null`: SQLite probe failed (DB missing, locked, schema
+ * drift, whatever). Don't guess; don't prompt on token state. Nudge 2FA
+ * if we know the password is set, otherwise stay quiet.
+ */
+async function handleUnknownTokens(r: Resolved): Promise<void> {
+  r.log("");
+  r.log("ℹ  Couldn't read vault token state (vault may be locked or offline).");
+  r.log("   Run `parachute vault tokens list` to check token config yourself.");
+  if (r.status.hasOwnerPassword && !r.status.hasTotp) {
+    r.log("");
+    r.log("   (While you're here: owner password is set, 2FA is not.)");
+    await offerTotp(r);
+  }
+}
+
+/**
+ * `all set`: password + 2FA + at least one token. Keep it tight.
+ */
+function handleAllGood(r: Resolved): void {
+  r.log("");
+  r.log("✓  Auth config looks good (password + 2FA + API tokens).");
+}
+
+/**
+ * Pick the branch. Pure function of the status — keeps test coverage trivial.
+ */
+function classify(
+  s: VaultAuthStatus,
+): "wide-open" | "password-no-totp" | "tokens-no-password" | "unknown-tokens" | "all-good" {
+  if (s.tokenCount === null) return "unknown-tokens";
+  const hasTokens = s.tokenCount > 0;
+  if (!s.hasOwnerPassword && !hasTokens) return "wide-open";
+  if (!s.hasOwnerPassword && hasTokens) return "tokens-no-password";
+  if (s.hasOwnerPassword && !s.hasTotp) return "password-no-totp";
+  return "all-good";
+}
+
+export async function runAuthPreflight(opts: AuthPreflightOpts = {}): Promise<void> {
+  const r = resolve(opts);
+  switch (classify(r.status)) {
+    case "wide-open":
+      await handleWideOpen(r);
+      return;
+    case "password-no-totp":
+      await handlePasswordNoTotp(r);
+      return;
+    case "tokens-no-password":
+      await handleTokensNoPassword(r);
+      return;
+    case "unknown-tokens":
+      await handleUnknownTokens(r);
+      return;
+    case "all-good":
+      handleAllGood(r);
+      return;
+  }
+}

--- a/src/commands/expose-interactive.ts
+++ b/src/commands/expose-interactive.ts
@@ -24,6 +24,7 @@ import {
 } from "../expose-last-provider.ts";
 import { getTailscaleStatus, isTailscaleInstalled } from "../tailscale/detect.ts";
 import { type Runner, defaultRunner } from "../tailscale/run.ts";
+import { type AuthPreflightOpts, runAuthPreflight } from "./expose-auth-preflight.ts";
 import {
   type ExposeCloudflareOpts,
   exposeCloudflareUp,
@@ -75,12 +76,20 @@ export interface ExposeInteractiveOpts {
    */
   preselect?: ExposeProvider;
   /**
+   * Options passed through to the post-exposure auth preflight. Set
+   * `authPreflight.status` in tests to bypass the real on-disk probe; leave
+   * unset in production. Only consulted when the handoff returns 0.
+   */
+  authPreflight?: AuthPreflightOpts;
+  /**
    * Test seams for the downstream entry points — lets us exercise the
    * interactive branches without standing up a full tailscale/cloudflared
    * stub stack. Production code never sets these.
    */
   exposePublicImpl?: (action: "up" | "off", opts: ExposeOpts) => Promise<number>;
   exposeCloudflareUpImpl?: (hostname: string, opts: ExposeCloudflareOpts) => Promise<number>;
+  /** Test seam for the preflight itself. Defaults to {@link runAuthPreflight}. */
+  runAuthPreflightImpl?: (opts: AuthPreflightOpts) => Promise<void>;
 }
 
 interface Resolved {
@@ -95,8 +104,10 @@ interface Resolved {
   exposeOpts: ExposeOpts;
   cloudflareOpts: ExposeCloudflareOpts;
   preselect: ExposeProvider | undefined;
+  authPreflight: AuthPreflightOpts;
   exposePublicImpl: (action: "up" | "off", opts: ExposeOpts) => Promise<number>;
   exposeCloudflareUpImpl: (hostname: string, opts: ExposeCloudflareOpts) => Promise<number>;
+  runAuthPreflightImpl: (opts: AuthPreflightOpts) => Promise<void>;
 }
 
 function resolve(opts: ExposeInteractiveOpts): Resolved {
@@ -112,8 +123,10 @@ function resolve(opts: ExposeInteractiveOpts): Resolved {
     exposeOpts: opts.exposeOpts ?? {},
     cloudflareOpts: opts.cloudflareOpts ?? {},
     preselect: opts.preselect,
+    authPreflight: opts.authPreflight ?? {},
     exposePublicImpl: opts.exposePublicImpl ?? exposePublic,
     exposeCloudflareUpImpl: opts.exposeCloudflareUpImpl ?? exposeCloudflareUp,
+    runAuthPreflightImpl: opts.runAuthPreflightImpl ?? runAuthPreflight,
   };
 }
 
@@ -380,7 +393,9 @@ export async function exposePublicInteractive(opts: ExposeInteractiveOpts = {}):
       return 1;
     }
     writeLastProvider("tailscale", { path: r.lastProviderPath, now: r.now });
-    return r.exposePublicImpl("up", r.exposeOpts);
+    const code = await r.exposePublicImpl("up", r.exposeOpts);
+    if (code === 0) await runPreflightSafely(r);
+    return code;
   }
 
   // Cloudflare path.
@@ -394,5 +409,20 @@ export async function exposePublicInteractive(opts: ExposeInteractiveOpts = {}):
     return 0;
   }
   writeLastProvider("cloudflare", { path: r.lastProviderPath, now: r.now });
-  return r.exposeCloudflareUpImpl(hostname, r.cloudflareOpts);
+  const code = await r.exposeCloudflareUpImpl(hostname, r.cloudflareOpts);
+  if (code === 0) await runPreflightSafely(r);
+  return code;
+}
+
+/**
+ * Catch anything the preflight throws and log it — the tunnel is already
+ * up, so an advisory module crashing must never swallow the user's success.
+ */
+async function runPreflightSafely(r: Resolved): Promise<void> {
+  try {
+    await r.runAuthPreflightImpl(r.authPreflight);
+  } catch (err) {
+    r.log("");
+    r.log(`(auth preflight check skipped: ${err instanceof Error ? err.message : String(err)})`);
+  }
 }

--- a/src/vault/auth-status.ts
+++ b/src/vault/auth-status.ts
@@ -1,0 +1,179 @@
+/**
+ * Read-only probe of vault's auth state, for the post-exposure preflight
+ * nudge. We don't want to lock the DB or mutate anything — this is a
+ * one-shot "should we warn the user their vault is wide open on the public
+ * internet?" check.
+ *
+ * Two sources:
+ *   1. ~/.parachute/vault/config.yaml   → owner_password_hash + totp_secret
+ *   2. ~/.parachute/vault/data/<name>/vault.db (SQLite) → tokens table count
+ *
+ * The YAML path uses line-anchored regex parsing that matches vault's own
+ * `readGlobalConfig()` semantics (parachute-vault src/config.ts): keys are
+ * optional, quoted scalars, and empty-string / missing-key both mean "not
+ * configured." We mirror that rather than bringing in a YAML dependency.
+ *
+ * The SQLite path is best-effort: if the DB is missing, locked (vault is
+ * writing), or the schema has drifted, `tokenCount` comes back as `null`
+ * and the caller surfaces "token status unknown" rather than lying with a
+ * false zero. The exposure flow has already succeeded by the time this
+ * runs — a probe failure must never block the user's happy path.
+ *
+ * Schema coupling note: we read the `tokens` table by name with a bare
+ * COUNT(*). If vault ever renames that table, that's a breaking change on
+ * vault's side and this probe is the least of the fallout. Post-launch,
+ * a public `/api/auth/status` endpoint on vault (tracked separately) would
+ * let us drop this coupling entirely.
+ */
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { configDir } from "../config.ts";
+
+export interface VaultAuthStatus {
+  hasOwnerPassword: boolean;
+  hasTotp: boolean;
+  /**
+   * `null` means we couldn't read the SQLite DB — distinct from "0 tokens
+   * exist." Callers branch the UI on this: `null` → "token status unknown,
+   * run `parachute vault tokens list` to check"; `0` → loud "no auth at
+   * all!" warning; `>0` → benign.
+   */
+  tokenCount: number | null;
+  /** Vault instance names discovered under data/. Empty when vault has
+   *  never been initialized (or the data dir is absent). */
+  vaultNames: string[];
+}
+
+export interface AuthStatusOpts {
+  /** Override `~/.parachute/vault` for tests. */
+  vaultHome?: string;
+  /** Read a YAML file; defaults to `readFileSync(path, "utf8")`. Missing
+   *  file should return `undefined` (not throw) so callers can distinguish
+   *  "no password configured" from "IO error." */
+  readText?: (path: string) => string | undefined;
+  /** List vault instance names. Defaults to `readdirSync(dataDir)` filtered
+   *  to entries that look like vaults (contain `vault.yaml`). */
+  listVaultNames?: (dataDir: string) => string[];
+  /** Open the given DB path and return `SELECT COUNT(*) FROM tokens`. Any
+   *  thrown error (missing, locked, schema drift) is caught by the caller
+   *  and mapped to `tokenCount: null`. */
+  countTokens?: (dbPath: string) => number;
+}
+
+interface Resolved {
+  vaultHome: string;
+  readText: (path: string) => string | undefined;
+  listVaultNames: (dataDir: string) => string[];
+  countTokens: (dbPath: string) => number;
+}
+
+function defaultVaultHome(): string {
+  // Mirrors vault's own resolution: honors $PARACHUTE_HOME via configDir(),
+  // then falls back to ~/.parachute. The `vault/` subdir is hard-coded on
+  // vault's side too (src/config.ts `vaultHomePath()`), so we match literally.
+  const root = configDir();
+  return root.length > 0 ? join(root, "vault") : join(homedir(), ".parachute", "vault");
+}
+
+function defaultReadText(path: string): string | undefined {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultListVaultNames(dataDir: string): string[] {
+  if (!existsSync(dataDir)) return [];
+  try {
+    return readdirSync(dataDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .filter((name) => existsSync(join(dataDir, name, "vault.yaml")));
+  } catch {
+    return [];
+  }
+}
+
+function defaultCountTokens(dbPath: string): number {
+  // Imported lazily so the module stays loadable in environments that stub
+  // `bun:sqlite` (our own tests inject a fake `countTokens` and never hit
+  // this path). `readonly: true` keeps us out of any write lock contention
+  // with a live vault process.
+  const { Database } = require("bun:sqlite");
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db.prepare("SELECT COUNT(*) AS n FROM tokens").get() as { n: number } | null;
+    return row?.n ?? 0;
+  } finally {
+    db.close();
+  }
+}
+
+function resolve(opts: AuthStatusOpts): Resolved {
+  return {
+    vaultHome: opts.vaultHome ?? defaultVaultHome(),
+    readText: opts.readText ?? defaultReadText,
+    listVaultNames: opts.listVaultNames ?? defaultListVaultNames,
+    countTokens: opts.countTokens ?? defaultCountTokens,
+  };
+}
+
+/**
+ * Mirrors vault's `readGlobalConfig()` regex on a single key, returning the
+ * captured quoted string when present and non-empty, otherwise `undefined`.
+ */
+function matchQuotedKey(yaml: string, key: string): string | undefined {
+  const re = new RegExp(`^${key}:\\s*"([^"]*)"`, "m");
+  const m = yaml.match(re);
+  if (!m) return undefined;
+  const captured = m[1];
+  if (captured === undefined || captured.length === 0) return undefined;
+  return captured;
+}
+
+function readGlobalAuth(r: Resolved): { hasOwnerPassword: boolean; hasTotp: boolean } {
+  const yaml = r.readText(join(r.vaultHome, "config.yaml"));
+  if (yaml === undefined) return { hasOwnerPassword: false, hasTotp: false };
+  return {
+    hasOwnerPassword: matchQuotedKey(yaml, "owner_password_hash") !== undefined,
+    hasTotp: matchQuotedKey(yaml, "totp_secret") !== undefined,
+  };
+}
+
+/**
+ * Sum token counts across every vault instance found under data/. If any
+ * probe throws (missing DB, locked, schema drift), the whole result
+ * degrades to `null` — partial counts would mislead the caller more than
+ * "unknown" does.
+ */
+function readTotalTokenCount(r: Resolved, vaultNames: string[]): number | null {
+  if (vaultNames.length === 0) return 0;
+  const dataDir = join(r.vaultHome, "data");
+  let total = 0;
+  for (const name of vaultNames) {
+    const dbPath = join(dataDir, name, "vault.db");
+    if (!existsSync(dbPath)) {
+      // Vault initialized the yaml but hasn't created the DB yet (fresh
+      // install). Count as zero for this vault; keep going.
+      continue;
+    }
+    try {
+      total += r.countTokens(dbPath);
+    } catch {
+      return null;
+    }
+  }
+  return total;
+}
+
+export function readVaultAuthStatus(opts: AuthStatusOpts = {}): VaultAuthStatus {
+  const r = resolve(opts);
+  const { hasOwnerPassword, hasTotp } = readGlobalAuth(r);
+  const dataDir = join(r.vaultHome, "data");
+  const vaultNames = r.listVaultNames(dataDir);
+  const tokenCount = readTotalTokenCount(r, vaultNames);
+  return { hasOwnerPassword, hasTotp, tokenCount, vaultNames };
+}


### PR DESCRIPTION
## Summary

Layer 2 of the `expose public` interactive refactor. After a successful exposure handoff (TTY only), probe vault auth state and nudge the user about anything missing — catches the "fresh vault just went public with no password or tokens" trap before someone else finds it first.

Five branches keyed off a pure `classify(status)`:

- **wide-open** (no password, no tokens): loud warning + offers password, 2FA, and token creation
- **password-no-totp**: short "consider 2FA" nudge
- **tokens-no-password**: "OAuth won't work until you add a password"
- **unknown-tokens** (SQLite probe failed): advisory only, no token-dependent prompts — avoids guessing between wide-open and tokens-only
- **all-good**: one-line confirmation

Prompts default to skip (Enter = decline). Subprocess failures log a hint but don't abort the preflight — tunnel is already up and the user can re-run any of the offered commands later.

## Design notes

- **File-read probe, not HTTP**: vault exposes no public status endpoints. Follow-up issue to file in parachute-vault for adding `/api/auth/status` so future versions can drop the config-file coupling.
- **Resilience**: any per-vault SQLite failure degrades `tokenCount` to `null` rather than returning a partial sum. A misleading partial count is worse than "unknown."
- **Invocation scope**: wired into `exposePublicInteractive` only. Path 3 (fully-flagged `--cloudflare --domain X`) is scripted and bypasses the preflight — that user chose the scripted path.
- **YAML parse** mirrors vault's own `readGlobalConfig` semantics: empty quoted strings count as absent.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 308 pass, 0 fail (21 new)
- [x] `bunx biome check --write .` — clean
- [ ] Manual smoke: run `expose public` against a fresh vault, verify wide-open warning + sequential offers
- [ ] Manual smoke: run against a password-set vault, verify only 2FA offered
- [ ] Manual smoke: run against a fully-configured vault, verify single-line "all good"

🤖 Generated with [Claude Code](https://claude.com/claude-code)