### PR TITLE
feat(hub): branded OAuth consent UI + scope explanations (0.3.2-rc.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.3.1-rc.4",
+  "version": "0.3.2-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -55,6 +55,12 @@ describe("authorizationServerMetadata", () => {
     expect(body.code_challenge_methods_supported).toEqual(["S256"]);
     expect(body.grant_types_supported).toContain("authorization_code");
     expect(body.grant_types_supported).toContain("refresh_token");
+    // closes #68 — scopes_supported populated from FIRST_PARTY_SCOPES
+    const scopesSupported = body.scopes_supported as string[];
+    expect(scopesSupported).toContain("vault:read");
+    expect(scopesSupported).toContain("vault:admin");
+    expect(scopesSupported).toContain("scribe:transcribe");
+    expect(scopesSupported).toContain("hub:admin");
   });
 });
 

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type AuthorizeFormParams,
+  escapeHtml,
+  renderConsent,
+  renderError,
+  renderHiddenInputs,
+  renderLogin,
+} from "../oauth-ui.ts";
+
+const PARAMS: AuthorizeFormParams = {
+  clientId: "client-abc",
+  redirectUri: "https://app.example/cb",
+  responseType: "code",
+  scope: "vault:read vault:admin",
+  codeChallenge: "ch",
+  codeChallengeMethod: "S256",
+  state: "xyz",
+};
+
+describe("escapeHtml", () => {
+  test("escapes the five HTML metacharacters", () => {
+    expect(escapeHtml(`<script>alert("x&y'z")</script>`)).toBe(
+      "&lt;script&gt;alert(&quot;x&amp;y&#39;z&quot;)&lt;/script&gt;",
+    );
+  });
+});
+
+describe("renderHiddenInputs", () => {
+  test("emits one hidden input per non-state field, plus state when present", () => {
+    const html = renderHiddenInputs(PARAMS);
+    expect(html).toContain('name="client_id" value="client-abc"');
+    expect(html).toContain('name="redirect_uri" value="https://app.example/cb"');
+    expect(html).toContain('name="response_type" value="code"');
+    expect(html).toContain('name="scope" value="vault:read vault:admin"');
+    expect(html).toContain('name="code_challenge" value="ch"');
+    expect(html).toContain('name="code_challenge_method" value="S256"');
+    expect(html).toContain('name="state" value="xyz"');
+  });
+
+  test("omits state input when state is null", () => {
+    const html = renderHiddenInputs({ ...PARAMS, state: null });
+    expect(html).not.toContain('name="state"');
+  });
+
+  test("escapes hostile values into hidden inputs", () => {
+    const html = renderHiddenInputs({ ...PARAMS, state: `"><script>alert(1)</script>` });
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+describe("renderLogin", () => {
+  test("contains form, hidden inputs, and a Sign in submit", () => {
+    const html = renderLogin({ params: PARAMS });
+    expect(html).toContain('action="/oauth/authorize"');
+    expect(html).toContain('name="__action" value="login"');
+    expect(html).toContain('name="username"');
+    expect(html).toContain('name="password"');
+    expect(html).toContain("Sign in");
+    // Hidden state echoed
+    expect(html).toContain('name="state" value="xyz"');
+    // Brand styling present
+    expect(html).toContain("Parachute");
+  });
+
+  test("renders an error banner when errorMessage is set", () => {
+    const html = renderLogin({ params: PARAMS, errorMessage: "bad pw" });
+    expect(html).toContain("error-banner");
+    expect(html).toContain("bad pw");
+  });
+
+  test("escapes the error message", () => {
+    const html = renderLogin({ params: PARAMS, errorMessage: "<script>x</script>" });
+    expect(html).not.toContain("<script>x</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+describe("renderConsent", () => {
+  test("shows client name, client_id, and a row per scope", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      clientId: "client-abc",
+      clientName: "MyApp",
+      scopes: ["vault:read", "vault:admin"],
+    });
+    expect(html).toContain("Authorize");
+    expect(html).toContain("MyApp");
+    expect(html).toContain("client-abc");
+    expect(html).toContain("vault:read");
+    expect(html).toContain("vault:admin");
+    // Scope explanations from the registry
+    expect(html).toContain("Read your notes");
+    expect(html).toContain("Full vault access");
+  });
+
+  test("highlights admin scopes with a danger color and badge", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:admin"],
+    });
+    expect(html).toContain("scope-admin");
+    expect(html).toContain("badge-admin");
+  });
+
+  test("renders unknown scopes verbatim with a muted explanation", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["mystery.module:do-thing"],
+    });
+    expect(html).toContain("scope-unknown");
+    expect(html).toContain("mystery.module:do-thing");
+    expect(html).toContain("no built-in description");
+  });
+
+  test("renders a placeholder when no scopes are requested", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      clientId: "c",
+      clientName: "App",
+      scopes: [],
+    });
+    expect(html).toContain("scope-empty");
+    expect(html).toContain("No scopes requested");
+  });
+
+  test("includes Approve and Deny buttons posting __action=consent", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      clientId: "c",
+      clientName: "App",
+      scopes: [],
+    });
+    expect(html).toContain('name="__action" value="consent"');
+    expect(html).toContain('name="approve" value="yes"');
+    expect(html).toContain('name="approve" value="no"');
+  });
+
+  test("escapes a hostile client name", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      clientId: "c",
+      clientName: "<img src=x onerror=alert(1)>",
+      scopes: [],
+    });
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;img");
+  });
+});
+
+describe("renderError", () => {
+  test("renders a card with title and message", () => {
+    const html = renderError({ title: "Boom", message: "something blew up", status: 400 });
+    expect(html).toContain("Boom");
+    expect(html).toContain("something blew up");
+    expect(html).toContain('class="card"');
+    // Brand mark visible so the user knows where they are
+    expect(html).toContain("Parachute");
+  });
+
+  test("escapes hostile title + message", () => {
+    const html = renderError({
+      title: "<script>1</script>",
+      message: '"><img>',
+      status: 400,
+    });
+    expect(html).not.toContain("<script>1</script>");
+    expect(html).not.toContain('"><img>');
+    expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+describe("CSS / styling guarantees", () => {
+  test("does not load fonts from a third-party CDN (privacy)", () => {
+    const html = renderLogin({ params: PARAMS });
+    expect(html).not.toContain("fonts.googleapis.com");
+    expect(html).not.toContain("fonts.gstatic.com");
+  });
+
+  test("sets referrer policy to no-referrer", () => {
+    expect(renderLogin({ params: PARAMS })).toContain('name="referrer" content="no-referrer"');
+  });
+
+  test("declares mobile-friendly viewport", () => {
+    expect(renderLogin({ params: PARAMS })).toContain(
+      'name="viewport" content="width=device-width, initial-scale=1"',
+    );
+  });
+});

--- a/src/__tests__/scope-explanations.test.ts
+++ b/src/__tests__/scope-explanations.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import {
+  FIRST_PARTY_SCOPES,
+  SCOPE_EXPLANATIONS,
+  explainScope,
+  scopeIsAdmin,
+} from "../scope-explanations.ts";
+
+describe("SCOPE_EXPLANATIONS", () => {
+  test("covers every canonical first-party scope from oauth-scopes.md", () => {
+    // Source of truth: parachute-patterns/patterns/oauth-scopes.md.
+    const expected = [
+      "vault:read",
+      "vault:write",
+      "vault:admin",
+      "scribe:transcribe",
+      "scribe:admin",
+      "channel:send",
+      "hub:admin",
+    ];
+    for (const s of expected) {
+      expect(SCOPE_EXPLANATIONS[s]).toBeDefined();
+      expect(SCOPE_EXPLANATIONS[s]?.label.length).toBeGreaterThan(10);
+    }
+  });
+
+  test("FIRST_PARTY_SCOPES is sorted and matches the keys of SCOPE_EXPLANATIONS", () => {
+    expect(FIRST_PARTY_SCOPES).toEqual([...FIRST_PARTY_SCOPES].sort());
+    expect(new Set(FIRST_PARTY_SCOPES)).toEqual(new Set(Object.keys(SCOPE_EXPLANATIONS)));
+  });
+});
+
+describe("explainScope", () => {
+  test("returns the entry for a known scope", () => {
+    expect(explainScope("vault:read")?.level).toBe("read");
+  });
+
+  test("returns null for an unknown scope", () => {
+    expect(explainScope("notes:weird-thing")).toBeNull();
+  });
+});
+
+describe("scopeIsAdmin", () => {
+  test("true for admin scopes", () => {
+    expect(scopeIsAdmin("vault:admin")).toBe(true);
+    expect(scopeIsAdmin("hub:admin")).toBe(true);
+  });
+
+  test("false for non-admin and unknown scopes", () => {
+    expect(scopeIsAdmin("vault:read")).toBe(false);
+    expect(scopeIsAdmin("channel:send")).toBe(false);
+    expect(scopeIsAdmin("unknown:anything")).toBe(false);
+  });
+});

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -15,8 +15,9 @@
  * launch surface (no machine-to-machine clients yet); the token endpoint
  * stubs it with `unsupported_grant_type`.
  *
- * Login + consent screens are minimal HTML — functional, not pretty. PR (d)
- * is the polish pass.
+ * HTML for login + consent + error views lives in `oauth-ui.ts` so the
+ * handlers stay focused on protocol logic and the templates stay focused
+ * on presentation.
  */
 import type { Database } from "bun:sqlite";
 import {
@@ -42,6 +43,8 @@ import {
   signAccessToken,
   signRefreshToken,
 } from "./jwt-sign.ts";
+import { type AuthorizeFormParams, renderConsent, renderError, renderLogin } from "./oauth-ui.ts";
+import { FIRST_PARTY_SCOPES } from "./scope-explanations.ts";
 import {
   SESSION_TTL_MS,
   buildSessionCookie,
@@ -78,13 +81,8 @@ function redirectResponse(location: string, extra: Record<string, string> = {}):
   return new Response(null, { status: 302, headers: { location, ...extra } });
 }
 
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+function htmlError(title: string, message: string, status: number): Response {
+  return htmlResponse(renderError({ title, message, status }), status);
 }
 
 function oauthErrorRedirect(
@@ -114,23 +112,13 @@ export function authorizationServerMetadata(deps: OAuthDeps): Response {
     grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
     token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
-    scopes_supported: [],
+    scopes_supported: FIRST_PARTY_SCOPES,
   });
 }
 
 // --- /oauth/authorize ------------------------------------------------------
 
-interface AuthorizeParams {
-  clientId: string;
-  redirectUri: string;
-  responseType: string;
-  scope: string;
-  codeChallenge: string;
-  codeChallengeMethod: string;
-  state: string | null;
-}
-
-function parseAuthorizeParams(url: URL): AuthorizeParams | { error: string } {
+function parseAuthorizeFormParams(url: URL): AuthorizeFormParams | { error: string } {
   const required = (k: string) => {
     const v = url.searchParams.get(k);
     return v && v.length > 0 ? v : null;
@@ -165,9 +153,9 @@ function parseAuthorizeParams(url: URL): AuthorizeParams | { error: string } {
  */
 export function handleAuthorizeGet(db: Database, req: Request, _deps: OAuthDeps): Response {
   const url = new URL(req.url);
-  const parsed = parseAuthorizeParams(url);
+  const parsed = parseAuthorizeFormParams(url);
   if ("error" in parsed) {
-    return htmlResponse(`<h1>OAuth error</h1><p>${escapeHtml(parsed.error)}</p>`, 400);
+    return htmlError("Invalid authorization request", parsed.error, 400);
   }
   if (parsed.responseType !== "code") {
     return oauthErrorRedirect(
@@ -189,13 +177,14 @@ export function handleAuthorizeGet(db: Database, req: Request, _deps: OAuthDeps)
   if (!client) {
     // Can't safely redirect — we don't trust the redirect_uri until we've
     // matched it against a registered client. Render an HTML error.
-    return htmlResponse("<h1>OAuth error</h1><p>unknown client_id</p>", 400);
+    return htmlError("Unknown application", "This client_id is not registered with this hub.", 400);
   }
   try {
     requireRegisteredRedirectUri(client, parsed.redirectUri);
   } catch {
-    return htmlResponse(
-      "<h1>OAuth error</h1><p>redirect_uri is not registered for this client</p>",
+    return htmlError(
+      "Redirect mismatch",
+      "The redirect_uri does not match any URI registered for this app.",
       400,
     );
   }
@@ -203,9 +192,9 @@ export function handleAuthorizeGet(db: Database, req: Request, _deps: OAuthDeps)
   const sessionId = parseSessionCookie(req.headers.get("cookie"));
   const session = sessionId ? findSession(db, sessionId) : null;
   if (!session) {
-    return htmlResponse(renderLoginForm(parsed));
+    return htmlResponse(renderLogin({ params: parsed }));
   }
-  return htmlResponse(renderConsentScreen(client, parsed));
+  return htmlResponse(renderConsent(consentProps(client, parsed)));
 }
 
 /**
@@ -226,7 +215,7 @@ export async function handleAuthorizePost(
   const action = String(form.get("__action") ?? "");
   if (action === "login") return await handleLoginSubmit(db, req, form, deps);
   if (action === "consent") return await handleConsentSubmit(db, req, form, deps);
-  return htmlResponse("<h1>OAuth error</h1><p>unknown form action</p>", 400);
+  return htmlError("Invalid form submission", "Unknown form action.", 400);
 }
 
 async function handleLoginSubmit(
@@ -239,15 +228,18 @@ async function handleLoginSubmit(
   const password = String(form.get("password") ?? "");
   const params = paramsFromForm(form);
   if (!username || !password) {
-    return htmlResponse(renderLoginForm(params, "username and password are required"), 400);
+    return htmlResponse(
+      renderLogin({ params, errorMessage: "Username and password are required." }),
+      400,
+    );
   }
   const user = getUserByUsername(db, username);
   if (!user) {
-    return htmlResponse(renderLoginForm(params, "invalid credentials"), 401);
+    return htmlResponse(renderLogin({ params, errorMessage: "Invalid credentials." }), 401);
   }
   const ok = await verifyPassword(user, password);
   if (!ok) {
-    return htmlResponse(renderLoginForm(params, "invalid credentials"), 401);
+    return htmlResponse(renderLogin({ params, errorMessage: "Invalid credentials." }), 401);
   }
   const session = createSession(db, { userId: user.id });
   const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
@@ -272,14 +264,23 @@ async function handleConsentSubmit(
   const session = sessionId ? findSession(db, sessionId) : null;
   if (!session) {
     // Session expired between login and consent submit. Send back to login.
-    return htmlResponse(renderLoginForm(params, "session expired; please sign in again"), 401);
+    return htmlResponse(
+      renderLogin({ params, errorMessage: "Your session expired — please sign in again." }),
+      401,
+    );
   }
   const client = getClient(db, params.clientId);
-  if (!client) return htmlResponse("<h1>OAuth error</h1><p>unknown client_id</p>", 400);
+  if (!client) {
+    return htmlError("Unknown application", "This client_id is not registered with this hub.", 400);
+  }
   try {
     requireRegisteredRedirectUri(client, params.redirectUri);
   } catch {
-    return htmlResponse("<h1>OAuth error</h1><p>redirect_uri mismatch</p>", 400);
+    return htmlError(
+      "Redirect mismatch",
+      "The redirect_uri does not match any URI registered for this app.",
+      400,
+    );
   }
   if (!approve) {
     return oauthErrorRedirect(
@@ -316,7 +317,7 @@ async function handleConsentSubmit(
   return redirectResponse(u.toString());
 }
 
-function paramsFromForm(form: Awaited<ReturnType<Request["formData"]>>): AuthorizeParams {
+function paramsFromForm(form: Awaited<ReturnType<Request["formData"]>>): AuthorizeFormParams {
   return {
     clientId: String(form.get("client_id") ?? ""),
     redirectUri: String(form.get("redirect_uri") ?? ""),
@@ -328,7 +329,7 @@ function paramsFromForm(form: Awaited<ReturnType<Request["formData"]>>): Authori
   };
 }
 
-function authorizeParamsToQuery(p: AuthorizeParams): Record<string, string> {
+function authorizeParamsToQuery(p: AuthorizeFormParams): Record<string, string> {
   const q: Record<string, string> = {
     client_id: p.clientId,
     redirect_uri: p.redirectUri,
@@ -596,86 +597,11 @@ export async function handleRegister(
   return jsonResponse(respBody, 201);
 }
 
-// --- HTML templates --------------------------------------------------------
-
-function renderLoginForm(params: AuthorizeParams, errorMessage?: string): string {
-  const hidden = renderHiddenInputs(params);
-  const err = errorMessage ? `<p class="err">${escapeHtml(errorMessage)}</p>` : "";
-  return baseDocument(
-    "Sign in to Parachute Hub",
-    `
-    <h1>Sign in</h1>
-    ${err}
-    <form method="POST" action="/oauth/authorize">
-      <input type="hidden" name="__action" value="login" />
-      ${hidden}
-      <label>Username<br/><input type="text" name="username" autofocus required /></label>
-      <label>Password<br/><input type="password" name="password" required /></label>
-      <button type="submit">Sign in</button>
-    </form>
-    `,
-  );
-}
-
-function renderConsentScreen(client: OAuthClient, params: AuthorizeParams): string {
-  const hidden = renderHiddenInputs(params);
-  const scopes = params.scope.split(" ").filter((s) => s.length > 0);
-  const clientName = client.clientName ?? client.clientId;
-  const scopeList =
-    scopes.length === 0
-      ? "<li>(no scopes requested)</li>"
-      : scopes.map((s) => `<li><code>${escapeHtml(s)}</code></li>`).join("");
-  return baseDocument(
-    `Authorize ${escapeHtml(clientName)}`,
-    `
-    <h1>Authorize <code>${escapeHtml(clientName)}</code>?</h1>
-    <p>This app is requesting access to your Parachute account with the following scopes:</p>
-    <ul>${scopeList}</ul>
-    <form method="POST" action="/oauth/authorize">
-      <input type="hidden" name="__action" value="consent" />
-      ${hidden}
-      <button type="submit" name="approve" value="yes">Approve</button>
-      <button type="submit" name="approve" value="no">Deny</button>
-    </form>
-    `,
-  );
-}
-
-function renderHiddenInputs(p: AuthorizeParams): string {
-  const fields: [string, string][] = [
-    ["client_id", p.clientId],
-    ["redirect_uri", p.redirectUri],
-    ["response_type", p.responseType],
-    ["scope", p.scope],
-    ["code_challenge", p.codeChallenge],
-    ["code_challenge_method", p.codeChallengeMethod],
-  ];
-  if (p.state) fields.push(["state", p.state]);
-  return fields
-    .map(([k, v]) => `<input type="hidden" name="${k}" value="${escapeHtml(v)}" />`)
-    .join("\n      ");
-}
-
-function baseDocument(title: string, body: string): string {
-  return `<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <title>${escapeHtml(title)}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <style>
-    body { font-family: system-ui, sans-serif; max-width: 28rem; margin: 4rem auto; padding: 0 1rem; }
-    h1 { font-size: 1.4rem; }
-    label { display: block; margin: 0.75rem 0; }
-    input[type=text], input[type=password] { width: 100%; padding: 0.5rem; box-sizing: border-box; }
-    button { padding: 0.5rem 1rem; margin-right: 0.5rem; }
-    .err { color: #b00020; }
-    code { background: #f3f3f3; padding: 0 0.25rem; border-radius: 3px; }
-    ul { padding-left: 1.25rem; }
-  </style>
-</head>
-<body>
-${body}
-</body>
-</html>`;
+function consentProps(client: OAuthClient, params: AuthorizeFormParams) {
+  return {
+    params,
+    clientId: client.clientId,
+    clientName: client.clientName ?? client.clientId,
+    scopes: params.scope.split(" ").filter((s) => s.length > 0),
+  };
 }

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -1,0 +1,480 @@
+/**
+ * Branded HTML templates for the OAuth login + consent + error screens.
+ *
+ * Pulled out of `oauth-handlers.ts` so the handlers stay focused on protocol
+ * logic and the templates stay focused on presentation. Pure functions —
+ * no DB access, no side channels.
+ *
+ * Design choices:
+ *   - **No external font CDN.** OAuth screens see who's logging in and what
+ *     they're authorizing; loading fonts from Google would leak that to a
+ *     third party. We use system-font fallbacks that approximate the
+ *     parachute.computer brand (Instrument Serif → Georgia for headings,
+ *     DM Sans → -apple-system for body, ui-monospace for `<code>`).
+ *   - **Inline CSS in `<style>`.** Single-file delivery; no extra round-trip
+ *     for a stylesheet, no caching headaches when the hub is bound to a
+ *     loopback origin.
+ *   - **Scope explanations come from `scope-explanations.ts`.** First-party
+ *     scopes get a one-sentence operator-facing label; admin scopes get a
+ *     red border so the operator looks twice. Unknown scopes (third-party
+ *     module scopes that the hub doesn't know about) render verbatim.
+ *   - **No JavaScript.** Entirely form-based. Submit is the only interaction.
+ */
+import { type ScopeExplanation, explainScope } from "./scope-explanations.ts";
+
+/** Brand palette — kept in sync with parachute.computer/style.css. */
+const PALETTE = {
+  bg: "#faf8f4",
+  bgSoft: "#f3f0ea",
+  fg: "#2c2a26",
+  fgMuted: "#6b6860",
+  fgDim: "#9a9690",
+  accent: "#4a7c59",
+  accentHover: "#3d6849",
+  accentSoft: "rgba(74, 124, 89, 0.08)",
+  border: "#e4e0d8",
+  borderLight: "#ece9e2",
+  cardBg: "#ffffff",
+  danger: "#a3392b",
+  dangerSoft: "rgba(163, 57, 43, 0.08)",
+} as const;
+
+const FONT_SERIF = `Georgia, "Times New Roman", serif`;
+const FONT_SANS = `-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`;
+const FONT_MONO = `ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", monospace`;
+
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export interface AuthorizeFormParams {
+  clientId: string;
+  redirectUri: string;
+  responseType: string;
+  scope: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  state: string | null;
+}
+
+export interface LoginViewProps {
+  params: AuthorizeFormParams;
+  errorMessage?: string;
+}
+
+export interface ConsentViewProps {
+  params: AuthorizeFormParams;
+  clientName: string;
+  clientId: string;
+  scopes: string[];
+}
+
+export interface ErrorViewProps {
+  title: string;
+  message: string;
+  status: number;
+}
+
+export function renderLogin(props: LoginViewProps): string {
+  const { params, errorMessage } = props;
+  const error = errorMessage ? `<p class="error-banner">${escapeHtml(errorMessage)}</p>` : "";
+  const body = `
+    <div class="card">
+      <div class="card-header">
+        <div class="brand">
+          <span class="brand-mark">⌬</span>
+          <span class="brand-name">Parachute</span>
+        </div>
+        <h1>Sign in</h1>
+        <p class="subtitle">to continue to your hub</p>
+      </div>
+      ${error}
+      <form method="POST" action="/oauth/authorize" class="auth-form">
+        <input type="hidden" name="__action" value="login" />
+        ${renderHiddenInputs(params)}
+        <label class="field">
+          <span class="field-label">Username</span>
+          <input type="text" name="username" autocomplete="username" autofocus required />
+        </label>
+        <label class="field">
+          <span class="field-label">Password</span>
+          <input type="password" name="password" autocomplete="current-password" required />
+        </label>
+        <button type="submit" class="btn btn-primary">Sign in</button>
+      </form>
+    </div>`;
+  return baseDocument("Sign in to Parachute Hub", body);
+}
+
+export function renderConsent(props: ConsentViewProps): string {
+  const { params, clientName, clientId, scopes } = props;
+  const scopeRows =
+    scopes.length === 0
+      ? `<li class="scope scope-empty">No scopes requested — the app gets a session token only.</li>`
+      : scopes.map(renderScopeRow).join("\n");
+  const body = `
+    <div class="card">
+      <div class="card-header">
+        <div class="brand">
+          <span class="brand-mark">⌬</span>
+          <span class="brand-name">Parachute</span>
+        </div>
+        <h1>Authorize <span class="client-name">${escapeHtml(clientName)}</span>?</h1>
+        <p class="subtitle">
+          This app is requesting access to your Parachute account.
+        </p>
+        <p class="client-meta">
+          <span class="client-meta-label">client_id</span>
+          <code>${escapeHtml(clientId)}</code>
+        </p>
+      </div>
+      <section class="scopes">
+        <h2 class="scopes-title">Permissions requested</h2>
+        <ul class="scope-list">${scopeRows}</ul>
+      </section>
+      <form method="POST" action="/oauth/authorize" class="auth-form consent-form">
+        <input type="hidden" name="__action" value="consent" />
+        ${renderHiddenInputs(params)}
+        <div class="button-row">
+          <button type="submit" name="approve" value="yes" class="btn btn-primary">Approve</button>
+          <button type="submit" name="approve" value="no" class="btn btn-secondary">Deny</button>
+        </div>
+      </form>
+    </div>`;
+  return baseDocument(`Authorize ${clientName}`, body);
+}
+
+export function renderError(props: ErrorViewProps): string {
+  const body = `
+    <div class="card">
+      <div class="card-header">
+        <div class="brand">
+          <span class="brand-mark">⌬</span>
+          <span class="brand-name">Parachute</span>
+        </div>
+        <h1 class="error-title">${escapeHtml(props.title)}</h1>
+        <p class="subtitle">${escapeHtml(props.message)}</p>
+      </div>
+      <p class="error-help">
+        If you reached this from a third-party app, the app's OAuth configuration
+        may be wrong. You can safely close this window.
+      </p>
+    </div>`;
+  return baseDocument(props.title, body);
+}
+
+function renderScopeRow(scope: string): string {
+  const explanation = explainScope(scope);
+  if (!explanation) {
+    return `<li class="scope scope-unknown">
+      <code class="scope-name">${escapeHtml(scope)}</code>
+      <span class="scope-label scope-label-muted">Defined by the requesting app — no built-in description.</span>
+    </li>`;
+  }
+  const cls = `scope scope-${explanation.level}`;
+  const badge = badgeForLevel(explanation);
+  return `<li class="${cls}">
+      <div class="scope-head">
+        <code class="scope-name">${escapeHtml(scope)}</code>
+        ${badge}
+      </div>
+      <span class="scope-label">${escapeHtml(explanation.label)}</span>
+    </li>`;
+}
+
+function badgeForLevel(explanation: ScopeExplanation): string {
+  switch (explanation.level) {
+    case "admin":
+      return `<span class="badge badge-admin">admin</span>`;
+    case "write":
+      return `<span class="badge badge-write">write</span>`;
+    case "send":
+      return `<span class="badge badge-send">send</span>`;
+    case "read":
+      return `<span class="badge badge-read">read</span>`;
+  }
+}
+
+export function renderHiddenInputs(p: AuthorizeFormParams): string {
+  const fields: [string, string][] = [
+    ["client_id", p.clientId],
+    ["redirect_uri", p.redirectUri],
+    ["response_type", p.responseType],
+    ["scope", p.scope],
+    ["code_challenge", p.codeChallenge],
+    ["code_challenge_method", p.codeChallengeMethod],
+  ];
+  if (p.state) fields.push(["state", p.state]);
+  return fields
+    .map(([k, v]) => `<input type="hidden" name="${k}" value="${escapeHtml(v)}" />`)
+    .join("\n        ");
+}
+
+function baseDocument(title: string, body: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>${escapeHtml(title)}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="referrer" content="no-referrer" />
+  <style>${STYLES}</style>
+</head>
+<body>
+  <main>
+${body}
+  </main>
+</body>
+</html>`;
+}
+
+const STYLES = `
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: ${FONT_SANS};
+    background: ${PALETTE.bg};
+    color: ${PALETTE.fg};
+    line-height: 1.55;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  main {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 1.5rem;
+  }
+  .card {
+    width: 100%;
+    max-width: 30rem;
+    background: ${PALETTE.cardBg};
+    border: 1px solid ${PALETTE.border};
+    border-radius: 12px;
+    padding: 2rem 1.75rem;
+    box-shadow: 0 1px 2px rgba(44, 42, 38, 0.04), 0 8px 24px rgba(44, 42, 38, 0.06);
+  }
+  .card-header { margin-bottom: 1.5rem; }
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: ${PALETTE.accent};
+    font-weight: 500;
+    font-size: 0.95rem;
+    margin-bottom: 1.25rem;
+  }
+  .brand-mark { font-size: 1.1rem; line-height: 1; }
+  .brand-name { letter-spacing: 0.01em; }
+  h1 {
+    font-family: ${FONT_SERIF};
+    font-weight: 400;
+    font-size: 1.75rem;
+    line-height: 1.2;
+    margin: 0 0 0.4rem;
+    color: ${PALETTE.fg};
+  }
+  h1 .client-name {
+    font-style: italic;
+    color: ${PALETTE.accent};
+  }
+  .subtitle {
+    margin: 0;
+    color: ${PALETTE.fgMuted};
+    font-size: 0.95rem;
+  }
+  .client-meta {
+    margin: 0.75rem 0 0;
+    font-size: 0.8rem;
+    color: ${PALETTE.fgDim};
+    display: flex;
+    gap: 0.4rem;
+    align-items: baseline;
+    flex-wrap: wrap;
+  }
+  .client-meta-label { text-transform: uppercase; letter-spacing: 0.05em; }
+  .client-meta code {
+    font-family: ${FONT_MONO};
+    font-size: 0.78rem;
+    background: ${PALETTE.bgSoft};
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    color: ${PALETTE.fgMuted};
+    word-break: break-all;
+  }
+
+  .auth-form { display: flex; flex-direction: column; gap: 0.9rem; }
+  .field { display: flex; flex-direction: column; gap: 0.35rem; }
+  .field-label {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: ${PALETTE.fgMuted};
+    letter-spacing: 0.01em;
+  }
+  input[type=text], input[type=password] {
+    font: inherit;
+    width: 100%;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid ${PALETTE.border};
+    border-radius: 6px;
+    background: ${PALETTE.bg};
+    color: ${PALETTE.fg};
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  input[type=text]:focus, input[type=password]:focus {
+    outline: none;
+    border-color: ${PALETTE.accent};
+    background: ${PALETTE.cardBg};
+    box-shadow: 0 0 0 3px ${PALETTE.accentSoft};
+  }
+
+  .btn {
+    font: inherit;
+    font-weight: 500;
+    padding: 0.65rem 1.25rem;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+    min-height: 2.5rem;
+  }
+  .btn-primary {
+    background: ${PALETTE.accent};
+    color: ${PALETTE.cardBg};
+    margin-top: 0.4rem;
+  }
+  .btn-primary:hover { background: ${PALETTE.accentHover}; }
+  .btn-secondary {
+    background: ${PALETTE.cardBg};
+    color: ${PALETTE.fgMuted};
+    border-color: ${PALETTE.border};
+  }
+  .btn-secondary:hover {
+    color: ${PALETTE.fg};
+    border-color: ${PALETTE.fgDim};
+  }
+  .button-row {
+    display: flex;
+    gap: 0.6rem;
+    margin-top: 0.5rem;
+  }
+  .button-row .btn { flex: 1; }
+  .consent-form { gap: 0; }
+
+  .error-banner {
+    background: ${PALETTE.dangerSoft};
+    border: 1px solid ${PALETTE.danger};
+    border-radius: 6px;
+    color: ${PALETTE.danger};
+    padding: 0.6rem 0.8rem;
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+  }
+  .error-title { color: ${PALETTE.danger}; }
+  .error-help {
+    margin-top: 1.5rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid ${PALETTE.borderLight};
+    color: ${PALETTE.fgMuted};
+    font-size: 0.88rem;
+  }
+
+  .scopes { margin: 0 0 1.5rem; }
+  .scopes-title {
+    font-family: ${FONT_SANS};
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: ${PALETTE.fgMuted};
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin: 0 0 0.6rem;
+  }
+  .scope-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .scope {
+    border: 1px solid ${PALETTE.border};
+    border-radius: 6px;
+    padding: 0.6rem 0.75rem;
+    background: ${PALETTE.bg};
+  }
+  .scope-empty {
+    color: ${PALETTE.fgMuted};
+    font-size: 0.9rem;
+    background: ${PALETTE.bgSoft};
+    border-style: dashed;
+  }
+  .scope-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.2rem;
+    flex-wrap: wrap;
+  }
+  .scope-name {
+    font-family: ${FONT_MONO};
+    font-size: 0.85rem;
+    color: ${PALETTE.fg};
+  }
+  .scope-label {
+    font-size: 0.88rem;
+    color: ${PALETTE.fgMuted};
+    display: block;
+  }
+  .scope-label-muted { color: ${PALETTE.fgDim}; font-style: italic; }
+  .scope-admin {
+    border-color: ${PALETTE.danger};
+    background: ${PALETTE.dangerSoft};
+  }
+  .scope-admin .scope-name { color: ${PALETTE.danger}; }
+
+  .badge {
+    display: inline-block;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 600;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    line-height: 1.4;
+  }
+  .badge-read { background: ${PALETTE.bgSoft}; color: ${PALETTE.fgMuted}; }
+  .badge-write { background: ${PALETTE.accentSoft}; color: ${PALETTE.accent}; }
+  .badge-send { background: ${PALETTE.accentSoft}; color: ${PALETTE.accent}; }
+  .badge-admin { background: ${PALETTE.danger}; color: ${PALETTE.cardBg}; }
+
+  @media (max-width: 480px) {
+    main { padding: 0.75rem; }
+    .card { padding: 1.5rem 1.25rem; border-radius: 10px; }
+    h1 { font-size: 1.5rem; }
+    .button-row { flex-direction: column; }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    body { background: #1a1815; color: #e8e4dc; }
+    .card { background: #25221d; border-color: #3a362f; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3); }
+    h1 { color: #f0ece4; }
+    .subtitle, .field-label { color: #a8a29a; }
+    input[type=text], input[type=password] { background: #1f1c18; border-color: #3a362f; color: #e8e4dc; }
+    input[type=text]:focus, input[type=password]:focus { background: #25221d; }
+    .scope { background: #1f1c18; border-color: #3a362f; }
+    .scope-name { color: #e8e4dc; }
+    .client-meta code { background: #1f1c18; color: #a8a29a; }
+    .btn-secondary { background: #25221d; border-color: #3a362f; color: #a8a29a; }
+    .btn-secondary:hover { color: #e8e4dc; border-color: #6b6860; }
+    .error-help { border-color: #3a362f; color: #a8a29a; }
+    .scope-empty { background: #1a1815; }
+  }
+`;

--- a/src/operator-token.ts
+++ b/src/operator-token.ts
@@ -27,7 +27,7 @@ import { signAccessToken } from "./jwt-sign.ts";
 export const OPERATOR_TOKEN_FILENAME = "operator.token";
 export const OPERATOR_TOKEN_TTL_SECONDS = 365 * 24 * 60 * 60;
 export const OPERATOR_TOKEN_AUDIENCE = "operator";
-export const OPERATOR_TOKEN_CLIENT_ID = "parachute-cli";
+export const OPERATOR_TOKEN_CLIENT_ID = "parachute-hub";
 export const OPERATOR_TOKEN_SCOPES = ["hub:admin", "vault:admin", "scribe:admin", "channel:send"];
 
 export function operatorTokenPath(dir: string = configDir()): string {

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -1,0 +1,79 @@
+/**
+ * Human-readable explanations for first-party Parachute OAuth scopes.
+ *
+ * Used by the consent screen to render each requested scope with a
+ * one-sentence description, and by `/.well-known/oauth-authorization-server`
+ * to populate `scopes_supported` (closes cli#68).
+ *
+ * Keep these short and operator-facing. The reader is the hub's owner
+ * deciding whether to grant a third-party app access — they need to
+ * understand *what data the app will see* in plain language, not the
+ * technical contract.
+ *
+ * Third-party module scopes pass through here without an entry —
+ * `explainScope` falls back to the raw scope string and the consent UI
+ * renders them verbatim. cli#56 (drop SERVICE_SPECS) plus the eventual
+ * `parachute.json` `scopes.defines` field will let modules ship their
+ * own descriptions; until then, the canonical Parachute scopes are
+ * hardcoded here.
+ *
+ * Source of truth for the scope shape:
+ * `parachute-patterns/patterns/oauth-scopes.md`.
+ */
+
+export interface ScopeExplanation {
+  /** One-sentence operator-facing description of what the scope grants. */
+  label: string;
+  /**
+   * "admin" scopes are highlighted in the consent UI — broad damage
+   * potential if the requesting app is compromised, so we make the
+   * operator look at them twice.
+   */
+  level: "read" | "write" | "admin" | "send";
+}
+
+export const SCOPE_EXPLANATIONS: Record<string, ScopeExplanation> = {
+  "vault:read": {
+    label: "Read your notes, tags, attachments, and vault config.",
+    level: "read",
+  },
+  "vault:write": {
+    label: "Create, edit, and delete notes, tags, and attachments.",
+    level: "write",
+  },
+  "vault:admin": {
+    label: "Full vault access plus configuration changes (rotate tokens, change settings).",
+    level: "admin",
+  },
+  "scribe:transcribe": {
+    label: "Send audio to Scribe for transcription.",
+    level: "write",
+  },
+  "scribe:admin": {
+    label: "Manage Scribe configuration (provider keys, models, quotas).",
+    level: "admin",
+  },
+  "channel:send": {
+    label: "Post messages to your Channel.",
+    level: "send",
+  },
+  "hub:admin": {
+    label: "Manage hub identity (user accounts, signing keys, registered OAuth clients).",
+    level: "admin",
+  },
+};
+
+/**
+ * Sorted list of every first-party scope the hub recognizes. Used as the
+ * baseline for `scopes_supported` in the OAuth-AS metadata; module-declared
+ * scopes (cli#68) are unioned on top.
+ */
+export const FIRST_PARTY_SCOPES = Object.keys(SCOPE_EXPLANATIONS).sort();
+
+export function explainScope(scope: string): ScopeExplanation | null {
+  return SCOPE_EXPLANATIONS[scope] ?? null;
+}
+
+export function scopeIsAdmin(scope: string): boolean {
+  return explainScope(scope)?.level === "admin";
+}


### PR DESCRIPTION
## Summary

Polish pass on the OAuth login + consent + error screens. Closes the cli#58 cascade started by #63 / #64 / #65 / #66.

- **`src/oauth-ui.ts`** is the single home for OAuth HTML — login, consent, branded error pages. Handlers stay focused on protocol; templates stay focused on presentation.
- **`src/scope-explanations.ts`** is the registry of operator-facing descriptions for the 7 first-party Parachute scopes. Admin scopes get a red border + admin badge so the operator looks twice. Unknown scopes (third-party / module-declared) render verbatim.
- Brand styling matches parachute.computer (sage green \`#4a7c59\`, cream \`#faf8f4\`, earth tones), system-font fallback (no third-party CDN — OAuth screens shouldn't leak who's logging in to a font host), card layout, mobile responsive, \`prefers-color-scheme: dark\` variant.
- Replaces bare \`<h1>OAuth error</h1>\` pages with branded error views that explain what likely went wrong.

## Bundles two adjacent fixes

- **closes #67** — operator-token \`client_id\` \`"parachute-cli"\` → \`"parachute-hub"\` (one-line, post-rename hangover)
- **closes #68** — \`scopes_supported\` in \`/.well-known/oauth-authorization-server\` is now populated from \`FIRST_PARTY_SCOPES\` instead of \`[]\`

## Versioning

\`0.3.1-rc.4\` → \`0.3.2-rc.1\`. New rc cycle since this is a separate user-visible feature on top of the merged native-issuer cutover.

## Test plan

- [x] \`bun test\` — 586 pass (24 new)
- [x] \`bun run typecheck\`
- [x] \`bunx biome check .\`
- [ ] Manual: hit \`/oauth/authorize\` from a registered client — login form renders with brand chrome
- [ ] Manual: with session cookie, consent screen shows scope explanations + admin badge for \`vault:admin\`
- [ ] Manual: hit \`/.well-known/oauth-authorization-server\` — \`scopes_supported\` is non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)