### PR TITLE
feat(admin-session): widen cookie Path + add CSRF (prep for #46)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.17",
+  "version": "0.4.0-rc.18",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/csrf.test.ts
+++ b/src/__tests__/csrf.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CSRF_COOKIE_NAME,
+  CSRF_FIELD_NAME,
+  buildCsrfCookie,
+  ensureCsrfToken,
+  generateCsrfToken,
+  parseCsrfCookie,
+  renderCsrfHiddenInput,
+  verifyCsrfToken,
+} from "../csrf.ts";
+
+function reqWith(cookie: string | null, formToken?: string | null): Request {
+  const headers = new Headers();
+  if (cookie !== null) headers.set("cookie", cookie);
+  return new Request("https://hub.example/oauth/authorize", { headers });
+}
+
+describe("generateCsrfToken", () => {
+  test("returns a base64url string with > 32 chars of entropy", () => {
+    const token = generateCsrfToken();
+    expect(token.length).toBeGreaterThan(32);
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  test("two calls produce distinct tokens", () => {
+    expect(generateCsrfToken()).not.toBe(generateCsrfToken());
+  });
+});
+
+describe("buildCsrfCookie", () => {
+  test("emits the expected attributes", () => {
+    const v = buildCsrfCookie("abc");
+    expect(v).toContain(`${CSRF_COOKIE_NAME}=abc`);
+    expect(v).toContain("HttpOnly");
+    expect(v).toContain("Secure");
+    expect(v).toContain("SameSite=Lax");
+    expect(v).toContain("Path=/");
+    expect(v).toContain("Max-Age=");
+  });
+});
+
+describe("parseCsrfCookie", () => {
+  test("extracts the token from a cookie header", () => {
+    expect(parseCsrfCookie(`${CSRF_COOKIE_NAME}=xyz`)).toBe("xyz");
+    expect(parseCsrfCookie(`other=foo; ${CSRF_COOKIE_NAME}=xyz; bar=baz`)).toBe("xyz");
+  });
+
+  test("returns null when absent or empty", () => {
+    expect(parseCsrfCookie(null)).toBeNull();
+    expect(parseCsrfCookie("")).toBeNull();
+    expect(parseCsrfCookie("other=foo")).toBeNull();
+  });
+});
+
+describe("ensureCsrfToken", () => {
+  test("mints a fresh cookie when none is present", () => {
+    const result = ensureCsrfToken(reqWith(null));
+    expect(result.token.length).toBeGreaterThan(32);
+    expect(result.setCookie).toContain(`${CSRF_COOKIE_NAME}=${result.token}`);
+  });
+
+  test("reuses the existing cookie token without re-setting", () => {
+    const result = ensureCsrfToken(reqWith(`${CSRF_COOKIE_NAME}=existing-token`));
+    expect(result.token).toBe("existing-token");
+    expect(result.setCookie).toBeUndefined();
+  });
+
+  test("mints fresh when the cookie is empty", () => {
+    const result = ensureCsrfToken(reqWith(`${CSRF_COOKIE_NAME}=`));
+    expect(result.token.length).toBeGreaterThan(0);
+    expect(result.setCookie).toBeDefined();
+  });
+});
+
+describe("verifyCsrfToken", () => {
+  test("returns true when cookie and form match", () => {
+    const token = "match-me";
+    const req = reqWith(`${CSRF_COOKIE_NAME}=${token}`);
+    expect(verifyCsrfToken(req, token)).toBe(true);
+  });
+
+  test("returns false when the form token differs", () => {
+    const req = reqWith(`${CSRF_COOKIE_NAME}=cookie-token`);
+    expect(verifyCsrfToken(req, "form-token")).toBe(false);
+  });
+
+  test("returns false when cookie token is missing", () => {
+    expect(verifyCsrfToken(reqWith(null), "form-token")).toBe(false);
+  });
+
+  test("returns false when form token is missing", () => {
+    const req = reqWith(`${CSRF_COOKIE_NAME}=cookie-token`);
+    expect(verifyCsrfToken(req, null)).toBe(false);
+  });
+
+  test("returns false when lengths differ (avoids timingSafeEqual throw)", () => {
+    const req = reqWith(`${CSRF_COOKIE_NAME}=abcd`);
+    expect(verifyCsrfToken(req, "abcdef")).toBe(false);
+  });
+});
+
+describe("renderCsrfHiddenInput", () => {
+  test("renders an HTML hidden input with the field name", () => {
+    const html = renderCsrfHiddenInput("token-123");
+    expect(html).toContain(`name="${CSRF_FIELD_NAME}"`);
+    expect(html).toContain('value="token-123"');
+    expect(html).toContain('type="hidden"');
+  });
+
+  test("escapes hostile token content into the value attribute", () => {
+    const html = renderCsrfHiddenInput(`"><script>alert(1)</script>`);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&quot;");
+    expect(html).toContain("&lt;script");
+  });
+});

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { registerClient } from "../clients.ts";
+import { CSRF_COOKIE_NAME } from "../csrf.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { validateAccessToken } from "../jwt-sign.ts";
 import {
@@ -20,6 +21,8 @@ import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.t
 import { createUser } from "../users.ts";
 
 const ISSUER = "https://hub.example";
+const TEST_CSRF = "csrf-test-token";
+const CSRF_COOKIE = `${CSRF_COOKIE_NAME}=${TEST_CSRF}`;
 
 async function makeDb() {
   const configDir = mkdtempSync(join(tmpdir(), "phub-oauth-"));
@@ -192,7 +195,7 @@ describe("handleAuthorizeGet", () => {
         }),
         {
           headers: {
-            cookie: buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000)),
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
           },
         },
       );
@@ -327,7 +330,7 @@ describe("handleAuthorizeGet — vault picker", () => {
         }),
         {
           headers: {
-            cookie: buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000)),
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
           },
         },
       );
@@ -364,7 +367,7 @@ describe("handleAuthorizeGet — vault picker", () => {
         }),
         {
           headers: {
-            cookie: buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000)),
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
           },
         },
       );
@@ -399,7 +402,7 @@ describe("handleAuthorizeGet — vault picker", () => {
         }),
         {
           headers: {
-            cookie: buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000)),
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
           },
         },
       );
@@ -428,6 +431,7 @@ describe("handleAuthorizePost — vault picker", () => {
       const { verifier, challenge } = makePkce();
       const consentForm = new URLSearchParams({
         __action: "consent",
+        __csrf: TEST_CSRF,
         approve: "yes",
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
@@ -442,7 +446,7 @@ describe("handleAuthorizePost — vault picker", () => {
         body: consentForm,
         headers: {
           "content-type": "application/x-www-form-urlencoded",
-          cookie: buildSessionCookie(session.id, 86400),
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
         },
       });
       const consentRes = await handleAuthorizePost(db, consentReq, {
@@ -490,6 +494,7 @@ describe("handleAuthorizePost — vault picker", () => {
       const { challenge } = makePkce();
       const consentForm = new URLSearchParams({
         __action: "consent",
+        __csrf: TEST_CSRF,
         approve: "yes",
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
@@ -505,7 +510,7 @@ describe("handleAuthorizePost — vault picker", () => {
           body: consentForm,
           headers: {
             "content-type": "application/x-www-form-urlencoded",
-            cookie: buildSessionCookie(session.id, 86400),
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
           },
         }),
         { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
@@ -527,6 +532,7 @@ describe("handleAuthorizePost — vault picker", () => {
       const { challenge } = makePkce();
       const consentForm = new URLSearchParams({
         __action: "consent",
+        __csrf: TEST_CSRF,
         approve: "yes",
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
@@ -543,7 +549,7 @@ describe("handleAuthorizePost — vault picker", () => {
           body: consentForm,
           headers: {
             "content-type": "application/x-www-form-urlencoded",
-            cookie: buildSessionCookie(session.id, 86400),
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
           },
         }),
         { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
@@ -565,6 +571,7 @@ describe("handleAuthorizePost — vault picker", () => {
       const { verifier, challenge } = makePkce();
       const consentForm = new URLSearchParams({
         __action: "consent",
+        __csrf: TEST_CSRF,
         approve: "yes",
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
@@ -581,7 +588,7 @@ describe("handleAuthorizePost — vault picker", () => {
           body: consentForm,
           headers: {
             "content-type": "application/x-www-form-urlencoded",
-            cookie: buildSessionCookie(session.id, 86400),
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
           },
         }),
         { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
@@ -620,6 +627,7 @@ describe("handleAuthorizePost — login submit", () => {
       const { challenge } = makePkce();
       const form = new URLSearchParams({
         __action: "login",
+        __csrf: TEST_CSRF,
         username: "owner",
         password: "hunter2",
         client_id: reg.client.clientId,
@@ -632,7 +640,10 @@ describe("handleAuthorizePost — login submit", () => {
       const req = new Request(`${ISSUER}/oauth/authorize`, {
         method: "POST",
         body: form,
-        headers: { "content-type": "application/x-www-form-urlencoded" },
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: CSRF_COOKIE,
+        },
       });
       const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
       expect(res.status).toBe(302);
@@ -653,6 +664,7 @@ describe("handleAuthorizePost — login submit", () => {
       const { challenge } = makePkce();
       const form = new URLSearchParams({
         __action: "login",
+        __csrf: TEST_CSRF,
         username: "owner",
         password: "wrong",
         client_id: reg.client.clientId,
@@ -664,11 +676,164 @@ describe("handleAuthorizePost — login submit", () => {
       const req = new Request(`${ISSUER}/oauth/authorize`, {
         method: "POST",
         body: form,
-        headers: { "content-type": "application/x-www-form-urlencoded" },
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: CSRF_COOKIE,
+        },
       });
       const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
       expect(res.status).toBe(401);
       expect(res.headers.get("set-cookie")).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("handleAuthorizePost — CSRF protection", () => {
+  test("rejects POST when CSRF cookie is absent", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "hunter2");
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const form = new URLSearchParams({
+        __action: "login",
+        __csrf: TEST_CSRF,
+        username: "owner",
+        password: "hunter2",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      });
+      const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(400);
+      expect(await res.text()).toContain("Invalid form submission");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rejects POST when CSRF form field is absent", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "hunter2");
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const form = new URLSearchParams({
+        __action: "login",
+        username: "owner",
+        password: "hunter2",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: CSRF_COOKIE,
+        },
+      });
+      const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(400);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rejects POST when CSRF cookie and form field do not match", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "hunter2");
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const form = new URLSearchParams({
+        __action: "login",
+        __csrf: "different-token",
+        username: "owner",
+        password: "hunter2",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: CSRF_COOKIE,
+        },
+      });
+      const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(400);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("GET /oauth/authorize sets CSRF cookie when none is present", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const url = authorizeUrl({
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const res = handleAuthorizeGet(db, new Request(url), { issuer: ISSUER });
+      expect(res.status).toBe(200);
+      const setCookie = res.headers.get("set-cookie") ?? "";
+      expect(setCookie).toContain(`${CSRF_COOKIE_NAME}=`);
+      expect(setCookie).toContain("HttpOnly");
+      // The rendered form must echo the same token as a hidden input.
+      const html = await res.text();
+      expect(html).toContain('name="__csrf"');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("GET /oauth/authorize reuses an existing CSRF cookie", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const url = authorizeUrl({
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const res = handleAuthorizeGet(db, new Request(url, { headers: { cookie: CSRF_COOKIE } }), {
+        issuer: ISSUER,
+      });
+      expect(res.status).toBe(200);
+      // No new cookie minted when one already exists.
+      expect(res.headers.get("set-cookie")).toBeNull();
+      const html = await res.text();
+      expect(html).toContain(`value="${TEST_CSRF}"`);
     } finally {
       cleanup();
     }
@@ -685,6 +850,7 @@ describe("handleAuthorizePost — consent submit", () => {
       const { challenge } = makePkce();
       const form = new URLSearchParams({
         __action: "consent",
+        __csrf: TEST_CSRF,
         approve: "yes",
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
@@ -699,7 +865,7 @@ describe("handleAuthorizePost — consent submit", () => {
         body: form,
         headers: {
           "content-type": "application/x-www-form-urlencoded",
-          cookie: buildSessionCookie(session.id, 86400),
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
         },
       });
       const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
@@ -724,6 +890,7 @@ describe("handleAuthorizePost — consent submit", () => {
       const { challenge } = makePkce();
       const form = new URLSearchParams({
         __action: "consent",
+        __csrf: TEST_CSRF,
         approve: "yes",
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
@@ -738,7 +905,7 @@ describe("handleAuthorizePost — consent submit", () => {
         body: form,
         headers: {
           "content-type": "application/x-www-form-urlencoded",
-          cookie: buildSessionCookie(session.id, 86400),
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
         },
       });
       const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
@@ -760,6 +927,7 @@ describe("handleAuthorizePost — consent submit", () => {
       const { challenge } = makePkce();
       const form = new URLSearchParams({
         __action: "consent",
+        __csrf: TEST_CSRF,
         approve: "no",
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
@@ -774,7 +942,7 @@ describe("handleAuthorizePost — consent submit", () => {
         body: form,
         headers: {
           "content-type": "application/x-www-form-urlencoded",
-          cookie: buildSessionCookie(session.id, 86400),
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
         },
       });
       const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
@@ -800,6 +968,7 @@ describe("handleToken — full OAuth dance", () => {
       // Approve consent → auth code lands in redirect_uri.
       const consentForm = new URLSearchParams({
         __action: "consent",
+        __csrf: TEST_CSRF,
         approve: "yes",
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
@@ -813,7 +982,7 @@ describe("handleToken — full OAuth dance", () => {
         body: consentForm,
         headers: {
           "content-type": "application/x-www-form-urlencoded",
-          cookie: buildSessionCookie(session.id, 86400),
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
         },
       });
       const consentRes = await handleAuthorizePost(db, consentReq, { issuer: ISSUER });
@@ -882,6 +1051,7 @@ describe("handleToken — full OAuth dance", () => {
       const { verifier, challenge } = makePkce();
       const consentForm = new URLSearchParams({
         __action: "consent",
+        __csrf: TEST_CSRF,
         approve: "yes",
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
@@ -895,7 +1065,7 @@ describe("handleToken — full OAuth dance", () => {
         body: consentForm,
         headers: {
           "content-type": "application/x-www-form-urlencoded",
-          cookie: buildSessionCookie(session.id, 86400),
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
         },
       });
       const consentRes = await handleAuthorizePost(db, consentReq, { issuer: ISSUER });
@@ -937,6 +1107,7 @@ describe("handleToken — full OAuth dance", () => {
       const { verifier, challenge } = makePkce();
       const consentForm = new URLSearchParams({
         __action: "consent",
+        __csrf: TEST_CSRF,
         approve: "yes",
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
@@ -950,7 +1121,7 @@ describe("handleToken — full OAuth dance", () => {
         body: consentForm,
         headers: {
           "content-type": "application/x-www-form-urlencoded",
-          cookie: buildSessionCookie(session.id, 86400),
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
         },
       });
       const consentRes = await handleAuthorizePost(db, consentReq, { issuer: ISSUER });
@@ -1036,6 +1207,7 @@ describe("handleToken — full OAuth dance", () => {
       const { challenge } = makePkce();
       const consentForm = new URLSearchParams({
         __action: "consent",
+        __csrf: TEST_CSRF,
         approve: "yes",
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
@@ -1051,7 +1223,7 @@ describe("handleToken — full OAuth dance", () => {
           body: consentForm,
           headers: {
             "content-type": "application/x-www-form-urlencoded",
-            cookie: buildSessionCookie(session.id, 86400),
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
           },
         }),
         { issuer: ISSUER },
@@ -1092,6 +1264,7 @@ describe("handleToken — full OAuth dance", () => {
       const { verifier, challenge } = makePkce();
       const consentForm = new URLSearchParams({
         __action: "consent",
+        __csrf: TEST_CSRF,
         approve: "yes",
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
@@ -1107,7 +1280,7 @@ describe("handleToken — full OAuth dance", () => {
           body: consentForm,
           headers: {
             "content-type": "application/x-www-form-urlencoded",
-            cookie: buildSessionCookie(session.id, 86400),
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
           },
         }),
         { issuer: ISSUER },
@@ -1148,6 +1321,7 @@ describe("handleToken — full OAuth dance", () => {
       const { verifier, challenge } = makePkce();
       const consentForm = new URLSearchParams({
         __action: "consent",
+        __csrf: TEST_CSRF,
         approve: "yes",
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
@@ -1163,7 +1337,7 @@ describe("handleToken — full OAuth dance", () => {
           body: consentForm,
           headers: {
             "content-type": "application/x-www-form-urlencoded",
-            cookie: buildSessionCookie(session.id, 86400),
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
           },
         }),
         { issuer: ISSUER },
@@ -1203,6 +1377,7 @@ describe("handleToken — full OAuth dance", () => {
       const { verifier, challenge } = makePkce();
       const consentForm = new URLSearchParams({
         __action: "consent",
+        __csrf: TEST_CSRF,
         approve: "yes",
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
@@ -1218,7 +1393,7 @@ describe("handleToken — full OAuth dance", () => {
           body: consentForm,
           headers: {
             "content-type": "application/x-www-form-urlencoded",
-            cookie: buildSessionCookie(session.id, 86400),
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
           },
         }),
         { issuer: ISSUER },
@@ -1258,6 +1433,7 @@ describe("handleToken — full OAuth dance", () => {
       const { verifier, challenge } = makePkce();
       const consentForm = new URLSearchParams({
         __action: "consent",
+        __csrf: TEST_CSRF,
         approve: "yes",
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
@@ -1273,7 +1449,7 @@ describe("handleToken — full OAuth dance", () => {
           body: consentForm,
           headers: {
             "content-type": "application/x-www-form-urlencoded",
-            cookie: buildSessionCookie(session.id, 86400),
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
           },
         }),
         { issuer: ISSUER },
@@ -1363,6 +1539,7 @@ describe("handleToken — confidential client authentication (#72)", () => {
     const { verifier, challenge } = makePkce();
     const consentForm = new URLSearchParams({
       __action: "consent",
+      __csrf: TEST_CSRF,
       approve: "yes",
       client_id: clientId,
       redirect_uri: "https://app.example/cb",
@@ -1378,7 +1555,7 @@ describe("handleToken — confidential client authentication (#72)", () => {
         body: consentForm,
         headers: {
           "content-type": "application/x-www-form-urlencoded",
-          cookie: buildSessionCookie(sessionId, 86400),
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(sessionId, 86400)}`,
         },
       }),
       { issuer: ISSUER },
@@ -2079,6 +2256,7 @@ describe("refresh-token rotation + /oauth/revoke (#73)", () => {
     const { verifier, challenge } = makePkce();
     const consentForm = new URLSearchParams({
       __action: "consent",
+      __csrf: TEST_CSRF,
       approve: "yes",
       client_id: clientId,
       redirect_uri: "https://app.example/cb",
@@ -2094,7 +2272,7 @@ describe("refresh-token rotation + /oauth/revoke (#73)", () => {
         body: consentForm,
         headers: {
           "content-type": "application/x-www-form-urlencoded",
-          cookie: buildSessionCookie(sessionId, 86400),
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(sessionId, 86400)}`,
         },
       }),
       { issuer: ISSUER },

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -18,6 +18,8 @@ const PARAMS: AuthorizeFormParams = {
   state: "xyz",
 };
 
+const CSRF = "csrf-token-fixture";
+
 describe("escapeHtml", () => {
   test("escapes the five HTML metacharacters", () => {
     expect(escapeHtml(`<script>alert("x&y'z")</script>`)).toBe(
@@ -52,7 +54,7 @@ describe("renderHiddenInputs", () => {
 
 describe("renderLogin", () => {
   test("contains form, hidden inputs, and a Sign in submit", () => {
-    const html = renderLogin({ params: PARAMS });
+    const html = renderLogin({ params: PARAMS, csrfToken: CSRF });
     expect(html).toContain('action="/oauth/authorize"');
     expect(html).toContain('name="__action" value="login"');
     expect(html).toContain('name="username"');
@@ -65,13 +67,17 @@ describe("renderLogin", () => {
   });
 
   test("renders an error banner when errorMessage is set", () => {
-    const html = renderLogin({ params: PARAMS, errorMessage: "bad pw" });
+    const html = renderLogin({ params: PARAMS, csrfToken: CSRF, errorMessage: "bad pw" });
     expect(html).toContain("error-banner");
     expect(html).toContain("bad pw");
   });
 
   test("escapes the error message", () => {
-    const html = renderLogin({ params: PARAMS, errorMessage: "<script>x</script>" });
+    const html = renderLogin({
+      params: PARAMS,
+      csrfToken: CSRF,
+      errorMessage: "<script>x</script>",
+    });
     expect(html).not.toContain("<script>x</script>");
     expect(html).toContain("&lt;script&gt;");
   });
@@ -81,6 +87,7 @@ describe("renderConsent", () => {
   test("shows client name, client_id, and a row per scope", () => {
     const html = renderConsent({
       params: PARAMS,
+      csrfToken: CSRF,
       clientId: "client-abc",
       clientName: "MyApp",
       scopes: ["vault:read", "vault:admin"],
@@ -98,6 +105,7 @@ describe("renderConsent", () => {
   test("highlights admin scopes with a danger color and badge", () => {
     const html = renderConsent({
       params: PARAMS,
+      csrfToken: CSRF,
       clientId: "c",
       clientName: "App",
       scopes: ["vault:admin"],
@@ -109,6 +117,7 @@ describe("renderConsent", () => {
   test("renders unknown scopes verbatim with a muted explanation", () => {
     const html = renderConsent({
       params: PARAMS,
+      csrfToken: CSRF,
       clientId: "c",
       clientName: "App",
       scopes: ["mystery.module:do-thing"],
@@ -121,6 +130,7 @@ describe("renderConsent", () => {
   test("renders a placeholder when no scopes are requested", () => {
     const html = renderConsent({
       params: PARAMS,
+      csrfToken: CSRF,
       clientId: "c",
       clientName: "App",
       scopes: [],
@@ -132,6 +142,7 @@ describe("renderConsent", () => {
   test("includes Approve and Deny buttons posting __action=consent", () => {
     const html = renderConsent({
       params: PARAMS,
+      csrfToken: CSRF,
       clientId: "c",
       clientName: "App",
       scopes: [],
@@ -144,6 +155,7 @@ describe("renderConsent", () => {
   test("escapes a hostile client name", () => {
     const html = renderConsent({
       params: PARAMS,
+      csrfToken: CSRF,
       clientId: "c",
       clientName: "<img src=x onerror=alert(1)>",
       scopes: [],
@@ -155,6 +167,7 @@ describe("renderConsent", () => {
   test("renders a vault picker when vaultPicker is set", () => {
     const html = renderConsent({
       params: PARAMS,
+      csrfToken: CSRF,
       clientId: "c",
       clientName: "App",
       scopes: ["vault:read"],
@@ -170,6 +183,7 @@ describe("renderConsent", () => {
   test("escapes a hostile vault name in the picker", () => {
     const html = renderConsent({
       params: PARAMS,
+      csrfToken: CSRF,
       clientId: "c",
       clientName: "App",
       scopes: ["vault:read"],
@@ -185,6 +199,7 @@ describe("renderConsent", () => {
   test("disables the Approve button when no vaults exist", () => {
     const html = renderConsent({
       params: PARAMS,
+      csrfToken: CSRF,
       clientId: "c",
       clientName: "App",
       scopes: ["vault:read"],
@@ -219,17 +234,19 @@ describe("renderError", () => {
 
 describe("CSS / styling guarantees", () => {
   test("does not load fonts from a third-party CDN (privacy)", () => {
-    const html = renderLogin({ params: PARAMS });
+    const html = renderLogin({ params: PARAMS, csrfToken: CSRF });
     expect(html).not.toContain("fonts.googleapis.com");
     expect(html).not.toContain("fonts.gstatic.com");
   });
 
   test("sets referrer policy to no-referrer", () => {
-    expect(renderLogin({ params: PARAMS })).toContain('name="referrer" content="no-referrer"');
+    expect(renderLogin({ params: PARAMS, csrfToken: CSRF })).toContain(
+      'name="referrer" content="no-referrer"',
+    );
   });
 
   test("declares mobile-friendly viewport", () => {
-    expect(renderLogin({ params: PARAMS })).toContain(
+    expect(renderLogin({ params: PARAMS, csrfToken: CSRF })).toContain(
       'name="viewport" content="width=device-width, initial-scale=1"',
     );
   });

--- a/src/__tests__/sessions.test.ts
+++ b/src/__tests__/sessions.test.ts
@@ -87,7 +87,8 @@ describe("buildSessionCookie", () => {
     expect(v).toContain("HttpOnly");
     expect(v).toContain("Secure");
     expect(v).toContain("SameSite=Lax");
-    expect(v).toContain("Path=/oauth/");
+    expect(v).toContain("Path=/");
+    expect(v).not.toContain("Path=/oauth");
     expect(v).toContain("Max-Age=86400");
   });
 });
@@ -97,7 +98,8 @@ describe("buildSessionClearCookie", () => {
     const v = buildSessionClearCookie();
     expect(v).toContain(`${SESSION_COOKIE_NAME}=`);
     expect(v).toContain("Max-Age=0");
-    expect(v).toContain("Path=/oauth/");
+    expect(v).toContain("Path=/");
+    expect(v).not.toContain("Path=/oauth");
   });
 });
 

--- a/src/csrf.ts
+++ b/src/csrf.ts
@@ -1,0 +1,96 @@
+/**
+ * CSRF protection for state-changing admin POSTs (login, consent, and any
+ * future admin form mounted off `/`).
+ *
+ * Pattern: double-submit cookie. On every GET that renders a form, we ensure
+ * a `parachute_hub_csrf` cookie exists (lazily generated, then reused for the
+ * cookie's lifetime) and embed the same value as a hidden `__csrf` input in
+ * the form. On POST, we compare the form-submitted token to the cookie value
+ * via constant-time compare; mismatch = 400.
+ *
+ * Why this and not session-bound tokens? Login forms are submitted *before*
+ * a session exists, so a session-bound CSRF would need a separate "pre-login"
+ * track anyway. Double-submit is uniform across both — same helper handles
+ * pre-login and post-login forms, and it works no matter how many tabs the
+ * operator has open.
+ *
+ * The cookie is HttpOnly (the form doesn't need JS to read it; the server
+ * embeds the value at render time), SameSite=Lax (matches the session
+ * cookie), Secure, and Path=/ (covers every admin form, OAuth or otherwise).
+ *
+ * Token entropy: 32 random bytes, base64url-encoded — same shape as session
+ * IDs. No HMAC needed: the value is opaque to the client and only ever
+ * compared to itself across the cookie/form boundary.
+ */
+import { randomBytes, timingSafeEqual } from "node:crypto";
+
+export const CSRF_COOKIE_NAME = "parachute_hub_csrf";
+export const CSRF_FIELD_NAME = "__csrf";
+/** 30 days. Cookie outlives the 24h session by design — closing the OAuth
+ * tab and reopening it later shouldn't force a re-mint of the CSRF token. */
+export const CSRF_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+export function generateCsrfToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export function buildCsrfCookie(token: string): string {
+  return [
+    `${CSRF_COOKIE_NAME}=${token}`,
+    "HttpOnly",
+    "Secure",
+    "SameSite=Lax",
+    "Path=/",
+    `Max-Age=${CSRF_TTL_SECONDS}`,
+  ].join("; ");
+}
+
+export function parseCsrfCookie(cookieHeader: string | null): string | null {
+  if (!cookieHeader) return null;
+  for (const part of cookieHeader.split(";")) {
+    const [name, ...rest] = part.trim().split("=");
+    if (name === CSRF_COOKIE_NAME) return rest.join("=");
+  }
+  return null;
+}
+
+export interface EnsuredCsrf {
+  token: string;
+  /** Set when the caller must include this Set-Cookie on the response. */
+  setCookie?: string;
+}
+
+/**
+ * Ensure the request carries a CSRF token cookie; mint and return one if not.
+ * Callers embed `result.token` in the rendered form and attach
+ * `result.setCookie` (if defined) to the response.
+ */
+export function ensureCsrfToken(req: Request): EnsuredCsrf {
+  const existing = parseCsrfCookie(req.headers.get("cookie"));
+  if (existing && existing.length > 0) return { token: existing };
+  const token = generateCsrfToken();
+  return { token, setCookie: buildCsrfCookie(token) };
+}
+
+/**
+ * Verify that a form-submitted CSRF token matches the cookie token via
+ * constant-time compare. Both must be present and equal.
+ */
+export function verifyCsrfToken(req: Request, formToken: string | null): boolean {
+  const cookieToken = parseCsrfCookie(req.headers.get("cookie"));
+  if (!cookieToken || !formToken) return false;
+  if (cookieToken.length !== formToken.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(cookieToken), Buffer.from(formToken));
+  } catch {
+    return false;
+  }
+}
+
+export function renderCsrfHiddenInput(token: string): string {
+  return `<input type="hidden" name="${CSRF_FIELD_NAME}" value="${escapeAttr(token)}" />`;
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -41,6 +41,7 @@ import {
   requireRegisteredRedirectUri,
   verifyClientSecret,
 } from "./clients.ts";
+import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
 import {
   ACCESS_TOKEN_TTL_SECONDS,
   findRefreshToken,
@@ -373,12 +374,18 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
 
   const sessionId = parseSessionCookie(req.headers.get("cookie"));
   const session = sessionId ? findSession(db, sessionId) : null;
+  const csrf = ensureCsrfToken(req);
+  const extra: Record<string, string> = csrf.setCookie ? { "set-cookie": csrf.setCookie } : {};
   if (!session) {
-    return htmlResponse(renderLogin({ params: parsed }));
+    return htmlResponse(renderLogin({ params: parsed, csrfToken: csrf.token }), 200, extra);
   }
   const manifest = (deps.loadServicesManifest ?? readServicesManifest)();
   const vaultNames = listVaultNames(manifest);
-  return htmlResponse(renderConsent(consentProps(client, parsed, vaultNames)));
+  return htmlResponse(
+    renderConsent(consentProps(client, parsed, vaultNames, csrf.token)),
+    200,
+    extra,
+  );
 }
 
 /**
@@ -396,9 +403,23 @@ export async function handleAuthorizePost(
   deps: OAuthDeps,
 ): Promise<Response> {
   const form = await req.formData();
+  const formCsrf = form.get(CSRF_FIELD_NAME);
+  if (!verifyCsrfToken(req, typeof formCsrf === "string" ? formCsrf : null)) {
+    // Same response shape for missing-cookie, missing-form-field, and mismatch
+    // — we don't want to leak which side failed. The browser can recover by
+    // GETting /oauth/authorize again, which mints a fresh cookie + token.
+    return htmlError(
+      "Invalid form submission",
+      "The form's CSRF token did not match. Reload the page and try again.",
+      400,
+    );
+  }
+  // Token is already verified above; reuse the form value for re-rendering
+  // any error views so the next submit keeps the same cookie/form pairing.
+  const csrfToken = typeof formCsrf === "string" ? formCsrf : "";
   const action = String(form.get("__action") ?? "");
-  if (action === "login") return await handleLoginSubmit(db, req, form, deps);
-  if (action === "consent") return await handleConsentSubmit(db, req, form, deps);
+  if (action === "login") return await handleLoginSubmit(db, req, form, deps, csrfToken);
+  if (action === "consent") return await handleConsentSubmit(db, req, form, deps, csrfToken);
   return htmlError("Invalid form submission", "Unknown form action.", 400);
 }
 
@@ -407,23 +428,30 @@ async function handleLoginSubmit(
   _req: Request,
   form: Awaited<ReturnType<Request["formData"]>>,
   _deps: OAuthDeps,
+  csrfToken: string,
 ): Promise<Response> {
   const username = String(form.get("username") ?? "");
   const password = String(form.get("password") ?? "");
   const params = paramsFromForm(form);
   if (!username || !password) {
     return htmlResponse(
-      renderLogin({ params, errorMessage: "Username and password are required." }),
+      renderLogin({ params, csrfToken, errorMessage: "Username and password are required." }),
       400,
     );
   }
   const user = getUserByUsername(db, username);
   if (!user) {
-    return htmlResponse(renderLogin({ params, errorMessage: "Invalid credentials." }), 401);
+    return htmlResponse(
+      renderLogin({ params, csrfToken, errorMessage: "Invalid credentials." }),
+      401,
+    );
   }
   const ok = await verifyPassword(user, password);
   if (!ok) {
-    return htmlResponse(renderLogin({ params, errorMessage: "Invalid credentials." }), 401);
+    return htmlResponse(
+      renderLogin({ params, csrfToken, errorMessage: "Invalid credentials." }),
+      401,
+    );
   }
   const session = createSession(db, { userId: user.id });
   const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
@@ -441,6 +469,7 @@ async function handleConsentSubmit(
   req: Request,
   form: Awaited<ReturnType<Request["formData"]>>,
   deps: OAuthDeps,
+  csrfToken: string,
 ): Promise<Response> {
   const params = paramsFromForm(form);
   const approve = String(form.get("approve") ?? "") === "yes";
@@ -449,7 +478,11 @@ async function handleConsentSubmit(
   if (!session) {
     // Session expired between login and consent submit. Send back to login.
     return htmlResponse(
-      renderLogin({ params, errorMessage: "Your session expired — please sign in again." }),
+      renderLogin({
+        params,
+        csrfToken,
+        errorMessage: "Your session expired — please sign in again.",
+      }),
       401,
     );
   }
@@ -1096,7 +1129,12 @@ export async function handleRegister(
   return jsonResponse(respBody, 201);
 }
 
-function consentProps(client: OAuthClient, params: AuthorizeFormParams, vaultNames: string[]) {
+function consentProps(
+  client: OAuthClient,
+  params: AuthorizeFormParams,
+  vaultNames: string[],
+  csrfToken: string,
+) {
   const scopes = params.scope.split(" ").filter((s) => s.length > 0);
   const unnamedVerbs = unnamedVaultVerbs(scopes);
   return {
@@ -1104,6 +1142,7 @@ function consentProps(client: OAuthClient, params: AuthorizeFormParams, vaultNam
     clientId: client.clientId,
     clientName: client.clientName ?? client.clientId,
     scopes,
+    csrfToken,
     vaultPicker:
       unnamedVerbs.length > 0 ? { unnamedVerbs, availableVaults: vaultNames } : undefined,
   };

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -20,6 +20,7 @@
  *     module scopes that the hub doesn't know about) render verbatim.
  *   - **No JavaScript.** Entirely form-based. Submit is the only interaction.
  */
+import { renderCsrfHiddenInput } from "./csrf.ts";
 import { type ScopeExplanation, explainScope } from "./scope-explanations.ts";
 
 /** Brand palette — kept in sync with parachute.computer/style.css. */
@@ -65,6 +66,7 @@ export interface AuthorizeFormParams {
 export interface LoginViewProps {
   params: AuthorizeFormParams;
   errorMessage?: string;
+  csrfToken: string;
 }
 
 export interface ConsentViewProps {
@@ -72,6 +74,7 @@ export interface ConsentViewProps {
   clientName: string;
   clientId: string;
   scopes: string[];
+  csrfToken: string;
   /**
    * Set when the request includes one or more unnamed `vault:<verb>` scopes.
    * The consent screen renders a vault selector; on submit, the picked vault
@@ -95,7 +98,7 @@ export interface ErrorViewProps {
 }
 
 export function renderLogin(props: LoginViewProps): string {
-  const { params, errorMessage } = props;
+  const { params, errorMessage, csrfToken } = props;
   const error = errorMessage ? `<p class="error-banner">${escapeHtml(errorMessage)}</p>` : "";
   const body = `
     <div class="card">
@@ -110,6 +113,7 @@ export function renderLogin(props: LoginViewProps): string {
       ${error}
       <form method="POST" action="/oauth/authorize" class="auth-form">
         <input type="hidden" name="__action" value="login" />
+        ${renderCsrfHiddenInput(csrfToken)}
         ${renderHiddenInputs(params)}
         <label class="field">
           <span class="field-label">Username</span>
@@ -126,7 +130,7 @@ export function renderLogin(props: LoginViewProps): string {
 }
 
 export function renderConsent(props: ConsentViewProps): string {
-  const { params, clientName, clientId, scopes, vaultPicker } = props;
+  const { params, clientName, clientId, scopes, vaultPicker, csrfToken } = props;
   const scopeRows =
     scopes.length === 0
       ? `<li class="scope scope-empty">No scopes requested — the app gets a session token only.</li>`
@@ -156,6 +160,7 @@ export function renderConsent(props: ConsentViewProps): string {
       </section>
       <form method="POST" action="/oauth/authorize" class="auth-form consent-form">
         <input type="hidden" name="__action" value="consent" />
+        ${renderCsrfHiddenInput(csrfToken)}
         ${renderHiddenInputs(params)}
         ${pickerSection}
         <div class="button-row">
@@ -168,9 +173,7 @@ export function renderConsent(props: ConsentViewProps): string {
 }
 
 function renderVaultPicker(picker: VaultPicker): string {
-  const verbList = picker.unnamedVerbs
-    .map((v) => `<code>vault:${escapeHtml(v)}</code>`)
-    .join(", ");
+  const verbList = picker.unnamedVerbs.map((v) => `<code>vault:${escapeHtml(v)}</code>`).join(", ");
   if (picker.availableVaults.length === 0) {
     return `
         <section class="vault-picker vault-picker-empty">

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -85,8 +85,10 @@ export function deleteSession(db: Database, id: string): void {
  * Build a `Set-Cookie` header value for the given session id. HttpOnly +
  * SameSite=Lax + Secure (we always assume a TLS terminator; localhost dev
  * still sets Secure because Tailscale serves with HTTPS even on the tailnet
- * mount). Path=/oauth/ scopes the cookie to the OAuth endpoints — it never
- * leaks to other parts of the hub.
+ * mount). Path=/ covers the whole hub origin: the operator's session is "logged
+ * into this hub", and admin pages outside /oauth/ (config portal, etc.) ride
+ * the same session. State-changing admin POSTs require a CSRF token (see
+ * src/csrf.ts) since SameSite=Lax alone doesn't prevent same-site CSRF.
  */
 export function buildSessionCookie(sessionId: string, maxAgeSeconds: number): string {
   return [
@@ -94,13 +96,13 @@ export function buildSessionCookie(sessionId: string, maxAgeSeconds: number): st
     "HttpOnly",
     "Secure",
     "SameSite=Lax",
-    "Path=/oauth/",
+    "Path=/",
     `Max-Age=${maxAgeSeconds}`,
   ].join("; ");
 }
 
 export function buildSessionClearCookie(): string {
-  return `${SESSION_COOKIE_NAME}=; HttpOnly; Secure; SameSite=Lax; Path=/oauth/; Max-Age=0`;
+  return `${SESSION_COOKIE_NAME}=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0`;
 }
 
 export function parseSessionCookie(cookieHeader: string | null): string | null {


### PR DESCRIPTION
## Summary

Two-commit prep for the #46 config portal. Both changes are scoped to admin-session plumbing — no UX change yet.

- **Commit A** (`78ae581`): widens session cookie `Path` from `/oauth/` to `/`, so the same operator session covers admin pages outside `/oauth/` (config portal, future surfaces). Updates the docstring to flag the CSRF dependency.
- **Commit B** (`2bd033a`): adds double-submit-cookie CSRF protection (`src/csrf.ts`) and applies it to login + consent POSTs. Required because `SameSite=Lax` alone isn't enough now that the cookie is host-wide.

Bumps `0.4.0-rc.17 → 0.4.0-rc.18`.

## Why CSRF here, why this shape

`src/csrf.ts` header docstring captures the thinking: double-submit cookie because login is submitted *before* a session exists, so a session-bound token would need a separate "pre-login" track. The same helper handles login + consent + any future admin form. 32-byte base64url token, constant-time compare, HttpOnly+Secure+SameSite=Lax+Path=/, 30-day cookie.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 763 pass / 0 fail
- [x] `biome check` on touched files — clean
- [x] New `csrf.test.ts` covers token gen, cookie shape, ensure/reuse, verify match/mismatch/missing, escaping
- [x] New `oauth-handlers.test.ts` block covers 400 on missing/wrong CSRF cookie + form field, GET sets cookie, GET reuses existing
- [ ] Manual: log into hub on a real install, confirm session works after upgrade

## Next

PR 2 is the actual #46 config portal feature, built on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)