### PR TITLE
chore(ports): drop speculative reservations (pendant, daily-v2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/cli",
-  "version": "0.2.8",
+  "version": "0.2.9-rc.1",
   "description": "parachute — the top-level CLI for the Parachute ecosystem.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -6,13 +6,11 @@ import type { ServiceEntry } from "./services-manifest.ts";
  * 1939–1949; third-party integrators are expected to avoid it.
  *
  *   1939  parachute-hub      internal static + proxy, CLI-managed
- *   1940  parachute-vault
- *   1941  parachute-channel
- *   1942  parachute-notes    static server over the PWA bundle
- *   1943  parachute-scribe
- *   1944  reserved — pendant
- *   1945  reserved — daily-v2
- *   1946–1949  reserved
+ *   1940  parachute-vault    committed core
+ *   1941  parachute-channel  exploration (may retire)
+ *   1942  parachute-notes    committed core (PWA bundle)
+ *   1943  parachute-scribe   committed core
+ *   1944–1949  unassigned
  *
  * Hub pins 1939: `parachute expose` composes hub targets as
  * `http://127.0.0.1:1939/` and that URL has to be stable across machines for
@@ -23,6 +21,10 @@ import type { ServiceEntry } from "./services-manifest.ts";
  * Ports outside the range aren't blocked. `parachute install` warns but
  * proceeds, since forks and non-standard deployments sometimes land on other
  * ports intentionally.
+ *
+ * **No speculative reservations.** Future first-party modules claim a slot
+ * the moment they ship, not before — pre-reservation for unbuilt things has
+ * proven a hold-place we kept reshaping.
  */
 export const CANONICAL_PORT_MIN = 1939;
 export const CANONICAL_PORT_MAX = 1949;
@@ -39,8 +41,8 @@ export const PORT_RESERVATIONS: readonly PortReservation[] = [
   { port: 1941, name: "parachute-channel", status: "assigned" },
   { port: 1942, name: "parachute-notes", status: "assigned" },
   { port: 1943, name: "parachute-scribe", status: "assigned" },
-  { port: 1944, name: "pendant", status: "reserved" },
-  { port: 1945, name: "daily-v2", status: "reserved" },
+  { port: 1944, name: "unassigned", status: "reserved" },
+  { port: 1945, name: "unassigned", status: "reserved" },
   { port: 1946, name: "unassigned", status: "reserved" },
   { port: 1947, name: "unassigned", status: "reserved" },
   { port: 1948, name: "unassigned", status: "reserved" },


### PR DESCRIPTION
Aaron retired the pendant + daily-v2 soft-reservations on 2026-04-25. Channel stays in PORT_RESERVATIONS (it ships and works at 1941) but is marked exploration in patterns docs (parachute-patterns#7 amend in flight).

## Why

Pre-reserving slots for unbuilt modules has proven a hold-place we kept reshaping. The new rule: future first-party modules claim a canonical slot at ship time, not before.

## Changes

- `src/service-spec.ts` PORT_RESERVATIONS: 1944 / 1945 are now `unassigned` (matching 1946–1949), not `pendant` / `daily-v2`.
- Header comment updated to reflect committed-core vs exploration tiers + no-speculative-reservations rule.
- Version bump 0.2.7 → 0.2.9-rc.1 (first PR under new RC convention; 0.2.8 held by #51 in flight).

## Patterns check

- Relates to: parachute-patterns canonical-ports.md (PR #7, amend in flight).
- Conforms to: the canonical-ports pattern as it will land post-amendment.
- No new patterns established.

## Test plan

- 421 tests pass, typecheck clean.
- The PORT_RESERVATIONS table is consumed by status logging + canonical-port warnings; both behave the same with `unassigned` rows as they did with `pendant` / `daily-v2` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)