### PR TITLE
feat(oauth-register): operator-approval gate for DCR (closes #74)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.13",
+  "version": "0.4.0-rc.14",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -553,3 +553,70 @@ describe("parachute auth rotate-operator", () => {
     }
   });
 });
+
+// closes #74 — the operator's surface for the DCR approval gate. The CLI
+// is the only approval path at launch (no admin UI yet); these tests pin
+// the round-trip so an operator can promote a pending registration.
+describe("parachute auth pending-clients / approve-client", () => {
+  test("pending-clients on an empty db says '(no pending OAuth clients)'", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = { dbPath: tmp.dbPath };
+      const { code, stdout } = await captureOutput(() => auth(["pending-clients"], deps));
+      expect(code).toBe(0);
+      expect(stdout).toContain("no pending OAuth clients");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("pending-clients lists pending rows; approve-client promotes them", async () => {
+    const tmp = makeTmp();
+    try {
+      const { registerClient } = await import("../clients.ts");
+      const db = openHubDb(tmp.dbPath);
+      let pendingId: string;
+      try {
+        pendingId = registerClient(db, {
+          redirectUris: ["https://app.example/cb"],
+          status: "pending",
+          clientName: "MyApp",
+        }).client.clientId;
+        registerClient(db, {
+          redirectUris: ["https://approved.example/cb"],
+          status: "approved",
+          clientName: "Already",
+        });
+      } finally {
+        db.close();
+      }
+      const deps: AuthDeps = { dbPath: tmp.dbPath };
+
+      // pending-clients shows only the pending row.
+      const list = await captureOutput(() => auth(["pending-clients"], deps));
+      expect(list.code).toBe(0);
+      expect(list.stdout).toContain(pendingId);
+      expect(list.stdout).toContain("MyApp");
+      expect(list.stdout).not.toContain("approved.example");
+
+      // approve-client without an arg is a usage error.
+      const noArg = await captureOutput(() => auth(["approve-client"], deps));
+      expect(noArg.code).toBe(1);
+      expect(noArg.stderr).toContain("missing client_id");
+
+      // approve-client <unknown> is a 1.
+      const unknown = await captureOutput(() => auth(["approve-client", "no-such"], deps));
+      expect(unknown.code).toBe(1);
+      expect(unknown.stderr).toContain("no OAuth client");
+
+      // approve-client <pending> succeeds and the row drops off pending-clients.
+      const ok = await captureOutput(() => auth(["approve-client", pendingId], deps));
+      expect(ok.code).toBe(0);
+      expect(ok.stdout).toContain("Approved");
+      const after = await captureOutput(() => auth(["pending-clients"], deps));
+      expect(after.stdout).toContain("no pending OAuth clients");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+});

--- a/src/__tests__/clients.test.ts
+++ b/src/__tests__/clients.test.ts
@@ -4,8 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   InvalidRedirectUriError,
+  approveClient,
   getClient,
   isValidRedirectUri,
+  listClientsByStatus,
   registerClient,
   requireRegisteredRedirectUri,
   verifyClientSecret,
@@ -163,6 +165,85 @@ describe("verifyClientSecret", () => {
     try {
       const r = registerClient(db, { redirectUris: ["https://example.com/cb"] });
       expect(verifyClientSecret(r.client, "anything")).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("approval gate (#74)", () => {
+  test("registerClient defaults status to approved (direct callers)", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const r = registerClient(db, { redirectUris: ["https://example.com/cb"] });
+      expect(r.client.status).toBe("approved");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("registerClient honors explicit status: pending (DCR path)", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const r = registerClient(db, {
+        redirectUris: ["https://example.com/cb"],
+        status: "pending",
+      });
+      expect(r.client.status).toBe("pending");
+      expect(getClient(db, r.client.clientId)?.status).toBe("pending");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("approveClient promotes pending → approved and is idempotent", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const r = registerClient(db, {
+        redirectUris: ["https://example.com/cb"],
+        status: "pending",
+      });
+      expect(approveClient(db, r.client.clientId)).toBe(true);
+      expect(getClient(db, r.client.clientId)?.status).toBe("approved");
+      // Second call is a no-op but still returns true.
+      expect(approveClient(db, r.client.clientId)).toBe(true);
+      expect(getClient(db, r.client.clientId)?.status).toBe("approved");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("approveClient returns false for unknown client", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      expect(approveClient(db, "no-such-client")).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("listClientsByStatus filters and orders by registered_at", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const a = registerClient(db, {
+        redirectUris: ["https://a.example/cb"],
+        status: "pending",
+        now: () => new Date("2026-01-01T00:00:00Z"),
+      });
+      const b = registerClient(db, {
+        redirectUris: ["https://b.example/cb"],
+        status: "approved",
+        now: () => new Date("2026-01-02T00:00:00Z"),
+      });
+      const c = registerClient(db, {
+        redirectUris: ["https://c.example/cb"],
+        status: "pending",
+        now: () => new Date("2026-01-03T00:00:00Z"),
+      });
+      const pending = listClientsByStatus(db, "pending").map((r) => r.clientId);
+      expect(pending).toEqual([a.client.clientId, c.client.clientId]);
+      const approved = listClientsByStatus(db, "approved").map((r) => r.clientId);
+      expect(approved).toEqual([b.client.clientId]);
     } finally {
       cleanup();
     }

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -1761,6 +1761,8 @@ describe("handleRegister — RFC 7591 DCR", () => {
       expect(body.token_endpoint_auth_method).toBe("none");
       expect(body.redirect_uris).toEqual(["https://app.example/cb"]);
       expect(body.client_name).toBe("MyApp");
+      // #74 — unauthenticated DCR lands as pending until an operator approves.
+      expect(body.status).toBe("pending");
     } finally {
       cleanup();
     }
@@ -1831,6 +1833,233 @@ describe("handleRegister — RFC 7591 DCR", () => {
       });
       const res = await handleRegister(db, req, { issuer: ISSUER });
       expect(res.status).toBe(400);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// closes #74 — DCR is now operator-gated. Self-served registrations land as
+// pending and cannot OAuth; operator-bearer (hub:admin) registrations land
+// as approved and can OAuth immediately. This block covers all four exposed
+// gates plus the bearer paths in /oauth/register.
+describe("DCR approval gate (#74)", () => {
+  async function buildAuthorizeRequest(
+    db: Awaited<ReturnType<typeof makeDb>>["db"],
+    clientId: string,
+  ) {
+    const { challenge } = makePkce();
+    return new Request(
+      authorizeUrl({
+        client_id: clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        scope: "vault:read",
+      }),
+    );
+  }
+
+  test("authorize: pending client → 403 HTML 'App not yet approved'", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "pending",
+      });
+      const res = handleAuthorizeGet(db, await buildAuthorizeRequest(db, reg.client.clientId), {
+        issuer: ISSUER,
+      });
+      expect(res.status).toBe(403);
+      const html = await res.text();
+      expect(html).toContain("App not yet approved");
+      expect(html).toContain("approve-client");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("authorize: approved client passes the gate (renders login)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const res = handleAuthorizeGet(db, await buildAuthorizeRequest(db, reg.client.clientId), {
+        issuer: ISSUER,
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toContain("Sign in");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("token: pending client → 401 invalid_client", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "pending",
+      });
+      const form = new URLSearchParams({
+        grant_type: "authorization_code",
+        code: "any",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        code_verifier: "any",
+      });
+      const res = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: form,
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_client");
+      expect(body.error_description).toContain("not been approved");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("token (refresh): pending client → 401 invalid_client", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "pending",
+      });
+      const form = new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: "any",
+        client_id: reg.client.clientId,
+      });
+      const res = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: form,
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_client");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("register: no Authorization header → status pending (public DCR path)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const req = new Request(`${ISSUER}/oauth/register`, {
+        method: "POST",
+        body: JSON.stringify({ redirect_uris: ["https://app.example/cb"] }),
+        headers: { "content-type": "application/json" },
+      });
+      const res = await handleRegister(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.status).toBe("pending");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("register: operator-bearer with hub:admin → status approved", async () => {
+    // First-party install path. Modules running `parachute install <name>`
+    // present the hub's operator.token; the bearer carries hub:admin so the
+    // self-registration lands as approved without a human follow-up.
+    const { db, cleanup } = await makeDb();
+    try {
+      const { rotateSigningKey } = await import("../signing-keys.ts");
+      const { mintOperatorToken } = await import("../operator-token.ts");
+      rotateSigningKey(db);
+      const user = await createUser(db, "owner", "pw");
+      const operator = await mintOperatorToken(db, user.id, { issuer: ISSUER });
+
+      const req = new Request(`${ISSUER}/oauth/register`, {
+        method: "POST",
+        body: JSON.stringify({ redirect_uris: ["https://app.example/cb"] }),
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${operator.token}`,
+        },
+      });
+      const res = await handleRegister(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.status).toBe("approved");
+      // Sanity: the freshly-approved client passes the authorize gate.
+      const aRes = handleAuthorizeGet(
+        db,
+        await buildAuthorizeRequest(db, body.client_id as string),
+        { issuer: ISSUER },
+      );
+      expect(aRes.status).toBe(200);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("register: bearer without hub:admin → 403 insufficient_scope", async () => {
+    // A consumer access token (vault:read) is not an operator credential.
+    // The endpoint must reject rather than silently downgrading to pending.
+    const { db, cleanup } = await makeDb();
+    try {
+      const { rotateSigningKey } = await import("../signing-keys.ts");
+      const { signAccessToken } = await import("../jwt-sign.ts");
+      rotateSigningKey(db);
+      const user = await createUser(db, "owner", "pw");
+      const consumer = await signAccessToken(db, {
+        sub: user.id,
+        scopes: ["vault:read"],
+        audience: "vault",
+        clientId: "some-client",
+        issuer: ISSUER,
+      });
+
+      const req = new Request(`${ISSUER}/oauth/register`, {
+        method: "POST",
+        body: JSON.stringify({ redirect_uris: ["https://app.example/cb"] }),
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${consumer.token}`,
+        },
+      });
+      const res = await handleRegister(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("insufficient_scope");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("register: malformed bearer → 401 invalid_token", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const req = new Request(`${ISSUER}/oauth/register`, {
+        method: "POST",
+        body: JSON.stringify({ redirect_uris: ["https://app.example/cb"] }),
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer not-a-jwt",
+        },
+      });
+      const res = await handleRegister(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_token");
     } finally {
       cleanup();
     }

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -9,16 +9,20 @@
  *     for the auth-code exchange. `client_secret_hash` is NULL for these.
  *   - **Confidential clients**: server-side apps. We mint a random
  *     `client_secret` on registration, store its sha256 hash, return the
- *     plaintext exactly once. PR (c) doesn't yet enforce client_secret on
- *     the token endpoint — that's a follow-up; for now confidential clients
- *     work the same as public ones plus an opaque secret they can present.
+ *     plaintext exactly once. The token endpoint enforces client_secret per
+ *     RFC 6749 §3.2.1 (closes #72).
  *
- * Self-registration is open. The brief defers consent gating (admin-approve
- * for new clients) to a later PR; today, any client_id seen for the first
- * time gets a row.
+ * Approval gate (closes #74): every row carries a `status` of `pending` or
+ * `approved`. New self-registrations default to `pending`; only registrations
+ * that authenticate with an operator token bearing `hub:admin` (the install-
+ * time path for first-party modules) land as `approved`. The OAuth flow
+ * rejects `pending` clients at `/oauth/authorize` and `/oauth/token`. An
+ * operator promotes a pending client via `parachute auth approve-client`.
  */
 import type { Database } from "bun:sqlite";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
+
+export type ClientStatus = "pending" | "approved";
 
 export interface OAuthClient {
   clientId: string;
@@ -28,6 +32,8 @@ export interface OAuthClient {
   scopes: string[];
   clientName: string | null;
   registeredAt: string;
+  /** Whether the client may participate in OAuth flows. See file header. */
+  status: ClientStatus;
 }
 
 export class ClientNotFoundError extends Error {
@@ -51,6 +57,7 @@ interface Row {
   scopes: string;
   client_name: string | null;
   registered_at: string;
+  status: string;
 }
 
 function rowToClient(r: Row): OAuthClient {
@@ -61,6 +68,7 @@ function rowToClient(r: Row): OAuthClient {
     scopes: r.scopes.split(" ").filter((s) => s.length > 0),
     clientName: r.client_name,
     registeredAt: r.registered_at,
+    status: r.status === "approved" ? "approved" : "pending",
   };
 }
 
@@ -72,6 +80,14 @@ export interface RegisterClientOpts {
   confidential?: boolean;
   /** Override the generated client_id. Mostly for tests + first-party seeds. */
   clientId?: string;
+  /**
+   * Approval status to write. Defaults to `approved` — direct callers
+   * (tests, install-time first-party seeds) want a row that can OAuth.
+   * The public DCR endpoint (`POST /oauth/register`) passes `pending`
+   * explicitly so self-served registrations require operator approval
+   * before they can run an OAuth flow (closes #74).
+   */
+  status?: ClientStatus;
   now?: () => Date;
 }
 
@@ -97,10 +113,11 @@ export function registerClient(db: Database, opts: RegisterClientOpts): Register
     : null;
   const registeredAt = (opts.now?.() ?? new Date()).toISOString();
   const scopes = (opts.scopes ?? []).join(" ");
+  const status: ClientStatus = opts.status ?? "approved";
   db.prepare(
     `INSERT INTO clients
-     (client_id, client_secret_hash, redirect_uris, scopes, client_name, registered_at)
-     VALUES (?, ?, ?, ?, ?, ?)`,
+     (client_id, client_secret_hash, redirect_uris, scopes, client_name, registered_at, status)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     clientId,
     clientSecretHash,
@@ -108,6 +125,7 @@ export function registerClient(db: Database, opts: RegisterClientOpts): Register
     scopes,
     opts.clientName ?? null,
     registeredAt,
+    status,
   );
   return {
     client: {
@@ -117,9 +135,32 @@ export function registerClient(db: Database, opts: RegisterClientOpts): Register
       scopes: opts.scopes ?? [],
       clientName: opts.clientName ?? null,
       registeredAt,
+      status,
     },
     clientSecret,
   };
+}
+
+/**
+ * Promote a `pending` client to `approved`. Idempotent — calling on an
+ * already-approved row is a no-op. Returns true when the row was found and
+ * is now approved (whether by this call or already), false when no such
+ * client exists. Used by `parachute auth approve-client`.
+ */
+export function approveClient(db: Database, clientId: string): boolean {
+  const existing = getClient(db, clientId);
+  if (!existing) return false;
+  if (existing.status === "approved") return true;
+  db.prepare("UPDATE clients SET status = 'approved' WHERE client_id = ?").run(clientId);
+  return true;
+}
+
+/** List clients filtered by status. Used by `parachute auth pending-clients`. */
+export function listClientsByStatus(db: Database, status: ClientStatus): OAuthClient[] {
+  const rows = db
+    .query<Row, [string]>("SELECT * FROM clients WHERE status = ? ORDER BY registered_at")
+    .all(status);
+  return rows.map(rowToClient);
 }
 
 export function getClient(db: Database, clientId: string): OAuthClient | null {

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -18,6 +18,7 @@
 
 import { join } from "node:path";
 import { createInterface } from "node:readline/promises";
+import { approveClient, listClientsByStatus } from "../clients.ts";
 import { CONFIG_DIR } from "../config.ts";
 import { readExposeState } from "../expose-state.ts";
 import { HUB_DEFAULT_PORT, readHubPort } from "../hub-control.ts";
@@ -52,6 +53,8 @@ const HUB_LOCAL_SUBCOMMANDS = new Set([
   "set-password",
   "list-users",
   "rotate-operator",
+  "pending-clients",
+  "approve-client",
 ]);
 
 export function authHelp(): string {
@@ -67,6 +70,8 @@ Usage:
   parachute auth 2fa backup-codes      Regenerate backup codes
   parachute auth rotate-key            Rotate the hub's JWT signing key
   parachute auth rotate-operator       Mint a fresh ~/.parachute/operator.token
+  parachute auth pending-clients       List OAuth clients awaiting approval
+  parachute auth approve-client <id>   Approve a pending OAuth client
 
 set-password and list-users are hub-local — they read/write
 ~/.parachute/hub.db. set-password is interactive by default (prompts for
@@ -90,6 +95,12 @@ rotate-operator mints a fresh long-lived operator token at
 ~/.parachute/operator.token (mode 0600). Local CLI tools read this file
 as their bearer when calling on-box services. set-password also writes
 the file on first-run / password reset.
+
+pending-clients + approve-client gate /oauth/register against operator
+approval (closes #74). Self-served DCR registrations land as 'pending'
+and cannot OAuth until you run \`parachute auth approve-client <id>\`.
+First-party install flows that present \`Authorization: Bearer
+<operator-token>\` with \`hub:admin\` scope land as 'approved' immediately.
 `;
 }
 
@@ -374,6 +385,47 @@ async function runRotateOperator(deps: AuthDeps): Promise<number> {
   }
 }
 
+function runPendingClients(deps: AuthDeps): number {
+  const db = deps.dbPath ? openHubDb(deps.dbPath) : openHubDb();
+  try {
+    const pending = listClientsByStatus(db, "pending");
+    if (pending.length === 0) {
+      console.log("(no pending OAuth clients)");
+      return 0;
+    }
+    console.log("CLIENT_ID                              NAME                 REGISTERED");
+    for (const c of pending) {
+      const id = c.clientId.padEnd(36).slice(0, 36);
+      const name = (c.clientName ?? "").padEnd(20).slice(0, 20);
+      console.log(`${id}  ${name} ${c.registeredAt}`);
+    }
+    return 0;
+  } finally {
+    db.close();
+  }
+}
+
+function runApproveClient(args: readonly string[], deps: AuthDeps): number {
+  const clientId = args[0];
+  if (!clientId) {
+    console.error("parachute auth approve-client: missing client_id argument");
+    console.error("usage: parachute auth approve-client <client_id>");
+    return 1;
+  }
+  const db = deps.dbPath ? openHubDb(deps.dbPath) : openHubDb();
+  try {
+    const ok = approveClient(db, clientId);
+    if (!ok) {
+      console.error(`no OAuth client registered with client_id "${clientId}"`);
+      return 1;
+    }
+    console.log(`Approved OAuth client "${clientId}".`);
+    return 0;
+  } finally {
+    db.close();
+  }
+}
+
 function runListUsers(deps: AuthDeps): number {
   const db = deps.dbPath ? openHubDb(deps.dbPath) : openHubDb();
   try {
@@ -441,6 +493,24 @@ export async function auth(args: readonly string[], deps: AuthDeps | Runner = {}
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`parachute auth rotate-operator: ${msg}`);
+        return 1;
+      }
+    }
+    if (sub === "pending-clients") {
+      try {
+        return runPendingClients(normalized);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`parachute auth pending-clients: ${msg}`);
+        return 1;
+      }
+    }
+    if (sub === "approve-client") {
+      try {
+        return runApproveClient(args.slice(1), normalized);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`parachute auth approve-client: ${msg}`);
         return 1;
       }
     }

--- a/src/hub-db.ts
+++ b/src/hub-db.ts
@@ -103,6 +103,19 @@ const MIGRATIONS: readonly Migration[] = [
       CREATE INDEX sessions_user ON sessions (user_id);
     `,
   },
+  {
+    version: 4,
+    sql: `
+      -- DCR approval gate (closes #74). Public DCR was unauthenticated before
+      -- this migration; pre-existing rows are grandfathered as 'approved' so
+      -- already-trusted clients keep working. New rows default to 'pending'
+      -- unless the registrant authenticates with an operator token carrying
+      -- hub:admin scope.
+      ALTER TABLE clients ADD COLUMN status TEXT NOT NULL DEFAULT 'pending';
+      UPDATE clients SET status = 'approved';
+      CREATE INDEX clients_status ON clients (status);
+    `,
+  },
 ];
 
 export function openHubDb(path: string = hubDbPath()): Database {

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -20,6 +20,7 @@
  * on presentation.
  */
 import type { Database } from "bun:sqlite";
+import { AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
 import {
   AuthCodeExpiredError,
   AuthCodeNotFoundError,
@@ -30,6 +31,7 @@ import {
   redeemAuthCode,
 } from "./auth-codes.ts";
 import {
+  type ClientStatus,
   type OAuthClient,
   type RegisteredClient,
   getClient,
@@ -285,6 +287,26 @@ function parseAuthorizeFormParams(url: URL): AuthorizeFormParams | { error: stri
   };
 }
 
+/** HTML response for pending clients hitting /oauth/authorize. */
+function pendingClientHtml(): Response {
+  return htmlError(
+    "App not yet approved",
+    "This client_id is registered but has not been approved by the hub operator. Ask the operator to run `parachute auth approve-client` for this app, then try again.",
+    403,
+  );
+}
+
+/** JSON response for pending clients hitting /oauth/token. */
+function pendingClientJson(): Response {
+  return jsonResponse(
+    {
+      error: "invalid_client",
+      error_description: "client is registered but has not been approved by the hub operator (#74)",
+    },
+    401,
+  );
+}
+
 /**
  * GET /oauth/authorize — entrypoint. Validates client + redirect_uri, then
  * either renders the login form (no session) or the consent screen (session
@@ -319,6 +341,7 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
     // matched it against a registered client. Render an HTML error.
     return htmlError("Unknown application", "This client_id is not registered with this hub.", 400);
   }
+  if (client.status !== "approved") return pendingClientHtml();
   try {
     requireRegisteredRedirectUri(client, parsed.redirectUri);
   } catch {
@@ -430,6 +453,7 @@ async function handleConsentSubmit(
   if (!client) {
     return htmlError("Unknown application", "This client_id is not registered with this hub.", 400);
   }
+  if (client.status !== "approved") return pendingClientHtml();
   try {
     requireRegisteredRedirectUri(client, params.redirectUri);
   } catch {
@@ -670,6 +694,7 @@ async function handleTokenAuthorizationCode(
   if (!client) {
     return jsonResponse({ error: "invalid_client", error_description: "unknown client_id" }, 401);
   }
+  if (client.status !== "approved") return pendingClientJson();
   const authFailure = authenticateClient(client, req, form, clientId);
   if (authFailure) return authFailure;
   let redeemed: ReturnType<typeof redeemAuthCode>;
@@ -744,6 +769,7 @@ async function handleTokenRefresh(
   if (!client) {
     return jsonResponse({ error: "invalid_client", error_description: "unknown client_id" }, 401);
   }
+  if (client.status !== "approved") return pendingClientJson();
   const authFailure = authenticateClient(client, req, form, clientId);
   if (authFailure) return authFailure;
   const row = findRefreshToken(db, refreshToken);
@@ -871,9 +897,19 @@ interface RegisterRequestBody {
 }
 
 /**
- * POST /oauth/register — RFC 7591 Dynamic Client Registration. Self-serve.
- * Returns the assigned `client_id` (and `client_secret` for confidential
- * clients). The brief defers admin-gating; today, any caller gets a row.
+ * POST /oauth/register — RFC 7591 Dynamic Client Registration.
+ *
+ * Approval gate (closes #74). New rows land as `pending` by default and
+ * cannot participate in OAuth flows until an operator runs
+ * `parachute auth approve-client <id>`. The single bypass is presenting an
+ * `Authorization: Bearer <operator-token>` whose token carries the
+ * `hub:admin` scope — the install-time path used by first-party modules so
+ * `parachute install vault` can self-register without a human follow-up.
+ *
+ * If a bearer is presented but invalid or insufficient, we reject with the
+ * RFC 6750 shape rather than silently downgrading to the public path: a
+ * caller who tried to authenticate but failed wants to know why, not get
+ * `pending` back and wonder why their module can't OAuth.
  */
 export async function handleRegister(
   db: Database,
@@ -907,6 +943,19 @@ export async function handleRegister(
       );
     }
   }
+  // Operator-bearer auto-approve. No header → public DCR path (status=pending).
+  // Header present → must validate as a hub:admin operator token; any failure
+  // is surfaced (don't silently fall through to pending).
+  let status: ClientStatus = "pending";
+  if (req.headers.get("authorization")) {
+    try {
+      await requireScope(db, req, "hub:admin", deps.issuer);
+      status = "approved";
+    } catch (err) {
+      if (err instanceof AdminAuthError) return adminAuthErrorResponse(err);
+      throw err;
+    }
+  }
   const confidential = body.token_endpoint_auth_method === "client_secret_post";
   const scopes = (body.scope ?? "").split(" ").filter((s) => s.length > 0);
   let registered: RegisteredClient;
@@ -916,6 +965,7 @@ export async function handleRegister(
       scopes,
       clientName: body.client_name,
       confidential,
+      status,
       now: deps.now,
     });
   } catch (err) {
@@ -929,6 +979,7 @@ export async function handleRegister(
     response_types: ["code"],
     token_endpoint_auth_method: confidential ? "client_secret_post" : "none",
     client_id_issued_at: Math.floor(new Date(registered.client.registeredAt).getTime() / 1000),
+    status: registered.client.status,
   };
   if (registered.client.scopes.length > 0) respBody.scope = registered.client.scopes.join(" ");
   if (registered.client.clientName) respBody.client_name = registered.client.clientName;


### PR DESCRIPTION
## Summary

- `POST /oauth/register` now lands self-served registrations as `pending` and the OAuth flow rejects pending clients (HTML 403 at `/oauth/authorize`, JSON 401 at `/oauth/token`).
- Bypass: `Authorization: Bearer <operator-token>` with `hub:admin` scope on `/oauth/register` lands the row as `approved` immediately — the install-time path used by first-party modules. Bearer present but invalid/insufficient returns 401/403 per RFC 6750 rather than silently downgrading.
- Operator surface (CLI only at launch): `parachute auth pending-clients` lists pending rows, `parachute auth approve-client <id>` promotes one. No admin UI yet — that's a follow-up.
- Pre-existing rows are grandfathered as `approved` in migration v4 so already-trusted clients keep working across the upgrade.

## Design ratifications

Proposed and ratified before coding:

1. **Rate limiter** — deferred (separate from this auth gate; not in #74's surface).
2. **Schema** — single `status TEXT NOT NULL DEFAULT 'pending'` column on `clients` (migration v4) plus a `clients_status` index. No new table.
3. **Auto-approve** — `Authorization: Bearer <hub:admin operator token>`. No magic config; the credential is the gate.
4. **Loopback exception** — dropped. Browser extensions and compromised postinstalls can hit 127.0.0.1; a loopback bypass would re-introduce exactly the surface this PR closes.
5. **Approval surface** — CLI only for launch. Admin UI is a follow-up issue.

## Test plan

- [x] `bun test` — 717 pass, 0 fail (15 new across `clients.test.ts`, `oauth-handlers.test.ts`, `auth.test.ts`)
- [x] `bun run typecheck` clean
- [x] `bun run lint` — 4 pre-existing errors only (unchanged from main)
- New gate tests cover: pending-rejected at authorize/token, approved-passes at authorize, no-bearer DCR → pending, hub:admin bearer DCR → approved + can OAuth, non-admin bearer → 403, malformed bearer → 401, `approveClient` idempotency, `listClientsByStatus` filtering, `pending-clients` + `approve-client` CLI round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)