### PR TITLE
feat(expose): auto-detect provider for `expose public off`

### DIFF
--- a/src/__tests__/expose-off-auto.test.ts
+++ b/src/__tests__/expose-off-auto.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, test } from "bun:test";
+import type { CloudflaredState } from "../cloudflare/state.ts";
+import {
+  type ExposePublicOffAutoOpts,
+  runExposePublicOffAutoDetect,
+} from "../commands/expose-off-auto.ts";
+import type { ExposeState } from "../expose-state.ts";
+
+function tailscaleState(overrides: Partial<ExposeState> = {}): ExposeState {
+  return {
+    version: 1,
+    layer: "public",
+    mode: "path",
+    canonicalFqdn: "box.tail-scale.ts.net",
+    port: 8080,
+    funnel: true,
+    entries: [
+      {
+        kind: "proxy",
+        mount: "/vault/default",
+        target: "http://127.0.0.1:8080",
+        service: "parachute-vault",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function cloudflaredState(overrides: Partial<CloudflaredState> = {}): CloudflaredState {
+  return {
+    version: 1,
+    pid: 4242,
+    tunnelUuid: "11111111-2222-3333-4444-555555555555",
+    tunnelName: "vault-tunnel",
+    hostname: "vault.example.com",
+    startedAt: "2026-04-23T10:00:00.000Z",
+    configPath: "/tmp/config.yml",
+    ...overrides,
+  };
+}
+
+interface Harness {
+  logs: string[];
+  prompts: string[];
+  tailscaleCalls: number;
+  cloudflareCalls: number;
+}
+
+function makeHarness(
+  input: {
+    tsState?: ExposeState;
+    cfState?: CloudflaredState;
+    promptAnswers?: string[];
+    isTty?: boolean;
+    tsExitCode?: number;
+    cfExitCode?: number;
+  } = {},
+): {
+  harness: Harness;
+  opts: ExposePublicOffAutoOpts;
+} {
+  const harness: Harness = {
+    logs: [],
+    prompts: [],
+    tailscaleCalls: 0,
+    cloudflareCalls: 0,
+  };
+  const answers = [...(input.promptAnswers ?? [])];
+  let i = 0;
+  const opts: ExposePublicOffAutoOpts = {
+    log: (l) => harness.logs.push(l),
+    isTty: input.isTty ?? true,
+    readTailscaleState: () => input.tsState,
+    readCloudflaredState: () => input.cfState,
+    prompt: async (q) => {
+      harness.prompts.push(q);
+      const a = answers[i++];
+      if (a === undefined) throw new Error(`prompt exhausted at: ${q}`);
+      return a;
+    },
+    exposePublicImpl: async (_action) => {
+      harness.tailscaleCalls++;
+      return input.tsExitCode ?? 0;
+    },
+    exposeCloudflareOffImpl: async () => {
+      harness.cloudflareCalls++;
+      return input.cfExitCode ?? 0;
+    },
+  };
+  return { harness, opts };
+}
+
+describe("runExposePublicOffAutoDetect — neither live", () => {
+  test("quiet no-op, exit 0, no teardown called", async () => {
+    const { harness, opts } = makeHarness();
+    const code = await runExposePublicOffAutoDetect(opts);
+    expect(code).toBe(0);
+    expect(harness.tailscaleCalls).toBe(0);
+    expect(harness.cloudflareCalls).toBe(0);
+    expect(harness.prompts).toHaveLength(0);
+    expect(harness.logs).toEqual(["No public exposure active. Nothing to tear down."]);
+  });
+
+  test("tailnet-layer state is NOT counted as public", async () => {
+    // A tailnet exposure has layer==="tailnet" and funnel===false. The auto
+    // path is scoped to public. State files co-exist; we must not tear down a
+    // tailnet exposure when the user typed `expose public off`.
+    const tsState = tailscaleState({ layer: "tailnet", funnel: false });
+    const { harness, opts } = makeHarness({ tsState });
+    const code = await runExposePublicOffAutoDetect(opts);
+    expect(code).toBe(0);
+    expect(harness.tailscaleCalls).toBe(0);
+    expect(harness.logs).toEqual(["No public exposure active. Nothing to tear down."]);
+  });
+
+  test("public state with no entries is not counted as live", async () => {
+    const tsState = tailscaleState({ entries: [] });
+    const { harness, opts } = makeHarness({ tsState });
+    const code = await runExposePublicOffAutoDetect(opts);
+    expect(code).toBe(0);
+    expect(harness.tailscaleCalls).toBe(0);
+  });
+});
+
+describe("runExposePublicOffAutoDetect — exactly one live", () => {
+  test("tailscale-only → tears down tailscale, prints summary", async () => {
+    const { harness, opts } = makeHarness({ tsState: tailscaleState() });
+    const code = await runExposePublicOffAutoDetect(opts);
+    expect(code).toBe(0);
+    expect(harness.tailscaleCalls).toBe(1);
+    expect(harness.cloudflareCalls).toBe(0);
+    expect(harness.logs).toContain(
+      "✓ Tore down Tailscale Funnel (was: https://box.tail-scale.ts.net)",
+    );
+  });
+
+  test("cloudflare-only → tears down cloudflare, prints summary", async () => {
+    const { harness, opts } = makeHarness({ cfState: cloudflaredState() });
+    const code = await runExposePublicOffAutoDetect(opts);
+    expect(code).toBe(0);
+    expect(harness.tailscaleCalls).toBe(0);
+    expect(harness.cloudflareCalls).toBe(1);
+    expect(harness.logs).toContain(
+      "✓ Tore down Cloudflare Tunnel (was: https://vault.example.com)",
+    );
+  });
+
+  test("teardown failure propagates exit code and suppresses summary line", async () => {
+    const { harness, opts } = makeHarness({ tsState: tailscaleState(), tsExitCode: 2 });
+    const code = await runExposePublicOffAutoDetect(opts);
+    expect(code).toBe(2);
+    expect(harness.tailscaleCalls).toBe(1);
+    // Summary line printed only on success — the inner teardown already
+    // explained what went wrong.
+    expect(harness.logs.some((l) => l.startsWith("✓ Tore down"))).toBe(false);
+  });
+});
+
+describe("runExposePublicOffAutoDetect — both live (TTY prompt)", () => {
+  test("Enter defaults to 'both' — tears down tailscale then cloudflare", async () => {
+    const { harness, opts } = makeHarness({
+      tsState: tailscaleState(),
+      cfState: cloudflaredState(),
+      promptAnswers: [""],
+      isTty: true,
+    });
+    const code = await runExposePublicOffAutoDetect(opts);
+    expect(code).toBe(0);
+    expect(harness.tailscaleCalls).toBe(1);
+    expect(harness.cloudflareCalls).toBe(1);
+    expect(harness.prompts).toHaveLength(1);
+  });
+
+  test("'1' tears down tailscale only", async () => {
+    const { harness, opts } = makeHarness({
+      tsState: tailscaleState(),
+      cfState: cloudflaredState(),
+      promptAnswers: ["1"],
+      isTty: true,
+    });
+    const code = await runExposePublicOffAutoDetect(opts);
+    expect(code).toBe(0);
+    expect(harness.tailscaleCalls).toBe(1);
+    expect(harness.cloudflareCalls).toBe(0);
+  });
+
+  test("'2' tears down cloudflare only", async () => {
+    const { harness, opts } = makeHarness({
+      tsState: tailscaleState(),
+      cfState: cloudflaredState(),
+      promptAnswers: ["2"],
+      isTty: true,
+    });
+    const code = await runExposePublicOffAutoDetect(opts);
+    expect(code).toBe(0);
+    expect(harness.tailscaleCalls).toBe(0);
+    expect(harness.cloudflareCalls).toBe(1);
+  });
+
+  test("'3' explicitly selects both", async () => {
+    const { harness, opts } = makeHarness({
+      tsState: tailscaleState(),
+      cfState: cloudflaredState(),
+      promptAnswers: ["3"],
+      isTty: true,
+    });
+    await runExposePublicOffAutoDetect(opts);
+    expect(harness.tailscaleCalls).toBe(1);
+    expect(harness.cloudflareCalls).toBe(1);
+  });
+
+  test("'4' cancels — exit 0, no teardown", async () => {
+    const { harness, opts } = makeHarness({
+      tsState: tailscaleState(),
+      cfState: cloudflaredState(),
+      promptAnswers: ["4"],
+      isTty: true,
+    });
+    const code = await runExposePublicOffAutoDetect(opts);
+    expect(code).toBe(0);
+    expect(harness.tailscaleCalls).toBe(0);
+    expect(harness.cloudflareCalls).toBe(0);
+    expect(harness.logs).toContain("Cancelled — no teardown.");
+  });
+
+  test("unknown input re-prompts", async () => {
+    const { harness, opts } = makeHarness({
+      tsState: tailscaleState(),
+      cfState: cloudflaredState(),
+      promptAnswers: ["huh?", "1"],
+      isTty: true,
+    });
+    const code = await runExposePublicOffAutoDetect(opts);
+    expect(code).toBe(0);
+    expect(harness.prompts).toHaveLength(2);
+    expect(harness.tailscaleCalls).toBe(1);
+    expect(harness.cloudflareCalls).toBe(0);
+  });
+
+  test("both-teardown: failure from tailscale propagates, cloudflare still runs", async () => {
+    const { harness, opts } = makeHarness({
+      tsState: tailscaleState(),
+      cfState: cloudflaredState(),
+      promptAnswers: ["3"],
+      isTty: true,
+      tsExitCode: 2,
+    });
+    const code = await runExposePublicOffAutoDetect(opts);
+    expect(code).toBe(2);
+    expect(harness.tailscaleCalls).toBe(1);
+    expect(harness.cloudflareCalls).toBe(1);
+  });
+});
+
+describe("runExposePublicOffAutoDetect — both live (non-TTY)", () => {
+  test("tears down both without prompting", async () => {
+    const { harness, opts } = makeHarness({
+      tsState: tailscaleState(),
+      cfState: cloudflaredState(),
+      isTty: false,
+    });
+    const code = await runExposePublicOffAutoDetect(opts);
+    expect(code).toBe(0);
+    expect(harness.prompts).toHaveLength(0);
+    expect(harness.tailscaleCalls).toBe(1);
+    expect(harness.cloudflareCalls).toBe(1);
+    expect(harness.logs).toContain("(non-TTY: tearing down both.)");
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -288,6 +288,15 @@ async function main(argv: string[]): Promise<number> {
         return await exposePublicInteractive({ exposeOpts });
       }
 
+      // `expose public off` (no `--cloudflare`) auto-detects which provider is
+      // live. The explicit `--cloudflare` off branch above still wins — this
+      // path is only for users who typed plain `off` and don't want to
+      // remember which provider they brought up last.
+      if (layer === "public" && action === "off") {
+        const { runExposePublicOffAutoDetect } = await import("./commands/expose-off-auto.ts");
+        return await runExposePublicOffAutoDetect({ tailscaleOffOpts: exposeOpts });
+      }
+
       return layer === "public"
         ? await exposePublic(action, exposeOpts)
         : await exposeTailnet(action, exposeOpts);

--- a/src/commands/expose-off-auto.ts
+++ b/src/commands/expose-off-auto.ts
@@ -1,0 +1,199 @@
+/**
+ * `parachute expose public off` (no `--cloudflare`) — auto-detect which
+ * provider is live and tear that one down. Layer 4 of the interactive arc.
+ *
+ * The CLI now has two teardown paths under `expose public off`:
+ *   - Tailscale Funnel — state in expose-state.json, torn down by exposeOff.
+ *   - Cloudflare Tunnel — state in cloudflared-state.json, torn down by
+ *     exposeCloudflareOff.
+ *
+ * Users shouldn't need to remember which provider they brought up last just
+ * to turn it off. This wrapper reads both state files and routes:
+ *
+ *   - Neither live  → quiet no-op, exit 0.
+ *   - Exactly one   → tear it down, print a single-line summary.
+ *   - Both live     → prompt (TTY) for which to tear down, or `both`;
+ *                     non-TTY tears down both (off means off).
+ *
+ * `--cloudflare` still works as an explicit override and skips this module
+ * entirely (see cli.ts). Shape mirrors the other Layer-N modules — every
+ * side-effectful edge is an injectable seam so the full decision tree is
+ * testable without touching real state files or spawning teardown.
+ */
+
+import { createInterface } from "node:readline/promises";
+import {
+  CLOUDFLARED_STATE_PATH,
+  type CloudflaredState,
+  readCloudflaredState,
+} from "../cloudflare/state.ts";
+import { EXPOSE_STATE_PATH, type ExposeState, readExposeState } from "../expose-state.ts";
+import {
+  type ExposeCloudflareOpts,
+  exposeCloudflareOff as defaultExposeCloudflareOff,
+} from "./expose-cloudflare.ts";
+import { type ExposeOpts, exposePublic as defaultExposePublic } from "./expose.ts";
+
+async function defaultPrompt(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return await rl.question(question);
+  } finally {
+    rl.close();
+  }
+}
+
+export interface ExposePublicOffAutoOpts {
+  /**
+   * Forwarded to the tailscale teardown (`exposePublic("off", …)`). Tests use
+   * this to inject a fake runner / log sink / statePath.
+   */
+  tailscaleOffOpts?: ExposeOpts;
+  /**
+   * Forwarded to the cloudflare teardown. Tests use it the same way.
+   */
+  cloudflareOffOpts?: ExposeCloudflareOpts;
+
+  prompt?: (question: string) => Promise<string>;
+  log?: (line: string) => void;
+  isTty?: boolean;
+
+  readTailscaleState?: (path?: string) => ExposeState | undefined;
+  readCloudflaredState?: (path?: string) => CloudflaredState | undefined;
+  exposePublicImpl?: (action: "off", opts: ExposeOpts) => Promise<number>;
+  exposeCloudflareOffImpl?: (opts: ExposeCloudflareOpts) => Promise<number>;
+}
+
+interface Resolved {
+  tailscaleOffOpts: ExposeOpts;
+  cloudflareOffOpts: ExposeCloudflareOpts;
+  prompt: (question: string) => Promise<string>;
+  log: (line: string) => void;
+  isTty: boolean;
+  readTailscaleState: (path?: string) => ExposeState | undefined;
+  readCloudflaredState: (path?: string) => CloudflaredState | undefined;
+  exposePublicImpl: (action: "off", opts: ExposeOpts) => Promise<number>;
+  exposeCloudflareOffImpl: (opts: ExposeCloudflareOpts) => Promise<number>;
+}
+
+function resolve(opts: ExposePublicOffAutoOpts): Resolved {
+  return {
+    tailscaleOffOpts: opts.tailscaleOffOpts ?? {},
+    cloudflareOffOpts: opts.cloudflareOffOpts ?? {},
+    prompt: opts.prompt ?? defaultPrompt,
+    log: opts.log ?? ((line) => console.log(line)),
+    isTty: opts.isTty ?? Boolean(process.stdin.isTTY && process.stdout.isTTY),
+    readTailscaleState: opts.readTailscaleState ?? readExposeState,
+    readCloudflaredState: opts.readCloudflaredState ?? readCloudflaredState,
+    exposePublicImpl: opts.exposePublicImpl ?? defaultExposePublic,
+    exposeCloudflareOffImpl: opts.exposeCloudflareOffImpl ?? defaultExposeCloudflareOff,
+  };
+}
+
+function tailscalePublicIsLive(state: ExposeState | undefined): state is ExposeState {
+  return !!state && state.layer === "public" && state.funnel === true && state.entries.length > 0;
+}
+
+function cloudflareIsLive(state: CloudflaredState | undefined): state is CloudflaredState {
+  return !!state;
+}
+
+function tailscaleUrl(state: ExposeState): string {
+  return `https://${state.canonicalFqdn}`;
+}
+
+function cloudflareUrl(state: CloudflaredState): string {
+  return `https://${state.hostname}`;
+}
+
+type BothChoice = "tailscale" | "cloudflare" | "both" | "cancel";
+
+async function promptBothLive(
+  r: Resolved,
+  tsState: ExposeState,
+  cfState: CloudflaredState,
+): Promise<BothChoice> {
+  r.log("Two public exposures are currently live:");
+  r.log(`  [1] Tailscale Funnel  — ${tailscaleUrl(tsState)}`);
+  r.log(`  [2] Cloudflare Tunnel — ${cloudflareUrl(cfState)}`);
+  r.log("  [3] both");
+  r.log("  [4] cancel");
+  while (true) {
+    const raw = (await r.prompt("Tear down which? [3]: ")).trim().toLowerCase();
+    if (raw === "" || raw === "3" || raw === "both") return "both";
+    if (raw === "1" || raw === "tailscale" || raw === "ts" || raw === "funnel") return "tailscale";
+    if (raw === "2" || raw === "cloudflare" || raw === "cf") return "cloudflare";
+    if (raw === "4" || raw === "cancel" || raw === "q") return "cancel";
+    r.log(`(didn't understand "${raw}" — please pick 1, 2, 3, or 4)`);
+  }
+}
+
+async function tearDownTailscale(r: Resolved, state: ExposeState): Promise<number> {
+  const url = tailscaleUrl(state);
+  const code = await r.exposePublicImpl("off", r.tailscaleOffOpts);
+  if (code === 0) r.log(`✓ Tore down Tailscale Funnel (was: ${url})`);
+  return code;
+}
+
+async function tearDownCloudflare(r: Resolved, state: CloudflaredState): Promise<number> {
+  const url = cloudflareUrl(state);
+  const code = await r.exposeCloudflareOffImpl(r.cloudflareOffOpts);
+  if (code === 0) r.log(`✓ Tore down Cloudflare Tunnel (was: ${url})`);
+  return code;
+}
+
+export async function runExposePublicOffAutoDetect(
+  opts: ExposePublicOffAutoOpts = {},
+): Promise<number> {
+  const r = resolve(opts);
+
+  const tsStatePath = r.tailscaleOffOpts.statePath ?? EXPOSE_STATE_PATH;
+  const cfStatePath = r.cloudflareOffOpts.statePath ?? CLOUDFLARED_STATE_PATH;
+  const tsState = r.readTailscaleState(tsStatePath);
+  const cfState = r.readCloudflaredState(cfStatePath);
+
+  const tsLive = tailscalePublicIsLive(tsState);
+  const cfLive = cloudflareIsLive(cfState);
+
+  if (!tsLive && !cfLive) {
+    r.log("No public exposure active. Nothing to tear down.");
+    return 0;
+  }
+
+  if (tsLive && !cfLive) {
+    return await tearDownTailscale(r, tsState);
+  }
+
+  if (!tsLive && cfLive) {
+    return await tearDownCloudflare(r, cfState);
+  }
+
+  // Both live. Unusual (typical flow brings one up at a time) but possible
+  // when a prior bring-up raced or a teardown was skipped. Off means off, so
+  // the non-TTY default is to clear both rather than refuse.
+  const choice: BothChoice = r.isTty
+    ? await promptBothLive(r, tsState as ExposeState, cfState as CloudflaredState)
+    : "both";
+
+  if (!r.isTty) {
+    r.log("Two public exposures are live (Tailscale Funnel + Cloudflare Tunnel).");
+    r.log("(non-TTY: tearing down both.)");
+  }
+
+  if (choice === "cancel") {
+    r.log("Cancelled — no teardown.");
+    return 0;
+  }
+
+  if (choice === "tailscale") {
+    return await tearDownTailscale(r, tsState as ExposeState);
+  }
+  if (choice === "cloudflare") {
+    return await tearDownCloudflare(r, cfState as CloudflaredState);
+  }
+
+  // both
+  const tsCode = await tearDownTailscale(r, tsState as ExposeState);
+  const cfCode = await tearDownCloudflare(r, cfState as CloudflaredState);
+  return tsCode !== 0 ? tsCode : cfCode;
+}


### PR DESCRIPTION
## Summary

Layer 4 of the four-layer interactive arc (PRs #33–#36). `parachute expose public off` now auto-detects which provider is currently live and routes the teardown accordingly.

## Behavior

| State | Behavior |
|---|---|
| Neither live | Quiet no-op: `No public exposure active. Nothing to tear down.` exit 0 |
| Only Tailscale live | Tear down tailscale, print `✓ Tore down Tailscale Funnel (was: https://<fqdn>)` |
| Only Cloudflare live | Tear down cloudflare, print `✓ Tore down Cloudflare Tunnel (was: https://<host>)` |
| Both live (TTY) | Prompt `[1] tailscale / [2] cloudflare / [3] both / [4] cancel` — default `both` on Enter |
| Both live (non-TTY) | Tear down both (off means off), prints `(non-TTY: tearing down both.)` |

`--cloudflare` still works as an explicit override and skips the auto-detect path entirely — scripted callers keep today's behavior.

## Why

Previously, `expose public off` only inspected tailscale state. A user who brought up a cloudflared tunnel with `expose public --cloudflare --domain …` had to remember the `--cloudflare` flag on teardown too, otherwise they got a misleading "No Public (Funnel) exposure recorded" message while the tunnel kept running.

## Test plan

- [x] `bun test` (337 pass, +14 new tests covering every branch: neither/one/both, TTY/non-TTY, cancel, teardown-failure propagation, tailnet-layer ignored, empty-entries ignored)
- [x] `bun run typecheck` clean
- [x] `biome check` clean
- [ ] Manual smoke on a live machine: `expose public --cloudflare --domain foo.example.com` then `expose public off` (no flag) — should detect and tear down cloudflare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)