### PR TITLE
feat(hub): native OAuth endpoint cutover (rc.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.3.1-rc.3",
+  "version": "0.3.1-rc.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -4,6 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type AuthDeps, type Runner, auth, authHelp } from "../commands/auth.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { validateAccessToken } from "../jwt-sign.ts";
+import {
+  OPERATOR_TOKEN_AUDIENCE,
+  OPERATOR_TOKEN_SCOPES,
+  readOperatorTokenFile,
+} from "../operator-token.ts";
 import { listUsers, verifyPassword } from "../users.ts";
 
 function makeRunner(result: number | (() => Promise<number>) = 0): {
@@ -20,9 +26,10 @@ function makeRunner(result: number | (() => Promise<number>) = 0): {
   return { runner, calls };
 }
 
-function makeTmp(): { dbPath: string; cleanup: () => void } {
+function makeTmp(): { dir: string; dbPath: string; cleanup: () => void } {
   const dir = mkdtempSync(join(tmpdir(), "phub-auth-"));
   return {
+    dir,
     dbPath: hubDbPath(dir),
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
   };
@@ -91,6 +98,7 @@ describe("parachute auth", () => {
       const code = await auth(["set-password", "--password", "pw"], {
         runner,
         dbPath: tmp.dbPath,
+        configDir: tmp.dir,
         isInteractive: () => false,
       });
       expect(code).toBe(0);
@@ -187,6 +195,7 @@ describe("parachute auth set-password", () => {
     try {
       const deps: AuthDeps = {
         dbPath: tmp.dbPath,
+        configDir: tmp.dir,
         isInteractive: () => false,
       };
       const { code, stdout } = await captureOutput(() =>
@@ -215,6 +224,7 @@ describe("parachute auth set-password", () => {
       const { code } = await captureOutput(() =>
         auth(["set-password", "--username", "aaron", "--password", "pw"], {
           dbPath: tmp.dbPath,
+          configDir: tmp.dir,
           isInteractive: () => false,
         }),
       );
@@ -233,7 +243,7 @@ describe("parachute auth set-password", () => {
   test("updates the existing user's password (single-user mode)", async () => {
     const tmp = makeTmp();
     try {
-      const deps: AuthDeps = { dbPath: tmp.dbPath, isInteractive: () => false };
+      const deps: AuthDeps = { dbPath: tmp.dbPath, configDir: tmp.dir, isInteractive: () => false };
       // First-run create.
       await captureOutput(() => auth(["set-password", "--password", "old"], deps));
       // Update.
@@ -258,7 +268,7 @@ describe("parachute auth set-password", () => {
   test("rejects --username mismatch without --allow-multi", async () => {
     const tmp = makeTmp();
     try {
-      const deps: AuthDeps = { dbPath: tmp.dbPath, isInteractive: () => false };
+      const deps: AuthDeps = { dbPath: tmp.dbPath, configDir: tmp.dir, isInteractive: () => false };
       await captureOutput(() => auth(["set-password", "--password", "p"], deps));
       const { code, stderr } = await captureOutput(() =>
         auth(["set-password", "--username", "second", "--password", "p"], deps),
@@ -273,7 +283,7 @@ describe("parachute auth set-password", () => {
   test("creates a second user with --allow-multi", async () => {
     const tmp = makeTmp();
     try {
-      const deps: AuthDeps = { dbPath: tmp.dbPath, isInteractive: () => false };
+      const deps: AuthDeps = { dbPath: tmp.dbPath, configDir: tmp.dir, isInteractive: () => false };
       await captureOutput(() => auth(["set-password", "--password", "p"], deps));
       const { code } = await captureOutput(() =>
         auth(["set-password", "--username", "second", "--password", "p", "--allow-multi"], deps),
@@ -298,7 +308,11 @@ describe("parachute auth set-password", () => {
     const tmp = makeTmp();
     try {
       const { code, stderr } = await captureOutput(() =>
-        auth(["set-password"], { dbPath: tmp.dbPath, isInteractive: () => false }),
+        auth(["set-password"], {
+          dbPath: tmp.dbPath,
+          configDir: tmp.dir,
+          isInteractive: () => false,
+        }),
       );
       expect(code).toBe(1);
       expect(stderr).toContain("--password is required");
@@ -313,6 +327,7 @@ describe("parachute auth set-password", () => {
       const prompts: string[] = [];
       const deps: AuthDeps = {
         dbPath: tmp.dbPath,
+        configDir: tmp.dir,
         isInteractive: () => true,
         readPassword: async (p) => {
           prompts.push(p);
@@ -341,6 +356,7 @@ describe("parachute auth set-password", () => {
       const answers = ["one", "two"];
       const deps: AuthDeps = {
         dbPath: tmp.dbPath,
+        configDir: tmp.dir,
         isInteractive: () => true,
         readPassword: async () => answers.shift() ?? "",
         readLine: async () => "y",
@@ -358,6 +374,7 @@ describe("parachute auth set-password", () => {
     try {
       const deps: AuthDeps = {
         dbPath: tmp.dbPath,
+        configDir: tmp.dir,
         isInteractive: () => true,
         readPassword: async () => "",
         readLine: async () => "y",
@@ -375,6 +392,7 @@ describe("parachute auth set-password", () => {
     try {
       const deps: AuthDeps = {
         dbPath: tmp.dbPath,
+        configDir: tmp.dir,
         isInteractive: () => true,
         readPassword: async () => "pw",
         readLine: async () => "n",
@@ -391,7 +409,11 @@ describe("parachute auth set-password", () => {
     const tmp = makeTmp();
     try {
       const { code, stderr } = await captureOutput(() =>
-        auth(["set-password", "--lol"], { dbPath: tmp.dbPath, isInteractive: () => false }),
+        auth(["set-password", "--lol"], {
+          dbPath: tmp.dbPath,
+          configDir: tmp.dir,
+          isInteractive: () => false,
+        }),
       );
       expect(code).toBe(1);
       expect(stderr).toContain("unknown flag");
@@ -418,7 +440,7 @@ describe("parachute auth list-users", () => {
   test("lists usernames after a set-password", async () => {
     const tmp = makeTmp();
     try {
-      const deps: AuthDeps = { dbPath: tmp.dbPath, isInteractive: () => false };
+      const deps: AuthDeps = { dbPath: tmp.dbPath, configDir: tmp.dir, isInteractive: () => false };
       await captureOutput(() =>
         auth(["set-password", "--username", "alice", "--password", "p"], deps),
       );
@@ -426,6 +448,106 @@ describe("parachute auth list-users", () => {
       expect(code).toBe(0);
       expect(stdout).toContain("USERNAME");
       expect(stdout).toContain("alice");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+});
+
+describe("set-password operator-token side-effect", () => {
+  // First-run set-password must seed ~/.parachute/operator.token. Without
+  // this, on-box CLI callers have nothing to present as a bearer when the
+  // hub starts requiring auth on every request (no loopback bypass).
+  test("creates operator.token on first-run, signed against active key, audience=operator", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      const { code, stdout } = await captureOutput(() =>
+        auth(["set-password", "--password", "pw"], deps),
+      );
+      expect(code).toBe(0);
+      expect(stdout).toContain("operator token");
+      const tokenOnDisk = await readOperatorTokenFile(tmp.dir);
+      expect(tokenOnDisk).not.toBeNull();
+      const db = openHubDb(tmp.dbPath);
+      try {
+        const validated = await validateAccessToken(db, tokenOnDisk ?? "");
+        expect(validated.payload.aud).toBe(OPERATOR_TOKEN_AUDIENCE);
+        expect(validated.payload.scope).toBe(OPERATOR_TOKEN_SCOPES.join(" "));
+        const users = listUsers(db);
+        expect(validated.payload.sub).toBe(users[0]?.id);
+      } finally {
+        db.close();
+      }
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  // Password reset rotates the file too — old token stays valid until its
+  // 1y TTL expires (the hub doesn't track operator-token jtis), but the
+  // file always carries the freshest one.
+  test("password update overwrites operator.token with a fresh JWT", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "old"], deps));
+      const first = await readOperatorTokenFile(tmp.dir);
+      // Sleep a beat to make sure the new JWT has a different iat — JWT
+      // claims are second-precision.
+      await new Promise((r) => setTimeout(r, 1100));
+      await captureOutput(() => auth(["set-password", "--password", "new"], deps));
+      const second = await readOperatorTokenFile(tmp.dir);
+      expect(second).not.toBeNull();
+      expect(second).not.toBe(first);
+    } finally {
+      tmp.cleanup();
+    }
+  });
+});
+
+describe("parachute auth rotate-operator", () => {
+  test("mints a fresh token, overwrites the file, exits 0", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const before = await readOperatorTokenFile(tmp.dir);
+      await new Promise((r) => setTimeout(r, 1100));
+      const { code, stdout } = await captureOutput(() => auth(["rotate-operator"], deps));
+      expect(code).toBe(0);
+      expect(stdout).toContain("Rotated operator token");
+      const after = await readOperatorTokenFile(tmp.dir);
+      expect(after).not.toBeNull();
+      expect(after).not.toBe(before);
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("with no users yet, exits 1 with a hint to run set-password", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      const { code, stderr } = await captureOutput(() => auth(["rotate-operator"], deps));
+      expect(code).toBe(1);
+      expect(stderr).toContain("set-password");
     } finally {
       tmp.cleanup();
     }

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -475,7 +475,7 @@ describe("expose tailnet up", () => {
     }
   });
 
-  test("emits 4 OAuth proxies targeting vault when vault is installed", async () => {
+  test("emits 4 OAuth proxies targeting the hub origin (hub IS the IdP)", async () => {
     const h = makeHarness();
     try {
       seedServices(h.manifestPath);
@@ -508,17 +508,15 @@ describe("expose tailnet up", () => {
           oauthTargets.set(mount, c[c.length - 1] ?? "");
         }
       }
-      expect(oauthTargets.get("/.well-known/oauth-authorization-server")).toBe(
-        "http://127.0.0.1:1940/vault/default/.well-known/oauth-authorization-server",
+      expect(oauthTargets.get("/.well-known/oauth-authorization-server")).toMatch(
+        /^http:\/\/127\.0\.0\.1:\d+\/\.well-known\/oauth-authorization-server$/,
       );
-      expect(oauthTargets.get("/oauth/authorize")).toBe(
-        "http://127.0.0.1:1940/vault/default/oauth/authorize",
+      expect(oauthTargets.get("/oauth/authorize")).toMatch(
+        /^http:\/\/127\.0\.0\.1:\d+\/oauth\/authorize$/,
       );
-      expect(oauthTargets.get("/oauth/token")).toBe(
-        "http://127.0.0.1:1940/vault/default/oauth/token",
-      );
-      expect(oauthTargets.get("/oauth/register")).toBe(
-        "http://127.0.0.1:1940/vault/default/oauth/register",
+      expect(oauthTargets.get("/oauth/token")).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/oauth\/token$/);
+      expect(oauthTargets.get("/oauth/register")).toMatch(
+        /^http:\/\/127\.0\.0\.1:\d+\/oauth\/register$/,
       );
 
       const state = readExposeState(h.statePath);
@@ -528,7 +526,7 @@ describe("expose tailnet up", () => {
     }
   });
 
-  test("skips OAuth proxies when no vault is installed", async () => {
+  test("emits OAuth proxies even when no vault is installed (hub IS the IdP)", async () => {
     const h = makeHarness();
     try {
       upsertService(
@@ -560,10 +558,15 @@ describe("expose tailnet up", () => {
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      // No vault → no OAuth proxies. Hub + well-known + notes = 3.
-      expect(serveCalls).toHaveLength(3);
-      const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path=")));
-      expect(mounts.every((m) => m !== undefined && !m.includes("/oauth/"))).toBe(true);
+      // Hub + well-known + notes + 4 OAuth proxies = 7. The hub serves OAuth
+      // regardless of which services are installed.
+      expect(serveCalls).toHaveLength(7);
+      const oauthMounts = serveCalls
+        .map((c) => c.find((a) => a.startsWith("--set-path=")))
+        .filter(
+          (m): m is string => !!m && (m.includes("/oauth/") || m.endsWith("authorization-server")),
+        );
+      expect(oauthMounts).toHaveLength(4);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -25,7 +25,7 @@ describe("hubFetch routing", () => {
     const h = makeHarness();
     try {
       writeFileSync(join(h.dir, "hub.html"), "<html><body>hi</body></html>");
-      const res = hubFetch(h.dir)(req("/"));
+      const res = await hubFetch(h.dir)(req("/"));
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
       expect(await res.text()).toContain("<html>");
@@ -38,7 +38,7 @@ describe("hubFetch routing", () => {
     const h = makeHarness();
     try {
       writeFileSync(join(h.dir, "hub.html"), "<html>x</html>");
-      const res = hubFetch(h.dir)(req("/hub.html"));
+      const res = await hubFetch(h.dir)(req("/hub.html"));
       expect(res.status).toBe(200);
       expect(await res.text()).toBe("<html>x</html>");
     } finally {
@@ -50,7 +50,7 @@ describe("hubFetch routing", () => {
     const h = makeHarness();
     try {
       writeFileSync(join(h.dir, "parachute.json"), '{"vaults":[]}\n');
-      const res = hubFetch(h.dir)(req("/.well-known/parachute.json"));
+      const res = await hubFetch(h.dir)(req("/.well-known/parachute.json"));
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("application/json");
       expect(await res.text()).toBe('{"vaults":[]}\n');
@@ -68,7 +68,7 @@ describe("hubFetch routing", () => {
     const h = makeHarness();
     try {
       writeFileSync(join(h.dir, "parachute.json"), '{"vaults":[]}\n');
-      const res = hubFetch(h.dir)(req("/.well-known/parachute.json"));
+      const res = await hubFetch(h.dir)(req("/.well-known/parachute.json"));
       expect(res.status).toBe(200);
       expect(res.headers.get("access-control-allow-origin")).toBe("*");
       expect(res.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
@@ -81,7 +81,7 @@ describe("hubFetch routing", () => {
     const h = makeHarness();
     try {
       // Note: no parachute.json on disk — preflight must not depend on it.
-      const res = hubFetch(h.dir)(req("/.well-known/parachute.json", { method: "OPTIONS" }));
+      const res = await hubFetch(h.dir)(req("/.well-known/parachute.json", { method: "OPTIONS" }));
       expect(res.status).toBe(204);
       expect(res.headers.get("access-control-allow-origin")).toBe("*");
       expect(res.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
@@ -95,7 +95,7 @@ describe("hubFetch routing", () => {
     // error and the consumer can't even tell the server is reachable.
     const h = makeHarness();
     try {
-      const res = hubFetch(h.dir)(req("/.well-known/parachute.json"));
+      const res = await hubFetch(h.dir)(req("/.well-known/parachute.json"));
       expect(res.status).toBe(404);
       expect(res.headers.get("access-control-allow-origin")).toBe("*");
     } finally {
@@ -107,7 +107,7 @@ describe("hubFetch routing", () => {
     const h = makeHarness();
     try {
       writeFileSync(join(h.dir, "hub.html"), "<html/>");
-      const res = hubFetch(h.dir)(req("/nope"));
+      const res = await hubFetch(h.dir)(req("/nope"));
       expect(res.status).toBe(404);
     } finally {
       h.cleanup();
@@ -118,7 +118,7 @@ describe("hubFetch routing", () => {
     const h = makeHarness();
     try {
       // dir exists but no files in it
-      const res = hubFetch(h.dir)(req("/"));
+      const res = await hubFetch(h.dir)(req("/"));
       expect(res.status).toBe(404);
     } finally {
       h.cleanup();
@@ -128,7 +128,7 @@ describe("hubFetch routing", () => {
   test("missing parachute.json returns 404 rather than crashing", async () => {
     const h = makeHarness();
     try {
-      const res = hubFetch(h.dir)(req("/.well-known/parachute.json"));
+      const res = await hubFetch(h.dir)(req("/.well-known/parachute.json"));
       expect(res.status).toBe(404);
     } finally {
       h.cleanup();
@@ -141,7 +141,7 @@ describe("hubFetch routing", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         const k = rotateSigningKey(db);
-        const res = hubFetch(h.dir, { getDb: () => db })(req("/.well-known/jwks.json"));
+        const res = await hubFetch(h.dir, { getDb: () => db })(req("/.well-known/jwks.json"));
         expect(res.status).toBe(200);
         expect(res.headers.get("content-type")).toBe("application/json");
         expect(res.headers.get("access-control-allow-origin")).toBe("*");
@@ -162,7 +162,7 @@ describe("hubFetch routing", () => {
     const h = makeHarness();
     try {
       // Pass a getDb that throws — preflight must not invoke it.
-      const res = hubFetch(h.dir, {
+      const res = await hubFetch(h.dir, {
         getDb: () => {
           throw new Error("getDb should not be called for OPTIONS");
         },
@@ -178,7 +178,7 @@ describe("hubFetch routing", () => {
   test("/.well-known/jwks.json returns 503 + CORS when db is not configured", async () => {
     const h = makeHarness();
     try {
-      const res = hubFetch(h.dir)(req("/.well-known/jwks.json"));
+      const res = await hubFetch(h.dir)(req("/.well-known/jwks.json"));
       expect(res.status).toBe(503);
       expect(res.headers.get("content-type")).toBe("application/json");
       expect(res.headers.get("access-control-allow-origin")).toBe("*");
@@ -192,9 +192,85 @@ describe("hubFetch routing", () => {
     try {
       const db = openHubDb(hubDbPath(h.dir));
       try {
-        const res = hubFetch(h.dir, { getDb: () => db })(req("/.well-known/jwks.json"));
+        const res = await hubFetch(h.dir, { getDb: () => db })(req("/.well-known/jwks.json"));
         expect(res.status).toBe(200);
         expect(await res.json()).toEqual({ keys: [] });
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/.well-known/oauth-authorization-server returns RFC 8414 metadata + CORS", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, {
+          getDb: () => db,
+          issuer: "https://hub.example",
+        })(req("/.well-known/oauth-authorization-server"));
+        expect(res.status).toBe(200);
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+        const body = (await res.json()) as Record<string, unknown>;
+        expect(body.issuer).toBe("https://hub.example");
+        expect(body.authorization_endpoint).toBe("https://hub.example/oauth/authorize");
+        expect(body.code_challenge_methods_supported).toEqual(["S256"]);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/oauth/authorize without configured db returns 503", async () => {
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir)(req("/oauth/authorize?client_id=x"));
+      expect(res.status).toBe(503);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/oauth/token rejects non-POST with 405", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db })(
+          req("/oauth/token", { method: "GET" }),
+        );
+        expect(res.status).toBe(405);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/oauth/register accepts POST with JSON body", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, {
+          getDb: () => db,
+          issuer: "https://hub.example",
+        })(
+          req("/oauth/register", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ redirect_uris: ["https://app.example/cb"] }),
+          }),
+        );
+        expect(res.status).toBe(201);
+        const body = (await res.json()) as Record<string, unknown>;
+        expect(typeof body.client_id).toBe("string");
       } finally {
         db.close();
       }

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -1,0 +1,705 @@
+import { describe, expect, test } from "bun:test";
+import { createHash, randomBytes } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerClient } from "../clients.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { validateAccessToken } from "../jwt-sign.ts";
+import {
+  authorizationServerMetadata,
+  handleAuthorizeGet,
+  handleAuthorizePost,
+  handleRegister,
+  handleToken,
+} from "../oauth-handlers.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "https://hub.example";
+
+async function makeDb() {
+  const configDir = mkdtempSync(join(tmpdir(), "phub-oauth-"));
+  const db = openHubDb(hubDbPath(configDir));
+  return {
+    db,
+    cleanup: () => {
+      db.close();
+      rmSync(configDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function makePkce() {
+  const verifier = randomBytes(32).toString("base64url");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  return { verifier, challenge };
+}
+
+function authorizeUrl(params: Record<string, string>): string {
+  const u = new URL("/oauth/authorize", ISSUER);
+  for (const [k, v] of Object.entries(params)) u.searchParams.set(k, v);
+  return u.toString();
+}
+
+describe("authorizationServerMetadata", () => {
+  test("emits RFC 8414 fields rooted at the issuer", async () => {
+    const res = authorizationServerMetadata({ issuer: ISSUER });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.issuer).toBe(ISSUER);
+    expect(body.authorization_endpoint).toBe(`${ISSUER}/oauth/authorize`);
+    expect(body.token_endpoint).toBe(`${ISSUER}/oauth/token`);
+    expect(body.registration_endpoint).toBe(`${ISSUER}/oauth/register`);
+    expect(body.jwks_uri).toBe(`${ISSUER}/.well-known/jwks.json`);
+    expect(body.code_challenge_methods_supported).toEqual(["S256"]);
+    expect(body.grant_types_supported).toContain("authorization_code");
+    expect(body.grant_types_supported).toContain("refresh_token");
+  });
+});
+
+describe("handleAuthorizeGet", () => {
+  test("renders login form when no session cookie is present", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault.read",
+          state: "xyz",
+        }),
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("Sign in");
+      expect(html).toContain('name="__action" value="login"');
+      // State + redirect_uri must be echoed via hidden inputs.
+      expect(html).toContain('name="state" value="xyz"');
+      expect(html).toContain('name="redirect_uri" value="https://app.example/cb"');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("renders consent screen when session is valid", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "MyApp",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault.read",
+        }),
+        {
+          headers: {
+            cookie: buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000)),
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("Authorize");
+      expect(html).toContain("MyApp");
+      expect(html).toContain("vault.read");
+      expect(html).toContain('name="__action" value="consent"');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rejects unknown client_id with 400", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: "no-such-client",
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        }),
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(400);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rejects redirect_uri not registered for this client", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://evil.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        }),
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(400);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rejects code_challenge_method=plain (PKCE S256 mandatory)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: "challenge",
+          code_challenge_method: "plain",
+        }),
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(302);
+      const loc = res.headers.get("location");
+      expect(loc).toContain("error=invalid_request");
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("handleAuthorizePost — login submit", () => {
+  test("sets session cookie and redirects to GET on valid credentials", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "hunter2");
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const form = new URLSearchParams({
+        __action: "login",
+        username: "owner",
+        password: "hunter2",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault.read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      });
+      const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toContain("/oauth/authorize?");
+      const cookie = res.headers.get("set-cookie");
+      expect(cookie).toContain("parachute_hub_session=");
+      expect(cookie).toContain("HttpOnly");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rejects bad password with 401, no cookie", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "hunter2");
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const form = new URLSearchParams({
+        __action: "login",
+        username: "owner",
+        password: "wrong",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      });
+      const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(401);
+      expect(res.headers.get("set-cookie")).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("handleAuthorizePost — consent submit", () => {
+  test("approve issues an auth code and redirects to redirect_uri", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const form = new URLSearchParams({
+        __action: "consent",
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault.read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        state: "abc123",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: buildSessionCookie(session.id, 86400),
+        },
+      });
+      const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.get("location") ?? "");
+      expect(loc.origin + loc.pathname).toBe("https://app.example/cb");
+      expect(loc.searchParams.get("code")?.length).toBeGreaterThan(20);
+      expect(loc.searchParams.get("state")).toBe("abc123");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("deny returns access_denied with state echoed", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const form = new URLSearchParams({
+        __action: "consent",
+        approve: "no",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault.read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        state: "abc",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: buildSessionCookie(session.id, 86400),
+        },
+      });
+      const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.get("location") ?? "");
+      expect(loc.searchParams.get("error")).toBe("access_denied");
+      expect(loc.searchParams.get("state")).toBe("abc");
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("handleToken — full OAuth dance", () => {
+  test("authorize → token → validate JWT", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { verifier, challenge } = makePkce();
+
+      // Approve consent → auth code lands in redirect_uri.
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault.read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const consentReq = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: consentForm,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: buildSessionCookie(session.id, 86400),
+        },
+      });
+      const consentRes = await handleAuthorizePost(db, consentReq, { issuer: ISSUER });
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      expect(code).toBeTruthy();
+
+      // Redeem.
+      const tokenForm = new URLSearchParams({
+        grant_type: "authorization_code",
+        code: code ?? "",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        code_verifier: verifier,
+      });
+      const tokenReq = new Request(`${ISSUER}/oauth/token`, {
+        method: "POST",
+        body: tokenForm,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      });
+      const tokenRes = await handleToken(db, tokenReq, { issuer: ISSUER });
+      expect(tokenRes.status).toBe(200);
+      const tokenBody = (await tokenRes.json()) as {
+        access_token: string;
+        refresh_token: string;
+        token_type: string;
+        expires_in: number;
+        scope: string;
+      };
+      expect(tokenBody.token_type).toBe("Bearer");
+      expect(tokenBody.scope).toBe("vault.read");
+      expect(tokenBody.refresh_token.length).toBeGreaterThan(20);
+
+      // JWT must verify against the hub's signing keys, with the right sub +
+      // aud (vault.read → "vault").
+      const { payload } = await validateAccessToken(db, tokenBody.access_token);
+      expect(payload.sub).toBe(user.id);
+      expect(payload.aud).toBe("vault");
+      expect(payload.scope).toBe("vault.read");
+      expect(payload.client_id).toBe(reg.client.clientId);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("auth code is single-use (replay returns invalid_grant)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { verifier, challenge } = makePkce();
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const consentReq = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: consentForm,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: buildSessionCookie(session.id, 86400),
+        },
+      });
+      const consentRes = await handleAuthorizePost(db, consentReq, { issuer: ISSUER });
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+
+      const exchange = () => {
+        const form = new URLSearchParams({
+          grant_type: "authorization_code",
+          code: code ?? "",
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          code_verifier: verifier,
+        });
+        const req = new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: form,
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        });
+        return handleToken(db, req, { issuer: ISSUER });
+      };
+
+      const first = await exchange();
+      expect(first.status).toBe(200);
+      const second = await exchange();
+      expect(second.status).toBe(400);
+      const err = (await second.json()) as Record<string, unknown>;
+      expect(err.error).toBe("invalid_grant");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("refresh_token grant rotates the pair and revokes the old refresh", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { verifier, challenge } = makePkce();
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault.read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const consentReq = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: consentForm,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: buildSessionCookie(session.id, 86400),
+        },
+      });
+      const consentRes = await handleAuthorizePost(db, consentReq, { issuer: ISSUER });
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const tokenForm = new URLSearchParams({
+        grant_type: "authorization_code",
+        code: code ?? "",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        code_verifier: verifier,
+      });
+      const tokenRes = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: tokenForm,
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER },
+      );
+      const initial = (await tokenRes.json()) as { refresh_token: string };
+
+      const refreshForm = new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: initial.refresh_token,
+        client_id: reg.client.clientId,
+      });
+      const refreshRes = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: refreshForm,
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER },
+      );
+      expect(refreshRes.status).toBe(200);
+      const rotated = (await refreshRes.json()) as { refresh_token: string };
+      expect(rotated.refresh_token).not.toBe(initial.refresh_token);
+
+      // Old refresh token should now fail (revoked).
+      const replayRes = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: refreshForm,
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER },
+      );
+      expect(replayRes.status).toBe(400);
+      const err = (await replayRes.json()) as Record<string, unknown>;
+      expect(err.error).toBe("invalid_grant");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("client_credentials returns unsupported_grant_type", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const form = new URLSearchParams({ grant_type: "client_credentials" });
+      const req = new Request(`${ISSUER}/oauth/token`, {
+        method: "POST",
+        body: form,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      });
+      const res = await handleToken(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(400);
+      const err = (await res.json()) as Record<string, unknown>;
+      expect(err.error).toBe("unsupported_grant_type");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("PKCE verifier mismatch returns invalid_grant", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const consentRes = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: buildSessionCookie(session.id, 86400),
+          },
+        }),
+        { issuer: ISSUER },
+      );
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const tokenForm = new URLSearchParams({
+        grant_type: "authorization_code",
+        code: code ?? "",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        code_verifier: "wrong-verifier",
+      });
+      const res = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: tokenForm,
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER },
+      );
+      expect(res.status).toBe(400);
+      const err = (await res.json()) as Record<string, unknown>;
+      expect(err.error).toBe("invalid_grant");
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("handleRegister — RFC 7591 DCR", () => {
+  test("registers a public client and returns 201 with client_id (no secret)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const req = new Request(`${ISSUER}/oauth/register`, {
+        method: "POST",
+        body: JSON.stringify({
+          redirect_uris: ["https://app.example/cb"],
+          scope: "vault.read",
+          client_name: "MyApp",
+        }),
+        headers: { "content-type": "application/json" },
+      });
+      const res = await handleRegister(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(typeof body.client_id).toBe("string");
+      expect(body.client_secret).toBeUndefined();
+      expect(body.token_endpoint_auth_method).toBe("none");
+      expect(body.redirect_uris).toEqual(["https://app.example/cb"]);
+      expect(body.client_name).toBe("MyApp");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("registers a confidential client and returns plaintext client_secret", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const req = new Request(`${ISSUER}/oauth/register`, {
+        method: "POST",
+        body: JSON.stringify({
+          redirect_uris: ["https://app.example/cb"],
+          token_endpoint_auth_method: "client_secret_post",
+        }),
+        headers: { "content-type": "application/json" },
+      });
+      const res = await handleRegister(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(typeof body.client_secret).toBe("string");
+      expect(body.token_endpoint_auth_method).toBe("client_secret_post");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rejects empty redirect_uris with invalid_redirect_uri", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const req = new Request(`${ISSUER}/oauth/register`, {
+        method: "POST",
+        body: JSON.stringify({ redirect_uris: [] }),
+        headers: { "content-type": "application/json" },
+      });
+      const res = await handleRegister(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(400);
+      const err = (await res.json()) as Record<string, unknown>;
+      expect(err.error).toBe("invalid_redirect_uri");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rejects javascript: redirect_uri", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const req = new Request(`${ISSUER}/oauth/register`, {
+        method: "POST",
+        body: JSON.stringify({ redirect_uris: ["javascript:alert(1)"] }),
+        headers: { "content-type": "application/json" },
+      });
+      const res = await handleRegister(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(400);
+      const err = (await res.json()) as Record<string, unknown>;
+      expect(err.error).toBe("invalid_redirect_uri");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rejects non-JSON body", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const req = new Request(`${ISSUER}/oauth/register`, {
+        method: "POST",
+        body: "not json",
+        headers: { "content-type": "application/json" },
+      });
+      const res = await handleRegister(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(400);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/__tests__/operator-token.test.ts
+++ b/src/__tests__/operator-token.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { validateAccessToken } from "../jwt-sign.ts";
+import {
+  OPERATOR_TOKEN_AUDIENCE,
+  OPERATOR_TOKEN_FILENAME,
+  OPERATOR_TOKEN_SCOPES,
+  OPERATOR_TOKEN_TTL_SECONDS,
+  issueOperatorToken,
+  mintOperatorToken,
+  operatorTokenPath,
+  readOperatorTokenFile,
+  writeOperatorTokenFile,
+} from "../operator-token.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+
+interface Harness {
+  dir: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-operator-"));
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe("mintOperatorToken", () => {
+  test("returns a JWT with operator audience, broad scopes, and ~1y TTL", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const minted = await mintOperatorToken(db, "user-abc", {
+          now: () => new Date("2026-04-26T00:00:00Z"),
+        });
+        expect(minted.token.split(".")).toHaveLength(3);
+        const validated = await validateAccessToken(db, minted.token);
+        expect(validated.payload.sub).toBe("user-abc");
+        expect(validated.payload.aud).toBe(OPERATOR_TOKEN_AUDIENCE);
+        expect(validated.payload.scope).toBe(OPERATOR_TOKEN_SCOPES.join(" "));
+        const exp = validated.payload.exp ?? 0;
+        const iat = validated.payload.iat ?? 0;
+        expect(exp - iat).toBe(OPERATOR_TOKEN_TTL_SECONDS);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("scopes include hub:admin + vault:admin + scribe:admin + channel:send", () => {
+    expect(OPERATOR_TOKEN_SCOPES).toEqual([
+      "hub:admin",
+      "vault:admin",
+      "scribe:admin",
+      "channel:send",
+    ]);
+  });
+});
+
+describe("writeOperatorTokenFile + readOperatorTokenFile", () => {
+  test("writes mode 0600 and round-trips the plaintext", async () => {
+    const h = makeHarness();
+    try {
+      const path = await writeOperatorTokenFile("plaintext-abc", h.dir);
+      expect(path).toBe(join(h.dir, OPERATOR_TOKEN_FILENAME));
+      const stat = statSync(path);
+      // Mask off file-type bits; just compare permission bits.
+      expect(stat.mode & 0o777).toBe(0o600);
+      const round = await readOperatorTokenFile(h.dir);
+      expect(round).toBe("plaintext-abc");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("readOperatorTokenFile returns null when missing", async () => {
+    const h = makeHarness();
+    try {
+      expect(await readOperatorTokenFile(h.dir)).toBeNull();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("overwrite is atomic — second write replaces the first plaintext", async () => {
+    const h = makeHarness();
+    try {
+      await writeOperatorTokenFile("first", h.dir);
+      await writeOperatorTokenFile("second", h.dir);
+      const round = await readOperatorTokenFile(h.dir);
+      expect(round).toBe("second");
+      // No leftover .tmp
+      const tmp = `${operatorTokenPath(h.dir)}.tmp`;
+      await readFile(tmp).then(
+        () => expect.unreachable("tmp file should be renamed away"),
+        (err: NodeJS.ErrnoException) => expect(err.code).toBe("ENOENT"),
+      );
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("issueOperatorToken", () => {
+  test("mints + writes the token to disk in one call", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const issued = await issueOperatorToken(db, "user-xyz", { dir: h.dir });
+        expect(issued.path).toBe(join(h.dir, OPERATOR_TOKEN_FILENAME));
+        const fromDisk = await readOperatorTokenFile(h.dir);
+        expect(fromDisk).toBe(issued.token);
+        const validated = await validateAccessToken(db, issued.token);
+        expect(validated.payload.sub).toBe("user-xyz");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -18,6 +18,7 @@
 
 import { createInterface } from "node:readline/promises";
 import { openHubDb } from "../hub-db.ts";
+import { issueOperatorToken } from "../operator-token.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 import {
   SingleUserModeError,
@@ -41,7 +42,12 @@ export const defaultRunner: Runner = {
 };
 
 const VAULT_FORWARDED_SUBCOMMANDS = new Set(["2fa"]);
-const HUB_LOCAL_SUBCOMMANDS = new Set(["rotate-key", "set-password", "list-users"]);
+const HUB_LOCAL_SUBCOMMANDS = new Set([
+  "rotate-key",
+  "set-password",
+  "list-users",
+  "rotate-operator",
+]);
 
 export function authHelp(): string {
   return `parachute auth — ecosystem identity commands (password + two-factor authentication)
@@ -55,6 +61,7 @@ Usage:
   parachute auth 2fa disable           Disable 2FA (requires password)
   parachute auth 2fa backup-codes      Regenerate backup codes
   parachute auth rotate-key            Rotate the hub's JWT signing key
+  parachute auth rotate-operator       Mint a fresh ~/.parachute/operator.token
 
 set-password and list-users are hub-local — they read/write
 ~/.parachute/hub.db. set-password is interactive by default (prompts for
@@ -73,6 +80,11 @@ you see "not found on PATH", install vault first:
 rotate-key generates a fresh RSA-2048 keypair and retires the previous
 one. The retired key keeps appearing in /.well-known/jwks.json for 24
 hours so cached client copies keep validating until their TTL expires.
+
+rotate-operator mints a fresh long-lived operator token at
+~/.parachute/operator.token (mode 0600). Local CLI tools read this file
+as their bearer when calling on-box services. set-password also writes
+the file on first-run / password reset.
 `;
 }
 
@@ -87,6 +99,11 @@ export interface AuthDeps {
   isInteractive?: () => boolean;
   /** Override the hub-db path. Tests point at a tmp dir. */
   dbPath?: string;
+  /**
+   * Override the directory where `operator.token` is written. Defaults to
+   * `configDir()` (i.e. `~/.parachute/`). Tests point at a tmp dir.
+   */
+  configDir?: string;
 }
 
 function defaultRotateKey(): { kid: string; createdAt: string } {
@@ -245,6 +262,8 @@ async function runSetPassword(args: readonly string[], deps: AuthDeps): Promise<
       if (target) {
         await setPassword(db, target.id, password);
         console.log(`Updated password for "${target.username}".`);
+        const issued = await issueOperatorToken(db, target.id, { dir: deps.configDir });
+        console.log(`Refreshed operator token at ${issued.path}.`);
         return 0;
       }
     }
@@ -269,6 +288,8 @@ async function runSetPassword(args: readonly string[], deps: AuthDeps): Promise<
     try {
       const u = await createUser(db, targetUsername, password, { allowMulti: flags.allowMulti });
       console.log(`Created hub user "${u.username}" (id=${u.id}).`);
+      const issued = await issueOperatorToken(db, u.id, { dir: deps.configDir });
+      console.log(`Wrote operator token to ${issued.path} (mode 0600).`);
       return 0;
     } catch (err) {
       if (err instanceof SingleUserModeError) {
@@ -281,6 +302,31 @@ async function runSetPassword(args: readonly string[], deps: AuthDeps): Promise<
       }
       throw err;
     }
+  } finally {
+    db.close();
+  }
+}
+
+async function runRotateOperator(deps: AuthDeps): Promise<number> {
+  const db = deps.dbPath ? openHubDb(deps.dbPath) : openHubDb();
+  try {
+    const users = listUsers(db);
+    const owner = users[0];
+    if (!owner) {
+      console.error(
+        "no hub users yet — run `parachute auth set-password` to create the first one before issuing an operator token",
+      );
+      return 1;
+    }
+    const issued = await issueOperatorToken(db, owner.id, { dir: deps.configDir });
+    console.log("Rotated operator token.");
+    console.log(`  user:       ${owner.username}`);
+    console.log(`  path:       ${issued.path}`);
+    console.log(`  expires_at: ${issued.expiresAt}`);
+    console.log(
+      "Previous tokens stay valid until they expire — the hub does not revoke them. Treat operator.token like an SSH key.",
+    );
+    return 0;
   } finally {
     db.close();
   }
@@ -346,6 +392,15 @@ export async function auth(args: readonly string[], deps: AuthDeps | Runner = {}
     }
     if (sub === "list-users") {
       return runListUsers(normalized);
+    }
+    if (sub === "rotate-operator") {
+      try {
+        return await runRotateOperator(normalized);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`parachute auth rotate-operator: ${msg}`);
+        return 1;
+      }
     }
   }
 

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -29,9 +29,7 @@ import {
   WELL_KNOWN_MOUNT,
   WELL_KNOWN_PATH,
   buildWellKnown,
-  isVaultEntry,
   shortName,
-  vaultInstanceName,
   writeWellKnownFile,
 } from "../well-known.ts";
 import { restart } from "./lifecycle.ts";
@@ -105,11 +103,14 @@ export interface ExposeOpts {
 const HUB_DEPENDENT_SHORTS = ["vault"] as const;
 
 /**
- * OAuth paths the hub fronts on behalf of vault (Phase 0: vault implements
- * OAuth, hub owns the public URL). The mount path is what clients see; the
- * target tail is what vault expects. tailscale strips the mount before
- * forwarding, so the target must include vault's `/vault/<name>` prefix to
- * land at the right handler.
+ * OAuth paths the hub serves natively. The mount path is what clients see;
+ * the target is the hub's loopback origin (where `hub-server.ts` is
+ * listening). tailscale strips the mount before forwarding, so the target
+ * must include the same path so the hub-server router sees the full URL.
+ *
+ * Pre-cli#58 (PR (c)) these were proxied to vault's `/vault/<name>/oauth/*`
+ * handlers; after PR (c) the hub IS the OAuth IdP and vault validates
+ * hub-issued JWTs (vault#169).
  */
 const OAUTH_PATHS = [
   "/.well-known/oauth-authorization-server",
@@ -117,14 +118,6 @@ const OAUTH_PATHS = [
   "/oauth/token",
   "/oauth/register",
 ] as const;
-
-/**
- * Single-vault launch assumption: find the first `parachute-vault` entry.
- * Multi-vault OAuth routing is Phase 2+ (design note open-question #4).
- */
-function primaryVault(services: readonly ServiceEntry[]): ServiceEntry | undefined {
-  return services.find((s) => isVaultEntry(s));
-}
 
 /**
  * Remap legacy `paths: ["/"]` entries to `/<shortname>` so they don't collide
@@ -228,21 +221,17 @@ function planEntries(services: readonly ServiceEntry[], hubPort: number): ServeE
     service: "well-known",
   });
 
-  // Phase 0 OAuth seam: hub origin owns the public OAuth URLs; vault owns
-  // the implementation. When vault is installed, mount the four endpoints
-  // at the hub origin and proxy them into vault's `/vault/<name>/oauth/*`.
-  const vault = primaryVault(services);
-  if (vault) {
-    const vaultMount = vault.paths[0] ?? `/vault/${vaultInstanceName(vault)}`;
-    const vaultBase = vaultMount.replace(/\/$/, "");
-    for (const oauthPath of OAUTH_PATHS) {
-      entries.push({
-        kind: "proxy",
-        mount: oauthPath,
-        target: `http://127.0.0.1:${vault.port}${vaultBase}${oauthPath}`,
-        service: `${vault.name}:oauth`,
-      });
-    }
+  // The hub is the OAuth IdP — mount the four endpoints at the canonical
+  // origin and proxy them to the hub's loopback. tailscale strips the mount
+  // before forwarding, so the target keeps the same path (matches the
+  // `serviceProxyTarget` rule of thumb in the doc above).
+  for (const oauthPath of OAUTH_PATHS) {
+    entries.push({
+      kind: "proxy",
+      mount: oauthPath,
+      target: serviceProxyTarget(hubPort, oauthPath),
+      service: "hub:oauth",
+    });
   }
   return entries;
 }
@@ -378,6 +367,13 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
   writeHubFile(hubFilePath);
   log(`Wrote ${hubFilePath}`);
 
+  // Resolve the public hub origin before spawning the hub server — it gets
+  // baked into the OAuth `iss` claim via the `--issuer` flag. Falling back to
+  // the request origin would put `http://127.0.0.1:<port>` in tokens, which
+  // any client following RFC 8414 would reject.
+  const hubOrigin =
+    deriveHubOrigin({ override: opts.hubOrigin, exposeFqdn: fqdn }) ?? canonicalOrigin;
+
   let hubPort: number;
   if (opts.skipHub) {
     const existing = readHubPort(configDir);
@@ -391,6 +387,7 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
       ...(opts.hubEnsureOpts ?? {}),
       configDir,
       wellKnownDir,
+      issuer: hubOrigin,
       log,
     });
     hubPort = hub.port;
@@ -415,8 +412,6 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
     return code;
   }
 
-  const hubOrigin =
-    deriveHubOrigin({ override: opts.hubOrigin, exposeFqdn: fqdn }) ?? canonicalOrigin;
   const state: ExposeState = {
     version: 1,
     layer,
@@ -440,9 +435,7 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
     log(`✓ Tailnet exposure active. Open: ${canonicalOrigin}/`);
   }
   log(`  Discovery: ${canonicalOrigin}${WELL_KNOWN_MOUNT}`);
-  if (primaryVault(services)) {
-    log(`  OAuth issuer: ${hubOrigin}`);
-  }
+  log(`  OAuth issuer: ${hubOrigin}`);
 
   // Auto-restart services that cache the hub origin. Aaron hit this on launch
   // day: after `expose public` first-run, vault kept its stale (loopback)

--- a/src/hub-control.ts
+++ b/src/hub-control.ts
@@ -124,6 +124,14 @@ export interface EnsureHubOpts {
   reservedPorts?: Iterable<number>;
   /** How long to wait after spawn before claiming readiness. Short — tests set to 0. */
   readyWaitMs?: number;
+  /**
+   * Public origin to use as the OAuth `iss` claim and as the base for the
+   * authorization-server metadata document. Forwarded to the hub server as
+   * `--issuer <url>`. When omitted, the hub falls back to the request's own
+   * origin — fine for loopback testing, wrong under tailscale where the
+   * request origin is `http://127.0.0.1:<port>`.
+   */
+  issuer?: string;
   log?: (line: string) => void;
 }
 
@@ -183,6 +191,7 @@ export async function ensureHubRunning(opts: EnsureHubOpts = {}): Promise<Ensure
     wellKnownDir,
     "--db",
     hubDbPath(configDir),
+    ...(opts.issuer ? ["--issuer", opts.issuer] : []),
   ];
   const pid = spawner.spawn(cmd, logFile);
   writePid(HUB_SVC, pid, configDir);

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -10,14 +10,18 @@
  * that localhost backing.
  *
  * Routes (all bound to 127.0.0.1):
- *   /                          → hub.html                (text/html)
- *   /hub.html                  → hub.html                (text/html)
- *   /.well-known/parachute.json → parachute.json         (application/json)
- *   /.well-known/jwks.json      → JWKS from hub.db        (application/json)
- *   anything else              → 404
+ *   /                                         → hub.html
+ *   /hub.html                                 → hub.html
+ *   /.well-known/parachute.json               → parachute.json
+ *   /.well-known/jwks.json                    → JWKS from hub.db
+ *   /.well-known/oauth-authorization-server   → RFC 8414 metadata (issuer, endpoints)
+ *   /oauth/authorize  (GET + POST)            → login → consent → auth code
+ *   /oauth/token      (POST)                  → authorization_code + refresh_token grants
+ *   /oauth/register   (POST)                  → RFC 7591 dynamic client registration
+ *   anything else                             → 404
  *
  * Invoked as:
- *   bun <this-file> --port <n> --well-known-dir <path> [--db <path>]
+ *   bun <this-file> --port <n> --well-known-dir <path> [--db <path>] [--issuer <url>]
  *
  * `--well-known-dir` is the directory containing both `hub.html` and
  * `parachute.json` (both written by `parachute expose`). Kept as one flag so
@@ -34,18 +38,27 @@ import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { hubDbPath, openHubDb } from "./hub-db.ts";
 import { pemToJwk } from "./jwks.ts";
+import {
+  authorizationServerMetadata,
+  handleAuthorizeGet,
+  handleAuthorizePost,
+  handleRegister,
+  handleToken,
+} from "./oauth-handlers.ts";
 import { getAllPublicKeys } from "./signing-keys.ts";
 
 interface Args {
   port: number;
   wellKnownDir: string;
   dbPath: string;
+  issuer: string | undefined;
 }
 
 function parseArgs(argv: string[]): Args {
   let port: number | undefined;
   let wellKnownDir: string | undefined;
   let dbPath: string | undefined;
+  let issuer: string | undefined;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--port") {
@@ -64,24 +77,43 @@ function parseArgs(argv: string[]): Args {
       const v = argv[++i];
       if (!v) throw new Error("--db requires a value");
       dbPath = resolve(v);
+    } else if (a === "--issuer") {
+      const v = argv[++i];
+      if (!v) throw new Error("--issuer requires a value");
+      issuer = v.replace(/\/+$/, "");
     } else {
       throw new Error(`unknown argument: ${a}`);
     }
   }
   if (port === undefined) throw new Error("--port is required");
   if (wellKnownDir === undefined) throw new Error("--well-known-dir is required");
-  return { port, wellKnownDir, dbPath: dbPath ?? hubDbPath() };
+  return { port, wellKnownDir, dbPath: dbPath ?? hubDbPath(), issuer };
 }
 
 export interface HubFetchDeps {
   /** Lazily opens (or returns a cached handle to) the hub DB. */
   getDb: () => Database;
+  /**
+   * Hub origin used as the OAuth `iss` claim and to build the authorization-
+   * server metadata document. When omitted, OAuth endpoints fall back to the
+   * request's own origin — fine for local dev, surprising under a reverse
+   * proxy where the request origin is the loopback.
+   */
+  issuer?: string;
 }
 
-export function hubFetch(wellKnownDir: string, deps?: HubFetchDeps): (req: Request) => Response {
+export function hubFetch(
+  wellKnownDir: string,
+  deps?: HubFetchDeps,
+): (req: Request) => Response | Promise<Response> {
   const hubHtmlPath = join(wellKnownDir, "hub.html");
   const parachuteJsonPath = join(wellKnownDir, "parachute.json");
   const getDb = deps?.getDb;
+  const configuredIssuer = deps?.issuer;
+
+  const oauthDeps = (req: Request) => ({
+    issuer: configuredIssuer ?? new URL(req.url).origin,
+  });
 
   return (req) => {
     const url = new URL(req.url);
@@ -153,12 +185,55 @@ export function hubFetch(wellKnownDir: string, deps?: HubFetchDeps): (req: Reque
       }
     }
 
+    if (pathname === "/.well-known/oauth-authorization-server") {
+      // Public discovery doc — clients pull this cross-origin to find the
+      // authorize/token endpoints. Same wildcard CORS shape as the JWKS
+      // and the parachute manifest.
+      const corsHeaders = {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "GET, OPTIONS",
+      };
+      if (req.method === "OPTIONS") {
+        return new Response(null, { status: 204, headers: corsHeaders });
+      }
+      const res = authorizationServerMetadata(oauthDeps(req));
+      // Fold CORS into the existing JSON response.
+      const merged = new Headers(res.headers);
+      for (const [k, v] of Object.entries(corsHeaders)) merged.set(k, v);
+      return new Response(res.body, { status: res.status, headers: merged });
+    }
+
+    if (pathname === "/oauth/authorize") {
+      if (!getDb) {
+        return new Response("hub db not configured", { status: 503 });
+      }
+      if (req.method === "GET") return handleAuthorizeGet(getDb(), req, oauthDeps(req));
+      if (req.method === "POST") return handleAuthorizePost(getDb(), req, oauthDeps(req));
+      return new Response("method not allowed", { status: 405 });
+    }
+
+    if (pathname === "/oauth/token") {
+      if (!getDb) {
+        return new Response("hub db not configured", { status: 503 });
+      }
+      if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+      return handleToken(getDb(), req, oauthDeps(req));
+    }
+
+    if (pathname === "/oauth/register") {
+      if (!getDb) {
+        return new Response("hub db not configured", { status: 503 });
+      }
+      if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+      return handleRegister(getDb(), req, oauthDeps(req));
+    }
+
     return new Response("not found", { status: 404 });
   };
 }
 
 if (import.meta.main) {
-  const { port, wellKnownDir, dbPath } = parseArgs(process.argv.slice(2));
+  const { port, wellKnownDir, dbPath, issuer } = parseArgs(process.argv.slice(2));
   let cachedDb: Database | undefined;
   const getDb = () => {
     if (!cachedDb) cachedDb = openHubDb(dbPath);
@@ -167,9 +242,11 @@ if (import.meta.main) {
   Bun.serve({
     port,
     hostname: "127.0.0.1",
-    fetch: hubFetch(wellKnownDir, { getDb }),
+    fetch: hubFetch(wellKnownDir, { getDb, issuer }),
   });
   console.log(
-    `parachute-hub listening on http://127.0.0.1:${port} (dir=${wellKnownDir}, db=${dbPath})`,
+    `parachute-hub listening on http://127.0.0.1:${port} (dir=${wellKnownDir}, db=${dbPath}${
+      issuer ? `, issuer=${issuer}` : ""
+    })`,
   );
 }

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -42,6 +42,11 @@ export interface SignAccessTokenOpts {
   clientId: string;
   /** Override the jti (defaults to random base64url(16)). Used by tests. */
   jti?: string;
+  /**
+   * Override the default 15-minute access-token TTL. Long-lived tokens
+   * (operator-token, ~1y) pass an explicit value here.
+   */
+  ttlSeconds?: number;
   now?: () => Date;
 }
 
@@ -60,7 +65,7 @@ export async function signAccessToken(
   const jti = opts.jti ?? randomBytes(16).toString("base64url");
   const nowMs = (opts.now?.() ?? new Date()).getTime();
   const iat = Math.floor(nowMs / 1000);
-  const exp = iat + ACCESS_TOKEN_TTL_SECONDS;
+  const exp = iat + (opts.ttlSeconds ?? ACCESS_TOKEN_TTL_SECONDS);
   const token = await new SignJWT({
     scope: opts.scopes.join(" "),
     client_id: opts.clientId,

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -1,0 +1,681 @@
+/**
+ * Native OAuth handlers for the hub. Each handler is a pure function over
+ * `(db, req)` returning a `Response` — no global state, no side channels —
+ * so the test harness can drive the full OAuth dance without standing up
+ * `Bun.serve` or going near the network.
+ *
+ * Endpoints implemented:
+ *   - GET  /.well-known/oauth-authorization-server  (RFC 8414 metadata)
+ *   - GET  /oauth/authorize                          (login → consent → code)
+ *   - POST /oauth/authorize                          (form posts: login + consent)
+ *   - POST /oauth/token                              (grant_type=authorization_code | refresh_token)
+ *   - POST /oauth/register                           (RFC 7591 DCR)
+ *
+ * `client_credentials` is intentionally unimplemented — it's not in the
+ * launch surface (no machine-to-machine clients yet); the token endpoint
+ * stubs it with `unsupported_grant_type`.
+ *
+ * Login + consent screens are minimal HTML — functional, not pretty. PR (d)
+ * is the polish pass.
+ */
+import type { Database } from "bun:sqlite";
+import {
+  AuthCodeExpiredError,
+  AuthCodeNotFoundError,
+  AuthCodePkceMismatchError,
+  AuthCodeRedirectMismatchError,
+  AuthCodeUsedError,
+  issueAuthCode,
+  redeemAuthCode,
+} from "./auth-codes.ts";
+import {
+  type OAuthClient,
+  type RegisteredClient,
+  getClient,
+  isValidRedirectUri,
+  registerClient,
+  requireRegisteredRedirectUri,
+} from "./clients.ts";
+import {
+  ACCESS_TOKEN_TTL_SECONDS,
+  findRefreshToken,
+  signAccessToken,
+  signRefreshToken,
+} from "./jwt-sign.ts";
+import {
+  SESSION_TTL_MS,
+  buildSessionCookie,
+  createSession,
+  findSession,
+  parseSessionCookie,
+} from "./sessions.ts";
+import { getUserByUsername, verifyPassword } from "./users.ts";
+
+export interface OAuthDeps {
+  /** Hub origin used for `iss`, `authorization_endpoint`, etc. */
+  issuer: string;
+  /** Override the clock for deterministic tests. */
+  now?: () => Date;
+}
+
+// --- helpers ---------------------------------------------------------------
+
+function jsonResponse(body: unknown, status = 200, extra: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...extra },
+  });
+}
+
+function htmlResponse(body: string, status = 200, extra: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/html; charset=utf-8", ...extra },
+  });
+}
+
+function redirectResponse(location: string, extra: Record<string, string> = {}): Response {
+  return new Response(null, { status: 302, headers: { location, ...extra } });
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function oauthErrorRedirect(
+  redirectUri: string,
+  error: string,
+  description: string,
+  state: string | null,
+): Response {
+  const u = new URL(redirectUri);
+  u.searchParams.set("error", error);
+  u.searchParams.set("error_description", description);
+  if (state) u.searchParams.set("state", state);
+  return redirectResponse(u.toString());
+}
+
+// --- /.well-known/oauth-authorization-server -------------------------------
+
+export function authorizationServerMetadata(deps: OAuthDeps): Response {
+  const iss = deps.issuer;
+  return jsonResponse({
+    issuer: iss,
+    authorization_endpoint: `${iss}/oauth/authorize`,
+    token_endpoint: `${iss}/oauth/token`,
+    registration_endpoint: `${iss}/oauth/register`,
+    jwks_uri: `${iss}/.well-known/jwks.json`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
+    scopes_supported: [],
+  });
+}
+
+// --- /oauth/authorize ------------------------------------------------------
+
+interface AuthorizeParams {
+  clientId: string;
+  redirectUri: string;
+  responseType: string;
+  scope: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  state: string | null;
+}
+
+function parseAuthorizeParams(url: URL): AuthorizeParams | { error: string } {
+  const required = (k: string) => {
+    const v = url.searchParams.get(k);
+    return v && v.length > 0 ? v : null;
+  };
+  const clientId = required("client_id");
+  const redirectUri = required("redirect_uri");
+  const responseType = required("response_type");
+  const scope = url.searchParams.get("scope") ?? "";
+  const codeChallenge = required("code_challenge");
+  const codeChallengeMethod = required("code_challenge_method");
+  if (!clientId) return { error: "missing client_id" };
+  if (!redirectUri) return { error: "missing redirect_uri" };
+  if (!responseType) return { error: "missing response_type" };
+  if (!codeChallenge) return { error: "missing code_challenge" };
+  if (!codeChallengeMethod) return { error: "missing code_challenge_method" };
+  return {
+    clientId,
+    redirectUri,
+    responseType,
+    scope,
+    codeChallenge,
+    codeChallengeMethod,
+    state: url.searchParams.get("state"),
+  };
+}
+
+/**
+ * GET /oauth/authorize — entrypoint. Validates client + redirect_uri, then
+ * either renders the login form (no session) or the consent screen (session
+ * present). All authorize-time params are echoed back via hidden inputs so
+ * the form POST keeps the binding intact.
+ */
+export function handleAuthorizeGet(db: Database, req: Request, _deps: OAuthDeps): Response {
+  const url = new URL(req.url);
+  const parsed = parseAuthorizeParams(url);
+  if ("error" in parsed) {
+    return htmlResponse(`<h1>OAuth error</h1><p>${escapeHtml(parsed.error)}</p>`, 400);
+  }
+  if (parsed.responseType !== "code") {
+    return oauthErrorRedirect(
+      parsed.redirectUri,
+      "unsupported_response_type",
+      "only response_type=code is supported",
+      parsed.state,
+    );
+  }
+  if (parsed.codeChallengeMethod !== "S256") {
+    return oauthErrorRedirect(
+      parsed.redirectUri,
+      "invalid_request",
+      "PKCE S256 is required",
+      parsed.state,
+    );
+  }
+  const client = getClient(db, parsed.clientId);
+  if (!client) {
+    // Can't safely redirect — we don't trust the redirect_uri until we've
+    // matched it against a registered client. Render an HTML error.
+    return htmlResponse("<h1>OAuth error</h1><p>unknown client_id</p>", 400);
+  }
+  try {
+    requireRegisteredRedirectUri(client, parsed.redirectUri);
+  } catch {
+    return htmlResponse(
+      "<h1>OAuth error</h1><p>redirect_uri is not registered for this client</p>",
+      400,
+    );
+  }
+
+  const sessionId = parseSessionCookie(req.headers.get("cookie"));
+  const session = sessionId ? findSession(db, sessionId) : null;
+  if (!session) {
+    return htmlResponse(renderLoginForm(parsed));
+  }
+  return htmlResponse(renderConsentScreen(client, parsed));
+}
+
+/**
+ * POST /oauth/authorize — handles two distinct submissions:
+ *   - login form: `__action=login` with username + password. On success,
+ *     create a session, set the cookie, redirect back to GET /oauth/authorize
+ *     so the user lands on the consent screen.
+ *   - consent submission: `__action=consent` with `approve=yes|no`. On
+ *     approve, mint an auth code and redirect to the client's redirect_uri.
+ *     On deny, redirect with `error=access_denied`.
+ */
+export async function handleAuthorizePost(
+  db: Database,
+  req: Request,
+  deps: OAuthDeps,
+): Promise<Response> {
+  const form = await req.formData();
+  const action = String(form.get("__action") ?? "");
+  if (action === "login") return await handleLoginSubmit(db, req, form, deps);
+  if (action === "consent") return await handleConsentSubmit(db, req, form, deps);
+  return htmlResponse("<h1>OAuth error</h1><p>unknown form action</p>", 400);
+}
+
+async function handleLoginSubmit(
+  db: Database,
+  _req: Request,
+  form: Awaited<ReturnType<Request["formData"]>>,
+  _deps: OAuthDeps,
+): Promise<Response> {
+  const username = String(form.get("username") ?? "");
+  const password = String(form.get("password") ?? "");
+  const params = paramsFromForm(form);
+  if (!username || !password) {
+    return htmlResponse(renderLoginForm(params, "username and password are required"), 400);
+  }
+  const user = getUserByUsername(db, username);
+  if (!user) {
+    return htmlResponse(renderLoginForm(params, "invalid credentials"), 401);
+  }
+  const ok = await verifyPassword(user, password);
+  if (!ok) {
+    return htmlResponse(renderLoginForm(params, "invalid credentials"), 401);
+  }
+  const session = createSession(db, { userId: user.id });
+  const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+  // Redirect back to GET /oauth/authorize with the original query string so
+  // the user lands on the consent screen with full params re-validated.
+  const u = new URL("/oauth/authorize", "http://placeholder");
+  for (const [k, v] of Object.entries(authorizeParamsToQuery(params))) {
+    u.searchParams.set(k, v);
+  }
+  return redirectResponse(`${u.pathname}${u.search}`, { "set-cookie": cookie });
+}
+
+async function handleConsentSubmit(
+  db: Database,
+  req: Request,
+  form: Awaited<ReturnType<Request["formData"]>>,
+  deps: OAuthDeps,
+): Promise<Response> {
+  const params = paramsFromForm(form);
+  const approve = String(form.get("approve") ?? "") === "yes";
+  const sessionId = parseSessionCookie(req.headers.get("cookie"));
+  const session = sessionId ? findSession(db, sessionId) : null;
+  if (!session) {
+    // Session expired between login and consent submit. Send back to login.
+    return htmlResponse(renderLoginForm(params, "session expired; please sign in again"), 401);
+  }
+  const client = getClient(db, params.clientId);
+  if (!client) return htmlResponse("<h1>OAuth error</h1><p>unknown client_id</p>", 400);
+  try {
+    requireRegisteredRedirectUri(client, params.redirectUri);
+  } catch {
+    return htmlResponse("<h1>OAuth error</h1><p>redirect_uri mismatch</p>", 400);
+  }
+  if (!approve) {
+    return oauthErrorRedirect(
+      params.redirectUri,
+      "access_denied",
+      "user denied the authorization request",
+      params.state,
+    );
+  }
+  const scopes = params.scope.split(" ").filter((s) => s.length > 0);
+  // Record the grant — gives PR (d) a place to skip the consent screen on
+  // re-authorization for already-granted scopes.
+  db.prepare(
+    `INSERT OR REPLACE INTO grants (user_id, client_id, scopes, granted_at)
+     VALUES (?, ?, ?, ?)`,
+  ).run(
+    session.userId,
+    client.clientId,
+    scopes.join(" "),
+    (deps.now?.() ?? new Date()).toISOString(),
+  );
+  const code = issueAuthCode(db, {
+    clientId: client.clientId,
+    userId: session.userId,
+    redirectUri: params.redirectUri,
+    scopes,
+    codeChallenge: params.codeChallenge,
+    codeChallengeMethod: params.codeChallengeMethod,
+    now: deps.now,
+  });
+  const u = new URL(params.redirectUri);
+  u.searchParams.set("code", code.code);
+  if (params.state) u.searchParams.set("state", params.state);
+  return redirectResponse(u.toString());
+}
+
+function paramsFromForm(form: Awaited<ReturnType<Request["formData"]>>): AuthorizeParams {
+  return {
+    clientId: String(form.get("client_id") ?? ""),
+    redirectUri: String(form.get("redirect_uri") ?? ""),
+    responseType: String(form.get("response_type") ?? "code"),
+    scope: String(form.get("scope") ?? ""),
+    codeChallenge: String(form.get("code_challenge") ?? ""),
+    codeChallengeMethod: String(form.get("code_challenge_method") ?? "S256"),
+    state: (form.get("state") as string | null) ?? null,
+  };
+}
+
+function authorizeParamsToQuery(p: AuthorizeParams): Record<string, string> {
+  const q: Record<string, string> = {
+    client_id: p.clientId,
+    redirect_uri: p.redirectUri,
+    response_type: p.responseType,
+    scope: p.scope,
+    code_challenge: p.codeChallenge,
+    code_challenge_method: p.codeChallengeMethod,
+  };
+  if (p.state) q.state = p.state;
+  return q;
+}
+
+// --- /oauth/token ----------------------------------------------------------
+
+/**
+ * POST /oauth/token — supports `authorization_code` + `refresh_token`.
+ * Confidential clients may pass `client_secret` in the body; for public
+ * clients the binding is PKCE alone. Errors return the RFC 6749 §5.2
+ * shape: 400 + `{error, error_description}`.
+ */
+export async function handleToken(db: Database, req: Request, deps: OAuthDeps): Promise<Response> {
+  const form = await req.formData();
+  const grantType = String(form.get("grant_type") ?? "");
+  if (grantType === "authorization_code") return await handleTokenAuthorizationCode(db, form, deps);
+  if (grantType === "refresh_token") return await handleTokenRefresh(db, form, deps);
+  return jsonResponse(
+    {
+      error: "unsupported_grant_type",
+      error_description: `grant_type "${grantType}" is not supported`,
+    },
+    400,
+  );
+}
+
+async function handleTokenAuthorizationCode(
+  db: Database,
+  form: Awaited<ReturnType<Request["formData"]>>,
+  deps: OAuthDeps,
+): Promise<Response> {
+  const code = String(form.get("code") ?? "");
+  const clientId = String(form.get("client_id") ?? "");
+  const redirectUri = String(form.get("redirect_uri") ?? "");
+  const codeVerifier = String(form.get("code_verifier") ?? "");
+  if (!code || !clientId || !redirectUri || !codeVerifier) {
+    return jsonResponse(
+      { error: "invalid_request", error_description: "missing required parameter" },
+      400,
+    );
+  }
+  const client = getClient(db, clientId);
+  if (!client) {
+    return jsonResponse({ error: "invalid_client", error_description: "unknown client_id" }, 401);
+  }
+  let redeemed: ReturnType<typeof redeemAuthCode>;
+  try {
+    redeemed = redeemAuthCode(db, { code, clientId, redirectUri, codeVerifier, now: deps.now });
+  } catch (err) {
+    return mapAuthCodeError(err);
+  }
+  const audience = inferAudience(redeemed.scopes);
+  const access = await signAccessToken(db, {
+    sub: redeemed.userId,
+    scopes: redeemed.scopes,
+    audience,
+    clientId: redeemed.clientId,
+    now: deps.now,
+  });
+  const refresh = signRefreshToken(db, {
+    jti: access.jti,
+    userId: redeemed.userId,
+    clientId: redeemed.clientId,
+    scopes: redeemed.scopes,
+    now: deps.now,
+  });
+  return jsonResponse({
+    access_token: access.token,
+    token_type: "Bearer",
+    expires_in: ACCESS_TOKEN_TTL_SECONDS,
+    refresh_token: refresh.token,
+    scope: redeemed.scopes.join(" "),
+  });
+}
+
+async function handleTokenRefresh(
+  db: Database,
+  form: Awaited<ReturnType<Request["formData"]>>,
+  deps: OAuthDeps,
+): Promise<Response> {
+  const refreshToken = String(form.get("refresh_token") ?? "");
+  const clientId = String(form.get("client_id") ?? "");
+  if (!refreshToken || !clientId) {
+    return jsonResponse(
+      { error: "invalid_request", error_description: "missing required parameter" },
+      400,
+    );
+  }
+  const client = getClient(db, clientId);
+  if (!client) {
+    return jsonResponse({ error: "invalid_client", error_description: "unknown client_id" }, 401);
+  }
+  const row = findRefreshToken(db, refreshToken);
+  if (!row) {
+    return jsonResponse(
+      { error: "invalid_grant", error_description: "refresh_token not found" },
+      400,
+    );
+  }
+  if (row.clientId !== clientId) {
+    return jsonResponse({ error: "invalid_grant", error_description: "client_id mismatch" }, 400);
+  }
+  if (row.revokedAt) {
+    return jsonResponse(
+      { error: "invalid_grant", error_description: "refresh_token revoked" },
+      400,
+    );
+  }
+  const now = deps.now?.() ?? new Date();
+  if (now.getTime() > new Date(row.expiresAt).getTime()) {
+    return jsonResponse(
+      { error: "invalid_grant", error_description: "refresh_token expired" },
+      400,
+    );
+  }
+  // Rotate: revoke the old refresh row, mint a new access + refresh pair.
+  db.prepare("UPDATE tokens SET revoked_at = ? WHERE jti = ?").run(now.toISOString(), row.jti);
+  const audience = inferAudience(row.scopes);
+  const access = await signAccessToken(db, {
+    sub: row.userId,
+    scopes: row.scopes,
+    audience,
+    clientId: row.clientId,
+    now: deps.now,
+  });
+  const refresh = signRefreshToken(db, {
+    jti: access.jti,
+    userId: row.userId,
+    clientId: row.clientId,
+    scopes: row.scopes,
+    now: deps.now,
+  });
+  return jsonResponse({
+    access_token: access.token,
+    token_type: "Bearer",
+    expires_in: ACCESS_TOKEN_TTL_SECONDS,
+    refresh_token: refresh.token,
+    scope: row.scopes.join(" "),
+  });
+}
+
+function mapAuthCodeError(err: unknown): Response {
+  if (err instanceof AuthCodeNotFoundError) {
+    return jsonResponse({ error: "invalid_grant", error_description: "code not found" }, 400);
+  }
+  if (err instanceof AuthCodeExpiredError) {
+    return jsonResponse({ error: "invalid_grant", error_description: "code expired" }, 400);
+  }
+  if (err instanceof AuthCodeUsedError) {
+    return jsonResponse(
+      { error: "invalid_grant", error_description: "code already redeemed" },
+      400,
+    );
+  }
+  if (err instanceof AuthCodePkceMismatchError) {
+    return jsonResponse(
+      { error: "invalid_grant", error_description: "code_verifier mismatch" },
+      400,
+    );
+  }
+  if (err instanceof AuthCodeRedirectMismatchError) {
+    return jsonResponse(
+      { error: "invalid_grant", error_description: "redirect_uri mismatch" },
+      400,
+    );
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  return jsonResponse({ error: "server_error", error_description: msg }, 500);
+}
+
+/**
+ * Picks the JWT `aud` claim based on the requested scopes. `vault.*` →
+ * "vault", `notes.*` → "notes", etc. Falls back to "hub" for hub-only
+ * scopes or empty scopes. This will become a more deliberate scope
+ * registry in PR (d) / cli#56; for now, prefix-match is enough.
+ */
+function inferAudience(scopes: string[]): string {
+  for (const s of scopes) {
+    const dot = s.indexOf(".");
+    if (dot > 0) return s.slice(0, dot);
+  }
+  return "hub";
+}
+
+// --- /oauth/register -------------------------------------------------------
+
+interface RegisterRequestBody {
+  redirect_uris?: string[];
+  scope?: string;
+  client_name?: string;
+  token_endpoint_auth_method?: string;
+}
+
+/**
+ * POST /oauth/register — RFC 7591 Dynamic Client Registration. Self-serve.
+ * Returns the assigned `client_id` (and `client_secret` for confidential
+ * clients). The brief defers admin-gating; today, any caller gets a row.
+ */
+export async function handleRegister(
+  db: Database,
+  req: Request,
+  deps: OAuthDeps,
+): Promise<Response> {
+  let body: RegisterRequestBody;
+  try {
+    body = (await req.json()) as RegisterRequestBody;
+  } catch {
+    return jsonResponse(
+      { error: "invalid_client_metadata", error_description: "body must be JSON" },
+      400,
+    );
+  }
+  const redirectUris = Array.isArray(body.redirect_uris) ? body.redirect_uris : [];
+  if (redirectUris.length === 0) {
+    return jsonResponse(
+      {
+        error: "invalid_redirect_uri",
+        error_description: "redirect_uris is required and must be non-empty",
+      },
+      400,
+    );
+  }
+  for (const uri of redirectUris) {
+    if (typeof uri !== "string" || !isValidRedirectUri(uri)) {
+      return jsonResponse(
+        { error: "invalid_redirect_uri", error_description: `invalid redirect_uri "${uri}"` },
+        400,
+      );
+    }
+  }
+  const confidential = body.token_endpoint_auth_method === "client_secret_post";
+  const scopes = (body.scope ?? "").split(" ").filter((s) => s.length > 0);
+  let registered: RegisteredClient;
+  try {
+    registered = registerClient(db, {
+      redirectUris,
+      scopes,
+      clientName: body.client_name,
+      confidential,
+      now: deps.now,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return jsonResponse({ error: "invalid_client_metadata", error_description: msg }, 400);
+  }
+  const respBody: Record<string, unknown> = {
+    client_id: registered.client.clientId,
+    redirect_uris: registered.client.redirectUris,
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    token_endpoint_auth_method: confidential ? "client_secret_post" : "none",
+    client_id_issued_at: Math.floor(new Date(registered.client.registeredAt).getTime() / 1000),
+  };
+  if (registered.client.scopes.length > 0) respBody.scope = registered.client.scopes.join(" ");
+  if (registered.client.clientName) respBody.client_name = registered.client.clientName;
+  if (registered.clientSecret) respBody.client_secret = registered.clientSecret;
+  return jsonResponse(respBody, 201);
+}
+
+// --- HTML templates --------------------------------------------------------
+
+function renderLoginForm(params: AuthorizeParams, errorMessage?: string): string {
+  const hidden = renderHiddenInputs(params);
+  const err = errorMessage ? `<p class="err">${escapeHtml(errorMessage)}</p>` : "";
+  return baseDocument(
+    "Sign in to Parachute Hub",
+    `
+    <h1>Sign in</h1>
+    ${err}
+    <form method="POST" action="/oauth/authorize">
+      <input type="hidden" name="__action" value="login" />
+      ${hidden}
+      <label>Username<br/><input type="text" name="username" autofocus required /></label>
+      <label>Password<br/><input type="password" name="password" required /></label>
+      <button type="submit">Sign in</button>
+    </form>
+    `,
+  );
+}
+
+function renderConsentScreen(client: OAuthClient, params: AuthorizeParams): string {
+  const hidden = renderHiddenInputs(params);
+  const scopes = params.scope.split(" ").filter((s) => s.length > 0);
+  const clientName = client.clientName ?? client.clientId;
+  const scopeList =
+    scopes.length === 0
+      ? "<li>(no scopes requested)</li>"
+      : scopes.map((s) => `<li><code>${escapeHtml(s)}</code></li>`).join("");
+  return baseDocument(
+    `Authorize ${escapeHtml(clientName)}`,
+    `
+    <h1>Authorize <code>${escapeHtml(clientName)}</code>?</h1>
+    <p>This app is requesting access to your Parachute account with the following scopes:</p>
+    <ul>${scopeList}</ul>
+    <form method="POST" action="/oauth/authorize">
+      <input type="hidden" name="__action" value="consent" />
+      ${hidden}
+      <button type="submit" name="approve" value="yes">Approve</button>
+      <button type="submit" name="approve" value="no">Deny</button>
+    </form>
+    `,
+  );
+}
+
+function renderHiddenInputs(p: AuthorizeParams): string {
+  const fields: [string, string][] = [
+    ["client_id", p.clientId],
+    ["redirect_uri", p.redirectUri],
+    ["response_type", p.responseType],
+    ["scope", p.scope],
+    ["code_challenge", p.codeChallenge],
+    ["code_challenge_method", p.codeChallengeMethod],
+  ];
+  if (p.state) fields.push(["state", p.state]);
+  return fields
+    .map(([k, v]) => `<input type="hidden" name="${k}" value="${escapeHtml(v)}" />`)
+    .join("\n      ");
+}
+
+function baseDocument(title: string, body: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>${escapeHtml(title)}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 28rem; margin: 4rem auto; padding: 0 1rem; }
+    h1 { font-size: 1.4rem; }
+    label { display: block; margin: 0.75rem 0; }
+    input[type=text], input[type=password] { width: 100%; padding: 0.5rem; box-sizing: border-box; }
+    button { padding: 0.5rem 1rem; margin-right: 0.5rem; }
+    .err { color: #b00020; }
+    code { background: #f3f3f3; padding: 0 0.25rem; border-radius: 3px; }
+    ul { padding-left: 1.25rem; }
+  </style>
+</head>
+<body>
+${body}
+</body>
+</html>`;
+}

--- a/src/operator-token.ts
+++ b/src/operator-token.ts
@@ -1,0 +1,115 @@
+/**
+ * Operator token — long-lived hub-issued JWT that local CLI tools use to
+ * authenticate against on-box services (vault / scribe / channel) without
+ * running an interactive OAuth dance every time.
+ *
+ * Why this exists: modules require auth on every request — there is no
+ * "loopback is trusted" bypass, because browser extensions and compromised
+ * postinstalls can hit 127.0.0.1 too. The operator token is the on-box
+ * caller's bearer credential; it lives in `~/.parachute/operator.token`
+ * with mode 0600 so a different unix user can't read it.
+ *
+ * Browser apps follow the OAuth flow and never touch this file. Service
+ * accounts (cron jobs, oncall scripts) read it; that's the whole point.
+ *
+ * Rotation: cheap. `parachute auth rotate-operator` mints a fresh token
+ * and overwrites the file. The previous token is *not* revoked at the
+ * issuer — the hub doesn't track operator-token jtis — so a leaked file
+ * stays valid until its 1-year TTL elapses. Treat operator.token like an
+ * SSH private key.
+ */
+import type { Database } from "bun:sqlite";
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { configDir } from "./config.ts";
+import { signAccessToken } from "./jwt-sign.ts";
+
+export const OPERATOR_TOKEN_FILENAME = "operator.token";
+export const OPERATOR_TOKEN_TTL_SECONDS = 365 * 24 * 60 * 60;
+export const OPERATOR_TOKEN_AUDIENCE = "operator";
+export const OPERATOR_TOKEN_CLIENT_ID = "parachute-cli";
+export const OPERATOR_TOKEN_SCOPES = ["hub:admin", "vault:admin", "scribe:admin", "channel:send"];
+
+export function operatorTokenPath(dir: string = configDir()): string {
+  return join(dir, OPERATOR_TOKEN_FILENAME);
+}
+
+export interface MintOperatorTokenOpts {
+  /** Override the JWT-sign clock — tests pin time. */
+  now?: () => Date;
+  /** Override the random jti — tests pin it. */
+  jti?: string;
+  /** Override the audience claim. Defaults to "operator". */
+  audience?: string;
+}
+
+export async function mintOperatorToken(
+  db: Database,
+  userId: string,
+  opts: MintOperatorTokenOpts = {},
+): Promise<{ token: string; jti: string; expiresAt: string }> {
+  return signAccessToken(db, {
+    sub: userId,
+    scopes: OPERATOR_TOKEN_SCOPES,
+    audience: opts.audience ?? OPERATOR_TOKEN_AUDIENCE,
+    clientId: OPERATOR_TOKEN_CLIENT_ID,
+    ttlSeconds: OPERATOR_TOKEN_TTL_SECONDS,
+    ...(opts.jti !== undefined ? { jti: opts.jti } : {}),
+    ...(opts.now !== undefined ? { now: opts.now } : {}),
+  });
+}
+
+/**
+ * Atomically writes the token to `<dir>/operator.token` with mode 0600.
+ * Atomic = write to `<path>.tmp` then rename, so a half-written file never
+ * exists at the canonical path.
+ */
+export async function writeOperatorTokenFile(
+  token: string,
+  dir: string = configDir(),
+): Promise<string> {
+  await fs.mkdir(dir, { recursive: true });
+  const path = operatorTokenPath(dir);
+  const tmp = `${path}.tmp`;
+  await fs.writeFile(tmp, `${token}\n`, { mode: 0o600 });
+  await fs.rename(tmp, path);
+  return path;
+}
+
+/**
+ * Reads the operator token file, trims trailing whitespace. Returns null
+ * if the file doesn't exist (caller decides whether that's an error). Any
+ * other read error propagates.
+ */
+export async function readOperatorTokenFile(dir: string = configDir()): Promise<string | null> {
+  const path = operatorTokenPath(dir);
+  try {
+    const buf = await fs.readFile(path, "utf8");
+    const trimmed = buf.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+export interface IssueOperatorTokenResult {
+  token: string;
+  jti: string;
+  expiresAt: string;
+  path: string;
+}
+
+/**
+ * Mint + write in one call. Used by `parachute auth set-password` (after
+ * password set) and `parachute auth rotate-operator`.
+ */
+export async function issueOperatorToken(
+  db: Database,
+  userId: string,
+  opts: MintOperatorTokenOpts & { dir?: string } = {},
+): Promise<IssueOperatorTokenResult> {
+  const minted = await mintOperatorToken(db, userId, opts);
+  const path = await writeOperatorTokenFile(minted.token, opts.dir);
+  return { ...minted, path };
+}


### PR DESCRIPTION
## Summary

PR (c2) of the cli#58 OAuth issuance cascade — closes the loop on #58.

**The hub becomes the OAuth IdP.** The four endpoints `/oauth/authorize`, `/oauth/token`, `/oauth/register`, and `/.well-known/oauth-authorization-server` are now served natively by the hub instead of being proxied to vault. Modules will validate hub-issued JWTs against `/.well-known/jwks.json`. (Vault keeps `pvt_*` token validation in its own steward — vault#169.)

**The operator token is the on-box CLI's bearer credential.** Local callers (cron jobs, oncall scripts, `parachute vault status` etc. once that surface lands) read `~/.parachute/operator.token` and present it as `Authorization: Bearer …` to whichever local service they're calling. Browser apps follow the OAuth flow and never touch the file. Modules will enforce auth on every request — no "loopback is trusted" bypass — per the updated security model.

Bumps `0.3.1-rc.3` → `0.3.1-rc.4`.

## What's in it

**Native OAuth handlers** (`src/oauth-handlers.ts`, `src/hub-server.ts`):
- `/oauth/authorize` GET → login or consent screen; POST → process login or consent decision; mints single-use codes on approval
- `/oauth/token` POST → `authorization_code` (PKCE S256, redirect-uri match, code single-use) + `refresh_token` (rotation, old revoked); `client_credentials` rejected as `unsupported_grant_type`
- `/oauth/register` POST → RFC 7591 DCR; public + confidential clients; redirect-uri allowlist
- `/.well-known/oauth-authorization-server` GET → RFC 8414 metadata advertising S256, the supported grant types, and the canonical issuer URL
- All four paths get CORS headers — browsers fetch the well-known doc cross-origin

**Issuer plumbing** (`src/commands/expose.ts`, `src/hub-control.ts`):
- `expose` now proxies the OAuth paths to the hub origin unconditionally (hub IS the IdP regardless of whether vault is installed)
- `hubOrigin` is computed before `ensureHubRunning` and passed in via a new `issuer` option, which forwards to the hub-server spawn as `--issuer https://…`. Required because the request-origin fallback would yield `http://127.0.0.1:1939` in JWT `iss` — wrong for cross-machine validation under tailscale

**Operator token** (`src/operator-token.ts`, `src/commands/auth.ts`, `src/jwt-sign.ts`):
- `mintOperatorToken(db, userId)` — RS256 JWT, scopes `hub:admin vault:admin scribe:admin channel:send`, audience `operator`, 1-year TTL
- `writeOperatorTokenFile(token, dir)` — atomic write at `<dir>/operator.token` mode 0600 (tmp+rename so half-written never visible at canonical path)
- `parachute auth set-password` mints+writes operator.token on both create and update paths
- `parachute auth rotate-operator` — fresh token, overwrites the file
- `signAccessToken` gains an optional `ttlSeconds` override (default 15min stays)

## Why split

Original PR (c) was ~2682 LOC. Per team-lead direction (Option 2):
- **PR (c1)** — `feat(hub): OAuth client registration + auth-codes + sessions (rc.3)` — the leaf modules with their unit tests. Already merged (#65).
- **PR (c2)** — *this PR* — `oauth-handlers.ts` + handler tests + `hub-server` wiring + `expose.ts` proxy retarget + operator-token + version bump.

c2 came in at 2056 LOC including the operator-token addition (~244 LOC of that). Folded in per team-lead's "use your judgment if it stays under ~2500" call.

## What's deferred

**CLI client-side bearer-from-file shim.** There is currently no `parachute …` subcommand that calls a local service over HTTP — `parachute vault <args>` execs `parachute-vault`, install runs npm, etc. The shim has no current caller to retrofit, so it lands with the first such command. The token *is written* to `~/.parachute/operator.token` today; it's just that nothing in this repo reads it yet.

**Vault dual-validation.** Vault's `pvt_*` token validation + adding hub-JWT acceptance is vault#169, separate steward.

## Loopback-bypass audit

`grep -E '127\.0\.0\.1|loopback|trustedOrigin|skipAuth' src/oauth-handlers.ts` → zero matches. Auth in the new handlers is enforced via session cookie + client_id + PKCE; no origin-based shortcuts. Other matches in the repo are infrastructure (bind addresses, URL formation, public-exposure declarations), not auth bypass.

## Test plan

- [x] `bunx biome check .` — 0 warnings
- [x] `bun run typecheck` — 0 errors
- [x] `bun test` — 562 pass / 0 fail / 1497 expect calls (+10 new for operator-token, +existing for handlers)
- [ ] Reviewer: end-to-end smoke against a real `expose tailnet` once merged — drive `/oauth/authorize` → `/oauth/token` → present access token to a service; confirm JWT `iss` is the FQDN
- [ ] Reviewer: `~/.parachute/operator.token` appears with mode 0600 after `parachute auth set-password`
- [ ] Reviewer: `parachute auth rotate-operator` overwrites the file with a different JWT

🤖 Generated with [Claude Code](https://claude.com/claude-code)