### PR TITLE
feat(hub): dynamic /.well-known/parachute.json (closes #135)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.28",
+  "version": "0.4.0-rc.29",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -4,20 +4,36 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { hubFetch } from "../hub-server.ts";
+import { type ServiceEntry, writeManifest } from "../services-manifest.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 
 interface Harness {
   dir: string;
+  manifestPath: string;
   cleanup: () => void;
 }
 
 function makeHarness(): Harness {
   const dir = mkdtempSync(join(tmpdir(), "pcli-hub-server-"));
-  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+  return {
+    dir,
+    manifestPath: join(dir, "services.json"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
 }
 
 function req(path: string, init?: RequestInit): Request {
   return new Request(`http://127.0.0.1/${path.replace(/^\//, "")}`, init);
+}
+
+function vaultEntry(name: string): ServiceEntry {
+  return {
+    name: `parachute-vault-${name}`,
+    port: 1940,
+    paths: [`/vault/${name}`],
+    health: "/health",
+    version: "0.4.0",
+  };
 }
 
 describe("hubFetch routing", () => {
@@ -46,14 +62,18 @@ describe("hubFetch routing", () => {
     }
   });
 
-  test("/.well-known/parachute.json serves JSON with application/json", async () => {
+  test("/.well-known/parachute.json builds the doc dynamically from services.json", async () => {
     const h = makeHarness();
     try {
-      writeFileSync(join(h.dir, "parachute.json"), '{"vaults":[]}\n');
-      const res = await hubFetch(h.dir)(req("/.well-known/parachute.json"));
+      writeManifest({ services: [vaultEntry("default")] }, h.manifestPath);
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(
+        req("/.well-known/parachute.json"),
+      );
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("application/json");
-      expect(await res.text()).toBe('{"vaults":[]}\n');
+      const body = (await res.json()) as { vaults: Array<{ name: string; url: string }> };
+      expect(body.vaults).toHaveLength(1);
+      expect(body.vaults[0]?.name).toBe("default");
     } finally {
       h.cleanup();
     }
@@ -67,8 +87,10 @@ describe("hubFetch routing", () => {
   test("/.well-known/parachute.json includes wildcard CORS headers on GET", async () => {
     const h = makeHarness();
     try {
-      writeFileSync(join(h.dir, "parachute.json"), '{"vaults":[]}\n');
-      const res = await hubFetch(h.dir)(req("/.well-known/parachute.json"));
+      writeManifest({ services: [] }, h.manifestPath);
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(
+        req("/.well-known/parachute.json"),
+      );
       expect(res.status).toBe(200);
       expect(res.headers.get("access-control-allow-origin")).toBe("*");
       expect(res.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
@@ -80,8 +102,10 @@ describe("hubFetch routing", () => {
   test("OPTIONS preflight on /.well-known/parachute.json returns 204 + CORS", async () => {
     const h = makeHarness();
     try {
-      // Note: no parachute.json on disk — preflight must not depend on it.
-      const res = await hubFetch(h.dir)(req("/.well-known/parachute.json", { method: "OPTIONS" }));
+      // Note: no services.json on disk — preflight must not depend on it.
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(
+        req("/.well-known/parachute.json", { method: "OPTIONS" }),
+      );
       expect(res.status).toBe(204);
       expect(res.headers.get("access-control-allow-origin")).toBe("*");
       expect(res.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
@@ -90,14 +114,115 @@ describe("hubFetch routing", () => {
     }
   });
 
-  test("missing parachute.json still returns CORS headers on the 404", async () => {
-    // If the response 404s without CORS, the browser treats it as a network
-    // error and the consumer can't even tell the server is reachable.
+  // The dispatch from team-lead specifically: a fresh hub install has no
+  // expose run yet, but `parachute vault create` writes services.json. The
+  // well-known doc must reflect that vault on the *next* GET — no expose,
+  // no parachute.json on disk.
+  test("/.well-known/parachute.json works on a fresh hub (services.json only, no expose run)", async () => {
     const h = makeHarness();
     try {
-      const res = await hubFetch(h.dir)(req("/.well-known/parachute.json"));
-      expect(res.status).toBe(404);
+      writeManifest({ services: [vaultEntry("default")] }, h.manifestPath);
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(
+        req("/.well-known/parachute.json"),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        vaults: Array<{ name: string }>;
+        services: Array<{ name: string }>;
+      };
+      expect(body.vaults.map((v) => v.name)).toEqual(["default"]);
+      expect(body.services.map((s) => s.name)).toEqual(["parachute-vault-default"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // The bug this PR fixes: `parachute vault create techne` updates
+  // services.json but the old code only re-derived parachute.json on
+  // `parachute expose`. With the dynamic build, the second GET reflects
+  // the new vault without any other action.
+  test("services.json change is reflected on the next GET (no restart, no expose)", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [vaultEntry("default")] }, h.manifestPath);
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+
+      const before = (await (await fetcher(req("/.well-known/parachute.json"))).json()) as {
+        vaults: Array<{ name: string }>;
+      };
+      expect(before.vaults.map((v) => v.name)).toEqual(["default"]);
+
+      writeManifest({ services: [vaultEntry("default"), vaultEntry("techne")] }, h.manifestPath);
+
+      const after = (await (await fetcher(req("/.well-known/parachute.json"))).json()) as {
+        vaults: Array<{ name: string }>;
+      };
+      expect(after.vaults.map((v) => v.name)).toEqual(["default", "techne"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("missing services.json yields an empty doc with CORS, not a 404", async () => {
+    // No expose, no `parachute vault create` yet — readManifest returns
+    // {services: []}, so the doc is well-formed-but-empty rather than a
+    // network-error-looking 404.
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(
+        req("/.well-known/parachute.json"),
+      );
+      expect(res.status).toBe(200);
       expect(res.headers.get("access-control-allow-origin")).toBe("*");
+      expect(await res.json()).toEqual({ vaults: [], services: [] });
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("canonicalOrigin uses configured issuer when present", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [vaultEntry("default")] }, h.manifestPath);
+      const res = await hubFetch(h.dir, {
+        manifestPath: h.manifestPath,
+        issuer: "https://hub.example",
+      })(req("/.well-known/parachute.json"));
+      const body = (await res.json()) as { vaults: Array<{ url: string }> };
+      expect(body.vaults[0]?.url).toBe("https://hub.example/vault/default");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // Same fallback shape as the OAuth handlers: when the hub isn't started
+  // with `--issuer` (local dev, direct loopback hit), use the request's own
+  // origin so the doc is still self-consistent.
+  test("canonicalOrigin falls back to the request origin when no issuer is configured", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [vaultEntry("default")] }, h.manifestPath);
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(
+        new Request("http://127.0.0.1:1939/.well-known/parachute.json"),
+      );
+      const body = (await res.json()) as { vaults: Array<{ url: string }> };
+      expect(body.vaults[0]?.url).toBe("http://127.0.0.1:1939/vault/default");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("malformed services.json returns 500 + CORS, not a crash", async () => {
+    const h = makeHarness();
+    try {
+      writeFileSync(h.manifestPath, "{ not json");
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(
+        req("/.well-known/parachute.json"),
+      );
+      expect(res.status).toBe(500);
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain("well-known build failed");
     } finally {
       h.cleanup();
     }
@@ -119,16 +244,6 @@ describe("hubFetch routing", () => {
     try {
       // dir exists but no files in it
       const res = await hubFetch(h.dir)(req("/"));
-      expect(res.status).toBe(404);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("missing parachute.json returns 404 rather than crashing", async () => {
-    const h = makeHarness();
-    try {
-      const res = await hubFetch(h.dir)(req("/.well-known/parachute.json"));
       expect(res.status).toBe(404);
     } finally {
       h.cleanup();
@@ -283,8 +398,12 @@ describe("hubFetch routing", () => {
     const h = makeHarness();
     try {
       writeFileSync(join(h.dir, "hub.html"), "<html>live</html>");
-      writeFileSync(join(h.dir, "parachute.json"), '{"services":[]}');
-      const server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: hubFetch(h.dir) });
+      writeManifest({ services: [] }, h.manifestPath);
+      const server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch: hubFetch(h.dir, { manifestPath: h.manifestPath }),
+      });
       try {
         const base = `http://127.0.0.1:${server.port}`;
         const r1 = await fetch(`${base}/`);
@@ -292,7 +411,7 @@ describe("hubFetch routing", () => {
         expect(await r1.text()).toBe("<html>live</html>");
         const r2 = await fetch(`${base}/.well-known/parachute.json`);
         expect(r2.headers.get("content-type")).toBe("application/json");
-        expect(await r2.json()).toEqual({ services: [] });
+        expect(await r2.json()).toEqual({ vaults: [], services: [] });
       } finally {
         server.stop(true);
       }

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -12,7 +12,7 @@
  * Routes (all bound to 127.0.0.1):
  *   /                                         → hub.html
  *   /hub.html                                 → hub.html
- *   /.well-known/parachute.json               → parachute.json
+ *   /.well-known/parachute.json               → built dynamically from services.json
  *   /.well-known/jwks.json                    → JWKS from hub.db
  *   /.well-known/oauth-authorization-server   → RFC 8414 metadata (issuer, endpoints)
  *   /oauth/authorize  (GET + POST)            → login → consent → auth code
@@ -23,9 +23,11 @@
  * Invoked as:
  *   bun <this-file> --port <n> --well-known-dir <path> [--db <path>] [--issuer <url>]
  *
- * `--well-known-dir` is the directory containing both `hub.html` and
- * `parachute.json` (both written by `parachute expose`). Kept as one flag so
- * the lifecycle side doesn't have to care how the hub server lays out files.
+ * `--well-known-dir` is the directory containing `hub.html` (written by
+ * `parachute expose`). The well-known doc is no longer served from this
+ * directory — it's built on every GET from `services.json` so changes to
+ * the installed-services list (e.g. `parachute vault create`) are visible
+ * immediately without a re-expose.
  *
  * `--db` is the path to `hub.db`. JWKS is served live from the DB so key
  * rotation takes effect on the next request without re-running
@@ -44,6 +46,7 @@ import {
   handleAdminLogoutPost,
 } from "./admin-handlers.ts";
 import { handleCreateVault } from "./admin-vaults.ts";
+import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import { hubDbPath, openHubDb } from "./hub-db.ts";
 import { pemToJwk } from "./jwks.ts";
 import {
@@ -54,7 +57,9 @@ import {
   handleRevoke,
   handleToken,
 } from "./oauth-handlers.ts";
+import { readManifest } from "./services-manifest.ts";
 import { getAllPublicKeys } from "./signing-keys.ts";
+import { buildWellKnown } from "./well-known.ts";
 
 interface Args {
   port: number;
@@ -100,8 +105,13 @@ function parseArgs(argv: string[]): Args {
 }
 
 export interface HubFetchDeps {
-  /** Lazily opens (or returns a cached handle to) the hub DB. */
-  getDb: () => Database;
+  /**
+   * Lazily opens (or returns a cached handle to) the hub DB. Optional so
+   * tests can exercise routes that don't touch the DB (the well-known doc,
+   * static assets) without standing up a fixture; runtime returns 503 for
+   * DB-dependent routes when this is absent.
+   */
+  getDb?: () => Database;
   /**
    * Hub origin used as the OAuth `iss` claim and to build the authorization-
    * server metadata document. When omitted, OAuth endpoints fall back to the
@@ -109,6 +119,13 @@ export interface HubFetchDeps {
    * proxy where the request origin is the loopback.
    */
   issuer?: string;
+  /**
+   * Path to the services manifest read on each `/.well-known/parachute.json`
+   * GET. Tests point this at a tmpdir; production uses the default ecosystem
+   * path. Read-on-each-request (cheap — single ~KB JSON parse) is what makes
+   * the doc reflect `parachute vault create` etc. without re-running expose.
+   */
+  manifestPath?: string;
 }
 
 export function hubFetch(
@@ -116,9 +133,9 @@ export function hubFetch(
   deps?: HubFetchDeps,
 ): (req: Request) => Response | Promise<Response> {
   const hubHtmlPath = join(wellKnownDir, "hub.html");
-  const parachuteJsonPath = join(wellKnownDir, "parachute.json");
   const getDb = deps?.getDb;
   const configuredIssuer = deps?.issuer;
+  const manifestPath = deps?.manifestPath ?? SERVICES_MANIFEST_PATH;
 
   const oauthDeps = (req: Request) => ({
     issuer: configuredIssuer ?? new URL(req.url).origin,
@@ -150,15 +167,30 @@ export function hubFetch(
       if (req.method === "OPTIONS") {
         return new Response(null, { status: 204, headers: corsHeaders });
       }
-      if (!existsSync(parachuteJsonPath)) {
-        return new Response("parachute.json not found", {
-          status: 404,
-          headers: corsHeaders,
+      // Built dynamically from services.json on every request — that's what
+      // makes `parachute vault create` show up here without re-running
+      // expose. canonicalOrigin reuses the OAuth issuer fallback: prefer the
+      // configured public origin (set by `--issuer https://<fqdn>`), else
+      // the request's own origin (fine for direct loopback hits).
+      try {
+        const manifest = readManifest(manifestPath);
+        const canonicalOrigin = configuredIssuer ?? new URL(req.url).origin;
+        const doc = buildWellKnown({
+          services: manifest.services,
+          canonicalOrigin,
+        });
+        return new Response(JSON.stringify(doc), {
+          headers: { "content-type": "application/json", ...corsHeaders },
+        });
+      } catch (err) {
+        // ServicesManifestError lands here too — corrupt JSON or schema
+        // violation in services.json shouldn't crash the hub for everyone.
+        const msg = err instanceof Error ? err.message : String(err);
+        return new Response(JSON.stringify({ error: `well-known build failed: ${msg}` }), {
+          status: 500,
+          headers: { "content-type": "application/json", ...corsHeaders },
         });
       }
-      return new Response(Bun.file(parachuteJsonPath), {
-        headers: { "content-type": "application/json", ...corsHeaders },
-      });
     }
 
     if (pathname === "/.well-known/jwks.json") {


### PR DESCRIPTION
## Summary

- Replace the static-file serve of `/.well-known/parachute.json` with on-the-fly generation from `services.json` so `parachute vault create techne` shows up in the well-known doc on the next GET — no `parachute expose` re-run needed (closes #135).
- `canonicalOrigin` reuses the OAuth issuer fallback already wired in `hub-server.ts:139` — `configuredIssuer ?? new URL(req.url).origin`. Configured issuer wins when the hub is started with `--issuer https://<fqdn>`; loopback hits in local dev fall back to the request origin.
- `getDb` made optional in `HubFetchDeps` (matches the runtime, which already returns 503 when it's absent — tests can now exercise non-DB routes without a fixture).
- `writeWellKnownFile` callers in `expose.ts` left intact for backward compat — older clients reading `~/.parachute/well-known/parachute.json` directly still work.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun test` — 884 pass / 0 fail
- [x] New tests in `src/__tests__/hub-server.test.ts`:
  - dynamic build from `services.json`
  - fresh-hub-no-expose path (the bug from the dispatch)
  - `services.json` change reflected on next GET
  - missing `services.json` → empty doc + CORS, not a 404
  - configured issuer used for `canonicalOrigin`
  - request-origin fallback when no issuer configured
  - malformed `services.json` → 500 + CORS, not a crash
- [x] rc bump: `0.4.0-rc.28` → `0.4.0-rc.29`

🤖 Generated with [Claude Code](https://claude.com/claude-code)