### PR TITLE
release: 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.3.0-rc.2",
+  "version": "0.3.0",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Promotes `0.3.0-rc.2` → `0.3.0` stable. The `-rc.N` suffix drops; nothing else changes.

This release captures three landed PRs:
- **#60** — rename `@openparachute/cli` → `@openparachute/hub` (the package's role widened past "CLI"; `parachute` binary name is unchanged)
- **#61** — pause-public docs sweep: tailnet is the supported exposure shape; public is exploratory until OAuth + per-module scope work lands (#57)
- **#61** — `publishConfig: { access: "public" }` so future `npm publish` doesn't need `--access public` on every release

## After merge (Aaron's steps)

```sh
npm publish
```

No `--tag` (defaults to `@latest`). No `--access public` (declared in package.json now). Lands `@openparachute/hub@0.3.0` on `@latest` — the package on the default install path.

## Gates

- `bun run typecheck` — clean
- `bun test` — 441 pass / 0 fail (1169 expects, 34 files)
- `bunx biome check .` — 77 files, no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>