### PR TITLE
Phase 1 cleanup: lock parachute:host:admin (#96) + admin-vaults nits (#97)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.10",
+  "version": "0.4.0-rc.11",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/admin-vaults.test.ts
+++ b/src/__tests__/admin-vaults.test.ts
@@ -264,7 +264,7 @@ describe("POST /vaults — orchestration", () => {
             },
             h.manifestPath,
           );
-          return { exitCode: 0, stdout: vaultCreateJson("work") };
+          return { exitCode: 0, stdout: vaultCreateJson("work"), stderr: "" };
         };
         const res = await call({
           db,
@@ -311,7 +311,7 @@ describe("POST /vaults — orchestration", () => {
             },
             h.manifestPath,
           );
-          return { exitCode: 0, stdout: "" };
+          return { exitCode: 0, stdout: "", stderr: "" };
         };
         const res = await call({
           db,
@@ -361,7 +361,11 @@ describe("POST /vaults — orchestration", () => {
             },
             h.manifestPath,
           );
-          return { exitCode: 0, stdout: vaultCreateJson("work", "pvt_supersecret") };
+          return {
+            exitCode: 0,
+            stdout: vaultCreateJson("work", "pvt_supersecret"),
+            stderr: "",
+          };
         };
         const res = await call({
           db,
@@ -408,6 +412,7 @@ describe("POST /vaults — orchestration", () => {
         const runCommand = async (): Promise<RunResult> => ({
           exitCode: 0,
           stdout: "this-is-not-json",
+          stderr: "",
         });
         const res = await call({
           db,
@@ -443,7 +448,7 @@ describe("POST /vaults — orchestration", () => {
         let runCalled = false;
         const runCommand = async (): Promise<RunResult> => {
           runCalled = true;
-          return { exitCode: 0, stdout: "" };
+          return { exitCode: 0, stdout: "", stderr: "" };
         };
         const res = await call({
           db,
@@ -467,7 +472,7 @@ describe("POST /vaults — orchestration", () => {
     }
   });
 
-  test("500 when CLI exits non-zero", async () => {
+  test("500 when CLI exits non-zero, error message includes full cmd + stderr tail", async () => {
     const h = makeHarness();
     try {
       const db = openHubDb(hubDbPath(h.dir));
@@ -483,7 +488,11 @@ describe("POST /vaults — orchestration", () => {
           },
           h.manifestPath,
         );
-        const runCommand = async (): Promise<RunResult> => ({ exitCode: 1, stdout: "" });
+        const runCommand = async (): Promise<RunResult> => ({
+          exitCode: 1,
+          stdout: "",
+          stderr: "vault create failed: name 'work' already exists\n",
+        });
         const res = await call({
           db,
           manifestPath: h.manifestPath,
@@ -491,6 +500,11 @@ describe("POST /vaults — orchestration", () => {
           runCommand,
         });
         expect(res.status).toBe(500);
+        const body = (await res.json()) as { error_description: string };
+        // #97 NIT: full cmd in the error message (cmd.join), not just argv[0..1].
+        expect(body.error_description).toContain("parachute-vault create work --json");
+        // #97 NIT: stderr tail surfaced so the operator can see why.
+        expect(body.error_description).toContain("name 'work' already exists");
       } finally {
         db.close();
       }
@@ -518,6 +532,7 @@ describe("POST /vaults — orchestration", () => {
         const runCommand = async (): Promise<RunResult> => ({
           exitCode: 0,
           stdout: vaultCreateJson("work"),
+          stderr: "",
         });
         const res = await call({
           db,

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -94,6 +94,16 @@ describe("authorizationServerMetadata", () => {
     expect(scopesSupported).toContain("scribe:transcribe");
     expect(scopesSupported).toContain("hub:admin");
   });
+
+  test("does NOT advertise non-requestable operator-only scopes", async () => {
+    // #96: parachute:host:admin is operator-only. RFC 8414 §2 frames
+    // scopes_supported as scopes a client *can* request — advertising what
+    // we always reject would mislead clients.
+    const res = authorizationServerMetadata({ issuer: ISSUER });
+    const body = (await res.json()) as Record<string, unknown>;
+    const scopesSupported = body.scopes_supported as string[];
+    expect(scopesSupported).not.toContain("parachute:host:admin");
+  });
 });
 
 describe("handleAuthorizeGet", () => {
@@ -199,6 +209,37 @@ describe("handleAuthorizeGet", () => {
       );
       const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
       expect(res.status).toBe(400);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rejects parachute:host:admin scope with invalid_scope redirect (#96)", async () => {
+    // Operator-only scopes — third-party apps cannot mint them via the
+    // public flow. Per RFC 6749 §4.1.2.1, scope failures redirect to the
+    // registered redirect_uri with error=invalid_scope, not an HTML error.
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:read parachute:host:admin",
+          state: "abc",
+        }),
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.get("location") ?? "");
+      expect(loc.origin + loc.pathname).toBe("https://app.example/cb");
+      expect(loc.searchParams.get("error")).toBe("invalid_scope");
+      expect(loc.searchParams.get("error_description")).toContain("parachute:host:admin");
+      expect(loc.searchParams.get("state")).toBe("abc");
     } finally {
       cleanup();
     }
@@ -632,6 +673,44 @@ describe("handleAuthorizePost — consent submit", () => {
       expect(loc.origin + loc.pathname).toBe("https://app.example/cb");
       expect(loc.searchParams.get("code")?.length).toBeGreaterThan(20);
       expect(loc.searchParams.get("state")).toBe("abc123");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rejects parachute:host:admin in form scope (defense-in-depth, #96)", async () => {
+    // GET-time gate already rejects, but a hand-crafted POST could carry
+    // an operator-only scope. Consent submit must independently reject.
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const form = new URLSearchParams({
+        __action: "consent",
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "parachute:host:admin",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        state: "abc",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: buildSessionCookie(session.id, 86400),
+        },
+      });
+      const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.get("location") ?? "");
+      expect(loc.searchParams.get("error")).toBe("invalid_scope");
+      expect(loc.searchParams.get("error_description")).toContain("parachute:host:admin");
     } finally {
       cleanup();
     }

--- a/src/__tests__/scope-explanations.test.ts
+++ b/src/__tests__/scope-explanations.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
   FIRST_PARTY_SCOPES,
+  NON_REQUESTABLE_SCOPES,
   SCOPE_EXPLANATIONS,
   explainScope,
+  isRequestableScope,
   scopeIsAdmin,
 } from "../scope-explanations.ts";
 
@@ -52,5 +54,41 @@ describe("scopeIsAdmin", () => {
     expect(scopeIsAdmin("vault:read")).toBe(false);
     expect(scopeIsAdmin("channel:send")).toBe(false);
     expect(scopeIsAdmin("unknown:anything")).toBe(false);
+  });
+});
+
+describe("NON_REQUESTABLE_SCOPES (#96)", () => {
+  test("contains parachute:host:admin", () => {
+    expect(NON_REQUESTABLE_SCOPES.has("parachute:host:admin")).toBe(true);
+  });
+
+  test("does NOT contain hub:admin (intentional asymmetry)", () => {
+    // hub:admin is service management an operator may legitimately delegate
+    // to a tooling app. parachute:host:admin is cross-vault data sovereignty
+    // and stays operator-only-mintable.
+    expect(NON_REQUESTABLE_SCOPES.has("hub:admin")).toBe(false);
+  });
+
+  test("every non-requestable scope is a known first-party scope", () => {
+    for (const s of NON_REQUESTABLE_SCOPES) {
+      expect(FIRST_PARTY_SCOPES).toContain(s);
+    }
+  });
+});
+
+describe("isRequestableScope", () => {
+  test("false for parachute:host:admin", () => {
+    expect(isRequestableScope("parachute:host:admin")).toBe(false);
+  });
+
+  test("true for hub:admin and other first-party scopes", () => {
+    expect(isRequestableScope("hub:admin")).toBe(true);
+    expect(isRequestableScope("vault:read")).toBe(true);
+    expect(isRequestableScope("vault:admin")).toBe(true);
+    expect(isRequestableScope("channel:send")).toBe(true);
+  });
+
+  test("true for unknown scopes (third-party module scopes pass through)", () => {
+    expect(isRequestableScope("notes:something-new")).toBe(true);
   });
 });

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -74,10 +74,16 @@ export interface VaultCreateJson {
   set_as_default: boolean;
 }
 
-/** Result of a single shell-out: exit code + captured stdout. */
+/** Result of a single shell-out: exit code + captured stdout/stderr. */
 export interface RunResult {
   exitCode: number;
   stdout: string;
+  /**
+   * Captured stderr. Always drained alongside stdout so a long-running
+   * child can't deadlock on a full pipe buffer (#97). Surfaced in error
+   * messages when exitCode != 0 so non-zero failures are diagnosable.
+   */
+  stderr: string;
 }
 
 export interface CreateVaultDeps {
@@ -188,9 +194,15 @@ function buildEntry(
 
 async function defaultRunCommand(cmd: readonly string[]): Promise<RunResult> {
   const proc = Bun.spawn([...cmd], { stdio: ["ignore", "pipe", "pipe"] });
-  const stdout = await new Response(proc.stdout).text();
+  // Drain both pipes in parallel — leaving stderr unread can deadlock long
+  // installs once the OS pipe buffer fills (#97). Captured stderr is folded
+  // into the orchestration error message on non-zero exit.
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
   const exitCode = await proc.exited;
-  return { exitCode, stdout };
+  return { exitCode, stdout, stderr };
 }
 
 interface OrchestrateOk {
@@ -228,10 +240,15 @@ async function orchestrate(
     return { ok: false, status: 500, message: `orchestration failed: ${msg}` };
   }
   if (result.exitCode !== 0) {
+    // Tail stderr (capped) so the error message names the actual failure
+    // mode — "exited 1" alone is useless when the CLI prints why it failed
+    // to stderr.
+    const stderrTail = result.stderr.trim();
+    const tailSuffix = stderrTail ? `: ${stderrTail.slice(-500)}` : "";
     return {
       ok: false,
       status: 500,
-      message: `${cmd[0]} ${cmd[1] ?? ""} exited with code ${result.exitCode}`,
+      message: `${cmd.join(" ")} exited with code ${result.exitCode}${tailSuffix}`,
     };
   }
   if (!vaultRegistered) {

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -44,7 +44,11 @@ import {
   signRefreshToken,
 } from "./jwt-sign.ts";
 import { type AuthorizeFormParams, renderConsent, renderError, renderLogin } from "./oauth-ui.ts";
-import { FIRST_PARTY_SCOPES } from "./scope-explanations.ts";
+import {
+  FIRST_PARTY_SCOPES,
+  NON_REQUESTABLE_SCOPES,
+  isRequestableScope,
+} from "./scope-explanations.ts";
 import { findUnknownScopes, loadDeclaredScopes } from "./scope-registry.ts";
 import {
   type ServicesManifest,
@@ -234,8 +238,17 @@ export function authorizationServerMetadata(deps: OAuthDeps): Response {
     grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
     token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
-    scopes_supported: FIRST_PARTY_SCOPES,
+    // Operator-only scopes (NON_REQUESTABLE_SCOPES) are intentionally absent
+    // — RFC 8414 §2 frames `scopes_supported` as "the OAuth 2.0 [...] scope
+    // values that this authorization server supports" for clients to request.
+    // Advertising what we always reject would mislead clients.
+    scopes_supported: FIRST_PARTY_SCOPES.filter(isRequestableScope),
   });
+}
+
+/** Find any requested scopes that the public flow refuses to mint. */
+function findNonRequestableScopes(scopes: readonly string[]): string[] {
+  return scopes.filter((s) => NON_REQUESTABLE_SCOPES.has(s));
 }
 
 // --- /oauth/authorize ------------------------------------------------------
@@ -308,6 +321,21 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
       "Redirect mismatch",
       "The redirect_uri does not match any URI registered for this app.",
       400,
+    );
+  }
+
+  // Operator-only scope gate (#96). Reject any request that names a scope
+  // we'll never mint via this flow — `parachute:host:admin` and friends.
+  // Per RFC 6749 §4.1.2.1, errors that aren't redirect-uri-related are
+  // delivered by redirect with `error=invalid_scope`.
+  const requestedScopes = parsed.scope.split(" ").filter((s) => s.length > 0);
+  const blocked = findNonRequestableScopes(requestedScopes);
+  if (blocked.length > 0) {
+    return oauthErrorRedirect(
+      parsed.redirectUri,
+      "invalid_scope",
+      `requested scopes are not available via the public authorization endpoint: ${blocked.join(", ")}`,
+      parsed.state,
     );
   }
 
@@ -415,6 +443,18 @@ async function handleConsentSubmit(
     );
   }
   let scopes = params.scope.split(" ").filter((s) => s.length > 0);
+  // Defense-in-depth (#96). The GET handler already rejects non-requestable
+  // scopes before consent renders, but a hand-crafted POST could carry one
+  // anyway — block it here too.
+  const blockedHere = findNonRequestableScopes(scopes);
+  if (blockedHere.length > 0) {
+    return oauthErrorRedirect(
+      params.redirectUri,
+      "invalid_scope",
+      `requested scopes are not available via the public authorization endpoint: ${blockedHere.join(", ")}`,
+      params.state,
+    );
+  }
   // Vault picker (Q1 of the vault-config-and-scopes design): an unnamed
   // `vault:<verb>` scope is ambiguous about which vault it grants access to.
   // Force the operator to pick before the JWT is minted, then rewrite the
@@ -803,8 +843,6 @@ function consentProps(client: OAuthClient, params: AuthorizeFormParams, vaultNam
     clientName: client.clientName ?? client.clientId,
     scopes,
     vaultPicker:
-      unnamedVerbs.length > 0
-        ? { unnamedVerbs, availableVaults: vaultNames }
-        : undefined,
+      unnamedVerbs.length > 0 ? { unnamedVerbs, availableVaults: vaultNames } : undefined,
   };
 }

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -62,7 +62,8 @@ export const SCOPE_EXPLANATIONS: Record<string, ScopeExplanation> = {
     level: "admin",
   },
   "parachute:host:admin": {
-    label: "Provision and manage vaults across this host (create new vaults, configure cross-vault settings).",
+    label:
+      "Provision and manage vaults across this host (create new vaults, configure cross-vault settings).",
     level: "admin",
   },
 };
@@ -73,6 +74,34 @@ export const SCOPE_EXPLANATIONS: Record<string, ScopeExplanation> = {
  * scopes (cli#68) are unioned on top.
  */
 export const FIRST_PARTY_SCOPES = Object.keys(SCOPE_EXPLANATIONS).sort();
+
+/**
+ * Scopes the hub will not mint via the public OAuth flow. Operator-only —
+ * available exclusively through the local operator-token mint path
+ * (`parachute auth rotate-operator`), which doesn't traverse
+ * `/oauth/authorize`. Listed here so the issuer can:
+ *
+ *   1. Reject early at `/oauth/authorize` with RFC 6749 `invalid_scope`
+ *      rather than letting the request walk to the consent screen.
+ *   2. Hide non-requestable scopes from `scopes_supported` in the AS
+ *      metadata — clients shouldn't be advertised what we always reject.
+ *      RFC 8414 §2 says `scopes_supported` is the list a client *can*
+ *      request, so omitting these is the spec-compliant call.
+ *
+ * Why `parachute:host:admin` is on this list and `hub:admin` is not:
+ * `parachute:host:admin` provisions and destroys vaults — cross-vault
+ * data sovereignty that the operator alone owns. `hub:admin` is service
+ * management (signing keys, registered clients, user accounts) which an
+ * operator may legitimately delegate to a tooling app. The asymmetry is
+ * intentional: the blast radius of compromised cross-vault admin doesn't
+ * justify third-party requestability.
+ */
+export const NON_REQUESTABLE_SCOPES: ReadonlySet<string> = new Set(["parachute:host:admin"]);
+
+/** True when the scope can appear in a public `/oauth/authorize` request. */
+export function isRequestableScope(scope: string): boolean {
+  return !NON_REQUESTABLE_SCOPES.has(scope);
+}
 
 export function explainScope(scope: string): ScopeExplanation | null {
   return SCOPE_EXPLANATIONS[scope] ?? null;


### PR DESCRIPTION
## Summary

Two-issue cleanup bundle off `main`. Per-issue commits.

### Closes #96 — Lock `parachute:host:admin` to operator-only mintable

- New `NON_REQUESTABLE_SCOPES` set in `src/scope-explanations.ts` containing `parachute:host:admin`, plus `isRequestableScope()` helper.
- `/oauth/authorize` GET rejects requested scopes in that set with an RFC 6749 `invalid_scope` redirect to `redirect_uri` (state echoed) — early reject before consent UI renders.
- Consent POST has a matching defense-in-depth gate against hand-crafted form submission.
- `scopes_supported` in the AS metadata response is filtered through `isRequestableScope` per RFC 8414 §2 (clients are advertised only what they can request).
- Asymmetry vs `hub:admin` documented in `scope-explanations.ts`: `hub:admin` is service mgmt an operator may delegate to a tooling app; `parachute:host:admin` is cross-vault data sovereignty (provision/destroy vaults) and only the local `rotate-operator` mint path can grant it. That path doesn't traverse `/oauth/authorize`, so operator tokens still get the scope by design.

### Closes #97 — `src/admin-vaults.ts` nits

1. `defaultRunCommand` now drains stdout + stderr in parallel via `Promise.all`. Was leaking — `Bun.spawn` with `stdio: ["ignore", "pipe", "pipe"]` and an unread stderr can deadlock once the OS pipe buffer fills (real risk on the chatty `parachute install vault` bootstrap path).
2. `orchestrate` exit-code error message now uses `cmd.join(" ")` (full diagnostic) and appends a capped tail (last 500 chars) of stderr. `"exited with code 1"` alone was useless.

`RunResult` gains a `stderr: string` field. All test stubs updated; the "500 when CLI exits non-zero" test now asserts the full command + stderr tail both surface in `error_description`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 691 pass / 0 fail
- [x] `bunx biome check` — clean on touched files (one pre-existing warning in `src/admin-auth.ts:74` is out of scope)
- [x] New tests in `src/__tests__/scope-explanations.test.ts` cover `NON_REQUESTABLE_SCOPES` membership + `isRequestableScope` semantics + asymmetry assertion against `hub:admin`.
- [x] New tests in `src/__tests__/oauth-handlers.test.ts`:
  - `scopes_supported` does not contain `parachute:host:admin`
  - `/oauth/authorize` GET with the scope returns RFC-compliant `invalid_scope` redirect
  - Consent POST with the scope returns the same redirect (defense-in-depth)

## Versioning

`0.4.0-rc.10` → `0.4.0-rc.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)