### PR TITLE
feat(deploy): first-boot bootstrap script (PR2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.26",
+  "version": "0.4.0-rc.27",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/deploy-bootstrap.test.ts
+++ b/src/__tests__/deploy-bootstrap.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type BootstrapMarker,
+  DEFAULT_MODULES,
+  DEFAULT_VAULT_NAME,
+  bootstrap,
+} from "../deploy/bootstrap.ts";
+
+function harness(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-bootstrap-"));
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+const FROZEN_NOW = () => new Date("2026-04-29T12:00:00.000Z");
+
+describe("bootstrap — fresh-boot path", () => {
+  test("default env installs vault+scribe+notes, writes marker, returns 0", async () => {
+    const h = harness();
+    try {
+      const logs: string[] = [];
+      const installCalls: Array<{ short: string; vaultName?: string }> = [];
+      const result = await bootstrap({
+        env: { CLAUDE_API_TOKEN: "sk-test-claude-token" },
+        configDir: h.dir,
+        log: (l) => logs.push(l),
+        installFn: async (short, opts) => {
+          installCalls.push({ short, vaultName: opts.vaultName });
+          return 0;
+        },
+        now: FROZEN_NOW,
+        parachuteVersion: "0.4.0-rc.27",
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.alreadyBootstrapped).toBeUndefined();
+      expect(installCalls.map((c) => c.short)).toEqual([...DEFAULT_MODULES]);
+
+      const vaultCall = installCalls.find((c) => c.short === "vault");
+      expect(vaultCall?.vaultName).toBe(DEFAULT_VAULT_NAME);
+
+      const markerPath = join(h.dir, "bootstrap.json");
+      expect(existsSync(markerPath)).toBe(true);
+      const marker = JSON.parse(readFileSync(markerPath, "utf8")) as BootstrapMarker;
+      expect(marker).toEqual({
+        bootstrapped_at: "2026-04-29T12:00:00.000Z",
+        modules: [...DEFAULT_MODULES],
+        vault_name: DEFAULT_VAULT_NAME,
+        parachute_version: "0.4.0-rc.27",
+      });
+      expect(result.marker).toEqual(marker);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("persists CLAUDE_API_TOKEN + ANTHROPIC_API_KEY into <configDir>/.env", async () => {
+    const h = harness();
+    try {
+      await bootstrap({
+        env: { CLAUDE_API_TOKEN: "sk-test-token-xyz" },
+        configDir: h.dir,
+        log: () => {},
+        installFn: async () => 0,
+        now: FROZEN_NOW,
+      });
+      const envText = readFileSync(join(h.dir, ".env"), "utf8");
+      expect(envText).toContain("CLAUDE_API_TOKEN=sk-test-token-xyz");
+      expect(envText).toContain("ANTHROPIC_API_KEY=sk-test-token-xyz");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("PARACHUTE_VAULT_NAME forwards to install() for the vault module", async () => {
+    const h = harness();
+    try {
+      const seen: Record<string, string | undefined> = {};
+      await bootstrap({
+        env: {
+          CLAUDE_API_TOKEN: "sk-test",
+          PARACHUTE_VAULT_NAME: "aaron-personal",
+        },
+        configDir: h.dir,
+        log: () => {},
+        installFn: async (short, opts) => {
+          seen[short] = opts.vaultName;
+          return 0;
+        },
+        now: FROZEN_NOW,
+      });
+      expect(seen.vault).toBe("aaron-personal");
+      expect(seen.notes).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("PARACHUTE_MODULES overrides the default list", async () => {
+    const h = harness();
+    try {
+      const calls: string[] = [];
+      const result = await bootstrap({
+        env: {
+          CLAUDE_API_TOKEN: "sk-test",
+          PARACHUTE_MODULES: "vault,notes",
+        },
+        configDir: h.dir,
+        log: () => {},
+        installFn: async (short) => {
+          calls.push(short);
+          return 0;
+        },
+        now: FROZEN_NOW,
+      });
+      expect(result.exitCode).toBe(0);
+      expect(calls).toEqual(["vault", "notes"]);
+      expect(result.marker?.modules).toEqual(["vault", "notes"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("PARACHUTE_SCRIBE_PROVIDER + KEY forward to install() for scribe", async () => {
+    const h = harness();
+    try {
+      const seen: Record<string, { provider?: string; key?: string }> = {};
+      await bootstrap({
+        env: {
+          CLAUDE_API_TOKEN: "sk-test",
+          PARACHUTE_MODULES: "scribe",
+          PARACHUTE_SCRIBE_PROVIDER: "deepgram",
+          PARACHUTE_SCRIBE_KEY: "dg_secret_99",
+        },
+        configDir: h.dir,
+        log: () => {},
+        installFn: async (short, opts) => {
+          seen[short] = { provider: opts.scribeProvider, key: opts.scribeKey };
+          return 0;
+        },
+        now: FROZEN_NOW,
+      });
+      expect(seen.scribe).toEqual({ provider: "deepgram", key: "dg_secret_99" });
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("bootstrap — idempotent re-run", () => {
+  test("marker present → no install calls, returns 0 with alreadyBootstrapped=true", async () => {
+    const h = harness();
+    try {
+      const existingMarker: BootstrapMarker = {
+        bootstrapped_at: "2026-04-28T10:00:00.000Z",
+        modules: ["vault", "scribe", "notes"],
+        vault_name: "default",
+        parachute_version: "0.4.0-rc.26",
+      };
+      writeFileSync(join(h.dir, "bootstrap.json"), `${JSON.stringify(existingMarker, null, 2)}\n`);
+
+      let installCalled = false;
+      const result = await bootstrap({
+        env: { CLAUDE_API_TOKEN: "sk-test" },
+        configDir: h.dir,
+        log: () => {},
+        installFn: async () => {
+          installCalled = true;
+          return 0;
+        },
+        now: FROZEN_NOW,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.alreadyBootstrapped).toBe(true);
+      expect(result.marker).toEqual(existingMarker);
+      expect(installCalled).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("malformed marker still short-circuits (alreadyBootstrapped=true, no marker)", async () => {
+    const h = harness();
+    try {
+      writeFileSync(join(h.dir, "bootstrap.json"), "{ not valid json");
+      let installCalled = false;
+      const result = await bootstrap({
+        env: { CLAUDE_API_TOKEN: "sk-test" },
+        configDir: h.dir,
+        log: () => {},
+        installFn: async () => {
+          installCalled = true;
+          return 0;
+        },
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.alreadyBootstrapped).toBe(true);
+      expect(result.marker).toBeUndefined();
+      expect(installCalled).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("bootstrap — error paths", () => {
+  test("missing CLAUDE_API_TOKEN → exit 1, no marker, no installs", async () => {
+    const h = harness();
+    try {
+      const logs: string[] = [];
+      let installCalled = false;
+      const result = await bootstrap({
+        env: {},
+        configDir: h.dir,
+        log: (l) => logs.push(l),
+        installFn: async () => {
+          installCalled = true;
+          return 0;
+        },
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.marker).toBeUndefined();
+      expect(installCalled).toBe(false);
+      expect(existsSync(join(h.dir, "bootstrap.json"))).toBe(false);
+      expect(logs.join("\n")).toContain("CLAUDE_API_TOKEN is required");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("blank CLAUDE_API_TOKEN (whitespace-only) is treated as missing", async () => {
+    const h = harness();
+    try {
+      const result = await bootstrap({
+        env: { CLAUDE_API_TOKEN: "   " },
+        configDir: h.dir,
+        log: () => {},
+        installFn: async () => 0,
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.marker).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("paraclaw in PARACHUTE_MODULES → exit 1 with Tier 2 message, no installs", async () => {
+    const h = harness();
+    try {
+      const logs: string[] = [];
+      let installCalled = false;
+      const result = await bootstrap({
+        env: {
+          CLAUDE_API_TOKEN: "sk-test",
+          PARACHUTE_MODULES: "vault,paraclaw",
+        },
+        configDir: h.dir,
+        log: (l) => logs.push(l),
+        installFn: async () => {
+          installCalled = true;
+          return 0;
+        },
+      });
+      expect(result.exitCode).toBe(1);
+      expect(installCalled).toBe(false);
+      expect(existsSync(join(h.dir, "bootstrap.json"))).toBe(false);
+      expect(logs.join("\n")).toMatch(/Tier 2/);
+      expect(logs.join("\n")).toContain("paraclaw");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("install failure aborts before marker is written", async () => {
+    const h = harness();
+    try {
+      const calls: string[] = [];
+      const result = await bootstrap({
+        env: { CLAUDE_API_TOKEN: "sk-test" },
+        configDir: h.dir,
+        log: () => {},
+        installFn: async (short) => {
+          calls.push(short);
+          return short === "scribe" ? 7 : 0;
+        },
+        now: FROZEN_NOW,
+      });
+      expect(result.exitCode).toBe(7);
+      expect(result.marker).toBeUndefined();
+      expect(existsSync(join(h.dir, "bootstrap.json"))).toBe(false);
+      // vault ran, then scribe failed; notes was not attempted
+      expect(calls).toEqual(["vault", "scribe"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("install failure leaves CLAUDE_API_TOKEN persisted (so retry doesn't need re-paste)", async () => {
+    const h = harness();
+    try {
+      await bootstrap({
+        env: { CLAUDE_API_TOKEN: "sk-test-keep" },
+        configDir: h.dir,
+        log: () => {},
+        installFn: async () => 1,
+      });
+      const envText = readFileSync(join(h.dir, ".env"), "utf8");
+      expect(envText).toContain("CLAUDE_API_TOKEN=sk-test-keep");
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/deploy/bootstrap.ts
+++ b/src/deploy/bootstrap.ts
@@ -1,0 +1,216 @@
+/**
+ * First-boot bootstrap for `parachute deploy` machines.
+ *
+ * Runs once when a freshly-provisioned cloud VM (Tier 1: Fly machine) starts.
+ * Reads a minimal env contract written by the deploy command, installs the
+ * configured Parachute modules onto the machine's persistent volume, and
+ * drops a marker so subsequent boots no-op.
+ *
+ * Design: docs/design/2026-04-29-parachute-deploy.md (§4 step 2 — first-boot bake).
+ *
+ * Env contract (all optional except CLAUDE_API_TOKEN):
+ *   - PARACHUTE_VAULT_NAME       — vault slug. Default: "default".
+ *   - PARACHUTE_MODULES          — comma-separated shortnames. Default: "vault,scribe,notes" (Tier 1).
+ *   - PARACHUTE_SCRIBE_PROVIDER  — pre-pick a scribe transcription provider so install
+ *                                  doesn't prompt on a non-TTY container.
+ *   - PARACHUTE_SCRIBE_KEY       — API key for the chosen scribe provider.
+ *   - CLAUDE_API_TOKEN           — required. Threaded from the user's paste at deploy time;
+ *                                  persisted to the config-dir .env so any module on the
+ *                                  box can read it (e.g. an Anthropic-backed scribe
+ *                                  provider, or paraclaw once Tier 2 lands).
+ *
+ * Idempotency: the marker at `<configDir>/bootstrap.json` short-circuits a
+ * re-run on machine restart. A failed install does NOT write the marker, so
+ * the next boot retries cleanly.
+ *
+ * Tier 2 modules (paraclaw) are rejected with a clear error — `parachute
+ * deploy` v1 only stands up the personal-knowledge tier.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { type InstallOpts, install } from "../commands/install.ts";
+import { configDir as defaultConfigDir } from "../config.ts";
+import { parseEnvFile, upsertEnvLine, writeEnvFile } from "../env-file.ts";
+
+/** Tier 1 module set per the parachute-deploy design doc. Hub is implicit. */
+export const DEFAULT_MODULES = ["vault", "scribe", "notes"] as const;
+
+/** Default vault slug when PARACHUTE_VAULT_NAME isn't supplied. */
+export const DEFAULT_VAULT_NAME = "default";
+
+/**
+ * Modules carved into Tier 2 by the parachute-deploy design. Passing one in
+ * PARACHUTE_MODULES is rejected with a load-bearing error so users (and
+ * misconfigured CI) don't silently try to install something v1 can't host.
+ */
+const TIER2_MODULES = new Set<string>(["paraclaw"]);
+
+export interface BootstrapMarker {
+  /** ISO 8601 timestamp of bootstrap completion. */
+  bootstrapped_at: string;
+  /** Modules that were installed on this machine (in install order). */
+  modules: string[];
+  /** Vault slug that was created. */
+  vault_name: string;
+  /** Hub package version that ran the bootstrap. */
+  parachute_version: string;
+}
+
+export interface BootstrapOpts {
+  /** Process env. Tests inject a synthetic env; production reads `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  /** Override the resolved config dir. Tests point this at a tmpdir. */
+  configDir?: string;
+  /** Output sink. Tests capture into an array; production logs to stdout. */
+  log?: (line: string) => void;
+  /** Test seam replacing the per-module install() call. */
+  installFn?: (input: string, installOpts: InstallOpts) => Promise<number>;
+  /** Extra opts merged into every install() call (runner, manifest path, …). */
+  baseInstallOpts?: Partial<InstallOpts>;
+  /** Test seam: deterministic timestamp for the marker. */
+  now?: () => Date;
+  /** Override the version stamped into the marker. Tests pin it. */
+  parachuteVersion?: string;
+}
+
+export interface BootstrapResult {
+  exitCode: number;
+  /** Present on success and on idempotent re-run; absent on failure. */
+  marker?: BootstrapMarker;
+  /** True when the marker already existed and bootstrap was a no-op. */
+  alreadyBootstrapped?: boolean;
+}
+
+export async function bootstrap(opts: BootstrapOpts = {}): Promise<BootstrapResult> {
+  const env = opts.env ?? process.env;
+  const dir = opts.configDir ?? defaultConfigDir(env);
+  const log = opts.log ?? ((line: string) => console.log(line));
+  const installFn = opts.installFn ?? install;
+  const now = opts.now ?? (() => new Date());
+  const version = opts.parachuteVersion ?? readPackageVersion();
+  const markerPath = join(dir, "bootstrap.json");
+
+  if (existsSync(markerPath)) {
+    log(`bootstrap: marker already at ${markerPath} — already provisioned, no-op.`);
+    const existing = readMarker(markerPath);
+    return existing
+      ? { exitCode: 0, marker: existing, alreadyBootstrapped: true }
+      : { exitCode: 0, alreadyBootstrapped: true };
+  }
+
+  const claudeToken = (env.CLAUDE_API_TOKEN ?? "").trim();
+  if (claudeToken.length === 0) {
+    log("bootstrap: ✗ CLAUDE_API_TOKEN is required.");
+    log("  The `parachute deploy` command threads it from the user's paste-at-deploy step;");
+    log("  missing it means the machine was started outside that flow.");
+    return { exitCode: 1 };
+  }
+
+  const vaultName = pickVaultName(env);
+  const modules = parseModuleList(env);
+
+  const tier2 = modules.filter((m) => TIER2_MODULES.has(m));
+  if (tier2.length > 0) {
+    log(
+      `bootstrap: ✗ module(s) ${tier2.join(", ")} are Tier 2 and not part of \`parachute deploy\` v1.`,
+    );
+    log(
+      "  See docs/design/2026-04-29-parachute-deploy.md — Tier 1 is hub + vault + scribe + notes.",
+    );
+    return { exitCode: 1 };
+  }
+
+  log(
+    `bootstrap: starting (modules: ${modules.join(", ")}, vault: ${vaultName}, configDir: ${dir})`,
+  );
+
+  // Persist CLAUDE_API_TOKEN into the config-dir .env. This makes the secret
+  // available to every module process on the box without forcing each one to
+  // know about a deploy-specific env var. ANTHROPIC_API_KEY is the name the
+  // Anthropic SDK + scribe's anthropic provider both look for; setting both
+  // covers the common cases and costs us nothing.
+  mkdirSync(dir, { recursive: true });
+  persistTokenIntoEnvFile(join(dir, ".env"), claudeToken);
+
+  for (const short of modules) {
+    log(`bootstrap: — ${short} —`);
+    const installOpts: InstallOpts = {
+      log,
+      configDir: dir,
+      ...opts.baseInstallOpts,
+    };
+    if (short === "vault") {
+      installOpts.vaultName = vaultName;
+    }
+    if (short === "scribe") {
+      const provider = (env.PARACHUTE_SCRIBE_PROVIDER ?? "").trim();
+      const key = (env.PARACHUTE_SCRIBE_KEY ?? "").trim();
+      if (provider.length > 0) installOpts.scribeProvider = provider;
+      if (key.length > 0) installOpts.scribeKey = key;
+    }
+    const code = await installFn(short, installOpts);
+    if (code !== 0) {
+      log(
+        `bootstrap: ✗ install ${short} exited ${code} — aborting, marker NOT written so the next boot retries.`,
+      );
+      return { exitCode: code };
+    }
+  }
+
+  const marker: BootstrapMarker = {
+    bootstrapped_at: now().toISOString(),
+    modules: [...modules],
+    vault_name: vaultName,
+    parachute_version: version,
+  };
+  writeFileSync(markerPath, `${JSON.stringify(marker, null, 2)}\n`);
+  log(`bootstrap: ✓ complete — marker written to ${markerPath}`);
+  return { exitCode: 0, marker };
+}
+
+function pickVaultName(env: NodeJS.ProcessEnv): string {
+  const raw = (env.PARACHUTE_VAULT_NAME ?? "").trim();
+  return raw.length > 0 ? raw : DEFAULT_VAULT_NAME;
+}
+
+function parseModuleList(env: NodeJS.ProcessEnv): string[] {
+  const raw = (env.PARACHUTE_MODULES ?? "").trim();
+  if (raw.length === 0) return [...DEFAULT_MODULES];
+  const parts = raw
+    .split(",")
+    .map((m) => m.trim())
+    .filter((m) => m.length > 0);
+  return parts.length > 0 ? parts : [...DEFAULT_MODULES];
+}
+
+function readMarker(path: string): BootstrapMarker | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as BootstrapMarker;
+  } catch {
+    return null;
+  }
+}
+
+function persistTokenIntoEnvFile(path: string, token: string): void {
+  const parsed = parseEnvFile(path);
+  let lines = parsed.lines;
+  lines = upsertEnvLine(lines, "CLAUDE_API_TOKEN", token);
+  lines = upsertEnvLine(lines, "ANTHROPIC_API_KEY", token);
+  writeEnvFile(path, lines);
+}
+
+function readPackageVersion(): string {
+  try {
+    const url = new URL("../../package.json", import.meta.url);
+    const pkg = JSON.parse(readFileSync(url, "utf8"));
+    return typeof pkg.version === "string" ? pkg.version : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+if (import.meta.main) {
+  const result = await bootstrap();
+  process.exit(result.exitCode);
+}


### PR DESCRIPTION
## Summary

PR2 of the `parachute deploy` initiative (design: `docs/design/2026-04-29-parachute-deploy.md`). PR1 (#125) shipped the `ProviderClient` + `FlyClient`; this PR ships the script that runs *inside* a freshly-provisioned Tier 1 Fly Machine to bring it up.

- New `src/deploy/bootstrap.ts` — orchestrator function with an `import.meta.main` runnable guard. Reads env (`CLAUDE_API_TOKEN` required; `PARACHUTE_VAULT_NAME`, `PARACHUTE_MODULES`, `PARACHUTE_SCRIBE_PROVIDER`, `PARACHUTE_SCRIBE_KEY` optional), persists the Claude token into `<configDir>/.env` as both `CLAUDE_API_TOKEN` and `ANTHROPIC_API_KEY`, then loops the existing `install()` chain over the modules.
- Idempotent via `<configDir>/bootstrap.json` marker — restart-safe. Failed installs leave the marker absent so the next boot retries cleanly, but the persisted Claude token survives so the user doesn't re-paste.
- Tier 2 modules (paraclaw) rejected up front with a load-bearing error.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun test` — 877 pass / 0 fail (11 new in `deploy-bootstrap.test.ts`)
- [x] Fresh-boot path: default env installs vault+scribe+notes, marker written
- [x] PARACHUTE_VAULT_NAME / PARACHUTE_MODULES / PARACHUTE_SCRIBE_* env wiring
- [x] Idempotent re-run (with and without parseable marker)
- [x] Error paths: missing token, blank token, Tier 2 module, install failure aborts before marker
- [x] Install failure leaves Claude token persisted (so retry doesn't re-prompt)

Followup nits from PR1 (hub#126/#127/#128) are intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)