### PR TITLE
fix(hub): CORS on /.well-known/parachute.json (closes #47)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/cli",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "parachute — the top-level CLI for the Parachute ecosystem.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -14,8 +14,8 @@ function makeHarness(): Harness {
   return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
 }
 
-function req(path: string): Request {
-  return new Request(`http://127.0.0.1/${path.replace(/^\//, "")}`);
+function req(path: string, init?: RequestInit): Request {
+  return new Request(`http://127.0.0.1/${path.replace(/^\//, "")}`, init);
 }
 
 describe("hubFetch routing", () => {
@@ -52,6 +52,50 @@ describe("hubFetch routing", () => {
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("application/json");
       expect(await res.text()).toBe('{"vaults":[]}\n');
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // CORS on the well-known doc: browsers running the Notes UI on
+  // http://localhost:1942 fetch this manifest cross-origin to auto-discover
+  // the user's vault. Without these headers the browser blocks the response
+  // body and the auto-discover flow silently falls back to manual paste.
+  // The doc itself is public (no secrets, no PII), so wildcard origin is OK.
+  test("/.well-known/parachute.json includes wildcard CORS headers on GET", async () => {
+    const h = makeHarness();
+    try {
+      writeFileSync(join(h.dir, "parachute.json"), '{"vaults":[]}\n');
+      const res = hubFetch(h.dir)(req("/.well-known/parachute.json"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+      expect(res.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("OPTIONS preflight on /.well-known/parachute.json returns 204 + CORS", async () => {
+    const h = makeHarness();
+    try {
+      // Note: no parachute.json on disk — preflight must not depend on it.
+      const res = hubFetch(h.dir)(req("/.well-known/parachute.json", { method: "OPTIONS" }));
+      expect(res.status).toBe(204);
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+      expect(res.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("missing parachute.json still returns CORS headers on the 404", async () => {
+    // If the response 404s without CORS, the browser treats it as a network
+    // error and the consumer can't even tell the server is reachable.
+    const h = makeHarness();
+    try {
+      const res = hubFetch(h.dir)(req("/.well-known/parachute.json"));
+      expect(res.status).toBe(404);
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
     } finally {
       h.cleanup();
     }

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -75,11 +75,26 @@ export function hubFetch(wellKnownDir: string): (req: Request) => Response {
     }
 
     if (pathname === "/.well-known/parachute.json") {
+      // The well-known doc is a public service-discovery manifest (no
+      // secrets, no PII), and Notes / future browser clients fetch it
+      // cross-origin from their own loopback port. Wildcard CORS is the
+      // shape it needs. Browsers send an OPTIONS preflight when the request
+      // adds non-simple headers; answer it with 204 + the same allow-list.
+      const corsHeaders = {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "GET, OPTIONS",
+      };
+      if (req.method === "OPTIONS") {
+        return new Response(null, { status: 204, headers: corsHeaders });
+      }
       if (!existsSync(parachuteJsonPath)) {
-        return new Response("parachute.json not found", { status: 404 });
+        return new Response("parachute.json not found", {
+          status: 404,
+          headers: corsHeaders,
+        });
       }
       return new Response(Bun.file(parachuteJsonPath), {
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", ...corsHeaders },
       });
     }
 


### PR DESCRIPTION
## Summary

- Add `Access-Control-Allow-Origin: *` + `Access-Control-Allow-Methods: GET, OPTIONS` to the well-known response in `src/hub-server.ts`
- Answer the `OPTIONS` preflight with `204` + same allow-list (preflight does not depend on `parachute.json` existing on disk)
- Bump 0.2.5 → 0.2.6

Surfaced by parachute-notes#80: the new browser-side `probeForVault()` was being silently blocked at the cross-origin boundary (`localhost:1942` → `localhost:1939`), so the standalone-install auto-discover fell through to the manual paste-URL form. The well-known doc is a public service manifest (no secrets, no PII), so wildcard origin is the right shape.

## Test plan
- [x] `bun test` — 372 pass (+3 new in `hub-server.test.ts`: GET CORS headers, OPTIONS preflight 204, 404 still carries CORS so the consumer can distinguish "no manifest" from "blocked by browser")
- [x] `bun run typecheck` — clean
- [x] `bun run lint` (biome) — clean
- [ ] Manually verify Notes auto-discover works end-to-end after merge & publish (parachute-notes#80 consumer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)