### PR TITLE
fix(tailscale): recognize bare "funnel" cap key + legacy URL form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "parachute — the top-level CLI for the Parachute ecosystem.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/__tests__/tailscale-detect.test.ts
+++ b/src/__tests__/tailscale-detect.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { getTailscaleStatus } from "../tailscale/detect.ts";
+import type { CommandResult, Runner } from "../tailscale/run.ts";
+
+function statusRunner(selfJson: Record<string, unknown>, code = 0): Runner {
+  return async (cmd) => {
+    if (cmd.slice(0, 2).join(" ") === "tailscale status") {
+      return {
+        code,
+        stdout: JSON.stringify({ Self: selfJson }),
+        stderr: "",
+      } as CommandResult;
+    }
+    throw new Error(`unexpected runner call: ${cmd.join(" ")}`);
+  };
+}
+
+describe("getTailscaleStatus funnelCapable", () => {
+  test("recognizes bare 'funnel' cap key (tailscaled ≥ 1.96)", async () => {
+    // Aaron's tailscaled 1.96.5 emits { funnel: null } — no URL-form key.
+    const runner = statusRunner({
+      DNSName: "host.example.ts.net.",
+      CapMap: { funnel: null },
+    });
+    const result = await getTailscaleStatus(runner);
+    expect(result).toEqual({ loggedIn: true, funnelCapable: true });
+  });
+
+  test("recognizes legacy URL-form cap key", async () => {
+    const runner = statusRunner({
+      DNSName: "host.example.ts.net.",
+      CapMap: { "https://tailscale.com/cap/funnel": ["*"] },
+    });
+    const result = await getTailscaleStatus(runner);
+    expect(result).toEqual({ loggedIn: true, funnelCapable: true });
+  });
+
+  test("funnel-ports cap alone does not imply funnel capability", async () => {
+    // funnel-ports declares *which* ports are allowed; it is not the grant.
+    const runner = statusRunner({
+      DNSName: "host.example.ts.net.",
+      CapMap: {
+        "https://tailscale.com/cap/funnel-ports?ports=443,8443,10000": null,
+      },
+    });
+    const result = await getTailscaleStatus(runner);
+    expect(result).toEqual({ loggedIn: true, funnelCapable: false });
+  });
+
+  test("no funnel cap key → funnelCapable false", async () => {
+    const runner = statusRunner({
+      DNSName: "host.example.ts.net.",
+      CapMap: { "default-auto-update": [true] },
+    });
+    const result = await getTailscaleStatus(runner);
+    expect(result).toEqual({ loggedIn: true, funnelCapable: false });
+  });
+
+  test("logged out → both false even with funnel cap", async () => {
+    const runner = statusRunner({ CapMap: { funnel: null } });
+    const result = await getTailscaleStatus(runner);
+    expect(result).toEqual({ loggedIn: false, funnelCapable: false });
+  });
+});

--- a/src/tailscale/detect.ts
+++ b/src/tailscale/detect.ts
@@ -1,11 +1,12 @@
 import type { Runner } from "./run.ts";
 import { TailscaleError } from "./run.ts";
 
-/** ACL capability key Tailscale emits on `Self.CapMap` when the node is
- * allowed to run Funnel. Internal-ish surface: the key string is stable in
- * practice but not documented as API. Treat the probe as best-effort (see
- * {@link getTailscaleStatus}). */
-const FUNNEL_CAP_KEY = "https://tailscale.com/cap/funnel";
+/** ACL capability keys Tailscale emits on `Self.CapMap` when the node is
+ * allowed to run Funnel. Modern tailscaled (≥ ~1.96) emits the bare
+ * `"funnel"` key; older builds emit the URL form. Accept either — the probe
+ * is best-effort (see {@link getTailscaleStatus}) and we'd rather cross
+ * versions than over-nag users whose ACL is correctly granted. */
+export const FUNNEL_CAP_KEYS = ["funnel", "https://tailscale.com/cap/funnel"] as const;
 
 export async function isTailscaleInstalled(runner: Runner): Promise<boolean> {
   try {
@@ -25,7 +26,7 @@ export async function isTailscaleInstalled(runner: Runner): Promise<boolean> {
  *   decide whether to prompt the user to run `tailscale up` before anything
  *   else.
  * - `funnelCapable` — best-effort probe for whether this node is allowed to
- *   expose Funnel, via `Self.CapMap[{@link FUNNEL_CAP_KEY}]`.
+ *   expose Funnel, via any key in {@link FUNNEL_CAP_KEYS} on `Self.CapMap`.
  *
  * Caveat on `funnelCapable`: `CapMap` is a semi-internal field whose shape
  * Tailscale can shift across versions. This probe is not load-bearing — a
@@ -50,7 +51,10 @@ export async function getTailscaleStatus(
     const loggedIn = typeof dnsName === "string" && dnsName.length > 0;
     const capMap = parsed.Self?.CapMap;
     const funnelCapable =
-      loggedIn && !!capMap && typeof capMap === "object" && FUNNEL_CAP_KEY in capMap;
+      loggedIn &&
+      !!capMap &&
+      typeof capMap === "object" &&
+      FUNNEL_CAP_KEYS.some((k) => k in capMap);
     return { loggedIn, funnelCapable };
   } catch {
     return { loggedIn: false, funnelCapable: false };


### PR DESCRIPTION
## Summary

Hotfix for `parachute expose public` on launch day. Users with a
correctly-granted Funnel ACL were being told by the preflight to go
configure the admin console first.

**Root cause.** `src/tailscale/detect.ts` probed `Self.CapMap` for only
the legacy URL-form key `"https://tailscale.com/cap/funnel"`. Modern
tailscaled (verified on 1.96.5) emits the Funnel grant under the bare
key `"funnel"` instead and no longer emits the URL form on fresh
installs. Result: `funnelCapable` was a false negative for anyone on a
recent Tailscale build.

**Smoking gun.** Aaron's `jq '.Self.CapMap'` on tailscaled 1.96.5:

```json
{
  "default-auto-update": [true],
  "funnel": null,
  "https": null,
  "https://tailscale.com/cap/file-sharing": null,
  "https://tailscale.com/cap/funnel-ports?ports=443,8443,10000": null,
  "tailnet-display-name": ["unforced.org"]
}
```

Note that `funnel-ports` is the separate "which ports are allowed" cap,
not the Funnel grant itself.

**Fix.** Accept either key shape. `FUNNEL_CAP_KEYS = ["funnel", "https://tailscale.com/cap/funnel"]`
and match if any is present. The URL form stays in as the legacy
fallback so we work across tailscaled versions.

Version bumped 0.2.1 → 0.2.2.

## Scope

- 5-line probe change + 5 new tests (bare key, legacy URL form,
  funnel-ports-only doesn't trigger, no cap, logged-out).
- No changes to hub, install, or other expose paths.
- No `--skip-preflight` bypass in this PR (can be a follow-up if it
  proves useful).

## Test plan

- [x] `bun test` — 343 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bunx biome check --write .` — clean
- [ ] Reviewer: confirm Aaron's CapMap shape is accepted
- [ ] Post-merge: publish 0.2.2 to npm; verify `parachute expose public`
      no longer nags on Aaron's machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)