### PR TITLE
fix(scope-registry): use installDir from services.json to find module.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.6",
+  "version": "0.4.0-rc.7",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -1314,13 +1314,14 @@ describe("install", () => {
     // `paraclaw` (the npm label) while lifecycle looks up by `claw` (the
     // canonical short) → "unknown service". Fix: services.json key is
     // always `manifest.name` for third-party.
-    const { path, cleanup } = makeTempPath();
+    const { path, configDir, cleanup } = makeTempPath();
     try {
       const startCalls: string[] = [];
       const logs: string[] = [];
       const code = await install("paraclaw", {
         runner: async () => 0,
         manifestPath: path,
+        configDir,
         startService: async (short) => {
           startCalls.push(short);
           return 0;

--- a/src/__tests__/scope-registry.test.ts
+++ b/src/__tests__/scope-registry.test.ts
@@ -137,6 +137,48 @@ describe("loadDeclaredScopes", () => {
     }
   });
 
+  test("readModuleScopes receives installDir from services.json (closes #85 follow-up)", () => {
+    // Regression: scope-registry was looking up by services.json `name` in
+    // bun-globals. For third-party modules where name (canonical short like
+    // "claw") differs from the npm package name on disk ("nanoclaw" for
+    // forks), that lookup fails and the module's scopes are never declared.
+    // installDir from hub#84 is the correct path source.
+    const { manifestPath, cleanup } = tmp();
+    try {
+      writeFileSync(
+        manifestPath,
+        JSON.stringify({
+          services: [
+            {
+              name: "claw",
+              port: 1944,
+              paths: ["/claw"],
+              health: "/api/health",
+              version: "0.0.0-linked",
+              installDir: "/Users/test/ParachuteComputer/paraclaw",
+            },
+          ],
+        }),
+      );
+      const calls: { pkg: string; installDir: string | undefined }[] = [];
+      const declared = loadDeclaredScopes({
+        manifestPath,
+        readModuleScopes: (pkg, installDir) => {
+          calls.push({ pkg, installDir });
+          return pkg === "claw" ? ["claw:read", "claw:write", "claw:admin"] : null;
+        },
+      });
+      expect(calls).toEqual([
+        { pkg: "claw", installDir: "/Users/test/ParachuteComputer/paraclaw" },
+      ]);
+      expect(declared.has("claw:read")).toBe(true);
+      expect(declared.has("claw:write")).toBe(true);
+      expect(declared.has("claw:admin")).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("services with no module.json don't crash the registry", () => {
     const { manifestPath, cleanup } = tmp();
     try {

--- a/src/scope-registry.ts
+++ b/src/scope-registry.ts
@@ -66,17 +66,34 @@ export function findUnknownScopes(
 }
 
 /**
- * Read `<bun-globals>/<pkg>/.parachute/module.json` for one registered
- * service and return its `scopes.defines`. Returns null when the module
- * doesn't ship a manifest (first-party today; eventually they all will).
+ * Read `<dir>/.parachute/module.json` and return its `scopes.defines`.
+ * Returns null when no manifest is found.
+ *
+ * Resolution order:
+ *   1. If `installDir` is provided (hub#84 stamps this on every services.json
+ *      row at install time), read directly from there. This is the canonical
+ *      path — services.json's `name` is the manifest's canonical short
+ *      (e.g. "claw"), which doesn't match the npm package name on disk
+ *      (e.g. "nanoclaw" for forks). bun-globals lookup-by-name fails for
+ *      that case; installDir is the source of truth.
+ *   2. Fall back to `<bun-globals>/<packageName>/.parachute/module.json`
+ *      for entries without installDir (older installs, or services that
+ *      registered themselves before hub#84 stamped the field).
  *
  * Tolerant of malformed JSON / validation errors — those are install-time
  * problems, not token-issuance problems. A bad manifest blocking token
  * issuance is the worst kind of cascade failure.
  */
-export function defaultReadModuleScopes(packageName: string): readonly string[] | null {
+export function defaultReadModuleScopes(
+  packageName: string,
+  installDir?: string,
+): readonly string[] | null {
+  const candidates: string[] = [];
+  if (installDir) candidates.push(join(installDir, ".parachute", "module.json"));
   for (const prefix of bunGlobalPrefixes()) {
-    const path = join(prefix, ...packageName.split("/"), ".parachute", "module.json");
+    candidates.push(join(prefix, ...packageName.split("/"), ".parachute", "module.json"));
+  }
+  for (const path of candidates) {
     let raw: unknown;
     try {
       raw = JSON.parse(readFileSync(path, "utf8"));
@@ -112,7 +129,7 @@ export interface LoadDeclaredScopesOpts {
    * walks bun's global prefixes for each registered service's
    * `.parachute/module.json`.
    */
-  readModuleScopes?: (packageName: string) => readonly string[] | null;
+  readModuleScopes?: (packageName: string, installDir?: string) => readonly string[] | null;
 }
 
 /**
@@ -126,14 +143,14 @@ export interface LoadDeclaredScopesOpts {
 export function loadDeclaredScopes(opts: LoadDeclaredScopesOpts = {}): Set<string> {
   const declared = new Set<string>(FIRST_PARTY_SCOPES);
   const readModuleScopes = opts.readModuleScopes ?? defaultReadModuleScopes;
-  let services: { name: string }[];
+  let services: { name: string; installDir?: string }[];
   try {
     services = readServicesManifest(opts.manifestPath).services;
   } catch {
     return declared;
   }
   for (const svc of services) {
-    const defined = readModuleScopes(svc.name);
+    const defined = readModuleScopes(svc.name, svc.installDir);
     if (!defined) continue;
     for (const scope of defined) declared.add(scope);
   }


### PR DESCRIPTION
## Smoke tested

Aaron hit this during 2026-04-27 browser smoke:

> OAuth dance succeeds through consent (paraclaw requests `claw:write`), but `/oauth/token` returns:
> ```
> hub /oauth/token failed: 400 {"error":"invalid_scope","error_description":"unknown scopes: claw:write","invalid_scopes":["claw:write"]}
> ```

Direct verification of fix:
```
$ bun -e 'import { loadDeclaredScopes } from "./src/scope-registry.ts";
          console.log([...loadDeclaredScopes()].sort())'
Pre-fix:  [channel:send, hub:admin, scribe:*, vault:*]            (only first-party)
Post-fix: [channel:send, claw:admin, claw:read, claw:write,
           hub:admin, scribe:*, vault:*]                          (paraclaw's claw:* now declared)
```

Aaron's running `parachute-hub` PID is on this code; a hard-refresh of the paraclaw tab should now complete the OAuth dance.

## Why

Pre-fix, `scope-registry` looked up `<bun-globals>/<services.json-name>/.parachute/module.json` for each registered service. For third-party modules where the canonical short (services.json `name`) differs from the npm package name on disk — e.g. paraclaw with `name: \"claw\"` but installed as `nanoclaw` (the fork preserves upstream's package.json name) — the lookup-by-name fails and `scopes.defines` is silently dropped, so the issuer refuses to mint tokens with those scopes.

hub#84 already stamps `installDir` on every services.json row at install time. The fix wires it through: `defaultReadModuleScopes` accepts an optional `installDir`, prepends it to the resolution candidates, and falls back to bun-globals for entries without installDir (first-party today; eventually replaced by their own `.parachute/module.json` shipped from npm).

## Changes

- `src/scope-registry.ts` — `defaultReadModuleScopes(packageName, installDir?)`; `loadDeclaredScopes` reads `installDir` from each services.json row and threads it through.
- `src/__tests__/scope-registry.test.ts` — regression test pinning the installDir code path (closes #85 follow-up).
- `package.json` — 0.4.0-rc.6 → 0.4.0-rc.7

## Adjacent finding (filing separately)

`/.well-known/oauth-authorization-server` still hardcodes `scopes_supported: FIRST_PARTY_SCOPES` at `src/oauth-handlers.ts:188`. That advertisement should also use `loadDeclaredScopes` so clients can discover third-party scopes via standard RFC 8414 discovery. Not blocking this PR — the actual `/oauth/token` issuance check uses `loadDeclaredScopes` correctly, and that's the path Aaron's smoke hit.

## Verification

- 640 tests pass (incl. new regression)
- typecheck clean
- biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)