### PR TITLE
feat(install): wire web/ui SPA build into install + publish chain (#159)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "typecheck": "tsc --noEmit",
     "build:spa": "cd web/ui && bun install --frozen-lockfile && bun run build",
     "postinstall": "if [ -d web/ui ]; then bun run build:spa; fi",
-    "prepublishOnly": "bun run build:spa"
+    "prepack": "bun run build:spa"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.40",
+  "version": "0.4.0-rc.41",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {
@@ -12,7 +12,7 @@
     "parachute": "src/cli.ts"
   },
   "workspaces": ["packages/*"],
-  "files": ["src", "README.md", "LICENSE"],
+  "files": ["src", "web/ui/dist", "README.md", "LICENSE"],
   "repository": {
     "type": "git",
     "url": "https://github.com/ParachuteComputer/parachute-hub.git"
@@ -23,7 +23,10 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "build:spa": "cd web/ui && bun install --frozen-lockfile && bun run build",
+    "postinstall": "if [ -d web/ui ]; then bun run build:spa; fi",
+    "prepublishOnly": "bun run build:spa"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/web/ui/CLAUDE.md
+++ b/web/ui/CLAUDE.md
@@ -81,16 +81,17 @@ bun run test         # vitest run
 `web/ui/dist/` is gitignored — the hub serves it from a co-located bundle
 that Vite produces. The root `package.json` wires this for you: a
 `postinstall` hook runs `bun run build:spa` after every `bun install` in
-the repo root, and `prepublishOnly` rebuilds before `bun publish` so
-the npm tarball ships a fresh `web/ui/dist/`. The `files` array in the
-root `package.json` includes `web/ui/dist`, so consumers of the
-published `@openparachute/hub` package get the bundle even though they
-don't get the SPA source.
+the repo root, and `prepack` rebuilds before `bun pack` / `bun publish`
+so the npm tarball always ships a fresh `web/ui/dist/`. The `files`
+array in the root `package.json` includes `web/ui/dist`, so consumers
+of the published `@openparachute/hub` package get the bundle even
+though they don't get the SPA source.
 
 If you ever need to manually rebuild, `cd web/ui && bun run build` still
 works. `src/hub-server.ts` handles a missing `dist/` by 503ing the
 `/hub/*` routes with a hint to run the build — usually means the
-postinstall hasn't run yet.
+postinstall hasn't run yet, or fired with `--ignore-scripts` (which
+suppresses lifecycle hooks).
 
 ## Brand tokens
 

--- a/web/ui/CLAUDE.md
+++ b/web/ui/CLAUDE.md
@@ -78,11 +78,19 @@ bun run typecheck    # tsc --noEmit
 bun run test         # vitest run
 ```
 
-`web/ui/dist/` is committed in `.gitignore` — the hub serves it from a
-co-located bundle that Vite produces during release builds. Until a
-release pipeline lands, run `bun run build` locally; `src/hub-server.ts`
-handles a missing `dist/` by 503ing the `/hub/*` routes with a hint to
-build the SPA.
+`web/ui/dist/` is gitignored — the hub serves it from a co-located bundle
+that Vite produces. The root `package.json` wires this for you: a
+`postinstall` hook runs `bun run build:spa` after every `bun install` in
+the repo root, and `prepublishOnly` rebuilds before `bun publish` so
+the npm tarball ships a fresh `web/ui/dist/`. The `files` array in the
+root `package.json` includes `web/ui/dist`, so consumers of the
+published `@openparachute/hub` package get the bundle even though they
+don't get the SPA source.
+
+If you ever need to manually rebuild, `cd web/ui && bun run build` still
+works. `src/hub-server.ts` handles a missing `dist/` by 503ing the
+`/hub/*` routes with a hint to run the build — usually means the
+postinstall hasn't run yet.
 
 ## Brand tokens
 


### PR DESCRIPTION
## Summary

Closes #159.

The hub serves a Vite-built bundle from `web/ui/dist/` for the `/hub/*` routes. Before this change, two install paths could land in the broken state:

- A fresh `git clone && bun install` left `web/ui/dist/` empty, so the first navigation to `/hub/*` returned a 503 with a "run \`bun run build\` in web/ui" hint — useful for the next dev, but easy to miss.
- A consumer `bun add -g @openparachute/hub` didn't ship the SPA bundle either: the npm tarball's `files` array only included `src/`, so even with the hint, a globally-installed user had no SPA source to build.

Three coordinated fixes in `package.json`:

| Hook | Trigger | What it does |
|---|---|---|
| `build:spa` | manual / shared | `cd web/ui && bun install --frozen-lockfile && bun run build` |
| `postinstall` | every root `bun install` | Runs `build:spa` if `web/ui/` exists. Guard skips this on consumer install where source isn't present. |
| `prepublishOnly` | `bun publish` | Re-runs `build:spa` so the tarball always carries a fresh, source-matching `dist/`. |

The `files` array gains `web/ui/dist` so the published tarball actually ships the bundle.

## Why these specific hooks

- **`postinstall` over `prepare`:** bun runs both, but `prepare` semantics around git-checkout vs published-package install vary across npm minor versions. `postinstall` is the most predictable trigger for "install just finished, run this." We want it to fire on every dev-side install, never on consumer-side install — the `if [ -d web/ui ]` guard handles the second half.
- **`prepublishOnly` over `prepare` for publish:** `prepublishOnly` only fires on actual publish (not on local `bun pm pack` or `bun install`). That's the right scope for "rebuild before shipping."
- **No infinite recursion:** the `postinstall` script does `cd web/ui && bun install`. Bun reads `web/ui/package.json`, which has no `postinstall`. Sibling hooks don't propagate back.

## Verification

End-to-end on a fresh state:

\`\`\`sh
$ rm -rf web/ui/dist web/ui/node_modules
$ bun install
+ react@19.2.5  + vite@6.4.2  + ... (188 packages installed)
$ tsc -b && vite build && node scripts/verify-base.mjs
✓ 45 modules transformed.
dist/index.html                   0.50 kB
dist/assets/index-Dyk6g7vT.css    4.90 kB
dist/assets/index-BpL7_n8Y.js   242.09 kB
verify-base: ✓ dist/index.html references /hub/-prefixed assets.
\`\`\`

Tarball check:

\`\`\`sh
$ bun pm pack --dry-run | grep web/ui
packed 242.1KB web/ui/dist/assets/index-BpL7_n8Y.js
packed 4.90KB  web/ui/dist/assets/index-Dyk6g7vT.css
packed 498B   web/ui/dist/index.html
\`\`\`

## Test plan

- [x] Fresh state: `rm -rf web/ui/{dist,node_modules}; bun install` produces working `web/ui/dist/` with no manual intervention
- [x] Tarball includes `web/ui/dist/*`: `bun pm pack --dry-run` confirms
- [x] Host gates: `bun run typecheck` clean, `bun run test` 923/0
- [x] No behavioural change to host code — package.json + CLAUDE.md only

## Notes for reviewer

- `web/ui/CLAUDE.md` updated to reflect the new automated flow; the manual `bun run build` is documented as a fallback rather than the primary path.
- Root `package.json` version bumped to 0.4.0-rc.41.
- Single-commit PR, per the team-lead's request — no per-feature split since the postinstall, prepublishOnly, and `files` change are interdependent (any one alone leaves a gap).