### PR TITLE
feat: hub-side Phase 1 — POST /vaults endpoint + OAuth vault picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.9",
+  "version": "0.4.0-rc.10",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/admin-auth.test.ts
+++ b/src/__tests__/admin-auth.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AdminAuthError, adminAuthErrorResponse, extractBearerToken, requireScope } from "../admin-auth.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { signAccessToken } from "../jwt-sign.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+
+const ISSUER = "http://127.0.0.1:1939";
+
+interface Harness {
+  dir: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-admin-auth-"));
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+async function mintToken(
+  db: ReturnType<typeof openHubDb>,
+  scopes: string[],
+  opts: { audience?: string; issuer?: string } = {},
+): Promise<string> {
+  const { token } = await signAccessToken(db, {
+    sub: "user-test",
+    scopes,
+    audience: opts.audience ?? "operator",
+    clientId: "test-client",
+    issuer: opts.issuer ?? ISSUER,
+  });
+  return token;
+}
+
+function reqWithAuth(authHeader: string | null): Request {
+  const headers = new Headers();
+  if (authHeader !== null) headers.set("authorization", authHeader);
+  return new Request("http://127.0.0.1:1939/test", { method: "POST", headers });
+}
+
+describe("extractBearerToken", () => {
+  test("returns the token from a well-formed header", () => {
+    const r = reqWithAuth("Bearer abc.def.ghi");
+    expect(extractBearerToken(r)).toBe("abc.def.ghi");
+  });
+
+  test("accepts lowercase scheme", () => {
+    const r = reqWithAuth("bearer abc.def.ghi");
+    expect(extractBearerToken(r)).toBe("abc.def.ghi");
+  });
+
+  test("throws 401 when header missing", () => {
+    const r = reqWithAuth(null);
+    expect(() => extractBearerToken(r)).toThrow(AdminAuthError);
+    try {
+      extractBearerToken(r);
+    } catch (err) {
+      expect((err as AdminAuthError).status).toBe(401);
+    }
+  });
+
+  test("throws 401 when scheme is not Bearer", () => {
+    const r = reqWithAuth("Basic dXNlcjpwYXNz");
+    expect(() => extractBearerToken(r)).toThrow(AdminAuthError);
+  });
+});
+
+describe("requireScope", () => {
+  test("returns context for a token with the required scope", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const token = await mintToken(db, ["parachute:host:admin", "vault:admin"]);
+        const ctx = await requireScope(
+          db,
+          reqWithAuth(`Bearer ${token}`),
+          "parachute:host:admin",
+          ISSUER,
+        );
+        expect(ctx.sub).toBe("user-test");
+        expect(ctx.scopes).toContain("parachute:host:admin");
+        expect(ctx.clientId).toBe("test-client");
+        expect(ctx.audience).toBe("operator");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("rejects 403 when token lacks the required scope", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const token = await mintToken(db, ["vault:read"]);
+        let caught: AdminAuthError | null = null;
+        try {
+          await requireScope(
+            db,
+            reqWithAuth(`Bearer ${token}`),
+            "parachute:host:admin",
+            ISSUER,
+          );
+        } catch (err) {
+          caught = err as AdminAuthError;
+        }
+        expect(caught).not.toBeNull();
+        expect(caught?.status).toBe(403);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("rejects 401 when issuer mismatches", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const token = await mintToken(db, ["parachute:host:admin"], {
+          issuer: "http://127.0.0.1:9999",
+        });
+        let caught: AdminAuthError | null = null;
+        try {
+          await requireScope(
+            db,
+            reqWithAuth(`Bearer ${token}`),
+            "parachute:host:admin",
+            ISSUER,
+          );
+        } catch (err) {
+          caught = err as AdminAuthError;
+        }
+        expect(caught?.status).toBe(401);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("rejects 401 when token is unverifiable garbage", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        let caught: AdminAuthError | null = null;
+        try {
+          await requireScope(
+            db,
+            reqWithAuth("Bearer not-a-real-jwt"),
+            "parachute:host:admin",
+            ISSUER,
+          );
+        } catch (err) {
+          caught = err as AdminAuthError;
+        }
+        expect(caught?.status).toBe(401);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("adminAuthErrorResponse", () => {
+  test("403 → insufficient_scope with WWW-Authenticate", async () => {
+    const res = adminAuthErrorResponse(new AdminAuthError(403, "needs admin"));
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("insufficient_scope");
+    expect(res.headers.get("www-authenticate") ?? "").toContain("insufficient_scope");
+  });
+
+  test("401 → invalid_token", async () => {
+    const res = adminAuthErrorResponse(new AdminAuthError(401, "bad sig"));
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_token");
+  });
+
+  test("non-AdminAuthError → 500 server_error", async () => {
+    const res = adminAuthErrorResponse(new Error("boom"));
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("server_error");
+  });
+});

--- a/src/__tests__/admin-vaults.test.ts
+++ b/src/__tests__/admin-vaults.test.ts
@@ -2,11 +2,25 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { HOST_ADMIN_SCOPE, handleCreateVault } from "../admin-vaults.ts";
+import { HOST_ADMIN_SCOPE, type RunResult, handleCreateVault } from "../admin-vaults.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { signAccessToken } from "../jwt-sign.ts";
 import { upsertService, writeManifest } from "../services-manifest.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
+
+/** Build the JSON shape parachute-vault create --json emits (PR #184). */
+function vaultCreateJson(name: string, token = `pvt_${name}_token`): string {
+  return JSON.stringify({
+    name,
+    token,
+    paths: {
+      vault_dir: `/home/test/.parachute/vault/${name}`,
+      vault_db: `/home/test/.parachute/vault/${name}/vault.db`,
+      vault_config: `/home/test/.parachute/vault/${name}/config.yaml`,
+    },
+    set_as_default: false,
+  });
+}
 
 const ISSUER = "http://127.0.0.1:1939";
 
@@ -53,7 +67,7 @@ interface CallOpts {
   contentType?: string | null;
   manifestPath: string;
   db: ReturnType<typeof openHubDb>;
-  runCommand?: (cmd: readonly string[]) => Promise<number>;
+  runCommand?: (cmd: readonly string[]) => Promise<RunResult>;
 }
 
 async function call(opts: CallOpts): Promise<Response> {
@@ -237,7 +251,7 @@ describe("POST /vaults — orchestration", () => {
           h.manifestPath,
         );
         const calls: Array<readonly string[]> = [];
-        const runCommand = async (cmd: readonly string[]) => {
+        const runCommand = async (cmd: readonly string[]): Promise<RunResult> => {
           calls.push(cmd);
           // Simulate successful CLI by adding the new path to the manifest.
           upsertService(
@@ -250,7 +264,7 @@ describe("POST /vaults — orchestration", () => {
             },
             h.manifestPath,
           );
-          return 0;
+          return { exitCode: 0, stdout: vaultCreateJson("work") };
         };
         const res = await call({
           db,
@@ -263,7 +277,7 @@ describe("POST /vaults — orchestration", () => {
         expect(body.name).toBe("work");
         expect(body.url).toBe(`${ISSUER}/vault/work`);
         expect(body.version).toBe("0.3.5");
-        expect(calls).toEqual([["parachute-vault", "create", "work"]]);
+        expect(calls).toEqual([["parachute-vault", "create", "work", "--json"]]);
       } finally {
         db.close();
       }
@@ -272,28 +286,82 @@ describe("POST /vaults — orchestration", () => {
     }
   });
 
-  test("201 on bootstrap path (vault not yet registered) → calls `parachute install vault --vault-name`", async () => {
+  test("201 on bootstrap path (vault not yet registered) → calls `parachute install vault`", async () => {
     const h = makeHarness();
     try {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
-        // Empty manifest: vault NOT registered yet.
+        // Empty manifest: vault NOT registered yet. The bootstrap path runs
+        // `parachute install vault`, which seeds the default vault. The
+        // `name` requested by the caller is honored on follow-up calls
+        // through the create-with-json branch (above); first-vault-on-host
+        // doesn't currently surface a token (install has no --json yet).
         writeManifest({ services: [] }, h.manifestPath);
         const calls: Array<readonly string[]> = [];
-        const runCommand = async (cmd: readonly string[]) => {
+        const runCommand = async (cmd: readonly string[]): Promise<RunResult> => {
           calls.push(cmd);
           upsertService(
             {
               name: "parachute-vault",
               port: 1940,
-              paths: ["/vault/work"],
+              paths: ["/vault/default"],
               health: "/health",
               version: "0.3.5",
             },
             h.manifestPath,
           );
-          return 0;
+          return { exitCode: 0, stdout: "" };
+        };
+        const res = await call({
+          db,
+          manifestPath: h.manifestPath,
+          body: { name: "default" },
+          runCommand,
+        });
+        expect(res.status).toBe(201);
+        expect(calls).toEqual([["parachute", "install", "vault"]]);
+        // Bootstrap path: response carries name/url/version, no token/paths
+        // (install doesn't emit JSON yet — known gap, follow-up issue).
+        const body = (await res.json()) as Record<string, unknown>;
+        expect(body.token).toBeUndefined();
+        expect(body.paths).toBeUndefined();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("201 response includes token + paths from `parachute-vault create --json` stdout", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/default"],
+            health: "/health",
+            version: "0.3.5",
+          },
+          h.manifestPath,
+        );
+        const runCommand = async (_cmd: readonly string[]): Promise<RunResult> => {
+          upsertService(
+            {
+              name: "parachute-vault",
+              port: 1940,
+              paths: ["/vault/default", "/vault/work"],
+              health: "/health",
+              version: "0.3.5",
+            },
+            h.manifestPath,
+          );
+          return { exitCode: 0, stdout: vaultCreateJson("work", "pvt_supersecret") };
         };
         const res = await call({
           db,
@@ -302,7 +370,17 @@ describe("POST /vaults — orchestration", () => {
           runCommand,
         });
         expect(res.status).toBe(201);
-        expect(calls).toEqual([["parachute", "install", "vault", "--vault-name", "work"]]);
+        const body = (await res.json()) as {
+          name: string;
+          token?: string;
+          paths?: { vault_dir: string; vault_db: string; vault_config: string };
+        };
+        expect(body.token).toBe("pvt_supersecret");
+        expect(body.paths).toEqual({
+          vault_dir: "/home/test/.parachute/vault/work",
+          vault_db: "/home/test/.parachute/vault/work/vault.db",
+          vault_config: "/home/test/.parachute/vault/work/config.yaml",
+        });
       } finally {
         db.close();
       }
@@ -311,7 +389,42 @@ describe("POST /vaults — orchestration", () => {
     }
   });
 
-  test("200 idempotent re-POST when vault already exists in services.json", async () => {
+  test("500 when `parachute-vault create --json` exits 0 but stdout is unparseable", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/default"],
+            health: "/health",
+            version: "0.3.5",
+          },
+          h.manifestPath,
+        );
+        const runCommand = async (): Promise<RunResult> => ({
+          exitCode: 0,
+          stdout: "this-is-not-json",
+        });
+        const res = await call({
+          db,
+          manifestPath: h.manifestPath,
+          body: { name: "work" },
+          runCommand,
+        });
+        expect(res.status).toBe(500);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("200 idempotent re-POST when vault already exists, no token in response", async () => {
     const h = makeHarness();
     try {
       const db = openHubDb(hubDbPath(h.dir));
@@ -328,9 +441,9 @@ describe("POST /vaults — orchestration", () => {
           h.manifestPath,
         );
         let runCalled = false;
-        const runCommand = async () => {
+        const runCommand = async (): Promise<RunResult> => {
           runCalled = true;
-          return 0;
+          return { exitCode: 0, stdout: "" };
         };
         const res = await call({
           db,
@@ -339,9 +452,12 @@ describe("POST /vaults — orchestration", () => {
           runCommand,
         });
         expect(res.status).toBe(200);
-        const body = (await res.json()) as { name: string; url: string };
+        const body = (await res.json()) as Record<string, unknown>;
         expect(body.name).toBe("work");
         expect(body.url).toBe(`${ISSUER}/vault/work`);
+        // Token is single-emit at create time — re-POST never re-emits it.
+        expect(body.token).toBeUndefined();
+        expect(body.paths).toBeUndefined();
         expect(runCalled).toBe(false);
       } finally {
         db.close();
@@ -367,7 +483,7 @@ describe("POST /vaults — orchestration", () => {
           },
           h.manifestPath,
         );
-        const runCommand = async () => 1;
+        const runCommand = async (): Promise<RunResult> => ({ exitCode: 1, stdout: "" });
         const res = await call({
           db,
           manifestPath: h.manifestPath,
@@ -399,7 +515,10 @@ describe("POST /vaults — orchestration", () => {
           },
           h.manifestPath,
         );
-        const runCommand = async () => 0;
+        const runCommand = async (): Promise<RunResult> => ({
+          exitCode: 0,
+          stdout: vaultCreateJson("work"),
+        });
         const res = await call({
           db,
           manifestPath: h.manifestPath,

--- a/src/__tests__/admin-vaults.test.ts
+++ b/src/__tests__/admin-vaults.test.ts
@@ -1,0 +1,440 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HOST_ADMIN_SCOPE, handleCreateVault } from "../admin-vaults.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { signAccessToken } from "../jwt-sign.ts";
+import { upsertService, writeManifest } from "../services-manifest.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+
+const ISSUER = "http://127.0.0.1:1939";
+
+interface Harness {
+  dir: string;
+  manifestPath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-admin-vaults-"));
+  return {
+    dir,
+    manifestPath: join(dir, "services.json"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+async function adminToken(db: ReturnType<typeof openHubDb>): Promise<string> {
+  const { token } = await signAccessToken(db, {
+    sub: "user-admin",
+    scopes: [HOST_ADMIN_SCOPE, "vault:admin"],
+    audience: "operator",
+    clientId: "test-client",
+    issuer: ISSUER,
+  });
+  return token;
+}
+
+async function readOnlyToken(db: ReturnType<typeof openHubDb>): Promise<string> {
+  const { token } = await signAccessToken(db, {
+    sub: "user-readonly",
+    scopes: ["vault:read"],
+    audience: "operator",
+    clientId: "test-client",
+    issuer: ISSUER,
+  });
+  return token;
+}
+
+interface CallOpts {
+  body?: unknown;
+  authHeader?: string | null;
+  contentType?: string | null;
+  manifestPath: string;
+  db: ReturnType<typeof openHubDb>;
+  runCommand?: (cmd: readonly string[]) => Promise<number>;
+}
+
+async function call(opts: CallOpts): Promise<Response> {
+  const headers = new Headers();
+  if (opts.authHeader === undefined) {
+    headers.set("authorization", `Bearer ${await adminToken(opts.db)}`);
+  } else if (opts.authHeader !== null) {
+    headers.set("authorization", opts.authHeader);
+  }
+  if (opts.contentType === undefined) headers.set("content-type", "application/json");
+  else if (opts.contentType !== null) headers.set("content-type", opts.contentType);
+
+  const init: RequestInit = { method: "POST", headers };
+  if (opts.body !== undefined) {
+    init.body = typeof opts.body === "string" ? opts.body : JSON.stringify(opts.body);
+  }
+  const req = new Request(`${ISSUER}/vaults`, init);
+  return handleCreateVault(req, {
+    db: opts.db,
+    issuer: ISSUER,
+    manifestPath: opts.manifestPath,
+    ...(opts.runCommand ? { runCommand: opts.runCommand } : {}),
+  });
+}
+
+describe("POST /vaults — auth", () => {
+  test("401 when Authorization header missing", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const res = await call({
+          db,
+          manifestPath: h.manifestPath,
+          authHeader: null,
+          body: { name: "work" },
+        });
+        expect(res.status).toBe(401);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("403 when token lacks parachute:host:admin scope", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const res = await call({
+          db,
+          manifestPath: h.manifestPath,
+          authHeader: `Bearer ${await readOnlyToken(db)}`,
+          body: { name: "work" },
+        });
+        expect(res.status).toBe(403);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("POST /vaults — body validation", () => {
+  test("400 when Content-Type is not application/json", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const res = await call({
+          db,
+          manifestPath: h.manifestPath,
+          contentType: "text/plain",
+          body: '{"name":"work"}',
+        });
+        expect(res.status).toBe(400);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("400 on malformed JSON", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const res = await call({
+          db,
+          manifestPath: h.manifestPath,
+          body: "not-json",
+        });
+        expect(res.status).toBe(400);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("400 when name is empty / missing / non-string", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        for (const body of [{}, { name: "" }, { name: 42 }, { name: null }]) {
+          const res = await call({ db, manifestPath: h.manifestPath, body });
+          expect(res.status).toBe(400);
+        }
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("400 when name has invalid characters", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        for (const name of ["my vault", "../etc", "foo/bar", "x.y", "a:b"]) {
+          const res = await call({ db, manifestPath: h.manifestPath, body: { name } });
+          expect(res.status).toBe(400);
+        }
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test('400 when name is the reserved "list"', async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const res = await call({ db, manifestPath: h.manifestPath, body: { name: "list" } });
+        expect(res.status).toBe(400);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("POST /vaults — orchestration", () => {
+  test("201 on happy path with vault already registered → calls `parachute-vault create`", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        // Seed services.json with the parachute-vault entry; vault is registered.
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/default"],
+            health: "/health",
+            version: "0.3.5",
+          },
+          h.manifestPath,
+        );
+        const calls: Array<readonly string[]> = [];
+        const runCommand = async (cmd: readonly string[]) => {
+          calls.push(cmd);
+          // Simulate successful CLI by adding the new path to the manifest.
+          upsertService(
+            {
+              name: "parachute-vault",
+              port: 1940,
+              paths: ["/vault/default", "/vault/work"],
+              health: "/health",
+              version: "0.3.5",
+            },
+            h.manifestPath,
+          );
+          return 0;
+        };
+        const res = await call({
+          db,
+          manifestPath: h.manifestPath,
+          body: { name: "work" },
+          runCommand,
+        });
+        expect(res.status).toBe(201);
+        const body = (await res.json()) as { name: string; url: string; version: string };
+        expect(body.name).toBe("work");
+        expect(body.url).toBe(`${ISSUER}/vault/work`);
+        expect(body.version).toBe("0.3.5");
+        expect(calls).toEqual([["parachute-vault", "create", "work"]]);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("201 on bootstrap path (vault not yet registered) → calls `parachute install vault --vault-name`", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        // Empty manifest: vault NOT registered yet.
+        writeManifest({ services: [] }, h.manifestPath);
+        const calls: Array<readonly string[]> = [];
+        const runCommand = async (cmd: readonly string[]) => {
+          calls.push(cmd);
+          upsertService(
+            {
+              name: "parachute-vault",
+              port: 1940,
+              paths: ["/vault/work"],
+              health: "/health",
+              version: "0.3.5",
+            },
+            h.manifestPath,
+          );
+          return 0;
+        };
+        const res = await call({
+          db,
+          manifestPath: h.manifestPath,
+          body: { name: "work" },
+          runCommand,
+        });
+        expect(res.status).toBe(201);
+        expect(calls).toEqual([["parachute", "install", "vault", "--vault-name", "work"]]);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("200 idempotent re-POST when vault already exists in services.json", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/default", "/vault/work"],
+            health: "/health",
+            version: "0.3.5",
+          },
+          h.manifestPath,
+        );
+        let runCalled = false;
+        const runCommand = async () => {
+          runCalled = true;
+          return 0;
+        };
+        const res = await call({
+          db,
+          manifestPath: h.manifestPath,
+          body: { name: "work" },
+          runCommand,
+        });
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { name: string; url: string };
+        expect(body.name).toBe("work");
+        expect(body.url).toBe(`${ISSUER}/vault/work`);
+        expect(runCalled).toBe(false);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("500 when CLI exits non-zero", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/default"],
+            health: "/health",
+            version: "0.3.5",
+          },
+          h.manifestPath,
+        );
+        const runCommand = async () => 1;
+        const res = await call({
+          db,
+          manifestPath: h.manifestPath,
+          body: { name: "work" },
+          runCommand,
+        });
+        expect(res.status).toBe(500);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("500 when CLI exits 0 but services.json doesn't reflect the new vault", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/default"],
+            health: "/health",
+            version: "0.3.5",
+          },
+          h.manifestPath,
+        );
+        const runCommand = async () => 0;
+        const res = await call({
+          db,
+          manifestPath: h.manifestPath,
+          body: { name: "work" },
+          runCommand,
+        });
+        expect(res.status).toBe(500);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("POST /vaults — method gating", () => {
+  test("405 on GET", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const req = new Request(`${ISSUER}/vaults`, { method: "GET" });
+        const res = await handleCreateVault(req, {
+          db,
+          issuer: ISSUER,
+          manifestPath: h.manifestPath,
+        });
+        expect(res.status).toBe(405);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -227,6 +227,314 @@ describe("handleAuthorizeGet", () => {
   });
 });
 
+// Q1 of 2026-04-28-vault-config-and-scopes.md: an unnamed `vault:<verb>` is
+// ambiguous, so the consent screen forces the operator to pick a vault before
+// the JWT is minted. Picked vault rewrites the scope to `vault:<picked>:<verb>`
+// and stamps `aud=vault.<picked>` so vault's strict per-resource enforcement
+// (Phase 1) can match the audience against the URL-derived vault name.
+describe("handleAuthorizeGet — vault picker", () => {
+  test("renders the picker when scope is unnamed vault:<verb>", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:read",
+        }),
+        {
+          headers: {
+            cookie: buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000)),
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("Pick a vault");
+      // The fixture manifest's `parachute-vault` has paths `["/vault/default"]`
+      // — that's the one available vault in the picker.
+      expect(html).toContain('name="vault_pick" value="default"');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("picker is omitted when scope is already named vault:<name>:<verb>", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:work:read",
+        }),
+        {
+          headers: {
+            cookie: buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000)),
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).not.toContain("Pick a vault");
+      expect(html).not.toContain('name="vault_pick"');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("picker shows a help message and disables Approve when no vaults exist", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:read",
+        }),
+        {
+          headers: {
+            cookie: buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000)),
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: () => ({ services: [] }),
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("Pick a vault");
+      expect(html).toContain("no vaults exist");
+      expect(html).toContain('name="approve" value="yes" class="btn btn-primary" disabled');
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("handleAuthorizePost — vault picker", () => {
+  test("approve with vault_pick narrows vault:read → vault:<picked>:read in the issued JWT", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { verifier, challenge } = makePkce();
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        vault_pick: "default",
+      });
+      const consentReq = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: consentForm,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: buildSessionCookie(session.id, 86400),
+        },
+      });
+      const consentRes = await handleAuthorizePost(db, consentReq, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(consentRes.status).toBe(302);
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      expect(code).toBeTruthy();
+
+      const tokenForm = new URLSearchParams({
+        grant_type: "authorization_code",
+        code: code ?? "",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        code_verifier: verifier,
+      });
+      const tokenRes = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: tokenForm,
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(tokenRes.status).toBe(200);
+      const body = (await tokenRes.json()) as { access_token: string; scope: string };
+      expect(body.scope).toBe("vault:default:read");
+
+      const { payload } = await validateAccessToken(db, body.access_token, ISSUER);
+      expect(payload.aud).toBe("vault.default");
+      expect(payload.scope).toBe("vault:default:read");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("approve without vault_pick on unnamed vault scope fails 400", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const res = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: buildSessionCookie(session.id, 86400),
+          },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(res.status).toBe(400);
+      const html = await res.text();
+      expect(html).toContain("Pick a vault");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("approve with vault_pick that names an unknown vault fails 400", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        vault_pick: "evil-vault",
+      });
+      const res = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: buildSessionCookie(session.id, 86400),
+          },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(res.status).toBe(400);
+      const html = await res.text();
+      expect(html).toContain("Unknown vault");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("multiple unnamed verbs are all narrowed to the picked vault", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { verifier, challenge } = makePkce();
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:read vault:write",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        vault_pick: "default",
+      });
+      const consentRes = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: buildSessionCookie(session.id, 86400),
+          },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const tokenRes = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: new URLSearchParams({
+            grant_type: "authorization_code",
+            code: code ?? "",
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            code_verifier: verifier,
+          }),
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(tokenRes.status).toBe(200);
+      const body = (await tokenRes.json()) as { scope: string };
+      expect(body.scope).toBe("vault:default:read vault:default:write");
+    } finally {
+      cleanup();
+    }
+  });
+});
+
 describe("handleAuthorizePost — login submit", () => {
   test("sets session cookie and redirects to GET on valid credentials", async () => {
     const { db, cleanup } = await makeDb();
@@ -305,7 +613,7 @@ describe("handleAuthorizePost — consent submit", () => {
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
         response_type: "code",
-        scope: "vault:read",
+        scope: "vault:default:read",
         code_challenge: challenge,
         code_challenge_method: "S256",
         state: "abc123",
@@ -382,7 +690,7 @@ describe("handleToken — full OAuth dance", () => {
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
         response_type: "code",
-        scope: "vault:read",
+        scope: "vault:default:read",
         code_challenge: challenge,
         code_challenge_method: "S256",
       });
@@ -425,17 +733,19 @@ describe("handleToken — full OAuth dance", () => {
         services: Record<string, { url: string; version: string }>;
       };
       expect(tokenBody.token_type).toBe("Bearer");
-      expect(tokenBody.scope).toBe("vault:read");
+      expect(tokenBody.scope).toBe("vault:default:read");
       expect(tokenBody.refresh_token.length).toBeGreaterThan(20);
 
       // JWT must verify against the hub's signing keys, with the right sub +
-      // aud (vault:read → "vault") and iss matching the configured issuer
-      // (closes #77 — vault rejects tokens with a missing or mismatched iss).
+      // aud (named `vault:default:read` → "vault.default" — RFC 8707-style
+      // resource binding from the vault-config-and-scopes Phase 1+2 design)
+      // and iss matching the configured issuer (closes #77 — vault rejects
+      // tokens with a missing or mismatched iss).
       const { payload } = await validateAccessToken(db, tokenBody.access_token, ISSUER);
       expect(payload.sub).toBe(user.id);
-      expect(payload.aud).toBe("vault");
+      expect(payload.aud).toBe("vault.default");
       expect(payload.iss).toBe(ISSUER);
-      expect(payload.scope).toBe("vault:read");
+      expect(payload.scope).toBe("vault:default:read");
       expect(payload.client_id).toBe(reg.client.clientId);
 
       // closes #81 — services catalog tells the client where vault lives so
@@ -517,7 +827,7 @@ describe("handleToken — full OAuth dance", () => {
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
         response_type: "code",
-        scope: "vault:read",
+        scope: "vault:default:read",
         code_challenge: challenge,
         code_challenge_method: "S256",
       });
@@ -672,7 +982,7 @@ describe("handleToken — full OAuth dance", () => {
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
         response_type: "code",
-        scope: "vault:read frobnicate:everything",
+        scope: "vault:default:read frobnicate:everything",
         code_challenge: challenge,
         code_challenge_method: "S256",
       });

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -151,6 +151,48 @@ describe("renderConsent", () => {
     expect(html).not.toContain("<img src=x");
     expect(html).toContain("&lt;img");
   });
+
+  test("renders a vault picker when vaultPicker is set", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read"],
+      vaultPicker: { unnamedVerbs: ["read"], availableVaults: ["work", "personal"] },
+    });
+    expect(html).toContain("Pick a vault");
+    expect(html).toContain('name="vault_pick" value="work"');
+    expect(html).toContain('name="vault_pick" value="personal"');
+    // First option pre-checked so a single-vault host doesn't force a click.
+    expect(html).toMatch(/name="vault_pick" value="work" checked/);
+  });
+
+  test("escapes a hostile vault name in the picker", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read"],
+      vaultPicker: {
+        unnamedVerbs: ["read"],
+        availableVaults: [`evil"><script>alert(1)</script>`],
+      },
+    });
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&quot;&gt;&lt;script&gt;");
+  });
+
+  test("disables the Approve button when no vaults exist", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read"],
+      vaultPicker: { unnamedVerbs: ["read"], availableVaults: [] },
+    });
+    expect(html).toContain("no vaults exist");
+    expect(html).toContain('value="yes" class="btn btn-primary" disabled');
+  });
 });
 
 describe("renderError", () => {

--- a/src/__tests__/operator-token.test.ts
+++ b/src/__tests__/operator-token.test.ts
@@ -58,9 +58,10 @@ describe("mintOperatorToken", () => {
     }
   });
 
-  test("scopes include hub:admin + vault:admin + scribe:admin + channel:send", () => {
+  test("scopes include hub:admin + parachute:host:admin + vault:admin + scribe:admin + channel:send", () => {
     expect(OPERATOR_TOKEN_SCOPES).toEqual([
       "hub:admin",
+      "parachute:host:admin",
       "vault:admin",
       "scribe:admin",
       "channel:send",

--- a/src/__tests__/scope-explanations.test.ts
+++ b/src/__tests__/scope-explanations.test.ts
@@ -17,6 +17,7 @@ describe("SCOPE_EXPLANATIONS", () => {
       "scribe:admin",
       "channel:send",
       "hub:admin",
+      "parachute:host:admin",
     ];
     for (const s of expected) {
       expect(SCOPE_EXPLANATIONS[s]).toBeDefined();
@@ -44,6 +45,7 @@ describe("scopeIsAdmin", () => {
   test("true for admin scopes", () => {
     expect(scopeIsAdmin("vault:admin")).toBe(true);
     expect(scopeIsAdmin("hub:admin")).toBe(true);
+    expect(scopeIsAdmin("parachute:host:admin")).toBe(true);
   });
 
   test("false for non-admin and unknown scopes", () => {

--- a/src/admin-auth.ts
+++ b/src/admin-auth.ts
@@ -1,0 +1,128 @@
+/**
+ * Bearer-token auth for hub-native admin endpoints (POST /vaults, future
+ * `/admin/*` routes). The hub validates its own JWTs against local signing
+ * keys — no JWKS round-trip — and asserts the presented token carries the
+ * required scope.
+ *
+ * Why this exists: until now the hub has been a *pure issuer* with no
+ * authenticated endpoints of its own. Phase 1 of the vault-config-and-scopes
+ * design adds POST /vaults, which mints+config-writes through privileged
+ * code paths. That call needs an admin scope, and its first reader is
+ * `parachute:host:admin` (the cross-vault provisioning capability).
+ *
+ * Errors are HTTP-shaped: `AdminAuthError(status, message)` so the route
+ * handler can `throw` and the boundary translates straight to a Response.
+ */
+import type { Database } from "bun:sqlite";
+import { validateAccessToken } from "./jwt-sign.ts";
+
+export interface AdminAuthContext {
+  /** JWT `sub` — the hub user id. */
+  sub: string;
+  /** Parsed `scope` claim. */
+  scopes: string[];
+  /** `client_id` claim, if present (operator token vs OAuth client). */
+  clientId: string | undefined;
+  /** `aud` claim, if present. Surfaced for logs / future cross-aud rules. */
+  audience: string | undefined;
+}
+
+export class AdminAuthError extends Error {
+  override name = "AdminAuthError";
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+/**
+ * Pull a Bearer token from `Authorization: Bearer <token>`. Throws
+ * `AdminAuthError(401)` when missing / malformed. Match is case-insensitive
+ * on the scheme (some clients send "bearer" lowercase) but the token itself
+ * is the raw JWT string.
+ */
+export function extractBearerToken(req: Request): string {
+  const header = req.headers.get("authorization");
+  if (!header) {
+    throw new AdminAuthError(401, "missing Authorization header");
+  }
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  if (!match || !match[1]) {
+    throw new AdminAuthError(401, "Authorization header must be 'Bearer <token>'");
+  }
+  return match[1].trim();
+}
+
+/**
+ * Validate a presented bearer token against the hub's local signing keys
+ * and check it carries `requiredScope`. Returns surfaced claims on success;
+ * throws `AdminAuthError` (401 or 403) otherwise.
+ *
+ * `expectedIssuer` MUST be the hub's own origin — the same value baked into
+ * tokens we sign. Defense in depth: even though we can only verify our own
+ * keys, the `iss` mismatch reject keeps cross-issuer confusion impossible.
+ */
+export async function requireScope(
+  db: Database,
+  req: Request,
+  requiredScope: string,
+  expectedIssuer: string,
+): Promise<AdminAuthContext> {
+  const token = extractBearerToken(req);
+
+  let validated;
+  try {
+    validated = await validateAccessToken(db, token, expectedIssuer);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new AdminAuthError(401, `invalid token: ${msg}`);
+  }
+
+  const sub = typeof validated.payload.sub === "string" ? validated.payload.sub : null;
+  if (!sub) throw new AdminAuthError(401, "token missing required `sub` claim");
+
+  const scopeClaim = (validated.payload as { scope?: unknown }).scope;
+  const scopes =
+    typeof scopeClaim === "string"
+      ? scopeClaim.split(/\s+/).filter((s) => s.length > 0)
+      : [];
+
+  if (!scopes.includes(requiredScope)) {
+    throw new AdminAuthError(
+      403,
+      `token missing required scope: ${requiredScope}`,
+    );
+  }
+
+  const clientIdRaw = (validated.payload as { client_id?: unknown }).client_id;
+  const clientId = typeof clientIdRaw === "string" ? clientIdRaw : undefined;
+  const aud = typeof validated.payload.aud === "string" ? validated.payload.aud : undefined;
+
+  return { sub, scopes, clientId, audience: aud };
+}
+
+/**
+ * Translate an AdminAuthError to an RFC-6750-style JSON Response.
+ * Convenience for route handlers that want to do
+ * `try { ctx = await requireScope(...) } catch (err) { return adminAuthErrorResponse(err); }`.
+ */
+export function adminAuthErrorResponse(err: unknown): Response {
+  if (err instanceof AdminAuthError) {
+    return new Response(
+      JSON.stringify({ error: err.status === 403 ? "insufficient_scope" : "invalid_token", error_description: err.message }),
+      {
+        status: err.status,
+        headers: {
+          "content-type": "application/json",
+          "www-authenticate": `Bearer error="${err.status === 403 ? "insufficient_scope" : "invalid_token"}", error_description="${err.message.replace(/"/g, "'")}"`,
+        },
+      },
+    );
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  return new Response(JSON.stringify({ error: "server_error", error_description: msg }), {
+    status: 500,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -1,0 +1,250 @@
+/**
+ * `POST /vaults` — provision a new vault on the host.
+ *
+ * The hub's first authenticated, mutating endpoint. Until now the hub has
+ * been a pure issuer; Phase 1 of the vault-config-and-scopes design (D1)
+ * lifts vault provisioning into a hub UI surface so paraclaw / hub-admin
+ * pages can mint a vault without shelling out to a terminal.
+ *
+ * Wire shape:
+ *   POST /vaults
+ *   Authorization: Bearer <jwt with parachute:host:admin>
+ *   Content-Type: application/json
+ *   { "name": "<vault-name>" }
+ *
+ *   201 → { name, url, version }   // vault freshly created
+ *   200 → { name, url, version }   // idempotent re-POST: existing vault
+ *   400 → { error: "invalid_request", error_description: ... }
+ *   401/403 → bearer-auth failure
+ *   500 → orchestration failure
+ *
+ * Orchestration:
+ *   - If `parachute-vault` is NOT yet registered in services.json: shell
+ *     out to `parachute install vault --vault-name <name>` (covers the
+ *     bootstrap case for a fresh host).
+ *   - If `parachute-vault` IS already registered: shell out to
+ *     `parachute-vault create <name>` (subsequent vaults).
+ *
+ * The CLI is the single source of truth for "how do you create a vault";
+ * we don't reimplement DB+yaml+token writes here. Mirrors D1 in the design
+ * doc: hub orchestrates the CLI, doesn't replace it.
+ *
+ * Idempotency: name validation matches `parachute-vault create` (regex +
+ * "list" reserved). When a vault with the requested name already exists,
+ * we return 200 with the existing entry rather than re-running the CLI —
+ * the CLI itself rejects an existing name with exit 1, but a re-POST is
+ * usually a UI retry, not an error to the caller.
+ */
+import type { Database } from "bun:sqlite";
+import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
+import { SERVICES_MANIFEST_PATH } from "./config.ts";
+import { findService, readManifest } from "./services-manifest.ts";
+import {
+  type WellKnownVaultEntry,
+  isVaultEntry,
+  vaultInstanceName,
+} from "./well-known.ts";
+
+/** Scope required to call POST /vaults. */
+export const HOST_ADMIN_SCOPE = "parachute:host:admin";
+
+/** Mirror parachute-vault's `cmdCreate` validation rules. */
+const VAULT_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const RESERVED_VAULT_NAMES = new Set(["list"]);
+
+export interface CreateVaultRequest {
+  name: string;
+}
+
+export interface CreateVaultDeps {
+  db: Database;
+  /** Hub origin used to validate JWT `iss` and to build the response `url`. */
+  issuer: string;
+  /** Override the services.json path. Defaults to `~/.parachute/services.json`. */
+  manifestPath?: string;
+  /**
+   * Test seam: run the orchestration command. Production spawns the real
+   * `parachute install` / `parachute-vault create` binaries; tests stub it
+   * to avoid touching the filesystem outside the temp dir.
+   */
+  runCommand?: (cmd: readonly string[]) => Promise<number>;
+}
+
+interface ParseResult {
+  ok: true;
+  body: CreateVaultRequest;
+}
+interface ParseError {
+  ok: false;
+  status: number;
+  message: string;
+}
+
+async function parseBody(req: Request): Promise<ParseResult | ParseError> {
+  const ctype = req.headers.get("content-type") ?? "";
+  if (!ctype.toLowerCase().includes("application/json")) {
+    return { ok: false, status: 400, message: "Content-Type must be application/json" };
+  }
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, status: 400, message: `invalid JSON body: ${msg}` };
+  }
+  if (!raw || typeof raw !== "object") {
+    return { ok: false, status: 400, message: "request body must be a JSON object" };
+  }
+  const name = (raw as Record<string, unknown>).name;
+  if (typeof name !== "string" || name.length === 0) {
+    return { ok: false, status: 400, message: '"name" must be a non-empty string' };
+  }
+  if (!VAULT_NAME_PATTERN.test(name)) {
+    return {
+      ok: false,
+      status: 400,
+      message: 'vault name must contain only letters, numbers, hyphens, and underscores',
+    };
+  }
+  if (RESERVED_VAULT_NAMES.has(name)) {
+    return { ok: false, status: 400, message: `"${name}" is a reserved vault name` };
+  }
+  return { ok: true, body: { name } };
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * Find an existing vault by name in services.json. Vaults live under one
+ * `parachute-vault` service entry with a multi-path array (per Q5 of the
+ * design — single entry, multi-path). We match on the path suffix.
+ */
+function findExistingVault(
+  manifestPath: string,
+  name: string,
+): { url: string; version: string; path: string } | null {
+  let manifest;
+  try {
+    manifest = readManifest(manifestPath);
+  } catch {
+    return null;
+  }
+  const target = `/vault/${name}`;
+  for (const svc of manifest.services) {
+    if (!isVaultEntry(svc)) continue;
+    // Multi-path single-entry shape (Q5): paths includes /vault/<name>.
+    if (svc.paths.includes(target)) {
+      return { url: target, version: svc.version, path: target };
+    }
+    // Per-vault entry shape (`parachute-vault-<name>`): instance name match.
+    if (vaultInstanceName(svc) === name) {
+      const path = svc.paths[0] ?? target;
+      return { url: path, version: svc.version, path };
+    }
+  }
+  return null;
+}
+
+function buildEntry(
+  name: string,
+  path: string,
+  version: string,
+  issuer: string,
+): WellKnownVaultEntry {
+  const base = issuer.replace(/\/$/, "");
+  const url = new URL(path, `${base}/`).toString();
+  return { name, url, version };
+}
+
+async function defaultRunCommand(cmd: readonly string[]): Promise<number> {
+  const proc = Bun.spawn([...cmd], { stdio: ["ignore", "pipe", "pipe"] });
+  return await proc.exited;
+}
+
+/**
+ * Run the orchestration step. Picks `parachute install` (bootstrap) vs
+ * `parachute-vault create` (subsequent) based on whether vault is already
+ * registered in services.json.
+ */
+async function orchestrate(
+  manifestPath: string,
+  name: string,
+  runCommand: (cmd: readonly string[]) => Promise<number>,
+): Promise<{ ok: true } | { ok: false; status: number; message: string }> {
+  const vaultRegistered = findService("parachute-vault", manifestPath) !== undefined;
+  const cmd = vaultRegistered
+    ? ["parachute-vault", "create", name]
+    : ["parachute", "install", "vault", "--vault-name", name];
+  let code: number;
+  try {
+    code = await runCommand(cmd);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, status: 500, message: `orchestration failed: ${msg}` };
+  }
+  if (code !== 0) {
+    return {
+      ok: false,
+      status: 500,
+      message: `${cmd[0]} ${cmd[1] ?? ""} exited with code ${code}`,
+    };
+  }
+  return { ok: true };
+}
+
+export async function handleCreateVault(req: Request, deps: CreateVaultDeps): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response("method not allowed", { status: 405 });
+  }
+  const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const runCommand = deps.runCommand ?? defaultRunCommand;
+
+  // Auth gate: parachute:host:admin scope. Maps an AdminAuthError straight
+  // to an RFC 6750 401/403 — the route handler doesn't care which.
+  try {
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+  } catch (err) {
+    return adminAuthErrorResponse(err as AdminAuthError);
+  }
+
+  const parsed = await parseBody(req);
+  if (!parsed.ok) {
+    return jsonError(parsed.status, "invalid_request", parsed.message);
+  }
+  const { name } = parsed.body;
+
+  // Idempotency: if the vault already exists, return 200 + existing entry.
+  // Skip the CLI shell-out — re-POST is usually a UI retry.
+  const existing = findExistingVault(manifestPath, name);
+  if (existing) {
+    return new Response(JSON.stringify(buildEntry(name, existing.path, existing.version, deps.issuer)), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  const result = await orchestrate(manifestPath, name, runCommand);
+  if (!result.ok) {
+    return jsonError(result.status, "server_error", result.message);
+  }
+
+  // Re-read services.json: the CLI just wrote it.
+  const created = findExistingVault(manifestPath, name);
+  if (!created) {
+    return jsonError(
+      500,
+      "server_error",
+      `vault "${name}" was provisioned but is not in services.json — manual recovery required`,
+    );
+  }
+
+  return new Response(JSON.stringify(buildEntry(name, created.path, created.version, deps.issuer)), {
+    status: 201,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -12,18 +12,28 @@
  *   Content-Type: application/json
  *   { "name": "<vault-name>" }
  *
- *   201 → { name, url, version }   // vault freshly created
- *   200 → { name, url, version }   // idempotent re-POST: existing vault
+ *   201 → { name, url, version, token?, paths? }
+ *           // vault freshly created. `token` (single-emit `pvt_*`) and
+ *           // filesystem `paths` are present when the create path took the
+ *           // `parachute-vault create --json` branch — that's the only time
+ *           // the just-emitted token is captured. The first-vault-on-host
+ *           // bootstrap (`parachute install vault`) doesn't emit JSON yet,
+ *           // so a fresh-box response carries name/url/version only.
+ *   200 → { name, url, version }
+ *           // idempotent re-POST: existing vault. Never includes `token` —
+ *           // tokens are single-emit at create time, not retrievable later.
  *   400 → { error: "invalid_request", error_description: ... }
  *   401/403 → bearer-auth failure
  *   500 → orchestration failure
  *
  * Orchestration:
  *   - If `parachute-vault` is NOT yet registered in services.json: shell
- *     out to `parachute install vault --vault-name <name>` (covers the
- *     bootstrap case for a fresh host).
+ *     out to `parachute install vault` (covers the bootstrap case for a
+ *     fresh host; runs `parachute-vault init` which creates the default
+ *     vault).
  *   - If `parachute-vault` IS already registered: shell out to
- *     `parachute-vault create <name>` (subsequent vaults).
+ *     `parachute-vault create --json <name>` (subsequent vaults). Stdout
+ *     is parsed for the bootstrap creds (name, token, paths).
  *
  * The CLI is the single source of truth for "how do you create a vault";
  * we don't reimplement DB+yaml+token writes here. Mirrors D1 in the design
@@ -39,11 +49,7 @@ import type { Database } from "bun:sqlite";
 import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import { findService, readManifest } from "./services-manifest.ts";
-import {
-  type WellKnownVaultEntry,
-  isVaultEntry,
-  vaultInstanceName,
-} from "./well-known.ts";
+import { type WellKnownVaultEntry, isVaultEntry, vaultInstanceName } from "./well-known.ts";
 
 /** Scope required to call POST /vaults. */
 export const HOST_ADMIN_SCOPE = "parachute:host:admin";
@@ -56,6 +62,24 @@ export interface CreateVaultRequest {
   name: string;
 }
 
+/** Output shape of `parachute-vault create --json` (vault PR #184). */
+export interface VaultCreateJson {
+  name: string;
+  token: string;
+  paths: {
+    vault_dir: string;
+    vault_db: string;
+    vault_config: string;
+  };
+  set_as_default: boolean;
+}
+
+/** Result of a single shell-out: exit code + captured stdout. */
+export interface RunResult {
+  exitCode: number;
+  stdout: string;
+}
+
 export interface CreateVaultDeps {
   db: Database;
   /** Hub origin used to validate JWT `iss` and to build the response `url`. */
@@ -65,9 +89,10 @@ export interface CreateVaultDeps {
   /**
    * Test seam: run the orchestration command. Production spawns the real
    * `parachute install` / `parachute-vault create` binaries; tests stub it
-   * to avoid touching the filesystem outside the temp dir.
+   * to avoid touching the filesystem outside the temp dir. Stdout is
+   * captured so the create branch can parse `parachute-vault create --json`.
    */
-  runCommand?: (cmd: readonly string[]) => Promise<number>;
+  runCommand?: (cmd: readonly string[]) => Promise<RunResult>;
 }
 
 interface ParseResult {
@@ -103,7 +128,7 @@ async function parseBody(req: Request): Promise<ParseResult | ParseError> {
     return {
       ok: false,
       status: 400,
-      message: 'vault name must contain only letters, numbers, hyphens, and underscores',
+      message: "vault name must contain only letters, numbers, hyphens, and underscores",
     };
   }
   if (RESERVED_VAULT_NAMES.has(name)) {
@@ -128,7 +153,7 @@ function findExistingVault(
   manifestPath: string,
   name: string,
 ): { url: string; version: string; path: string } | null {
-  let manifest;
+  let manifest: ReturnType<typeof readManifest>;
   try {
     manifest = readManifest(manifestPath);
   } catch {
@@ -161,40 +186,80 @@ function buildEntry(
   return { name, url, version };
 }
 
-async function defaultRunCommand(cmd: readonly string[]): Promise<number> {
+async function defaultRunCommand(cmd: readonly string[]): Promise<RunResult> {
   const proc = Bun.spawn([...cmd], { stdio: ["ignore", "pipe", "pipe"] });
-  return await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  const exitCode = await proc.exited;
+  return { exitCode, stdout };
+}
+
+interface OrchestrateOk {
+  ok: true;
+  /** Present only when create-with-json branch ran and parsed cleanly. */
+  createJson: VaultCreateJson | null;
+}
+interface OrchestrateError {
+  ok: false;
+  status: number;
+  message: string;
 }
 
 /**
  * Run the orchestration step. Picks `parachute install` (bootstrap) vs
- * `parachute-vault create` (subsequent) based on whether vault is already
- * registered in services.json.
+ * `parachute-vault create --json` (subsequent) based on whether vault is
+ * already registered in services.json. The create branch parses stdout for
+ * the just-emitted `pvt_*` token + filesystem paths so the caller can talk
+ * to the new vault — those creds are single-emit.
  */
 async function orchestrate(
   manifestPath: string,
   name: string,
-  runCommand: (cmd: readonly string[]) => Promise<number>,
-): Promise<{ ok: true } | { ok: false; status: number; message: string }> {
+  runCommand: (cmd: readonly string[]) => Promise<RunResult>,
+): Promise<OrchestrateOk | OrchestrateError> {
   const vaultRegistered = findService("parachute-vault", manifestPath) !== undefined;
   const cmd = vaultRegistered
-    ? ["parachute-vault", "create", name]
-    : ["parachute", "install", "vault", "--vault-name", name];
-  let code: number;
+    ? ["parachute-vault", "create", name, "--json"]
+    : ["parachute", "install", "vault"];
+  let result: RunResult;
   try {
-    code = await runCommand(cmd);
+    result = await runCommand(cmd);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return { ok: false, status: 500, message: `orchestration failed: ${msg}` };
   }
-  if (code !== 0) {
+  if (result.exitCode !== 0) {
     return {
       ok: false,
       status: 500,
-      message: `${cmd[0]} ${cmd[1] ?? ""} exited with code ${code}`,
+      message: `${cmd[0]} ${cmd[1] ?? ""} exited with code ${result.exitCode}`,
     };
   }
-  return { ok: true };
+  if (!vaultRegistered) {
+    return { ok: true, createJson: null };
+  }
+  let createJson: VaultCreateJson;
+  try {
+    createJson = JSON.parse(result.stdout.trim()) as VaultCreateJson;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      status: 500,
+      message: `parachute-vault create --json returned unparseable stdout: ${msg}`,
+    };
+  }
+  if (
+    typeof createJson.name !== "string" ||
+    typeof createJson.token !== "string" ||
+    !createJson.paths
+  ) {
+    return {
+      ok: false,
+      status: 500,
+      message: "parachute-vault create --json output missing required fields (name/token/paths)",
+    };
+  }
+  return { ok: true, createJson };
 }
 
 export async function handleCreateVault(req: Request, deps: CreateVaultDeps): Promise<Response> {
@@ -222,10 +287,13 @@ export async function handleCreateVault(req: Request, deps: CreateVaultDeps): Pr
   // Skip the CLI shell-out — re-POST is usually a UI retry.
   const existing = findExistingVault(manifestPath, name);
   if (existing) {
-    return new Response(JSON.stringify(buildEntry(name, existing.path, existing.version, deps.issuer)), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify(buildEntry(name, existing.path, existing.version, deps.issuer)),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
   }
 
   const result = await orchestrate(manifestPath, name, runCommand);
@@ -243,7 +311,18 @@ export async function handleCreateVault(req: Request, deps: CreateVaultDeps): Pr
     );
   }
 
-  return new Response(JSON.stringify(buildEntry(name, created.path, created.version, deps.issuer)), {
+  const entry = buildEntry(name, created.path, created.version, deps.issuer);
+  // Token + filesystem paths are single-emit at create time. We surface them
+  // here so the caller can immediately bootstrap a connection to the new
+  // vault. Idempotent re-POSTs intentionally never include them.
+  const body: WellKnownVaultEntry & {
+    token?: string;
+    paths?: VaultCreateJson["paths"];
+  } = result.createJson
+    ? { ...entry, token: result.createJson.token, paths: result.createJson.paths }
+    : entry;
+
+  return new Response(JSON.stringify(body), {
     status: 201,
     headers: { "content-type": "application/json" },
   });

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -36,6 +36,7 @@
 import type { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { handleCreateVault } from "./admin-vaults.ts";
 import { hubDbPath, openHubDb } from "./hub-db.ts";
 import { pemToJwk } from "./jwks.ts";
 import {
@@ -226,6 +227,16 @@ export function hubFetch(
       }
       if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
       return handleRegister(getDb(), req, oauthDeps(req));
+    }
+
+    if (pathname === "/vaults") {
+      if (!getDb) {
+        return new Response("hub db not configured", { status: 503 });
+      }
+      return handleCreateVault(req, {
+        db: getDb(),
+        issuer: oauthDeps(req).issuer,
+      });
     }
 
     return new Response("not found", { status: 404 });

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -58,7 +58,56 @@ import {
   parseSessionCookie,
 } from "./sessions.ts";
 import { getUserByUsername, verifyPassword } from "./users.ts";
-import { isVaultEntry, shortName } from "./well-known.ts";
+import { isVaultEntry, shortName, vaultInstanceName } from "./well-known.ts";
+
+const VAULT_VERBS = new Set(["read", "write", "admin"]);
+
+/** Verbs whose unnamed `vault:<verb>` form needs picker disambiguation. */
+function unnamedVaultVerbs(scopes: string[]): string[] {
+  const verbs: string[] = [];
+  for (const s of scopes) {
+    const parts = s.split(":");
+    const verb = parts[1];
+    if (parts.length === 2 && parts[0] === "vault" && verb && VAULT_VERBS.has(verb)) {
+      verbs.push(verb);
+    }
+  }
+  return verbs;
+}
+
+/**
+ * Vault instance names registered on this host, derived from services.json.
+ * Walks both manifest shapes: single-entry-multi-path (`paths: ["/vault/work",
+ * "/vault/personal"]`) and per-vault entries (`parachute-vault-work`).
+ */
+function listVaultNames(manifest: ServicesManifest): string[] {
+  const names = new Set<string>();
+  for (const svc of manifest.services) {
+    if (!isVaultEntry(svc)) continue;
+    let foundFromPaths = false;
+    for (const path of svc.paths) {
+      const m = path.match(/^\/vault\/([^/]+)/);
+      if (m?.[1]) {
+        names.add(m[1]);
+        foundFromPaths = true;
+      }
+    }
+    if (!foundFromPaths) names.add(vaultInstanceName(svc));
+  }
+  return Array.from(names).sort();
+}
+
+/** Rewrite each unnamed `vault:<verb>` to `vault:<picked>:<verb>`. */
+function narrowVaultScopes(scopes: string[], pickedVault: string): string[] {
+  return scopes.map((s) => {
+    const parts = s.split(":");
+    const verb = parts[1];
+    if (parts.length === 2 && parts[0] === "vault" && verb && VAULT_VERBS.has(verb)) {
+      return `vault:${pickedVault}:${verb}`;
+    }
+    return s;
+  });
+}
 
 export interface OAuthDeps {
   /** Hub origin used for `iss`, `authorization_endpoint`, etc. */
@@ -224,7 +273,7 @@ function parseAuthorizeFormParams(url: URL): AuthorizeFormParams | { error: stri
  * present). All authorize-time params are echoed back via hidden inputs so
  * the form POST keeps the binding intact.
  */
-export function handleAuthorizeGet(db: Database, req: Request, _deps: OAuthDeps): Response {
+export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps): Response {
   const url = new URL(req.url);
   const parsed = parseAuthorizeFormParams(url);
   if ("error" in parsed) {
@@ -267,7 +316,9 @@ export function handleAuthorizeGet(db: Database, req: Request, _deps: OAuthDeps)
   if (!session) {
     return htmlResponse(renderLogin({ params: parsed }));
   }
-  return htmlResponse(renderConsent(consentProps(client, parsed)));
+  const manifest = (deps.loadServicesManifest ?? readServicesManifest)();
+  const vaultNames = listVaultNames(manifest);
+  return htmlResponse(renderConsent(consentProps(client, parsed, vaultNames)));
 }
 
 /**
@@ -363,7 +414,33 @@ async function handleConsentSubmit(
       params.state,
     );
   }
-  const scopes = params.scope.split(" ").filter((s) => s.length > 0);
+  let scopes = params.scope.split(" ").filter((s) => s.length > 0);
+  // Vault picker (Q1 of the vault-config-and-scopes design): an unnamed
+  // `vault:<verb>` scope is ambiguous about which vault it grants access to.
+  // Force the operator to pick before the JWT is minted, then rewrite the
+  // unnamed scope to `vault:<picked>:<verb>` so vault's strict per-resource
+  // enforcement (Phase 1) sees a name it can match against the URL.
+  const unnamedVerbs = unnamedVaultVerbs(scopes);
+  if (unnamedVerbs.length > 0) {
+    const pickedVault = String(form.get("vault_pick") ?? "").trim();
+    if (!pickedVault) {
+      return htmlError(
+        "Pick a vault",
+        "This app requested vault access without naming a vault. Pick which vault to grant access to and try again.",
+        400,
+      );
+    }
+    const manifest = (deps.loadServicesManifest ?? readServicesManifest)();
+    const validNames = listVaultNames(manifest);
+    if (!validNames.includes(pickedVault)) {
+      return htmlError(
+        "Unknown vault",
+        `vault "${pickedVault}" is not registered on this host.`,
+        400,
+      );
+    }
+    scopes = narrowVaultScopes(scopes, pickedVault);
+  }
   // Record the grant — gives PR (d) a place to skip the consent screen on
   // re-authorization for already-granted scopes.
   db.prepare(
@@ -613,13 +690,28 @@ function mapAuthCodeError(err: unknown): Response {
 }
 
 /**
- * Picks the JWT `aud` claim based on the requested scopes. `vault:*` →
- * "vault", `scribe:*` → "scribe", etc. Falls back to "hub" for hub-only
- * scopes or empty scopes. The split character is `:` per
- * `parachute-patterns/patterns/oauth-scopes.md`; the previous `.` form was
- * never canonical (cli#71 caught it during the scope-validation cutover).
+ * Picks the JWT `aud` claim based on the requested scopes. Per the
+ * vault-config-and-scopes design (Phase 1+2):
+ *   - A named `vault:<name>:<verb>` → `vault.<name>` (RFC 8707-style resource
+ *     binding; vault enforces this strict-equality against the URL-derived
+ *     vault name).
+ *   - An unnamed `<service>:<verb>` → `<service>` (legacy shape; vault's
+ *     strict-check rejects unnamed `vault:*` audiences, so the consent
+ *     picker rewrites those before this is reached).
+ *
+ * Named vault scopes win over unnamed ones — an OAuth flow that mixes
+ * `vault:work:read` + `scribe:transcribe` audiences is grounded on the vault
+ * (the more sensitive resource), and tokens are issued per-flow anyway.
  */
 function inferAudience(scopes: string[]): string {
+  for (const s of scopes) {
+    const parts = s.split(":");
+    const name = parts[1];
+    const verb = parts[2];
+    if (parts.length === 3 && parts[0] === "vault" && name && verb && VAULT_VERBS.has(verb)) {
+      return `vault.${name}`;
+    }
+  }
   for (const s of scopes) {
     const colon = s.indexOf(":");
     if (colon > 0) return s.slice(0, colon);
@@ -702,11 +794,17 @@ export async function handleRegister(
   return jsonResponse(respBody, 201);
 }
 
-function consentProps(client: OAuthClient, params: AuthorizeFormParams) {
+function consentProps(client: OAuthClient, params: AuthorizeFormParams, vaultNames: string[]) {
+  const scopes = params.scope.split(" ").filter((s) => s.length > 0);
+  const unnamedVerbs = unnamedVaultVerbs(scopes);
   return {
     params,
     clientId: client.clientId,
     clientName: client.clientName ?? client.clientId,
-    scopes: params.scope.split(" ").filter((s) => s.length > 0),
+    scopes,
+    vaultPicker:
+      unnamedVerbs.length > 0
+        ? { unnamedVerbs, availableVaults: vaultNames }
+        : undefined,
   };
 }

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -72,6 +72,20 @@ export interface ConsentViewProps {
   clientName: string;
   clientId: string;
   scopes: string[];
+  /**
+   * Set when the request includes one or more unnamed `vault:<verb>` scopes.
+   * The consent screen renders a vault selector; on submit, the picked vault
+   * narrows every unnamed scope to `vault:<picked>:<verb>` (Q1 of the
+   * vault-config-and-scopes design — force the picker, don't default).
+   */
+  vaultPicker?: VaultPicker;
+}
+
+export interface VaultPicker {
+  /** Verbs (`read`, `write`, `admin`) requested in unnamed shape. */
+  unnamedVerbs: string[];
+  /** Vault names registered on this host. Empty → caller can't approve. */
+  availableVaults: string[];
 }
 
 export interface ErrorViewProps {
@@ -112,11 +126,14 @@ export function renderLogin(props: LoginViewProps): string {
 }
 
 export function renderConsent(props: ConsentViewProps): string {
-  const { params, clientName, clientId, scopes } = props;
+  const { params, clientName, clientId, scopes, vaultPicker } = props;
   const scopeRows =
     scopes.length === 0
       ? `<li class="scope scope-empty">No scopes requested — the app gets a session token only.</li>`
       : scopes.map(renderScopeRow).join("\n");
+  const pickerSection = vaultPicker ? renderVaultPicker(vaultPicker) : "";
+  const approveDisabled =
+    vaultPicker && vaultPicker.availableVaults.length === 0 ? " disabled" : "";
   const body = `
     <div class="card">
       <div class="card-header">
@@ -140,13 +157,48 @@ export function renderConsent(props: ConsentViewProps): string {
       <form method="POST" action="/oauth/authorize" class="auth-form consent-form">
         <input type="hidden" name="__action" value="consent" />
         ${renderHiddenInputs(params)}
+        ${pickerSection}
         <div class="button-row">
-          <button type="submit" name="approve" value="yes" class="btn btn-primary">Approve</button>
+          <button type="submit" name="approve" value="yes" class="btn btn-primary"${approveDisabled}>Approve</button>
           <button type="submit" name="approve" value="no" class="btn btn-secondary">Deny</button>
         </div>
       </form>
     </div>`;
   return baseDocument(`Authorize ${clientName}`, body);
+}
+
+function renderVaultPicker(picker: VaultPicker): string {
+  const verbList = picker.unnamedVerbs
+    .map((v) => `<code>vault:${escapeHtml(v)}</code>`)
+    .join(", ");
+  if (picker.availableVaults.length === 0) {
+    return `
+        <section class="vault-picker vault-picker-empty">
+          <h2 class="scopes-title">Pick a vault</h2>
+          <p class="picker-help">
+            ${verbList} need to be bound to a specific vault, but no vaults exist on this host yet.
+            Create one with <code>parachute-vault create &lt;name&gt;</code> and try again.
+          </p>
+        </section>`;
+  }
+  const options = picker.availableVaults
+    .map(
+      (name, i) => `
+            <label class="vault-option">
+              <input type="radio" name="vault_pick" value="${escapeHtml(name)}"${i === 0 ? " checked" : ""} required />
+              <span class="vault-option-name"><code>${escapeHtml(name)}</code></span>
+            </label>`,
+    )
+    .join("");
+  return `
+        <section class="vault-picker">
+          <h2 class="scopes-title">Pick a vault</h2>
+          <p class="picker-help">
+            ${verbList} apply to the vault you select below.
+          </p>
+          <div class="vault-options">${options}
+          </div>
+        </section>`;
 }
 
 export function renderError(props: ErrorViewProps): string {
@@ -439,6 +491,53 @@ const STYLES = `
     background: ${PALETTE.dangerSoft};
   }
   .scope-admin .scope-name { color: ${PALETTE.danger}; }
+
+  .vault-picker {
+    margin: 0 0 1.25rem;
+    padding: 0.75rem 0.85rem;
+    border: 1px solid ${PALETTE.borderLight};
+    border-radius: 6px;
+    background: ${PALETTE.bgSoft};
+  }
+  .vault-picker .scopes-title { margin-bottom: 0.4rem; }
+  .picker-help {
+    margin: 0 0 0.6rem;
+    font-size: 0.88rem;
+    color: ${PALETTE.fgMuted};
+  }
+  .picker-help code {
+    font-family: ${FONT_MONO};
+    font-size: 0.82rem;
+    background: ${PALETTE.cardBg};
+    padding: 0.05rem 0.35rem;
+    border-radius: 4px;
+    color: ${PALETTE.fg};
+  }
+  .vault-options {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .vault-option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.45rem 0.6rem;
+    border: 1px solid ${PALETTE.border};
+    border-radius: 6px;
+    background: ${PALETTE.cardBg};
+    cursor: pointer;
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  .vault-option:hover { border-color: ${PALETTE.accent}; }
+  .vault-option input[type=radio]:focus { outline: 2px solid ${PALETTE.accent}; outline-offset: 2px; }
+  .vault-option-name code {
+    font-family: ${FONT_MONO};
+    font-size: 0.88rem;
+    color: ${PALETTE.fg};
+  }
+  .vault-picker-empty .picker-help { color: ${PALETTE.danger}; }
+  .vault-picker-empty .picker-help code { color: ${PALETTE.fg}; }
 
   .badge {
     display: inline-block;

--- a/src/operator-token.ts
+++ b/src/operator-token.ts
@@ -28,7 +28,13 @@ export const OPERATOR_TOKEN_FILENAME = "operator.token";
 export const OPERATOR_TOKEN_TTL_SECONDS = 365 * 24 * 60 * 60;
 export const OPERATOR_TOKEN_AUDIENCE = "operator";
 export const OPERATOR_TOKEN_CLIENT_ID = "parachute-hub";
-export const OPERATOR_TOKEN_SCOPES = ["hub:admin", "vault:admin", "scribe:admin", "channel:send"];
+export const OPERATOR_TOKEN_SCOPES = [
+  "hub:admin",
+  "parachute:host:admin",
+  "vault:admin",
+  "scribe:admin",
+  "channel:send",
+];
 
 export function operatorTokenPath(dir: string = configDir()): string {
   return join(dir, OPERATOR_TOKEN_FILENAME);

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -61,6 +61,10 @@ export const SCOPE_EXPLANATIONS: Record<string, ScopeExplanation> = {
     label: "Manage hub identity (user accounts, signing keys, registered OAuth clients).",
     level: "admin",
   },
+  "parachute:host:admin": {
+    label: "Provision and manage vaults across this host (create new vaults, configure cross-vault settings).",
+    level: "admin",
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary

Hub-side companion to parachute-vault#179 (the vault-config-and-scopes design). Lifts vault provisioning into a hub REST surface and tightens the OAuth issuance path so vault's just-shipped strict scope+audience enforcement (vault#234) gets exactly what it expects.

Five commits, one PR — they're tightly coupled (a new scope, an auth helper, the endpoint that uses both, the issuance path that mints tokens vault will accept, and the create-with-JSON wire-up that returns bootstrap creds).

> **Heads-up for operators:** existing operator tokens don't carry `parachute:host:admin` retroactively. Anyone running a hub today must rotate their operator token (`parachute auth rotate-operator`) before calling `POST /vaults` — otherwise the call comes back 403.

### Commit 1 — `parachute:host:admin` scope (`669a6e0`)

New first-party scope for cross-vault host operations (provisioning, listing). Distinct from `vault:<name>:admin` (resource-scoped) and from `hub:admin` (hub-internal admin). Resolves Q3 of the design doc — "yes, but call it `parachute:host:admin` to keep the `vault:` namespace clean."

Bundled with this change: operator token now mints `parachute:host:admin` so the local CLI can hit the new endpoint without a separate flow.

### Commit 2 — `admin-auth.ts` bearer-token gate (`10b10c8`)

First authenticated mutating endpoint on the hub means there's no existing scope-gating shim. New helper `requireScope(db, req, requiredScope, expectedIssuer)`:

- Pulls the bearer token (handles RFC 6750 + lowercase scheme).
- Validates against the hub's own signing keys via `validateAccessToken` — no JWKS round-trip since the hub *is* the issuer.
- Maps failures to `AdminAuthError` (401 `invalid_token` / 403 `insufficient_scope`) with WWW-Authenticate per RFC 6750.

11 tests cover the gate's three layers (extract → require → response shape).

### Commit 3 — `POST /vaults` endpoint (`228ba87`)

Mounted at `/vaults` in `hub-server.ts`. Auth: `parachute:host:admin`. Body: `{ "name": "<vault-name>" }`. Returns the `WellKnownVaultEntry` shape (`{ name, url, version }`) — extended in commit 5 to include `token` and `paths` on the create branch.

Orchestration follows D1 of the design — hub doesn't reimplement vault provisioning, it shells out:

- Vault not yet registered in services.json → `parachute install vault` (bootstrap).
- Vault already registered → `parachute-vault create --json <name>` (subsequent vaults).

Idempotency: re-POST the same name → 200 + existing entry, no shell-out and no token in the response (single-emit creds aren't recoverable). The CLI itself rejects duplicate names with exit 1, but a re-POST is usually a UI retry, so the endpoint short-circuits.

### Commit 4 — Vault picker on consent screen + per-vault audience (`5b9fb7d`)

When a client requests unnamed `vault:<verb>` (which today's OAuth clients all do), the consent screen now forces the operator to pick which vault. Picked vault rewrites the scope to `vault:<picked>:<verb>` and the JWT carries `aud=vault.<picked>` — exactly what vault#234 strict-checks.

Resolves Q1 of the design — force the picker rather than defaulting to one vault. Silent disambiguation would mint the opposite of what at least one reading of `vault:read` intended.

Named scopes (`vault:work:read`) skip the picker.

11 new tests (4 picker UI, 7 issuance + scope-narrowing). All 6 existing oauth-handlers tests updated to either use named scopes (cleanest path) or include `vault_pick` in the form.

### Commit 5 — Wire `--json` flag on the create branch (`298e641`)

Reviewer revise: pre-revise, the create branch shelled `parachute-vault create <name>` and parsed services.json post-hoc. Vault PR #184 added `--json` so the just-emitted `pvt_*` token and filesystem paths could be captured by the caller — paraclaw's deep-link path needs those creds to bootstrap a connection. Pre-revise, the token was silently dropped.

Now: create branch runs `parachute-vault create <name> --json`, parses stdout per the documented shape (`{name, token, paths, set_as_default}`), and surfaces `token` + `paths` on the 201 response. Idempotent re-POST never re-emits (asserted by test). Bootstrap path (`parachute install vault`) keeps returning name/url/version only — install doesn't emit JSON yet, filed as a follow-up.

15 tests cover auth (401/403), body validation (5 cases — content-type, malformed JSON, missing/invalid name, reserved "list"), orchestration (happy path → calls --json + asserts token + paths in response, bootstrap path, idempotent → no token, CLI-fail, manifest-out-of-sync, unparseable JSON), and method gating.

## Deferred

- **Admin HTML UI for create-vault.** Existing sessions are scoped to `Path=/oauth/`, so an HTML form at `/admin/vaults` wouldn't see them. Wiring sessions for `/admin/*` is a separate concern with implications for CSRF posture; keeping it out of this PR. The REST endpoint is sufficient to unblock paraclaw's "create vault" deep-link from the design doc.
- **Bootstrap-path JSON.** `parachute install vault` doesn't emit JSON yet, so the first-vault-on-host response carries name/url/version only (no token). Operators on a fresh box still see the token in install stdout. Filed as a follow-up to thread `--json` through install.
- **Reviewer nits filed as follow-up issues:** error-message `cmd.join(" ")` cleanup, drain stdout/stderr pipes (long install could fill pipe buffer), `NON_REQUESTABLE_SCOPES` set for operator-only-mintable scopes (Aaron is filing separately).
- **Phase 2 cleanup.** Dropping the unnamed-`vault:read` shim entirely lands in a follow-up once paraclaw and notes have moved to picker-based flows.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 682 pass / 0 fail across 50 files
- [ ] Manual smoke: rotate operator token, `parachute start hub`, hit `POST /vaults` with operator token, observe `pvt_*` token + paths in 201 response
- [ ] Manual smoke: OAuth flow with `scope=vault:read`, observe picker, approve, decode JWT and confirm `aud=vault.<picked>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)