### PR TITLE
fix(oauth): set iss claim on all hub-issued JWTs (closes #77)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.2",
+  "version": "0.4.0-rc.3",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/jwt-sign.test.ts
+++ b/src/__tests__/jwt-sign.test.ts
@@ -37,6 +37,7 @@ describe("signAccessToken", () => {
         scopes: ["vault.read", "vault.write"],
         audience: "vault",
         clientId: "notes-pwa",
+        issuer: "https://hub.example",
       });
       const header = decodeProtectedHeader(token);
       expect(header.alg).toBe("RS256");
@@ -65,6 +66,7 @@ describe("signAccessToken", () => {
         scopes: ["vault.read"],
         audience: "vault",
         clientId: "c",
+        issuer: "https://hub.example",
       });
       const count = (
         db.query<{ n: number }, []>("SELECT COUNT(*) AS n FROM tokens").get() ?? {
@@ -72,6 +74,43 @@ describe("signAccessToken", () => {
         }
       ).n;
       expect(count).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("sets `iss` claim from opts.issuer (closes #77)", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const issuer = "http://127.0.0.1:1939";
+      const { token } = await signAccessToken(db, {
+        sub: "user-1",
+        scopes: ["vault.read"],
+        audience: "vault",
+        clientId: "c",
+        issuer,
+      });
+      const payload = decodeJwt(token);
+      expect(payload.iss).toBe(issuer);
+      // Validation accepts the matching issuer.
+      const { payload: validated } = await validateAccessToken(db, token, issuer);
+      expect(validated.iss).toBe(issuer);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("validateAccessToken rejects a token with a mismatched iss (defense in depth)", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const { token } = await signAccessToken(db, {
+        sub: "user-1",
+        scopes: [],
+        audience: "vault",
+        clientId: "c",
+        issuer: "http://127.0.0.1:1939",
+      });
+      await expect(validateAccessToken(db, token, "https://other.example")).rejects.toThrow();
     } finally {
       cleanup();
     }
@@ -174,6 +213,7 @@ describe("validateAccessToken", () => {
         scopes: ["s"],
         audience: "vault",
         clientId: "c",
+        issuer: "https://hub.example",
       });
       const { payload, kid } = await validateAccessToken(db, token);
       expect(payload.sub).toBe("u");
@@ -191,6 +231,7 @@ describe("validateAccessToken", () => {
         scopes: [],
         audience: "vault",
         clientId: "c",
+        issuer: "https://hub.example",
       });
       // Rotate — old key becomes retired but stays in JWKS for 24h.
       rotateSigningKey(db);
@@ -209,6 +250,7 @@ describe("validateAccessToken", () => {
         scopes: [],
         audience: "vault",
         clientId: "c",
+        issuer: "https://hub.example",
       });
       // Force the prior active key past 24h retention.
       const past = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -393,10 +393,12 @@ describe("handleToken — full OAuth dance", () => {
       expect(tokenBody.refresh_token.length).toBeGreaterThan(20);
 
       // JWT must verify against the hub's signing keys, with the right sub +
-      // aud (vault:read → "vault").
-      const { payload } = await validateAccessToken(db, tokenBody.access_token);
+      // aud (vault:read → "vault") and iss matching the configured issuer
+      // (closes #77 — vault rejects tokens with a missing or mismatched iss).
+      const { payload } = await validateAccessToken(db, tokenBody.access_token, ISSUER);
       expect(payload.sub).toBe(user.id);
       expect(payload.aud).toBe("vault");
+      expect(payload.iss).toBe(ISSUER);
       expect(payload.scope).toBe("vault:read");
       expect(payload.client_id).toBe(reg.client.clientId);
     } finally {

--- a/src/__tests__/operator-token.test.ts
+++ b/src/__tests__/operator-token.test.ts
@@ -28,6 +28,8 @@ function makeHarness(): Harness {
   return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
 }
 
+const TEST_ISSUER = "http://127.0.0.1:1939";
+
 describe("mintOperatorToken", () => {
   test("returns a JWT with operator audience, broad scopes, and ~1y TTL", async () => {
     const h = makeHarness();
@@ -36,12 +38,14 @@ describe("mintOperatorToken", () => {
       try {
         rotateSigningKey(db);
         const minted = await mintOperatorToken(db, "user-abc", {
+          issuer: TEST_ISSUER,
           now: () => new Date("2026-04-26T00:00:00Z"),
         });
         expect(minted.token.split(".")).toHaveLength(3);
-        const validated = await validateAccessToken(db, minted.token);
+        const validated = await validateAccessToken(db, minted.token, TEST_ISSUER);
         expect(validated.payload.sub).toBe("user-abc");
         expect(validated.payload.aud).toBe(OPERATOR_TOKEN_AUDIENCE);
+        expect(validated.payload.iss).toBe(TEST_ISSUER);
         expect(validated.payload.scope).toBe(OPERATOR_TOKEN_SCOPES.join(" "));
         const exp = validated.payload.exp ?? 0;
         const iat = validated.payload.iat ?? 0;
@@ -115,12 +119,16 @@ describe("issueOperatorToken", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
-        const issued = await issueOperatorToken(db, "user-xyz", { dir: h.dir });
+        const issued = await issueOperatorToken(db, "user-xyz", {
+          dir: h.dir,
+          issuer: TEST_ISSUER,
+        });
         expect(issued.path).toBe(join(h.dir, OPERATOR_TOKEN_FILENAME));
         const fromDisk = await readOperatorTokenFile(h.dir);
         expect(fromDisk).toBe(issued.token);
-        const validated = await validateAccessToken(db, issued.token);
+        const validated = await validateAccessToken(db, issued.token, TEST_ISSUER);
         expect(validated.payload.sub).toBe("user-xyz");
+        expect(validated.payload.iss).toBe(TEST_ISSUER);
       } finally {
         db.close();
       }

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -16,8 +16,13 @@
  *   - `2fa` — TOTP enroll/disable/backup-codes.
  */
 
+import { join } from "node:path";
 import { createInterface } from "node:readline/promises";
+import { CONFIG_DIR } from "../config.ts";
+import { readExposeState } from "../expose-state.ts";
+import { HUB_DEFAULT_PORT, readHubPort } from "../hub-control.ts";
 import { openHubDb } from "../hub-db.ts";
+import { deriveHubOrigin } from "../hub-origin.ts";
 import { issueOperatorToken } from "../operator-token.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 import {
@@ -104,6 +109,34 @@ export interface AuthDeps {
    * `configDir()` (i.e. `~/.parachute/`). Tests point at a tmp dir.
    */
   configDir?: string;
+  /**
+   * Override the hub origin written into the operator token's `iss` claim.
+   * When unset, derived from `expose-state.json` → hub.port → canonical
+   * `http://127.0.0.1:1939`, mirroring the resolution `parachute start` uses
+   * for `PARACHUTE_HUB_ORIGIN` so the token's iss matches what services see.
+   */
+  hubOrigin?: string;
+}
+
+/**
+ * Resolve the hub origin used as `iss` for operator tokens. Mirrors
+ * lifecycle.resolveHubOrigin's order, but falls back to the canonical
+ * loopback (`http://127.0.0.1:1939`) instead of `undefined` — operator
+ * tokens MUST carry an issuer, and on first-run before any expose has
+ * happened the canonical loopback is what services will validate against.
+ */
+function resolveHubIssuer(override: string | undefined, configDir: string): string {
+  if (override) {
+    const fromOverride = deriveHubOrigin({ override });
+    if (fromOverride) return fromOverride;
+  }
+  const state = readExposeState(join(configDir, "expose-state.json"));
+  if (state?.hubOrigin) return state.hubOrigin;
+  const exposeFqdn = state?.canonicalFqdn;
+  return (
+    deriveHubOrigin({ exposeFqdn, hubPort: readHubPort(configDir) }) ??
+    `http://127.0.0.1:${HUB_DEFAULT_PORT}`
+  );
 }
 
 function defaultRotateKey(): { kid: string; createdAt: string } {
@@ -262,7 +295,10 @@ async function runSetPassword(args: readonly string[], deps: AuthDeps): Promise<
       if (target) {
         await setPassword(db, target.id, password);
         console.log(`Updated password for "${target.username}".`);
-        const issued = await issueOperatorToken(db, target.id, { dir: deps.configDir });
+        const issued = await issueOperatorToken(db, target.id, {
+          dir: deps.configDir,
+          issuer: resolveHubIssuer(deps.hubOrigin, deps.configDir ?? CONFIG_DIR),
+        });
         console.log(`Refreshed operator token at ${issued.path}.`);
         return 0;
       }
@@ -288,7 +324,10 @@ async function runSetPassword(args: readonly string[], deps: AuthDeps): Promise<
     try {
       const u = await createUser(db, targetUsername, password, { allowMulti: flags.allowMulti });
       console.log(`Created hub user "${u.username}" (id=${u.id}).`);
-      const issued = await issueOperatorToken(db, u.id, { dir: deps.configDir });
+      const issued = await issueOperatorToken(db, u.id, {
+        dir: deps.configDir,
+        issuer: resolveHubIssuer(deps.hubOrigin, deps.configDir ?? CONFIG_DIR),
+      });
       console.log(`Wrote operator token to ${issued.path} (mode 0600).`);
       return 0;
     } catch (err) {
@@ -318,7 +357,10 @@ async function runRotateOperator(deps: AuthDeps): Promise<number> {
       );
       return 1;
     }
-    const issued = await issueOperatorToken(db, owner.id, { dir: deps.configDir });
+    const issued = await issueOperatorToken(db, owner.id, {
+      dir: deps.configDir,
+      issuer: resolveHubIssuer(deps.hubOrigin, deps.configDir ?? CONFIG_DIR),
+    });
     console.log("Rotated operator token.");
     console.log(`  user:       ${owner.username}`);
     console.log(`  path:       ${issued.path}`);

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -40,6 +40,13 @@ export interface SignAccessTokenOpts {
   /** Module short name (vault, notes, …) or "hub" — sets `aud`. */
   audience: string;
   clientId: string;
+  /**
+   * Hub origin — sets the `iss` claim. Required: every consumer (vault,
+   * scribe, channel) validates `iss` against `PARACHUTE_HUB_ORIGIN`, and a
+   * missing claim is rejected. Callers derive this via `deriveHubOrigin()`
+   * or thread it from `OAuthDeps.issuer`.
+   */
+  issuer: string;
   /** Override the jti (defaults to random base64url(16)). Used by tests. */
   jti?: string;
   /**
@@ -72,6 +79,7 @@ export async function signAccessToken(
   })
     .setProtectedHeader({ alg: SIGNING_ALGORITHM, kid: key.kid })
     .setSubject(opts.sub)
+    .setIssuer(opts.issuer)
     .setIssuedAt(iat)
     .setExpirationTime(exp)
     .setAudience(opts.audience)
@@ -127,10 +135,16 @@ export interface ValidatedAccessToken {
  * up the matching key from `signing_keys`. Active + recently-retired keys
  * (whatever's in JWKS) are accepted; older retired keys throw. Expiry is
  * checked by `jose` automatically.
+ *
+ * Pass `expectedIssuer` to enforce that the JWT's `iss` claim matches what
+ * this hub advertises — the same check vault performs against its own
+ * `PARACHUTE_HUB_ORIGIN`. Defense in depth: tokens forged or replayed from
+ * a different issuer get rejected at validation as well as issuance.
  */
 export async function validateAccessToken(
   db: Database,
   token: string,
+  expectedIssuer?: string,
 ): Promise<ValidatedAccessToken> {
   const header = decodeProtectedHeader(token);
   const kid = header.kid;
@@ -138,7 +152,11 @@ export async function validateAccessToken(
   const match = getAllPublicKeys(db).find((k) => k.kid === kid);
   if (!match) throw new Error(`validateAccessToken: unknown or expired kid ${kid}`);
   const pub = await importSPKI(match.publicKeyPem, SIGNING_ALGORITHM);
-  const { payload } = await jwtVerify(token, pub);
+  const { payload } = await jwtVerify(
+    token,
+    pub,
+    expectedIssuer ? { issuer: expectedIssuer } : undefined,
+  );
   return { payload, kid };
 }
 

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -421,6 +421,7 @@ async function handleTokenAuthorizationCode(
     scopes: redeemed.scopes,
     audience,
     clientId: redeemed.clientId,
+    issuer: deps.issuer,
     now: deps.now,
   });
   const refresh = signRefreshToken(db, {
@@ -487,6 +488,7 @@ async function handleTokenRefresh(
     scopes: row.scopes,
     audience,
     clientId: row.clientId,
+    issuer: deps.issuer,
     now: deps.now,
   });
   const refresh = signRefreshToken(db, {

--- a/src/operator-token.ts
+++ b/src/operator-token.ts
@@ -35,6 +35,13 @@ export function operatorTokenPath(dir: string = configDir()): string {
 }
 
 export interface MintOperatorTokenOpts {
+  /**
+   * Hub origin — written into the JWT's `iss` claim. On-box services
+   * (vault, scribe, channel) reject tokens whose `iss` doesn't match the
+   * `PARACHUTE_HUB_ORIGIN` they were started with. Callers derive this via
+   * `deriveHubOrigin()`.
+   */
+  issuer: string;
   /** Override the JWT-sign clock — tests pin time. */
   now?: () => Date;
   /** Override the random jti — tests pin it. */
@@ -46,13 +53,14 @@ export interface MintOperatorTokenOpts {
 export async function mintOperatorToken(
   db: Database,
   userId: string,
-  opts: MintOperatorTokenOpts = {},
+  opts: MintOperatorTokenOpts,
 ): Promise<{ token: string; jti: string; expiresAt: string }> {
   return signAccessToken(db, {
     sub: userId,
     scopes: OPERATOR_TOKEN_SCOPES,
     audience: opts.audience ?? OPERATOR_TOKEN_AUDIENCE,
     clientId: OPERATOR_TOKEN_CLIENT_ID,
+    issuer: opts.issuer,
     ttlSeconds: OPERATOR_TOKEN_TTL_SECONDS,
     ...(opts.jti !== undefined ? { jti: opts.jti } : {}),
     ...(opts.now !== undefined ? { now: opts.now } : {}),
@@ -107,7 +115,7 @@ export interface IssueOperatorTokenResult {
 export async function issueOperatorToken(
   db: Database,
   userId: string,
-  opts: MintOperatorTokenOpts & { dir?: string } = {},
+  opts: MintOperatorTokenOpts & { dir?: string },
 ): Promise<IssueOperatorTokenResult> {
   const minted = await mintOperatorToken(db, userId, opts);
   const path = await writeOperatorTokenFile(minted.token, opts.dir);


### PR DESCRIPTION
## Summary

Hotfix for [#77](https://github.com/ParachuteComputer/parachute-hub/issues/77). Every hub-issued JWT was missing the `iss` claim — `signAccessToken` built the SignJWT chain with sub/aud/jti/iat/exp but never called `.setIssuer()`. Vault's `validateHubJwt` requires `iss` and rejects tokens missing it, so the entire cli#58 cascade was non-functional in production despite green tests. The gap hid because every hub-side test validated tokens against the hub itself, which didn't enforce `iss`.

- `SignAccessTokenOpts` gains a required `issuer: string`; chain calls `.setIssuer(opts.issuer)`.
- `mintOperatorToken` / `issueOperatorToken` require an issuer; `auth.ts` derives it via `resolveHubIssuer` (same shape as `lifecycle.resolveHubOrigin` but with an `http://127.0.0.1:1939` fallback so first-run operator tokens always have an issuer).
- `handleTokenAuthorizationCode` and `handleTokenRefresh` thread `deps.issuer` through.
- `validateAccessToken` accepts an optional `expectedIssuer` — defense in depth so the hub also rejects mismatched-iss tokens.

Bump `0.4.0-rc.1` → `0.4.0-rc.3` (rc.2 is reserved for in-flight scope-validation PR #76).

## Test plan

- [x] `bun run typecheck`
- [x] `bun test` — 606 pass / 0 fail
- [x] `bunx biome check .` — clean
- [x] New `signAccessToken` test asserts `payload.iss` round-trips
- [x] New `validateAccessToken` test asserts mismatched-iss rejection
- [x] `mintOperatorToken` test now validates with `expectedIssuer`
- [x] OAuth handler round-trip asserts `payload.iss === ISSUER`
- [ ] Aaron retests end-to-end against vault — operator token + OAuth user token both accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)