### PR TITLE
feat(lifecycle): third-party modules via installDir + module.json (closes #83)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.4",
+  "version": "0.4.0-rc.5",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -1258,9 +1258,44 @@ describe("install", () => {
       expect(calls[0]).toEqual(["bun", "add", "-g", pkgDir]);
       const seeded = findService("@local/demo", path);
       expect(seeded?.name).toBe("@local/demo");
+      // hub#83: lifecycle needs installDir to find module.json + spawn cwd.
+      expect(seeded?.installDir).toBe(pkgDir);
     } finally {
       cleanup();
       rmSync(pkgDir, { recursive: true, force: true });
+    }
+  });
+
+  test("npm-installed third-party module persists installDir from bun globals", async () => {
+    // hub#83: for `parachute install <npm-pkg>`, installDir is dirname of
+    // the package.json that findGlobalInstall returns. Without this,
+    // lifecycle has no way to locate the module's `.parachute/module.json`
+    // and third-party `parachute start <name>` fails post-install.
+    const { path, cleanup } = makeTempPath();
+    try {
+      const fakePrefix = "/fake/bun-globals/node_modules/@vendor/widget";
+      const code = await install("@vendor/widget", {
+        runner: async () => 0,
+        manifestPath: path,
+        startService: async () => 0,
+        isLinked: () => false,
+        portProbe: async () => false,
+        log: () => {},
+        readManifest: async () => ({
+          name: "widget",
+          manifestName: "@vendor/widget",
+          kind: "api",
+          port: 1952,
+          paths: ["/widget"],
+          health: "/widget/health",
+        }),
+        findGlobalInstall: () => `${fakePrefix}/package.json`,
+      });
+      expect(code).toBe(0);
+      const seeded = findService("@vendor/widget", path);
+      expect(seeded?.installDir).toBe(fakePrefix);
+    } finally {
+      cleanup();
     }
   });
 

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { logs, restart, start, stop } from "../commands/lifecycle.ts";
@@ -48,12 +48,62 @@ function seedNotes(manifestPath: string): void {
   );
 }
 
+interface ThirdPartySeed {
+  installDir: string;
+  manifestName?: string;
+  startCmd?: readonly string[];
+  port?: number;
+}
+
+/**
+ * Seed a third-party services.json row + write a `.parachute/module.json` at
+ * `installDir`. Mirrors what `parachute install /tmp/foo` produces in
+ * production: row carries `installDir`, lifecycle resolves spec from the
+ * filesystem.
+ */
+function seedThirdParty(
+  manifestPath: string,
+  configDirRoot: string,
+  name: string,
+  opts: ThirdPartySeed,
+): string {
+  const installDir = opts.installDir;
+  mkdirSync(join(installDir, ".parachute"), { recursive: true });
+  const manifest = {
+    name,
+    manifestName: opts.manifestName ?? name,
+    kind: "api" as const,
+    port: opts.port ?? 1944,
+    paths: [`/${name}`],
+    health: `/${name}/health`,
+    ...(opts.startCmd ? { startCmd: opts.startCmd } : {}),
+  };
+  writeFileSync(join(installDir, ".parachute", "module.json"), JSON.stringify(manifest));
+  upsertService(
+    {
+      name: opts.manifestName ?? name,
+      port: opts.port ?? 1944,
+      paths: [`/${name}`],
+      health: `/${name}/health`,
+      version: "0.0.1",
+      installDir,
+    },
+    manifestPath,
+  );
+  return configDirRoot;
+}
+
 interface SpawnerStub {
-  spawn: (cmd: readonly string[], logFile: string, env?: Record<string, string>) => number;
+  spawn: (
+    cmd: readonly string[],
+    logFile: string,
+    opts?: { env?: Record<string, string>; cwd?: string },
+  ) => number;
   calls: Array<{
     cmd: readonly string[];
     logFile: string;
     env?: Record<string, string>;
+    cwd?: string;
   }>;
 }
 
@@ -62,12 +112,13 @@ function makeSpawner(pidSequence: number[]): SpawnerStub {
     cmd: readonly string[];
     logFile: string;
     env?: Record<string, string>;
+    cwd?: string;
   }> = [];
   let i = 0;
   return {
     calls,
-    spawn(cmd, logFile, env) {
-      calls.push({ cmd: [...cmd], logFile, env });
+    spawn(cmd, logFile, opts) {
+      calls.push({ cmd: [...cmd], logFile, env: opts?.env, cwd: opts?.cwd });
       return pidSequence[i++] ?? 99999;
     },
   };
@@ -428,6 +479,141 @@ describe("parachute start", () => {
       h.cleanup();
     }
   });
+
+  test("third-party module starts via installDir module.json with cwd", async () => {
+    // hub#83: services.json rows that carry installDir resolve their spec
+    // from `<installDir>/.parachute/module.json` at lifecycle time. Spawn
+    // gets cwd=installDir so manifest-declared relative paths work.
+    const h = makeHarness();
+    try {
+      const installDir = join(h.configDir, "_pkg-claw");
+      seedThirdParty(h.manifestPath, h.configDir, "claw", {
+        installDir,
+        startCmd: ["bun", "web/server/src/server.ts"],
+        port: 1944,
+      });
+      const spawner = makeSpawner([8080]);
+      const code = await start("claw", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(spawner.calls).toHaveLength(1);
+      expect(spawner.calls[0]?.cmd).toEqual(["bun", "web/server/src/server.ts"]);
+      expect(spawner.calls[0]?.cwd).toBe(installDir);
+      expect(readPid("claw", h.configDir)).toBe(8080);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("third-party with no installDir errors as unknown service", async () => {
+    // A row whose name isn't a known short name AND has no installDir is
+    // unmanageable — we have no way to find a spec for it.
+    const h = makeHarness();
+    try {
+      upsertService(
+        {
+          name: "mystery",
+          port: 1944,
+          paths: ["/mystery"],
+          health: "/mystery/health",
+          version: "0.0.1",
+        },
+        h.manifestPath,
+      );
+      const lines: string[] = [];
+      const code = await start("mystery", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => lines.push(l),
+      });
+      expect(code).toBe(1);
+      expect(lines.join("\n")).toMatch(/unknown service "mystery"/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("start (no svc) sweeps both first-party and third-party rows", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const installDir = join(h.configDir, "_pkg-claw");
+      seedThirdParty(h.manifestPath, h.configDir, "claw", {
+        installDir,
+        startCmd: ["bun", "server.ts"],
+        port: 1944,
+      });
+      const spawner = makeSpawner([4242, 8080]);
+      const code = await start(undefined, {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(spawner.calls).toHaveLength(2);
+      const cmds = spawner.calls.map((c) => c.cmd);
+      expect(cmds).toContainEqual(["parachute-vault", "serve"]);
+      expect(cmds).toContainEqual(["bun", "server.ts"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("third-party with malformed module.json fails clearly", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.configDir, "_pkg-broken");
+      mkdirSync(join(installDir, ".parachute"), { recursive: true });
+      writeFileSync(join(installDir, ".parachute", "module.json"), "{ not valid json");
+      upsertService(
+        {
+          name: "broken",
+          port: 1944,
+          paths: ["/broken"],
+          health: "/broken/health",
+          version: "0.0.1",
+          installDir,
+        },
+        h.manifestPath,
+      );
+      const lines: string[] = [];
+      const code = await start("broken", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => lines.push(l),
+      });
+      expect(code).toBe(1);
+      expect(lines.join("\n")).toMatch(/broken: invalid module\.json/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("third-party with no startCmd in module.json reports lifecycle-unsupported", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.configDir, "_pkg-noop");
+      seedThirdParty(h.manifestPath, h.configDir, "noop", {
+        installDir,
+        port: 1945,
+      });
+      const lines: string[] = [];
+      const code = await start("noop", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => lines.push(l),
+      });
+      expect(code).toBe(1);
+      expect(lines.join("\n")).toMatch(/lifecycle not yet supported/);
+    } finally {
+      h.cleanup();
+    }
+  });
 });
 
 describe("parachute stop", () => {
@@ -601,6 +787,29 @@ describe("parachute logs", () => {
       });
       expect(code).toBe(1);
       expect(lines.join("\n")).toMatch(/unknown service/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("third-party module name with installDir is recognised", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.configDir, "_pkg-claw");
+      seedThirdParty(h.manifestPath, h.configDir, "claw", {
+        installDir,
+        startCmd: ["bun", "server.ts"],
+      });
+      const p = ensureLogPath("claw", h.configDir);
+      writeFileSync(p, "claw line 1\nclaw line 2\n");
+      const lines: string[] = [];
+      const code = await logs("claw", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => lines.push(l),
+      });
+      expect(code).toBe(0);
+      expect(lines).toEqual(["claw line 1", "claw line 2"]);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/services-manifest.test.ts
+++ b/src/__tests__/services-manifest.test.ts
@@ -174,4 +174,26 @@ describe("services-manifest", () => {
       cleanup();
     }
   });
+
+  test("round-trips optional installDir", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const full: ServiceEntry = { ...vault, installDir: "/abs/path/to/pkg" };
+      upsertService(full, path);
+      expect(readManifest(path).services[0]).toEqual(full);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rejects non-string installDir", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      expect(() => upsertService({ ...vault, installDir: 42 as unknown as string }, path)).toThrow(
+        /installDir/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
 });

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -237,6 +237,27 @@ function defaultReadPackageName(absPath: string): string | null {
 }
 
 /**
+ * Resolve the absolute path to the installed package directory. Local-path
+ * installs are their own source. Npm installs land under a bun globals
+ * prefix; we locate via `findGlobalInstall`. Returns null when the dir
+ * can't be located (first-party fallback path: not fatal; third-party:
+ * the manifest read downstream surfaces the error).
+ */
+function resolveInstallDir(
+  target: ResolvedTarget,
+  findGlobalInstall: (pkg: string) => string | null,
+): string | null {
+  if (target.kind === "local-path") {
+    // The local checkout itself is the source. We could also re-read from
+    // bun's globals after install, but reading the original avoids any
+    // weirdness with bun symlinking the dir vs. copying it.
+    return target.absPath;
+  }
+  const pkgJsonPath = findGlobalInstall(target.packageName);
+  return pkgJsonPath ? dirname(pkgJsonPath) : null;
+}
+
+/**
  * Read the installed package's `.parachute/module.json`.
  *
  * Returns `null` when the package doesn't ship one (first-party falls back to
@@ -247,29 +268,18 @@ function defaultReadPackageName(absPath: string): string | null {
  */
 async function readInstalledManifest(
   target: ResolvedTarget,
+  packageDir: string | null,
   deps: {
-    findGlobalInstall: (pkg: string) => string | null;
     readManifest: (packageDir: string) => Promise<ModuleManifest | null>;
     log: (line: string) => void;
   },
 ): Promise<ModuleManifest | null | "error"> {
-  let packageDir: string | null = null;
-  if (target.kind === "local-path") {
-    // The local checkout itself is the source. We could also re-read from
-    // bun's globals after install, but reading the original avoids any
-    // weirdness with bun symlinking the dir vs. copying it.
-    packageDir = target.absPath;
-  } else {
-    const pkgJsonPath = deps.findGlobalInstall(target.packageName);
-    if (!pkgJsonPath) {
-      // First-party fallback path (typical in tests): we don't actually need
-      // a real install dir — the vendored manifest covers us.
-      if (target.kind === "first-party") return null;
-      // Third-party: bun-add succeeded but we couldn't locate the install dir.
-      // Caller already logged a probe-list — just say nothing's there.
-      return null;
-    }
-    packageDir = dirname(pkgJsonPath);
+  if (!packageDir) {
+    // First-party fallback path (typical in tests): we don't actually need
+    // a real install dir — the vendored manifest covers us.
+    // Third-party: bun-add succeeded but we couldn't locate the install dir;
+    // caller already logged a probe-list — just say nothing's there.
+    return null;
   }
   try {
     return await deps.readManifest(packageDir);
@@ -421,8 +431,8 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
   // third-party (npm / local-path) the manifest is the contract — its
   // absence hard-errors here. See
   // `parachute-patterns/patterns/module-json-extensibility.md`.
-  const installedManifest = await readInstalledManifest(target, {
-    findGlobalInstall,
+  const installDir = resolveInstallDir(target, findGlobalInstall);
+  const installedManifest = await readInstalledManifest(target, installDir, {
     readManifest,
     log,
   });
@@ -533,6 +543,17 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
     );
   }
 
+  // Stamp installDir on the row. Lifecycle reads it back to find the
+  // module's `.parachute/module.json` (third-party startCmd) and to spawn
+  // with cwd. Done after seed/port-update so we cover all paths uniformly:
+  // the service's own init may have written the row without installDir, and
+  // the seed itself doesn't carry it (composeServiceSpec → seedEntry uses
+  // the manifest, which doesn't know its own install location).
+  if (entry && installDir && entry.installDir !== installDir) {
+    upsertService({ ...entry, installDir }, manifestPath);
+    entry = findService(spec.manifestName, manifestPath);
+  }
+
   if (!entry) {
     log(
       `Installed, but no services.json entry for "${spec.manifestName}" yet. Run \`parachute status\` after the service has started.`,
@@ -607,7 +628,14 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
   // last line of the install always reflects ground truth, not an early
   // snapshot. Surfaced by parachute-hub#44 — defensive logging that turns a
   // missing entry into a visible failure rather than a silent one.
-  const finalEntry = findService(spec.manifestName, manifestPath);
+  let finalEntry = findService(spec.manifestName, manifestPath);
+  // Re-stamp installDir if the service's first boot rewrote the row without
+  // it. Lifecycle commands beyond install (start/stop/restart/logs) need it
+  // present; we own this field, services don't have to know it exists.
+  if (finalEntry && installDir && finalEntry.installDir !== installDir) {
+    upsertService({ ...finalEntry, installDir }, manifestPath);
+    finalEntry = findService(spec.manifestName, manifestPath);
+  }
   if (!finalEntry) {
     log(
       `⚠ ${spec.manifestName} is not in services.json after install. \`parachute status\` won't see it. Re-run install or file a bug.`,

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -5,6 +5,7 @@ import { readEnvFileValues } from "../env-file.ts";
 import { readExposeState } from "../expose-state.ts";
 import { readHubPort } from "../hub-control.ts";
 import { HUB_ORIGIN_ENV, deriveHubOrigin } from "../hub-origin.ts";
+import { ModuleManifestError } from "../module-manifest.ts";
 import {
   type AliveFn,
   clearPid,
@@ -15,7 +16,13 @@ import {
   readPid,
   writePid,
 } from "../process-state.ts";
-import { getSpec, knownServices, shortNameForManifest } from "../service-spec.ts";
+import {
+  type ServiceSpec,
+  getSpec,
+  getSpecFromInstallDir,
+  knownServices,
+  shortNameForManifest,
+} from "../service-spec.ts";
 import { type ServiceEntry, readManifest } from "../services-manifest.ts";
 
 /**
@@ -26,18 +33,30 @@ import { type ServiceEntry, readManifest } from "../services-manifest.ts";
  * `env`, when provided, is merged into the child's environment on top of the
  * parent's — today's only caller is `start`, which injects
  * PARACHUTE_HUB_ORIGIN so vault's OAuth issuer matches the hub URL.
+ *
+ * `cwd`, when provided, is the child's working directory. Set to the
+ * service's installDir for third-party modules so manifest-declared
+ * relative startCmds (e.g. `["bun", "web/server/src/server.ts"]`) resolve
+ * against the package root.
  */
+export interface SpawnerOptions {
+  env?: Record<string, string>;
+  cwd?: string;
+}
+
 export interface Spawner {
-  spawn(cmd: readonly string[], logFile: string, env?: Record<string, string>): number;
+  spawn(cmd: readonly string[], logFile: string, opts?: SpawnerOptions): number;
 }
 
 export const defaultSpawner: Spawner = {
-  spawn(cmd, logFile, env) {
+  spawn(cmd, logFile, opts) {
     const fd = openSync(logFile, "a");
-    const proc = Bun.spawn([...cmd], {
+    const spawnOpts: Parameters<typeof Bun.spawn>[1] = {
       stdio: ["ignore", fd, fd],
-      env: env ? { ...process.env, ...env } : undefined,
-    });
+    };
+    if (opts?.env) spawnOpts.env = { ...process.env, ...opts.env };
+    if (opts?.cwd) spawnOpts.cwd = opts.cwd;
+    const proc = Bun.spawn([...cmd], spawnOpts);
     proc.unref();
     return proc.pid;
   },
@@ -120,41 +139,92 @@ function resolveHubOrigin(override: string | undefined, configDir: string): stri
   return deriveHubOrigin({ exposeFqdn, hubPort: readHubPort(configDir) });
 }
 
+interface ResolvedTarget {
+  short: string;
+  entry: ServiceEntry;
+  /**
+   * Lifecycle spec resolved at request time. First-party comes from
+   * `getSpec(short)`; third-party comes from
+   * `getSpecFromInstallDir(entry.installDir, ...)`. May be undefined when
+   * a row has neither — lifecycle prints "lifecycle not yet supported"
+   * for that service rather than crashing the whole sweep.
+   */
+  spec: ServiceSpec | undefined;
+}
+
+async function specForEntry(
+  short: string,
+  entry: ServiceEntry,
+): Promise<{ spec: ServiceSpec | undefined; error?: string }> {
+  const firstParty = getSpec(short);
+  if (firstParty) return { spec: firstParty };
+  if (!entry.installDir) return { spec: undefined };
+  try {
+    const spec = await getSpecFromInstallDir(entry.installDir, entry.name);
+    return { spec: spec ?? undefined };
+  } catch (err) {
+    if (err instanceof ModuleManifestError) {
+      return { spec: undefined, error: err.message };
+    }
+    throw err;
+  }
+}
+
 /**
  * Services selected by the `[svc]` positional. `undefined` targets every
- * installed service (looked up via the manifest). Unknown names get a
- * friendly error up front rather than a confusing spawn failure downstream.
+ * manageable service (first-party shortnames OR third-party rows that
+ * carry `installDir`). Unknown names get a friendly error up front rather
+ * than a confusing spawn failure downstream.
+ *
+ * Third-party modules are addressed by the `name` field from their
+ * `module.json` (which is what install copied to `entry.name` for
+ * third-party). First-party are addressed by their short name (vault,
+ * notes, …) and matched via `shortNameForManifest`.
  */
-function resolveTargets(
+async function resolveTargets(
   svc: string | undefined,
   manifestPath: string,
-): { targets: Array<{ short: string; entry: ServiceEntry }> } | { error: string } {
+): Promise<{ targets: ResolvedTarget[] } | { error: string }> {
   const manifest = readManifest(manifestPath);
   if (manifest.services.length === 0) {
     return { error: "No services installed yet. Try: parachute install vault" };
   }
 
   if (svc !== undefined) {
-    const spec = getSpec(svc);
-    if (!spec) {
-      return {
-        error: `unknown service "${svc}". known: ${knownServices().join(", ")}`,
-      };
+    // Try first-party (svc is a short name → known fallback).
+    const firstPartySpec = getSpec(svc);
+    if (firstPartySpec) {
+      const entry = manifest.services.find((s) => s.name === firstPartySpec.manifestName);
+      if (!entry) {
+        return { error: `${svc} isn't installed. Run \`parachute install ${svc}\` first.` };
+      }
+      return { targets: [{ short: svc, entry, spec: firstPartySpec }] };
     }
-    const entry = manifest.services.find((s) => s.name === spec.manifestName);
-    if (!entry) {
-      return {
-        error: `${svc} isn't installed. Run \`parachute install ${svc}\` first.`,
-      };
+    // Third-party: match a services.json row by name. Third-party rows
+    // carry `installDir`; without it we have no way to resolve a spec.
+    const entry = manifest.services.find((s) => s.name === svc);
+    if (entry?.installDir) {
+      const { spec, error } = await specForEntry(svc, entry);
+      if (error) return { error: `${svc}: invalid module.json — ${error}` };
+      return { targets: [{ short: svc, entry, spec }] };
     }
-    return { targets: [{ short: svc, entry }] };
+    return {
+      error: `unknown service "${svc}". known: ${knownServices().join(", ")}`,
+    };
   }
 
-  const targets: Array<{ short: string; entry: ServiceEntry }> = [];
+  const targets: ResolvedTarget[] = [];
   for (const entry of manifest.services) {
     const short = shortNameForManifest(entry.name);
-    if (!short) continue;
-    targets.push({ short, entry });
+    if (short) {
+      const spec = getSpec(short);
+      targets.push({ short, entry, spec });
+      continue;
+    }
+    if (entry.installDir) {
+      const { spec } = await specForEntry(entry.name, entry);
+      targets.push({ short: entry.name, entry, spec });
+    }
   }
   if (targets.length === 0) {
     return { error: "No manageable services in services.json." };
@@ -164,14 +234,14 @@ function resolveTargets(
 
 export async function start(svc: string | undefined, opts: LifecycleOpts = {}): Promise<number> {
   const r = resolve(opts);
-  const picked = resolveTargets(svc, r.manifestPath);
+  const picked = await resolveTargets(svc, r.manifestPath);
   if ("error" in picked) {
     r.log(picked.error);
     return 1;
   }
 
   let failures = 0;
-  for (const { short, entry } of picked.targets) {
+  for (const { short, entry, spec } of picked.targets) {
     const state = processState(short, r.configDir, r.alive);
     if (state.status === "running") {
       r.log(`${short} already running (pid ${state.pid}).`);
@@ -182,7 +252,6 @@ export async function start(svc: string | undefined, opts: LifecycleOpts = {}): 
       clearPid(short, r.configDir);
     }
 
-    const spec = getSpec(short);
     const cmd = spec?.startCmd?.(entry);
     if (!cmd || cmd.length === 0) {
       r.log(`${short}: lifecycle not yet supported for this service.`);
@@ -200,9 +269,16 @@ export async function start(svc: string | undefined, opts: LifecycleOpts = {}): 
     const fileEnv = readEnvFileValues(join(r.configDir, short, ".env"));
     const env: Record<string, string> = { ...fileEnv };
     if (r.hubOrigin) env[HUB_ORIGIN_ENV] = r.hubOrigin;
-    const envForSpawn = Object.keys(env).length > 0 ? env : undefined;
+    const spawnerOpts: { env?: Record<string, string>; cwd?: string } = {};
+    if (Object.keys(env).length > 0) spawnerOpts.env = env;
+    // Third-party modules ship clean relative startCmds — `cwd: installDir`
+    // makes those resolve. First-party fallbacks use absolute / PATH binaries
+    // so their cwd is irrelevant; passing it doesn't hurt.
+    if (entry.installDir) spawnerOpts.cwd = entry.installDir;
+    const passOpts =
+      spawnerOpts.env !== undefined || spawnerOpts.cwd !== undefined ? spawnerOpts : undefined;
     try {
-      const pid = r.spawner.spawn(cmd, logFile, envForSpawn);
+      const pid = r.spawner.spawn(cmd, logFile, passOpts);
       writePid(short, pid, r.configDir);
       r.log(`✓ ${short} started (pid ${pid}); logs: ${logFile}`);
       if (r.hubOrigin) r.log(`  ${HUB_ORIGIN_ENV}=${r.hubOrigin}`);
@@ -217,7 +293,7 @@ export async function start(svc: string | undefined, opts: LifecycleOpts = {}): 
 
 export async function stop(svc: string | undefined, opts: LifecycleOpts = {}): Promise<number> {
   const r = resolve(opts);
-  const picked = resolveTargets(svc, r.manifestPath);
+  const picked = await resolveTargets(svc, r.manifestPath);
   if ("error" in picked) {
     r.log(picked.error);
     return 1;
@@ -274,6 +350,7 @@ export async function restart(svc: string | undefined, opts: LifecycleOpts = {})
 
 export interface LogsOpts {
   configDir?: string;
+  manifestPath?: string;
   log?: (line: string) => void;
   /** Tail stream — if omitted, uses `tail -n <lines> -f <file>` via spawn. */
   tailSpawner?: Spawner;
@@ -284,14 +361,22 @@ export interface LogsOpts {
 
 export async function logs(svc: string, opts: LogsOpts = {}): Promise<number> {
   const configDir = opts.configDir ?? CONFIG_DIR;
+  const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
   const log = opts.log ?? ((line) => console.log(line));
   const lines = opts.lines ?? 200;
   const follow = opts.follow ?? false;
 
-  const spec = getSpec(svc);
-  if (!spec) {
-    log(`unknown service "${svc}". known: ${knownServices().join(", ")}`);
-    return 1;
+  // logs only needs a valid short name to find the log file. First-party
+  // wins via the spec lookup; third-party rows match by `entry.name`. We
+  // don't need the full spec here — we just need to confirm the name maps
+  // to something the CLI manages.
+  const isFirstParty = getSpec(svc) !== undefined;
+  if (!isFirstParty) {
+    const entry = readManifest(manifestPath).services.find((s) => s.name === svc);
+    if (!entry?.installDir) {
+      log(`unknown service "${svc}". known: ${knownServices().join(", ")}`);
+      return 1;
+    }
   }
 
   const path = logPathFor(svc, configDir);

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from "node:url";
-import type { ModuleManifest } from "./module-manifest.ts";
+import { type ModuleManifest, readModuleManifest } from "./module-manifest.ts";
 import type { ServiceEntry } from "./services-manifest.ts";
 
 /**
@@ -403,11 +403,9 @@ export function knownServices(): string[] {
 
 /**
  * Resolve the runtime spec for a known short name. Returns undefined for
- * unknown names; third-party modules installed via `module.json` don't get
- * a runtime spec out of this lookup yet — that's a follow-up. For now,
- * lifecycle / status / expose treat unknown names as "we have a
- * services.json row but no spec" (skip lifecycle, fall back to defaults
- * for URL / exposure), exactly as before.
+ * unknown names; third-party modules installed via `module.json` resolve
+ * via {@link getSpecFromInstallDir} instead, since their spec isn't
+ * compiled in.
  */
 export function getSpec(short: string): ServiceSpec | undefined {
   const fb = FIRST_PARTY_FALLBACKS[short];
@@ -417,6 +415,31 @@ export function getSpec(short: string): ServiceSpec | undefined {
     manifest: fb.manifest,
     extras: fb.extras,
   });
+}
+
+/**
+ * Resolve a third-party module's runtime spec by reading its
+ * `<installDir>/.parachute/module.json` fresh. Re-reading at lifecycle time
+ * (rather than baking the spec into services.json at install) means the
+ * module can ship `startCmd` updates without a re-install.
+ *
+ * Returns null when the manifest is missing — caller falls back to the
+ * "lifecycle not yet supported" message (same shape as a first-party spec
+ * with no startCmd). Throws ModuleManifestError on a malformed manifest;
+ * lifecycle catches and surfaces it as a per-service failure rather than
+ * crashing the whole sweep.
+ *
+ * `packageName` is informational only — the spec carries it forward for
+ * diagnostics. Lifecycle doesn't care; install passes it through from the
+ * services.json row's name.
+ */
+export async function getSpecFromInstallDir(
+  installDir: string,
+  packageName: string,
+): Promise<ServiceSpec | null> {
+  const manifest = await readModuleManifest(installDir);
+  if (!manifest) return null;
+  return composeServiceSpec({ packageName, manifest });
 }
 
 /**

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -34,6 +34,17 @@ export interface ServiceEntry {
   tagline?: string;
   /** Opt-in or opt-out of public-facing expose layers. See PublicExposure. */
   publicExposure?: PublicExposure;
+  /**
+   * Absolute path to the installed package directory. Set at install time
+   * for both npm-installed (`bunGlobalPrefixes()/<package>`) and local-path
+   * installs (`<absPath>`); first-party fallbacks may leave it absent.
+   *
+   * Lifecycle (`parachute start`) reads `<installDir>/.parachute/module.json`
+   * to recover startCmd for third-party modules whose spec isn't in
+   * FIRST_PARTY_FALLBACKS, and spawns with `cwd: installDir` so manifests
+   * can use clean relative paths in their `startCmd`.
+   */
+  installDir?: string;
 }
 
 export interface ServicesManifest {
@@ -74,6 +85,7 @@ function validateEntry(raw: unknown, where: string): ServiceEntry {
   const displayName = e.displayName;
   const tagline = e.tagline;
   const publicExposure = e.publicExposure;
+  const installDir = e.installDir;
   if (displayName !== undefined && typeof displayName !== "string") {
     throw new ServicesManifestError(`${where}: "displayName" must be a string if present`);
   }
@@ -90,10 +102,14 @@ function validateEntry(raw: unknown, where: string): ServiceEntry {
       `${where}: "publicExposure" must be "allowed" | "loopback" | "auth-required" if present`,
     );
   }
+  if (installDir !== undefined && (typeof installDir !== "string" || installDir.length === 0)) {
+    throw new ServicesManifestError(`${where}: "installDir" must be a non-empty string if present`);
+  }
   const entry: ServiceEntry = { name, port, paths: paths as string[], health, version };
   if (displayName !== undefined) entry.displayName = displayName;
   if (tagline !== undefined) entry.tagline = tagline;
   if (publicExposure !== undefined) entry.publicExposure = publicExposure as PublicExposure;
+  if (installDir !== undefined) entry.installDir = installDir;
   return entry;
 }
 


### PR DESCRIPTION
## Summary

- Persist `installDir` on services.json rows at install time (npm: `dirname(findGlobalInstall(pkg))`; local-path: `target.absPath`).
- Lifecycle resolves third-party `startCmd` by reading `<installDir>/.parachute/module.json` fresh, via new `getSpecFromInstallDir()`.
- Spawner gains `cwd` option, plumbed through `start` from `entry.installDir`. Manifests can now ship clean relative paths (`["bun", "web/server/src/server.ts"]`) and they resolve against the package root.
- `parachute logs <name>` accepts third-party names whose row carries `installDir`.

Implements option B from the issue. ~280 LOC of code + ~270 LOC of tests (the +484 in the diff includes both).

## What this fixes

`parachute install /tmp/test-module` succeeded in shipping cli#56, but `parachute start <name>` was still gated by `getSpec()` which only knew about `FIRST_PARTY_FALLBACKS`. Third-party modules were installable but not startable. This made cli#56's "drop SERVICE_SPECS" claim half-true and blocked paraclaw#12 + every other third-party module.

## Why option B

`module.json` stays the single source of truth — no startCmd duplication into services.json, no install-time string-baking. Re-reading at lifecycle time means a module update without re-install picks up new `startCmd`. The cwd primitive is small and reusable for any future per-module spawn need.

## Test plan

- [x] `bun test` — 638 pass (+9 new)
- [x] `bun run typecheck` — clean
- [x] `bunx biome check .` — clean
- [ ] Manual: `parachute install /tmp/fixture` with a `.parachute/module.json` carrying a relative `startCmd`; `parachute start <name>` spawns with cwd
- [ ] Manual: existing first-party modules (vault, notes, scribe) start unchanged (no installDir on their rows; first-party fallback path still wins)
- [ ] After paraclaw#12 ships, `parachute install /path/to/paraclaw` → `parachute start claw` works end-to-end

## RC bump

`0.4.0-rc.4` → `0.4.0-rc.5`. Behavior change to lifecycle.

## Patterns

`parachute-patterns/patterns/module-json-extensibility.md` — this is the runtime side of that contract. No new pattern needed; this implements what's documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)