### PR TITLE
fix(hub): dynamic /vault/<name>/* routing for new vaults (#144)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.31",
+  "version": "0.4.0-rc.32",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -143,6 +143,10 @@ describe("expose tailnet up", () => {
       expect(calls.every((c) => c[1] !== "funnel")).toBe(true);
 
       const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path="))).sort();
+      // Vault paths consolidate to a single `/vault/` mount → hub (#144);
+      // the hub then picks the specific vault instance per request from
+      // services.json. Notes (and other non-vault services) keep their
+      // direct mount.
       expect(mounts).toEqual([
         "--set-path=/",
         "--set-path=/.well-known/oauth-authorization-server",
@@ -151,7 +155,7 @@ describe("expose tailnet up", () => {
         "--set-path=/oauth/authorize",
         "--set-path=/oauth/register",
         "--set-path=/oauth/token",
-        "--set-path=/vault/default",
+        "--set-path=/vault/",
       ]);
 
       // Hub + well-known now point at localhost HTTP, not a file path.
@@ -165,12 +169,14 @@ describe("expose tailnet up", () => {
         /^http:\/\/127\.0\.0\.1:\d+\/\.well-known\/parachute\.json$/,
       );
 
-      // Service targets also include their mount path to prevent tailscale
-      // from stripping the prefix before forwarding to a base-aware backend.
+      // Non-vault service targets include the mount path so tailscale's
+      // strip-then-forward is a no-op against base-aware backends.
       const notesCall = serveCalls.find((c) => c.includes("--set-path=/notes"));
       expect(notesCall?.[notesCall.length - 1]).toBe("http://127.0.0.1:5173/notes");
-      const vaultCall = serveCalls.find((c) => c.includes("--set-path=/vault/default"));
-      expect(vaultCall?.[vaultCall.length - 1]).toBe("http://127.0.0.1:1940/vault/default");
+      // Vault mount targets the hub's loopback port (the hub re-proxies to
+      // the right vault backend on each request) — port is dynamic per test.
+      const vaultCall = serveCalls.find((c) => c.includes("--set-path=/vault/"));
+      expect(vaultCall?.[vaultCall.length - 1]).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/vault\/$/);
 
       expect(existsSync(h.wellKnownPath)).toBe(true);
       expect(existsSync(h.hubPath)).toBe(true);
@@ -288,7 +294,10 @@ describe("expose tailnet up", () => {
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
       const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path="))).sort();
-      expect(mounts).toContain("--set-path=/vault");
+      // Even with the legacy `/` remap, the vault rolls into the consolidated
+      // `/vault/` mount → hub. The remap warning still fires; the mount shape
+      // just doesn't reflect the original `/<shortname>` since #144.
+      expect(mounts).toContain("--set-path=/vault/");
       expect(mounts).toContain("--set-path=/");
       expect(mounts.filter((m) => m === "--set-path=/")).toHaveLength(1);
 
@@ -1066,8 +1075,10 @@ describe("expose publicExposure filter", () => {
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
       const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path=")));
-      // Vault + its 4 OAuth proxies + hub + well-known — but no /scribe.
-      expect(mounts).toContain("--set-path=/vault/default");
+      // Vault rolls into the consolidated `/vault/` mount → hub (#144);
+      // its 4 OAuth proxies, hub, and well-known are still individually
+      // mounted. /scribe is loopback-only and absent.
+      expect(mounts).toContain("--set-path=/vault/");
       expect(mounts).not.toContain("--set-path=/scribe");
 
       // Operator-visible notice explaining the withhold.
@@ -1210,7 +1221,8 @@ describe("expose publicExposure filter", () => {
       const mounts = calls
         .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
         .map((c) => c.find((a) => a.startsWith("--set-path=")));
-      expect(mounts).toContain("--set-path=/vault/default");
+      // Vault → consolidated `/vault/` mount (#144).
+      expect(mounts).toContain("--set-path=/vault/");
     } finally {
       h.cleanup();
     }
@@ -1577,6 +1589,183 @@ describe("expose teardown tolerance for already-gone entries", () => {
       expect(bringupCalls.length).toBeGreaterThan(0);
       const state = readExposeState(h.statePath);
       expect(state?.layer).toBe("public");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("expose vault mount consolidation (#144)", () => {
+  // Pre-#144: tailscale plan emitted one mount per vault path. New vault →
+  // had to re-run `parachute expose` to get a tailnet route. Post-#144: a
+  // single `/vault/` → hub mount, hub does the per-request lookup.
+
+  test("single vault, single path → exactly one /vault/ mount, no per-instance entry", async () => {
+    const h = makeHarness();
+    try {
+      upsertService(
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.4.0",
+        },
+        h.manifestPath,
+      );
+      const { runner, calls } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      const mounts = calls
+        .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
+        .map((c) => c.find((a) => a.startsWith("--set-path=")));
+      expect(mounts).toContain("--set-path=/vault/");
+      expect(mounts).not.toContain("--set-path=/vault/default");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("multi-path single ServiceEntry still emits exactly one /vault/ mount", async () => {
+    // The current vault manifest shape: one ServiceEntry whose `paths` lists
+    // every instance. The plan must collapse them all to the hub-routed
+    // `/vault/` instead of one mount per instance.
+    const h = makeHarness();
+    try {
+      upsertService(
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default", "/vault/techne"],
+          health: "/vault/default/health",
+          version: "0.4.0",
+        },
+        h.manifestPath,
+      );
+      const { runner, calls } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      const mounts = calls
+        .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
+        .map((c) => c.find((a) => a.startsWith("--set-path=")));
+      const vaultMounts = mounts.filter((m) => m?.startsWith("--set-path=/vault"));
+      expect(vaultMounts).toEqual(["--set-path=/vault/"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("multiple separate vault ServiceEntries still emit exactly one /vault/ mount", async () => {
+    // Pathological but representable: someone might install a second
+    // parachute-vault-archive backend alongside the bare parachute-vault.
+    // Both fold into the single `/vault/` mount; hub disambiguates per
+    // request.
+    const h = makeHarness();
+    try {
+      upsertService(
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.4.0",
+        },
+        h.manifestPath,
+      );
+      upsertService(
+        {
+          name: "parachute-vault-archive",
+          port: 1941,
+          paths: ["/vault/archive"],
+          health: "/vault/archive/health",
+          version: "0.4.0",
+        },
+        h.manifestPath,
+      );
+      const { runner, calls } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      const mounts = calls
+        .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
+        .map((c) => c.find((a) => a.startsWith("--set-path=")));
+      const vaultMounts = mounts.filter((m) => m?.startsWith("--set-path=/vault"));
+      expect(vaultMounts).toEqual(["--set-path=/vault/"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("no vault installed → no /vault/ mount in the plan", async () => {
+    const h = makeHarness();
+    try {
+      upsertService(
+        {
+          name: "parachute-notes",
+          port: 5173,
+          paths: ["/notes"],
+          health: "/notes/health",
+          version: "0.0.1",
+        },
+        h.manifestPath,
+      );
+      const { runner, calls } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      const mounts = calls
+        .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
+        .map((c) => c.find((a) => a.startsWith("--set-path=")));
+      expect(mounts).not.toContain("--set-path=/vault/");
+      // /notes is still individually mounted — non-vault services keep
+      // their direct route.
+      expect(mounts).toContain("--set-path=/notes");
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
-import { hubFetch } from "../hub-server.ts";
+import { findVaultUpstream, hubFetch } from "../hub-server.ts";
 import { type ServiceEntry, writeManifest } from "../services-manifest.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 
@@ -443,3 +443,335 @@ describe("hubFetch routing", () => {
     }
   });
 });
+
+describe("findVaultUpstream (#144)", () => {
+  test("matches a single-path vault on its exact mount", () => {
+    const services: ServiceEntry[] = [vaultEntry("default")];
+    const m = findVaultUpstream(services, "/vault/default");
+    expect(m?.mount).toBe("/vault/default");
+    expect(m?.port).toBe(1940);
+  });
+
+  test("matches a vault on any descendant pathname", () => {
+    const services: ServiceEntry[] = [vaultEntry("default")];
+    expect(findVaultUpstream(services, "/vault/default/health")?.mount).toBe("/vault/default");
+    expect(findVaultUpstream(services, "/vault/default/notes/abc")?.mount).toBe("/vault/default");
+  });
+
+  test("returns undefined when no vault claims the path", () => {
+    const services: ServiceEntry[] = [vaultEntry("default")];
+    expect(findVaultUpstream(services, "/vault/missing")).toBeUndefined();
+    expect(findVaultUpstream(services, "/vault/missing/health")).toBeUndefined();
+    expect(findVaultUpstream(services, "/notes/foo")).toBeUndefined();
+  });
+
+  test("non-vault services are ignored even when their path begins with /vault/", () => {
+    const odd: ServiceEntry = {
+      name: "parachute-vaultkeeper", // not a vault — see isVaultEntry
+      port: 9999,
+      paths: ["/vault/keeper"],
+      health: "/health",
+      version: "0.0.1",
+    };
+    expect(findVaultUpstream([odd], "/vault/keeper")).toBeUndefined();
+  });
+
+  test("multi-path single ServiceEntry — both paths route to the same backend", () => {
+    // Post-#179/vault#208: one parachute-vault backend hosts every instance,
+    // expressed as a single ServiceEntry with multiple paths. The lookup must
+    // pick the matching path for each request.
+    const multi: ServiceEntry = {
+      name: "parachute-vault",
+      port: 1940,
+      paths: ["/vault/default", "/vault/techne"],
+      health: "/vault/default/health",
+      version: "0.4.0",
+    };
+    expect(findVaultUpstream([multi], "/vault/default/notes")?.mount).toBe("/vault/default");
+    expect(findVaultUpstream([multi], "/vault/techne/notes")?.mount).toBe("/vault/techne");
+    expect(findVaultUpstream([multi], "/vault/other")).toBeUndefined();
+  });
+
+  test("longest mount wins on overlapping prefixes", () => {
+    // Pathological but representable: a vault claims `/vault` AND another
+    // claims `/vault/inner`. Request for `/vault/inner/x` should pick the
+    // more specific mount.
+    const a: ServiceEntry = {
+      name: "parachute-vault",
+      port: 1940,
+      paths: ["/vault"],
+      health: "/health",
+      version: "0.4.0",
+    };
+    const b: ServiceEntry = {
+      name: "parachute-vault-inner",
+      port: 1941,
+      paths: ["/vault/inner"],
+      health: "/health",
+      version: "0.4.0",
+    };
+    const m = findVaultUpstream([a, b], "/vault/inner/x");
+    expect(m?.mount).toBe("/vault/inner");
+    expect(m?.port).toBe(1941);
+  });
+});
+
+describe("hubFetch /vault/<name>/* dynamic proxy (#144)", () => {
+  // The bug: tailscale serve config is built once at expose-time, so a vault
+  // created later was unreachable on the tailnet (404 from the `/` fallback)
+  // until the user re-ran `parachute expose`. The fix puts a single `/vault/`
+  // tailscale mount → hub, and hub picks the specific vault per request.
+  // These tests verify the hub-side picker works with a real upstream.
+
+  function startUpstream(replyTag: string): { port: number; stop: () => void } {
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: async (req) => {
+        const u = new URL(req.url);
+        // Echo enough metadata for tests to verify path + method + body
+        // arrive intact end-to-end.
+        const body = req.body ? await req.text() : "";
+        return new Response(
+          JSON.stringify({
+            tag: replyTag,
+            method: req.method,
+            pathname: u.pathname,
+            search: u.search,
+            body,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      },
+    });
+    // server.port is `number | undefined` in Bun's types, but `Bun.serve()`
+    // returns synchronously with the bound port — non-null assertion is safe.
+    return { port: server.port as number, stop: () => server.stop(true) };
+  }
+
+  test("proxies a /vault/<name>/* request to the matching upstream", async () => {
+    const h = makeHarness();
+    const upstream = startUpstream("default-vault");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: upstream.port,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(req("/vault/default/health?ok=1"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { tag: string; pathname: string; search: string };
+      expect(body.tag).toBe("default-vault");
+      // Path is preserved end-to-end — vault since paraclaw#18 expects requests
+      // at `/vault/<name>/...` rather than stripped.
+      expect(body.pathname).toBe("/vault/default/health");
+      expect(body.search).toBe("?ok=1");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("a freshly-added vault is routable on the very next request, no restart", async () => {
+    // The whole reason hub#144 exists: `parachute vault create techne` writes
+    // services.json but the user shouldn't need to re-expose to reach the new
+    // vault. Read-on-each-request makes this work.
+    const h = makeHarness();
+    const u1 = startUpstream("default-vault");
+    const u2 = startUpstream("techne-vault");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: u1.port,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+
+      // Before: /vault/techne 404s — no entry yet.
+      const before = await fetcher(req("/vault/techne/health"));
+      expect(before.status).toBe(404);
+
+      // Simulate `parachute vault create techne` — multi-path single
+      // ServiceEntry shape is what vault writes today.
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: u2.port,
+              paths: ["/vault/default", "/vault/techne"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+
+      // After: same hubFetch instance, no restart, /vault/techne is reachable.
+      const after = await fetcher(req("/vault/techne/health"));
+      expect(after.status).toBe(200);
+      const body = (await after.json()) as { tag: string; pathname: string };
+      expect(body.tag).toBe("techne-vault");
+      expect(body.pathname).toBe("/vault/techne/health");
+    } finally {
+      u1.stop();
+      u2.stop();
+      h.cleanup();
+    }
+  });
+
+  test("a removed vault returns 404 from the hub on the next request", async () => {
+    const h = makeHarness();
+    const upstream = startUpstream("default-vault");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: upstream.port,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      expect((await fetcher(req("/vault/default/health"))).status).toBe(200);
+
+      // Vault detached — services.json no longer mentions it.
+      writeManifest({ services: [] }, h.manifestPath);
+      const after = await fetcher(req("/vault/default/health"));
+      expect(after.status).toBe(404);
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("preserves method + body for POSTs", async () => {
+    const h = makeHarness();
+    const upstream = startUpstream("default-vault");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: upstream.port,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(
+        req("/vault/default/notes", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ content: "hello" }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { method: string; body: string };
+      expect(body.method).toBe("POST");
+      expect(JSON.parse(body.body)).toEqual({ content: "hello" });
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("returns 502 when the matching vault upstream is unreachable", async () => {
+    // Vault is in services.json but the port has nothing listening — vault
+    // crashed, port shifted, or the user is mid-restart. We owe the caller a
+    // useful error instead of a hang or a silent 404.
+    const h = makeHarness();
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              // Bind a port + immediately release it so the proxy gets ECONNREFUSED.
+              port: await pickClosedPort(),
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(req("/vault/default/health"));
+      expect(res.status).toBe(502);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain("vault upstream unreachable");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("non-vault path inside /vault/ namespace falls through to 404", async () => {
+    // `/vault/keeper` belongs to no installed service — no longest-prefix
+    // match, no proxy attempt, hub answers with the generic 404.
+    const h = makeHarness();
+    const upstream = startUpstream("default-vault");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: upstream.port,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(req("/vault/keeper/health"));
+      expect(res.status).toBe(404);
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+});
+
+/** Find a port that no one is listening on by binding briefly and releasing. */
+async function pickClosedPort(): Promise<number> {
+  const s = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("x") });
+  const port = s.port as number;
+  s.stop(true);
+  return port;
+}

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -29,6 +29,7 @@ import {
   WELL_KNOWN_MOUNT,
   WELL_KNOWN_PATH,
   buildWellKnown,
+  isVaultEntry,
   shortName,
   writeWellKnownFile,
 } from "../well-known.ts";
@@ -120,6 +121,19 @@ const OAUTH_PATHS = [
 ] as const;
 
 /**
+ * Single tailscale serve mount that catches every `/vault/<name>/...` request
+ * and routes it through the hub. The hub then reads services.json on each
+ * request to pick the right vault backend (#144). Consolidating to one mount
+ * means `parachute vault create techne` is reachable on the tailnet without
+ * re-running `parachute expose` — only the hub-internal lookup needs to know
+ * about the new path.
+ *
+ * Trailing slash distinguishes the mount from `/vaults` (the create-vault
+ * POST endpoint, an exact-match on hub).
+ */
+const VAULT_MOUNT = "/vault/";
+
+/**
  * Remap legacy `paths: ["/"]` entries to `/<shortname>` so they don't collide
  * with the hub page at `/`. Emits a warning per remapped service. This is the
  * transitional path for services installed before the vault PR that writes
@@ -205,13 +219,29 @@ function planEntries(services: readonly ServiceEntry[], hubPort: number): ServeE
     target: serviceProxyTarget(hubPort, HUB_MOUNT),
     service: "hub",
   });
+  let anyVault = false;
   for (const s of services) {
+    if (isVaultEntry(s)) {
+      // Vault paths route through the single `/vault/` → hub mount below so
+      // `parachute vault create <name>` is reachable on the tailnet without
+      // a re-expose. Hub does the per-request services.json lookup (#144).
+      anyVault = true;
+      continue;
+    }
     const mount = s.paths[0] ?? `/${shortName(s.name)}`;
     entries.push({
       kind: "proxy",
       mount,
       target: serviceProxyTarget(s.port, mount),
       service: s.name,
+    });
+  }
+  if (anyVault) {
+    entries.push({
+      kind: "proxy",
+      mount: VAULT_MOUNT,
+      target: serviceProxyTarget(hubPort, VAULT_MOUNT),
+      service: "vault",
     });
   }
   entries.push({

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -57,9 +57,9 @@ import {
   handleRevoke,
   handleToken,
 } from "./oauth-handlers.ts";
-import { readManifest } from "./services-manifest.ts";
+import { type ServiceEntry, readManifest } from "./services-manifest.ts";
 import { getAllPublicKeys } from "./signing-keys.ts";
-import { buildWellKnown } from "./well-known.ts";
+import { buildWellKnown, isVaultEntry } from "./well-known.ts";
 
 interface Args {
   port: number;
@@ -104,6 +104,98 @@ function parseArgs(argv: string[]): Args {
   return { port, wellKnownDir, dbPath: dbPath ?? hubDbPath(), issuer };
 }
 
+/**
+ * Resolve which vault ServiceEntry should handle a given request pathname.
+ *
+ * Vault paths look like `/vault/<name>` or `/vault/<name>/<rest>`. A request
+ * matches a vault entry if the pathname equals one of its mount paths exactly
+ * or starts with `<mount>/`. When several mounts could match (one vault has
+ * `/vault` and another has `/vault/foo` — pathological but representable),
+ * the longer mount wins so the more specific install handles it.
+ *
+ * Returns `undefined` when no vault is mounted at this pathname; the caller
+ * 404s. The lookup is per-request because services.json mutates whenever
+ * `parachute vault create` runs and we don't want the user to re-expose just
+ * to make a freshly-created vault routable on the tailnet (#144).
+ */
+export function findVaultUpstream(
+  services: readonly ServiceEntry[],
+  pathname: string,
+): { port: number; mount: string; entry: ServiceEntry } | undefined {
+  let best: { port: number; mount: string; entry: ServiceEntry } | undefined;
+  for (const s of services) {
+    if (!isVaultEntry(s)) continue;
+    for (const path of s.paths) {
+      if (pathname === path || pathname.startsWith(`${path}/`)) {
+        if (!best || path.length > best.mount.length) {
+          best = { port: s.port, mount: path, entry: s };
+        }
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Reverse-proxy a `/vault/<name>/*` request onto the vault backend's loopback
+ * port. The path is preserved end-to-end (vault since paraclaw#18 expects
+ * requests at `/vault/<name>/...` not stripped to `/...`), so the upstream URL
+ * mirrors the incoming pathname exactly.
+ *
+ * `manifestPath` is the services.json path from `HubFetchDeps`. Read on every
+ * proxied request so a vault created seconds ago is reachable without a
+ * re-expose — same dynamism as the well-known doc (#135).
+ *
+ * Returns `undefined` when no vault is currently mounted at this pathname so
+ * the caller falls through to the catch-all 404. Returns a 502 response when
+ * the upstream connection fails (vault crashed, port shifted) — the upstream
+ * URL was valid; we just couldn't reach it.
+ *
+ * Hop-by-hop notes: WebSocket upgrades and HTTP/2 trailers don't traverse
+ * fetch-based proxies cleanly. Vault uses neither today; if a future service
+ * needs them, switch to a Node http.IncomingMessage / http.request pair.
+ */
+async function proxyToVault(req: Request, manifestPath: string): Promise<Response | undefined> {
+  let services: readonly ServiceEntry[];
+  try {
+    services = readManifest(manifestPath).services;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return new Response(JSON.stringify({ error: `vault routing failed: ${msg}` }), {
+      status: 500,
+      headers: { "content-type": "application/json" },
+    });
+  }
+  const url = new URL(req.url);
+  const match = findVaultUpstream(services, url.pathname);
+  if (!match) return undefined;
+
+  const upstream = `http://127.0.0.1:${match.port}${url.pathname}${url.search}`;
+  const headers = new Headers(req.headers);
+  // Host comes from the requester (tailnet FQDN); the loopback target wants
+  // its own. Bun's fetch fills it in when omitted.
+  headers.delete("host");
+
+  const init: RequestInit & { duplex?: "half" } = {
+    method: req.method,
+    headers,
+    redirect: "manual",
+  };
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    init.body = req.body;
+    init.duplex = "half";
+  }
+  try {
+    return await fetch(upstream, init);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return new Response(JSON.stringify({ error: `vault upstream unreachable: ${msg}` }), {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    });
+  }
+}
+
 export interface HubFetchDeps {
   /**
    * Lazily opens (or returns a cached handle to) the hub DB. Optional so
@@ -141,7 +233,7 @@ export function hubFetch(
     issuer: configuredIssuer ?? new URL(req.url).origin,
   });
 
-  return (req) => {
+  return async (req) => {
     const url = new URL(req.url);
     const pathname = url.pathname;
 
@@ -314,6 +406,17 @@ export function hubFetch(
         return new Response("not found", { status: 404 });
       }
       return handleAdminConfigPost(getDb(), req, name);
+    }
+
+    // Dynamic vault routing — services.json is the source of truth, read per
+    // request so a `parachute vault create` performed after `parachute expose`
+    // is immediately reachable on the tailnet (#144). Tailscale serve mounts
+    // a single `/vault/` → hub entry; this handler picks the specific vault
+    // backend by longest-mount-prefix on every request.
+    if (pathname.startsWith("/vault/")) {
+      const proxied = await proxyToVault(req, manifestPath);
+      if (proxied) return proxied;
+      // Fall through to the catch-all 404 below — no vault claims this path.
     }
 
     return new Response("not found", { status: 404 });


### PR DESCRIPTION
## Summary

Fixes #144 — newly-created vaults were unreachable on the tailnet until `parachute expose` was re-run. Tailscale's serve table is built once at expose time and stays stale; well-known correctly listed the new vault but the proxy didn't.

**Approach (option A, pre-blessed):** consolidate all per-vault tailscale mounts into a single `/vault/` mount that points at the hub, and have hub do per-request services.json lookup to find the right upstream port. Path is preserved end-to-end (vault expects `/vault/<name>/...`, not stripped).

- `hub-server.ts` — `findVaultUpstream()` does longest-prefix match across vault entries' `paths`; `proxyToVault()` reads manifest per-request and forwards via `fetch` with body streaming (`duplex: "half"`). Inner handler is now async.
- `commands/expose.ts` — `planEntries` collapses N vault entries into a single `/vault/` → hub mount instead of N per-vault mounts.

## Test plan

- [x] Typecheck clean
- [x] Biome lint clean
- [x] 904 tests pass / 0 fail (16 new on top of existing 888)
  - 6 unit tests for `findVaultUpstream` (exact, descendant, no-match, non-vault rejection, multi-path single entry, longest-prefix wins)
  - 6 integration tests for `/vault/<name>/*` proxy (round-trip, freshly-added vault routable on next request, removed vault → 404, POST body preservation, 502 on unreachable upstream, namespace fallthrough 404)
  - 4 new expose tests for vault mount consolidation; 4 existing expose tests updated for new mount shape

## Notes

- Hop-by-hop: WebSocket upgrades and HTTP/2 trailers don't traverse fetch-based proxies; vault uses neither today.
- RC bump: `0.4.0-rc.31` → `0.4.0-rc.32`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)