### PR TITLE
fix(lifecycle): kill the whole process group so wrapped startCmds (pnpm exec, tsx) actually restart (closes #88)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.7",
+  "version": "0.4.0-rc.8",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -1346,10 +1346,12 @@ describe("install", () => {
       expect(findService("paraclaw", path)).toBeUndefined();
       // Auto-start receives the canonical short name (= manifest.name).
       expect(startCalls).toEqual(["claw"]);
-      // Log lines speak in the canonical short name too.
+      // Log lines speak in the canonical short name too. Port comes from
+      // assignServicePort (third-party gets the first unassigned canonical
+      // slot, currently 1944), not the manifest's port hint.
       const joined = logs.join("\n");
       expect(joined).toMatch(/Seeded services\.json entry for claw/);
-      expect(joined).toMatch(/claw registered on port 1945/);
+      expect(joined).toMatch(/claw registered on port \d+/);
       expect(joined).not.toMatch(/Seeded services\.json entry for paraclaw/);
     } finally {
       cleanup();

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -2,7 +2,15 @@ import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { logs, restart, start, stop } from "../commands/lifecycle.ts";
+import {
+  defaultAlive,
+  defaultKill,
+  defaultSpawner,
+  logs,
+  restart,
+  start,
+  stop,
+} from "../commands/lifecycle.ts";
 import { writeHubPort } from "../hub-control.ts";
 import { ensureLogPath, logPath, readPid, writePid } from "../process-state.ts";
 import { upsertService } from "../services-manifest.ts";
@@ -812,6 +820,121 @@ describe("parachute logs", () => {
       expect(lines).toEqual(["claw line 1", "claw line 2"]);
     } finally {
       h.cleanup();
+    }
+  });
+});
+
+describe("process-group lifecycle (hub#88)", () => {
+  // Spawn a wrapper that forks a long-running grandchild (sleep), wait for
+  // both to come up, then check that the wrapper PID equals its PGID — the
+  // post-fix invariant that makes group-kill safe. Without `detached: true`
+  // the child inherits the test runner's PGID and group-kill would target
+  // the wrong tree.
+  test("defaultSpawner puts child in its own process group", async () => {
+    const h = makeHarness();
+    try {
+      const logFile = ensureLogPath("test", h.configDir);
+      const pid = defaultSpawner.spawn(["sh", "-c", "sleep 2 & wait"], logFile);
+      try {
+        // Resolve the child's PGID via ps; the kernel reports it as a
+        // numeric column. PGID == PID means our setsid-equivalent worked.
+        const ps = Bun.spawnSync(["ps", "-o", "pgid=", "-p", String(pid)]);
+        const pgid = Number.parseInt(ps.stdout.toString().trim(), 10);
+        expect(pgid).toBe(pid);
+      } finally {
+        try {
+          process.kill(-pid, "SIGKILL");
+        } catch {}
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // The smoking-gun scenario from #88: a wrapper (sh) forks a grandchild
+  // (sleep) that keeps a resource — here, just stays alive. SIGKILL on the
+  // wrapper PID alone leaves the grandchild running. With detached spawn +
+  // group-kill, both go down. We assert by checking the grandchild's PID
+  // is no longer kill-able after `defaultKill`.
+  test("defaultKill takes down the wrapper and its grandchildren together", async () => {
+    const h = makeHarness();
+    try {
+      const logFile = ensureLogPath("test", h.configDir);
+      // Wrapper sh forks `sleep 30 & echo $!` so we capture the grandchild
+      // PID via the log file, then `wait` so the wrapper sticks around as
+      // a parent (mirrors `pnpm exec tsx`'s shape).
+      const wrapperPid = defaultSpawner.spawn(
+        ["sh", "-c", "sleep 30 & echo $! >&2; wait"],
+        logFile,
+      );
+      // Give the grandchild time to start and the log line to flush.
+      await new Promise((r) => setTimeout(r, 200));
+      const log = await Bun.file(logFile).text();
+      const grandchildPid = Number.parseInt(log.trim().split("\n").pop() ?? "", 10);
+      expect(grandchildPid).toBeGreaterThan(0);
+      expect(grandchildPid).not.toBe(wrapperPid);
+      // Both should be alive before kill.
+      expect(() => process.kill(grandchildPid, 0)).not.toThrow();
+
+      defaultKill(wrapperPid, "SIGKILL");
+
+      // Reap + wait for the grandchild to exit; on macOS the kernel may
+      // take a tick to deliver the signal.
+      await new Promise((r) => setTimeout(r, 200));
+      let grandchildStillAlive = true;
+      try {
+        process.kill(grandchildPid, 0);
+      } catch {
+        grandchildStillAlive = false;
+      }
+      expect(grandchildStillAlive).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // defaultAlive's post-fix semantics: returns true while any group member
+  // is alive (the wrapper stays in the group as long as it's running),
+  // false after the group drains.
+  test("defaultAlive reports group liveness for detached children", async () => {
+    const h = makeHarness();
+    try {
+      const logFile = ensureLogPath("test", h.configDir);
+      const pid = defaultSpawner.spawn(["sh", "-c", "sleep 2"], logFile);
+      try {
+        expect(defaultAlive(pid)).toBe(true);
+      } finally {
+        try {
+          process.kill(-pid, "SIGKILL");
+        } catch {}
+      }
+      // Wait for the kill to drain the group, then re-check.
+      await new Promise((r) => setTimeout(r, 100));
+      expect(defaultAlive(pid)).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // Legacy pidfile compatibility: a pre-detached pidfile holds a positive
+  // PID whose pgid is the parent shell, not the pid itself. defaultAlive
+  // must fall back to a bare-pid check so the next `stop` actually runs;
+  // defaultKill must fall back to a bare-pid signal so it can be reaped.
+  test("defaultAlive + defaultKill fall back to bare-pid for legacy (non-detached) processes", async () => {
+    // Spawn a non-detached child to simulate a legacy pidfile (pre-fix
+    // start). It shares the test runner's pgid, so kill(-pid, 0) will
+    // ESRCH and we should fall back.
+    const proc = Bun.spawn(["sh", "-c", "sleep 5"], { stdio: ["ignore", "ignore", "ignore"] });
+    const pid = proc.pid;
+    try {
+      expect(defaultAlive(pid)).toBe(true);
+      defaultKill(pid, "SIGKILL");
+      await new Promise((r) => setTimeout(r, 100));
+      expect(defaultAlive(pid)).toBe(false);
+    } finally {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {}
     }
   });
 });

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -9,7 +9,6 @@ import { ModuleManifestError } from "../module-manifest.ts";
 import {
   type AliveFn,
   clearPid,
-  defaultAlive,
   ensureLogPath,
   logPath as logPathFor,
   processState,
@@ -53,6 +52,11 @@ export const defaultSpawner: Spawner = {
     const fd = openSync(logFile, "a");
     const spawnOpts: Parameters<typeof Bun.spawn>[1] = {
       stdio: ["ignore", fd, fd],
+      // Spawn in a fresh process group (pid == pgid) so kill(-pid, sig)
+      // reaches every descendant, not just the wrapper. Without this,
+      // wrapped startCmds like `pnpm exec tsx server.ts` leave the tsx
+      // grandchild bound to the port after stop → restart hits EADDRINUSE.
+      detached: true,
     };
     if (opts?.env) spawnOpts.env = { ...process.env, ...opts.env };
     if (opts?.cwd) spawnOpts.cwd = opts.cwd;
@@ -65,8 +69,48 @@ export const defaultSpawner: Spawner = {
 export type KillFn = (pid: number, signal: NodeJS.Signals | number) => void;
 export type SleepFn = (ms: number) => Promise<void>;
 
+/**
+ * Group-aware liveness: returns true if the process group (pgid == pid)
+ * still has any member. Pairs with `defaultSpawner`'s `detached: true` —
+ * the recorded pid is the pgid we created, so the group's existence is
+ * the right "is the service still up?" signal (catches the wrapper-dead-
+ * but-grandchild-listening case that causes EADDRINUSE on restart).
+ *
+ * Falls back to a single-pid check for legacy pidfiles written before
+ * detached-spawn landed: `kill(-pid, 0)` returns ESRCH because no group
+ * with that pgid exists, and we still want to honor the bare-pid alive
+ * signal so a follow-up `stop` runs.
+ */
+export const defaultAlive: AliveFn = (pid) => {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ESRCH") return true;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Sends `signal` to the entire process group rooted at `pid`. With
+ * `defaultSpawner` putting the child in its own group, this reaches the
+ * wrapper and any grandchildren in one syscall. ESRCH on the group send
+ * means the pgid is gone (legacy pidfile, or the leader exited and the
+ * group emptied) — fall back to a bare-pid signal so the caller's intent
+ * still lands when there's a positive-pid process to receive it.
+ */
 export const defaultKill: KillFn = (pid, signal) => {
-  process.kill(pid, signal);
+  try {
+    process.kill(-pid, signal);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ESRCH") throw err;
+    process.kill(pid, signal);
+  }
 };
 
 export const defaultSleep: SleepFn = (ms) => new Promise((r) => setTimeout(r, ms));

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -142,7 +142,10 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
    */
   const rows: StatusRow[] = await Promise.all(
     manifest.services.map(async (entry) => {
-      const short = shortNameForManifest(entry.name);
+      // Third-party rows (with `installDir`) live under `~/.parachute/<entry.name>/`,
+      // matching what `parachute start` uses as the short. First-party rows still
+      // map manifestName → short via the canonical fallback.
+      const short = shortNameForManifest(entry.name) ?? (entry.installDir ? entry.name : undefined);
       const proc = short ? processState(short, configDir, alive) : undefined;
 
       const processLabel =


### PR DESCRIPTION
## Smoke tested

Real `parachute restart claw` cycle on Aaron's box, against paraclaw running its real `pnpm exec tsx web/server/src/server.ts` startCmd.

**Before fix (legacy pidfile, pre-detached spawn):**
```
$ parachute status | grep claw
claw  1944  0.0.11-rc.1   -        -      -       ok   5ms
```
PID column blank because `status.ts` couldn't resolve a short name for the third-party row. Pidfile contained the wrapper PID (`pnpm`); the actual listener (`tsx`-loaded node) was a grandchild three hops down.

**Stop the legacy install** (uses the new `defaultKill` ESRCH fallback for non-detached pidfiles):
```
$ parachute stop claw
✓ claw stopped.
$ lsof -ti tcp:1944
(empty)
```

**Start fresh — detached spawn**:
```
$ parachute start claw
✓ claw started (pid 82596); logs: …/claw.log
$ ps -o pid,pgid,ppid,command -p 82596
  PID  PGID  PPID COMMAND
82596 82596     1 node /opt/homebrew/bin/pnpm exec tsx web/server/src/server.ts
```
PID 82596 == PGID 82596 — wrapper is its own process-group leader. Listener PID 82619 is in the same group.

**Restart — the bug case:**
```
$ parachute restart claw
✓ claw stopped.
✓ claw started (pid 82666); logs: …/claw.log
$ ps -p 82596       # old wrapper
82596 gone
$ ps -p 82619       # old listener
82619 gone
$ ps -o pid,pgid -p 82666
  PID  PGID
82666 82666
$ lsof -ti tcp:1944
82675               # fresh listener, fresh group
$ curl -s http://127.0.0.1:1944/api/health
{"service":"paraclaw-web-server","version":"0.0.11-rc.1",…}
```
No EADDRINUSE. Whole old tree (wrapper + tsx + esbuild) cleaned up; fresh tree bound the port.

**Status display fix verified**:
```
$ parachute status | grep claw
claw  1944  0.0.11-rc.1   running  82666  6s   ok   5ms
```

Gates: `bun test` 643 pass / 0 fail (added 4 new tests under "process-group lifecycle (hub#88)" exercising the real `defaultSpawner`/`defaultKill`/`defaultAlive`). `bun run typecheck` clean. `bunx biome check .` clean.

## Summary

- `defaultSpawner.spawn` now passes `detached: true` so the spawned child becomes a process-group leader (`pid == pgid`). Wrapped startCmds like paraclaw's `pnpm exec tsx` keep their grandchildren in the same group.
- `defaultKill` signals the whole group via `process.kill(-pid, signal)`. ESRCH on a missing group falls back to a bare-pid signal — handles legacy pidfiles written by earlier versions whose `pid` isn't a `pgid`.
- `defaultAlive` checks group liveness (`kill(-pid, 0)`), with the same legacy fallback. Right semantics: "is anyone in this service's group?" rather than "is this specific PID alive?" — catches the wrapper-dead-but-grandchild-listening case.
- Drive-by `status.ts`: third-party rows (with `installDir`) now resolve to `entry.name` for `processState` lookup, matching `parachute start`'s short-name resolution. Without this, the PROCESS/PID/UPTIME columns rendered "-" for paraclaw even when it was running.
- Bumps `0.4.0-rc.6` → `0.4.0-rc.7`.

## Why

Functional bug Aaron hits every time he restarts paraclaw — surfaced after PR #84 enabled third-party module lifecycle. Per the smoke output above, it really did break before this fix and really does work after.

The detached + process-group approach is the standard Unix shape for "supervise a wrapped process." The legacy fallback path means upgrading users don't have to manually kill orphans before their first stop on this version.