### PR TITLE
fix(install): use manifest.name (not manifestName) for services.json key + log + auto-start (closes #85)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.5",
+  "version": "0.4.0-rc.6",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -1170,9 +1170,14 @@ describe("install", () => {
       });
       expect(code).toBe(0);
       expect(calls[0]).toEqual(["bun", "add", "-g", "@acme/widget"]);
-      const seeded = findService("@acme/widget", path);
-      expect(seeded?.name).toBe("@acme/widget");
+      // hub#85: third-party rows are keyed by `manifest.name` (canonical
+      // short — what `parachute start <svc>` accepts), not `manifestName`.
+      const seeded = findService("widget", path);
+      expect(seeded?.name).toBe("widget");
       expect(seeded?.port).toBe(1950);
+      expect(findService("@acme/widget", path)).toBeUndefined();
+      expect(logs.join("\n")).toMatch(/Seeded services\.json entry for widget/);
+      expect(logs.join("\n")).toMatch(/widget registered on port 1950/);
     } finally {
       cleanup();
     }
@@ -1256,8 +1261,10 @@ describe("install", () => {
       });
       expect(code).toBe(0);
       expect(calls[0]).toEqual(["bun", "add", "-g", pkgDir]);
-      const seeded = findService("@local/demo", path);
-      expect(seeded?.name).toBe("@local/demo");
+      // hub#85: third-party row keys by `manifest.name`, not `manifestName`.
+      const seeded = findService("demo", path);
+      expect(seeded?.name).toBe("demo");
+      expect(findService("@local/demo", path)).toBeUndefined();
       // hub#83: lifecycle needs installDir to find module.json + spawn cwd.
       expect(seeded?.installDir).toBe(pkgDir);
     } finally {
@@ -1292,8 +1299,57 @@ describe("install", () => {
         findGlobalInstall: () => `${fakePrefix}/package.json`,
       });
       expect(code).toBe(0);
-      const seeded = findService("@vendor/widget", path);
+      // hub#85: third-party row keys by `manifest.name`, not `manifestName`.
+      const seeded = findService("widget", path);
       expect(seeded?.installDir).toBe(fakePrefix);
+      expect(findService("@vendor/widget", path)).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("third-party with diverging name/manifestName keys services.json by name (hub#85)", async () => {
+    // Repro for parachute-hub#85: paraclaw ships `name: "claw",
+    // manifestName: "paraclaw"`. Install used to seed services.json under
+    // `paraclaw` (the npm label) while lifecycle looks up by `claw` (the
+    // canonical short) → "unknown service". Fix: services.json key is
+    // always `manifest.name` for third-party.
+    const { path, cleanup } = makeTempPath();
+    try {
+      const startCalls: string[] = [];
+      const logs: string[] = [];
+      const code = await install("paraclaw", {
+        runner: async () => 0,
+        manifestPath: path,
+        startService: async (short) => {
+          startCalls.push(short);
+          return 0;
+        },
+        isLinked: () => false,
+        portProbe: async () => false,
+        log: (l) => logs.push(l),
+        readManifest: async () => ({
+          name: "claw",
+          manifestName: "paraclaw",
+          kind: "api",
+          port: 1945,
+          paths: ["/claw"],
+          health: "/claw/health",
+          startCmd: ["bun", "server.ts"],
+        }),
+        findGlobalInstall: () => "/fake/prefix/paraclaw/package.json",
+      });
+      expect(code).toBe(0);
+      // services.json is keyed by `name`, not `manifestName`.
+      expect(findService("claw", path)?.name).toBe("claw");
+      expect(findService("paraclaw", path)).toBeUndefined();
+      // Auto-start receives the canonical short name (= manifest.name).
+      expect(startCalls).toEqual(["claw"]);
+      // Log lines speak in the canonical short name too.
+      const joined = logs.join("\n");
+      expect(joined).toMatch(/Seeded services\.json entry for claw/);
+      expect(joined).toMatch(/claw registered on port 1945/);
+      expect(joined).not.toMatch(/Seeded services\.json entry for paraclaw/);
     } finally {
       cleanup();
     }

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -469,6 +469,14 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
     manifest,
     extras,
   });
+  // services.json key. Third-party modules key by `manifest.name` (canonical
+  // short — what `parachute start <svc>` accepts). First-party services keep
+  // keying by `manifestName` ("parachute-vault" etc.) because the upstream
+  // services write themselves to services.json under that name; switching the
+  // CLI seed alone would create dueling rows. The first-party migration to
+  // name-keyed rows happens when each upstream ships its own module.json
+  // (parachute-hub#56 follow-ups). See parachute-hub#85.
+  const entryName = target.kind === "first-party" ? spec.manifestName : manifest.name;
 
   if (spec.init) {
     log(`Running ${spec.init.join(" ")}…`);
@@ -486,14 +494,9 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
   // user-edited ports survive across upgrades. Compiled-in service-side
   // fallbacks (vault → 1940 etc.) stay; this just adds a CLI-managed
   // override.
-  const preInitEntry = findService(spec.manifestName, manifestPath);
+  const preInitEntry = findService(entryName, manifestPath);
   const probe = opts.portProbe ?? defaultPortProbe;
-  const occupied = await collectOccupiedPorts(
-    manifestPath,
-    spec.manifestName,
-    preInitEntry?.port,
-    probe,
-  );
+  const occupied = await collectOccupiedPorts(manifestPath, entryName, preInitEntry?.port, probe);
   const envPath = join(configDir, short, ".env");
   const canonicalPort = spec.seedEntry?.().port ?? preInitEntry?.port;
   const portResult = assignServicePort({
@@ -514,20 +517,24 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
   // parachute-hub#44 reported notes not appearing in services.json on a fresh
   // bun 1.2.x install; the gate logic was already correct, but a verify-step
   // turns silent loss into something an operator can spot.
-  let entry = findService(spec.manifestName, manifestPath);
+  let entry = findService(entryName, manifestPath);
   if (!entry && spec.seedEntry) {
     const seedBase = spec.seedEntry();
+    // seedEntryFromManifest sets `name = manifest.manifestName`; for
+    // third-party we override to `entryName` (= manifest.name) so the row
+    // matches the lifecycle lookup key. First-party leaves it alone.
+    const withName = seedBase.name === entryName ? seedBase : { ...seedBase, name: entryName };
     const seed =
-      seedBase.port === portResult.port ? seedBase : { ...seedBase, port: portResult.port };
+      withName.port === portResult.port ? withName : { ...withName, port: portResult.port };
     upsertService(seed, manifestPath);
-    entry = findService(spec.manifestName, manifestPath);
+    entry = findService(entryName, manifestPath);
     if (entry) {
       log(
-        `Seeded services.json entry for ${spec.manifestName} (placeholder; service's own boot will overwrite).`,
+        `Seeded services.json entry for ${entryName} (placeholder; service's own boot will overwrite).`,
       );
     } else {
       log(
-        `⚠ tried to seed services.json entry for ${spec.manifestName}, but the readback came back empty.`,
+        `⚠ tried to seed services.json entry for ${entryName}, but the readback came back empty.`,
       );
       log(`  manifest path: ${manifestPath}`);
       log("  Re-run `parachute install` once the underlying issue is resolved.");
@@ -537,9 +544,9 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
     // different one (collision). Reflect the CLI's choice so the hub and
     // status views stay consistent with the .env we just wrote.
     upsertService({ ...entry, port: portResult.port }, manifestPath);
-    entry = findService(spec.manifestName, manifestPath);
+    entry = findService(entryName, manifestPath);
     log(
-      `Updated services.json port to ${portResult.port} for ${spec.manifestName} (was ${preInitEntry?.port ?? "—"}).`,
+      `Updated services.json port to ${portResult.port} for ${entryName} (was ${preInitEntry?.port ?? "—"}).`,
     );
   }
 
@@ -551,15 +558,15 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
   // the manifest, which doesn't know its own install location).
   if (entry && installDir && entry.installDir !== installDir) {
     upsertService({ ...entry, installDir }, manifestPath);
-    entry = findService(spec.manifestName, manifestPath);
+    entry = findService(entryName, manifestPath);
   }
 
   if (!entry) {
     log(
-      `Installed, but no services.json entry for "${spec.manifestName}" yet. Run \`parachute status\` after the service has started.`,
+      `Installed, but no services.json entry for "${entryName}" yet. Run \`parachute status\` after the service has started.`,
     );
   } else {
-    log(`✓ ${spec.manifestName} registered on port ${entry.port}`);
+    log(`✓ ${entryName} registered on port ${entry.port}`);
     if (!isCanonicalPort(entry.port)) {
       log(
         `⚠ port ${entry.port} is outside the canonical Parachute range (${CANONICAL_PORT_MIN}–${CANONICAL_PORT_MAX}); may conflict with other software.`,
@@ -628,17 +635,17 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
   // last line of the install always reflects ground truth, not an early
   // snapshot. Surfaced by parachute-hub#44 — defensive logging that turns a
   // missing entry into a visible failure rather than a silent one.
-  let finalEntry = findService(spec.manifestName, manifestPath);
+  let finalEntry = findService(entryName, manifestPath);
   // Re-stamp installDir if the service's first boot rewrote the row without
   // it. Lifecycle commands beyond install (start/stop/restart/logs) need it
   // present; we own this field, services don't have to know it exists.
   if (finalEntry && installDir && finalEntry.installDir !== installDir) {
     upsertService({ ...finalEntry, installDir }, manifestPath);
-    finalEntry = findService(spec.manifestName, manifestPath);
+    finalEntry = findService(entryName, manifestPath);
   }
   if (!finalEntry) {
     log(
-      `⚠ ${spec.manifestName} is not in services.json after install. \`parachute status\` won't see it. Re-run install or file a bug.`,
+      `⚠ ${entryName} is not in services.json after install. \`parachute status\` won't see it. Re-run install or file a bug.`,
     );
   }
 


### PR DESCRIPTION
## Summary

- Third-party install seeds services.json under `manifest.name` (canonical short) instead of `manifestName` (npm label), so lifecycle's `parachute start <name>` lookup actually finds the row.
- Log lines (`Seeded …`, `✓ … registered on port …`, `⚠ … is not in services.json …`) speak in the canonical short name for third-party.
- Auto-start path was already correct (passes `short = manifest.name`); just confirms via the new test.
- First-party stays on `manifestName` keys for now — switching the CLI seed alone would create dueling rows alongside what upstream services already write. The first-party migration will land per-service when each upstream ships its own `module.json`.

Repro from #85 (paraclaw: `name: "claw"`, `manifestName: "paraclaw"`):
- Before: services.json key is `paraclaw`; `parachute start claw` → "unknown service".
- After: services.json key is `claw`; `parachute start claw` works.

Bump `0.4.0-rc.5` → `0.4.0-rc.6`.

## Test plan

- [x] `bun test` — 639 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bunx biome check .` — clean
- [ ] Manual: `parachute uninstall paraclaw` (or hand-edit services.json), reinstall via `parachute install ~/ParachuteComputer/paraclaw`, then `parachute start claw` → daemon starts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)