### PR TITLE
fix(install): defensive logging for services.json registration (closes #44)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/cli",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "parachute — the top-level CLI for the Parachute ecosystem.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -160,6 +160,98 @@ describe("install", () => {
     }
   });
 
+  test("notes tolerance path: bun add exit 1 + package present → seedEntry still fires", async () => {
+    // Mirror of the vault tolerance test for notes (#44). notes has no
+    // spec.init, so the only path to a services.json entry on a fresh
+    // install is the seedEntry block. Verifies that gate is reached even
+    // when bun's exit code says "failed."
+    const { path, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      const code = await install("notes", {
+        runner: async (cmd) => (cmd[0] === "bun" ? 1 : 0),
+        manifestPath: path,
+        startService: async () => 0,
+        isLinked: () => false,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/notes"
+            ? "/fake/bun/global/node_modules/@openparachute/notes/package.json"
+            : null,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      const seeded = findService("parachute-notes", path);
+      expect(seeded?.port).toBe(1942);
+      expect(logs.join("\n")).toMatch(/Seeded services\.json entry for parachute-notes/);
+      expect(logs.join("\n")).toMatch(/bun 1\.2\.x lockfile quirk/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("non-tolerance bun add failure logs the prefixes that were probed", async () => {
+    // Defensive logging from #44: when findGlobalInstall returns null we want
+    // operators on non-standard bun layouts to see WHERE we looked, so they
+    // can spot a BUN_INSTALL or homebrew-prefix mismatch. The prefixes line
+    // is the actionable signal.
+    const { path, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      const code = await install("vault", {
+        runner: async () => 1,
+        manifestPath: path,
+        startService: async () => 0,
+        isLinked: () => false,
+        findGlobalInstall: () => null,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(1);
+      expect(logs.join("\n")).toMatch(/probed bun globals at:/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("final registration check warns when the entry is missing at install exit", async () => {
+    // Unknown / third-party services with no spec are rejected upfront, but
+    // a registered service whose spec lacks both `init` AND `seedEntry` could
+    // exit install with no manifest entry. We can't trigger that with the
+    // real ServiceSpec catalog, so simulate it by removing the entry mid-
+    // flight via a runner side-effect.
+    const { path, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      const code = await install("vault", {
+        runner: async (cmd) => {
+          // vault's init "succeeds" but never writes services.json. seedEntry
+          // fires (vault has one) → entry present. Then we sabotage by
+          // emptying the manifest before the final check, simulating an
+          // external clobber that the verify-step is designed to catch.
+          if (cmd[0] === "parachute-vault") {
+            // no-op (init didn't write)
+          }
+          return 0;
+        },
+        manifestPath: path,
+        // After install runs through to auto-start, the startService stub
+        // gets called. We use it as the very last hook before the final
+        // check to wipe the manifest.
+        startService: async () => {
+          // Wipe services.json so the final findService comes back empty.
+          const { writeFileSync } = await import("node:fs");
+          writeFileSync(path, JSON.stringify({ services: [] }, null, 2));
+          return 0;
+        },
+        isLinked: () => false,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(logs.join("\n")).toMatch(/parachute-vault is not in services\.json after install/);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("warns when manifest entry lands outside the canonical port range", async () => {
     // Historically the notes PWA wrote 5173 (Vite's dev default). Canonical
     // is 1939–1949; warn so integrators know their service could conflict

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -182,7 +182,14 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
           "Known bun 1.2.x lockfile quirk — the package landed despite the warning. Proceeding. `bun upgrade` to 1.3.x avoids it.",
         );
       } else {
+        // Make the failure mode legible: enumerating the prefixes we probed
+        // turns "bun add -g failed" into something an operator on a non-
+        // standard bun layout can act on. (Surfaced by parachute-cli#44 — a
+        // bun 1.2.x report where `notes` never registered; if the same
+        // failure mode ever manifests via findGlobalInstall returning null,
+        // the log tells us where to look.)
         log(`bun add -g ${addSpec} failed (exit ${addCode})`);
+        log(`  probed bun globals at: ${bunGlobalPrefixes().join(", ")}`);
         return addCode;
       }
     }
@@ -197,13 +204,28 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
     }
   }
 
+  // Find-or-seed the manifest entry. Re-read after the seed write so a silent
+  // upsert failure (filesystem permission, races against an external writer)
+  // surfaces as a loud log line instead of a phantom "registered" claim.
+  // parachute-cli#44 reported notes not appearing in services.json on a fresh
+  // bun 1.2.x install; the gate logic was already correct, but a verify-step
+  // turns silent loss into something an operator can spot.
   let entry = findService(spec.manifestName, manifestPath);
   if (!entry && spec.seedEntry) {
-    entry = spec.seedEntry();
-    upsertService(entry, manifestPath);
-    log(
-      `Seeded services.json entry for ${spec.manifestName} (placeholder; service's own boot will overwrite).`,
-    );
+    const seed = spec.seedEntry();
+    upsertService(seed, manifestPath);
+    entry = findService(spec.manifestName, manifestPath);
+    if (entry) {
+      log(
+        `Seeded services.json entry for ${spec.manifestName} (placeholder; service's own boot will overwrite).`,
+      );
+    } else {
+      log(
+        `⚠ tried to seed services.json entry for ${spec.manifestName}, but the readback came back empty.`,
+      );
+      log(`  manifest path: ${manifestPath}`);
+      log("  Re-run `parachute install` once the underlying issue is resolved.");
+    }
   }
 
   if (!entry) {
@@ -274,6 +296,19 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
   const footer = spec.postInstallFooter?.();
   if (footer) {
     for (const line of footer) log(line);
+  }
+
+  // Final registration check — the service may have written its own
+  // authoritative entry during init or first boot, replacing the seed (or
+  // filling a gap when the service had no seedEntry). Re-read at exit so the
+  // last line of the install always reflects ground truth, not an early
+  // snapshot. Surfaced by parachute-cli#44 — defensive logging that turns a
+  // missing entry into a visible failure rather than a silent one.
+  const finalEntry = findService(spec.manifestName, manifestPath);
+  if (!finalEntry) {
+    log(
+      `⚠ ${spec.manifestName} is not in services.json after install. \`parachute status\` won't see it. Re-run install or file a bug.`,
+    );
   }
 
   return 0;


### PR DESCRIPTION
## Summary

Issue #44: a fresh bun 1.2.x install of `notes` reportedly ended with the package on PATH and the daemon running, but no entry in `~/.parachute/services.json` (and so no `/notes` route on the hub).

**Trace finding**: the existing tolerance gate is correct. For services with no `spec.init` (notes), the bun-add tolerance path falls through directly to the `seedEntry` block. For services with init (vault), the tolerance test already in the suite covers the gate. Couldn't reproduce locally on bun 1.3.x — the lockfile-recovery quirk doesn't fire on that branch.

**Tightening** so a future repro produces actionable signal instead of silence:

- **Notes-tolerance test** mirrors the existing vault test; locks in the no-init seedEntry gate that the report names.
- **Post-write verification**: after `upsertService`, re-read `findService` and log loudly if the readback comes back empty.
- **Probed-prefixes logging** when `findGlobalInstall` returns null on a non-zero `bun add` exit. Operators on non-standard bun layouts (BUN_INSTALL set, homebrew prefix) can spot the mismatch instead of guessing.
- **Final registration check** at install exit: re-read services.json and warn explicitly if the entry isn't there. The last line of install now reflects ground truth, not a snapshot taken before auto-start.

## Verify on 1.2.x

The fix is defensive logging — the install code path is unchanged for the tolerance/success case (existing tolerance tests still pass). Worth a quick smoke on a 1.2.x box: `parachute install notes` should end with `✓ parachute-notes registered on port 1942` in the logs and the entry actually present in `~/.parachute/services.json`. If the original repro was a transient bun-side issue (rather than a CLI gate bug), the new warnings will surface it next time.

## Test plan

- [x] `bun test` — 424 pass (3 new; 0 fail)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Smoke on bun 1.2.x: `parachute install notes`, confirm `services.json` contains `parachute-notes`
- [ ] Smoke non-tolerance failure: simulate `bun add` exit 1 with package missing; confirm prefixes line is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)