### PR TITLE
review nit bundle 2 — hub#136/#137/#139

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.29",
+  "version": "0.4.0-rc.30",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/deploy-bootstrap.test.ts
+++ b/src/__tests__/deploy-bootstrap.test.ts
@@ -186,12 +186,36 @@ describe("bootstrap — ephemeral-layer guard (#131)", () => {
     }
   });
 
-  test("does not warn when configDir lives outside homedir (typical test path)", async () => {
+  // #136: heuristic keys off the env (what production would resolve to), not
+  // the injected configDir. So even with configDir pointed at a tmpdir
+  // outside homedir, the warn still fires when PARACHUTE_HOME is unset —
+  // because in production, that same env would land at ~/.parachute.
+  test("warns based on env, not the injected configDir (closes #136)", async () => {
     const h = harness();
     try {
       const logs: string[] = [];
       await bootstrap({
         env: { CLAUDE_API_TOKEN: "sk-test" },
+        configDir: h.dir,
+        log: (l) => logs.push(l),
+        installFn: async () => 0,
+        now: FROZEN_NOW,
+      });
+      expect(logs.find((l) => l.includes("PARACHUTE_HOME is not set"))).toBeDefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // Symmetric case: PARACHUTE_HOME pointing at a non-homedir mount (the
+  // production shape on a Fly machine), configDir injected to a tmpdir
+  // for the test. Heuristic must NOT warn — env is correct.
+  test("does not warn when PARACHUTE_HOME points at a non-homedir mount", async () => {
+    const h = harness();
+    try {
+      const logs: string[] = [];
+      await bootstrap({
+        env: { CLAUDE_API_TOKEN: "sk-test", PARACHUTE_HOME: "/data" },
         configDir: h.dir,
         log: (l) => logs.push(l),
         installFn: async () => 0,

--- a/src/__tests__/deploy-bootstrap.test.ts
+++ b/src/__tests__/deploy-bootstrap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -51,6 +51,12 @@ describe("bootstrap — fresh-boot path", () => {
         parachute_version: "0.4.0-rc.27",
       });
       expect(result.marker).toEqual(marker);
+
+      // #137: writeMarkerAtomic uses tmp+rename. The rename must complete
+      // (otherwise readMarker on next boot picks up a half-written file),
+      // so no `bootstrap.json.tmp-*` should remain.
+      const tmpLeftover = readdirSync(h.dir).filter((f) => f.startsWith("bootstrap.json.tmp-"));
+      expect(tmpLeftover).toEqual([]);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -351,6 +351,29 @@ describe("hubFetch routing", () => {
     }
   });
 
+  test("every DB-dependent route returns 503 when getDb is absent (closes #139)", async () => {
+    const h = makeHarness();
+    try {
+      const fetch = hubFetch(h.dir);
+      const cases: Array<[string, RequestInit]> = [
+        ["/oauth/token", { method: "POST" }],
+        ["/oauth/register", { method: "POST" }],
+        ["/oauth/revoke", { method: "POST" }],
+        ["/vaults", { method: "POST" }],
+        ["/admin/login", { method: "POST" }],
+        ["/admin/logout", { method: "POST" }],
+        ["/admin/config", { method: "GET" }],
+        ["/admin/config/example", { method: "POST" }],
+      ];
+      for (const [path, init] of cases) {
+        const res = await fetch(req(path, init));
+        expect(res.status).toBe(503);
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("/oauth/token rejects non-POST with 405", async () => {
     const h = makeHarness();
     try {

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -57,7 +57,7 @@ export interface ExposeOpts {
   statePath?: string;
   wellKnownPath?: string;
   hubPath?: string;
-  /** Directory holding hub.html + parachute.json (passed to the hub server). */
+  /** Directory holding hub.html (passed to the hub server). */
   wellKnownDir?: string;
   configDir?: string;
   port?: number;
@@ -361,6 +361,9 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
     );
   }
 
+  // Kept for manual debugging / inspection only — the hub server now builds
+  // /.well-known/parachute.json dynamically from services.json at request time
+  // (#135), so this on-disk copy is no longer load-bearing for any consumer.
   const wellKnownDoc = buildWellKnown({ services, canonicalOrigin });
   writeWellKnownFile(wellKnownDoc, wellKnownFilePath);
   log(`Wrote ${wellKnownFilePath}`);
@@ -490,6 +493,8 @@ export async function exposeOff(layer: ExposeLayer, opts: ExposeOpts = {}): Prom
   }
 
   clearExposeState(statePath);
+  // Pair to the debug-only write at expose-up — clean up the inspection artifact
+  // on teardown so it doesn't outlive the layer it described.
   if (existsSync(wellKnownFilePath)) {
     unlinkSync(wellKnownFilePath);
   }

--- a/src/deploy/bootstrap.ts
+++ b/src/deploy/bootstrap.ts
@@ -115,7 +115,13 @@ export async function bootstrap(opts: BootstrapOpts = {}): Promise<BootstrapResu
   // looks fine until the next deploy/restart wipes it. Warn loudly so a
   // misconfigured machine config gets caught before the user notices their
   // vault evaporated.
-  if ((env.PARACHUTE_HOME ?? "").length === 0 && dir.startsWith(homedir())) {
+  //
+  // We check `defaultConfigDir(env)` rather than the resolved `dir` so an
+  // injected `opts.configDir` (tests, future integration harnesses) doesn't
+  // false-positive when the override happens to live under homedir; the
+  // question is "what would the production resolver return for this env?",
+  // not "where is this particular invocation writing".
+  if ((env.PARACHUTE_HOME ?? "").length === 0 && defaultConfigDir(env).startsWith(homedir())) {
     log(`bootstrap: ⚠ PARACHUTE_HOME is not set — config dir resolved to ${dir} (under homedir).`);
     log(
       "  On a containerized deploy this is the ephemeral image layer; data will NOT survive restart.",


### PR DESCRIPTION
## Summary

Three small follow-up nits from the deploy + well-known PRs, bundled per team-lead dispatch:

- **closes #136** — tighten `bootstrap.ts` PARACHUTE_HOME heuristic to key off `defaultConfigDir(env)` rather than the resolved (possibly injected) `configDir`. The question is "what would the production resolver return for this env?", not "where is this particular invocation writing." Test seam injection no longer false-positives the warn.
- **closes #137** — assert `bootstrap.json.tmp-*` is not left behind after the atomic `writeMarkerAtomic` rename. Guards against a future regression where the rename is dropped or the tmp path leaks.
- **closes #139** — drop the stale `parachute.json` mention in `ExposeOpts.wellKnownDir` JSDoc; mark the on-disk well-known write/unlink as debug-only now that the hub serves it dynamically (#135). Adds a parameterized test asserting every DB-dependent route on the hub server (token, register, revoke, vaults, admin/{login,logout,config}) returns 503 when `HubFetchDeps.getDb` is absent.

Per-issue commits. RC bumped 29 → 30.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun test` — 886 pass / 0 fail
- [ ] Reviewer-cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)