### PR TITLE
fix(expose): treat "already gone" teardown errors as success

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/cli",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "parachute — the top-level CLI for the Parachute ecosystem.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -1391,3 +1391,191 @@ describe("expose auto-restart of hub-dependent services", () => {
     }
   });
 });
+
+describe("expose teardown tolerance for already-gone entries", () => {
+  // Launch-day bug (2026-04-23): Aaron ran `tailscale funnel reset` while
+  // debugging, then re-ran `parachute expose public`. expose-state.json still
+  // recorded 8 entries; the CLI tried to tear them down; tailscale returned
+  // `error: failed to remove web serve: handler does not exist` for each; the
+  // CLI aborted and never got to bringup. Tailscale's `off` is idempotent
+  // from the user's perspective — if the handler is already gone, that's the
+  // outcome we wanted.
+  function makePublicPriorState(statePath: string, entryCount: number): void {
+    const entries = Array.from({ length: entryCount }, (_, i) => ({
+      kind: "proxy" as const,
+      mount: `/svc${i}`,
+      target: `http://127.0.0.1:${2000 + i}`,
+      service: `parachute-svc${i}`,
+    }));
+    writeExposeState(
+      {
+        version: 1,
+        layer: "public",
+        mode: "path",
+        canonicalFqdn: "parachute.taildf9ce2.ts.net",
+        port: 443,
+        funnel: true,
+        entries,
+      },
+      statePath,
+    );
+  }
+
+  test("exposeOff treats 'handler does not exist' as success and clears state", async () => {
+    const h = makeHarness();
+    try {
+      makePublicPriorState(h.statePath, 3);
+      const runner: Runner = async (cmd) => {
+        if (cmd[cmd.length - 1] === "off") {
+          return {
+            code: 1,
+            stdout: "",
+            stderr: "error: failed to remove web serve: handler does not exist",
+          };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      };
+      const logs: string[] = [];
+      const code = await exposePublic("off", {
+        runner,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubStopOpts: hubStopOpts(),
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(existsSync(h.statePath)).toBe(false);
+      const joined = logs.join("\n");
+      expect(joined).toMatch(/already gone/);
+      expect(joined).toMatch(/✓ Public \(Funnel\) exposure removed/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("exposeOff handles a mix of clean and already-gone entries", async () => {
+    const h = makeHarness();
+    try {
+      makePublicPriorState(h.statePath, 3);
+      let i = 0;
+      const runner: Runner = async (cmd) => {
+        if (cmd[cmd.length - 1] === "off") {
+          const idx = i++;
+          if (idx === 1) {
+            return {
+              code: 1,
+              stdout: "",
+              stderr: "error: failed to remove web serve: listener does not exist",
+            };
+          }
+          return { code: 0, stdout: "", stderr: "" };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      };
+      const code = await exposePublic("off", {
+        runner,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubStopOpts: hubStopOpts(),
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(existsSync(h.statePath)).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("exposeOff still aborts on a real (non-already-gone) error", async () => {
+    const h = makeHarness();
+    try {
+      makePublicPriorState(h.statePath, 2);
+      const runner: Runner = async (cmd) => {
+        if (cmd[cmd.length - 1] === "off") {
+          return {
+            code: 1,
+            stdout: "",
+            stderr: "failed to connect to tailscaled: is it running?",
+          };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      };
+      const logs: string[] = [];
+      const code = await exposePublic("off", {
+        runner,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubStopOpts: hubStopOpts(),
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(1);
+      expect(existsSync(h.statePath)).toBe(true);
+      expect(logs.join("\n")).toMatch(/Teardown failed/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("exposeUp tolerates already-gone prior entries and proceeds to bringup", async () => {
+    // Aaron's exact repro: prior expose-state lingered after an external
+    // `tailscale funnel reset`, re-running `parachute expose public` aborted
+    // because every teardown said "handler does not exist".
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      makePublicPriorState(h.statePath, 2);
+      const { spawner } = makeHubSpawner(1111);
+      const bringupCalls: string[][] = [];
+      const runner: Runner = async (cmd) => {
+        if (cmd[0] === "tailscale" && cmd[1] === "version") {
+          return { code: 0, stdout: "1.96.5\n", stderr: "" };
+        }
+        if (cmd[0] === "tailscale" && cmd[1] === "status" && cmd[2] === "--json") {
+          return {
+            code: 0,
+            stdout: JSON.stringify({ Self: { DNSName: "parachute.taildf9ce2.ts.net." } }),
+            stderr: "",
+          };
+        }
+        if (cmd[cmd.length - 1] === "off") {
+          return {
+            code: 1,
+            stdout: "",
+            stderr: "error: failed to remove web serve: handler does not exist",
+          };
+        }
+        if (cmd.includes("--bg")) {
+          bringupCalls.push([...cmd]);
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      };
+      const code = await exposePublic("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(bringupCalls.length).toBeGreaterThan(0);
+      const state = readExposeState(h.statePath);
+      expect(state?.layer).toBe("public");
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -263,6 +263,45 @@ async function runEach(
   return 0;
 }
 
+/**
+ * Tailscale's `serve/funnel … off` exits non-zero with stderr like
+ * `error: failed to remove web serve: handler does not exist` when the entry
+ * is already absent from tailscale's state. This happens when the user ran
+ * `tailscale funnel reset` externally, tailscaled restarted and dropped
+ * ephemeral state, or a prior teardown partially succeeded. From the user's
+ * perspective `off` is idempotent — the goal is "this handler is gone" and
+ * it already is. Match the narrow `does not exist` phrase; real errors
+ * (auth, daemon down) don't include it and still abort.
+ */
+function teardownAlreadyGone(stderr: string): boolean {
+  return stderr.toLowerCase().includes("does not exist");
+}
+
+/**
+ * Like `runEach` but tolerant of already-gone entries. Each command that
+ * fails with a "does not exist" stderr is logged and skipped; any other
+ * non-zero exit still aborts so real failures surface.
+ */
+async function runTeardown(
+  runner: Runner,
+  commands: string[][],
+  log: (line: string) => void,
+): Promise<number> {
+  for (const cmd of commands) {
+    log(`  $ ${cmd.join(" ")}`);
+    const { code, stderr } = await runner(cmd);
+    if (code === 0) continue;
+    if (teardownAlreadyGone(stderr)) {
+      const firstLine = stderr.trim().split("\n")[0] ?? "already gone";
+      log(`  (already gone — ${firstLine})`);
+      continue;
+    }
+    if (stderr.trim()) log(stderr.trim());
+    return code;
+  }
+  return 0;
+}
+
 function layerLabel(layer: ExposeLayer): string {
   return layer === "public" ? "Public (Funnel)" : "Tailnet";
 }
@@ -301,7 +340,7 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
     const teardownCmds = prior.entries.map((e) =>
       teardownCommand(e, { port: prior.port, funnel: prior.funnel }),
     );
-    const code = await runEach(runner, teardownCmds, log);
+    const code = await runTeardown(runner, teardownCmds, log);
     if (code !== 0) {
       log("Teardown of prior state failed; aborting.");
       return code;
@@ -448,7 +487,7 @@ export async function exposeOff(layer: ExposeLayer, opts: ExposeOpts = {}): Prom
   const cmds = state.entries.map((e) =>
     teardownCommand(e, { port: state.port, funnel: state.funnel }),
   );
-  const code = await runEach(runner, cmds, log);
+  const code = await runTeardown(runner, cmds, log);
   if (code !== 0) {
     log("Teardown failed. State file left in place so you can retry.");
     return code;


### PR DESCRIPTION
## Why

Launch-day bug Aaron hit during `parachute expose public` re-run:

```
Found prior Public (Funnel) exposure; tearing down 8 entries first…
  $ tailscale serve --https=443 --set-path=/ off
error: failed to remove web serve: handler does not exist
Teardown of prior state failed; aborting.
```

Repro path: Aaron had run `tailscale funnel reset` externally while debugging. Tailscale's state was clean, but the CLI's `~/.parachute/expose-state.json` still recorded 8 entries from a prior exposure. On re-run, every teardown returned `handler does not exist`. The CLI treated non-zero as a hard failure, aborted before bringup, and never cleaned up its own state. User stuck until they hand-deleted `expose-state.json`.

Tailscale's `serve/funnel … off` is idempotent from the user's perspective — the goal is "this handler is gone," and it already is. Real errors (daemon down, auth) don't say "does not exist" and should still abort.

## What

- New `runTeardown` helper alongside `runEach`. Same shape, but when a command exits non-zero with stderr containing `does not exist`, logs `(already gone — <stderr>)` and continues instead of aborting.
- Swapped into both teardown sites:
  - `exposeUp` prior-state sweep (the block that got Aaron stuck).
  - `exposeOff` teardown.
- `runEach` unchanged — bringup never hits "already gone," so no tolerance needed there.
- Narrow match: `stderr.toLowerCase().includes("does not exist")` covers both `handler does not exist` and `listener does not exist`. Auth / daemon-down / network errors don't include the phrase and still abort.

Version bump 0.2.3 → 0.2.4.

## Test plan

- [x] `bun test` — 351 passing, 4 new tests in `expose teardown tolerance for already-gone entries`:
  - `exposeOff`: every entry already-gone → success, state cleared
  - `exposeOff`: mix of clean + already-gone → success
  - `exposeOff`: real non-matching error → aborts with state preserved
  - `exposeUp`: Aaron's exact repro — prior entries already gone, teardown tolerated, bringup proceeds, state rewritten
- [x] `bun run typecheck` clean
- [x] `bunx biome check` clean
- [ ] Post-merge: Aaron re-runs the repro (`tailscale funnel reset` then `parachute expose public`) and confirms it completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)