### PR TITLE
deploy: nit cleanup bundle (#130/#131/#132)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.27",
+  "version": "0.4.0-rc.28",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/deploy-bootstrap.test.ts
+++ b/src/__tests__/deploy-bootstrap.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   type BootstrapMarker,
@@ -143,6 +143,61 @@ describe("bootstrap — fresh-boot path", () => {
         now: FROZEN_NOW,
       });
       expect(seen.scribe).toEqual({ provider: "deepgram", key: "dg_secret_99" });
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("bootstrap — ephemeral-layer guard (#131)", () => {
+  test("warns when PARACHUTE_HOME is unset and configDir resolves under homedir", async () => {
+    const dir = mkdtempSync(join(homedir(), ".test-pcli-bootstrap-eph-"));
+    try {
+      const logs: string[] = [];
+      await bootstrap({
+        env: { CLAUDE_API_TOKEN: "sk-test" },
+        configDir: dir,
+        log: (l) => logs.push(l),
+        installFn: async () => 0,
+        now: FROZEN_NOW,
+      });
+      const warnLine = logs.find((l) => l.includes("PARACHUTE_HOME is not set"));
+      expect(warnLine).toBeDefined();
+      expect(logs.join("\n")).toContain("ephemeral image layer");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not warn when PARACHUTE_HOME is set", async () => {
+    const dir = mkdtempSync(join(homedir(), ".test-pcli-bootstrap-eph-"));
+    try {
+      const logs: string[] = [];
+      await bootstrap({
+        env: { CLAUDE_API_TOKEN: "sk-test", PARACHUTE_HOME: dir },
+        configDir: dir,
+        log: (l) => logs.push(l),
+        installFn: async () => 0,
+        now: FROZEN_NOW,
+      });
+      expect(logs.find((l) => l.includes("PARACHUTE_HOME is not set"))).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not warn when configDir lives outside homedir (typical test path)", async () => {
+    const h = harness();
+    try {
+      const logs: string[] = [];
+      await bootstrap({
+        env: { CLAUDE_API_TOKEN: "sk-test" },
+        configDir: h.dir,
+        log: (l) => logs.push(l),
+        installFn: async () => 0,
+        now: FROZEN_NOW,
+      });
+      expect(logs.find((l) => l.includes("PARACHUTE_HOME is not set"))).toBeUndefined();
     } finally {
       h.cleanup();
     }

--- a/src/deploy/bootstrap.ts
+++ b/src/deploy/bootstrap.ts
@@ -28,6 +28,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { type InstallOpts, install } from "../commands/install.ts";
 import { configDir as defaultConfigDir } from "../config.ts";
@@ -105,6 +106,23 @@ export async function bootstrap(opts: BootstrapOpts = {}): Promise<BootstrapResu
     log("  The `parachute deploy` command threads it from the user's paste-at-deploy step;");
     log("  missing it means the machine was started outside that flow.");
     return { exitCode: 1 };
+  }
+
+  // Container-bootstrap ephemeral-layer guard: PARACHUTE_HOME must point at
+  // the persistent volume mount (e.g. /data on a Fly machine). When it isn't
+  // set, configDir() falls back to ~/.parachute under the running user's
+  // homedir, which on a Fly machine is a writable layer of the *image* —
+  // looks fine until the next deploy/restart wipes it. Warn loudly so a
+  // misconfigured machine config gets caught before the user notices their
+  // vault evaporated.
+  if ((env.PARACHUTE_HOME ?? "").length === 0 && dir.startsWith(homedir())) {
+    log(
+      `bootstrap: ⚠ PARACHUTE_HOME is not set — config dir resolved to ${dir} (under homedir).`,
+    );
+    log(
+      "  On a containerized deploy this is the ephemeral image layer; data will NOT survive restart.",
+    );
+    log("  Set PARACHUTE_HOME to your volume mount path (e.g. /data) in the machine env.");
   }
 
   const vaultName = pickVaultName(env);

--- a/src/deploy/bootstrap.ts
+++ b/src/deploy/bootstrap.ts
@@ -27,7 +27,7 @@
  * deploy` v1 only stands up the personal-knowledge tier.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { type InstallOpts, install } from "../commands/install.ts";
@@ -116,9 +116,7 @@ export async function bootstrap(opts: BootstrapOpts = {}): Promise<BootstrapResu
   // misconfigured machine config gets caught before the user notices their
   // vault evaporated.
   if ((env.PARACHUTE_HOME ?? "").length === 0 && dir.startsWith(homedir())) {
-    log(
-      `bootstrap: ⚠ PARACHUTE_HOME is not set — config dir resolved to ${dir} (under homedir).`,
-    );
+    log(`bootstrap: ⚠ PARACHUTE_HOME is not set — config dir resolved to ${dir} (under homedir).`);
     log(
       "  On a containerized deploy this is the ephemeral image layer; data will NOT survive restart.",
     );
@@ -186,9 +184,20 @@ export async function bootstrap(opts: BootstrapOpts = {}): Promise<BootstrapResu
     vault_name: vaultName,
     parachute_version: version,
   };
-  writeFileSync(markerPath, `${JSON.stringify(marker, null, 2)}\n`);
+  writeMarkerAtomic(markerPath, marker);
   log(`bootstrap: ✓ complete — marker written to ${markerPath}`);
   return { exitCode: 0, marker };
+}
+
+/**
+ * Atomic marker write — tmp + rename, mirroring `writeEnvFile` in env-file.ts.
+ * Guards against the readMarker() check at next boot picking up a half-written
+ * file if the process is killed mid-write (Fly host maintenance, OOM kill, etc).
+ */
+function writeMarkerAtomic(path: string, marker: BootstrapMarker): void {
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, `${JSON.stringify(marker, null, 2)}\n`);
+  renameSync(tmp, path);
 }
 
 function pickVaultName(env: NodeJS.ProcessEnv): string {

--- a/src/deploy/bootstrap.ts
+++ b/src/deploy/bootstrap.ts
@@ -133,6 +133,10 @@ export async function bootstrap(opts: BootstrapOpts = {}): Promise<BootstrapResu
   mkdirSync(dir, { recursive: true });
   persistTokenIntoEnvFile(join(dir, ".env"), claudeToken);
 
+  // install() is itself idempotent (see install.ts:418-441 — the bun-add gate
+  // skips re-linking when the package is already wired). That's what lets a
+  // failed mid-loop bootstrap retry cleanly on the next boot without
+  // double-installing the modules that already succeeded.
   for (const short of modules) {
     log(`bootstrap: — ${short} —`);
     const installOpts: InstallOpts = {


### PR DESCRIPTION
## Summary

Three reviewer nits from PR1 (#125) and PR2 (#129), bundled per-issue. All in `src/deploy/bootstrap.ts`.

- **#130** — Documents the `install()` idempotency contract directly in the bootstrap install loop (4-line comment citing `install.ts:418-441`). Makes the retry story explicit and grep-able.
- **#131** — Warn-level log when `PARACHUTE_HOME` is unset and `configDir` resolves under `homedir()`. On a Fly machine, the user homedir is the ephemeral image layer, not the persistent volume — silent misconfig means the user notices their vault evaporated only after a restart. Bootstrap continues either way; this is a heads-up, not a hard fail.
- **#132** — Atomic write for `bootstrap.json` marker. Tmp + `renameSync` mirroring the pattern in `env-file.ts` `writeEnvFile`. Guards the readMarker() check at next boot against picking up a half-written file if the process is killed mid-write.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun test` — 880 pass / 0 fail (was 877; +3 new for #131)
- [x] #130: comment renders inline near the install loop
- [x] #131: three-test describe block — warns when PARACHUTE_HOME unset and dir under homedir; silent when PARACHUTE_HOME is set; silent when dir lives outside homedir
- [x] #132: existing fresh-boot test still validates marker lands at markerPath

## Note

Even though Aaron may move PR1/PR2 out of hub eventually (to a `parachute-cloud` repo), polishing now while they're here keeps the lift cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)