### PR TITLE
feat(hub): JWT signing keys + JWKS plumbing (0.3.1-rc.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.3.0",
+  "version": "0.3.1-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -93,9 +93,41 @@ describe("authHelp", () => {
     expect(h).toContain("parachute auth 2fa enroll");
     expect(h).toContain("parachute auth 2fa disable");
     expect(h).toContain("parachute auth 2fa backup-codes");
+    expect(h).toContain("parachute auth rotate-key");
   });
 
   test("mentions the vault-install hint", () => {
     expect(h).toContain("parachute install vault");
+  });
+
+  test("explains rotate-key is hub-local and the 24h JWKS retention", () => {
+    expect(h).toContain("hub-local");
+    expect(h).toContain("24 hours");
+  });
+});
+
+describe("parachute auth rotate-key", () => {
+  test("invokes the rotate hook and exits 0; does not spawn vault", async () => {
+    const { runner, calls } = makeRunner(0);
+    let hookCalls = 0;
+    const code = await auth(["rotate-key"], {
+      runner,
+      rotateKey: () => {
+        hookCalls++;
+        return { kid: "test-kid-abc", createdAt: "2026-04-26T00:00:00.000Z" };
+      },
+    });
+    expect(code).toBe(0);
+    expect(hookCalls).toBe(1);
+    expect(calls).toEqual([]);
+  });
+
+  test("propagates rotate errors as exit 1", async () => {
+    const code = await auth(["rotate-key"], {
+      rotateKey: () => {
+        throw new Error("disk full");
+      },
+    });
+    expect(code).toBe(1);
   });
 });

--- a/src/__tests__/hub-db.test.ts
+++ b/src/__tests__/hub-db.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+
+interface Harness {
+  configDir: string;
+  dbPath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const configDir = mkdtempSync(join(tmpdir(), "phub-db-"));
+  return {
+    configDir,
+    dbPath: hubDbPath(configDir),
+    cleanup: () => rmSync(configDir, { recursive: true, force: true }),
+  };
+}
+
+describe("openHubDb + migrate", () => {
+  test("creates schema_version + signing_keys on a fresh db", () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(h.dbPath);
+      try {
+        const tables = (
+          db
+            .query<{ name: string }, []>(
+              "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
+            )
+            .all() ?? []
+        ).map((r) => r.name);
+        expect(tables).toContain("schema_version");
+        expect(tables).toContain("signing_keys");
+        const versions = (
+          db.query<{ version: number }, []>("SELECT version FROM schema_version").all() ?? []
+        ).map((r) => r.version);
+        expect(versions).toContain(1);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("re-opening an already-migrated db is a no-op (no duplicate version rows)", () => {
+    const h = makeHarness();
+    try {
+      const db1 = openHubDb(h.dbPath);
+      db1.close();
+      const db2 = openHubDb(h.dbPath);
+      try {
+        const rows = db2
+          .query<{ version: number; applied_at: string }, []>(
+            "SELECT version, applied_at FROM schema_version",
+          )
+          .all();
+        expect(rows.length).toBe(1);
+        expect(rows[0]?.version).toBe(1);
+      } finally {
+        db2.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("signing_keys schema enforces required columns", () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(h.dbPath);
+      try {
+        // Missing private_key_pem must fail (NOT NULL).
+        expect(() =>
+          db
+            .prepare(
+              "INSERT INTO signing_keys (kid, public_key_pem, algorithm, created_at) VALUES (?, ?, ?, ?)",
+            )
+            .run("k1", "pem", "RS256", new Date().toISOString()),
+        ).toThrow();
+        // Full row works; retired_at is nullable.
+        db.prepare(
+          `INSERT INTO signing_keys (kid, public_key_pem, private_key_pem, algorithm, created_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        ).run("k2", "pub", "priv", "RS256", new Date().toISOString());
+        const row = db
+          .query<{ retired_at: string | null }, [string]>(
+            "SELECT retired_at FROM signing_keys WHERE kid = ?",
+          )
+          .get("k2");
+        expect(row?.retired_at).toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { hubFetch } from "../hub-server.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
 
 interface Harness {
   dir: string;
@@ -128,6 +130,74 @@ describe("hubFetch routing", () => {
     try {
       const res = hubFetch(h.dir)(req("/.well-known/parachute.json"));
       expect(res.status).toBe(404);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/.well-known/jwks.json returns the JWKS from the live db", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const k = rotateSigningKey(db);
+        const res = hubFetch(h.dir, { getDb: () => db })(req("/.well-known/jwks.json"));
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toBe("application/json");
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+        const body = (await res.json()) as { keys: Array<{ kid: string; alg: string; n: string }> };
+        expect(body.keys.length).toBe(1);
+        expect(body.keys[0]?.kid).toBe(k.kid);
+        expect(body.keys[0]?.alg).toBe("RS256");
+        expect(body.keys[0]?.n.length).toBeGreaterThan(0);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("OPTIONS preflight on /.well-known/jwks.json returns 204 + CORS without touching the db", async () => {
+    const h = makeHarness();
+    try {
+      // Pass a getDb that throws — preflight must not invoke it.
+      const res = hubFetch(h.dir, {
+        getDb: () => {
+          throw new Error("getDb should not be called for OPTIONS");
+        },
+      })(req("/.well-known/jwks.json", { method: "OPTIONS" }));
+      expect(res.status).toBe(204);
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+      expect(res.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/.well-known/jwks.json returns 503 + CORS when db is not configured", async () => {
+    const h = makeHarness();
+    try {
+      const res = hubFetch(h.dir)(req("/.well-known/jwks.json"));
+      expect(res.status).toBe(503);
+      expect(res.headers.get("content-type")).toBe("application/json");
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/.well-known/jwks.json on an empty db returns {keys: []}", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = hubFetch(h.dir, { getDb: () => db })(req("/.well-known/jwks.json"));
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ keys: [] });
+      } finally {
+        db.close();
+      }
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/jwks.test.ts
+++ b/src/__tests__/jwks.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
+import { pemToJwk } from "../jwks.ts";
+
+function freshRsaPem(): string {
+  const { publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  return publicKey.export({ format: "pem", type: "spki" }).toString();
+}
+
+describe("pemToJwk", () => {
+  test("returns a JWK with kty=RSA, alg=RS256, use=sig, and the supplied kid", () => {
+    const pem = freshRsaPem();
+    const jwk = pemToJwk(pem, "test-kid");
+    expect(jwk.kty).toBe("RSA");
+    expect(jwk.alg).toBe("RS256");
+    expect(jwk.use).toBe("sig");
+    expect(jwk.kid).toBe("test-kid");
+    // n + e are non-empty base64url strings.
+    expect(jwk.n.length).toBeGreaterThan(0);
+    expect(jwk.e.length).toBeGreaterThan(0);
+    expect(jwk.n).not.toMatch(/[+/=]/);
+    expect(jwk.e).not.toMatch(/[+/=]/);
+  });
+
+  test("rejects a non-RSA key", () => {
+    const { publicKey } = generateKeyPairSync("ed25519");
+    const pem = publicKey.export({ format: "pem", type: "spki" }).toString();
+    expect(() => pemToJwk(pem, "bad")).toThrow();
+  });
+
+  test("is deterministic for the same PEM + kid", () => {
+    const pem = freshRsaPem();
+    const a = pemToJwk(pem, "k");
+    const b = pemToJwk(pem, "k");
+    expect(b).toEqual(a);
+  });
+});

--- a/src/__tests__/signing-keys.test.ts
+++ b/src/__tests__/signing-keys.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import {
+  JWKS_RETENTION_MS,
+  computeKid,
+  getActiveSigningKey,
+  getAllPublicKeys,
+  rotateSigningKey,
+} from "../signing-keys.ts";
+
+function makeDb() {
+  const configDir = mkdtempSync(join(tmpdir(), "phub-sk-"));
+  const db = openHubDb(hubDbPath(configDir));
+  return { db, cleanup: () => rmSync(configDir, { recursive: true, force: true }) };
+}
+
+describe("computeKid", () => {
+  test("is deterministic and base64url-shaped", () => {
+    const a = computeKid("-----BEGIN PUBLIC KEY-----\nABC\n-----END PUBLIC KEY-----\n");
+    const b = computeKid("-----BEGIN PUBLIC KEY-----\nABC\n-----END PUBLIC KEY-----\n");
+    expect(a).toBe(b);
+    // base64url has no `+`, `/`, or `=` padding.
+    expect(a).not.toMatch(/[+/=]/);
+    // SHA-256 → 32 bytes → 43 base64url chars.
+    expect(a.length).toBe(43);
+  });
+
+  test("differs for different PEMs", () => {
+    const a = computeKid("PEM-A");
+    const b = computeKid("PEM-B");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("getActiveSigningKey", () => {
+  test("auto-seeds an active key on a fresh db", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const k = getActiveSigningKey(db);
+      expect(k.kid.length).toBe(43);
+      expect(k.algorithm).toBe("RS256");
+      expect(k.retiredAt).toBeNull();
+      expect(k.publicKeyPem).toContain("BEGIN PUBLIC KEY");
+      expect(k.privateKeyPem).toContain("BEGIN PRIVATE KEY");
+      // kid is content-addressed against the public PEM.
+      expect(k.kid).toBe(computeKid(k.publicKeyPem));
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("is idempotent — repeat calls return the same active key", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const a = getActiveSigningKey(db);
+      const b = getActiveSigningKey(db);
+      expect(b.kid).toBe(a.kid);
+      expect(b.privateKeyPem).toBe(a.privateKeyPem);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("rotateSigningKey", () => {
+  test("retires the prior active key and creates a fresh one", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const old = getActiveSigningKey(db);
+      const fresh = rotateSigningKey(db);
+      expect(fresh.kid).not.toBe(old.kid);
+      expect(fresh.retiredAt).toBeNull();
+      const next = getActiveSigningKey(db);
+      expect(next.kid).toBe(fresh.kid);
+
+      const oldRow = db
+        .query<{ retired_at: string | null }, [string]>(
+          "SELECT retired_at FROM signing_keys WHERE kid = ?",
+        )
+        .get(old.kid);
+      expect(oldRow?.retired_at).not.toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("transactional — if the insert succeeds, exactly one active key remains", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      getActiveSigningKey(db);
+      rotateSigningKey(db);
+      rotateSigningKey(db);
+      const activeCount = (
+        db
+          .query<{ n: number }, []>(
+            "SELECT COUNT(*) AS n FROM signing_keys WHERE retired_at IS NULL",
+          )
+          .get() ?? { n: -1 }
+      ).n;
+      expect(activeCount).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("getAllPublicKeys", () => {
+  test("includes active + recently-retired (within 24h)", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const old = getActiveSigningKey(db);
+      const fresh = rotateSigningKey(db);
+      const keys = getAllPublicKeys(db);
+      const kids = keys.map((k) => k.kid).sort();
+      expect(kids).toEqual([old.kid, fresh.kid].sort());
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("excludes retired keys past 24h retention", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const old = getActiveSigningKey(db);
+      const fresh = rotateSigningKey(db);
+      // Force the retired_at far enough in the past to be filtered out.
+      const oldRetired = new Date(Date.now() - JWKS_RETENTION_MS - 60_000).toISOString();
+      db.prepare("UPDATE signing_keys SET retired_at = ? WHERE kid = ?").run(oldRetired, old.kid);
+
+      const kids = getAllPublicKeys(db).map((k) => k.kid);
+      expect(kids).toContain(fresh.kid);
+      expect(kids).not.toContain(old.kid);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("on a fresh db with no keys, returns []", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      expect(getAllPublicKeys(db)).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("retention boundary is 24h to the millisecond", () => {
+    expect(JWKS_RETENTION_MS).toBe(24 * 60 * 60 * 1000);
+  });
+});

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -3,11 +3,18 @@
  *
  * Identity (password + 2FA) is an ecosystem concern now that the hub owns
  * OAuth issuance (Phase 0). The *implementation* still lives in
- * parachute-vault — these commands are thin shell-forwards to the vault
- * binary so beta users learn the blessed namespace from day one.
+ * parachute-vault for password + 2FA — these commands are thin shell-forwards
+ * to the vault binary so beta users learn the blessed namespace from day one.
+ *
+ * `rotate-key` is hub-local: signing keys live in `~/.parachute/hub.db` and
+ * back the JWT issuance the hub will start doing in cli#58 PR (b). Rotation
+ * is a hub concern, not a vault concern.
  *
  * Vault keeps its own `set-password` / `2fa` commands for back-compat.
  */
+
+import { openHubDb } from "../hub-db.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
 
 export interface Runner {
   run(cmd: readonly string[]): Promise<number>;
@@ -20,7 +27,8 @@ export const defaultRunner: Runner = {
   },
 };
 
-const AUTH_SUBCOMMANDS = new Set(["set-password", "2fa"]);
+const VAULT_FORWARDED_SUBCOMMANDS = new Set(["set-password", "2fa"]);
+const HUB_LOCAL_SUBCOMMANDS = new Set(["rotate-key"]);
 
 export function authHelp(): string {
   return `parachute auth — ecosystem identity commands (password + two-factor authentication)
@@ -32,24 +40,67 @@ Usage:
   parachute auth 2fa enroll           Enable TOTP 2FA (QR + backup codes)
   parachute auth 2fa disable          Disable 2FA (requires password)
   parachute auth 2fa backup-codes     Regenerate backup codes
+  parachute auth rotate-key           Rotate the hub's JWT signing key
 
-All subcommands forward to \`parachute-vault\` which implements the storage
-and crypto. If you see "not found on PATH", install vault first:
+set-password and 2fa forward to \`parachute-vault\` which implements the
+storage and crypto. If you see "not found on PATH", install vault first:
 
   parachute install vault
+
+rotate-key is hub-local — it generates a fresh RSA-2048 keypair in
+~/.parachute/hub.db and retires the previous one. The retired key keeps
+appearing in /.well-known/jwks.json for 24 hours so cached client copies
+keep validating until their TTL expires.
 `;
 }
 
-export async function auth(
-  args: readonly string[],
-  runner: Runner = defaultRunner,
-): Promise<number> {
+export interface AuthDeps {
+  runner?: Runner;
+  rotateKey?: () => { kid: string; createdAt: string };
+}
+
+function defaultRotateKey(): { kid: string; createdAt: string } {
+  const db = openHubDb();
+  try {
+    const k = rotateSigningKey(db);
+    return { kid: k.kid, createdAt: k.createdAt };
+  } finally {
+    db.close();
+  }
+}
+
+export async function auth(args: readonly string[], deps: AuthDeps | Runner = {}): Promise<number> {
+  // Back-compat shim: callers used to pass a Runner directly. Detect that
+  // shape (a `run` method) and lift it into the new deps bag.
+  const normalized: AuthDeps =
+    typeof (deps as Runner).run === "function" ? { runner: deps as Runner } : (deps as AuthDeps);
+  const runner = normalized.runner ?? defaultRunner;
+  const rotateKey = normalized.rotateKey ?? defaultRotateKey;
+
   const sub = args[0];
   if (sub === undefined || sub === "--help" || sub === "-h" || sub === "help") {
     console.log(authHelp());
     return 0;
   }
-  if (!AUTH_SUBCOMMANDS.has(sub)) {
+
+  if (HUB_LOCAL_SUBCOMMANDS.has(sub)) {
+    if (sub === "rotate-key") {
+      try {
+        const { kid, createdAt } = rotateKey();
+        console.log("Rotated hub signing key.");
+        console.log(`  kid:        ${kid}`);
+        console.log(`  created_at: ${createdAt}`);
+        console.log("Previous key keeps validating tokens for 24h via /.well-known/jwks.json.");
+        return 0;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`parachute auth rotate-key: ${msg}`);
+        return 1;
+      }
+    }
+  }
+
+  if (!VAULT_FORWARDED_SUBCOMMANDS.has(sub)) {
     console.error(`parachute auth: unknown subcommand "${sub}"`);
     console.error("run `parachute auth --help` for usage");
     return 1;

--- a/src/hub-control.ts
+++ b/src/hub-control.ts
@@ -3,6 +3,7 @@ import { createServer } from "node:net";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { CONFIG_DIR } from "./config.ts";
+import { hubDbPath } from "./hub-db.ts";
 import {
   type AliveFn,
   clearPid,
@@ -180,6 +181,8 @@ export async function ensureHubRunning(opts: EnsureHubOpts = {}): Promise<Ensure
     String(chosenPort),
     "--well-known-dir",
     wellKnownDir,
+    "--db",
+    hubDbPath(configDir),
   ];
   const pid = spawner.spawn(cmd, logFile);
   writePid(HUB_SVC, pid, configDir);

--- a/src/hub-db.ts
+++ b/src/hub-db.ts
@@ -1,0 +1,73 @@
+/**
+ * Hub-local SQLite database. Opens `~/.parachute/hub.db` (overridable via
+ * `$PARACHUTE_HOME`). Holds anything the hub itself owns — currently just
+ * JWT signing keys; user accounts and OAuth state land here in subsequent
+ * PRs (cli#58 b/c).
+ *
+ * Each open() runs `migrate()` to bring the schema up to date. A
+ * `schema_version` table records every applied migration so re-opens are
+ * cheap and idempotent. Migrations are append-only — never edit a prior
+ * entry; add a new one with a higher number.
+ */
+import { Database } from "bun:sqlite";
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { CONFIG_DIR } from "./config.ts";
+
+export function hubDbPath(configDir: string = CONFIG_DIR): string {
+  return join(configDir, "hub.db");
+}
+
+interface Migration {
+  version: number;
+  sql: string;
+}
+
+const MIGRATIONS: readonly Migration[] = [
+  {
+    version: 1,
+    sql: `
+      CREATE TABLE signing_keys (
+        kid TEXT PRIMARY KEY,
+        public_key_pem TEXT NOT NULL,
+        private_key_pem TEXT NOT NULL,
+        algorithm TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        retired_at TEXT
+      );
+      CREATE INDEX signing_keys_active ON signing_keys (retired_at)
+        WHERE retired_at IS NULL;
+    `,
+  },
+];
+
+export function openHubDb(path: string = hubDbPath()): Database {
+  mkdirSync(dirname(path), { recursive: true });
+  const db = new Database(path);
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  migrate(db);
+  return db;
+}
+
+export function migrate(db: Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_version (
+      version INTEGER PRIMARY KEY,
+      applied_at TEXT NOT NULL
+    );
+  `);
+  const applied = new Set<number>(
+    (db.query("SELECT version FROM schema_version").all() as { version: number }[]).map(
+      (r) => r.version,
+    ),
+  );
+  const insert = db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (?, ?)");
+  for (const m of MIGRATIONS) {
+    if (applied.has(m.version)) continue;
+    db.transaction(() => {
+      db.exec(m.sql);
+      insert.run(m.version, new Date().toISOString());
+    })();
+  }
+}

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -13,27 +13,39 @@
  *   /                          → hub.html                (text/html)
  *   /hub.html                  → hub.html                (text/html)
  *   /.well-known/parachute.json → parachute.json         (application/json)
+ *   /.well-known/jwks.json      → JWKS from hub.db        (application/json)
  *   anything else              → 404
  *
  * Invoked as:
- *   bun <this-file> --port <n> --well-known-dir <path>
+ *   bun <this-file> --port <n> --well-known-dir <path> [--db <path>]
  *
  * `--well-known-dir` is the directory containing both `hub.html` and
  * `parachute.json` (both written by `parachute expose`). Kept as one flag so
  * the lifecycle side doesn't have to care how the hub server lays out files.
+ *
+ * `--db` is the path to `hub.db`. JWKS is served live from the DB so key
+ * rotation takes effect on the next request without re-running
+ * `parachute expose`. Defaults to `~/.parachute/hub.db` (overridable via
+ * `$PARACHUTE_HOME`).
  */
 
+import type { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { hubDbPath, openHubDb } from "./hub-db.ts";
+import { pemToJwk } from "./jwks.ts";
+import { getAllPublicKeys } from "./signing-keys.ts";
 
 interface Args {
   port: number;
   wellKnownDir: string;
+  dbPath: string;
 }
 
 function parseArgs(argv: string[]): Args {
   let port: number | undefined;
   let wellKnownDir: string | undefined;
+  let dbPath: string | undefined;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--port") {
@@ -48,18 +60,28 @@ function parseArgs(argv: string[]): Args {
       const v = argv[++i];
       if (!v) throw new Error("--well-known-dir requires a value");
       wellKnownDir = resolve(v);
+    } else if (a === "--db") {
+      const v = argv[++i];
+      if (!v) throw new Error("--db requires a value");
+      dbPath = resolve(v);
     } else {
       throw new Error(`unknown argument: ${a}`);
     }
   }
   if (port === undefined) throw new Error("--port is required");
   if (wellKnownDir === undefined) throw new Error("--well-known-dir is required");
-  return { port, wellKnownDir };
+  return { port, wellKnownDir, dbPath: dbPath ?? hubDbPath() };
 }
 
-export function hubFetch(wellKnownDir: string): (req: Request) => Response {
+export interface HubFetchDeps {
+  /** Lazily opens (or returns a cached handle to) the hub DB. */
+  getDb: () => Database;
+}
+
+export function hubFetch(wellKnownDir: string, deps?: HubFetchDeps): (req: Request) => Response {
   const hubHtmlPath = join(wellKnownDir, "hub.html");
   const parachuteJsonPath = join(wellKnownDir, "parachute.json");
+  const getDb = deps?.getDb;
 
   return (req) => {
     const url = new URL(req.url);
@@ -98,16 +120,56 @@ export function hubFetch(wellKnownDir: string): (req: Request) => Response {
       });
     }
 
+    if (pathname === "/.well-known/jwks.json") {
+      // JWKS is also a cross-origin fetch target (browser-side OAuth
+      // libraries pull this to verify access tokens). Same wildcard CORS
+      // shape as parachute.json — JWKS is public-by-design (only public
+      // keys leave the server).
+      const corsHeaders = {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "GET, OPTIONS",
+      };
+      if (req.method === "OPTIONS") {
+        return new Response(null, { status: 204, headers: corsHeaders });
+      }
+      if (!getDb) {
+        return new Response('{"error":"jwks unavailable: db not configured"}', {
+          status: 503,
+          headers: { "content-type": "application/json", ...corsHeaders },
+        });
+      }
+      try {
+        const db = getDb();
+        const keys = getAllPublicKeys(db).map((k) => pemToJwk(k.publicKeyPem, k.kid));
+        return new Response(JSON.stringify({ keys }), {
+          headers: { "content-type": "application/json", ...corsHeaders },
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return new Response(JSON.stringify({ error: `jwks failed: ${msg}` }), {
+          status: 500,
+          headers: { "content-type": "application/json", ...corsHeaders },
+        });
+      }
+    }
+
     return new Response("not found", { status: 404 });
   };
 }
 
 if (import.meta.main) {
-  const { port, wellKnownDir } = parseArgs(process.argv.slice(2));
+  const { port, wellKnownDir, dbPath } = parseArgs(process.argv.slice(2));
+  let cachedDb: Database | undefined;
+  const getDb = () => {
+    if (!cachedDb) cachedDb = openHubDb(dbPath);
+    return cachedDb;
+  };
   Bun.serve({
     port,
     hostname: "127.0.0.1",
-    fetch: hubFetch(wellKnownDir),
+    fetch: hubFetch(wellKnownDir, { getDb }),
   });
-  console.log(`parachute-hub listening on http://127.0.0.1:${port} (dir=${wellKnownDir})`);
+  console.log(
+    `parachute-hub listening on http://127.0.0.1:${port} (dir=${wellKnownDir}, db=${dbPath})`,
+  );
 }

--- a/src/jwks.ts
+++ b/src/jwks.ts
@@ -1,0 +1,41 @@
+/**
+ * PEM → JWK conversion for the hub's `/.well-known/jwks.json` endpoint.
+ *
+ * `node:crypto.createPublicKey(pem).export({format: 'jwk'})` already returns
+ * the canonical {kty, n, e} for an RSA public key. We layer the JWKS-level
+ * fields (`kid`, `alg`, `use`) on top so consumers can pick the right key
+ * without extra metadata.
+ */
+import { createPublicKey } from "node:crypto";
+
+export interface Jwk {
+  kty: "RSA";
+  n: string;
+  e: string;
+  kid: string;
+  alg: "RS256";
+  use: "sig";
+}
+
+export interface Jwks {
+  keys: Jwk[];
+}
+
+export function pemToJwk(publicKeyPem: string, kid: string): Jwk {
+  const exported = createPublicKey(publicKeyPem).export({ format: "jwk" }) as {
+    kty?: string;
+    n?: string;
+    e?: string;
+  };
+  if (exported.kty !== "RSA" || !exported.n || !exported.e) {
+    throw new Error(`pemToJwk: expected RSA public key, got kty=${String(exported.kty)}`);
+  }
+  return {
+    kty: "RSA",
+    n: exported.n,
+    e: exported.e,
+    kid,
+    alg: "RS256",
+    use: "sig",
+  };
+}

--- a/src/signing-keys.ts
+++ b/src/signing-keys.ts
@@ -1,0 +1,120 @@
+/**
+ * RSA-2048 signing keys backing the hub's JWT issuance + JWKS endpoint.
+ *
+ * Lifecycle:
+ *   - One *active* key at a time (`retired_at IS NULL`). Used to sign new
+ *     JWTs.
+ *   - On rotation, the old key gets `retired_at` stamped and a fresh one
+ *     becomes active. Retired keys keep validating tokens issued before the
+ *     rotation, but only for a limited window.
+ *
+ * Retention: `JWKS_RETENTION_MS = 24h`. Access tokens are 15-min JWTs, so
+ * the cryptographic window is tiny — but JWKS responses are typically cached
+ * by clients for up to ~24h, and we don't want a client's stale cache to
+ * blackhole valid signatures during that window. 24h is the upper bound on
+ * any reasonable client cache; older retired rows stay in the DB for audit
+ * but stop appearing in JWKS.
+ */
+import type { Database } from "bun:sqlite";
+import { createHash, generateKeyPairSync } from "node:crypto";
+
+export const JWKS_RETENTION_MS = 24 * 60 * 60 * 1000;
+export const SIGNING_ALGORITHM = "RS256";
+
+export interface SigningKey {
+  kid: string;
+  publicKeyPem: string;
+  privateKeyPem: string;
+  algorithm: string;
+  createdAt: string;
+  retiredAt: string | null;
+}
+
+interface Row {
+  kid: string;
+  public_key_pem: string;
+  private_key_pem: string;
+  algorithm: string;
+  created_at: string;
+  retired_at: string | null;
+}
+
+function rowToKey(r: Row): SigningKey {
+  return {
+    kid: r.kid,
+    publicKeyPem: r.public_key_pem,
+    privateKeyPem: r.private_key_pem,
+    algorithm: r.algorithm,
+    createdAt: r.created_at,
+    retiredAt: r.retired_at,
+  };
+}
+
+/**
+ * `kid = base64url(SHA-256(public_key_pem))` — stable, content-addressed,
+ * impossible to clash within a database that already has the public key as
+ * a unique column.
+ */
+export function computeKid(publicKeyPem: string): string {
+  return createHash("sha256").update(publicKeyPem).digest("base64url");
+}
+
+/**
+ * Returns the active signing key, generating + inserting a fresh keypair on
+ * an empty database. Idempotent: subsequent calls return the same row.
+ */
+export function getActiveSigningKey(db: Database, now: () => Date = () => new Date()): SigningKey {
+  const existing = db
+    .query("SELECT * FROM signing_keys WHERE retired_at IS NULL ORDER BY created_at DESC LIMIT 1")
+    .get() as Row | null;
+  if (existing) return rowToKey(existing);
+  return rotateSigningKey(db, now);
+}
+
+/**
+ * Generates a new RSA-2048 keypair, retires every currently-active key, and
+ * returns the new active key. The retire+insert runs in a single transaction
+ * so a partial failure can't leave the DB with zero active keys.
+ */
+export function rotateSigningKey(db: Database, now: () => Date = () => new Date()): SigningKey {
+  const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const publicKeyPem = publicKey.export({ format: "pem", type: "spki" }).toString();
+  const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+  const kid = computeKid(publicKeyPem);
+  const stamp = now().toISOString();
+
+  db.transaction(() => {
+    db.prepare("UPDATE signing_keys SET retired_at = ? WHERE retired_at IS NULL").run(stamp);
+    db.prepare(
+      `INSERT INTO signing_keys (kid, public_key_pem, private_key_pem, algorithm, created_at, retired_at)
+       VALUES (?, ?, ?, ?, ?, NULL)`,
+    ).run(kid, publicKeyPem, privateKeyPem, SIGNING_ALGORITHM, stamp);
+  })();
+
+  return {
+    kid,
+    publicKeyPem,
+    privateKeyPem,
+    algorithm: SIGNING_ALGORITHM,
+    createdAt: stamp,
+    retiredAt: null,
+  };
+}
+
+/**
+ * Public keys to advertise on `/.well-known/jwks.json`: every active key plus
+ * any retired key whose `retired_at` is within `JWKS_RETENTION_MS`. Older
+ * retired rows stay in the DB for audit/debug — they just stop being
+ * advertised.
+ */
+export function getAllPublicKeys(db: Database, now: () => Date = () => new Date()): SigningKey[] {
+  const cutoff = new Date(now().getTime() - JWKS_RETENTION_MS).toISOString();
+  const rows = db
+    .query(
+      `SELECT * FROM signing_keys
+       WHERE retired_at IS NULL OR retired_at >= ?
+       ORDER BY created_at DESC`,
+    )
+    .all(cutoff) as Row[];
+  return rows.map(rowToKey);
+}


### PR DESCRIPTION
## Summary

cli#58 PR (a) — cryptographic infrastructure for the hub's upcoming JWT issuance. No user-visible behavior change; lays the groundwork that PRs (b) and (c) will sign tokens against and that browser-side OAuth clients will fetch JWKS from to verify them.

- **`src/hub-db.ts`** — opens `~/.parachute/hub.db` via `bun:sqlite` with a versioned-migration runner. v1 creates the `signing_keys` table.
- **`src/signing-keys.ts`** — RSA-2048 keypair generation; content-addressed `kid` (`base64url(SHA-256(public_pem))`); one-active-key invariant; rotation-with-retirement in a single transaction. `JWKS_RETENTION_MS = 24h`.
- **`src/jwks.ts`** — PEM → JWK via `node:crypto.createPublicKey`. Returns `{kty:"RSA", n, e, kid, alg:"RS256", use:"sig"}`.
- **`/.well-known/jwks.json`** on the hub server — served live from `hub.db` so rotation takes effect on the next request without re-running `parachute expose`. Same wildcard-CORS shape as `parachute.json`.
- **`parachute auth rotate-key`** — hub-local subcommand (does not forward to vault). Generates a fresh keypair and retires the prior one; retired key keeps appearing in JWKS for 24h so cached client copies keep validating until their TTL expires.

## Why 24h JWKS retention (not 30d)

Access tokens are 15-min JWTs (signed with the active key). Refresh tokens are *opaque*, so they don't need JWKS validation. A retired key therefore only needs to validate access tokens issued before rotation but not yet expired — max window = 15 min. The reason to keep it longer is that clients cache JWKS responses (typical HTTP cache TTL 1–24h); if rotation happens between fetches, the client's cache is stale until TTL expires. 24h covers any reasonable client-side cache TTL while keeping JWKS small.

## Test plan

- [x] `bun test` — 464/464 pass (4 new test files: `hub-db.test.ts`, `signing-keys.test.ts`, `jwks.test.ts`; `auth.test.ts` + `hub-server.test.ts` extended)
- [x] `bun run typecheck` — clean
- [x] `bunx biome check .` — clean
- [ ] Manual: `parachute auth rotate-key` against a real `~/.parachute/hub.db` (deferred to PR (b) when JWT signing wires up the active key)
- [ ] Manual: hit `/.well-known/jwks.json` through `parachute expose tailnet` and verify the JWK round-trips through a JOSE library (deferred to PR (b))

## What's NOT in this PR

- JWT signing helper (`signJwt`) — PR (b)
- `/oauth/*` endpoint replacement + `pvt_*` migration — PR (c)
- User accounts table — PR (b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)