### PR TITLE
fix(hub): bundle — hub#148 manual-hub detection + hub#143 vault-name unify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.33",
+  "version": "0.4.0-rc.34",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { HUB_SVC, hubPortPath } from "../hub-control.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { findVaultUpstream, hubFetch } from "../hub-server.ts";
+import { pidPath } from "../process-state.ts";
 import { type ServiceEntry, writeManifest } from "../services-manifest.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 
@@ -775,3 +778,58 @@ async function pickClosedPort(): Promise<number> {
   s.stop(true);
   return port;
 }
+
+const HUB_SERVER_PATH = fileURLToPath(new URL("../hub-server.ts", import.meta.url));
+
+async function pollUntil(check: () => boolean, timeoutMs = 3000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (check()) return true;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return false;
+}
+
+describe("hub-server.ts startup PID/port registration (#148)", () => {
+  test("manual `bun src/hub-server.ts` writes hub.pid and hub.port; SIGTERM clears them", async () => {
+    const port = await pickClosedPort();
+    const configDir = mkdtempSync(join(tmpdir(), "pcli-hub-startup-"));
+    const wellKnownDir = join(configDir, "well-known");
+    const dbPath = join(configDir, "hub.db");
+
+    const proc = Bun.spawn(
+      [
+        process.execPath,
+        HUB_SERVER_PATH,
+        "--port",
+        String(port),
+        "--well-known-dir",
+        wellKnownDir,
+        "--db",
+        dbPath,
+      ],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, PARACHUTE_HOME: configDir },
+      },
+    );
+    const pidFile = pidPath(HUB_SVC, configDir);
+    const portFile = hubPortPath(configDir);
+    try {
+      const ready = await pollUntil(() => existsSync(pidFile) && existsSync(portFile));
+      expect(ready).toBe(true);
+      expect(Number.parseInt(readFileSync(pidFile, "utf8").trim(), 10)).toBe(proc.pid);
+      expect(Number.parseInt(readFileSync(portFile, "utf8").trim(), 10)).toBe(port);
+      proc.kill("SIGTERM");
+      await proc.exited;
+      // After SIGTERM the cleanup handler should have rm'd both files —
+      // proves manual starts also play nice with `parachute expose` teardown.
+      expect(existsSync(pidFile)).toBe(false);
+      expect(existsSync(portFile)).toBe(false);
+    } finally {
+      if (!proc.killed) proc.kill("SIGKILL");
+      rmSync(configDir, { recursive: true, force: true });
+    }
+  }, 10_000);
+});

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -49,7 +49,7 @@ import type { Database } from "bun:sqlite";
 import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import { findService, readManifest } from "./services-manifest.ts";
-import { type WellKnownVaultEntry, isVaultEntry, vaultInstanceName } from "./well-known.ts";
+import { type WellKnownVaultEntry, isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
 
 /** Scope required to call POST /vaults. */
 export const HOST_ADMIN_SCOPE = "parachute:host:admin";
@@ -152,8 +152,10 @@ function jsonError(status: number, error: string, description: string): Response
 
 /**
  * Find an existing vault by name in services.json. Vaults live under one
- * `parachute-vault` service entry with a multi-path array (per Q5 of the
- * design — single entry, multi-path). We match on the path suffix.
+ * `parachute-vault` service entry, which may carry a multi-path array (per
+ * Q5 of the design — single entry, multi-path) or a per-vault `parachute-
+ * vault-<name>` entry. Delegates name resolution to `vaultInstanceNameFor`
+ * so well-known.ts, oauth-handlers.ts, and this lookup all agree (#143).
  */
 function findExistingVault(
   manifestPath: string,
@@ -168,14 +170,16 @@ function findExistingVault(
   const target = `/vault/${name}`;
   for (const svc of manifest.services) {
     if (!isVaultEntry(svc)) continue;
-    // Multi-path single-entry shape (Q5): paths includes /vault/<name>.
-    if (svc.paths.includes(target)) {
-      return { url: target, version: svc.version, path: target };
+    if (svc.paths.length === 0) {
+      if (vaultInstanceNameFor(svc.name, undefined) === name) {
+        return { url: target, version: svc.version, path: target };
+      }
+      continue;
     }
-    // Per-vault entry shape (`parachute-vault-<name>`): instance name match.
-    if (vaultInstanceName(svc) === name) {
-      const path = svc.paths[0] ?? target;
-      return { url: path, version: svc.version, path };
+    for (const path of svc.paths) {
+      if (vaultInstanceNameFor(svc.name, path) === name) {
+        return { url: path, version: svc.version, path };
+      }
     }
   }
   return null;

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -47,6 +47,7 @@ import {
 } from "./admin-handlers.ts";
 import { handleCreateVault } from "./admin-vaults.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
+import { HUB_SVC, clearHubPort, writeHubPort } from "./hub-control.ts";
 import { hubDbPath, openHubDb } from "./hub-db.ts";
 import { pemToJwk } from "./jwks.ts";
 import {
@@ -57,6 +58,7 @@ import {
   handleRevoke,
   handleToken,
 } from "./oauth-handlers.ts";
+import { clearPid, writePid } from "./process-state.ts";
 import { type ServiceEntry, readManifest } from "./services-manifest.ts";
 import { getAllPublicKeys } from "./signing-keys.ts";
 import { buildWellKnown, isVaultEntry } from "./well-known.ts";
@@ -435,6 +437,26 @@ if (import.meta.main) {
     hostname: "127.0.0.1",
     fetch: hubFetch(wellKnownDir, { getDb, issuer }),
   });
+  // Register PID + port from the running hub itself so any startup path
+  // (spawn-via-`ensureHubRunning` or a direct `bun src/hub-server.ts` from
+  // a developer or supervisor) lands the same lifecycle files at
+  // ~/.parachute/hub/run/. Manual starts used to be invisible — `parachute
+  // expose` then spawned another hub that collided on 1939 (#148).
+  writePid(HUB_SVC, process.pid);
+  writeHubPort(port);
+  const cleanup = () => {
+    clearPid(HUB_SVC);
+    clearHubPort();
+  };
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(0);
+  });
+  process.on("SIGTERM", () => {
+    cleanup();
+    process.exit(0);
+  });
+  process.on("exit", cleanup);
   console.log(
     `parachute-hub listening on http://127.0.0.1:${port} (dir=${wellKnownDir}, db=${dbPath}${
       issuer ? `, issuer=${issuer}` : ""

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -67,7 +67,7 @@ import {
   parseSessionCookie,
 } from "./sessions.ts";
 import { getUserByUsername, verifyPassword } from "./users.ts";
-import { isVaultEntry, shortName, vaultInstanceName } from "./well-known.ts";
+import { isVaultEntry, shortName, vaultInstanceNameFor } from "./well-known.ts";
 
 const VAULT_VERBS = new Set(["read", "write", "admin"]);
 
@@ -86,22 +86,20 @@ function unnamedVaultVerbs(scopes: string[]): string[] {
 
 /**
  * Vault instance names registered on this host, derived from services.json.
- * Walks both manifest shapes: single-entry-multi-path (`paths: ["/vault/work",
- * "/vault/personal"]`) and per-vault entries (`parachute-vault-work`).
+ * Walks both manifest shapes — single-entry-multi-path (`paths: ["/vault/work",
+ * "/vault/personal"]`) and per-vault entries (`parachute-vault-work`) — by
+ * delegating each (name, path) pair to the canonical `vaultInstanceNameFor`
+ * helper. Entries with no paths still resolve to a name via the helper's
+ * manifest-suffix fallback (#143).
  */
 function listVaultNames(manifest: ServicesManifest): string[] {
   const names = new Set<string>();
   for (const svc of manifest.services) {
     if (!isVaultEntry(svc)) continue;
-    let foundFromPaths = false;
-    for (const path of svc.paths) {
-      const m = path.match(/^\/vault\/([^/]+)/);
-      if (m?.[1]) {
-        names.add(m[1]);
-        foundFromPaths = true;
-      }
+    const paths = svc.paths.length > 0 ? svc.paths : [undefined];
+    for (const path of paths) {
+      names.add(vaultInstanceNameFor(svc.name, path));
     }
-    if (!foundFromPaths) names.add(vaultInstanceName(svc));
   }
   return Array.from(names).sort();
 }


### PR DESCRIPTION
Bundle of two small infra-layer fixes.

## hub#148 — manually-started hub not detected

`ensureHubRunning` in `src/hub-control.ts:160-169` decides whether to spawn the hub by reading the PID + port files at `~/.parachute/hub/run/`. Those files were written only by the hub-control parent on spawn, so a manual `bun src/hub-server.ts` invocation (developer, foreground supervisor, etc.) left the files absent — the next `parachute expose` then thought no hub was running, spawned a second one, and collided on port 1939. Aaron hit this earlier today.

**Fix:** move the PID + port write into the hub-server startup block so any launch path registers the same lifecycle files. Add SIGINT/SIGTERM/exit handlers so external shutdowns don't leave stale state.

**Test:** new real-spawn integration test asserts files are written on startup and removed on SIGTERM.

## hub#143 — unify vault-name resolution

Three places derived the vault instance name from a `ServiceEntry` independently:
- `well-known.ts` (canonical `vaultInstanceNameFor(name, path)`)
- `oauth-handlers.ts:listVaultNames` (own `/vault/<name>` regex + fallback)
- `admin-vaults.ts:findExistingVault` (`paths.includes()` + separate `vaultInstanceName` fallback)

Move the latter two onto the canonical helper. All three now agree on multi-path single-entry shape, per-vault entry shape, and the manifest-suffix fallback. The wrapper `vaultInstanceName(entry)` stays as a one-liner over `vaultInstanceNameFor(entry.name, entry.paths[0])` — used by tests and harmless to keep.

## Issue closures (separate, no-PR cleanup)

These four reference `src/deploy/` code retired in PR #147 (lifted to parachute-cloud in cloud#10):
- hub#126 — deploy: listMachines test
- hub#127 — deploy: appCreated flag rename
- hub#128 — deploy: ProvisionOpts.name doc
- hub#131 — deploy: PARACHUTE_HOME warn

Will close each with the canonical "moved to parachute-cloud" comment after this PR opens.

## Test plan

- [x] Typecheck clean
- [x] Biome lint clean
- [x] 864 tests pass / 0 fail (was 863; +1 new manual-start integration test)

## Versioning

`0.4.0-rc.33` → `0.4.0-rc.34`

🤖 Generated with [Claude Code](https://claude.com/claude-code)