### PR TITLE
feat(hub): vault-management SPA Phase 1 (list + create) at /hub/*

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.38",
+  "version": "0.4.0-rc.39",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "start": "bun src/cli.ts",
-    "test": "bun test",
+    "test": "bun test ./src",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",

--- a/src/__tests__/admin-host-admin-token.test.ts
+++ b/src/__tests__/admin-host-admin-token.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the SPA's session→bearer mint endpoint. Covers:
+ *   - 401 when no admin session cookie is present.
+ *   - 401 when the cookie names a deleted/expired session.
+ *   - 200 + JWT carrying parachute:host:admin when the session is valid.
+ *   - Token validates against the hub's own keys and the configured issuer.
+ *   - Method-not-allowed on POST.
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HOST_ADMIN_TOKEN_TTL_SECONDS, handleHostAdminToken } from "../admin-host-admin-token.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { validateAccessToken } from "../jwt-sign.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession, deleteSession } from "../sessions.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "https://hub.test";
+
+interface Harness {
+  db: Database;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-host-admin-token-"));
+  const db = openHubDb(hubDbPath(dir));
+  return {
+    db,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+async function withSession(): Promise<{ cookie: string; userId: string }> {
+  const user = await createUser(harness.db, "operator", "hunter2");
+  const session = createSession(harness.db, { userId: user.id });
+  const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+  return { cookie, userId: user.id };
+}
+
+describe("handleHostAdminToken", () => {
+  test("401 when no session cookie is present", async () => {
+    const req = new Request(`${ISSUER}/admin/host-admin-token`);
+    const res = await handleHostAdminToken(req, { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("unauthenticated");
+  });
+
+  test("401 when the cookie names a deleted session", async () => {
+    const { cookie } = await withSession();
+    // Pluck the session id back out of the cookie + delete its row.
+    const sid = cookie.match(/parachute_hub_session=([^;]+)/)?.[1] ?? "";
+    deleteSession(harness.db, sid);
+    const req = new Request(`${ISSUER}/admin/host-admin-token`, {
+      headers: { cookie },
+    });
+    const res = await handleHostAdminToken(req, { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(401);
+  });
+
+  test("405 on POST", async () => {
+    const { cookie } = await withSession();
+    const req = new Request(`${ISSUER}/admin/host-admin-token`, {
+      method: "POST",
+      headers: { cookie },
+    });
+    const res = await handleHostAdminToken(req, { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(405);
+  });
+
+  test("200 mints a JWT carrying parachute:host:admin and the configured issuer", async () => {
+    const { cookie, userId } = await withSession();
+    const req = new Request(`${ISSUER}/admin/host-admin-token`, {
+      headers: { cookie },
+    });
+    const res = await handleHostAdminToken(req, { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+
+    const body = (await res.json()) as {
+      token: string;
+      expires_at: string;
+      scopes: string[];
+    };
+    expect(body.scopes).toEqual(["parachute:host:admin"]);
+    expect(body.token.length).toBeGreaterThan(20);
+
+    // expires_at is roughly TTL_SECONDS in the future.
+    const expMs = new Date(body.expires_at).getTime();
+    const skew = expMs - Date.now();
+    expect(skew).toBeGreaterThan((HOST_ADMIN_TOKEN_TTL_SECONDS - 30) * 1000);
+    expect(skew).toBeLessThan((HOST_ADMIN_TOKEN_TTL_SECONDS + 30) * 1000);
+
+    // JWT verifies against the hub's own signing key + issuer.
+    const validated = await validateAccessToken(harness.db, body.token, ISSUER);
+    expect(validated.payload.sub).toBe(userId);
+    expect(validated.payload.iss).toBe(ISSUER);
+    const scopeClaim = (validated.payload as { scope?: string }).scope ?? "";
+    expect(scopeClaim.split(/\s+/)).toContain("parachute:host:admin");
+  });
+});

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -27,6 +27,10 @@ function makeHarness(): Harness {
 
 function req(path: string, init?: RequestInit): Request {
   return new Request(`http://127.0.0.1/${path.replace(/^\//, "")}`, init);
+}
+
+function mkdirIfMissing(dir: string): void {
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 }
 
 function vaultEntry(name: string): ServiceEntry {
@@ -344,6 +348,80 @@ describe("hubFetch routing", () => {
     }
   });
 
+  test("/hub/ serves index.html when the SPA bundle exists", async () => {
+    const h = makeHarness();
+    try {
+      const dist = join(h.dir, "dist");
+      writeFileSync(join(h.dir, "hub.html"), "<html>hub</html>");
+      mkdirIfMissing(dist);
+      writeFileSync(join(dist, "index.html"), "<!doctype html><div id=root></div>");
+      const fetch = hubFetch(h.dir, { spaDistDir: dist });
+      const res = await fetch(req("/hub/"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      expect(await res.text()).toContain("<div id=root>");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/hub/vaults (client-side route) falls back to index.html", async () => {
+    const h = makeHarness();
+    try {
+      const dist = join(h.dir, "dist");
+      mkdirIfMissing(dist);
+      writeFileSync(join(dist, "index.html"), "<!doctype html><div id=root></div>");
+      const res = await hubFetch(h.dir, { spaDistDir: dist })(req("/hub/vaults"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      expect(await res.text()).toContain("<div id=root>");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/hub/assets/*.js is served with the matching content-type", async () => {
+    const h = makeHarness();
+    try {
+      const dist = join(h.dir, "dist");
+      const assets = join(dist, "assets");
+      mkdirIfMissing(dist);
+      mkdirIfMissing(assets);
+      writeFileSync(join(dist, "index.html"), "<!doctype html>");
+      writeFileSync(join(assets, "main.js"), "console.log('hi');");
+      const res = await hubFetch(h.dir, { spaDistDir: dist })(req("/hub/assets/main.js"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("application/javascript; charset=utf-8");
+      expect(await res.text()).toContain("console.log");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/hub/* returns 503 with build hint when dist is missing", async () => {
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir, { spaDistDir: join(h.dir, "missing") })(req("/hub/"));
+      expect(res.status).toBe(503);
+      expect(await res.text()).toContain("bun run build");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/hub rejects non-GET methods with 405", async () => {
+    const h = makeHarness();
+    try {
+      const dist = join(h.dir, "dist");
+      mkdirIfMissing(dist);
+      writeFileSync(join(dist, "index.html"), "<!doctype html>");
+      const res = await hubFetch(h.dir, { spaDistDir: dist })(req("/hub/", { method: "POST" }));
+      expect(res.status).toBe(405);
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("/oauth/authorize without configured db returns 503", async () => {
     const h = makeHarness();
     try {
@@ -367,6 +445,7 @@ describe("hubFetch routing", () => {
         ["/admin/logout", { method: "POST" }],
         ["/admin/config", { method: "GET" }],
         ["/admin/config/example", { method: "POST" }],
+        ["/admin/host-admin-token", { method: "GET" }],
       ];
       for (const [path, init] of cases) {
         const res = await fetch(req(path, init));

--- a/src/admin-host-admin-token.ts
+++ b/src/admin-host-admin-token.ts
@@ -1,0 +1,83 @@
+/**
+ * `GET /admin/host-admin-token` — exchange a valid admin session cookie for a
+ * short-lived JWT carrying `parachute:host:admin`.
+ *
+ * Why this exists: the hub's vault-management SPA (served under `/hub/`)
+ * needs a Bearer to call admin endpoints like `POST /vaults`, but
+ * `parachute:host:admin` is in `NON_REQUESTABLE_SCOPES` — the public
+ * `/oauth/authorize` endpoint refuses to mint it so third-party apps can't
+ * acquire cross-vault provisioning capability via consent.
+ *
+ * The local mint path now has two surfaces:
+ *   1. `parachute auth ...` — operator-token file (~1y, on-disk, mode 0600).
+ *   2. THIS endpoint — short-lived JWT (10 min) handed to the SPA in memory.
+ *
+ * Both paths require already-proved local-operator identity:
+ *   - operator-token mint runs as the operator's unix user.
+ *   - this endpoint requires a valid `parachute_hub_session` cookie, which
+ *     was set by `/admin/login` after a password check.
+ *
+ * Tokens minted here are deliberately NOT persisted in the `tokens` table
+ * (no refresh, no revocation tracking). They expire on their own; the SPA
+ * re-fetches when the JWT is about to lapse.
+ */
+import type { Database } from "bun:sqlite";
+import { signAccessToken } from "./jwt-sign.ts";
+import { findSession, parseSessionCookie } from "./sessions.ts";
+
+/** Short TTL — page-snapshot threats can't carry the token forever. */
+export const HOST_ADMIN_TOKEN_TTL_SECONDS = 10 * 60;
+const HOST_ADMIN_AUDIENCE = "hub";
+const HOST_ADMIN_CLIENT_ID = "parachute-hub-spa";
+export const HOST_ADMIN_SCOPES = ["parachute:host:admin"] as const;
+
+export interface MintHostAdminTokenDeps {
+  db: Database;
+  /** Hub origin — written into JWT `iss`. */
+  issuer: string;
+}
+
+export async function handleHostAdminToken(
+  req: Request,
+  deps: MintHostAdminTokenDeps,
+): Promise<Response> {
+  if (req.method !== "GET") {
+    return jsonError(405, "method_not_allowed", "use GET");
+  }
+  const sid = parseSessionCookie(req.headers.get("cookie"));
+  const session = sid ? findSession(deps.db, sid) : null;
+  if (!session) {
+    return jsonError(401, "unauthenticated", "no admin session — sign in at /admin/login first");
+  }
+  const minted = await signAccessToken(deps.db, {
+    sub: session.userId,
+    scopes: [...HOST_ADMIN_SCOPES],
+    audience: HOST_ADMIN_AUDIENCE,
+    clientId: HOST_ADMIN_CLIENT_ID,
+    issuer: deps.issuer,
+    ttlSeconds: HOST_ADMIN_TOKEN_TTL_SECONDS,
+  });
+  return new Response(
+    JSON.stringify({
+      token: minted.token,
+      expires_at: minted.expiresAt,
+      scopes: HOST_ADMIN_SCOPES,
+    }),
+    {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+        // No browser cache — token rotates per-fetch, and a stale 200 from a
+        // back/forward navigation could hand the SPA a long-expired JWT.
+        "cache-control": "no-store",
+      },
+    },
+  );
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -287,8 +287,9 @@ function spaContentType(pathname: string): string {
 /**
  * Serve a single file under the SPA mount, falling back to `index.html`
  * for client-side-routed paths (anything that doesn't resolve to a real
- * file under `dist/`). Path-traversal guard is the substring check on
- * the resolved absolute path — Bun.file gives us no built-in clamp.
+ * file under `dist/`). Path-traversal is blocked twice: the asset-shape
+ * filter rejects sub-paths containing "..", and the resolved absolute
+ * path is checked to start with `dist/` before any read.
  */
 async function serveSpa(spaDistDir: string, pathname: string): Promise<Response> {
   if (!existsSync(spaDistDir)) {
@@ -302,9 +303,9 @@ async function serveSpa(spaDistDir: string, pathname: string): Promise<Response>
   const indexPath = join(spaDistDir, "index.html");
 
   // Empty / mount-root / any non-asset request → SPA shell. The router takes
-  // it from there. Path traversal can't escape because we only construct a
-  // candidate path for assets that look like static files (have an extension
-  // and don't contain "..") — bare paths get the shell.
+  // it from there. First defense against traversal: bare paths and anything
+  // containing ".." never enter the asset branch — they fall through to the
+  // shell below.
   const looksLikeAsset = sub.length > 0 && /\.[a-z0-9]+$/i.test(sub) && !sub.includes("..");
   if (!looksLikeAsset) {
     return new Response(Bun.file(indexPath), {
@@ -313,7 +314,8 @@ async function serveSpa(spaDistDir: string, pathname: string): Promise<Response>
   }
 
   const filePath = resolve(spaDistDir, `.${sub}`);
-  // Belt-and-braces: if resolution lands outside dist/, deny.
+  // Second defense: even if a future tweak loosens looksLikeAsset, refuse
+  // any resolved path that escapes dist/. Belt-and-braces.
   if (!filePath.startsWith(`${spaDistDir}/`)) {
     return new Response("not found", { status: 404 });
   }

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -37,7 +37,8 @@
 
 import type { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   handleAdminConfigGet,
   handleAdminConfigPost,
@@ -45,6 +46,7 @@ import {
   handleAdminLoginPost,
   handleAdminLogoutPost,
 } from "./admin-handlers.ts";
+import { handleHostAdminToken } from "./admin-host-admin-token.ts";
 import { handleCreateVault } from "./admin-vaults.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import { HUB_SVC, clearHubPort, writeHubPort } from "./hub-control.ts";
@@ -220,6 +222,111 @@ export interface HubFetchDeps {
    * the doc reflect `parachute vault create` etc. without re-running expose.
    */
   manifestPath?: string;
+  /**
+   * Directory containing the built SPA bundle (`index.html` + `assets/`). When
+   * absent, the hub auto-resolves to `<repo>/web/ui/dist/` — handy for the
+   * default bun-linked checkout. Tests point this at a fixture (or omit it +
+   * disable the mount). When the dir doesn't exist on disk, `/hub/*` routes
+   * 503 with a "run `bun run build` in web/ui" hint.
+   */
+  spaDistDir?: string;
+}
+
+/**
+ * Resolve the SPA bundle dir. We anchor to this file's location so a
+ * `bun src/hub-server.ts` from any cwd still finds `<repo>/web/ui/dist/`.
+ * Tests / production override via `HubFetchDeps.spaDistDir`.
+ */
+function defaultSpaDistDir(): string {
+  // import.meta.dir is the dir holding *this* file (`src/`); the SPA bundle
+  // sits at `<repo>/web/ui/dist/`, two hops up + over.
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, "..", "web", "ui", "dist");
+}
+
+const SPA_MOUNT = "/hub";
+
+/**
+ * Pick a content type for static assets the SPA build produces. Vite's
+ * standard fingerprinted output is the realistic surface — js / css / svg /
+ * png / woff2 / ico. We don't reach for a full mime db; mismatches show up
+ * loud (a `.js` served as `text/html` is unmistakable) and the list is
+ * trivially extensible if a future feature adds an asset type.
+ */
+function spaContentType(pathname: string): string {
+  const ext = pathname.slice(pathname.lastIndexOf(".") + 1).toLowerCase();
+  switch (ext) {
+    case "html":
+      return "text/html; charset=utf-8";
+    case "js":
+    case "mjs":
+      return "application/javascript; charset=utf-8";
+    case "css":
+      return "text/css; charset=utf-8";
+    case "svg":
+      return "image/svg+xml";
+    case "png":
+      return "image/png";
+    case "ico":
+      return "image/x-icon";
+    case "woff2":
+      return "font/woff2";
+    case "woff":
+      return "font/woff";
+    case "json":
+      return "application/json";
+    case "map":
+      return "application/json";
+    case "txt":
+      return "text/plain; charset=utf-8";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+/**
+ * Serve a single file under the SPA mount, falling back to `index.html`
+ * for client-side-routed paths (anything that doesn't resolve to a real
+ * file under `dist/`). Path-traversal guard is the substring check on
+ * the resolved absolute path — Bun.file gives us no built-in clamp.
+ */
+async function serveSpa(spaDistDir: string, pathname: string): Promise<Response> {
+  if (!existsSync(spaDistDir)) {
+    return new Response(
+      "hub SPA bundle not found — run `bun run build` in web/ui/ to produce dist/",
+      { status: 503, headers: { "content-type": "text/plain; charset=utf-8" } },
+    );
+  }
+  // Strip the mount prefix; "/hub" → "", "/hub/" → "/", "/hub/x" → "/x".
+  const sub = pathname === SPA_MOUNT ? "" : pathname.slice(SPA_MOUNT.length);
+  const indexPath = join(spaDistDir, "index.html");
+
+  // Empty / mount-root / any non-asset request → SPA shell. The router takes
+  // it from there. Path traversal can't escape because we only construct a
+  // candidate path for assets that look like static files (have an extension
+  // and don't contain "..") — bare paths get the shell.
+  const looksLikeAsset = sub.length > 0 && /\.[a-z0-9]+$/i.test(sub) && !sub.includes("..");
+  if (!looksLikeAsset) {
+    return new Response(Bun.file(indexPath), {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  }
+
+  const filePath = resolve(spaDistDir, `.${sub}`);
+  // Belt-and-braces: if resolution lands outside dist/, deny.
+  if (!filePath.startsWith(`${spaDistDir}/`)) {
+    return new Response("not found", { status: 404 });
+  }
+  if (!existsSync(filePath)) {
+    // Asset request that doesn't resolve to a real file → SPA shell.
+    // (e.g. `/hub/vaults` with a typo'd extension shouldn't 404 the page.)
+    return new Response(Bun.file(indexPath), {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  }
+  return new Response(Bun.file(filePath), {
+    headers: { "content-type": spaContentType(filePath) },
+  });
 }
 
 export function hubFetch(
@@ -230,6 +337,7 @@ export function hubFetch(
   const getDb = deps?.getDb;
   const configuredIssuer = deps?.issuer;
   const manifestPath = deps?.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const spaDistDir = deps?.spaDistDir ?? defaultSpaDistDir();
 
   const oauthDeps = (req: Request) => ({
     issuer: configuredIssuer ?? new URL(req.url).origin,
@@ -376,6 +484,23 @@ export function hubFetch(
         return new Response("hub db not configured", { status: 503 });
       }
       return handleCreateVault(req, {
+        db: getDb(),
+        issuer: oauthDeps(req).issuer,
+      });
+    }
+
+    // Hub vault-management SPA. Mount root + nested routes both land here;
+    // serveSpa picks index.html vs. an asset by extension. Only GET — POSTs
+    // for vault create go to /vaults, not the SPA mount. (HEAD is harmless
+    // but we keep the contract narrow.)
+    if (pathname === SPA_MOUNT || pathname.startsWith(`${SPA_MOUNT}/`)) {
+      if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
+      return serveSpa(spaDistDir, pathname);
+    }
+
+    if (pathname === "/admin/host-admin-token") {
+      if (!getDb) return new Response("hub db not configured", { status: 503 });
+      return handleHostAdminToken(req, {
         db: getDb(),
         issuer: oauthDeps(req).issuer,
       });

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -77,9 +77,17 @@ export const FIRST_PARTY_SCOPES = Object.keys(SCOPE_EXPLANATIONS).sort();
 
 /**
  * Scopes the hub will not mint via the public OAuth flow. Operator-only —
- * available exclusively through the local operator-token mint path
- * (`parachute auth rotate-operator`), which doesn't traverse
- * `/oauth/authorize`. Listed here so the issuer can:
+ * available exclusively through local mint paths that have already proven
+ * the caller is the on-box operator:
+ *
+ *   - `parachute auth rotate-operator` writes the long-lived operator token
+ *     (`~/.parachute/operator.token`, mode 0600) for service accounts.
+ *   - `GET /admin/host-admin-token` exchanges a valid `parachute_hub_session`
+ *     cookie (set by `/admin/login` after a password check) for a
+ *     short-lived JWT consumed by the in-tree vault-management SPA.
+ *
+ * Both surfaces predicate on local-operator identity that the public OAuth
+ * flow can't establish. Listed here so the issuer can:
  *
  *   1. Reject early at `/oauth/authorize` with RFC 6749 `invalid_scope`
  *      rather than letting the request walk to the consent screen.

--- a/web/ui/CLAUDE.md
+++ b/web/ui/CLAUDE.md
@@ -1,0 +1,94 @@
+# Hub web UI
+
+Vite + React + TypeScript SPA mounted at `/hub/` on the running hub. Serves
+the vault management surface (Phase 1: list + create; Phase 2+ will add
+mint/revoke/config).
+
+## Mount-aware contract
+
+The same bundle has to work two places:
+
+- **Production / tailnet** — served by `src/hub-server.ts` at `/hub/*`.
+  Vite's `base` defaults to `/hub/` (`vite.config.ts`), so asset URLs come
+  out as `/hub/assets/...` and react-router's `basename` resolves to
+  `/hub`.
+- **Dev** (`bun run dev`) — Vite serves at `http://127.0.0.1:5174/hub/`
+  with a proxy that forwards `/admin`, `/vaults`, and `/.well-known` to
+  `HUB_ORIGIN` (default `http://127.0.0.1:1939`). Override the base with
+  `VITE_BASE_PATH=/` if you need to dev against the origin root.
+
+`scripts/verify-base.mjs` runs after every build and aborts if
+`dist/index.html` doesn't carry the `/hub/`-prefixed asset URLs — same
+regression check paraclaw#25 codified after a silent base-drift.
+
+**Lesson: never hardcode a leading-slash URL** in `Link to=`, `fetch`,
+or `<a href>`. `Link` resolves against `BASE_URL` automatically; `fetch`
+calls hit the origin root regardless of mount, which is what we want for
+`/.well-known/parachute.json` and `/vaults`. If you need the mounted
+prefix, use `import.meta.env.BASE_URL`.
+
+## Auth
+
+The SPA leans on the hub's existing `parachute_hub_session` cookie
+instead of running its own OAuth dance. `src/lib/auth.ts:getHostAdminToken()`
+hits `GET /admin/host-admin-token`, which trades the session cookie for
+a short-lived JWT carrying `parachute:host:admin`.
+
+That scope is in `NON_REQUESTABLE_SCOPES` server-side, so the public
+`/oauth/authorize` flow refuses to mint it — only the session-cookie
+path can. See `src/scope-explanations.ts` for why and how to extend the
+list.
+
+The cached JWT lives in module-scoped state — never `localStorage`. Page
+snapshots can't carry it past a refresh, and the XSS surface is the
+narrowest possible.
+
+## Layout
+
+```
+web/ui/
+├── index.html              # vite entry, mounts #root
+├── package.json            # @openparachute/hub-web-ui
+├── vite.config.ts          # base=/hub/ + dev proxy
+├── vitest.config.ts        # jsdom + setup file
+├── tsconfig.json
+├── scripts/verify-base.mjs # post-build regression check
+└── src/
+    ├── main.tsx            # BrowserRouter w/ mount-aware basename
+    ├── App.tsx             # nav + Routes
+    ├── styles.css          # brand tokens (kept in sync with oauth-ui.ts)
+    ├── lib/
+    │   ├── auth.ts         # session→JWT mint, in-memory cache
+    │   └── api.ts          # listVaults + createVault
+    ├── routes/
+    │   ├── VaultsList.tsx  # /vaults
+    │   ├── NewVault.tsx    # /vaults/new (single-emit pvt_* banner)
+    │   └── VaultDetail.tsx # /vaults/:name (Phase 2 placeholder)
+    └── test/setup.ts
+```
+
+## Build + dev
+
+```sh
+cd web/ui
+bun install
+bun run dev          # http://127.0.0.1:5174/hub/  (proxies to :1939)
+bun run build        # → dist/  (then verify-base.mjs)
+bun run typecheck    # tsc --noEmit
+bun run test         # vitest run
+```
+
+`web/ui/dist/` is committed in `.gitignore` — the hub serves it from a
+co-located bundle that Vite produces during release builds. Until a
+release pipeline lands, run `bun run build` locally; `src/hub-server.ts`
+handles a missing `dist/` by 503ing the `/hub/*` routes with a hint to
+build the SPA.
+
+## Brand tokens
+
+`src/styles.css` is the single source of truth for the SPA's palette,
+typography, and components. The tokens (`--accent`, `--bg`, etc.) are
+lifted from `src/oauth-ui.ts` and `src/admin-config-ui.ts` so the SPA
+stays visually continuous with the password-login → consent flow the
+operator just walked through. Don't drift them without updating both
+server-rendered surfaces.

--- a/web/ui/bun.lock
+++ b/web/ui/bun.lock
@@ -1,0 +1,503 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@openparachute/hub-web-ui",
+      "dependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-router-dom": "^7.0.0",
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^22.19.17",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^4.3.0",
+        "@vitest/ui": "^4.1.5",
+        "jsdom": "^25.0.1",
+        "typescript": "^5.6.0",
+        "vite": "^6.0.0",
+        "vitest": "^4.1.5",
+      },
+    },
+  },
+  "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.3", "", {}, "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg=="],
+
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
+    "@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@3.1.0", "", { "dependencies": { "@csstools/color-helpers": "^5.1.0", "@csstools/css-calc": "^2.1.4" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.2", "", { "os": "android", "cpu": "arm64" }, "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.2", "", { "os": "none", "cpu": "arm64" }, "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.5", "", { "dependencies": { "@vitest/spy": "4.1.5", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.5", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.5", "", { "dependencies": { "@vitest/utils": "4.1.5", "pathe": "^2.0.3" } }, "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "@vitest/utils": "4.1.5", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.5", "", {}, "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ=="],
+
+    "@vitest/ui": ["@vitest/ui@4.1.5", "", { "dependencies": { "@vitest/utils": "4.1.5", "fflate": "^0.8.2", "flatted": "^3.4.2", "pathe": "^2.0.3", "sirv": "^3.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "vitest": "4.1.5" } }, "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.25", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001791", "", {}, "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
+    "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.349", "", {}, "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A=="],
+
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsdom": ["jsdom@25.0.1", "", { "dependencies": { "cssstyle": "^4.1.0", "data-urls": "^5.0.0", "decimal.js": "^10.4.3", "form-data": "^4.0.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.5", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.12", "parse5": "^7.1.2", "rrweb-cssom": "^0.7.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.0.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^2.11.2" }, "optionalPeers": ["canvas"] }, "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
+    "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
+
+    "nwsapi": ["nwsapi@2.2.23", "", {}, "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="],
+
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.13", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
+    "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "react-router": ["react-router@7.14.2", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw=="],
+
+    "react-router-dom": ["react-router-dom@7.14.2", "", { "dependencies": { "react-router": "7.14.2" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ=="],
+
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
+
+    "rrweb-cssom": ["rrweb-cssom@0.7.1", "", {}, "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
+
+    "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
+
+    "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
+
+    "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
+
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
+
+    "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
+  }
+}

--- a/web/ui/index.html
+++ b/web/ui/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Parachute Hub</title>
+    <meta name="description" content="Manage vaults registered with this Parachute hub." />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@openparachute/hub-web-ui",
+  "version": "0.0.1-rc.1",
+  "private": true,
+  "description": "Hub web UI — Vite + React + TypeScript. Vault management SPA mounted under /hub/.",
+  "license": "AGPL-3.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build && node scripts/verify-base.mjs",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^22.19.17",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "@vitest/ui": "^4.1.5",
+    "jsdom": "^25.0.1",
+    "typescript": "^5.6.0",
+    "vite": "^6.0.0",
+    "vitest": "^4.1.5"
+  }
+}

--- a/web/ui/scripts/verify-base.mjs
+++ b/web/ui/scripts/verify-base.mjs
@@ -1,0 +1,30 @@
+// Regression check mirroring paraclaw's verify-base: the canonical-mount
+// default build must produce asset URLs prefixed with `/hub/`. If
+// `vite.config.ts`'s `base` ever drifts back to `/`, the bundle HTML loses
+// the prefix and 404s under the hub mount — the same silent failure
+// paraclaw#25 codified in mount-path-convention.md.
+//
+// Skipped when VITE_BASE_PATH is set explicitly (legitimate override).
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const override = process.env.VITE_BASE_PATH;
+if (override && override !== "/hub/") {
+  console.log(`verify-base: VITE_BASE_PATH=${override} (override) — skipping default-mount check.`);
+  process.exit(0);
+}
+
+const html = readFileSync(resolve("dist/index.html"), "utf8");
+const wantPrefix = "/hub/assets/";
+const hasMounted = html.includes(`src="${wantPrefix}`) || html.includes(`href="${wantPrefix}`);
+if (!hasMounted) {
+  console.error(
+    "✖ verify-base: dist/index.html is missing /hub/-prefixed asset URLs.\n" +
+      "  This means vite's `base` resolved to something other than `/hub/`.\n" +
+      "  Check web/ui/vite.config.ts (default should be `/hub/`) and any\n" +
+      "  VITE_BASE_PATH env var leaking into the build environment.",
+  );
+  process.exit(1);
+}
+console.log("verify-base: ✓ dist/index.html references /hub/-prefixed assets.");

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,0 +1,35 @@
+import { Link, Route, Routes } from "react-router-dom";
+import { NewVault } from "./routes/NewVault.tsx";
+import { VaultDetail } from "./routes/VaultDetail.tsx";
+import { VaultsList } from "./routes/VaultsList.tsx";
+
+export function App() {
+  return (
+    <div className="page">
+      <nav className="nav">
+        <Link to="/vaults" className="brand">
+          Parachute Hub <span className="sub">vault management</span>
+        </Link>
+        <Link to="/vaults">Vaults</Link>
+        <a href="/" title="Hub discovery page (top-level)">
+          Discovery
+        </a>
+      </nav>
+
+      <Routes>
+        <Route path="/" element={<VaultsList />} />
+        <Route path="/vaults" element={<VaultsList />} />
+        <Route path="/vaults/new" element={<NewVault />} />
+        <Route path="/vaults/:name" element={<VaultDetail />} />
+        <Route
+          path="*"
+          element={
+            <div className="empty">
+              404 — back to <Link to="/vaults">vaults</Link>.
+            </div>
+          }
+        />
+      </Routes>
+    </div>
+  );
+}

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -132,6 +132,28 @@ describe("createVault", () => {
     );
   });
 
+  it("on 200 idempotent re-POST returns the existing entry without a token", async () => {
+    // Server short-circuits when the vault already exists: same name + url +
+    // version, but no fresh `token` (we only emit once, on first create).
+    // NewVault.tsx must handle the missing-token branch without claiming
+    // success-with-banner.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(200, {
+          name: "work",
+          url: "http://hub.local/vault/work/",
+          version: "0.5.1",
+        }),
+      ),
+    );
+    const api = await import("./api.ts");
+    const result = await api.createVault({ name: "work" });
+    expect(result.name).toBe("work");
+    expect(result.token).toBeUndefined();
+    expect(result.paths).toBeUndefined();
+  });
+
   it("on 401 clears the cached token and throws HttpError(401)", async () => {
     vi.stubGlobal(
       "fetch",

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -1,0 +1,164 @@
+/**
+ * api.ts unit tests — list + create flows.
+ *
+ * `listVaults` is anonymous (no Bearer); `createVault` mints + sends one.
+ * The mock surface is `fetch` for the wire, plus `./auth.ts` for the
+ * mint helper. We don't exercise the real auth flow here — that's
+ * covered separately — only that the Bearer makes it onto the request
+ * and that 401/403 causes `clearCachedToken` to fire so the next
+ * mint attempt redirects to /admin/login.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as auth from "./auth.ts";
+
+vi.mock("./auth.ts", () => ({
+  getHostAdminToken: vi.fn(),
+  clearCachedToken: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.mocked(auth.getHostAdminToken).mockResolvedValue("test-bearer");
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("listVaults", () => {
+  it("derives path from services entry when present", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(200, {
+        vaults: [{ name: "work", url: "http://hub.local/vault/work/", version: "0.5.1" }],
+        services: [{ name: "parachute-vault-work", path: "/vault/work" }],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = await import("./api.ts");
+    const vaults = await api.listVaults();
+
+    expect(vaults).toEqual([
+      {
+        name: "work",
+        url: "http://hub.local/vault/work/",
+        version: "0.5.1",
+        path: "/vault/work",
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/.well-known/parachute.json",
+      expect.objectContaining({ headers: { accept: "application/json" } }),
+    );
+  });
+
+  it("falls back to URL pathname when services entry is missing", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(200, {
+          vaults: [{ name: "scratch", url: "http://hub.local/vault/scratch", version: "0.5.1" }],
+        }),
+      ),
+    );
+    const api = await import("./api.ts");
+    const vaults = await api.listVaults();
+    expect(vaults[0]?.path).toBe("/vault/scratch");
+  });
+
+  it("throws HttpError on non-2xx", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 503 })),
+    );
+    const api = await import("./api.ts");
+    await expect(api.listVaults()).rejects.toMatchObject({
+      name: "HttpError",
+      status: 503,
+    });
+  });
+
+  it("returns [] when the doc has no vaults key", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(200, { services: [] })),
+    );
+    const api = await import("./api.ts");
+    expect(await api.listVaults()).toEqual([]);
+  });
+});
+
+describe("createVault", () => {
+  it("sends Bearer + JSON body and returns the parsed result", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(201, {
+        name: "work",
+        url: "http://hub.local/vault/work/",
+        version: "0.5.1",
+        token: "pvt_abc123",
+        paths: {
+          vault_dir: "/home/u/.parachute/vault/work",
+          vault_db: "/home/u/.parachute/vault/work/vault.db",
+          vault_config: "/home/u/.parachute/vault/work/config.yaml",
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = await import("./api.ts");
+    const result = await api.createVault({ name: "work" });
+
+    expect(result.token).toBe("pvt_abc123");
+    expect(result.paths?.vault_dir).toContain("/vault/work");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/vaults",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          authorization: "Bearer test-bearer",
+          "content-type": "application/json",
+        }),
+        body: JSON.stringify({ name: "work" }),
+      }),
+    );
+  });
+
+  it("on 401 clears the cached token and throws HttpError(401)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(401, { error: "unauthenticated", error_description: "bad" })),
+    );
+    const api = await import("./api.ts");
+    await expect(api.createVault({ name: "x" })).rejects.toMatchObject({
+      name: "HttpError",
+      status: 401,
+    });
+    expect(auth.clearCachedToken).toHaveBeenCalled();
+  });
+
+  it("surfaces error_description from the body when present", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(400, {
+          error: "invalid_request",
+          error_description: '"name" must be a non-empty string',
+        }),
+      ),
+    );
+    const api = await import("./api.ts");
+    await expect(api.createVault({ name: "" })).rejects.toMatchObject({
+      status: 400,
+      message: '"name" must be a non-empty string',
+    });
+  });
+});

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -110,6 +110,13 @@ export async function createVault(input: CreateVaultInput): Promise<CreateVaultR
     // the cached JWT lapsed mid-flight. Drop the cache; the auth helper
     // navigates to /admin/login on the next mint attempt if the cookie has
     // also expired. Surface the 401 so the form can re-issue cleanly.
+    //
+    // Deliberate: we don't auto-mint-and-retry transparently. A failed
+    // POST gets surfaced to the operator and a re-click drives the next
+    // attempt — which mints fresh after `clearCachedToken`. Manual retry
+    // keeps a stale-token mid-submit visible (vs. silently swallowing
+    // a state mismatch) and avoids retrying a request the user might
+    // not actually want repeated.
     clearCachedToken();
     throw new HttpError(res.status, await readError(res));
   }

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1,0 +1,133 @@
+/**
+ * HTTP client for the hub SPA. Two surfaces:
+ *
+ *   - `/.well-known/parachute.json` — public discovery doc (no auth).
+ *   - `/vaults` — admin endpoint (POST creates, requires
+ *     `parachute:host:admin` Bearer).
+ *
+ * The Bearer comes from `lib/auth.ts:getHostAdminToken()`, which trades
+ * the `parachute_hub_session` cookie for a short-lived JWT. On 401 from
+ * the admin endpoint after a fresh mint, the auth helper navigates the
+ * browser to /admin/login — we don't try to recover.
+ */
+import { clearCachedToken, getHostAdminToken } from "./auth.ts";
+
+export interface VaultListing {
+  name: string;
+  url: string;
+  version: string;
+  /** Path under the hub origin where the vault is mounted (e.g. /vault/work). */
+  path: string;
+}
+
+export interface CreateVaultInput {
+  name: string;
+}
+
+export interface CreateVaultResult {
+  name: string;
+  url: string;
+  version: string;
+  /** Single-emit `pvt_*` token from `parachute-vault create --json`. Only on first creation. */
+  token?: string;
+  paths?: {
+    vault_dir: string;
+    vault_db: string;
+    vault_config: string;
+  };
+}
+
+/** Status code carried alongside the message so callers can branch numerically. */
+export class HttpError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "HttpError";
+  }
+}
+
+/**
+ * Fetch the well-known discovery doc. Anonymous — no Bearer needed. The hub
+ * serves this at the origin root with `Access-Control-Allow-Origin: *` so a
+ * cross-origin SPA could read it too, but ours is same-origin.
+ */
+export async function listVaults(): Promise<VaultListing[]> {
+  const res = await fetch("/.well-known/parachute.json", {
+    headers: { accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new HttpError(res.status, `well-known fetch failed: ${res.status}`);
+  }
+  const body = (await res.json()) as {
+    vaults?: Array<{ name: string; url: string; version: string }>;
+    services?: Array<{ name: string; path: string }>;
+  };
+  const vaults = body.vaults ?? [];
+  const services = body.services ?? [];
+  return vaults.map((v) => ({
+    name: v.name,
+    url: v.url,
+    version: v.version,
+    path: pathFor(v.name, v.url, services),
+  }));
+}
+
+function pathFor(
+  name: string,
+  url: string,
+  services: Array<{ name: string; path: string }>,
+): string {
+  // Prefer the well-known `services` entry's path — it's the canonical mount
+  // the hub itself uses for routing. Fall back to deriving from the URL's
+  // pathname when the entry is missing (older hubs / odd shapes).
+  const match = services.find(
+    (s) => s.name === `parachute-vault-${name}` || s.path === `/vault/${name}`,
+  );
+  if (match) return match.path;
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return `/vault/${name}`;
+  }
+}
+
+/** POST /vaults — create a new vault. Requires `parachute:host:admin`. */
+export async function createVault(input: CreateVaultInput): Promise<CreateVaultResult> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch("/vaults", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json",
+      authorization: `Bearer ${bearer}`,
+    },
+    body: JSON.stringify(input),
+  });
+  if (res.status === 401 || res.status === 403) {
+    // Token didn't carry the scope (shouldn't happen — mint ensures it) OR
+    // the cached JWT lapsed mid-flight. Drop the cache; the auth helper
+    // navigates to /admin/login on the next mint attempt if the cookie has
+    // also expired. Surface the 401 so the form can re-issue cleanly.
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  return (await res.json()) as CreateVaultResult;
+}
+
+async function readError(res: Response): Promise<string> {
+  try {
+    const text = await res.text();
+    const parsed = JSON.parse(text) as { error?: string; error_description?: string };
+    if (parsed.error_description) return parsed.error_description;
+    if (parsed.error) return parsed.error;
+    if (text) return text;
+  } catch {
+    // not JSON
+  }
+  return `${res.status} ${res.statusText}`;
+}

--- a/web/ui/src/lib/auth.test.ts
+++ b/web/ui/src/lib/auth.test.ts
@@ -1,0 +1,122 @@
+/**
+ * auth.ts unit tests — token cache + 401 redirect.
+ *
+ * The module holds module-scoped state (cached token, in-flight
+ * promise). Each test does a dynamic import after `vi.resetModules()`
+ * so the cache starts empty.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("getHostAdminToken", () => {
+  it("fetches the mint endpoint and caches the result", async () => {
+    const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(200, {
+        token: "jwt-1",
+        expires_at: expiresAt,
+        scopes: ["parachute:host:admin"],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const auth = await import("./auth.ts");
+    expect(await auth.getHostAdminToken()).toBe("jwt-1");
+    // Second call hits the cache, not the wire.
+    expect(await auth.getHostAdminToken()).toBe("jwt-1");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/admin/host-admin-token",
+      expect.objectContaining({ credentials: "same-origin" }),
+    );
+  });
+
+  it("on 401 calls window.location.replace with /admin/login?next=…", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 401 })),
+    );
+    const replace = vi.fn();
+    vi.stubGlobal("window", {
+      location: { pathname: "/vaults/new", search: "?x=1", replace },
+    } as unknown as Window & typeof globalThis);
+
+    const auth = await import("./auth.ts");
+    // The promise hangs by design — we only need to assert the redirect
+    // fired. Race the promise against a microtask flush so the test
+    // doesn't hang on the never-resolving Promise.
+    void auth.getHostAdminToken();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(replace).toHaveBeenCalledWith(
+      `/admin/login?next=${encodeURIComponent("/vaults/new?x=1")}`,
+    );
+  });
+
+  it("dedupes concurrent in-flight mint requests", async () => {
+    let resolveFetch: (r: Response) => void = () => {};
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const auth = await import("./auth.ts");
+    const a = auth.getHostAdminToken();
+    const b = auth.getHostAdminToken();
+    resolveFetch(
+      jsonResponse(200, {
+        token: "jwt-shared",
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+        scopes: ["parachute:host:admin"],
+      }),
+    );
+    expect(await a).toBe("jwt-shared");
+    expect(await b).toBe("jwt-shared");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches when the cached token is within the refresh buffer of expiry", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          token: "jwt-near-expiry",
+          // 10s out — well inside the 30s refresh buffer.
+          expires_at: new Date(Date.now() + 10_000).toISOString(),
+          scopes: ["parachute:host:admin"],
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          token: "jwt-fresh",
+          expires_at: new Date(Date.now() + 600_000).toISOString(),
+          scopes: ["parachute:host:admin"],
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const auth = await import("./auth.ts");
+    expect(await auth.getHostAdminToken()).toBe("jwt-near-expiry");
+    expect(await auth.getHostAdminToken()).toBe("jwt-fresh");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -1,0 +1,106 @@
+/**
+ * Auth helper for the hub SPA. Unlike paraclaw's hub-as-issuer OAuth flow,
+ * this SPA is served BY the hub itself — so it leans on the existing
+ * password-gated `/admin/login` session cookie instead of running its own
+ * OAuth dance.
+ *
+ * Flow:
+ *   1. SPA bootstrap calls `getHostAdminToken()`.
+ *   2. That hits `GET /admin/host-admin-token`. The endpoint:
+ *      - reads `parachute_hub_session` cookie (set by /admin/login)
+ *      - mints a short-lived (~10 min) JWT carrying `parachute:host:admin`
+ *        and returns it as JSON.
+ *   3. Token is held in module-scoped state — NOT localStorage. Page
+ *      snapshots can't carry it past a refresh, and XSS surface is the
+ *      narrowest possible.
+ *   4. On 401, redirect the browser to `/admin/login?next=<current path>`.
+ *      The hub's standard login form then cookie-signs the operator and
+ *      bounces back here.
+ *
+ * The narrow `parachute:host:admin` scope is in `NON_REQUESTABLE_SCOPES`
+ * server-side, so the public `/oauth/authorize` flow refuses to mint it.
+ * Only this session-cookie path can — see hub#scope-explanations.ts.
+ */
+
+interface MintedToken {
+  token: string;
+  expiresAt: number; // epoch ms
+}
+
+let cached: MintedToken | null = null;
+let inFlight: Promise<string> | null = null;
+
+/** Minimum slack we keep on the cached token before refetching. */
+const REFRESH_BUFFER_MS = 30_000;
+
+function tokenEndpoint(): string {
+  // Mount-aware: BASE_URL is `/hub/` in production builds, `/` in dev. The
+  // mint endpoint sits at the origin root (`/admin/host-admin-token`) — same
+  // origin in both modes, so we never prefix with BASE_URL here.
+  return "/admin/host-admin-token";
+}
+
+function loginRedirectUrl(): string {
+  // Round-trip the *current* SPA URL — origin + pathname + search — so the
+  // post-login redirect drops the operator back where they started. Hash is
+  // intentionally dropped: the /admin/login `next=` param is server-rendered
+  // and doesn't survive a fragment round-trip cleanly.
+  const next = `${window.location.pathname}${window.location.search}`;
+  return `/admin/login?next=${encodeURIComponent(next)}`;
+}
+
+/**
+ * Returns the cached host-admin JWT, refreshing it if it's about to expire
+ * (or if we don't have one yet). Concurrent callers share the in-flight
+ * fetch — we don't want a burst of API calls to mint a token each.
+ *
+ * On 401 (no admin session), navigates the browser to /admin/login and
+ * returns a never-resolving Promise so callers don't try to use a missing
+ * token. Caller code does not need to check for null.
+ */
+export async function getHostAdminToken(): Promise<string> {
+  const now = Date.now();
+  if (cached && cached.expiresAt - now > REFRESH_BUFFER_MS) {
+    return cached.token;
+  }
+  if (inFlight) return inFlight;
+  inFlight = fetchToken().finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}
+
+async function fetchToken(): Promise<string> {
+  const res = await fetch(tokenEndpoint(), {
+    method: "GET",
+    headers: { accept: "application/json" },
+    credentials: "same-origin",
+  });
+  if (res.status === 401) {
+    cached = null;
+    window.location.replace(loginRedirectUrl());
+    // Hang — the navigation will tear down this page. Returning a rejected
+    // promise would surface "session expired" errors the operator can't act
+    // on; the right UX is "you've already left."
+    return new Promise<string>(() => {});
+  }
+  if (!res.ok) {
+    throw new Error(`/admin/host-admin-token failed: ${res.status} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { token: string; expires_at: string };
+  if (!body.token || !body.expires_at) {
+    throw new Error("/admin/host-admin-token returned malformed body");
+  }
+  cached = { token: body.token, expiresAt: new Date(body.expires_at).getTime() };
+  return body.token;
+}
+
+/** Drop the cached token. Useful after sign-out or an explicit invalidation. */
+export function clearCachedToken(): void {
+  cached = null;
+}
+
+/** Test seam: replace the cached token directly. */
+export function _setCachedTokenForTest(token: string, expiresAt: number): void {
+  cached = { token, expiresAt };
+}

--- a/web/ui/src/main.tsx
+++ b/web/ui/src/main.tsx
@@ -1,0 +1,20 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { App } from "./App.tsx";
+import "./styles.css";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("#root not found");
+
+// `basename` is mount-aware: production builds use `/hub/`, dev uses `/`.
+// Stripping the trailing slash matches react-router's expectation. Without
+// this the SPA's <Link to="/vaults"> would resolve to /vaults at the origin
+// root, blowing past the hub's reverse proxy and 404ing on tailnet.
+createRoot(root).render(
+  <StrictMode>
+    <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, "")}>
+      <App />
+    </BrowserRouter>
+  </StrictMode>,
+);

--- a/web/ui/src/routes/NewVault.test.tsx
+++ b/web/ui/src/routes/NewVault.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * NewVault smoke tests — validation, submit, single-emit token banner.
+ *
+ * We mock `../lib/api.ts:createVault` so the form's submit path is
+ * exercised without touching the wire. The token banner is the
+ * single-emit surface — once it renders, the operator must dismiss
+ * before the navigate fires.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import { NewVault } from "./NewVault.tsx";
+
+vi.mock("../lib/api.ts", async () => {
+  const actual = await vi.importActual<typeof api>("../lib/api.ts");
+  return {
+    ...actual,
+    createVault: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderForm() {
+  return render(
+    <MemoryRouter initialEntries={["/vaults/new"]}>
+      <Routes>
+        <Route path="/vaults/new" element={<NewVault />} />
+        <Route path="/vaults/:name" element={<div>detail</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("NewVault", () => {
+  it("disables submit until a valid name is entered", async () => {
+    renderForm();
+    const user = userEvent.setup();
+    const input = screen.getByLabelText(/vault name/i);
+    const submit = screen.getByRole("button", { name: /create vault/i });
+
+    expect(submit).toBeDisabled();
+    await user.type(input, "work!");
+    expect(
+      screen.getByText(/letters, numbers, hyphens, and underscores only/i),
+    ).toBeInTheDocument();
+    expect(submit).toBeDisabled();
+
+    await user.clear(input);
+    await user.type(input, "work");
+    expect(submit).toBeEnabled();
+  });
+
+  it("rejects 'list' as a reserved name", async () => {
+    renderForm();
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/vault name/i), "list");
+    expect(screen.getByText(/reserved name/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create vault/i })).toBeDisabled();
+  });
+
+  it("renders the single-emit token banner on a 201 with token", async () => {
+    vi.mocked(api.createVault).mockResolvedValue({
+      name: "work",
+      url: "http://hub.local/vault/work/",
+      version: "0.5.1",
+      token: "pvt_abc123secret",
+      paths: {
+        vault_dir: "/home/u/.parachute/vault/work",
+        vault_db: "/home/u/.parachute/vault/work/vault.db",
+        vault_config: "/home/u/.parachute/vault/work/config.yaml",
+      },
+    });
+    renderForm();
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/vault name/i), "work");
+    await user.click(screen.getByRole("button", { name: /create vault/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/your vault token \(shown once\)/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText("pvt_abc123secret")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /done/i })).toBeInTheDocument();
+    expect(screen.getByText(/vault\.db/)).toBeInTheDocument();
+  });
+
+  it("renders the no-token branch on idempotent re-POST (200)", async () => {
+    vi.mocked(api.createVault).mockResolvedValue({
+      name: "work",
+      url: "http://hub.local/vault/work/",
+      version: "0.5.1",
+    });
+    renderForm();
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/vault name/i), "work");
+    await user.click(screen.getByRole("button", { name: /create vault/i }));
+
+    await waitFor(() => expect(screen.getByText(/already existed/i)).toBeInTheDocument());
+    expect(screen.queryByText(/shown once/i)).not.toBeInTheDocument();
+  });
+
+  it("surfaces the API error_description on failure", async () => {
+    const { HttpError } = await import("../lib/api.ts");
+    vi.mocked(api.createVault).mockRejectedValue(
+      new HttpError(400, "vault name must contain only letters, numbers, hyphens"),
+    );
+    renderForm();
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/vault name/i), "work");
+    await user.click(screen.getByRole("button", { name: /create vault/i }));
+
+    await waitFor(() => expect(screen.getByText(/couldn't create vault/i)).toBeInTheDocument());
+    expect(screen.getByText(/400: vault name must contain/i)).toBeInTheDocument();
+  });
+});

--- a/web/ui/src/routes/NewVault.tsx
+++ b/web/ui/src/routes/NewVault.tsx
@@ -1,0 +1,235 @@
+/**
+ * /vaults/new — create a new vault.
+ *
+ * Two-stage UI:
+ *   1. Form: ask for a name. Mirrors the CLI's validation (regex +
+ *      "list" reserved) client-side so the operator gets immediate
+ *      feedback, but the server is still authoritative — see admin-
+ *      vaults.ts for the canonical list.
+ *   2. Result: on 201 with `token`, render the single-emit `pvt_*`
+ *      banner with copy + a "Done" dismiss. The token is shown ONCE,
+ *      ever — refreshing the page or navigating away loses it; the hub
+ *      can't re-emit it. We block navigation away while the banner is
+ *      live so an accidental Back doesn't strand the operator.
+ *
+ * 200 (idempotent re-POST against an existing vault) is treated as
+ * success but renders without a token banner — there's nothing to copy
+ * because the original token was already emitted.
+ */
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { type CreateVaultResult, HttpError, createVault } from "../lib/api.ts";
+
+const VAULT_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const RESERVED_VAULT_NAMES = new Set(["list"]);
+
+type State =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "created"; result: CreateVaultResult }
+  | { kind: "error"; message: string };
+
+export function NewVault() {
+  const navigate = useNavigate();
+  const [name, setName] = useState("");
+  const [state, setState] = useState<State>({ kind: "idle" });
+
+  // Block accidental navigation while a single-emit token is on-screen.
+  // The browser's "leave this page?" dialog is the cheapest belt-and-
+  // braces — react-router won't intercept window.close, but it covers
+  // refresh + tab-close, which are the realistic mistakes here.
+  const hasUnsavedToken = state.kind === "created" && state.result.token != null;
+  useEffect(() => {
+    if (!hasUnsavedToken) return;
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [hasUnsavedToken]);
+
+  const validation = validateName(name);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (validation) return;
+    setState({ kind: "submitting" });
+    try {
+      const result = await createVault({ name });
+      setState({ kind: "created", result });
+    } catch (err) {
+      const message =
+        err instanceof HttpError
+          ? `${err.status}: ${err.message}`
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      setState({ kind: "error", message });
+    }
+  };
+
+  if (state.kind === "created") {
+    return (
+      <CreatedView
+        result={state.result}
+        onDone={() => navigate(`/vaults/${encodeURIComponent(state.result.name)}`)}
+      />
+    );
+  }
+
+  return (
+    <div>
+      <h2>Create a vault</h2>
+      <p className="muted">
+        A vault stores tokens, secrets, and notes scoped to this hub. The hub provisions it via{" "}
+        <code>parachute-vault create</code> on the host filesystem and registers it in{" "}
+        <code>services.json</code>.
+      </p>
+
+      {state.kind === "error" && (
+        <div className="error-banner">
+          Couldn't create vault: <code>{state.message}</code>
+        </div>
+      )}
+
+      <form onSubmit={onSubmit} className="section">
+        <div className="row">
+          <label htmlFor="vault-name">Vault name</label>
+          <input
+            id="vault-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. work, home, scratch"
+            disabled={state.kind === "submitting"}
+          />
+          {validation ? (
+            <div className="field-error">{validation}</div>
+          ) : (
+            <div className="field-hint">
+              Letters, numbers, hyphens, and underscores. Becomes the path under{" "}
+              <code>/vault/&lt;name&gt;</code>.
+            </div>
+          )}
+        </div>
+        <div className="actions">
+          <button
+            type="submit"
+            disabled={name.length === 0 || !!validation || state.kind === "submitting"}
+          >
+            {state.kind === "submitting" ? "Creating…" : "Create vault"}
+          </button>
+          <Link to="/vaults" className="muted">
+            Cancel
+          </Link>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function CreatedView({
+  result,
+  onDone,
+}: {
+  result: CreateVaultResult;
+  onDone: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = async () => {
+    if (!result.token) return;
+    try {
+      await navigator.clipboard.writeText(result.token);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard can fail in non-secure contexts; the token is still
+      // visible in the codebox for manual copy. Don't block the flow.
+    }
+  };
+
+  return (
+    <div>
+      <h2>Vault created</h2>
+
+      {result.token ? (
+        <div className="mint-banner">
+          <h3>Your vault token (shown once)</h3>
+          <p className="muted">
+            This is the only time the hub will show this token. Copy it and store it somewhere safe
+            — a password manager, the operator's notes, paraclaw's secrets store. If you lose it,
+            you'll need to mint a new one from the vault directly.
+          </p>
+          <div className="token-box">
+            <code>{result.token}</code>
+            <button type="button" onClick={onCopy} className="secondary">
+              {copied ? "Copied" : "Copy"}
+            </button>
+          </div>
+          <p className="warn">⚠ Don't navigate away until you've saved this token.</p>
+          <div className="actions">
+            <button type="button" onClick={onDone}>
+              Done — I've saved the token
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="section">
+          <p>
+            Vault <code>{result.name}</code> already existed; nothing new was minted. Use the
+            existing token, or mint a fresh one from the vault directly with{" "}
+            <code>parachute-vault mint-token</code>.
+          </p>
+          <div className="actions">
+            <Link to={`/vaults/${encodeURIComponent(result.name)}`}>
+              <button type="button">Continue</button>
+            </Link>
+          </div>
+        </div>
+      )}
+
+      <div className="kv section">
+        <div>Name</div>
+        <div>
+          <code>{result.name}</code>
+        </div>
+        <div>URL</div>
+        <div>
+          <code>{result.url}</code>
+        </div>
+        <div>Version</div>
+        <div>
+          <code>{result.version}</code>
+        </div>
+        {result.paths && (
+          <>
+            <div>Vault dir</div>
+            <div>
+              <code>{result.paths.vault_dir}</code>
+            </div>
+            <div>Database</div>
+            <div>
+              <code>{result.paths.vault_db}</code>
+            </div>
+            <div>Config</div>
+            <div>
+              <code>{result.paths.vault_config}</code>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function validateName(name: string): string | null {
+  if (name.length === 0) return null;
+  if (!VAULT_NAME_PATTERN.test(name)) {
+    return "Letters, numbers, hyphens, and underscores only.";
+  }
+  if (RESERVED_VAULT_NAMES.has(name)) {
+    return `"${name}" is a reserved name.`;
+  }
+  return null;
+}

--- a/web/ui/src/routes/VaultDetail.tsx
+++ b/web/ui/src/routes/VaultDetail.tsx
@@ -1,0 +1,117 @@
+/**
+ * /vaults/:name — vault detail.
+ *
+ * Phase 1 placeholder. Phase 2+ will surface token mint/revoke,
+ * attached-paraclaw-groups, and config edit. For now the page just
+ * confirms the vault exists in the well-known doc and links the
+ * operator to the vault's mounted URL.
+ */
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { type VaultListing, listVaults } from "../lib/api.ts";
+
+type State =
+  | { kind: "loading" }
+  | { kind: "ok"; vault: VaultListing }
+  | { kind: "missing" }
+  | { kind: "error"; message: string };
+
+export function VaultDetail() {
+  const { name } = useParams<{ name: string }>();
+  const [state, setState] = useState<State>({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!name) {
+      setState({ kind: "missing" });
+      return;
+    }
+    listVaults()
+      .then((vaults) => {
+        if (cancelled) return;
+        const vault = vaults.find((v) => v.name === name);
+        setState(vault ? { kind: "ok", vault } : { kind: "missing" });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ kind: "error", message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [name]);
+
+  if (state.kind === "loading") {
+    return (
+      <div>
+        <h2>Vault</h2>
+        <p className="muted">Loading…</p>
+      </div>
+    );
+  }
+  if (state.kind === "error") {
+    return (
+      <div>
+        <h2>Vault</h2>
+        <div className="error-banner">
+          <code>{state.message}</code>
+        </div>
+        <Link to="/vaults">← Back to vaults</Link>
+      </div>
+    );
+  }
+  if (state.kind === "missing") {
+    return (
+      <div>
+        <h2>Vault not found</h2>
+        <p className="muted">
+          No vault named <code>{name}</code> is registered with this hub.
+        </p>
+        <Link to="/vaults">← Back to vaults</Link>
+      </div>
+    );
+  }
+
+  const { vault } = state;
+  return (
+    <div>
+      <div className="list-header">
+        <h2>
+          Vault <code>{vault.name}</code>
+        </h2>
+        <Link to="/vaults" className="muted">
+          ← All vaults
+        </Link>
+      </div>
+
+      <div className="kv section">
+        <div>Name</div>
+        <div>
+          <code>{vault.name}</code>
+        </div>
+        <div>Mount</div>
+        <div>
+          <code>{vault.path}</code>
+        </div>
+        <div>URL</div>
+        <div>
+          <a href={vault.url} target="_blank" rel="noreferrer">
+            <code>{vault.url}</code>
+          </a>
+        </div>
+        <div>Version</div>
+        <div>
+          <code>{vault.version}</code>
+        </div>
+      </div>
+
+      <div className="section">
+        <p className="muted">
+          Token mint/revoke, paraclaw attachments, and config editing land here in Phase 2. For now,
+          manage the vault directly with <code>parachute-vault</code> on the host.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web/ui/src/routes/VaultsList.test.tsx
+++ b/web/ui/src/routes/VaultsList.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * VaultsList smoke tests — loading → ok / empty / error.
+ *
+ * We mock `../lib/api.ts` to control the well-known fetch shape. The
+ * router wrapper is MemoryRouter — react-router uses the same context
+ * regardless of the basename, and we don't care about URLs here.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import { VaultsList } from "./VaultsList.tsx";
+
+vi.mock("../lib/api.ts", () => ({
+  listVaults: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderList() {
+  return render(
+    <MemoryRouter>
+      <VaultsList />
+    </MemoryRouter>,
+  );
+}
+
+describe("VaultsList", () => {
+  it("renders empty state with a 'Create a vault' link when no vaults", async () => {
+    vi.mocked(api.listVaults).mockResolvedValue([]);
+    renderList();
+    await waitFor(() => expect(screen.getByText(/no vaults yet/i)).toBeInTheDocument());
+    expect(screen.getByRole("link", { name: /create a vault/i })).toHaveAttribute(
+      "href",
+      "/vaults/new",
+    );
+  });
+
+  it("renders one row per vault with name + version + URL", async () => {
+    vi.mocked(api.listVaults).mockResolvedValue([
+      {
+        name: "work",
+        url: "http://hub.local/vault/work/",
+        version: "0.5.1",
+        path: "/vault/work",
+      },
+      {
+        name: "scratch",
+        url: "http://hub.local/vault/scratch/",
+        version: "0.5.1",
+        path: "/vault/scratch",
+      },
+    ]);
+    renderList();
+    await waitFor(() => expect(screen.getByText(/Vaults \(2\)/)).toBeInTheDocument());
+    expect(screen.getByText("work")).toBeInTheDocument();
+    expect(screen.getByText("scratch")).toBeInTheDocument();
+    expect(screen.getAllByText(/v0\.5\.1/)).toHaveLength(2);
+  });
+
+  it("renders the error banner + retry button on failure", async () => {
+    vi.mocked(api.listVaults).mockRejectedValue(new Error("network down"));
+    renderList();
+    await waitFor(() => expect(screen.getByText(/couldn't load vaults/i)).toBeInTheDocument());
+    expect(screen.getByText("network down")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+});

--- a/web/ui/src/routes/VaultsList.tsx
+++ b/web/ui/src/routes/VaultsList.tsx
@@ -1,0 +1,122 @@
+/**
+ * /vaults — index page.
+ *
+ * Reads the hub's well-known discovery doc anonymously and renders a row
+ * per vault. No auth required for read; clicking "New vault" lands on the
+ * create form which mints a host-admin JWT via session cookie.
+ *
+ * State is a tagged union (loading | ok | error) so the page never flashes
+ * partial UI: either a skeleton, the rows, or an error banner with retry.
+ */
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { type VaultListing, listVaults } from "../lib/api.ts";
+
+type State =
+  | { kind: "loading" }
+  | { kind: "ok"; vaults: VaultListing[] }
+  | { kind: "error"; message: string };
+
+export function VaultsList() {
+  const [state, setState] = useState<State>({ kind: "loading" });
+  const [reload, setReload] = useState(0);
+
+  useEffect(() => {
+    // `reload` is the trigger — re-running the effect on bump is the
+    // whole point of the dep. Biome's exhaustive-deps rule doesn't
+    // know about "trigger only" deps, so suppress the warning here.
+    void reload;
+    let cancelled = false;
+    listVaults()
+      .then((vaults) => {
+        if (cancelled) return;
+        setState({ kind: "ok", vaults });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ kind: "error", message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reload]);
+
+  if (state.kind === "loading") {
+    return (
+      <div>
+        <div className="list-header">
+          <h2>Vaults</h2>
+        </div>
+        <p className="muted">Loading…</p>
+      </div>
+    );
+  }
+
+  if (state.kind === "error") {
+    return (
+      <div>
+        <div className="list-header">
+          <h2>Vaults</h2>
+          <Link to="/vaults/new">
+            <button type="button">New vault</button>
+          </Link>
+        </div>
+        <div className="error-banner">
+          Couldn't load vaults: <code>{state.message}</code>
+        </div>
+        <button type="button" onClick={() => setReload((n) => n + 1)} className="secondary">
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="list-header">
+        <h2>Vaults ({state.vaults.length})</h2>
+        <Link to="/vaults/new">
+          <button type="button">New vault</button>
+        </Link>
+      </div>
+
+      <p className="muted">
+        Vaults registered with this hub at <code>/.well-known/parachute.json</code>.
+      </p>
+
+      {state.vaults.length === 0 ? (
+        <div className="empty empty-rich">
+          <p className="empty-headline">No vaults yet.</p>
+          <p className="muted">
+            Create your first vault to start storing tokens, secrets, and notes scoped to this hub.
+          </p>
+          <p style={{ marginTop: "0.75rem" }}>
+            <Link to="/vaults/new">Create a vault →</Link>
+          </p>
+        </div>
+      ) : (
+        <div style={{ marginTop: "1rem" }}>
+          {state.vaults.map((v) => (
+            <Link key={v.name} to={`/vaults/${encodeURIComponent(v.name)}`} className="vault-row">
+              <div className="body">
+                <div className="name">
+                  <code>{v.name}</code>
+                  <span className="tag muted" title="Vault version">
+                    v{v.version}
+                  </span>
+                </div>
+                <div className="dim url">
+                  <code>{v.url}</code>
+                </div>
+              </div>
+              <span className="chev" aria-hidden="true">
+                ›
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -1,0 +1,342 @@
+/*
+ * Brand tokens lifted from src/oauth-ui.ts + src/admin-config-ui.ts so the
+ * SPA stays visually continuous with the password-login → consent flow the
+ * operator will have just walked through. Don't drift these without
+ * updating both server-rendered surfaces.
+ */
+:root {
+  --bg: #faf8f4;
+  --bg-soft: #f3f0ea;
+  --fg: #2c2a26;
+  --fg-muted: #6b6860;
+  --fg-dim: #9a9690;
+  --accent: #4a7c59;
+  --accent-soft: rgba(74, 124, 89, 0.08);
+  --accent-hover: #3d6849;
+  --border: #e4e0d8;
+  --border-light: #ece9e2;
+  --card-bg: #ffffff;
+  --error: #a3392b;
+  --error-soft: rgba(163, 57, 43, 0.08);
+  --warn: #b08023;
+  --warn-soft: rgba(176, 128, 35, 0.08);
+  --success: #3d6849;
+  --success-soft: rgba(61, 104, 73, 0.08);
+  --font-serif: Georgia, "Times New Roman", serif;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", monospace;
+  font-family: var(--font-sans);
+}
+
+* {
+  box-sizing: border-box;
+}
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+}
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+
+button {
+  font: inherit;
+  background: var(--accent);
+  color: white;
+  border: 0;
+  border-radius: 6px;
+  padding: 0.55rem 1.1rem;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+button:hover {
+  background: var(--accent-hover);
+}
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+button.secondary {
+  background: white;
+  color: var(--fg);
+  border: 1px solid var(--border);
+}
+button.secondary:hover {
+  background: var(--bg-soft);
+}
+
+input,
+select,
+textarea {
+  font: inherit;
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.55rem 0.75rem;
+  color: var(--fg);
+}
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--bg-soft);
+  padding: 0.1em 0.3em;
+  border-radius: 3px;
+}
+
+.page {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 6rem;
+}
+
+.nav {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 2rem;
+}
+.nav .brand {
+  font-weight: 600;
+  font-family: var(--font-serif);
+  font-size: 1.15rem;
+  margin-right: auto;
+}
+.nav .brand .sub {
+  color: var(--fg-dim);
+  font-size: 0.78rem;
+  font-weight: 400;
+  margin-left: 0.4rem;
+  font-family: var(--font-sans);
+}
+.nav a {
+  color: var(--fg-muted);
+  font-size: 0.95rem;
+}
+.nav a:hover {
+  text-decoration: none;
+  color: var(--fg);
+}
+
+h2 {
+  margin: 0 0 1rem;
+  font-size: 1.4rem;
+  font-weight: 500;
+}
+
+.muted {
+  color: var(--fg-muted);
+  font-size: 0.92rem;
+}
+.dim {
+  color: var(--fg-dim);
+  font-size: 0.85rem;
+}
+
+.error-banner {
+  background: var(--error-soft);
+  border: 1px solid var(--error);
+  color: var(--error);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+.warn-banner {
+  background: var(--warn-soft);
+  border: 1px solid var(--warn);
+  color: var(--warn);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.empty {
+  padding: 3rem 1.5rem;
+  text-align: center;
+  color: var(--fg-muted);
+  background: var(--bg-soft);
+  border-radius: 10px;
+}
+.empty-rich {
+  text-align: left;
+  padding: 2rem 1.75rem;
+  background: white;
+  border: 1px solid var(--border);
+}
+.empty-rich .empty-headline {
+  font-size: 1.05rem;
+  color: var(--fg);
+  margin: 0 0 0.5rem;
+  font-weight: 500;
+}
+
+.list-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.list-header h2 {
+  margin: 0;
+}
+
+.tag {
+  display: inline-block;
+  padding: 0.1em 0.55em;
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-radius: 4px;
+  font-size: 0.78rem;
+  font-weight: 500;
+}
+.tag.muted {
+  background: var(--bg-soft);
+  color: var(--fg-muted);
+}
+
+.vault-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s ease;
+}
+.vault-row:hover {
+  border-color: var(--accent);
+  text-decoration: none;
+}
+.vault-row .body {
+  flex: 1;
+  min-width: 0;
+}
+.vault-row .name {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.vault-row .name code {
+  font-size: 0.95em;
+}
+.vault-row .url {
+  margin-top: 0.25rem;
+  word-break: break-all;
+}
+.vault-row .chev {
+  color: var(--fg-dim);
+  font-size: 1.2rem;
+}
+
+form .row {
+  margin-bottom: 1rem;
+}
+form label {
+  display: block;
+  font-size: 0.9rem;
+  color: var(--fg-muted);
+  margin-bottom: 0.3rem;
+  font-weight: 500;
+}
+form input[type="text"] {
+  width: 100%;
+}
+form .actions {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  margin-top: 1rem;
+}
+form .field-hint {
+  margin-top: 0.35rem;
+  font-size: 0.82rem;
+  color: var(--fg-dim);
+}
+form .field-error {
+  margin-top: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--error);
+}
+
+.section {
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+/* Mint banner — single-emit token reveal. */
+.mint-banner {
+  background: var(--success-soft);
+  border: 1px solid var(--success);
+  border-radius: 10px;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+.mint-banner h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  color: var(--success);
+}
+.mint-banner .token-box {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.85rem 0 0.5rem;
+}
+.mint-banner code {
+  flex: 1;
+  font-size: 0.9rem;
+  padding: 0.6rem 0.75rem;
+  background: white;
+  border: 1px solid var(--border);
+  word-break: break-all;
+  user-select: all;
+}
+.mint-banner .warn {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: var(--warn);
+}
+.mint-banner .actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.kv {
+  display: grid;
+  grid-template-columns: 8.5rem 1fr;
+  gap: 0.5rem 1rem;
+  font-size: 0.92rem;
+}
+.kv > div:nth-child(odd) {
+  color: var(--fg-muted);
+}
+.kv code {
+  word-break: break-all;
+}

--- a/web/ui/src/test/setup.ts
+++ b/web/ui/src/test/setup.ts
@@ -1,0 +1,8 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});

--- a/web/ui/tsconfig.json
+++ b/web/ui/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/web/ui/vite.config.ts
+++ b/web/ui/vite.config.ts
@@ -1,0 +1,41 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// The hub mounts this SPA at `/hub/` (see src/hub-server.ts dispatch table).
+// Build default IS the canonical mount so asset URLs resolve under the hub
+// path on tailnet — the same drift paraclaw#25 hit when its base was `/`.
+// Override with `VITE_BASE_PATH=/` for stand-alone dev served at the origin
+// root.
+const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/hub/");
+
+function normalizeBase(input: string): string {
+  let b = input.startsWith("/") ? input : `/${input}`;
+  if (!b.endsWith("/")) b += "/";
+  return b;
+}
+
+export default defineConfig({
+  base: basePath,
+  plugins: [react()],
+  server: {
+    port: 5174,
+    proxy: {
+      // Dev server runs under /hub/ to mirror the production mount. The hub's
+      // admin + vault API lives at the origin root (/admin/*, /vaults,
+      // /.well-known/*) so we only proxy those exact prefixes — everything
+      // else falls through to the SPA's static assets.
+      "/admin": {
+        target: process.env.HUB_ORIGIN ?? "http://127.0.0.1:1939",
+        changeOrigin: true,
+      },
+      "/vaults": {
+        target: process.env.HUB_ORIGIN ?? "http://127.0.0.1:1939",
+        changeOrigin: true,
+      },
+      "/.well-known": {
+        target: process.env.HUB_ORIGIN ?? "http://127.0.0.1:1939",
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/web/ui/vitest.config.ts
+++ b/web/ui/vitest.config.ts
@@ -1,0 +1,20 @@
+/**
+ * Vitest config for the hub web UI. Mirrors paraclaw's setup — separate from
+ * vite.config.ts so the production-bundle base path doesn't co-mingle with
+ * test concerns. jsdom is the rendering target; setupFiles extends `expect`
+ * with @testing-library/jest-dom matchers and resets fetch / storage mocks
+ * per test.
+ */
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.ts"],
+    css: false,
+    restoreMocks: true,
+    clearMocks: true,
+  },
+});


### PR DESCRIPTION
## Summary

Phase 1 of the in-tree vault-management UI. The hub now serves a Vite +
React SPA at `/hub/*` so an operator can list registered vaults and
create new ones from a browser, without dropping to a terminal.

- `/admin/host-admin-token` (new): trades the existing
  `parachute_hub_session` cookie for a short-lived JWT carrying
  `parachute:host:admin`. The SPA needs that scope to call POST /vaults,
  but the scope is in `NON_REQUESTABLE_SCOPES` so the public OAuth flow
  refuses it — only this session-cookie path can mint it. **Auth
  strategy approved by team-lead** (Option A: stays inside the existing
  security boundary).
- SPA scaffold under `web/ui/` (Vite + React + TypeScript, mount-aware
  via `BASE_URL`). Brand tokens lifted from `oauth-ui.ts` /
  `admin-config-ui.ts` so the SPA stays visually continuous with the
  password-login → consent flow.
- Two pages today: `/vaults` (list, anonymous read of well-known) and
  `/vaults/new` (create form + single-emit `pvt_*` token banner with
  copy + beforeunload guard). `/vaults/:name` is a Phase-2 placeholder.

## Auth shape (why a custom mint endpoint)

Brief originally called for the public OAuth flow, but
`parachute:host:admin` is in `NON_REQUESTABLE_SCOPES` server-side — the
public `/oauth/authorize` rejects it. Adding it would weaken a
load-bearing policy meant to keep third-party clients out of host
admin. Approved alternative: a session-cookie-gated mint endpoint that
mirrors `/admin/config`'s auth pattern. JWT lives in module-scoped
state (no localStorage), narrowest XSS surface possible.

## 401 on POST /vaults — manual retry, not auto-retry (option A)

When `createVault` gets 401/403 the SPA clears the cached JWT and
surfaces the error to the operator; the next form submission mints
fresh and re-tries. We deliberately don't chain mint-and-retry
transparently:

- A stale-token mid-submit stays visible to the operator instead of
  being silently swallowed.
- A request the operator might not want repeated isn't auto-replayed.
- A failure mode where mint succeeds but the subsequent POST keeps
  failing for a *different* reason can't masquerade as an auth issue.

Documented inline in `web/ui/src/lib/api.ts:createVault` so a future
reader sees the call was deliberate.

## Phase-2 follow-up filed

`#160` — SPA build is not in the install chain; a fresh checkout will
503 on `/hub/*` until `bun run build` runs in `web/ui/`. Resolution
options outlined in the issue. Out of scope for this PR.

## Test plan

- [x] `bun run typecheck` (host) — clean
- [x] `bun test ./src` (host) — 905 pass, 0 fail
- [x] `bun run typecheck` (web/ui) — clean
- [x] `bun run test` (web/ui) — 20 pass, 0 fail (added idempotent re-POST coverage)
- [x] `bun run build` (web/ui) — verify-base passes (`/hub/`-prefixed assets)
- [x] biome on touched files — clean (host has unrelated pre-existing lint debt on cli.test.ts + expose-public-auto.ts; not folded into this PR)
- [ ] Local smoke: `bun src/cli.ts expose tailnet on`, hit `/hub/vaults` in a browser, walk through Login → Vaults → New vault → see `pvt_*` banner. *(Pre-merge — leaving for human review walkthrough.)*

## Files of note

- `src/admin-host-admin-token.ts` — the mint endpoint
- `src/hub-server.ts` — `serveSpa` + `/hub/*` route + `HubFetchDeps.spaDistDir`
- `web/ui/CLAUDE.md` — SPA structure, mount-aware contract, auth shape
- `web/ui/scripts/verify-base.mjs` — paraclaw#25 base-drift guard

## Per-governance

- Bumped to `0.4.0-rc.39`.
- Single PR, 4 per-feature commits (mint endpoint / SPA + mount / chore / review fold).
- No auto-merge. RC versioning before `@latest`.
- Patterns touched: mount-path-convention (paraclaw#25 base-drift) — conformed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)