### PR TITLE
feat(well-known): plural arrays for every kind (closes #92)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.14",
+  "version": "0.4.0-rc.15",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/well-known.test.ts
+++ b/src/__tests__/well-known.test.ts
@@ -92,7 +92,7 @@ describe("vaultInstanceName", () => {
 });
 
 describe("buildWellKnown", () => {
-  test("vaults is always an array, other services are flat entries, services[] includes all", () => {
+  test("every kind is a plural array; services[] includes all (#92)", () => {
     const doc = buildWellKnown({
       services: [vault, notes, scribe],
       canonicalOrigin: "https://parachute.taildf9ce2.ts.net",
@@ -104,18 +104,34 @@ describe("buildWellKnown", () => {
         version: "0.2.4",
       },
     ]);
-    expect(doc.notes).toEqual({
-      url: "https://parachute.taildf9ce2.ts.net/notes",
-      version: "0.0.1",
-    });
-    expect(doc.scribe).toEqual({
-      url: "https://parachute.taildf9ce2.ts.net/scribe",
-      version: "0.1.0",
-    });
+    expect(doc.notes).toEqual([
+      {
+        url: "https://parachute.taildf9ce2.ts.net/notes",
+        version: "0.0.1",
+      },
+    ]);
+    expect(doc.scribe).toEqual([
+      {
+        url: "https://parachute.taildf9ce2.ts.net/scribe",
+        version: "0.1.0",
+      },
+    ]);
     expect(doc.services.map((s) => s.name)).toEqual([
       "parachute-vault",
       "parachute-notes",
       "parachute-scribe",
+    ]);
+  });
+
+  test("multiple installs of the same kind both land in the array (#92)", () => {
+    const work: ServiceEntry = { ...notes, paths: ["/notes-work"], port: 5174 };
+    const doc = buildWellKnown({
+      services: [notes, work],
+      canonicalOrigin: "https://x.example",
+    });
+    expect(doc.notes).toEqual([
+      { url: "https://x.example/notes", version: "0.0.1" },
+      { url: "https://x.example/notes-work", version: "0.0.1" },
     ]);
   });
 
@@ -158,7 +174,7 @@ describe("buildWellKnown", () => {
     });
     expect(doc.vaults).toEqual([]);
     expect(doc.services).toHaveLength(1);
-    expect(doc.notes).toEqual({ url: "https://x.example/notes", version: "0.0.1" });
+    expect(doc.notes).toEqual([{ url: "https://x.example/notes", version: "0.0.1" }]);
   });
 
   test("multiple vault instances all land in the vaults array", () => {

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -31,23 +31,18 @@ export interface WellKnownServicesEntry {
 /**
  * Canonical `/.well-known/parachute.json` shape.
  *
- * Three parts, all additive so old clients keep working:
- *   - `vaults: []` — always an array; vault is the ecosystem's only
- *     multi-tenant service.
+ * Two parts:
+ *   - `vaults: []`, `notes: []`, `claw: []`, … — every kind is a plural
+ *     array, so consumers always read `notes[0]` if they want "the one" and
+ *     the multi-install case is visible at every call site (closes #92).
  *   - `services: []` — flat list the hub page iterates. Scales to N frontends
  *     without the consumer needing to know every shortName.
- *   - Top-level flat keys (`notes`, `scribe`, …) — kept for back-compat with
- *     clients that predate `services[]`.
  */
 export type WellKnownDocument = {
   vaults: WellKnownVaultEntry[];
   services: WellKnownServicesEntry[];
 } & {
-  [shortName: string]:
-    | WellKnownVaultEntry[]
-    | WellKnownServicesEntry[]
-    | WellKnownServiceEntry
-    | undefined;
+  [shortName: string]: WellKnownVaultEntry[] | WellKnownServicesEntry[] | WellKnownServiceEntry[];
 };
 
 export const WELL_KNOWN_DIR = join(CONFIG_DIR, "well-known");
@@ -110,7 +105,10 @@ export function buildWellKnown(opts: BuildWellKnownOpts): WellKnownDocument {
     if (isVaultEntry(s)) {
       doc.vaults.push({ name: vaultInstanceName(s), url, version: s.version });
     } else {
-      doc[shortName(s.name)] = { url, version: s.version };
+      const key = shortName(s.name);
+      const bucket = (doc[key] as WellKnownServiceEntry[] | undefined) ?? [];
+      bucket.push({ url, version: s.version });
+      doc[key] = bucket;
     }
   }
   return doc;


### PR DESCRIPTION
## Summary

- Convert `notes:`, `scribe:`, `claw:` (and any future shortName) in `/.well-known/parachute.json` from singular-object to plural-array, matching `vaults: []` already-plural shape (closes #92).
- Drop singular convenience keys entirely — pre-launch, no public consumers to break.
- Tighten `WellKnownDocument` type to plural-only: every shortName key is now `WellKnownVaultEntry[] | WellKnownServicesEntry[] | WellKnownServiceEntry[]`. No more singular union member.
- Bump 0.4.0-rc.14 → 0.4.0-rc.15.

## Why this shape

Consumers always read `notes[0]` / `claw[0]` / `vaults[0]` if they want "the one" — explicit indexing makes the multi-install case visible at every call site, so a second `parachute install notes` doesn't silently overwrite the first entry. Filed pre-emptively before paraclaw / third-party modules / scribe-on-tailnet hardcode the singular shape.

## In-repo consumer audit

- `src/hub.ts` (hub page client-side fetch): only reads `doc.services[]` — unaffected.
- `src/oauth-handlers.ts` `buildServicesCatalog`: separate format (OAuth token-response catalog, keyed by audience), stays singular by design — comment in oauth-handlers.ts:160 already calls out that per-vault keys are deferred.
- `src/commands/expose.ts`: only calls `buildWellKnown` + `writeWellKnownFile`, doesn't read kind-specific keys.
- No grep hits for `doc.notes` / `doc.scribe` / `doc.claw` in production code; the well-known test was the only consumer of the singular shape.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 718 pass, 0 fail (50 files)
- [x] `bunx biome check src/well-known.ts src/__tests__/well-known.test.ts` — clean
- [x] Updated `well-known.test.ts` expectations: every kind asserts plural-array now; added a "multiple installs of the same kind both land in the array" test
- [ ] Manual: after merge, on a host with vault + notes installed, `curl /.well-known/parachute.json` shows `notes: [{ url, version }]` rather than `notes: { url, version }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)