### PR TITLE
review polish for native CF Tunnel — close #154, #155

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,16 @@
         "typescript": "^5",
       },
     },
+    "packages/scope-guard": {
+      "name": "@openparachute/scope-guard",
+      "version": "0.1.0-rc.1",
+      "dependencies": {
+        "jose": "^6.2.2",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
   },
   "packages": {
     "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
@@ -73,6 +83,8 @@
     "@node-rs/argon2-win32-ia32-msvc": ["@node-rs/argon2-win32-ia32-msvc@2.0.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-GsE2ezwAYwh72f9gIjbGTZOf4HxEksb5M2eCaj+Y5rGYVwAdt7C12Q2e9H5LRYxWcFvLH4m4jiSZpQQ4upnPAQ=="],
 
     "@node-rs/argon2-win32-x64-msvc": ["@node-rs/argon2-win32-x64-msvc@2.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-cJxWXanH4Ew9CfuZ4IAEiafpOBCe97bzoKowHCGk5lG/7kR4WF/eknnBlHW9m8q7t10mKq75kruPLtbSDqgRTw=="],
+
+    "@openparachute/scope-guard": ["@openparachute/scope-guard@workspace:packages/scope-guard"],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.37",
+  "version": "0.4.0-rc.38",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -149,6 +149,32 @@ describe("cli per-subcommand help", () => {
     expect(stdout).toMatch(/--tunnel-name\b/);
   });
 
+  test("expose public --skip-provider-check pins to Tailscale-Funnel default (skips auto-pick)", async () => {
+    // With PATH="" tailscale isn't on PATH, so exposePublic prints its own
+    // install hint. That's distinct from the auto-pick "no exposure provider
+    // is set up" output — proving the skip flag bypassed auto-pick and went
+    // straight to the Funnel path. If we regressed and skip-flag tumbled
+    // into auto-pick, we'd see the auto-pick neither-ready report instead.
+    const proc = Bun.spawn(
+      [process.execPath, CLI, "expose", "public", "--skip-provider-check"],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          PATH: "",
+          HOME: "/tmp/parachute-hub-nonexistent-home",
+          PARACHUTE_HOME: "/tmp/parachute-hub-nonexistent-home",
+        },
+      },
+    );
+    const [stdout, code] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+    expect(code).toBe(1);
+    expect(stdout).toMatch(/tailscale is not installed or not on PATH/);
+    expect(stdout).not.toMatch(/no exposure provider is set up/);
+    expect(stdout).not.toMatch(/Auto-detected/);
+  });
+
   test("expose with missing --domain value exits 1", async () => {
     const { code, stderr } = await runCli(["expose", "public", "--cloudflare", "--domain"]);
     expect(code).toBe(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -473,6 +473,14 @@ async function main(argv: string[]): Promise<number> {
       // environment is already pre-flighted and the auto-pick would just
       // print noise. Both paths run only on `expose public up`; tailnet
       // exposure has only one provider so nothing to pick.
+      //
+      // `domain` and `tunnelName` are deliberately *not* threaded into
+      // auto-pick. Both are Cloudflare-only flags; if a user passes them
+      // without `--cloudflare`, threading would silently route them to
+      // Cloudflare. Better to drop the flags here and let auto-pick decide
+      // purely from what's installed — if it lands on cloudflare-only-ready,
+      // it prints the explicit `--cloudflare --domain` hint instead of
+      // guessing intent.
       if (layer === "public" && action === "up" && !flagExtract.skipProviderCheck) {
         const { exposePublicAutoPick } = await import("./commands/expose-public-auto.ts");
         return await exposePublicAutoPick({ tailscaleOpts: exposeOpts });
@@ -487,9 +495,15 @@ async function main(argv: string[]): Promise<number> {
         return await runExposePublicOffAutoDetect({ tailscaleOffOpts: exposeOpts });
       }
 
-      return layer === "public"
-        ? await exposePublic(action, exposeOpts)
-        : await exposeTailnet(action, exposeOpts);
+      // `--skip-provider-check` fallthrough: pin to today's Tailscale-Funnel
+      // default for `expose public up`. Made explicit (rather than letting
+      // it tumble through the layer ternary) so the escape-hatch branch is
+      // visible at a glance.
+      if (layer === "public" && action === "up" && flagExtract.skipProviderCheck) {
+        return await exposePublic("up", exposeOpts);
+      }
+
+      return await exposeTailnet(action, exposeOpts);
     }
 
     case "start": {

--- a/src/commands/expose-public-auto.ts
+++ b/src/commands/expose-public-auto.ts
@@ -28,6 +28,7 @@
  * tailscale/cloudflared.
  */
 
+import { DEFAULT_CLOUDFLARED_HOME } from "../cloudflare/detect.ts";
 import {
   type ProviderAvailability,
   type DetectProvidersOpts,
@@ -50,6 +51,8 @@ export interface ExposePublicAutoOpts {
   tailscaleOpts?: ExposeOpts;
   /** Forwarded to the Cloudflare handoff. */
   cloudflareOpts?: ExposeCloudflareOpts;
+  /** Override `~/.cloudflared` (parity with the interactive picker's seam). */
+  cloudflaredHome?: string;
   log?: (line: string) => void;
 
   /** Test seams. */
@@ -63,6 +66,7 @@ interface Resolved {
   tunnelName: string | undefined;
   tailscaleOpts: ExposeOpts;
   cloudflareOpts: ExposeCloudflareOpts;
+  cloudflaredHome: string;
   log: (line: string) => void;
   detectProvidersImpl: (opts: DetectProvidersOpts) => Promise<ProviderAvailability>;
   exposePublicImpl: (action: "up", opts: ExposeOpts) => Promise<number>;
@@ -75,6 +79,7 @@ function resolve(opts: ExposePublicAutoOpts): Resolved {
     tunnelName: opts.tunnelName,
     tailscaleOpts: opts.tailscaleOpts ?? {},
     cloudflareOpts: opts.cloudflareOpts ?? {},
+    cloudflaredHome: opts.cloudflaredHome ?? DEFAULT_CLOUDFLARED_HOME,
     log: opts.log ?? ((line) => console.log(line)),
     detectProvidersImpl: opts.detectProvidersImpl ?? detectProviders,
     exposePublicImpl: opts.exposePublicImpl ?? ((a, o) => defaultExposePublic(a, o)),
@@ -153,7 +158,7 @@ export async function exposePublicAutoPick(
   opts: ExposePublicAutoOpts = {},
 ): Promise<number> {
   const r = resolve(opts);
-  const availability = await r.detectProvidersImpl({});
+  const availability = await r.detectProvidersImpl({ cloudflaredHome: r.cloudflaredHome });
   const tsReady = isTailnetReady(availability);
   const cfReady = isCloudflareReady(availability);
 


### PR DESCRIPTION
## Summary

Five follow-up nits from the #29 review that were folded after #153 had already merged. Reapplied here on a fresh branch off `main`.

- **`expose-public-auto.ts`** — added `cloudflaredHome?: string` to `ExposePublicAutoOpts` and forwarded it to `detectProvidersImpl({ cloudflaredHome: r.cloudflaredHome })`. Parity with the interactive picker's `probeReadiness` seam — keeps `~/.cloudflared` overridable in tests and `$HOME`-free environments.
- **`cli.ts:481`** — added a comment explaining why `--domain` / `--tunnel-name` are not threaded into the auto-pick call. Both are Cloudflare-only flags; threading would silently route the user to Cloudflare even when they didn't pass `--cloudflare`. Better to drop them here and let auto-pick decide purely from installed-state, then emit the explicit-flag hint when it lands on cloudflare-only-ready.
- **`bun.lock`** — picked up the `@openparachute/scope-guard@workspace:packages/scope-guard` entry that landed via #152. Legitimate drift from running `bun install` on clean checkout.
- **`cli.test.ts`** — new test asserting `parachute expose public --skip-provider-check` reaches `exposePublic` (Tailscale Funnel path) instead of auto-pick. Distinguishes via `tailscale is not installed or not on PATH` (exposePublic's hint) vs the auto-pick "no exposure provider is set up" report.
- **`cli.ts`** — replaced the implicit fallthrough (`return layer === "public" ? exposePublic : exposeTailnet`) with an explicit `if (layer === "public" && action === "up" && flagExtract.skipProviderCheck) return await exposePublic("up", exposeOpts);` branch. The escape-hatch path is now visible at a glance.

Bumps `0.4.0-rc.37` → `0.4.0-rc.38`.

Closes #154
Closes #155

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 960 pass / 0 fail / 2468 expect() across 62 files (was 959, +1 from the new skip-provider-check test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)