### PR TITLE
fix(oauth): pre-launch rotation hardening (#107 + #108)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.19",
+  "version": "0.4.0-rc.20",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/jwt-sign.test.ts
+++ b/src/__tests__/jwt-sign.test.ts
@@ -201,6 +201,57 @@ describe("signRefreshToken", () => {
     }
   });
 
+  test("when wrapped in db.transaction() the UPDATE rolls back on INSERT failure (#107)", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "owner", "pw");
+      // Seed the row that simulates the pre-rotation refresh token.
+      signRefreshToken(db, {
+        jti: "old-jti",
+        userId: u.id,
+        clientId: "c",
+        scopes: [],
+      });
+      // Pre-insert a row at the new jti so the rotation INSERT will collide.
+      signRefreshToken(db, {
+        jti: "new-jti",
+        userId: u.id,
+        clientId: "c",
+        scopes: [],
+      });
+
+      // Mirror the rotation: revoke old + insert new, atomically.
+      let caught: unknown;
+      try {
+        db.transaction(() => {
+          db.prepare("UPDATE tokens SET revoked_at = ? WHERE jti = ?").run(
+            new Date().toISOString(),
+            "old-jti",
+          );
+          signRefreshToken(db, {
+            jti: "new-jti",
+            userId: u.id,
+            clientId: "c",
+            scopes: [],
+          });
+        })();
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(RefreshTokenInsertError);
+
+      // The UPDATE on "old-jti" must have been rolled back: the row
+      // is still active, so the legitimate client can retry the refresh.
+      const row = db
+        .query<{ revoked_at: string | null }, [string]>(
+          "SELECT revoked_at FROM tokens WHERE jti = ?",
+        )
+        .get("old-jti");
+      expect(row?.revoked_at).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
 });
 
 describe("findRefreshToken", () => {

--- a/src/__tests__/jwt-sign.test.ts
+++ b/src/__tests__/jwt-sign.test.ts
@@ -7,6 +7,7 @@ import { hubDbPath, openHubDb } from "../hub-db.ts";
 import {
   ACCESS_TOKEN_TTL_SECONDS,
   REFRESH_TOKEN_TTL_MS,
+  RefreshTokenInsertError,
   findRefreshToken,
   signAccessToken,
   signRefreshToken,
@@ -171,6 +172,35 @@ describe("signRefreshToken", () => {
       cleanup();
     }
   });
+
+  test("throws RefreshTokenInsertError on UNIQUE jti collision (#108)", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "owner", "pw");
+      signRefreshToken(db, {
+        jti: "duplicate-jti",
+        userId: u.id,
+        clientId: "c",
+        scopes: [],
+      });
+      let caught: unknown;
+      try {
+        signRefreshToken(db, {
+          jti: "duplicate-jti",
+          userId: u.id,
+          clientId: "c",
+          scopes: [],
+        });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(RefreshTokenInsertError);
+      expect((caught as RefreshTokenInsertError).cause).toBeDefined();
+    } finally {
+      cleanup();
+    }
+  });
+
 });
 
 describe("findRefreshToken", () => {

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -114,25 +114,48 @@ export interface SignedRefreshToken {
   expiresAt: string;
 }
 
+/**
+ * Thrown when the `tokens` row INSERT fails — most plausibly a UNIQUE jti
+ * collision caused by a concurrent rotation racing on the same prior refresh
+ * token. Callers in the OAuth grant path catch this and surface a clean
+ * `invalid_grant` 400 instead of letting the SQLite error bubble as a 500
+ * (#108).
+ */
+export class RefreshTokenInsertError extends Error {
+  override name = "RefreshTokenInsertError";
+  override cause: unknown;
+  constructor(message: string, cause: unknown) {
+    super(message);
+    this.cause = cause;
+  }
+}
+
 export function signRefreshToken(db: Database, opts: SignRefreshTokenOpts): SignedRefreshToken {
   const token = randomBytes(32).toString("base64url");
   const refreshTokenHash = createHash("sha256").update(token).digest("hex");
   const now = opts.now?.() ?? new Date();
   const expiresAt = new Date(now.getTime() + REFRESH_TOKEN_TTL_MS).toISOString();
   const familyId = opts.familyId ?? randomUUID();
-  db.prepare(
-    `INSERT INTO tokens (jti, user_id, client_id, scopes, refresh_token_hash, family_id, expires_at, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    opts.jti,
-    opts.userId,
-    opts.clientId,
-    opts.scopes.join(" "),
-    refreshTokenHash,
-    familyId,
-    expiresAt,
-    now.toISOString(),
-  );
+  try {
+    db.prepare(
+      `INSERT INTO tokens (jti, user_id, client_id, scopes, refresh_token_hash, family_id, expires_at, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      opts.jti,
+      opts.userId,
+      opts.clientId,
+      opts.scopes.join(" "),
+      refreshTokenHash,
+      familyId,
+      expiresAt,
+      now.toISOString(),
+    );
+  } catch (err) {
+    throw new RefreshTokenInsertError(
+      `failed to insert refresh token row: ${err instanceof Error ? err.message : String(err)}`,
+      err,
+    );
+  }
   return { token, refreshTokenHash, familyId, expiresAt };
 }
 

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -44,6 +44,7 @@ import {
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
 import {
   ACCESS_TOKEN_TTL_SECONDS,
+  RefreshTokenInsertError,
   findRefreshToken,
   findTokenRowByJti,
   revokeFamily,
@@ -843,7 +844,14 @@ async function handleTokenRefresh(
   // Rotate: revoke the old refresh row, mint a new access + refresh pair
   // bound to the same family so a future replay of *any* descendant can
   // walk the chain.
-  db.prepare("UPDATE tokens SET revoked_at = ? WHERE jti = ?").run(now.toISOString(), row.jti);
+  //
+  // Mint the access token *before* opening the rotation transaction. JWT
+  // signing is async (jose returns a Promise) and bun:sqlite's
+  // `db.transaction()` is sync — running async work inside the closure
+  // would silently break atomicity. Once we have the JWT, the UPDATE
+  // (revoke old) + INSERT (mint new refresh row) commit or roll back as
+  // a unit, so a mid-rotation crash can't dead-old-without-replacement
+  // (#107).
   const audience = inferAudience(row.scopes);
   const access = await signAccessToken(db, {
     sub: row.userId,
@@ -853,14 +861,34 @@ async function handleTokenRefresh(
     issuer: deps.issuer,
     now: deps.now,
   });
-  const refresh = signRefreshToken(db, {
-    jti: access.jti,
-    userId: row.userId,
-    clientId: row.clientId,
-    scopes: row.scopes,
-    familyId: row.familyId,
-    now: deps.now,
-  });
+  let refresh: ReturnType<typeof signRefreshToken>;
+  try {
+    refresh = db.transaction(() => {
+      db.prepare("UPDATE tokens SET revoked_at = ? WHERE jti = ?").run(now.toISOString(), row.jti);
+      return signRefreshToken(db, {
+        jti: access.jti,
+        userId: row.userId,
+        clientId: row.clientId,
+        scopes: row.scopes,
+        familyId: row.familyId,
+        now: deps.now,
+      });
+    })();
+  } catch (err) {
+    // Concurrent rotation: a sibling refresh of the same row already
+    // committed and ours collides on the `tokens.jti` PRIMARY KEY (or any
+    // other INSERT-time DB error). Surface a clean `invalid_grant` 400 —
+    // RFC 6749 §5.2 — instead of letting the SQLite error bubble as a 500
+    // (#108). The transaction is already rolled back at this point, so
+    // the row's revoked_at is unchanged for the losing request.
+    if (err instanceof RefreshTokenInsertError) {
+      return jsonResponse(
+        { error: "invalid_grant", error_description: "refresh_token rotation conflict" },
+        400,
+      );
+    }
+    throw err;
+  }
   const services = buildServicesCatalog(
     (deps.loadServicesManifest ?? readServicesManifest)(),
     deps.issuer,


### PR DESCRIPTION
## Summary

Pre-launch security hardening for refresh-token rotation. Two coupled
correctness bugs filed during PR #106 review, both with user-visible
failure modes.

- **#107 — atomicity** — `handleTokenRefresh` was: (1) UPDATE old token
  revoked_at, (2) `await signAccessToken`, (3) INSERT new refresh row.
  A crash between (1) and (3) silently locks the user out: the old
  token is dead and no replacement exists. Fix: pull `signAccessToken`
  out before the DB writes (it's async; `db.transaction()` is sync) and
  wrap UPDATE+INSERT in a single transaction so a partial commit can't
  happen.
- **#108 — clean 400 on conflict** — A failed rotation INSERT (UNIQUE
  collision from a concurrent rotation, or any DB error) bubbled as a
  500. RFC 6749 §5.2 says one rotation should win and the other should
  get `invalid_grant`. Fix: typed `RefreshTokenInsertError` from
  `signRefreshToken`; rotation handler maps it to `invalid_grant` 400.
  Atomicity from #107 ensures the loser's UPDATE rolls back, so the
  legitimate client can retry with the winning new token.

Per-issue commits. `0.4.0-rc.19 → rc.20` per governance (rc.N before
`@latest`).

## Test plan
- [x] `bun test` — 802 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] New unit test: `signRefreshToken` throws `RefreshTokenInsertError`
      on UNIQUE jti collision (#108).
- [x] New unit test: when wrapped in `db.transaction()`, the UPDATE
      rolls back on INSERT failure — old row stays active (#107).
- [x] Existing rotation tests still pass — golden path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)