### PR TITLE
fix(oauth-token): enforce client_secret for confidential clients (#72)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.12",
+  "version": "0.4.0-rc.13",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -1347,6 +1347,399 @@ describe("handleToken — full OAuth dance", () => {
   });
 });
 
+// closes #72 — RFC 6749 §3.2.1 + §2.3.1: confidential clients must
+// authenticate at /oauth/token via Authorization: Basic header (preferred)
+// or form-body client_secret. Public clients (PKCE-only) are unaffected
+// because PKCE replaces the secret for them.
+describe("handleToken — confidential client authentication (#72)", () => {
+  // Helper: drive the consent screen for `clientId` to a fresh auth code.
+  // Returns the code + the verifier so the caller can hit /oauth/token.
+  async function consentAndGetCode(
+    db: Awaited<ReturnType<typeof makeDb>>["db"],
+    clientId: string,
+    sessionId: string,
+  ): Promise<{ code: string; verifier: string }> {
+    const { verifier, challenge } = makePkce();
+    const consentForm = new URLSearchParams({
+      __action: "consent",
+      approve: "yes",
+      client_id: clientId,
+      redirect_uri: "https://app.example/cb",
+      response_type: "code",
+      scope: "vault:default:read",
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+    });
+    const consentRes = await handleAuthorizePost(
+      db,
+      new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: consentForm,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: buildSessionCookie(sessionId, 86400),
+        },
+      }),
+      { issuer: ISSUER },
+    );
+    const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+    return { code: code ?? "", verifier };
+  }
+
+  function tokenRequest(form: URLSearchParams, headers: Record<string, string> = {}): Request {
+    return new Request(`${ISSUER}/oauth/token`, {
+      method: "POST",
+      body: form,
+      headers: { "content-type": "application/x-www-form-urlencoded", ...headers },
+    });
+  }
+
+  test("authorization_code: confidential client + correct secret in form body → 200", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        confidential: true,
+      });
+      expect(reg.clientSecret).not.toBeNull();
+      const { code, verifier } = await consentAndGetCode(db, reg.client.clientId, session.id);
+      const tokenForm = new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        code_verifier: verifier,
+        client_secret: reg.clientSecret ?? "",
+      });
+      const res = await handleToken(db, tokenRequest(tokenForm), {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(200);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("authorization_code: confidential client + correct secret in Authorization: Basic header → 200", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        confidential: true,
+      });
+      const { code, verifier } = await consentAndGetCode(db, reg.client.clientId, session.id);
+      const tokenForm = new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        code_verifier: verifier,
+        // No client_secret in the body — the header carries it.
+      });
+      // RFC 6749 §2.3.1 requires form-encoding the credentials before base64.
+      const basic = btoa(
+        `${encodeURIComponent(reg.client.clientId)}:${encodeURIComponent(reg.clientSecret ?? "")}`,
+      );
+      const res = await handleToken(
+        db,
+        tokenRequest(tokenForm, { authorization: `Basic ${basic}` }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(res.status).toBe(200);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("authorization_code: confidential client + wrong secret → 401 + WWW-Authenticate Basic", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        confidential: true,
+      });
+      const { code, verifier } = await consentAndGetCode(db, reg.client.clientId, session.id);
+      const tokenForm = new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        code_verifier: verifier,
+        client_secret: "definitely-not-the-real-secret",
+      });
+      const res = await handleToken(db, tokenRequest(tokenForm), { issuer: ISSUER });
+      expect(res.status).toBe(401);
+      expect(res.headers.get("www-authenticate")).toMatch(/^Basic\b/i);
+      const err = (await res.json()) as Record<string, unknown>;
+      expect(err.error).toBe("invalid_client");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("authorization_code: confidential client + missing secret → 401 + WWW-Authenticate Basic", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        confidential: true,
+      });
+      const { code, verifier } = await consentAndGetCode(db, reg.client.clientId, session.id);
+      // No client_secret in form, no Authorization header.
+      const tokenForm = new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        code_verifier: verifier,
+      });
+      const res = await handleToken(db, tokenRequest(tokenForm), { issuer: ISSUER });
+      expect(res.status).toBe(401);
+      expect(res.headers.get("www-authenticate")).toMatch(/^Basic\b/i);
+      const err = (await res.json()) as Record<string, unknown>;
+      expect(err.error).toBe("invalid_client");
+      expect(err.error_description).toMatch(/required/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("authorization_code: Basic header client_id mismatch with body → 401", async () => {
+    // Defensive: a header authenticating as one client while the body claims
+    // another is a confused or hostile request — refuse rather than guess.
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        confidential: true,
+      });
+      const { code, verifier } = await consentAndGetCode(db, reg.client.clientId, session.id);
+      const tokenForm = new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        code_verifier: verifier,
+      });
+      const basic = btoa(
+        `${encodeURIComponent("some-other-client")}:${encodeURIComponent(reg.clientSecret ?? "")}`,
+      );
+      const res = await handleToken(
+        db,
+        tokenRequest(tokenForm, { authorization: `Basic ${basic}` }),
+        { issuer: ISSUER },
+      );
+      expect(res.status).toBe(401);
+      const err = (await res.json()) as Record<string, unknown>;
+      expect(err.error).toBe("invalid_client");
+      expect(err.error_description).toMatch(/header client_id/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("authorization_code: public client unaffected (no secret required) → 200", async () => {
+    // Regression: PKCE-only clients must keep working with no client_secret.
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      expect(reg.clientSecret).toBeNull();
+      const { code, verifier } = await consentAndGetCode(db, reg.client.clientId, session.id);
+      const tokenForm = new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        code_verifier: verifier,
+      });
+      const res = await handleToken(db, tokenRequest(tokenForm), {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(200);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("refresh_token: confidential client + correct secret rotates the pair", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        confidential: true,
+      });
+      // Mint an initial refresh token (one full dance with the secret).
+      const { code, verifier } = await consentAndGetCode(db, reg.client.clientId, session.id);
+      const initialTokenRes = await handleToken(
+        db,
+        tokenRequest(
+          new URLSearchParams({
+            grant_type: "authorization_code",
+            code,
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            code_verifier: verifier,
+            client_secret: reg.clientSecret ?? "",
+          }),
+        ),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      const initial = (await initialTokenRes.json()) as { refresh_token: string };
+
+      // Refresh with secret → 200.
+      const refreshForm = new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: initial.refresh_token,
+        client_id: reg.client.clientId,
+        client_secret: reg.clientSecret ?? "",
+      });
+      const refreshRes = await handleToken(db, tokenRequest(refreshForm), {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(refreshRes.status).toBe(200);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("refresh_token: confidential client + missing secret → 401", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        confidential: true,
+      });
+      const { code, verifier } = await consentAndGetCode(db, reg.client.clientId, session.id);
+      const initialTokenRes = await handleToken(
+        db,
+        tokenRequest(
+          new URLSearchParams({
+            grant_type: "authorization_code",
+            code,
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            code_verifier: verifier,
+            client_secret: reg.clientSecret ?? "",
+          }),
+        ),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      const initial = (await initialTokenRes.json()) as { refresh_token: string };
+
+      const refreshForm = new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: initial.refresh_token,
+        client_id: reg.client.clientId,
+        // No client_secret.
+      });
+      const res = await handleToken(db, tokenRequest(refreshForm), { issuer: ISSUER });
+      expect(res.status).toBe(401);
+      expect(res.headers.get("www-authenticate")).toMatch(/^Basic\b/i);
+      const err = (await res.json()) as Record<string, unknown>;
+      expect(err.error).toBe("invalid_client");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("refresh_token: confidential client + wrong secret → 401", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        confidential: true,
+      });
+      const { code, verifier } = await consentAndGetCode(db, reg.client.clientId, session.id);
+      const initialTokenRes = await handleToken(
+        db,
+        tokenRequest(
+          new URLSearchParams({
+            grant_type: "authorization_code",
+            code,
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            code_verifier: verifier,
+            client_secret: reg.clientSecret ?? "",
+          }),
+        ),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      const initial = (await initialTokenRes.json()) as { refresh_token: string };
+
+      const refreshForm = new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: initial.refresh_token,
+        client_id: reg.client.clientId,
+        client_secret: "wrong-secret",
+      });
+      const res = await handleToken(db, tokenRequest(refreshForm), { issuer: ISSUER });
+      expect(res.status).toBe(401);
+      const err = (await res.json()) as Record<string, unknown>;
+      expect(err.error).toBe("invalid_client");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("refresh_token: public client unaffected (no secret required) → 200", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { code, verifier } = await consentAndGetCode(db, reg.client.clientId, session.id);
+      const initialTokenRes = await handleToken(
+        db,
+        tokenRequest(
+          new URLSearchParams({
+            grant_type: "authorization_code",
+            code,
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            code_verifier: verifier,
+          }),
+        ),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      const initial = (await initialTokenRes.json()) as { refresh_token: string };
+
+      const refreshForm = new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: initial.refresh_token,
+        client_id: reg.client.clientId,
+      });
+      const res = await handleToken(db, tokenRequest(refreshForm), {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(200);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
 describe("handleRegister — RFC 7591 DCR", () => {
   test("registers a public client and returns 201 with client_id (no secret)", async () => {
     const { db, cleanup } = await makeDb();

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -36,6 +36,7 @@ import {
   isValidRedirectUri,
   registerClient,
   requireRegisteredRedirectUri,
+  verifyClientSecret,
 } from "./clients.ts";
 import {
   ACCESS_TOKEN_TTL_SECONDS,
@@ -539,16 +540,107 @@ function authorizeParamsToQuery(p: AuthorizeFormParams): Record<string, string> 
 // --- /oauth/token ----------------------------------------------------------
 
 /**
+ * Extract a presented client_secret from either the `Authorization: Basic`
+ * header (RFC 6749 §2.3.1 preferred) or the form-body `client_secret`. If
+ * both are present, the header wins — the spec says clients SHOULD use one
+ * mechanism per request; when they don't, picking deterministically (header
+ * = the more-secure form, harder to log accidentally than a body field)
+ * keeps the auth gate predictable.
+ *
+ * Returns `{ clientId, clientSecret }` so callers can cross-check the body's
+ * `client_id` against the header's. RFC §2.3.1 doesn't explicitly require
+ * matching, but a mismatch is a client bug we shouldn't paper over.
+ *
+ * Returns null secret when no credential was presented at all.
+ */
+function extractClientCredentials(
+  req: Request,
+  form: Awaited<ReturnType<Request["formData"]>>,
+): { headerClientId: string | null; clientSecret: string | null } {
+  const auth = req.headers.get("authorization");
+  // RFC 7235 §2.1 — auth-scheme is case-insensitive ("Basic" / "basic" / "BASIC").
+  if (auth && /^basic\s+/i.test(auth)) {
+    try {
+      const decoded = atob(auth.replace(/^basic\s+/i, "").trim());
+      const colon = decoded.indexOf(":");
+      if (colon >= 0) {
+        // RFC 6749 §2.3.1 mandates form-encoding the basic-auth values
+        // (because client_id may legitimately contain `:`). Decode them
+        // back so a client that registered the spec-correct way works.
+        const headerClientId = decodeURIComponent(decoded.slice(0, colon));
+        const clientSecret = decodeURIComponent(decoded.slice(colon + 1));
+        return { headerClientId, clientSecret };
+      }
+    } catch {
+      // Malformed base64 → treat as no header credential, fall through to
+      // form body. The auth gate will reject if the client is confidential
+      // and didn't also send a body secret.
+    }
+  }
+  const bodySecret = form.get("client_secret");
+  return {
+    headerClientId: null,
+    clientSecret: typeof bodySecret === "string" && bodySecret.length > 0 ? bodySecret : null,
+  };
+}
+
+/**
+ * 401 response shape for token-endpoint client-auth failures. WWW-Authenticate
+ * declares Basic per RFC 6749 §5.2 + RFC 7235 — it tells a compliant client
+ * "this endpoint accepts Basic auth" so it can retry with credentials.
+ */
+function clientAuthFailure(description: string): Response {
+  return jsonResponse({ error: "invalid_client", error_description: description }, 401, {
+    "www-authenticate": 'Basic realm="hub"',
+  });
+}
+
+/**
+ * Gate the per-grant handlers behind RFC 6749 §3.2.1 client authentication.
+ * Public clients (clientSecretHash == null) pass through unchanged — PKCE
+ * already binds their auth-code redemption. Confidential clients must
+ * present a matching client_secret via Basic header or form body.
+ *
+ * Returns null on success; a 401 Response on failure for the caller to
+ * return directly.
+ */
+function authenticateClient(
+  client: OAuthClient,
+  req: Request,
+  form: Awaited<ReturnType<Request["formData"]>>,
+  bodyClientId: string,
+): Response | null {
+  if (!client.clientSecretHash) return null; // public client: no secret required
+  const { headerClientId, clientSecret } = extractClientCredentials(req, form);
+  if (!clientSecret) {
+    return clientAuthFailure("client_secret required for confidential client");
+  }
+  // If the Basic header was used, its client_id must match the body's —
+  // RFC 6749 §3.2.1 says the auth identifies the client; a body claiming
+  // a different client_id is a bug or an attempt to confuse the gate.
+  if (headerClientId !== null && headerClientId !== bodyClientId) {
+    return clientAuthFailure("authorization header client_id does not match request body");
+  }
+  if (!verifyClientSecret(client, clientSecret)) {
+    return clientAuthFailure("client_secret mismatch");
+  }
+  return null;
+}
+
+/**
  * POST /oauth/token — supports `authorization_code` + `refresh_token`.
- * Confidential clients may pass `client_secret` in the body; for public
- * clients the binding is PKCE alone. Errors return the RFC 6749 §5.2
- * shape: 400 + `{error, error_description}`.
+ * Confidential clients (registered with a client_secret) must authenticate
+ * via the Authorization: Basic header or a form-body `client_secret` per
+ * RFC 6749 §2.3.1; public clients (PKCE-only) need no client_secret because
+ * PKCE already binds the redemption. Errors return the RFC 6749 §5.2 shape:
+ * 400/401 + `{error, error_description}`.
  */
 export async function handleToken(db: Database, req: Request, deps: OAuthDeps): Promise<Response> {
   const form = await req.formData();
   const grantType = String(form.get("grant_type") ?? "");
-  if (grantType === "authorization_code") return await handleTokenAuthorizationCode(db, form, deps);
-  if (grantType === "refresh_token") return await handleTokenRefresh(db, form, deps);
+  if (grantType === "authorization_code")
+    return await handleTokenAuthorizationCode(db, req, form, deps);
+  if (grantType === "refresh_token") return await handleTokenRefresh(db, req, form, deps);
   return jsonResponse(
     {
       error: "unsupported_grant_type",
@@ -560,6 +652,7 @@ export async function handleToken(db: Database, req: Request, deps: OAuthDeps): 
 
 async function handleTokenAuthorizationCode(
   db: Database,
+  req: Request,
   form: Awaited<ReturnType<Request["formData"]>>,
   deps: OAuthDeps,
 ): Promise<Response> {
@@ -577,6 +670,8 @@ async function handleTokenAuthorizationCode(
   if (!client) {
     return jsonResponse({ error: "invalid_client", error_description: "unknown client_id" }, 401);
   }
+  const authFailure = authenticateClient(client, req, form, clientId);
+  if (authFailure) return authFailure;
   let redeemed: ReturnType<typeof redeemAuthCode>;
   try {
     redeemed = redeemAuthCode(db, { code, clientId, redirectUri, codeVerifier, now: deps.now });
@@ -633,6 +728,7 @@ async function handleTokenAuthorizationCode(
 
 async function handleTokenRefresh(
   db: Database,
+  req: Request,
   form: Awaited<ReturnType<Request["formData"]>>,
   deps: OAuthDeps,
 ): Promise<Response> {
@@ -648,6 +744,8 @@ async function handleTokenRefresh(
   if (!client) {
     return jsonResponse({ error: "invalid_client", error_description: "unknown client_id" }, 401);
   }
+  const authFailure = authenticateClient(client, req, form, clientId);
+  if (authFailure) return authFailure;
   const row = findRefreshToken(db, refreshToken);
   if (!row) {
     return jsonResponse(


### PR DESCRIPTION
## Summary

Closes #72.

RFC 6749 §3.2.1 + §2.3.1 require confidential clients to authenticate at `/oauth/token`. The hub had been registering confidential clients (with `clientSecretHash` populated by `registerClient`), but the token endpoint never validated the presented secret — the auth-code grant only checked PKCE, and the refresh grant did neither. A leaked `refresh_token` or `code` from a confidential client could be redeemed by anyone.

Both grant handlers (`handleTokenAuthorizationCode`, `handleTokenRefresh`) now run `authenticateClient()` after `getClient()`:

- **Authorization: Basic** preferred (RFC 6749 §2.3.1), with case-insensitive scheme match per RFC 7235 §2.1 and `decodeURIComponent` on the percent-encoded credential parts
- **`client_secret` form-body** accepted as fallback (also RFC 6749 §2.3.1)
- **Header/body `client_id` mismatch** → 401 (defensive: prevents an attacker who knows one client's secret from swapping in another `client_id` in the body)
- **Missing/wrong secret** → `401 invalid_client` with `WWW-Authenticate: Basic realm="hub"` (RFC 6749 §5.2)
- **Public clients** (`clientSecretHash IS NULL`) — completely untouched, still PKCE-only

Constant-time comparison via the existing `verifyClientSecret` helper in `clients.ts` (uses `timingSafeEqualHex`).

Pre-existing comment in `clients.ts` line 12-14 ("PR (c) doesn't yet enforce client_secret on the token endpoint — that's a follow-up") was the trail-marker; this PR is that follow-up.

Version bumped `0.4.0-rc.12 → 0.4.0-rc.13`.

## Test plan

- [x] 10 new tests in `oauth-handlers.test.ts` under `describe("handleToken — confidential client authentication (#72)")`:
  - authorization_code: confidential w/ form-body secret → 200
  - authorization_code: confidential w/ Basic header → 200
  - authorization_code: confidential w/ wrong secret → 401 + `WWW-Authenticate: Basic`
  - authorization_code: confidential w/ missing secret → 401
  - authorization_code: header `client_id` ≠ body `client_id` → 401
  - authorization_code: public client unaffected (regression)
  - refresh_token: same five cases (minus the header/body mismatch where redundant)
- [x] `bun run typecheck` clean
- [x] `bun test` — 702 pass / 0 fail (was 692 before; +10 new)
- [x] `bun run lint` — same 4 pre-existing errors as `main`, no new errors from this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)