### PR TITLE
feat(install): first-run UX — auto-start + URL clarity (closes #42)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/cli",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "parachute — the top-level CLI for the Parachute ecosystem.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/__tests__/auto-wire.test.ts
+++ b/src/__tests__/auto-wire.test.ts
@@ -2,68 +2,97 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { SCRIBE_AUTH_ENV_KEY, autoWireScribeAuth } from "../auto-wire.ts";
+import { SCRIBE_AUTH_ENV_KEY, SCRIBE_URL_ENV_KEY, autoWireScribeAuth } from "../auto-wire.ts";
+import { writePid } from "../process-state.ts";
 
 function makeHarness(): { dir: string; cleanup: () => void } {
   const dir = mkdtempSync(join(tmpdir(), "pcli-autowire-"));
   return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
 }
 
+const DEFAULT_SCRIBE_URL = "http://127.0.0.1:1943";
+
 describe("autoWireScribeAuth", () => {
-  test("first call: writes new token to both vault .env and scribe config.json", async () => {
+  test("first call: writes new token + SCRIBE_URL to vault .env and token to scribe config.json", async () => {
     const h = makeHarness();
     try {
       const logs: string[] = [];
-      const result = autoWireScribeAuth({
+      const result = await autoWireScribeAuth({
         configDir: h.dir,
         randomToken: () => "deadbeef00".repeat(6),
         log: (l) => logs.push(l),
       });
       expect(result.generated).toBe(true);
       expect(result.token).toBe("deadbeef00".repeat(6));
+      expect(result.scribeUrl).toBe(DEFAULT_SCRIBE_URL);
 
       const envText = readFileSync(join(h.dir, "vault", ".env"), "utf8");
-      expect(envText).toBe(`${SCRIBE_AUTH_ENV_KEY}=${result.token}\n`);
+      expect(envText).toContain(`${SCRIBE_AUTH_ENV_KEY}=${result.token}`);
+      expect(envText).toContain(`${SCRIBE_URL_ENV_KEY}=${DEFAULT_SCRIBE_URL}`);
 
       const scribeCfg = JSON.parse(readFileSync(join(h.dir, "scribe", "config.json"), "utf8"));
       expect(scribeCfg).toEqual({ auth: { required_token: result.token } });
 
-      expect(logs.join("\n")).toMatch(/Auto-wired shared secret for vault → scribe/);
+      expect(logs.join("\n")).toMatch(/Auto-wired shared secret \+ SCRIBE_URL/);
     } finally {
       h.cleanup();
     }
   });
 
-  test("idempotent: pre-existing SCRIBE_AUTH_TOKEN in vault .env is preserved", async () => {
+  test("idempotent: pre-existing SCRIBE_AUTH_TOKEN in vault .env is preserved; SCRIBE_URL still wired", async () => {
     const h = makeHarness();
     try {
-      // Seed a prior wire (or operator-set value). The helper must not
+      // Seed a prior wire (or operator-set token). The helper must not
       // regenerate on repeat install — churning the token would break a
       // running vault worker that already has the old one in its process env.
+      // SCRIBE_URL was missing from the prior write (this is a 0.2.4 → 0.2.5
+      // upgrade scenario), so it should still be added.
       const envPath = join(h.dir, "vault", ".env");
       const seed = "seeded-token-abc123";
       mkdirSync(join(h.dir, "vault"), { recursive: true });
       writeFileSync(envPath, `FOO=bar\n${SCRIBE_AUTH_ENV_KEY}=${seed}\nOTHER=baz\n`);
 
-      const result = autoWireScribeAuth({
+      const result = await autoWireScribeAuth({
         configDir: h.dir,
-        // If randomToken is ever called, test would notice — result.token
-        // would change, assertion fails.
         randomToken: () => "should-not-be-used",
         log: () => {},
       });
       expect(result.generated).toBe(false);
       expect(result.token).toBe(seed);
+      expect(result.scribeUrl).toBe(DEFAULT_SCRIBE_URL);
 
-      // vault .env unchanged — other keys intact, token unchanged.
       const envText = readFileSync(envPath, "utf8");
       expect(envText).toContain("FOO=bar");
       expect(envText).toContain(`${SCRIBE_AUTH_ENV_KEY}=${seed}`);
       expect(envText).toContain("OTHER=baz");
+      expect(envText).toContain(`${SCRIBE_URL_ENV_KEY}=${DEFAULT_SCRIBE_URL}`);
       // And scribe config.json gets the seeded value (so drift between the
       // two sides repairs on repeat install).
       const scribeCfg = JSON.parse(readFileSync(join(h.dir, "scribe", "config.json"), "utf8"));
       expect(scribeCfg.auth.required_token).toBe(seed);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("preserves operator-set SCRIBE_URL (e.g., a non-loopback override)", async () => {
+    const h = makeHarness();
+    try {
+      const envPath = join(h.dir, "vault", ".env");
+      const customUrl = "http://scribe.lan:1943";
+      mkdirSync(join(h.dir, "vault"), { recursive: true });
+      writeFileSync(envPath, `${SCRIBE_URL_ENV_KEY}=${customUrl}\n`);
+
+      const result = await autoWireScribeAuth({
+        configDir: h.dir,
+        randomToken: () => "fresh-token",
+        log: () => {},
+      });
+      expect(result.scribeUrl).toBe(customUrl);
+
+      const envText = readFileSync(envPath, "utf8");
+      expect(envText).toContain(`${SCRIBE_URL_ENV_KEY}=${customUrl}`);
+      expect(envText).not.toContain(`${SCRIBE_URL_ENV_KEY}=${DEFAULT_SCRIBE_URL}`);
     } finally {
       h.cleanup();
     }
@@ -76,7 +105,7 @@ describe("autoWireScribeAuth", () => {
       mkdirSync(join(h.dir, "vault"), { recursive: true });
       writeFileSync(envPath, "VAULT_SECRET=xyz\nLOG_LEVEL=debug\n");
 
-      autoWireScribeAuth({
+      await autoWireScribeAuth({
         configDir: h.dir,
         randomToken: () => "fresh-token-123",
         log: () => {},
@@ -86,6 +115,7 @@ describe("autoWireScribeAuth", () => {
       expect(envText).toContain("VAULT_SECRET=xyz");
       expect(envText).toContain("LOG_LEVEL=debug");
       expect(envText).toContain(`${SCRIBE_AUTH_ENV_KEY}=fresh-token-123`);
+      expect(envText).toContain(`${SCRIBE_URL_ENV_KEY}=${DEFAULT_SCRIBE_URL}`);
     } finally {
       h.cleanup();
     }
@@ -94,9 +124,6 @@ describe("autoWireScribeAuth", () => {
   test("merges into existing scribe config.json, preserving other keys", async () => {
     const h = makeHarness();
     try {
-      // Simulate a scribe with its own config already on disk (e.g., user
-      // set a whisper model) — auto-wire must add `auth.required_token`
-      // without nuking the rest.
       const scribeCfgPath = join(h.dir, "scribe", "config.json");
       mkdirSync(join(h.dir, "scribe"), { recursive: true });
       writeFileSync(
@@ -104,7 +131,7 @@ describe("autoWireScribeAuth", () => {
         JSON.stringify({ whisper: { model: "medium.en" }, auth: { other: "kept" } }, null, 2),
       );
 
-      autoWireScribeAuth({
+      await autoWireScribeAuth({
         configDir: h.dir,
         randomToken: () => "tok",
         log: () => {},
@@ -120,15 +147,13 @@ describe("autoWireScribeAuth", () => {
   });
 
   test("handles quoted token values in vault .env (preserves the raw value)", async () => {
-    // Operators sometimes quote .env values. Parse the quotes off so the
-    // token we write to scribe config.json matches what vault actually reads.
     const h = makeHarness();
     try {
       const envPath = join(h.dir, "vault", ".env");
       mkdirSync(join(h.dir, "vault"), { recursive: true });
       writeFileSync(envPath, `${SCRIBE_AUTH_ENV_KEY}="quoted-value"\n`);
 
-      const result = autoWireScribeAuth({
+      const result = await autoWireScribeAuth({
         configDir: h.dir,
         randomToken: () => "should-not-be-used",
         log: () => {},
@@ -146,17 +171,111 @@ describe("autoWireScribeAuth", () => {
   test("creates vault/ and scribe/ dirs if missing", async () => {
     const h = makeHarness();
     try {
-      // Fresh config dir — no per-service subdirs yet. Helper must create
-      // them (matches how the rest of the CLI creates dirs on demand).
       expect(existsSync(join(h.dir, "vault"))).toBe(false);
       expect(existsSync(join(h.dir, "scribe"))).toBe(false);
-      autoWireScribeAuth({
+      await autoWireScribeAuth({
         configDir: h.dir,
         randomToken: () => "tok",
         log: () => {},
       });
       expect(existsSync(join(h.dir, "vault", ".env"))).toBe(true);
       expect(existsSync(join(h.dir, "scribe", "config.json"))).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("restarts vault when the worker is running so the new env takes effect", async () => {
+    // The whole point of writing SCRIBE_URL is that vault's transcription
+    // worker can find scribe. If vault is already running when we wire,
+    // the worker keeps its stale env until we restart it — exactly the
+    // launch-day footgun where voice memos sat on `_Transcript pending._`
+    // forever. Mirrors the auto-restart-on-expose pattern from PR #39.
+    const h = makeHarness();
+    try {
+      writePid("vault", 4242, h.dir);
+      const restartCalls: string[] = [];
+      const result = await autoWireScribeAuth({
+        configDir: h.dir,
+        randomToken: () => "tok",
+        log: () => {},
+        alive: () => true,
+        restartService: async (short) => {
+          restartCalls.push(short);
+          return 0;
+        },
+      });
+      expect(result.restartedVault).toBe(true);
+      expect(restartCalls).toEqual(["vault"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("does not restart vault when nothing changed (idempotent repeat call)", async () => {
+    // Both keys already present, vault running — there's nothing to pick up
+    // on restart, so we shouldn't churn a healthy daemon.
+    const h = makeHarness();
+    try {
+      mkdirSync(join(h.dir, "vault"), { recursive: true });
+      writeFileSync(
+        join(h.dir, "vault", ".env"),
+        `${SCRIBE_AUTH_ENV_KEY}=already\n${SCRIBE_URL_ENV_KEY}=${DEFAULT_SCRIBE_URL}\n`,
+      );
+      writePid("vault", 4242, h.dir);
+      const restartCalls: string[] = [];
+      const result = await autoWireScribeAuth({
+        configDir: h.dir,
+        log: () => {},
+        alive: () => true,
+        restartService: async (short) => {
+          restartCalls.push(short);
+          return 0;
+        },
+      });
+      expect(result.restartedVault).toBe(false);
+      expect(restartCalls).toEqual([]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("does not restart vault when it isn't running", async () => {
+    // No PID file → processState reports "unknown" → no restart. Avoids
+    // launching a daemon as a side effect of install.
+    const h = makeHarness();
+    try {
+      const restartCalls: string[] = [];
+      const result = await autoWireScribeAuth({
+        configDir: h.dir,
+        randomToken: () => "tok",
+        log: () => {},
+        restartService: async (short) => {
+          restartCalls.push(short);
+          return 0;
+        },
+      });
+      expect(result.restartedVault).toBe(false);
+      expect(restartCalls).toEqual([]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("logs a clear hint when the auto-restart fails", async () => {
+    const h = makeHarness();
+    try {
+      writePid("vault", 4242, h.dir);
+      const logs: string[] = [];
+      const result = await autoWireScribeAuth({
+        configDir: h.dir,
+        randomToken: () => "tok",
+        log: (l) => logs.push(l),
+        alive: () => true,
+        restartService: async () => 1,
+      });
+      expect(result.restartedVault).toBe(false);
+      expect(logs.join("\n")).toMatch(/vault restart failed.*parachute restart vault/);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -21,6 +21,7 @@ describe("install", () => {
       const code = await install("mystery", {
         runner: async () => 0,
         manifestPath: path,
+        startService: async () => 0,
         isLinked: () => false,
         log: (l) => logs.push(l),
       });
@@ -42,6 +43,7 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        startService: async () => 0,
         isLinked: () => false,
         log: (l) => logs.push(l),
       });
@@ -78,6 +80,7 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        startService: async () => 0,
         isLinked: () => false,
         log: (l) => logs.push(l),
       });
@@ -101,6 +104,7 @@ describe("install", () => {
           return 42;
         },
         manifestPath: path,
+        startService: async () => 0,
         isLinked: () => false,
         findGlobalInstall: () => null,
         log: () => {},
@@ -130,6 +134,7 @@ describe("install", () => {
           return cmd[0] === "bun" ? 1 : 0;
         },
         manifestPath: path,
+        startService: async () => 0,
         isLinked: () => false,
         findGlobalInstall: (pkg) =>
           pkg === "@openparachute/vault"
@@ -180,6 +185,7 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        startService: async () => 0,
         isLinked: () => false,
         log: (l) => logs.push(l),
       });
@@ -206,6 +212,7 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        startService: async () => 0,
         isLinked: () => false,
         log: (l) => logs.push(l),
       });
@@ -241,6 +248,7 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        startService: async () => 0,
         isLinked: () => false,
         log: (l) => logs.push(l),
       });
@@ -261,6 +269,7 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        startService: async () => 0,
         isLinked: () => false,
         log: (l) => logs.push(l),
       });
@@ -290,6 +299,7 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        startService: async () => 0,
         isLinked: (pkg) => pkg === "@openparachute/scribe",
         log: (l) => logs.push(l),
       });
@@ -318,6 +328,7 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        startService: async () => 0,
         isLinked: () => false,
         log: (l) => logs.push(l),
         tag: "rc",
@@ -340,6 +351,7 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        startService: async () => 0,
         isLinked: () => false,
         log: () => {},
         tag: "0.3.0-rc.1",
@@ -363,6 +375,7 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        startService: async () => 0,
         isLinked: () => true,
         log: (l) => logs.push(l),
         tag: "rc",
@@ -382,6 +395,7 @@ describe("install", () => {
       const code = await install("vault", {
         runner: async () => 1,
         manifestPath: path,
+        startService: async () => 0,
         isLinked: () => false,
         findGlobalInstall: () => null,
         log: (l) => logs.push(l),
@@ -417,6 +431,7 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        startService: async () => 0,
         isLinked: () => true,
         log: (l) => logs.push(l),
       });
@@ -453,6 +468,7 @@ describe("install", () => {
         runner: async () => 0,
         manifestPath: path,
         configDir,
+        startService: async () => 0,
         isLinked: () => false,
         log: (l) => logs.push(l),
         randomToken: () => "test-token-value",
@@ -469,7 +485,7 @@ describe("install", () => {
       const cfg = JSON.parse(readFileSync(scribeCfgPath, "utf8"));
       expect(cfg.auth.required_token).toBe("test-token-value");
 
-      expect(logs.join("\n")).toMatch(/Auto-wired shared secret for vault → scribe/);
+      expect(logs.join("\n")).toMatch(/Auto-wired shared secret \+ SCRIBE_URL/);
     } finally {
       cleanup();
     }
@@ -484,6 +500,7 @@ describe("install", () => {
         runner: async () => 0,
         manifestPath: path,
         configDir,
+        startService: async () => 0,
         isLinked: () => false,
         log: (l) => logs.push(l),
         randomToken: () => "should-not-fire",
@@ -516,6 +533,7 @@ describe("install", () => {
         runner: async () => 0,
         manifestPath: path,
         configDir,
+        startService: async () => 0,
         isLinked: () => false,
         log: () => {},
         randomToken: () => "install-vault-side-token",
@@ -547,6 +565,7 @@ describe("install", () => {
         runner: async () => 0,
         manifestPath: path,
         configDir,
+        startService: async () => 0,
         isLinked: () => false,
         log: () => {},
         randomToken: () => "first-token",
@@ -557,6 +576,7 @@ describe("install", () => {
         runner: async () => 0,
         manifestPath: path,
         configDir,
+        startService: async () => 0,
         isLinked: () => false,
         log: () => {},
         randomToken: () => "should-not-replace",
@@ -600,12 +620,167 @@ describe("install", () => {
         runner: async () => 0,
         manifestPath: path,
         configDir,
+        startService: async () => 0,
         isLinked: () => false,
         log: () => {},
         randomToken: () => "should-not-fire",
       });
       expect(existsSync(join(configDir, "vault", ".env"))).toBe(false);
       expect(existsSync(join(configDir, "scribe", "config.json"))).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Auto-start: launch-day demo had Aaron running `parachute install scribe`
+  // and then having to remember `parachute start scribe` separately. After
+  // 0.2.5, install ends with the daemon running.
+  test("auto-starts the service after a successful install", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const startCalls: string[] = [];
+      const code = await install("scribe", {
+        runner: async () => 0,
+        manifestPath: path,
+        startService: async (short) => {
+          startCalls.push(short);
+          return 0;
+        },
+        isLinked: () => false,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(startCalls).toEqual(["scribe"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("--no-start suppresses the auto-start", async () => {
+    // Piped / CI installs that own their own process model want the install
+    // to land but not spawn anything.
+    const { path, cleanup } = makeTempPath();
+    try {
+      const startCalls: string[] = [];
+      const code = await install("scribe", {
+        runner: async () => 0,
+        manifestPath: path,
+        startService: async (short) => {
+          startCalls.push(short);
+          return 0;
+        },
+        isLinked: () => false,
+        log: () => {},
+        noStart: true,
+      });
+      expect(code).toBe(0);
+      expect(startCalls).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("auto-start uses the resolved (post-alias) short name", async () => {
+    // `install lens` aliases to notes — the start call must target notes,
+    // not the alias the user typed.
+    const { path, cleanup } = makeTempPath();
+    try {
+      const startCalls: string[] = [];
+      const code = await install("lens", {
+        runner: async () => 0,
+        manifestPath: path,
+        startService: async (short) => {
+          startCalls.push(short);
+          return 0;
+        },
+        isLinked: () => false,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(startCalls).toEqual(["notes"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("logs a hint when auto-start fails but doesn't fail the install itself", async () => {
+    // The install completed; a flaky daemon launch shouldn't roll it back.
+    // User gets a clear pointer to retry manually.
+    const { path, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      const code = await install("scribe", {
+        runner: async () => 0,
+        manifestPath: path,
+        startService: async () => 1,
+        isLinked: () => false,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(logs.join("\n")).toMatch(/scribe didn't start cleanly.*parachute start scribe/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("scribe install emits the post-install footer with provider hints", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      const code = await install("scribe", {
+        runner: async () => 0,
+        manifestPath: path,
+        startService: async () => 0,
+        isLinked: () => false,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      const joined = logs.join("\n");
+      expect(joined).toMatch(/Scribe is listening on http:\/\/127\.0\.0\.1:1943/);
+      expect(joined).toMatch(/parakeet-mlx/);
+      expect(joined).toMatch(/groq.*openai/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("notes install emits the post-install footer pointing at the Notes UI", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      const code = await install("notes", {
+        runner: async () => 0,
+        manifestPath: path,
+        startService: async () => 0,
+        isLinked: () => false,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      const joined = logs.join("\n");
+      expect(joined).toMatch(/Open your Notes UI at http:\/\/localhost:1942\/notes/);
+      expect(joined).toMatch(/http:\/\/127\.0\.0\.1:1940\/vault\/default/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("vault install does not emit a CLI-side footer (vault prints its own)", async () => {
+    // PR #166 has parachute-vault init print a richer footer with the API
+    // token; the CLI shouldn't double up. spec.postInstallFooter is left
+    // undefined for vault on purpose.
+    const { path, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      await install("vault", {
+        runner: async () => 0,
+        manifestPath: path,
+        startService: async () => 0,
+        isLinked: () => false,
+        log: (l) => logs.push(l),
+      });
+      const joined = logs.join("\n");
+      expect(joined).not.toMatch(/Open your Notes UI/);
+      expect(joined).not.toMatch(/Scribe is listening/);
     } finally {
       cleanup();
     }

--- a/src/__tests__/status.test.ts
+++ b/src/__tests__/status.test.ts
@@ -188,4 +188,160 @@ describe("status", () => {
       cleanup();
     }
   });
+
+  // URL column: the launch-day pain was a user staring at the table not
+  // knowing where to point Claude.ai or curl. Each row gets a "  → URL"
+  // continuation line so the next step is obvious.
+  test("vault row prints MCP URL beneath it (path + /mcp suffix)", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.2.4",
+        },
+        path,
+      );
+      const lines: string[] = [];
+      await status({
+        manifestPath: path,
+        fetchImpl: async () => new Response(null, { status: 200 }),
+        print: (l) => lines.push(l),
+      });
+      expect(lines.some((l) => l.includes("→ http://127.0.0.1:1940/vault/default/mcp"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("scribe row prints root URL (API is at /, ignore path prefix)", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        {
+          name: "parachute-scribe",
+          port: 1943,
+          paths: ["/scribe"],
+          health: "/scribe/health",
+          version: "0.1.0",
+        },
+        path,
+      );
+      const lines: string[] = [];
+      await status({
+        manifestPath: path,
+        fetchImpl: async () => new Response(null, { status: 200 }),
+        print: (l) => lines.push(l),
+      });
+      expect(lines.some((l) => l === "  → http://127.0.0.1:1943")).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("notes row prints UI URL (port + /notes mount)", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        {
+          name: "parachute-notes",
+          port: 1942,
+          paths: ["/notes"],
+          health: "/notes/health",
+          version: "0.0.1",
+        },
+        path,
+      );
+      const lines: string[] = [];
+      await status({
+        manifestPath: path,
+        fetchImpl: async () => new Response(null, { status: 200 }),
+        print: (l) => lines.push(l),
+      });
+      expect(lines.some((l) => l === "  → http://127.0.0.1:1942/notes")).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("channel row prints port + /channel mount", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        {
+          name: "parachute-channel",
+          port: 1941,
+          paths: ["/channel"],
+          health: "/channel/health",
+          version: "0.1.0",
+        },
+        path,
+      );
+      const lines: string[] = [];
+      await status({
+        manifestPath: path,
+        fetchImpl: async () => new Response(null, { status: 200 }),
+        print: (l) => lines.push(l),
+      });
+      expect(lines.some((l) => l === "  → http://127.0.0.1:1941/channel")).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("unknown service falls back to bare host:port + paths[0]", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        {
+          name: "third-party-thing",
+          port: 9000,
+          paths: ["/widget"],
+          health: "/health",
+          version: "1.0.0",
+        },
+        path,
+      );
+      const lines: string[] = [];
+      await status({
+        manifestPath: path,
+        fetchImpl: async () => new Response(null, { status: 200 }),
+        print: (l) => lines.push(l),
+      });
+      expect(lines.some((l) => l === "  → http://127.0.0.1:9000/widget")).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("stopped services still render a URL line so the user knows where to point clients post-start", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.2.4",
+        },
+        path,
+      );
+      writePid("vault", 4242, configDir);
+      const lines: string[] = [];
+      await status({
+        manifestPath: path,
+        configDir,
+        alive: () => false,
+        fetchImpl: async () => new Response(null, { status: 200 }),
+        print: (l) => lines.push(l),
+      });
+      expect(lines.some((l) => l.includes("→ http://127.0.0.1:1940/vault/default/mcp"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
 });

--- a/src/auto-wire.ts
+++ b/src/auto-wire.ts
@@ -1,36 +1,50 @@
 import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { restart as lifecycleRestart } from "./commands/lifecycle.ts";
+import { type AliveFn, defaultAlive, processState } from "./process-state.ts";
+import { PORT_RESERVATIONS } from "./service-spec.ts";
 
 /**
  * Cross-service auto-wiring for shared secrets.
  *
  * Vault's transcription worker authenticates to scribe over loopback using a
- * shared bearer token. On install, when both services are present, we mint
- * one and write it to both sides so the operator never has to. Missing either
- * service → no-op; token already present in vault's .env → preserved.
+ * shared bearer token, and reaches scribe at SCRIBE_URL. On install, when both
+ * services are present, we mint the secret and pin the URL on vault's side so
+ * the operator never has to. Missing either service → no-op; values already
+ * present in vault's .env → preserved.
  *
  * Storage locations (convention, matches what each service reads at boot):
  *   ~/.parachute/vault/.env        SCRIBE_AUTH_TOKEN=<value>
+ *                                  SCRIBE_URL=http://127.0.0.1:1943
  *   ~/.parachute/scribe/config.json  { "auth": { "required_token": "<value>" } }
  *
- * Idempotency rule: we don't regenerate if vault's .env already carries the
- * var. This preserves operator-set overrides and keeps repeat installs from
- * churning the token (which would break an already-running vault worker).
+ * Idempotency rule: we don't regenerate the token if vault's .env already
+ * carries it, and we don't overwrite SCRIBE_URL if already set. This preserves
+ * operator-set overrides and keeps repeat installs from churning state in a
+ * way that would break an already-running vault worker.
+ *
+ * After writing, if vault is running, restart it so the worker re-reads the
+ * .env. Without the restart vault keeps the old (or empty) values in process
+ * env and voice memos sit with `_Transcript pending._` forever — exactly the
+ * launch-day footgun this auto-wire exists to prevent.
  */
 
 export const SCRIBE_AUTH_ENV_KEY = "SCRIBE_AUTH_TOKEN";
+export const SCRIBE_URL_ENV_KEY = "SCRIBE_URL";
 
 export interface AutoWireOpts {
   configDir: string;
   /** Override for tests; must return a hex string of any reasonable length. */
   randomToken?: () => string;
   log?: (line: string) => void;
+  /** Test seam: liveness check used to decide whether to restart vault. */
+  alive?: AliveFn;
   /**
-   * Guard: if either service isn't installed, skip silently. The install
-   * command owns this check (it reads services.json); the helper itself
-   * trusts the caller and just writes.
+   * Test seam: restart hook for vault. Defaults to `lifecycle.restart("vault")`.
+   * Tests inject a fake to assert the call without spawning a real child.
    */
+  restartService?: (short: string) => Promise<number>;
 }
 
 export interface AutoWireResult {
@@ -38,46 +52,74 @@ export interface AutoWireResult {
   generated: boolean;
   /** The token value, whether newly minted or pre-existing. */
   token: string;
+  /** The SCRIBE_URL value present in vault .env after this call. */
+  scribeUrl: string;
   vaultEnvPath: string;
   scribeConfigPath: string;
+  /** True when vault was running and we issued a restart. */
+  restartedVault: boolean;
 }
 
 function defaultRandomToken(): string {
-  // 32 bytes = 256 bits, hex-encoded. Matches the brief; width plenty for an
-  // HMAC-grade shared secret without pulling in base64url concerns.
   return randomBytes(32).toString("hex");
 }
 
-function readVaultEnv(path: string): { lines: string[]; existingToken: string | undefined } {
-  if (!existsSync(path)) return { lines: [], existingToken: undefined };
-  const content = readFileSync(path, "utf8");
-  const lines = content.length === 0 ? [] : content.split("\n");
-  // Drop a trailing empty string from a file that ends in "\n" so we don't
-  // double up newlines when we round-trip.
-  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
-  let existing: string | undefined;
-  for (const line of lines) {
-    if (line.startsWith(`${SCRIBE_AUTH_ENV_KEY}=`)) {
-      existing = line.slice(SCRIBE_AUTH_ENV_KEY.length + 1);
-      // Strip surrounding quotes if present — common .env style.
-      if (
-        existing.length >= 2 &&
-        ((existing.startsWith('"') && existing.endsWith('"')) ||
-          (existing.startsWith("'") && existing.endsWith("'")))
-      ) {
-        existing = existing.slice(1, -1);
-      }
-      break;
-    }
-  }
-  return { lines, existingToken: existing };
+function defaultScribeUrl(): string {
+  // Pull scribe's canonical port from the single source of truth so a future
+  // port change doesn't drift between auto-wire and the rest of the CLI.
+  const port = PORT_RESERVATIONS.find((p) => p.name === "parachute-scribe")?.port ?? 1943;
+  return `http://127.0.0.1:${port}`;
 }
 
-function writeVaultEnv(path: string, lines: string[], token: string): void {
+interface ParsedEnv {
+  lines: string[];
+  values: Record<string, string>;
+}
+
+function parseEnvLines(content: string): ParsedEnv {
+  const raw = content.length === 0 ? [] : content.split("\n");
+  // Drop a trailing empty string from a file that ends in "\n" so we don't
+  // double up newlines when we round-trip.
+  if (raw.length > 0 && raw[raw.length - 1] === "") raw.pop();
+  const values: Record<string, string> = {};
+  for (const line of raw) {
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq);
+    let value = line.slice(eq + 1);
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    values[key] = value;
+  }
+  return { lines: raw, values };
+}
+
+function readVaultEnv(path: string): ParsedEnv {
+  if (!existsSync(path)) return { lines: [], values: {} };
+  return parseEnvLines(readFileSync(path, "utf8"));
+}
+
+function upsertEnvLine(lines: string[], key: string, value: string): string[] {
+  const next = [...lines];
+  const prefix = `${key}=`;
+  const idx = next.findIndex((line) => line.startsWith(prefix));
+  if (idx >= 0) {
+    next[idx] = `${key}=${value}`;
+  } else {
+    next.push(`${key}=${value}`);
+  }
+  return next;
+}
+
+function writeVaultEnv(path: string, lines: string[]): void {
   mkdirSync(dirname(path), { recursive: true });
-  const rendered = [...lines, `${SCRIBE_AUTH_ENV_KEY}=${token}`].join("\n");
   const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
-  writeFileSync(tmp, `${rendered}\n`);
+  writeFileSync(tmp, `${lines.join("\n")}\n`);
   renameSync(tmp, path);
 }
 
@@ -109,29 +151,85 @@ function writeScribeConfig(path: string, token: string): void {
 }
 
 /**
- * Mint (or preserve) a shared secret and persist it to vault and scribe.
- * Caller has already confirmed both services are installed.
+ * Mint (or preserve) a shared secret and persist it to vault and scribe, plus
+ * pin SCRIBE_URL on vault's side. Caller has already confirmed both services
+ * are installed. Restarts vault if it's running so the worker re-reads .env.
  */
-export function autoWireScribeAuth(opts: AutoWireOpts): AutoWireResult {
+export async function autoWireScribeAuth(opts: AutoWireOpts): Promise<AutoWireResult> {
   const random = opts.randomToken ?? defaultRandomToken;
   const log = opts.log ?? (() => {});
+  const alive = opts.alive ?? defaultAlive;
+  const restartService =
+    opts.restartService ??
+    ((short: string) =>
+      lifecycleRestart(short, {
+        configDir: opts.configDir,
+        log,
+      }));
+
   const vaultEnvPath = join(opts.configDir, "vault", ".env");
   const scribeConfigPath = join(opts.configDir, "scribe", "config.json");
 
-  const { lines, existingToken } = readVaultEnv(vaultEnvPath);
-  if (existingToken !== undefined && existingToken.length > 0) {
-    // Preserve whatever is already there — operator-set or previously wired.
-    // Still re-assert scribe's copy in case the two drifted.
-    writeScribeConfig(scribeConfigPath, existingToken);
-    log(`${SCRIBE_AUTH_ENV_KEY} already set in vault .env — preserved. Synced scribe config.json.`);
-    return { generated: false, token: existingToken, vaultEnvPath, scribeConfigPath };
+  const parsed = readVaultEnv(vaultEnvPath);
+  let lines = parsed.lines;
+  let didWriteEnv = false;
+
+  const existingToken = parsed.values[SCRIBE_AUTH_ENV_KEY];
+  const tokenAlreadySet = existingToken !== undefined && existingToken.length > 0;
+  const token = tokenAlreadySet ? existingToken : random();
+  if (!tokenAlreadySet) {
+    lines = upsertEnvLine(lines, SCRIBE_AUTH_ENV_KEY, token);
+    didWriteEnv = true;
   }
 
-  const token = random();
-  writeVaultEnv(vaultEnvPath, lines, token);
+  const existingUrl = parsed.values[SCRIBE_URL_ENV_KEY];
+  const urlAlreadySet = existingUrl !== undefined && existingUrl.length > 0;
+  const scribeUrl = urlAlreadySet ? existingUrl : defaultScribeUrl();
+  if (!urlAlreadySet) {
+    lines = upsertEnvLine(lines, SCRIBE_URL_ENV_KEY, scribeUrl);
+    didWriteEnv = true;
+  }
+
+  if (didWriteEnv) writeVaultEnv(vaultEnvPath, lines);
   writeScribeConfig(scribeConfigPath, token);
-  log(
-    `Auto-wired shared secret for vault → scribe transcription. Stored in ${vaultEnvPath} and ${scribeConfigPath}.`,
-  );
-  return { generated: true, token, vaultEnvPath, scribeConfigPath };
+
+  if (tokenAlreadySet && urlAlreadySet) {
+    log(
+      `${SCRIBE_AUTH_ENV_KEY} and ${SCRIBE_URL_ENV_KEY} already set in vault .env — preserved. Synced scribe config.json.`,
+    );
+  } else if (tokenAlreadySet) {
+    log(
+      `${SCRIBE_AUTH_ENV_KEY} already set in vault .env — preserved. Wired ${SCRIBE_URL_ENV_KEY}=${scribeUrl}. Synced scribe config.json.`,
+    );
+  } else {
+    log(
+      `Auto-wired shared secret + ${SCRIBE_URL_ENV_KEY} for vault → scribe transcription. Stored in ${vaultEnvPath} and ${scribeConfigPath}.`,
+    );
+  }
+
+  // Vault caches .env on process start; without a restart the worker keeps
+  // running with stale (or absent) SCRIBE_URL/SCRIBE_AUTH_TOKEN and voice
+  // memos never transcribe. Mirrors the auto-restart-on-expose pattern from
+  // PR #39 — skip silently if vault isn't running.
+  let restartedVault = false;
+  if (didWriteEnv && processState("vault", opts.configDir, alive).status === "running") {
+    log("Restarting vault to pick up new transcription wiring…");
+    const code = await restartService("vault");
+    if (code === 0) {
+      restartedVault = true;
+    } else {
+      log(
+        "⚠ vault restart failed. Run manually once the issue is resolved: parachute restart vault",
+      );
+    }
+  }
+
+  return {
+    generated: !tokenAlreadySet,
+    token,
+    scribeUrl,
+    vaultEnvPath,
+    scribeConfigPath,
+    restartedVault,
+  };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,14 +171,17 @@ async function main(argv: string[]): Promise<number> {
         console.error(`parachute install: ${tagExtract.error}`);
         return 1;
       }
-      const installArgs = tagExtract.rest;
+      const noStart = tagExtract.rest.includes("--no-start");
+      const installArgs = tagExtract.rest.filter((a) => a !== "--no-start");
       const service = installArgs[0];
       if (!service) {
-        console.error("usage: parachute install <service|all> [--tag <name>]");
+        console.error("usage: parachute install <service|all> [--tag <name>] [--no-start]");
         console.error(`services: ${knownServices().join(", ")}`);
         return 1;
       }
-      const installOpts = tagExtract.tag ? { tag: tagExtract.tag } : {};
+      const installOpts: Parameters<typeof install>[1] = {};
+      if (tagExtract.tag) installOpts.tag = tagExtract.tag;
+      if (noStart) installOpts.noStart = true;
       if (service === "all") {
         // Bootstrap the whole ecosystem to one dist-tag — the RC-testing payload.
         // Bail on first failure so a broken channel doesn't mask a working tag.

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -11,6 +11,7 @@ import {
   knownServices,
 } from "../service-spec.ts";
 import { findService, upsertService } from "../services-manifest.ts";
+import { start as lifecycleStart } from "./lifecycle.ts";
 import { migrateNotice } from "./migrate.ts";
 
 export type Runner = (cmd: readonly string[]) => Promise<number>;
@@ -62,6 +63,18 @@ export interface InstallOpts {
    * `bunGlobalPrefixes()`.
    */
   findGlobalInstall?: (pkg: string) => string | null;
+  /**
+   * Skip the post-install daemon start. The launch-day default is to leave
+   * the service running so users don't have to remember the second command;
+   * pass `true` for piped / CI installs that own their own process model.
+   */
+  noStart?: boolean;
+  /**
+   * Test seam: lifecycle start hook used by the post-install auto-start.
+   * Defaults to `lifecycle.start(short, …)`. Tests inject a fake to assert
+   * the call without spawning a real child.
+   */
+  startService?: (short: string) => Promise<number>;
 }
 
 async function defaultRunner(cmd: readonly string[]): Promise<number> {
@@ -184,21 +197,48 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
     }
   }
 
-  // Auto-wire the vault↔scribe shared secret when both services end up
-  // installed. Fires from either install order (scribe then vault, or vault
-  // then scribe). Idempotent — preserves any pre-existing token in vault .env.
+  // Auto-wire the vault↔scribe shared secret + SCRIBE_URL when both services
+  // end up installed. Fires from either install order (scribe then vault, or
+  // vault then scribe). Idempotent — preserves any pre-existing values in
+  // vault .env. Restarts vault if it's running so the worker re-reads .env.
   if (spec.manifestName === "parachute-vault" || spec.manifestName === "parachute-scribe") {
     const vaultPresent = !!findService("parachute-vault", manifestPath);
     const scribePresent = !!findService("parachute-scribe", manifestPath);
     if (vaultPresent && scribePresent) {
       const autoWireOpts: Parameters<typeof autoWireScribeAuth>[0] = { configDir, log };
       if (opts.randomToken) autoWireOpts.randomToken = opts.randomToken;
-      autoWireScribeAuth(autoWireOpts);
+      await autoWireScribeAuth(autoWireOpts);
     }
   }
 
   const notice = migrateNotice(configDir, now());
   if (notice) log(notice);
+
+  // Auto-start: vault and notes' inits historically left a daemon running, but
+  // scribe (and any service without a daemon-launching init) didn't — so
+  // launch-day `install scribe` ended with a silent install and the user
+  // wondering why nothing happened. Always end with the daemon running unless
+  // the caller opted out (CI / piped scripts). Idempotent: if the service is
+  // already up, lifecycle.start no-ops via the existing PID-file check.
+  if (!opts.noStart) {
+    const startService =
+      opts.startService ??
+      ((short: string) => lifecycleStart(short, { manifestPath, configDir, log }));
+    const startCode = await startService(resolvedService);
+    if (startCode !== 0) {
+      log(
+        `⚠ ${resolvedService} didn't start cleanly. Run manually: parachute start ${resolvedService}`,
+      );
+    }
+  }
+
+  // Per-service install footer — canonical next-step URLs and configuration
+  // hints. Vault prints its own (richer) footer from `parachute-vault init`
+  // (PR #166), so the spec leaves vault out and we don't double up here.
+  const footer = spec.postInstallFooter?.();
+  if (footer) {
+    for (const line of footer) log(line);
+  }
 
   return 0;
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,7 +1,7 @@
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import { HUB_SVC, readHubPort } from "../hub-control.ts";
 import { type AliveFn, defaultAlive, formatUptime, processState } from "../process-state.ts";
-import { shortNameForManifest } from "../service-spec.ts";
+import { getSpec, shortNameForManifest } from "../service-spec.ts";
 import { type ServiceEntry, readManifest } from "../services-manifest.ts";
 
 export type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
@@ -71,8 +71,23 @@ interface StatusRow {
   uptimeLabel: string;
   healthLabel: string;
   latencyLabel: string;
+  url: string | undefined;
   healthy: boolean;
   skipped: boolean;
+}
+
+/**
+ * Canonical reachable URL for a row. Spec-driven where possible (vault appends
+ * `/mcp`, scribe is at the root, …). Unknown services fall back to bare
+ * `http://127.0.0.1:<port>` plus the first declared path so third-party
+ * services still get a useful pointer rather than an empty cell.
+ */
+function urlForEntry(entry: ServiceEntry, short: string | undefined): string | undefined {
+  const spec = short ? getSpec(short) : undefined;
+  const fromSpec = spec?.urlForEntry?.(entry);
+  if (fromSpec) return fromSpec;
+  const first = entry.paths[0]?.replace(/\/+$/, "") ?? "";
+  return `http://127.0.0.1:${entry.port}${first}`;
 }
 
 function hubRow(configDir: string, alive: AliveFn, nowDate: Date): StatusRow | undefined {
@@ -93,6 +108,7 @@ function hubRow(configDir: string, alive: AliveFn, nowDate: Date): StatusRow | u
     uptimeLabel,
     healthLabel: "-",
     latencyLabel: "-",
+    url: port !== undefined ? `http://127.0.0.1:${port}` : undefined,
     healthy: true,
     skipped: true,
   };
@@ -136,6 +152,8 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
       const uptimeLabel =
         proc?.status === "running" && proc.startedAt ? formatUptime(proc.startedAt, nowDate) : "-";
 
+      const url = urlForEntry(entry, short);
+
       // Only skip probe when we know the process is dead (PID file was
       // present but kill(pid, 0) failed). "unknown" status (no PID file)
       // still probes — externally-managed services should report health.
@@ -149,6 +167,7 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
           uptimeLabel,
           healthLabel: "-",
           latencyLabel: "-",
+          url,
           healthy: false,
           skipped: true,
         };
@@ -169,6 +188,7 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
         uptimeLabel,
         healthLabel,
         latencyLabel: `${p.latencyMs}ms`,
+        url,
         healthy: p.healthy,
         skipped: false,
       };
@@ -195,7 +215,17 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
     Math.max(header[i]?.length ?? 0, ...textRows.map((r) => r[i]?.length ?? 0)),
   );
   print(formatRow(header, widths));
-  for (const r of textRows) print(formatRow(r, widths));
+  // URL stays on a continuation line rather than a column. URLs are long
+  // (vault's MCP path runs ~40 chars), and a ninth column would push the
+  // table past 80 cols on every install. The "  → " prefix groups visually
+  // with the row above without misleading the table widths.
+  for (let i = 0; i < textRows.length; i++) {
+    const cells = textRows[i];
+    const row = rows[i];
+    if (!cells || !row) continue;
+    print(formatRow(cells, widths));
+    if (row.url) print(`  → ${row.url}`);
+  }
 
   /**
    * Overall exit: non-zero if any *probed* service is unhealthy. A stopped

--- a/src/help.ts
+++ b/src/help.ts
@@ -31,8 +31,8 @@ export function installHelp(): string {
   return `parachute install — install and register a Parachute service
 
 Usage:
-  parachute install <service> [--tag <name>]
-  parachute install all       [--tag <name>]
+  parachute install <service> [--tag <name>] [--no-start]
+  parachute install all       [--tag <name>] [--no-start]
 
 Services:
   ${knownServices().join(", ")}
@@ -42,17 +42,22 @@ What it does:
   1. bun add -g @openparachute/<service>[@<tag>]
   2. run any service-specific init (e.g. \`parachute-vault init\`)
   3. verify the service registered itself in ~/.parachute/services.json
+  4. start the service in the background (idempotent — no-op if already up)
 
 Flags:
   --tag <name>      npm dist-tag or exact version to install
                     (e.g. \`--tag rc\` → \`bun add -g @openparachute/vault@rc\`)
                     Skipped if the package is already \`bun link\`-ed locally.
+  --no-start        skip the post-install daemon start. For piped / CI
+                    installs that own their own process model.
 
 Examples:
-  parachute install vault           # installs + runs \`parachute-vault init\`
-  parachute install notes           # installs notes (no init required)
+  parachute install vault           # installs, runs \`parachute-vault init\`, starts vault
+  parachute install notes           # installs and starts notes
+  parachute install scribe          # installs and starts scribe
   parachute install vault --tag rc  # pin to the rc dist-tag for pre-release testing
   parachute install all --tag rc    # bootstrap the whole ecosystem to rc
+  parachute install vault --no-start  # install without auto-starting (CI / scripts)
 
 Aliases:
   lens → notes                      # accepted for one release cycle after
@@ -85,7 +90,9 @@ Example:
   $ parachute status
   SERVICE          PORT  VERSION  PROCESS  PID    UPTIME  HEALTH  LATENCY
   parachute-vault  1940  0.2.4    running  12345  2h 13m  ok      2ms
-  parachute-notes  5173  0.0.1    stopped  -      -       -       -
+    → http://127.0.0.1:1940/vault/default/mcp
+  parachute-notes  1942  0.0.1    stopped  -      -       -       -
+    → http://127.0.0.1:1942/notes
 `;
 }
 

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -100,6 +100,24 @@ export interface ServiceSpec {
    * conservatively false for scribe until its auth-gate ships.
    */
   readonly hasAuth?: boolean;
+  /**
+   * Canonical reachable URL for the service given its manifest entry. Drives
+   * the URL column in `parachute status` and any other place we need to
+   * render "where do I point a client?". Most services use port + paths[0],
+   * but some need to append a fixed suffix (vault's MCP endpoint lives at
+   * `/vault/<name>/mcp`, not the bare mount path).
+   *
+   * Returns undefined when the entry doesn't carry enough info — callers
+   * should fall back to the bare `http://127.0.0.1:<port>` form.
+   */
+  readonly urlForEntry?: (entry: ServiceEntry) => string | undefined;
+  /**
+   * Lines printed at the end of `parachute install <svc>` so the user has a
+   * clear next step. Vault's footer comes from `parachute-vault init` itself
+   * (PR #166) — richer because it can read the freshly-minted API token —
+   * so vault's spec leaves this off.
+   */
+  readonly postInstallFooter?: () => readonly string[];
 }
 
 const NOTES_SERVE_PATH = fileURLToPath(new URL("./notes-serve.ts", import.meta.url));
@@ -111,6 +129,13 @@ const NOTES_SERVE_PATH = fileURLToPath(new URL("./notes-serve.ts", import.meta.u
  * will overwrite with its own authoritative write.
  */
 const SEED_VERSION = "0.0.0-linked";
+
+function pathBasedUrl(entry: ServiceEntry): string {
+  const first = entry.paths[0] ?? "";
+  // Strip a trailing slash so concatenation never doubles up.
+  const path = first.replace(/\/+$/, "");
+  return `http://127.0.0.1:${entry.port}${path}`;
+}
 
 export const SERVICE_SPECS: Record<string, ServiceSpec> = {
   vault: {
@@ -127,6 +152,10 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
       health: "/vault/default/health",
       version: SEED_VERSION,
     }),
+    // Vault's MCP endpoint lives one segment past the mount path. The bare
+    // `/vault/<name>` URL is the discovery shape; clients (claude.ai et al.)
+    // need `/vault/<name>/mcp` to actually open the stream.
+    urlForEntry: (entry) => `${pathBasedUrl(entry)}/mcp`,
   },
   notes: {
     // Frontend product name is "Notes". vault's internal `/api/notes` endpoint
@@ -146,6 +175,13 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
       health: "/notes/health",
       version: SEED_VERSION,
     }),
+    urlForEntry: pathBasedUrl,
+    postInstallFooter: () => [
+      "",
+      "Open your Notes UI at http://localhost:1942/notes — paste the vault URL",
+      "  http://127.0.0.1:1940/vault/default",
+      "and the API token from your vault install.",
+    ],
   },
   scribe: {
     package: "@openparachute/scribe",
@@ -163,6 +199,17 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
       health: "/scribe/health",
       version: SEED_VERSION,
     }),
+    // Scribe's API is at the root, not under `/scribe`. The path prefix only
+    // shows up in the health endpoint; clients hit the bare port.
+    urlForEntry: (entry) => `http://127.0.0.1:${entry.port}`,
+    postInstallFooter: () => [
+      "",
+      "Scribe is listening on http://127.0.0.1:1943.",
+      "Vault will auto-call this for transcription (SCRIBE_URL has been wired to the vault env).",
+      "Configure the transcription provider at ~/.parachute/scribe/scribe.config.json — defaults",
+      "to `parakeet-mlx` (Apple Silicon, requires `parakeet-mlx` binary). Pick `groq` / `openai`",
+      "/ `cloudflare` / `whisper-cpp` if you want a different one.",
+    ],
   },
   channel: {
     package: "@openparachute/channel",
@@ -177,6 +224,7 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
       health: "/channel/health",
       version: SEED_VERSION,
     }),
+    urlForEntry: pathBasedUrl,
   },
 };
 


### PR DESCRIPTION
## Summary

Bundle of four launch-day-driven CLI improvements (issue #42, walkthrough on 2026-04-23/24). After this PR a fresh `parachute install <svc>` lands the service running, with vault wired to scribe, with a clear pointer to the URL clients should hit.

Bumps `0.2.4 → 0.2.5` (patch — UX polish, no breaking changes).

## Fixes

### 4.1 Auto-start after install

`install` now ends with `lifecycle.start(<svc>)` (called directly, not shelled out). Idempotent — already-running services no-op via the existing PID-file check. `--no-start` flag added for piped / CI installs that own their own process model. Surfaces a clear retry hint if start exits non-zero, but doesn't roll back the install.

### 4.2 Auto-wire SCRIBE_URL into vault `.env`

Parallel to the existing `SCRIBE_AUTH_TOKEN` write in `autoWireScribeAuth`, also write `SCRIBE_URL=http://127.0.0.1:1943` into `~/.parachute/vault/.env`. Idempotent — preserves operator-set overrides. The scribe port comes from `PORT_RESERVATIONS` so a future port change won't drift between auto-wire and the rest of the CLI.

When vault is running at wire time, the function now also calls `lifecycle.restart("vault")` so the transcription worker re-reads `.env` — without that the worker keeps stale (or absent) values and voice memos sit with `_Transcript pending._` forever, the launch-day footgun this fix is closing. Mirrors the auto-restart-on-expose pattern from #39 (test seam injectable, `alive`-gated, hint on failure).

`autoWireScribeAuth` becomes async to await the restart; `install.ts` and existing tests updated accordingly.

### 4.3 URL line under each `parachute status` row

Each service row now renders a `  → URL` continuation line below it:

```
SERVICE          PORT  VERSION  PROCESS  PID    UPTIME  HEALTH  LATENCY
parachute-vault  1940  0.2.4    running  12345  2h 13m  ok      2ms
  → http://127.0.0.1:1940/vault/default/mcp
parachute-notes  1942  0.0.1    stopped  -      -       -       -
  → http://127.0.0.1:1942/notes
```

Continuation line rather than a ninth column because URLs are long (vault's MCP path runs ~40 chars) and a column would push the table past 80 cols on every install. Spec-driven via a new `urlForEntry?(entry)` field on `ServiceSpec` — vault appends `/mcp`, scribe sits at the root, others use `port + paths[0]`. Unknown services fall back to `http://127.0.0.1:<port><paths[0]>` so third-party rows still get a useful pointer.

### 4.4 Per-service install footer

Adds an optional `postInstallFooter?(): readonly string[]` field to `ServiceSpec`. `install.ts` prints those lines after the auto-start. Implementations:

- **notes** — points the operator at `http://localhost:1942/notes` and the vault URL + token they need to paste.
- **scribe** — names the listening URL, confirms `SCRIBE_URL` was wired, points at `~/.parachute/scribe/scribe.config.json` for provider configuration (defaults to `parakeet-mlx`; alternatives listed).

Vault is intentionally left without a CLI-side footer — `parachute-vault init` already prints a richer, token-aware one (#166). Tests assert vault doesn't double up.

(Note: notes' footer hardcodes vault name `default`. Once parachute-vault#167 lands and vaults can have arbitrary names, that footer needs to read the actual default vault name. Out of scope here; will follow up after #167.)

## Test plan
- [x] `bun test` — 369 pass, 0 fail (was 351).
- [x] `bun run typecheck` clean.
- [x] `bunx biome check .` clean.
- [x] New tests: `auto-wire.test.ts` adds SCRIBE_URL coverage + restart wiring; `install.test.ts` adds auto-start + footer coverage; `status.test.ts` adds URL-column coverage for vault/notes/scribe/channel + unknown fallback + stopped services.
- [ ] Manual smoke: clean machine, `parachute install vault && parachute install scribe && parachute install notes` — each one ends running; `parachute status` shows URL lines; voice memo in notes transcribes end-to-end.

## Out of scope (separate issues)
- Scribe provider interactive prompt — #43.
- `parachute setup` walk-through — #45.
- `services.json` registration bug — #44.
- Notes footer reading the actual default vault name — pending parachute-vault#167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)