### PR TITLE
feat(deploy): provider-client interface + FlyClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.25",
+  "version": "0.4.0-rc.26",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/fly-client.test.ts
+++ b/src/__tests__/fly-client.test.ts
@@ -96,10 +96,10 @@ describe("FlyClient.validateToken", () => {
     expect(v.reason).toContain("403");
   });
 
-  test("404 (org not found) → valid=true with explanatory reason", async () => {
+  test("404 (org not found) → valid=false with explanatory reason", async () => {
     fake.handler = () => new Response("no such org", { status: 404 });
     const v = await client.validateToken();
-    expect(v.valid).toBe(true);
+    expect(v.valid).toBe(false);
     expect(v.reason).toContain("not found");
   });
 
@@ -250,9 +250,10 @@ describe("FlyClient.provisionMachine — failure paths", () => {
     expect(fake.requests).toHaveLength(1);
   });
 
-  test("volume-create 5xx (placement failure) → ProviderError, no machine call", async () => {
+  test("volume-create 5xx (placement failure) → ProviderError, then cleanup DELETE", async () => {
     let n = 0;
-    fake.handler = () => {
+    fake.handler = (req) => {
+      if (req.method === "DELETE") return new Response("", { status: 200 });
       n++;
       if (n === 1) return new Response("{}", { status: 201 });
       return new Response("placement failed", { status: 503 });
@@ -267,12 +268,17 @@ describe("FlyClient.provisionMachine — failure paths", () => {
         env: {},
       }),
     ).rejects.toMatchObject({ statusCode: 503 });
-    expect(fake.requests).toHaveLength(2);
+    expect(fake.requests).toHaveLength(3);
+    expect(fake.requests[2]).toMatchObject({
+      method: "DELETE",
+      path: "/v1/apps/parachute-x?force=true",
+    });
   });
 
-  test("machine-create 4xx → ProviderError surfaces status", async () => {
+  test("machine-create 4xx → ProviderError surfaces status, then cleanup DELETE", async () => {
     let n = 0;
-    fake.handler = () => {
+    fake.handler = (req) => {
+      if (req.method === "DELETE") return new Response("", { status: 200 });
       n++;
       if (n === 1) return new Response("{}", { status: 201 });
       if (n === 2) return new Response(JSON.stringify({ id: "vol_z", name: "x" }), { status: 200 });
@@ -288,7 +294,91 @@ describe("FlyClient.provisionMachine — failure paths", () => {
         env: {},
       }),
     ).rejects.toMatchObject({ statusCode: 400 });
-    expect(fake.requests).toHaveLength(3);
+    expect(fake.requests).toHaveLength(4);
+    expect(fake.requests[3]).toMatchObject({
+      method: "DELETE",
+      path: "/v1/apps/parachute-bad?force=true",
+    });
+  });
+
+  test("name without parachute- prefix → ProviderError, no API calls", async () => {
+    await expect(
+      client.provisionMachine({
+        name: "my-app",
+        region: "ord",
+        size: "small",
+        volumeSizeGb: 10,
+        image: "x",
+        env: {},
+      }),
+    ).rejects.toMatchObject({ name: "ProviderError", provider: "fly" });
+    expect(fake.requests).toHaveLength(0);
+  });
+
+  test("app-create 409 (conflict — already exists in another org) → ProviderError with status", async () => {
+    fake.handler = () => new Response("name not available", { status: 409 });
+    await expect(
+      client.provisionMachine({
+        name: "parachute-taken",
+        region: "ord",
+        size: "small",
+        volumeSizeGb: 10,
+        image: "x",
+        env: {},
+      }),
+    ).rejects.toMatchObject({
+      name: "ProviderError",
+      provider: "fly",
+      statusCode: 409,
+    });
+    expect(fake.requests).toHaveLength(1);
+  });
+});
+
+describe("FlyClient — token does not leak into error messages", () => {
+  const token = "fly_test_token_xyz";
+
+  test("provisionMachine app-failure error message has no token", async () => {
+    fake.handler = () => new Response(`internal: bearer ${token} echoed back`, { status: 500 });
+    let err: unknown;
+    try {
+      await client.provisionMachine({
+        name: "parachute-leak",
+        region: "ord",
+        size: "small",
+        volumeSizeGb: 10,
+        image: "x",
+        env: {},
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ProviderError);
+    expect((err as Error).message).not.toContain(token);
+  });
+
+  test("destroyMachine 500 error message has no token", async () => {
+    fake.handler = () => new Response(`echoed: ${token}`, { status: 500 });
+    let err: unknown;
+    try {
+      await client.destroyMachine("parachute-leak");
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ProviderError);
+    expect((err as Error).message).not.toContain(token);
+  });
+
+  test("listMachines 500 error message has no token", async () => {
+    fake.handler = () => new Response(`echoed: ${token}`, { status: 500 });
+    let err: unknown;
+    try {
+      await client.listMachines();
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ProviderError);
+    expect((err as Error).message).not.toContain(token);
   });
 });
 

--- a/src/__tests__/fly-client.test.ts
+++ b/src/__tests__/fly-client.test.ts
@@ -1,0 +1,427 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { FlyClient, PARACHUTE_VOLUME_NAME } from "../deploy/fly-client.ts";
+import { ProviderError } from "../deploy/provider-client.ts";
+
+interface RecordedRequest {
+  method: string;
+  path: string;
+  authorization: string | null;
+  contentType: string | null;
+  body: unknown;
+}
+
+interface FakeFly {
+  origin: string;
+  requests: RecordedRequest[];
+  /** Replace per-test to control responses. Default returns 200/empty for everything. */
+  handler: (req: Request, url: URL) => Promise<Response> | Response;
+  stop: () => Promise<void>;
+}
+
+async function startFakeFly(): Promise<FakeFly> {
+  const requests: RecordedRequest[] = [];
+  const fake: FakeFly = {
+    origin: "",
+    requests,
+    handler: () => new Response("{}", { status: 200 }),
+    stop: async () => {},
+  };
+  const server = Bun.serve({
+    port: 0,
+    fetch: async (req) => {
+      const url = new URL(req.url);
+      let body: unknown = null;
+      if (req.method !== "GET" && req.method !== "DELETE") {
+        const text = await req.text();
+        try {
+          body = text ? JSON.parse(text) : null;
+        } catch {
+          body = text;
+        }
+      }
+      requests.push({
+        method: req.method,
+        path: `${url.pathname}${url.search}`,
+        authorization: req.headers.get("authorization"),
+        contentType: req.headers.get("content-type"),
+        body,
+      });
+      return fake.handler(req, url);
+    },
+  });
+  fake.origin = `http://localhost:${server.port}`;
+  fake.stop = async () => {
+    await server.stop(true);
+  };
+  return fake;
+}
+
+let fake: FakeFly;
+let client: FlyClient;
+
+beforeEach(async () => {
+  fake = await startFakeFly();
+  client = new FlyClient({
+    token: "fly_test_token_xyz",
+    orgSlug: "personal",
+    apiOrigin: fake.origin,
+  });
+});
+
+afterEach(async () => {
+  await fake.stop();
+});
+
+describe("FlyClient.validateToken", () => {
+  test("200 from /v1/apps → valid + orgSlug", async () => {
+    fake.handler = () => new Response(JSON.stringify({ apps: [] }), { status: 200 });
+    const v = await client.validateToken();
+    expect(v.valid).toBe(true);
+    expect(v.orgSlug).toBe("personal");
+    expect(fake.requests[0]?.path).toBe("/v1/apps?org_slug=personal");
+    expect(fake.requests[0]?.authorization).toBe("Bearer fly_test_token_xyz");
+  });
+
+  test("401 → invalid with reason", async () => {
+    fake.handler = () => new Response("nope", { status: 401 });
+    const v = await client.validateToken();
+    expect(v.valid).toBe(false);
+    expect(v.reason).toContain("401");
+  });
+
+  test("403 → invalid with reason", async () => {
+    fake.handler = () => new Response("forbidden", { status: 403 });
+    const v = await client.validateToken();
+    expect(v.valid).toBe(false);
+    expect(v.reason).toContain("403");
+  });
+
+  test("404 (org not found) → valid=true with explanatory reason", async () => {
+    fake.handler = () => new Response("no such org", { status: 404 });
+    const v = await client.validateToken();
+    expect(v.valid).toBe(true);
+    expect(v.reason).toContain("not found");
+  });
+
+  test("500 → invalid with status in reason", async () => {
+    fake.handler = () => new Response("oops", { status: 500 });
+    const v = await client.validateToken();
+    expect(v.valid).toBe(false);
+    expect(v.reason).toContain("500");
+  });
+});
+
+describe("FlyClient.provisionMachine — happy path", () => {
+  test("makes app + volume + machine calls in order with correct shapes", async () => {
+    const responses: Array<() => Response> = [
+      () => new Response(JSON.stringify({ name: "parachute-aaron" }), { status: 201 }),
+      () =>
+        new Response(JSON.stringify({ id: "vol_abc", name: PARACHUTE_VOLUME_NAME }), {
+          status: 200,
+        }),
+      () =>
+        new Response(
+          JSON.stringify({
+            id: "m_123",
+            region: "ord",
+            state: "starting",
+            created_at: "2026-04-29T12:00:00Z",
+          }),
+          { status: 200 },
+        ),
+    ];
+    let i = 0;
+    fake.handler = () => {
+      const r = responses[i++];
+      if (!r) return new Response("unexpected", { status: 500 });
+      return r();
+    };
+
+    const rec = await client.provisionMachine({
+      name: "parachute-aaron",
+      region: "ord",
+      size: "small",
+      volumeSizeGb: 10,
+      image: "ghcr.io/openparachute/parachute:0.4.0",
+      env: { HUB_PORT: "1939" },
+    });
+
+    expect(fake.requests).toHaveLength(3);
+
+    expect(fake.requests[0]).toMatchObject({
+      method: "POST",
+      path: "/v1/apps",
+      authorization: "Bearer fly_test_token_xyz",
+      contentType: "application/json",
+      body: { app_name: "parachute-aaron", org_slug: "personal" },
+    });
+
+    expect(fake.requests[1]).toMatchObject({
+      method: "POST",
+      path: "/v1/apps/parachute-aaron/volumes",
+      body: { name: PARACHUTE_VOLUME_NAME, region: "ord", size_gb: 10 },
+    });
+
+    const machineCall = fake.requests[2];
+    if (!machineCall) throw new Error("missing machine call");
+    expect(machineCall.method).toBe("POST");
+    expect(machineCall.path).toBe("/v1/apps/parachute-aaron/machines");
+    const machineBody = machineCall.body as {
+      region: string;
+      config: {
+        image: string;
+        env: Record<string, string>;
+        guest: { cpu_kind: string; cpus: number; memory_mb: number };
+        mounts: Array<{ volume: string; path: string }>;
+        services: Array<{ internal_port: number }>;
+      };
+    };
+    expect(machineBody.region).toBe("ord");
+    expect(machineBody.config.image).toBe("ghcr.io/openparachute/parachute:0.4.0");
+    expect(machineBody.config.env).toEqual({ HUB_PORT: "1939" });
+    expect(machineBody.config.guest).toEqual({ cpu_kind: "shared", cpus: 1, memory_mb: 1024 });
+    expect(machineBody.config.mounts[0]).toEqual({ volume: "vol_abc", path: "/data" });
+    expect(machineBody.config.services[0]?.internal_port).toBe(1939);
+
+    expect(rec).toEqual({
+      name: "parachute-aaron",
+      provider: "fly",
+      region: "ord",
+      url: "https://parachute-aaron.fly.dev",
+      status: "starting",
+      createdAt: "2026-04-29T12:00:00Z",
+    });
+  });
+
+  test("size=medium → 2048 MB guest config", async () => {
+    fake.handler = (_req, url) => {
+      if (url.pathname.endsWith("/volumes")) {
+        return new Response(JSON.stringify({ id: "vol_x", name: PARACHUTE_VOLUME_NAME }), {
+          status: 200,
+        });
+      }
+      if (url.pathname.endsWith("/machines")) {
+        return new Response(
+          JSON.stringify({
+            id: "m_x",
+            region: "ams",
+            state: "starting",
+            created_at: "2026-04-29T12:00:00Z",
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("{}", { status: 200 });
+    };
+
+    await client.provisionMachine({
+      name: "parachute-bigger",
+      region: "ams",
+      size: "medium",
+      volumeSizeGb: 20,
+      image: "x",
+      env: {},
+    });
+
+    const machineCall = fake.requests.find((r) => r.path.endsWith("/machines"));
+    expect(
+      (machineCall?.body as { config: { guest: { memory_mb: number } } }).config.guest.memory_mb,
+    ).toBe(2048);
+  });
+});
+
+describe("FlyClient.provisionMachine — failure paths", () => {
+  test("app-create 422 → ProviderError with status, no further calls", async () => {
+    fake.handler = () => new Response("name taken", { status: 422 });
+    await expect(
+      client.provisionMachine({
+        name: "parachute-dup",
+        region: "ord",
+        size: "small",
+        volumeSizeGb: 10,
+        image: "x",
+        env: {},
+      }),
+    ).rejects.toMatchObject({
+      name: "ProviderError",
+      provider: "fly",
+      statusCode: 422,
+    });
+    expect(fake.requests).toHaveLength(1);
+  });
+
+  test("volume-create 5xx (placement failure) → ProviderError, no machine call", async () => {
+    let n = 0;
+    fake.handler = () => {
+      n++;
+      if (n === 1) return new Response("{}", { status: 201 });
+      return new Response("placement failed", { status: 503 });
+    };
+    await expect(
+      client.provisionMachine({
+        name: "parachute-x",
+        region: "ord",
+        size: "small",
+        volumeSizeGb: 10,
+        image: "x",
+        env: {},
+      }),
+    ).rejects.toMatchObject({ statusCode: 503 });
+    expect(fake.requests).toHaveLength(2);
+  });
+
+  test("machine-create 4xx → ProviderError surfaces status", async () => {
+    let n = 0;
+    fake.handler = () => {
+      n++;
+      if (n === 1) return new Response("{}", { status: 201 });
+      if (n === 2) return new Response(JSON.stringify({ id: "vol_z", name: "x" }), { status: 200 });
+      return new Response("bad guest config", { status: 400 });
+    };
+    await expect(
+      client.provisionMachine({
+        name: "parachute-bad",
+        region: "ord",
+        size: "small",
+        volumeSizeGb: 10,
+        image: "x",
+        env: {},
+      }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    expect(fake.requests).toHaveLength(3);
+  });
+});
+
+describe("FlyClient.destroyMachine", () => {
+  test("200 → resolves; one DELETE call with force=true", async () => {
+    fake.handler = () => new Response("", { status: 200 });
+    await client.destroyMachine("parachute-aaron");
+    expect(fake.requests).toEqual([
+      {
+        method: "DELETE",
+        path: "/v1/apps/parachute-aaron?force=true",
+        authorization: "Bearer fly_test_token_xyz",
+        contentType: null,
+        body: null,
+      },
+    ]);
+  });
+
+  test("404 → resolves (idempotent — already gone is success)", async () => {
+    fake.handler = () => new Response("not found", { status: 404 });
+    await expect(client.destroyMachine("parachute-gone")).resolves.toBeUndefined();
+  });
+
+  test("410 → resolves (gone but historically present)", async () => {
+    fake.handler = () => new Response("", { status: 410 });
+    await expect(client.destroyMachine("parachute-gone")).resolves.toBeUndefined();
+  });
+
+  test("500 → ProviderError with status", async () => {
+    fake.handler = () => new Response("server error", { status: 500 });
+    await expect(client.destroyMachine("parachute-x")).rejects.toMatchObject({
+      name: "ProviderError",
+      statusCode: 500,
+    });
+  });
+});
+
+describe("FlyClient.listMachines", () => {
+  test("filters apps by parachute- prefix and enriches with machine state", async () => {
+    fake.handler = (_req, url) => {
+      if (url.pathname === "/v1/apps") {
+        return new Response(
+          JSON.stringify({
+            apps: [
+              { name: "parachute-aaron", status: "deployed" },
+              { name: "unrelated-side-project", status: "deployed" },
+              { name: "parachute-test", status: "pending" },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.pathname === "/v1/apps/parachute-aaron/machines") {
+        return new Response(
+          JSON.stringify([
+            { id: "m1", region: "ord", state: "started", created_at: "2026-04-29T10:00:00Z" },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (url.pathname === "/v1/apps/parachute-test/machines") {
+        return new Response(
+          JSON.stringify([
+            { id: "m2", region: "ams", state: "starting", created_at: "2026-04-29T11:00:00Z" },
+          ]),
+          { status: 200 },
+        );
+      }
+      return new Response("not expected", { status: 500 });
+    };
+
+    const list = await client.listMachines();
+    expect(list).toHaveLength(2);
+    const names = list.map((d) => d.name).sort();
+    expect(names).toEqual(["parachute-aaron", "parachute-test"]);
+    const aaron = list.find((d) => d.name === "parachute-aaron");
+    expect(aaron).toMatchObject({
+      provider: "fly",
+      region: "ord",
+      url: "https://parachute-aaron.fly.dev",
+      status: "running",
+      createdAt: "2026-04-29T10:00:00Z",
+    });
+  });
+
+  test("orphan app (no machines) returns record with status=unknown", async () => {
+    fake.handler = (_req, url) => {
+      if (url.pathname === "/v1/apps") {
+        return new Response(
+          JSON.stringify({ apps: [{ name: "parachute-orphan", status: "pending" }] }),
+          { status: 200 },
+        );
+      }
+      if (url.pathname.endsWith("/machines")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response("nope", { status: 500 });
+    };
+
+    const list = await client.listMachines();
+    expect(list).toEqual([
+      {
+        name: "parachute-orphan",
+        provider: "fly",
+        region: "",
+        url: "https://parachute-orphan.fly.dev",
+        status: "unknown",
+        createdAt: "",
+      },
+    ]);
+  });
+
+  test("empty app list → empty record list", async () => {
+    fake.handler = () => new Response(JSON.stringify({ apps: [] }), { status: 200 });
+    expect(await client.listMachines()).toEqual([]);
+  });
+
+  test("app-list 5xx → ProviderError", async () => {
+    fake.handler = () => new Response("down", { status: 503 });
+    await expect(client.listMachines()).rejects.toMatchObject({
+      name: "ProviderError",
+      statusCode: 503,
+    });
+  });
+});
+
+describe("FlyClient — deferred surfaces", () => {
+  test("tailLogs throws ProviderError on first iteration", async () => {
+    const it = client.tailLogs("parachute-aaron")[Symbol.asyncIterator]();
+    await expect(it.next()).rejects.toBeInstanceOf(ProviderError);
+  });
+
+  test("sshExec rejects with ProviderError", async () => {
+    await expect(client.sshExec("parachute-aaron", "ls /")).rejects.toBeInstanceOf(ProviderError);
+  });
+});

--- a/src/deploy/fly-client.ts
+++ b/src/deploy/fly-client.ts
@@ -26,9 +26,15 @@ import {
 const DEFAULT_API_ORIGIN = "https://api.machines.dev";
 
 /**
+ * Machines API version. Hoisted so a future v2 grep / migration is mechanical.
+ */
+const API_VERSION = "v1";
+
+/**
  * Apps not prefixed with this string aren't surfaced by `listMachines`; users
  * typically have non-Parachute apps in the same Fly org and we don't want to
- * imply ownership over them.
+ * imply ownership over them. `provisionMachine` enforces the prefix on input
+ * so the listMachines filter never misses a real Parachute deployment.
  */
 export const PARACHUTE_APP_PREFIX = "parachute-";
 
@@ -81,12 +87,14 @@ export class FlyClient implements ProviderClient {
   }
 
   async validateToken(): Promise<TokenValidation> {
-    const res = await this.request(`/v1/apps?org_slug=${encodeURIComponent(this.orgSlug)}`);
+    const res = await this.request(
+      `/${API_VERSION}/apps?org_slug=${encodeURIComponent(this.orgSlug)}`,
+    );
     if (res.status === 401 || res.status === 403) {
       return { valid: false, reason: `Token rejected by Fly (${res.status})` };
     }
     if (res.status === 404) {
-      return { valid: true, reason: `Org "${this.orgSlug}" not found for this token` };
+      return { valid: false, reason: `Org "${this.orgSlug}" not found for this token` };
     }
     if (!res.ok) {
       return { valid: false, reason: `Fly returned ${res.status}` };
@@ -95,7 +103,14 @@ export class FlyClient implements ProviderClient {
   }
 
   async provisionMachine(opts: ProvisionOpts): Promise<DeploymentRecord> {
-    const appRes = await this.request("/v1/apps", {
+    if (!opts.name.startsWith(PARACHUTE_APP_PREFIX)) {
+      throw new ProviderError(
+        `Deployment name "${opts.name}" must start with "${PARACHUTE_APP_PREFIX}" — listMachines depends on this prefix to identify Parachute deployments.`,
+        "fly",
+      );
+    }
+
+    const appRes = await this.request(`/${API_VERSION}/apps`, {
       method: "POST",
       body: JSON.stringify({
         app_name: opts.name,
@@ -104,102 +119,123 @@ export class FlyClient implements ProviderClient {
     });
     if (!appRes.ok) {
       throw new ProviderError(
-        `Fly app creation failed (${appRes.status}): ${await safeText(appRes)}`,
+        `Fly app creation failed (${appRes.status}): ${await this.safeText(appRes)}`,
         "fly",
         appRes.status,
       );
     }
 
-    const volRes = await this.request(`/v1/apps/${encodeURIComponent(opts.name)}/volumes`, {
-      method: "POST",
-      body: JSON.stringify({
-        name: PARACHUTE_VOLUME_NAME,
-        region: opts.region,
-        size_gb: opts.volumeSizeGb,
-      }),
-    });
-    if (!volRes.ok) {
-      throw new ProviderError(
-        `Fly volume creation failed (${volRes.status}): ${await safeText(volRes)}`,
-        "fly",
-        volRes.status,
-      );
-    }
-    const volume = (await volRes.json()) as FlyVolume;
-
-    const machineRes = await this.request(`/v1/apps/${encodeURIComponent(opts.name)}/machines`, {
-      method: "POST",
-      body: JSON.stringify({
-        region: opts.region,
-        config: {
-          image: opts.image,
-          env: opts.env,
-          guest: sizeToFlyGuest(opts.size),
-          mounts: [{ volume: volume.id, path: "/data" }],
-          services: [
-            {
-              ports: [
-                { port: 80, handlers: ["http"] },
-                { port: 443, handlers: ["http", "tls"] },
-              ],
-              protocol: "tcp",
-              internal_port: HUB_INTERNAL_PORT,
-            },
-          ],
-          checks: {
-            health: {
-              type: "http",
-              port: HUB_INTERNAL_PORT,
-              path: "/health",
-              interval: "15s",
-              timeout: "10s",
-            },
-          },
-          auto_destroy: false,
+    // From here on, the app exists in the user's Fly org. Any failure must
+    // tear it down before throwing, otherwise we leave a ghost app billing
+    // and cluttering the user's dashboard.
+    let appCreated = true;
+    try {
+      const volRes = await this.request(
+        `/${API_VERSION}/apps/${encodeURIComponent(opts.name)}/volumes`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            name: PARACHUTE_VOLUME_NAME,
+            region: opts.region,
+            size_gb: opts.volumeSizeGb,
+          }),
         },
-      }),
-    });
-    if (!machineRes.ok) {
-      throw new ProviderError(
-        `Fly machine creation failed (${machineRes.status}): ${await safeText(machineRes)}`,
-        "fly",
-        machineRes.status,
       );
-    }
-    const machine = (await machineRes.json()) as FlyMachine;
+      if (!volRes.ok) {
+        throw new ProviderError(
+          `Fly volume creation failed (${volRes.status}): ${await this.safeText(volRes)}`,
+          "fly",
+          volRes.status,
+        );
+      }
+      const volume = (await volRes.json()) as FlyVolume;
 
-    return {
-      name: opts.name,
-      provider: "fly",
-      region: machine.region || opts.region,
-      url: `https://${opts.name}.fly.dev`,
-      status: mapFlyStatus(machine.state),
-      createdAt: machine.created_at || new Date().toISOString(),
-    };
+      const machineRes = await this.request(
+        `/${API_VERSION}/apps/${encodeURIComponent(opts.name)}/machines`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            region: opts.region,
+            config: {
+              image: opts.image,
+              env: opts.env,
+              guest: sizeToFlyGuest(opts.size),
+              mounts: [{ volume: volume.id, path: "/data" }],
+              services: [
+                {
+                  ports: [
+                    { port: 80, handlers: ["http"] },
+                    { port: 443, handlers: ["http", "tls"] },
+                  ],
+                  protocol: "tcp",
+                  internal_port: HUB_INTERNAL_PORT,
+                },
+              ],
+              checks: {
+                health: {
+                  type: "http",
+                  port: HUB_INTERNAL_PORT,
+                  path: "/health",
+                  interval: "15s",
+                  timeout: "10s",
+                },
+              },
+              auto_destroy: false,
+            },
+          }),
+        },
+      );
+      if (!machineRes.ok) {
+        throw new ProviderError(
+          `Fly machine creation failed (${machineRes.status}): ${await this.safeText(machineRes)}`,
+          "fly",
+          machineRes.status,
+        );
+      }
+      const machine = (await machineRes.json()) as FlyMachine;
+      appCreated = false;
+      return {
+        name: opts.name,
+        provider: "fly",
+        region: machine.region || opts.region,
+        url: `https://${opts.name}.fly.dev`,
+        status: mapFlyStatus(machine.state),
+        createdAt: machine.created_at || new Date().toISOString(),
+      };
+    } catch (err) {
+      if (appCreated) {
+        await this.destroyMachine(opts.name).catch(() => {
+          // Cleanup is best-effort. Surface the original failure, not the
+          // cleanup failure — the user already knows provisioning broke.
+        });
+      }
+      throw err;
+    }
   }
 
   async destroyMachine(name: string): Promise<void> {
-    const res = await this.request(`/v1/apps/${encodeURIComponent(name)}?force=true`, {
+    const res = await this.request(`/${API_VERSION}/apps/${encodeURIComponent(name)}?force=true`, {
       method: "DELETE",
     });
     if (res.ok || res.status === 404 || res.status === 410) return;
     throw new ProviderError(
-      `Fly app destroy failed (${res.status}): ${await safeText(res)}`,
+      `Fly app destroy failed (${res.status}): ${await this.safeText(res)}`,
       "fly",
       res.status,
     );
   }
 
   async listMachines(): Promise<DeploymentRecord[]> {
-    const res = await this.request(`/v1/apps?org_slug=${encodeURIComponent(this.orgSlug)}`);
+    const res = await this.request(
+      `/${API_VERSION}/apps?org_slug=${encodeURIComponent(this.orgSlug)}`,
+    );
     if (!res.ok) {
       throw new ProviderError(`Fly app list failed (${res.status})`, "fly", res.status);
     }
     const body = (await res.json()) as FlyAppListResponse;
     const apps = (body.apps ?? []).filter((a) => a.name.startsWith(PARACHUTE_APP_PREFIX));
 
-    const records = await Promise.all(apps.map((app) => this.toDeploymentRecord(app)));
-    return records.filter((r): r is DeploymentRecord => r !== null);
+    return Promise.all(apps.map((app) => this.toDeploymentRecord(app)));
   }
 
   tailLogs(_name: string, _opts?: { follow?: boolean }): AsyncIterable<LogLine> {
@@ -238,12 +274,25 @@ export class FlyClient implements ProviderClient {
   }
 
   /**
+   * Read up to 500 chars of a response body for inclusion in error messages,
+   * redacting the bearer token in case the upstream echoes request headers.
+   */
+  private async safeText(res: Response): Promise<string> {
+    try {
+      const body = (await res.text()).slice(0, 500);
+      return body.split(this.token).join("[redacted]");
+    } catch {
+      return "<no body>";
+    }
+  }
+
+  /**
    * Best-effort lookup of a Parachute app's first machine. If the app has no
    * machines (orphan / mid-destroy), returns a record with status "unknown"
    * and empty region rather than throwing — the caller wants a list, not a fault.
    */
-  private async toDeploymentRecord(app: FlyApp): Promise<DeploymentRecord | null> {
-    const res = await this.request(`/v1/apps/${encodeURIComponent(app.name)}/machines`);
+  private async toDeploymentRecord(app: FlyApp): Promise<DeploymentRecord> {
+    const res = await this.request(`/${API_VERSION}/apps/${encodeURIComponent(app.name)}/machines`);
     if (!res.ok) {
       return {
         name: app.name,
@@ -311,13 +360,5 @@ function mapFlyStatus(state: string | undefined): DeploymentStatus {
       return "destroyed";
     default:
       return "unknown";
-  }
-}
-
-async function safeText(res: Response): Promise<string> {
-  try {
-    return (await res.text()).slice(0, 500);
-  } catch {
-    return "<no body>";
   }
 }

--- a/src/deploy/fly-client.ts
+++ b/src/deploy/fly-client.ts
@@ -1,0 +1,323 @@
+/**
+ * Fly.io implementation of ProviderClient against the Machines API
+ * (https://api.machines.dev). See docs/design/2026-04-29-parachute-deploy.md.
+ *
+ * Provisioning is three calls — POST /v1/apps, POST /v1/apps/{app}/volumes,
+ * POST /v1/apps/{app}/machines. Destroy is a single DELETE that cascades.
+ *
+ * tailLogs and sshExec aren't on the Machines REST API — Fly serves logs over
+ * NATS / GraphQL and SSH over an mTLS proxy. They're declared here for
+ * interface parity but throw `ProviderError("not yet wired")` so PR3/PR4 can
+ * land their integrations behind a stable type.
+ */
+
+import {
+  type DeploymentRecord,
+  type DeploymentSize,
+  type DeploymentStatus,
+  type ExecResult,
+  type LogLine,
+  type ProviderClient,
+  ProviderError,
+  type ProvisionOpts,
+  type TokenValidation,
+} from "./provider-client.ts";
+
+const DEFAULT_API_ORIGIN = "https://api.machines.dev";
+
+/**
+ * Apps not prefixed with this string aren't surfaced by `listMachines`; users
+ * typically have non-Parachute apps in the same Fly org and we don't want to
+ * imply ownership over them.
+ */
+export const PARACHUTE_APP_PREFIX = "parachute-";
+
+/** Default volume name inside a Parachute deployment. Mounted at /data. */
+export const PARACHUTE_VOLUME_NAME = "parachute_data";
+
+/** Internal port hub listens on — services exposed publicly via 80/443. */
+const HUB_INTERNAL_PORT = 1939;
+
+export interface FlyClientConfig {
+  /** Fly personal access token. Bearer-auth on every request. */
+  token: string;
+  /** Org slug the token operates against (e.g. "personal" or "open-parachute"). */
+  orgSlug: string;
+  /** Test-only override. Production callers leave this unset. */
+  apiOrigin?: string;
+}
+
+interface FlyApp {
+  name: string;
+  status?: string;
+}
+
+interface FlyAppListResponse {
+  apps?: FlyApp[];
+}
+
+interface FlyMachine {
+  id: string;
+  name?: string;
+  region: string;
+  state: string;
+  created_at: string;
+}
+
+interface FlyVolume {
+  id: string;
+  name: string;
+}
+
+export class FlyClient implements ProviderClient {
+  private readonly token: string;
+  private readonly orgSlug: string;
+  private readonly apiOrigin: string;
+
+  constructor(config: FlyClientConfig) {
+    this.token = config.token;
+    this.orgSlug = config.orgSlug;
+    this.apiOrigin = config.apiOrigin ?? DEFAULT_API_ORIGIN;
+  }
+
+  async validateToken(): Promise<TokenValidation> {
+    const res = await this.request(`/v1/apps?org_slug=${encodeURIComponent(this.orgSlug)}`);
+    if (res.status === 401 || res.status === 403) {
+      return { valid: false, reason: `Token rejected by Fly (${res.status})` };
+    }
+    if (res.status === 404) {
+      return { valid: true, reason: `Org "${this.orgSlug}" not found for this token` };
+    }
+    if (!res.ok) {
+      return { valid: false, reason: `Fly returned ${res.status}` };
+    }
+    return { valid: true, orgSlug: this.orgSlug };
+  }
+
+  async provisionMachine(opts: ProvisionOpts): Promise<DeploymentRecord> {
+    const appRes = await this.request("/v1/apps", {
+      method: "POST",
+      body: JSON.stringify({
+        app_name: opts.name,
+        org_slug: this.orgSlug,
+      }),
+    });
+    if (!appRes.ok) {
+      throw new ProviderError(
+        `Fly app creation failed (${appRes.status}): ${await safeText(appRes)}`,
+        "fly",
+        appRes.status,
+      );
+    }
+
+    const volRes = await this.request(`/v1/apps/${encodeURIComponent(opts.name)}/volumes`, {
+      method: "POST",
+      body: JSON.stringify({
+        name: PARACHUTE_VOLUME_NAME,
+        region: opts.region,
+        size_gb: opts.volumeSizeGb,
+      }),
+    });
+    if (!volRes.ok) {
+      throw new ProviderError(
+        `Fly volume creation failed (${volRes.status}): ${await safeText(volRes)}`,
+        "fly",
+        volRes.status,
+      );
+    }
+    const volume = (await volRes.json()) as FlyVolume;
+
+    const machineRes = await this.request(`/v1/apps/${encodeURIComponent(opts.name)}/machines`, {
+      method: "POST",
+      body: JSON.stringify({
+        region: opts.region,
+        config: {
+          image: opts.image,
+          env: opts.env,
+          guest: sizeToFlyGuest(opts.size),
+          mounts: [{ volume: volume.id, path: "/data" }],
+          services: [
+            {
+              ports: [
+                { port: 80, handlers: ["http"] },
+                { port: 443, handlers: ["http", "tls"] },
+              ],
+              protocol: "tcp",
+              internal_port: HUB_INTERNAL_PORT,
+            },
+          ],
+          checks: {
+            health: {
+              type: "http",
+              port: HUB_INTERNAL_PORT,
+              path: "/health",
+              interval: "15s",
+              timeout: "10s",
+            },
+          },
+          auto_destroy: false,
+        },
+      }),
+    });
+    if (!machineRes.ok) {
+      throw new ProviderError(
+        `Fly machine creation failed (${machineRes.status}): ${await safeText(machineRes)}`,
+        "fly",
+        machineRes.status,
+      );
+    }
+    const machine = (await machineRes.json()) as FlyMachine;
+
+    return {
+      name: opts.name,
+      provider: "fly",
+      region: machine.region || opts.region,
+      url: `https://${opts.name}.fly.dev`,
+      status: mapFlyStatus(machine.state),
+      createdAt: machine.created_at || new Date().toISOString(),
+    };
+  }
+
+  async destroyMachine(name: string): Promise<void> {
+    const res = await this.request(`/v1/apps/${encodeURIComponent(name)}?force=true`, {
+      method: "DELETE",
+    });
+    if (res.ok || res.status === 404 || res.status === 410) return;
+    throw new ProviderError(
+      `Fly app destroy failed (${res.status}): ${await safeText(res)}`,
+      "fly",
+      res.status,
+    );
+  }
+
+  async listMachines(): Promise<DeploymentRecord[]> {
+    const res = await this.request(`/v1/apps?org_slug=${encodeURIComponent(this.orgSlug)}`);
+    if (!res.ok) {
+      throw new ProviderError(`Fly app list failed (${res.status})`, "fly", res.status);
+    }
+    const body = (await res.json()) as FlyAppListResponse;
+    const apps = (body.apps ?? []).filter((a) => a.name.startsWith(PARACHUTE_APP_PREFIX));
+
+    const records = await Promise.all(apps.map((app) => this.toDeploymentRecord(app)));
+    return records.filter((r): r is DeploymentRecord => r !== null);
+  }
+
+  tailLogs(_name: string, _opts?: { follow?: boolean }): AsyncIterable<LogLine> {
+    return {
+      [Symbol.asyncIterator]: () => ({
+        next: () =>
+          Promise.reject(
+            new ProviderError(
+              "Fly log streaming is not exposed via the Machines REST API. Wiring (NATS or GraphQL) lands in a follow-up PR.",
+              "fly",
+            ),
+          ),
+      }),
+    };
+  }
+
+  sshExec(_name: string, _command: string): Promise<ExecResult> {
+    return Promise.reject(
+      new ProviderError(
+        "Fly SSH exec is not exposed via the Machines REST API. Wiring (Fly mTLS SSH proxy) lands in a follow-up PR.",
+        "fly",
+      ),
+    );
+  }
+
+  private async request(path: string, init?: RequestInit): Promise<Response> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.token}`,
+      Accept: "application/json",
+    };
+    if (init?.body) headers["Content-Type"] = "application/json";
+    return fetch(`${this.apiOrigin}${path}`, {
+      ...init,
+      headers: { ...headers, ...(init?.headers as Record<string, string> | undefined) },
+    });
+  }
+
+  /**
+   * Best-effort lookup of a Parachute app's first machine. If the app has no
+   * machines (orphan / mid-destroy), returns a record with status "unknown"
+   * and empty region rather than throwing — the caller wants a list, not a fault.
+   */
+  private async toDeploymentRecord(app: FlyApp): Promise<DeploymentRecord | null> {
+    const res = await this.request(`/v1/apps/${encodeURIComponent(app.name)}/machines`);
+    if (!res.ok) {
+      return {
+        name: app.name,
+        provider: "fly",
+        region: "",
+        url: `https://${app.name}.fly.dev`,
+        status: "unknown",
+        createdAt: "",
+      };
+    }
+    const machines = (await res.json()) as FlyMachine[];
+    const first = machines[0];
+    if (!first) {
+      return {
+        name: app.name,
+        provider: "fly",
+        region: "",
+        url: `https://${app.name}.fly.dev`,
+        status: "unknown",
+        createdAt: "",
+      };
+    }
+    return {
+      name: app.name,
+      provider: "fly",
+      region: first.region,
+      url: `https://${app.name}.fly.dev`,
+      status: mapFlyStatus(first.state),
+      createdAt: first.created_at,
+    };
+  }
+}
+
+function sizeToFlyGuest(size: DeploymentSize): {
+  cpu_kind: "shared";
+  cpus: number;
+  memory_mb: number;
+} {
+  return {
+    cpu_kind: "shared",
+    cpus: 1,
+    memory_mb: size === "small" ? 1024 : 2048,
+  };
+}
+
+/**
+ * Fly machine state vocabulary → DeploymentStatus.
+ * Source: https://fly.io/docs/machines/working-with-machines/#machine-states
+ */
+function mapFlyStatus(state: string | undefined): DeploymentStatus {
+  switch (state) {
+    case "started":
+    case "running":
+      return "running";
+    case "created":
+    case "starting":
+      return "starting";
+    case "stopping":
+    case "stopped":
+    case "suspending":
+    case "suspended":
+      return "stopped";
+    case "destroying":
+    case "destroyed":
+      return "destroyed";
+    default:
+      return "unknown";
+  }
+}
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 500);
+  } catch {
+    return "<no body>";
+  }
+}

--- a/src/deploy/provider-client.ts
+++ b/src/deploy/provider-client.ts
@@ -1,0 +1,107 @@
+/**
+ * Provider-agnostic interface for cloud VM provisioning.
+ *
+ * Implemented per provider — FlyClient ships in this PR; RenderClient is a
+ * follow-up. Used by the `parachute deploy` command (PR3) and its sibling
+ * subcommands (PR4: list, logs, ssh, destroy).
+ *
+ * Design: docs/design/2026-04-29-parachute-deploy.md
+ *
+ * v1 targets Tier 1 — hub + vault + scribe + notes — on a single machine.
+ * Paraclaw (Tier 2) is excluded; this surface deliberately doesn't model
+ * multi-machine deployments yet.
+ */
+
+export type ProviderName = "fly" | "render";
+
+/**
+ * Tier 1 baseline. `small` = 1 GB / 1 shared vCPU, fits hub + vault + scribe
+ * + notes inside the $10/mo budget. `medium` = 2 GB for headroom. Both share
+ * a single CPU; deployments wanting a dedicated CPU live outside this surface.
+ */
+export type DeploymentSize = "small" | "medium";
+
+export type DeploymentStatus = "starting" | "running" | "stopped" | "destroyed" | "unknown";
+
+export interface DeploymentRecord {
+  /** Provider-side app/slug name. Must be unique within the provider org. */
+  name: string;
+  provider: ProviderName;
+  /** Provider region code (Fly: ord, ams, syd…). Empty if not known yet. */
+  region: string;
+  /** Public HTTPS URL for the deployment, including provider-issued subdomain. */
+  url: string;
+  status: DeploymentStatus;
+  /** ISO 8601. Empty if the provider hasn't reported it yet. */
+  createdAt: string;
+}
+
+export interface ProvisionOpts {
+  /** Slug for the app + machine. We prefix `parachute-` at the call site. */
+  name: string;
+  region: string;
+  size: DeploymentSize;
+  /** Persistent volume size in gigabytes. 10 is the Tier 1 default. */
+  volumeSizeGb: number;
+  /** OCI image reference for the Parachute deploy image (PR2). */
+  image: string;
+  /** Environment variables baked into the machine config. */
+  env: Record<string, string>;
+}
+
+export interface TokenValidation {
+  valid: boolean;
+  /** When valid, the org slug the token was confirmed against. */
+  orgSlug?: string;
+  /** When invalid (or partially valid), human-readable explanation. */
+  reason?: string;
+}
+
+export interface LogLine {
+  timestamp: string;
+  message: string;
+  /** Provider-specific source (e.g. machine ID). Optional. */
+  source?: string;
+}
+
+export interface ExecResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Common contract every provider must satisfy. */
+export interface ProviderClient {
+  /** Confirm the token works and (when present) belongs to the configured org. */
+  validateToken(): Promise<TokenValidation>;
+
+  /** Create app + volume + machine. Returns a record once provisioning starts. */
+  provisionMachine(opts: ProvisionOpts): Promise<DeploymentRecord>;
+
+  /** Destroy app + volume + machine. Idempotent — already-gone is a success. */
+  destroyMachine(name: string): Promise<void>;
+
+  /** List Parachute deployments visible to the configured token. */
+  listMachines(): Promise<DeploymentRecord[]>;
+
+  /** Stream log lines from the named deployment. Caller owns iteration lifetime. */
+  tailLogs(name: string, opts?: { follow?: boolean }): AsyncIterable<LogLine>;
+
+  /** Run a one-shot command on the named deployment. */
+  sshExec(name: string, command: string): Promise<ExecResult>;
+}
+
+/**
+ * Provider-tagged error. Lets the deploy command branch on `provider`
+ * and surface `statusCode` in error output without coupling to fetch types.
+ */
+export class ProviderError extends Error {
+  constructor(
+    message: string,
+    public readonly provider: ProviderName,
+    public readonly statusCode?: number,
+  ) {
+    super(message);
+    this.name = "ProviderError";
+  }
+}


### PR DESCRIPTION
## Summary

PR1 of the `parachute deploy` work. Lands the provider-agnostic interface and a Fly.io implementation against the Machines API at `https://api.machines.dev`.

Design: [`docs/design/2026-04-29-parachute-deploy.md`](https://github.com/ParachuteComputer/parachute-hub/blob/main/docs/design/2026-04-29-parachute-deploy.md). Tier framing: #124 (depends-on, lands separately).

## What ships

`src/deploy/provider-client.ts` — provider-agnostic types + interface:

- `ProviderClient` with `validateToken / provisionMachine / destroyMachine / listMachines / tailLogs / sshExec`
- `DeploymentRecord`, `ProvisionOpts`, `TokenValidation`, `LogLine`, `ExecResult`, `ProviderError`

`src/deploy/fly-client.ts` — `FlyClient implements ProviderClient`:

- **validateToken**: `GET /v1/apps?org_slug=<configured-org>`. 401/403 → invalid. 404 → valid with "org not found" reason. 5xx → invalid with status.
- **provisionMachine**: three calls in order — `POST /v1/apps`, `POST /v1/apps/{name}/volumes`, `POST /v1/apps/{name}/machines`. Errors at each step throw `ProviderError` with upstream status. Machine config wires volume at `/data`, exposes hub on `1939` internally with public 80/443, and configures `/health` check.
- **destroyMachine**: single `DELETE /v1/apps/{name}?force=true`. Idempotent against 404/410.
- **listMachines**: `GET /v1/apps`, filter by `parachute-` prefix, then parallel-fetch each app's first machine for region + status enrichment.

Deferred via explicit `ProviderError` on call:

- **tailLogs** — Fly logs are NATS/GraphQL, not Machines REST. Wires up alongside `parachute deploy logs` in PR4.
- **sshExec** — Fly SSH is mTLS proxy, not Machines REST. Same follow-up.

## Tests

`src/__tests__/fly-client.test.ts` spins up a `Bun.serve` fake on a random port; client gets the origin via `apiOrigin` constructor override. 20 cases:

- `validateToken`: 200, 401, 403, 404, 500
- `provisionMachine` happy path: asserts all three calls in order with correct shapes (auth header, content-type, body fields, guest config, mount, services); medium size → 2048 MB
- `provisionMachine` failures: app-create 422 stops further calls; volume-create 503 stops machine call; machine-create 400 surfaces status
- `destroyMachine`: 200 ok; 404 idempotent; 410 idempotent; 500 throws
- `listMachines`: prefix filter; orphan apps → status=unknown; empty list; 5xx throws
- Deferred surfaces: `tailLogs` async iterator throws; `sshExec` rejects

## What this PR does NOT include

Per the brief:

- No `parachute deploy` command — PR3
- No first-boot script / Parachute deploy image — PR2
- No paraclaw module references (Tier 2 — lives outside this v1 surface)
- No Render adapter — abstraction lets it slot in later

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun test` — 860 pass / 0 fail (840 prior + 20 new)
- [ ] Aaron reviews API shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)