### PR TITLE
fix(install): seed services.json by manifest.name for third-party (0.4.0-rc.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.5",
+  "version": "0.4.0-rc.6",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -53,7 +53,7 @@ describe("install", () => {
       expect(code).toBe(0);
       expect(calls[0]).toEqual(["bun", "add", "-g", "@openparachute/vault"]);
       expect(calls[1]).toEqual(["parachute-vault", "init"]);
-      expect(logs.join("\n")).toMatch(/Seeded services\.json entry for parachute-vault/);
+      expect(logs.join("\n")).toMatch(/Seeded services\.json entry for vault/);
       const seeded = findService("parachute-vault", path);
       expect(seeded?.port).toBe(1940);
       expect(seeded?.version).toBe("0.0.0-linked");
@@ -190,7 +190,7 @@ describe("install", () => {
       expect(code).toBe(0);
       const seeded = findService("parachute-notes", path);
       expect(seeded?.port).toBe(1942);
-      expect(logs.join("\n")).toMatch(/Seeded services\.json entry for parachute-notes/);
+      expect(logs.join("\n")).toMatch(/Seeded services\.json entry for notes/);
       expect(logs.join("\n")).toMatch(/bun 1\.2\.x lockfile quirk/);
     } finally {
       cleanup();
@@ -256,7 +256,7 @@ describe("install", () => {
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
-      expect(logs.join("\n")).toMatch(/parachute-vault is not in services\.json after install/);
+      expect(logs.join("\n")).toMatch(/vault is not in services\.json after install/);
     } finally {
       cleanup();
     }
@@ -419,7 +419,7 @@ describe("install", () => {
       // scribe has no init, so seedEntry fires — no authoritative entry to defer to.
       const seeded = findService("parachute-scribe", path);
       expect(seeded?.port).toBe(1943);
-      expect(logs.join("\n")).toMatch(/Seeded services\.json entry for parachute-scribe/);
+      expect(logs.join("\n")).toMatch(/Seeded services\.json entry for scribe/);
     } finally {
       cleanup();
     }
@@ -1170,9 +1170,47 @@ describe("install", () => {
       });
       expect(code).toBe(0);
       expect(calls[0]).toEqual(["bun", "add", "-g", "@acme/widget"]);
-      const seeded = findService("@acme/widget", path);
-      expect(seeded?.name).toBe("@acme/widget");
+      const seeded = findService("widget", path);
+      expect(seeded?.name).toBe("widget");
       expect(seeded?.port).toBe(1950);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("third-party install seeds services.json by manifest.name (closes #85)", async () => {
+    // Regression: install previously seeded the row under `manifestName`
+    // ("paraclaw" / "@acme/widget"), but lifecycle's resolveTargets looks up
+    // by `manifest.name` ("claw" / "widget") for third-party. The mismatch
+    // left every third-party install unreachable to `parachute start <name>`.
+    // Pin the contract: services.json key MUST be `manifest.name`.
+    const { path, cleanup } = makeTempPath();
+    try {
+      const logs: string[] = [];
+      const code = await install("@acme/diverging", {
+        runner: async () => 0,
+        manifestPath: path,
+        startService: async () => 0,
+        isLinked: () => false,
+        portProbe: async () => false,
+        log: (l) => logs.push(l),
+        readManifest: async () => ({
+          name: "div",
+          manifestName: "@acme/diverging",
+          kind: "api",
+          port: 1955,
+          paths: ["/div"],
+          health: "/healthz",
+        }),
+        findGlobalInstall: () => "/fake/prefix/@acme/diverging/package.json",
+      });
+      expect(code).toBe(0);
+      // Services.json keyed by name (not manifestName) — that's what lifecycle reads.
+      expect(findService("div", path)).toBeDefined();
+      expect(findService("@acme/diverging", path)).toBeUndefined();
+      // User-facing log uses the canonical short, matching what they'd type.
+      expect(logs.join("\n")).toMatch(/Seeded services\.json entry for div/);
+      expect(logs.join("\n")).toMatch(/✓ div registered on port 1955/);
     } finally {
       cleanup();
     }
@@ -1256,8 +1294,8 @@ describe("install", () => {
       });
       expect(code).toBe(0);
       expect(calls[0]).toEqual(["bun", "add", "-g", pkgDir]);
-      const seeded = findService("@local/demo", path);
-      expect(seeded?.name).toBe("@local/demo");
+      const seeded = findService("demo", path);
+      expect(seeded?.name).toBe("demo");
       // hub#83: lifecycle needs installDir to find module.json + spawn cwd.
       expect(seeded?.installDir).toBe(pkgDir);
     } finally {
@@ -1292,7 +1330,7 @@ describe("install", () => {
         findGlobalInstall: () => `${fakePrefix}/package.json`,
       });
       expect(code).toBe(0);
-      const seeded = findService("@vendor/widget", path);
+      const seeded = findService("widget", path);
       expect(seeded?.installDir).toBe(fakePrefix);
     } finally {
       cleanup();

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -469,6 +469,14 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
     manifest,
     extras,
   });
+  // services.json key contract: for first-party, the row's `name` is the
+  // bin-style `manifestName` ("parachute-vault" etc.) — that's what the
+  // service's own boot writes, and what `findService` looks up. For
+  // third-party, lifecycle commands address the row by the canonical short
+  // (= `manifest.name`) per `lifecycle.ts:resolveTargets` — so install seeds
+  // and looks up under that. Mixing keys (parachute-hub#85) leaves
+  // third-party rows unreachable to `parachute start <name>`.
+  const lookupKey = target.kind === "first-party" ? spec.manifestName : short;
 
   if (spec.init) {
     log(`Running ${spec.init.join(" ")}…`);
@@ -486,14 +494,9 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
   // user-edited ports survive across upgrades. Compiled-in service-side
   // fallbacks (vault → 1940 etc.) stay; this just adds a CLI-managed
   // override.
-  const preInitEntry = findService(spec.manifestName, manifestPath);
+  const preInitEntry = findService(lookupKey, manifestPath);
   const probe = opts.portProbe ?? defaultPortProbe;
-  const occupied = await collectOccupiedPorts(
-    manifestPath,
-    spec.manifestName,
-    preInitEntry?.port,
-    probe,
-  );
+  const occupied = await collectOccupiedPorts(manifestPath, lookupKey, preInitEntry?.port, probe);
   const envPath = join(configDir, short, ".env");
   const canonicalPort = spec.seedEntry?.().port ?? preInitEntry?.port;
   const portResult = assignServicePort({
@@ -514,21 +517,26 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
   // parachute-hub#44 reported notes not appearing in services.json on a fresh
   // bun 1.2.x install; the gate logic was already correct, but a verify-step
   // turns silent loss into something an operator can spot.
-  let entry = findService(spec.manifestName, manifestPath);
+  let entry = findService(lookupKey, manifestPath);
   if (!entry && spec.seedEntry) {
     const seedBase = spec.seedEntry();
+    // For third-party, seedEntryFromManifest produces `name: manifestName`
+    // (legacy first-party convention). Override to the canonical short so
+    // the row is addressable via `parachute start <name>` (parachute-hub#85).
+    const seedNamed =
+      target.kind !== "first-party" && seedBase.name !== short
+        ? { ...seedBase, name: short }
+        : seedBase;
     const seed =
-      seedBase.port === portResult.port ? seedBase : { ...seedBase, port: portResult.port };
+      seedNamed.port === portResult.port ? seedNamed : { ...seedNamed, port: portResult.port };
     upsertService(seed, manifestPath);
-    entry = findService(spec.manifestName, manifestPath);
+    entry = findService(lookupKey, manifestPath);
     if (entry) {
       log(
-        `Seeded services.json entry for ${spec.manifestName} (placeholder; service's own boot will overwrite).`,
+        `Seeded services.json entry for ${short} (placeholder; service's own boot will overwrite).`,
       );
     } else {
-      log(
-        `⚠ tried to seed services.json entry for ${spec.manifestName}, but the readback came back empty.`,
-      );
+      log(`⚠ tried to seed services.json entry for ${short}, but the readback came back empty.`);
       log(`  manifest path: ${manifestPath}`);
       log("  Re-run `parachute install` once the underlying issue is resolved.");
     }
@@ -537,9 +545,9 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
     // different one (collision). Reflect the CLI's choice so the hub and
     // status views stay consistent with the .env we just wrote.
     upsertService({ ...entry, port: portResult.port }, manifestPath);
-    entry = findService(spec.manifestName, manifestPath);
+    entry = findService(lookupKey, manifestPath);
     log(
-      `Updated services.json port to ${portResult.port} for ${spec.manifestName} (was ${preInitEntry?.port ?? "—"}).`,
+      `Updated services.json port to ${portResult.port} for ${short} (was ${preInitEntry?.port ?? "—"}).`,
     );
   }
 
@@ -551,15 +559,15 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
   // the manifest, which doesn't know its own install location).
   if (entry && installDir && entry.installDir !== installDir) {
     upsertService({ ...entry, installDir }, manifestPath);
-    entry = findService(spec.manifestName, manifestPath);
+    entry = findService(lookupKey, manifestPath);
   }
 
   if (!entry) {
     log(
-      `Installed, but no services.json entry for "${spec.manifestName}" yet. Run \`parachute status\` after the service has started.`,
+      `Installed, but no services.json entry for "${short}" yet. Run \`parachute status\` after the service has started.`,
     );
   } else {
-    log(`✓ ${spec.manifestName} registered on port ${entry.port}`);
+    log(`✓ ${short} registered on port ${entry.port}`);
     if (!isCanonicalPort(entry.port)) {
       log(
         `⚠ port ${entry.port} is outside the canonical Parachute range (${CANONICAL_PORT_MIN}–${CANONICAL_PORT_MAX}); may conflict with other software.`,
@@ -628,17 +636,17 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
   // last line of the install always reflects ground truth, not an early
   // snapshot. Surfaced by parachute-hub#44 — defensive logging that turns a
   // missing entry into a visible failure rather than a silent one.
-  let finalEntry = findService(spec.manifestName, manifestPath);
+  let finalEntry = findService(lookupKey, manifestPath);
   // Re-stamp installDir if the service's first boot rewrote the row without
   // it. Lifecycle commands beyond install (start/stop/restart/logs) need it
   // present; we own this field, services don't have to know it exists.
   if (finalEntry && installDir && finalEntry.installDir !== installDir) {
     upsertService({ ...finalEntry, installDir }, manifestPath);
-    finalEntry = findService(spec.manifestName, manifestPath);
+    finalEntry = findService(lookupKey, manifestPath);
   }
   if (!finalEntry) {
     log(
-      `⚠ ${spec.manifestName} is not in services.json after install. \`parachute status\` won't see it. Re-run install or file a bug.`,
+      `⚠ ${short} is not in services.json after install. \`parachute status\` won't see it. Re-run install or file a bug.`,
     );
   }
 


### PR DESCRIPTION
## Summary

Closes #85.

Third-party install previously seeded the services.json row under `manifestName` (npm-style label), but lifecycle's `resolveTargets` addresses third-party rows by `manifest.name` (canonical short). The mismatch left every third-party install unreachable to `parachute start <name>` post-install.

## Repro (pre-fix)

paraclaw's manifest: `{name: "claw", manifestName: "paraclaw"}`.

\`\`\`sh
parachute install ~/ParachuteComputer/paraclaw
# ...
# ✓ paraclaw registered on port 1944    ← seeded under "paraclaw"
# unknown service "claw". known: vault, notes, scribe, channel  ← lifecycle uses name
\`\`\`

## Fix

`install.ts` threads a `lookupKey` through `findService`/`upsert`/`collectOccupiedPorts`:
- **First-party**: lookupKey = `spec.manifestName` (back-compat with vault/notes/scribe/channel rows that the service's own boot writes under that key).
- **Third-party**: lookupKey = `short` (= `manifest.name`). Seed entry's `name` field is overridden to match.

User-facing logs use the canonical short on both paths — operator sees `✓ vault registered on port 1940` instead of `✓ parachute-vault registered`, matching what they'd type for `parachute start vault`.

## Tests

- New regression test (`third-party install seeds services.json by manifest.name`): manifest with `name: "div"`, `manifestName: "@acme/diverging"` → services.json keyed by `div`, log says `Seeded ... for div`, log says `✓ div registered`.
- Existing third-party assertions updated: `findService("widget", ...)` instead of `findService("@acme/widget", ...)`.
- Existing first-party log assertions updated to the new short-name format (`Seeded ... for vault` instead of `... for parachute-vault`).

639/639 tests pass. Typecheck clean. Biome clean.

## RC bump

`0.4.0-rc.5` → `0.4.0-rc.6`. Hotfix for the broken third-party install path.

## Pattern

`parachute-patterns/patterns/module-protocol.md` — `name` is the canonical short. This PR honors it consistently.