### PR TITLE
feat(hub): parachute upgrade <service> for bun-linked + npm installs (#80)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.21",
+  "version": "0.4.0-rc.22",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/upgrade.test.ts
+++ b/src/__tests__/upgrade.test.ts
@@ -1,0 +1,541 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { UpgradeRunner } from "../commands/upgrade.ts";
+import { upgrade } from "../commands/upgrade.ts";
+import { upsertService } from "../services-manifest.ts";
+
+interface RunCall {
+  cmd: string[];
+  cwd?: string;
+  kind: "run" | "capture";
+}
+
+interface MockRunner {
+  runner: UpgradeRunner;
+  calls: RunCall[];
+}
+
+/**
+ * Build a runner stub that scripts responses by command-prefix match. The
+ * matcher walks the responses array in order; the first entry whose `match`
+ * function returns true wins. Unmatched commands return code 0 / empty
+ * stdout, which keeps the happy path quiet.
+ */
+function makeRunner(
+  responses: Array<{
+    match: (cmd: readonly string[]) => boolean;
+    code?: number;
+    stdout?: string;
+  }> = [],
+): MockRunner {
+  const calls: RunCall[] = [];
+  const find = (cmd: readonly string[]) => responses.find((r) => r.match(cmd));
+  return {
+    calls,
+    runner: {
+      async run(cmd, opts) {
+        calls.push({ cmd: [...cmd], cwd: opts?.cwd, kind: "run" });
+        return find(cmd)?.code ?? 0;
+      },
+      async capture(cmd, opts) {
+        calls.push({ cmd: [...cmd], cwd: opts?.cwd, kind: "capture" });
+        const r = find(cmd);
+        return { code: r?.code ?? 0, stdout: r?.stdout ?? "" };
+      },
+    },
+  };
+}
+
+interface Harness {
+  configDir: string;
+  manifestPath: string;
+  installRoot: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-upgrade-"));
+  return {
+    configDir: dir,
+    manifestPath: join(dir, "services.json"),
+    installRoot: join(dir, "installs"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+function writePackageJson(dir: string, body: Record<string, unknown>): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "package.json"), JSON.stringify(body, null, 2));
+}
+
+function seedVault(manifestPath: string, installDir: string, version = "0.4.0"): void {
+  upsertService(
+    {
+      name: "parachute-vault",
+      port: 1940,
+      paths: ["/vault/default"],
+      health: "/vault/default/health",
+      version,
+      installDir,
+    },
+    manifestPath,
+  );
+}
+
+describe("parachute upgrade", () => {
+  test("errors cleanly when no services installed", async () => {
+    const h = makeHarness();
+    try {
+      const logs: string[] = [];
+      const m = makeRunner();
+      const code = await upgrade(undefined, {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner: m.runner,
+        findGlobalInstall: () => null,
+        restartFn: async () => 0,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(1);
+      expect(logs.join("\n")).toMatch(/No services installed/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("errors cleanly on unknown service", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath, join(h.installRoot, "vault"));
+      const logs: string[] = [];
+      const m = makeRunner();
+      const code = await upgrade("nope", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner: m.runner,
+        findGlobalInstall: () => null,
+        restartFn: async () => 0,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(1);
+      expect(logs.join("\n")).toMatch(/unknown service/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("bun-linked happy path: pulls, reinstalls deps, restarts", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir);
+
+      const m = makeRunner([
+        {
+          match: (c) => c[0] === "git" && c[1] === "rev-parse" && c[2] === "--is-inside-work-tree",
+          code: 0,
+        },
+        {
+          match: (c) => c[0] === "git" && c[1] === "status" && c[2] === "--porcelain",
+          code: 0,
+          stdout: "",
+        },
+        // First HEAD read (before pull) — old SHA
+        // Sequence: capture matchers fire in order; we use a stateful counter
+      ]);
+
+      // Stateful HEAD: first capture returns "abc", second returns "def"
+      let headCalls = 0;
+      const runner: UpgradeRunner = {
+        async run(cmd, opts) {
+          m.calls.push({ cmd: [...cmd], cwd: opts?.cwd, kind: "run" });
+          if (cmd[0] === "git" && cmd[1] === "pull") return 0;
+          if (cmd[0] === "bun" && cmd[1] === "install") return 0;
+          return 0;
+        },
+        async capture(cmd, opts) {
+          m.calls.push({ cmd: [...cmd], cwd: opts?.cwd, kind: "capture" });
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 0, stdout: "true" };
+          }
+          if (cmd[1] === "status") return { code: 0, stdout: "" };
+          if (cmd[1] === "rev-parse" && cmd[2] === "HEAD") {
+            headCalls++;
+            return { code: 0, stdout: headCalls === 1 ? "aaaaaaa" : "bbbbbbb" };
+          }
+          if (cmd[1] === "diff") {
+            return { code: 0, stdout: "package.json\nsrc/foo.ts" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      let restartedShort: string | undefined;
+      const logs: string[] = [];
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async (svc) => {
+          restartedShort = svc;
+          return 0;
+        },
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(restartedShort).toBe("vault");
+      const joined = logs.join("\n");
+      expect(joined).toMatch(/bun-linked checkout/);
+      expect(joined).toMatch(/git pull --ff-only/);
+      expect(joined).toMatch(/bun install --frozen-lockfile/);
+      expect(joined).toMatch(/aaaaaa.*→.*bbbbbb/);
+      expect(joined).toMatch(/restarting/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("bun-linked, HEAD unchanged: no-op skip-restart", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir);
+
+      const runner: UpgradeRunner = {
+        async run() {
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 0, stdout: "true" };
+          }
+          if (cmd[1] === "status") return { code: 0, stdout: "" };
+          if (cmd[1] === "rev-parse" && cmd[2] === "HEAD") {
+            return { code: 0, stdout: "abcdef0" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      let restartCalled = false;
+      const logs: string[] = [];
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async () => {
+          restartCalled = true;
+          return 0;
+        },
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(restartCalled).toBe(false);
+      expect(logs.join("\n")).toMatch(/already up to date/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("bun-linked refuses on dirty working tree", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir);
+
+      const runner: UpgradeRunner = {
+        async run() {
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 0, stdout: "true" };
+          }
+          if (cmd[1] === "status") {
+            return { code: 0, stdout: " M src/foo.ts\n" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      let restartCalled = false;
+      const logs: string[] = [];
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async () => {
+          restartCalled = true;
+          return 0;
+        },
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(1);
+      expect(restartCalled).toBe(false);
+      expect(logs.join("\n")).toMatch(/dirty working tree/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("bun-linked frontend: runs bun run build before restart", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "notes");
+      writePackageJson(installDir, {
+        name: "@openparachute/notes",
+        version: "0.0.1",
+        scripts: { build: "vite build" },
+      });
+      upsertService(
+        {
+          name: "parachute-notes",
+          port: 1942,
+          paths: ["/notes"],
+          health: "/notes/health",
+          version: "0.0.1",
+          installDir,
+        },
+        h.manifestPath,
+      );
+
+      let headCalls = 0;
+      const ranBuild = { value: false };
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          if (cmd[0] === "bun" && cmd[1] === "run" && cmd[2] === "build") {
+            ranBuild.value = true;
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 0, stdout: "true" };
+          }
+          if (cmd[1] === "status") return { code: 0, stdout: "" };
+          if (cmd[1] === "rev-parse" && cmd[2] === "HEAD") {
+            headCalls++;
+            return { code: 0, stdout: headCalls === 1 ? "111" : "222" };
+          }
+          if (cmd[1] === "diff") return { code: 0, stdout: "src/x.ts" };
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      const code = await upgrade("notes", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async () => 0,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(ranBuild.value).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("npm-installed happy path: bun add -g, version bumps, restarts", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      // Initial version 0.4.0
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.4.0");
+
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          // Simulate `bun add -g` rewriting the package.json with a new version
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            writePackageJson(installDir, { name: "@openparachute/vault", version: "0.5.0" });
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          // Not a git checkout
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "fatal: not a git repository\n" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      let restartedShort: string | undefined;
+      const logs: string[] = [];
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async (svc) => {
+          restartedShort = svc;
+          return 0;
+        },
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(restartedShort).toBe("vault");
+      const joined = logs.join("\n");
+      expect(joined).toMatch(/npm-installed/);
+      expect(joined).toMatch(/bun add -g @openparachute\/vault@latest/);
+      expect(joined).toMatch(/0\.4\.0 → 0\.5\.0/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("npm-installed: version unchanged → skip restart", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.4.0");
+
+      // Don't change package.json on bun add -g — same version after.
+      const runner: UpgradeRunner = {
+        async run() {
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      let restartCalled = false;
+      const logs: string[] = [];
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async () => {
+          restartCalled = true;
+          return 0;
+        },
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(restartCalled).toBe(false);
+      expect(logs.join("\n")).toMatch(/already at 0\.4\.0/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("npm-installed: --tag is forwarded to bun add -g", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.4.0");
+
+      const seenCmd: string[][] = [];
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          seenCmd.push([...cmd]);
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async () => 0,
+        tag: "rc",
+        log: () => {},
+      });
+      const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
+      expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/vault@rc"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("sweep (no svc): partial failure — later targets still run; first failure code wins", async () => {
+    const h = makeHarness();
+    try {
+      const vaultDir = join(h.installRoot, "vault");
+      const notesDir = join(h.installRoot, "notes");
+      writePackageJson(vaultDir, { name: "@openparachute/vault", version: "0.4.0" });
+      writePackageJson(notesDir, { name: "@openparachute/notes", version: "0.0.1" });
+      seedVault(h.manifestPath, vaultDir);
+      upsertService(
+        {
+          name: "parachute-notes",
+          port: 1942,
+          paths: ["/notes"],
+          health: "/notes/health",
+          version: "0.0.1",
+          installDir: notesDir,
+        },
+        h.manifestPath,
+      );
+
+      // vault is npm-installed (no git); bun add -g fails with 7
+      // notes is npm-installed and succeeds with version bump
+      const runner: UpgradeRunner = {
+        async run(cmd, opts) {
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            const pkg = cmd[3] ?? "";
+            if (pkg.startsWith("@openparachute/vault")) return 7;
+            if (pkg.startsWith("@openparachute/notes")) {
+              writePackageJson(notesDir, { name: "@openparachute/notes", version: "0.1.0" });
+              return 0;
+            }
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      const restartCalls: string[] = [];
+      const logs: string[] = [];
+      const code = await upgrade(undefined, {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) => {
+          if (pkg === "@openparachute/vault") return join(vaultDir, "package.json");
+          if (pkg === "@openparachute/notes") return join(notesDir, "package.json");
+          return null;
+        },
+        restartFn: async (svc) => {
+          restartCalls.push(svc);
+          return 0;
+        },
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(7);
+      expect(restartCalls).toEqual(["notes"]);
+      expect(logs.join("\n")).toMatch(/vault: bun add -g failed \(exit 7\)/);
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import { logs, restart, start, stop } from "./commands/lifecycle.ts";
 import { migrate } from "./commands/migrate.ts";
 import { setup } from "./commands/setup.ts";
 import { status } from "./commands/status.ts";
+import { upgrade } from "./commands/upgrade.ts";
 import { dispatchVault } from "./commands/vault.ts";
 import { ExposeStateError } from "./expose-state.ts";
 import {
@@ -28,6 +29,7 @@ import {
   statusHelp,
   stopHelp,
   topLevelHelp,
+  upgradeHelp,
 } from "./help.ts";
 import { knownServices } from "./service-spec.ts";
 import { ServicesManifestError } from "./services-manifest.ts";
@@ -404,6 +406,27 @@ async function main(argv: string[]): Promise<number> {
         return 0;
       }
       return await restart(rest[0]);
+    }
+
+    case "upgrade": {
+      if (isHelpFlag(rest[0])) {
+        console.log(upgradeHelp());
+        return 0;
+      }
+      const tagExtract = extractTag(rest);
+      if (tagExtract.error) {
+        console.error(`parachute upgrade: ${tagExtract.error}`);
+        return 1;
+      }
+      const remaining = tagExtract.rest;
+      if (remaining.length > 1) {
+        console.error(`parachute upgrade: unexpected argument "${remaining[1]}"`);
+        console.error("usage: parachute upgrade [<service>] [--tag <name>]");
+        return 1;
+      }
+      const upgradeOpts: Parameters<typeof upgrade>[1] = {};
+      if (tagExtract.tag) upgradeOpts.tag = tagExtract.tag;
+      return await upgrade(remaining[0], upgradeOpts);
     }
 
     case "logs": {

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,0 +1,429 @@
+/**
+ * `parachute upgrade [<service>]` — pull / re-install / restart in one step.
+ *
+ * Detects whether the target service is bun-linked from a local checkout (the
+ * dev-mode install shape) or npm-installed from a published artifact, then
+ * does the right thing for each:
+ *
+ *   bun-linked:   git -C <checkout> pull --ff-only;
+ *                 bun install --frozen-lockfile (if package.json/bun.lock changed);
+ *                 bun run build (frontend kind, if `build` script exists);
+ *                 parachute restart <svc>.
+ *
+ *   npm-installed: bun add -g <pkg>@<tag>; parachute restart <svc>.
+ *
+ * Skip-restart heuristics: bun-linked path skips when HEAD is unchanged after
+ * pull; npm path skips when the installed package.json `version` is unchanged
+ * after `bun add -g`. Idempotent — re-running the command on an up-to-date
+ * install is a fast no-op rather than a needless restart.
+ *
+ * Refuses to operate on a dirty git working tree. The whole point of the
+ * dev-mode flow is to make the operator's checkout a first-class artifact;
+ * blowing past their uncommitted changes with `git pull` is exactly what we
+ * shouldn't do. They can stash and re-run.
+ *
+ * Detection of "is this a git checkout?" goes through git itself (`git
+ * rev-parse --is-inside-work-tree`). A bare bun-link symlink isn't enough —
+ * `bun add -g <abspath>` produces a non-symlinked install dir whose realpath
+ * is still the operator's checkout, and we want to treat that the same as a
+ * `bun link` install. The git-repo test is the right load-bearing signal.
+ *
+ * The npm-install branch reads the package.json `version` before and after
+ * `bun add -g` to detect "already at latest" (the dist-tag didn't move).
+ * Doing this avoids an unnecessary restart on a stable channel — a lot
+ * cheaper than re-spawning a daemon that's already running the right code.
+ */
+
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
+import { ModuleManifestError } from "../module-manifest.ts";
+import {
+  type ServiceSpec,
+  getSpec,
+  getSpecFromInstallDir,
+  knownServices,
+  shortNameForManifest,
+} from "../service-spec.ts";
+import { type ServiceEntry, readManifest } from "../services-manifest.ts";
+import { type LifecycleOpts, restart as lifecycleRestart } from "./lifecycle.ts";
+
+export interface UpgradeRunner {
+  /** Run a command, inheriting stdio. Returns the child's exit code. */
+  run(cmd: readonly string[], opts?: { cwd?: string }): Promise<number>;
+  /** Run a command, capturing combined stdout+stderr. Used for git rev-parse / status / diff. */
+  capture(
+    cmd: readonly string[],
+    opts?: { cwd?: string },
+  ): Promise<{ code: number; stdout: string }>;
+}
+
+export const defaultRunner: UpgradeRunner = {
+  async run(cmd, opts) {
+    const proc = Bun.spawn([...cmd], {
+      cwd: opts?.cwd,
+      stdio: ["inherit", "inherit", "inherit"],
+    });
+    return await proc.exited;
+  },
+  async capture(cmd, opts) {
+    const proc = Bun.spawn([...cmd], {
+      cwd: opts?.cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    const code = await proc.exited;
+    return { code, stdout: stdout + stderr };
+  },
+};
+
+export interface UpgradeOpts {
+  runner?: UpgradeRunner;
+  manifestPath?: string;
+  configDir?: string;
+  log?: (line: string) => void;
+  /**
+   * Override how we locate a package's bun-globals install. Defaults to
+   * scanning bun's standard global node_modules prefixes for
+   * `<prefix>/<pkg>/package.json`. Tests inject a deterministic stub that
+   * points at a tmp dir.
+   */
+  findGlobalInstall?: (pkg: string) => string | null;
+  /**
+   * Override the lifecycle restart call. Production proxies to
+   * `lifecycle.restart(svc, opts)`; tests inject `async () => 0` so the
+   * upgrade flow can be exercised without spawning real children.
+   */
+  restartFn?: (svc: string, opts: LifecycleOpts) => Promise<number>;
+  /** npm dist-tag for the npm-installed branch. Defaults to `latest`. Ignored when bun-linked. */
+  tag?: string;
+}
+
+interface ResolvedTarget {
+  short: string;
+  entry: ServiceEntry;
+  spec: ServiceSpec | undefined;
+  packageName: string;
+}
+
+interface Resolved {
+  runner: UpgradeRunner;
+  manifestPath: string;
+  configDir: string;
+  log: (line: string) => void;
+  findGlobalInstall: (pkg: string) => string | null;
+  restartFn: (svc: string, opts: LifecycleOpts) => Promise<number>;
+  tag: string;
+}
+
+function bunGlobalPrefixes(): string[] {
+  const prefixes: string[] = [];
+  const fromEnv = process.env.BUN_INSTALL;
+  if (fromEnv) prefixes.push(join(fromEnv, "install", "global", "node_modules"));
+  prefixes.push(join(homedir(), ".bun", "install", "global", "node_modules"));
+  return prefixes;
+}
+
+function defaultFindGlobalInstall(pkg: string): string | null {
+  for (const prefix of bunGlobalPrefixes()) {
+    const pkgJsonPath = join(prefix, ...pkg.split("/"), "package.json");
+    if (existsSync(pkgJsonPath)) return pkgJsonPath;
+  }
+  return null;
+}
+
+function resolve(opts: UpgradeOpts): Resolved {
+  return {
+    runner: opts.runner ?? defaultRunner,
+    manifestPath: opts.manifestPath ?? SERVICES_MANIFEST_PATH,
+    configDir: opts.configDir ?? CONFIG_DIR,
+    log: opts.log ?? ((line) => console.log(line)),
+    findGlobalInstall: opts.findGlobalInstall ?? defaultFindGlobalInstall,
+    restartFn: opts.restartFn ?? ((svc, lifecycleOpts) => lifecycleRestart(svc, lifecycleOpts)),
+    tag: opts.tag ?? "latest",
+  };
+}
+
+async function resolveTargets(
+  svc: string | undefined,
+  manifestPath: string,
+): Promise<{ targets: ResolvedTarget[] } | { error: string }> {
+  const manifest = readManifest(manifestPath);
+  if (manifest.services.length === 0) {
+    return { error: "No services installed yet. Try: parachute install <service>" };
+  }
+
+  if (svc !== undefined) {
+    const firstPartySpec = getSpec(svc);
+    if (firstPartySpec) {
+      const entry = manifest.services.find((s) => s.name === firstPartySpec.manifestName);
+      if (!entry) {
+        return { error: `${svc} isn't installed. Run \`parachute install ${svc}\` first.` };
+      }
+      return {
+        targets: [{ short: svc, entry, spec: firstPartySpec, packageName: firstPartySpec.package }],
+      };
+    }
+    const entry = manifest.services.find((s) => s.name === svc);
+    if (entry?.installDir) {
+      try {
+        const spec = (await getSpecFromInstallDir(entry.installDir, entry.name)) ?? undefined;
+        return {
+          targets: [{ short: svc, entry, spec, packageName: spec?.package ?? entry.name }],
+        };
+      } catch (err) {
+        if (err instanceof ModuleManifestError) {
+          return { error: `${svc}: invalid module.json — ${err.message}` };
+        }
+        throw err;
+      }
+    }
+    return { error: `unknown service "${svc}". known: ${knownServices().join(", ")}` };
+  }
+
+  const targets: ResolvedTarget[] = [];
+  for (const entry of manifest.services) {
+    const short = shortNameForManifest(entry.name);
+    if (short) {
+      const spec = getSpec(short);
+      if (spec) targets.push({ short, entry, spec, packageName: spec.package });
+      continue;
+    }
+    if (entry.installDir) {
+      try {
+        const spec = (await getSpecFromInstallDir(entry.installDir, entry.name)) ?? undefined;
+        targets.push({
+          short: entry.name,
+          entry,
+          spec,
+          packageName: spec?.package ?? entry.name,
+        });
+      } catch {
+        // Malformed third-party manifest — skip silently here; lifecycle/install
+        // surface that error in their own paths.
+      }
+    }
+  }
+  if (targets.length === 0) return { error: "No upgradeable services in services.json." };
+  return { targets };
+}
+
+/**
+ * Realpath the package.json in bun's globals to find where the source
+ * actually lives. For npm installs this stays inside bun globals; for `bun
+ * link` and `bun add -g <abspath>` it follows out to the operator's checkout.
+ */
+function resolveSourceDir(
+  packageName: string,
+  findGlobalInstall: (pkg: string) => string | null,
+  fallbackInstallDir: string | undefined,
+): string | null {
+  const fromGlobals = findGlobalInstall(packageName);
+  if (fromGlobals) {
+    try {
+      return dirname(realpathSync(fromGlobals));
+    } catch {
+      // fall through to manifest-recorded installDir
+    }
+  }
+  if (fallbackInstallDir) {
+    try {
+      return realpathSync(fallbackInstallDir);
+    } catch {
+      return fallbackInstallDir;
+    }
+  }
+  return null;
+}
+
+async function isGitCheckout(dir: string, runner: UpgradeRunner): Promise<boolean> {
+  const { code } = await runner.capture(["git", "rev-parse", "--is-inside-work-tree"], {
+    cwd: dir,
+  });
+  return code === 0;
+}
+
+async function readGitHead(
+  dir: string,
+  runner: UpgradeRunner,
+): Promise<{ code: number; sha: string }> {
+  const { code, stdout } = await runner.capture(["git", "rev-parse", "HEAD"], { cwd: dir });
+  return { code, sha: stdout.trim() };
+}
+
+async function listChangedFiles(
+  dir: string,
+  before: string,
+  after: string,
+  runner: UpgradeRunner,
+): Promise<string[]> {
+  if (before === after) return [];
+  const { code, stdout } = await runner.capture(
+    ["git", "diff", "--name-only", `${before}..${after}`],
+    { cwd: dir },
+  );
+  if (code !== 0) return [];
+  return stdout.trim().split("\n").filter(Boolean);
+}
+
+function packageHasScript(pkgJsonPath: string, name: string): boolean {
+  try {
+    const json = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+    return Boolean(json?.scripts && typeof json.scripts[name] === "string");
+  } catch {
+    return false;
+  }
+}
+
+function readPackageVersion(pkgJsonPath: string): string | null {
+  try {
+    const json = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+    return typeof json?.version === "string" ? json.version : null;
+  } catch {
+    return null;
+  }
+}
+
+async function upgradeLinked(
+  target: ResolvedTarget,
+  sourceDir: string,
+  r: Resolved,
+): Promise<number> {
+  r.log(`${target.short}: bun-linked checkout at ${sourceDir}`);
+
+  const status = await r.runner.capture(["git", "status", "--porcelain"], { cwd: sourceDir });
+  if (status.code !== 0) {
+    r.log(`✗ ${target.short}: git status failed in ${sourceDir}`);
+    return status.code;
+  }
+  if (status.stdout.trim().length > 0) {
+    r.log(
+      `✗ ${target.short}: dirty working tree at ${sourceDir} — commit or stash first, then re-run.`,
+    );
+    return 1;
+  }
+
+  const before = await readGitHead(sourceDir, r.runner);
+  if (before.code !== 0) {
+    r.log(`✗ ${target.short}: failed to read HEAD in ${sourceDir}`);
+    return before.code;
+  }
+
+  r.log(`${target.short}: git pull --ff-only`);
+  const pull = await r.runner.run(["git", "pull", "--ff-only"], { cwd: sourceDir });
+  if (pull !== 0) {
+    r.log(`✗ ${target.short}: git pull --ff-only failed (exit ${pull}). Resolve and retry.`);
+    return pull;
+  }
+
+  const after = await readGitHead(sourceDir, r.runner);
+  if (after.code !== 0) {
+    r.log(`✗ ${target.short}: failed to read HEAD post-pull`);
+    return after.code;
+  }
+
+  if (before.sha === after.sha) {
+    r.log(`${target.short}: already up to date (${before.sha.slice(0, 7)}). Skipping restart.`);
+    return 0;
+  }
+
+  const changed = await listChangedFiles(sourceDir, before.sha, after.sha, r.runner);
+  const depsChanged =
+    changed.includes("package.json") ||
+    changed.includes("bun.lock") ||
+    changed.includes("bun.lockb");
+  if (depsChanged) {
+    r.log(`${target.short}: package.json/bun.lock changed — bun install --frozen-lockfile`);
+    const inst = await r.runner.run(["bun", "install", "--frozen-lockfile"], { cwd: sourceDir });
+    if (inst !== 0) {
+      r.log(`✗ ${target.short}: bun install failed (exit ${inst})`);
+      return inst;
+    }
+  }
+
+  if (target.spec?.kind === "frontend") {
+    const pkgJsonPath = join(sourceDir, "package.json");
+    if (packageHasScript(pkgJsonPath, "build")) {
+      r.log(`${target.short}: bun run build`);
+      const build = await r.runner.run(["bun", "run", "build"], { cwd: sourceDir });
+      if (build !== 0) {
+        r.log(`✗ ${target.short}: bun run build failed (exit ${build})`);
+        return build;
+      }
+    }
+  }
+
+  r.log(`${target.short}: ${before.sha.slice(0, 7)} → ${after.sha.slice(0, 7)}; restarting…`);
+  return await r.restartFn(target.short, { manifestPath: r.manifestPath, configDir: r.configDir });
+}
+
+async function upgradeNpm(target: ResolvedTarget, sourceDir: string, r: Resolved): Promise<number> {
+  r.log(`${target.short}: npm-installed (${sourceDir})`);
+  const beforeVersion = readPackageVersion(join(sourceDir, "package.json"));
+  const spec = `${target.packageName}@${r.tag}`;
+  r.log(`${target.short}: bun add -g ${spec}`);
+  const code = await r.runner.run(["bun", "add", "-g", spec]);
+  if (code !== 0) {
+    r.log(`✗ ${target.short}: bun add -g failed (exit ${code})`);
+    return code;
+  }
+
+  const afterVersion = readPackageVersion(join(sourceDir, "package.json"));
+  if (beforeVersion && afterVersion && beforeVersion === afterVersion) {
+    r.log(`${target.short}: already at ${afterVersion}. Skipping restart.`);
+    return 0;
+  }
+
+  r.log(`${target.short}: ${beforeVersion ?? "?"} → ${afterVersion ?? "?"}; restarting…`);
+  return await r.restartFn(target.short, { manifestPath: r.manifestPath, configDir: r.configDir });
+}
+
+async function upgradeOne(target: ResolvedTarget, r: Resolved): Promise<number> {
+  const sourceDir = resolveSourceDir(
+    target.packageName,
+    r.findGlobalInstall,
+    target.entry.installDir,
+  );
+  if (!sourceDir) {
+    r.log(
+      `✗ ${target.short}: can't locate install dir for ${target.packageName}. Try \`parachute install ${target.short}\` first.`,
+    );
+    return 1;
+  }
+  if (!existsSync(sourceDir)) {
+    r.log(`✗ ${target.short}: install dir ${sourceDir} does not exist.`);
+    return 1;
+  }
+
+  if (await isGitCheckout(sourceDir, r.runner)) {
+    return await upgradeLinked(target, sourceDir, r);
+  }
+  return await upgradeNpm(target, sourceDir, r);
+}
+
+/**
+ * Sweep one or all installed services through the upgrade flow. Returns 0
+ * when every target succeeds; non-zero is the exit code of the first failure
+ * (subsequent targets still run — partial success is preferable to halting
+ * mid-sweep on a flake).
+ */
+export async function upgrade(svc: string | undefined, opts: UpgradeOpts = {}): Promise<number> {
+  const r = resolve(opts);
+  const picked = await resolveTargets(svc, r.manifestPath);
+  if ("error" in picked) {
+    r.log(picked.error);
+    return 1;
+  }
+
+  let firstFailure = 0;
+  for (const target of picked.targets) {
+    const code = await upgradeOne(target, r);
+    if (code !== 0 && firstFailure === 0) firstFailure = code;
+  }
+  return firstFailure;
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -13,6 +13,7 @@ Usage:
   parachute start   [service]       start all services (or one) in the background
   parachute stop    [service]       stop all services (or one) — SIGTERM then SIGKILL
   parachute restart [service]       stop + start
+  parachute upgrade [service]       pull / re-install + restart (skips if no changes)
   parachute logs <service> [-f]     print service logs; -f to tail
   parachute expose tailnet [off]    HTTPS across your tailnet (supported)
   parachute expose public  [off]    HTTPS on the public internet (exploratory)
@@ -283,6 +284,39 @@ Usage:
 
 What it does:
   Equivalent to \`parachute stop <svc> && parachute start <svc>\`.
+`;
+}
+
+export function upgradeHelp(): string {
+  return `parachute upgrade — pull / re-install + restart in one step
+
+Usage:
+  parachute upgrade                 upgrade every installed service
+  parachute upgrade <service>       upgrade just that one
+  parachute upgrade [svc] --tag <name>
+                                    npm-installed services only — pin a dist-tag
+                                    (default: latest). Ignored when bun-linked.
+
+What it does:
+  Detects whether the target service is bun-linked from a local checkout
+  (the dev-mode shape) or npm-installed from a published artifact:
+
+    bun-linked  git pull --ff-only in the checkout, bun install if
+                package.json/bun.lock changed, bun run build for frontend
+                modules with a build script, then \`parachute restart\`.
+                Refuses on a dirty working tree — commit or stash first.
+
+    npm         bun add -g <pkg>@<tag>, then \`parachute restart\` if the
+                installed version actually moved.
+
+  Idempotent: if the source didn't change (HEAD unchanged after pull, or
+  package.json version unchanged after bun add -g), the restart is skipped.
+  Re-running on an up-to-date install is a fast no-op.
+
+Examples:
+  parachute upgrade                 sweep every installed service
+  parachute upgrade vault           just vault
+  parachute upgrade vault --tag rc  pin the rc dist-tag (npm path only)
 `;
 }
 


### PR DESCRIPTION
## Summary

Adds `parachute upgrade [<service>]` — pulls + reinstalls + restarts a service in place, taking the right path for whichever way the operator installed it.

- **bun-linked checkout** (a real git repo on disk, whether via `bun link` or `bun add -g <abspath>`): refuse on dirty tree → `git pull --ff-only` → if `package.json`/`bun.lock` changed, `bun install --frozen-lockfile` → if `kind === \"frontend\"` and a `build` script exists, `bun run build` → restart via lifecycle.
- **npm-installed**: `bun add -g @openparachute/<svc>@<tag>` → restart via lifecycle.
- **Idempotent**: skip the restart when nothing actually changed (HEAD unchanged for checkouts; version unchanged for npm). Logs `(already at latest)`.
- **Sweep mode**: `parachute upgrade` (no service) iterates every installed module in `services.json` order. Continues past failures and returns the first non-zero exit code.
- **`--tag <name>`**: forwarded to `bun add -g` (npm path only). Defaults to `latest`.

The detector uses `git rev-parse --is-inside-work-tree` against the realpath of `<bun prefix>/<pkg>` — a symlink check alone misses the `bun add -g <abspath>` case, where the entry is a regular dir whose realpath still points at a checkout.

Bumps `0.4.0-rc.21 → 0.4.0-rc.22`.

## Test plan

- [x] 10 new tests in `src/__tests__/upgrade.test.ts` cover both code paths plus dirty-tree refusal, frontend build trigger, idempotent skip, --tag forwarding, and partial-failure sweep
- [x] \`bun test\` — 817 pass / 0 fail across 55 files
- [x] \`bun run lint\` clean
- [x] \`bun run typecheck\` clean
- [ ] Smoke: \`parachute upgrade vault\` against the real bun-linked vault checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)