### PR TITLE
chore: pre-launch nit cleanup bundle (#102, #109, #111, #113)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.20",
+  "version": "0.4.0-rc.21",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/admin-handlers.test.ts
+++ b/src/__tests__/admin-handlers.test.ts
@@ -8,12 +8,18 @@ import {
   handleAdminConfigPost,
   handleAdminLoginGet,
   handleAdminLoginPost,
+  handleAdminLogoutPost,
 } from "../admin-handlers.ts";
 import { CSRF_COOKIE_NAME, CSRF_FIELD_NAME } from "../csrf.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import type { ConfigSchema, ModuleManifest } from "../module-manifest.ts";
 import type { ServicesManifest } from "../services-manifest.ts";
-import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
+import {
+  SESSION_TTL_MS,
+  buildSessionCookie,
+  createSession,
+  findSession,
+} from "../sessions.ts";
 import { createUser } from "../users.ts";
 
 const TEST_CSRF = "csrf-handlers-test-token";
@@ -132,6 +138,24 @@ describe("handleAdminLoginGet", () => {
     expect(html).toContain('value="/admin/config"');
     expect(html).not.toContain("evil.example");
   });
+
+  test("hidden __csrf input value matches the freshly-minted cookie value (#113)", async () => {
+    const req = new Request("http://hub.test/admin/login");
+    const res = handleAdminLoginGet(harness.db, req);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    const cookieMatch = setCookie.match(
+      new RegExp(`${CSRF_COOKIE_NAME}=([A-Za-z0-9_-]+)`),
+    );
+    expect(cookieMatch).not.toBeNull();
+    const cookieToken = cookieMatch?.[1] ?? "";
+    expect(cookieToken.length).toBeGreaterThan(0);
+    const html = await res.text();
+    const formMatch = html.match(
+      new RegExp(`name="${CSRF_FIELD_NAME}" value="([^"]+)"`),
+    );
+    expect(formMatch).not.toBeNull();
+    expect(formMatch?.[1]).toBe(cookieToken);
+  });
 });
 
 describe("handleAdminLoginPost", () => {
@@ -206,6 +230,56 @@ describe("handleAdminLoginPost", () => {
     const res = await handleAdminLoginPost(harness.db, req);
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe("/admin/config");
+  });
+});
+
+describe("handleAdminLogoutPost (#113)", () => {
+  test("rejects when CSRF token doesn't match the cookie", async () => {
+    const cookie = await cookieForUser(harness.db, "admin", "pw");
+    const { body, headers } = formBody({ [CSRF_FIELD_NAME]: "wrong" });
+    const req = new Request("http://hub.test/admin/logout", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAdminLogoutPost(harness.db, req);
+    expect(res.status).toBe(400);
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  test("clears session cookie, deletes session row, and redirects to /admin/login", async () => {
+    const user = await createUser(harness.db, "admin", "pw");
+    const session = createSession(harness.db, { userId: user.id });
+    const cookie = `${CSRF_COOKIE}; ${buildSessionCookie(
+      session.id,
+      Math.floor(SESSION_TTL_MS / 1000),
+    )}`;
+    const { body, headers } = formBody({ [CSRF_FIELD_NAME]: TEST_CSRF });
+    const req = new Request("http://hub.test/admin/logout", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAdminLogoutPost(harness.db, req);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/admin/login");
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("parachute_hub_session=;");
+    expect(setCookie).toContain("Max-Age=0");
+    expect(findSession(harness.db, session.id)).toBeNull();
+  });
+
+  test("idempotent — clears cookie even with no active session", async () => {
+    const { body, headers } = formBody({ [CSRF_FIELD_NAME]: TEST_CSRF });
+    const req = new Request("http://hub.test/admin/logout", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAdminLogoutPost(harness.db, req);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/admin/login");
+    expect(res.headers.get("set-cookie") ?? "").toContain("parachute_hub_session=;");
   });
 });
 

--- a/src/__tests__/admin-handlers.test.ts
+++ b/src/__tests__/admin-handlers.test.ts
@@ -14,12 +14,7 @@ import { CSRF_COOKIE_NAME, CSRF_FIELD_NAME } from "../csrf.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import type { ConfigSchema, ModuleManifest } from "../module-manifest.ts";
 import type { ServicesManifest } from "../services-manifest.ts";
-import {
-  SESSION_TTL_MS,
-  buildSessionCookie,
-  createSession,
-  findSession,
-} from "../sessions.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession, findSession } from "../sessions.ts";
 import { createUser } from "../users.ts";
 
 const TEST_CSRF = "csrf-handlers-test-token";
@@ -143,16 +138,12 @@ describe("handleAdminLoginGet", () => {
     const req = new Request("http://hub.test/admin/login");
     const res = handleAdminLoginGet(harness.db, req);
     const setCookie = res.headers.get("set-cookie") ?? "";
-    const cookieMatch = setCookie.match(
-      new RegExp(`${CSRF_COOKIE_NAME}=([A-Za-z0-9_-]+)`),
-    );
+    const cookieMatch = setCookie.match(new RegExp(`${CSRF_COOKIE_NAME}=([A-Za-z0-9_-]+)`));
     expect(cookieMatch).not.toBeNull();
     const cookieToken = cookieMatch?.[1] ?? "";
     expect(cookieToken.length).toBeGreaterThan(0);
     const html = await res.text();
-    const formMatch = html.match(
-      new RegExp(`name="${CSRF_FIELD_NAME}" value="([^"]+)"`),
-    );
+    const formMatch = html.match(new RegExp(`name="${CSRF_FIELD_NAME}" value="([^"]+)"`));
     expect(formMatch).not.toBeNull();
     expect(formMatch?.[1]).toBe(cookieToken);
   });

--- a/src/__tests__/setup.test.ts
+++ b/src/__tests__/setup.test.ts
@@ -284,6 +284,45 @@ describe("setup", () => {
     }
   });
 
+  test("retries pick prompt on invalid token then accepts a valid one (#111)", async () => {
+    const h = makeHarness();
+    try {
+      const availability = scriptedAvailability([
+        "9", // out-of-range index — loop re-prompts
+        "nope", // unknown name — loop re-prompts again
+        "notes", // single pick, no follow-up prompts
+      ]);
+      const code = await setup({
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        log: (l) => h.logs.push(l),
+        availability,
+        installFn: async (short, opts) => {
+          h.calls.push({ short, opts });
+          upsertService(
+            {
+              name: "parachute-notes",
+              version: "0.1.0",
+              port: 1942,
+              paths: ["/notes"],
+              health: "/health",
+            },
+            opts.manifestPath ?? h.manifestPath,
+          );
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      expect(h.calls.map((c) => c.short)).toEqual(["notes"]);
+      expect(availability.remaining()).toBe(0);
+      const joined = h.logs.join("\n");
+      expect(joined).toMatch(/out-of-range/);
+      expect(joined).toMatch(/unknown service/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("retries on invalid vault name then accepts a valid one", async () => {
     const h = makeHarness();
     try {

--- a/src/admin-handlers.ts
+++ b/src/admin-handlers.ts
@@ -37,8 +37,10 @@ import {
 } from "./services-manifest.ts";
 import {
   SESSION_TTL_MS,
+  buildSessionClearCookie,
   buildSessionCookie,
   createSession,
+  deleteSession,
   findSession,
   parseSessionCookie,
 } from "./sessions.ts";
@@ -143,6 +145,35 @@ export async function handleAdminLoginPost(db: Database, req: Request): Promise<
   const session = createSession(db, { userId: user.id });
   const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
   return redirect(next, { "set-cookie": cookie });
+}
+
+// --- /admin/logout ---------------------------------------------------------
+
+/**
+ * POST-only — logout is state-changing, so it rides the same double-submit
+ * CSRF discipline as login + config posts. Without CSRF, a malicious
+ * cross-origin form could log the operator out (annoyance, not catastrophe,
+ * but the safety belt is already on the bus).
+ *
+ * Always idempotent: clearing the cookie succeeds even if there's no
+ * matching session row. Returns 302 → /admin/login so the operator lands
+ * back on the form ready to re-authenticate.
+ */
+export async function handleAdminLogoutPost(db: Database, req: Request): Promise<Response> {
+  const form = await req.formData();
+  const formCsrf = form.get(CSRF_FIELD_NAME);
+  if (!verifyCsrfToken(req, typeof formCsrf === "string" ? formCsrf : null)) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Invalid form submission",
+        message: "The form's CSRF token did not match. Reload the page and try again.",
+      }),
+      400,
+    );
+  }
+  const sid = parseSessionCookie(req.headers.get("cookie"));
+  if (sid) deleteSession(db, sid);
+  return redirect("/admin/login", { "set-cookie": buildSessionClearCookie() });
 }
 
 // --- /admin/config ---------------------------------------------------------

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -75,7 +75,10 @@ interface ScribeAnswer {
   apiKey: string | undefined;
 }
 
-const VAULT_NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+// Reject leading and trailing hyphens. The previous form `[a-z0-9][a-z0-9-]*`
+// permitted `my-vault-` which round-trips poorly through path segments and
+// some shells. Single-char names (`a`, `7`) stay legal.
+const VAULT_NAME_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
 
 function defaultAvailability(): InteractiveAvailability {
   if (!process.stdin.isTTY || !process.stdout.isTTY) return { kind: "not-tty" };

--- a/src/csrf.ts
+++ b/src/csrf.ts
@@ -6,7 +6,12 @@
  * a `parachute_hub_csrf` cookie exists (lazily generated, then reused for the
  * cookie's lifetime) and embed the same value as a hidden `__csrf` input in
  * the form. On POST, we compare the form-submitted token to the cookie value
- * via constant-time compare; mismatch = 400.
+ * via constant-time compare; mismatch = 400 Bad Request. We pick 400 over 403
+ * because the failure mode is a malformed/stale form (the operator's tab sat
+ * past cookie expiry, two tabs raced, or the form was hand-rolled), not an
+ * authorization failure — they're already authenticated; the *form* is what
+ * the server can't accept. All callers (admin login, admin config, OAuth
+ * authorize) agree on 400.
  *
  * Why this and not session-bound tokens? Login forms are submitted *before*
  * a session exists, so a session-bound CSRF would need a separate "pre-login"

--- a/src/help.ts
+++ b/src/help.ts
@@ -103,7 +103,8 @@ What it does:
 
 Behavior:
   - Partial success is preserved: if one install fails, prior successful
-    installs are NOT rolled back. The exit code reflects the last failure.
+    installs are NOT rolled back. The exit code reflects the FIRST failure
+    (root cause), so subsequent fallout doesn't mask the original problem.
   - Non-TTY / piped invocations should use \`parachute install <svc>\` per
     service instead — \`setup\` assumes a terminal for the prompts.
   - Selection accepts numbers (\`1,3\`), names (\`vault, notes\`), or \`all\`.

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -41,6 +41,7 @@ import {
   handleAdminConfigPost,
   handleAdminLoginGet,
   handleAdminLoginPost,
+  handleAdminLogoutPost,
 } from "./admin-handlers.ts";
 import { handleCreateVault } from "./admin-vaults.ts";
 import { hubDbPath, openHubDb } from "./hub-db.ts";
@@ -259,6 +260,12 @@ export function hubFetch(
       if (req.method === "GET") return handleAdminLoginGet(getDb(), req);
       if (req.method === "POST") return handleAdminLoginPost(getDb(), req);
       return new Response("method not allowed", { status: 405 });
+    }
+
+    if (pathname === "/admin/logout") {
+      if (!getDb) return new Response("hub db not configured", { status: 503 });
+      if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+      return handleAdminLogoutPost(getDb(), req);
     }
 
     if (pathname === "/admin/config") {


### PR DESCRIPTION
## Summary

Bundles 4 launch-cycle reviewer NITs into one PR. Each issue is its own commit so reverting one doesn't affect the others.

- **#102** — advertise `client_secret_basic` in AS metadata (RFC 6749 §2.3.1 prefers Basic over form-body)
- **#109** — drop dead `&& !row` from /oauth/revoke + document the single-row vs family-cascade asymmetry
- **#111** — tighten `VAULT_NAME_RE` to reject trailing hyphens; correct setup help docstring; add integration test for the pick-prompt retry loop
- **#113** — document why CSRF mismatch returns 400 not 403; add cookie-form-match test; add `POST /admin/logout` route (uses `buildSessionClearCookie` + `deleteSession`)

PR A (#115) ships #107 + #108 (rotation atomicity + clean 400 mapping) — that one is launch-critical and should land first; this PR is post-launch-OK polish.

## Stacked-on-PR-A note

This branch was cut from main when main was at rc.19; PR A bumped to rc.20; this PR bumps to rc.21 to avoid version collision. When PR A merges first, this PR rebases cleanly. If PR B somehow lands first, PR A will need a one-line package.json conflict resolution.

## Patterns check

No pattern boundaries crossed. No new exported helpers, no new conventions — this is reviewer NIT cleanup.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean  
- [x] `bun test` — 805 pass, 0 fail
- [x] New tests added for #111 (pick retry loop) and #113 (cookie-form match + 3 logout cases)