### PR TITLE
fix(well-known): emit one vaults entry per path for multi-path vault services

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.30",
+  "version": "0.4.0-rc.31",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/well-known.test.ts
+++ b/src/__tests__/well-known.test.ts
@@ -193,6 +193,63 @@ describe("buildWellKnown", () => {
     expect(doc.vaults.map((v) => v.name).sort()).toEqual(["default", "work"]);
   });
 
+  test("single vault ServiceEntry with multiple paths emits one entry per path (closes #141)", () => {
+    // Reflects the post-#179/vault#208 manifest shape: one parachute-vault
+    // backend hosts every vault instance, expressed as one ServiceEntry with
+    // multiple paths.
+    const multi: ServiceEntry = {
+      ...vault,
+      paths: ["/vault/default", "/vault/techne"],
+    };
+    const doc = buildWellKnown({
+      services: [multi],
+      canonicalOrigin: "https://x.example",
+    });
+    expect(doc.vaults).toEqual([
+      { name: "default", url: "https://x.example/vault/default", version: "0.2.4" },
+      { name: "techne", url: "https://x.example/vault/techne", version: "0.2.4" },
+    ]);
+    // services[] mirrors the per-path expansion so the hub page and any
+    // generic consumer iterate every instance.
+    expect(doc.services).toEqual([
+      {
+        name: "parachute-vault",
+        url: "https://x.example/vault/default",
+        path: "/vault/default",
+        version: "0.2.4",
+        infoUrl: "https://x.example/vault/default/.parachute/info",
+      },
+      {
+        name: "parachute-vault",
+        url: "https://x.example/vault/techne",
+        path: "/vault/techne",
+        version: "0.2.4",
+        infoUrl: "https://x.example/vault/techne/.parachute/info",
+      },
+    ]);
+  });
+
+  test("multi-path vault entry is independent of multi-ServiceEntry shape (#141)", () => {
+    // A user could plausibly mix shapes: one multi-path bare `parachute-vault`
+    // plus a separately-installed `parachute-vault-archive`. All instances
+    // should surface.
+    const multi: ServiceEntry = {
+      ...vault,
+      paths: ["/vault/default", "/vault/techne"],
+    };
+    const archive: ServiceEntry = {
+      ...vault,
+      name: "parachute-vault-archive",
+      paths: ["/vault/archive"],
+      port: 1942,
+    };
+    const doc = buildWellKnown({
+      services: [multi, archive],
+      canonicalOrigin: "https://x.example",
+    });
+    expect(doc.vaults.map((v) => v.name).sort()).toEqual(["archive", "default", "techne"]);
+  });
+
   test("handles canonicalOrigin with trailing slash", () => {
     const doc = buildWellKnown({
       services: [vault],

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -66,20 +66,28 @@ export function isVaultEntry(entry: ServiceEntry): boolean {
 }
 
 /**
- * Derive a vault instance name. Prefer a `/vault/<name>` path segment; fall
- * back to the manifest-name suffix (`parachute-vault-work` → `work`); last
- * resort is "default".
+ * Derive a vault instance name from a single mount path + manifest name.
+ * Prefer a `/vault/<name>` path segment; fall back to the manifest-name
+ * suffix (`parachute-vault-work` → `work`); last resort is "default".
  */
-export function vaultInstanceName(entry: ServiceEntry): string {
-  const path = entry.paths[0];
+export function vaultInstanceNameFor(name: string, path: string | undefined): string {
   if (path) {
     const match = path.match(/^\/vault\/([^/]+)/);
     if (match?.[1]) return match[1];
   }
-  if (entry.name.startsWith(`${VAULT_MANIFEST_PREFIX}-`)) {
-    return entry.name.slice(VAULT_MANIFEST_PREFIX.length + 1);
+  if (name.startsWith(`${VAULT_MANIFEST_PREFIX}-`)) {
+    return name.slice(VAULT_MANIFEST_PREFIX.length + 1);
   }
   return "default";
+}
+
+/**
+ * Back-compat wrapper that resolves a vault instance name from the entry's
+ * first mount path. Prefer `vaultInstanceNameFor(name, path)` when iterating
+ * a multi-path entry.
+ */
+export function vaultInstanceName(entry: ServiceEntry): string {
+  return vaultInstanceNameFor(entry.name, entry.paths[0]);
 }
 
 export interface BuildWellKnownOpts {
@@ -97,18 +105,31 @@ export function buildWellKnown(opts: BuildWellKnownOpts): WellKnownDocument {
   const base = opts.canonicalOrigin.replace(/\/$/, "");
   const doc: WellKnownDocument = { vaults: [], services: [] };
   for (const s of opts.services) {
-    const path = s.paths[0] ?? "/";
-    const url = new URL(path, `${base}/`).toString();
-    const infoPath = joinInfoPath(path);
-    const infoUrl = new URL(infoPath, `${base}/`).toString();
-    doc.services.push({ name: s.name, url, path, version: s.version, infoUrl });
-    if (isVaultEntry(s)) {
-      doc.vaults.push({ name: vaultInstanceName(s), url, version: s.version });
-    } else {
-      const key = shortName(s.name);
-      const bucket = (doc[key] as WellKnownServiceEntry[] | undefined) ?? [];
-      bucket.push({ url, version: s.version });
-      doc[key] = bucket;
+    // Vault services are mounted at one path per vault instance — a single
+    // ServiceEntry with `paths: ["/vault/default", "/vault/techne"]` represents
+    // two distinct vault instances behind the same backend. Iterate each path
+    // so consumers (paraclaw vault picker, hub page) see every instance
+    // (closes #141). Non-vault services keep the legacy paths[0] semantic;
+    // multi-path on those is treated as aliases rather than separate
+    // installs.
+    const isVault = isVaultEntry(s);
+    const pathsToEmit = isVault && s.paths.length > 0 ? s.paths : [s.paths[0] ?? "/"];
+    for (const path of pathsToEmit) {
+      const url = new URL(path, `${base}/`).toString();
+      const infoUrl = new URL(joinInfoPath(path), `${base}/`).toString();
+      doc.services.push({ name: s.name, url, path, version: s.version, infoUrl });
+      if (isVault) {
+        doc.vaults.push({
+          name: vaultInstanceNameFor(s.name, path),
+          url,
+          version: s.version,
+        });
+      } else {
+        const key = shortName(s.name);
+        const bucket = (doc[key] as WellKnownServiceEntry[] | undefined) ?? [];
+        bucket.push({ url, version: s.version });
+        doc[key] = bucket;
+      }
     }
   }
   return doc;


### PR DESCRIPTION
## Summary

Closes **#141** — high-priority. Aaron is hitting it live: paraclaw's vault picker only sees `default`, not `techne`, despite services.json correctly carrying both paths.

Root cause: `buildWellKnown` in `src/well-known.ts` was keying off `paths[0]` per ServiceEntry, blind to the multi-path single-service shape that vault PR #179 + vault#208 settled. A single `parachute-vault` backend with `paths: ["/vault/default", "/vault/techne"]` represents two distinct vault instances, but only the first surfaced in `/.well-known/parachute.json`.

Fix: for vault-shaped services, iterate every path and emit one entry in both `vaults[]` and `services[]`. Each per-path instance name is derived via the new `vaultInstanceNameFor(name, path)` helper. Non-vault services keep the legacy `paths[0]` semantic — multi-path on those is treated as aliases rather than separate installs (no consumer relies on per-path expansion for non-vault services today; we can extend if/when one does).

`vaultInstanceName(entry)` is preserved as a thin back-compat wrapper over `vaultInstanceNameFor` for external callers.

## Test plan

- [x] New test: single ServiceEntry with `paths: ["/vault/default", "/vault/techne"]` emits both in `vaults[]` and `services[]` (closes #141)
- [x] New test: mixed shapes — multi-path bare `parachute-vault` + separately-installed `parachute-vault-archive` — surface all instances
- [x] Existing test: separate ServiceEntries for each vault still works
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun test` — 888 pass / 0 fail
- [ ] Manual: Aaron restarts hub, paraclaw vault picker shows `techne`

🤖 Generated with [Claude Code](https://claude.com/claude-code)