### PR TITLE
fix(lifecycle): parachute start|stop|restart|logs hub (#166)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.42",
+  "version": "0.4.0-rc.43",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -938,3 +938,185 @@ describe("process-group lifecycle (hub#88)", () => {
     }
   });
 });
+
+/**
+ * `parachute start|stop|restart hub` — the bug Aaron filed as hub#166. Hub
+ * isn't a row in services.json, so the generic services-manifest path
+ * surfaced "unknown service: hub". The fix dispatches `svc === "hub"`
+ * straight to hub-control.ts. These tests inject `ensureRunning`/`stop`
+ * stubs so we don't actually fork bun.
+ */
+describe("parachute start|stop|restart hub", () => {
+  test("start hub: dispatches to ensureHubRunning, propagates configDir + issuer", async () => {
+    const h = makeHarness();
+    try {
+      const log: string[] = [];
+      const ensureCalls: Array<{ configDir?: string; issuer?: string }> = [];
+      const code = await start("hub", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        hubOrigin: "https://hub.example.com",
+        hub: {
+          ensureRunning: async (opts) => {
+            ensureCalls.push({ configDir: opts.configDir, issuer: opts.issuer });
+            return { pid: 4711, port: 1939, started: true };
+          },
+        },
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(ensureCalls).toHaveLength(1);
+      expect(ensureCalls[0]).toEqual({
+        configDir: h.configDir,
+        issuer: "https://hub.example.com",
+      });
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("start hub: reports already-running cleanly when ensureHubRunning returns started=false", async () => {
+    const h = makeHarness();
+    try {
+      const log: string[] = [];
+      const code = await start("hub", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        hub: {
+          ensureRunning: async () => ({ pid: 8888, port: 1939, started: false }),
+        },
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(log.join("\n")).toMatch(/hub already running \(pid 8888\) on port 1939/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("start hub: surfaces ensureHubRunning errors as exit 1", async () => {
+    const h = makeHarness();
+    try {
+      const log: string[] = [];
+      const code = await start("hub", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        hub: {
+          ensureRunning: async () => {
+            throw new Error("hub: port 1939 unavailable");
+          },
+        },
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(1);
+      expect(log.join("\n")).toMatch(/hub failed to start.*port 1939 unavailable/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("stop hub: dispatches to stopHub, true → '✓ hub stopped'", async () => {
+    const h = makeHarness();
+    try {
+      const log: string[] = [];
+      const stopCalls: Array<{ configDir?: string }> = [];
+      const code = await stop("hub", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        hub: {
+          stop: async (opts) => {
+            stopCalls.push({ configDir: opts.configDir });
+            return true;
+          },
+        },
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(stopCalls).toHaveLength(1);
+      expect(stopCalls[0]?.configDir).toBe(h.configDir);
+      expect(log.join("\n")).toMatch(/✓ hub stopped/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("stop hub: false → 'wasn't running' (still exit 0)", async () => {
+    const h = makeHarness();
+    try {
+      const log: string[] = [];
+      const code = await stop("hub", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        hub: { stop: async () => false },
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(log.join("\n")).toMatch(/hub wasn't running/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("restart hub: chains stop then start through the same hub seam", async () => {
+    const h = makeHarness();
+    try {
+      const log: string[] = [];
+      const order: string[] = [];
+      const code = await restart("hub", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        hub: {
+          stop: async () => {
+            order.push("stop");
+            return true;
+          },
+          ensureRunning: async () => {
+            order.push("start");
+            return { pid: 5151, port: 1939, started: true };
+          },
+        },
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(order).toEqual(["stop", "start"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("logs hub: doesn't reject 'hub' as an unknown service", async () => {
+    const h = makeHarness();
+    try {
+      // No log file yet — exercise the "no logs yet" branch, which still
+      // returns 0. Goal of this test is just the unknown-service guard.
+      const log: string[] = [];
+      const code = await logs("hub", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(log.join("\n")).toMatch(/no logs yet for hub/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("logs hub: prints the tail when a log file exists", async () => {
+    const h = makeHarness();
+    try {
+      const path = ensureLogPath("hub", h.configDir);
+      writeFileSync(path, "hub line one\nhub line two\n");
+      const log: string[] = [];
+      const code = await logs("hub", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(log).toEqual(["hub line one", "hub line two"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ import {
   topLevelHelp,
   upgradeHelp,
 } from "./help.ts";
+import { HUB_SVC } from "./hub-control.ts";
 import { knownServices } from "./service-spec.ts";
 import { ServicesManifestError } from "./services-manifest.ts";
 import { TailscaleError } from "./tailscale/run.ts";
@@ -565,7 +566,7 @@ async function main(argv: string[]): Promise<number> {
       const svc = rest[0];
       if (!svc) {
         console.error("usage: parachute logs <service> [-f]");
-        console.error(`services: hub, ${knownServices().join(", ")}`);
+        console.error(`services: ${[HUB_SVC, ...knownServices()].join(", ")}`);
         return 1;
       }
       const follow = rest.includes("-f") || rest.includes("--follow");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -565,7 +565,7 @@ async function main(argv: string[]): Promise<number> {
       const svc = rest[0];
       if (!svc) {
         console.error("usage: parachute logs <service> [-f]");
-        console.error(`services: ${knownServices().join(", ")}`);
+        console.error(`services: hub, ${knownServices().join(", ")}`);
         return 1;
       }
       const follow = rest.includes("-f") || rest.includes("--follow");

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -423,13 +423,20 @@ export async function restart(svc: string | undefined, opts: LifecycleOpts = {})
  * port-fallback probe, the port-file write, and the issuer flag — none of
  * which fit a generic `SERVICE_SPECS` entry. The hub origin (when known)
  * doubles as the OAuth `iss` claim, so we forward it as `issuer`.
+ *
+ * Silences `ensureHubRunning`'s own log and emits our own `✓ hub started …`
+ * line so the output matches the service-start shape (`✓ vault started
+ * (pid X); logs: …`) and `stopHubSvc`'s `✓ hub stopped.` symmetry.
  */
 async function startHubSvc(r: Resolved): Promise<number> {
-  const ensureOpts: EnsureHubOpts = { configDir: r.configDir, log: r.log };
+  const ensureOpts: EnsureHubOpts = { configDir: r.configDir, log: () => {} };
   if (r.hubOrigin) ensureOpts.issuer = r.hubOrigin;
   try {
     const result = await r.ensureHub(ensureOpts);
-    if (!result.started) {
+    if (result.started) {
+      const logFile = logPathFor(HUB_SVC, r.configDir);
+      r.log(`✓ hub started (pid ${result.pid}) on port ${result.port}; logs: ${logFile}`);
+    } else {
       r.log(`hub already running (pid ${result.pid}) on port ${result.port}.`);
     }
     return 0;

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -3,7 +3,15 @@ import { join } from "node:path";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import { readEnvFileValues } from "../env-file.ts";
 import { readExposeState } from "../expose-state.ts";
-import { readHubPort } from "../hub-control.ts";
+import {
+  type EnsureHubOpts,
+  type EnsureHubResult,
+  HUB_SVC,
+  type StopHubOpts,
+  ensureHubRunning,
+  readHubPort,
+  stopHub,
+} from "../hub-control.ts";
 import { HUB_ORIGIN_ENV, deriveHubOrigin } from "../hub-origin.ts";
 import { ModuleManifestError } from "../module-manifest.ts";
 import {
@@ -135,6 +143,18 @@ export interface LifecycleOpts {
    * and the service advertises its own default issuer.
    */
   hubOrigin?: string;
+  /**
+   * Hub-lifecycle seams for `parachute start|stop|restart hub`. The hub
+   * doesn't go through the generic services-manifest path because its
+   * start has special semantics (port-fallback probe, port-file write,
+   * --issuer flag) — `lifecycle.start("hub")` dispatches to
+   * `ensureHubRunning` and `lifecycle.stop("hub")` dispatches to
+   * `stopHub`. Tests inject stubs to avoid spawning real bun processes.
+   */
+  hub?: {
+    ensureRunning?: (opts: EnsureHubOpts) => Promise<EnsureHubResult>;
+    stop?: (opts: StopHubOpts) => Promise<boolean>;
+  };
 }
 
 interface Resolved {
@@ -149,6 +169,8 @@ interface Resolved {
   killWaitMs: number;
   pollIntervalMs: number;
   hubOrigin: string | undefined;
+  ensureHub: (opts: EnsureHubOpts) => Promise<EnsureHubResult>;
+  stopHubFn: (opts: StopHubOpts) => Promise<boolean>;
 }
 
 function resolve(opts: LifecycleOpts): Resolved {
@@ -165,6 +187,8 @@ function resolve(opts: LifecycleOpts): Resolved {
     killWaitMs: opts.killWaitMs ?? 10_000,
     pollIntervalMs: opts.pollIntervalMs ?? 200,
     hubOrigin: resolveHubOrigin(opts.hubOrigin, configDir),
+    ensureHub: opts.hub?.ensureRunning ?? ensureHubRunning,
+    stopHubFn: opts.hub?.stop ?? stopHub,
   };
 }
 
@@ -278,6 +302,7 @@ async function resolveTargets(
 
 export async function start(svc: string | undefined, opts: LifecycleOpts = {}): Promise<number> {
   const r = resolve(opts);
+  if (svc === HUB_SVC) return startHubSvc(r);
   const picked = await resolveTargets(svc, r.manifestPath);
   if ("error" in picked) {
     r.log(picked.error);
@@ -337,6 +362,7 @@ export async function start(svc: string | undefined, opts: LifecycleOpts = {}): 
 
 export async function stop(svc: string | undefined, opts: LifecycleOpts = {}): Promise<number> {
   const r = resolve(opts);
+  if (svc === HUB_SVC) return stopHubSvc(r);
   const picked = await resolveTargets(svc, r.manifestPath);
   if ("error" in picked) {
     r.log(picked.error);
@@ -392,6 +418,48 @@ export async function restart(svc: string | undefined, opts: LifecycleOpts = {})
   return await start(svc, opts);
 }
 
+/**
+ * Start the internal hub. Delegates to `ensureHubRunning`, which owns the
+ * port-fallback probe, the port-file write, and the issuer flag — none of
+ * which fit a generic `SERVICE_SPECS` entry. The hub origin (when known)
+ * doubles as the OAuth `iss` claim, so we forward it as `issuer`.
+ */
+async function startHubSvc(r: Resolved): Promise<number> {
+  const ensureOpts: EnsureHubOpts = { configDir: r.configDir, log: r.log };
+  if (r.hubOrigin) ensureOpts.issuer = r.hubOrigin;
+  try {
+    const result = await r.ensureHub(ensureOpts);
+    if (!result.started) {
+      r.log(`hub already running (pid ${result.pid}) on port ${result.port}.`);
+    }
+    return 0;
+  } catch (err) {
+    r.log(`✗ hub failed to start: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}
+
+/**
+ * Stop the internal hub. `stopHub` returns false when nothing was running
+ * (no pidfile, or stale pidfile cleared) — that's a clean no-op for the
+ * operator, so we still exit 0.
+ */
+async function stopHubSvc(r: Resolved): Promise<number> {
+  try {
+    const stopped = await r.stopHubFn({
+      configDir: r.configDir,
+      log: r.log,
+      killWaitMs: r.killWaitMs,
+      pollIntervalMs: r.pollIntervalMs,
+    });
+    r.log(stopped ? "✓ hub stopped." : "hub wasn't running.");
+    return 0;
+  } catch (err) {
+    r.log(`✗ hub failed to stop: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}
+
 export interface LogsOpts {
   configDir?: string;
   manifestPath?: string;
@@ -411,14 +479,15 @@ export async function logs(svc: string, opts: LogsOpts = {}): Promise<number> {
   const follow = opts.follow ?? false;
 
   // logs only needs a valid short name to find the log file. First-party
-  // wins via the spec lookup; third-party rows match by `entry.name`. We
-  // don't need the full spec here — we just need to confirm the name maps
-  // to something the CLI manages.
+  // wins via the spec lookup; third-party rows match by `entry.name`; the
+  // internal hub is a known short outside of services.json. We don't need
+  // the full spec here — we just need to confirm the name maps to
+  // something the CLI manages.
   const isFirstParty = getSpec(svc) !== undefined;
-  if (!isFirstParty) {
+  if (!isFirstParty && svc !== HUB_SVC) {
     const entry = readManifest(manifestPath).services.find((s) => s.name === svc);
     if (!entry?.installDir) {
-      log(`unknown service "${svc}". known: ${knownServices().join(", ")}`);
+      log(`unknown service "${svc}". known: ${[HUB_SVC, ...knownServices()].join(", ")}`);
       return 1;
     }
   }

--- a/src/help.ts
+++ b/src/help.ts
@@ -243,6 +243,7 @@ export function startHelp(): string {
 Usage:
   parachute start                   start every installed service
   parachute start <service>         start just that one
+  parachute start hub               start the internal hub (port 1939)
 
 What it does:
   For each target service, spawns its start command detached, redirects
@@ -253,16 +254,23 @@ What it does:
   If a stale PID file exists (process died without cleanup), it's cleared
   and the service starts fresh.
 
+  \`parachute start hub\` brings up the internal hub directly (normally
+  spawned implicitly by \`parachute expose\`). Useful when restarting a
+  hub that crashed without an active expose layer.
+
 Flags:
   --hub-origin <url>    override PARACHUTE_HUB_ORIGIN passed to services
-                        (default: current expose-state hub origin, else loopback)
+                        (default: current expose-state hub origin, else loopback).
+                        For \`start hub\`, also doubles as the hub's --issuer.
 
 Examples:
   parachute start                   bring everything up
   parachute start vault             just vault
+  parachute start hub               just the internal hub
   parachute logs vault              watch what just started
 
 Start commands by service:
+  hub       bun <cli>/hub-server.ts --port <picked> ...
   vault     parachute-vault serve
   scribe    parachute-scribe serve
   channel   parachute-channel daemon
@@ -276,6 +284,7 @@ export function stopHelp(): string {
 Usage:
   parachute stop                    stop every installed service
   parachute stop <service>          stop just that one
+  parachute stop hub                stop the internal hub
 
 What it does:
   Sends SIGTERM, waits up to 10s for a clean exit, then escalates to
@@ -283,9 +292,13 @@ What it does:
 
   No-op if the service wasn't running.
 
+  Bare \`parachute stop\` (no service) does NOT stop the hub — that's
+  managed by the active expose layer (or \`parachute stop hub\` directly).
+
 Examples:
   parachute stop                    stop everything before sleep
   parachute stop vault              just vault
+  parachute stop hub                just the internal hub
 `;
 }
 
@@ -295,6 +308,7 @@ export function restartHelp(): string {
 Usage:
   parachute restart                 restart every installed service
   parachute restart <service>       restart just that one
+  parachute restart hub             restart the internal hub
 
 What it does:
   Equivalent to \`parachute stop <svc> && parachute start <svc>\`.
@@ -340,6 +354,7 @@ export function logsHelp(): string {
 Usage:
   parachute logs <service>          print the last 200 lines
   parachute logs <service> -f       tail the log (like \`tail -f\`)
+  parachute logs hub                logs for the internal hub
 
 Log file:
   ~/.parachute/<service>/logs/<service>.log


### PR DESCRIPTION
## Summary

Closes #166. `parachute stop hub` (and `start`/`restart`/`logs`) was returning `unknown service: hub` because `lifecycle.start|stop|logs` checked `getSpec(svc)` and the hub isn't in `SERVICE_SPECS`. The fix routes `svc === "hub"` to the existing self-managed lifecycle in `hub-control.ts`.

- `parachute start hub` → `ensureHubRunning(...)` (port-fallback probe + port-file write + `--issuer` flag, all already there). Threads `--hub-origin` through as the OAuth `iss` claim.
- `parachute stop hub` → `stopHub(...)`. Returns `false` for "wasn't running" — surfaced as a clean message, still exit 0.
- `parachute restart hub` falls out of the existing `stop → start` chain.
- `parachute logs hub` skips the unknown-service guard. The log file already lives at `~/.parachute/hub/logs/hub.log` via `process-state.ts`'s `HUB_SVC` constant — no new wiring needed.
- Bare `parachute stop` / `parachute start` (no svc) intentionally still does NOT touch the hub. The active `expose` layer owns hub lifecycle for that case; explicit `stop hub` is the operator's lever.

## Why approach B (special-case dispatch), not A (hub-in-SERVICE_SPECS)

The brief leaned A, but two real reasons against:

1. **No launchctl/systemctl integration exists.** The brief hypothesized the hub was started via launchd plists today; it isn't. The hub is a plain `Bun.spawn(detached)` from `hub-control.ts`. So there's no "system command" to dispatch to via SERVICE_SPECS.
2. **Hub's start has special semantics that don't fit a generic spec.** Port-fallback probe (it walks 1939 only — no walking into 1940+ services), port-file write (`hub.port`), `--issuer` flag (OAuth iss claim plumbing). Adding these into ServiceSpec would either bloat the interface with hub-only fields or duplicate the logic.

The hub IS already self-managed (the team-lead's framing was right). The dispatch lives in `lifecycle.ts` instead of via a `SERVICE_SPECS` row, but it's a small, well-scoped seam (3 commands × ~10 lines each + a `LifecycleOpts.hub` test seam).

## Files

- `src/commands/lifecycle.ts` — adds `LifecycleOpts.hub` test seam, hub-special-case at the top of `start()`, `stop()`, `logs()`. `restart` chains the two and works automatically. New `startHubSvc`/`stopHubSvc` helpers.
- `src/help.ts` — documents `hub` target on `start`/`stop`/`restart`/`logs` help; spells out that bare `stop` doesn't touch the hub.
- `src/cli.ts` — `parachute logs` no-arg error hint now lists `hub` first.
- `src/__tests__/lifecycle.test.ts` — 8 new tests (`describe("parachute start|stop|restart hub")`).
- `package.json` — `0.4.0-rc.42` → `0.4.0-rc.43`.

## Gates

- typecheck clean
- 944/944 host tests pass (936 prior + 8 new)
- biome on touched files clean

## Smoke

Sandboxed `PARACHUTE_HOME=/tmp/smoke-hub-svc-$$`:

```
$ parachute stop hub
hub wasn't running.                                    # pre-fix: "unknown service: hub"

$ parachute start hub
✗ hub failed to start: hub: port 1939 unavailable...   # pre-fix: "unknown service: hub"
                                                       # (Aaron's real hub on 1939 — proves dispatch works)
```

Both branches that were returning "unknown service" now reach the real hub-control.ts code path. The happy-path is covered by unit tests; the smoke-rig couldn't free 1939 without disturbing Aaron's running hub.

## Test plan

- [x] `parachute stop hub` returns "hub wasn't running" or "✓ hub stopped" instead of "unknown service: hub"
- [x] `parachute start hub` dispatches to `ensureHubRunning` and threads `--hub-origin` as `--issuer`
- [x] `parachute restart hub` chains stop + start in order
- [x] `parachute logs hub` finds `~/.parachute/hub/logs/hub.log` (or "no logs yet" hint)
- [x] Bare `parachute stop` (no svc) does NOT stop the hub
- [x] Help text mentions `hub` on each lifecycle command

🤖 Generated with [Claude Code](https://claude.com/claude-code)