### PR TITLE
feat(expose): --tunnel-name flag for cloudflare tunnels (#32)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.35",
+  "version": "0.4.0-rc.36",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/cloudflare-state.test.ts
+++ b/src/__tests__/cloudflare-state.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   type CloudflaredState,
   CloudflaredStateError,
+  type CloudflaredTunnelRecord,
   clearCloudflaredState,
+  findTunnelRecord,
+  listTunnelRecords,
   readCloudflaredState,
+  withTunnelRecord,
+  withoutTunnelRecord,
   writeCloudflaredState,
 } from "../cloudflare/state.ts";
 
@@ -18,14 +23,18 @@ function makeTempPath(): { path: string; cleanup: () => void } {
   };
 }
 
-const sample: CloudflaredState = {
-  version: 1,
+const sampleRecord: CloudflaredTunnelRecord = {
   pid: 12345,
   tunnelUuid: "2c1a7c7e-1234-5678-9abc-def012345678",
   tunnelName: "parachute",
   hostname: "vault.example.com",
   startedAt: "2026-04-22T12:00:00.000Z",
-  configPath: "/home/x/.parachute/cloudflared/config.yml",
+  configPath: "/home/x/.parachute/cloudflared/parachute/config.yml",
+};
+
+const sample: CloudflaredState = {
+  version: 2,
+  tunnels: { parachute: sampleRecord },
 };
 
 describe("cloudflared state", () => {
@@ -63,18 +72,40 @@ describe("cloudflared state", () => {
   test("throws on unsupported version", () => {
     const { path, cleanup } = makeTempPath();
     try {
-      writeFileSync(path, JSON.stringify({ ...sample, version: 99 }));
+      writeFileSync(path, JSON.stringify({ version: 99, tunnels: {} }));
       expect(() => readCloudflaredState(path)).toThrow(/unsupported version/);
     } finally {
       cleanup();
     }
   });
 
-  test("throws on non-positive pid", () => {
+  test("throws on non-positive pid in a tunnel record", () => {
     const { path, cleanup } = makeTempPath();
     try {
-      writeFileSync(path, JSON.stringify({ ...sample, pid: -1 }));
+      writeFileSync(
+        path,
+        JSON.stringify({
+          version: 2,
+          tunnels: { parachute: { ...sampleRecord, pid: -1 } },
+        }),
+      );
       expect(() => readCloudflaredState(path)).toThrow(CloudflaredStateError);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("throws when tunnel record's name doesn't match its key", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writeFileSync(
+        path,
+        JSON.stringify({
+          version: 2,
+          tunnels: { parachute: { ...sampleRecord, tunnelName: "different" } },
+        }),
+      );
+      expect(() => readCloudflaredState(path)).toThrow(/must equal its key/);
     } finally {
       cleanup();
     }
@@ -88,5 +119,134 @@ describe("cloudflared state", () => {
     } finally {
       cleanup();
     }
+  });
+
+  test("migrates v1 single-record state to v2 on read", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      // v1 — pre-#32 shape with the single record at the top level. cloudflared
+      // installs in the wild may still have this on disk; reading it must not
+      // explode and must yield the canonical v2 shape.
+      const legacy = {
+        version: 1,
+        pid: 12345,
+        tunnelUuid: "2c1a7c7e-1234-5678-9abc-def012345678",
+        tunnelName: "parachute",
+        hostname: "vault.example.com",
+        startedAt: "2026-04-22T12:00:00.000Z",
+        configPath: "/home/x/.parachute/cloudflared/config.yml",
+      };
+      writeFileSync(path, JSON.stringify(legacy));
+
+      const state = readCloudflaredState(path);
+      expect(state).toEqual({
+        version: 2,
+        tunnels: {
+          parachute: {
+            pid: 12345,
+            tunnelUuid: "2c1a7c7e-1234-5678-9abc-def012345678",
+            tunnelName: "parachute",
+            hostname: "vault.example.com",
+            startedAt: "2026-04-22T12:00:00.000Z",
+            configPath: "/home/x/.parachute/cloudflared/config.yml",
+          },
+        },
+      });
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("v1 migration is read-only until the next write", () => {
+    // The migration is silent on read but doesn't rewrite disk on its own —
+    // disk only flips when the next write commits. Mirrors how other state
+    // migrations in the repo behave; documents the contract.
+    const { path, cleanup } = makeTempPath();
+    try {
+      const legacy = {
+        version: 1,
+        pid: 12345,
+        tunnelUuid: "2c1a7c7e-1234-5678-9abc-def012345678",
+        tunnelName: "parachute",
+        hostname: "vault.example.com",
+        startedAt: "2026-04-22T12:00:00.000Z",
+        configPath: "/home/x/.parachute/cloudflared/config.yml",
+      };
+      writeFileSync(path, JSON.stringify(legacy));
+      readCloudflaredState(path); // returns v2 in memory
+      const onDisk = JSON.parse(readFileSync(path, "utf8"));
+      expect(onDisk.version).toBe(1);
+
+      // After a write, disk reflects v2.
+      const state = readCloudflaredState(path);
+      writeCloudflaredState(state as CloudflaredState, path);
+      const onDiskAfter = JSON.parse(readFileSync(path, "utf8"));
+      expect(onDiskAfter.version).toBe(2);
+      expect(onDiskAfter.tunnels.parachute.tunnelName).toBe("parachute");
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("cloudflared state — record helpers", () => {
+  const recordA: CloudflaredTunnelRecord = {
+    pid: 1001,
+    tunnelUuid: "aaaaaaaa-0000-0000-0000-000000000001",
+    tunnelName: "alpha",
+    hostname: "alpha.example.com",
+    startedAt: "2026-04-23T10:00:00.000Z",
+    configPath: "/tmp/alpha/config.yml",
+  };
+  const recordB: CloudflaredTunnelRecord = {
+    pid: 1002,
+    tunnelUuid: "bbbbbbbb-0000-0000-0000-000000000002",
+    tunnelName: "beta",
+    hostname: "beta.example.com",
+    startedAt: "2026-04-23T11:00:00.000Z",
+    configPath: "/tmp/beta/config.yml",
+  };
+
+  test("findTunnelRecord returns undefined for unknown name and the record for known name", () => {
+    const state: CloudflaredState = { version: 2, tunnels: { alpha: recordA } };
+    expect(findTunnelRecord(state, "alpha")).toEqual(recordA);
+    expect(findTunnelRecord(state, "beta")).toBeUndefined();
+    expect(findTunnelRecord(undefined, "alpha")).toBeUndefined();
+  });
+
+  test("withTunnelRecord inserts into empty/undefined state", () => {
+    const next = withTunnelRecord(undefined, recordA);
+    expect(next).toEqual({ version: 2, tunnels: { alpha: recordA } });
+  });
+
+  test("withTunnelRecord adds a second tunnel without disturbing the first", () => {
+    const initial = withTunnelRecord(undefined, recordA);
+    const next = withTunnelRecord(initial, recordB);
+    expect(next.tunnels).toEqual({ alpha: recordA, beta: recordB });
+  });
+
+  test("withTunnelRecord replaces an existing record under the same name", () => {
+    const initial = withTunnelRecord(undefined, recordA);
+    const replaced: CloudflaredTunnelRecord = { ...recordA, pid: 9999 };
+    const next = withTunnelRecord(initial, replaced);
+    expect(next.tunnels.alpha).toEqual(replaced);
+    expect(Object.keys(next.tunnels)).toEqual(["alpha"]);
+  });
+
+  test("withoutTunnelRecord drops the named tunnel and returns undefined when empty", () => {
+    const initial = withTunnelRecord(undefined, recordA);
+    expect(withoutTunnelRecord(initial, "alpha")).toBeUndefined();
+  });
+
+  test("withoutTunnelRecord leaves other tunnels in place", () => {
+    const both = withTunnelRecord(withTunnelRecord(undefined, recordA), recordB);
+    const next = withoutTunnelRecord(both, "alpha");
+    expect(next).toEqual({ version: 2, tunnels: { beta: recordB } });
+  });
+
+  test("listTunnelRecords returns sorted-by-name order", () => {
+    const both = withTunnelRecord(withTunnelRecord(undefined, recordB), recordA);
+    expect(listTunnelRecords(both).map((r) => r.tunnelName)).toEqual(["alpha", "beta"]);
+    expect(listTunnelRecords(undefined)).toEqual([]);
   });
 });

--- a/src/__tests__/expose-cloudflare.test.ts
+++ b/src/__tests__/expose-cloudflare.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { readCloudflaredState, writeCloudflaredState } from "../cloudflare/state.ts";
+import {
+  type CloudflaredTunnelRecord,
+  findTunnelRecord,
+  readCloudflaredState,
+  withTunnelRecord,
+  writeCloudflaredState,
+} from "../cloudflare/state.ts";
 import {
   type CloudflaredSpawner,
   exposeCloudflareOff,
@@ -29,8 +35,8 @@ function makeEnv(opts: { includeVault?: boolean; loggedIn?: boolean } = {}): Tes
   const cloudflaredHome = join(dir, "cloudflared");
   const manifestPath = join(configDir, "services.json");
   const statePath = join(configDir, "cloudflared-state.json");
-  const configPath = join(configDir, "cloudflared", "config.yml");
-  const logPath = join(configDir, "cloudflared", "cloudflared.log");
+  const configPath = join(configDir, "cloudflared", "parachute", "config.yml");
+  const logPath = join(configDir, "cloudflared", "parachute", "cloudflared.log");
 
   require("node:fs").mkdirSync(configDir, { recursive: true });
   require("node:fs").mkdirSync(cloudflaredHome, { recursive: true });
@@ -148,13 +154,17 @@ describe("exposeCloudflareUp", () => {
 
       const state = readCloudflaredState(env.statePath);
       expect(state).toEqual({
-        version: 1,
-        pid: 42000,
-        tunnelUuid: uuid,
-        tunnelName: "parachute",
-        hostname: "vault.example.com",
-        startedAt: "2026-04-22T12:00:00.000Z",
-        configPath: env.configPath,
+        version: 2,
+        tunnels: {
+          parachute: {
+            pid: 42000,
+            tunnelUuid: uuid,
+            tunnelName: "parachute",
+            hostname: "vault.example.com",
+            startedAt: "2026-04-22T12:00:00.000Z",
+            configPath: env.configPath,
+          },
+        },
       });
 
       const yaml = readFileSync(env.configPath, "utf8");
@@ -231,6 +241,33 @@ describe("exposeCloudflareUp", () => {
       expect(code).toBe(1);
       expect(calls).toHaveLength(0);
       expect(logs.join("\n")).toContain("--domain must be a valid hostname");
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("rejects invalid tunnel names up front", async () => {
+    const env = makeEnv();
+    try {
+      const { runner, calls } = queueRunner([]);
+      const { spawner } = fakeSpawner(0);
+      const logs: string[] = [];
+
+      const code = await exposeCloudflareUp("vault.example.com", {
+        runner,
+        spawner,
+        log: (l) => logs.push(l),
+        manifestPath: env.manifestPath,
+        statePath: env.statePath,
+        configPath: env.configPath,
+        logPath: env.logPath,
+        cloudflaredHome: env.cloudflaredHome,
+        tunnelName: "bad name with spaces",
+      });
+
+      expect(code).toBe(1);
+      expect(calls).toHaveLength(0);
+      expect(logs.join("\n")).toContain("--tunnel-name must be alphanumeric");
     } finally {
       env.cleanup();
     }
@@ -353,18 +390,15 @@ describe("exposeCloudflareUp", () => {
   test("stops a prior cloudflared process before spawning a new one", async () => {
     const env = makeEnv();
     try {
-      writeCloudflaredState(
-        {
-          version: 1,
-          pid: 99999,
-          tunnelUuid: "old-tunnel-uuid",
-          tunnelName: "parachute",
-          hostname: "vault.example.com",
-          startedAt: "2026-04-21T00:00:00.000Z",
-          configPath: env.configPath,
-        },
-        env.statePath,
-      );
+      const priorRecord: CloudflaredTunnelRecord = {
+        pid: 99999,
+        tunnelUuid: "old-tunnel-uuid",
+        tunnelName: "parachute",
+        hostname: "vault.example.com",
+        startedAt: "2026-04-21T00:00:00.000Z",
+        configPath: env.configPath,
+      };
+      writeCloudflaredState({ version: 2, tunnels: { parachute: priorRecord } }, env.statePath);
 
       const { runner } = queueRunner([
         { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
@@ -396,7 +430,83 @@ describe("exposeCloudflareUp", () => {
       expect(code).toBe(0);
       expect(killed).toEqual([{ pid: 99999, sig: "SIGTERM" }]);
       const state = readCloudflaredState(env.statePath);
-      expect(state?.pid).toBe(42010);
+      expect(findTunnelRecord(state, "parachute")?.pid).toBe(42010);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("two tunnels with different --tunnel-name coexist in state", async () => {
+    const env = makeEnv();
+    try {
+      const uuidA = "aaaa1111-aaaa-1111-aaaa-111111111111";
+      const uuidB = "bbbb2222-bbbb-2222-bbbb-222222222222";
+      // Up #1 — default name "parachute"
+      const r1 = queueRunner([
+        { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
+        { code: 0, stdout: "[]", stderr: "" },
+        {
+          code: 0,
+          stdout: `Created tunnel parachute with id ${uuidA}\n`,
+          stderr: "",
+        },
+        { code: 0, stdout: "", stderr: "" },
+      ]);
+      const s1 = fakeSpawner(50001);
+      const code1 = await exposeCloudflareUp("alpha.example.com", {
+        runner: r1.runner,
+        spawner: s1.spawner,
+        alive: () => false,
+        kill: () => {},
+        log: () => {},
+        manifestPath: env.manifestPath,
+        statePath: env.statePath,
+        cloudflaredHome: env.cloudflaredHome,
+        // Use defaults for configPath/logPath so they're per-tunnel-derived.
+      });
+      expect(code1).toBe(0);
+
+      // Up #2 — explicit --tunnel-name "second"
+      const r2 = queueRunner([
+        { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
+        { code: 0, stdout: "[]", stderr: "" },
+        {
+          code: 0,
+          stdout: `Created tunnel second with id ${uuidB}\n`,
+          stderr: "",
+        },
+        { code: 0, stdout: "", stderr: "" },
+      ]);
+      const s2 = fakeSpawner(50002);
+      const code2 = await exposeCloudflareUp("beta.example.com", {
+        runner: r2.runner,
+        spawner: s2.spawner,
+        alive: () => false,
+        kill: () => {},
+        log: () => {},
+        manifestPath: env.manifestPath,
+        statePath: env.statePath,
+        cloudflaredHome: env.cloudflaredHome,
+        tunnelName: "second",
+      });
+      expect(code2).toBe(0);
+
+      // Both tunnels should be present in state, keyed by tunnel name.
+      const state = readCloudflaredState(env.statePath);
+      expect(Object.keys(state?.tunnels ?? {}).sort()).toEqual(["parachute", "second"]);
+      expect(findTunnelRecord(state, "parachute")?.hostname).toBe("alpha.example.com");
+      expect(findTunnelRecord(state, "second")?.hostname).toBe("beta.example.com");
+      expect(findTunnelRecord(state, "second")?.pid).toBe(50002);
+
+      // Each tunnel should have written its own config file at the per-tunnel
+      // path under `~/.parachute/cloudflared/<tunnelName>/config.yml`.
+      const cfgA = findTunnelRecord(state, "parachute")?.configPath ?? "";
+      const cfgB = findTunnelRecord(state, "second")?.configPath ?? "";
+      expect(cfgA).not.toBe(cfgB);
+      expect(cfgA.endsWith("/parachute/config.yml")).toBe(true);
+      expect(cfgB.endsWith("/second/config.yml")).toBe(true);
+      expect(existsSync(cfgA)).toBe(true);
+      expect(existsSync(cfgB)).toBe(true);
     } finally {
       env.cleanup();
     }
@@ -424,13 +534,17 @@ describe("exposeCloudflareOff", () => {
     try {
       writeCloudflaredState(
         {
-          version: 1,
-          pid: 55555,
-          tunnelUuid: "dddddddd-0000-0000-0000-000000000004",
-          tunnelName: "parachute",
-          hostname: "vault.example.com",
-          startedAt: "2026-04-22T12:00:00.000Z",
-          configPath: env.configPath,
+          version: 2,
+          tunnels: {
+            parachute: {
+              pid: 55555,
+              tunnelUuid: "dddddddd-0000-0000-0000-000000000004",
+              tunnelName: "parachute",
+              hostname: "vault.example.com",
+              startedAt: "2026-04-22T12:00:00.000Z",
+              configPath: env.configPath,
+            },
+          },
         },
         env.statePath,
       );
@@ -457,13 +571,17 @@ describe("exposeCloudflareOff", () => {
     try {
       writeCloudflaredState(
         {
-          version: 1,
-          pid: 55556,
-          tunnelUuid: "eeeeeeee-0000-0000-0000-000000000005",
-          tunnelName: "parachute",
-          hostname: "vault.example.com",
-          startedAt: "2026-04-22T12:00:00.000Z",
-          configPath: env.configPath,
+          version: 2,
+          tunnels: {
+            parachute: {
+              pid: 55556,
+              tunnelUuid: "eeeeeeee-0000-0000-0000-000000000005",
+              tunnelName: "parachute",
+              hostname: "vault.example.com",
+              startedAt: "2026-04-22T12:00:00.000Z",
+              configPath: env.configPath,
+            },
+          },
         },
         env.statePath,
       );
@@ -477,6 +595,83 @@ describe("exposeCloudflareOff", () => {
       expect(code).toBe(0);
       expect(killed).toEqual([]);
       expect(existsSync(env.statePath)).toBe(false);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("targets the named tunnel and leaves siblings intact", async () => {
+    const env = makeEnv();
+    try {
+      const recordA: CloudflaredTunnelRecord = {
+        pid: 60001,
+        tunnelUuid: "aaaa-uuid",
+        tunnelName: "alpha",
+        hostname: "alpha.example.com",
+        startedAt: "2026-04-23T10:00:00.000Z",
+        configPath: "/tmp/alpha/config.yml",
+      };
+      const recordB: CloudflaredTunnelRecord = {
+        pid: 60002,
+        tunnelUuid: "bbbb-uuid",
+        tunnelName: "beta",
+        hostname: "beta.example.com",
+        startedAt: "2026-04-23T11:00:00.000Z",
+        configPath: "/tmp/beta/config.yml",
+      };
+      writeCloudflaredState(
+        withTunnelRecord(withTunnelRecord(undefined, recordA), recordB),
+        env.statePath,
+      );
+
+      const killed: number[] = [];
+      const code = await exposeCloudflareOff({
+        statePath: env.statePath,
+        alive: () => true,
+        kill: (pid) => killed.push(pid),
+        log: () => {},
+        tunnelName: "alpha",
+      });
+      expect(code).toBe(0);
+      // Only alpha's pid is killed.
+      expect(killed).toEqual([60001]);
+
+      // beta is still recorded; alpha is gone.
+      const state = readCloudflaredState(env.statePath);
+      expect(findTunnelRecord(state, "alpha")).toBeUndefined();
+      expect(findTunnelRecord(state, "beta")).toEqual(recordB);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("reports tunnel-name mismatch and lists known tunnels", async () => {
+    const env = makeEnv();
+    try {
+      const recordA: CloudflaredTunnelRecord = {
+        pid: 60001,
+        tunnelUuid: "aaaa-uuid",
+        tunnelName: "alpha",
+        hostname: "alpha.example.com",
+        startedAt: "2026-04-23T10:00:00.000Z",
+        configPath: "/tmp/alpha/config.yml",
+      };
+      writeCloudflaredState({ version: 2, tunnels: { alpha: recordA } }, env.statePath);
+
+      const logs: string[] = [];
+      const code = await exposeCloudflareOff({
+        statePath: env.statePath,
+        alive: () => true,
+        kill: () => {},
+        log: (l) => logs.push(l),
+        tunnelName: "ghost",
+      });
+      expect(code).toBe(0);
+      expect(logs.join("\n")).toContain('No Cloudflare exposure recorded for tunnel "ghost"');
+      expect(logs.join("\n")).toContain("alpha");
+      // alpha is untouched.
+      const state = readCloudflaredState(env.statePath);
+      expect(findTunnelRecord(state, "alpha")).toEqual(recordA);
     } finally {
       env.cleanup();
     }

--- a/src/__tests__/expose-off-auto.test.ts
+++ b/src/__tests__/expose-off-auto.test.ts
@@ -26,16 +26,22 @@ function tailscaleState(overrides: Partial<ExposeState> = {}): ExposeState {
   };
 }
 
-function cloudflaredState(overrides: Partial<CloudflaredState> = {}): CloudflaredState {
+function cloudflaredState(
+  overrides: { hostname?: string; tunnelName?: string; pid?: number } = {},
+): CloudflaredState {
+  const tunnelName = overrides.tunnelName ?? "vault-tunnel";
   return {
-    version: 1,
-    pid: 4242,
-    tunnelUuid: "11111111-2222-3333-4444-555555555555",
-    tunnelName: "vault-tunnel",
-    hostname: "vault.example.com",
-    startedAt: "2026-04-23T10:00:00.000Z",
-    configPath: "/tmp/config.yml",
-    ...overrides,
+    version: 2,
+    tunnels: {
+      [tunnelName]: {
+        pid: overrides.pid ?? 4242,
+        tunnelUuid: "11111111-2222-3333-4444-555555555555",
+        tunnelName,
+        hostname: overrides.hostname ?? "vault.example.com",
+        startedAt: "2026-04-23T10:00:00.000Z",
+        configPath: "/tmp/config.yml",
+      },
+    },
   };
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -144,19 +144,22 @@ function extractNamedFlag(
 
 /**
  * Extract the Cloudflare-mode flags from `parachute expose public …`:
- * `--cloudflare` (boolean) + `--domain=<host>` / `--domain <host>`. Returns
- * the stripped argv so the layer/action parser sees `[layer, action?]`
- * regardless of flag placement.
+ * `--cloudflare` (boolean), `--domain=<host>` / `--domain <host>`, and the
+ * optional `--tunnel-name=<name>` / `--tunnel-name <name>` (#32) used to
+ * coexist multiple tunnels on one box. Returns the stripped argv so the
+ * layer/action parser sees `[layer, action?]` regardless of flag placement.
  */
 function extractCloudflareFlags(args: string[]): {
   cloudflare: boolean;
   domain?: string;
+  tunnelName?: string;
   rest: string[];
   error?: string;
 } {
   const rest: string[] = [];
   let cloudflare = false;
   let domain: string | undefined;
+  let tunnelName: string | undefined;
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === "--cloudflare") {
@@ -175,9 +178,27 @@ function extractCloudflareFlags(args: string[]): {
       if (!domain) return { cloudflare, rest, error: "--domain requires a hostname argument" };
       continue;
     }
+    if (a === "--tunnel-name") {
+      const v = args[i + 1];
+      if (!v) return { cloudflare, rest, error: "--tunnel-name requires a name argument" };
+      tunnelName = v;
+      i++;
+      continue;
+    }
+    if (a?.startsWith("--tunnel-name=")) {
+      tunnelName = a.slice("--tunnel-name=".length);
+      if (!tunnelName) return { cloudflare, rest, error: "--tunnel-name requires a name argument" };
+      continue;
+    }
     if (a !== undefined) rest.push(a);
   }
-  return { cloudflare, domain, rest };
+  const out: { cloudflare: boolean; domain?: string; tunnelName?: string; rest: string[] } = {
+    cloudflare,
+    rest,
+  };
+  if (domain !== undefined) out.domain = domain;
+  if (tunnelName !== undefined) out.tunnelName = tunnelName;
+  return out;
 }
 
 async function main(argv: string[]): Promise<number> {
@@ -324,8 +345,9 @@ async function main(argv: string[]): Promise<number> {
         const { exposeCloudflareUp, exposeCloudflareOff } = await import(
           "./commands/expose-cloudflare.ts"
         );
+        const cfOpts = cfExtract.tunnelName ? { tunnelName: cfExtract.tunnelName } : {};
         if (action === "off") {
-          return await exposeCloudflareOff();
+          return await exposeCloudflareOff(cfOpts);
         }
         if (!cfExtract.domain) {
           // Partial flag promotion: the user told us they want Cloudflare but
@@ -349,7 +371,7 @@ async function main(argv: string[]): Promise<number> {
           console.error("  parachute expose public");
           return 1;
         }
-        return await exposeCloudflareUp(cfExtract.domain);
+        return await exposeCloudflareUp(cfExtract.domain, cfOpts);
       }
 
       const exposeOpts = hubExtract.hubOrigin ? { hubOrigin: hubExtract.hubOrigin } : {};

--- a/src/cloudflare/config.ts
+++ b/src/cloudflare/config.ts
@@ -3,8 +3,30 @@ import { dirname, join } from "node:path";
 import { CONFIG_DIR } from "../config.ts";
 
 export const CLOUDFLARED_DIR = join(CONFIG_DIR, "cloudflared");
-export const CLOUDFLARED_CONFIG_PATH = join(CLOUDFLARED_DIR, "config.yml");
-export const CLOUDFLARED_LOG_PATH = join(CLOUDFLARED_DIR, "cloudflared.log");
+
+export const DEFAULT_TUNNEL_NAME = "parachute";
+
+/**
+ * Per-tunnel config + log file paths. Each tunnel gets its own subdirectory
+ * under `~/.parachute/cloudflared/<tunnelName>/` so multiple tunnels on one
+ * box don't trample each other's config.yml or interleave log lines.
+ *
+ * The default tunnel ("parachute") lives at
+ * `~/.parachute/cloudflared/parachute/{config.yml,cloudflared.log}` — a
+ * location change from pre-#32 (`~/.parachute/cloudflared/config.yml`).
+ * Re-running `parachute expose public --cloudflare` regenerates the file
+ * at the new path; the legacy file is left in place but unused.
+ */
+export function cloudflaredPathsFor(tunnelName: string): {
+  configPath: string;
+  logPath: string;
+} {
+  const dir = join(CLOUDFLARED_DIR, tunnelName);
+  return {
+    configPath: join(dir, "config.yml"),
+    logPath: join(dir, "cloudflared.log"),
+  };
+}
 
 export interface TunnelConfigOpts {
   tunnelUuid: string;
@@ -48,10 +70,7 @@ ingress:
 `;
 }
 
-export function writeConfig(
-  opts: TunnelConfigOpts,
-  configPath: string = CLOUDFLARED_CONFIG_PATH,
-): string {
+export function writeConfig(opts: TunnelConfigOpts, configPath: string): string {
   mkdirSync(dirname(configPath), { recursive: true });
   writeFileSync(configPath, renderConfig(opts));
   return configPath;

--- a/src/cloudflare/state.ts
+++ b/src/cloudflare/state.ts
@@ -11,8 +11,12 @@ import { CONFIG_DIR } from "../config.ts";
 
 export const CLOUDFLARED_STATE_PATH = join(CONFIG_DIR, "cloudflared-state.json");
 
-export interface CloudflaredState {
-  version: 1;
+/**
+ * Per-tunnel state. The fields that used to live at the top of the file in
+ * v1 (#32) — pid, hostname, etc. — now hang off a per-tunnel record so we
+ * can track multiple coexisting Cloudflare tunnels on one box.
+ */
+export interface CloudflaredTunnelRecord {
   pid: number;
   tunnelUuid: string;
   tunnelName: string;
@@ -23,8 +27,51 @@ export interface CloudflaredState {
   configPath: string;
 }
 
+/**
+ * v2 (current) — keys tunnels by name so a host can run multiple tunnels.
+ *
+ * v1 had a single record at top level. `readCloudflaredState` migrates v1
+ * files in place: parses the legacy shape, wraps the record under its
+ * `tunnelName`, returns v2. The next write commits the migration to disk.
+ */
+export interface CloudflaredState {
+  version: 2;
+  tunnels: Record<string, CloudflaredTunnelRecord>;
+}
+
 export class CloudflaredStateError extends Error {
   override name = "CloudflaredStateError";
+}
+
+function requireString(r: Record<string, unknown>, key: string, path: string): string {
+  const v = r[key];
+  if (typeof v !== "string" || v.length === 0) {
+    throw new CloudflaredStateError(`${path}: ${key} must be a non-empty string`);
+  }
+  return v;
+}
+
+function requirePositiveInt(r: Record<string, unknown>, key: string, path: string): number {
+  const v = r[key];
+  if (typeof v !== "number" || !Number.isInteger(v) || v <= 0) {
+    throw new CloudflaredStateError(`${path}: ${key} must be a positive integer`);
+  }
+  return v;
+}
+
+function validateRecord(raw: unknown, path: string): CloudflaredTunnelRecord {
+  if (!raw || typeof raw !== "object") {
+    throw new CloudflaredStateError(`${path}: tunnel record must be an object`);
+  }
+  const r = raw as Record<string, unknown>;
+  return {
+    pid: requirePositiveInt(r, "pid", path),
+    tunnelUuid: requireString(r, "tunnelUuid", path),
+    tunnelName: requireString(r, "tunnelName", path),
+    hostname: requireString(r, "hostname", path),
+    startedAt: requireString(r, "startedAt", path),
+    configPath: requireString(r, "configPath", path),
+  };
 }
 
 function validate(raw: unknown, path: string): CloudflaredState {
@@ -32,36 +79,29 @@ function validate(raw: unknown, path: string): CloudflaredState {
     throw new CloudflaredStateError(`${path}: root must be an object`);
   }
   const r = raw as Record<string, unknown>;
-  if (r.version !== 1) {
+  if (r.version === 1) {
+    // v1 — single record at top level. Migrate by wrapping it under its
+    // tunnelName. Disk isn't rewritten until the next write.
+    const record = validateRecord(r, path);
+    return { version: 2, tunnels: { [record.tunnelName]: record } };
+  }
+  if (r.version !== 2) {
     throw new CloudflaredStateError(`${path}: unsupported version ${String(r.version)}`);
   }
-  if (typeof r.pid !== "number" || !Number.isInteger(r.pid) || r.pid <= 0) {
-    throw new CloudflaredStateError(`${path}: pid must be a positive integer`);
+  if (!r.tunnels || typeof r.tunnels !== "object") {
+    throw new CloudflaredStateError(`${path}: tunnels must be an object`);
   }
-  if (typeof r.tunnelUuid !== "string" || r.tunnelUuid.length === 0) {
-    throw new CloudflaredStateError(`${path}: tunnelUuid must be a non-empty string`);
+  const tunnels: Record<string, CloudflaredTunnelRecord> = {};
+  for (const [key, val] of Object.entries(r.tunnels as Record<string, unknown>)) {
+    const record = validateRecord(val, `${path}.tunnels.${key}`);
+    if (record.tunnelName !== key) {
+      throw new CloudflaredStateError(
+        `${path}: tunnels.${key}.tunnelName must equal its key (got "${record.tunnelName}")`,
+      );
+    }
+    tunnels[key] = record;
   }
-  if (typeof r.tunnelName !== "string" || r.tunnelName.length === 0) {
-    throw new CloudflaredStateError(`${path}: tunnelName must be a non-empty string`);
-  }
-  if (typeof r.hostname !== "string" || r.hostname.length === 0) {
-    throw new CloudflaredStateError(`${path}: hostname must be a non-empty string`);
-  }
-  if (typeof r.startedAt !== "string" || r.startedAt.length === 0) {
-    throw new CloudflaredStateError(`${path}: startedAt must be a non-empty string`);
-  }
-  if (typeof r.configPath !== "string" || r.configPath.length === 0) {
-    throw new CloudflaredStateError(`${path}: configPath must be a non-empty string`);
-  }
-  return {
-    version: 1,
-    pid: r.pid,
-    tunnelUuid: r.tunnelUuid,
-    tunnelName: r.tunnelName,
-    hostname: r.hostname,
-    startedAt: r.startedAt,
-    configPath: r.configPath,
-  };
+  return { version: 2, tunnels };
 }
 
 export function readCloudflaredState(
@@ -93,4 +133,44 @@ export function writeCloudflaredState(
 
 export function clearCloudflaredState(path: string = CLOUDFLARED_STATE_PATH): void {
   if (existsSync(path)) unlinkSync(path);
+}
+
+/** Look up a tunnel record by name. */
+export function findTunnelRecord(
+  state: CloudflaredState | undefined,
+  tunnelName: string,
+): CloudflaredTunnelRecord | undefined {
+  return state?.tunnels[tunnelName];
+}
+
+/** Pure: insert/replace the record in state under its tunnelName. */
+export function withTunnelRecord(
+  state: CloudflaredState | undefined,
+  record: CloudflaredTunnelRecord,
+): CloudflaredState {
+  const tunnels = { ...(state?.tunnels ?? {}), [record.tunnelName]: record };
+  return { version: 2, tunnels };
+}
+
+/**
+ * Pure: drop the named tunnel from state. Returns undefined when the result
+ * would be empty so callers can `clearCloudflaredState` instead of writing
+ * an empty file.
+ */
+export function withoutTunnelRecord(
+  state: CloudflaredState | undefined,
+  tunnelName: string,
+): CloudflaredState | undefined {
+  if (!state) return undefined;
+  const { [tunnelName]: _dropped, ...rest } = state.tunnels;
+  if (Object.keys(rest).length === 0) return undefined;
+  return { version: 2, tunnels: rest };
+}
+
+/** All tunnel records, in name-sorted order so output is deterministic. */
+export function listTunnelRecords(state: CloudflaredState | undefined): CloudflaredTunnelRecord[] {
+  if (!state) return [];
+  return Object.keys(state.tunnels)
+    .sort()
+    .map((k) => state.tunnels[k]) as CloudflaredTunnelRecord[];
 }

--- a/src/commands/expose-cloudflare.ts
+++ b/src/commands/expose-cloudflare.ts
@@ -1,11 +1,6 @@
 import { mkdirSync, openSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join } from "node:path";
-import {
-  CLOUDFLARED_CONFIG_PATH,
-  CLOUDFLARED_LOG_PATH,
-  writeConfig,
-} from "../cloudflare/config.ts";
+import { dirname } from "node:path";
+import { DEFAULT_TUNNEL_NAME, cloudflaredPathsFor, writeConfig } from "../cloudflare/config.ts";
 import {
   DEFAULT_CLOUDFLARED_HOME,
   cloudflaredInstallHint,
@@ -14,9 +9,13 @@ import {
 } from "../cloudflare/detect.ts";
 import {
   CLOUDFLARED_STATE_PATH,
-  type CloudflaredState,
+  type CloudflaredTunnelRecord,
   clearCloudflaredState,
+  findTunnelRecord,
+  listTunnelRecords,
   readCloudflaredState,
+  withTunnelRecord,
+  withoutTunnelRecord,
   writeCloudflaredState,
 } from "../cloudflare/state.ts";
 import {
@@ -32,18 +31,20 @@ import { type AliveFn, defaultAlive } from "../process-state.ts";
 import { readManifest } from "../services-manifest.ts";
 import { type Runner, defaultRunner } from "../tailscale/run.ts";
 
-/**
- * Single canonical tunnel name reused across runs. Creating fresh tunnels
- * per invocation would leave orphaned tunnels in the user's Cloudflare
- * account every time they rotated hostnames; re-use keeps that clean.
- *
- * If someone needs multiple tunnels on one box (dev + prod, two domains),
- * we'll add `--tunnel-name` later. Single-tunnel covers the launch use case.
- */
-const TUNNEL_NAME = "parachute";
-
 const AUTH_DOC_URL =
   "https://github.com/ParachuteComputer/parachute-vault/blob/main/docs/auth-model.md";
+
+/**
+ * Tunnel-name validation. We mirror the conservative shape Cloudflare itself
+ * uses for tunnel identifiers — alphanumerics, hyphens, underscores — and
+ * keep it short enough to fit in a path segment without surprising the
+ * filesystem (e.g. macOS encoded NFC quirks). Anything more permissive would
+ * just push validation work onto the cloudflared binary.
+ */
+export function isValidTunnelName(name: string): boolean {
+  if (name.length === 0 || name.length > 64) return false;
+  return /^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(name);
+}
 
 /**
  * Hostname validation — permissive by design. We reject the obviously broken
@@ -86,9 +87,21 @@ export interface ExposeCloudflareOpts {
   log?: (line: string) => void;
   manifestPath?: string;
   statePath?: string;
-  /** Path to the cloudflared config.yml this invocation writes. */
+  /**
+   * Tunnel name targeted by this invocation. Defaults to `parachute` —
+   * the canonical single-tunnel name. Override to run multiple tunnels on
+   * one box (#32).
+   */
+  tunnelName?: string;
+  /**
+   * Path to the cloudflared config.yml this invocation writes. Defaults to
+   * the per-tunnel layout `~/.parachute/cloudflared/<tunnelName>/config.yml`.
+   */
   configPath?: string;
-  /** Path to the log file the spawned cloudflared appends to. */
+  /**
+   * Path to the log file the spawned cloudflared appends to. Defaults to
+   * the per-tunnel layout `~/.parachute/cloudflared/<tunnelName>/cloudflared.log`.
+   */
   logPath?: string;
   /** Override `~/.cloudflared` for tests and `$HOME`-free environments. */
   cloudflaredHome?: string;
@@ -103,6 +116,7 @@ interface Resolved {
   log: (line: string) => void;
   manifestPath: string;
   statePath: string;
+  tunnelName: string;
   configPath: string;
   logPath: string;
   cloudflaredHome: string;
@@ -110,6 +124,8 @@ interface Resolved {
 }
 
 function resolve(opts: ExposeCloudflareOpts): Resolved {
+  const tunnelName = opts.tunnelName ?? DEFAULT_TUNNEL_NAME;
+  const paths = cloudflaredPathsFor(tunnelName);
   return {
     runner: opts.runner ?? defaultRunner,
     spawner: opts.spawner ?? defaultCloudflaredSpawner,
@@ -118,8 +134,9 @@ function resolve(opts: ExposeCloudflareOpts): Resolved {
     log: opts.log ?? ((line) => console.log(line)),
     manifestPath: opts.manifestPath ?? SERVICES_MANIFEST_PATH,
     statePath: opts.statePath ?? CLOUDFLARED_STATE_PATH,
-    configPath: opts.configPath ?? CLOUDFLARED_CONFIG_PATH,
-    logPath: opts.logPath ?? CLOUDFLARED_LOG_PATH,
+    tunnelName,
+    configPath: opts.configPath ?? paths.configPath,
+    logPath: opts.logPath ?? paths.logPath,
     cloudflaredHome: opts.cloudflaredHome ?? DEFAULT_CLOUDFLARED_HOME,
     now: opts.now ?? (() => new Date()),
   };
@@ -152,6 +169,13 @@ export async function exposeCloudflareUp(
   opts: ExposeCloudflareOpts = {},
 ): Promise<number> {
   const r = resolve(opts);
+
+  if (!isValidTunnelName(r.tunnelName)) {
+    r.log(
+      `parachute expose public --cloudflare: --tunnel-name must be alphanumeric with -/_ (got "${r.tunnelName}").`,
+    );
+    return 1;
+  }
 
   if (!isValidHostname(hostname)) {
     r.log(
@@ -194,25 +218,25 @@ export async function exposeCloudflareUp(
 
   let tunnel: Tunnel | undefined;
   try {
-    tunnel = await findTunnelByName(r.runner, TUNNEL_NAME);
+    tunnel = await findTunnelByName(r.runner, r.tunnelName);
   } catch (err) {
     return reportCloudflaredError(err, r.log);
   }
   if (!tunnel) {
-    r.log(`Creating Cloudflare tunnel "${TUNNEL_NAME}"…`);
+    r.log(`Creating Cloudflare tunnel "${r.tunnelName}"…`);
     try {
-      tunnel = await createTunnel(r.runner, TUNNEL_NAME);
+      tunnel = await createTunnel(r.runner, r.tunnelName);
     } catch (err) {
       return reportCloudflaredError(err, r.log);
     }
     r.log(`✓ Created tunnel ${tunnel.id}`);
   } else {
-    r.log(`✓ Reusing existing tunnel "${TUNNEL_NAME}" (${tunnel.id})`);
+    r.log(`✓ Reusing existing tunnel "${r.tunnelName}" (${tunnel.id})`);
   }
 
   r.log(`Routing DNS: ${hostname} → tunnel ${tunnel.id}…`);
   try {
-    await routeDns(r.runner, TUNNEL_NAME, hostname);
+    await routeDns(r.runner, r.tunnelName, hostname);
   } catch (err) {
     if (err instanceof CloudflaredError) {
       r.log("");
@@ -241,32 +265,31 @@ export async function exposeCloudflareUp(
   );
   r.log(`✓ Wrote ${r.configPath}`);
 
-  const prior = readCloudflaredState(r.statePath);
+  const stateBefore = readCloudflaredState(r.statePath);
+  const prior = findTunnelRecord(stateBefore, r.tunnelName);
   if (prior && r.alive(prior.pid)) {
     try {
       r.kill(prior.pid, "SIGTERM");
       r.log(`Stopped prior cloudflared (pid ${prior.pid}).`);
     } catch {
-      // Process is already gone — safe to ignore; clearCloudflaredState drops the state file below.
+      // Process is already gone — safe to ignore; we replace the record below.
     }
   }
-  if (prior) clearCloudflaredState(r.statePath);
 
   const pid = r.spawner.spawn(
     ["cloudflared", "tunnel", "--config", r.configPath, "run"],
     r.logPath,
   );
 
-  const state: CloudflaredState = {
-    version: 1,
+  const record: CloudflaredTunnelRecord = {
     pid,
     tunnelUuid: tunnel.id,
-    tunnelName: TUNNEL_NAME,
+    tunnelName: r.tunnelName,
     hostname,
     startedAt: r.now().toISOString(),
     configPath: r.configPath,
   };
-  writeCloudflaredState(state, r.statePath);
+  writeCloudflaredState(withTunnelRecord(stateBefore, record), r.statePath);
 
   const baseUrl = `https://${hostname}`;
   // A well-formed vault manifest always lists at least one mount path. If
@@ -295,28 +318,45 @@ export async function exposeCloudflareUp(
 
 export async function exposeCloudflareOff(opts: ExposeCloudflareOpts = {}): Promise<number> {
   const r = resolve(opts);
-  const state = readCloudflaredState(r.statePath);
-  if (!state) {
-    r.log("No Cloudflare exposure recorded. Nothing to tear down.");
+  const stateBefore = readCloudflaredState(r.statePath);
+  const record = findTunnelRecord(stateBefore, r.tunnelName);
+  if (!record) {
+    if (stateBefore && Object.keys(stateBefore.tunnels).length > 0) {
+      const others = listTunnelRecords(stateBefore)
+        .map((t) => t.tunnelName)
+        .join(", ");
+      r.log(
+        `No Cloudflare exposure recorded for tunnel "${r.tunnelName}". Other tunnels: ${others}.`,
+      );
+    } else {
+      r.log("No Cloudflare exposure recorded. Nothing to tear down.");
+    }
     return 0;
   }
-  if (r.alive(state.pid)) {
+  if (r.alive(record.pid)) {
     try {
-      r.kill(state.pid, "SIGTERM");
-      r.log(`✓ Stopped cloudflared (pid ${state.pid}).`);
+      r.kill(record.pid, "SIGTERM");
+      r.log(`✓ Stopped cloudflared (pid ${record.pid}).`);
     } catch (err) {
       r.log(`✗ Failed to stop cloudflared: ${err instanceof Error ? err.message : String(err)}`);
       return 1;
     }
   } else {
-    r.log(`cloudflared (pid ${state.pid}) wasn't running; clearing stale state.`);
+    r.log(`cloudflared (pid ${record.pid}) wasn't running; clearing stale state.`);
   }
-  clearCloudflaredState(r.statePath);
-  r.log(`  ${state.hostname} is no longer reachable through this machine.`);
+  const stateAfter = withoutTunnelRecord(stateBefore, r.tunnelName);
+  if (stateAfter) {
+    writeCloudflaredState(stateAfter, r.statePath);
+  } else {
+    clearCloudflaredState(r.statePath);
+  }
+  r.log(`  ${record.hostname} is no longer reachable through this machine.`);
   r.log(
-    `  Tunnel "${state.tunnelName}" (${state.tunnelUuid}) remains defined in Cloudflare; re-running`,
+    `  Tunnel "${record.tunnelName}" (${record.tunnelUuid}) remains defined in Cloudflare; re-running`,
   );
-  r.log(`  \`parachute expose public --cloudflare --domain ${state.hostname}\` reuses it.`);
+  r.log(
+    `  \`parachute expose public --cloudflare --domain ${record.hostname}${record.tunnelName === DEFAULT_TUNNEL_NAME ? "" : ` --tunnel-name ${record.tunnelName}`}\` reuses it.`,
+  );
   return 0;
 }
 

--- a/src/commands/expose-off-auto.ts
+++ b/src/commands/expose-off-auto.ts
@@ -15,6 +15,10 @@
  *   - Both live     → prompt (TTY) for which to tear down, or `both`;
  *                     non-TTY tears down both (off means off).
  *
+ * Since #32 the cloudflared-state.json holds a map of tunnels keyed by
+ * name, so "cloudflare is live" means any tunnel record exists; tearing
+ * down "cloudflare" iterates every recorded tunnel.
+ *
  * `--cloudflare` still works as an explicit override and skips this module
  * entirely (see cli.ts). Shape mirrors the other Layer-N modules — every
  * side-effectful edge is an injectable seam so the full decision tree is
@@ -25,6 +29,7 @@ import { createInterface } from "node:readline/promises";
 import {
   CLOUDFLARED_STATE_PATH,
   type CloudflaredState,
+  listTunnelRecords,
   readCloudflaredState,
 } from "../cloudflare/state.ts";
 import { EXPOSE_STATE_PATH, type ExposeState, readExposeState } from "../expose-state.ts";
@@ -50,7 +55,9 @@ export interface ExposePublicOffAutoOpts {
    */
   tailscaleOffOpts?: ExposeOpts;
   /**
-   * Forwarded to the cloudflare teardown. Tests use it the same way.
+   * Forwarded to the cloudflare teardown. Tests use it the same way. The
+   * wrapper sets `tunnelName` per record when iterating; callers don't need
+   * to provide it.
    */
   cloudflareOffOpts?: ExposeCloudflareOpts;
 
@@ -95,15 +102,11 @@ function tailscalePublicIsLive(state: ExposeState | undefined): state is ExposeS
 }
 
 function cloudflareIsLive(state: CloudflaredState | undefined): state is CloudflaredState {
-  return !!state;
+  return !!state && Object.keys(state.tunnels).length > 0;
 }
 
 function tailscaleUrl(state: ExposeState): string {
   return `https://${state.canonicalFqdn}`;
-}
-
-function cloudflareUrl(state: CloudflaredState): string {
-  return `https://${state.hostname}`;
 }
 
 type BothChoice = "tailscale" | "cloudflare" | "both" | "cancel";
@@ -113,9 +116,14 @@ async function promptBothLive(
   tsState: ExposeState,
   cfState: CloudflaredState,
 ): Promise<BothChoice> {
+  const records = listTunnelRecords(cfState);
+  const cfSummary =
+    records.length === 1
+      ? `https://${records[0]?.hostname}`
+      : records.map((t) => `https://${t.hostname}`).join(", ");
   r.log("Two public exposures are currently live:");
   r.log(`  [1] Tailscale Funnel  — ${tailscaleUrl(tsState)}`);
-  r.log(`  [2] Cloudflare Tunnel — ${cloudflareUrl(cfState)}`);
+  r.log(`  [2] Cloudflare Tunnel — ${cfSummary}`);
   r.log("  [3] both");
   r.log("  [4] cancel");
   while (true) {
@@ -136,10 +144,18 @@ async function tearDownTailscale(r: Resolved, state: ExposeState): Promise<numbe
 }
 
 async function tearDownCloudflare(r: Resolved, state: CloudflaredState): Promise<number> {
-  const url = cloudflareUrl(state);
-  const code = await r.exposeCloudflareOffImpl(r.cloudflareOffOpts);
-  if (code === 0) r.log(`✓ Tore down Cloudflare Tunnel (was: ${url})`);
-  return code;
+  const records = listTunnelRecords(state);
+  let firstFailure = 0;
+  for (const record of records) {
+    const url = `https://${record.hostname}`;
+    const code = await r.exposeCloudflareOffImpl({
+      ...r.cloudflareOffOpts,
+      tunnelName: record.tunnelName,
+    });
+    if (code === 0) r.log(`✓ Tore down Cloudflare Tunnel (was: ${url})`);
+    if (code !== 0 && firstFailure === 0) firstFailure = code;
+  }
+  return firstFailure;
 }
 
 export async function runExposePublicOffAutoDetect(


### PR DESCRIPTION
Closes #32.

## Summary

- Add `--tunnel-name <name>` to `parachute expose public --cloudflare`. Optional; defaults to `parachute` so existing single-tunnel installs are untouched.
- Two cloudflared tunnels can now coexist on one box. Each tunnel gets its own per-tunnel layout: `~/.parachute/cloudflared/<tunnelName>/{config.yml,cloudflared.log}`.
- `cloudflared-state.json` becomes a tunnels-keyed-by-name map (v2). The old single-record shape (v1) reads as v2 in memory; disk flips on the next write — silent + idempotent.
- `parachute expose public off --cloudflare --tunnel-name <name>` targets that specific tunnel. The auto-detect `expose public off` path ("Two public exposures are live…") iterates every recorded cloudflare tunnel.

## Why

`expose --cloudflare` was hardcoded to a single tunnel called `parachute`. Anyone wanting a dev tunnel + a prod tunnel on the same box had to bring one down to bring the other up. The state file shape made it impossible to track more than one. Now multiple tunnels are first-class.

## What changed

- `src/cloudflare/state.ts` — v1→v2 schema with `tunnels: Record<name, record>` map. Helpers: `findTunnelRecord`, `withTunnelRecord`, `withoutTunnelRecord`, `listTunnelRecords`. Migration on read; v2 invariant: `tunnels[key].tunnelName === key`.
- `src/cloudflare/config.ts` — `cloudflaredPathsFor(tunnelName)` returns per-tunnel `configPath` + `logPath`. `DEFAULT_TUNNEL_NAME = "parachute"` exported.
- `src/commands/expose-cloudflare.ts` — `tunnelName` threaded through `ExposeCloudflareOpts`. Up command finds-prior-by-name + writes the new record; off command tears down only the named tunnel and leaves siblings intact. Off message hints `--tunnel-name <name>` when the tunnel isn't the default.
- `src/commands/expose-off-auto.ts` — "cloudflare is live" means any recorded tunnel; tear-down iterates all of them.
- `src/cli.ts` — parses `--tunnel-name <name>` and `--tunnel-name=<name>`; threads through expose / expose-off cases.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test` — 880 pass, 0 fail
- [x] Default behavior unchanged (no `--tunnel-name` → uses `parachute`) — covered by happy-path test
- [x] Two tunnels coexist with different `--tunnel-name` — new test asserts both records in state with distinct configPaths
- [x] `off --tunnel-name <name>` targets correct tunnel — new test asserts only that tunnel is killed and removed
- [x] v1 single-record state file migrates cleanly on read; disk flips on next write — new test pair

Bump `0.4.0-rc.35 → 0.4.0-rc.36`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)