### PR TITLE
fix(grants): tx-wrap recordGrant + audit log on skip-consent (#119, #120)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.34",
+  "version": "0.4.0-rc.35",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/grants.test.ts
+++ b/src/__tests__/grants.test.ts
@@ -122,6 +122,30 @@ describe("grants module (#75)", () => {
     }
   });
 
+  test("recordGrant: concurrent calls produce one row with the union of scopes (#119)", async () => {
+    const h = await harness();
+    try {
+      // Fire two recordGrant calls "concurrently" via Promise.all. The
+      // transaction wrapper means the read-merge-write is atomic, so the
+      // second writer always sees the first writer's scopes — neither set
+      // gets dropped.
+      await Promise.all([
+        Promise.resolve().then(() => recordGrant(h.db, h.userId, h.clientId, ["a", "b"])),
+        Promise.resolve().then(() => recordGrant(h.db, h.userId, h.clientId, ["c", "d"])),
+      ]);
+      const rowCount = (
+        h.db
+          .prepare("SELECT COUNT(*) AS n FROM grants WHERE user_id = ? AND client_id = ?")
+          .get(h.userId, h.clientId) as { n: number }
+      ).n;
+      expect(rowCount).toBe(1);
+      const grant = findGrant(h.db, h.userId, h.clientId);
+      expect(new Set(grant?.scopes)).toEqual(new Set(["a", "b", "c", "d"]));
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("listGrantsForUser orders most-recent first", async () => {
     const h = await harness();
     try {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -2777,6 +2777,47 @@ describe("handleAuthorizeGet — skip consent when scope already granted (#75)",
     }
   });
 
+  test("skip-consent emits an audit log line with client_id, user_id, and scopes (#120)", async () => {
+    const { db, cleanup } = await makeDb();
+    const originalLog = console.log;
+    const lines: string[] = [];
+    console.log = (...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(" "));
+    };
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const { recordGrant } = await import("../grants.ts");
+      recordGrant(db, user.id, reg.client.clientId, ["vault:default:read", "scribe:transcribe"]);
+
+      const getReq = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          scope: "vault:default:read scribe:transcribe",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          state: "skip",
+        }),
+        { headers: { cookie: buildSessionCookie(session.id, 86400) } },
+      );
+      const getRes = handleAuthorizeGet(db, getReq, { issuer: ISSUER });
+      expect(getRes.status).toBe(302);
+
+      const skip = lines.find((l) => l.startsWith("consent skipped:"));
+      expect(skip).toBeDefined();
+      expect(skip).toContain(`client_id=${reg.client.clientId}`);
+      expect(skip).toContain(`user_id=${user.id}`);
+      expect(skip).toContain("scopes=vault:default:read scribe:transcribe");
+    } finally {
+      console.log = originalLog;
+      cleanup();
+    }
+  });
+
   test("subset of granted scopes also skips consent", async () => {
     const { db, cleanup } = await makeDb();
     try {

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -72,18 +72,24 @@ export function recordGrant(
   newScopes: readonly string[],
   now: Date = new Date(),
 ): Grant {
-  const existing = findGrant(db, userId, clientId);
-  const merged = new Set<string>(existing?.scopes ?? []);
-  for (const s of newScopes) {
-    if (s.length > 0) merged.add(s);
-  }
-  const scopes = Array.from(merged).sort();
-  const grantedAt = now.toISOString();
-  db.prepare(
-    `INSERT OR REPLACE INTO grants (user_id, client_id, scopes, granted_at)
-     VALUES (?, ?, ?, ?)`,
-  ).run(userId, clientId, scopes.join(" "), grantedAt);
-  return { userId, clientId, scopes, grantedAt };
+  // Wrapped in a transaction so the read-merge-write is atomic. Without
+  // this, two concurrent consents for the same (user, client) could both
+  // SELECT the same prior row and then race to INSERT OR REPLACE, with the
+  // later writer's UNION missing scopes the earlier writer added.
+  return db.transaction(() => {
+    const existing = findGrant(db, userId, clientId);
+    const merged = new Set<string>(existing?.scopes ?? []);
+    for (const s of newScopes) {
+      if (s.length > 0) merged.add(s);
+    }
+    const scopes = Array.from(merged).sort();
+    const grantedAt = now.toISOString();
+    db.prepare(
+      `INSERT OR REPLACE INTO grants (user_id, client_id, scopes, granted_at)
+       VALUES (?, ?, ?, ?)`,
+    ).run(userId, clientId, scopes.join(" "), grantedAt);
+    return { userId, clientId, scopes, grantedAt };
+  })();
 }
 
 /**

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -392,6 +392,9 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   //     something new) falls through to the consent screen.
   const hasUnnamedVault = unnamedVaultVerbs(requestedScopes).length > 0;
   if (!hasUnnamedVault && isCoveredByGrant(db, session.userId, client.clientId, requestedScopes)) {
+    console.log(
+      `consent skipped: existing grant covers requested scope client_id=${client.clientId} user_id=${session.userId} scopes=${requestedScopes.join(" ")}`,
+    );
     return issueAuthCodeRedirect(db, parsed, requestedScopes, session.userId, deps);
   }
 


### PR DESCRIPTION
## Summary

Bundle of two grants-related correctness/visibility fixes:

- **#119** — `recordGrant` is now wrapped in `db.transaction(() => { ... })()`. The function does a SELECT (via `findGrant`) then an INSERT OR REPLACE; without atomicity, two concurrent consents for the same `(user, client)` pair could both read the same prior row and race to write, with the later writer dropping scopes the earlier writer added.
- **#120** — when `isCoveredByGrant` short-circuits the consent screen, we now emit a log line: `consent skipped: existing grant covers requested scope client_id=... user_id=... scopes=...`. Without this, a skipped consent was invisible in production logs.

## Commits

- `e2e0852` — fix(grants): wrap recordGrant in db.transaction() for concurrent safety (#119) — adds an integration test that fires two `recordGrant` calls via `Promise.all` and asserts exactly one row exists post-merge with the union of all scopes.
- `016c6f0` — feat(grants): audit log when consent is skipped by existing grant (#120) — adds a test that captures `console.log`, runs the skip-consent path, and asserts the log line shape (client_id, user_id, scopes).

Bumps to 0.4.0-rc.35.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (biome)
- [x] `bun test` — 866 pass / 0 fail (was 864; +1 for #119, +1 for #120)