### PR TITLE
feat(api): per-vault grants admin UI at /hub/permissions (#162)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.41",
+  "version": "0.4.0-rc.42",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/admin-grants.test.ts
+++ b/src/__tests__/admin-grants.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for /api/grants and /api/grants/:client_id.
+ *
+ * Covers:
+ *   - GET: 401 without Bearer, 403 with the wrong scope, 200 with the right
+ *     scope; vault filter; client_name surfaced; multi-user isolation.
+ *   - DELETE: 401/403 mirror the GET surface; 404 when no grant exists; 204
+ *     on success; audit log emitted.
+ *   - 405 on wrong methods.
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleListGrants, handleRevokeGrant } from "../admin-grants.ts";
+import { registerClient } from "../clients.ts";
+import { recordGrant } from "../grants.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { signAccessToken } from "../jwt-sign.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "https://hub.test";
+
+interface Harness {
+  db: Database;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-admin-grants-"));
+  const db = openHubDb(hubDbPath(dir));
+  return {
+    db,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+async function makeOperatorBearer(scopes = ["parachute:host:admin"]): Promise<{
+  bearer: string;
+  userId: string;
+}> {
+  const user = await createUser(harness.db, "operator", "pw");
+  const minted = await signAccessToken(harness.db, {
+    sub: user.id,
+    scopes,
+    audience: "hub",
+    clientId: "parachute-hub-spa",
+    issuer: ISSUER,
+    ttlSeconds: 600,
+  });
+  return { bearer: minted.token, userId: user.id };
+}
+
+function reg(name?: string): string {
+  const r = registerClient(harness.db, {
+    redirectUris: ["https://app.example/cb"],
+    ...(name !== undefined ? { clientName: name } : {}),
+  });
+  return r.client.clientId;
+}
+
+function listReq(query = ""): Request {
+  return new Request(`${ISSUER}/api/grants${query}`);
+}
+function listReqWithBearer(bearer: string, query = ""): Request {
+  return new Request(`${ISSUER}/api/grants${query}`, {
+    headers: { authorization: `Bearer ${bearer}` },
+  });
+}
+function deleteReq(clientId: string, bearer?: string): Request {
+  const headers: Record<string, string> = {};
+  if (bearer) headers.authorization = `Bearer ${bearer}`;
+  return new Request(`${ISSUER}/api/grants/${clientId}`, {
+    method: "DELETE",
+    headers,
+  });
+}
+
+describe("handleListGrants", () => {
+  test("401 with no Authorization header", async () => {
+    const res = await handleListGrants(listReq(), { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(401);
+  });
+
+  test("403 when token lacks parachute:host:admin", async () => {
+    const { bearer } = await makeOperatorBearer(["other:scope"]);
+    const res = await handleListGrants(listReqWithBearer(bearer), {
+      db: harness.db,
+      issuer: ISSUER,
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("405 on POST", async () => {
+    const { bearer } = await makeOperatorBearer();
+    const req = new Request(`${ISSUER}/api/grants`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearer}` },
+    });
+    const res = await handleListGrants(req, { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(405);
+  });
+
+  test("200 returns operator's grants enriched with client_name", async () => {
+    const { bearer, userId } = await makeOperatorBearer();
+    const cidA = reg("App A");
+    const cidB = reg(); // no display name
+    recordGrant(harness.db, userId, cidA, ["vault:work:read", "vault:work:write"]);
+    recordGrant(harness.db, userId, cidB, ["notes:read"]);
+
+    const res = await handleListGrants(listReqWithBearer(bearer), {
+      db: harness.db,
+      issuer: ISSUER,
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    const body = (await res.json()) as { grants: Array<Record<string, unknown>> };
+    expect(body.grants).toHaveLength(2);
+
+    const a = body.grants.find((g) => g.client_id === cidA);
+    expect(a).toBeDefined();
+    expect(a?.client_name).toBe("App A");
+    expect(a?.scopes).toEqual(["vault:work:read", "vault:work:write"]);
+
+    const b = body.grants.find((g) => g.client_id === cidB);
+    expect(b?.client_name).toBeNull();
+  });
+
+  test("?vault=<name> filters to grants whose scopes touch that vault", async () => {
+    const { bearer, userId } = await makeOperatorBearer();
+    const work = reg("Work app");
+    const scratch = reg("Scratch app");
+    recordGrant(harness.db, userId, work, ["vault:work:read"]);
+    recordGrant(harness.db, userId, scratch, ["vault:scratch:read", "vault:scratch:write"]);
+
+    const res = await handleListGrants(listReqWithBearer(bearer, "?vault=work"), {
+      db: harness.db,
+      issuer: ISSUER,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { grants: Array<{ client_id: string }> };
+    expect(body.grants).toHaveLength(1);
+    expect(body.grants[0]?.client_id).toBe(work);
+  });
+
+  test("?vault filter rejects garbage names with 400", async () => {
+    const { bearer } = await makeOperatorBearer();
+    const res = await handleListGrants(listReqWithBearer(bearer, "?vault=hi%2Fthere"), {
+      db: harness.db,
+      issuer: ISSUER,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("does not leak grants belonging to a different user", async () => {
+    const { bearer, userId } = await makeOperatorBearer();
+    // A second user with their own grant — must not appear in operator A's list.
+    const otherUser = await createUser(harness.db, "other", "pw", { allowMulti: true });
+    const cid = reg("Some app");
+    recordGrant(harness.db, otherUser.id, cid, ["vault:work:read"]);
+    recordGrant(harness.db, userId, cid, ["notes:read"]);
+
+    const res = await handleListGrants(listReqWithBearer(bearer), {
+      db: harness.db,
+      issuer: ISSUER,
+    });
+    const body = (await res.json()) as { grants: Array<{ user_id: string; scopes: string[] }> };
+    expect(body.grants).toHaveLength(1);
+    expect(body.grants[0]?.user_id).toBe(userId);
+    expect(body.grants[0]?.scopes).toEqual(["notes:read"]);
+  });
+});
+
+describe("handleRevokeGrant", () => {
+  test("401 with no Authorization header", async () => {
+    const res = await handleRevokeGrant(deleteReq("nope"), "nope", {
+      db: harness.db,
+      issuer: ISSUER,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("403 when token lacks parachute:host:admin", async () => {
+    const { bearer } = await makeOperatorBearer(["other:scope"]);
+    const res = await handleRevokeGrant(deleteReq("nope", bearer), "nope", {
+      db: harness.db,
+      issuer: ISSUER,
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("405 on GET", async () => {
+    const { bearer } = await makeOperatorBearer();
+    const cid = reg();
+    const req = new Request(`${ISSUER}/api/grants/${cid}`, {
+      method: "GET",
+      headers: { authorization: `Bearer ${bearer}` },
+    });
+    const res = await handleRevokeGrant(req, cid, { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(405);
+  });
+
+  test("404 when no grant exists for (user, client)", async () => {
+    const { bearer } = await makeOperatorBearer();
+    const cid = reg();
+    const res = await handleRevokeGrant(deleteReq(cid, bearer), cid, {
+      db: harness.db,
+      issuer: ISSUER,
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("204 deletes the operator's grant and emits an audit log line", async () => {
+    const { bearer, userId } = await makeOperatorBearer();
+    const cid = reg("App A");
+    recordGrant(harness.db, userId, cid, ["vault:work:read"]);
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    };
+    try {
+      const res = await handleRevokeGrant(deleteReq(cid, bearer), cid, {
+        db: harness.db,
+        issuer: ISSUER,
+      });
+      expect(res.status).toBe(204);
+    } finally {
+      console.log = originalLog;
+    }
+    // Grant is gone.
+    const followup = await handleRevokeGrant(deleteReq(cid, bearer), cid, {
+      db: harness.db,
+      issuer: ISSUER,
+    });
+    expect(followup.status).toBe(404);
+
+    // Audit line carries client_id, user_id, and the scopes that were revoked.
+    const line = logs.find((l) => l.startsWith("grant revoked:"));
+    expect(line).toBeDefined();
+    expect(line).toContain(`client_id=${cid}`);
+    expect(line).toContain(`user_id=${userId}`);
+    expect(line).toContain("scopes=vault:work:read");
+  });
+
+  test("404 when the operator tries to revoke another user's grant", async () => {
+    const { bearer } = await makeOperatorBearer();
+    const otherUser = await createUser(harness.db, "other", "pw", { allowMulti: true });
+    const cid = reg();
+    recordGrant(harness.db, otherUser.id, cid, ["vault:work:read"]);
+
+    const res = await handleRevokeGrant(deleteReq(cid, bearer), cid, {
+      db: harness.db,
+      issuer: ISSUER,
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/admin-grants.ts
+++ b/src/admin-grants.ts
@@ -32,7 +32,6 @@ import {
   requireScope,
 } from "./admin-auth.ts";
 import { HOST_ADMIN_SCOPE } from "./admin-vaults.ts";
-import { getClient } from "./clients.ts";
 import { listGrantsForUser, revokeGrant } from "./grants.ts";
 
 export interface AdminGrantsDeps {
@@ -72,10 +71,23 @@ export async function handleListGrants(req: Request, deps: AdminGrantsDeps): Pro
     ? grants.filter((g) => grantTouchesVault(g.scopes, vaultFilter))
     : grants;
 
+  // One bulk lookup keyed by client_id, instead of N getClient calls. Empty
+  // list short-circuits because `IN ()` is a SQL syntax error.
+  const names = new Map<string, string | null>();
+  if (filtered.length > 0) {
+    const placeholders = filtered.map(() => "?").join(",");
+    const rows = deps.db
+      .query<{ client_id: string; client_name: string | null }, string[]>(
+        `SELECT client_id, client_name FROM clients WHERE client_id IN (${placeholders})`,
+      )
+      .all(...filtered.map((g) => g.clientId));
+    for (const r of rows) names.set(r.client_id, r.client_name);
+  }
+
   const enriched: AdminGrantListing[] = filtered.map((g) => ({
     user_id: g.userId,
     client_id: g.clientId,
-    client_name: getClient(deps.db, g.clientId)?.clientName ?? null,
+    client_name: names.get(g.clientId) ?? null,
     scopes: g.scopes,
     granted_at: g.grantedAt,
   }));

--- a/src/admin-grants.ts
+++ b/src/admin-grants.ts
@@ -1,0 +1,148 @@
+/**
+ * Admin endpoints for the operator's OAuth-grant skip-list.
+ *
+ *   GET    /api/grants[?vault=<name>]    list operator's grants
+ *   DELETE /api/grants/<client_id>       revoke one grant
+ *
+ * Both gated by `parachute:host:admin` Bearer (the SPA mints one via the
+ * session cookie at `/admin/host-admin-token`). The "operator" is the JWT
+ * `sub` — list and revoke are both scoped to that user, so a host-admin
+ * token can't enumerate or delete another user's grants. (The hub is
+ * single-operator today; this is forward-looking.)
+ *
+ * The grants table's primary key is composite `(user_id, client_id)`. Since
+ * `user_id` is fixed by the bearer, `client_id` alone is sufficient as the
+ * URL-segment "id" — and matches the operator's mental model: "revoke this
+ * app's access".
+ *
+ * Optional `?vault=<name>` filter narrows the list to grants whose scope
+ * set touches `vault:<name>:*`. The match is per-grant (any matching scope
+ * keeps the row); the row's full scope set is still returned, not a slice.
+ *
+ * Audit: revocation emits a `console.log("grant revoked: ...")` line in the
+ * same `key=value` shape as the existing `consent skipped:` line at
+ * `oauth-handlers.ts`. No structured-logging infra exists in the hub yet;
+ * matching the prevailing format keeps log-grep ergonomics consistent.
+ */
+import type { Database } from "bun:sqlite";
+import {
+  type AdminAuthContext,
+  type AdminAuthError,
+  adminAuthErrorResponse,
+  requireScope,
+} from "./admin-auth.ts";
+import { HOST_ADMIN_SCOPE } from "./admin-vaults.ts";
+import { getClient } from "./clients.ts";
+import { listGrantsForUser, revokeGrant } from "./grants.ts";
+
+export interface AdminGrantsDeps {
+  db: Database;
+  /** Hub origin — passed through to JWT validation as the expected `iss`. */
+  issuer: string;
+}
+
+export interface AdminGrantListing {
+  user_id: string;
+  client_id: string;
+  /** Display name from `clients.client_name`. Null when the client never set one. */
+  client_name: string | null;
+  scopes: string[];
+  granted_at: string;
+}
+
+export async function handleListGrants(req: Request, deps: AdminGrantsDeps): Promise<Response> {
+  if (req.method !== "GET") {
+    return jsonError(405, "method_not_allowed", "use GET");
+  }
+  let ctx: AdminAuthContext;
+  try {
+    ctx = await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+  } catch (err) {
+    return adminAuthErrorResponse(err as AdminAuthError);
+  }
+
+  const url = new URL(req.url);
+  const vaultFilter = url.searchParams.get("vault");
+  if (vaultFilter !== null && !isValidVaultName(vaultFilter)) {
+    return jsonError(400, "invalid_request", "?vault must match [a-zA-Z0-9_-]+");
+  }
+
+  const grants = listGrantsForUser(deps.db, ctx.sub);
+  const filtered = vaultFilter
+    ? grants.filter((g) => grantTouchesVault(g.scopes, vaultFilter))
+    : grants;
+
+  const enriched: AdminGrantListing[] = filtered.map((g) => ({
+    user_id: g.userId,
+    client_id: g.clientId,
+    client_name: getClient(deps.db, g.clientId)?.clientName ?? null,
+    scopes: g.scopes,
+    granted_at: g.grantedAt,
+  }));
+
+  return new Response(JSON.stringify({ grants: enriched }), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": "no-store",
+    },
+  });
+}
+
+export async function handleRevokeGrant(
+  req: Request,
+  clientId: string,
+  deps: AdminGrantsDeps,
+): Promise<Response> {
+  if (req.method !== "DELETE") {
+    return jsonError(405, "method_not_allowed", "use DELETE");
+  }
+  let ctx: AdminAuthContext;
+  try {
+    ctx = await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+  } catch (err) {
+    return adminAuthErrorResponse(err as AdminAuthError);
+  }
+
+  // Capture the prior scopes for the audit line — `revokeGrant` only returns
+  // a boolean, and we want the deleted scope set on disk in the log.
+  const grants = listGrantsForUser(deps.db, ctx.sub);
+  const target = grants.find((g) => g.clientId === clientId);
+  if (!target) {
+    return jsonError(404, "not_found", `no grant for client ${clientId}`);
+  }
+
+  const removed = revokeGrant(deps.db, ctx.sub, clientId);
+  if (!removed) {
+    // Race: another revoke landed between the read and the delete. Treat
+    // as 404 since the operator's intent (no grant for this client) is
+    // already satisfied.
+    return jsonError(404, "not_found", `no grant for client ${clientId}`);
+  }
+  console.log(
+    `grant revoked: client_id=${clientId} user_id=${ctx.sub} scopes=${target.scopes.join(" ")}`,
+  );
+  return new Response(null, { status: 204 });
+}
+
+const VAULT_NAME_RE = /^[a-zA-Z0-9_-]+$/;
+const VAULT_SCOPE_PREFIX = /^vault:([^:]+):/;
+
+function isValidVaultName(name: string): boolean {
+  return VAULT_NAME_RE.test(name);
+}
+
+function grantTouchesVault(scopes: readonly string[], vault: string): boolean {
+  for (const s of scopes) {
+    const m = s.match(VAULT_SCOPE_PREFIX);
+    if (m && m[1] === vault) return true;
+  }
+  return false;
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -39,6 +39,7 @@ import type { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { handleListGrants, handleRevokeGrant } from "./admin-grants.ts";
 import {
   handleAdminConfigGet,
   handleAdminConfigPost,
@@ -572,6 +573,26 @@ export function hubFetch(
         db: getDb(),
         issuer: oauthDeps(req).issuer,
         knownVaultNames,
+      });
+    }
+
+    if (pathname === "/api/grants") {
+      if (!getDb) return new Response("hub db not configured", { status: 503 });
+      return handleListGrants(req, {
+        db: getDb(),
+        issuer: oauthDeps(req).issuer,
+      });
+    }
+
+    if (pathname.startsWith("/api/grants/")) {
+      if (!getDb) return new Response("hub db not configured", { status: 503 });
+      const clientId = decodeURIComponent(pathname.slice("/api/grants/".length));
+      if (!clientId || clientId.includes("/")) {
+        return new Response("not found", { status: 404 });
+      }
+      return handleRevokeGrant(req, clientId, {
+        db: getDb(),
+        issuer: oauthDeps(req).issuer,
       });
     }
 

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,5 +1,6 @@
 import { Link, Route, Routes } from "react-router-dom";
 import { NewVault } from "./routes/NewVault.tsx";
+import { Permissions } from "./routes/Permissions.tsx";
 import { VaultsList } from "./routes/VaultsList.tsx";
 
 export function App() {
@@ -10,6 +11,7 @@ export function App() {
           Parachute Hub <span className="sub">vault management</span>
         </Link>
         <Link to="/vaults">Vaults</Link>
+        <Link to="/permissions">Permissions</Link>
         <a href="/" title="Hub discovery page (top-level)">
           Discovery
         </a>
@@ -19,6 +21,7 @@ export function App() {
         <Route path="/" element={<VaultsList />} />
         <Route path="/vaults" element={<VaultsList />} />
         <Route path="/vaults/new" element={<NewVault />} />
+        <Route path="/permissions" element={<Permissions />} />
         <Route
           path="*"
           element={

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -279,6 +279,122 @@ describe("mintVaultAdminToken", () => {
   });
 });
 
+describe("listGrants", () => {
+  it("sends Bearer + parses {grants: [...]} body", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(200, {
+        grants: [
+          {
+            user_id: "u1",
+            client_id: "c1",
+            client_name: "App A",
+            scopes: ["vault:work:read"],
+            granted_at: "2026-04-01T12:00:00.000Z",
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = await import("./api.ts");
+    const grants = await api.listGrants();
+
+    expect(grants).toHaveLength(1);
+    expect(grants[0]?.client_name).toBe("App A");
+    expect(grants[0]?.scopes).toEqual(["vault:work:read"]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/grants",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          authorization: "Bearer test-bearer",
+          accept: "application/json",
+        }),
+      }),
+    );
+  });
+
+  it("appends ?vault=<name> when the option is provided", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, { grants: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = await import("./api.ts");
+    await api.listGrants({ vault: "work space" });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/grants?vault=work%20space", expect.anything());
+  });
+
+  it("returns [] when the body has no grants key", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(200, {})),
+    );
+    const api = await import("./api.ts");
+    expect(await api.listGrants()).toEqual([]);
+  });
+
+  it("on 401 clears the cached token and throws HttpError(401)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(401, { error: "unauthenticated" })),
+    );
+    const api = await import("./api.ts");
+    await expect(api.listGrants()).rejects.toMatchObject({
+      name: "HttpError",
+      status: 401,
+    });
+    expect(auth.clearCachedToken).toHaveBeenCalled();
+  });
+});
+
+describe("revokeGrant", () => {
+  it("sends DELETE with Bearer and resolves on 204", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = await import("./api.ts");
+    await api.revokeGrant("client-abc");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/grants/client-abc",
+      expect.objectContaining({
+        method: "DELETE",
+        headers: expect.objectContaining({ authorization: "Bearer test-bearer" }),
+      }),
+    );
+  });
+
+  it("URL-encodes the client_id", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const api = await import("./api.ts");
+    await api.revokeGrant("with/slash");
+    expect(fetchMock).toHaveBeenCalledWith("/api/grants/with%2Fslash", expect.anything());
+  });
+
+  it("throws HttpError on 404", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(404, { error: "not_found" })),
+    );
+    const api = await import("./api.ts");
+    await expect(api.revokeGrant("nope")).rejects.toMatchObject({
+      name: "HttpError",
+      status: 404,
+    });
+  });
+
+  it("on 401 clears the cached token", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(401, { error: "unauthenticated" })),
+    );
+    const api = await import("./api.ts");
+    await expect(api.revokeGrant("c")).rejects.toMatchObject({ status: 401 });
+    expect(auth.clearCachedToken).toHaveBeenCalled();
+  });
+});
+
 describe("resolveManagementUrl", () => {
   // Note: the manifest validator (`asManagementUrl` in module-manifest.ts)
   // rejects paths that don't start with `/`, so the bare-relative branch

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -170,6 +170,69 @@ export async function mintVaultAdminToken(name: string): Promise<MintedVaultAdmi
 }
 
 /**
+ * Operator-visible OAuth grant from `GET /api/grants`. The hub returns a
+ * snake_case row to keep the wire format aligned with the underlying
+ * sqlite schema; the SPA reads it directly.
+ */
+export interface AdminGrantListing {
+  user_id: string;
+  client_id: string;
+  /** Display name from the OAuth client registration. Null when the client never set one. */
+  client_name: string | null;
+  scopes: string[];
+  granted_at: string;
+}
+
+/**
+ * GET /api/grants — list the operator's OAuth-grant skip-list. Optional
+ * `vault` filter narrows to grants whose scope set touches `vault:<name>:*`.
+ * Same Bearer pattern as `createVault`: a 401/403 dumps the cached token so
+ * the next call re-mints from the session cookie (or hands off to login).
+ */
+export async function listGrants(opts: { vault?: string } = {}): Promise<AdminGrantListing[]> {
+  const bearer = await getHostAdminToken();
+  const query = opts.vault ? `?vault=${encodeURIComponent(opts.vault)}` : "";
+  const res = await fetch(`/api/grants${query}`, {
+    method: "GET",
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${bearer}`,
+    },
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  const body = (await res.json()) as { grants: AdminGrantListing[] };
+  return body.grants ?? [];
+}
+
+/**
+ * DELETE /api/grants/<client_id> — revoke a single grant. Returns void on
+ * 204; throws HttpError on 4xx. Note: revoking a grant only forces the
+ * next OAuth flow for this client to show the consent screen again — it
+ * does NOT revoke active access tokens. That's a separate `/oauth/revoke`
+ * call (out of scope for the admin UI).
+ */
+export async function revokeGrant(clientId: string): Promise<void> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch(`/api/grants/${encodeURIComponent(clientId)}`, {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${bearer}` },
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+}
+
+/**
  * Resolve a vault's `managementUrl` against the vault's mounted URL.
  * Absolute URL → returned verbatim. Path → joined onto `vaultUrl` after
  * stripping the trailing slash so we don't double-slash.

--- a/web/ui/src/routes/Permissions.test.tsx
+++ b/web/ui/src/routes/Permissions.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Permissions route smoke tests — loading, ok with rows, empty, error,
+ * filter submit, revoke confirm flow (cancel + confirm), revoke failure.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import { Permissions } from "./Permissions.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    listGrants: vi.fn(),
+    revokeGrant: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderRoute() {
+  return render(
+    <MemoryRouter>
+      <Permissions />
+    </MemoryRouter>,
+  );
+}
+
+const grant = (clientId: string, name: string | null, scopes: string[]) => ({
+  user_id: "u1",
+  client_id: clientId,
+  client_name: name,
+  scopes,
+  granted_at: "2026-04-01T12:00:00.000Z",
+});
+
+describe("Permissions", () => {
+  it("renders the empty state when no grants exist", async () => {
+    vi.mocked(api.listGrants).mockResolvedValue([]);
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/no grants\./i)).toBeInTheDocument());
+  });
+
+  it("renders one row per grant with client_name + scopes", async () => {
+    vi.mocked(api.listGrants).mockResolvedValue([
+      grant("c1", "App A", ["vault:work:read", "vault:work:write"]),
+      grant("c2", null, ["notes:read"]),
+    ]);
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("App A")).toBeInTheDocument());
+    expect(screen.getByText("c2")).toBeInTheDocument(); // null name → falls back to client_id
+    expect(screen.getByText("vault:work:read")).toBeInTheDocument();
+    expect(screen.getByText("notes:read")).toBeInTheDocument();
+  });
+
+  it("renders the error banner + retry on listGrants failure", async () => {
+    vi.mocked(api.listGrants).mockRejectedValue(new Error("network down"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/couldn't load grants/i)).toBeInTheDocument());
+    expect(screen.getByText("network down")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("Apply filter calls listGrants with the entered vault name", async () => {
+    vi.mocked(api.listGrants).mockResolvedValue([]);
+    renderRoute();
+    // Initial unfiltered call.
+    await waitFor(() => expect(api.listGrants).toHaveBeenCalledWith({}));
+    const input = screen.getByLabelText(/filter by vault/i);
+    fireEvent.change(input, { target: { value: "work" } });
+    fireEvent.click(screen.getByRole("button", { name: /apply/i }));
+    await waitFor(() => expect(api.listGrants).toHaveBeenCalledWith({ vault: "work" }));
+  });
+
+  it("revoke button opens confirm dialog; cancel returns to list without DELETE", async () => {
+    vi.mocked(api.listGrants).mockResolvedValue([grant("c1", "App A", ["vault:work:read"])]);
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /^revoke app a$/i }));
+    // Confirm dialog visible.
+    expect(screen.getByRole("dialog", { name: /confirm revoke app a/i })).toBeInTheDocument();
+    // Cancel.
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: /confirm revoke/i })).toBeNull(),
+    );
+    expect(api.revokeGrant).not.toHaveBeenCalled();
+  });
+
+  it("confirm revoke calls DELETE then refreshes the list", async () => {
+    const listMock = vi.mocked(api.listGrants);
+    listMock.mockResolvedValueOnce([grant("c1", "App A", ["vault:work:read"])]);
+    listMock.mockResolvedValueOnce([]);
+    vi.mocked(api.revokeGrant).mockResolvedValue();
+
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /^revoke app a$/i }));
+    // The dialog renders its own Revoke button — pick the one inside the dialog.
+    const dialog = screen.getByRole("dialog", { name: /confirm revoke app a/i });
+    const confirmBtn = dialog.querySelector("button:not(.secondary)") as HTMLButtonElement;
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => expect(api.revokeGrant).toHaveBeenCalledWith("c1"));
+    // Row gone, empty state shows.
+    await waitFor(() => expect(screen.getByText(/no grants\./i)).toBeInTheDocument());
+  });
+
+  it("surfaces a per-row error banner when revoke fails", async () => {
+    vi.mocked(api.listGrants).mockResolvedValue([grant("c1", "App A", ["vault:work:read"])]);
+    vi.mocked(api.revokeGrant).mockRejectedValue(new api.HttpError(409, "in flight"));
+
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /^revoke app a$/i }));
+    const dialog = screen.getByRole("dialog", { name: /confirm revoke app a/i });
+    const confirmBtn = dialog.querySelector("button:not(.secondary)") as HTMLButtonElement;
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() =>
+      expect(screen.getByText(/revoke failed \(409\): in flight/i)).toBeInTheDocument(),
+    );
+  });
+});

--- a/web/ui/src/routes/Permissions.test.tsx
+++ b/web/ui/src/routes/Permissions.test.tsx
@@ -2,7 +2,7 @@
  * Permissions route smoke tests — loading, ok with rows, empty, error,
  * filter submit, revoke confirm flow (cancel + confirm), revoke failure.
  */
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -102,10 +102,10 @@ describe("Permissions", () => {
 
     renderRoute();
     fireEvent.click(await screen.findByRole("button", { name: /^revoke app a$/i }));
-    // The dialog renders its own Revoke button — pick the one inside the dialog.
+    // Scope the selector to the dialog so we don't pick up the row's own
+    // Revoke button (which is hidden while the dialog is open anyway).
     const dialog = screen.getByRole("dialog", { name: /confirm revoke app a/i });
-    const confirmBtn = dialog.querySelector("button:not(.secondary)") as HTMLButtonElement;
-    fireEvent.click(confirmBtn);
+    fireEvent.click(within(dialog).getByRole("button", { name: /^revoke$/i }));
 
     await waitFor(() => expect(api.revokeGrant).toHaveBeenCalledWith("c1"));
     // Row gone, empty state shows.
@@ -119,8 +119,7 @@ describe("Permissions", () => {
     renderRoute();
     fireEvent.click(await screen.findByRole("button", { name: /^revoke app a$/i }));
     const dialog = screen.getByRole("dialog", { name: /confirm revoke app a/i });
-    const confirmBtn = dialog.querySelector("button:not(.secondary)") as HTMLButtonElement;
-    fireEvent.click(confirmBtn);
+    fireEvent.click(within(dialog).getByRole("button", { name: /^revoke$/i }));
 
     await waitFor(() =>
       expect(screen.getByText(/revoke failed \(409\): in flight/i)).toBeInTheDocument(),

--- a/web/ui/src/routes/Permissions.tsx
+++ b/web/ui/src/routes/Permissions.tsx
@@ -121,18 +121,26 @@ export function Permissions() {
         ) : null}
       </form>
 
-      {renderBody(state, revoke, setRevoke, onConfirmRevoke, () => setReload((n) => n + 1))}
+      {renderBody({
+        state,
+        revoke,
+        setRevoke,
+        onConfirm: onConfirmRevoke,
+        onRetry: () => setReload((n) => n + 1),
+      })}
     </div>
   );
 }
 
-function renderBody(
-  state: State,
-  revoke: RevokeState,
-  setRevoke: (s: RevokeState) => void,
-  onConfirm: (grant: AdminGrantListing) => Promise<void>,
-  onRetry: () => void,
-) {
+interface RenderBodyProps {
+  state: State;
+  revoke: RevokeState;
+  setRevoke: (s: RevokeState) => void;
+  onConfirm: (grant: AdminGrantListing) => Promise<void>;
+  onRetry: () => void;
+}
+
+function renderBody({ state, revoke, setRevoke, onConfirm, onRetry }: RenderBodyProps) {
   if (state.kind === "loading") {
     return <p className="muted">Loading…</p>;
   }
@@ -175,7 +183,7 @@ function renderBody(
               </div>
               <div className="dim">
                 <span className="muted">granted </span>
-                <code>{g.granted_at}</code>
+                <code title={g.granted_at}>{formatGrantedAt(g.granted_at)}</code>
               </div>
               <div className="dim" style={{ marginTop: "0.25rem" }}>
                 <span className="muted">scopes: </span>
@@ -239,4 +247,9 @@ function renderBody(
       })}
     </div>
   );
+}
+
+function formatGrantedAt(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
 }

--- a/web/ui/src/routes/Permissions.tsx
+++ b/web/ui/src/routes/Permissions.tsx
@@ -1,0 +1,242 @@
+/**
+ * /permissions — operator's OAuth-grant skip-list.
+ *
+ * Lists every grant the operator has handed out via consent. A grant means
+ * "next time this client asks for these scopes, skip the consent screen."
+ * Revoking a grant *only* forces the consent screen back on the next
+ * authorize flow; active tokens keep working until they expire (or the
+ * operator hits /oauth/revoke separately, out of scope here).
+ *
+ * The `?vault=<name>` filter narrows to grants that touch a specific
+ * vault. We pass it through as a query string on `listGrants`; the server
+ * scope-matches `vault:<name>:*`. Empty filter means "all grants".
+ *
+ * Revoke flow is two-step: click → confirm modal → DELETE → refresh list.
+ * The confirm modal exists because revoking is destructive (consent flow
+ * comes back; the user re-approves from scratch); a stray click should
+ * not erase a grant silently.
+ */
+import { type FormEvent, useEffect, useState } from "react";
+import { type AdminGrantListing, HttpError, listGrants, revokeGrant } from "../lib/api.ts";
+
+type State =
+  | { kind: "loading" }
+  | { kind: "ok"; grants: AdminGrantListing[] }
+  | { kind: "error"; message: string };
+
+type RevokeState =
+  | { kind: "idle" }
+  | { kind: "confirming"; grant: AdminGrantListing }
+  | { kind: "revoking"; clientId: string }
+  | { kind: "error"; clientId: string; message: string };
+
+export function Permissions() {
+  const [state, setState] = useState<State>({ kind: "loading" });
+  const [vaultInput, setVaultInput] = useState("");
+  const [vaultFilter, setVaultFilter] = useState<string>("");
+  const [reload, setReload] = useState(0);
+  const [revoke, setRevoke] = useState<RevokeState>({ kind: "idle" });
+
+  useEffect(() => {
+    // `reload` is a trigger dep — re-running the effect is the whole
+    // point of incrementing it. Same pattern as VaultsList.
+    void reload;
+    let cancelled = false;
+    setState({ kind: "loading" });
+    const opts = vaultFilter ? { vault: vaultFilter } : {};
+    listGrants(opts)
+      .then((grants) => {
+        if (cancelled) return;
+        setState({ kind: "ok", grants });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ kind: "error", message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reload, vaultFilter]);
+
+  function onSubmitFilter(e: FormEvent) {
+    e.preventDefault();
+    setVaultFilter(vaultInput.trim());
+  }
+  function onClearFilter() {
+    setVaultInput("");
+    setVaultFilter("");
+  }
+
+  async function onConfirmRevoke(grant: AdminGrantListing): Promise<void> {
+    setRevoke({ kind: "revoking", clientId: grant.client_id });
+    try {
+      await revokeGrant(grant.client_id);
+      setRevoke({ kind: "idle" });
+      setReload((n) => n + 1);
+    } catch (err) {
+      const message =
+        err instanceof HttpError
+          ? `revoke failed (${err.status}): ${err.message}`
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      setRevoke({ kind: "error", clientId: grant.client_id, message });
+    }
+  }
+
+  return (
+    <div>
+      <div className="list-header">
+        <h2>Permissions</h2>
+      </div>
+
+      <p className="muted">
+        Apps you've granted OAuth scopes to. Revoking a grant forces the consent screen on the next
+        authorize flow — it does <em>not</em> invalidate tokens already issued.
+      </p>
+
+      <form onSubmit={onSubmitFilter} style={{ marginTop: "1rem", marginBottom: "1rem" }}>
+        <label htmlFor="vault-filter" className="muted" style={{ marginRight: "0.5rem" }}>
+          Filter by vault:
+        </label>
+        <input
+          id="vault-filter"
+          type="text"
+          value={vaultInput}
+          onChange={(e) => setVaultInput(e.target.value)}
+          placeholder="e.g. work"
+          style={{ marginRight: "0.5rem" }}
+        />
+        <button type="submit">Apply</button>
+        {vaultFilter ? (
+          <button
+            type="button"
+            onClick={onClearFilter}
+            className="secondary"
+            style={{ marginLeft: "0.5rem" }}
+          >
+            Clear
+          </button>
+        ) : null}
+      </form>
+
+      {renderBody(state, revoke, setRevoke, onConfirmRevoke, () => setReload((n) => n + 1))}
+    </div>
+  );
+}
+
+function renderBody(
+  state: State,
+  revoke: RevokeState,
+  setRevoke: (s: RevokeState) => void,
+  onConfirm: (grant: AdminGrantListing) => Promise<void>,
+  onRetry: () => void,
+) {
+  if (state.kind === "loading") {
+    return <p className="muted">Loading…</p>;
+  }
+  if (state.kind === "error") {
+    return (
+      <>
+        <div className="error-banner">
+          Couldn't load grants: <code>{state.message}</code>
+        </div>
+        <button type="button" onClick={onRetry} className="secondary">
+          Retry
+        </button>
+      </>
+    );
+  }
+  if (state.grants.length === 0) {
+    return (
+      <div className="empty empty-rich">
+        <p className="empty-headline">No grants.</p>
+        <p className="muted">
+          When an app asks for OAuth scopes and you approve them, the grant lands here. Revoking it
+          forces the consent screen on the next authorize flow.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ marginTop: "1rem" }}>
+      {state.grants.map((g) => {
+        const isRevoking = revoke.kind === "revoking" && revoke.clientId === g.client_id;
+        const rowError = revoke.kind === "error" && revoke.clientId === g.client_id ? revoke : null;
+        const isConfirming = revoke.kind === "confirming" && revoke.grant.client_id === g.client_id;
+
+        return (
+          <div key={g.client_id} className="vault-row">
+            <div className="body">
+              <div className="name">
+                <code>{g.client_name ?? g.client_id}</code>
+              </div>
+              <div className="dim">
+                <span className="muted">granted </span>
+                <code>{g.granted_at}</code>
+              </div>
+              <div className="dim" style={{ marginTop: "0.25rem" }}>
+                <span className="muted">scopes: </span>
+                {g.scopes.map((s, i) => (
+                  <span key={s}>
+                    <code>{s}</code>
+                    {i < g.scopes.length - 1 ? " " : null}
+                  </span>
+                ))}
+              </div>
+              {rowError ? (
+                <div className="error-banner" style={{ marginTop: "0.5rem" }}>
+                  <code>{rowError.message}</code>
+                </div>
+              ) : null}
+              {isConfirming ? (
+                <dialog
+                  open
+                  className="error-banner"
+                  style={{ marginTop: "0.5rem", background: "var(--bg-warn, #fffbe6)" }}
+                  aria-label={`Confirm revoke ${g.client_name ?? g.client_id}`}
+                >
+                  <p>
+                    Revoke <code>{g.client_name ?? g.client_id}</code>? Next OAuth flow for this app
+                    will prompt you to consent again.
+                  </p>
+                  <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.5rem" }}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void onConfirm(g);
+                      }}
+                      disabled={isRevoking}
+                    >
+                      {isRevoking ? "Revoking…" : "Revoke"}
+                    </button>
+                    <button
+                      type="button"
+                      className="secondary"
+                      onClick={() => setRevoke({ kind: "idle" })}
+                      disabled={isRevoking}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </dialog>
+              ) : null}
+            </div>
+            {isConfirming ? null : (
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => setRevoke({ kind: "confirming", grant: g })}
+                aria-label={`Revoke ${g.client_name ?? g.client_id}`}
+              >
+                Revoke
+              </button>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #162. Operator can now view and revoke OAuth grants from the SPA without dropping to the CLI.

- `GET /api/grants[?vault=<name>]` — list operator's grants (Bearer-gated, `parachute:host:admin`).
- `DELETE /api/grants/<client_id>` — revoke one grant; emits an audit log line.
- `/hub/permissions` — new SPA route with list / filter / two-step-confirm revoke flow.

The grants table's PK is `(user_id, client_id)`. Since the operator's `user_id` is fixed by the JWT `sub`, `client_id` alone is the URL-segment "id" — and matches the operator mental model ("revoke this app's access") rather than an opaque surrogate. List + revoke are both scoped to that user, so a host-admin token can't reach across users (forward-looking; hub is single-operator today).

## Files

**Server (commit 1):**
- `src/admin-grants.ts` — handlers + ?vault filter + audit log.
- `src/hub-server.ts` — wire `/api/grants` and `/api/grants/:client_id`.
- `src/__tests__/admin-grants.test.ts` — 13 cases (auth surface, vault filter, multi-user isolation, audit log shape).

**SPA (commit 2):**
- `web/ui/src/lib/api.ts` — `listGrants` + `revokeGrant` helpers + `AdminGrantListing` type.
- `web/ui/src/routes/Permissions.tsx` — new route. Filter form, empty / error / loading states, two-step revoke via native `<dialog open>`.
- `web/ui/src/App.tsx` — register route + nav link.
- `web/ui/src/lib/api.test.ts` — 7 new cases (Bearer, ?vault encoding, 401 cache-clear).
- `web/ui/src/routes/Permissions.test.tsx` — 7 new cases (loading→ok / empty / error, filter Apply, revoke confirm cancel + happy + error).

**Version (commit 3):** `0.4.0-rc.41` → `0.4.0-rc.42`.

## Audit log shape

Matches the existing `oauth-handlers.ts:395` pattern (`consent skipped: client_id=… user_id=… scopes=…`). No structured-logging infra exists in the hub yet; matching the prevailing format keeps log-grep ergonomics consistent.

```
grant revoked: client_id=<cid> user_id=<sub> scopes=<space-separated>
```

## Smoke (bun-linked checkout)

Spun the hub on a sandboxed port and probed:

- `GET /api/grants` no auth → `401` + RFC 6750 body (`missing Authorization header`). ✓
- `GET /api/grants` bogus bearer → `401`. ✓
- `DELETE /api/grants/abc` no auth → `401`. ✓
- `DELETE /api/grants/with%2Fslash` → `404` (the `includes('/')` guard catches encoded slashes after decode). ✓
- `GET /hub/permissions` → `200` HTML (SPA bundle includes the new route). ✓

## Gates

- `bun run typecheck` — clean (host + SPA both).
- `bun run test` — host: 936 / 936 pass (up from 923; +13 grants-handler cases).
- `bun run -C web/ui test` — SPA: 46 / 46 pass (up from 31; +14 cases for new helpers + route).
- `bun run build:spa` — clean, `verify-base` green.
- `bunx biome check` on touched files — clean.

## Pre-existing biome errors (out of scope)

3 pre-existing biome errors in `src/__tests__/cli.test.ts` (formatter) and `src/commands/expose-public-auto.ts` (formatter + organizeImports) carry over from `main` and are unrelated to this work. Touched files are all clean. Same flag the previous PR carried.

## Note on hub#164

I filed hub#164 yesterday claiming `vi.mock(..., async (orig) => …)` was broken under vitest 4.1.5. On this branch, all 46 SPA tests pass — including the `(orig)` factory pattern in `VaultsList.test.tsx`. The original failure may have been a transient state on a stale checkout, or specific to a particular `node_modules` snapshot. I'll leave #164 open for a verifying eye but the regression is not currently observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)