### PR TITLE
chore: pause-public docs + add publishConfig (0.3.0-rc.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ parachute status
 #    OpenCode, Cursor, Zed, Cline, your own agent) at:
 #      http://127.0.0.1:1940/vault/default/mcp
 
-# 6. Expose beyond localhost — Tailscale Funnel or Cloudflare Tunnel.
-#    Polishing for broad launch, but live today for early testers:
-parachute expose --help
+# 6. Expose across your tailnet — HTTPS, MagicDNS, only your devices.
+#    The supported exposure shape today; public-internet exposure is
+#    exploratory (see "Public exposure" below).
+parachute expose tailnet
 ```
 
-Tear down with `parachute expose tailnet off` or `parachute expose public off`. Layers are independent — `off` only affects the layer you name.
+Tear down with `parachute expose tailnet off`. The public layer (`expose public off`) tears down independently — `off` only affects the layer you name.
 
 ## Service lifecycle
 
@@ -87,13 +88,18 @@ parachute migrate --yes           # unattended
 
 Anything swept goes to `~/.parachute/.archive-<YYYY-MM-DD>/` with its original name — nothing is deleted. Recognized entries (per-service dirs, `services.json`, `expose-state.json`, `well-known/`) are left in place, and so is anything starting with a dot (so `.env` and prior `.archive-*` dirs are safe).
 
-## Three layers of addressability
+## Two supported layers (plus an exploratory third)
 
 Each additive; each can be turned off without affecting the layer below.
 
 - **Local** — services on loopback. Zero config. Browsers treat `localhost` as a secure context, so OAuth, PKCE, and Web Crypto all just work out of the box.
-- **Tailnet** — `parachute expose tailnet` wraps `tailscale serve` for every registered service. HTTPS via Tailscale's MagicDNS cert. Only machines on your tailnet can reach the URL.
-- **Public** — `parachute expose public` routes each handler through `tailscale funnel` so the same URLs become reachable from the public internet. At launch, Funnel is the only supported backend; Caddy + your-own-domain and cloudflared tunnels are planned post-launch.
+- **Tailnet** — `parachute expose tailnet` wraps `tailscale serve` for every registered service. HTTPS via Tailscale's MagicDNS cert. Only machines on your tailnet can reach the URL. **This is the documented shape for the hub today.** Tailnet is already authenticated at the network layer, every user's tailnet is their own, and the OAuth + module access work happening in the hub is being designed against this shape first.
+
+### Public exposure (exploratory)
+
+`parachute expose public` exists for early testers. It routes each handler through `tailscale funnel` (or, with `--cloudflare`, a named Cloudflare tunnel) so the same URLs become reachable from the public internet. The code path is live and the flag still works, but the public-internet posture (DNS, cross-internet OAuth, Funnel quirks) hasn't been hardened the way tailnet has — expect rough edges.
+
+When the hub's OAuth issuer + per-module scope enforcement land, public will re-enter the documented narrative as "now safe." Until then, prefer tailnet.
 
 Under the hood, tailnet mode uses `tailscale serve` and public mode uses `tailscale funnel`; both write into the same node-level serve config. The CLI records which layer is live so that `expose <other-layer> off` is a no-op rather than a surprise teardown of the active layer.
 
@@ -142,10 +148,8 @@ The `/.well-known/parachute.json` document is an always-present descriptor — f
 
 Why path-routing and not subdomain-per-service? Two reasons:
 
-1. **Tailscale Funnel HTTPS is capped at three ports per node** (443, 8443, 10000). Pinning every service to 443 behind a path means you can install any number of services without ever hitting that cap.
+1. **Tailscale Funnel HTTPS is capped at three ports per node** (443, 8443, 10000). Pinning every service to 443 behind a path means you can install any number of services without ever hitting that cap. (Funnel is the public-exposure backend; the cap shapes the tailnet-mode design too, since both modes share one serve config.)
 2. **Subdomain-per-service requires the Tailscale Services feature** (virtual-IP advertisement per service), which is more than a MagicDNS wildcard — it needs admin-side setup that's out of scope for a one-command install. When it's a launch-grade path, we'll add `parachute expose tailnet --mode subdomain`.
-
-Funnel has bandwidth quotas on Tailscale's free tier. See [tailscale.com/kb/1223/funnel](https://tailscale.com/kb/1223/funnel) for current limits; for heavy traffic, the post-launch Caddy / cloudflared modes will be the answer.
 
 ## Ports
 
@@ -250,13 +254,11 @@ parachute expose tailnet
 # Also confirm the discovery document:
 curl -s https://parachute.<tailnet>.ts.net/.well-known/parachute.json | jq .
 
-# Flip to public (Funnel)
-parachute expose public
-# Open the same URL in a browser NOT on your tailnet — phone on cell, say.
-
 # Tear down
-parachute expose public off
+parachute expose tailnet off
 ```
+
+Public-internet exposure (`parachute expose public`) is exploratory — see "Public exposure" above. The flag still works for early testers; the supported smoke is tailnet.
 
 ## Subcommand reference
 
@@ -269,8 +271,8 @@ parachute start   [service]       start services in the background
 parachute stop    [service]       stop services (SIGTERM → 10s → SIGKILL)
 parachute restart [service]       stop + start
 parachute logs <service> [-f]     print/tail service logs
-parachute expose tailnet [off]    HTTPS across your tailnet
-parachute expose public  [off]    HTTPS on the public internet (Funnel)
+parachute expose tailnet [off]    HTTPS across your tailnet (supported)
+parachute expose public  [off]    HTTPS on the public internet (exploratory)
 parachute migrate [--dry-run]     archive legacy files at ecosystem root
 parachute vault <args...>         dispatch to parachute-vault
 ```

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "module": "src/cli.ts",
   "bin": {

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -433,6 +433,9 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
   if (layer === "public") {
     log(`✓ Public exposure active (Funnel). Open: ${canonicalOrigin}/`);
     log("  This node is reachable from the public internet.");
+    log(
+      "  Note: public is exploratory. Tailnet is the supported exposure shape today; the hub's OAuth + scope work targets tailnet first. Prefer `parachute expose tailnet` unless you specifically need a public URL.",
+    );
   } else {
     log(`✓ Tailnet exposure active. Open: ${canonicalOrigin}/`);
   }

--- a/src/help.ts
+++ b/src/help.ts
@@ -13,8 +13,8 @@ Usage:
   parachute stop    [service]       stop all services (or one) — SIGTERM then SIGKILL
   parachute restart [service]       stop + start
   parachute logs <service> [-f]     print service logs; -f to tail
-  parachute expose tailnet [off]    HTTPS across your tailnet
-  parachute expose public  [off]    HTTPS on the public internet (Funnel)
+  parachute expose tailnet [off]    HTTPS across your tailnet (supported)
+  parachute expose public  [off]    HTTPS on the public internet (exploratory)
   parachute migrate [--dry-run]     archive legacy files at ecosystem root
   parachute auth <cmd>              identity (set password, manage 2FA)
   parachute vault <args...>         vault-specific ops (tokens, 2fa, config, init,
@@ -119,6 +119,15 @@ Usage:
   parachute expose public  --cloudflare --domain <hostname>
   parachute expose public  off --cloudflare
 
+Status:
+  tailnet is the supported exposure shape. The hub's OAuth + per-module
+  scope work is being designed against tailnet first (already auth'd at
+  the network layer, every user's tailnet is their own).
+  public is exploratory — the flag still works for early testers, but
+  the public-internet posture (DNS, cross-internet OAuth, Funnel quirks)
+  hasn't been hardened. Prefer tailnet until public re-enters the
+  documented narrative post-OAuth.
+
 Interactive:
   Run in a terminal with no flags, \`parachute expose public\` walks you
   through provider selection (Tailscale Funnel vs. Cloudflare Tunnel),
@@ -127,8 +136,8 @@ Interactive:
   scripted behavior: default to Tailscale, flags override.
 
 Layers:
-  tailnet    HTTPS across your tailnet (tailscale serve)
-  public     HTTPS on the public internet
+  tailnet    HTTPS across your tailnet (tailscale serve) — supported
+  public     HTTPS on the public internet — exploratory
              - default: Tailscale Funnel (no domain needed, *.ts.net URL)
              - --cloudflare + --domain: named Cloudflare tunnel on your own
                domain (stable URL, free, no bandwidth caps)


### PR DESCRIPTION
## Summary

Foreground tailnet as the documented exposure shape for the hub. Public-internet exposure stays available (the code path is unchanged) but is reframed as exploratory — the hub's OAuth + per-module scope work targets tailnet first, and public's posture (DNS, cross-internet OAuth, Funnel quirks) hasn't been hardened yet. Public will re-enter the documented narrative post-OAuth.

Also folds in a tiny operational-hygiene fix: `publishConfig: { access: "public" }` so Aaron doesn't need `--access public` on every publish (he just hit this on 0.3.0-rc.1).

## Touch list

### Pause-public docs (#57)

- [x] `README.md`
  - First-5-minutes step 6 — leads with `parachute expose tailnet` (was a generic "expose --help" hand-wave that gave public equal billing)
  - "Three layers of addressability" → "Two supported layers (plus an exploratory third)"; new `Public exposure (exploratory)` subsection explains the deferred posture and what it's waiting on
  - Smoke walkthrough — tear-down line uses tailnet; the public flip is documented as exploratory
  - Subcommand-reference table — `tailnet` tagged `(supported)`, `public` tagged `(exploratory)`
- [x] `src/help.ts`
  - Top-level help mirrors the supported/exploratory tags
  - `exposeHelp()` gets a `Status:` block at the top + same tags on the Layers list
- [x] `src/commands/expose.ts`
  - `exposePublic` up-path prints a one-line note after `✓ Public exposure active` pointing back at tailnet

### publishConfig (operational hygiene, no separate issue)

- [x] `package.json`
  - `publishConfig: { access: "public" }` — durable fix for the `--access public` dance
  - version `0.3.0-rc.1` → `0.3.0-rc.2` per RC-versioning governance

## Out of scope (per #57)

Cross-repo doc work (vault / notes / scribe / patterns / paraclaw / site / parachute.computer install.njk) — separate PRs against those repos. This PR is hub-only.

Public-exposure code paths are untouched. Existing flag, interactive picker, cloudflare mode, and all teardown logic still work.

## Gates

- `bun run typecheck` — clean
- `bun test` — 441 pass / 0 fail (1169 expects, 34 files)
- `bunx biome check .` — 77 files, no issues
- Existing `/Public exposure active/` substring test still matches (the new note is appended, not replacing the banner)
- Existing CLI help tests still match — `expose public`, `Funnel`, `443`, `--cloudflare`, `--domain` all still in the help output

Closes #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>