### PR TITLE
fix(oauth): set services catalog on /oauth/token response (closes #81)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.3",
+  "version": "0.4.0-rc.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -902,6 +902,26 @@ describe("handleToken — full OAuth dance", () => {
     // hub-only scopes don't reference any installed module catalog entry.
     expect(buildServicesCatalog(FIXTURE_MANIFEST, ISSUER, ["hub:admin"])).toEqual({});
   });
+
+  // closes #81 — vault URL must follow paths[0] from services.json, NOT a
+  // hardcoded `/vault/default`. Users who installed with `--vault-name work`
+  // have `paths: ["/vault/work"]` and the catalog must reflect that.
+  test("services catalog reads paths[0] verbatim — handles custom vault names", () => {
+    const customManifest: ServicesManifest = {
+      services: [
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/work"],
+          health: "/health",
+          version: "0.3.0",
+        },
+      ],
+    };
+    expect(buildServicesCatalog(customManifest, ISSUER, ["vault:read"])).toEqual({
+      vault: { url: `${ISSUER}/vault/work`, version: "0.3.0" },
+    });
+  });
 });
 
 describe("handleRegister — RFC 7591 DCR", () => {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -8,11 +8,13 @@ import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { validateAccessToken } from "../jwt-sign.ts";
 import {
   authorizationServerMetadata,
+  buildServicesCatalog,
   handleAuthorizeGet,
   handleAuthorizePost,
   handleRegister,
   handleToken,
 } from "../oauth-handlers.ts";
+import type { ServicesManifest } from "../services-manifest.ts";
 import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
 import { createUser } from "../users.ts";
 
@@ -40,6 +42,36 @@ function authorizeUrl(params: Record<string, string>): string {
   const u = new URL("/oauth/authorize", ISSUER);
   for (const [k, v] of Object.entries(params)) u.searchParams.set(k, v);
   return u.toString();
+}
+
+const FIXTURE_MANIFEST: ServicesManifest = {
+  services: [
+    {
+      name: "parachute-vault",
+      port: 1940,
+      paths: ["/vault/default"],
+      health: "/health",
+      version: "0.3.0",
+    },
+    {
+      name: "parachute-scribe",
+      port: 1943,
+      paths: ["/scribe"],
+      health: "/health",
+      version: "0.3.0-rc.1",
+    },
+    {
+      name: "parachute-notes",
+      port: 1942,
+      paths: ["/notes"],
+      health: "/notes/health",
+      version: "0.3.0",
+    },
+  ],
+};
+
+function fixtureLoadServicesManifest(): ServicesManifest {
+  return FIXTURE_MANIFEST;
 }
 
 describe("authorizationServerMetadata", () => {
@@ -379,7 +411,10 @@ describe("handleToken — full OAuth dance", () => {
         body: tokenForm,
         headers: { "content-type": "application/x-www-form-urlencoded" },
       });
-      const tokenRes = await handleToken(db, tokenReq, { issuer: ISSUER });
+      const tokenRes = await handleToken(db, tokenReq, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
       expect(tokenRes.status).toBe(200);
       const tokenBody = (await tokenRes.json()) as {
         access_token: string;
@@ -387,6 +422,7 @@ describe("handleToken — full OAuth dance", () => {
         token_type: string;
         expires_in: number;
         scope: string;
+        services: Record<string, { url: string; version: string }>;
       };
       expect(tokenBody.token_type).toBe("Bearer");
       expect(tokenBody.scope).toBe("vault:read");
@@ -401,6 +437,13 @@ describe("handleToken — full OAuth dance", () => {
       expect(payload.iss).toBe(ISSUER);
       expect(payload.scope).toBe("vault:read");
       expect(payload.client_id).toBe(reg.client.clientId);
+
+      // closes #81 — services catalog tells the client where vault lives so
+      // notes doesn't have to re-probe /.well-known/parachute.json. A
+      // vault:read token only sees the vault entry.
+      expect(tokenBody.services).toEqual({
+        vault: { url: `${ISSUER}/vault/default`, version: "0.3.0" },
+      });
     } finally {
       cleanup();
     }
@@ -779,6 +822,85 @@ describe("handleToken — full OAuth dance", () => {
     } finally {
       cleanup();
     }
+  });
+
+  // closes #81 — services-catalog filtering + multi-service shape.
+  test("services catalog omits services the token has no scope for", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { verifier, challenge } = makePkce();
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "scribe:transcribe",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const consentRes = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: buildSessionCookie(session.id, 86400),
+          },
+        }),
+        { issuer: ISSUER },
+      );
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const tokenForm = new URLSearchParams({
+        grant_type: "authorization_code",
+        code: code ?? "",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        code_verifier: verifier,
+      });
+      const res = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: tokenForm,
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        services: Record<string, { url: string; version: string }>;
+      };
+      expect(body.services).toEqual({
+        scribe: { url: `${ISSUER}/scribe`, version: "0.3.0-rc.1" },
+      });
+      expect(body.services.vault).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("services catalog includes every service the token has a scope for", async () => {
+    // buildServicesCatalog is a pure helper — exercise the multi-scope shape
+    // here without re-running the full PKCE dance.
+    const catalog = buildServicesCatalog(FIXTURE_MANIFEST, ISSUER, [
+      "vault:read",
+      "scribe:transcribe",
+    ]);
+    expect(catalog).toEqual({
+      vault: { url: `${ISSUER}/vault/default`, version: "0.3.0" },
+      scribe: { url: `${ISSUER}/scribe`, version: "0.3.0-rc.1" },
+    });
+  });
+
+  test("services catalog is empty when the token has no resource-prefixed scopes", () => {
+    expect(buildServicesCatalog(FIXTURE_MANIFEST, ISSUER, [])).toEqual({});
+    // hub-only scopes don't reference any installed module catalog entry.
+    expect(buildServicesCatalog(FIXTURE_MANIFEST, ISSUER, ["hub:admin"])).toEqual({});
   });
 });
 

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -94,15 +94,23 @@ export type ServicesCatalog = Record<string, ServicesCatalogEntry>;
  * version, so OAuth clients don't have to re-probe `/.well-known/parachute.json`
  * to know where vault lives.
  *
+ * URL source: `entry.paths[0]` from services.json verbatim — never hardcode
+ * `/vault/default`. Users who installed with `parachute install vault
+ * --vault-name work` have `paths: ["/vault/work"]` in their manifest, and the
+ * catalog URL must follow that. The custom-vault-name regression test in
+ * oauth-handlers.test.ts pins this.
+ *
  * Filtering: only services for which the token has at least one scope are
  * included. A scope `vault:read` admits the `vault` service; a token with only
  * `scribe:transcribe` gets a catalog with no vault entry. The check is on the
  * audience prefix (`<aud>:<verb>`) — same shape `inferAudience` uses.
  *
  * Multi-vault: Phase 1 collapses every vault entry under the single key
- * `vault`, using the first matching `parachute-vault*` row from services.json.
- * Per-vault keys (`services.vault.work.url` etc.) are deferred to a future
- * design once notes ships its vault picker.
+ * `vault`, first matching `parachute-vault*` row wins. Per-vault keys
+ * (`services.vault.work.url` or `services["vault:work"].url`) are deferred
+ * to a future design once notes ships its vault picker; multi-vault clients
+ * need to probe `/.well-known/parachute.json` for the full vaults array
+ * until then.
  */
 export function buildServicesCatalog(
   manifest: ServicesManifest,

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -47,6 +47,10 @@ import { type AuthorizeFormParams, renderConsent, renderError, renderLogin } fro
 import { FIRST_PARTY_SCOPES } from "./scope-explanations.ts";
 import { findUnknownScopes, loadDeclaredScopes } from "./scope-registry.ts";
 import {
+  type ServicesManifest,
+  readManifest as readServicesManifest,
+} from "./services-manifest.ts";
+import {
   SESSION_TTL_MS,
   buildSessionCookie,
   createSession,
@@ -54,6 +58,7 @@ import {
   parseSessionCookie,
 } from "./sessions.ts";
 import { getUserByUsername, verifyPassword } from "./users.ts";
+import { isVaultEntry, shortName } from "./well-known.ts";
 
 export interface OAuthDeps {
   /** Hub origin used for `iss`, `authorization_endpoint`, etc. */
@@ -68,6 +73,57 @@ export interface OAuthDeps {
    * See cli#71 + `oauth-scopes.md`.
    */
   loadDeclaredScopes?: () => ReadonlySet<string>;
+  /**
+   * Resolve the installed-services manifest used to populate the `services`
+   * catalog in /oauth/token responses (cli#81). Production reads
+   * `~/.parachute/services.json`; tests inject a fixture.
+   */
+  loadServicesManifest?: () => ServicesManifest;
+}
+
+export interface ServicesCatalogEntry {
+  url: string;
+  version: string;
+}
+
+export type ServicesCatalog = Record<string, ServicesCatalogEntry>;
+
+/**
+ * Build the `services` map embedded in /oauth/token responses. Each entry maps
+ * a short service name (`vault`, `scribe`, `notes`, …) to its absolute URL +
+ * version, so OAuth clients don't have to re-probe `/.well-known/parachute.json`
+ * to know where vault lives.
+ *
+ * Filtering: only services for which the token has at least one scope are
+ * included. A scope `vault:read` admits the `vault` service; a token with only
+ * `scribe:transcribe` gets a catalog with no vault entry. The check is on the
+ * audience prefix (`<aud>:<verb>`) — same shape `inferAudience` uses.
+ *
+ * Multi-vault: Phase 1 collapses every vault entry under the single key
+ * `vault`, using the first matching `parachute-vault*` row from services.json.
+ * Per-vault keys (`services.vault.work.url` etc.) are deferred to a future
+ * design once notes ships its vault picker.
+ */
+export function buildServicesCatalog(
+  manifest: ServicesManifest,
+  issuer: string,
+  scopes: readonly string[],
+): ServicesCatalog {
+  const audiences = new Set<string>();
+  for (const s of scopes) {
+    const colon = s.indexOf(":");
+    if (colon > 0) audiences.add(s.slice(0, colon));
+  }
+  const base = issuer.replace(/\/$/, "");
+  const catalog: ServicesCatalog = {};
+  for (const entry of manifest.services) {
+    const path = entry.paths[0] ?? "/";
+    const key = isVaultEntry(entry) ? "vault" : shortName(entry.name);
+    if (!audiences.has(key)) continue;
+    if (catalog[key]) continue; // first vault wins; deterministic for clients
+    catalog[key] = { url: `${base}${path}`, version: entry.version };
+  }
+  return catalog;
 }
 
 // --- helpers ---------------------------------------------------------------
@@ -431,12 +487,18 @@ async function handleTokenAuthorizationCode(
     scopes: redeemed.scopes,
     now: deps.now,
   });
+  const services = buildServicesCatalog(
+    (deps.loadServicesManifest ?? readServicesManifest)(),
+    deps.issuer,
+    redeemed.scopes,
+  );
   return jsonResponse({
     access_token: access.token,
     token_type: "Bearer",
     expires_in: ACCESS_TOKEN_TTL_SECONDS,
     refresh_token: refresh.token,
     scope: redeemed.scopes.join(" "),
+    services,
   });
 }
 
@@ -498,12 +560,18 @@ async function handleTokenRefresh(
     scopes: row.scopes,
     now: deps.now,
   });
+  const services = buildServicesCatalog(
+    (deps.loadServicesManifest ?? readServicesManifest)(),
+    deps.issuer,
+    row.scopes,
+  );
   return jsonResponse({
     access_token: access.token,
     token_type: "Bearer",
     expires_in: ACCESS_TOKEN_TTL_SECONDS,
     refresh_token: refresh.token,
     scope: row.scopes.join(" "),
+    services,
   });
 }
 


### PR DESCRIPTION
## Summary

- Both `/oauth/token` grant paths (`authorization_code` + `refresh_token`) now return `services: {<short>: {url, version}}` alongside the access + refresh tokens.
- Catalog is built by reading `~/.parachute/services.json` (overridable via `OAuthDeps.loadServicesManifest` for tests), then filtered by the token's scopes — a `scribe:transcribe`-only token gets no `vault` entry.
- Multi-vault: every `parachute-vault*` entry collapses under the single key `vault`, first match wins. Per-vault keys are deferred to a separate design.
- Bump 0.4.0-rc.3 → 0.4.0-rc.4.

## Why

notes#79 reads `token.services?.vault?.url` to know which vault URL to call. When undefined, it falls back to the bare hub origin and calls `<hub>/api/notes` — vault is at `<hub>/vault/default/api/notes`, so every notes-via-OAuth request 404s. Smoke-tested 2026-04-27.

## Test plan

- [x] `bun test src/__tests__/oauth-handlers.test.ts` — 26 pass (round-trip asserts the catalog shape; new tests cover scope filtering + multi-service + empty catalog).
- [x] `bun test` — 628 pass / 0 fail.
- [x] `bun run typecheck` — clean.
- [x] `bunx biome check .` — clean.
- [ ] End-to-end smoke against notes#79 once published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)