### PR TITLE
feat(setup): unified parachute setup walk-through (#45)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.16",
+  "version": "0.4.0-rc.17",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/setup.test.ts
+++ b/src/__tests__/setup.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { InstallOpts } from "../commands/install.ts";
+import { parseServicePicks, setup } from "../commands/setup.ts";
+import { upsertService } from "../services-manifest.ts";
+
+interface InstallCall {
+  short: string;
+  opts: InstallOpts;
+}
+
+interface Harness {
+  manifestPath: string;
+  configDir: string;
+  logs: string[];
+  calls: InstallCall[];
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-setup-"));
+  const logs: string[] = [];
+  const calls: InstallCall[] = [];
+  return {
+    manifestPath: join(dir, "services.json"),
+    configDir: dir,
+    logs,
+    calls,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+function scriptedAvailability(answers: string[]) {
+  const queue = [...answers];
+  return {
+    kind: "available" as const,
+    prompt: async (_q: string) => {
+      const next = queue.shift();
+      if (next === undefined) throw new Error("scripted prompt exhausted");
+      return next;
+    },
+    remaining: () => queue.length,
+  };
+}
+
+const offered = [
+  // The exact ServiceChoice shape used internally; we only need the surface
+  // parseServicePicks reads — the export accepts the live structure.
+  {
+    short: "vault",
+    installed: false,
+    manifestName: "parachute-vault",
+    spec: { manifestName: "parachute-vault" } as never,
+  },
+  {
+    short: "notes",
+    installed: false,
+    manifestName: "parachute-notes",
+    spec: { manifestName: "parachute-notes" } as never,
+  },
+  {
+    short: "scribe",
+    installed: false,
+    manifestName: "parachute-scribe",
+    spec: { manifestName: "parachute-scribe" } as never,
+  },
+];
+
+describe("parseServicePicks", () => {
+  test("empty input picks every offered service", () => {
+    const result = parseServicePicks("", offered);
+    if ("error" in result) throw new Error(result.error);
+    expect(result.picks.map((p) => p.short)).toEqual(["vault", "notes", "scribe"]);
+  });
+
+  test("'all' picks every offered service", () => {
+    const result = parseServicePicks("all", offered);
+    if ("error" in result) throw new Error(result.error);
+    expect(result.picks.map((p) => p.short)).toEqual(["vault", "notes", "scribe"]);
+  });
+
+  test("numeric indices", () => {
+    const result = parseServicePicks("1, 3", offered);
+    if ("error" in result) throw new Error(result.error);
+    expect(result.picks.map((p) => p.short)).toEqual(["vault", "scribe"]);
+  });
+
+  test("shortnames", () => {
+    const result = parseServicePicks("vault scribe", offered);
+    if ("error" in result) throw new Error(result.error);
+    expect(result.picks.map((p) => p.short)).toEqual(["vault", "scribe"]);
+  });
+
+  test("dedupes repeated picks", () => {
+    const result = parseServicePicks("1, vault, 1", offered);
+    if ("error" in result) throw new Error(result.error);
+    expect(result.picks.map((p) => p.short)).toEqual(["vault"]);
+  });
+
+  test("out-of-range index errors", () => {
+    const result = parseServicePicks("9", offered);
+    expect("error" in result && result.error).toMatch(/out-of-range/);
+  });
+
+  test("unknown name errors", () => {
+    const result = parseServicePicks("nope", offered);
+    expect("error" in result && result.error).toMatch(/unknown service/);
+  });
+});
+
+describe("setup", () => {
+  test("exits 0 with friendly note when every known service is installed", async () => {
+    const h = makeHarness();
+    try {
+      // Pre-seed every first-party shortname so survey returns all-installed.
+      for (const m of [
+        "parachute-vault",
+        "parachute-notes",
+        "parachute-scribe",
+        "parachute-channel",
+      ]) {
+        upsertService(
+          {
+            name: m,
+            version: "0.0.0",
+            port: 1940,
+            paths: [`/${m.replace(/^parachute-/, "")}`],
+            health: "/health",
+          },
+          h.manifestPath,
+        );
+      }
+      const code = await setup({
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        log: (l) => h.logs.push(l),
+        availability: { kind: "not-tty" },
+        installFn: async (short, opts) => {
+          h.calls.push({ short, opts });
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      expect(h.calls).toHaveLength(0);
+      expect(h.logs.join("\n")).toMatch(/All known services are already installed/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("rejects non-TTY when there's work to offer", async () => {
+    const h = makeHarness();
+    try {
+      const code = await setup({
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        log: (l) => h.logs.push(l),
+        availability: { kind: "not-tty" },
+        installFn: async () => 0,
+      });
+      expect(code).toBe(1);
+      expect(h.logs.join("\n")).toMatch(/needs a TTY/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("happy path: pick vault + scribe; threads vaultName + scribe answers to install()", async () => {
+    const h = makeHarness();
+    try {
+      const availability = scriptedAvailability([
+        "vault, scribe", // multi-select
+        "myvault", // vault name
+        "1", // scribe provider (parakeet-mlx)
+      ]);
+      const code = await setup({
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        log: (l) => h.logs.push(l),
+        availability,
+        installFn: async (short, opts) => {
+          h.calls.push({ short, opts });
+          // Simulate install registering the service so the summary banner finds it.
+          const manifestName =
+            short === "vault"
+              ? "parachute-vault"
+              : short === "scribe"
+                ? "parachute-scribe"
+                : `parachute-${short}`;
+          const port = short === "vault" ? 1940 : 1941;
+          upsertService(
+            { name: manifestName, version: "0.1.0", port, paths: [`/${short}`], health: "/health" },
+            opts.manifestPath ?? h.manifestPath,
+          );
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      expect(h.calls.map((c) => c.short)).toEqual(["vault", "scribe"]);
+      const vaultCall = h.calls.find((c) => c.short === "vault");
+      const scribeCall = h.calls.find((c) => c.short === "scribe");
+      expect(vaultCall?.opts.vaultName).toBe("myvault");
+      expect(scribeCall?.opts.scribeProvider).toBe("parakeet-mlx");
+      expect(scribeCall?.opts.scribeKey).toBeUndefined();
+      expect(availability.remaining()).toBe(0);
+      expect(h.logs.join("\n")).toMatch(/Setup complete/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("threads --tag and --no-start to every install()", async () => {
+    const h = makeHarness();
+    try {
+      const availability = scriptedAvailability([
+        "notes", // single pick — no follow-up prompts
+      ]);
+      const code = await setup({
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        log: (l) => h.logs.push(l),
+        availability,
+        installFn: async (short, opts) => {
+          h.calls.push({ short, opts });
+          upsertService(
+            {
+              name: "parachute-notes",
+              version: "0.1.0",
+              port: 1942,
+              paths: ["/notes"],
+              health: "/health",
+            },
+            opts.manifestPath ?? h.manifestPath,
+          );
+          return 0;
+        },
+        tag: "rc",
+        noStart: true,
+      });
+      expect(code).toBe(0);
+      expect(h.calls).toHaveLength(1);
+      expect(h.calls[0]?.opts.tag).toBe("rc");
+      expect(h.calls[0]?.opts.noStart).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("partial failure: later picks still run; exit code reflects first failure", async () => {
+    const h = makeHarness();
+    try {
+      const availability = scriptedAvailability([
+        "vault, notes", // multi-select
+        "default", // vault name
+      ]);
+      const code = await setup({
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        log: (l) => h.logs.push(l),
+        availability,
+        installFn: async (short, opts) => {
+          h.calls.push({ short, opts });
+          if (short === "vault") return 7; // fail vault
+          upsertService(
+            {
+              name: "parachute-notes",
+              version: "0.1.0",
+              port: 1942,
+              paths: ["/notes"],
+              health: "/health",
+            },
+            opts.manifestPath ?? h.manifestPath,
+          );
+          return 0;
+        },
+      });
+      expect(code).toBe(7);
+      expect(h.calls.map((c) => c.short)).toEqual(["vault", "notes"]);
+      expect(h.logs.join("\n")).toMatch(/non-zero exit code/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("retries on invalid vault name then accepts a valid one", async () => {
+    const h = makeHarness();
+    try {
+      const availability = scriptedAvailability([
+        "vault",
+        "Bad Name!", // rejected
+        "good-vault", // accepted
+      ]);
+      const code = await setup({
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        log: (l) => h.logs.push(l),
+        availability,
+        installFn: async (short, opts) => {
+          h.calls.push({ short, opts });
+          upsertService(
+            {
+              name: "parachute-vault",
+              version: "0.1.0",
+              port: 1940,
+              paths: ["/vault"],
+              health: "/health",
+            },
+            opts.manifestPath ?? h.manifestPath,
+          );
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      expect(h.calls[0]?.opts.vaultName).toBe("good-vault");
+      expect(h.logs.join("\n")).toMatch(/invalid name "Bad Name!"/);
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { exposePublic, exposeTailnet } from "./commands/expose.ts";
 import { install } from "./commands/install.ts";
 import { logs, restart, start, stop } from "./commands/lifecycle.ts";
 import { migrate } from "./commands/migrate.ts";
+import { setup } from "./commands/setup.ts";
 import { status } from "./commands/status.ts";
 import { dispatchVault } from "./commands/vault.ts";
 import { ExposeStateError } from "./expose-state.ts";
@@ -22,6 +23,7 @@ import {
   logsHelp,
   migrateHelp,
   restartHelp,
+  setupHelp,
   startHelp,
   statusHelp,
   stopHelp,
@@ -191,6 +193,29 @@ async function main(argv: string[]): Promise<number> {
     case "-v":
       console.log(pkg.version);
       return 0;
+
+    case "setup": {
+      if (isHelpFlag(rest[0])) {
+        console.log(setupHelp());
+        return 0;
+      }
+      const tagExtract = extractTag(rest);
+      if (tagExtract.error) {
+        console.error(`parachute setup: ${tagExtract.error}`);
+        return 1;
+      }
+      const noStart = tagExtract.rest.includes("--no-start");
+      const remaining = tagExtract.rest.filter((a) => a !== "--no-start");
+      if (remaining.length > 0) {
+        console.error(`parachute setup: unknown argument "${remaining[0]}"`);
+        console.error("usage: parachute setup [--tag <name>] [--no-start]");
+        return 1;
+      }
+      const setupOpts: Parameters<typeof setup>[0] = {};
+      if (tagExtract.tag) setupOpts.tag = tagExtract.tag;
+      if (noStart) setupOpts.noStart = true;
+      return await setup(setupOpts);
+    }
 
     case "install": {
       if (isHelpFlag(rest[0])) {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -100,6 +100,12 @@ export interface InstallOpts {
    */
   startService?: (short: string) => Promise<number>;
   /**
+   * `parachute install vault` only: skip the vault-name prompt by forwarding
+   * `--vault-name <name>` to `parachute-vault init`. Used by `parachute setup`
+   * (#45) to pre-collect the answer up front. Ignored for non-vault installs.
+   */
+  vaultName?: string;
+  /**
    * `parachute install scribe` only: pre-pick the transcription provider so
    * the prompt doesn't fire. Validated against scribe's known providers — an
    * unknown name is logged and the config is left at default.
@@ -525,10 +531,16 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
   const entryName = target.kind === "first-party" ? spec.manifestName : manifest.name;
 
   if (spec.init) {
-    log(`Running ${spec.init.join(" ")}…`);
-    const initCode = await runner(spec.init);
+    // Forward --vault-name from the InstallOpts when set so `parachute setup`
+    // (and any future programmatic caller) can pre-answer the name prompt.
+    const initCmd =
+      short === "vault" && opts.vaultName
+        ? [...spec.init, "--vault-name", opts.vaultName]
+        : spec.init;
+    log(`Running ${initCmd.join(" ")}…`);
+    const initCode = await runner(initCmd);
     if (initCode !== 0) {
-      log(`${spec.init.join(" ")} exited ${initCode}`);
+      log(`${initCmd.join(" ")} exited ${initCode}`);
       return initCode;
     }
   }

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,0 +1,363 @@
+import { createInterface } from "node:readline/promises";
+import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
+import {
+  SCRIBE_PROVIDERS,
+  type ScribeProviderKey,
+  apiKeyEnvFor,
+  isKnownScribeProvider,
+} from "../scribe-config.ts";
+import {
+  FIRST_PARTY_FALLBACKS,
+  type ServiceSpec,
+  composeServiceSpec,
+  knownServices,
+} from "../service-spec.ts";
+import { findService } from "../services-manifest.ts";
+import { type InstallOpts, install } from "./install.ts";
+import type { InteractiveAvailability } from "./scribe-provider-interactive.ts";
+
+/**
+ * `parachute setup` — unified, prompt-up-front walk-through that orchestrates
+ * the existing per-service install flows behind a single command.
+ *
+ * Shape (closes #45):
+ *   1. Detect what's already in services.json.
+ *   2. Multi-select prompt: which uninstalled services to install (default
+ *      all). Already-installed services aren't offered — re-running setup is
+ *      idempotent.
+ *   3. Per-service follow-ups asked **before** any install runs, so the
+ *      operator answers everything in one sitting instead of stopping mid-
+ *      stream:
+ *        - vault   → vault name (default: "default")
+ *        - scribe  → transcription provider + (cloud-only) API key
+ *        - notes   → nothing extra
+ *   4. Iterate `install(short, opts)` per pick with the pre-collected
+ *      answers threaded through. Reuses every existing seam: bun add, init,
+ *      port assignment, services.json seed, auto-wire, footer.
+ *   5. Final summary banner with running URLs + a "try Claude Code" hint.
+ *
+ * Errors in one service don't roll back earlier ones — partial setup beats
+ * losing already-working installs. The caller sees a non-zero exit code if
+ * any step failed; the rest of the work still landed.
+ *
+ * Existing `parachute install <svc>` keeps working — setup is additive.
+ */
+
+export interface SetupOpts {
+  manifestPath?: string;
+  configDir?: string;
+  log?: (line: string) => void;
+  /** Test seam: drives every prompt. Defaults to a real readline against the TTY. */
+  availability?: InteractiveAvailability;
+  /** Test seam: replaces the per-service `install()` call. */
+  installFn?: (input: string, installOpts: InstallOpts) => Promise<number>;
+  /** Test seam: extra opts merged into every `install()` call (runner, port probe, …). */
+  baseInstallOpts?: Partial<InstallOpts>;
+  /** Forwarded to install(): npm dist-tag for `bun add -g <pkg>@<tag>`. */
+  tag?: string;
+  /** Forwarded to install(): skip auto-start. */
+  noStart?: boolean;
+}
+
+interface ServiceChoice {
+  short: string;
+  installed: boolean;
+  manifestName: string;
+  spec: ServiceSpec;
+}
+
+interface VaultAnswer {
+  vaultName: string;
+}
+
+interface ScribeAnswer {
+  provider: ScribeProviderKey;
+  apiKey: string | undefined;
+}
+
+const VAULT_NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+function defaultAvailability(): InteractiveAvailability {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return { kind: "not-tty" };
+  return {
+    kind: "available",
+    prompt: async (question: string) => {
+      const rl = createInterface({ input: process.stdin, output: process.stdout });
+      try {
+        return await rl.question(question);
+      } finally {
+        rl.close();
+      }
+    },
+  };
+}
+
+/**
+ * Survey the eligible services. We include the four first-party shortnames
+ * (vault / notes / scribe / channel) but flag channel as exploratory in the
+ * blurb so operators don't grab it by reflex. `installed` is true when the
+ * service has a row in services.json.
+ */
+function surveyServices(manifestPath: string): ServiceChoice[] {
+  return knownServices().map((short) => {
+    const fb = FIRST_PARTY_FALLBACKS[short];
+    if (!fb) throw new Error(`setup: unexpected first-party shortname ${short}`);
+    const spec = composeServiceSpec({
+      packageName: fb.package,
+      manifest: fb.manifest,
+      extras: fb.extras,
+    });
+    return {
+      short,
+      manifestName: spec.manifestName,
+      spec,
+      installed: !!findService(spec.manifestName, manifestPath),
+    };
+  });
+}
+
+const BLURBS: Record<string, string> = {
+  vault: "knowledge graph (MCP) — your owner-authenticated note + tag store",
+  notes: "Notes PWA — web/mobile UI on top of vault",
+  scribe: "audio transcription for dictation + recordings",
+  channel: "(exploratory — may retire) notification fan-out across modules",
+};
+
+function blurbFor(choice: ServiceChoice): string {
+  return BLURBS[choice.short] ?? choice.spec.manifestName;
+}
+
+/**
+ * Parse the user's pick string into a list of indices into `offered`.
+ * Accepts:
+ *   - empty / whitespace        → every offered service (the "Enter for all" path)
+ *   - "all"                     → every offered service
+ *   - "1,3" or "1 3" or "1, 3"  → those specific 1-based indices
+ *   - "vault,scribe"            → those specific shortnames (matched against `offered`)
+ *
+ * Unknown tokens raise an error string the caller surfaces — no silent
+ * dropouts.
+ */
+export function parseServicePicks(
+  raw: string,
+  offered: ServiceChoice[],
+): { picks: ServiceChoice[] } | { error: string } {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0 || trimmed.toLowerCase() === "all") {
+    return { picks: [...offered] };
+  }
+  const tokens = trimmed
+    .split(/[\s,]+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+  const picks: ServiceChoice[] = [];
+  const seen = new Set<string>();
+  for (const tok of tokens) {
+    let match: ServiceChoice | undefined;
+    if (/^\d+$/.test(tok)) {
+      const idx = Number.parseInt(tok, 10) - 1;
+      if (idx < 0 || idx >= offered.length) {
+        return { error: `out-of-range index "${tok}" (offered 1..${offered.length})` };
+      }
+      match = offered[idx];
+    } else {
+      match = offered.find((c) => c.short === tok.toLowerCase());
+      if (!match) return { error: `unknown service "${tok}"` };
+    }
+    if (match && !seen.has(match.short)) {
+      picks.push(match);
+      seen.add(match.short);
+    }
+  }
+  return { picks };
+}
+
+async function askVaultName(
+  prompt: (q: string) => Promise<string>,
+  log: (line: string) => void,
+): Promise<VaultAnswer> {
+  for (;;) {
+    const raw = (await prompt("vault — name (default: default): ")).trim();
+    const candidate = raw.length === 0 ? "default" : raw;
+    if (VAULT_NAME_RE.test(candidate)) return { vaultName: candidate };
+    log(
+      `  invalid name "${candidate}" — must start with [a-z0-9] and contain only [a-z0-9-]. Try again.`,
+    );
+  }
+}
+
+async function askScribeProvider(
+  prompt: (q: string) => Promise<string>,
+  log: (line: string) => void,
+): Promise<ScribeAnswer> {
+  log("");
+  log("scribe — transcription provider:");
+  for (let i = 0; i < SCRIBE_PROVIDERS.length; i++) {
+    const p = SCRIBE_PROVIDERS[i];
+    if (!p) continue;
+    log(`  [${i + 1}] ${p.label} — ${p.blurb}`);
+  }
+  let provider: ScribeProviderKey | undefined;
+  while (!provider) {
+    const raw = (await prompt("Pick a provider (Enter for parakeet-mlx): ")).trim();
+    if (raw.length === 0) {
+      provider = "parakeet-mlx";
+      break;
+    }
+    if (/^\d+$/.test(raw)) {
+      const idx = Number.parseInt(raw, 10) - 1;
+      const hit = SCRIBE_PROVIDERS[idx];
+      if (hit) {
+        provider = hit.key;
+        break;
+      }
+      log(`  out of range — pick 1..${SCRIBE_PROVIDERS.length}`);
+      continue;
+    }
+    if (isKnownScribeProvider(raw)) {
+      provider = raw;
+      break;
+    }
+    log(`  unknown provider "${raw}" — try a number from the list above`);
+  }
+  const apiKeyEnv = apiKeyEnvFor(provider);
+  let apiKey: string | undefined;
+  if (apiKeyEnv) {
+    const raw = (await prompt(`scribe — ${apiKeyEnv} (or Enter to skip): `)).trim();
+    if (raw.length > 0) apiKey = raw;
+  }
+  return { provider, apiKey };
+}
+
+function summarizeUrls(
+  manifestPath: string,
+  picks: ServiceChoice[],
+  log: (line: string) => void,
+): void {
+  log("");
+  log("Setup complete.");
+  log("");
+  for (const choice of picks) {
+    const entry = findService(choice.manifestName, manifestPath);
+    if (!entry) {
+      log(`  ⚠ ${choice.manifestName} not in services.json — re-run install if expected`);
+      continue;
+    }
+    const url = choice.spec.urlForEntry?.(entry);
+    log(`  ✓ ${entry.name}${url ? ` — ${url}` : ""}`);
+  }
+  log("");
+  log(
+    "Discovery: ~/.parachute/services.json (CLI) and the hub's /.well-known/parachute.json (HTTP).",
+  );
+  log("");
+  log("Next: open Claude Code and try");
+  log('  claude "Hello, can you help me set up my Parachute vault?"');
+}
+
+export async function setup(opts: SetupOpts = {}): Promise<number> {
+  const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const configDir = opts.configDir ?? CONFIG_DIR;
+  const log = opts.log ?? ((line) => console.log(line));
+  const availability = opts.availability ?? defaultAvailability();
+  const installFn = opts.installFn ?? install;
+
+  log("Welcome to Parachute setup.");
+  log("");
+  log("This walks you through installing the Parachute services and configuring");
+  log("them for first use. Existing installs are detected and skipped.");
+  log("");
+
+  const survey = surveyServices(manifestPath);
+  const installed = survey.filter((s) => s.installed);
+  const offered = survey.filter((s) => !s.installed);
+
+  if (installed.length > 0) {
+    log("Already installed:");
+    for (const s of installed) log(`  ✓ ${s.short}`);
+    log("");
+  }
+
+  if (offered.length === 0) {
+    log("All known services are already installed. Nothing to do.");
+    return 0;
+  }
+
+  if (availability.kind !== "available") {
+    log(
+      "Non-interactive shell — `parachute setup` needs a TTY. Run interactively, or use `parachute install <svc>` directly.",
+    );
+    return 1;
+  }
+  const prompt = availability.prompt;
+
+  log("Available to install:");
+  for (let i = 0; i < offered.length; i++) {
+    const c = offered[i];
+    if (!c) continue;
+    log(`  [${i + 1}] ${c.short.padEnd(8)} — ${blurbFor(c)}`);
+  }
+  log("");
+
+  let picks: ServiceChoice[] | undefined;
+  while (!picks) {
+    const raw = await prompt("Which to install? (numbers/names, comma-separated; Enter for all): ");
+    const result = parseServicePicks(raw, offered);
+    if ("error" in result) {
+      log(`  ${result.error}`);
+      continue;
+    }
+    if (result.picks.length === 0) {
+      log("  no services picked — try again");
+      continue;
+    }
+    picks = result.picks;
+  }
+
+  // Pre-collect per-service answers so the operator sits through one batch
+  // of questions instead of mid-stream interruptions.
+  const vaultPick = picks.find((p) => p.short === "vault");
+  const scribePick = picks.find((p) => p.short === "scribe");
+
+  let vaultAnswer: VaultAnswer | undefined;
+  if (vaultPick) {
+    log("");
+    vaultAnswer = await askVaultName(prompt, log);
+  }
+
+  let scribeAnswer: ScribeAnswer | undefined;
+  if (scribePick) {
+    scribeAnswer = await askScribeProvider(prompt, log);
+  }
+
+  log("");
+  log("Configuring…");
+  log("");
+
+  let firstFailure = 0;
+  for (const choice of picks) {
+    log(`— ${choice.short} —`);
+    const installOpts: InstallOpts = { manifestPath, configDir, log, ...opts.baseInstallOpts };
+    if (opts.tag !== undefined) installOpts.tag = opts.tag;
+    if (opts.noStart) installOpts.noStart = true;
+    if (choice.short === "vault" && vaultAnswer) {
+      installOpts.vaultName = vaultAnswer.vaultName;
+    }
+    if (choice.short === "scribe" && scribeAnswer) {
+      installOpts.scribeProvider = scribeAnswer.provider;
+      if (scribeAnswer.apiKey) installOpts.scribeKey = scribeAnswer.apiKey;
+    }
+    const code = await installFn(choice.short, installOpts);
+    if (code !== 0 && firstFailure === 0) firstFailure = code;
+    log("");
+  }
+
+  if (firstFailure !== 0) {
+    log(`⚠ One or more installs returned a non-zero exit code (${firstFailure}).`);
+    log("  Re-run `parachute install <svc>` for the failing service to retry.");
+    return firstFailure;
+  }
+
+  summarizeUrls(manifestPath, picks, log);
+  return 0;
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -6,6 +6,7 @@ export function topLevelHelp(): string {
   return `parachute ${pkg.version} — top-level CLI for the Parachute ecosystem
 
 Usage:
+  parachute setup                   interactive walk-through: install services + configure
   parachute install <service>       install and register a service
                                     services: ${services}
   parachute status                  show installed services, process state, health
@@ -77,6 +78,46 @@ Aliases:
   lens → notes                      # accepted for one release cycle after
                                     # the brief Lens rebrand was reverted on
                                     # 2026-04-22; prints a rename notice.
+`;
+}
+
+export function setupHelp(): string {
+  return `parachute setup — interactive walk-through to install + configure services
+
+Usage:
+  parachute setup [--tag <name>] [--no-start]
+
+What it does:
+  1. surveys ~/.parachute/services.json — already-installed services are
+     reported, then skipped from the picker
+  2. shows a numbered multi-select for the remaining first-party services
+     (vault, notes, scribe; channel is exploratory and only offered by name)
+  3. pre-collects all interactive answers up front so the installs can run
+     without further prompting:
+       - vault: vault name (default \`default\`)
+       - scribe: transcription provider + API key for cloud providers
+  4. iterates \`parachute install <svc>\` per pick, threading the collected
+     answers and the shared --tag / --no-start flags
+  5. prints a summary banner with the running URLs (hub, vault, notes, scribe)
+     and a hint for connecting Claude Code
+
+Behavior:
+  - Partial success is preserved: if one install fails, prior successful
+    installs are NOT rolled back. The exit code reflects the last failure.
+  - Non-TTY / piped invocations should use \`parachute install <svc>\` per
+    service instead — \`setup\` assumes a terminal for the prompts.
+  - Selection accepts numbers (\`1,3\`), names (\`vault, notes\`), or \`all\`.
+
+Flags:
+  --tag <name>     npm dist-tag or exact version, applied to every install
+                   in this walk-through (e.g. \`--tag rc\`)
+  --no-start       skip the post-install daemon start for every service.
+                   For CI / scripted bring-up.
+
+Examples:
+  parachute setup                   # interactive walk-through
+  parachute setup --tag rc          # bootstrap to the rc dist-tag
+  parachute setup --no-start        # install without auto-starting (CI)
 `;
 }
 


### PR DESCRIPTION
## Summary

Closes #45 — a single \`parachute setup\` command that orchestrates the existing per-service install flows behind a unified, prompt-up-front walk-through.

- detects what's already in \`services.json\` and skips those services
- multi-select prompt for the rest (numbers, names, or \`all\`; channel marked exploratory)
- pre-collects every interactive answer up front (vault name, scribe provider + optional API key) so installs run without further prompts
- iterates the existing \`install()\` per pick, threading \`--tag\` / \`--no-start\` and the collected answers
- partial-failure behavior: a failed install does NOT roll back prior successes; exit code reflects the first failure
- non-TTY shells get a clear hint to use \`parachute install <svc>\` directly

Net new: \`src/commands/setup.ts\`, \`src/__tests__/setup.test.ts\`, \`InstallOpts.vaultName\` threaded into \`vault init\` via \`--vault-name <x>\`, and a \`parachute setup\` case in the CLI dispatch + help.

Bumps \`0.4.0-rc.16\` → \`0.4.0-rc.17\`.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun test\` — full suite green (743 pass)
- [x] \`bun test src/__tests__/setup.test.ts\` — 13 new tests cover \`parseServicePicks\` (empty/all/numbers/names/dedupe/out-of-range/unknown) and the \`setup()\` flow (all-installed short-circuit, non-TTY rejection, vaultName + scribe threading, --tag/--no-start, partial-failure exit code, vault-name retry on validation)
- [x] \`biome check\` clean on touched files (pre-existing violations in \`oauth-ui.ts\`, \`admin-auth.ts\`, \`admin-auth.test.ts\` are not from this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)