### PR TITLE
fix: tolerate bun 1.2.x lockfile-quirk exit 1 on bun add -g

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "parachute — the top-level CLI for the Parachute ecosystem.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -91,7 +91,7 @@ describe("install", () => {
     }
   });
 
-  test("propagates non-zero exit from bun add", async () => {
+  test("propagates non-zero exit from bun add when package not present at global prefix", async () => {
     const { path, cleanup } = makeTempPath();
     try {
       const calls: string[][] = [];
@@ -102,10 +102,54 @@ describe("install", () => {
         },
         manifestPath: path,
         isLinked: () => false,
+        findGlobalInstall: () => null,
         log: () => {},
       });
       expect(code).toBe(42);
       expect(calls).toHaveLength(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("tolerates bun add exit 1 when the package is actually installed (bun 1.2.x lockfile quirk)", async () => {
+    // Repro: `bun add -g @openparachute/vault` on bun 1.2.19 can print
+    // "InvalidPackageResolution" + "Failed to install 1 package" and exit 1,
+    // while the package *is* installed (see "installed @openparachute/vault…
+    // with binaries" in the same output). If we bail on the exit code, init
+    // + seed never runs and `parachute status` shows nothing even though
+    // the binary is on PATH — day-one breakage for anyone on bun 1.2.x.
+    const { path, cleanup } = makeTempPath();
+    try {
+      const calls: string[][] = [];
+      const logs: string[] = [];
+      const code = await install("vault", {
+        runner: async (cmd) => {
+          calls.push([...cmd]);
+          // `bun add -g` exits 1; `parachute-vault init` succeeds.
+          return cmd[0] === "bun" ? 1 : 0;
+        },
+        manifestPath: path,
+        isLinked: () => false,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/vault"
+            ? "/fake/bun/global/node_modules/@openparachute/vault/package.json"
+            : null,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      // Warning mentions the found path and the bun 1.2.x quirk.
+      expect(logs.join("\n")).toMatch(
+        /bun add reported exit 1 but @openparachute\/vault is installed at/,
+      );
+      expect(logs.join("\n")).toMatch(/bun 1\.2\.x lockfile quirk/);
+      // Crucially: init still ran, and the service got seeded.
+      expect(calls).toEqual([
+        ["bun", "add", "-g", "@openparachute/vault"],
+        ["parachute-vault", "init"],
+      ]);
+      const seeded = findService("parachute-vault", path);
+      expect(seeded?.port).toBe(1940);
     } finally {
       cleanup();
     }
@@ -339,6 +383,7 @@ describe("install", () => {
         runner: async () => 1,
         manifestPath: path,
         isLinked: () => false,
+        findGlobalInstall: () => null,
         log: (l) => logs.push(l),
         tag: "rc",
       });

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,4 +1,4 @@
-import { lstatSync } from "node:fs";
+import { lstatSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { autoWireScribeAuth } from "../auto-wire.ts";
@@ -53,6 +53,15 @@ export interface InstallOpts {
    * Tests pass a deterministic string; production uses crypto.randomBytes.
    */
   randomToken?: () => string;
+  /**
+   * Probe whether `pkg` is present at bun's global node_modules (returns the
+   * package.json path on hit, null on miss). Used after `bun add -g` returns
+   * non-zero to distinguish a real failure from bun 1.2.x's noisy
+   * lockfile-recovery path — where the package *is* actually installed
+   * despite the exit code. Defaults to a filesystem probe against
+   * `bunGlobalPrefixes()`.
+   */
+  findGlobalInstall?: (pkg: string) => string | null;
 }
 
 async function defaultRunner(cmd: readonly string[]): Promise<number> {
@@ -80,6 +89,21 @@ function defaultIsLinked(pkg: string): boolean {
   return false;
 }
 
+function defaultFindGlobalInstall(pkg: string): string | null {
+  for (const prefix of bunGlobalPrefixes()) {
+    const pkgJsonPath = join(prefix, ...pkg.split("/"), "package.json");
+    try {
+      const parsed = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+      if (typeof parsed?.name === "string" && typeof parsed?.version === "string") {
+        return pkgJsonPath;
+      }
+    } catch {
+      // Not present / not valid at this prefix; try the next.
+    }
+  }
+  return null;
+}
+
 export async function install(service: string, opts: InstallOpts = {}): Promise<number> {
   const runner = opts.runner ?? defaultRunner;
   const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
@@ -87,6 +111,7 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
   const now = opts.now ?? (() => new Date());
   const log = opts.log ?? ((line) => console.log(line));
   const isLinked = opts.isLinked ?? defaultIsLinked;
+  const findGlobalInstall = opts.findGlobalInstall ?? defaultFindGlobalInstall;
 
   const aliased = SERVICE_ALIASES[service];
   if (aliased !== undefined) {
@@ -108,8 +133,23 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
     log(`Installing ${addSpec}…`);
     const addCode = await runner(["bun", "add", "-g", addSpec]);
     if (addCode !== 0) {
-      log(`bun add -g ${addSpec} failed (exit ${addCode})`);
-      return addCode;
+      // Bun 1.2.x has a noisy lockfile-recovery path where `bun add -g` prints
+      // InvalidPackageResolution + "Failed to install 1 package" and exits 1,
+      // *even though the package is successfully installed* (you can see
+      // "installed @openparachute/<foo> with binaries" in the same output).
+      // Bailing here on exit code alone means the caller-visible install
+      // fails and downstream init/seed never runs — so probe the global
+      // prefix before treating non-zero as fatal.
+      const foundAt = findGlobalInstall(spec.package);
+      if (foundAt) {
+        log(`bun add reported exit ${addCode} but ${spec.package} is installed at ${foundAt}.`);
+        log(
+          "Known bun 1.2.x lockfile quirk — the package landed despite the warning. Proceeding. `bun upgrade` to 1.3.x avoids it.",
+        );
+      } else {
+        log(`bun add -g ${addSpec} failed (exit ${addCode})`);
+        return addCode;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Bun 1.2.x has a noisy lockfile-recovery path where `bun add -g <pkg>` prints `InvalidPackageResolution: failed to parse lockfile: 'bun.lock'` + `Failed to install 1 package` and exits **1** — even though the same output shows `installed @openparachute/<foo>@<ver> with binaries`. The package *is* on disk; the exit code lies.

`src/commands/install.ts` was bailing on that exit code, so `parachute-vault init` (or the seed path for services without init) never ran, and `~/.parachute/services.json` stayed empty. Observable symptom from Aaron's other machine (bun 1.2.19):

```
$ parachute install vault
Installing @openparachute/vault…
bun add v1.2.19
… InvalidPackageResolution … FileNotFound … 
installed @openparachute/vault@0.3.0 with binaries:
 - parachute-vault
Failed to install 1 package
[1.75s] done
bun add -g @openparachute/vault failed (exit 1)
```

This is day-one breakage for anyone running bun 1.2.x.

## What changed

After `bun add -g` returns non-zero, probe bun's global `node_modules` for the package's `package.json` (via the same prefixes `isLinked` already walks). If it exists and parses with a `name` + `version`, log a warning and keep going — init + seed run normally. If the probe comes up empty, treat as a real failure exactly as before.

- New `defaultFindGlobalInstall(pkg): string | null` sibling to `defaultIsLinked`. Reads `package.json` from `<prefix>/<scoped>/package.json` and validates shape.
- New `findGlobalInstall?: (pkg) => string | null` opt on `InstallOpts` so tests can inject deterministically (no touching real `~/.bun/`).
- The non-zero path now logs:
  ```
  bun add reported exit 1 but @openparachute/vault is installed at <path>.
  Known bun 1.2.x lockfile quirk — the package landed despite the warning. Proceeding. `bun upgrade` to 1.3.x avoids it.
  ```

Version bump: **0.2.0 → 0.2.1** (patch — public command surface unchanged, pure bugfix).

## Test plan

- [x] `bun test` — 338 pass, 0 fail (one new test added, one existing test narrowed to make the no-fallback path explicit)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` (biome) — clean
- [x] New test `tolerates bun add exit 1 when the package is actually installed (bun 1.2.x lockfile quirk)` covers the repro: runner returns 1, `findGlobalInstall` returns a path, install proceeds through init + seed.
- [x] Existing `propagates non-zero exit from bun add when package not present at global prefix` retains the real-failure path (wires `findGlobalInstall: () => null`).
- [ ] Manual verification on a bun 1.2.x box — relying on Aaron's other machine as the natural repro environment after merge + publish.

## Scope

One PR, one concern. No force-upgrade prompt, no bun-version gate, no lockfile-clearing shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)