### PR TITLE
feat(hub): scope-validation at /oauth/token (0.4.0-rc.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.1",
+  "version": "0.4.0-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -77,7 +77,7 @@ describe("handleAuthorizeGet", () => {
           response_type: "code",
           code_challenge: challenge,
           code_challenge_method: "S256",
-          scope: "vault.read",
+          scope: "vault:read",
           state: "xyz",
         }),
       );
@@ -111,7 +111,7 @@ describe("handleAuthorizeGet", () => {
           response_type: "code",
           code_challenge: challenge,
           code_challenge_method: "S256",
-          scope: "vault.read",
+          scope: "vault:read",
         }),
         {
           headers: {
@@ -124,7 +124,7 @@ describe("handleAuthorizeGet", () => {
       const html = await res.text();
       expect(html).toContain("Authorize");
       expect(html).toContain("MyApp");
-      expect(html).toContain("vault.read");
+      expect(html).toContain("vault:read");
       expect(html).toContain('name="__action" value="consent"');
     } finally {
       cleanup();
@@ -209,7 +209,7 @@ describe("handleAuthorizePost — login submit", () => {
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
         response_type: "code",
-        scope: "vault.read",
+        scope: "vault:read",
         code_challenge: challenge,
         code_challenge_method: "S256",
       });
@@ -273,7 +273,7 @@ describe("handleAuthorizePost — consent submit", () => {
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
         response_type: "code",
-        scope: "vault.read",
+        scope: "vault:read",
         code_challenge: challenge,
         code_challenge_method: "S256",
         state: "abc123",
@@ -310,7 +310,7 @@ describe("handleAuthorizePost — consent submit", () => {
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
         response_type: "code",
-        scope: "vault.read",
+        scope: "vault:read",
         code_challenge: challenge,
         code_challenge_method: "S256",
         state: "abc",
@@ -350,7 +350,7 @@ describe("handleToken — full OAuth dance", () => {
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
         response_type: "code",
-        scope: "vault.read",
+        scope: "vault:read",
         code_challenge: challenge,
         code_challenge_method: "S256",
       });
@@ -389,15 +389,15 @@ describe("handleToken — full OAuth dance", () => {
         scope: string;
       };
       expect(tokenBody.token_type).toBe("Bearer");
-      expect(tokenBody.scope).toBe("vault.read");
+      expect(tokenBody.scope).toBe("vault:read");
       expect(tokenBody.refresh_token.length).toBeGreaterThan(20);
 
       // JWT must verify against the hub's signing keys, with the right sub +
-      // aud (vault.read → "vault").
+      // aud (vault:read → "vault").
       const { payload } = await validateAccessToken(db, tokenBody.access_token);
       expect(payload.sub).toBe(user.id);
       expect(payload.aud).toBe("vault");
-      expect(payload.scope).toBe("vault.read");
+      expect(payload.scope).toBe("vault:read");
       expect(payload.client_id).toBe(reg.client.clientId);
     } finally {
       cleanup();
@@ -472,7 +472,7 @@ describe("handleToken — full OAuth dance", () => {
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
         response_type: "code",
-        scope: "vault.read",
+        scope: "vault:read",
         code_challenge: challenge,
         code_challenge_method: "S256",
       });
@@ -611,6 +611,173 @@ describe("handleToken — full OAuth dance", () => {
       cleanup();
     }
   });
+
+  // cli#71 — scope-validation gate at /oauth/token. The hub must not sign a
+  // JWT carrying scopes the issuer never declared.
+  test("unknown scope at /oauth/token returns invalid_scope (400)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { verifier, challenge } = makePkce();
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:read frobnicate:everything",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const consentRes = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: buildSessionCookie(session.id, 86400),
+          },
+        }),
+        { issuer: ISSUER },
+      );
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const tokenForm = new URLSearchParams({
+        grant_type: "authorization_code",
+        code: code ?? "",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        code_verifier: verifier,
+      });
+      const res = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: tokenForm,
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER },
+      );
+      expect(res.status).toBe(400);
+      const err = (await res.json()) as Record<string, unknown>;
+      expect(err.error).toBe("invalid_scope");
+      expect(err.error_description).toMatch(/frobnicate:everything/);
+      expect(err.invalid_scopes).toEqual(["frobnicate:everything"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("third-party scope from injected declared set is accepted", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { verifier, challenge } = makePkce();
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "widget:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const consentRes = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: buildSessionCookie(session.id, 86400),
+          },
+        }),
+        { issuer: ISSUER },
+      );
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const tokenForm = new URLSearchParams({
+        grant_type: "authorization_code",
+        code: code ?? "",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        code_verifier: verifier,
+      });
+      const declared = new Set(["widget:read"]);
+      const res = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: tokenForm,
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER, loadDeclaredScopes: () => declared },
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { scope: string };
+      expect(body.scope).toBe("widget:read");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("per-resource narrowing (vault:work:read against declared vault:read)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { verifier, challenge } = makePkce();
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:work:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const consentRes = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: buildSessionCookie(session.id, 86400),
+          },
+        }),
+        { issuer: ISSUER },
+      );
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const tokenForm = new URLSearchParams({
+        grant_type: "authorization_code",
+        code: code ?? "",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        code_verifier: verifier,
+      });
+      const res = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: tokenForm,
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER },
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { scope: string };
+      expect(body.scope).toBe("vault:work:read");
+    } finally {
+      cleanup();
+    }
+  });
 });
 
 describe("handleRegister — RFC 7591 DCR", () => {
@@ -621,7 +788,7 @@ describe("handleRegister — RFC 7591 DCR", () => {
         method: "POST",
         body: JSON.stringify({
           redirect_uris: ["https://app.example/cb"],
-          scope: "vault.read",
+          scope: "vault:read",
           client_name: "MyApp",
         }),
         headers: { "content-type": "application/json" },

--- a/src/__tests__/scope-registry.test.ts
+++ b/src/__tests__/scope-registry.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  findUnknownScopes,
+  isKnownScope,
+  loadDeclaredScopes,
+  parseScopeString,
+} from "../scope-registry.ts";
+
+describe("parseScopeString", () => {
+  test("splits on whitespace per RFC 6749", () => {
+    expect(parseScopeString("vault:read scribe:transcribe")).toEqual([
+      "vault:read",
+      "scribe:transcribe",
+    ]);
+  });
+
+  test("accepts tabs + newlines + multi-space runs", () => {
+    expect(parseScopeString("vault:read\tscribe:transcribe\n  channel:send")).toEqual([
+      "vault:read",
+      "scribe:transcribe",
+      "channel:send",
+    ]);
+  });
+
+  test("empty string yields empty array", () => {
+    expect(parseScopeString("")).toEqual([]);
+    expect(parseScopeString("   ")).toEqual([]);
+  });
+});
+
+describe("isKnownScope", () => {
+  const declared = new Set(["vault:read", "vault:write", "scribe:transcribe", "hub:admin"]);
+
+  test("exact match passes", () => {
+    expect(isKnownScope("vault:read", declared)).toBe(true);
+    expect(isKnownScope("scribe:transcribe", declared)).toBe(true);
+  });
+
+  test("unknown scopes fail", () => {
+    expect(isKnownScope("frobnicate:everything", declared)).toBe(false);
+    expect(isKnownScope("vault:exfiltrate", declared)).toBe(false);
+  });
+
+  test("per-resource narrowing collapses to <svc>:<verb>", () => {
+    expect(isKnownScope("vault:work:read", declared)).toBe(true);
+    expect(isKnownScope("vault:default:write", declared)).toBe(true);
+    expect(isKnownScope("scribe:groq:transcribe", declared)).toBe(true);
+  });
+
+  test("narrowing only collapses if collapsed form is declared", () => {
+    expect(isKnownScope("vault:work:exfiltrate", declared)).toBe(false);
+  });
+
+  test("admin scope does NOT inherit read/write at the issuer", () => {
+    // Inheritance is the resource server's call (vault enforces admin ⊇ write
+    // ⊇ read at request time). The issuer only mints what was declared.
+    const adminOnly = new Set(["vault:admin"]);
+    expect(isKnownScope("vault:read", adminOnly)).toBe(false);
+  });
+
+  test("malformed scopes (no colon, single segment) fail", () => {
+    expect(isKnownScope("vaultread", declared)).toBe(false);
+    expect(isKnownScope("vault:", declared)).toBe(false);
+  });
+});
+
+describe("findUnknownScopes", () => {
+  const declared = new Set(["vault:read", "vault:write", "scribe:transcribe"]);
+
+  test("returns only the unknown ones", () => {
+    expect(
+      findUnknownScopes(["vault:read", "frobnicate:everything", "scribe:transcribe"], declared),
+    ).toEqual(["frobnicate:everything"]);
+  });
+
+  test("returns [] when all declared", () => {
+    expect(findUnknownScopes(["vault:read", "scribe:transcribe"], declared)).toEqual([]);
+  });
+
+  test("returns [] for empty input", () => {
+    expect(findUnknownScopes([], declared)).toEqual([]);
+  });
+});
+
+describe("loadDeclaredScopes", () => {
+  function tmp(): { dir: string; manifestPath: string; cleanup: () => void } {
+    const dir = mkdtempSync(join(tmpdir(), "phub-scope-reg-"));
+    return {
+      dir,
+      manifestPath: join(dir, "services.json"),
+      cleanup: () => rmSync(dir, { recursive: true, force: true }),
+    };
+  }
+
+  test("returns FIRST_PARTY_SCOPES baseline when services.json is absent", () => {
+    const { manifestPath, cleanup } = tmp();
+    try {
+      const declared = loadDeclaredScopes({ manifestPath });
+      expect(declared.has("vault:read")).toBe(true);
+      expect(declared.has("scribe:transcribe")).toBe(true);
+      expect(declared.has("hub:admin")).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("unions module.json scopes.defines on top of FIRST_PARTY_SCOPES", () => {
+    const { manifestPath, cleanup } = tmp();
+    try {
+      writeFileSync(
+        manifestPath,
+        JSON.stringify({
+          services: [
+            {
+              name: "@acme/widget",
+              port: 1950,
+              paths: ["/widget"],
+              health: "/healthz",
+              version: "0.0.0-linked",
+            },
+          ],
+        }),
+      );
+      const declared = loadDeclaredScopes({
+        manifestPath,
+        readModuleScopes: (pkg) =>
+          pkg === "@acme/widget" ? ["widget:read", "widget:write"] : null,
+      });
+      expect(declared.has("vault:read")).toBe(true); // baseline
+      expect(declared.has("widget:read")).toBe(true);
+      expect(declared.has("widget:write")).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("services with no module.json don't crash the registry", () => {
+    const { manifestPath, cleanup } = tmp();
+    try {
+      writeFileSync(
+        manifestPath,
+        JSON.stringify({
+          services: [
+            {
+              name: "parachute-vault",
+              port: 1940,
+              paths: ["/vault"],
+              health: "/healthz",
+              version: "0.0.0-linked",
+            },
+          ],
+        }),
+      );
+      const declared = loadDeclaredScopes({
+        manifestPath,
+        readModuleScopes: () => null,
+      });
+      expect(declared.has("vault:read")).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("malformed services.json falls back to baseline", () => {
+    const { manifestPath, cleanup } = tmp();
+    try {
+      writeFileSync(manifestPath, "{not json");
+      const declared = loadDeclaredScopes({ manifestPath });
+      expect(declared.has("vault:read")).toBe(true);
+      expect(declared.size).toBeGreaterThan(0);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -45,6 +45,7 @@ import {
 } from "./jwt-sign.ts";
 import { type AuthorizeFormParams, renderConsent, renderError, renderLogin } from "./oauth-ui.ts";
 import { FIRST_PARTY_SCOPES } from "./scope-explanations.ts";
+import { findUnknownScopes, loadDeclaredScopes } from "./scope-registry.ts";
 import {
   SESSION_TTL_MS,
   buildSessionCookie,
@@ -59,6 +60,14 @@ export interface OAuthDeps {
   issuer: string;
   /** Override the clock for deterministic tests. */
   now?: () => Date;
+  /**
+   * Resolve the declared-scope set the issuer is willing to sign. Production
+   * walks `services.json` + each module's `.parachute/module.json`
+   * `scopes.defines` and unions with `FIRST_PARTY_SCOPES`. Tests inject a
+   * pinned set so the gate is deterministic without a fixture services.json.
+   * See cli#71 + `oauth-scopes.md`.
+   */
+  loadDeclaredScopes?: () => ReadonlySet<string>;
 }
 
 // --- helpers ---------------------------------------------------------------
@@ -389,6 +398,23 @@ async function handleTokenAuthorizationCode(
   } catch (err) {
     return mapAuthCodeError(err);
   }
+  // Scope-validation gate (cli#71). Reject any requested scope that the
+  // issuer never declared — `FIRST_PARTY_SCOPES` ∪ each module's `module.json`
+  // `scopes.defines`. Per RFC 6749 §5.2: `error: "invalid_scope"`. We add
+  // `invalid_scopes: [...]` as an extension field so clients can report the
+  // exact culprits without re-parsing the description string.
+  const declared = (deps.loadDeclaredScopes ?? loadDeclaredScopes)();
+  const unknown = findUnknownScopes(redeemed.scopes, declared);
+  if (unknown.length > 0) {
+    return jsonResponse(
+      {
+        error: "invalid_scope",
+        error_description: `unknown scopes: ${unknown.join(", ")}`,
+        invalid_scopes: unknown,
+      },
+      400,
+    );
+  }
   const audience = inferAudience(redeemed.scopes);
   const access = await signAccessToken(db, {
     sub: redeemed.userId,
@@ -509,15 +535,16 @@ function mapAuthCodeError(err: unknown): Response {
 }
 
 /**
- * Picks the JWT `aud` claim based on the requested scopes. `vault.*` →
- * "vault", `notes.*` → "notes", etc. Falls back to "hub" for hub-only
- * scopes or empty scopes. This will become a more deliberate scope
- * registry in PR (d) / cli#56; for now, prefix-match is enough.
+ * Picks the JWT `aud` claim based on the requested scopes. `vault:*` →
+ * "vault", `scribe:*` → "scribe", etc. Falls back to "hub" for hub-only
+ * scopes or empty scopes. The split character is `:` per
+ * `parachute-patterns/patterns/oauth-scopes.md`; the previous `.` form was
+ * never canonical (cli#71 caught it during the scope-validation cutover).
  */
 function inferAudience(scopes: string[]): string {
   for (const s of scopes) {
-    const dot = s.indexOf(".");
-    if (dot > 0) return s.slice(0, dot);
+    const colon = s.indexOf(":");
+    if (colon > 0) return s.slice(0, colon);
   }
   return "hub";
 }

--- a/src/scope-registry.ts
+++ b/src/scope-registry.ts
@@ -1,0 +1,141 @@
+/**
+ * Scope registry — the issuer's view of which OAuth scopes are blessed.
+ *
+ * The hub signs JWTs whose `scope` claim is the contract the resource server
+ * trusts. Issuing a token with a scope no module ever declared is a protocol
+ * violation: in Phase B2 (multi-RS validation), an unknown scope reaching a
+ * downstream service should be rejected, but defense-in-depth says don't
+ * sign claims you don't understand. This module is the gate.
+ *
+ * Source of truth for scope shape: `parachute-patterns/patterns/oauth-scopes.md`.
+ *
+ * Declared scopes come from two places:
+ *   1. `FIRST_PARTY_SCOPES` — the canonical Parachute scopes hardcoded in
+ *      `scope-explanations.ts` (vault:read, scribe:transcribe, …).
+ *   2. Each registered service's `.parachute/module.json` `scopes.defines`
+ *      array — third-party modules opt in by declaring up front.
+ *
+ * Resolution is per-token-request, not cached: services.json + module.json
+ * lookups cost a few ms at the launch scale (<10 services), and a stale cache
+ * is the kind of bug that takes days to surface. Re-read each call.
+ */
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { type ModuleManifest, validateModuleManifest } from "./module-manifest.ts";
+import { FIRST_PARTY_SCOPES } from "./scope-explanations.ts";
+import { readManifest as readServicesManifest } from "./services-manifest.ts";
+
+/**
+ * RFC 6749 §3.3: scope strings are 1*( SP scope-token ). We accept any
+ * whitespace run (incl. tabs/newlines) per the looser parser rules in
+ * `oauth-scopes.md` so a CRLF-mangled form post still parses.
+ */
+export function parseScopeString(scope: string): string[] {
+  return scope.split(/\s+/).filter((s) => s.length > 0);
+}
+
+/**
+ * Match a requested scope against the declared set, applying per-resource
+ * narrowing per `oauth-scopes.md`.
+ *
+ *   - Exact match: `vault:read` against declared `vault:read` → true.
+ *   - Narrowing: `vault:work:read` against declared `vault:read` → true
+ *     (collapse middle segments to `<svc>:<verb>`). Phase 2 will treat
+ *     middle segments as resource constraints, not synonyms; for now they
+ *     parse but don't narrow enforcement.
+ *
+ * No inheritance here: `vault:admin` declared does NOT cover requested
+ * `vault:read`. The issuer signs exactly what the consent screen showed —
+ * inheritance is the resource server's call (vault enforces `admin ⊇ write
+ * ⊇ read` at request time, not at JWT mint).
+ */
+export function isKnownScope(scope: string, declared: ReadonlySet<string>): boolean {
+  if (declared.has(scope)) return true;
+  const parts = scope.split(":");
+  if (parts.length < 3) return false;
+  const collapsed = `${parts[0]}:${parts[parts.length - 1]}`;
+  return declared.has(collapsed);
+}
+
+export function findUnknownScopes(
+  scopes: readonly string[],
+  declared: ReadonlySet<string>,
+): string[] {
+  return scopes.filter((s) => !isKnownScope(s, declared));
+}
+
+/**
+ * Read `<bun-globals>/<pkg>/.parachute/module.json` for one registered
+ * service and return its `scopes.defines`. Returns null when the module
+ * doesn't ship a manifest (first-party today; eventually they all will).
+ *
+ * Tolerant of malformed JSON / validation errors — those are install-time
+ * problems, not token-issuance problems. A bad manifest blocking token
+ * issuance is the worst kind of cascade failure.
+ */
+export function defaultReadModuleScopes(packageName: string): readonly string[] | null {
+  for (const prefix of bunGlobalPrefixes()) {
+    const path = join(prefix, ...packageName.split("/"), ".parachute", "module.json");
+    let raw: unknown;
+    try {
+      raw = JSON.parse(readFileSync(path, "utf8"));
+    } catch {
+      continue;
+    }
+    let m: ModuleManifest;
+    try {
+      m = validateModuleManifest(raw, path);
+    } catch {
+      // Malformed manifest — `parachute install` would have surfaced it; the
+      // token endpoint shouldn't refuse to mint over it.
+      return null;
+    }
+    return m.scopes?.defines ?? [];
+  }
+  return null;
+}
+
+function bunGlobalPrefixes(): string[] {
+  const prefixes: string[] = [];
+  const fromEnv = process.env.BUN_INSTALL;
+  if (fromEnv) prefixes.push(join(fromEnv, "install", "global", "node_modules"));
+  prefixes.push(join(homedir(), ".bun", "install", "global", "node_modules"));
+  return prefixes;
+}
+
+export interface LoadDeclaredScopesOpts {
+  /** Path to services.json. Defaults to `~/.parachute/services.json`. */
+  manifestPath?: string;
+  /**
+   * Test seam: read a module's declared scopes by package name. Production
+   * walks bun's global prefixes for each registered service's
+   * `.parachute/module.json`.
+   */
+  readModuleScopes?: (packageName: string) => readonly string[] | null;
+}
+
+/**
+ * Compute the union of scopes the issuer is willing to sign. Order:
+ *   1. `FIRST_PARTY_SCOPES` — always-on baseline.
+ *   2. Each registered service's `module.json` `scopes.defines`.
+ *
+ * Errors reading services.json fail open (return baseline only) — a missing
+ * services.json shouldn't break OAuth.
+ */
+export function loadDeclaredScopes(opts: LoadDeclaredScopesOpts = {}): Set<string> {
+  const declared = new Set<string>(FIRST_PARTY_SCOPES);
+  const readModuleScopes = opts.readModuleScopes ?? defaultReadModuleScopes;
+  let services: { name: string }[];
+  try {
+    services = readServicesManifest(opts.manifestPath).services;
+  } catch {
+    return declared;
+  }
+  for (const svc of services) {
+    const defined = readModuleScopes(svc.name);
+    if (!defined) continue;
+    for (const scope of defined) declared.add(scope);
+  }
+  return declared;
+}


### PR DESCRIPTION
## Summary

The hub now validates requested scopes against the issuer's declared scope list before signing a JWT. Unknown scopes return `invalid_scope` with an `invalid_scopes: [...]` extension field for client diagnosis (RFC 6749 §5.2).

- New `src/scope-registry.ts` — `parseScopeString` (RFC 6749 whitespace split), `isKnownScope` (exact match + per-resource narrowing per `oauth-scopes.md` — `vault:work:read` collapses to `vault:read`), `findUnknownScopes`, `loadDeclaredScopes` which unions `FIRST_PARTY_SCOPES` with each registered service's `module.json` `scopes.defines`.
- `src/oauth-handlers.ts` — gate added to `handleTokenAuthorizationCode` between code redeem and JWT signing. New `loadDeclaredScopes` test seam on `OAuthDeps` for deterministic unit tests.
- **Bug fix surfaced in passing**: `inferAudience` was splitting scopes on `.` (legacy shape, never canonical per `oauth-scopes.md`) so `vault:read` was falling back to `aud: "hub"`. Now splits on `:` — `vault:read` → "vault".
- Tests: 16 new scope-registry cases + 3 new /oauth/token cases (unknown scope rejected, third-party scope from injected declared set accepted, per-resource narrowing accepted). Existing tests fixed up from the legacy `vault.read` (dot) to canonical `vault:read` (colon).

Defense-in-depth: `scopes_supported` in OAuth metadata becomes load-bearing, and downstream Phase B2 multi-RS validators get a clean contract.

Closes #71.

## Design notes

- **No inheritance at the issuer**: `vault:admin` declared does NOT cover requested `vault:read`. Inheritance is the resource server's call (vault enforces `admin ⊇ write ⊇ read` at request time, oauth-scopes.md). The issuer signs exactly what the consent screen showed.
- **Refresh-token flow not gated** in this PR — refresh tokens carry already-validated scopes from their original auth-code grant. Adding a gate there would silently break refresh-flows for tokens issued before the registry tightens. Out of scope; revisit if needed.
- **Per-token-request resolution**, not cached: services.json + module.json lookups cost a few ms at launch scale (<10 services), and stale-cache bugs are days-to-debug. Re-read each call.

## Test plan

- [x] `bun test` — 623 pass (was 604, +16 scope-registry +3 oauth-handlers, no regressions)
- [x] `bun run typecheck` clean
- [x] `bunx biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)