### PR TITLE
feat(hub): skip OAuth consent when scope already granted (#75)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.22",
+  "version": "0.4.0-rc.23",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { registerClient } from "../clients.ts";
 import { type AuthDeps, type Runner, auth, authHelp } from "../commands/auth.ts";
+import { findGrant, recordGrant } from "../grants.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { validateAccessToken } from "../jwt-sign.ts";
 import {
@@ -10,7 +12,7 @@ import {
   OPERATOR_TOKEN_SCOPES,
   readOperatorTokenFile,
 } from "../operator-token.ts";
-import { listUsers, verifyPassword } from "../users.ts";
+import { createUser, listUsers, verifyPassword } from "../users.ts";
 
 function makeRunner(result: number | (() => Promise<number>) = 0): {
   runner: Runner;
@@ -615,6 +617,178 @@ describe("parachute auth pending-clients / approve-client", () => {
       expect(ok.stdout).toContain("Approved");
       const after = await captureOutput(() => auth(["pending-clients"], deps));
       expect(after.stdout).toContain("no pending OAuth clients");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+});
+
+// closes #75 — operator-facing controls for the OAuth consent skip-list.
+describe("parachute auth list-grants / revoke-grant", () => {
+  test("list-grants shows the seeding hint when no users exist", async () => {
+    const tmp = makeTmp();
+    try {
+      const { code, stderr } = await captureOutput(() =>
+        auth(["list-grants"], { dbPath: tmp.dbPath }),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("no hub users yet");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("list-grants shows '(no OAuth grants)' when the user has none", async () => {
+    const tmp = makeTmp();
+    try {
+      const db = openHubDb(tmp.dbPath);
+      try {
+        await createUser(db, "owner", "pw");
+      } finally {
+        db.close();
+      }
+      const { code, stdout } = await captureOutput(() =>
+        auth(["list-grants"], { dbPath: tmp.dbPath }),
+      );
+      expect(code).toBe(0);
+      expect(stdout).toContain("no OAuth grants on record");
+      expect(stdout).toContain("owner");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("list-grants prints rows with client_id + client_name + scopes", async () => {
+    const tmp = makeTmp();
+    try {
+      const db = openHubDb(tmp.dbPath);
+      let userId: string;
+      let clientId: string;
+      try {
+        const user = await createUser(db, "owner", "pw");
+        userId = user.id;
+        const reg = registerClient(db, {
+          redirectUris: ["https://app.example/cb"],
+          clientName: "MyApp",
+        });
+        clientId = reg.client.clientId;
+        recordGrant(db, userId, clientId, ["vault:default:read", "scribe:transcribe"]);
+      } finally {
+        db.close();
+      }
+      const { code, stdout } = await captureOutput(() =>
+        auth(["list-grants"], { dbPath: tmp.dbPath }),
+      );
+      expect(code).toBe(0);
+      expect(stdout).toContain(clientId);
+      expect(stdout).toContain("MyApp");
+      expect(stdout).toContain("vault:default:read");
+      expect(stdout).toContain("scribe:transcribe");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("revoke-grant without args prints usage", async () => {
+    const tmp = makeTmp();
+    try {
+      const { code, stderr } = await captureOutput(() =>
+        auth(["revoke-grant"], { dbPath: tmp.dbPath }),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("missing client_id");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("revoke-grant for an unknown client errors", async () => {
+    const tmp = makeTmp();
+    try {
+      const db = openHubDb(tmp.dbPath);
+      try {
+        await createUser(db, "owner", "pw");
+      } finally {
+        db.close();
+      }
+      const { code, stderr } = await captureOutput(() =>
+        auth(["revoke-grant", "no-such"], { dbPath: tmp.dbPath }),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("no grant on record");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("revoke-grant deletes the row and surfaces a friendly message", async () => {
+    const tmp = makeTmp();
+    try {
+      const db = openHubDb(tmp.dbPath);
+      let userId: string;
+      let clientId: string;
+      try {
+        const user = await createUser(db, "owner", "pw");
+        userId = user.id;
+        const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+        clientId = reg.client.clientId;
+        recordGrant(db, userId, clientId, ["vault:default:read"]);
+        expect(findGrant(db, userId, clientId)).not.toBeNull();
+      } finally {
+        db.close();
+      }
+      const { code, stdout } = await captureOutput(() =>
+        auth(["revoke-grant", clientId], { dbPath: tmp.dbPath }),
+      );
+      expect(code).toBe(0);
+      expect(stdout).toContain("Revoked OAuth grant");
+      expect(stdout).toContain("re-prompt for consent");
+
+      // Row gone.
+      const verifyDb = openHubDb(tmp.dbPath);
+      try {
+        expect(findGrant(verifyDb, userId, clientId)).toBeNull();
+      } finally {
+        verifyDb.close();
+      }
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("multi-user mode requires --username on revoke-grant", async () => {
+    const tmp = makeTmp();
+    try {
+      const db = openHubDb(tmp.dbPath);
+      let aliceId: string;
+      let clientId: string;
+      try {
+        const alice = await createUser(db, "alice", "pw");
+        aliceId = alice.id;
+        await createUser(db, "bob", "pw", { allowMulti: true });
+        const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+        clientId = reg.client.clientId;
+        recordGrant(db, aliceId, clientId, ["vault:default:read"]);
+      } finally {
+        db.close();
+      }
+      const ambig = await captureOutput(() =>
+        auth(["revoke-grant", clientId], { dbPath: tmp.dbPath }),
+      );
+      expect(ambig.code).toBe(1);
+      expect(ambig.stderr).toContain("multiple hub users exist");
+
+      const targeted = await captureOutput(() =>
+        auth(["revoke-grant", clientId, "--username", "alice"], { dbPath: tmp.dbPath }),
+      );
+      expect(targeted.code).toBe(0);
+      expect(targeted.stdout).toContain("alice");
+
+      // Bob never had this grant, so revoking his side is a 1.
+      const bobMiss = await captureOutput(() =>
+        auth(["revoke-grant", clientId, "--username", "bob"], { dbPath: tmp.dbPath }),
+      );
+      expect(bobMiss.code).toBe(1);
     } finally {
       tmp.cleanup();
     }

--- a/src/__tests__/grants.test.ts
+++ b/src/__tests__/grants.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerClient } from "../clients.ts";
+import {
+  findGrant,
+  isCoveredByGrant,
+  listGrantsForUser,
+  recordGrant,
+  revokeGrant,
+} from "../grants.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { createUser } from "../users.ts";
+
+async function harness() {
+  const dir = mkdtempSync(join(tmpdir(), "phub-grants-"));
+  const db = openHubDb(hubDbPath(dir));
+  const user = await createUser(db, "owner", "pw");
+  const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+  return {
+    db,
+    userId: user.id,
+    clientId: reg.client.clientId,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("grants module (#75)", () => {
+  test("findGrant returns null when no row exists", async () => {
+    const h = await harness();
+    try {
+      expect(findGrant(h.db, h.userId, h.clientId)).toBeNull();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("recordGrant inserts a row with sorted scopes", async () => {
+    const h = await harness();
+    try {
+      const grant = recordGrant(h.db, h.userId, h.clientId, ["b", "a", "c"]);
+      // Sorted to keep on-disk order deterministic; test pins the contract.
+      expect(grant.scopes).toEqual(["a", "b", "c"]);
+      const fromDb = findGrant(h.db, h.userId, h.clientId);
+      expect(fromDb?.scopes).toEqual(["a", "b", "c"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("recordGrant unions new scopes into existing grant", async () => {
+    const h = await harness();
+    try {
+      recordGrant(h.db, h.userId, h.clientId, ["a", "b", "c"]);
+      recordGrant(h.db, h.userId, h.clientId, ["a", "d"]);
+      const grant = findGrant(h.db, h.userId, h.clientId);
+      expect(new Set(grant?.scopes)).toEqual(new Set(["a", "b", "c", "d"]));
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("recordGrant skips empty strings inside the scope list", async () => {
+    const h = await harness();
+    try {
+      recordGrant(h.db, h.userId, h.clientId, ["", "a", ""]);
+      const grant = findGrant(h.db, h.userId, h.clientId);
+      expect(grant?.scopes).toEqual(["a"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("isCoveredByGrant: false when no grant exists", async () => {
+    const h = await harness();
+    try {
+      expect(isCoveredByGrant(h.db, h.userId, h.clientId, ["a"])).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("isCoveredByGrant: true for exact match and subset, false for superset", async () => {
+    const h = await harness();
+    try {
+      recordGrant(h.db, h.userId, h.clientId, ["a", "b", "c"]);
+      expect(isCoveredByGrant(h.db, h.userId, h.clientId, ["a", "b", "c"])).toBe(true);
+      expect(isCoveredByGrant(h.db, h.userId, h.clientId, ["a"])).toBe(true);
+      expect(isCoveredByGrant(h.db, h.userId, h.clientId, ["a", "b"])).toBe(true);
+      expect(isCoveredByGrant(h.db, h.userId, h.clientId, ["a", "d"])).toBe(false);
+      expect(isCoveredByGrant(h.db, h.userId, h.clientId, ["d"])).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("isCoveredByGrant: empty request returns false (no auto-approve for empty)", async () => {
+    const h = await harness();
+    try {
+      recordGrant(h.db, h.userId, h.clientId, ["a"]);
+      // Empty scope flow is suspicious — surface it through consent rather
+      // than silently auto-approving.
+      expect(isCoveredByGrant(h.db, h.userId, h.clientId, [])).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("revokeGrant returns true when a row was removed, false when none existed", async () => {
+    const h = await harness();
+    try {
+      expect(revokeGrant(h.db, h.userId, h.clientId)).toBe(false);
+      recordGrant(h.db, h.userId, h.clientId, ["a"]);
+      expect(revokeGrant(h.db, h.userId, h.clientId)).toBe(true);
+      expect(findGrant(h.db, h.userId, h.clientId)).toBeNull();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("listGrantsForUser orders most-recent first", async () => {
+    const h = await harness();
+    try {
+      const reg2 = registerClient(h.db, { redirectUris: ["https://other.example/cb"] });
+      // Older grant first.
+      recordGrant(h.db, h.userId, h.clientId, ["a"], new Date("2026-04-01T00:00:00Z"));
+      recordGrant(h.db, h.userId, reg2.client.clientId, ["b"], new Date("2026-04-15T00:00:00Z"));
+      const grants = listGrantsForUser(h.db, h.userId);
+      expect(grants).toHaveLength(2);
+      expect(grants[0]?.clientId).toBe(reg2.client.clientId);
+      expect(grants[1]?.clientId).toBe(h.clientId);
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -2717,3 +2717,355 @@ describe("refresh-token rotation + /oauth/revoke (#73)", () => {
     expect(body.revocation_endpoint).toBe(`${ISSUER}/oauth/revoke`);
   });
 });
+
+// closes #75 — once the user has approved a scope-set for a client, the next
+// /oauth/authorize for the same client and a covered scope-set goes straight
+// to the auth-code redirect. Strict superset (incremental scope) and
+// revoked grants still show consent.
+describe("handleAuthorizeGet — skip consent when scope already granted (#75)", () => {
+  test("first approval records grant; second flow with same scopes skips consent", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        __csrf: TEST_CSRF,
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:default:read scribe:transcribe",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const consentReq = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: consentForm,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+        },
+      });
+      const consentRes = await handleAuthorizePost(db, consentReq, { issuer: ISSUER });
+      expect(consentRes.status).toBe(302);
+
+      // Second flow, same scopes — skip consent.
+      const getReq = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          scope: "vault:default:read scribe:transcribe",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          state: "second",
+        }),
+        { headers: { cookie: buildSessionCookie(session.id, 86400) } },
+      );
+      const getRes = handleAuthorizeGet(db, getReq, { issuer: ISSUER });
+      expect(getRes.status).toBe(302);
+      const loc = new URL(getRes.headers.get("location") ?? "");
+      expect(loc.origin + loc.pathname).toBe("https://app.example/cb");
+      expect(loc.searchParams.get("code")?.length).toBeGreaterThan(20);
+      expect(loc.searchParams.get("state")).toBe("second");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("subset of granted scopes also skips consent", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+
+      // Grant [a, b, c].
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        __csrf: TEST_CSRF,
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:default:read vault:default:write scribe:transcribe",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+          },
+        }),
+        { issuer: ISSUER },
+      );
+
+      // Re-flow with strict subset [a, c] — must skip.
+      const getReq = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          scope: "vault:default:read scribe:transcribe",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        }),
+        { headers: { cookie: buildSessionCookie(session.id, 86400) } },
+      );
+      const getRes = handleAuthorizeGet(db, getReq, { issuer: ISSUER });
+      expect(getRes.status).toBe(302);
+      const loc = new URL(getRes.headers.get("location") ?? "");
+      expect(loc.origin + loc.pathname).toBe("https://app.example/cb");
+      expect(loc.searchParams.get("code")?.length).toBeGreaterThan(20);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("strict superset shows consent (incremental scope grant)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+
+      // Grant [vault:default:read].
+      await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: new URLSearchParams({
+            __action: "consent",
+            __csrf: TEST_CSRF,
+            approve: "yes",
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            scope: "vault:default:read",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+          }),
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+          },
+        }),
+        { issuer: ISSUER },
+      );
+
+      // Re-flow asking for [vault:default:read, scribe:transcribe] — superset
+      // → must render consent (200 HTML), not redirect with code.
+      const getReq = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          scope: "vault:default:read scribe:transcribe",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        }),
+        { headers: { cookie: buildSessionCookie(session.id, 86400) } },
+      );
+      const getRes = handleAuthorizeGet(db, getReq, { issuer: ISSUER });
+      expect(getRes.status).toBe(200);
+      expect(getRes.headers.get("content-type")).toContain("text/html");
+      const body = await getRes.text();
+      // Both scopes appear on the consent page so the user knows they're
+      // approving the new addition explicitly.
+      expect(body).toContain("scribe:transcribe");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("revoke-grant brings consent back", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+
+      // Grant + verify skip works.
+      await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: new URLSearchParams({
+            __action: "consent",
+            __csrf: TEST_CSRF,
+            approve: "yes",
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            scope: "vault:default:read",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+          }),
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+          },
+        }),
+        { issuer: ISSUER },
+      );
+
+      // Revoke via the grants module directly (CLI runner is exercised in
+      // auth.test.ts; here we just need the row gone).
+      const { revokeGrant } = await import("../grants.ts");
+      const removed = revokeGrant(db, user.id, reg.client.clientId);
+      expect(removed).toBe(true);
+
+      // Now the same flow should render consent, not redirect.
+      const getReq = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          scope: "vault:default:read",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        }),
+        { headers: { cookie: buildSessionCookie(session.id, 86400) } },
+      );
+      const getRes = handleAuthorizeGet(db, getReq, { issuer: ISSUER });
+      expect(getRes.status).toBe(200);
+      expect(getRes.headers.get("content-type")).toContain("text/html");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("unnamed vault scope always renders consent (picker required)", async () => {
+    // Even if we somehow stored a grant matching an unnamed `vault:read`,
+    // the picker is the only way to bind the scope to a specific vault.
+    // The skip-consent path must defer to consent for unnamed vault verbs.
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      // Pre-seed a grant with an unnamed scope — defensive, just in case.
+      const { recordGrant } = await import("../grants.ts");
+      recordGrant(db, user.id, reg.client.clientId, ["vault:read"]);
+
+      const getReq = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          scope: "vault:read",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        }),
+        { headers: { cookie: buildSessionCookie(session.id, 86400) } },
+      );
+      const getRes = handleAuthorizeGet(db, getReq, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(getRes.status).toBe(200);
+      expect(getRes.headers.get("content-type")).toContain("text/html");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("re-registered client_id (different uuid) requires fresh consent", async () => {
+    // Re-registration mints a new client_id; the grant row is keyed on
+    // (user, client_id), so the new client has no prior grant. Consent
+    // must show.
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const oldReg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+
+      // Grant for the old client.
+      const { recordGrant } = await import("../grants.ts");
+      recordGrant(db, user.id, oldReg.client.clientId, ["vault:default:read"]);
+
+      // Re-register — fresh client_id.
+      const newReg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      expect(newReg.client.clientId).not.toBe(oldReg.client.clientId);
+
+      const getReq = new Request(
+        authorizeUrl({
+          client_id: newReg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          scope: "vault:default:read",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        }),
+        { headers: { cookie: buildSessionCookie(session.id, 86400) } },
+      );
+      const getRes = handleAuthorizeGet(db, getReq, { issuer: ISSUER });
+      expect(getRes.status).toBe(200);
+      expect(getRes.headers.get("content-type")).toContain("text/html");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("consent submit unions new scopes into existing grant", async () => {
+    // Direct check on the storage shape: grant [a, b], later approve [a, c],
+    // the row should hold {a, b, c} so a future flow asking [b] still skips.
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+
+      const submit = (scope: string) =>
+        handleAuthorizePost(
+          db,
+          new Request(`${ISSUER}/oauth/authorize`, {
+            method: "POST",
+            body: new URLSearchParams({
+              __action: "consent",
+              __csrf: TEST_CSRF,
+              approve: "yes",
+              client_id: reg.client.clientId,
+              redirect_uri: "https://app.example/cb",
+              response_type: "code",
+              scope,
+              code_challenge: challenge,
+              code_challenge_method: "S256",
+            }),
+            headers: {
+              "content-type": "application/x-www-form-urlencoded",
+              cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+            },
+          }),
+          { issuer: ISSUER },
+        );
+
+      await submit("vault:default:read vault:default:write");
+      await submit("vault:default:read scribe:transcribe");
+
+      const { findGrant } = await import("../grants.ts");
+      const grant = findGrant(db, user.id, reg.client.clientId);
+      expect(grant).not.toBeNull();
+      expect(new Set(grant?.scopes)).toEqual(
+        new Set(["vault:default:read", "vault:default:write", "scribe:transcribe"]),
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -18,9 +18,10 @@
 
 import { join } from "node:path";
 import { createInterface } from "node:readline/promises";
-import { approveClient, listClientsByStatus } from "../clients.ts";
+import { approveClient, getClient, listClientsByStatus } from "../clients.ts";
 import { CONFIG_DIR } from "../config.ts";
 import { readExposeState } from "../expose-state.ts";
+import { listGrantsForUser, revokeGrant } from "../grants.ts";
 import { HUB_DEFAULT_PORT, readHubPort } from "../hub-control.ts";
 import { openHubDb } from "../hub-db.ts";
 import { deriveHubOrigin } from "../hub-origin.ts";
@@ -55,6 +56,8 @@ const HUB_LOCAL_SUBCOMMANDS = new Set([
   "rotate-operator",
   "pending-clients",
   "approve-client",
+  "list-grants",
+  "revoke-grant",
 ]);
 
 export function authHelp(): string {
@@ -72,6 +75,11 @@ Usage:
   parachute auth rotate-operator       Mint a fresh ~/.parachute/operator.token
   parachute auth pending-clients       List OAuth clients awaiting approval
   parachute auth approve-client <id>   Approve a pending OAuth client
+  parachute auth list-grants [--username <name>]
+                                       Show OAuth scope grants on record
+  parachute auth revoke-grant <client_id> [--username <name>]
+                                       Forget a granted scope-set so the next
+                                       OAuth flow re-prompts for consent
 
 set-password and list-users are hub-local — they read/write
 ~/.parachute/hub.db. set-password is interactive by default (prompts for
@@ -101,6 +109,14 @@ approval (closes #74). Self-served DCR registrations land as 'pending'
 and cannot OAuth until you run \`parachute auth approve-client <id>\`.
 First-party install flows that present \`Authorization: Bearer
 <operator-token>\` with \`hub:admin\` scope land as 'approved' immediately.
+
+list-grants + revoke-grant manage the OAuth consent skip-list (closes
+#75). When you approve a scope-set on the consent screen, the hub
+records it so re-running the same flow goes straight to the auth-code
+redirect — no second consent prompt for scopes you've already approved.
+revoke-grant deletes the row so the next flow shows consent again.
+Existing access tokens are NOT touched by revoke-grant; use
+\`/oauth/revoke\` (or wait for them to expire) to terminate live sessions.
 `;
 }
 
@@ -426,6 +442,135 @@ function runApproveClient(args: readonly string[], deps: AuthDeps): number {
   }
 }
 
+interface UsernameFlag {
+  username?: string;
+  rest: string[];
+  error?: string;
+}
+
+function extractUsernameFlag(args: readonly string[]): UsernameFlag {
+  let username: string | undefined;
+  const rest: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--username") {
+      const v = args[++i];
+      if (!v) return { rest, error: "--username requires a value" };
+      username = v;
+    } else if (a?.startsWith("--username=")) {
+      username = a.slice("--username=".length);
+      if (!username) return { rest, error: "--username requires a value" };
+    } else if (a !== undefined) {
+      rest.push(a);
+    }
+  }
+  return { username, rest };
+}
+
+/**
+ * Resolve the user a grant subcommand operates on. Default is "the only hub
+ * user" (single-user mode); --username is required when multiple users exist.
+ */
+function resolveTargetUser(
+  db: ReturnType<typeof openHubDb>,
+  flagUsername: string | undefined,
+  cmd: string,
+): { id: string; username: string } | { error: string } {
+  if (flagUsername) {
+    const u = getUserByUsername(db, flagUsername);
+    if (!u) return { error: `no hub user named "${flagUsername}"` };
+    return { id: u.id, username: u.username };
+  }
+  const users = listUsers(db);
+  if (users.length === 0)
+    return { error: "no hub users yet — run `parachute auth set-password` first" };
+  if (users.length > 1) {
+    return {
+      error: `multiple hub users exist; pass --username <name> to ${cmd} a specific user's grant`,
+    };
+  }
+  const only = users[0]!;
+  return { id: only.id, username: only.username };
+}
+
+function runListGrants(args: readonly string[], deps: AuthDeps): number {
+  const flag = extractUsernameFlag(args);
+  if (flag.error) {
+    console.error(`parachute auth list-grants: ${flag.error}`);
+    return 1;
+  }
+  if (flag.rest.length > 0) {
+    console.error(`parachute auth list-grants: unexpected argument "${flag.rest[0]}"`);
+    console.error("usage: parachute auth list-grants [--username <name>]");
+    return 1;
+  }
+  const db = deps.dbPath ? openHubDb(deps.dbPath) : openHubDb();
+  try {
+    const target = resolveTargetUser(db, flag.username, "list");
+    if ("error" in target) {
+      console.error(`parachute auth list-grants: ${target.error}`);
+      return 1;
+    }
+    const grants = listGrantsForUser(db, target.id);
+    if (grants.length === 0) {
+      console.log(`(no OAuth grants on record for "${target.username}")`);
+      return 0;
+    }
+    console.log(`OAuth grants for "${target.username}":`);
+    console.log(
+      "CLIENT_ID                              NAME                 GRANTED_AT                SCOPES",
+    );
+    for (const g of grants) {
+      const client = getClient(db, g.clientId);
+      const id = g.clientId.padEnd(36).slice(0, 36);
+      const name = (client?.clientName ?? "").padEnd(20).slice(0, 20);
+      const at = g.grantedAt.padEnd(24).slice(0, 24);
+      console.log(`${id}  ${name} ${at}  ${g.scopes.join(" ")}`);
+    }
+    return 0;
+  } finally {
+    db.close();
+  }
+}
+
+function runRevokeGrant(args: readonly string[], deps: AuthDeps): number {
+  const flag = extractUsernameFlag(args);
+  if (flag.error) {
+    console.error(`parachute auth revoke-grant: ${flag.error}`);
+    return 1;
+  }
+  const clientId = flag.rest[0];
+  if (!clientId) {
+    console.error("parachute auth revoke-grant: missing client_id argument");
+    console.error("usage: parachute auth revoke-grant <client_id> [--username <name>]");
+    return 1;
+  }
+  if (flag.rest.length > 1) {
+    console.error(`parachute auth revoke-grant: unexpected argument "${flag.rest[1]}"`);
+    return 1;
+  }
+  const db = deps.dbPath ? openHubDb(deps.dbPath) : openHubDb();
+  try {
+    const target = resolveTargetUser(db, flag.username, "revoke");
+    if ("error" in target) {
+      console.error(`parachute auth revoke-grant: ${target.error}`);
+      return 1;
+    }
+    const removed = revokeGrant(db, target.id, clientId);
+    if (!removed) {
+      console.error(`no grant on record for "${target.username}" → "${clientId}"`);
+      return 1;
+    }
+    console.log(`Revoked OAuth grant: "${target.username}" → "${clientId}".`);
+    console.log(
+      "Existing access tokens are unaffected — they expire on their own. The next /oauth/authorize for this client will re-prompt for consent.",
+    );
+    return 0;
+  } finally {
+    db.close();
+  }
+}
+
 function runListUsers(deps: AuthDeps): number {
   const db = deps.dbPath ? openHubDb(deps.dbPath) : openHubDb();
   try {
@@ -511,6 +656,24 @@ export async function auth(args: readonly string[], deps: AuthDeps | Runner = {}
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`parachute auth approve-client: ${msg}`);
+        return 1;
+      }
+    }
+    if (sub === "list-grants") {
+      try {
+        return runListGrants(args.slice(1), normalized);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`parachute auth list-grants: ${msg}`);
+        return 1;
+      }
+    }
+    if (sub === "revoke-grant") {
+      try {
+        return runRevokeGrant(args.slice(1), normalized);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`parachute auth revoke-grant: ${msg}`);
         return 1;
       }
     }

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -1,0 +1,136 @@
+/**
+ * Grants — record of "user U has approved scope-set S for client C".
+ *
+ * Closes #75. The OAuth consent screen is UX, not protocol — RFC 6749 §3
+ * doesn't mandate it. Once a user has approved a set of scopes for a given
+ * client, re-running the same flow with the same (or a subset of) scopes
+ * shouldn't show consent again. Token-endpoint scope validation still gates
+ * actual issuance, so this is purely about not re-asking the human.
+ *
+ * Storage: one row per (user_id, client_id) in the `grants` table (created
+ * in hub-db migration v3). The `scopes` column is a space-separated set of
+ * every scope the user has ever approved for this client — recording is
+ * UNION semantics, not overwrite. That way, a user who approved [a, b, c]
+ * once and later approves only [a, b] for an incremental flow doesn't lose
+ * their c grant; the next flow asking [a, c] still skips consent.
+ *
+ * Skip rule: a flow may skip consent iff every requested scope is already
+ * in the grant's set. A strict superset (the client wants something new)
+ * shows the consent screen with the full requested set so the user is
+ * approving the new addition explicitly. A strict subset skips.
+ *
+ * Re-registered clients have a fresh client_id, so grants are not carried
+ * across — a re-registered app must earn consent again. That's by design:
+ * if the client_id changed, the operator can't tell from the URL whether
+ * it's the same app or an impostor.
+ */
+
+import type { Database } from "bun:sqlite";
+
+export interface Grant {
+  userId: string;
+  clientId: string;
+  scopes: string[];
+  grantedAt: string;
+}
+
+interface GrantRow {
+  user_id: string;
+  client_id: string;
+  scopes: string;
+  granted_at: string;
+}
+
+function rowToGrant(row: GrantRow): Grant {
+  return {
+    userId: row.user_id,
+    clientId: row.client_id,
+    scopes: row.scopes.split(" ").filter((s) => s.length > 0),
+    grantedAt: row.granted_at,
+  };
+}
+
+/** Look up the grant for (user, client). Returns null when none exists. */
+export function findGrant(db: Database, userId: string, clientId: string): Grant | null {
+  const row = db
+    .prepare(
+      "SELECT user_id, client_id, scopes, granted_at FROM grants WHERE user_id = ? AND client_id = ?",
+    )
+    .get(userId, clientId) as GrantRow | undefined;
+  return row ? rowToGrant(row) : null;
+}
+
+/**
+ * Record a consent approval. Merges `newScopes` into any existing grant for
+ * (user, client) — UNION semantics — and bumps `granted_at` to `now`. Empty
+ * `newScopes` is a no-op (we don't want to insert empty rows).
+ */
+export function recordGrant(
+  db: Database,
+  userId: string,
+  clientId: string,
+  newScopes: readonly string[],
+  now: Date = new Date(),
+): Grant {
+  const existing = findGrant(db, userId, clientId);
+  const merged = new Set<string>(existing?.scopes ?? []);
+  for (const s of newScopes) {
+    if (s.length > 0) merged.add(s);
+  }
+  const scopes = Array.from(merged).sort();
+  const grantedAt = now.toISOString();
+  db.prepare(
+    `INSERT OR REPLACE INTO grants (user_id, client_id, scopes, granted_at)
+     VALUES (?, ?, ?, ?)`,
+  ).run(userId, clientId, scopes.join(" "), grantedAt);
+  return { userId, clientId, scopes, grantedAt };
+}
+
+/**
+ * Test whether `requestedScopes` is fully covered by the existing grant —
+ * the rule for skipping the consent screen. Returns false when:
+ *   - no grant exists for (user, client), or
+ *   - any requested scope is missing from the grant's set, or
+ *   - `requestedScopes` is empty (we don't auto-approve "ask for nothing"
+ *     flows; they're almost certainly client bugs and showing consent will
+ *     surface that to the operator).
+ */
+export function isCoveredByGrant(
+  db: Database,
+  userId: string,
+  clientId: string,
+  requestedScopes: readonly string[],
+): boolean {
+  if (requestedScopes.length === 0) return false;
+  const grant = findGrant(db, userId, clientId);
+  if (!grant) return false;
+  const granted = new Set(grant.scopes);
+  for (const s of requestedScopes) {
+    if (!granted.has(s)) return false;
+  }
+  return true;
+}
+
+/** All grants for a user, ordered most-recent first. Used by `parachute auth list-grants`. */
+export function listGrantsForUser(db: Database, userId: string): Grant[] {
+  const rows = db
+    .prepare(
+      "SELECT user_id, client_id, scopes, granted_at FROM grants WHERE user_id = ? ORDER BY granted_at DESC",
+    )
+    .all(userId) as GrantRow[];
+  return rows.map(rowToGrant);
+}
+
+/**
+ * Delete a grant. Returns true when a row was removed; false when no grant
+ * existed for (user, client). Note this does not revoke existing tokens —
+ * an operator who wants to revoke active sessions runs `/oauth/revoke` (or
+ * its CLI wrapper) separately. Removing the grant only forces the next
+ * /oauth/authorize flow to show consent again.
+ */
+export function revokeGrant(db: Database, userId: string, clientId: string): boolean {
+  const res = db
+    .prepare("DELETE FROM grants WHERE user_id = ? AND client_id = ?")
+    .run(userId, clientId);
+  return res.changes > 0;
+}

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -42,6 +42,7 @@ import {
   verifyClientSecret,
 } from "./clients.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
+import { isCoveredByGrant, recordGrant } from "./grants.ts";
 import {
   ACCESS_TOKEN_TTL_SECONDS,
   RefreshTokenInsertError,
@@ -380,6 +381,22 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   if (!session) {
     return htmlResponse(renderLogin({ params: parsed, csrfToken: csrf.token }), 200, extra);
   }
+
+  // Skip-consent gate (#75). If the user has previously granted every
+  // requested scope to this client, mint the auth code immediately. Two
+  // important constraints:
+  //   - Unnamed vault verbs (`vault:read`) need the picker even if a prior
+  //     grant exists, because the operator's vault choice isn't recorded
+  //     literally — grants store narrowed `vault:<name>:<verb>` scopes, so
+  //     a fresh unnamed request never matches. Force consent to re-pick.
+  //   - The grant covers `requestedScopes` exactly when every requested
+  //     scope appears in the stored set. A strict superset (client wants
+  //     something new) falls through to the consent screen.
+  const hasUnnamedVault = unnamedVaultVerbs(requestedScopes).length > 0;
+  if (!hasUnnamedVault && isCoveredByGrant(db, session.userId, client.clientId, requestedScopes)) {
+    return issueAuthCodeRedirect(db, parsed, requestedScopes, session.userId, deps);
+  }
+
   const manifest = (deps.loadServicesManifest ?? readServicesManifest)();
   const vaultNames = listVaultNames(manifest);
   return htmlResponse(
@@ -387,6 +404,34 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
     200,
     extra,
   );
+}
+
+/**
+ * Mint an auth code and redirect to the client's redirect_uri. Shared by
+ * the consent-submit path (`handleConsentSubmit`) and the skip-consent path
+ * in `handleAuthorizeGet` (#75). Caller is responsible for having already
+ * validated the client + redirect_uri + scopes.
+ */
+function issueAuthCodeRedirect(
+  db: Database,
+  params: AuthorizeFormParams,
+  scopes: string[],
+  userId: string,
+  deps: OAuthDeps,
+): Response {
+  const code = issueAuthCode(db, {
+    clientId: params.clientId,
+    userId,
+    redirectUri: params.redirectUri,
+    scopes,
+    codeChallenge: params.codeChallenge,
+    codeChallengeMethod: params.codeChallengeMethod,
+    now: deps.now,
+  });
+  const u = new URL(params.redirectUri);
+  u.searchParams.set("code", code.code);
+  if (params.state) u.searchParams.set("state", params.state);
+  return redirectResponse(u.toString());
 }
 
 /**
@@ -548,30 +593,13 @@ async function handleConsentSubmit(
     }
     scopes = narrowVaultScopes(scopes, pickedVault);
   }
-  // Record the grant — gives PR (d) a place to skip the consent screen on
-  // re-authorization for already-granted scopes.
-  db.prepare(
-    `INSERT OR REPLACE INTO grants (user_id, client_id, scopes, granted_at)
-     VALUES (?, ?, ?, ?)`,
-  ).run(
-    session.userId,
-    client.clientId,
-    scopes.join(" "),
-    (deps.now?.() ?? new Date()).toISOString(),
-  );
-  const code = issueAuthCode(db, {
-    clientId: client.clientId,
-    userId: session.userId,
-    redirectUri: params.redirectUri,
-    scopes,
-    codeChallenge: params.codeChallenge,
-    codeChallengeMethod: params.codeChallengeMethod,
-    now: deps.now,
-  });
-  const u = new URL(params.redirectUri);
-  u.searchParams.set("code", code.code);
-  if (params.state) u.searchParams.set("state", params.state);
-  return redirectResponse(u.toString());
+  // Record (or extend) the grant so the next /oauth/authorize for this
+  // (user, client) with these scopes — or any subset — can skip the consent
+  // screen (#75). UNION semantics: if the user previously granted [a, b, c]
+  // and now grants [a, d], the row becomes [a, b, c, d]. Subset re-flows
+  // still match.
+  recordGrant(db, session.userId, client.clientId, scopes, deps.now?.() ?? new Date());
+  return issueAuthCodeRedirect(db, params, scopes, session.userId, deps);
 }
 
 function paramsFromForm(form: Awaited<ReturnType<Request["formData"]>>): AuthorizeFormParams {


### PR DESCRIPTION
## Summary

- Once a user approves a scope-set for a client, re-running the same flow skips the consent screen and issues the auth-code redirect directly. RFC 6749 §3 doesn't mandate consent — it's UX — and the token endpoint still gates actual issuance.
- Skip rule: requested scopes ⊆ granted scopes. Strict superset shows consent (incremental scope grant). Unnamed `vault:<verb>` always shows consent so the picker can bind to a specific vault.
- New `parachute auth list-grants` / `revoke-grant` subcommands. Revoking a grant only forces the next `/oauth/authorize` flow to re-prompt — it does not revoke live tokens (use `/oauth/revoke` for that).

## Implementation

- New `src/grants.ts` — `findGrant`, `recordGrant` (UNION semantics), `isCoveredByGrant`, `listGrantsForUser`, `revokeGrant`. `grants` table already exists from hub-db migration v3.
- `handleAuthorizeGet` adds skip-consent gate after session validation, with `hasUnnamedVault` short-circuit.
- `handleConsentSubmit` now records grants via `recordGrant` (UNION) instead of inline `INSERT OR REPLACE`, so earlier approvals aren't lost when later flows ask for fewer scopes.
- Shared `issueAuthCodeRedirect` helper used by both consent submit and skip-consent paths.

## Tests (23 new)

- 9 unit tests for `grants` module (UNION, sorting, subset/superset/empty rules, revoke, ordering)
- 7 OAuth handler tests covering: same-scope skip, subset skip, superset shows consent, revoke restores consent, unnamed vault forces consent, re-registered client forces consent, consent submit unions scopes
- 7 CLI tests for `list-grants` / `revoke-grant` (formatting, missing arg, multi-user `--username`, etc.)

840 tests pass total. Lint + typecheck clean. rc bumped 0.4.0-rc.22 → 0.4.0-rc.23.

## Test plan

- [x] `bun test` — 840 pass
- [x] `bun run lint` — 0 errors / 0 warnings
- [x] `bun run typecheck` — clean

Closes #75.