### PR TITLE
fix(install): skip bun add -g for already-linked local paths (closes #89)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.8",
+  "version": "0.4.0-rc.9",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { install } from "../commands/install.ts";
@@ -1267,6 +1267,96 @@ describe("install", () => {
       expect(findService("@local/demo", path)).toBeUndefined();
       // hub#83: lifecycle needs installDir to find module.json + spawn cwd.
       expect(seeded?.installDir).toBe(pkgDir);
+    } finally {
+      cleanup();
+      rmSync(pkgDir, { recursive: true, force: true });
+    }
+  });
+
+  test("local-path re-install skips bun add when symlink already points at it (hub#89)", async () => {
+    // Reproduces the lockfile-pollution loop from hub#89: every
+    // `parachute install /path/to/checkout` shells out `bun add -g
+    // /path/to/checkout`, which appends a duplicate dependency to
+    // ~/.bun/install/global/package.json. After ~5 re-installs bun's
+    // lockfile parser gives up. Fix: if the global symlink already
+    // resolves to this exact path, the install is a no-op for bun-add.
+    const { path, cleanup } = makeTempPath();
+    const pkgDir = mkdtempSync(join(tmpdir(), "pcli-localpkg-"));
+    // macOS tmpdir is symlinked (/var → /private/var); install resolves
+    // both sides via realpath, so the stub must too.
+    const pkgDirReal = realpathSync(pkgDir);
+    try {
+      const calls: string[][] = [];
+      const logs: string[] = [];
+      const code = await install(pkgDir, {
+        runner: async (cmd) => {
+          calls.push([...cmd]);
+          return 0;
+        },
+        manifestPath: path,
+        startService: async () => 0,
+        isLinked: () => false,
+        // The symlink at <bun-globals>/node_modules/@local/demo already
+        // points at the same checkout we're installing — second-+ run.
+        linkedPath: (pkg) => (pkg === "@local/demo" ? pkgDirReal : null),
+        portProbe: async () => false,
+        log: (l) => logs.push(l),
+        readManifest: async () => ({
+          name: "demo",
+          manifestName: "@local/demo",
+          kind: "api",
+          port: 1951,
+          paths: ["/demo"],
+          health: "/healthz",
+        }),
+        readPackageName: () => "@local/demo",
+      });
+      expect(code).toBe(0);
+      // No `bun add -g <pkgDir>` invocation — that's the whole point.
+      const bunAddCalls = calls.filter((c) => c[0] === "bun" && c[1] === "add");
+      expect(bunAddCalls).toEqual([]);
+      // Downstream init/seed/installDir wiring still ran.
+      const seeded = findService("demo", path);
+      expect(seeded?.installDir).toBe(pkgDir);
+      // Operator-visible breadcrumb so they understand why `bun add` was skipped.
+      expect(logs.join("\n")).toMatch(/already linked at .* — skipping bun add/);
+    } finally {
+      cleanup();
+      rmSync(pkgDir, { recursive: true, force: true });
+    }
+  });
+
+  test("local-path install still bun-adds when symlink points elsewhere (hub#89)", async () => {
+    // Operator moved their checkout: the global symlink is stale, pointing at
+    // a different abspath. Re-run bun add against the new path so the link
+    // gets refreshed (don't silently keep using the old target).
+    const { path, cleanup } = makeTempPath();
+    const pkgDir = mkdtempSync(join(tmpdir(), "pcli-localpkg-"));
+    try {
+      const calls: string[][] = [];
+      const code = await install(pkgDir, {
+        runner: async (cmd) => {
+          calls.push([...cmd]);
+          return 0;
+        },
+        manifestPath: path,
+        startService: async () => 0,
+        isLinked: () => false,
+        linkedPath: () => "/Users/someone/old/checkout",
+        portProbe: async () => false,
+        log: () => {},
+        readManifest: async () => ({
+          name: "demo",
+          manifestName: "@local/demo",
+          kind: "api",
+          port: 1951,
+          paths: ["/demo"],
+          health: "/healthz",
+        }),
+        readPackageName: () => "@local/demo",
+      });
+      expect(code).toBe(0);
+      expect(calls[0]).toEqual(["bun", "add", "-g", pkgDir]);
     } finally {
       cleanup();
       rmSync(pkgDir, { recursive: true, force: true });

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, readFileSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, realpathSync } from "node:fs";
 import { createConnection } from "node:net";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -57,6 +57,15 @@ export interface InstallOpts {
    * Defaults to a symlink check against bun's global node_modules prefix.
    */
   isLinked?: (pkg: string) => boolean;
+  /**
+   * Returns the absolute path a global symlink points at, or null if no
+   * symlink exists. Used by local-path installs to skip a redundant
+   * `bun add -g <abspath>` when the path is already wired up — repeatedly
+   * `bun add -g <abspath>`'ing the same path appends duplicate entries to
+   * `~/.bun/install/global/package.json` until the lockfile parser breaks
+   * (hub#89). Defaults to a `readlink` against bun's global prefixes.
+   */
+  linkedPath?: (pkg: string) => string | null;
   /**
    * Optional npm dist-tag or exact version to install. When set, the
    * `bun add -g` call is composed as `<package>@<tag>` so RC testers can
@@ -152,6 +161,24 @@ function defaultIsLinked(pkg: string): boolean {
     }
   }
   return false;
+}
+
+function defaultLinkedPath(pkg: string): string | null {
+  // bun has two install shapes for "linked-style" globals:
+  //   - `bun link`: <prefix>/node_modules/<pkg> is itself a symlink to source.
+  //   - `bun add -g <abspath>`: <prefix>/node_modules/<pkg> is a real dir
+  //     whose entries (package.json, etc.) are file-level symlinks to source.
+  // Resolving <prefix>/node_modules/<pkg>/package.json follows the link to
+  // the source package.json in either shape; dirname is the source dir.
+  for (const prefix of bunGlobalPrefixes()) {
+    const pkgJson = join(prefix, ...pkg.split("/"), "package.json");
+    try {
+      return dirname(realpathSync(pkgJson));
+    } catch {
+      // Not present at this prefix; try the next.
+    }
+  }
+  return null;
 }
 
 /**
@@ -375,18 +402,37 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
   const now = opts.now ?? (() => new Date());
   const log = opts.log ?? ((line) => console.log(line));
   const isLinked = opts.isLinked ?? defaultIsLinked;
+  const linkedPath = opts.linkedPath ?? defaultLinkedPath;
   const findGlobalInstall = opts.findGlobalInstall ?? defaultFindGlobalInstall;
   const readManifest = opts.readManifest ?? readModuleManifest;
 
   const target = resolveInstallTarget(input, opts, log);
   if (!target) return 1;
 
-  // bun-add gate: skipped only for first-party packages already bun-linked
-  // locally (the scribe motivator — package isn't on npm yet, link beats
-  // add). Local-path installs always go through `bun add -g <abspath>` so
-  // bun's link plumbing produces a binary on PATH.
+  // bun-add gate: skip when the package is already wired up.
+  //   - first-party + isLinked: scribe-style `bun link` against an unpublished
+  //     local checkout. `bun add -g` would 404.
+  //   - local-path + symlink already points at this path: re-installing the
+  //     same checkout. `bun add -g <abspath>` accumulates duplicate entries
+  //     in `~/.bun/install/global/package.json` until bun's lockfile parser
+  //     gives up (hub#89 — caught during paraclaw smoke testing 2026-04-27).
+  // Otherwise run `bun add -g <spec>` so bun's link plumbing produces a
+  // binary on PATH.
+  const localAlreadyLinkedTo = target.kind === "local-path" ? linkedPath(target.packageName) : null;
+  // Compare via realpath on the input side too, so symlinks in the path
+  // the user typed don't make us miss an existing match.
+  let targetReal: string | undefined;
+  if (target.kind === "local-path") {
+    try {
+      targetReal = realpathSync(target.absPath);
+    } catch {
+      targetReal = target.absPath;
+    }
+  }
   if (target.kind === "first-party" && isLinked(target.packageName)) {
     log(`${target.packageName} is already linked globally (bun link) — skipping bun add.`);
+  } else if (target.kind === "local-path" && localAlreadyLinkedTo === targetReal) {
+    log(`${target.packageName} is already linked at ${target.absPath} — skipping bun add.`);
   } else {
     const addSpec =
       target.kind === "local-path"


### PR DESCRIPTION
## Smoke tested

On Aaron's bun-linked checkout, against `~/ParachuteComputer/paraclaw`.

**Pre-fix** (rc.6, observed earlier this session): each
`parachute install /Users/parachute/ParachuteComputer/paraclaw` shelled
`bun add -g <abspath>`, which appended a duplicate `nanoclaw` key to
`~/.bun/install/global/package.json`. Bun warns up to a point and then
the lockfile parser refuses entirely — every future global install fails.

**Post-fix** (this branch):
1. Cleaned `~/.bun/install/global/package.json` to a single `nanoclaw` entry.
2. `parachute install /Users/parachute/ParachuteComputer/paraclaw` →
   `nanoclaw is already linked at /Users/parachute/ParachuteComputer/paraclaw — skipping bun add.`
   No `bun add` process spawned. `~/.bun/install/global/package.json` unchanged.
3. Re-ran a second time with the same result. Entry count stays at 1.
4. `claw registered on port 1944`, downstream services.json wiring still runs.
5. `bun test` 641/641, `tsc --noEmit` clean, `biome check` clean.

## Summary

- New `linkedPath` resolver follows
  `<bun-globals>/node_modules/<pkg>/package.json` to its source dir via
  `realpathSync` + `dirname`. Handles both shapes:
    - `bun link` — directory itself is a symlink to source
    - `bun add -g <abspath>` — directory is real, but `package.json`
      inside is a file-level symlink to source
- Extended the bun-add gate: skip when
  `target.kind === "local-path" && resolved === target.absPath`.
  Compared via `realpathSync` on both sides so symlinked input paths
  (e.g. `/var` vs `/private/var` on macOS) still match.
- Stale-symlink case (operator moved their checkout) still re-runs
  `bun add` so the global link gets refreshed.
- Two new tests pin the gate (skip when matched, re-add when stale).

## Version

`0.4.0-rc.6` → `0.4.0-rc.9`. (rc.7 is on #90, rc.8 is on #93.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)