### PR TITLE
feat(oauth): refresh-token rotation + RFC 7009 revocation (#73)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.15",
+  "version": "0.4.0-rc.16",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -12,6 +12,7 @@ import {
   handleAuthorizeGet,
   handleAuthorizePost,
   handleRegister,
+  handleRevoke,
   handleToken,
 } from "../oauth-handlers.ts";
 import type { ServicesManifest } from "../services-manifest.ts";
@@ -2063,5 +2064,478 @@ describe("DCR approval gate (#74)", () => {
     } finally {
       cleanup();
     }
+  });
+});
+
+// closes #73 — RFC 6749 §6 refresh-token rotation, RFC 6819 §5.2.2.3 replay
+// detection (family-wide revocation), RFC 7009 token revocation.
+describe("refresh-token rotation + /oauth/revoke (#73)", () => {
+  async function consentAndGetCode(
+    db: Awaited<ReturnType<typeof makeDb>>["db"],
+    clientId: string,
+    sessionId: string,
+    scope = "vault:default:read",
+  ): Promise<{ code: string; verifier: string }> {
+    const { verifier, challenge } = makePkce();
+    const consentForm = new URLSearchParams({
+      __action: "consent",
+      approve: "yes",
+      client_id: clientId,
+      redirect_uri: "https://app.example/cb",
+      response_type: "code",
+      scope,
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+    });
+    const consentRes = await handleAuthorizePost(
+      db,
+      new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: consentForm,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: buildSessionCookie(sessionId, 86400),
+        },
+      }),
+      { issuer: ISSUER },
+    );
+    const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+    return { code: code ?? "", verifier };
+  }
+
+  function tokenRequest(form: URLSearchParams): Request {
+    return new Request(`${ISSUER}/oauth/token`, {
+      method: "POST",
+      body: form,
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+    });
+  }
+
+  function revokeRequest(form: URLSearchParams): Request {
+    return new Request(`${ISSUER}/oauth/revoke`, {
+      method: "POST",
+      body: form,
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+    });
+  }
+
+  async function mintInitialPair(
+    db: Awaited<ReturnType<typeof makeDb>>["db"],
+    clientId: string,
+    userId: string,
+    sessionId: string,
+    extra: Record<string, string> = {},
+  ): Promise<{ access_token: string; refresh_token: string }> {
+    const { code, verifier } = await consentAndGetCode(db, clientId, sessionId);
+    const form = new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      client_id: clientId,
+      redirect_uri: "https://app.example/cb",
+      code_verifier: verifier,
+      ...extra,
+    });
+    const res = await handleToken(db, tokenRequest(form), {
+      issuer: ISSUER,
+      loadServicesManifest: fixtureLoadServicesManifest,
+    });
+    expect(res.status).toBe(200);
+    return (await res.json()) as { access_token: string; refresh_token: string };
+  }
+
+  function familyIdFor(
+    db: Awaited<ReturnType<typeof makeDb>>["db"],
+    refreshTokenPlaintext: string,
+  ): string {
+    const hash = createHash("sha256").update(refreshTokenPlaintext).digest("hex");
+    const row = db
+      .query<{ family_id: string }, [string]>(
+        "SELECT family_id FROM tokens WHERE refresh_token_hash = ?",
+      )
+      .get(hash);
+    if (!row) throw new Error("no row for refresh token");
+    return row.family_id;
+  }
+
+  test("initial auth-code issuance assigns a fresh family_id", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const initial = await mintInitialPair(db, reg.client.clientId, user.id, session.id);
+      const family = familyIdFor(db, initial.refresh_token);
+      // Fresh UUID, not jti — backfill case is for legacy rows only.
+      expect(family).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rotation preserves family_id across the chain", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const initial = await mintInitialPair(db, reg.client.clientId, user.id, session.id);
+      const family = familyIdFor(db, initial.refresh_token);
+
+      const refreshForm = new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: initial.refresh_token,
+        client_id: reg.client.clientId,
+      });
+      const refreshRes = await handleToken(db, tokenRequest(refreshForm), {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(refreshRes.status).toBe(200);
+      const rotated = (await refreshRes.json()) as { refresh_token: string };
+      expect(rotated.refresh_token).not.toBe(initial.refresh_token);
+
+      const rotatedFamily = familyIdFor(db, rotated.refresh_token);
+      expect(rotatedFamily).toBe(family);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("replay of revoked refresh token revokes the entire family", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const initial = await mintInitialPair(db, reg.client.clientId, user.id, session.id);
+      const family = familyIdFor(db, initial.refresh_token);
+
+      // First rotation (legitimate client).
+      const r1 = await handleToken(
+        db,
+        tokenRequest(
+          new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token: initial.refresh_token,
+            client_id: reg.client.clientId,
+          }),
+        ),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      const rotated1 = (await r1.json()) as { refresh_token: string };
+
+      // Second rotation off the rotated token (still legitimate).
+      const r2 = await handleToken(
+        db,
+        tokenRequest(
+          new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token: rotated1.refresh_token,
+            client_id: reg.client.clientId,
+          }),
+        ),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      const rotated2 = (await r2.json()) as { refresh_token: string };
+
+      // Replay the ORIGINAL (already revoked at step 1). Should walk the
+      // family and revoke every descendant — including rotated2, which was
+      // still valid up to this point.
+      const replay = await handleToken(
+        db,
+        tokenRequest(
+          new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token: initial.refresh_token,
+            client_id: reg.client.clientId,
+          }),
+        ),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(replay.status).toBe(400);
+
+      // Every row in the family is revoked.
+      const live = db
+        .query<{ n: number }, [string]>(
+          "SELECT COUNT(*) AS n FROM tokens WHERE family_id = ? AND revoked_at IS NULL",
+        )
+        .get(family);
+      expect(live?.n).toBe(0);
+
+      // The currently-live rotated2 token can no longer mint a new pair —
+      // its row is now revoked, so the next refresh attempt is a replay too.
+      const afterReplay = await handleToken(
+        db,
+        tokenRequest(
+          new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token: rotated2.refresh_token,
+            client_id: reg.client.clientId,
+          }),
+        ),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(afterReplay.status).toBe(400);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("/oauth/revoke refresh_token: revokes the row, second use rejected", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const initial = await mintInitialPair(db, reg.client.clientId, user.id, session.id);
+
+      const revRes = await handleRevoke(
+        db,
+        revokeRequest(
+          new URLSearchParams({
+            token: initial.refresh_token,
+            token_type_hint: "refresh_token",
+            client_id: reg.client.clientId,
+          }),
+        ),
+        { issuer: ISSUER },
+      );
+      expect(revRes.status).toBe(200);
+
+      // Idempotent — second revoke also 200.
+      const revRes2 = await handleRevoke(
+        db,
+        revokeRequest(
+          new URLSearchParams({
+            token: initial.refresh_token,
+            client_id: reg.client.clientId,
+          }),
+        ),
+        { issuer: ISSUER },
+      );
+      expect(revRes2.status).toBe(200);
+
+      // The revoked refresh token cannot mint a new access token.
+      const refreshAttempt = await handleToken(
+        db,
+        tokenRequest(
+          new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token: initial.refresh_token,
+            client_id: reg.client.clientId,
+          }),
+        ),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(refreshAttempt.status).toBe(400);
+      const err = (await refreshAttempt.json()) as Record<string, unknown>;
+      expect(err.error).toBe("invalid_grant");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("/oauth/revoke access_token: validateAccessToken rejects after revoke", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const initial = await mintInitialPair(db, reg.client.clientId, user.id, session.id);
+
+      // Pre-revoke: token validates.
+      const preCheck = await validateAccessToken(db, initial.access_token, ISSUER);
+      expect(preCheck.payload.sub).toBe(user.id);
+
+      const revRes = await handleRevoke(
+        db,
+        revokeRequest(
+          new URLSearchParams({
+            token: initial.access_token,
+            token_type_hint: "access_token",
+            client_id: reg.client.clientId,
+          }),
+        ),
+        { issuer: ISSUER },
+      );
+      expect(revRes.status).toBe(200);
+
+      // Post-revoke: token is rejected — signature still verifies, but the
+      // jti's tokens row is marked revoked.
+      await expect(validateAccessToken(db, initial.access_token, ISSUER)).rejects.toThrow(
+        /revoked/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("/oauth/revoke unknown token returns 200 (no existence disclosure)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const res = await handleRevoke(
+        db,
+        revokeRequest(
+          new URLSearchParams({
+            token: "totally-not-a-real-token",
+            client_id: reg.client.clientId,
+          }),
+        ),
+        { issuer: ISSUER },
+      );
+      expect(res.status).toBe(200);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("/oauth/revoke missing token returns 400", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const res = await handleRevoke(
+        db,
+        revokeRequest(new URLSearchParams({ client_id: reg.client.clientId })),
+        { issuer: ISSUER },
+      );
+      expect(res.status).toBe(400);
+      const err = (await res.json()) as Record<string, unknown>;
+      expect(err.error).toBe("invalid_request");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("/oauth/revoke missing client_id returns 400", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const res = await handleRevoke(
+        db,
+        revokeRequest(new URLSearchParams({ token: "anything" })),
+        { issuer: ISSUER },
+      );
+      expect(res.status).toBe(400);
+      const err = (await res.json()) as Record<string, unknown>;
+      expect(err.error).toBe("invalid_request");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("/oauth/revoke confidential client without secret → 401", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        confidential: true,
+      });
+      const initial = await mintInitialPair(db, reg.client.clientId, user.id, session.id, {
+        client_secret: reg.clientSecret ?? "",
+      });
+
+      const res = await handleRevoke(
+        db,
+        revokeRequest(
+          new URLSearchParams({
+            token: initial.refresh_token,
+            client_id: reg.client.clientId,
+            // no client_secret
+          }),
+        ),
+        { issuer: ISSUER },
+      );
+      expect(res.status).toBe(401);
+      const err = (await res.json()) as Record<string, unknown>;
+      expect(err.error).toBe("invalid_client");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("/oauth/revoke confidential client with correct secret → 200", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        confidential: true,
+      });
+      const initial = await mintInitialPair(db, reg.client.clientId, user.id, session.id, {
+        client_secret: reg.clientSecret ?? "",
+      });
+
+      const res = await handleRevoke(
+        db,
+        revokeRequest(
+          new URLSearchParams({
+            token: initial.refresh_token,
+            client_id: reg.client.clientId,
+            client_secret: reg.clientSecret ?? "",
+          }),
+        ),
+        { issuer: ISSUER },
+      );
+      expect(res.status).toBe(200);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("/oauth/revoke from a different client: 200 but row stays live", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const issuingClient = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const otherClient = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const initial = await mintInitialPair(db, issuingClient.client.clientId, user.id, session.id);
+
+      const res = await handleRevoke(
+        db,
+        revokeRequest(
+          new URLSearchParams({
+            token: initial.refresh_token,
+            client_id: otherClient.client.clientId,
+          }),
+        ),
+        { issuer: ISSUER },
+      );
+      // Spec-compliant 200, but the row should still be unrevoked.
+      expect(res.status).toBe(200);
+
+      const hash = createHash("sha256").update(initial.refresh_token).digest("hex");
+      const row = db
+        .query<{ revoked_at: string | null }, [string]>(
+          "SELECT revoked_at FROM tokens WHERE refresh_token_hash = ?",
+        )
+        .get(hash);
+      expect(row?.revoked_at).toBeNull();
+
+      // The original client can still rotate it.
+      const refreshRes = await handleToken(
+        db,
+        tokenRequest(
+          new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token: initial.refresh_token,
+            client_id: issuingClient.client.clientId,
+          }),
+        ),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(refreshRes.status).toBe(200);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("authorizationServerMetadata advertises revocation_endpoint", async () => {
+    const res = authorizationServerMetadata({ issuer: ISSUER });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.revocation_endpoint).toBe(`${ISSUER}/oauth/revoke`);
   });
 });

--- a/src/hub-db.ts
+++ b/src/hub-db.ts
@@ -116,6 +116,20 @@ const MIGRATIONS: readonly Migration[] = [
       CREATE INDEX clients_status ON clients (status);
     `,
   },
+  {
+    version: 5,
+    sql: `
+      -- Refresh-token rotation + replay detection (closes #73). Each chain
+      -- of rotated refresh tokens shares a family_id; replaying a revoked
+      -- refresh token in a family signals theft and revokes every row in
+      -- that family (RFC 6819 §5.2.2.3). Pre-existing rows are backfilled
+      -- with their own jti as the family — grandfathered as singletons so
+      -- in-flight tokens keep working without spurious family revocation.
+      ALTER TABLE tokens ADD COLUMN family_id TEXT;
+      UPDATE tokens SET family_id = jti WHERE family_id IS NULL;
+      CREATE INDEX tokens_family ON tokens (family_id) WHERE family_id IS NOT NULL;
+    `,
+  },
 ];
 
 export function openHubDb(path: string = hubDbPath()): Database {

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -44,6 +44,7 @@ import {
   handleAuthorizeGet,
   handleAuthorizePost,
   handleRegister,
+  handleRevoke,
   handleToken,
 } from "./oauth-handlers.ts";
 import { getAllPublicKeys } from "./signing-keys.ts";
@@ -227,6 +228,14 @@ export function hubFetch(
       }
       if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
       return handleRegister(getDb(), req, oauthDeps(req));
+    }
+
+    if (pathname === "/oauth/revoke") {
+      if (!getDb) {
+        return new Response("hub db not configured", { status: 503 });
+      }
+      if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+      return handleRevoke(getDb(), req, oauthDeps(req));
     }
 
     if (pathname === "/vaults") {

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -18,7 +18,7 @@
  * PR just sets up the storage shape. 30-day expiry is the *initial* TTL.
  */
 import type { Database } from "bun:sqlite";
-import { createHash, randomBytes } from "node:crypto";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
 import {
   type JWTPayload,
   SignJWT,
@@ -94,6 +94,13 @@ export interface SignRefreshTokenOpts {
   userId: string;
   clientId: string;
   scopes: string[];
+  /**
+   * Shared identifier across a chain of rotated refresh tokens. Initial
+   * issuance (auth-code grant) omits this — a fresh family is minted.
+   * Rotation (refresh_token grant) passes the prior row's family_id so
+   * replay detection can revoke every descendant in one query (#73).
+   */
+  familyId?: string;
   now?: () => Date;
 }
 
@@ -102,6 +109,8 @@ export interface SignedRefreshToken {
   token: string;
   /** SHA-256 hex digest of `token`, stored in `tokens.refresh_token_hash`. */
   refreshTokenHash: string;
+  /** Family identifier (new UUID for initial issuance, inherited on rotation). */
+  familyId: string;
   expiresAt: string;
 }
 
@@ -110,19 +119,21 @@ export function signRefreshToken(db: Database, opts: SignRefreshTokenOpts): Sign
   const refreshTokenHash = createHash("sha256").update(token).digest("hex");
   const now = opts.now?.() ?? new Date();
   const expiresAt = new Date(now.getTime() + REFRESH_TOKEN_TTL_MS).toISOString();
+  const familyId = opts.familyId ?? randomUUID();
   db.prepare(
-    `INSERT INTO tokens (jti, user_id, client_id, scopes, refresh_token_hash, expires_at, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO tokens (jti, user_id, client_id, scopes, refresh_token_hash, family_id, expires_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     opts.jti,
     opts.userId,
     opts.clientId,
     opts.scopes.join(" "),
     refreshTokenHash,
+    familyId,
     expiresAt,
     now.toISOString(),
   );
-  return { token, refreshTokenHash, expiresAt };
+  return { token, refreshTokenHash, familyId, expiresAt };
 }
 
 export interface ValidatedAccessToken {
@@ -157,48 +168,85 @@ export async function validateAccessToken(
     pub,
     expectedIssuer ? { issuer: expectedIssuer } : undefined,
   );
+  // RFC 7009 revocation enforcement (#73). OAuth-issued tokens carry a
+  // tokens row keyed by jti; if that row is marked revoked, the JWT is
+  // dead even though its signature + expiry are still valid. Tokens that
+  // never had a row (operator tokens, ad-hoc internal mints) bypass this
+  // check — they're not part of the OAuth grant lifecycle.
+  if (typeof payload.jti === "string") {
+    const row = findTokenRowByJti(db, payload.jti);
+    if (row?.revokedAt) throw new Error("validateAccessToken: token has been revoked");
+  }
   return { payload, kid };
 }
 
 /**
  * Convenience for the `tokens` row matching a presented refresh token. Hash
- * the plaintext, look up by hash, return the row if it exists and isn't
- * expired/revoked. PR (c) will use this in the refresh-token grant handler.
+ * the plaintext, look up by hash, return the row if it exists. The caller
+ * decides what to do with `revokedAt` — the rotation path treats a revoked
+ * row as theft (RFC 6819 §5.2.2.3).
  */
 export interface RefreshTokenRow {
   jti: string;
   userId: string;
   clientId: string;
   scopes: string[];
+  /** Family identifier — shared across rotated descendants (#73). */
+  familyId: string;
   expiresAt: string;
   revokedAt: string | null;
   createdAt: string;
 }
 
-export function findRefreshToken(db: Database, plaintext: string): RefreshTokenRow | null {
-  const refreshTokenHash = createHash("sha256").update(plaintext).digest("hex");
-  const row = db
-    .query<
-      {
-        jti: string;
-        user_id: string;
-        client_id: string;
-        scopes: string;
-        expires_at: string;
-        revoked_at: string | null;
-        created_at: string;
-      },
-      [string]
-    >("SELECT * FROM tokens WHERE refresh_token_hash = ? LIMIT 1")
-    .get(refreshTokenHash);
-  if (!row) return null;
+interface TokenRowDb {
+  jti: string;
+  user_id: string;
+  client_id: string;
+  scopes: string;
+  family_id: string | null;
+  expires_at: string;
+  revoked_at: string | null;
+  created_at: string;
+}
+
+function rowToRefreshToken(row: TokenRowDb): RefreshTokenRow {
   return {
     jti: row.jti,
     userId: row.user_id,
     clientId: row.client_id,
     scopes: row.scopes.split(" ").filter((s) => s.length > 0),
+    familyId: row.family_id ?? row.jti,
     expiresAt: row.expires_at,
     revokedAt: row.revoked_at,
     createdAt: row.created_at,
   };
+}
+
+export function findRefreshToken(db: Database, plaintext: string): RefreshTokenRow | null {
+  const refreshTokenHash = createHash("sha256").update(plaintext).digest("hex");
+  const row = db
+    .query<TokenRowDb, [string]>("SELECT * FROM tokens WHERE refresh_token_hash = ? LIMIT 1")
+    .get(refreshTokenHash);
+  return row ? rowToRefreshToken(row) : null;
+}
+
+/** Look up a tokens row by jti. Used by the revocation endpoint to find an
+ * access-token row from its JWT jti claim, and by validateAccessToken to
+ * honor revoked_at. */
+export function findTokenRowByJti(db: Database, jti: string): RefreshTokenRow | null {
+  const row = db.query<TokenRowDb, [string]>("SELECT * FROM tokens WHERE jti = ? LIMIT 1").get(jti);
+  return row ? rowToRefreshToken(row) : null;
+}
+
+/**
+ * Revoke every row in a refresh-token family. Called by the refresh handler
+ * when an already-revoked refresh token is presented again — the spec-defined
+ * theft signal (RFC 6819 §5.2.2.3). Idempotent: rows already revoked keep
+ * their existing revoked_at.
+ */
+export function revokeFamily(db: Database, familyId: string, now: Date): number {
+  const res = db
+    .prepare("UPDATE tokens SET revoked_at = ? WHERE family_id = ? AND revoked_at IS NULL")
+    .run(now.toISOString(), familyId);
+  return Number(res.changes);
 }

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -10,6 +10,7 @@
  *   - POST /oauth/authorize                          (form posts: login + consent)
  *   - POST /oauth/token                              (grant_type=authorization_code | refresh_token)
  *   - POST /oauth/register                           (RFC 7591 DCR)
+ *   - POST /oauth/revoke                             (RFC 7009 token revocation)
  *
  * `client_credentials` is intentionally unimplemented — it's not in the
  * launch surface (no machine-to-machine clients yet); the token endpoint
@@ -43,6 +44,8 @@ import {
 import {
   ACCESS_TOKEN_TTL_SECONDS,
   findRefreshToken,
+  findTokenRowByJti,
+  revokeFamily,
   signAccessToken,
   signRefreshToken,
 } from "./jwt-sign.ts";
@@ -240,6 +243,7 @@ export function authorizationServerMetadata(deps: OAuthDeps): Response {
     authorization_endpoint: `${iss}/oauth/authorize`,
     token_endpoint: `${iss}/oauth/token`,
     registration_endpoint: `${iss}/oauth/register`,
+    revocation_endpoint: `${iss}/oauth/revoke`,
     jwks_uri: `${iss}/.well-known/jwks.json`,
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "refresh_token"],
@@ -782,20 +786,30 @@ async function handleTokenRefresh(
   if (row.clientId !== clientId) {
     return jsonResponse({ error: "invalid_grant", error_description: "client_id mismatch" }, 400);
   }
+  const now = deps.now?.() ?? new Date();
   if (row.revokedAt) {
+    // Replay of an already-rotated refresh token. Per RFC 6819 §5.2.2.3 the
+    // working assumption is theft — the legitimate client received a new
+    // refresh token at the prior rotation, so anyone presenting the old one
+    // either lost a race (rare) or stole it (the case we must defend
+    // against). Either way: revoke every descendant in the family so the
+    // attacker can't keep refreshing, and force the legitimate client to
+    // re-authorize. Cheaper than tracking which call was first.
+    revokeFamily(db, row.familyId, now);
     return jsonResponse(
       { error: "invalid_grant", error_description: "refresh_token revoked" },
       400,
     );
   }
-  const now = deps.now?.() ?? new Date();
   if (now.getTime() > new Date(row.expiresAt).getTime()) {
     return jsonResponse(
       { error: "invalid_grant", error_description: "refresh_token expired" },
       400,
     );
   }
-  // Rotate: revoke the old refresh row, mint a new access + refresh pair.
+  // Rotate: revoke the old refresh row, mint a new access + refresh pair
+  // bound to the same family so a future replay of *any* descendant can
+  // walk the chain.
   db.prepare("UPDATE tokens SET revoked_at = ? WHERE jti = ?").run(now.toISOString(), row.jti);
   const audience = inferAudience(row.scopes);
   const access = await signAccessToken(db, {
@@ -811,6 +825,7 @@ async function handleTokenRefresh(
     userId: row.userId,
     clientId: row.clientId,
     scopes: row.scopes,
+    familyId: row.familyId,
     now: deps.now,
   });
   const services = buildServicesCatalog(
@@ -826,6 +841,100 @@ async function handleTokenRefresh(
     scope: row.scopes.join(" "),
     services,
   });
+}
+
+// --- /oauth/revoke ---------------------------------------------------------
+
+/**
+ * POST /oauth/revoke — RFC 7009 token revocation.
+ *
+ * Accepts `token` + optional `token_type_hint` (`refresh_token` or
+ * `access_token`) form-encoded. Authenticates the client (confidential
+ * clients via `client_secret`; public clients pass through with PKCE-style
+ * client_id-only auth, same gate as the token endpoint).
+ *
+ * Lookup strategy: try the refresh-token-hash first when the hint is
+ * `refresh_token` or absent (the common case — clients usually revoke
+ * refresh tokens), then fall back to JWT decode + jti lookup for access
+ * tokens. JWT decode here is unverified-decode of the payload only; we
+ * just need the jti to find the row. A signature check would be
+ * ceremonial — if the row exists we own it; if it doesn't, we return 200
+ * anyway per spec.
+ *
+ * Response: 200 with empty body on success OR when the token is unknown
+ * (RFC 7009 §2.2 — "the authorization server responds with HTTP status
+ * code 200 [...] or if the client submitted an invalid token"). We
+ * intentionally don't surface "found vs not-found" so a caller probing
+ * with random strings can't enumerate live tokens.
+ *
+ * Closes #73.
+ */
+export async function handleRevoke(
+  db: Database,
+  req: Request,
+  _deps: OAuthDeps,
+): Promise<Response> {
+  const form = await req.formData();
+  const token = String(form.get("token") ?? "");
+  const hint = String(form.get("token_type_hint") ?? "");
+  const bodyClientId = String(form.get("client_id") ?? "");
+  if (!token || !bodyClientId) {
+    return jsonResponse(
+      { error: "invalid_request", error_description: "missing required parameter" },
+      400,
+    );
+  }
+  const client = getClient(db, bodyClientId);
+  if (!client) {
+    return jsonResponse({ error: "invalid_client", error_description: "unknown client_id" }, 401);
+  }
+  const authFailure = authenticateClient(client, req, form, bodyClientId);
+  if (authFailure) return authFailure;
+
+  // Lookup. Hint is advisory per RFC 7009 §2.1 — clients that get it wrong
+  // still expect revocation to succeed, so we always try both shapes.
+  const now = new Date();
+  let row = hint === "access_token" ? null : findRefreshToken(db, token);
+  if (!row) {
+    const jti = unverifiedJtiOf(token);
+    if (jti) row = findTokenRowByJti(db, jti);
+    if (!row && hint === "access_token" && !row) {
+      // hint said access_token but the JWT didn't decode; check
+      // refresh-token shape as a last resort.
+      row = findRefreshToken(db, token);
+    }
+  }
+  if (row && row.clientId !== client.clientId) {
+    // RFC 7009 §2.1: revocation must be authenticated to the same client
+    // the token was issued to. A different client presenting a valid
+    // token is invalid_grant; we collapse it to 200 to avoid existence
+    // disclosure to unrelated clients.
+    return new Response(null, { status: 200 });
+  }
+  if (row && !row.revokedAt) {
+    db.prepare("UPDATE tokens SET revoked_at = ? WHERE jti = ?").run(now.toISOString(), row.jti);
+  }
+  return new Response(null, { status: 200 });
+}
+
+/**
+ * Best-effort jti extraction for revocation lookup. Not signature-checked —
+ * we only need the claim to find a row. If the row doesn't exist or the
+ * client doesn't own it, the caller bails out anyway.
+ */
+function unverifiedJtiOf(token: string): string | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const payload = parts[1];
+  if (!payload) return null;
+  try {
+    const json = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+      jti?: unknown;
+    };
+    return typeof json.jti === "string" ? json.jti : null;
+  } catch {
+    return null;
+  }
 }
 
 function mapAuthCodeError(err: unknown): Response {


### PR DESCRIPTION
## Summary

Closes #73. RFC compliance for the OAuth lifecycle: rotation + replay defense + spec-defined revocation.

- **Rotation**: every `/oauth/token` refresh issues a new refresh token; the old row is marked revoked. The chain shares a `family_id` so a single replay can walk the whole tree.
- **Replay → family revocation (RFC 6819 §5.2.2.3)**: presenting an already-revoked refresh token revokes every live row in the family — not just the replayed one. Forces the legitimate client to re-authorize once theft is suspected.
- **`POST /oauth/revoke` (RFC 7009)**: accepts `token` + optional `token_type_hint`. Same client-auth shape as #72 (confidential clients require `client_secret`; PKCE clients don't). Idempotent. Unknown / cross-client tokens collapse to 200 to avoid existence disclosure.
- **Validation gate**: `validateAccessToken` now looks up the `tokens` row by `jti` and rejects when `revoked_at` is set — so a revoked access token stops working at the resource as well as at issuance. Operator tokens (no `tokens` row) bypass the lookup, which matches their "SSH-key-shaped, non-revocable by design" charter.
- Schema migration v5 adds `tokens.family_id` (backfilled with `jti` for pre-existing rows so in-flight tokens stay singletons).
- AS metadata now advertises `revocation_endpoint`.

## Test plan

- [x] `bun test` — 730 pass (was 718; +12 from 11 new tests)
- [x] `bun run typecheck` clean
- [x] `bunx @biomejs/biome check` on touched files clean
- [x] New tests cover: fresh family on initial issuance, family preserved across rotation, replay revokes the entire family, /oauth/revoke happy path (refresh + access), /oauth/revoke idempotent, unknown-token returns 200, missing token/client_id returns 400, confidential-client auth required, cross-client revoke is no-op + 200, AS metadata advertises endpoint
- [ ] Sanity check on a live hub: revoke a refresh token via /oauth/revoke, confirm subsequent rotate is `invalid_grant`

🤖 Generated with [Claude Code](https://claude.com/claude-code)