### PR TITLE
feat(hub): drop SERVICE_SPECS gate; install via .parachute/module.json (0.4.0-rc.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.3.2-rc.1",
+  "version": "0.4.0-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -15,7 +15,7 @@ function makeTempPath(): { path: string; configDir: string; cleanup: () => void 
 }
 
 describe("install", () => {
-  test("rejects unknown service with exit 1", async () => {
+  test("rejects third-party package with no module.json (hard error)", async () => {
     const { path, cleanup } = makeTempPath();
     try {
       const logs: string[] = [];
@@ -28,7 +28,7 @@ describe("install", () => {
         log: (l) => logs.push(l),
       });
       expect(code).toBe(1);
-      expect(logs.join("\n")).toMatch(/unknown service/);
+      expect(logs.join("\n")).toMatch(/does not ship \.parachute\/module\.json/);
     } finally {
       cleanup();
     }
@@ -1138,6 +1138,146 @@ describe("install", () => {
       const entry = findService("parachute-vault", path);
       expect(entry?.port).toBe(1944);
       expect(logs.join("\n")).toMatch(/canonical port 1940 is in use/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("third-party npm package with valid module.json installs", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const calls: string[][] = [];
+      const logs: string[] = [];
+      const code = await install("@acme/widget", {
+        runner: async (cmd) => {
+          calls.push([...cmd]);
+          return 0;
+        },
+        manifestPath: path,
+        startService: async () => 0,
+        isLinked: () => false,
+        portProbe: async () => false,
+        log: (l) => logs.push(l),
+        readManifest: async () => ({
+          name: "widget",
+          manifestName: "@acme/widget",
+          kind: "api",
+          port: 1950,
+          paths: ["/widget"],
+          health: "/healthz",
+        }),
+        findGlobalInstall: () => "/fake/prefix/@acme/widget/package.json",
+      });
+      expect(code).toBe(0);
+      expect(calls[0]).toEqual(["bun", "add", "-g", "@acme/widget"]);
+      const seeded = findService("@acme/widget", path);
+      expect(seeded?.name).toBe("@acme/widget");
+      expect(seeded?.port).toBe(1950);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("third-party npm package without module.json hard-errors", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      const code = await install("@acme/widget", {
+        runner: async () => 0,
+        manifestPath: path,
+        startService: async () => 0,
+        isLinked: () => false,
+        portProbe: async () => false,
+        log: (l) => logs.push(l),
+        readManifest: async () => null,
+        findGlobalInstall: () => "/fake/prefix/@acme/widget/package.json",
+      });
+      expect(code).toBe(1);
+      expect(logs.join("\n")).toMatch(/does not ship \.parachute\/module\.json/);
+      expect(logs.join("\n")).toMatch(/module-json-extensibility\.md/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("third-party module name colliding with first-party shortname is rejected", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      const code = await install("@evil/squatter", {
+        runner: async () => 0,
+        manifestPath: path,
+        startService: async () => 0,
+        isLinked: () => false,
+        portProbe: async () => false,
+        log: (l) => logs.push(l),
+        readManifest: async () => ({
+          name: "vault",
+          manifestName: "@evil/squatter",
+          kind: "api",
+          port: 1950,
+          paths: ["/vault"],
+          health: "/healthz",
+        }),
+        findGlobalInstall: () => "/fake/prefix/@evil/squatter/package.json",
+      });
+      expect(code).toBe(1);
+      expect(logs.join("\n")).toMatch(/collides with a first-party/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("local absolute path resolves package name + module.json", async () => {
+    const { path, cleanup } = makeTempPath();
+    const pkgDir = mkdtempSync(join(tmpdir(), "pcli-localpkg-"));
+    try {
+      const calls: string[][] = [];
+      const logs: string[] = [];
+      const code = await install(pkgDir, {
+        runner: async (cmd) => {
+          calls.push([...cmd]);
+          return 0;
+        },
+        manifestPath: path,
+        startService: async () => 0,
+        isLinked: () => false,
+        portProbe: async () => false,
+        log: (l) => logs.push(l),
+        readManifest: async () => ({
+          name: "demo",
+          manifestName: "@local/demo",
+          kind: "api",
+          port: 1951,
+          paths: ["/demo"],
+          health: "/healthz",
+        }),
+        readPackageName: () => "@local/demo",
+      });
+      expect(code).toBe(0);
+      expect(calls[0]).toEqual(["bun", "add", "-g", pkgDir]);
+      const seeded = findService("@local/demo", path);
+      expect(seeded?.name).toBe("@local/demo");
+    } finally {
+      cleanup();
+      rmSync(pkgDir, { recursive: true, force: true });
+    }
+  });
+
+  test("local absolute path that doesn't exist fails fast", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      const code = await install("/nonexistent/path/xyz", {
+        runner: async () => 0,
+        manifestPath: path,
+        startService: async () => 0,
+        isLinked: () => false,
+        portProbe: async () => false,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(1);
+      expect(logs.join("\n")).toMatch(/path does not exist/);
     } finally {
       cleanup();
     }

--- a/src/__tests__/module-manifest.test.ts
+++ b/src/__tests__/module-manifest.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ModuleManifestError,
+  readModuleManifest,
+  validateModuleManifest,
+} from "../module-manifest.ts";
+
+const VALID = {
+  name: "demo",
+  manifestName: "@example/demo",
+  kind: "api",
+  port: 1950,
+  paths: ["/demo"],
+  health: "/healthz",
+} as const;
+
+describe("validateModuleManifest", () => {
+  test("accepts a minimal valid manifest", () => {
+    const m = validateModuleManifest(VALID, "test");
+    expect(m.name).toBe("demo");
+    expect(m.kind).toBe("api");
+    expect(m.port).toBe(1950);
+    expect(m.paths).toEqual(["/demo"]);
+    expect(m.health).toBe("/healthz");
+  });
+
+  test("rejects non-object root", () => {
+    expect(() => validateModuleManifest("nope", "where")).toThrow(ModuleManifestError);
+    expect(() => validateModuleManifest([1, 2], "where")).toThrow(/root must be an object/);
+  });
+
+  test("rejects missing required fields", () => {
+    expect(() => validateModuleManifest({ ...VALID, name: undefined }, "x")).toThrow(/name/);
+    expect(() => validateModuleManifest({ ...VALID, kind: "weird" }, "x")).toThrow(/kind/);
+    expect(() => validateModuleManifest({ ...VALID, port: -1 }, "x")).toThrow(/port/);
+    expect(() => validateModuleManifest({ ...VALID, port: 99999 }, "x")).toThrow(/port/);
+    expect(() => validateModuleManifest({ ...VALID, paths: "not-array" }, "x")).toThrow(/paths/);
+    expect(() => validateModuleManifest({ ...VALID, health: "no-leading-slash" }, "x")).toThrow(
+      /health/,
+    );
+  });
+
+  test("rejects invalid name shape", () => {
+    expect(() => validateModuleManifest({ ...VALID, name: "Demo" }, "x")).toThrow(/name/);
+    expect(() => validateModuleManifest({ ...VALID, name: "1demo" }, "x")).toThrow(/name/);
+    expect(() => validateModuleManifest({ ...VALID, name: "a_b" }, "x")).toThrow(/name/);
+  });
+
+  test("scope namespace must match module name", () => {
+    expect(() =>
+      validateModuleManifest({ ...VALID, scopes: { defines: ["vault:read"] } }, "x"),
+    ).toThrow(/namespace.*does not match/);
+    const ok = validateModuleManifest(
+      { ...VALID, scopes: { defines: ["demo:read", "demo:write"] } },
+      "x",
+    );
+    expect(ok.scopes?.defines).toEqual(["demo:read", "demo:write"]);
+  });
+
+  test("scope without colon is rejected", () => {
+    expect(() => validateModuleManifest({ ...VALID, scopes: { defines: ["demo"] } }, "x")).toThrow(
+      /namespaced/,
+    );
+  });
+
+  test("dependencies block accepts optional + scopes", () => {
+    const m = validateModuleManifest(
+      {
+        ...VALID,
+        dependencies: {
+          "parachute-vault": { optional: false, scopes: ["vault:read"] },
+          "parachute-scribe": { optional: true },
+        },
+      },
+      "x",
+    );
+    expect(m.dependencies?.["parachute-vault"]?.optional).toBe(false);
+    expect(m.dependencies?.["parachute-vault"]?.scopes).toEqual(["vault:read"]);
+    expect(m.dependencies?.["parachute-scribe"]?.optional).toBe(true);
+  });
+
+  test("startCmd must be non-empty if present", () => {
+    expect(() => validateModuleManifest({ ...VALID, startCmd: [] }, "x")).toThrow(/startCmd/);
+    const m = validateModuleManifest({ ...VALID, startCmd: ["bin", "--flag"] }, "x");
+    expect(m.startCmd).toEqual(["bin", "--flag"]);
+  });
+
+  test("optional displayName + tagline pass through", () => {
+    const m = validateModuleManifest(
+      { ...VALID, displayName: "Demo", tagline: "a demo module" },
+      "x",
+    );
+    expect(m.displayName).toBe("Demo");
+    expect(m.tagline).toBe("a demo module");
+  });
+});
+
+describe("readModuleManifest", () => {
+  function tmp(): { dir: string; cleanup: () => void } {
+    const dir = mkdtempSync(join(tmpdir(), "pcli-manifest-"));
+    return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+  }
+
+  test("returns null when .parachute/module.json is absent", async () => {
+    const { dir, cleanup } = tmp();
+    try {
+      expect(await readModuleManifest(dir)).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("reads + validates a real on-disk manifest", async () => {
+    const { dir, cleanup } = tmp();
+    try {
+      mkdirSync(join(dir, ".parachute"));
+      writeFileSync(join(dir, ".parachute", "module.json"), JSON.stringify(VALID));
+      const m = await readModuleManifest(dir);
+      expect(m?.name).toBe("demo");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("throws ModuleManifestError on malformed JSON", async () => {
+    const { dir, cleanup } = tmp();
+    try {
+      mkdirSync(join(dir, ".parachute"));
+      writeFileSync(join(dir, ".parachute", "module.json"), "{not json");
+      await expect(readModuleManifest(dir)).rejects.toThrow(ModuleManifestError);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("throws ModuleManifestError on validation failure", async () => {
+    const { dir, cleanup } = tmp();
+    try {
+      mkdirSync(join(dir, ".parachute"));
+      writeFileSync(join(dir, ".parachute", "module.json"), JSON.stringify({ name: "x" }));
+      await expect(readModuleManifest(dir)).rejects.toThrow(ModuleManifestError);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,16 +1,24 @@
-import { lstatSync, readFileSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync } from "node:fs";
 import { createConnection } from "node:net";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { autoWireScribeAuth } from "../auto-wire.ts";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
+import {
+  type ModuleManifest,
+  ModuleManifestError,
+  readModuleManifest,
+  validateModuleManifest,
+} from "../module-manifest.ts";
 import { assignServicePort } from "../port-assign.ts";
 import {
   CANONICAL_PORT_MAX,
   CANONICAL_PORT_MIN,
-  getSpec,
+  FIRST_PARTY_FALLBACKS,
+  type FirstPartyFallback,
+  type ServiceSpec,
+  composeServiceSpec,
   isCanonicalPort,
-  knownServices,
 } from "../service-spec.ts";
 import { findService, readManifest, upsertService } from "../services-manifest.ts";
 import { start as lifecycleStart } from "./lifecycle.ts";
@@ -106,6 +114,19 @@ export interface InstallOpts {
    * unless the test populates services.json directly.
    */
   portProbe?: (port: number) => Promise<boolean>;
+  /**
+   * Test seam for reading `<packageDir>/.parachute/module.json`. Production
+   * uses the real file reader; tests inject a map from package-dir → manifest
+   * (or throw to simulate malformed JSON). Returns null when the package
+   * doesn't ship a manifest.
+   */
+  readManifest?: (packageDir: string) => Promise<ModuleManifest | null>;
+  /**
+   * Test seam for reading `<absPath>/package.json` during local-path install.
+   * Production reads + parses the file; tests inject a stub. Returns the
+   * package's `name` (used to find the install dir post-bun-add).
+   */
+  readPackageName?: (absPath: string) => string | null;
 }
 
 async function defaultRunner(cmd: readonly string[]): Promise<number> {
@@ -206,7 +227,138 @@ function defaultFindGlobalInstall(pkg: string): string | null {
   return null;
 }
 
-export async function install(service: string, opts: InstallOpts = {}): Promise<number> {
+function defaultReadPackageName(absPath: string): string | null {
+  try {
+    const parsed = JSON.parse(readFileSync(join(absPath, "package.json"), "utf8"));
+    return typeof parsed?.name === "string" && parsed.name.length > 0 ? parsed.name : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the installed package's `.parachute/module.json`.
+ *
+ * Returns `null` when the package doesn't ship one (first-party falls back to
+ * the vendored manifest; third-party hard-errors at the call site). Returns
+ * `"error"` when the manifest exists but is malformed (or the install
+ * directory itself can't be located post-install) — caller treats both as
+ * an install-aborting error and the helper has already logged.
+ */
+async function readInstalledManifest(
+  target: ResolvedTarget,
+  deps: {
+    findGlobalInstall: (pkg: string) => string | null;
+    readManifest: (packageDir: string) => Promise<ModuleManifest | null>;
+    log: (line: string) => void;
+  },
+): Promise<ModuleManifest | null | "error"> {
+  let packageDir: string | null = null;
+  if (target.kind === "local-path") {
+    // The local checkout itself is the source. We could also re-read from
+    // bun's globals after install, but reading the original avoids any
+    // weirdness with bun symlinking the dir vs. copying it.
+    packageDir = target.absPath;
+  } else {
+    const pkgJsonPath = deps.findGlobalInstall(target.packageName);
+    if (!pkgJsonPath) {
+      // First-party fallback path (typical in tests): we don't actually need
+      // a real install dir — the vendored manifest covers us.
+      if (target.kind === "first-party") return null;
+      // Third-party: bun-add succeeded but we couldn't locate the install dir.
+      // Caller already logged a probe-list — just say nothing's there.
+      return null;
+    }
+    packageDir = dirname(pkgJsonPath);
+  }
+  try {
+    return await deps.readManifest(packageDir);
+  } catch (err) {
+    if (err instanceof ModuleManifestError) {
+      deps.log(`✗ ${target.packageName}: invalid .parachute/module.json — ${err.message}`);
+    } else {
+      const msg = err instanceof Error ? err.message : String(err);
+      deps.log(`✗ ${target.packageName}: failed to read .parachute/module.json — ${msg}`);
+    }
+    return "error";
+  }
+}
+
+/**
+ * What `parachute install <input>` resolved to. The CLI accepts three forms,
+ * and the resolution decides everything downstream — package name to bun-add,
+ * whether a vendored fallback applies, whether a missing
+ * `.parachute/module.json` is a hard error.
+ */
+type ResolvedTarget =
+  | {
+      readonly kind: "first-party";
+      readonly short: string;
+      readonly packageName: string;
+      readonly fallback: FirstPartyFallback;
+    }
+  | {
+      readonly kind: "npm";
+      readonly packageName: string;
+    }
+  | {
+      readonly kind: "local-path";
+      readonly absPath: string;
+      readonly packageName: string;
+    };
+
+/**
+ * Map an `<input>` (shortname / npm package / absolute path) to a target.
+ * Returns null on resolution failure (with logs already written).
+ *
+ * Order matters: first-party shortnames win over a hypothetical npm package
+ * literally named "vault", and absolute-path detection has to come before the
+ * "anything else is npm" fallback.
+ */
+function resolveInstallTarget(
+  input: string,
+  opts: InstallOpts,
+  log: (line: string) => void,
+): ResolvedTarget | null {
+  // Aliases (lens → notes) apply only to shortnames — npm packages and
+  // absolute paths pass through unaltered.
+  const aliased = SERVICE_ALIASES[input];
+  const candidate = aliased ?? input;
+
+  const fb = FIRST_PARTY_FALLBACKS[candidate];
+  if (fb) {
+    if (aliased !== undefined) {
+      log(`"${input}" has been renamed to "${aliased}"; installing ${aliased}.`);
+    }
+    return {
+      kind: "first-party",
+      short: candidate,
+      packageName: fb.package,
+      fallback: fb,
+    };
+  }
+
+  if (input.startsWith("/")) {
+    if (!existsSync(input)) {
+      log(`unknown service: "${input}" (path does not exist)`);
+      return null;
+    }
+    const readName = opts.readPackageName ?? defaultReadPackageName;
+    const packageName = readName(input);
+    if (!packageName) {
+      log(`✗ ${input} has no readable package.json — can't install as a Parachute module.`);
+      return null;
+    }
+    return { kind: "local-path", absPath: input, packageName };
+  }
+
+  // Anything else is treated as an npm package (bare or @scope/name). The
+  // module.json contract gates this — third-party packages without a
+  // manifest fail post-install with a clear error, not silently.
+  return { kind: "npm", packageName: input };
+}
+
+export async function install(input: string, opts: InstallOpts = {}): Promise<number> {
   const runner = opts.runner ?? defaultRunner;
   const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
   const configDir = opts.configDir ?? CONFIG_DIR;
@@ -214,24 +366,24 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
   const log = opts.log ?? ((line) => console.log(line));
   const isLinked = opts.isLinked ?? defaultIsLinked;
   const findGlobalInstall = opts.findGlobalInstall ?? defaultFindGlobalInstall;
+  const readManifest = opts.readManifest ?? readModuleManifest;
 
-  const aliased = SERVICE_ALIASES[service];
-  if (aliased !== undefined) {
-    log(`"${service}" has been renamed to "${aliased}"; installing ${aliased}.`);
-  }
-  const resolvedService = aliased ?? service;
+  const target = resolveInstallTarget(input, opts, log);
+  if (!target) return 1;
 
-  const spec = getSpec(resolvedService);
-  if (!spec) {
-    log(`unknown service: "${resolvedService}"`);
-    log(`known services: ${knownServices().join(", ")}`);
-    return 1;
-  }
-
-  if (isLinked(spec.package)) {
-    log(`${spec.package} is already linked globally (bun link) — skipping bun add.`);
+  // bun-add gate: skipped only for first-party packages already bun-linked
+  // locally (the scribe motivator — package isn't on npm yet, link beats
+  // add). Local-path installs always go through `bun add -g <abspath>` so
+  // bun's link plumbing produces a binary on PATH.
+  if (target.kind === "first-party" && isLinked(target.packageName)) {
+    log(`${target.packageName} is already linked globally (bun link) — skipping bun add.`);
   } else {
-    const addSpec = opts.tag ? `${spec.package}@${opts.tag}` : spec.package;
+    const addSpec =
+      target.kind === "local-path"
+        ? target.absPath
+        : opts.tag
+          ? `${target.packageName}@${opts.tag}`
+          : target.packageName;
     log(`Installing ${addSpec}…`);
     const addCode = await runner(["bun", "add", "-g", addSpec]);
     if (addCode !== 0) {
@@ -242,9 +394,11 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
       // Bailing here on exit code alone means the caller-visible install
       // fails and downstream init/seed never runs — so probe the global
       // prefix before treating non-zero as fatal.
-      const foundAt = findGlobalInstall(spec.package);
+      const foundAt = findGlobalInstall(target.packageName);
       if (foundAt) {
-        log(`bun add reported exit ${addCode} but ${spec.package} is installed at ${foundAt}.`);
+        log(
+          `bun add reported exit ${addCode} but ${target.packageName} is installed at ${foundAt}.`,
+        );
         log(
           "Known bun 1.2.x lockfile quirk — the package landed despite the warning. Proceeding. `bun upgrade` to 1.3.x avoids it.",
         );
@@ -261,6 +415,50 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
       }
     }
   }
+
+  // Read the installed `.parachute/module.json` (target convention). For
+  // first-party we fall back to the vendored manifest when absent; for
+  // third-party (npm / local-path) the manifest is the contract — its
+  // absence hard-errors here. See
+  // `parachute-patterns/patterns/module-json-extensibility.md`.
+  const installedManifest = await readInstalledManifest(target, {
+    findGlobalInstall,
+    readManifest,
+    log,
+  });
+  if (installedManifest === "error") return 1;
+
+  let manifest: ModuleManifest;
+  let extras = undefined as FirstPartyFallback["extras"] | undefined;
+  if (target.kind === "first-party") {
+    manifest = installedManifest ?? target.fallback.manifest;
+    extras = target.fallback.extras;
+  } else {
+    if (!installedManifest) {
+      log(`✗ ${target.packageName} does not ship .parachute/module.json — not a Parachute module.`);
+      log(
+        "  Authors: see parachute-patterns/patterns/module-json-extensibility.md for the contract.",
+      );
+      return 1;
+    }
+    // Third-party `name` collides with a first-party shortname → reject
+    // before we mint a services.json row that would hide a real first-party
+    // install. (Scope namespace is also `name`; collision == squatting.)
+    if (FIRST_PARTY_FALLBACKS[installedManifest.name] !== undefined) {
+      log(
+        `✗ ${target.packageName}: module name "${installedManifest.name}" collides with a first-party Parachute module.`,
+      );
+      return 1;
+    }
+    manifest = installedManifest;
+  }
+
+  const short = target.kind === "first-party" ? target.short : manifest.name;
+  const spec: ServiceSpec = composeServiceSpec({
+    packageName: target.packageName,
+    manifest,
+    extras,
+  });
 
   if (spec.init) {
     log(`Running ${spec.init.join(" ")}…`);
@@ -286,7 +484,7 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
     preInitEntry?.port,
     probe,
   );
-  const envPath = join(configDir, resolvedService, ".env");
+  const envPath = join(configDir, short, ".env");
   const canonicalPort = spec.seedEntry?.().port ?? preInitEntry?.port;
   const portResult = assignServicePort({
     envPath,
@@ -368,7 +566,7 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
   // ourselves if it was already running, mirroring the auto-wire pattern.
   // Failure here doesn't fail the install: a flaky restart shouldn't undo a
   // successful `bun add`.
-  if (resolvedService === "scribe") {
+  if (short === "scribe") {
     const setupOpts: SetupScribeProviderOpts = { configDir, log };
     if (opts.scribeProvider) setupOpts.preselectProvider = opts.scribeProvider;
     if (opts.scribeKey) setupOpts.preselectKey = opts.scribeKey;
@@ -389,11 +587,9 @@ export async function install(service: string, opts: InstallOpts = {}): Promise<
     const startService =
       opts.startService ??
       ((short: string) => lifecycleStart(short, { manifestPath, configDir, log }));
-    const startCode = await startService(resolvedService);
+    const startCode = await startService(short);
     if (startCode !== 0) {
-      log(
-        `⚠ ${resolvedService} didn't start cleanly. Run manually: parachute start ${resolvedService}`,
-      );
+      log(`⚠ ${short} didn't start cleanly. Run manually: parachute start ${short}`);
     }
   }
 

--- a/src/module-manifest.ts
+++ b/src/module-manifest.ts
@@ -1,0 +1,248 @@
+/**
+ * `.parachute/module.json` — the contract that makes a package a Parachute
+ * module. Author-controlled, shipped in the published artifact, read by the
+ * CLI on `parachute install <package>`.
+ *
+ * The shape mirrors `parachute-patterns/patterns/module-json-extensibility.md`.
+ * Third-party modules are first-class: no `@openparachute/` scope or
+ * `parachute-*` prefix required — `module.json` is what makes a package a
+ * module. First-party modules will eventually ship their own `module.json`
+ * and the vendored fallbacks in `service-spec.ts` go away one by one.
+ *
+ * Design note — what's NOT in this manifest:
+ *   - `version`: that's the package's own `package.json` version, not a
+ *     module-protocol versioning lever. If we ever break the manifest shape
+ *     we'll add `manifestVersion: 1` (deferred until v2 is real).
+ *   - imperative behaviors like `init` argv, post-install footers, dynamic
+ *     startCmd that needs per-install entry data: those live in the
+ *     first-party fallback's `extras` block in `service-spec.ts` because
+ *     they don't fit a static schema.
+ *   - runtime metadata: `displayName`, `tagline`, capabilities etc. that the
+ *     hub renders are at `/.parachute/info` (runtime, can change without
+ *     reinstall). The boundary: install-time → here; runtime → there.
+ */
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+
+export type ModuleKind = "api" | "frontend" | "tool";
+
+export interface ModuleScopeBlock {
+  /** OAuth scopes this module owns. Namespaced by `name` per oauth-scopes.md. */
+  readonly defines?: readonly string[];
+}
+
+export interface ModuleDependency {
+  /** True = absent dependency is fine; false = install fails without it. */
+  readonly optional?: boolean;
+  /** Scopes this module wants on the dependency, for auto-wired tokens. */
+  readonly scopes?: readonly string[];
+}
+
+export interface ModuleManifest {
+  /** Stable ecosystem identifier — `[a-z][a-z0-9-]*`, also the services.json key. */
+  readonly name: string;
+  /** User-facing manifest name (often === name). */
+  readonly manifestName: string;
+  /** Human label rendered on the hub card. */
+  readonly displayName?: string;
+  /** One-line subtitle rendered under displayName. */
+  readonly tagline?: string;
+  /** Drives card vs. iframe vs. launcher in the hub. */
+  readonly kind: ModuleKind;
+  /** Default loopback port. CLI warns on conflict, doesn't block. */
+  readonly port: number;
+  /** URL paths the module serves under the hub origin. */
+  readonly paths: readonly string[];
+  /** Path for liveness probes — must start with `/`. */
+  readonly health: string;
+  /** Argv the CLI invokes for `parachute start <name>`. Resolved relative to
+   *  the installed package; static (not entry-aware). */
+  readonly startCmd?: readonly string[];
+  /** OAuth scopes block — see oauth-scopes.md. */
+  readonly scopes?: ModuleScopeBlock;
+  /** Auto-wire targets — see service-to-service-auth.md. */
+  readonly dependencies?: Record<string, ModuleDependency>;
+}
+
+export class ModuleManifestError extends Error {
+  override name = "ModuleManifestError";
+}
+
+const NAME_RE = /^[a-z][a-z0-9-]*$/;
+
+function asString(v: unknown, where: string, field: string): string {
+  if (typeof v !== "string" || v.length === 0) {
+    throw new ModuleManifestError(`${where}: "${field}" must be a non-empty string`);
+  }
+  return v;
+}
+
+function asOptionalString(v: unknown, where: string, field: string): string | undefined {
+  if (v === undefined) return undefined;
+  if (typeof v !== "string") {
+    throw new ModuleManifestError(`${where}: "${field}" must be a string if present`);
+  }
+  return v;
+}
+
+function asKind(v: unknown, where: string): ModuleKind {
+  if (v !== "api" && v !== "frontend" && v !== "tool") {
+    throw new ModuleManifestError(`${where}: "kind" must be "api" | "frontend" | "tool"`);
+  }
+  return v;
+}
+
+function asPort(v: unknown, where: string): number {
+  if (typeof v !== "number" || !Number.isInteger(v) || v <= 0 || v > 65535) {
+    throw new ModuleManifestError(`${where}: "port" must be an integer 1..65535`);
+  }
+  return v;
+}
+
+function asStringArray(v: unknown, where: string, field: string): readonly string[] {
+  if (!Array.isArray(v) || v.some((p) => typeof p !== "string")) {
+    throw new ModuleManifestError(`${where}: "${field}" must be an array of strings`);
+  }
+  return v as readonly string[];
+}
+
+function asHealthPath(v: unknown, where: string): string {
+  const s = asString(v, where, "health");
+  if (!s.startsWith("/")) {
+    throw new ModuleManifestError(`${where}: "health" must start with "/"`);
+  }
+  return s;
+}
+
+function asScopes(v: unknown, where: string): ModuleScopeBlock | undefined {
+  if (v === undefined) return undefined;
+  if (!v || typeof v !== "object") {
+    throw new ModuleManifestError(`${where}: "scopes" must be an object if present`);
+  }
+  const defines = (v as Record<string, unknown>).defines;
+  if (defines === undefined) return {};
+  return { defines: asStringArray(defines, where, "scopes.defines") };
+}
+
+function asDependencies(v: unknown, where: string): Record<string, ModuleDependency> | undefined {
+  if (v === undefined) return undefined;
+  if (!v || typeof v !== "object" || Array.isArray(v)) {
+    throw new ModuleManifestError(`${where}: "dependencies" must be an object if present`);
+  }
+  const out: Record<string, ModuleDependency> = {};
+  for (const [k, raw] of Object.entries(v as Record<string, unknown>)) {
+    if (!raw || typeof raw !== "object") {
+      throw new ModuleManifestError(`${where}: "dependencies.${k}" must be an object`);
+    }
+    const dep = raw as Record<string, unknown>;
+    const entry: ModuleDependency = {};
+    if (dep.optional !== undefined) {
+      if (typeof dep.optional !== "boolean") {
+        throw new ModuleManifestError(`${where}: "dependencies.${k}.optional" must be boolean`);
+      }
+      (entry as { optional?: boolean }).optional = dep.optional;
+    }
+    if (dep.scopes !== undefined) {
+      (entry as { scopes?: readonly string[] }).scopes = asStringArray(
+        dep.scopes,
+        where,
+        `dependencies.${k}.scopes`,
+      );
+    }
+    out[k] = entry;
+  }
+  return out;
+}
+
+/**
+ * Strict validator. Throws `ModuleManifestError` with the source path so
+ * malformed third-party modules get a clear-enough error to fix. Required
+ * fields are name, manifestName, kind, port, paths, health.
+ */
+export function validateModuleManifest(raw: unknown, where: string): ModuleManifest {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ModuleManifestError(`${where}: root must be an object`);
+  }
+  const m = raw as Record<string, unknown>;
+
+  const name = asString(m.name, where, "name");
+  if (!NAME_RE.test(name)) {
+    throw new ModuleManifestError(
+      `${where}: "name" must match ${NAME_RE} (lowercase letters, digits, hyphens; lead with a letter)`,
+    );
+  }
+  const manifestName = asString(m.manifestName, where, "manifestName");
+  const kind = asKind(m.kind, where);
+  const port = asPort(m.port, where);
+  const paths = asStringArray(m.paths, where, "paths");
+  const health = asHealthPath(m.health, where);
+  const displayName = asOptionalString(m.displayName, where, "displayName");
+  const tagline = asOptionalString(m.tagline, where, "tagline");
+
+  let startCmd: readonly string[] | undefined;
+  if (m.startCmd !== undefined) {
+    startCmd = asStringArray(m.startCmd, where, "startCmd");
+    if (startCmd.length === 0) {
+      throw new ModuleManifestError(`${where}: "startCmd" must be non-empty if present`);
+    }
+  }
+
+  const scopes = asScopes(m.scopes, where);
+  // Scope-namespace rule: `name:foo` scopes must match the module's name. This
+  // prevents a third party from declaring `vault:read` and squatting on a
+  // namespace the user already trusts for a different module.
+  if (scopes?.defines) {
+    for (const s of scopes.defines) {
+      const colon = s.indexOf(":");
+      if (colon <= 0) {
+        throw new ModuleManifestError(
+          `${where}: scope "${s}" must be namespaced as "<name>:<verb>"`,
+        );
+      }
+      const ns = s.slice(0, colon);
+      if (ns !== name) {
+        throw new ModuleManifestError(
+          `${where}: scope "${s}" namespace "${ns}" does not match module name "${name}"`,
+        );
+      }
+    }
+  }
+
+  const dependencies = asDependencies(m.dependencies, where);
+
+  const out: ModuleManifest = { name, manifestName, kind, port, paths, health };
+  if (displayName !== undefined) (out as { displayName?: string }).displayName = displayName;
+  if (tagline !== undefined) (out as { tagline?: string }).tagline = tagline;
+  if (startCmd !== undefined) (out as { startCmd?: readonly string[] }).startCmd = startCmd;
+  if (scopes !== undefined) (out as { scopes?: ModuleScopeBlock }).scopes = scopes;
+  if (dependencies !== undefined) {
+    (out as { dependencies?: Record<string, ModuleDependency> }).dependencies = dependencies;
+  }
+  return out;
+}
+
+/**
+ * Read `<packageDir>/.parachute/module.json`. Returns null if the file is
+ * absent (caller decides whether that's an error — first-party modules fall
+ * back to the vendored manifest; third-party hard-errors). Throws
+ * `ModuleManifestError` on parse / validation failure.
+ */
+export async function readModuleManifest(packageDir: string): Promise<ModuleManifest | null> {
+  const path = join(packageDir, ".parachute", "module.json");
+  let buf: string;
+  try {
+    buf = await fs.readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(buf);
+  } catch (err) {
+    throw new ModuleManifestError(
+      `${path}: failed to parse JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  return validateModuleManifest(parsed, path);
+}

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath } from "node:url";
+import type { ModuleManifest } from "./module-manifest.ts";
 import type { ServiceEntry } from "./services-manifest.ts";
 
 /**
@@ -74,6 +75,71 @@ export function isCanonicalPort(port: number): boolean {
  */
 export type ServiceKind = "api" | "tool" | "frontend";
 
+/**
+ * Imperative behaviors that don't fit the static `module.json` schema.
+ *
+ * First-party only. Each first-party fallback declares its own extras
+ * alongside its embedded manifest; when the upstream module ships its own
+ * `.parachute/module.json`, the corresponding fallback entry — extras and
+ * manifest both — gets deleted in one PR per module.
+ *
+ * Third-party modules don't get extras: anything they need at install time
+ * has to fit the manifest contract (or live as a runtime concern at
+ * `/.parachute/info`). The boundary is intentional — extras is the seam
+ * for transitional behavior, not a permanent escape hatch.
+ */
+export interface FirstPartyExtras {
+  /** Init command spawned post-install (e.g., `["parachute-vault", "init"]`). */
+  readonly init?: readonly string[];
+  /**
+   * Override startCmd to take the per-install services.json entry. Used by
+   * notes (which needs `--port` + `--mount` derived from the entry); plain
+   * static-argv `manifest.startCmd` covers everything else.
+   */
+  readonly startCmd?: (entry: ServiceEntry) => readonly string[] | undefined;
+  /** Lines printed at the end of `parachute install <svc>`. */
+  readonly postInstallFooter?: () => readonly string[];
+  /**
+   * Does the service gate its endpoints behind auth today? Drives
+   * `effectivePublicExposure`'s default for api/tool services. True for
+   * vault/channel; conservatively false for scribe until its auth-gate ships.
+   */
+  readonly hasAuth?: boolean;
+  /**
+   * Override the canonical reachable URL for `parachute status`. Most
+   * services use `port + paths[0]`; vault appends `/mcp`, scribe is at root.
+   */
+  readonly urlForEntry?: (entry: ServiceEntry) => string | undefined;
+}
+
+/**
+ * Vendored fallback for a first-party module.
+ *
+ * The CLI prefers the installed module's own `.parachute/module.json` when
+ * present and falls back to this embedded manifest otherwise. The plan is
+ * to delete each fallback as its upstream module starts shipping the real
+ * file — see the `// FALLBACK: Delete when ...` markers below for the
+ * specific upstream reference per entry.
+ *
+ * Third-party modules never have a fallback; they ship `module.json` or
+ * the install hard-errors.
+ */
+export interface FirstPartyFallback {
+  /** npm package name for `bun add -g`. */
+  readonly package: string;
+  /** Embedded module.json — used when the install dir has no `.parachute/module.json`. */
+  readonly manifest: ModuleManifest;
+  /** Imperative behaviors not expressible in module.json. Optional. */
+  readonly extras?: FirstPartyExtras;
+}
+
+/**
+ * Façade combining a module's manifest with its install-time extras. All
+ * consumers (install, lifecycle, status, expose) read this — they don't
+ * care whether it came from a vendored fallback or a real
+ * `.parachute/module.json`. Non-readonly nothing — every field is read-only
+ * from the consumer's perspective.
+ */
 export interface ServiceSpec {
   readonly package: string;
   readonly manifestName: string;
@@ -81,55 +147,23 @@ export interface ServiceSpec {
   /**
    * Command to spawn for `parachute start <svc>`. Receives the services.json
    * entry so commands that need per-install data (e.g., the notes static-serve
-   * shim needs the configured port) can pull it from there.
-   *
-   * Returns `undefined` to declare "lifecycle not supported for this service."
-   * That never applies today but leaves a seam for future services that
-   * shouldn't be managed by `parachute start`.
+   * shim needs the configured port) can pull it from there. Returns
+   * `undefined` to declare "lifecycle not supported for this service."
    */
   readonly startCmd?: (entry: ServiceEntry) => readonly string[] | undefined;
   /**
    * Canonical initial services.json entry used when the service hasn't
-   * written its own entry yet. Fires post-install only if `findService`
-   * returns undefined — normal npm installs hit this almost never (the
-   * service's init or first boot writes the authoritative entry first).
-   *
-   * Main use case: `bun link` local-dev installs where the service hasn't
-   * run yet but `parachute expose` / `parachute start` need an entry to
-   * plan against. First service boot overwrites the seed with its own
-   * authoritative version.
+   * written its own. Fires post-install only if `findService` returns
+   * undefined — normal npm installs hit this almost never (the service's
+   * init or first boot writes the authoritative entry first). Main use case:
+   * `bun link` local-dev installs where the service hasn't run yet but
+   * `parachute expose` / `parachute start` need an entry to plan against.
+   * First service boot overwrites the seed with its own authoritative version.
    */
   readonly seedEntry?: () => ServiceEntry;
-  /**
-   * Declares the service's broad shape. Drives exposure defaults: api/tool
-   * services without auth fall back to `publicExposure: "auth-required"`
-   * (treated as loopback at launch); frontends default to "allowed".
-   */
-  readonly kind?: ServiceKind;
-  /**
-   * Does the service gate its endpoints behind auth today? Used together with
-   * `kind` to pick a safe default when the services.json entry omits
-   * `publicExposure`. True for vault/channel (owner-authenticated);
-   * conservatively false for scribe until its auth-gate ships.
-   */
+  readonly kind: ServiceKind;
   readonly hasAuth?: boolean;
-  /**
-   * Canonical reachable URL for the service given its manifest entry. Drives
-   * the URL column in `parachute status` and any other place we need to
-   * render "where do I point a client?". Most services use port + paths[0],
-   * but some need to append a fixed suffix (vault's MCP endpoint lives at
-   * `/vault/<name>/mcp`, not the bare mount path).
-   *
-   * Returns undefined when the entry doesn't carry enough info — callers
-   * should fall back to the bare `http://127.0.0.1:<port>` form.
-   */
   readonly urlForEntry?: (entry: ServiceEntry) => string | undefined;
-  /**
-   * Lines printed at the end of `parachute install <svc>` so the user has a
-   * clear next step. Vault's footer comes from `parachute-vault init` itself
-   * (PR #166) — richer because it can read the freshly-minted API token —
-   * so vault's spec leaves this off.
-   */
   readonly postInstallFooter?: () => readonly string[];
 }
 
@@ -150,45 +184,118 @@ function pathBasedUrl(entry: ServiceEntry): string {
   return `http://127.0.0.1:${entry.port}${path}`;
 }
 
-export const SERVICE_SPECS: Record<string, ServiceSpec> = {
-  vault: {
-    package: "@openparachute/vault",
+/**
+ * Build a services.json seed row from a module manifest. Pure: doesn't
+ * read the filesystem. The `version` is intentionally `0.0.0-linked` to
+ * telegraph "stopgap" — the service's own boot overwrites this entry.
+ */
+export function seedEntryFromManifest(manifest: ModuleManifest): ServiceEntry {
+  const entry: ServiceEntry = {
+    name: manifest.manifestName,
+    port: manifest.port,
+    paths: [...manifest.paths],
+    health: manifest.health,
+    version: SEED_VERSION,
+  };
+  if (manifest.displayName !== undefined) entry.displayName = manifest.displayName;
+  if (manifest.tagline !== undefined) entry.tagline = manifest.tagline;
+  return entry;
+}
+
+/**
+ * Build the runtime ServiceSpec façade from a manifest + optional extras.
+ * Used by both the first-party-fallback path and the
+ * read-installed-`module.json` path so both produce identical specs.
+ */
+export function composeServiceSpec(opts: {
+  packageName: string;
+  manifest: ModuleManifest;
+  extras?: FirstPartyExtras;
+}): ServiceSpec {
+  const { packageName, manifest, extras } = opts;
+  const startCmd = extras?.startCmd ?? (manifest.startCmd ? () => manifest.startCmd : undefined);
+  const spec: ServiceSpec = {
+    package: packageName,
+    manifestName: manifest.manifestName,
+    seedEntry: () => seedEntryFromManifest(manifest),
+    kind: manifest.kind,
+  };
+  if (extras?.init !== undefined) (spec as { init?: readonly string[] }).init = extras.init;
+  if (startCmd !== undefined) {
+    (spec as { startCmd?: (e: ServiceEntry) => readonly string[] | undefined }).startCmd = startCmd;
+  }
+  if (extras?.hasAuth !== undefined) (spec as { hasAuth?: boolean }).hasAuth = extras.hasAuth;
+  if (extras?.urlForEntry !== undefined) {
+    (
+      spec as {
+        urlForEntry?: (e: ServiceEntry) => string | undefined;
+      }
+    ).urlForEntry = extras.urlForEntry;
+  }
+  if (extras?.postInstallFooter !== undefined) {
+    (spec as { postInstallFooter?: () => readonly string[] }).postInstallFooter =
+      extras.postInstallFooter;
+  }
+  return spec;
+}
+
+// ---------------------------------------------------------------------------
+// First-party fallbacks
+//
+// Each entry below is a "delete-when-X-ships" marker — when the upstream
+// module starts publishing its own `.parachute/module.json`, the matching
+// FALLBACK comment names the issue that retires the vendored manifest +
+// extras. One cleanup PR per module; the markers make those PRs a one-grep
+// operation (`rg "FALLBACK: Delete when"`).
+// ---------------------------------------------------------------------------
+
+// FALLBACK: Delete when @openparachute/vault ships .parachute/module.json
+// (parachute-vault repo: file follow-up after parachute-hub#56 lands).
+const VAULT_FALLBACK: FirstPartyFallback = {
+  package: "@openparachute/vault",
+  manifest: {
+    name: "vault",
     manifestName: "parachute-vault",
+    displayName: "Vault",
+    tagline: "Your owner-authenticated MCP knowledge store.",
+    kind: "api",
+    port: 1940,
+    paths: ["/vault/default"],
+    health: "/vault/default/health",
+  },
+  extras: {
     init: ["parachute-vault", "init"],
     startCmd: () => ["parachute-vault", "serve"],
-    kind: "api",
     hasAuth: true,
-    seedEntry: () => ({
-      name: "parachute-vault",
-      port: 1940,
-      paths: ["/vault/default"],
-      health: "/vault/default/health",
-      version: SEED_VERSION,
-    }),
     // Vault's MCP endpoint lives one segment past the mount path. The bare
     // `/vault/<name>` URL is the discovery shape; clients (claude.ai et al.)
     // need `/vault/<name>/mcp` to actually open the stream.
     urlForEntry: (entry) => `${pathBasedUrl(entry)}/mcp`,
   },
-  notes: {
-    // Frontend product name is "Notes". vault's internal `/api/notes` endpoint
+};
+
+// FALLBACK: Delete when @openparachute/notes ships .parachute/module.json
+// (parachute-notes repo: file follow-up after parachute-hub#56 lands).
+const NOTES_FALLBACK: FirstPartyFallback = {
+  package: "@openparachute/notes",
+  manifest: {
+    // Frontend product name is "Notes". Vault's internal `/api/notes` endpoint
     // is unrelated — different concept (vault data primitive vs. PWA brand).
-    package: "@openparachute/notes",
+    name: "notes",
     manifestName: "parachute-notes",
+    displayName: "Notes",
+    tagline: "Notes PWA backed by your vault.",
+    kind: "frontend",
+    port: 1942,
+    paths: ["/notes"],
+    health: "/notes/health",
+  },
+  extras: {
     startCmd: (entry) => {
       const first = entry.paths[0] ?? "/notes";
       const mount = first === "/" ? "" : first.replace(/\/+$/, "");
       return ["bun", NOTES_SERVE_PATH, "--port", String(entry.port), "--mount", mount];
     },
-    kind: "frontend",
-    seedEntry: () => ({
-      name: "parachute-notes",
-      port: 1942,
-      paths: ["/notes"],
-      health: "/notes/health",
-      version: SEED_VERSION,
-    }),
-    urlForEntry: pathBasedUrl,
     postInstallFooter: () => [
       "",
       "Open your Notes UI at http://localhost:1942/notes — paste the vault URL",
@@ -196,22 +303,28 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
       "and the API token from your vault install.",
     ],
   },
-  scribe: {
-    package: "@openparachute/scribe",
+};
+
+// FALLBACK: Delete when @openparachute/scribe ships .parachute/module.json
+// (parachute-scribe repo: file follow-up after parachute-hub#56 lands).
+const SCRIBE_FALLBACK: FirstPartyFallback = {
+  package: "@openparachute/scribe",
+  manifest: {
+    name: "scribe",
     manifestName: "parachute-scribe",
-    startCmd: () => ["parachute-scribe", "serve"],
-    // No auth gate today. Scribe's launch PR adds optional SCRIBE_AUTH_TOKEN;
-    // once it lands and scribe writes `publicExposure: "allowed"` when a token
-    // is configured, that explicit declaration overrides this default.
+    displayName: "Scribe",
+    tagline: "Local audio transcription for vault recordings.",
     kind: "api",
+    port: 1943,
+    paths: ["/scribe"],
+    health: "/scribe/health",
+    startCmd: ["parachute-scribe", "serve"],
+  },
+  extras: {
+    // No auth gate today. Scribe's launch PR adds optional SCRIBE_AUTH_TOKEN;
+    // once it lands and scribe writes `publicExposure: "allowed"` when a
+    // token is configured, that explicit declaration overrides this default.
     hasAuth: false,
-    seedEntry: () => ({
-      name: "parachute-scribe",
-      port: 1943,
-      paths: ["/scribe"],
-      health: "/scribe/health",
-      version: SEED_VERSION,
-    }),
     // Scribe's API is at the root, not under `/scribe`. The path prefix only
     // shows up in the health endpoint; clients hit the bare port.
     urlForEntry: (entry) => `http://127.0.0.1:${entry.port}`,
@@ -224,21 +337,40 @@ export const SERVICE_SPECS: Record<string, ServiceSpec> = {
       "whisper, groq, openai.",
     ],
   },
-  channel: {
-    package: "@openparachute/channel",
+};
+
+// FALLBACK: Delete when @openparachute/channel ships .parachute/module.json
+// (parachute-channel repo: file follow-up after parachute-hub#56 lands;
+// channel is exploration tier — may be retired before module.json ships).
+const CHANNEL_FALLBACK: FirstPartyFallback = {
+  package: "@openparachute/channel",
+  manifest: {
+    name: "channel",
     manifestName: "parachute-channel",
-    startCmd: () => ["parachute-channel", "daemon"],
+    displayName: "Channel",
+    tagline: "Notification fan-out across modules.",
     kind: "api",
-    hasAuth: true,
-    seedEntry: () => ({
-      name: "parachute-channel",
-      port: 1941,
-      paths: ["/channel"],
-      health: "/channel/health",
-      version: SEED_VERSION,
-    }),
-    urlForEntry: pathBasedUrl,
+    port: 1941,
+    paths: ["/channel"],
+    health: "/channel/health",
+    startCmd: ["parachute-channel", "daemon"],
   },
+  extras: {
+    hasAuth: true,
+  },
+};
+
+/**
+ * Vendored manifests + extras for first-party modules. Indexed by short name
+ * (the `parachute install <X>` token). Each entry retires when its upstream
+ * module starts shipping `.parachute/module.json` — see the per-entry
+ * `FALLBACK:` markers above.
+ */
+export const FIRST_PARTY_FALLBACKS: Record<string, FirstPartyFallback> = {
+  vault: VAULT_FALLBACK,
+  notes: NOTES_FALLBACK,
+  scribe: SCRIBE_FALLBACK,
+  channel: CHANNEL_FALLBACK,
 };
 
 /**
@@ -254,19 +386,37 @@ export function effectivePublicExposure(
 ): "allowed" | "loopback" | "auth-required" {
   if (entry.publicExposure !== undefined) return entry.publicExposure;
   const short = shortNameForManifest(entry.name);
-  const spec = short !== undefined ? SERVICE_SPECS[short] : undefined;
-  if (spec && (spec.kind === "api" || spec.kind === "tool") && spec.hasAuth === false) {
+  const fb = short !== undefined ? FIRST_PARTY_FALLBACKS[short] : undefined;
+  if (
+    fb &&
+    (fb.manifest.kind === "api" || fb.manifest.kind === "tool") &&
+    fb.extras?.hasAuth === false
+  ) {
     return "auth-required";
   }
   return "allowed";
 }
 
 export function knownServices(): string[] {
-  return Object.keys(SERVICE_SPECS);
+  return Object.keys(FIRST_PARTY_FALLBACKS);
 }
 
-export function getSpec(service: string): ServiceSpec | undefined {
-  return SERVICE_SPECS[service];
+/**
+ * Resolve the runtime spec for a known short name. Returns undefined for
+ * unknown names; third-party modules installed via `module.json` don't get
+ * a runtime spec out of this lookup yet — that's a follow-up. For now,
+ * lifecycle / status / expose treat unknown names as "we have a
+ * services.json row but no spec" (skip lifecycle, fall back to defaults
+ * for URL / exposure), exactly as before.
+ */
+export function getSpec(short: string): ServiceSpec | undefined {
+  const fb = FIRST_PARTY_FALLBACKS[short];
+  if (!fb) return undefined;
+  return composeServiceSpec({
+    packageName: fb.package,
+    manifest: fb.manifest,
+    extras: fb.extras,
+  });
 }
 
 /**
@@ -286,11 +436,11 @@ const LEGACY_MANIFEST_ALIASES: Record<string, string> = {
   "parachute-lens": "notes",
 };
 
-/** Short name (the key into SERVICE_SPECS) for a given manifest name, e.g.
- *  `parachute-vault` → `vault`. Returns undefined for unknown manifests. */
+/** Short name (the key into FIRST_PARTY_FALLBACKS) for a given manifest name,
+ *  e.g. `parachute-vault` → `vault`. Returns undefined for unknown manifests. */
 export function shortNameForManifest(manifestName: string): string | undefined {
-  for (const [short, spec] of Object.entries(SERVICE_SPECS)) {
-    if (spec.manifestName === manifestName) return short;
+  for (const [short, fb] of Object.entries(FIRST_PARTY_FALLBACKS)) {
+    if (fb.manifest.manifestName === manifestName) return short;
   }
   return LEGACY_MANIFEST_ALIASES[manifestName];
 }


### PR DESCRIPTION
## Summary

- Replaces hardcoded `SERVICE_SPECS` registry with `.parachute/module.json` resolution. Third-party packages are now first-class — any package shipping `.parachute/module.json` is installable.
- New `src/module-manifest.ts`: `ModuleManifest` contract + strict validator (NAME_RE, scope-namespace check, kind/port/paths/health). Implements `parachute-patterns/patterns/module-json-extensibility.md`.
- `src/service-spec.ts`: `SERVICE_SPECS` → `FIRST_PARTY_FALLBACKS` (vault, notes, scribe, channel) — vendored manifests + extras (init argv, dynamic startCmd, post-install footers, hasAuth, urlForEntry). Each carries a `// FALLBACK` marker pointing at the upstream repo where the module.json should eventually live. `ServiceSpec` stays as the consumer-facing façade; new `composeServiceSpec()` derives it from manifest+extras.
- `src/commands/install.ts`: `resolveInstallTarget()` handles three forms — first-party shortname, npm package, absolute local path. Third-party with no `module.json` hard-errors. Third-party `name` colliding with a first-party shortname is rejected. First-party falls back to vendored manifest when the package doesn't ship one yet.
- Tests: 13 new module-manifest cases, 5 new install scenarios (third-party valid / hard-error / collision / local-path / bad path). Existing 586 tests pass unchanged.

Closes #56.

## Follow-up after merge

File issues in each first-party repo asking it to ship `.parachute/module.json`:
- `parachute-vault`
- `parachute-notes`
- `parachute-scribe`
- `parachute-channel`

When each repo ships its manifest, the corresponding `// FALLBACK` block in `service-spec.ts` deletes one by one.

## Test plan

- [x] `bun test` — 604 pass, 0 fail
- [x] `bun run typecheck` clean
- [x] `bunx biome check` clean
- [ ] Smoke: `bun src/cli.ts install vault` against a clean install (post-merge, on stable)
- [ ] Smoke: third-party rejection — install a random npm pkg, see hard error

🤖 Generated with [Claude Code](https://claude.com/claude-code)