### PR TITLE
feat(scope-guard): @openparachute/scope-guard library (Step 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "bin": {
     "parachute": "src/cli.ts"
   },
+  "workspaces": ["packages/*"],
   "files": ["src", "README.md", "LICENSE"],
   "repository": {
     "type": "git",

--- a/packages/scope-guard/README.md
+++ b/packages/scope-guard/README.md
@@ -1,0 +1,64 @@
+# @openparachute/scope-guard
+
+Hub-issued JWT validation for Parachute resource servers (vault, scribe, paraclaw, third-party modules).
+
+The Parachute hub mints OAuth access tokens as RS256 JWTs and publishes its public keys at `/.well-known/jwks.json`. This library is the consumer-side mirror: every resource server uses the same verifier so the trust kernel doesn't drift between modules.
+
+## What's in the box
+
+- **`createScopeGuard({ hubOrigin, jwks?, jwksGetter? })`** — factory bound to a hub origin. Holds the JWKS getter so the cache lives across requests. `hubOrigin` may be a string or a resolver function (for layered env-var precedence).
+- **`guard.validateHubJwt(token, { expectedAudience? })`** — JWKS-backed verify. Pins `iss` to the configured hub origin, strict-checks `aud` (RFC 7519 string-or-array) when supplied. Throws `HubJwtError` (with a `code`) on failure.
+- **`parseScopes(raw)` / `extractBearer(authHeader)` / `looksLikeJwt(token)`** — string helpers every consumer reaches for.
+- **`hasScope(granted, required)`** — generic `<resource>:<verb>` and `<resource>:<name>:<verb>` matcher with `admin ⊇ write ⊇ read` inheritance. The lib is the engine, not the dictionary; per-service vocabularies and cross-resource catch-alls stay in each service.
+- **`HubJwtError.code`** — single error class with a coarse code: `signature | issuer | expired | kid | jwks | audience | shape`. Branch on `code` rather than catching subclasses.
+
+## Quick start
+
+```ts
+import { createScopeGuard, extractBearer, hasScope } from "@openparachute/scope-guard";
+
+const guard = createScopeGuard({
+  hubOrigin: () => process.env.PARACHUTE_HUB_ORIGIN ?? "http://127.0.0.1:1939",
+});
+
+async function enforceAuth(req: Request, vaultName: string) {
+  const token = extractBearer(req.headers.get("authorization"));
+  if (!token) return new Response("missing bearer token", { status: 401 });
+
+  try {
+    const claims = await guard.validateHubJwt(token, {
+      expectedAudience: `vault.${vaultName}`,
+    });
+    if (!hasScope(claims.scopes, `vault:${vaultName}:read`)) {
+      return new Response("insufficient scope", { status: 403 });
+    }
+    return { ok: true as const, claims };
+  } catch (err) {
+    return new Response(`invalid token (${(err as { code?: string }).code ?? "unknown"})`, {
+      status: 401,
+    });
+  }
+}
+```
+
+## Design
+
+See [`parachute-hub/docs/design/2026-04-29-scope-guard-library.md`](https://github.com/ParachuteComputer/parachute-hub/blob/main/docs/design/2026-04-29-scope-guard-library.md) for full rationale, alternatives considered, and the migration sequence (vault → scribe → paraclaw).
+
+The lib lives as a sub-package of `parachute-hub` because the hub owns the JWT-issuance side and the scope vocabulary. It's published independently to npm as `@openparachute/scope-guard`.
+
+## Versioning
+
+Pre-1.0 (`0.x.y`) — this is a young library:
+
+- **Patches (`0.1.0` → `0.1.1`)** are additive and behavior-preserving. Adopters can take patch bumps without review.
+- **Minors (`0.1.x` → `0.2.0`)** may break adopters. Read the CHANGELOG before bumping.
+- **`-rc.N` prereleases** match the broader Parachute ecosystem's pre-1.0 governance — landed on the `rc` dist-tag on every code-touching PR; promotion to `@latest` is a deliberate `npm dist-tag` step.
+
+The library's RC cadence is **independent of `@openparachute/hub`'s** — they're shipped from the same repo but aren't coupled in version. A hub release doesn't imply a scope-guard release and vice versa.
+
+Post-1.0 the library will follow standard semver — minors backward-compatible, majors with a migration note.
+
+## License
+
+AGPL-3.0

--- a/packages/scope-guard/package.json
+++ b/packages/scope-guard/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@openparachute/scope-guard",
+  "version": "0.1.0-rc.1",
+  "description": "Hub-issued JWT validation for Parachute resource servers (vault, scribe, paraclaw, third-party modules).",
+  "license": "AGPL-3.0",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist", "README.md", "LICENSE"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ParachuteComputer/parachute-hub.git",
+    "directory": "packages/scope-guard"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "bun run build",
+    "test": "bun test src",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  },
+  "dependencies": {
+    "jose": "^6.2.2"
+  }
+}

--- a/packages/scope-guard/src/__tests__/integration.test.ts
+++ b/packages/scope-guard/src/__tests__/integration.test.ts
@@ -1,0 +1,152 @@
+/**
+ * End-to-end integration test: mint a JWT through hub's real `signAccessToken`
+ * (hits the actual `signing_keys` table, signs with the active key), serve
+ * the corresponding `/.well-known/jwks.json` from the same db, then validate
+ * through `createScopeGuard`. Asserts:
+ *
+ *   - valid hub-issued JWT → claims surface, scope check passes
+ *   - missing scope → `hasScope` returns false (consumers map this to 403)
+ *   - missing token → `extractBearer` returns undefined (→ 401)
+ *   - expired token → HubJwtError(code: "expired") (→ 401)
+ *
+ * The hub imports here intentionally use `.ts` extensions — they live under
+ * the parent hub package which uses `allowImportingTsExtensions`. This test
+ * file lives under the scope-guard sub-package, but Bun resolves the imports
+ * at runtime regardless of tsconfig.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hubDbPath, openHubDb } from "../../../../src/hub-db.ts";
+import { pemToJwk } from "../../../../src/jwks.ts";
+import { signAccessToken } from "../../../../src/jwt-sign.ts";
+import { getAllPublicKeys } from "../../../../src/signing-keys.ts";
+import { extractBearer, hasScope } from "../index";
+import { HubJwtError, createScopeGuard } from "../validate";
+
+type HubDb = ReturnType<typeof openHubDb>;
+
+interface Harness {
+  origin: string;
+  db: HubDb;
+  cleanup: () => void;
+}
+
+function startHarness(): Harness {
+  const configDir = mkdtempSync(join(tmpdir(), "scope-guard-it-"));
+  const db = openHubDb(hubDbPath(configDir));
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname !== "/.well-known/jwks.json") {
+        return new Response("not found", { status: 404 });
+      }
+      const keys = getAllPublicKeys(db).map((k) => pemToJwk(k.publicKeyPem, k.kid));
+      return Response.json({ keys });
+    },
+  });
+  return {
+    origin: `http://127.0.0.1:${server.port}`,
+    db,
+    cleanup: () => {
+      server.stop(true);
+      db.close();
+      rmSync(configDir, { recursive: true, force: true });
+    },
+  };
+}
+
+let h: Harness;
+
+beforeAll(() => {
+  h = startHarness();
+});
+
+afterAll(() => {
+  h.cleanup();
+});
+
+describe("integration: real hub JWT through scope-guard", () => {
+  test("valid JWT → claims surface, scope check passes", async () => {
+    const { token } = await signAccessToken(h.db, {
+      sub: "user-1",
+      scopes: ["vault:work:write"],
+      audience: "vault.work",
+      clientId: "test-client",
+      issuer: h.origin,
+    });
+    const guard = createScopeGuard({ hubOrigin: h.origin });
+    const claims = await guard.validateHubJwt(token, { expectedAudience: "vault.work" });
+    expect(claims.sub).toBe("user-1");
+    expect(claims.scopes).toEqual(["vault:work:write"]);
+    expect(claims.aud).toBe("vault.work");
+    expect(claims.clientId).toBe("test-client");
+    expect(hasScope(claims.scopes, "vault:work:read")).toBe(true);
+    expect(hasScope(claims.scopes, "vault:read")).toBe(true);
+    guard.resetJwksCache();
+  });
+
+  test("missing scope → hasScope returns false (consumer maps to 403)", async () => {
+    const { token } = await signAccessToken(h.db, {
+      sub: "user-1",
+      scopes: ["vault:work:read"],
+      audience: "vault.work",
+      clientId: "test-client",
+      issuer: h.origin,
+    });
+    const guard = createScopeGuard({ hubOrigin: h.origin });
+    const claims = await guard.validateHubJwt(token, { expectedAudience: "vault.work" });
+    expect(hasScope(claims.scopes, "vault:work:write")).toBe(false);
+    expect(hasScope(claims.scopes, "vault:work:admin")).toBe(false);
+    guard.resetJwksCache();
+  });
+
+  test("missing Authorization header → extractBearer returns undefined (consumer maps to 401)", () => {
+    expect(extractBearer(undefined)).toBeUndefined();
+    expect(extractBearer(null)).toBeUndefined();
+    expect(extractBearer("")).toBeUndefined();
+  });
+
+  test("expired token → HubJwtError(code: 'expired')", async () => {
+    const { token } = await signAccessToken(h.db, {
+      sub: "user-1",
+      scopes: ["vault:work:read"],
+      audience: "vault.work",
+      clientId: "test-client",
+      issuer: h.origin,
+      ttlSeconds: -10, // already expired
+    });
+    const guard = createScopeGuard({ hubOrigin: h.origin });
+    let caught: HubJwtError | undefined;
+    try {
+      await guard.validateHubJwt(token, { expectedAudience: "vault.work" });
+    } catch (e) {
+      caught = e as HubJwtError;
+    }
+    expect(caught).toBeInstanceOf(HubJwtError);
+    expect(caught?.code).toBe("expired");
+    guard.resetJwksCache();
+  });
+
+  test("audience mismatch is the resource-server backstop", async () => {
+    const { token } = await signAccessToken(h.db, {
+      sub: "user-1",
+      scopes: ["vault:work:read"],
+      audience: "vault.work",
+      clientId: "test-client",
+      issuer: h.origin,
+    });
+    const guard = createScopeGuard({ hubOrigin: h.origin });
+    let caught: HubJwtError | undefined;
+    try {
+      // Token stamped for vault.work; resource server is vault.personal.
+      await guard.validateHubJwt(token, { expectedAudience: "vault.personal" });
+    } catch (e) {
+      caught = e as HubJwtError;
+    }
+    expect(caught?.code).toBe("audience");
+    guard.resetJwksCache();
+  });
+});

--- a/packages/scope-guard/src/__tests__/parse.test.ts
+++ b/packages/scope-guard/src/__tests__/parse.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { extractBearer, looksLikeJwt, parseScopes } from "../parse";
+
+describe("parseScopes", () => {
+  test("null / undefined / empty → []", () => {
+    expect(parseScopes(null)).toEqual([]);
+    expect(parseScopes(undefined)).toEqual([]);
+    expect(parseScopes("")).toEqual([]);
+  });
+
+  test("whitespace-only → []", () => {
+    expect(parseScopes("   ")).toEqual([]);
+    expect(parseScopes("\t\n  ")).toEqual([]);
+  });
+
+  test("single scope", () => {
+    expect(parseScopes("vault:read")).toEqual(["vault:read"]);
+  });
+
+  test("multi-scope, single space", () => {
+    expect(parseScopes("vault:read vault:write")).toEqual(["vault:read", "vault:write"]);
+  });
+
+  test("multi-scope, mixed whitespace", () => {
+    expect(parseScopes("  vault:read \t vault:write\n vault:admin  ")).toEqual([
+      "vault:read",
+      "vault:write",
+      "vault:admin",
+    ]);
+  });
+
+  test("preserves unrecognized scopes verbatim — vocabulary is the consumer's job", () => {
+    expect(parseScopes("foo:bar baz")).toEqual(["foo:bar", "baz"]);
+  });
+});
+
+describe("looksLikeJwt", () => {
+  test("`eyJ` prefix → true", () => {
+    expect(looksLikeJwt("eyJhbGciOiJSUzI1NiJ9.body.sig")).toBe(true);
+  });
+
+  test("pvt_ token → false", () => {
+    expect(looksLikeJwt("pvt_abcdef0123456789")).toBe(false);
+  });
+
+  test("empty / bare string → false", () => {
+    expect(looksLikeJwt("")).toBe(false);
+    expect(looksLikeJwt("hello")).toBe(false);
+  });
+});
+
+describe("extractBearer", () => {
+  test("standard Bearer header", () => {
+    expect(extractBearer("Bearer abc.def.ghi")).toBe("abc.def.ghi");
+  });
+
+  test("case-insensitive scheme", () => {
+    expect(extractBearer("bearer abc")).toBe("abc");
+    expect(extractBearer("BEARER abc")).toBe("abc");
+  });
+
+  test("tolerant of extra whitespace", () => {
+    expect(extractBearer("Bearer    abc.def")).toBe("abc.def");
+    expect(extractBearer("Bearer abc.def   ")).toBe("abc.def");
+  });
+
+  test("missing / null / undefined → undefined", () => {
+    expect(extractBearer(null)).toBeUndefined();
+    expect(extractBearer(undefined)).toBeUndefined();
+    expect(extractBearer("")).toBeUndefined();
+  });
+
+  test("non-Bearer scheme → undefined", () => {
+    expect(extractBearer("Basic dXNlcjpwYXNz")).toBeUndefined();
+    expect(extractBearer("Token abc")).toBeUndefined();
+  });
+
+  test("empty token after Bearer → undefined", () => {
+    // Regex requires at least one non-whitespace char so this matches the
+    // "no token" branch via failed regex match, not the trim-empty branch.
+    expect(extractBearer("Bearer ")).toBeUndefined();
+  });
+});

--- a/packages/scope-guard/src/__tests__/scope.test.ts
+++ b/packages/scope-guard/src/__tests__/scope.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import { hasScope } from "../scope";
+
+describe("hasScope — exact match", () => {
+  test("exact string match → true", () => {
+    expect(hasScope(["vault:read"], "vault:read")).toBe(true);
+    expect(hasScope(["scribe:transcribe"], "scribe:transcribe")).toBe(true);
+  });
+
+  test("non-match → false", () => {
+    expect(hasScope([], "vault:read")).toBe(false);
+    expect(hasScope(["vault:read"], "vault:write")).toBe(false);
+  });
+});
+
+describe("hasScope — broad inheritance (admin ⊇ write ⊇ read)", () => {
+  test("admin satisfies write", () => {
+    expect(hasScope(["vault:admin"], "vault:write")).toBe(true);
+  });
+
+  test("admin satisfies read", () => {
+    expect(hasScope(["vault:admin"], "vault:read")).toBe(true);
+  });
+
+  test("write satisfies read", () => {
+    expect(hasScope(["vault:write"], "vault:read")).toBe(true);
+  });
+
+  test("write does NOT satisfy admin", () => {
+    expect(hasScope(["vault:write"], "vault:admin")).toBe(false);
+  });
+
+  test("read does NOT satisfy write", () => {
+    expect(hasScope(["vault:read"], "vault:write")).toBe(false);
+  });
+});
+
+describe("hasScope — narrowed inheritance", () => {
+  test("narrowed admin satisfies same-name read query", () => {
+    expect(hasScope(["vault:work:admin"], "vault:work:read")).toBe(true);
+  });
+
+  test("narrowed write satisfies same-name read", () => {
+    expect(hasScope(["vault:work:write"], "vault:work:read")).toBe(true);
+  });
+
+  test("narrowed write does NOT satisfy same-name admin", () => {
+    expect(hasScope(["vault:work:write"], "vault:work:admin")).toBe(false);
+  });
+
+  test("narrowed grant satisfies broad query (same resource)", () => {
+    expect(hasScope(["vault:work:write"], "vault:write")).toBe(true);
+    expect(hasScope(["vault:work:write"], "vault:read")).toBe(true);
+  });
+
+  test("narrowed grant does NOT cross to a different name", () => {
+    expect(hasScope(["vault:work:write"], "vault:home:read")).toBe(false);
+  });
+
+  test("broad grant does NOT satisfy narrowed query (policy lives in consumer)", () => {
+    // Per the design doc: broad grants do not satisfy narrowed queries
+    // through this function. Consumers that want the reverse semantics
+    // (e.g. "this URL names vault `work`; does the token authorize it?")
+    // pass the narrowed form into `required` themselves.
+    expect(hasScope(["vault:write"], "vault:work:read")).toBe(false);
+  });
+});
+
+describe("hasScope — cross-resource never matches", () => {
+  test("vault:admin does NOT satisfy claw:read", () => {
+    expect(hasScope(["vault:admin"], "claw:read")).toBe(false);
+  });
+
+  test("vault:admin does NOT satisfy scribe:read", () => {
+    expect(hasScope(["vault:admin"], "scribe:read")).toBe(false);
+  });
+});
+
+describe("hasScope — non-ladder verbs are exact-match only", () => {
+  test("scribe:admin does NOT imply scribe:transcribe", () => {
+    expect(hasScope(["scribe:admin"], "scribe:transcribe")).toBe(false);
+  });
+
+  test("scribe:transcribe does NOT imply scribe:read", () => {
+    // `transcribe` isn't part of the inheritance ladder; it doesn't decompose,
+    // so it can only satisfy itself.
+    expect(hasScope(["scribe:transcribe"], "scribe:read")).toBe(false);
+  });
+
+  test("scribe:transcribe satisfies itself (exact match)", () => {
+    expect(hasScope(["scribe:transcribe"], "scribe:transcribe")).toBe(true);
+  });
+});
+
+describe("hasScope — malformed inputs", () => {
+  test("empty granted list → false", () => {
+    expect(hasScope([], "vault:read")).toBe(false);
+  });
+
+  test("malformed required (1-part) → false", () => {
+    expect(hasScope(["vault:admin"], "vault")).toBe(false);
+  });
+
+  test("malformed granted (4-part) is ignored", () => {
+    expect(hasScope(["vault:work:foo:read"], "vault:read")).toBe(false);
+  });
+
+  test("empty resource segment in granted → ignored", () => {
+    expect(hasScope([":read"], "vault:read")).toBe(false);
+  });
+
+  test("empty name segment in granted (vault::read) → ignored", () => {
+    // A hand-crafted DB row with that shape must not satisfy any vault scope
+    // check — matches vault's existing `decomposeVaultScope` rule.
+    expect(hasScope(["vault::read"], "vault:read")).toBe(false);
+  });
+});
+
+describe("hasScope — multiple grants, mixed shapes", () => {
+  test("any one of multiple grants is enough", () => {
+    expect(hasScope(["scribe:read", "vault:write"], "vault:read")).toBe(true);
+  });
+
+  test("narrowed alongside broad — narrowed satisfies broad query", () => {
+    expect(hasScope(["vault:work:write", "vault:home:read"], "vault:read")).toBe(true);
+  });
+});

--- a/packages/scope-guard/src/__tests__/validate.test.ts
+++ b/packages/scope-guard/src/__tests__/validate.test.ts
@@ -1,0 +1,350 @@
+/**
+ * createScopeGuard / validateHubJwt — fake JWKS endpoint, locally-signed JWTs.
+ *
+ * Spins up a Bun.serve fake JWKS endpoint with a known RSA keypair, then
+ * exercises every validation path the design doc names: signature pass/fail,
+ * wrong issuer, expired, missing kid, missing sub, JWKS unreachable, plus
+ * the audience matrix (string match, array match, mismatches both shapes,
+ * missing-when-expected, no-expectation-set).
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { SignJWT, exportJWK, generateKeyPair } from "jose";
+import { HubJwtError, createScopeGuard } from "../validate";
+
+interface Keypair {
+  privateKey: CryptoKey;
+  publicJwk: { kty: string; n: string; e: string; kid: string; alg: string; use: string };
+  kid: string;
+}
+
+async function makeKeypair(kid: string): Promise<Keypair> {
+  const { privateKey, publicKey } = await generateKeyPair("RS256", { extractable: true });
+  const jwk = await exportJWK(publicKey);
+  return {
+    privateKey,
+    publicJwk: {
+      kty: "RSA",
+      n: jwk.n!,
+      e: jwk.e!,
+      kid,
+      alg: "RS256",
+      use: "sig",
+    },
+    kid,
+  };
+}
+
+interface JwksFixture {
+  origin: string;
+  stop: () => void;
+  setKeys: (keys: Keypair[]) => void;
+  setUnreachable: (down: boolean) => void;
+}
+
+function startJwksFixture(): JwksFixture {
+  let keys: Keypair[] = [];
+  let down = false;
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname !== "/.well-known/jwks.json") {
+        return new Response("not found", { status: 404 });
+      }
+      if (down) return new Response("upstream down", { status: 503 });
+      return Response.json({ keys: keys.map((k) => k.publicJwk) });
+    },
+  });
+  return {
+    origin: `http://127.0.0.1:${server.port}`,
+    stop: () => server.stop(true),
+    setKeys: (next) => {
+      keys = next;
+    },
+    setUnreachable: (v) => {
+      down = v;
+    },
+  };
+}
+
+interface SignOpts {
+  iss?: string;
+  aud?: string | string[];
+  sub?: string;
+  scope?: string;
+  jti?: string;
+  clientId?: string;
+  ttlSeconds?: number;
+  expiresAtSeconds?: number;
+  omitKid?: boolean;
+  kid?: string;
+}
+
+async function signJwt(kp: Keypair, opts: SignOpts): Promise<string> {
+  const iat = Math.floor(Date.now() / 1000);
+  const exp = opts.expiresAtSeconds ?? iat + (opts.ttlSeconds ?? 60);
+  const builder = new SignJWT({
+    scope: opts.scope ?? "vault:read",
+    client_id: opts.clientId ?? "test-client",
+  })
+    .setProtectedHeader(opts.omitKid ? { alg: "RS256" } : { alg: "RS256", kid: opts.kid ?? kp.kid })
+    .setIssuer(opts.iss ?? "http://issuer.invalid")
+    .setSubject(opts.sub ?? "user-1")
+    .setAudience(opts.aud ?? "operator")
+    .setIssuedAt(iat)
+    .setExpirationTime(exp)
+    .setJti(opts.jti ?? "jti-1");
+  return await builder.sign(kp.privateKey);
+}
+
+let fixture: JwksFixture;
+let kp: Keypair;
+
+beforeAll(async () => {
+  fixture = startJwksFixture();
+  kp = await makeKeypair("k1");
+  fixture.setKeys([kp]);
+});
+
+afterAll(() => {
+  fixture.stop();
+});
+
+beforeEach(() => {
+  fixture.setUnreachable(false);
+  fixture.setKeys([kp]);
+});
+
+function makeGuard() {
+  // Each test gets a fresh guard with its own JWKS cache. Tests that need
+  // to swap origins use createScopeGuard's per-instance state directly
+  // rather than relying on the module-scoped cache.
+  return createScopeGuard({ hubOrigin: fixture.origin });
+}
+
+describe("createScopeGuard — happy path", () => {
+  test("valid JWT with correct iss → claims surface", async () => {
+    const guard = makeGuard();
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      scope: "vault:work:read vault:work:write",
+    });
+    const claims = await guard.validateHubJwt(token);
+    expect(claims.sub).toBe("user-1");
+    expect(claims.scopes).toEqual(["vault:work:read", "vault:work:write"]);
+    expect(claims.aud).toBe("operator");
+    expect(claims.jti).toBe("jti-1");
+    expect(claims.clientId).toBe("test-client");
+    guard.resetJwksCache();
+  });
+
+  test("hubOrigin as resolver function", async () => {
+    const guard = createScopeGuard({ hubOrigin: () => fixture.origin });
+    const token = await signJwt(kp, { iss: fixture.origin });
+    const claims = await guard.validateHubJwt(token);
+    expect(claims.sub).toBe("user-1");
+    guard.resetJwksCache();
+  });
+
+  test("trailing slash on origin is stripped (matches hub-minted iss)", async () => {
+    const guard = createScopeGuard({ hubOrigin: `${fixture.origin}/` });
+    const token = await signJwt(kp, { iss: fixture.origin });
+    const claims = await guard.validateHubJwt(token);
+    expect(claims.sub).toBe("user-1");
+    guard.resetJwksCache();
+  });
+
+  test("empty scope claim → empty scopes array", async () => {
+    const guard = makeGuard();
+    const token = await signJwt(kp, { iss: fixture.origin, scope: "" });
+    const claims = await guard.validateHubJwt(token);
+    expect(claims.scopes).toEqual([]);
+    guard.resetJwksCache();
+  });
+});
+
+describe("createScopeGuard — audience strict-check", () => {
+  test("string aud match → passes, claim surfaces", async () => {
+    const guard = makeGuard();
+    const token = await signJwt(kp, { iss: fixture.origin, aud: "vault.work" });
+    const claims = await guard.validateHubJwt(token, { expectedAudience: "vault.work" });
+    expect(claims.aud).toBe("vault.work");
+    guard.resetJwksCache();
+  });
+
+  test("string aud mismatch → throws audience error", async () => {
+    const guard = makeGuard();
+    const token = await signJwt(kp, { iss: fixture.origin, aud: "vault.personal" });
+    let caught: HubJwtError | undefined;
+    try {
+      await guard.validateHubJwt(token, { expectedAudience: "vault.work" });
+    } catch (e) {
+      caught = e as HubJwtError;
+    }
+    expect(caught).toBeInstanceOf(HubJwtError);
+    expect(caught?.code).toBe("audience");
+    expect(caught?.message).toMatch(/audience mismatch.*vault\.work.*vault\.personal/);
+    guard.resetJwksCache();
+  });
+
+  test("array aud: passes when expected is one of the entries", async () => {
+    const guard = makeGuard();
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: ["vault.work", "vault.personal", "operator"],
+    });
+    const claims = await guard.validateHubJwt(token, { expectedAudience: "vault.personal" });
+    expect(claims.aud).toBe("vault.personal");
+    guard.resetJwksCache();
+  });
+
+  test("array aud: throws audience error when expected is missing", async () => {
+    const guard = makeGuard();
+    const token = await signJwt(kp, { iss: fixture.origin, aud: ["vault.work", "operator"] });
+    let caught: HubJwtError | undefined;
+    try {
+      await guard.validateHubJwt(token, { expectedAudience: "vault.personal" });
+    } catch (e) {
+      caught = e as HubJwtError;
+    }
+    expect(caught?.code).toBe("audience");
+    expect(caught?.message).toMatch(/audience mismatch.*vault\.personal.*vault\.work.*operator/);
+    guard.resetJwksCache();
+  });
+
+  test("expectedAudience: null skips the check", async () => {
+    const guard = makeGuard();
+    const token = await signJwt(kp, { iss: fixture.origin, aud: "vault.anything" });
+    const claims = await guard.validateHubJwt(token, { expectedAudience: null });
+    expect(claims.aud).toBe("vault.anything");
+    guard.resetJwksCache();
+  });
+
+  test("array aud: surfaces first entry when no expectation", async () => {
+    const guard = makeGuard();
+    const token = await signJwt(kp, { iss: fixture.origin, aud: ["vault.first", "vault.second"] });
+    const claims = await guard.validateHubJwt(token);
+    expect(claims.aud).toBe("vault.first");
+    guard.resetJwksCache();
+  });
+});
+
+describe("createScopeGuard — failure modes (HubJwtError.code)", () => {
+  async function expectError(
+    promise: Promise<unknown>,
+    code: HubJwtError["code"],
+    msgPattern?: RegExp,
+  ): Promise<HubJwtError> {
+    let caught: HubJwtError | undefined;
+    try {
+      await promise;
+    } catch (e) {
+      caught = e as HubJwtError;
+    }
+    expect(caught).toBeInstanceOf(HubJwtError);
+    expect(caught?.code).toBe(code);
+    if (msgPattern) expect(caught?.message).toMatch(msgPattern);
+    return caught!;
+  }
+
+  test("wrong issuer → code: issuer", async () => {
+    const guard = makeGuard();
+    const token = await signJwt(kp, { iss: "http://attacker.example" });
+    await expectError(guard.validateHubJwt(token), "issuer", /verification failed/);
+    guard.resetJwksCache();
+  });
+
+  test("expired token → code: expired", async () => {
+    const guard = makeGuard();
+    const past = Math.floor(Date.now() / 1000) - 10;
+    const token = await signJwt(kp, { iss: fixture.origin, expiresAtSeconds: past });
+    await expectError(guard.validateHubJwt(token), "expired");
+    guard.resetJwksCache();
+  });
+
+  test("bad signature (token signed by an unpublished key) → code: signature", async () => {
+    const guard = makeGuard();
+    const otherKp = await makeKeypair("k1"); // same kid, different key
+    const token = await signJwt(otherKp, { iss: fixture.origin });
+    await expectError(guard.validateHubJwt(token), "signature");
+    guard.resetJwksCache();
+  });
+
+  test("unknown kid → code: kid", async () => {
+    const guard = makeGuard();
+    const token = await signJwt(kp, { iss: fixture.origin, kid: "does-not-exist" });
+    await expectError(guard.validateHubJwt(token), "kid");
+    guard.resetJwksCache();
+  });
+
+  test("missing kid header (multi-key JWKS) → code: kid", async () => {
+    const guard = makeGuard();
+    const kp2 = await makeKeypair("k2");
+    fixture.setKeys([kp, kp2]);
+    guard.resetJwksCache(); // re-fetch the now-multi-key JWKS
+    const token = await signJwt(kp, { iss: fixture.origin, omitKid: true });
+    // jose throws JWKSMultipleMatchingKeys here — bucketed under jwks.
+    await expectError(guard.validateHubJwt(token), "jwks");
+    guard.resetJwksCache();
+  });
+
+  test("JWKS unreachable → code: jwks", async () => {
+    const guard = makeGuard();
+    fixture.setUnreachable(true);
+    const token = await signJwt(kp, { iss: fixture.origin });
+    // 503 → jose JWKSInvalid; "down" path is a 503, not a network failure,
+    // so this surfaces as `jwks`.
+    await expectError(guard.validateHubJwt(token), "jwks");
+    guard.resetJwksCache();
+  });
+
+  test("missing `sub` claim → code: shape", async () => {
+    const guard = makeGuard();
+    const iat = Math.floor(Date.now() / 1000);
+    const token = await new SignJWT({ scope: "vault:read" })
+      .setProtectedHeader({ alg: "RS256", kid: kp.kid })
+      .setIssuer(fixture.origin)
+      .setAudience("operator")
+      .setIssuedAt(iat)
+      .setExpirationTime(iat + 60)
+      .setJti("jti-no-sub")
+      .sign(kp.privateKey);
+    await expectError(guard.validateHubJwt(token), "shape", /missing required `sub`/);
+    guard.resetJwksCache();
+  });
+});
+
+describe("createScopeGuard — injected JWKS getter", () => {
+  test("uses injected getter, ignores cache + origin fetch", async () => {
+    const realGuard = makeGuard();
+    // Steal the cached getter by validating once to warm it…
+    const warmupToken = await signJwt(kp, { iss: fixture.origin });
+    await realGuard.validateHubJwt(warmupToken);
+    // …then build a separate guard using the SAME getter under a DIFFERENT
+    // origin string — if the getter were re-derived from origin, this would
+    // fail; injection should make the origin string only matter for `iss`
+    // matching (which we keep aligned with the getter's actual JWKS).
+    const { getOrCreateJwksGetter } = await import("../jwks");
+    const sharedGetter = getOrCreateJwksGetter(fixture.origin);
+    const otherGuard = createScopeGuard({
+      hubOrigin: fixture.origin,
+      jwksGetter: sharedGetter,
+    });
+    const token = await signJwt(kp, { iss: fixture.origin });
+    const claims = await otherGuard.validateHubJwt(token);
+    expect(claims.sub).toBe("user-1");
+
+    realGuard.resetJwksCache();
+  });
+
+  test("resetJwksCache is a no-op when getter is injected", async () => {
+    const { getOrCreateJwksGetter } = await import("../jwks");
+    const injected = getOrCreateJwksGetter(fixture.origin);
+    const guard = createScopeGuard({
+      hubOrigin: fixture.origin,
+      jwksGetter: injected,
+    });
+    // Should not throw; should not affect the injected getter's state.
+    expect(() => guard.resetJwksCache()).not.toThrow();
+  });
+});

--- a/packages/scope-guard/src/index.ts
+++ b/packages/scope-guard/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @openparachute/scope-guard
+ *
+ * See README.md for the full overview. Public API is built up across the
+ * following commits — this file re-exports it from the per-concern modules.
+ */
+export {};

--- a/packages/scope-guard/src/index.ts
+++ b/packages/scope-guard/src/index.ts
@@ -1,7 +1,12 @@
 /**
  * @openparachute/scope-guard
  *
- * See README.md for the full overview. Public API is built up across the
- * following commits — this file re-exports it from the per-concern modules.
+ * Hub-issued JWT validation for Parachute resource servers. Build a
+ * `ScopeGuard` bound to your hub origin once per process, then call
+ * `guard.validateHubJwt(token, { expectedAudience? })` on each request.
+ *
+ * See README.md for the full API rundown and design.
  */
-export {};
+
+export { extractBearer, looksLikeJwt, parseScopes } from "./parse";
+export { hasScope } from "./scope";

--- a/packages/scope-guard/src/index.ts
+++ b/packages/scope-guard/src/index.ts
@@ -10,3 +10,13 @@
 
 export { extractBearer, looksLikeJwt, parseScopes } from "./parse";
 export { hasScope } from "./scope";
+export type { JwksGetter, JwksOptions } from "./jwks";
+export {
+  createScopeGuard,
+  HubJwtError,
+  type CreateScopeGuardOptions,
+  type HubJwtClaims,
+  type HubJwtErrorCode,
+  type ScopeGuard,
+  type ValidateHubJwtOptions,
+} from "./validate";

--- a/packages/scope-guard/src/jwks.ts
+++ b/packages/scope-guard/src/jwks.ts
@@ -1,0 +1,71 @@
+import { createRemoteJWKSet } from "jose";
+
+/**
+ * JWKS getter caching. `jose.createRemoteJWKSet` returns a getter that
+ * internally caches keys with a configurable TTL. We hold one getter per
+ * origin in a module-scoped map so that retries / kid lookups across
+ * `validateHubJwt` calls reuse the same in-flight fetches and the same
+ * cached key set.
+ *
+ * The cache is per-process; rotation is handled inside jose by re-fetching
+ * after `cacheMaxAge` expires. Tests use `resetCache()` to drop entries
+ * between cases (e.g. swapping the fake JWKS endpoint origin).
+ */
+
+export type JwksGetter = ReturnType<typeof createRemoteJWKSet>;
+
+export interface JwksOptions {
+  /** Max age of a cached key set, in ms. Default 5min. */
+  cacheMaxAge?: number;
+  /** Min interval between failed JWKS fetches, in ms. Default 30s. */
+  cooldownDuration?: number;
+}
+
+const DEFAULT_CACHE_MAX_AGE_MS = 5 * 60 * 1000;
+const DEFAULT_COOLDOWN_MS = 30 * 1000;
+
+interface CacheEntry {
+  getter: JwksGetter;
+  cacheMaxAge: number;
+  cooldownDuration: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Resolve (and lazily create) the JWKS getter for a given origin. If the
+ * options change between calls for the same origin, the entry is rebuilt —
+ * configuration changes are rare but mid-process tuning shouldn't silently
+ * use stale settings.
+ */
+export function getOrCreateJwksGetter(origin: string, opts: JwksOptions = {}): JwksGetter {
+  const cacheMaxAge = opts.cacheMaxAge ?? DEFAULT_CACHE_MAX_AGE_MS;
+  const cooldownDuration = opts.cooldownDuration ?? DEFAULT_COOLDOWN_MS;
+  const existing = cache.get(origin);
+  if (
+    existing &&
+    existing.cacheMaxAge === cacheMaxAge &&
+    existing.cooldownDuration === cooldownDuration
+  ) {
+    return existing.getter;
+  }
+  const getter = createRemoteJWKSet(new URL(`${origin}/.well-known/jwks.json`), {
+    cacheMaxAge,
+    cooldownDuration,
+  });
+  cache.set(origin, { getter, cacheMaxAge, cooldownDuration });
+  return getter;
+}
+
+/**
+ * Drop a single cached entry (or all of them) — tests use this to switch
+ * origins between cases. Production callers shouldn't need it; origin is
+ * process-stable.
+ */
+export function resetCache(origin?: string): void {
+  if (origin === undefined) {
+    cache.clear();
+    return;
+  }
+  cache.delete(origin);
+}

--- a/packages/scope-guard/src/parse.ts
+++ b/packages/scope-guard/src/parse.ts
@@ -1,0 +1,42 @@
+/**
+ * Cheap parsers + extractors used by every consumer of the lib. None of these
+ * touch the network or the JWKS cache — they're pure string functions.
+ */
+
+/**
+ * A presented bearer token is JWT-shaped iff it begins with `eyJ` — the
+ * base64url encoding of `{"` from a `{"alg":...}` JSON header. Cheap
+ * pre-check so we don't try to verify shared-secret / `pvt_*` tokens as JWTs.
+ */
+export function looksLikeJwt(token: string): boolean {
+  return token.startsWith("eyJ");
+}
+
+/**
+ * Parse a whitespace-separated OAuth `scope` claim into a scope list.
+ *
+ *   - Empty / null / undefined → []
+ *   - Trim + split on any whitespace
+ *   - Unrecognized scopes are preserved as-is — `hasScope` decides what
+ *     each satisfies. The lib doesn't enforce a vocabulary.
+ */
+export function parseScopes(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(/\s+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Pull the bearer token off an `Authorization` header. Case-insensitive on
+ * the scheme; tolerant of extra whitespace. Returns `undefined` if the
+ * header is missing, malformed, or non-Bearer.
+ */
+export function extractBearer(authHeader: string | null | undefined): string | undefined {
+  if (!authHeader) return undefined;
+  const m = /^Bearer\s+(.+)$/i.exec(authHeader);
+  if (!m || m[1] === undefined) return undefined;
+  const token = m[1].trim();
+  return token.length > 0 ? token : undefined;
+}

--- a/packages/scope-guard/src/scope.ts
+++ b/packages/scope-guard/src/scope.ts
@@ -1,0 +1,98 @@
+/**
+ * Generic scope matcher with `admin ⊇ write ⊇ read` inheritance.
+ *
+ * Two shapes are recognized for inheritance:
+ *
+ *   - **Broad**     `<resource>:<verb>`               e.g. `vault:read`
+ *   - **Narrowed**  `<resource>:<name>:<verb>`        e.g. `vault:work:write`
+ *
+ * Matching rules:
+ *
+ *   - Exact-string match always wins.
+ *   - For broad-vs-broad and narrowed-vs-broad queries on the same resource,
+ *     a granted scope satisfies the query if its verb rank is ≥ the required
+ *     verb rank (admin=2, write=1, read=0).
+ *   - Narrowed grants satisfy broad queries on the same resource (a
+ *     `vault:work:write` token is *more* constrained than `vault:write`, but
+ *     it's strictly enough to satisfy a `vault:write` check).
+ *   - Broad grants do NOT satisfy narrowed queries through this function —
+ *     consumers that want the reverse semantics (e.g. "this URL names vault
+ *     `work`; does the token authorize it?") should write a per-resource
+ *     wrapper or pass the resource-pinned form into `required` themselves.
+ *   - Different `<resource>` never matches.
+ *   - Verbs outside the `admin/write/read` ladder (e.g. `scribe:transcribe`)
+ *     get exact-match-only treatment — `scribe:admin` does NOT imply
+ *     `scribe:transcribe`. Cross-resource catch-alls are policy and belong
+ *     in the consumer.
+ */
+
+type Verb = "read" | "write" | "admin";
+
+const VERB_RANK: Record<Verb, number> = { read: 0, write: 1, admin: 2 };
+
+function isVerb(s: string): s is Verb {
+  return s === "read" || s === "write" || s === "admin";
+}
+
+interface Decomposed {
+  resource: string;
+  /** `null` for broad form (`<resource>:<verb>`), the name otherwise. */
+  name: string | null;
+  verb: Verb;
+}
+
+function decompose(scope: string): Decomposed | null {
+  const parts = scope.split(":");
+  if (parts.length === 2) {
+    const resource = parts[0];
+    const verb = parts[1];
+    if (!resource || !verb || !isVerb(verb)) return null;
+    return { resource, name: null, verb };
+  }
+  if (parts.length === 3) {
+    const resource = parts[0];
+    const name = parts[1];
+    const verb = parts[2];
+    if (!resource || !name || !verb || !isVerb(verb)) return null;
+    return { resource, name, verb };
+  }
+  return null;
+}
+
+/**
+ * Does `granted` satisfy `required`?
+ *
+ *   - Exact string match → true
+ *   - Both sides decompose to the inheritance ladder, same resource, and
+ *     (a) required is broad form (any matching-resource grant with verb
+ *     rank ≥ required satisfies), or
+ *     (b) required is narrowed and granted is the same narrowed name
+ *     with verb rank ≥ required.
+ *   - Otherwise → false.
+ */
+export function hasScope(granted: string[], required: string): boolean {
+  if (granted.includes(required)) return true;
+
+  const reqD = decompose(required);
+  if (!reqD) return false;
+  const reqRank = VERB_RANK[reqD.verb];
+
+  for (const g of granted) {
+    const gD = decompose(g);
+    if (!gD) continue;
+    if (gD.resource !== reqD.resource) continue;
+
+    if (reqD.name === null) {
+      // Broad query: any same-resource grant (broad OR narrowed) with verb
+      // rank ≥ required satisfies. Narrowed grant is strictly more specific
+      // than broad query — token holder has access to a subset, not none.
+      if (VERB_RANK[gD.verb] >= reqRank) return true;
+    } else {
+      // Narrowed query: only grants pinned to the same name (or the same
+      // narrowed name) satisfy — broad grants do NOT satisfy narrowed
+      // queries through this function. See module doc for rationale.
+      if (gD.name === reqD.name && VERB_RANK[gD.verb] >= reqRank) return true;
+    }
+  }
+  return false;
+}

--- a/packages/scope-guard/src/validate.ts
+++ b/packages/scope-guard/src/validate.ts
@@ -1,0 +1,225 @@
+import { type JWTPayload, jwtVerify } from "jose";
+import { type JwksGetter, type JwksOptions, getOrCreateJwksGetter, resetCache } from "./jwks";
+import { parseScopes } from "./parse";
+
+/**
+ * Hub-issued JWT validation, factored out of vault/scribe/paraclaw's
+ * near-identical implementations.
+ *
+ * Trust model:
+ *   - The hub origin is the trust pin. `iss` MUST equal it; without that
+ *     check, anyone could mint a token against any RSA key and pass JWKS
+ *     verification (jose verifies the signature, not who issued the token).
+ *   - JWKS is fetched from `<origin>/.well-known/jwks.json`.
+ *   - `aud` is strict-checked against `expectedAudience` when supplied —
+ *     this is the resource-server backstop for per-resource binding.
+ *
+ * Scope-shape policy (e.g. "no broad `vault:<verb>` from hub JWTs") is
+ * enforced one layer up by the consumer — this function stays focused on
+ * JWT-level concerns and is generic across all Parachute resource servers.
+ */
+
+/** Surface of claims returned to callers. Everything else is dropped. */
+export interface HubJwtClaims {
+  /** Subject — operator's stable id. */
+  sub: string;
+  /** Parsed `scope` claim (whitespace-separated → array). */
+  scopes: string[];
+  /**
+   * Representative audience. When `expectedAudience` is supplied and
+   * matches, this is that exact value. Otherwise it's the first array
+   * element (or the string itself if `aud` was a single string), or
+   * `undefined` if no `aud` claim was present.
+   */
+  aud: string | undefined;
+  /** Token id. Surfaced for logging / future revocation lookups. */
+  jti: string | undefined;
+  /** Client id from the `client_id` claim, if present. */
+  clientId: string | undefined;
+}
+
+/** Reasons a hub JWT may fail validation. Each maps to a `HubJwtError.code`. */
+export type HubJwtErrorCode =
+  | "signature"
+  | "issuer"
+  | "expired"
+  | "kid"
+  | "jwks"
+  | "audience"
+  | "shape";
+
+/**
+ * Single error class for all validation failures. Branch on `code` rather
+ * than catching a subclass — services format their error responses anyway,
+ * and a flat error keeps consumer code simple.
+ */
+export class HubJwtError extends Error {
+  override name = "HubJwtError";
+  readonly code: HubJwtErrorCode;
+
+  constructor(code: HubJwtErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export interface CreateScopeGuardOptions {
+  /**
+   * The hub's origin. Either a literal string or a resolver function — the
+   * function form lets consumers layer their own env-var precedence (e.g.
+   * paraclaw's `PARACLAW_HUB_ORIGIN` over `PARACHUTE_HUB_ORIGIN`). Trailing
+   * slashes are stripped so the canonical form matches what the hub mints.
+   */
+  hubOrigin: string | (() => string);
+
+  /** Optional JWKS cache tuning. Defaults: 5min cacheMaxAge, 30s cooldown. */
+  jwks?: JwksOptions;
+
+  /**
+   * Inject a JWKS getter directly. When provided, the lib uses it verbatim
+   * and does NOT consult the cache or `jwks` options. Tests use this to
+   * point at a fake JWKS endpoint without needing to register the origin
+   * with jose's remote-fetcher; non-default JWKS topologies (e.g. local
+   * static keys) can use it to bypass the network entirely.
+   */
+  jwksGetter?: JwksGetter;
+}
+
+export interface ValidateHubJwtOptions {
+  /**
+   * If set, strict-check the JWT `aud` claim against this exact value.
+   * Used by per-resource auth paths: each request derives the expected
+   * audience (e.g. `vault.work`) and rejects tokens stamped for a
+   * different resource. Pass `null` (or omit) to skip.
+   *
+   * The audience strict-check is the resource-server backstop. Even if
+   * scope narrowing slips upstream, `aud=vault.work` cannot reach
+   * `/vault/personal/*` because the audience-mismatch reject fires first.
+   */
+  expectedAudience?: string | null;
+}
+
+export interface ScopeGuard {
+  /**
+   * Verify a presented JWT. Returns surfaced claims on success; throws
+   * `HubJwtError` (with a `code`) on any failure.
+   */
+  validateHubJwt(token: string, opts?: ValidateHubJwtOptions): Promise<HubJwtClaims>;
+
+  /**
+   * Drop the cached JWKS getter for this guard's origin. Tests use this to
+   * switch fake JWKS endpoints between cases; production callers shouldn't
+   * need it (origin is process-stable, key rotation is handled inside the
+   * jose getter by re-fetching after `cacheMaxAge`).
+   */
+  resetJwksCache(): void;
+}
+
+function resolveOrigin(input: string | (() => string)): string {
+  const raw = typeof input === "function" ? input() : input;
+  return raw.replace(/\/$/, "");
+}
+
+/**
+ * Build a scope guard bound to a hub origin. The guard holds the JWKS
+ * getter, so the cache lives across requests — instantiate once per process
+ * and reuse.
+ */
+export function createScopeGuard(opts: CreateScopeGuardOptions): ScopeGuard {
+  const { hubOrigin, jwks: jwksOpts, jwksGetter: injected } = opts;
+
+  function pickGetter(origin: string): JwksGetter {
+    if (injected) return injected;
+    return getOrCreateJwksGetter(origin, jwksOpts);
+  }
+
+  return {
+    async validateHubJwt(token, validateOpts = {}) {
+      const origin = resolveOrigin(hubOrigin);
+      const getter = pickGetter(origin);
+
+      let payload: JWTPayload;
+      try {
+        const verified = await jwtVerify(token, getter, { issuer: origin });
+        payload = verified.payload;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        const code = classifyJoseError(err);
+        throw new HubJwtError(code, `hub JWT verification failed: ${msg}`);
+      }
+
+      if (typeof payload.sub !== "string" || payload.sub.length === 0) {
+        throw new HubJwtError("shape", "hub JWT missing required `sub` claim");
+      }
+
+      // RFC 7519 §4.1.3: `aud` may be a string OR an array of strings. We
+      // unify into an array internally and check membership; the value
+      // surfaced to callers collapses to a single representative — the
+      // matched expectation when supplied, else the first array element.
+      const audRaw = payload.aud;
+      const auds: string[] =
+        typeof audRaw === "string"
+          ? [audRaw]
+          : Array.isArray(audRaw)
+            ? audRaw.filter((a): a is string => typeof a === "string")
+            : [];
+
+      if (validateOpts.expectedAudience != null) {
+        if (!auds.includes(validateOpts.expectedAudience)) {
+          const got = auds.length === 0 ? "(missing)" : auds.join(", ");
+          throw new HubJwtError(
+            "audience",
+            `hub JWT audience mismatch: expected "${validateOpts.expectedAudience}", got "${got}"`,
+          );
+        }
+      }
+      const aud: string | undefined =
+        validateOpts.expectedAudience != null ? validateOpts.expectedAudience : auds[0];
+
+      const scopeRaw = (payload as { scope?: unknown }).scope;
+      const scopes = typeof scopeRaw === "string" ? parseScopes(scopeRaw) : [];
+
+      const jti = typeof payload.jti === "string" ? payload.jti : undefined;
+      const clientIdRaw = (payload as { client_id?: unknown }).client_id;
+      const clientId = typeof clientIdRaw === "string" ? clientIdRaw : undefined;
+
+      return { sub: payload.sub, scopes, aud, jti, clientId };
+    },
+
+    resetJwksCache() {
+      if (injected) return; // injected getter has no cache we own
+      const origin = resolveOrigin(hubOrigin);
+      resetCache(origin);
+    },
+  };
+}
+
+/**
+ * Translate a jose error into our coarse `code` taxonomy. jose uses string
+ * `name`s like `JWTExpired`, `JWTClaimValidationFailed`, `JWSSignatureVerificationFailed`,
+ * `JWKSNoMatchingKey`. Anything we can't classify is bucketed as `signature`
+ * — a conservative default since the wrapped message still surfaces.
+ */
+function classifyJoseError(err: unknown): HubJwtErrorCode {
+  if (!(err instanceof Error)) return "signature";
+  const name = err.name;
+  if (name === "JWTExpired") return "expired";
+  if (name === "JWKSNoMatchingKey") return "kid";
+  if (name === "JWKSInvalid" || name === "JWKSTimeout" || name === "JWKSMultipleMatchingKeys") {
+    return "jwks";
+  }
+  if (name === "JWTClaimValidationFailed") {
+    // jose throws this for issuer/audience claim mismatches. We only
+    // configure `issuer` on jwtVerify, so map to `issuer`. Audience handling
+    // is done by us, not jose, and surfaces as `audience`.
+    return "issuer";
+  }
+  // Low-level fetch failures surface as TypeError when JWKS is unreachable.
+  if (name === "TypeError") return "jwks";
+  // Generic `JOSEError` for non-200 JWKS HTTP responses (e.g. 503). The
+  // typed JWKS* subclasses cover the structural cases above; HTTP-level
+  // failures fall through to the base class with a "JSON Web Key Set HTTP
+  // response" message.
+  if (name === "JOSEError" && /JSON Web Key Set/i.test(err.message)) return "jwks";
+  return "signature";
+}

--- a/packages/scope-guard/tsconfig.json
+++ b/packages/scope-guard/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "allowImportingTsExtensions": false,
+    "verbatimModuleSyntax": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/__tests__"]
+}


### PR DESCRIPTION
## Summary

Ships the **`@openparachute/scope-guard`** library as a sub-package of `parachute-hub`, published independently to npm. Step 1 of the 4-step migration in the design doc — **library only, no consumer migration**. Vault / scribe / paraclaw adoption are separate PRs that come later.

Design: [`docs/design/2026-04-29-scope-guard-library.md`](https://github.com/ParachuteComputer/parachute-hub/blob/main/docs/design/2026-04-29-scope-guard-library.md)

Closes #59

## API surface (per design doc)

- **`createScopeGuard({ hubOrigin, jwks?, jwksGetter? })`** → `ScopeGuard`
  - `hubOrigin: string | (() => string)` — resolver fn lets consumers layer env-var precedence (paraclaw's `PARACLAW_HUB_ORIGIN` → `PARACHUTE_HUB_ORIGIN` → loopback).
  - `jwks?: { cacheMaxAge?: number; cooldownDuration?: number }` — defaults 5 min / 30 s, matching the values battle-tested in vault/scribe/paraclaw.
  - `jwksGetter?: ReturnType<typeof createRemoteJWKSet>` — injectable getter for tests / static-key topologies.
- **`guard.validateHubJwt(token, { expectedAudience? }) → Promise<HubJwtClaims>`** — throws `HubJwtError`. RFC 7519 string-or-array `aud` from day one.
- **`HubJwtClaims`** — `{ sub, scopes, aud, jti, clientId }` (representative aud collapses to the matched expectation when supplied, else first array entry).
- **`parseScopes`, `looksLikeJwt`, `extractBearer`** — pure string helpers.
- **`hasScope(granted, required)`** — generic `<resource>:<verb>` / `<resource>:<name>:<verb>` matcher with `admin ⊇ write ⊇ read` inheritance. Non-ladder verbs (e.g. `transcribe`) get exact-match-only — cross-resource catch-alls are policy and stay in each consumer.
- **`guard.resetJwksCache()`** — tests only; production callers don't need it.

## Three open-question decisions baked in (per team-lead brief)

1. **Injectable JWKS getter:** YES — `createScopeGuard` accepts an optional `jwksGetter`. When provided, it's used verbatim and the cache is bypassed.
2. **HubJwtError shape:** single class with a `code` field — `'signature' | 'issuer' | 'expired' | 'kid' | 'jwks' | 'audience' | 'shape'`. No subclass hierarchy. Branch on `code`.
3. **Versioning:** independent of hub's RC cadence. Starts at `0.1.0-rc.1`. Semver expectations documented in the package README.

## Test plan

| Suite | File | What it covers |
|---|---|---|
| parse | `__tests__/parse.test.ts` | `parseScopes` (empty/null/whitespace/multi/preserve-unknown), `looksLikeJwt`, `extractBearer` (case-insensitive scheme, whitespace tolerance, non-Bearer rejection) |
| scope | `__tests__/scope.test.ts` | exact / broad inheritance / narrowed inheritance / cross-resource non-match / non-ladder verb exact-only / malformed shapes ignored |
| validate | `__tests__/validate.test.ts` | signature pass+fail, wrong-issuer, expired, missing/unknown kid, multi-key JWKS missing-kid, JWKS unreachable (503), missing `sub`, audience matrix (string match, array match, both mismatch shapes, expectation: null skips). HubJwtError.code asserted on every failure. |
| integration | `__tests__/integration.test.ts` | Mints real hub JWT through `signAccessToken(db, opts)`, serves `/.well-known/jwks.json` from `getAllPublicKeys + pemToJwk`, validates end-to-end. Asserts the four consumer outcomes (valid → claims, missing scope → false, missing token → undefined, expired → 401-shaped). |

Gate results:

```
$ bun run typecheck   # tsc --noEmit       → clean
$ bun run lint        # biome check .      → 133 files clean
$ bun test            # at hub root        → 944 pass / 0 fail (was 880 pre-PR; +64 from this lib)
$ bun test packages/scope-guard            → 64 pass / 0 fail
```

## Reviewer-friendly commit ladder

1. `chore(workspaces): enable bun workspaces for packages/*`
2. `feat(scope-guard): package skeleton`
3. `feat(scope-guard): parseScopes, hasScope, looksLikeJwt, extractBearer`
4. `feat(scope-guard): createScopeGuard + validateHubJwt`
5. `test(scope-guard): unit tests for parse, scope, validate`
6. `test(scope-guard): integration test against real hub JWTs`
7. `docs(scope-guard): add package README`

## What's NOT in this PR

- **Consumer migrations.** Vault / scribe / paraclaw stay on their inlined copies until their own PRs. The lib's API was designed against vault's canonical impl (most-demanding consumer), so adoption should be near-mechanical.
- **No hub version bump.** `parachute-hub@0.4.0-rc.36` unchanged. Sub-package starts at `@openparachute/scope-guard@0.1.0-rc.1`.
- **No publishing to npm.** `prepublishOnly` runs `tsc` to emit `dist/` — actual publish is a separate operation after this lands.

## Notes for review

- `packages/scope-guard/tsconfig.json` overrides three flags from the root config (`noEmit: false`, `allowImportingTsExtensions: false`, `verbatimModuleSyntax: false`) so the package can emit `dist/` for npm consumers. Source files in this package use bare imports (`./parse`) — only the integration test (which crosses into hub source) uses `.ts` extensions, since it runs through Bun directly.
- The error classifier (`classifyJoseError` in `validate.ts`) maps jose's typed errors (`JWTExpired`, `JWKSNoMatchingKey`, etc.) to our coarse `code` taxonomy. JOSEError 503-from-JWKS endpoints fall through to the message-based bucket (`/JSON Web Key Set/i` → `jwks`).

## Test plan (post-merge)

- [ ] Reviewer verifies typecheck + lint + tests all green locally
- [ ] After merge, npm publish workflow can ship `@openparachute/scope-guard@0.1.0-rc.1` to the `rc` dist-tag (separate operation; not auto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)