### PR TITLE
feat(oauth-as): advertise declared scopes in AS metadata (closes #91)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.11",
+  "version": "0.4.0-rc.12",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -104,6 +104,40 @@ describe("authorizationServerMetadata", () => {
     const scopesSupported = body.scopes_supported as string[];
     expect(scopesSupported).not.toContain("parachute:host:admin");
   });
+
+  test("advertises third-party module scopes from loadDeclaredScopes", async () => {
+    // #91: scopes_supported pulls from `loadDeclaredScopes()` (FIRST_PARTY ∪
+    // each registered module's `scopes.defines`) so standards-following
+    // clients discover third-party scopes the same way they discover
+    // first-party ones. The token-issuance path already uses
+    // loadDeclaredScopes (#90); the AS metadata had to follow or its public
+    // advertisement would be a strict subset of what it'll actually sign.
+    const declared = new Set<string>([
+      "vault:read",
+      "vault:admin",
+      "hub:admin",
+      "parachute:host:admin", // declared but operator-only — must still be filtered
+      "claw:read",
+      "claw:write",
+      "mymodule:do-thing",
+    ]);
+    const res = authorizationServerMetadata({
+      issuer: ISSUER,
+      loadDeclaredScopes: () => declared,
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    const scopesSupported = body.scopes_supported as string[];
+    // Third-party scopes show up
+    expect(scopesSupported).toContain("claw:read");
+    expect(scopesSupported).toContain("claw:write");
+    expect(scopesSupported).toContain("mymodule:do-thing");
+    // First-party still advertised — no regression
+    expect(scopesSupported).toContain("vault:read");
+    expect(scopesSupported).toContain("vault:admin");
+    expect(scopesSupported).toContain("hub:admin");
+    // NON_REQUESTABLE filter still applies even when the scope is declared
+    expect(scopesSupported).not.toContain("parachute:host:admin");
+  });
 });
 
 describe("handleAuthorizeGet", () => {

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -44,11 +44,7 @@ import {
   signRefreshToken,
 } from "./jwt-sign.ts";
 import { type AuthorizeFormParams, renderConsent, renderError, renderLogin } from "./oauth-ui.ts";
-import {
-  FIRST_PARTY_SCOPES,
-  NON_REQUESTABLE_SCOPES,
-  isRequestableScope,
-} from "./scope-explanations.ts";
+import { NON_REQUESTABLE_SCOPES, isRequestableScope } from "./scope-explanations.ts";
 import { findUnknownScopes, loadDeclaredScopes } from "./scope-registry.ts";
 import {
   type ServicesManifest,
@@ -228,6 +224,14 @@ function oauthErrorRedirect(
 
 export function authorizationServerMetadata(deps: OAuthDeps): Response {
   const iss = deps.issuer;
+  // Advertise the full declared-scope set — FIRST_PARTY ∪ each registered
+  // module's `scopes.defines` — so standards-following clients discover
+  // third-party scopes (e.g. paraclaw's `claw:*`) the same way they discover
+  // first-party ones. The token-issuance path already consults
+  // `loadDeclaredScopes` (see #90); metadata had to follow or the issuer's
+  // public advertisement would be a strict subset of what it'll actually
+  // sign. Closes #91.
+  const declared = (deps.loadDeclaredScopes ?? loadDeclaredScopes)();
   return jsonResponse({
     issuer: iss,
     authorization_endpoint: `${iss}/oauth/authorize`,
@@ -242,7 +246,7 @@ export function authorizationServerMetadata(deps: OAuthDeps): Response {
     // — RFC 8414 §2 frames `scopes_supported` as "the OAuth 2.0 [...] scope
     // values that this authorization server supports" for clients to request.
     // Advertising what we always reject would mislead clients.
-    scopes_supported: FIRST_PARTY_SCOPES.filter(isRequestableScope),
+    scopes_supported: Array.from(declared).filter(isRequestableScope),
   });
 }
 


### PR DESCRIPTION
## Summary
- `scopes_supported` in `/.well-known/oauth-authorization-server` now pulls from `loadDeclaredScopes()` (FIRST_PARTY ∪ each registered module's `scopes.defines`) instead of `FIRST_PARTY_SCOPES`.
- Token-issuance already uses `loadDeclaredScopes` (#90); the AS metadata had to follow or the issuer's RFC 8414 advertisement would be a strict subset of what it'll actually sign.
- NON_REQUESTABLE_SCOPES filter (#96) still applies — `parachute:host:admin` stays out of the public advertisement even when declared.

## Why
Standards-following clients only saw first-party scopes today and never learned about third-party module declarations like paraclaw's `claw:*`. They had to rely on out-of-band knowledge to request scopes the hub would happily mint. This brings the public advertisement into agreement with the issuance gate.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun test` — 692 pass / 0 fail
- [x] New test: third-party scope (`claw:read`, `mymodule:do-thing`) appears in `scopes_supported` when injected via `loadDeclaredScopes`
- [x] Existing test: FIRST_PARTY scopes (`vault:read`, `vault:admin`, `scribe:transcribe`, `hub:admin`) still advertised — no regression
- [x] Existing test + new assertion: `parachute:host:admin` still filtered even when declared in the injected set

Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)