### PR TITLE
feat(hub): collapse home page into one tile per module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.43",
+  "version": "0.4.0-rc.44",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub.test.ts
+++ b/src/__tests__/hub.test.ts
@@ -13,10 +13,10 @@ describe("renderHub", () => {
     expect(html).toContain("<script>");
   });
 
-  test("fetches /.well-known/parachute.json and iterates services[]", () => {
+  test("fetches /.well-known/parachute.json and reads services[] + vaults[]", () => {
     expect(html).toContain("/.well-known/parachute.json");
     expect(html).toContain("doc.services");
-    expect(html).toContain("infoUrl");
+    expect(html).toContain("doc.vaults");
   });
 
   test("uses parachute.computer sage palette and serif/sans fonts", () => {
@@ -30,72 +30,78 @@ describe("renderHub", () => {
     expect(html).toContain("prefers-color-scheme: dark");
   });
 
-  test("falls back to a generic icon when service has none", () => {
+  test("falls back to a generic icon for module tiles", () => {
     expect(html).toContain("fallbackIcon");
   });
 
-  test("branches card rendering on info.kind (api/tool → interactive, else link)", () => {
-    // Script picks the element type and wires up toggling based on info.kind.
-    expect(html).toContain("isInteractiveKind");
-    expect(html).toContain("'api'");
-    expect(html).toContain("'tool'");
-    expect(html).toContain("'frontend'");
+  test("renders one tile per module type, not per service instance", () => {
+    expect(html).toContain("aggregate(services, vaults)");
+    expect(html).toContain("renderTile");
+    expect(html).toContain("MODULE_ORDER");
   });
 
-  test("interactive cards get keyboard + aria affordances", () => {
-    expect(html).toContain("role");
-    expect(html).toContain("tabindex");
-    expect(html).toContain("aria-expanded");
-    expect(html).toContain("Enter");
+  test("known module display order is vault → scribe → notes → claw", () => {
+    expect(html).toContain("['vault', 'scribe', 'notes', 'claw']");
   });
 
-  test("detail panel surfaces OAuth discovery, MCP, open-in-Notes, service URL", () => {
-    expect(html).toContain("/.well-known/oauth-authorization-server");
-    expect(html).toContain("info.mcpUrl");
-    expect(html).toContain("info.openInNotesUrl");
-    expect(html).toContain("Service URL");
-    expect(html).toContain("OAuth discovery");
+  test("vault tile counts vaults[] (per instance) and links to /hub/vaults", () => {
+    // Vault count is the length of doc.vaults — one entry per /vault/<name>
+    // mount, so a single ServiceEntry with paths=[a,b,c] still shows "3
+    // registered". The manage link is the hub's vault SPA, never an
+    // individual vault backend.
+    expect(html).toContain("vaults.length");
+    expect(html).toContain("'/hub/vaults'");
   });
 
-  test("details panel is hidden until the card is expanded", () => {
-    expect(html).toContain(".details {");
-    expect(html).toContain("display: none");
-    expect(html).toContain(".card.expanded .details");
+  test("non-vault tiles take their manageUrl from the service's path", () => {
+    // shortName('parachute-scribe') = 'scribe' → tile links to svc.path,
+    // which is whatever the module declared (e.g. /scribe, /notes, /claw).
+    // Hardcoding the link would silently break on a custom mount.
+    expect(html).toContain("manageUrl: svc.path");
   });
 
-  test("lazy-fetches /.parachute/config/schema + /.parachute/config on first expand", () => {
-    expect(html).toContain("fetchConfig");
-    expect(html).toContain("/.parachute/config/schema");
-    expect(html).toContain("/.parachute/config");
-    // Lazy: fetch happens inside the toggle, guarded by configLoaded.
-    expect(html).toContain("configLoaded");
+  test("tiles for module types with zero instances are hidden", () => {
+    // Aggregate only inserts a group when the type has at least one entry;
+    // tilesInOrder iterates the map. No "0 registered" surface.
+    expect(html).not.toContain("0 registered");
+    expect(html).toContain("count === 1 ? '1 registered'");
   });
 
-  test("renders config form fields with disabled inputs (read-only in this launch)", () => {
-    expect(html).toContain("renderConfigField");
-    expect(html).toContain("input.disabled = true");
-    expect(html).toContain("aria-readonly");
-    // Hint text tells users where to edit instead.
-    expect(html).toContain("read-only in this launch");
+  test("module labels are humanized (Vault / Scribe / Notes / Claw)", () => {
+    expect(html).toContain("vault: 'Vault'");
+    expect(html).toContain("scribe: 'Scribe'");
+    expect(html).toContain("notes: 'Notes'");
+    expect(html).toContain("claw: 'Claw'");
   });
 
-  test("config field types: enum→select, boolean→checkbox, number→number, uri→url", () => {
-    expect(html).toContain("schema.enum");
-    expect(html).toContain("'checkbox'");
-    expect(html).toContain("'number'");
-    expect(html).toContain("'url'");
+  test("vault-name detection covers parachute-vault and parachute-vault-<name>", () => {
+    // Phase-1 multi-vault keeps a single ServiceEntry with multiple paths
+    // (parachute-vault), but the door is open for per-instance entries
+    // (parachute-vault-techne). isVaultName has to accept both.
+    expect(html).toContain("isVaultName");
+    expect(html).toContain("'parachute-vault'");
+    expect(html).toContain("'parachute-vault-'");
   });
 
-  test("writeOnly fields render a bullet placeholder instead of the raw value", () => {
-    expect(html).toContain("writeOnly");
-    // Six bullets as the placeholder (template literal resolves \u2022 → •).
-    expect(html).toContain("\u2022\u2022\u2022\u2022\u2022\u2022");
+  test("empty state when no modules are registered", () => {
+    expect(html).toContain("No modules installed yet");
+    expect(html).toContain("parachute install vault");
   });
 
-  test("schema 404 path renders nothing (no error surfaced)", () => {
-    // fetchConfig returns null on non-ok; caller skips render.
-    expect(html).toContain("if (!schemaResp || !schemaResp.ok) return null");
-    expect(html).toContain("if (data)");
+  test("error state surfaces the underlying message", () => {
+    expect(html).toContain("Could not load modules");
+  });
+
+  test("does not retain the per-service interactive-card / config-form code", () => {
+    // The home page is now a directory of modules — per-instance config
+    // forms and detail panels live behind the Manage links (vault SPA at
+    // /hub/vaults, the running module's own UI elsewhere). Keeping the
+    // dead code around is a maintenance trap.
+    expect(html).not.toContain("renderConfigField");
+    expect(html).not.toContain("fetchConfig");
+    expect(html).not.toContain("kind-badge");
+    expect(html).not.toContain("info.mcpUrl");
+    expect(html).not.toContain("info.openInNotesUrl");
   });
 });
 

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -3,20 +3,19 @@ import { dirname, join } from "node:path";
 import { CONFIG_DIR } from "./config.ts";
 
 /**
- * Hub page served at `/` when the node is exposed. Lists every installed
- * service via a client-side fetch to `/.well-known/parachute.json` and each
- * service's own `/.parachute/info`. Everything that needs personalization
- * (name, tagline, icon) comes from the service, not the CLI — adding a new
- * frontend requires zero hub-page changes.
+ * Hub page served at `/` when the node is exposed.
  *
- * Card kinds (from `info.kind`, optional):
- *   "frontend" | undefined  → whole card is an <a> that navigates to svc.url
- *   "api" | "tool"          → card is non-navigating; click toggles a detail
- *                             panel with OAuth/MCP/open-in-Notes links, so
- *                             API-only services don't dead-end on raw JSON.
+ * The page is a *module directory*: one tile per module type (vault, scribe,
+ * notes, claw), not one row per service instance. Aaron's original shape
+ * iterated `services[]` and rendered a card per entry — fine at one vault,
+ * but at three vaults plus scribe + notes + claw the page reads as a flat
+ * list of instances rather than the modules themselves (#168). The new shape
+ * aggregates: "Vault — 3 registered — Manage →" links to the per-vault SPA at
+ * `/hub/vaults`; "Scribe — 1 registered" links to the running scribe instance;
+ * etc. Zero-count types are hidden entirely.
  *
- * The file is fully self-contained (inline CSS + JS, no external assets)
- * so `tailscale serve` can mount it directly from disk with `--set-path=/`.
+ * The file stays self-contained (inline CSS + JS, no external assets) so
+ * `tailscale serve` can mount it directly from disk with `--set-path=/`.
  */
 
 export const HUB_PATH = join(CONFIG_DIR, "well-known", "hub.html");
@@ -169,7 +168,7 @@ const HTML = `<!doctype html>
     margin: 0;
     line-height: 1.1;
   }
-  .card-tagline {
+  .card-count {
     color: var(--fg-muted);
     font-size: 0.95rem;
     margin: 0;
@@ -183,126 +182,13 @@ const HTML = `<!doctype html>
     font-size: 0.8rem;
     color: var(--fg-dim);
   }
-  .version {
-    font-family: ui-monospace, 'SF Mono', Monaco, monospace;
-    padding: 0.1rem 0.5rem;
-    background: var(--bg-soft);
-    border-radius: 999px;
-    border: 1px solid var(--border);
-  }
   .path {
     font-family: ui-monospace, 'SF Mono', Monaco, monospace;
     color: var(--fg-muted);
   }
-  .kind-badge {
-    font-size: 0.7rem;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    color: var(--fg-dim);
-    padding: 0.1rem 0.45rem;
-    border-radius: 999px;
-    border: 1px solid var(--border);
-  }
-  .card.interactive { cursor: pointer; }
-  .card.interactive:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-  }
-  .details {
-    display: none;
-    flex-direction: column;
-    gap: 0.5rem;
-    margin-top: 0.75rem;
-    padding-top: 0.75rem;
-    border-top: 1px dashed var(--border);
-    font-size: 0.9rem;
-  }
-  .card.expanded .details { display: flex; }
-  .details a {
+  .manage {
     color: var(--accent);
-    text-decoration: none;
-    border-bottom: 1px solid transparent;
-    transition: border-color 0.15s ease;
-    word-break: break-all;
-  }
-  .details a:hover { border-bottom-color: var(--accent-light); }
-  .details .row {
-    display: flex;
-    flex-direction: column;
-    gap: 0.15rem;
-  }
-  .details .row .label {
-    font-size: 0.75rem;
-    color: var(--fg-dim);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-  }
-  .config {
-    display: flex;
-    flex-direction: column;
-    gap: 0.6rem;
-    margin-top: 0.5rem;
-    padding-top: 0.6rem;
-    border-top: 1px dashed var(--border);
-  }
-  .config h3 {
-    font-family: var(--serif);
-    font-size: 1.05rem;
-    font-weight: 400;
-    margin: 0;
-  }
-  .config .hint {
-    color: var(--fg-dim);
-    font-size: 0.78rem;
-    font-style: italic;
-  }
-  .config fieldset {
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 0.6rem 0.8rem;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-  .config legend {
-    padding: 0 0.35rem;
-    font-size: 0.75rem;
-    color: var(--fg-dim);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-  }
-  .config .field {
-    display: flex;
-    flex-direction: column;
-    gap: 0.15rem;
-  }
-  .config .field-label {
-    font-size: 0.82rem;
-    color: var(--fg-muted);
     font-weight: 500;
-  }
-  .config .field-description {
-    font-size: 0.75rem;
-    color: var(--fg-dim);
-  }
-  .config input,
-  .config select,
-  .config textarea {
-    font-family: var(--sans);
-    font-size: 0.88rem;
-    padding: 0.35rem 0.5rem;
-    background: var(--bg-soft);
-    color: var(--fg);
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    opacity: 0.85;
-    cursor: not-allowed;
-  }
-  .config input[type="checkbox"] {
-    width: 1rem;
-    height: 1rem;
-    padding: 0;
   }
   .empty, .error {
     text-align: center;
@@ -347,10 +233,10 @@ const HTML = `<!doctype html>
 <main>
   <header>
     <h1>Parachute</h1>
-    <p class="tagline">Your personal-computing services.</p>
+    <p class="tagline">Your personal-computing modules.</p>
   </header>
-  <section id="services" class="grid" aria-live="polite">
-    <div class="empty" id="loading">Loading services\u2026</div>
+  <section id="modules" class="grid" aria-live="polite">
+    <div class="empty" id="loading">Loading modules\u2026</div>
   </section>
   <footer>
     <a href="/.well-known/parachute.json">discovery</a>
@@ -358,298 +244,115 @@ const HTML = `<!doctype html>
 </main>
 <script>
 (async () => {
-  const root = document.getElementById('services');
+  const root = document.getElementById('modules');
   const fallbackIcon = \`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="9"/></svg>\`;
+
+  // Display order for known module types. Unknown short-names append after,
+  // so a third-party module mounted at /foo still gets a tile.
+  const MODULE_ORDER = ['vault', 'scribe', 'notes', 'claw'];
+  const MODULE_LABELS = {
+    vault: 'Vault',
+    scribe: 'Scribe',
+    notes: 'Notes',
+    claw: 'Claw',
+  };
+
+  function isVaultName(name) {
+    return name === 'parachute-vault' || name.startsWith('parachute-vault-');
+  }
 
   function shortName(manifestName) {
     return manifestName.replace(/^parachute-/, '');
   }
 
-  function fetchWithTimeout(url, ms) {
-    const ctl = new AbortController();
-    const t = setTimeout(() => ctl.abort(), ms);
-    return fetch(url, { signal: ctl.signal, credentials: 'omit' })
-      .finally(() => clearTimeout(t));
+  function labelFor(type) {
+    if (MODULE_LABELS[type]) return MODULE_LABELS[type];
+    return type.charAt(0).toUpperCase() + type.slice(1);
   }
 
-  async function loadInfo(infoUrl) {
-    try {
-      const r = await fetchWithTimeout(infoUrl, 2000);
-      if (!r.ok) return null;
-      return await r.json();
-    } catch { return null; }
-  }
-
-  function isInteractiveKind(kind) {
-    return kind === 'api' || kind === 'tool';
-  }
-
-  function appendDetailRow(parent, label, node) {
-    const row = document.createElement('div');
-    row.className = 'row';
-    const lab = document.createElement('span');
-    lab.className = 'label';
-    lab.textContent = label;
-    row.appendChild(lab);
-    row.appendChild(node);
-    parent.appendChild(row);
-  }
-
-  function linkNode(href, text) {
-    const a = document.createElement('a');
-    a.href = href;
-    a.textContent = text || href;
-    a.target = '_blank';
-    a.rel = 'noopener';
-    return a;
-  }
-
-  function renderDetails(svc, info) {
-    const box = document.createElement('div');
-    box.className = 'details';
-    // OAuth discovery is served by the hub (this origin) per the Phase 0 seam.
-    appendDetailRow(
-      box,
-      'OAuth discovery',
-      linkNode('/.well-known/oauth-authorization-server'),
-    );
-    if (info && typeof info.mcpUrl === 'string' && info.mcpUrl) {
-      appendDetailRow(box, 'MCP endpoint', linkNode(info.mcpUrl));
+  // Aggregate services + vaults into one entry per module type. Vault is
+  // special-cased because its count comes from doc.vaults[] (one entry per
+  // vault instance / mount path) and its manage link goes to the hub's
+  // per-vault SPA at /hub/vaults — not to any single vault backend.
+  function aggregate(services, vaults) {
+    const groups = new Map();
+    if (vaults.length > 0) {
+      groups.set('vault', {
+        type: 'vault',
+        label: 'Vault',
+        count: vaults.length,
+        manageUrl: '/hub/vaults',
+      });
     }
-    if (info && typeof info.openInNotesUrl === 'string' && info.openInNotesUrl) {
-      appendDetailRow(box, 'Open in Notes', linkNode(info.openInNotesUrl, 'Open →'));
-    }
-    // Direct URL is still useful for power users even if the card doesn't navigate.
-    appendDetailRow(box, 'Service URL', linkNode(svc.url));
-    // Empty slot — config fetched + populated lazily on first expand.
-    const configSlot = document.createElement('div');
-    configSlot.className = 'config-slot';
-    box.appendChild(configSlot);
-    return { box, configSlot };
-  }
-
-  async function fetchConfig(svcUrl) {
-    // Schema endpoint may 404 for modules that haven't shipped config yet;
-    // in that case we render nothing (no error surfaced).
-    const schemaResp = await fetchWithTimeout(
-      svcUrl.replace(/\\/+$/, '') + '/.parachute/config/schema',
-      2000,
-    ).catch(() => null);
-    if (!schemaResp || !schemaResp.ok) return null;
-    const schema = await schemaResp.json().catch(() => null);
-    if (!schema || typeof schema !== 'object') return null;
-    const valuesResp = await fetchWithTimeout(
-      svcUrl.replace(/\\/+$/, '') + '/.parachute/config',
-      2000,
-    ).catch(() => null);
-    const values = valuesResp && valuesResp.ok ? await valuesResp.json().catch(() => ({})) : {};
-    return { schema, values: values && typeof values === 'object' ? values : {} };
-  }
-
-  function labelFor(name, schema) {
-    return (schema && typeof schema.title === 'string' && schema.title) || name;
-  }
-
-  function renderConfigField(name, schema, value) {
-    const field = document.createElement('div');
-    field.className = 'field';
-
-    const label = document.createElement('span');
-    label.className = 'field-label';
-    label.textContent = labelFor(name, schema);
-    field.appendChild(label);
-
-    const type = schema && typeof schema.type === 'string' ? schema.type : 'string';
-    const writeOnly = schema && schema.writeOnly === true;
-
-    let input;
-    if (type === 'string' && Array.isArray(schema.enum)) {
-      input = document.createElement('select');
-      for (const opt of schema.enum) {
-        const o = document.createElement('option');
-        o.value = String(opt);
-        o.textContent = String(opt);
-        if (String(opt) === String(value ?? '')) o.selected = true;
-        input.appendChild(o);
-      }
-    } else if (type === 'boolean') {
-      input = document.createElement('input');
-      input.type = 'checkbox';
-      input.checked = value === true;
-    } else if (type === 'integer' || type === 'number') {
-      input = document.createElement('input');
-      input.type = 'number';
-      if (value !== undefined && value !== null) input.value = String(value);
-    } else {
-      input = document.createElement('input');
-      input.type = schema && schema.format === 'uri' ? 'url' : 'text';
-      if (writeOnly) {
-        input.placeholder = '\u2022\u2022\u2022\u2022\u2022\u2022';
-        input.value = '';
-      } else if (value !== undefined && value !== null) {
-        input.value = String(value);
-      }
-    }
-    input.disabled = true;
-    input.setAttribute('aria-readonly', 'true');
-    field.appendChild(input);
-
-    if (schema && typeof schema.description === 'string' && schema.description) {
-      const desc = document.createElement('span');
-      desc.className = 'field-description';
-      desc.textContent = schema.description;
-      field.appendChild(desc);
-    }
-
-    return field;
-  }
-
-  function renderConfigObject(schema, values, legendText) {
-    const fs = document.createElement('fieldset');
-    if (legendText) {
-      const lg = document.createElement('legend');
-      lg.textContent = legendText;
-      fs.appendChild(lg);
-    }
-    const props =
-      schema && typeof schema.properties === 'object' && schema.properties ? schema.properties : {};
-    for (const [name, propSchema] of Object.entries(props)) {
-      const v = values && typeof values === 'object' ? values[name] : undefined;
-      if (propSchema && propSchema.type === 'object') {
-        fs.appendChild(renderConfigObject(propSchema, v || {}, labelFor(name, propSchema)));
-      } else if (propSchema && propSchema.type === 'array') {
-        // Phase 2: arrays render as a disabled textarea summary; add/remove is Phase 3.
-        const f = document.createElement('div');
-        f.className = 'field';
-        const label = document.createElement('span');
-        label.className = 'field-label';
-        label.textContent = labelFor(name, propSchema);
-        f.appendChild(label);
-        const ta = document.createElement('textarea');
-        ta.rows = 2;
-        ta.value = Array.isArray(v) ? v.join('\\n') : '';
-        ta.disabled = true;
-        ta.setAttribute('aria-readonly', 'true');
-        f.appendChild(ta);
-        fs.appendChild(f);
+    for (const svc of services) {
+      if (isVaultName(svc.name)) continue;
+      const t = shortName(svc.name);
+      const existing = groups.get(t);
+      if (existing) {
+        existing.count += 1;
       } else {
-        fs.appendChild(renderConfigField(name, propSchema, v));
+        groups.set(t, {
+          type: t,
+          label: labelFor(t),
+          count: 1,
+          manageUrl: svc.path,
+        });
       }
     }
-    return fs;
+    return groups;
   }
 
-  function renderConfigBody(schema, values) {
-    const wrap = document.createElement('div');
-    wrap.className = 'config';
-    const title = document.createElement('h3');
-    title.textContent = (schema && schema.title) || 'Configuration';
-    wrap.appendChild(title);
-    const hint = document.createElement('span');
-    hint.className = 'hint';
-    hint.textContent =
-      'Configuration is read-only in this launch — edit via CLI or ~/.parachute/<svc>/.env.';
-    wrap.appendChild(hint);
-    wrap.appendChild(renderConfigObject(schema, values, null));
-    return wrap;
-  }
-
-  function renderCard(svc, info) {
-    const kind = info && typeof info.kind === 'string' ? info.kind : 'frontend';
-    const interactive = isInteractiveKind(kind);
-    const root = document.createElement(interactive ? 'div' : 'a');
-    root.className = 'card' + (interactive ? ' interactive' : '');
-    if (!interactive) root.href = svc.url;
-    let configSlotRef = null;
-    let configLoaded = false;
-    if (interactive) {
-      root.setAttribute('role', 'button');
-      root.setAttribute('tabindex', '0');
-      root.setAttribute('aria-expanded', 'false');
-      const toggle = async () => {
-        const next = !root.classList.contains('expanded');
-        root.classList.toggle('expanded', next);
-        root.setAttribute('aria-expanded', next ? 'true' : 'false');
-        if (next && !configLoaded && configSlotRef) {
-          configLoaded = true;
-          const data = await fetchConfig(svc.url);
-          if (data) configSlotRef.appendChild(renderConfigBody(data.schema, data.values));
-        }
-      };
-      root.addEventListener('click', (e) => {
-        if (e.target && e.target.closest && e.target.closest('.details')) return;
-        toggle();
-      });
-      root.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          toggle();
-        }
-      });
+  function tilesInOrder(groups) {
+    const out = [];
+    for (const t of MODULE_ORDER) {
+      const g = groups.get(t);
+      if (g) out.push(g);
     }
+    const known = new Set(MODULE_ORDER);
+    const extras = [...groups.values()]
+      .filter((g) => !known.has(g.type))
+      .sort((a, b) => a.type.localeCompare(b.type));
+    return out.concat(extras);
+  }
+
+  function renderTile(group) {
+    const a = document.createElement('a');
+    a.className = 'card';
+    a.href = group.manageUrl;
 
     const head = document.createElement('div');
     head.className = 'card-head';
 
     const icon = document.createElement('div');
     icon.className = 'icon';
-    const iconUrl = info && info.icon ? new URL(info.icon, svc.url).toString() : null;
-    if (iconUrl) {
-      const img = document.createElement('img');
-      img.src = iconUrl;
-      img.alt = '';
-      img.onerror = () => { icon.innerHTML = fallbackIcon; };
-      icon.appendChild(img);
-    } else {
-      icon.innerHTML = fallbackIcon;
-    }
+    icon.innerHTML = fallbackIcon;
 
     const title = document.createElement('h2');
     title.className = 'card-title';
-    title.textContent = (info && info.displayName) || shortName(svc.name);
+    title.textContent = group.label;
 
     head.appendChild(icon);
     head.appendChild(title);
-    root.appendChild(head);
+    a.appendChild(head);
 
-    const tag = info && info.tagline;
-    if (tag) {
-      const p = document.createElement('p');
-      p.className = 'card-tagline';
-      p.textContent = tag;
-      root.appendChild(p);
-    }
+    const count = document.createElement('p');
+    count.className = 'card-count';
+    count.textContent = group.count === 1 ? '1 registered' : group.count + ' registered';
+    a.appendChild(count);
 
     const meta = document.createElement('div');
     meta.className = 'card-meta';
     const path = document.createElement('span');
     path.className = 'path';
-    path.textContent = svc.path;
-    const right = document.createElement('span');
-    right.style.display = 'inline-flex';
-    right.style.gap = '0.35rem';
-    right.style.alignItems = 'center';
-    if (interactive) {
-      const badge = document.createElement('span');
-      badge.className = 'kind-badge';
-      badge.textContent = kind;
-      right.appendChild(badge);
-    }
-    const ver = document.createElement('span');
-    ver.className = 'version';
-    ver.textContent = 'v' + svc.version;
-    right.appendChild(ver);
+    path.textContent = group.manageUrl;
+    const manage = document.createElement('span');
+    manage.className = 'manage';
+    manage.textContent = 'Manage \u2192';
     meta.appendChild(path);
-    meta.appendChild(right);
-    root.appendChild(meta);
+    meta.appendChild(manage);
+    a.appendChild(meta);
 
-    if (interactive) {
-      const d = renderDetails(svc, info);
-      configSlotRef = d.configSlot;
-      root.appendChild(d.box);
-    }
-
-    return root;
+    return a;
   }
 
   try {
@@ -657,15 +360,19 @@ const HTML = `<!doctype html>
     if (!wk.ok) throw new Error('well-known fetch failed: ' + wk.status);
     const doc = await wk.json();
     const services = Array.isArray(doc.services) ? doc.services : [];
-    if (services.length === 0) {
-      root.innerHTML = '<div class="empty">No services installed yet. Try <code>parachute install vault</code>.</div>';
+    const vaults = Array.isArray(doc.vaults) ? doc.vaults : [];
+
+    const groups = aggregate(services, vaults);
+    const tiles = tilesInOrder(groups);
+
+    if (tiles.length === 0) {
+      root.innerHTML = '<div class="empty">No modules installed yet. Try <code>parachute install vault</code>.</div>';
       return;
     }
-    const infos = await Promise.all(services.map((s) => loadInfo(s.infoUrl)));
     root.innerHTML = '';
-    services.forEach((svc, i) => root.appendChild(renderCard(svc, infos[i])));
+    for (const g of tiles) root.appendChild(renderTile(g));
   } catch (err) {
-    root.innerHTML = '<div class="error">Could not load services: ' + (err && err.message ? err.message : String(err)) + '</div>';
+    root.innerHTML = '<div class="error">Could not load modules: ' + (err && err.message ? err.message : String(err)) + '</div>';
   }
 })();
 </script>


### PR DESCRIPTION
## Summary

- Home page at `/` now renders one tile per module type (vault, scribe, notes, claw) instead of one card per `ServiceEntry`. With three vaults + scribe + notes + claw on a node, the page reads as a directory of modules instead of a flat instance list.
- Vault tile counts `doc.vaults[]` (one entry per `/vault/<name>` mount) and links to the per-vault SPA at `/hub/vaults` — the existing destination shipped in #157 / #161 / #165.
- Other tiles take their manage link from the service's declared `path`, so a custom-mount third-party module also routes correctly. Types with zero instances are hidden — no "0 registered" surface.
- Display order pins `vault → scribe → notes → claw`; any unknown short-name from a third-party module appends after alphabetically.
- Drops the per-service interactive-card / config-form / detail-panel machinery from the home page. That detail belongs behind the Manage links now (vault SPA at `/hub/vaults`; the running module's own UI elsewhere).

Closes #168.

## Verification

- `bun run typecheck` clean (`tsc --noEmit`).
- `bun test ./src` — 945/945 host tests pass; `src/__tests__/hub.test.ts` rewritten for the new shape (16 cases covering aggregation, ordering, vault-name detection, tile-link mapping, zero-count hiding, empty + error states, and absence of the dead config-form code).
- `bunx biome check src/hub.ts src/__tests__/hub.test.ts` clean.
- Walked the live `/.well-known/parachute.json` from Aaron's running hub — 3 vault paths + scribe + notes + claw — confirms `aggregate()` produces the brief's exact 4-tile layout (Vault: 3 registered, Scribe/Notes/Claw: 1 each) in the right order.

## Notes for reviewer / merger

The home page HTML (`hub.html`) is **rewritten by `parachute expose`**, not on every hub start. After Aaron pulls main and restarts hub, he'll need to re-run `parachute expose <layer>` (or whatever currently runs his exposure) to regenerate `~/.parachute/well-known/hub.html` with the new content. The unit tests cover the rendered HTML directly via `renderHub()`, so the gate doesn't depend on the disk artifact.

Bumps `0.4.0-rc.43` → `0.4.0-rc.44`. RC tag per pre-1.0 governance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)