### PR TITLE
chore: rename @openparachute/cli → @openparachute/hub (0.3.0-rc.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,10 @@
-# Parachute CLI
+# Parachute Hub
 
-`parachute` — the top-level CLI. Installs services, runs them as background processes, and exposes them over Tailscale. Coordinator, not a service: each Parachute package (`vault`, `notes`, `scribe`, `channel`) stays standalone; this CLI stitches them together.
+`@openparachute/hub` — the local hub for the Parachute ecosystem. The `parachute` binary is one of its surfaces; the long-running daemon (discovery on `:1939`, soon OAuth issuance) is another. Coordinator, not a service: each Parachute package (`vault`, `notes`, `scribe`, `channel`) stays standalone; the hub stitches them together.
 
-User-facing README is the right intro for operators. This file is for agents and humans working *on* the CLI itself.
+Renamed from `@openparachute/cli` / `parachute-cli` on 2026-04-26 — same binary name (`parachute`), same code, broader role. The "CLI" framing was always partial.
+
+User-facing README is the right intro for operators. This file is for agents and humans working *on* the hub itself.
 
 ## Architecture
 
@@ -70,7 +72,7 @@ Every PR here is reviewer-gated — no direct-to-main, even for one-line fixes. 
 ## Naming
 
 - Domain: `parachute.computer`
-- npm scope: `@openparachute/` (this package: `@openparachute/cli`)
+- npm scope: `@openparachute/` (this package: `@openparachute/hub`; previously `@openparachute/cli` pre-2026-04-26)
 - Bin name: `parachute`
 - Config root: `~/.parachute/` (override with `PARACHUTE_HOME`)
 - Per-service dirs: `~/.parachute/<short>/` (e.g. `~/.parachute/vault/`)

--- a/LAUNCH_SMOKE.md
+++ b/LAUNCH_SMOKE.md
@@ -11,7 +11,7 @@ Run this on a fresh macOS or Linux (or a VM) with nothing pre-installed under `~
 ## 1. Install the CLI from npm
 
 ```sh
-bun add -g @openparachute/cli
+bun add -g @openparachute/hub
 parachute --version           # Expect: 0.2.0
 parachute --help              # Lists install, status, start, stop, restart, logs, expose, migrate
 ```

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-# Parachute CLI
+# Parachute Hub
 
-`parachute` — the top-level command for the [Parachute](https://parachute.computer) ecosystem.
+`@openparachute/hub` — the local hub for the [Parachute](https://parachute.computer) ecosystem. The `parachute` binary is one of its surfaces.
 
-Install, inspect, and (soon) expose Parachute services with one command. Each service (vault, notes, scribe, channel, …) stays a standalone package; this CLI is the coordinator.
+The hub coordinates the modules running on your machine: it installs them, runs them as background processes, exposes them over Tailscale, serves the discovery document at `/.well-known/parachute.json`, and (soon) issues OAuth tokens. Each module (vault, notes, scribe, channel, …) stays a standalone package; the hub stitches them together.
+
+> Previously published as `@openparachute/cli`. Renamed 2026-04-26 to better reflect the role — see [parachute-patterns/hub-as-issuer](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/hub-as-issuer.md). The `parachute` binary name is unchanged.
 
 ## Install
 
 ```sh
-bun add -g @openparachute/cli
+bun add -g @openparachute/hub
 ```
 
 Prereqs: [Bun](https://bun.sh) 1.3.0 or later. `parachute expose` also requires [Tailscale](https://tailscale.com/download) **1.82 or newer** (installed + `tailscale up` run once); the `expose` path is under active polish for launch, so expect rough edges.
@@ -15,8 +17,8 @@ Prereqs: [Bun](https://bun.sh) 1.3.0 or later. `parachute expose` also requires 
 ## First 5 minutes
 
 ```sh
-# 1. Install the CLI (one line)
-bun add -g @openparachute/cli
+# 1. Install the hub (one line — installs the `parachute` binary)
+bun add -g @openparachute/hub
 
 # 2. Install a service (runs `bun add -g @openparachute/vault` + `parachute-vault init`)
 parachute install vault
@@ -204,10 +206,10 @@ export PARACHUTE_HOME=/some/other/path
 
 ## Already have parachute-vault installed?
 
-Install the CLI and `parachute vault ...` forwards to your existing `parachute-vault` binary:
+Install the hub and `parachute vault ...` forwards to your existing `parachute-vault` binary:
 
 ```sh
-bun add -g @openparachute/cli
+bun add -g @openparachute/hub
 parachute vault init     # dispatches to parachute-vault init
 parachute vault --help   # dispatches to parachute-vault --help
 ```
@@ -220,7 +222,7 @@ Copy-paste to verify the whole chain. Everything here is idempotent.
 
 ```sh
 # Install
-bun add -g @openparachute/cli
+bun add -g @openparachute/hub
 
 # Verify CLI
 parachute --version

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "@openparachute/cli",
+      "name": "@openparachute/hub",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@types/bun": "latest",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@openparachute/cli",
-  "version": "0.2.10-rc.1",
-  "description": "parachute — the top-level CLI for the Parachute ecosystem.",
+  "name": "@openparachute/hub",
+  "version": "0.3.0-rc.1",
+  "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "type": "module",
   "module": "src/cli.ts",
@@ -11,7 +11,7 @@
   "files": ["src", "README.md", "LICENSE"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ParachuteComputer/parachute-cli.git"
+    "url": "https://github.com/ParachuteComputer/parachute-hub.git"
   },
   "scripts": {
     "start": "bun src/cli.ts",

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -14,8 +14,8 @@ async function runCli(
     stderr: "pipe",
     env: {
       ...process.env,
-      HOME: "/tmp/parachute-cli-nonexistent-home",
-      PARACHUTE_HOME: "/tmp/parachute-cli-nonexistent-home",
+      HOME: "/tmp/parachute-hub-nonexistent-home",
+      PARACHUTE_HOME: "/tmp/parachute-hub-nonexistent-home",
       ...env,
     },
   });
@@ -144,8 +144,8 @@ describe("cli per-subcommand help", () => {
       env: {
         ...process.env,
         PATH: "",
-        HOME: "/tmp/parachute-cli-nonexistent-home",
-        PARACHUTE_HOME: "/tmp/parachute-cli-nonexistent-home",
+        HOME: "/tmp/parachute-hub-nonexistent-home",
+        PARACHUTE_HOME: "/tmp/parachute-hub-nonexistent-home",
       },
     });
     const [stderr, code] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
@@ -165,8 +165,8 @@ describe("cli per-subcommand help", () => {
       env: {
         ...process.env,
         PATH: "",
-        HOME: "/tmp/parachute-cli-nonexistent-home",
-        PARACHUTE_HOME: "/tmp/parachute-cli-nonexistent-home",
+        HOME: "/tmp/parachute-hub-nonexistent-home",
+        PARACHUTE_HOME: "/tmp/parachute-hub-nonexistent-home",
       },
     });
     const [stderr, code] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -251,7 +251,7 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
       } else {
         // Make the failure mode legible: enumerating the prefixes we probed
         // turns "bun add -g failed" into something an operator on a non-
-        // standard bun layout can act on. (Surfaced by parachute-cli#44 — a
+        // standard bun layout can act on. (Surfaced by parachute-hub#44 — a
         // bun 1.2.x report where `notes` never registered; if the same
         // failure mode ever manifests via findGlobalInstall returning null,
         // the log tells us where to look.)
@@ -303,7 +303,7 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
   // Find-or-seed the manifest entry. Re-read after the seed write so a silent
   // upsert failure (filesystem permission, races against an external writer)
   // surfaces as a loud log line instead of a phantom "registered" claim.
-  // parachute-cli#44 reported notes not appearing in services.json on a fresh
+  // parachute-hub#44 reported notes not appearing in services.json on a fresh
   // bun 1.2.x install; the gate logic was already correct, but a verify-step
   // turns silent loss into something an operator can spot.
   let entry = findService(spec.manifestName, manifestPath);
@@ -409,7 +409,7 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
   // authoritative entry during init or first boot, replacing the seed (or
   // filling a gap when the service had no seedEntry). Re-read at exit so the
   // last line of the install always reflects ground truth, not an early
-  // snapshot. Surfaced by parachute-cli#44 — defensive logging that turns a
+  // snapshot. Surfaced by parachute-hub#44 — defensive logging that turns a
   // missing entry into a visible failure rather than a silent one.
   const finalEntry = findService(spec.manifestName, manifestPath);
   if (!finalEntry) {


### PR DESCRIPTION
## Summary

In-place rename of the package to reflect its role. The `parachute` binary name is unchanged — users still run `parachute install`, `parachute expose`, etc. The package becomes `@openparachute/hub`; the GitHub repo was already renamed to `parachute-hub` (with redirect from `parachute-cli`).

Why a 0.3.0-rc.1 bump and not a 0.2.x: new package name is a major contract change for installers (`bun add -g @openparachute/cli` no longer resolves to the latest version). Using the rename moment to also signal the broader role (OAuth issuer, config portal, module-protocol install resolution coming next).

## Touch list

- [x] `package.json` — `name` → `@openparachute/hub`, `version` → `0.3.0-rc.1`, `repository.url` → `parachute-hub.git`, `description` tightened to "the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth)"
- [x] `bun.lock` — workspace name mirrored
- [x] `README.md` — title (`Parachute CLI` → `Parachute Hub`), first paragraph reframed (hub is the package; CLI is the binary surface), install lines (`@openparachute/cli` → `@openparachute/hub` in 4 places), short rename note pointing at `parachute-patterns/hub-as-issuer`
- [x] `CLAUDE.md` — title, role description, rename note, naming section (`this package: @openparachute/hub; previously @openparachute/cli pre-2026-04-26`)
- [x] `LAUNCH_SMOKE.md` — install line
- [x] `src/commands/install.ts` — three `parachute-cli#44` comment refs → `parachute-hub#44` (GH redirects work either way; new name is cleaner)
- [x] `src/__tests__/cli.test.ts` — tmp HOME paths

Not touched (out of scope per #55):
- Command implementations
- `services-manifest.ts` schema
- `bin` entry — stays `parachute`
- `package.json` `bin` block — unchanged
- Cross-repo references (vault / notes / scribe / patterns / paraclaw / site) — separate PRs per repo, post-merge

## Gates

- `bun run typecheck` — clean
- `bun test` — 441 pass / 0 fail (1169 expects, 34 files)
- `bunx biome check .` — 77 files, no issues

## Follow-ups (separate PRs after this merges)

- Aaron publishes `@openparachute/hub@0.3.0-rc.1` to npm with `--tag rc`
- `parachute-cli-tombstone` repo + final `@openparachute/cli@0.3.0` postinstall redirect (per #55 plan)
- Cross-repo doc sweep — vault, notes, scribe, patterns, paraclaw, site (one PR per repo)

Closes #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>