### PR TITLE
feat(vault): interactive `parachute vault tokens create` picker

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -153,6 +153,26 @@ describe("cli per-subcommand help", () => {
     expect(stderr).toMatch(/parachute-vault not found on PATH/);
     expect(stderr).toMatch(/parachute install vault/);
   });
+
+  test("vault tokens create in non-TTY passes through without prompting", async () => {
+    // Spawned-subprocess stdio is piped, so isTtyInteractive() returns false
+    // and the command falls through to the passthrough. Clearing PATH forces
+    // ENOENT — same probe as the `vault no-args` test. If we regressed into
+    // prompting, this subprocess would hang on stdin instead of exiting 127.
+    const proc = Bun.spawn([process.execPath, CLI, "vault", "tokens", "create"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        PATH: "",
+        HOME: "/tmp/parachute-cli-nonexistent-home",
+        PARACHUTE_HOME: "/tmp/parachute-cli-nonexistent-home",
+      },
+    });
+    const [stderr, code] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
+    expect(code).toBe(127);
+    expect(stderr).toMatch(/parachute-vault not found on PATH/);
+  });
 });
 
 describe("cli friendly errors", () => {

--- a/src/__tests__/vault-tokens-create-interactive.test.ts
+++ b/src/__tests__/vault-tokens-create-interactive.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "bun:test";
+import { runVaultTokensCreateInteractive } from "../commands/vault-tokens-create-interactive.ts";
+
+interface Harness {
+  logs: string[];
+  prompts: string[];
+  promptAnswers: string[];
+  commands: string[][];
+  exitCode: number;
+}
+
+function makeHarness(
+  answers: string[],
+  opts: { exitCode?: number } = {},
+): {
+  harness: Harness;
+  wire: {
+    log: (l: string) => void;
+    prompt: (q: string) => Promise<string>;
+    interactiveRunner: (cmd: readonly string[]) => Promise<number>;
+  };
+} {
+  const harness: Harness = {
+    logs: [],
+    prompts: [],
+    promptAnswers: [...answers],
+    commands: [],
+    exitCode: opts.exitCode ?? 0,
+  };
+  let i = 0;
+  return {
+    harness,
+    wire: {
+      log: (line) => harness.logs.push(line),
+      prompt: async (q) => {
+        harness.prompts.push(q);
+        const a = harness.promptAnswers[i++];
+        if (a === undefined) throw new Error(`prompt exhausted at: ${q}`);
+        return a;
+      },
+      interactiveRunner: async (cmd) => {
+        harness.commands.push([...cmd]);
+        return harness.exitCode;
+      },
+    },
+  };
+}
+
+describe("runVaultTokensCreateInteractive — scope picker", () => {
+  test("Enter defaults to read (safer choice)", async () => {
+    const { harness, wire } = makeHarness(["", ""]); // scope=default, label=skip
+    const code = await runVaultTokensCreateInteractive({ args: [], ...wire });
+    expect(code).toBe(0);
+    expect(harness.commands).toHaveLength(1);
+    const cmd = harness.commands[0]!;
+    expect(cmd).toEqual(["parachute-vault", "tokens", "create", "--read"]);
+  });
+
+  test("'1' also selects read", async () => {
+    const { harness, wire } = makeHarness(["1", ""]);
+    await runVaultTokensCreateInteractive({ args: [], ...wire });
+    expect(harness.commands[0]).toContain("--read");
+  });
+
+  test("'2' selects write (vault:write scope)", async () => {
+    const { harness, wire } = makeHarness(["2", ""]);
+    await runVaultTokensCreateInteractive({ args: [], ...wire });
+    const cmd = harness.commands[0]!;
+    expect(cmd).toEqual(["parachute-vault", "tokens", "create", "--scope", "vault:write"]);
+  });
+
+  test("'3' selects admin (vault:admin scope)", async () => {
+    const { harness, wire } = makeHarness(["3", ""]);
+    await runVaultTokensCreateInteractive({ args: [], ...wire });
+    const cmd = harness.commands[0]!;
+    expect(cmd).toEqual(["parachute-vault", "tokens", "create", "--scope", "vault:admin"]);
+  });
+
+  test("'4' cancels with exit 0 and no subprocess", async () => {
+    const { harness, wire } = makeHarness(["4"]);
+    const code = await runVaultTokensCreateInteractive({ args: [], ...wire });
+    expect(code).toBe(0);
+    expect(harness.commands).toHaveLength(0);
+    expect(harness.logs.join("\n")).toContain("Cancelled");
+  });
+
+  test("'q' also cancels", async () => {
+    const { harness, wire } = makeHarness(["q"]);
+    const code = await runVaultTokensCreateInteractive({ args: [], ...wire });
+    expect(code).toBe(0);
+    expect(harness.commands).toHaveLength(0);
+  });
+
+  test("word aliases accepted case-insensitively", async () => {
+    for (const [answer, expected] of [
+      ["READ", "--read"],
+      ["Write", "vault:write"],
+      ["admin", "vault:admin"],
+    ] as const) {
+      const { harness, wire } = makeHarness([answer, ""]);
+      await runVaultTokensCreateInteractive({ args: [], ...wire });
+      expect(harness.commands[0]!.join(" ")).toContain(expected);
+    }
+  });
+
+  test("garbage input reprompts, keeping the scope picker tight", async () => {
+    const { harness, wire } = makeHarness(["bogus", "5", "2", ""]);
+    await runVaultTokensCreateInteractive({ args: [], ...wire });
+    expect(harness.commands).toHaveLength(1);
+    expect(harness.commands[0]).toContain("vault:write");
+    // Three scope prompts were asked (bogus, 5, then the valid 2); one label.
+    expect(harness.prompts.filter((p) => p.startsWith("Choice"))).toHaveLength(3);
+  });
+});
+
+describe("runVaultTokensCreateInteractive — label prompt", () => {
+  test("blank label = no --label flag forwarded", async () => {
+    const { harness, wire } = makeHarness(["1", ""]);
+    await runVaultTokensCreateInteractive({ args: [], ...wire });
+    expect(harness.commands[0]!.includes("--label")).toBe(false);
+  });
+
+  test("non-blank label is appended verbatim", async () => {
+    const { harness, wire } = makeHarness(["1", "n8n-sync"]);
+    await runVaultTokensCreateInteractive({ args: [], ...wire });
+    const cmd = harness.commands[0]!;
+    expect(cmd).toContain("--label");
+    expect(cmd[cmd.indexOf("--label") + 1]).toBe("n8n-sync");
+  });
+
+  test("label with spaces is passed as a single arg (not re-split)", async () => {
+    const { harness, wire } = makeHarness(["1", "pendant prototype"]);
+    await runVaultTokensCreateInteractive({ args: [], ...wire });
+    const cmd = harness.commands[0]!;
+    expect(cmd[cmd.indexOf("--label") + 1]).toBe("pendant prototype");
+  });
+
+  test("pre-supplied --label skips the label prompt entirely", async () => {
+    const { harness, wire } = makeHarness(["1"]); // ONLY the scope prompt
+    await runVaultTokensCreateInteractive({
+      args: ["--label", "existing"],
+      ...wire,
+    });
+    // Prompts only include the scope picker, not a label prompt.
+    expect(harness.prompts.some((p) => p.toLowerCase().includes("label"))).toBe(false);
+    // The user-supplied --label stays in place; we didn't double-append.
+    const cmd = harness.commands[0]!;
+    const labelIdxs: number[] = [];
+    cmd.forEach((a, idx) => {
+      if (a === "--label") labelIdxs.push(idx);
+    });
+    expect(labelIdxs).toHaveLength(1);
+    expect(cmd[labelIdxs[0]! + 1]).toBe("existing");
+  });
+});
+
+describe("runVaultTokensCreateInteractive — passthrough of pre-supplied args", () => {
+  test("--vault / --expires forwarded verbatim, scope appended", async () => {
+    const { harness, wire } = makeHarness(["1", ""]);
+    await runVaultTokensCreateInteractive({
+      args: ["--vault", "work", "--expires", "30d"],
+      ...wire,
+    });
+    const cmd = harness.commands[0]!;
+    // Original argv stays in order, scope flag appended after.
+    expect(cmd).toEqual([
+      "parachute-vault",
+      "tokens",
+      "create",
+      "--vault",
+      "work",
+      "--expires",
+      "30d",
+      "--read",
+    ]);
+  });
+
+  test("subprocess exit code is returned to the caller", async () => {
+    const { wire } = makeHarness(["1", ""], { exitCode: 5 });
+    const code = await runVaultTokensCreateInteractive({ args: [], ...wire });
+    expect(code).toBe(5);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -357,11 +357,34 @@ async function main(argv: string[]): Promise<number> {
     case "auth":
       return await auth(rest);
 
-    case "vault":
+    case "vault": {
       // `parachute vault` with no args forwards --help to parachute-vault so
       // users see the actual vault surface, not a CLI-side stub. Anything
       // after `vault` (including --help) is passed through verbatim.
-      return await dispatchVault(rest.length === 0 ? ["--help"] : rest);
+      if (rest.length === 0) return await dispatchVault(["--help"]);
+
+      // `parachute vault tokens create` in a TTY with no scope-narrowing flag
+      // → guided flow. Any of --scope / --read / --permission means the user
+      // has already decided, so we stay out of the way. Non-TTY always
+      // bypasses (no way to answer a prompt). Label is orthogonal — the
+      // guided flow prompts for it only if --label wasn't supplied.
+      const wantsGuidedTokenCreate =
+        rest[0] === "tokens" &&
+        rest[1] === "create" &&
+        isTtyInteractive() &&
+        !rest.includes("--scope") &&
+        !rest.includes("--read") &&
+        !rest.includes("--permission") &&
+        !isHelpFlag(rest[2]);
+      if (wantsGuidedTokenCreate) {
+        const { runVaultTokensCreateInteractive } = await import(
+          "./commands/vault-tokens-create-interactive.ts"
+        );
+        return await runVaultTokensCreateInteractive({ args: rest.slice(2) });
+      }
+
+      return await dispatchVault(rest);
+    }
 
     default:
       console.error(`parachute: unknown command "${command}"`);

--- a/src/commands/vault-tokens-create-interactive.ts
+++ b/src/commands/vault-tokens-create-interactive.ts
@@ -1,0 +1,137 @@
+/**
+ * `parachute vault tokens create` (no narrowing flags, in a TTY) — guided
+ * token creation. Same command with any of `--scope` / `--read` /
+ * `--permission`, or running under a non-TTY, bypasses this module and passes
+ * through to `parachute-vault tokens create` unchanged.
+ *
+ * Two prompts:
+ *
+ *   1. Scope — read / write / admin / cancel. Default is `read` on Enter:
+ *      the two-factor reasoning is (a) a read-only token is the least
+ *      dangerous thing to mint by mistake, and (b) most callers of this
+ *      command interactively are plumbing in a new read-only consumer
+ *      (hooks, dashboards, n8n triggers). Users who actually want admin can
+ *      type "3" in ~1 second.
+ *
+ *   2. Label — free-form string, blank skips the prompt entirely (vault's
+ *      own `--label` default of "default" then applies). Skipped outright
+ *      if the user already supplied `--label …` on the command line.
+ *
+ * The resolved flags are appended to the original argv and forwarded to
+ * `parachute-vault tokens create` via an inherit-stdio subprocess so the
+ * generated token and its usage block print directly to the user's terminal.
+ *
+ * Shape mirrors `expose-interactive.ts`: every side-effectful edge is an
+ * injectable seam so the full prompt tree is testable without spawning.
+ */
+
+import { createInterface } from "node:readline/promises";
+
+export type InteractiveRunner = (cmd: readonly string[]) => Promise<number>;
+
+const defaultInteractiveRunner: InteractiveRunner = async (cmd) => {
+  const proc = Bun.spawn([...cmd], { stdio: ["inherit", "inherit", "inherit"] });
+  return await proc.exited;
+};
+
+async function defaultPrompt(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return await rl.question(question);
+  } finally {
+    rl.close();
+  }
+}
+
+export interface VaultTokensCreateInteractiveOpts {
+  /**
+   * Original argv after `vault tokens create`. Flags the user already
+   * supplied (`--vault <name>`, `--expires <dur>`, `--label <x>`) are
+   * forwarded verbatim to `parachute-vault`; only the scope dimension is
+   * resolved interactively.
+   */
+  args: readonly string[];
+  prompt?: (question: string) => Promise<string>;
+  interactiveRunner?: InteractiveRunner;
+  log?: (line: string) => void;
+}
+
+interface Resolved {
+  args: readonly string[];
+  prompt: (question: string) => Promise<string>;
+  interactiveRunner: InteractiveRunner;
+  log: (line: string) => void;
+}
+
+function resolve(opts: VaultTokensCreateInteractiveOpts): Resolved {
+  return {
+    args: opts.args,
+    prompt: opts.prompt ?? defaultPrompt,
+    interactiveRunner: opts.interactiveRunner ?? defaultInteractiveRunner,
+    log: opts.log ?? ((line) => console.log(line)),
+  };
+}
+
+type ScopeChoice = "read" | "write" | "admin" | "cancel";
+
+async function promptScope(r: Resolved): Promise<ScopeChoice> {
+  r.log("Scope for this token?");
+  r.log("  [1] read   — query-only (safer default)");
+  r.log("  [2] write  — read + create/update");
+  r.log("  [3] admin  — full access (token + config management)");
+  r.log("  [4] cancel");
+  while (true) {
+    const raw = (await r.prompt("Choice [1]: ")).trim().toLowerCase();
+    if (raw === "" || raw === "1" || raw === "read") return "read";
+    if (raw === "2" || raw === "write") return "write";
+    if (raw === "3" || raw === "admin") return "admin";
+    if (raw === "4" || raw === "cancel" || raw === "q") return "cancel";
+    r.log(`(didn't understand "${raw}" — please pick 1, 2, 3, or 4)`);
+  }
+}
+
+async function promptLabel(r: Resolved): Promise<string | undefined> {
+  r.log("");
+  const raw = (await r.prompt('Label for this token (e.g. "n8n-sync", blank to skip): ')).trim();
+  return raw === "" ? undefined : raw;
+}
+
+/**
+ * Map the scope choice to the CLI flag sequence vault expects. We pass the
+ * canonical form for each level so anyone inspecting the spawned argv can
+ * see exactly what got minted — `--read` reads clearer than `--scope
+ * vault:read` for the common case, and `vault:write`/`vault:admin` are the
+ * canonical OAuth-style scope names for the other two.
+ */
+function scopeFlagsFor(choice: "read" | "write" | "admin"): string[] {
+  if (choice === "read") return ["--read"];
+  if (choice === "write") return ["--scope", "vault:write"];
+  return ["--scope", "vault:admin"];
+}
+
+export async function runVaultTokensCreateInteractive(
+  opts: VaultTokensCreateInteractiveOpts,
+): Promise<number> {
+  const r = resolve(opts);
+
+  const scope = await promptScope(r);
+  if (scope === "cancel") {
+    r.log("Cancelled — no token created.");
+    return 0;
+  }
+
+  const hasLabelFlag = r.args.includes("--label");
+  const label = hasLabelFlag ? undefined : await promptLabel(r);
+
+  const forwarded: string[] = [
+    "parachute-vault",
+    "tokens",
+    "create",
+    ...r.args,
+    ...scopeFlagsFor(scope),
+  ];
+  if (label !== undefined) forwarded.push("--label", label);
+
+  r.log("");
+  return await r.interactiveRunner(forwarded);
+}


### PR DESCRIPTION
## Summary

Layer 3 of the expose/auth interactive refactor. When `parachute vault tokens create` runs in a TTY with no scope-narrowing flag, prompt for scope and label inline before handing off to `parachute-vault`. The scripted path (any `--scope`/`--read`/`--permission` present, or non-TTY stdin) is unchanged.

### Prompts

1. **Scope** — `[1] read / [2] write / [3] admin / [4] cancel`. Default on Enter is `read` (safer). Accepts 1/2/3/4, words (`read`/`write`/`admin`/`cancel`), and `q` for cancel. Case-insensitive.
2. **Label** — free-form, blank skips entirely (vault's own `--label` default of `default` applies). Skipped outright if the user already supplied `--label …` on the command line, so we never double-label.

Resolved flags are appended to the original argv and handed to `parachute-vault tokens create` via inherit-stdio, so the generated token and its usage block print directly to the user's terminal.

### Design notes

- **Scope → canonical flag mapping**: `read → --read`, `write → --scope vault:write`, `admin → --scope vault:admin`. Picked the form that reads cleanest in spawned-argv logs for each level.
- **No schema change needed in vault**: the `tokens` table already has a first-class `label` column with default `"default"`.
- **Same DI seam pattern as Layers 1/2**: `prompt`, `interactiveRunner`, `log` all injectable. 14 unit tests cover the full prompt tree without spawning anything.
- **Non-TTY smoke test**: added to `cli.test.ts` to guarantee the spawned-subprocess passthrough path stays flag-driven (never hangs on stdin).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 323 pass, 0 fail (15 new)
- [x] `bunx biome check --write .` — clean
- [ ] Manual smoke: `parachute vault tokens create` → scope picker defaults to read
- [ ] Manual smoke: select write, custom label → token created with `vault:write` scope and label
- [ ] Manual smoke: `parachute vault tokens create --read` → bypasses interactive (scripted path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)