### PR TITLE
fix(expose): auto-restart vault on hub-origin change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "parachute — the top-level CLI for the Parachute ecosystem.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -1255,3 +1255,139 @@ describe("expose publicExposure filter", () => {
     }
   });
 });
+
+describe("expose auto-restart of hub-dependent services", () => {
+  // Launch-day bug (2026-04-23): `expose public` updated hubOrigin in
+  // expose-state.json, but a vault already running kept its stale
+  // PARACHUTE_HUB_ORIGIN in memory, so the OAuth issuer didn't match what
+  // clients saw and claude.ai MCP failed to reach the server. The CLI used
+  // to print a "Restart vault to pick up…" hint that got lost in the wall
+  // of expose output. Auto-restart the service instead.
+  test("restarts vault when vault is running", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      writePid("vault", 4242, h.configDir);
+      const { runner } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const restarted: string[] = [];
+      const code = await exposePublic("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        alive: () => true,
+        restartService: async (short) => {
+          restarted.push(short);
+          return 0;
+        },
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(restarted).toEqual(["vault"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("skips restart when vault is not running", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      // No writePid → vault has no pidfile → processState returns "unknown".
+      const { runner } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const restarted: string[] = [];
+      const code = await exposePublic("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        alive: () => true,
+        restartService: async (short) => {
+          restarted.push(short);
+          return 0;
+        },
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(restarted).toEqual([]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("skips restart when pidfile is stale (process dead)", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      writePid("vault", 4242, h.configDir);
+      const { runner } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const restarted: string[] = [];
+      const code = await exposePublic("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        // Simulate pid-file-present-but-process-dead. processState returns
+        // "stopped", not "running", so we should skip.
+        alive: () => false,
+        restartService: async (short) => {
+          restarted.push(short);
+          return 0;
+        },
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(restarted).toEqual([]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("restart failure logs warning but expose still succeeds", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      writePid("vault", 4242, h.configDir);
+      const { runner } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const logs: string[] = [];
+      const code = await exposePublic("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        alive: () => true,
+        restartService: async () => 1,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(logs.join("\n")).toMatch(/vault restart failed/);
+      expect(logs.join("\n")).toMatch(/parachute restart vault/);
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -18,6 +18,7 @@ import {
 } from "../hub-control.ts";
 import { deriveHubOrigin } from "../hub-origin.ts";
 import { HUB_MOUNT, HUB_PATH, writeHubFile } from "../hub.ts";
+import { type AliveFn, processState } from "../process-state.ts";
 import { effectivePublicExposure, shortNameForManifest } from "../service-spec.ts";
 import { type ServiceEntry, readManifest } from "../services-manifest.ts";
 import { type ServeEntry, bringupCommand, teardownCommand } from "../tailscale/commands.ts";
@@ -33,6 +34,7 @@ import {
   vaultInstanceName,
   writeWellKnownFile,
 } from "../well-known.ts";
+import { restart } from "./lifecycle.ts";
 
 /**
  * Two exposure layers share a single tailscale serve config on this node.
@@ -83,7 +85,24 @@ export interface ExposeOpts {
    * through to vault (and future services) via PARACHUTE_HUB_ORIGIN.
    */
   hubOrigin?: string;
+  /** Process-liveness check for auto-restart — test seam. */
+  alive?: AliveFn;
+  /**
+   * Restart a service by short name after exposure changes. Defaults to the
+   * lifecycle `restart`; tests inject a fake to assert the call without
+   * spawning real child processes.
+   */
+  restartService?: (short: string) => Promise<number>;
 }
+
+/**
+ * Short names whose running process caches the hub origin (today:
+ * PARACHUTE_HUB_ORIGIN → vault's OAuth issuer). `exposeUp` restarts these
+ * after writing new expose-state so in-memory state matches what clients see.
+ * Hard-coded while vault is the only dependent; a services.json field will
+ * generalize this once a second service needs it.
+ */
+const HUB_DEPENDENT_SHORTS = ["vault"] as const;
 
 /**
  * OAuth paths the hub fronts on behalf of vault (Phase 0: vault implements
@@ -381,7 +400,26 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
   log(`  Discovery: ${canonicalOrigin}${WELL_KNOWN_MOUNT}`);
   if (primaryVault(services)) {
     log(`  OAuth issuer: ${hubOrigin}`);
-    log("  Restart vault to pick up the new hub origin: parachute restart vault");
+  }
+
+  // Auto-restart services that cache the hub origin. Aaron hit this on launch
+  // day: after `expose public` first-run, vault kept its stale (loopback)
+  // PARACHUTE_HUB_ORIGIN, the OAuth issuer didn't match what clients saw, and
+  // claude.ai MCP failed with a cryptic "Couldn't reach the MCP server". The
+  // old output told the user to restart manually; it got buried in the wall
+  // of expose output. Do the restart ourselves.
+  const doRestart =
+    opts.restartService ?? ((short: string) => restart(short, { manifestPath, configDir, log }));
+  for (const short of HUB_DEPENDENT_SHORTS) {
+    if (processState(short, configDir, opts.alive).status !== "running") continue;
+    log("");
+    log(`Restarting ${short} to pick up new hub origin…`);
+    const rcode = await doRestart(short);
+    if (rcode !== 0) {
+      log(
+        `⚠ ${short} restart failed. Run manually once the issue is resolved: parachute restart ${short}`,
+      );
+    }
   }
   return 0;
 }


### PR DESCRIPTION
## Why

Launch-day bug Aaron hit running `parachute expose public` for the first time on a clean machine:

1. CLI set up the tailscale funnel correctly, wrote `services.json`, updated the hub, and ended with `✓ Public exposure active`.
2. The quiet line `Restart vault to pick up the new hub origin: parachute restart vault` got lost in the wall of expose output.
3. claude.ai's MCP custom connector then failed with `Couldn't reach the MCP server` — OAuth chain was all reachable via curl, but vault's in-memory `PARACHUTE_HUB_ORIGIN` was stale (still loopback), so the issuer didn't match what clients saw.
4. `parachute restart vault` fixed it instantly.

Silent launch-blocker for anyone running expose for the first time with vault already running. The fix is to do the restart ourselves instead of telling the user to.

## What

- `exposeUp` checks `processState("vault", …)` after writing new expose-state. If vault is running, it calls lifecycle `restart`, which picks up the new `hubOrigin` from `expose-state.json` on `start` and injects `PARACHUTE_HUB_ORIGIN` into the restarted process.
- Not running → skip silently.
- Restart failure → warning + manual-recovery hint, but expose still reports success (the exposure *is* live; the user just needs to restart vault by hand).
- `HUB_DEPENDENT_SHORTS = ["vault"]` hard-coded for now. When a second service needs the same treatment we'll lift it to a `services.json` field.
- Adds two test seams to `ExposeOpts`: `alive?: AliveFn` and `restartService?: (short) => Promise<number>`.

Version bump 0.2.2 → 0.2.3.

## Test plan

- [x] `bun test` — 347 passing, 4 new tests in `expose auto-restart of hub-dependent services`:
  - vault running → restart invoked
  - vault not running (no pidfile) → no restart
  - stale pidfile (process dead) → no restart
  - restart failure → warning + exposeUp returns 0
- [x] `bun run typecheck` clean
- [x] `bunx biome check` clean
- [ ] Post-merge: Aaron runs `parachute expose public` on his machine and confirms claude.ai MCP connects on first try without a manual `parachute restart vault`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)