### PR TITLE
feat(install): CLI assigns canonical port at install time (closes #53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,13 +154,19 @@ Parachute services reserve a block of loopback ports in the canonical range **19
 | 1939 | parachute-hub (internal proxy + static) |
 | 1940 | parachute-vault    |
 | 1941 | parachute-channel  |
-| 1942 | parachute-lens     |
+| 1942 | parachute-notes    |
 | 1943 | parachute-scribe   |
-| 1944 | *reserved — pendant*  |
-| 1945 | *reserved — daily-v2* |
-| 1946–1949 | *reserved* |
+| 1944–1949 | *unassigned (CLI fallback range)* |
 
-The hub pins 1939 — no fallback. If something else is on 1939 when you run `parachute expose`, the command fails with a pointer to `lsof -iTCP:1939` rather than walking up into another service's slot. `parachute install` warns (but doesn't block) if a service's declared port lands outside the canonical range.
+The hub pins 1939 — no fallback. If something else is on 1939 when you run `parachute expose`, the command fails with a pointer to `lsof -iTCP:1939` rather than walking up into another service's slot.
+
+**The CLI is the port authority.** `parachute install <svc>` picks the port at install time and writes `PORT=<port>` into `~/.parachute/<svc>/.env`; lifecycle.start merges that .env into the spawn env so the next daemon boot binds the port the CLI assigned. The algorithm:
+
+1. Prefer the canonical slot (e.g. vault → 1940).
+2. On collision, walk the unassigned range (1944–1949).
+3. Range exhausted: assign past 1949 with a warning.
+
+Idempotent: an existing `PORT=` in `~/.parachute/<svc>/.env` wins, so re-installs and operator-edited ports survive across upgrades. Services keep their compiled-in fallbacks (vault → 1940 etc.) so a stand-alone `bun run` still works without a CLI-managed .env.
 
 `parachute expose` probes every service's port at bringup. A service that isn't responding still gets exposed, but you get a `⚠ parachute-<svc> (port …) is not responding` line so proxied requests never silently 502 without explanation.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/cli",
-  "version": "0.2.9-rc.1",
+  "version": "0.2.10-rc.1",
   "description": "parachute — the top-level CLI for the Parachute ecosystem.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -5,10 +5,11 @@ import { join } from "node:path";
 import { install } from "../commands/install.ts";
 import { findService, upsertService } from "../services-manifest.ts";
 
-function makeTempPath(): { path: string; cleanup: () => void } {
+function makeTempPath(): { path: string; configDir: string; cleanup: () => void } {
   const dir = mkdtempSync(join(tmpdir(), "pcli-install-"));
   return {
     path: join(dir, "services.json"),
+    configDir: dir,
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
   };
 }
@@ -23,6 +24,7 @@ describe("install", () => {
         manifestPath: path,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(1);
@@ -45,6 +47,7 @@ describe("install", () => {
         manifestPath: path,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -82,6 +85,7 @@ describe("install", () => {
         manifestPath: path,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -106,6 +110,7 @@ describe("install", () => {
         manifestPath: path,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         findGlobalInstall: () => null,
         log: () => {},
       });
@@ -136,6 +141,7 @@ describe("install", () => {
         manifestPath: path,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         findGlobalInstall: (pkg) =>
           pkg === "@openparachute/vault"
             ? "/fake/bun/global/node_modules/@openparachute/vault/package.json"
@@ -165,14 +171,16 @@ describe("install", () => {
     // spec.init, so the only path to a services.json entry on a fresh
     // install is the seedEntry block. Verifies that gate is reached even
     // when bun's exit code says "failed."
-    const { path, cleanup } = makeTempPath();
+    const { path, configDir, cleanup } = makeTempPath();
     try {
       const logs: string[] = [];
       const code = await install("notes", {
         runner: async (cmd) => (cmd[0] === "bun" ? 1 : 0),
         manifestPath: path,
+        configDir,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         findGlobalInstall: (pkg) =>
           pkg === "@openparachute/notes"
             ? "/fake/bun/global/node_modules/@openparachute/notes/package.json"
@@ -202,6 +210,7 @@ describe("install", () => {
         manifestPath: path,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         findGlobalInstall: () => null,
         log: (l) => logs.push(l),
       });
@@ -243,6 +252,7 @@ describe("install", () => {
           return 0;
         },
         isLinked: () => false,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -252,12 +262,12 @@ describe("install", () => {
     }
   });
 
-  test("warns when manifest entry lands outside the canonical port range", async () => {
-    // Historically the notes PWA wrote 5173 (Vite's dev default). Canonical
-    // is 1939–1949; warn so integrators know their service could conflict
-    // with other software on the box, but don't block — forks may
-    // intentionally deviate.
-    const { path, cleanup } = makeTempPath();
+  test("CLI overrides a non-canonical port written by init when canonical is free", async () => {
+    // Pre-#53 the CLI deferred to whatever port the service's init wrote
+    // (e.g. 5173, Vite's dev default for notes). With CLI-as-port-authority
+    // the canonical slot wins when free: the manifest is updated and the
+    // .env carries PORT=<canonical> so the next daemon boot binds it.
+    const { path, configDir, cleanup } = makeTempPath();
     try {
       const logs: string[] = [];
       const code = await install("notes", {
@@ -277,13 +287,46 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        configDir,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
-      expect(logs.join("\n")).toMatch(/registered on port 5173/);
-      expect(logs.join("\n")).toMatch(/outside the canonical Parachute range/);
+      expect(logs.join("\n")).toMatch(/Updated services\.json port to 1942/);
+      expect(logs.join("\n")).toMatch(/registered on port 1942/);
+      expect(logs.join("\n")).not.toMatch(/outside the canonical Parachute range/);
+      const entry = findService("parachute-notes", path);
+      expect(entry?.port).toBe(1942);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("warns when canonical range is exhausted and assignment falls outside", async () => {
+    // Defensive: if every canonical slot 1939–1949 is occupied (probe says
+    // so), assignPort falls outside the range and surfaces a warning so
+    // operators can free a slot or accept the conflict risk.
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      const code = await install("vault", {
+        runner: async () => 0,
+        manifestPath: path,
+        configDir,
+        startService: async () => 0,
+        isLinked: () => false,
+        // Every canonical slot is taken.
+        portProbe: async () => true,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      const joined = logs.join("\n");
+      expect(joined).toMatch(/canonical range.*1939–1949.*is full/);
+      expect(joined).toMatch(/outside the canonical Parachute range/);
+      const entry = findService("parachute-vault", path);
+      expect(entry?.port).toBeGreaterThan(1949);
     } finally {
       cleanup();
     }
@@ -294,7 +337,7 @@ describe("install", () => {
     // reverted on launch eve (Apr 22). Accepted for one release cycle so
     // anyone who ran `parachute install lens` during the ~3-day window
     // keeps working; removed after launch users have re-installed.
-    const { path, cleanup } = makeTempPath();
+    const { path, configDir, cleanup } = makeTempPath();
     try {
       const calls: string[][] = [];
       const logs: string[] = [];
@@ -304,8 +347,10 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        configDir,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -342,6 +387,7 @@ describe("install", () => {
         manifestPath: path,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
       });
       expect(logs.join("\n")).not.toMatch(/outside the canonical/);
@@ -351,7 +397,7 @@ describe("install", () => {
   });
 
   test("skips init when spec has none (scribe)", async () => {
-    const { path, cleanup } = makeTempPath();
+    const { path, configDir, cleanup } = makeTempPath();
     try {
       const calls: string[][] = [];
       const logs: string[] = [];
@@ -361,8 +407,10 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        configDir,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -381,7 +429,7 @@ describe("install", () => {
     // The scribe motivator: package isn't published to npm yet, so `bun add -g`
     // 404s. If bun link already points the global node_modules at a local
     // checkout, detect that and proceed to init + seeding.
-    const { path, cleanup } = makeTempPath();
+    const { path, configDir, cleanup } = makeTempPath();
     try {
       const calls: string[][] = [];
       const logs: string[] = [];
@@ -391,8 +439,10 @@ describe("install", () => {
           return 0;
         },
         manifestPath: path,
+        configDir,
         startService: async () => 0,
         isLinked: (pkg) => pkg === "@openparachute/scribe",
+        portProbe: async () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -422,6 +472,7 @@ describe("install", () => {
         manifestPath: path,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
         tag: "rc",
       });
@@ -445,6 +496,7 @@ describe("install", () => {
         manifestPath: path,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: () => {},
         tag: "0.3.0-rc.1",
       });
@@ -469,6 +521,7 @@ describe("install", () => {
         manifestPath: path,
         startService: async () => 0,
         isLinked: () => true,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
         tag: "rc",
       });
@@ -489,6 +542,7 @@ describe("install", () => {
         manifestPath: path,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         findGlobalInstall: () => null,
         log: (l) => logs.push(l),
         tag: "rc",
@@ -525,6 +579,7 @@ describe("install", () => {
         manifestPath: path,
         startService: async () => 0,
         isLinked: () => true,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -562,6 +617,7 @@ describe("install", () => {
         configDir,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
         randomToken: () => "test-token-value",
       });
@@ -594,6 +650,7 @@ describe("install", () => {
         configDir,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
         randomToken: () => "should-not-fire",
       });
@@ -627,6 +684,7 @@ describe("install", () => {
         configDir,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: () => {},
         randomToken: () => "install-vault-side-token",
       });
@@ -659,6 +717,7 @@ describe("install", () => {
         configDir,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: () => {},
         randomToken: () => "first-token",
       });
@@ -670,6 +729,7 @@ describe("install", () => {
         configDir,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: () => {},
         randomToken: () => "should-not-replace",
       });
@@ -714,6 +774,7 @@ describe("install", () => {
         configDir,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: () => {},
         randomToken: () => "should-not-fire",
       });
@@ -739,6 +800,7 @@ describe("install", () => {
           return 0;
         },
         isLinked: () => false,
+        portProbe: async () => false,
         log: () => {},
       });
       expect(code).toBe(0);
@@ -762,6 +824,7 @@ describe("install", () => {
           return 0;
         },
         isLinked: () => false,
+        portProbe: async () => false,
         log: () => {},
         noStart: true,
       });
@@ -786,6 +849,7 @@ describe("install", () => {
           return 0;
         },
         isLinked: () => false,
+        portProbe: async () => false,
         log: () => {},
       });
       expect(code).toBe(0);
@@ -806,6 +870,7 @@ describe("install", () => {
         manifestPath: path,
         startService: async () => 1,
         isLinked: () => false,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -824,6 +889,7 @@ describe("install", () => {
         manifestPath: path,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -845,6 +911,7 @@ describe("install", () => {
         manifestPath: path,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -868,6 +935,7 @@ describe("install", () => {
         manifestPath: path,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: (l) => logs.push(l),
       });
       const joined = logs.join("\n");
@@ -888,6 +956,7 @@ describe("install", () => {
         configDir,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: () => {},
         scribeProvider: "groq",
         scribeKey: "gsk_test_value",
@@ -915,6 +984,7 @@ describe("install", () => {
         configDir,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: () => {},
         scribeAvailability: {
           kind: "available",
@@ -941,6 +1011,7 @@ describe("install", () => {
         configDir,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: () => {},
         scribeAvailability: { kind: "not-tty" },
       });
@@ -962,6 +1033,7 @@ describe("install", () => {
         configDir,
         startService: async () => 0,
         isLinked: () => false,
+        portProbe: async () => false,
         log: () => {},
         // If the installer were to call setupScribeProvider here, the absent
         // availability seam would default to detecting a real TTY and (in
@@ -970,6 +1042,102 @@ describe("install", () => {
       });
       expect(code).toBe(0);
       expect(existsSync(join(configDir, "scribe", "config.json"))).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  // CLI-as-port-authority (#53). Install assigns the service's port up front
+  // and writes `PORT=<port>` into `<configDir>/<svc>/.env`. lifecycle.start
+  // merges that .env into spawn env, so the next daemon boot binds the port
+  // the CLI picked.
+  test("install writes PORT=<canonical> to .env when the slot is free", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      const code = await install("vault", {
+        runner: async () => 0,
+        manifestPath: path,
+        configDir,
+        startService: async () => 0,
+        isLinked: () => false,
+        portProbe: async () => false,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      const envText = readFileSync(join(configDir, "vault", ".env"), "utf8");
+      expect(envText).toContain("PORT=1940");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("install preserves a pre-existing PORT in .env across re-installs", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      // First install assigns canonical 1940.
+      await install("vault", {
+        runner: async () => 0,
+        manifestPath: path,
+        configDir,
+        startService: async () => 0,
+        isLinked: () => false,
+        portProbe: async () => false,
+        log: () => {},
+      });
+      // Hand-edit .env to use a custom port (operator override).
+      const envPath = join(configDir, "vault", ".env");
+      const original = readFileSync(envPath, "utf8");
+      const edited = original.replace("PORT=1940", "PORT=1947");
+      const { writeFileSync } = await import("node:fs");
+      writeFileSync(envPath, edited);
+
+      // Second install must preserve the operator's choice, not stomp it.
+      await install("vault", {
+        runner: async () => 0,
+        manifestPath: path,
+        configDir,
+        startService: async () => 0,
+        isLinked: () => false,
+        portProbe: async () => false,
+        log: () => {},
+      });
+      expect(readFileSync(envPath, "utf8")).toContain("PORT=1947");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("install falls back inside the canonical range when the slot is occupied", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      // Pretend something else is on 1940.
+      upsertService(
+        {
+          name: "squatter-on-vault-port",
+          port: 1940,
+          paths: ["/squatter"],
+          health: "/squatter/health",
+          version: "0.0.0",
+        },
+        path,
+      );
+      const logs: string[] = [];
+      const code = await install("vault", {
+        runner: async () => 0,
+        manifestPath: path,
+        configDir,
+        startService: async () => 0,
+        isLinked: () => false,
+        portProbe: async () => false,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      // First reservation slot is 1944.
+      const envText = readFileSync(join(configDir, "vault", ".env"), "utf8");
+      expect(envText).toContain("PORT=1944");
+      const entry = findService("parachute-vault", path);
+      expect(entry?.port).toBe(1944);
+      expect(logs.join("\n")).toMatch(/canonical port 1940 is in use/);
     } finally {
       cleanup();
     }

--- a/src/__tests__/port-assign.test.ts
+++ b/src/__tests__/port-assign.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { assignPort, assignServicePort } from "../port-assign.ts";
+import { CANONICAL_PORT_MAX, CANONICAL_PORT_MIN } from "../service-spec.ts";
+
+function makeTempDir(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-port-assign-"));
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe("assignPort (pure)", () => {
+  test("returns the canonical slot when free", () => {
+    const result = assignPort(1940, []);
+    expect(result.port).toBe(1940);
+    expect(result.source).toBe("canonical");
+    expect(result.warning).toBeUndefined();
+  });
+
+  test("returns canonical even when other unrelated ports are taken", () => {
+    const result = assignPort(1940, [1939, 1942, 1943, 5173]);
+    expect(result.port).toBe(1940);
+    expect(result.source).toBe("canonical");
+  });
+
+  test("walks the unassigned reservation range when canonical is occupied", () => {
+    // 1940 is taken; canonical reserved range starts at 1944 → first hit.
+    const result = assignPort(1940, [1940]);
+    expect(result.port).toBe(1944);
+    expect(result.source).toBe("fallback-in-range");
+    expect(result.warning).toMatch(/canonical port 1940 is in use/);
+    expect(result.warning).toMatch(/1944/);
+  });
+
+  test("skips reservations that are also occupied", () => {
+    // Canonical 1940 + the first three reserved slots are all in use.
+    const result = assignPort(1940, [1940, 1944, 1945, 1946]);
+    expect(result.port).toBe(1947);
+    expect(result.source).toBe("fallback-in-range");
+  });
+
+  test("falls outside the range with a warning when reservations are exhausted", () => {
+    const occupied = [];
+    for (let p = CANONICAL_PORT_MIN; p <= CANONICAL_PORT_MAX; p++) occupied.push(p);
+    const result = assignPort(1940, occupied);
+    expect(result.port).toBe(CANONICAL_PORT_MAX + 1);
+    expect(result.source).toBe("fallback-out-of-range");
+    expect(result.warning).toMatch(/canonical range/);
+    expect(result.warning).toMatch(/1950/);
+    expect(result.warning).toMatch(/may conflict/);
+  });
+
+  test("walks past out-of-range collisions too", () => {
+    const occupied = [];
+    for (let p = CANONICAL_PORT_MIN; p <= CANONICAL_PORT_MAX + 2; p++) occupied.push(p);
+    const result = assignPort(1940, occupied);
+    expect(result.port).toBe(CANONICAL_PORT_MAX + 3);
+    expect(result.source).toBe("fallback-out-of-range");
+  });
+
+  test("third-party (no canonical slot) jumps straight to the reservation range", () => {
+    const result = assignPort(undefined, []);
+    expect(result.port).toBe(1944);
+    expect(result.source).toBe("fallback-in-range");
+    expect(result.warning).toMatch(/no canonical slot/);
+    expect(result.warning).toMatch(/1944/);
+  });
+
+  test("third-party with reservations occupied walks further in the range", () => {
+    const result = assignPort(undefined, [1944, 1945]);
+    expect(result.port).toBe(1946);
+    expect(result.source).toBe("fallback-in-range");
+  });
+});
+
+describe("assignServicePort (.env round-trip)", () => {
+  test("preserves an existing PORT in .env (idempotent re-install)", () => {
+    const { dir, cleanup } = makeTempDir();
+    try {
+      const envPath = join(dir, ".env");
+      writeFileSync(envPath, "PORT=1944\nOTHER=keepme\n");
+      const result = assignServicePort({
+        envPath,
+        canonical: 1940,
+        // Even though canonical is free, the existing .env wins.
+        occupied: [],
+      });
+      expect(result.port).toBe(1944);
+      expect(result.source).toBe("preserved");
+      expect(result.written).toBe(false);
+      // File untouched — no rewrite means OTHER stays as-is.
+      const text = readFileSync(envPath, "utf8");
+      expect(text).toContain("PORT=1944");
+      expect(text).toContain("OTHER=keepme");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("writes PORT into a fresh .env when canonical is free", () => {
+    const { dir, cleanup } = makeTempDir();
+    try {
+      const envPath = join(dir, "subdir", ".env");
+      const result = assignServicePort({
+        envPath,
+        canonical: 1940,
+        occupied: [],
+      });
+      expect(result.port).toBe(1940);
+      expect(result.source).toBe("canonical");
+      expect(result.written).toBe(true);
+      expect(result.warning).toBeUndefined();
+      expect(existsSync(envPath)).toBe(true);
+      expect(readFileSync(envPath, "utf8")).toContain("PORT=1940");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("writes a fallback PORT and surfaces the warning when canonical is occupied", () => {
+    const { dir, cleanup } = makeTempDir();
+    try {
+      const envPath = join(dir, ".env");
+      const result = assignServicePort({
+        envPath,
+        canonical: 1940,
+        occupied: [1940],
+      });
+      expect(result.port).toBe(1944);
+      expect(result.source).toBe("fallback-in-range");
+      expect(result.written).toBe(true);
+      expect(result.warning).toMatch(/canonical port 1940 is in use/);
+      expect(readFileSync(envPath, "utf8")).toContain("PORT=1944");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("ignores a non-numeric PORT and assigns a fresh one", () => {
+    const { dir, cleanup } = makeTempDir();
+    try {
+      const envPath = join(dir, ".env");
+      writeFileSync(envPath, "PORT=garbage\n");
+      const result = assignServicePort({
+        envPath,
+        canonical: 1940,
+        occupied: [],
+      });
+      expect(result.port).toBe(1940);
+      expect(result.written).toBe(true);
+      // The garbage value got upserted to a real number.
+      expect(readFileSync(envPath, "utf8")).toContain("PORT=1940");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("preserves surrounding lines on rewrite", () => {
+    const { dir, cleanup } = makeTempDir();
+    try {
+      const envPath = join(dir, ".env");
+      writeFileSync(envPath, "FOO=bar\nBAZ=qux\n");
+      const result = assignServicePort({
+        envPath,
+        canonical: 1940,
+        occupied: [],
+      });
+      expect(result.written).toBe(true);
+      const text = readFileSync(envPath, "utf8");
+      expect(text).toContain("FOO=bar");
+      expect(text).toContain("BAZ=qux");
+      expect(text).toContain("PORT=1940");
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,8 +1,10 @@
 import { lstatSync, readFileSync } from "node:fs";
+import { createConnection } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { autoWireScribeAuth } from "../auto-wire.ts";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
+import { assignServicePort } from "../port-assign.ts";
 import {
   CANONICAL_PORT_MAX,
   CANONICAL_PORT_MIN,
@@ -10,7 +12,7 @@ import {
   isCanonicalPort,
   knownServices,
 } from "../service-spec.ts";
-import { findService, upsertService } from "../services-manifest.ts";
+import { findService, readManifest, upsertService } from "../services-manifest.ts";
 import { start as lifecycleStart } from "./lifecycle.ts";
 import { migrateNotice } from "./migrate.ts";
 import {
@@ -97,6 +99,13 @@ export interface InstallOpts {
    * the default sense `process.stdin.isTTY`.
    */
   scribeAvailability?: InteractiveAvailability;
+  /**
+   * Test seam for the canonical-slot TCP probe. Production probes
+   * `127.0.0.1:<port>` with a short timeout; tests inject deterministic
+   * answers. Always returns false in tests so canonical slots stay free
+   * unless the test populates services.json directly.
+   */
+  portProbe?: (port: number) => Promise<boolean>;
 }
 
 async function defaultRunner(cmd: readonly string[]): Promise<number> {
@@ -122,6 +131,64 @@ function defaultIsLinked(pkg: string): boolean {
     }
   }
   return false;
+}
+
+/**
+ * Short-timeout TCP probe of `127.0.0.1:<port>`. Used by `parachute install`
+ * to detect canonical slots that something else is already on. Fail-open:
+ * timeouts and errors return `false` so a flaky probe never blocks an
+ * install.
+ */
+async function defaultPortProbe(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (taken: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(taken);
+    };
+    try {
+      const socket = createConnection({ host: "127.0.0.1", port });
+      socket.setTimeout(150, () => {
+        socket.destroy();
+        finish(false);
+      });
+      socket.on("connect", () => {
+        socket.end();
+        finish(true);
+      });
+      socket.on("error", () => finish(false));
+    } catch {
+      finish(false);
+    }
+  });
+}
+
+async function collectOccupiedPorts(
+  manifestPath: string,
+  selfManifestName: string,
+  selfPort: number | undefined,
+  probe: (port: number) => Promise<boolean>,
+): Promise<Set<number>> {
+  const ports = new Set<number>();
+  try {
+    const manifest = readManifest(manifestPath);
+    for (const svc of manifest.services) {
+      if (svc.name === selfManifestName) continue;
+      ports.add(svc.port);
+    }
+  } catch {
+    // Manifest missing or malformed — fall back to the TCP probe alone.
+  }
+  for (let p = CANONICAL_PORT_MIN; p <= CANONICAL_PORT_MAX; p++) {
+    if (selfPort !== undefined && p === selfPort) continue;
+    try {
+      if (await probe(p)) ports.add(p);
+    } catch {
+      // Probe error — fail-open per CLI port-authority policy.
+    }
+  }
+  return ports;
 }
 
 function defaultFindGlobalInstall(pkg: string): string | null {
@@ -204,6 +271,35 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
     }
   }
 
+  // CLI-as-port-authority (#53): pick the service's port now and persist it
+  // via `~/.parachute/<svc>/.env`. lifecycle.start merges that .env into the
+  // spawn env (PR #50), so the next daemon boot binds the port we picked.
+  // Idempotent — an existing PORT in .env wins, so re-installs and
+  // user-edited ports survive across upgrades. Compiled-in service-side
+  // fallbacks (vault → 1940 etc.) stay; this just adds a CLI-managed
+  // override.
+  const preInitEntry = findService(spec.manifestName, manifestPath);
+  const probe = opts.portProbe ?? defaultPortProbe;
+  const occupied = await collectOccupiedPorts(
+    manifestPath,
+    spec.manifestName,
+    preInitEntry?.port,
+    probe,
+  );
+  const envPath = join(configDir, resolvedService, ".env");
+  const canonicalPort = spec.seedEntry?.().port ?? preInitEntry?.port;
+  const portResult = assignServicePort({
+    envPath,
+    canonical: canonicalPort,
+    occupied,
+  });
+  if (portResult.warning) {
+    log(`⚠ ${portResult.warning}`);
+  }
+  if (portResult.written) {
+    log(`Wrote PORT=${portResult.port} to ${envPath}.`);
+  }
+
   // Find-or-seed the manifest entry. Re-read after the seed write so a silent
   // upsert failure (filesystem permission, races against an external writer)
   // surfaces as a loud log line instead of a phantom "registered" claim.
@@ -212,7 +308,9 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
   // turns silent loss into something an operator can spot.
   let entry = findService(spec.manifestName, manifestPath);
   if (!entry && spec.seedEntry) {
-    const seed = spec.seedEntry();
+    const seedBase = spec.seedEntry();
+    const seed =
+      seedBase.port === portResult.port ? seedBase : { ...seedBase, port: portResult.port };
     upsertService(seed, manifestPath);
     entry = findService(spec.manifestName, manifestPath);
     if (entry) {
@@ -226,6 +324,15 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
       log(`  manifest path: ${manifestPath}`);
       log("  Re-run `parachute install` once the underlying issue is resolved.");
     }
+  } else if (entry && entry.port !== portResult.port) {
+    // init wrote an entry on the canonical port but the CLI assigned a
+    // different one (collision). Reflect the CLI's choice so the hub and
+    // status views stay consistent with the .env we just wrote.
+    upsertService({ ...entry, port: portResult.port }, manifestPath);
+    entry = findService(spec.manifestName, manifestPath);
+    log(
+      `Updated services.json port to ${portResult.port} for ${spec.manifestName} (was ${preInitEntry?.port ?? "—"}).`,
+    );
   }
 
   if (!entry) {

--- a/src/help.ts
+++ b/src/help.ts
@@ -42,10 +42,13 @@ Services:
 What it does:
   1. bun add -g @openparachute/<service>[@<tag>]
   2. run any service-specific init (e.g. \`parachute-vault init\`)
-  3. verify the service registered itself in ~/.parachute/services.json
-  4. for scribe in a TTY: prompt for transcription provider + API key
+  3. assign a canonical port (1939–1949) and write \`PORT=<port>\` into
+     \`~/.parachute/<service>/.env\`. Idempotent — an existing PORT wins, so
+     re-installs and operator-edited ports survive across upgrades.
+  4. verify the service registered itself in ~/.parachute/services.json
+  5. for scribe in a TTY: prompt for transcription provider + API key
      (or take \`--scribe-provider\` / \`--scribe-key\`)
-  5. start the service in the background (idempotent — no-op if already up)
+  6. start the service in the background (idempotent — no-op if already up)
 
 Flags:
   --tag <name>              npm dist-tag or exact version to install

--- a/src/port-assign.ts
+++ b/src/port-assign.ts
@@ -1,0 +1,125 @@
+import { parseEnvFile, upsertEnvLine, writeEnvFile } from "./env-file.ts";
+import { CANONICAL_PORT_MAX, CANONICAL_PORT_MIN, PORT_RESERVATIONS } from "./service-spec.ts";
+
+/**
+ * The CLI is the port authority for Parachute services. At install time it
+ * picks a port for each service, writes `PORT=<port>` into the service's
+ * `~/.parachute/<svc>/.env`, and reflects the chosen port in services.json.
+ * Services keep a compiled-in fallback (e.g. vault → 1940) so a stand-alone
+ * `bun run` still works, but the CLI's PORT env var wins on installs it
+ * manages.
+ *
+ * Why up-front assignment instead of detect-on-collision-at-boot:
+ *   - Two services racing to bind the same port produces an opaque "address in
+ *     use" deep inside one of them. Assigning at install lets the CLI keep
+ *     a single coherent picture of who owns what.
+ *   - The hub's reverse-proxy targets are computed from services.json. If a
+ *     service silently falls back to a different port at runtime, the hub
+ *     proxies to a dead port and the user sees a 502 with no explanation.
+ *   - Re-installs stay idempotent: the existing `PORT=` in .env wins, so a
+ *     user who edited their port keeps it across upgrades.
+ */
+
+export type AssignmentSource = "canonical" | "fallback-in-range" | "fallback-out-of-range";
+
+export interface PortAssignment {
+  readonly port: number;
+  readonly source: AssignmentSource;
+  /** Set when the canonical slot wasn't available — caller logs it. */
+  readonly warning?: string;
+}
+
+/**
+ * Pure: pick a port given the canonical default and the set of ports we
+ * already know to be taken.
+ *
+ *   1. Prefer canonical (the slot the service expects, e.g. vault → 1940).
+ *   2. On collision, walk the unassigned canonical reservations (1944..1949
+ *      today) — keeps the install inside the Parachute range so other
+ *      software doesn't accidentally land on the same port.
+ *   3. Range exhausted: walk past CANONICAL_PORT_MAX. The warning lets the
+ *      caller surface it; the install still proceeds.
+ *
+ * Third-party services (no canonical slot) skip step 1 and start at step 2.
+ */
+export function assignPort(
+  canonical: number | undefined,
+  occupied: Iterable<number>,
+): PortAssignment {
+  const taken = new Set(occupied);
+
+  if (canonical !== undefined && !taken.has(canonical)) {
+    return { port: canonical, source: "canonical" };
+  }
+
+  for (const reservation of PORT_RESERVATIONS) {
+    if (reservation.status !== "reserved") continue;
+    if (taken.has(reservation.port)) continue;
+    const warning =
+      canonical !== undefined
+        ? `canonical port ${canonical} is in use; assigned ${reservation.port} from the unassigned Parachute range.`
+        : `assigned port ${reservation.port} from the unassigned Parachute range (no canonical slot for this service).`;
+    return { port: reservation.port, source: "fallback-in-range", warning };
+  }
+
+  let p = CANONICAL_PORT_MAX + 1;
+  while (taken.has(p) && p < 65536) p++;
+  return {
+    port: p,
+    source: "fallback-out-of-range",
+    warning: `Parachute canonical range (${CANONICAL_PORT_MIN}–${CANONICAL_PORT_MAX}) is full; assigned ${p} outside the range — may conflict with other software.`,
+  };
+}
+
+export interface AssignServicePortOpts {
+  /** Path to the service's `.env` file. */
+  readonly envPath: string;
+  /** Canonical default for this service, or undefined for third-party. */
+  readonly canonical?: number;
+  /** Ports we already know to be taken. */
+  readonly occupied: Iterable<number>;
+}
+
+export interface AssignServicePortResult {
+  readonly port: number;
+  /** "preserved" when an existing PORT in .env was kept; otherwise the
+   *  source from `assignPort`. */
+  readonly source: "preserved" | AssignmentSource;
+  /** True when we wrote PORT into .env on this call. */
+  readonly written: boolean;
+  /** Warning to surface to the user, if any. */
+  readonly warning?: string;
+}
+
+/**
+ * Reconcile a service's PORT with its `.env`. Idempotent:
+ *   - If PORT is already set in .env, preserve it (`source: "preserved"`).
+ *     Re-installs and user-edited ports survive across upgrades.
+ *   - Otherwise call `assignPort` and write `PORT=<port>` into .env.
+ *
+ * Reads only the value of PORT from .env; everything else is round-tripped
+ * untouched via `parseEnvFile` / `upsertEnvLine` / `writeEnvFile`.
+ */
+export function assignServicePort(opts: AssignServicePortOpts): AssignServicePortResult {
+  const env = parseEnvFile(opts.envPath);
+  const existing = env.values.PORT;
+  if (existing !== undefined && /^[1-9]\d{0,4}$/.test(existing)) {
+    const port = Number(existing);
+    if (port > 0 && port < 65536) {
+      return { port, source: "preserved", written: false };
+    }
+  }
+
+  const assignment = assignPort(opts.canonical, opts.occupied);
+  const nextLines = upsertEnvLine(env.lines, "PORT", String(assignment.port));
+  writeEnvFile(opts.envPath, nextLines);
+  const result: AssignServicePortResult = {
+    port: assignment.port,
+    source: assignment.source,
+    written: true,
+  };
+  if (assignment.warning) {
+    return { ...result, warning: assignment.warning };
+  }
+  return result;
+}

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -18,9 +18,20 @@ import type { ServiceEntry } from "./services-manifest.ts";
  * (see hub-control.ts) — if something else is on 1939 we fail loudly rather
  * than walking up into a service's slot.
  *
- * Ports outside the range aren't blocked. `parachute install` warns but
- * proceeds, since forks and non-standard deployments sometimes land on other
- * ports intentionally.
+ * **CLI is the port authority.** `parachute install <svc>` picks the port at
+ * install time and writes `PORT=<port>` into `~/.parachute/<svc>/.env`.
+ * lifecycle.start merges that .env into the spawn env, so the next daemon
+ * boot binds the port the CLI assigned. Algorithm (see port-assign.ts):
+ *
+ *   1. Prefer the canonical slot (`spec.seedEntry().port`).
+ *   2. On collision, walk the unassigned range (1944–1949 today).
+ *   3. Range exhausted: assign past 1949 with a warning.
+ *
+ * Idempotent: an existing `PORT=` in .env wins, so re-installs and
+ * operator-edited ports survive across upgrades. Services keep their
+ * compiled-in fallbacks (vault → 1940 etc.) so a stand-alone `bun run`
+ * still works without a CLI-managed .env, but the CLI's PORT wins on any
+ * install it manages.
  *
  * **No speculative reservations.** Future first-party modules claim a slot
  * the moment they ship, not before — pre-reservation for unbuilt things has


### PR DESCRIPTION
## Summary

Make the CLI the port authority. `parachute install <svc>` now picks the service's port up front and writes `PORT=<port>` into `~/.parachute/<svc>/.env`. `lifecycle.start` (PR #50) merges that .env into the spawn env, so the next daemon boot binds the port the CLI assigned.

Algorithm in `src/port-assign.ts`:

1. Prefer the canonical slot (e.g. vault → 1940).
2. On collision, walk the unassigned canonical reservations (1944–1949).
3. Range exhausted: assign past 1949 with a warning.

Idempotent: an existing `PORT=` in .env wins, so re-installs and operator-edited ports survive across upgrades. Services keep their compiled-in fallbacks (vault → 1940 etc.) so a stand-alone `bun run` still works without a CLI-managed .env.

Occupied set = services.json port fields (excluding self) + short-timeout TCP probe of canonical slots. Both fail-open: a flaky probe never blocks an install.

When init writes a non-canonical port (e.g. an old vault that wrote 5173), the CLI now updates the manifest entry to match the assigned port — keeps the hub's reverse-proxy targets consistent with the .env the next daemon boot will read.

No service-side changes.

## Patterns check

- Touches the territory of `parachute-patterns/patterns/canonical-ports.md` — establishes a new "CLI as port authority" convention layered on top of the existing canonical range.
- Follow-up: file a patterns issue post-merge to capture this pattern as a doc. (Not drafting the pattern doc here per team-lead's instruction.)

## Scope notes

- Channel still reads `PARACHUTE_CHANNEL_PORT` rather than `PORT`; it'll see PORT=<assigned> in env via lifecycle but ignore it. Out of scope per "no service-side changes" — captured for follow-up.
- Cross-machine port discovery is not in scope here; this PR only handles single-host port assignment.

## Test plan

- [x] `bun test` — 441 pass, 0 fail (added 13 port-assign + 4 install integration cases)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Manual smoke on a clean machine: `parachute install vault`, then `cat ~/.parachute/vault/.env` → `PORT=1940`. Re-install → still `PORT=1940`. Hand-edit to `PORT=1947` → re-install → still `PORT=1947`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)