### PR TITLE
feat(hub): config portal — render module configSchema as form (#46)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.18",
+  "version": "0.4.0-rc.19",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/admin-auth.test.ts
+++ b/src/__tests__/admin-auth.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { AdminAuthError, adminAuthErrorResponse, extractBearerToken, requireScope } from "../admin-auth.ts";
+import {
+  AdminAuthError,
+  adminAuthErrorResponse,
+  extractBearerToken,
+  requireScope,
+} from "../admin-auth.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { signAccessToken } from "../jwt-sign.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
@@ -102,12 +107,7 @@ describe("requireScope", () => {
         const token = await mintToken(db, ["vault:read"]);
         let caught: AdminAuthError | null = null;
         try {
-          await requireScope(
-            db,
-            reqWithAuth(`Bearer ${token}`),
-            "parachute:host:admin",
-            ISSUER,
-          );
+          await requireScope(db, reqWithAuth(`Bearer ${token}`), "parachute:host:admin", ISSUER);
         } catch (err) {
           caught = err as AdminAuthError;
         }
@@ -132,12 +132,7 @@ describe("requireScope", () => {
         });
         let caught: AdminAuthError | null = null;
         try {
-          await requireScope(
-            db,
-            reqWithAuth(`Bearer ${token}`),
-            "parachute:host:admin",
-            ISSUER,
-          );
+          await requireScope(db, reqWithAuth(`Bearer ${token}`), "parachute:host:admin", ISSUER);
         } catch (err) {
           caught = err as AdminAuthError;
         }

--- a/src/__tests__/admin-config.test.ts
+++ b/src/__tests__/admin-config.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  configPathFor,
+  discoverConfigurableModules,
+  readModuleConfig,
+  validateAndCoerce,
+  writeModuleConfig,
+} from "../admin-config.ts";
+import type { ConfigSchema, ModuleManifest } from "../module-manifest.ts";
+import type { ServicesManifest } from "../services-manifest.ts";
+
+function tmp(): string {
+  return mkdtempSync(join(tmpdir(), "admin-config-"));
+}
+
+const VAULT_SCHEMA: ConfigSchema = {
+  type: "object",
+  required: ["transcribe_provider"],
+  properties: {
+    transcribe_provider: {
+      type: "string",
+      description: "Speech-to-text backend.",
+      enum: ["openai", "deepgram", "groq"],
+      default: "openai",
+    },
+    max_tags_per_note: { type: "integer", default: 10 },
+    public: { type: "boolean", default: false },
+  },
+};
+
+const VAULT_MANIFEST: ModuleManifest = {
+  name: "vault",
+  manifestName: "parachute-vault",
+  displayName: "Vault",
+  kind: "api",
+  port: 1940,
+  paths: ["/vault"],
+  health: "/health",
+  configSchema: VAULT_SCHEMA,
+};
+
+const NOTES_MANIFEST: ModuleManifest = {
+  name: "notes",
+  manifestName: "parachute-notes",
+  displayName: "Notes",
+  kind: "frontend",
+  port: 1941,
+  paths: ["/"],
+  health: "/health",
+  // No configSchema — should be skipped.
+};
+
+function services(...entries: { name: string; installDir?: string }[]): ServicesManifest {
+  return {
+    services: entries.map((e) => ({
+      name: e.name,
+      port: 1940,
+      paths: ["/"],
+      health: "/health",
+      version: "0.0.0",
+      ...(e.installDir ? { installDir: e.installDir } : {}),
+    })),
+  };
+}
+
+describe("discoverConfigurableModules", () => {
+  test("includes only modules with a configSchema", async () => {
+    const dir = tmp();
+    try {
+      const result = await discoverConfigurableModules({
+        loadServicesManifest: () =>
+          services(
+            { name: "vault", installDir: "/fake/vault" },
+            { name: "notes", installDir: "/fake/notes" },
+          ),
+        configDir: dir,
+        readManifest: async (installDir) => {
+          if (installDir === "/fake/vault") return VAULT_MANIFEST;
+          if (installDir === "/fake/notes") return NOTES_MANIFEST;
+          return null;
+        },
+      });
+      expect(result.map((m) => m.name)).toEqual(["vault"]);
+      const first = result[0]!;
+      expect(first.schema).toBe(VAULT_SCHEMA);
+      expect(first.configPath).toBe(configPathFor(dir, "vault"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("skips entries without an installDir", async () => {
+    const result = await discoverConfigurableModules({
+      loadServicesManifest: () => services({ name: "vault" }),
+      configDir: tmp(),
+      readManifest: async () => VAULT_MANIFEST,
+    });
+    expect(result).toEqual([]);
+  });
+
+  test("skips entries whose manifest fails to read (returns null)", async () => {
+    const result = await discoverConfigurableModules({
+      loadServicesManifest: () => services({ name: "vault", installDir: "/missing" }),
+      configDir: tmp(),
+      readManifest: async () => null,
+    });
+    expect(result).toEqual([]);
+  });
+
+  test("doesn't take down the portal when one manifest throws", async () => {
+    const result = await discoverConfigurableModules({
+      loadServicesManifest: () =>
+        services(
+          { name: "vault", installDir: "/fake/vault" },
+          { name: "rogue", installDir: "/fake/rogue" },
+        ),
+      configDir: tmp(),
+      readManifest: async (installDir) => {
+        if (installDir === "/fake/vault") return VAULT_MANIFEST;
+        throw new Error("malformed module.json");
+      },
+    });
+    expect(result.map((m) => m.name)).toEqual(["vault"]);
+  });
+
+  test("sorts results by displayName", async () => {
+    const aManifest: ModuleManifest = { ...VAULT_MANIFEST, name: "alpha", displayName: "Alpha" };
+    const zManifest: ModuleManifest = { ...VAULT_MANIFEST, name: "omega", displayName: "Omega" };
+    const result = await discoverConfigurableModules({
+      loadServicesManifest: () =>
+        services({ name: "omega", installDir: "/o" }, { name: "alpha", installDir: "/a" }),
+      configDir: tmp(),
+      readManifest: async (d) => (d === "/o" ? zManifest : aManifest),
+    });
+    expect(result.map((m) => m.name)).toEqual(["alpha", "omega"]);
+  });
+});
+
+describe("validateAndCoerce", () => {
+  test("coerces strings, integers, numbers, booleans", () => {
+    const r = validateAndCoerce(
+      {
+        transcribe_provider: "deepgram",
+        max_tags_per_note: "42",
+        public: true,
+      },
+      VAULT_SCHEMA,
+    );
+    expect(r.ok).toBe(true);
+    expect(r.data).toEqual({
+      transcribe_provider: "deepgram",
+      max_tags_per_note: 42,
+      public: true,
+    });
+  });
+
+  test("rejects an integer that is not an integer", () => {
+    const r = validateAndCoerce(
+      { transcribe_provider: "openai", max_tags_per_note: "3.14", public: false },
+      VAULT_SCHEMA,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.errors.max_tags_per_note).toBe("must be an integer");
+  });
+
+  test("rejects values outside the enum", () => {
+    const r = validateAndCoerce(
+      { transcribe_provider: "whisper", max_tags_per_note: "10", public: false },
+      VAULT_SCHEMA,
+    );
+    expect(r.ok).toBe(false);
+    expect(r.errors.transcribe_provider).toContain("must be one of");
+  });
+
+  test("rejects required fields when missing", () => {
+    const r = validateAndCoerce({ public: false }, VAULT_SCHEMA);
+    expect(r.ok).toBe(false);
+    expect(r.errors.transcribe_provider).toBe("required");
+  });
+
+  test("missing optional non-boolean fields are omitted from output", () => {
+    const r = validateAndCoerce({ transcribe_provider: "openai", public: false }, VAULT_SCHEMA);
+    expect(r.ok).toBe(true);
+    expect(r.data).toEqual({ transcribe_provider: "openai", public: false });
+    expect("max_tags_per_note" in (r.data ?? {})).toBe(false);
+  });
+
+  test("missing booleans default to false rather than failing required", () => {
+    const required: ConfigSchema = {
+      type: "object",
+      required: ["public"],
+      properties: { public: { type: "boolean" } },
+    };
+    const r = validateAndCoerce({}, required);
+    expect(r.ok).toBe(true);
+    expect(r.data).toEqual({ public: false });
+  });
+
+  test("number coercion accepts decimals", () => {
+    const schema: ConfigSchema = {
+      type: "object",
+      properties: { ratio: { type: "number" } },
+    };
+    expect(validateAndCoerce({ ratio: "0.25" }, schema).data).toEqual({ ratio: 0.25 });
+    expect(validateAndCoerce({ ratio: "garbage" }, schema).errors.ratio).toBe("must be a number");
+  });
+
+  test("string values pass through verbatim", () => {
+    const schema: ConfigSchema = {
+      type: "object",
+      properties: { motto: { type: "string" } },
+    };
+    const r = validateAndCoerce({ motto: "  whitespace preserved  " }, schema);
+    expect(r.data?.motto).toBe("  whitespace preserved  ");
+  });
+});
+
+describe("readModuleConfig + writeModuleConfig", () => {
+  test("returns {} when the file does not exist", () => {
+    const dir = tmp();
+    try {
+      expect(readModuleConfig(join(dir, "missing.json"))).toEqual({ data: {} });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("round-trips a config object atomically", () => {
+    const dir = tmp();
+    try {
+      const path = join(dir, "vault", "config.json");
+      writeModuleConfig(path, { transcribe_provider: "openai", max_tags_per_note: 10 });
+      expect(existsSync(path)).toBe(true);
+      const { data, parseError } = readModuleConfig(path);
+      expect(parseError).toBeUndefined();
+      expect(data).toEqual({ transcribe_provider: "openai", max_tags_per_note: 10 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("surfaces a parse error without erroring", () => {
+    const dir = tmp();
+    try {
+      const path = join(dir, "config.json");
+      writeFileSync(path, "{not valid json");
+      const r = readModuleConfig(path);
+      expect(r.data).toEqual({});
+      expect(r.parseError).toBeDefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("surfaces a parse error when the file is a JSON array, not object", () => {
+    const dir = tmp();
+    try {
+      const path = join(dir, "config.json");
+      writeFileSync(path, "[]");
+      const r = readModuleConfig(path);
+      expect(r.data).toEqual({});
+      expect(r.parseError).toContain("must contain a JSON object");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("trailing newline preserved on write", () => {
+    const dir = tmp();
+    try {
+      const path = join(dir, "config.json");
+      writeModuleConfig(path, { x: 1 });
+      expect(readFileSync(path, "utf8").endsWith("\n")).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/admin-handlers.test.ts
+++ b/src/__tests__/admin-handlers.test.ts
@@ -1,0 +1,465 @@
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  handleAdminConfigGet,
+  handleAdminConfigPost,
+  handleAdminLoginGet,
+  handleAdminLoginPost,
+} from "../admin-handlers.ts";
+import { CSRF_COOKIE_NAME, CSRF_FIELD_NAME } from "../csrf.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import type { ConfigSchema, ModuleManifest } from "../module-manifest.ts";
+import type { ServicesManifest } from "../services-manifest.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
+import { createUser } from "../users.ts";
+
+const TEST_CSRF = "csrf-handlers-test-token";
+const CSRF_COOKIE = `${CSRF_COOKIE_NAME}=${TEST_CSRF}`;
+
+const VAULT_SCHEMA: ConfigSchema = {
+  type: "object",
+  required: ["transcribe_provider"],
+  properties: {
+    transcribe_provider: {
+      type: "string",
+      description: "Speech-to-text backend.",
+      enum: ["openai", "deepgram", "groq"],
+      default: "openai",
+    },
+    max_tags_per_note: { type: "integer", default: 10 },
+    public: { type: "boolean", default: false },
+  },
+};
+
+const VAULT_MANIFEST: ModuleManifest = {
+  name: "vault",
+  manifestName: "parachute-vault",
+  displayName: "Vault",
+  kind: "api",
+  port: 1940,
+  paths: ["/vault"],
+  health: "/health",
+  configSchema: VAULT_SCHEMA,
+};
+
+function vaultServices(): ServicesManifest {
+  return {
+    services: [
+      {
+        name: "vault",
+        port: 1940,
+        paths: ["/vault"],
+        health: "/health",
+        version: "0.0.0",
+        installDir: "/fake/vault",
+      },
+    ],
+  };
+}
+
+interface Harness {
+  db: Database;
+  configDir: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const configDir = mkdtempSync(join(tmpdir(), "phub-admin-handlers-"));
+  const db = openHubDb(hubDbPath(configDir));
+  return {
+    db,
+    configDir,
+    cleanup: () => {
+      db.close();
+      rmSync(configDir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function cookieForUser(db: Database, username: string, password: string): Promise<string> {
+  const user = await createUser(db, username, password);
+  const session = createSession(db, { userId: user.id });
+  return `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`;
+}
+
+function formBody(values: Record<string, string>): {
+  body: string;
+  headers: Record<string, string>;
+} {
+  const params = new URLSearchParams();
+  for (const [k, v] of Object.entries(values)) params.append(k, v);
+  return {
+    body: params.toString(),
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+  };
+}
+
+function fakeReadManifest(installDir: string): Promise<ModuleManifest | null> {
+  if (installDir === "/fake/vault") return Promise.resolve(VAULT_MANIFEST);
+  return Promise.resolve(null);
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+describe("handleAdminLoginGet", () => {
+  test("renders login form and mints a CSRF cookie when none is present", () => {
+    const req = new Request("http://hub.test/admin/login");
+    const res = handleAdminLoginGet(harness.db, req);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("set-cookie") ?? "").toContain(CSRF_COOKIE_NAME);
+  });
+
+  test("echoes the next= query param into the form", async () => {
+    const req = new Request("http://hub.test/admin/login?next=/admin/config");
+    const res = handleAdminLoginGet(harness.db, req);
+    const html = await res.text();
+    expect(html).toContain('value="/admin/config"');
+  });
+
+  test("rewrites unsafe next= to /admin/config", async () => {
+    const req = new Request("http://hub.test/admin/login?next=https%3A%2F%2Fevil.example%2Fpwn");
+    const res = handleAdminLoginGet(harness.db, req);
+    const html = await res.text();
+    expect(html).toContain('value="/admin/config"');
+    expect(html).not.toContain("evil.example");
+  });
+});
+
+describe("handleAdminLoginPost", () => {
+  test("rejects when CSRF token doesn't match the cookie", async () => {
+    await createUser(harness.db, "admin", "pw");
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: "wrong",
+      username: "admin",
+      password: "pw",
+      next: "/admin/config",
+    });
+    const req = new Request("http://hub.test/admin/login", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAdminLoginPost(harness.db, req);
+    expect(res.status).toBe(400);
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  test("rejects bad credentials with 401 and re-renders login", async () => {
+    await createUser(harness.db, "admin", "correct-pw");
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "admin",
+      password: "wrong",
+      next: "/admin/config",
+    });
+    const req = new Request("http://hub.test/admin/login", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAdminLoginPost(harness.db, req);
+    expect(res.status).toBe(401);
+    expect(await res.text()).toContain("Invalid credentials");
+  });
+
+  test("redirects to next= and sets session cookie on success", async () => {
+    await createUser(harness.db, "admin", "pw");
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "admin",
+      password: "pw",
+      next: "/admin/config",
+    });
+    const req = new Request("http://hub.test/admin/login", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAdminLoginPost(harness.db, req);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/admin/config");
+    expect(res.headers.get("set-cookie") ?? "").toContain("parachute_hub_session=");
+  });
+
+  test("ignores an absolute-URL next= from the form", async () => {
+    await createUser(harness.db, "admin", "pw");
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "admin",
+      password: "pw",
+      next: "https://evil.example/pwn",
+    });
+    const req = new Request("http://hub.test/admin/login", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAdminLoginPost(harness.db, req);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/admin/config");
+  });
+});
+
+describe("handleAdminConfigGet", () => {
+  test("redirects unauthenticated requests to /admin/login", async () => {
+    const req = new Request("http://hub.test/admin/config");
+    const res = await handleAdminConfigGet(harness.db, req);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/admin/login?next=%2Fadmin%2Fconfig");
+  });
+
+  test("renders the empty-state when no module declares a configSchema", async () => {
+    const cookie = await cookieForUser(harness.db, "admin", "pw");
+    const req = new Request("http://hub.test/admin/config", {
+      headers: { cookie },
+    });
+    const res = await handleAdminConfigGet(harness.db, req, {
+      loadServicesManifest: () => ({ services: [] }),
+      configDir: harness.configDir,
+      readManifest: fakeReadManifest,
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("No installed module declares");
+  });
+
+  test("renders one section per configurable module", async () => {
+    const cookie = await cookieForUser(harness.db, "admin", "pw");
+    const req = new Request("http://hub.test/admin/config", {
+      headers: { cookie },
+    });
+    const res = await handleAdminConfigGet(harness.db, req, {
+      loadServicesManifest: vaultServices,
+      configDir: harness.configDir,
+      readManifest: fakeReadManifest,
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('id="module-vault"');
+    expect(html).toContain("transcribe_provider");
+    expect(html).toContain('action="/admin/config/vault"');
+  });
+
+  test("surfaces flash success message after a saved redirect", async () => {
+    const cookie = await cookieForUser(harness.db, "admin", "pw");
+    const req = new Request("http://hub.test/admin/config?_status=saved&_module=vault", {
+      headers: { cookie },
+    });
+    const res = await handleAdminConfigGet(harness.db, req, {
+      loadServicesManifest: vaultServices,
+      configDir: harness.configDir,
+      readManifest: fakeReadManifest,
+    });
+    const html = await res.text();
+    expect(html).toContain("Saved and restarted Vault");
+  });
+});
+
+describe("handleAdminConfigPost", () => {
+  function postBody(values: Record<string, string>) {
+    return formBody({ [CSRF_FIELD_NAME]: TEST_CSRF, ...values });
+  }
+
+  test("redirects unauthenticated requests to /admin/login", async () => {
+    const { body, headers } = postBody({ transcribe_provider: "openai" });
+    const req = new Request("http://hub.test/admin/config/vault", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAdminConfigPost(harness.db, req, "vault", {
+      loadServicesManifest: vaultServices,
+      configDir: harness.configDir,
+      readManifest: fakeReadManifest,
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("/admin/login");
+  });
+
+  test("returns 400 when the CSRF token is wrong", async () => {
+    const cookie = await cookieForUser(harness.db, "admin", "pw");
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: "wrong",
+      transcribe_provider: "openai",
+    });
+    const req = new Request("http://hub.test/admin/config/vault", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAdminConfigPost(harness.db, req, "vault", {
+      loadServicesManifest: vaultServices,
+      configDir: harness.configDir,
+      readManifest: fakeReadManifest,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 404 for unknown module names", async () => {
+    const cookie = await cookieForUser(harness.db, "admin", "pw");
+    const { body, headers } = postBody({});
+    const req = new Request("http://hub.test/admin/config/nope", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAdminConfigPost(harness.db, req, "nope", {
+      loadServicesManifest: vaultServices,
+      configDir: harness.configDir,
+      readManifest: fakeReadManifest,
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("re-renders with field errors (422) when validation fails", async () => {
+    const cookie = await cookieForUser(harness.db, "admin", "pw");
+    const restarts: string[] = [];
+    const { body, headers } = postBody({
+      transcribe_provider: "whisper", // not in enum
+      max_tags_per_note: "10",
+    });
+    const req = new Request("http://hub.test/admin/config/vault", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAdminConfigPost(harness.db, req, "vault", {
+      loadServicesManifest: vaultServices,
+      configDir: harness.configDir,
+      readManifest: fakeReadManifest,
+      restartService: async (name) => {
+        restarts.push(name);
+        return 0;
+      },
+    });
+    expect(res.status).toBe(422);
+    const html = await res.text();
+    expect(html).toContain("must be one of");
+    expect(restarts).toEqual([]); // restart never called
+    // The on-disk config must not have been written.
+    expect(existsSync(join(harness.configDir, "vault", "config.json"))).toBe(false);
+  });
+
+  test("writes config + triggers restart + redirects with saved flash", async () => {
+    const cookie = await cookieForUser(harness.db, "admin", "pw");
+    const restarts: string[] = [];
+    const { body, headers } = postBody({
+      transcribe_provider: "deepgram",
+      max_tags_per_note: "25",
+      // checkbox absent → public stays false
+    });
+    const req = new Request("http://hub.test/admin/config/vault", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAdminConfigPost(harness.db, req, "vault", {
+      loadServicesManifest: vaultServices,
+      configDir: harness.configDir,
+      readManifest: fakeReadManifest,
+      restartService: async (name) => {
+        restarts.push(name);
+        return 0;
+      },
+    });
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("/admin/config?");
+    expect(location).toContain("_status=saved");
+    expect(location).toContain("_module=vault");
+    expect(location).toContain("#module-vault");
+    expect(restarts).toEqual(["vault"]);
+    const written = JSON.parse(
+      readFileSync(join(harness.configDir, "vault", "config.json"), "utf8"),
+    );
+    expect(written).toEqual({
+      transcribe_provider: "deepgram",
+      max_tags_per_note: 25,
+      public: false,
+    });
+  });
+
+  test("flashes saved-restart-failed when the restart returns non-zero", async () => {
+    const cookie = await cookieForUser(harness.db, "admin", "pw");
+    const { body, headers } = postBody({
+      transcribe_provider: "openai",
+      max_tags_per_note: "5",
+    });
+    const req = new Request("http://hub.test/admin/config/vault", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAdminConfigPost(harness.db, req, "vault", {
+      loadServicesManifest: vaultServices,
+      configDir: harness.configDir,
+      readManifest: fakeReadManifest,
+      restartService: async () => 1,
+    });
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("_status=saved-restart-failed");
+    // Config was still written before the restart attempt.
+    expect(existsSync(join(harness.configDir, "vault", "config.json"))).toBe(true);
+  });
+
+  test("flashes saved-restart-failed with err detail when restart throws", async () => {
+    const cookie = await cookieForUser(harness.db, "admin", "pw");
+    const { body, headers } = postBody({
+      transcribe_provider: "openai",
+      max_tags_per_note: "5",
+    });
+    const req = new Request("http://hub.test/admin/config/vault", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAdminConfigPost(harness.db, req, "vault", {
+      loadServicesManifest: vaultServices,
+      configDir: harness.configDir,
+      readManifest: fakeReadManifest,
+      restartService: async () => {
+        throw new Error("launchctl unavailable");
+      },
+    });
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("_status=saved-restart-failed");
+    const errParam = new URL(location, "http://hub.test").searchParams.get("_err") ?? "";
+    expect(errParam).toContain("launchctl unavailable");
+  });
+
+  test("checkbox-on translates to `public: true` in the written config", async () => {
+    const cookie = await cookieForUser(harness.db, "admin", "pw");
+    const { body, headers } = postBody({
+      transcribe_provider: "openai",
+      max_tags_per_note: "5",
+      public: "true",
+    });
+    const req = new Request("http://hub.test/admin/config/vault", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAdminConfigPost(harness.db, req, "vault", {
+      loadServicesManifest: vaultServices,
+      configDir: harness.configDir,
+      readManifest: fakeReadManifest,
+      restartService: async () => 0,
+    });
+    expect(res.status).toBe(302);
+    const written = JSON.parse(
+      readFileSync(join(harness.configDir, "vault", "config.json"), "utf8"),
+    );
+    expect(written.public).toBe(true);
+  });
+});

--- a/src/admin-auth.ts
+++ b/src/admin-auth.ts
@@ -71,7 +71,7 @@ export async function requireScope(
 ): Promise<AdminAuthContext> {
   const token = extractBearerToken(req);
 
-  let validated;
+  let validated: Awaited<ReturnType<typeof validateAccessToken>>;
   try {
     validated = await validateAccessToken(db, token, expectedIssuer);
   } catch (err) {
@@ -84,15 +84,10 @@ export async function requireScope(
 
   const scopeClaim = (validated.payload as { scope?: unknown }).scope;
   const scopes =
-    typeof scopeClaim === "string"
-      ? scopeClaim.split(/\s+/).filter((s) => s.length > 0)
-      : [];
+    typeof scopeClaim === "string" ? scopeClaim.split(/\s+/).filter((s) => s.length > 0) : [];
 
   if (!scopes.includes(requiredScope)) {
-    throw new AdminAuthError(
-      403,
-      `token missing required scope: ${requiredScope}`,
-    );
+    throw new AdminAuthError(403, `token missing required scope: ${requiredScope}`);
   }
 
   const clientIdRaw = (validated.payload as { client_id?: unknown }).client_id;
@@ -110,7 +105,10 @@ export async function requireScope(
 export function adminAuthErrorResponse(err: unknown): Response {
   if (err instanceof AdminAuthError) {
     return new Response(
-      JSON.stringify({ error: err.status === 403 ? "insufficient_scope" : "invalid_token", error_description: err.message }),
+      JSON.stringify({
+        error: err.status === 403 ? "insufficient_scope" : "invalid_token",
+        error_description: err.message,
+      }),
       {
         status: err.status,
         headers: {

--- a/src/admin-config-ui.ts
+++ b/src/admin-config-ui.ts
@@ -1,0 +1,534 @@
+/**
+ * Branded HTML for the hub admin pages — login + config portal (#46). Same
+ * privacy posture as `oauth-ui.ts` (no third-party fonts, inline CSS, no JS),
+ * but laid out wider and quieter — admin pages aren't an authorization
+ * decision, they're a config form. Sharing the brand mark + palette but not
+ * the per-page chrome keeps the visual context distinct ("you're configuring
+ * a module" vs. "you're authorizing an app").
+ *
+ * Pure functions — DB, filesystem, lifecycle live in `admin-handlers.ts`.
+ */
+import { renderCsrfHiddenInput } from "./csrf.ts";
+import type { ConfigSchemaProperty } from "./module-manifest.ts";
+import { escapeHtml } from "./oauth-ui.ts";
+
+import type { ConfigurableModule } from "./admin-config.ts";
+
+// --- shared chrome ---------------------------------------------------------
+
+const PALETTE = {
+  bg: "#faf8f4",
+  bgSoft: "#f3f0ea",
+  fg: "#2c2a26",
+  fgMuted: "#6b6860",
+  fgDim: "#9a9690",
+  accent: "#4a7c59",
+  accentHover: "#3d6849",
+  accentSoft: "rgba(74, 124, 89, 0.08)",
+  border: "#e4e0d8",
+  borderLight: "#ece9e2",
+  cardBg: "#ffffff",
+  danger: "#a3392b",
+  dangerSoft: "rgba(163, 57, 43, 0.08)",
+  success: "#3d6849",
+  successSoft: "rgba(61, 104, 73, 0.08)",
+} as const;
+
+const FONT_SERIF = `Georgia, "Times New Roman", serif`;
+const FONT_SANS = `-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`;
+const FONT_MONO = `ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", monospace`;
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}
+
+function baseDocument(title: string, body: string, layout: "narrow" | "wide" = "narrow"): string {
+  const cls = layout === "wide" ? "main-wide" : "";
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>${escapeHtml(title)}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="referrer" content="no-referrer" />
+  <style>${STYLES}</style>
+</head>
+<body>
+  <main class="${cls}">
+${body}
+  </main>
+</body>
+</html>`;
+}
+
+// --- /admin/login ----------------------------------------------------------
+
+export interface AdminLoginProps {
+  /** Continuation path after successful login — submitted as a hidden field. */
+  next: string;
+  csrfToken: string;
+  errorMessage?: string;
+}
+
+export function renderAdminLogin(props: AdminLoginProps): string {
+  const { next, csrfToken, errorMessage } = props;
+  const error = errorMessage ? `<p class="error-banner">${escapeHtml(errorMessage)}</p>` : "";
+  const body = `
+    <div class="card">
+      <div class="card-header">
+        <div class="brand">
+          <span class="brand-mark">⌬</span>
+          <span class="brand-name">Parachute</span>
+          <span class="brand-tag">admin</span>
+        </div>
+        <h1>Sign in</h1>
+        <p class="subtitle">to administer this hub</p>
+      </div>
+      ${error}
+      <form method="POST" action="/admin/login" class="auth-form">
+        ${renderCsrfHiddenInput(csrfToken)}
+        <input type="hidden" name="next" value="${escapeAttr(next)}" />
+        <label class="field">
+          <span class="field-label">Username</span>
+          <input type="text" name="username" autocomplete="username" autofocus required />
+        </label>
+        <label class="field">
+          <span class="field-label">Password</span>
+          <input type="password" name="password" autocomplete="current-password" required />
+        </label>
+        <button type="submit" class="btn btn-primary">Sign in</button>
+      </form>
+    </div>`;
+  return baseDocument("Sign in to Parachute Hub admin", body);
+}
+
+// --- /admin/config ---------------------------------------------------------
+
+export interface ModuleStatus {
+  /** Top-level error (e.g. config write failed). */
+  errorMessage?: string;
+  /** Per-field errors keyed by property name. */
+  fieldErrors?: Record<string, string>;
+  /** "Saved" / "Saved and restarted" banner. */
+  successMessage?: string;
+  /** Pending values to re-render on validation failure. */
+  pending?: Record<string, string | boolean | undefined>;
+}
+
+export interface AdminConfigModuleView {
+  module: ConfigurableModule;
+  /** Current on-disk values; `validateAndCoerce`-ready (strings/numbers/booleans). */
+  current: Record<string, unknown>;
+  /** Set when config.json existed but couldn't be parsed. */
+  parseError?: string;
+  status?: ModuleStatus;
+}
+
+export interface AdminConfigPageProps {
+  modules: AdminConfigModuleView[];
+  csrfToken: string;
+}
+
+export function renderAdminConfigPage(props: AdminConfigPageProps): string {
+  const { modules, csrfToken } = props;
+  if (modules.length === 0) {
+    const body = `
+    <div class="card admin-empty">
+      ${header()}
+      <h1>Module config</h1>
+      <p class="subtitle">No installed module declares a <code>configSchema</code> in its <code>.parachute/module.json</code>.</p>
+      <p class="empty-hint">
+        Once a module ships an editable config schema, this page will let you tune its values and restart it
+        without leaving the hub. Until then there's nothing to configure here.
+      </p>
+    </div>`;
+    return baseDocument("Module config — Parachute Hub", body);
+  }
+  const sections = modules.map((m) => renderModuleSection(m, csrfToken)).join("\n");
+  const body = `
+    <div class="page-header">
+      ${header()}
+      <h1>Module config</h1>
+      <p class="subtitle">Edit a module's configuration and restart it without leaving the hub.</p>
+    </div>
+    ${sections}`;
+  return baseDocument("Module config — Parachute Hub", body, "wide");
+}
+
+function header(): string {
+  return `
+        <div class="brand">
+          <span class="brand-mark">⌬</span>
+          <span class="brand-name">Parachute</span>
+          <span class="brand-tag">admin</span>
+        </div>`;
+}
+
+function renderModuleSection(view: AdminConfigModuleView, csrfToken: string): string {
+  const { module, current, parseError, status } = view;
+  const action = `/admin/config/${encodeURIComponent(module.name)}`;
+  const banner = renderStatusBanner(status, parseError);
+  const tagline = module.tagline
+    ? `<p class="module-tagline">${escapeHtml(module.tagline)}</p>`
+    : "";
+  const fields = Object.entries(module.schema.properties)
+    .map(([key, prop]) => {
+      const required = (module.schema.required ?? []).includes(key);
+      const error = status?.fieldErrors?.[key];
+      const pending = status?.pending?.[key];
+      const value = pending !== undefined ? pending : current[key];
+      return renderField(key, prop, value, required, error);
+    })
+    .join("\n        ");
+  return `
+    <section class="card module-card" id="module-${escapeAttr(module.name)}">
+      <header class="module-header">
+        <h2 class="module-name">${escapeHtml(module.displayName)}</h2>
+        <code class="module-id">${escapeHtml(module.name)}</code>
+        ${tagline}
+      </header>
+      ${banner}
+      <form method="POST" action="${escapeAttr(action)}" class="config-form">
+        ${renderCsrfHiddenInput(csrfToken)}
+        ${fields}
+        <div class="button-row">
+          <button type="submit" class="btn btn-primary">Save &amp; restart ${escapeHtml(module.displayName)}</button>
+        </div>
+      </form>
+    </section>`;
+}
+
+function renderStatusBanner(
+  status: ModuleStatus | undefined,
+  parseError: string | undefined,
+): string {
+  if (status?.successMessage) {
+    return `<p class="banner banner-success">${escapeHtml(status.successMessage)}</p>`;
+  }
+  if (status?.errorMessage) {
+    return `<p class="banner banner-error">${escapeHtml(status.errorMessage)}</p>`;
+  }
+  if (parseError) {
+    return `<p class="banner banner-warn">Existing <code>config.json</code> couldn't be parsed (${escapeHtml(parseError)}). Submitting will overwrite it with the values below.</p>`;
+  }
+  return "";
+}
+
+function renderField(
+  key: string,
+  prop: ConfigSchemaProperty,
+  current: unknown,
+  required: boolean,
+  error: string | undefined,
+): string {
+  const description = prop.description
+    ? `<span class="field-description">${escapeHtml(prop.description)}</span>`
+    : "";
+  const errorEl = error ? `<span class="field-error">${escapeHtml(error)}</span>` : "";
+  const requiredMark = required ? `<span class="field-required" aria-hidden="true">*</span>` : "";
+  const labelText = `${escapeHtml(key)}${requiredMark}`;
+  const inputHtml = renderInput(key, prop, current);
+  return `<label class="field${error ? " field-has-error" : ""}">
+          <span class="field-label">${labelText}</span>
+          ${description}
+          ${inputHtml}
+          ${errorEl}
+        </label>`;
+}
+
+function renderInput(key: string, prop: ConfigSchemaProperty, current: unknown): string {
+  const name = escapeAttr(key);
+  if (prop.type === "boolean") {
+    const checked = coerceBooleanCurrent(current, prop) ? " checked" : "";
+    return `<span class="checkbox-row">
+            <input type="checkbox" name="${name}" value="true"${checked} />
+            <span class="checkbox-hint">${escapeHtml(prop.description ?? "Enabled when checked.")}</span>
+          </span>`;
+  }
+  if (prop.enum) {
+    const fallback = prop.default ?? prop.enum[0];
+    const selected = current ?? fallback;
+    const options = prop.enum
+      .map((opt) => {
+        const v = String(opt);
+        const isSelected = String(selected) === v ? " selected" : "";
+        return `<option value="${escapeAttr(v)}"${isSelected}>${escapeHtml(v)}</option>`;
+      })
+      .join("");
+    return `<select name="${name}">${options}</select>`;
+  }
+  const inputType = prop.type === "string" ? "text" : "number";
+  const step = prop.type === "integer" ? ' step="1"' : prop.type === "number" ? ' step="any"' : "";
+  const fallback = prop.default;
+  const value = current !== undefined && current !== null ? current : fallback;
+  const valueAttr =
+    value !== undefined && value !== null ? ` value="${escapeAttr(String(value))}"` : "";
+  const placeholder =
+    prop.default !== undefined ? ` placeholder="${escapeAttr(`default: ${prop.default}`)}"` : "";
+  return `<input type="${inputType}" name="${name}"${step}${valueAttr}${placeholder} />`;
+}
+
+function coerceBooleanCurrent(current: unknown, prop: ConfigSchemaProperty): boolean {
+  if (typeof current === "boolean") return current;
+  if (current === undefined || current === null) {
+    return prop.default === true;
+  }
+  if (typeof current === "string") return current === "true";
+  return false;
+}
+
+// --- error page ------------------------------------------------------------
+
+export function renderAdminError(props: { title: string; message: string }): string {
+  const body = `
+    <div class="card">
+      ${header()}
+      <h1 class="error-title">${escapeHtml(props.title)}</h1>
+      <p class="subtitle">${escapeHtml(props.message)}</p>
+    </div>`;
+  return baseDocument(props.title, body);
+}
+
+// --- styles ----------------------------------------------------------------
+
+const STYLES = `
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: ${FONT_SANS};
+    background: ${PALETTE.bg};
+    color: ${PALETTE.fg};
+    line-height: 1.55;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  main {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 1.5rem;
+  }
+  main.main-wide {
+    align-items: flex-start;
+    padding: 2.5rem 1.5rem;
+  }
+  .card {
+    width: 100%;
+    max-width: 30rem;
+    background: ${PALETTE.cardBg};
+    border: 1px solid ${PALETTE.border};
+    border-radius: 12px;
+    padding: 2rem 1.75rem;
+    box-shadow: 0 1px 2px rgba(44, 42, 38, 0.04), 0 8px 24px rgba(44, 42, 38, 0.06);
+  }
+  main.main-wide { flex-direction: column; align-items: center; gap: 1.25rem; }
+  main.main-wide .card { max-width: 42rem; }
+  .page-header {
+    width: 100%;
+    max-width: 42rem;
+    margin-bottom: 0.25rem;
+    padding: 0 0.25rem;
+  }
+  .page-header h1 { font-size: 2rem; }
+  .card-header { margin-bottom: 1.5rem; }
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: ${PALETTE.accent};
+    font-weight: 500;
+    font-size: 0.95rem;
+    margin-bottom: 1.25rem;
+  }
+  .brand-mark { font-size: 1.1rem; line-height: 1; }
+  .brand-name { letter-spacing: 0.01em; }
+  .brand-tag {
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 0.7rem;
+    color: ${PALETTE.fgMuted};
+    border: 1px solid ${PALETTE.borderLight};
+    padding: 0.05rem 0.4rem;
+    border-radius: 999px;
+  }
+  h1 {
+    font-family: ${FONT_SERIF};
+    font-weight: 400;
+    font-size: 1.75rem;
+    line-height: 1.2;
+    margin: 0 0 0.4rem;
+    color: ${PALETTE.fg};
+  }
+  .subtitle { margin: 0; color: ${PALETTE.fgMuted}; font-size: 0.95rem; }
+
+  .auth-form, .config-form { display: flex; flex-direction: column; gap: 0.9rem; }
+  .field { display: flex; flex-direction: column; gap: 0.35rem; }
+  .field-label {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: ${PALETTE.fgMuted};
+    letter-spacing: 0.01em;
+    font-family: ${FONT_MONO};
+  }
+  .field-required { color: ${PALETTE.danger}; margin-left: 0.2rem; }
+  .field-description {
+    font-size: 0.85rem;
+    color: ${PALETTE.fgMuted};
+    line-height: 1.45;
+  }
+  .field-error {
+    font-size: 0.82rem;
+    color: ${PALETTE.danger};
+    font-weight: 500;
+  }
+  .field-has-error input[type=text],
+  .field-has-error input[type=number],
+  .field-has-error select {
+    border-color: ${PALETTE.danger};
+  }
+  input[type=text], input[type=password], input[type=number], select {
+    font: inherit;
+    width: 100%;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid ${PALETTE.border};
+    border-radius: 6px;
+    background: ${PALETTE.bg};
+    color: ${PALETTE.fg};
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  input[type=text]:focus, input[type=password]:focus, input[type=number]:focus, select:focus {
+    outline: none;
+    border-color: ${PALETTE.accent};
+    background: ${PALETTE.cardBg};
+    box-shadow: 0 0 0 3px ${PALETTE.accentSoft};
+  }
+  .checkbox-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.45rem 0;
+  }
+  .checkbox-row input[type=checkbox] { margin-top: 0.2rem; }
+  .checkbox-hint { font-size: 0.85rem; color: ${PALETTE.fgMuted}; }
+
+  .btn {
+    font: inherit;
+    font-weight: 500;
+    padding: 0.65rem 1.25rem;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+    min-height: 2.5rem;
+  }
+  .btn-primary {
+    background: ${PALETTE.accent};
+    color: ${PALETTE.cardBg};
+    margin-top: 0.4rem;
+  }
+  .btn-primary:hover { background: ${PALETTE.accentHover}; }
+  .button-row { display: flex; gap: 0.6rem; margin-top: 0.5rem; }
+
+  .error-banner {
+    background: ${PALETTE.dangerSoft};
+    border: 1px solid ${PALETTE.danger};
+    border-radius: 6px;
+    color: ${PALETTE.danger};
+    padding: 0.6rem 0.8rem;
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+  }
+  .error-title { color: ${PALETTE.danger}; }
+
+  .module-card { padding: 1.5rem 1.5rem 1.75rem; }
+  .module-header { margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid ${PALETTE.borderLight}; }
+  .module-name {
+    font-family: ${FONT_SERIF};
+    font-weight: 400;
+    font-size: 1.4rem;
+    margin: 0 0 0.25rem;
+    color: ${PALETTE.fg};
+  }
+  .module-id {
+    font-family: ${FONT_MONO};
+    font-size: 0.78rem;
+    color: ${PALETTE.fgMuted};
+    background: ${PALETTE.bgSoft};
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+  }
+  .module-tagline {
+    margin: 0.5rem 0 0;
+    color: ${PALETTE.fgMuted};
+    font-size: 0.9rem;
+  }
+
+  .banner {
+    margin: 0 0 1rem;
+    padding: 0.55rem 0.75rem;
+    border-radius: 6px;
+    font-size: 0.88rem;
+  }
+  .banner-success {
+    background: ${PALETTE.successSoft};
+    border: 1px solid ${PALETTE.success};
+    color: ${PALETTE.success};
+  }
+  .banner-error {
+    background: ${PALETTE.dangerSoft};
+    border: 1px solid ${PALETTE.danger};
+    color: ${PALETTE.danger};
+  }
+  .banner-warn {
+    background: ${PALETTE.bgSoft};
+    border: 1px dashed ${PALETTE.fgDim};
+    color: ${PALETTE.fgMuted};
+  }
+  .banner code {
+    font-family: ${FONT_MONO};
+    background: ${PALETTE.cardBg};
+    padding: 0.05rem 0.35rem;
+    border-radius: 4px;
+  }
+
+  .empty-hint {
+    margin-top: 1rem;
+    color: ${PALETTE.fgMuted};
+    font-size: 0.9rem;
+  }
+  .empty-hint code {
+    font-family: ${FONT_MONO};
+    font-size: 0.82rem;
+    background: ${PALETTE.bgSoft};
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+  }
+
+  @media (max-width: 480px) {
+    main { padding: 0.75rem; }
+    main.main-wide { padding: 1rem 0.75rem; }
+    .card { padding: 1.5rem 1.25rem; border-radius: 10px; }
+    h1 { font-size: 1.5rem; }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    body { background: #1a1815; color: #e8e4dc; }
+    .card { background: #25221d; border-color: #3a362f; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3); }
+    h1 { color: #f0ece4; }
+    .subtitle, .field-label, .field-description { color: #a8a29a; }
+    input[type=text], input[type=password], input[type=number], select {
+      background: #1f1c18; border-color: #3a362f; color: #e8e4dc;
+    }
+    input[type=text]:focus, input[type=password]:focus, input[type=number]:focus, select:focus {
+      background: #25221d;
+    }
+    .module-id { background: #1f1c18; color: #a8a29a; }
+    .module-header { border-color: #3a362f; }
+    .empty-hint code { background: #1f1c18; }
+    .banner-warn { background: #1f1c18; }
+    .banner code { background: #1a1815; }
+    .brand-tag { border-color: #3a362f; color: #a8a29a; }
+  }
+`;

--- a/src/admin-config.ts
+++ b/src/admin-config.ts
@@ -1,0 +1,226 @@
+/**
+ * Hub config portal logic (#46) — pure functions over the module manifest +
+ * filesystem. Render-side and HTTP-side helpers live in `admin-config-ui.ts`
+ * and `admin-handlers.ts`; this file is io + validation.
+ *
+ * Design choices:
+ *
+ *   - **JSON-only at v1.** The team-lead's brief covers .env / YAML / TOML
+ *     follow-ups; this commit ships the JSON path so the surface is real
+ *     for at least one module. Each configurable module's values land at
+ *     `<configDir>/<name>/config.json` — the same per-module config dir
+ *     auto-wire and lifecycle already use.
+ *
+ *   - **Skip modules without a `configSchema`.** A module that hasn't
+ *     declared its operator-editable keys gets no card on the portal, no
+ *     empty form. This is the explicit edge case from the brief.
+ *
+ *   - **Atomic writes.** Same `tmp + rename` shape as
+ *     `services-manifest.ts` and `auto-wire.ts` — a crash mid-write must
+ *     not leave a half-truncated config.json next to a running module.
+ *
+ *   - **Validation = coercion + check.** HTML form values arrive as
+ *     strings; `validateAndCoerce` coerces each per its declared type
+ *     (and the `enum` allow-list, when present), reports the first error
+ *     per field, and returns the typed object on success. Booleans
+ *     follow the standard form convention: present (any non-empty value)
+ *     = true, absent = false. Required booleans are accepted as either
+ *     state — required means "the key is in the schema", not "must be
+ *     truthy".
+ */
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  type ConfigSchema,
+  type ConfigSchemaProperty,
+  type ModuleManifest,
+  readModuleManifest,
+} from "./module-manifest.ts";
+import type { ServiceEntry, ServicesManifest } from "./services-manifest.ts";
+
+export interface ConfigurableModule {
+  /** Stable ecosystem name (services.json key, route segment). */
+  name: string;
+  /** Operator-facing label rendered in the portal. */
+  displayName: string;
+  /** One-line subtitle if the manifest provides one. */
+  tagline?: string;
+  /** The validated schema from `.parachute/module.json`. */
+  schema: ConfigSchema;
+  /** Absolute path to `<configDir>/<name>/config.json`. */
+  configPath: string;
+}
+
+export interface DiscoverDeps {
+  /** Resolves installed services (production: `services-manifest.readManifest`). */
+  loadServicesManifest: () => ServicesManifest;
+  /** `~/.parachute` (or `$PARACHUTE_HOME`) — per-module config lives at `<configDir>/<name>/config.json`. */
+  configDir: string;
+  /** Test seam — defaults to `module-manifest.readModuleManifest`. */
+  readManifest?: (installDir: string) => Promise<ModuleManifest | null>;
+}
+
+export function configPathFor(configDir: string, moduleName: string): string {
+  return join(configDir, moduleName, "config.json");
+}
+
+/**
+ * Walk services.json, read each module's `.parachute/module.json` (when its
+ * row carries an `installDir`), keep only those with a `configSchema`. The
+ * result is sorted by `displayName` so the portal renders deterministically.
+ */
+export async function discoverConfigurableModules(
+  deps: DiscoverDeps,
+): Promise<ConfigurableModule[]> {
+  const reader = deps.readManifest ?? readModuleManifest;
+  const manifest = deps.loadServicesManifest();
+  const out: ConfigurableModule[] = [];
+  for (const svc of manifest.services) {
+    const mod = await readModuleFor(svc, reader);
+    if (!mod || !mod.configSchema) continue;
+    const entry: ConfigurableModule = {
+      name: svc.name,
+      displayName: svc.displayName ?? mod.displayName ?? mod.manifestName ?? svc.name,
+      schema: mod.configSchema,
+      configPath: configPathFor(deps.configDir, svc.name),
+    };
+    if (svc.tagline ?? mod.tagline) entry.tagline = svc.tagline ?? mod.tagline;
+    out.push(entry);
+  }
+  out.sort((a, b) => a.displayName.localeCompare(b.displayName));
+  return out;
+}
+
+async function readModuleFor(
+  svc: ServiceEntry,
+  reader: (installDir: string) => Promise<ModuleManifest | null>,
+): Promise<ModuleManifest | null> {
+  if (!svc.installDir) return null;
+  try {
+    return await reader(svc.installDir);
+  } catch {
+    // A malformed third-party manifest shouldn't take down the whole portal —
+    // skip the module and let the operator see the others. Logging the
+    // skip is the lifecycle layer's job; this stays pure.
+    return null;
+  }
+}
+
+/**
+ * Read `<configDir>/<name>/config.json`. Returns `{}` for a missing file,
+ * `{}` for a malformed file (with a `parseError` flag) — the portal renders
+ * defaults for missing keys either way; surfacing parse failures in the UI
+ * without erroring the page lets the operator overwrite a corrupted file.
+ */
+export interface ReadConfigResult {
+  data: Record<string, unknown>;
+  parseError?: string;
+}
+
+export function readModuleConfig(configPath: string): ReadConfigResult {
+  if (!existsSync(configPath)) return { data: {} };
+  let raw: string;
+  try {
+    raw = readFileSync(configPath, "utf8");
+  } catch (err) {
+    return { data: {}, parseError: err instanceof Error ? err.message : String(err) };
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { data: {}, parseError: "config.json must contain a JSON object" };
+    }
+    return { data: parsed as Record<string, unknown> };
+  } catch (err) {
+    return { data: {}, parseError: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Atomic write: tmp file + rename, mkdir -p first. Same pattern as
+ * services-manifest. Trailing newline so the file plays nice with
+ * line-oriented tooling (`wc -l`, diffs).
+ */
+export function writeModuleConfig(configPath: string, data: Record<string, unknown>): void {
+  mkdirSync(dirname(configPath), { recursive: true });
+  const tmp = `${configPath}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, `${JSON.stringify(data, null, 2)}\n`);
+  renameSync(tmp, configPath);
+}
+
+export interface ValidateConfigResult {
+  ok: boolean;
+  /** Field-level errors; empty when ok === true. */
+  errors: Record<string, string>;
+  /** Coerced typed values; populated only when ok === true. */
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Coerce + validate a form-data submission against `schema`. `formValues`
+ * is keyed by property name; checkbox semantics are encoded in the caller
+ * (booleans missing → false). The first failure per field is reported;
+ * once any field fails, `data` is omitted.
+ */
+export function validateAndCoerce(
+  formValues: Record<string, string | boolean | undefined>,
+  schema: ConfigSchema,
+): ValidateConfigResult {
+  const errors: Record<string, string> = {};
+  const data: Record<string, unknown> = {};
+  const required = new Set(schema.required ?? []);
+  for (const [key, prop] of Object.entries(schema.properties)) {
+    const raw = formValues[key];
+    const present = raw !== undefined && raw !== "";
+    if (!present) {
+      if (prop.type === "boolean") {
+        // Booleans are always "present" — checkbox absence = false.
+        data[key] = false;
+        continue;
+      }
+      if (required.has(key)) {
+        errors[key] = "required";
+        continue;
+      }
+      // Missing optional field → omit from output rather than write a null.
+      continue;
+    }
+    const coerced = coerceValue(raw, prop);
+    if ("error" in coerced) {
+      errors[key] = coerced.error;
+      continue;
+    }
+    if (prop.enum && !prop.enum.includes(coerced.value as string | number)) {
+      errors[key] = `must be one of: ${prop.enum.join(", ")}`;
+      continue;
+    }
+    data[key] = coerced.value;
+  }
+  if (Object.keys(errors).length > 0) return { ok: false, errors };
+  return { ok: true, errors, data };
+}
+
+function coerceValue(
+  raw: string | boolean,
+  prop: ConfigSchemaProperty,
+): { value: string | number | boolean } | { error: string } {
+  switch (prop.type) {
+    case "string":
+      return { value: typeof raw === "string" ? raw : String(raw) };
+    case "boolean":
+      if (typeof raw === "boolean") return { value: raw };
+      return { value: raw.length > 0 && raw !== "false" && raw !== "0" };
+    case "number": {
+      const s = typeof raw === "string" ? raw : String(raw);
+      const n = Number(s);
+      if (!Number.isFinite(n)) return { error: "must be a number" };
+      return { value: n };
+    }
+    case "integer": {
+      const s = typeof raw === "string" ? raw : String(raw);
+      const n = Number(s);
+      if (!Number.isFinite(n) || !Number.isInteger(n)) return { error: "must be an integer" };
+      return { value: n };
+    }
+  }
+}

--- a/src/admin-handlers.ts
+++ b/src/admin-handlers.ts
@@ -1,0 +1,334 @@
+/**
+ * HTTP handlers for the hub admin surface — login (`/admin/login`) and the
+ * config portal (`/admin/config`, `/admin/config/<name>`). Sessions ride the
+ * same `parachute_hub_session` cookie that the OAuth login mints, since PR
+ * #112 widened the cookie path from `/oauth/` to `/`.
+ *
+ * Every state-changing POST is double-submit-CSRF protected
+ * (`parachute_hub_csrf` cookie + `__csrf` form field, constant-time compare),
+ * and every authenticated GET issues a 302 to `/admin/login?next=<path>`
+ * when no session is found rather than rendering an inline login form —
+ * keeps each route's intent clean and lets the operator bookmark
+ * `/admin/config` without thinking about state.
+ */
+import type { Database } from "bun:sqlite";
+import {
+  type AdminConfigModuleView,
+  type ModuleStatus,
+  renderAdminConfigPage,
+  renderAdminError,
+  renderAdminLogin,
+} from "./admin-config-ui.ts";
+import {
+  type ConfigurableModule,
+  configPathFor,
+  discoverConfigurableModules,
+  readModuleConfig,
+  validateAndCoerce,
+  writeModuleConfig,
+} from "./admin-config.ts";
+import { restart as lifecycleRestart } from "./commands/lifecycle.ts";
+import { CONFIG_DIR } from "./config.ts";
+import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
+import type { ModuleManifest } from "./module-manifest.ts";
+import {
+  type ServicesManifest,
+  readManifest as readServicesManifest,
+} from "./services-manifest.ts";
+import {
+  SESSION_TTL_MS,
+  buildSessionCookie,
+  createSession,
+  findSession,
+  parseSessionCookie,
+} from "./sessions.ts";
+import { getUserByUsername, verifyPassword } from "./users.ts";
+
+export interface AdminDeps {
+  /** Resolves the installed-services manifest (production: `services-manifest.readManifest`). */
+  loadServicesManifest?: () => ServicesManifest;
+  /** Per-module `.parachute/module.json` reader (production: `module-manifest.readModuleManifest`). */
+  readManifest?: (installDir: string) => Promise<ModuleManifest | null>;
+  /** `~/.parachute` (defaults to `CONFIG_DIR`). Module configs land at `<configDir>/<name>/config.json`. */
+  configDir?: string;
+  /** Test seam — defaults to `commands/lifecycle.restart`. */
+  restartService?: (name: string) => Promise<number>;
+  /** Test seam — defaults to logging to stderr. */
+  log?: (line: string) => void;
+  /** Test seam — defaults to real clock. */
+  now?: () => Date;
+}
+
+function htmlResponse(body: string, status = 200, extra: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/html; charset=utf-8", ...extra },
+  });
+}
+
+function redirect(location: string, extra: Record<string, string> = {}): Response {
+  return new Response(null, { status: 302, headers: { location, ...extra } });
+}
+
+// --- session gate ----------------------------------------------------------
+
+/**
+ * Return the active session for this request, or null. Caller decides what
+ * to do on null — most paths should redirect to `/admin/login?next=<path>`.
+ */
+function activeSession(db: Database, req: Request) {
+  const sid = parseSessionCookie(req.headers.get("cookie"));
+  return sid ? findSession(db, sid) : null;
+}
+
+function loginRedirect(req: Request, extra: Record<string, string> = {}): Response {
+  const url = new URL(req.url);
+  const next = `${url.pathname}${url.search}`;
+  return redirect(`/admin/login?next=${encodeURIComponent(next)}`, extra);
+}
+
+function safeNext(raw: string | null): string {
+  if (!raw) return "/admin/config";
+  // Only allow same-origin paths — never honor an absolute URL or scheme.
+  if (!raw.startsWith("/") || raw.startsWith("//")) return "/admin/config";
+  return raw;
+}
+
+// --- /admin/login ----------------------------------------------------------
+
+export function handleAdminLoginGet(_db: Database, req: Request): Response {
+  const url = new URL(req.url);
+  const next = safeNext(url.searchParams.get("next"));
+  const csrf = ensureCsrfToken(req);
+  const extra: Record<string, string> = csrf.setCookie ? { "set-cookie": csrf.setCookie } : {};
+  return htmlResponse(renderAdminLogin({ next, csrfToken: csrf.token }), 200, extra);
+}
+
+export async function handleAdminLoginPost(db: Database, req: Request): Promise<Response> {
+  const form = await req.formData();
+  const formCsrf = form.get(CSRF_FIELD_NAME);
+  if (!verifyCsrfToken(req, typeof formCsrf === "string" ? formCsrf : null)) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Invalid form submission",
+        message: "The form's CSRF token did not match. Reload the page and try again.",
+      }),
+      400,
+    );
+  }
+  const username = String(form.get("username") ?? "");
+  const password = String(form.get("password") ?? "");
+  const next = safeNext(String(form.get("next") ?? ""));
+  const csrfToken = typeof formCsrf === "string" ? formCsrf : "";
+  if (!username || !password) {
+    return htmlResponse(
+      renderAdminLogin({ next, csrfToken, errorMessage: "Username and password are required." }),
+      400,
+    );
+  }
+  const user = getUserByUsername(db, username);
+  if (!user) {
+    return htmlResponse(
+      renderAdminLogin({ next, csrfToken, errorMessage: "Invalid credentials." }),
+      401,
+    );
+  }
+  const ok = await verifyPassword(user, password);
+  if (!ok) {
+    return htmlResponse(
+      renderAdminLogin({ next, csrfToken, errorMessage: "Invalid credentials." }),
+      401,
+    );
+  }
+  const session = createSession(db, { userId: user.id });
+  const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+  return redirect(next, { "set-cookie": cookie });
+}
+
+// --- /admin/config ---------------------------------------------------------
+
+export async function handleAdminConfigGet(
+  db: Database,
+  req: Request,
+  deps: AdminDeps = {},
+): Promise<Response> {
+  const session = activeSession(db, req);
+  if (!session) return loginRedirect(req);
+
+  const csrf = ensureCsrfToken(req);
+  const setCookieExtra: Record<string, string> = csrf.setCookie
+    ? { "set-cookie": csrf.setCookie }
+    : {};
+
+  const modules = await loadModuleViews(deps);
+  const flash = parseFlash(req);
+  if (flash) applyFlashTo(modules, flash);
+  return htmlResponse(
+    renderAdminConfigPage({ modules, csrfToken: csrf.token }),
+    200,
+    setCookieExtra,
+  );
+}
+
+export async function handleAdminConfigPost(
+  db: Database,
+  req: Request,
+  moduleName: string,
+  deps: AdminDeps = {},
+): Promise<Response> {
+  const session = activeSession(db, req);
+  if (!session) return loginRedirect(req);
+
+  const form = await req.formData();
+  const formCsrf = form.get(CSRF_FIELD_NAME);
+  if (!verifyCsrfToken(req, typeof formCsrf === "string" ? formCsrf : null)) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Invalid form submission",
+        message: "The form's CSRF token did not match. Reload the page and try again.",
+      }),
+      400,
+    );
+  }
+
+  const modules = await discoverConfigurableModules(discoverDeps(deps));
+  const target = modules.find((m) => m.name === moduleName);
+  if (!target) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Unknown module",
+        message: `No installed module named "${moduleName}" declares a config schema on this hub.`,
+      }),
+      404,
+    );
+  }
+
+  const csrfToken = typeof formCsrf === "string" ? formCsrf : "";
+  const submitted = collectFormValues(form, target);
+  const result = validateAndCoerce(submitted, target.schema);
+  if (!result.ok) {
+    return rerenderWithStatus(deps, target, csrfToken, {
+      fieldErrors: result.errors,
+      pending: submitted,
+      errorMessage: "Some fields need attention before this config can be saved.",
+    });
+  }
+
+  try {
+    writeModuleConfig(target.configPath, result.data ?? {});
+  } catch (err) {
+    return rerenderWithStatus(deps, target, csrfToken, {
+      pending: submitted,
+      errorMessage: `Failed to write ${target.configPath}: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
+
+  const restartFn = deps.restartService ?? defaultRestart(deps);
+  let restartCode = 0;
+  try {
+    restartCode = await restartFn(target.name);
+  } catch (err) {
+    return successRedirect(target.name, "saved-restart-failed", err);
+  }
+  if (restartCode !== 0) return successRedirect(target.name, "saved-restart-failed");
+  return successRedirect(target.name, "saved");
+}
+
+function defaultRestart(deps: AdminDeps): (name: string) => Promise<number> {
+  return (name) =>
+    lifecycleRestart(name, {
+      configDir: deps.configDir ?? CONFIG_DIR,
+      log: deps.log,
+    });
+}
+
+function discoverDeps(deps: AdminDeps) {
+  const out: Parameters<typeof discoverConfigurableModules>[0] = {
+    loadServicesManifest: deps.loadServicesManifest ?? readServicesManifest,
+    configDir: deps.configDir ?? CONFIG_DIR,
+  };
+  if (deps.readManifest) out.readManifest = deps.readManifest;
+  return out;
+}
+
+async function loadModuleViews(deps: AdminDeps): Promise<AdminConfigModuleView[]> {
+  const modules = await discoverConfigurableModules(discoverDeps(deps));
+  return modules.map((module) => {
+    const { data, parseError } = readModuleConfig(module.configPath);
+    const view: AdminConfigModuleView = { module, current: data };
+    if (parseError) view.parseError = parseError;
+    return view;
+  });
+}
+
+function collectFormValues(
+  form: Awaited<ReturnType<Request["formData"]>>,
+  module: ConfigurableModule,
+): Record<string, string | boolean | undefined> {
+  const out: Record<string, string | boolean | undefined> = {};
+  for (const [key, prop] of Object.entries(module.schema.properties)) {
+    if (prop.type === "boolean") {
+      // Unchecked checkboxes don't appear in form data — absence = false.
+      out[key] = form.has(key);
+      continue;
+    }
+    const v = form.get(key);
+    out[key] = typeof v === "string" ? v : undefined;
+  }
+  return out;
+}
+
+// --- flash + redirect helpers ---------------------------------------------
+
+const FLASH_PARAM = "_status";
+const FLASH_MODULE_PARAM = "_module";
+
+function successRedirect(moduleName: string, status: string, err?: unknown): Response {
+  const target = new URL("/admin/config", "http://placeholder");
+  target.searchParams.set(FLASH_PARAM, status);
+  target.searchParams.set(FLASH_MODULE_PARAM, moduleName);
+  if (err) target.searchParams.set("_err", err instanceof Error ? err.message : String(err));
+  target.hash = `module-${moduleName}`;
+  return redirect(`${target.pathname}${target.search}${target.hash}`);
+}
+
+function parseFlash(req: Request): { module: string; status: string; errMessage?: string } | null {
+  const url = new URL(req.url);
+  const status = url.searchParams.get(FLASH_PARAM);
+  const mod = url.searchParams.get(FLASH_MODULE_PARAM);
+  if (!status || !mod) return null;
+  const errMessage = url.searchParams.get("_err") ?? undefined;
+  const out: { module: string; status: string; errMessage?: string } = { module: mod, status };
+  if (errMessage) out.errMessage = errMessage;
+  return out;
+}
+
+function applyFlashTo(
+  views: AdminConfigModuleView[],
+  flash: { module: string; status: string; errMessage?: string },
+): void {
+  const view = views.find((v) => v.module.name === flash.module);
+  if (!view) return;
+  if (flash.status === "saved") {
+    view.status = { successMessage: `Saved and restarted ${view.module.displayName}.` };
+    return;
+  }
+  if (flash.status === "saved-restart-failed") {
+    const tail = flash.errMessage ? ` (${flash.errMessage})` : "";
+    view.status = {
+      errorMessage: `Saved ${view.module.displayName} config but the restart did not succeed${tail}. Run \`parachute restart ${view.module.name}\` and check logs.`,
+    };
+  }
+}
+
+async function rerenderWithStatus(
+  deps: AdminDeps,
+  target: ConfigurableModule,
+  csrfToken: string,
+  status: ModuleStatus,
+): Promise<Response> {
+  const views = await loadModuleViews(deps);
+  const view = views.find((v) => v.module.name === target.name);
+  if (view) view.status = status;
+  return htmlResponse(renderAdminConfigPage({ modules: views, csrfToken }), 422);
+}

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -36,6 +36,12 @@
 import type { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
+import {
+  handleAdminConfigGet,
+  handleAdminConfigPost,
+  handleAdminLoginGet,
+  handleAdminLoginPost,
+} from "./admin-handlers.ts";
 import { handleCreateVault } from "./admin-vaults.ts";
 import { hubDbPath, openHubDb } from "./hub-db.ts";
 import { pemToJwk } from "./jwks.ts";
@@ -246,6 +252,29 @@ export function hubFetch(
         db: getDb(),
         issuer: oauthDeps(req).issuer,
       });
+    }
+
+    if (pathname === "/admin/login") {
+      if (!getDb) return new Response("hub db not configured", { status: 503 });
+      if (req.method === "GET") return handleAdminLoginGet(getDb(), req);
+      if (req.method === "POST") return handleAdminLoginPost(getDb(), req);
+      return new Response("method not allowed", { status: 405 });
+    }
+
+    if (pathname === "/admin/config") {
+      if (!getDb) return new Response("hub db not configured", { status: 503 });
+      if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
+      return handleAdminConfigGet(getDb(), req);
+    }
+
+    if (pathname.startsWith("/admin/config/")) {
+      if (!getDb) return new Response("hub db not configured", { status: 503 });
+      if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+      const name = decodeURIComponent(pathname.slice("/admin/config/".length));
+      if (!name || name.includes("/")) {
+        return new Response("not found", { status: 404 });
+      }
+      return handleAdminConfigPost(getDb(), req, name);
     }
 
     return new Response("not found", { status: 404 });

--- a/src/module-manifest.ts
+++ b/src/module-manifest.ts
@@ -38,6 +38,35 @@ export interface ModuleDependency {
   readonly scopes?: readonly string[];
 }
 
+/**
+ * Subset of JSON Schema understood by the hub config portal (#46). Author-
+ * controlled: each module declares the keys an operator can edit and the
+ * type/constraints on each. The portal renders a form from this declaration,
+ * validates+coerces submits against it, and writes the result to
+ * `<configDir>/<name>/config.json`.
+ *
+ * Intentionally narrow at v1 — flat string/number/integer/boolean keys, with
+ * optional `enum` and `default`. Nested objects, arrays, oneOf, allOf, $ref
+ * are deferred until a concrete module asks for them.
+ */
+export type ConfigPropertyType = "string" | "number" | "integer" | "boolean";
+
+export interface ConfigSchemaProperty {
+  readonly type: ConfigPropertyType;
+  /** Operator-facing label rendered next to the input. */
+  readonly description?: string;
+  /** Pre-fill value when no config.json exists yet. */
+  readonly default?: string | number | boolean;
+  /** Restrict to a fixed set; rendered as a `<select>`. Only meaningful for string/number/integer. */
+  readonly enum?: readonly (string | number)[];
+}
+
+export interface ConfigSchema {
+  readonly type: "object";
+  readonly properties: Record<string, ConfigSchemaProperty>;
+  readonly required?: readonly string[];
+}
+
 export interface ModuleManifest {
   /** Stable ecosystem identifier — `[a-z][a-z0-9-]*`, also the services.json key. */
   readonly name: string;
@@ -62,6 +91,14 @@ export interface ModuleManifest {
   readonly scopes?: ModuleScopeBlock;
   /** Auto-wire targets — see service-to-service-auth.md. */
   readonly dependencies?: Record<string, ModuleDependency>;
+  /**
+   * Operator-editable config keys — see hub#46 + this file's `ConfigSchema`.
+   * When present, the hub config portal renders a form for these keys and
+   * writes the submitted values to `<configDir>/<name>/config.json` (JSON-only
+   * at v1 — modules using `.env`/YAML/TOML are deferred). When absent, the
+   * portal skips the module rather than rendering an empty form.
+   */
+  readonly configSchema?: ConfigSchema;
 }
 
 export class ModuleManifestError extends Error {
@@ -122,6 +159,108 @@ function asScopes(v: unknown, where: string): ModuleScopeBlock | undefined {
   const defines = (v as Record<string, unknown>).defines;
   if (defines === undefined) return {};
   return { defines: asStringArray(defines, where, "scopes.defines") };
+}
+
+const CONFIG_PROPERTY_TYPES = new Set<ConfigPropertyType>([
+  "string",
+  "number",
+  "integer",
+  "boolean",
+]);
+
+function asConfigSchemaProperty(v: unknown, where: string, field: string): ConfigSchemaProperty {
+  if (!v || typeof v !== "object" || Array.isArray(v)) {
+    throw new ModuleManifestError(`${where}: "${field}" must be an object`);
+  }
+  const p = v as Record<string, unknown>;
+  if (typeof p.type !== "string" || !CONFIG_PROPERTY_TYPES.has(p.type as ConfigPropertyType)) {
+    throw new ModuleManifestError(
+      `${where}: "${field}.type" must be one of "string" | "number" | "integer" | "boolean"`,
+    );
+  }
+  const type = p.type as ConfigPropertyType;
+  const out: ConfigSchemaProperty = { type };
+  if (p.description !== undefined) {
+    if (typeof p.description !== "string") {
+      throw new ModuleManifestError(`${where}: "${field}.description" must be a string if present`);
+    }
+    (out as { description?: string }).description = p.description;
+  }
+  if (p.default !== undefined) {
+    const t = typeof p.default;
+    if (t !== "string" && t !== "number" && t !== "boolean") {
+      throw new ModuleManifestError(
+        `${where}: "${field}.default" must be string | number | boolean if present`,
+      );
+    }
+    (out as { default?: string | number | boolean }).default = p.default as
+      | string
+      | number
+      | boolean;
+  }
+  if (p.enum !== undefined) {
+    if (!Array.isArray(p.enum) || p.enum.length === 0) {
+      throw new ModuleManifestError(
+        `${where}: "${field}.enum" must be a non-empty array if present`,
+      );
+    }
+    if (type === "boolean") {
+      throw new ModuleManifestError(`${where}: "${field}.enum" is not meaningful for boolean type`);
+    }
+    for (const v of p.enum) {
+      const t = typeof v;
+      if (type === "string" && t !== "string") {
+        throw new ModuleManifestError(
+          `${where}: "${field}.enum" entries must be strings when type is "string"`,
+        );
+      }
+      if ((type === "number" || type === "integer") && t !== "number") {
+        throw new ModuleManifestError(
+          `${where}: "${field}.enum" entries must be numbers when type is "${type}"`,
+        );
+      }
+      if (type === "integer" && !Number.isInteger(v)) {
+        throw new ModuleManifestError(
+          `${where}: "${field}.enum" entries must be integers when type is "integer"`,
+        );
+      }
+    }
+    (out as { enum?: readonly (string | number)[] }).enum = p.enum as readonly (string | number)[];
+  }
+  return out;
+}
+
+function asConfigSchema(v: unknown, where: string): ConfigSchema | undefined {
+  if (v === undefined) return undefined;
+  if (!v || typeof v !== "object" || Array.isArray(v)) {
+    throw new ModuleManifestError(`${where}: "configSchema" must be an object if present`);
+  }
+  const s = v as Record<string, unknown>;
+  if (s.type !== "object") {
+    throw new ModuleManifestError(`${where}: "configSchema.type" must be "object"`);
+  }
+  if (!s.properties || typeof s.properties !== "object" || Array.isArray(s.properties)) {
+    throw new ModuleManifestError(`${where}: "configSchema.properties" must be an object`);
+  }
+  const propsRaw = s.properties as Record<string, unknown>;
+  const properties: Record<string, ConfigSchemaProperty> = {};
+  for (const [k, raw] of Object.entries(propsRaw)) {
+    properties[k] = asConfigSchemaProperty(raw, where, `configSchema.properties.${k}`);
+  }
+  let required: readonly string[] | undefined;
+  if (s.required !== undefined) {
+    required = asStringArray(s.required, where, "configSchema.required");
+    for (const r of required) {
+      if (!properties[r]) {
+        throw new ModuleManifestError(
+          `${where}: "configSchema.required" names "${r}" but it is not declared in "properties"`,
+        );
+      }
+    }
+  }
+  const out: ConfigSchema = { type: "object", properties };
+  if (required !== undefined) (out as { required?: readonly string[] }).required = required;
+  return out;
 }
 
 function asDependencies(v: unknown, where: string): Record<string, ModuleDependency> | undefined {
@@ -209,6 +348,7 @@ export function validateModuleManifest(raw: unknown, where: string): ModuleManif
   }
 
   const dependencies = asDependencies(m.dependencies, where);
+  const configSchema = asConfigSchema(m.configSchema, where);
 
   const out: ModuleManifest = { name, manifestName, kind, port, paths, health };
   if (displayName !== undefined) (out as { displayName?: string }).displayName = displayName;
@@ -217,6 +357,9 @@ export function validateModuleManifest(raw: unknown, where: string): ModuleManif
   if (scopes !== undefined) (out as { scopes?: ModuleScopeBlock }).scopes = scopes;
   if (dependencies !== undefined) {
     (out as { dependencies?: Record<string, ModuleDependency> }).dependencies = dependencies;
+  }
+  if (configSchema !== undefined) {
+    (out as { configSchema?: ConfigSchema }).configSchema = configSchema;
   }
   return out;
 }


### PR DESCRIPTION
## Summary

- Adds `/admin/config` (and `/admin/login`): one form per installed module that declares a `configSchema` in its `.parachute/module.json`. Submit writes JSON to `<configDir>/<name>/config.json` and triggers a lifecycle restart, all without leaving the page.
- Extends `module-manifest.ts` with a narrow JSON-Schema-subset (`string` / `number` / `integer` / `boolean`, with optional `enum` + `default` + `required`). Validator + types ride alongside the existing manifest validators.
- Pure logic in `admin-config.ts` (discovery, atomic file IO, coerce-and-validate); rendering in `admin-config-ui.ts` (no JS, no external fonts, dark-mode-aware, matches the OAuth admin palette); handlers in `admin-handlers.ts` (session-gated, double-submit-CSRF protected, flash-message redirect on success).
- Modules without a `configSchema` are skipped per the brief — no empty form. JSON-only at v1; `.env` / YAML / TOML are explicit follow-ups.

## Auth model

Sessions ride the existing `parachute_hub_session` cookie that PR #112 widened to `Path=/`; state-changing POSTs require a matching `parachute_hub_csrf` double-submit token (also from #112). Unauthenticated requests 302 to `/admin/login?next=<path>` rather than rendering an inline form, so each route stays single-intent and the operator can bookmark `/admin/config`.

## Drive-by

`src/admin-auth.ts:74` — added a type annotation to a `let validated;` declaration so biome's `noImplicitAnyLet` rule passes. It was the only outstanding lint error on `main` and was blocking this PR's lint gate.

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors
- [x] `bun test` — 800 pass, 0 fail (37 new across `admin-config.test.ts` + `admin-handlers.test.ts`)
- [x] Tests cover the brief's three scenarios:
  - schema-rendering happy path (handler-level, asserts `id="module-vault"` + per-property inputs)
  - type-mismatch validation (rejects integer `"3.14"`, rejects out-of-enum value, no file written, no restart called)
  - module-restart triggered (asserts the `restartService` test seam was called with the module name; asserts disk file contains the coerced typed values)
- [ ] Manual smoke deferred to merge — first real consumer of `configSchema` is the next module to declare one (vault is the obvious candidate).

## Follow-ups

- Document the `configSchema` field in [`parachute-patterns/patterns/module-protocol.md`](https://github.com/ParachuteComputer/parachute-patterns) — currently described only inline in the type doc-comment.
- Validator tests for `asConfigSchema` / `asConfigSchemaProperty` in `module-manifest.test.ts` (currently exercised transitively via `admin-config.test.ts`).
- `.env` / YAML / TOML config writers — same `configSchema` declaration, different on-disk format. Each module declares its preferred format.
- Hot-reload signal (e.g. `SIGHUP`) as an alternative to stop+start, for modules that support it.
- Add a "view raw config.json" link per module for operators who want to confirm what the form is about to overwrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)