### PR TITLE
feat(hub): rename /hub/vaults → /vault for module-pattern symmetry + fix vault-admin-token audience mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.44",
+  "version": "0.4.0-rc.45",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.45",
+  "version": "0.4.0-rc.46",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/admin-vault-admin-token.test.ts
+++ b/src/__tests__/admin-vault-admin-token.test.ts
@@ -144,7 +144,47 @@ describe("handleVaultAdminToken", () => {
     const validated = await validateAccessToken(harness.db, body.token, ISSUER);
     expect(validated.payload.sub).toBe(userId);
     expect(validated.payload.iss).toBe(ISSUER);
+    // Per-vault audience: vault validates `aud === "vault.<name>"` against
+    // its own URL-bound config (parachute-vault src/auth.ts ~line 167).
+    // A constant `aud: "hub"` here would be rejected by every vault.
+    expect(validated.payload.aud).toBe("vault.work");
     const scopeClaim = (validated.payload as { scope?: string }).scope ?? "";
     expect(scopeClaim.split(/\s+/)).toContain("vault:work:admin");
+  });
+
+  test("audience is per-vault — different vaults get different aud claims", async () => {
+    // Regression for PR #173 follow-up: a single shared audience constant
+    // meant a token minted for vault `boulder` carried `aud: "hub"` and
+    // got rejected by vault's strict-equality check against
+    // `vault.boulder`. Mint twice and confirm each token is bound to its
+    // own vault.
+    const { cookie } = await withSession();
+    const namesSet = known("default", "boulder");
+
+    const reqDefault = new Request(`${ISSUER}/admin/vault-admin-token/default`, {
+      headers: { cookie },
+    });
+    const resDefault = await handleVaultAdminToken(reqDefault, "default", {
+      db: harness.db,
+      issuer: ISSUER,
+      knownVaultNames: namesSet,
+    });
+    expect(resDefault.status).toBe(200);
+    const bodyDefault = (await resDefault.json()) as { token: string };
+    const validatedDefault = await validateAccessToken(harness.db, bodyDefault.token, ISSUER);
+    expect(validatedDefault.payload.aud).toBe("vault.default");
+
+    const reqBoulder = new Request(`${ISSUER}/admin/vault-admin-token/boulder`, {
+      headers: { cookie },
+    });
+    const resBoulder = await handleVaultAdminToken(reqBoulder, "boulder", {
+      db: harness.db,
+      issuer: ISSUER,
+      knownVaultNames: namesSet,
+    });
+    expect(resBoulder.status).toBe(200);
+    const bodyBoulder = (await resBoulder.json()) as { token: string };
+    const validatedBoulder = await validateAccessToken(harness.db, bodyBoulder.token, ISSUER);
+    expect(validatedBoulder.payload.aud).toBe("vault.boulder");
   });
 });

--- a/src/__tests__/admin-vaults.test.ts
+++ b/src/__tests__/admin-vaults.test.ts
@@ -230,6 +230,47 @@ describe("POST /vaults — body validation", () => {
       h.cleanup();
     }
   });
+
+  test('400 when name is "new" (would shadow SPA create route)', async () => {
+    // Without the reservation, a vault named "new" would capture
+    // `/vault/new` via the dynamic-proxy lookup and render the SPA's
+    // create-vault page unreachable.
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const res = await call({ db, manifestPath: h.manifestPath, body: { name: "new" } });
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as { error_description: string };
+        expect(body.error_description).toMatch(/reserved/i);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test('400 when name is "assets" (would shadow SPA static bundle)', async () => {
+    // A vault named "assets" would capture `/vault/assets/*` and break
+    // SPA JS/CSS loading at both /vault and /hub mounts.
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const res = await call({ db, manifestPath: h.manifestPath, body: { name: "assets" } });
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as { error_description: string };
+        expect(body.error_description).toMatch(/reserved/i);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
 });
 
 describe("POST /vaults — orchestration", () => {

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -398,15 +398,24 @@ describe("hubFetch routing", () => {
     }
   });
 
-  test("/hub/ serves index.html when the SPA bundle exists", async () => {
+  // SPA mounts after hub#168-realignment:
+  //   /vault — primary (vault list, NewVault, etc.)
+  //   /hub   — back-compat (only /hub/permissions; /hub/vaults* is 301'd
+  //            below, /hub/ root falls through to the SPA's 404 route)
+  //
+  // Same bundle at both mounts. Build base is /vault/, so asset URLs are
+  // origin-absolute and resolve regardless of which mount served the HTML.
+
+  test("/vault serves index.html when the SPA bundle exists", async () => {
     const h = makeHarness();
     try {
       const dist = join(h.dir, "dist");
-      writeFileSync(join(h.dir, "hub.html"), "<html>hub</html>");
       mkdirIfMissing(dist);
       writeFileSync(join(dist, "index.html"), "<!doctype html><div id=root></div>");
-      const fetch = hubFetch(h.dir, { spaDistDir: dist });
-      const res = await fetch(req("/hub/"));
+      writeManifest({ services: [] }, h.manifestPath);
+      const res = await hubFetch(h.dir, { spaDistDir: dist, manifestPath: h.manifestPath })(
+        req("/vault"),
+      );
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
       expect(await res.text()).toContain("<div id=root>");
@@ -415,13 +424,19 @@ describe("hubFetch routing", () => {
     }
   });
 
-  test("/hub/vaults (client-side route) falls back to index.html", async () => {
+  test("/vault/new (client-side route, no matching vault) falls back to index.html", async () => {
+    // Routing-order check: `new` isn't a known vault, so proxyToVault
+    // returns undefined and we fall through to the SPA shell. The router
+    // takes over client-side and renders the NewVault form.
     const h = makeHarness();
     try {
       const dist = join(h.dir, "dist");
       mkdirIfMissing(dist);
       writeFileSync(join(dist, "index.html"), "<!doctype html><div id=root></div>");
-      const res = await hubFetch(h.dir, { spaDistDir: dist })(req("/hub/vaults"));
+      writeManifest({ services: [] }, h.manifestPath);
+      const res = await hubFetch(h.dir, { spaDistDir: dist, manifestPath: h.manifestPath })(
+        req("/vault/new"),
+      );
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
       expect(await res.text()).toContain("<div id=root>");
@@ -430,7 +445,7 @@ describe("hubFetch routing", () => {
     }
   });
 
-  test("/hub/assets/*.js is served with the matching content-type", async () => {
+  test("/vault/assets/*.js is served with the matching content-type", async () => {
     const h = makeHarness();
     try {
       const dist = join(h.dir, "dist");
@@ -439,7 +454,10 @@ describe("hubFetch routing", () => {
       mkdirIfMissing(assets);
       writeFileSync(join(dist, "index.html"), "<!doctype html>");
       writeFileSync(join(assets, "main.js"), "console.log('hi');");
-      const res = await hubFetch(h.dir, { spaDistDir: dist })(req("/hub/assets/main.js"));
+      writeManifest({ services: [] }, h.manifestPath);
+      const res = await hubFetch(h.dir, { spaDistDir: dist, manifestPath: h.manifestPath })(
+        req("/vault/assets/main.js"),
+      );
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("application/javascript; charset=utf-8");
       expect(await res.text()).toContain("console.log");
@@ -448,10 +466,55 @@ describe("hubFetch routing", () => {
     }
   });
 
+  test("/vault/* returns 503 with build hint when dist is missing", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [] }, h.manifestPath);
+      const res = await hubFetch(h.dir, {
+        spaDistDir: join(h.dir, "missing"),
+        manifestPath: h.manifestPath,
+      })(req("/vault"));
+      expect(res.status).toBe(503);
+      expect(await res.text()).toContain("bun run build");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/vault rejects non-GET methods with 405", async () => {
+    const h = makeHarness();
+    try {
+      const dist = join(h.dir, "dist");
+      mkdirIfMissing(dist);
+      writeFileSync(join(dist, "index.html"), "<!doctype html>");
+      const res = await hubFetch(h.dir, { spaDistDir: dist })(req("/vault", { method: "POST" }));
+      expect(res.status).toBe(405);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/hub/permissions serves the SPA shell (back-compat mount)", async () => {
+    const h = makeHarness();
+    try {
+      const dist = join(h.dir, "dist");
+      mkdirIfMissing(dist);
+      writeFileSync(join(dist, "index.html"), "<!doctype html><div id=root></div>");
+      const res = await hubFetch(h.dir, { spaDistDir: dist })(req("/hub/permissions"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      expect(await res.text()).toContain("<div id=root>");
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("/hub/* returns 503 with build hint when dist is missing", async () => {
     const h = makeHarness();
     try {
-      const res = await hubFetch(h.dir, { spaDistDir: join(h.dir, "missing") })(req("/hub/"));
+      const res = await hubFetch(h.dir, { spaDistDir: join(h.dir, "missing") })(
+        req("/hub/permissions"),
+      );
       expect(res.status).toBe(503);
       expect(await res.text()).toContain("bun run build");
     } finally {
@@ -465,8 +528,45 @@ describe("hubFetch routing", () => {
       const dist = join(h.dir, "dist");
       mkdirIfMissing(dist);
       writeFileSync(join(dist, "index.html"), "<!doctype html>");
-      const res = await hubFetch(h.dir, { spaDistDir: dist })(req("/hub/", { method: "POST" }));
+      const res = await hubFetch(h.dir, { spaDistDir: dist })(
+        req("/hub/permissions", { method: "POST" }),
+      );
       expect(res.status).toBe(405);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/hub/vaults issues a 301 redirect to /vault", async () => {
+    // Back-compat for bookmarks. The exact mount path used to be /hub/vaults
+    // before the realignment; permanent redirect keeps stale URLs working.
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir)(req("/hub/vaults"));
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("/vault");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/hub/vaults/new redirects to /vault/new", async () => {
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir)(req("/hub/vaults/new"));
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("/vault/new");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/hub/vaults/* preserves the query string in the redirect", async () => {
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir)(req("/hub/vaults/foo?bar=1&baz=2"));
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("/vault/foo?bar=1&baz=2");
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -998,6 +998,57 @@ describe("hubFetch /vault/<name>/* dynamic proxy (#144)", () => {
       h.cleanup();
     }
   });
+
+  test("single-segment /vault/<name> picks proxy when registered, SPA shell when not", async () => {
+    // Two cases share one fixture so the contrast is explicit:
+    //   - `/vault/default` is registered → proxy answers (200, JSON tag).
+    //   - `/vault/nonexistent` has no match → falls through to the SPA
+    //     shell (200, text/html). The SPA's :name route renders client-side
+    //     and shows a 404 in-app, but at the wire it's the shell.
+    // This is the routing-order seam #173 introduced — proxy is consulted
+    // before the SPA fallback, and the fallback only triggers when no
+    // vault claims the path.
+    const h = makeHarness();
+    const upstream = startUpstream("default-vault");
+    try {
+      const dist = join(h.dir, "dist");
+      mkdirIfMissing(dist);
+      writeFileSync(join(dist, "index.html"), "<!doctype html><div id=root></div>");
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: upstream.port,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, {
+        spaDistDir: dist,
+        manifestPath: h.manifestPath,
+      });
+
+      const proxied = await fetcher(req("/vault/default"));
+      expect(proxied.status).toBe(200);
+      expect(proxied.headers.get("content-type")).toContain("application/json");
+      const body = (await proxied.json()) as { tag: string; pathname: string };
+      expect(body.tag).toBe("default-vault");
+      expect(body.pathname).toBe("/vault/default");
+
+      const shelled = await fetcher(req("/vault/nonexistent"));
+      expect(shelled.status).toBe(200);
+      expect(shelled.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      expect(await shelled.text()).toContain("<div id=root>");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
 });
 
 /** Find a port that no one is listening on by binding briefly and releasing. */

--- a/src/__tests__/hub.test.ts
+++ b/src/__tests__/hub.test.ts
@@ -44,13 +44,14 @@ describe("renderHub", () => {
     expect(html).toContain("['vault', 'scribe', 'notes', 'claw']");
   });
 
-  test("vault tile counts vaults[] (per instance) and links to /hub/vaults", () => {
+  test("vault tile counts vaults[] (per instance) and links to /vault", () => {
     // Vault count is the length of doc.vaults — one entry per /vault/<name>
     // mount, so a single ServiceEntry with paths=[a,b,c] still shows "3
-    // registered". The manage link is the hub's vault SPA, never an
-    // individual vault backend.
+    // registered". The manage link is the hub's vault SPA at /vault
+    // (renamed from /hub/vaults in the realignment), never an individual
+    // vault backend.
     expect(html).toContain("vaults.length");
-    expect(html).toContain("'/hub/vaults'");
+    expect(html).toContain("'/vault'");
   });
 
   test("non-vault tiles take their manageUrl from the service's path", () => {
@@ -95,7 +96,7 @@ describe("renderHub", () => {
   test("does not retain the per-service interactive-card / config-form code", () => {
     // The home page is now a directory of modules — per-instance config
     // forms and detail panels live behind the Manage links (vault SPA at
-    // /hub/vaults, the running module's own UI elsewhere). Keeping the
+    // /vault, the running module's own UI elsewhere). Keeping the
     // dead code around is a maintenance trap.
     expect(html).not.toContain("renderConfigField");
     expect(html).not.toContain("fetchConfig");

--- a/src/admin-vault-admin-token.ts
+++ b/src/admin-vault-admin-token.ts
@@ -25,7 +25,6 @@ import { findSession, parseSessionCookie } from "./sessions.ts";
 
 /** Short TTL — matches host-admin-token. SPA re-fetches on near-expiry. */
 export const VAULT_ADMIN_TOKEN_TTL_SECONDS = 10 * 60;
-const VAULT_ADMIN_AUDIENCE = "hub";
 const VAULT_ADMIN_CLIENT_ID = "parachute-hub-spa";
 
 /** Same shape as the manifest name validator — keeps URL-injection out. */
@@ -59,10 +58,18 @@ export async function handleVaultAdminToken(
     return jsonError(401, "unauthenticated", "no admin session — sign in at /admin/login first");
   }
   const scope = `vault:${vaultName}:admin`;
+  // Per-vault audience: vault validates the JWT's `aud` claim against
+  // `vault.<name>` derived from its own URL-bound config (vault src/auth.ts
+  // line ~167 — `expectedAudience: vault.${vaultConfig.name}`). Same shape
+  // as `inferAudience` in oauth-handlers.ts for the public OAuth flow, so
+  // hub-minted and OAuth-minted tokens are indistinguishable to vault. A
+  // single `audience: "hub"` constant here was wrong end-to-end and broke
+  // every Manage-button click against the vault SPA (PR #173 follow-up).
+  const audience = `vault.${vaultName}`;
   const minted = await signAccessToken(deps.db, {
     sub: session.userId,
     scopes: [scope],
-    audience: VAULT_ADMIN_AUDIENCE,
+    audience,
     clientId: VAULT_ADMIN_CLIENT_ID,
     issuer: deps.issuer,
     ttlSeconds: VAULT_ADMIN_TOKEN_TTL_SECONDS,

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -39,8 +39,10 @@
  * we don't reimplement DB+yaml+token writes here. Mirrors D1 in the design
  * doc: hub orchestrates the CLI, doesn't replace it.
  *
- * Idempotency: name validation matches `parachute-vault create` (regex +
- * "list" reserved). When a vault with the requested name already exists,
+ * Idempotency: name validation matches `parachute-vault create`'s rules
+ * (regex + "list" reserved), with `new` and `assets` also reserved at
+ * the hub edge for SPA-route shadowing. When a vault with the requested
+ * name already exists,
  * we return 200 with the existing entry rather than re-running the CLI —
  * the CLI itself rejects an existing name with exit 1, but a re-POST is
  * usually a UI retry, not an error to the caller.
@@ -54,9 +56,16 @@ import { type WellKnownVaultEntry, isVaultEntry, vaultInstanceNameFor } from "./
 /** Scope required to call POST /vaults. */
 export const HOST_ADMIN_SCOPE = "parachute:host:admin";
 
-/** Mirror parachute-vault's `cmdCreate` validation rules. */
+/**
+ * Mirror parachute-vault's `cmdCreate` validation rules, plus hub-only
+ * reservations for SPA-route shadowing. `list` matches the CLI; `new` and
+ * `assets` would collide with `/vault/new` (the SPA's create-vault route)
+ * and `/vault/assets/*` (the SPA's static asset bundle) respectively, so
+ * the hub rejects them at the API edge before a vault under those names
+ * can register and capture the proxy path.
+ */
 const VAULT_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
-const RESERVED_VAULT_NAMES = new Set(["list"]);
+const RESERVED_VAULT_NAMES = new Set(["list", "new", "assets"]);
 
 export interface CreateVaultRequest {
   name: string;

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -667,12 +667,13 @@ export function hubFetch(
     //      from services.json by longest-mount-prefix. Read per request so a
     //      `parachute vault create` performed after `parachute expose` is
     //      immediately reachable (#144).
-    //   3. `/vault/<anything else>` → SPA shell. `/vault/new`, `/vault/<name>`
-    //      detail (planned), and `/vault/assets/*` static assets all land
-    //      here. Caveat: a vault named `new` or `assets` would shadow the
-    //      SPA route — relying on the operator not naming vaults after
-    //      reserved-looking words is the same shape the existing
-    //      RESERVED_VAULT_NAMES set uses.
+    //   3. `/vault/<spa-route>` → SPA shell. Only single-segment paths
+    //      (`/vault/new`, `/vault/<name>`) and `/vault/assets/*` count as
+    //      SPA routes. Multi-segment requests like `/vault/<unknown>/health`
+    //      are vault-API shapes targeting a non-existent vault and 404 —
+    //      otherwise the SPA shell would mask backend 404s with HTML.
+    //      Caveat: a vault named `new` or `assets` would shadow the SPA
+    //      route — `RESERVED_VAULT_NAMES` already enforces this.
     if (pathname === "/vault") {
       if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
       return serveSpa(spaDistDir, pathname, "/vault");
@@ -680,10 +681,9 @@ export function hubFetch(
     if (pathname.startsWith("/vault/")) {
       const proxied = await proxyToVault(req, manifestPath);
       if (proxied) return proxied;
-      // No vault claims this path — fall through to the SPA shell so the
-      // client-side router can render a `/new`, `/:name`, etc. route. Only
-      // GET reaches the SPA; non-GET writes that don't hit a vault upstream
-      // are operator errors, not SPA traffic, so 404 them.
+      const sub = pathname.slice("/vault/".length);
+      const isSpaRoute = !sub.includes("/") || sub.startsWith("assets/");
+      if (!isSpaRoute) return new Response("not found", { status: 404 });
       if (req.method !== "GET") return new Response("not found", { status: 404 });
       return serveSpa(spaDistDir, pathname, "/vault");
     }

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -287,7 +287,23 @@ function defaultSpaDistDir(): string {
   return resolve(here, "..", "web", "ui", "dist");
 }
 
-const SPA_MOUNT = "/hub";
+/**
+ * The SPA serves at two mounts:
+ *
+ * - `/vault` — primary, since hub#168-realignment. Matches the operator
+ *   pattern of `/<module>` as the entry point (alongside `/notes`, `/claw`,
+ *   `/scribe`). VaultsList, NewVault, and per-vault detail routes hang off
+ *   here.
+ * - `/hub` — back-compat. `/hub/permissions` (cross-vault grants) is a hub
+ *   concern and stays where bookmarks expect it. `/hub/vaults*` is a 301 to
+ *   `/vault*` further up the dispatch — keeping it out of this mount.
+ *
+ * Both mounts serve the same SPA bundle. Asset URLs are origin-absolute
+ * (`/vault/assets/...`) per the build base, so the HTML loads correctly
+ * regardless of which mount served it. main.tsx detects the active mount
+ * at runtime and configures react-router's `basename` accordingly.
+ */
+type SpaMount = "/vault" | "/hub";
 
 /**
  * Pick a content type for static assets the SPA build produces. Vite's
@@ -333,16 +349,19 @@ function spaContentType(pathname: string): string {
  * file under `dist/`). Path-traversal is blocked twice: the asset-shape
  * filter rejects sub-paths containing "..", and the resolved absolute
  * path is checked to start with `dist/` before any read.
+ *
+ * `mount` is the prefix being served (`/vault` or `/hub`); we strip it
+ * from `pathname` to land on the file path inside `dist/`.
  */
-async function serveSpa(spaDistDir: string, pathname: string): Promise<Response> {
+async function serveSpa(spaDistDir: string, pathname: string, mount: SpaMount): Promise<Response> {
   if (!existsSync(spaDistDir)) {
     return new Response(
       "hub SPA bundle not found — run `bun run build` in web/ui/ to produce dist/",
       { status: 503, headers: { "content-type": "text/plain; charset=utf-8" } },
     );
   }
-  // Strip the mount prefix; "/hub" → "", "/hub/" → "/", "/hub/x" → "/x".
-  const sub = pathname === SPA_MOUNT ? "" : pathname.slice(SPA_MOUNT.length);
+  // Strip the mount prefix; "/vault" → "", "/vault/" → "/", "/vault/x" → "/x".
+  const sub = pathname === mount ? "" : pathname.slice(mount.length);
   const indexPath = join(spaDistDir, "index.html");
 
   // Empty / mount-root / any non-asset request → SPA shell. The router takes
@@ -364,7 +383,7 @@ async function serveSpa(spaDistDir: string, pathname: string): Promise<Response>
   }
   if (!existsSync(filePath)) {
     // Asset request that doesn't resolve to a real file → SPA shell.
-    // (e.g. `/hub/vaults` with a typo'd extension shouldn't 404 the page.)
+    // (e.g. `/vault/foo` with a typo'd extension shouldn't 404 the page.)
     return new Response(Bun.file(indexPath), {
       headers: { "content-type": "text/html; charset=utf-8" },
     });
@@ -539,13 +558,14 @@ export function hubFetch(
       });
     }
 
-    // Hub vault-management SPA. Mount root + nested routes both land here;
-    // serveSpa picks index.html vs. an asset by extension. Only GET — POSTs
-    // for vault create go to /vaults, not the SPA mount. (HEAD is harmless
-    // but we keep the contract narrow.)
-    if (pathname === SPA_MOUNT || pathname.startsWith(`${SPA_MOUNT}/`)) {
+    // /hub SPA mount (back-compat). Kept for `/hub/permissions` and any other
+    // hub-level admin surface that lived under /hub/ before the realignment.
+    // /hub/vaults* is a separate concern handled by the 301 redirect lower
+    // down — the redirect runs first so it never reaches here. Only GET —
+    // POSTs for vault create go to /vaults, not the SPA mount.
+    if (pathname === "/hub" || pathname.startsWith("/hub/")) {
       if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
-      return serveSpa(spaDistDir, pathname);
+      return serveSpa(spaDistDir, pathname, "/hub");
     }
 
     if (pathname === "/admin/host-admin-token") {
@@ -625,15 +645,32 @@ export function hubFetch(
       return handleAdminConfigPost(getDb(), req, name);
     }
 
-    // Dynamic vault routing — services.json is the source of truth, read per
-    // request so a `parachute vault create` performed after `parachute expose`
-    // is immediately reachable on the tailnet (#144). Tailscale serve mounts
-    // a single `/vault/` → hub entry; this handler picks the specific vault
-    // backend by longest-mount-prefix on every request.
+    // /vault — primary SPA mount + dynamic per-vault proxy share this
+    // namespace. Order matters:
+    //   1. `/vault` exact → SPA shell (vault list).
+    //   2. `/vault/<known-vault>/...` → proxy to the vault backend, picked
+    //      from services.json by longest-mount-prefix. Read per request so a
+    //      `parachute vault create` performed after `parachute expose` is
+    //      immediately reachable (#144).
+    //   3. `/vault/<anything else>` → SPA shell. `/vault/new`, `/vault/<name>`
+    //      detail (planned), and `/vault/assets/*` static assets all land
+    //      here. Caveat: a vault named `new` or `assets` would shadow the
+    //      SPA route — relying on the operator not naming vaults after
+    //      reserved-looking words is the same shape the existing
+    //      RESERVED_VAULT_NAMES set uses.
+    if (pathname === "/vault") {
+      if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
+      return serveSpa(spaDistDir, pathname, "/vault");
+    }
     if (pathname.startsWith("/vault/")) {
       const proxied = await proxyToVault(req, manifestPath);
       if (proxied) return proxied;
-      // Fall through to the catch-all 404 below — no vault claims this path.
+      // No vault claims this path — fall through to the SPA shell so the
+      // client-side router can render a `/new`, `/:name`, etc. route. Only
+      // GET reaches the SPA; non-GET writes that don't hit a vault upstream
+      // are operator errors, not SPA traffic, so 404 them.
+      if (req.method !== "GET") return new Response("not found", { status: 404 });
+      return serveSpa(spaDistDir, pathname, "/vault");
     }
 
     return new Response("not found", { status: 404 });

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -672,8 +672,10 @@ export function hubFetch(
     //      SPA routes. Multi-segment requests like `/vault/<unknown>/health`
     //      are vault-API shapes targeting a non-existent vault and 404 —
     //      otherwise the SPA shell would mask backend 404s with HTML.
-    //      Caveat: a vault named `new` or `assets` would shadow the SPA
-    //      route — `RESERVED_VAULT_NAMES` already enforces this.
+    //      `new` and `assets` are reserved vault names (see
+    //      `RESERVED_VAULT_NAMES` in admin-vaults.ts) so an operator
+    //      can't register a vault that shadows the SPA's create route or
+    //      its static asset bundle.
     if (pathname === "/vault") {
       if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
       return serveSpa(spaDistDir, pathname, "/vault");

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -411,6 +411,21 @@ export function hubFetch(
     const url = new URL(req.url);
     const pathname = url.pathname;
 
+    // 301 back-compat: `/hub/vaults*` was the SPA's vault-management entry
+    // before hub#168-realignment. Bookmarks and any cached operator-typed
+    // URLs land here; permanent redirect keeps them working without leaving
+    // a dangling SPA route. Query string preserved; fragment is client-side
+    // and survives the redirect at the browser. Method-agnostic — even a
+    // misrouted POST gets the redirect, since there's no /hub/vaults POST
+    // endpoint to protect.
+    if (pathname === "/hub/vaults" || pathname.startsWith("/hub/vaults/")) {
+      const newPath = `/vault${pathname.slice("/hub/vaults".length)}`;
+      return new Response("", {
+        status: 301,
+        headers: { location: `${newPath}${url.search}` },
+      });
+    }
+
     if (pathname === "/" || pathname === "/hub.html") {
       if (!existsSync(hubHtmlPath)) {
         return new Response("hub.html not found", { status: 404 });

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -11,7 +11,7 @@ import { CONFIG_DIR } from "./config.ts";
  * but at three vaults plus scribe + notes + claw the page reads as a flat
  * list of instances rather than the modules themselves (#168). The new shape
  * aggregates: "Vault — 3 registered — Manage →" links to the per-vault SPA at
- * `/hub/vaults`; "Scribe — 1 registered" links to the running scribe instance;
+ * `/vault`; "Scribe — 1 registered" links to the running scribe instance;
  * etc. Zero-count types are hidden entirely.
  *
  * The file stays self-contained (inline CSS + JS, no external assets) so
@@ -273,7 +273,7 @@ const HTML = `<!doctype html>
   // Aggregate services + vaults into one entry per module type. Vault is
   // special-cased because its count comes from doc.vaults[] (one entry per
   // vault instance / mount path) and its manage link goes to the hub's
-  // per-vault SPA at /hub/vaults — not to any single vault backend.
+  // per-vault SPA at /vault — not to any single vault backend.
   function aggregate(services, vaults) {
     const groups = new Map();
     if (vaults.length > 0) {
@@ -281,7 +281,7 @@ const HTML = `<!doctype html>
         type: 'vault',
         label: 'Vault',
         count: vaults.length,
-        manageUrl: '/hub/vaults',
+        manageUrl: '/vault',
       });
     }
     for (const svc of services) {

--- a/web/ui/CLAUDE.md
+++ b/web/ui/CLAUDE.md
@@ -1,31 +1,52 @@
 # Hub web UI
 
-Vite + React + TypeScript SPA mounted at `/hub/` on the running hub. Serves
-the vault management surface (Phase 1: list + create; Phase 2+ will add
-mint/revoke/config).
+Vite + React + TypeScript SPA. The bundle serves at two mounts on the
+running hub: `/vault/*` (primary, since the hub#168 realignment) and
+`/hub/*` (back-compat for `/hub/permissions` and any bookmark that
+predates the rename). Vault management Phase 1 surfaces: list + create;
+Phase 2+ will add mint/revoke/config.
 
 ## Mount-aware contract
 
-The same bundle has to work two places:
+Same bundle, two mounts. Asset URLs are origin-absolute
+(`/vault/assets/...`) per Vite's `base` setting, which means the HTML
+loads correctly regardless of which mount served it. The mount-specific
+state is the react-router `basename`, detected at runtime in
+`src/main.tsx`:
 
-- **Production / tailnet** — served by `src/hub-server.ts` at `/hub/*`.
-  Vite's `base` defaults to `/hub/` (`vite.config.ts`), so asset URLs come
-  out as `/hub/assets/...` and react-router's `basename` resolves to
-  `/hub`.
-- **Dev** (`bun run dev`) — Vite serves at `http://127.0.0.1:5174/hub/`
-  with a proxy that forwards `/admin`, `/vaults`, and `/.well-known` to
-  `HUB_ORIGIN` (default `http://127.0.0.1:1939`). Override the base with
-  `VITE_BASE_PATH=/` if you need to dev against the origin root.
+- `window.location.pathname` starts with `/vault` → `basename = "/vault"`
+- `window.location.pathname` starts with `/hub`   → `basename = "/hub"`
+- otherwise → `basename = ""` (dev / origin root)
+
+`src/App.tsx` uses the same detection to swap route sets — under `/vault`
+the SPA renders the vault list / create / detail; under `/hub` it
+renders `/permissions` (cross-vault grants) and otherwise 404s.
+
+**Production / tailnet.** `src/hub-server.ts` mounts the SPA at both
+prefixes. `/hub/vaults*` is intercepted earlier and 301-redirected to
+`/vault*`. `/vault/<name>/*` first tries the dynamic vault proxy
+(longest-mount-prefix off `services.json`); only single-segment SPA
+routes (`/vault`, `/vault/new`, `/vault/<name>`) and `/vault/assets/*`
+fall through to the SPA shell when no vault matches. Multi-segment
+`/vault/<unknown>/*` requests 404 instead of being masked by HTML.
+
+**Dev** (`bun run dev`). Vite serves at `http://127.0.0.1:5174/vault/`
+with a proxy that forwards `/admin`, `/vaults`, and `/.well-known` to
+`HUB_ORIGIN` (default `http://127.0.0.1:1939`). Override the base with
+`VITE_BASE_PATH=/` if you need to dev against the origin root.
 
 `scripts/verify-base.mjs` runs after every build and aborts if
-`dist/index.html` doesn't carry the `/hub/`-prefixed asset URLs — same
+`dist/index.html` doesn't carry the `/vault/`-prefixed asset URLs — same
 regression check paraclaw#25 codified after a silent base-drift.
 
 **Lesson: never hardcode a leading-slash URL** in `Link to=`, `fetch`,
-or `<a href>`. `Link` resolves against `BASE_URL` automatically; `fetch`
-calls hit the origin root regardless of mount, which is what we want for
-`/.well-known/parachute.json` and `/vaults`. If you need the mounted
-prefix, use `import.meta.env.BASE_URL`.
+or `<a href>` for in-SPA navigation. `Link` resolves against the active
+basename automatically; `fetch` calls hit the origin root regardless of
+mount, which is what we want for `/.well-known/parachute.json` and
+`/vaults`. If you need the mounted prefix, use
+`import.meta.env.BASE_URL`. Cross-mount nav (e.g. `/vault` → `/hub/permissions`)
+must use `<a href>`, since `<Link>` resolves against the active basename
+and would mangle the absolute path.
 
 ## Auth
 
@@ -49,7 +70,7 @@ narrowest possible.
 web/ui/
 ├── index.html              # vite entry, mounts #root
 ├── package.json            # @openparachute/hub-web-ui
-├── vite.config.ts          # base=/hub/ + dev proxy
+├── vite.config.ts          # base=/vault/ + dev proxy
 ├── vitest.config.ts        # jsdom + setup file
 ├── tsconfig.json
 ├── scripts/verify-base.mjs # post-build regression check
@@ -61,9 +82,9 @@ web/ui/
     │   ├── auth.ts         # session→JWT mint, in-memory cache
     │   └── api.ts          # listVaults + createVault
     ├── routes/
-    │   ├── VaultsList.tsx  # /vaults
-    │   ├── NewVault.tsx    # /vaults/new (single-emit pvt_* banner)
-    │   └── VaultDetail.tsx # /vaults/:name (Phase 2 placeholder)
+    │   ├── VaultsList.tsx  # / (under /vault basename)
+    │   ├── NewVault.tsx    # /new (single-emit pvt_* banner)
+    │   └── VaultDetail.tsx # /:name (Phase 2 placeholder)
     └── test/setup.ts
 ```
 
@@ -72,7 +93,7 @@ web/ui/
 ```sh
 cd web/ui
 bun install
-bun run dev          # http://127.0.0.1:5174/hub/  (proxies to :1939)
+bun run dev          # http://127.0.0.1:5174/vault/  (proxies to :1939)
 bun run build        # → dist/  (then verify-base.mjs)
 bun run typecheck    # tsc --noEmit
 bun run test         # vitest run
@@ -89,9 +110,9 @@ though they don't get the SPA source.
 
 If you ever need to manually rebuild, `cd web/ui && bun run build` still
 works. `src/hub-server.ts` handles a missing `dist/` by 503ing the
-`/hub/*` routes with a hint to run the build — usually means the
-postinstall hasn't run yet, or fired with `--ignore-scripts` (which
-suppresses lifecycle hooks).
+`/vault/*` and `/hub/*` SPA routes with a hint to run the build —
+usually means the postinstall hasn't run yet, or fired with
+`--ignore-scripts` (which suppresses lifecycle hooks).
 
 ## Brand tokens
 

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -2,7 +2,7 @@
   "name": "@openparachute/hub-web-ui",
   "version": "0.0.1-rc.1",
   "private": true,
-  "description": "Hub web UI — Vite + React + TypeScript. Vault management SPA mounted under /hub/.",
+  "description": "Hub web UI — Vite + React + TypeScript. Vault management SPA mounted at /vault (and /hub for back-compat).",
   "license": "AGPL-3.0",
   "type": "module",
   "scripts": {

--- a/web/ui/scripts/verify-base.mjs
+++ b/web/ui/scripts/verify-base.mjs
@@ -1,8 +1,8 @@
 // Regression check mirroring paraclaw's verify-base: the canonical-mount
-// default build must produce asset URLs prefixed with `/hub/`. If
-// `vite.config.ts`'s `base` ever drifts back to `/`, the bundle HTML loses
-// the prefix and 404s under the hub mount — the same silent failure
-// paraclaw#25 codified in mount-path-convention.md.
+// default build must produce asset URLs prefixed with `/vault/`. If
+// `vite.config.ts`'s `base` ever drifts back to `/` or to the old `/hub/`,
+// the bundle HTML loses the right prefix and assets 404 under the SPA mount —
+// the same silent failure paraclaw#25 codified in mount-path-convention.md.
 //
 // Skipped when VITE_BASE_PATH is set explicitly (legitimate override).
 
@@ -10,21 +10,21 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const override = process.env.VITE_BASE_PATH;
-if (override && override !== "/hub/") {
+if (override && override !== "/vault/") {
   console.log(`verify-base: VITE_BASE_PATH=${override} (override) — skipping default-mount check.`);
   process.exit(0);
 }
 
 const html = readFileSync(resolve("dist/index.html"), "utf8");
-const wantPrefix = "/hub/assets/";
+const wantPrefix = "/vault/assets/";
 const hasMounted = html.includes(`src="${wantPrefix}`) || html.includes(`href="${wantPrefix}`);
 if (!hasMounted) {
   console.error(
-    "✖ verify-base: dist/index.html is missing /hub/-prefixed asset URLs.\n" +
-      "  This means vite's `base` resolved to something other than `/hub/`.\n" +
-      "  Check web/ui/vite.config.ts (default should be `/hub/`) and any\n" +
+    "✖ verify-base: dist/index.html is missing /vault/-prefixed asset URLs.\n" +
+      "  This means vite's `base` resolved to something other than `/vault/`.\n" +
+      "  Check web/ui/vite.config.ts (default should be `/vault/`) and any\n" +
       "  VITE_BASE_PATH env var leaking into the build environment.",
   );
   process.exit(1);
 }
-console.log("verify-base: ✓ dist/index.html references /hub/-prefixed assets.");
+console.log("verify-base: ✓ dist/index.html references /vault/-prefixed assets.");

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -3,33 +3,56 @@ import { NewVault } from "./routes/NewVault.tsx";
 import { Permissions } from "./routes/Permissions.tsx";
 import { VaultsList } from "./routes/VaultsList.tsx";
 
+// Same SPA bundle, two mounts: /vault (primary, vault management) and
+// /hub (back-compat, /hub/permissions only). The active mount picks the
+// route table — we don't render every route under both basenames since
+// they are unrelated concerns. Cross-mount navigation uses plain <a href>
+// because <Link> resolves against the active basename.
+const isPermissionsMount =
+  typeof window !== "undefined" &&
+  (window.location.pathname === "/hub" || window.location.pathname.startsWith("/hub/"));
+
 export function App() {
   return (
     <div className="page">
       <nav className="nav">
-        <Link to="/vaults" className="brand">
+        <a href="/vault" className="brand">
           Parachute Hub <span className="sub">vault management</span>
-        </Link>
-        <Link to="/vaults">Vaults</Link>
-        <Link to="/permissions">Permissions</Link>
+        </a>
+        <a href="/vault">Vaults</a>
+        <a href="/hub/permissions">Permissions</a>
         <a href="/" title="Hub discovery page (top-level)">
           Discovery
         </a>
       </nav>
 
       <Routes>
-        <Route path="/" element={<VaultsList />} />
-        <Route path="/vaults" element={<VaultsList />} />
-        <Route path="/vaults/new" element={<NewVault />} />
-        <Route path="/permissions" element={<Permissions />} />
-        <Route
-          path="*"
-          element={
-            <div className="empty">
-              404 — back to <Link to="/vaults">vaults</Link>.
-            </div>
-          }
-        />
+        {isPermissionsMount ? (
+          <>
+            <Route path="/permissions" element={<Permissions />} />
+            <Route
+              path="*"
+              element={
+                <div className="empty">
+                  404 — back to <a href="/vault">vaults</a>.
+                </div>
+              }
+            />
+          </>
+        ) : (
+          <>
+            <Route path="/" element={<VaultsList />} />
+            <Route path="/new" element={<NewVault />} />
+            <Route
+              path="*"
+              element={
+                <div className="empty">
+                  404 — back to <Link to="/">vaults</Link>.
+                </div>
+              }
+            />
+          </>
+        )}
       </Routes>
     </div>
   );

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -15,6 +15,11 @@ import * as auth from "./auth.ts";
 vi.mock("./auth.ts", () => ({
   getHostAdminToken: vi.fn(),
   clearCachedToken: vi.fn(),
+  // Default to a hanging promise so 401 paths in api.ts behave like the
+  // real helper (the page is mid-redirect, the continuation never runs).
+  // Individual tests stub this differently when they need to assert the
+  // redirect side-effect.
+  redirectToLoginAndHang: vi.fn(() => new Promise(() => {})),
 }));
 
 beforeEach(() => {
@@ -266,15 +271,38 @@ describe("mintVaultAdminToken", () => {
     );
   });
 
-  it("throws HttpError on non-2xx", async () => {
+  it("on 401 calls redirectToLoginAndHang (no error surfaces)", async () => {
+    // Same shape as auth.ts:fetchToken — a missing session means the page
+    // is about to navigate to /admin/login. Surfacing an HttpError gave
+    // operators the raw "no admin session" string with no recourse
+    // (PR #173 follow-up bug).
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => jsonResponse(401, { error: "unauthenticated" })),
     );
     const api = await import("./api.ts");
+    const pending = api.mintVaultAdminToken("work");
+    // Yield once so the fetch + status branch can run.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(auth.redirectToLoginAndHang).toHaveBeenCalledTimes(1);
+    // The promise never resolves — match the contract callers rely on. Race
+    // against a microtask flush so the test doesn't hang.
+    const winner = await Promise.race([
+      pending.then(() => "resolved"),
+      new Promise((r) => setTimeout(() => r("hung"), 10)),
+    ]);
+    expect(winner).toBe("hung");
+  });
+
+  it("throws HttpError on non-401 non-2xx (e.g. 500)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(500, { error: "boom" })),
+    );
+    const api = await import("./api.ts");
     await expect(api.mintVaultAdminToken("work")).rejects.toMatchObject({
       name: "HttpError",
-      status: 401,
+      status: 500,
     });
   });
 });

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -10,7 +10,7 @@
  * the admin endpoint after a fresh mint, the auth helper navigates the
  * browser to /admin/login — we don't try to recover.
  */
-import { clearCachedToken, getHostAdminToken } from "./auth.ts";
+import { clearCachedToken, getHostAdminToken, redirectToLoginAndHang } from "./auth.ts";
 
 export interface VaultListing {
   name: string;
@@ -150,8 +150,9 @@ export async function createVault(input: CreateVaultInput): Promise<CreateVaultR
  *
  * Same session-cookie origin as `getHostAdminToken()`, so we don't reuse
  * the host-admin Bearer here — the endpoint reads the cookie directly.
- * On 401 the operator's session is gone; we surface the error so the
- * caller can hand off to /admin/login.
+ * On 401 the operator's session is gone; we redirect to /admin/login and
+ * hang the promise — same shape as `getHostAdminToken()` so the operator
+ * never sees a "no admin session" message they can't act on.
  */
 export async function mintVaultAdminToken(name: string): Promise<MintedVaultAdminToken> {
   const res = await fetch(`/admin/vault-admin-token/${encodeURIComponent(name)}`, {
@@ -159,6 +160,9 @@ export async function mintVaultAdminToken(name: string): Promise<MintedVaultAdmi
     headers: { accept: "application/json" },
     credentials: "same-origin",
   });
+  if (res.status === 401) {
+    return redirectToLoginAndHang<MintedVaultAdminToken>();
+  }
   if (!res.ok) {
     throw new HttpError(res.status, await readError(res));
   }

--- a/web/ui/src/lib/auth.test.ts
+++ b/web/ui/src/lib/auth.test.ts
@@ -54,7 +54,7 @@ describe("getHostAdminToken", () => {
     );
     const replace = vi.fn();
     vi.stubGlobal("window", {
-      location: { pathname: "/vaults/new", search: "?x=1", replace },
+      location: { pathname: "/vault/new", search: "?x=1", replace },
     } as unknown as Window & typeof globalThis);
 
     const auth = await import("./auth.ts");
@@ -65,7 +65,7 @@ describe("getHostAdminToken", () => {
     await new Promise((r) => setTimeout(r, 0));
 
     expect(replace).toHaveBeenCalledWith(
-      `/admin/login?next=${encodeURIComponent("/vaults/new?x=1")}`,
+      `/admin/login?next=${encodeURIComponent("/vault/new?x=1")}`,
     );
   });
 

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -50,6 +50,23 @@ function loginRedirectUrl(): string {
 }
 
 /**
+ * Navigate to /admin/login (round-tripping the current SPA URL via `next=`)
+ * and return a never-resolving Promise so the caller's continuation never
+ * runs. The browser is about to tear down the page; surfacing a "session
+ * expired" error to the operator gives them no useful action — the right
+ * UX is "you've already left."
+ *
+ * Shared between the host-admin mint here and the per-vault mint in
+ * `lib/api.ts:mintVaultAdminToken`. Both endpoints rely on the same
+ * `parachute_hub_session` cookie, so a 401 on either means the same thing
+ * and deserves the same handler.
+ */
+export function redirectToLoginAndHang<T>(): Promise<T> {
+  window.location.replace(loginRedirectUrl());
+  return new Promise<T>(() => {});
+}
+
+/**
  * Returns the cached host-admin JWT, refreshing it if it's about to expire
  * (or if we don't have one yet). Concurrent callers share the in-flight
  * fetch — we don't want a burst of API calls to mint a token each.
@@ -78,11 +95,7 @@ async function fetchToken(): Promise<string> {
   });
   if (res.status === 401) {
     cached = null;
-    window.location.replace(loginRedirectUrl());
-    // Hang — the navigation will tear down this page. Returning a rejected
-    // promise would surface "session expired" errors the operator can't act
-    // on; the right UX is "you've already left."
-    return new Promise<string>(() => {});
+    return redirectToLoginAndHang<string>();
   }
   if (!res.ok) {
     throw new Error(`/admin/host-admin-token failed: ${res.status} ${await res.text()}`);

--- a/web/ui/src/main.tsx
+++ b/web/ui/src/main.tsx
@@ -7,13 +7,24 @@ import "./styles.css";
 const root = document.getElementById("root");
 if (!root) throw new Error("#root not found");
 
-// `basename` is mount-aware: production builds use `/hub/`, dev uses `/`.
-// Stripping the trailing slash matches react-router's expectation. Without
-// this the SPA's <Link to="/vaults"> would resolve to /vaults at the origin
-// root, blowing past the hub's reverse proxy and 404ing on tailnet.
+// Dual-mount basename detection. The SPA serves at /vault (primary, since
+// hub#168-realignment) and /hub (back-compat for /hub/permissions). The
+// bundle is identical at both — `import.meta.env.BASE_URL` points at the
+// build base (/vault/) regardless of which mount served us — but react-
+// router needs the *runtime* mount so <Link to="/"> resolves under the
+// right one. Without this, a user landing at /hub/permissions would have
+// the router try to strip /vault from a /hub URL and refuse to render.
+function detectBasename(): string {
+  const path = window.location.pathname;
+  if (path === "/hub" || path.startsWith("/hub/")) return "/hub";
+  if (path === "/vault" || path.startsWith("/vault/")) return "/vault";
+  // Stand-alone dev served at origin root (VITE_BASE_PATH=/).
+  return "";
+}
+
 createRoot(root).render(
   <StrictMode>
-    <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, "")}>
+    <BrowserRouter basename={detectBasename()}>
       <App />
     </BrowserRouter>
   </StrictMode>,

--- a/web/ui/src/routes/NewVault.test.tsx
+++ b/web/ui/src/routes/NewVault.test.tsx
@@ -32,10 +32,10 @@ afterEach(() => {
 
 function renderForm() {
   return render(
-    <MemoryRouter initialEntries={["/vaults/new"]}>
+    <MemoryRouter initialEntries={["/new"]}>
       <Routes>
-        <Route path="/vaults/new" element={<NewVault />} />
-        <Route path="/vaults/:name" element={<div>detail</div>} />
+        <Route path="/new" element={<NewVault />} />
+        <Route path="/:name" element={<div>detail</div>} />
       </Routes>
     </MemoryRouter>,
   );

--- a/web/ui/src/routes/NewVault.tsx
+++ b/web/ui/src/routes/NewVault.tsx
@@ -73,7 +73,7 @@ export function NewVault() {
     return (
       <CreatedView
         result={state.result}
-        onDone={() => navigate(`/vaults/${encodeURIComponent(state.result.name)}`)}
+        onDone={() => navigate(`/${encodeURIComponent(state.result.name)}`)}
       />
     );
   }
@@ -120,7 +120,7 @@ export function NewVault() {
           >
             {state.kind === "submitting" ? "Creating…" : "Create vault"}
           </button>
-          <Link to="/vaults" className="muted">
+          <Link to="/" className="muted">
             Cancel
           </Link>
         </div>
@@ -182,7 +182,7 @@ function CreatedView({
             <code>parachute-vault mint-token</code>.
           </p>
           <div className="actions">
-            <Link to={`/vaults/${encodeURIComponent(result.name)}`}>
+            <Link to={`/${encodeURIComponent(result.name)}`}>
               <button type="button">Continue</button>
             </Link>
           </div>

--- a/web/ui/src/routes/VaultsList.test.tsx
+++ b/web/ui/src/routes/VaultsList.test.tsx
@@ -59,7 +59,7 @@ describe("VaultsList", () => {
     await waitFor(() => expect(screen.getByText(/no vaults yet/i)).toBeInTheDocument());
     expect(screen.getByRole("link", { name: /create a vault/i })).toHaveAttribute(
       "href",
-      "/vaults/new",
+      "/new",
     );
   });
 

--- a/web/ui/src/routes/VaultsList.test.tsx
+++ b/web/ui/src/routes/VaultsList.test.tsx
@@ -57,10 +57,7 @@ describe("VaultsList", () => {
     vi.mocked(api.listVaults).mockResolvedValue([]);
     renderList();
     await waitFor(() => expect(screen.getByText(/no vaults yet/i)).toBeInTheDocument());
-    expect(screen.getByRole("link", { name: /create a vault/i })).toHaveAttribute(
-      "href",
-      "/new",
-    );
+    expect(screen.getByRole("link", { name: /create a vault/i })).toHaveAttribute("href", "/new");
   });
 
   it("renders one row per vault with name + version + URL", async () => {

--- a/web/ui/src/routes/VaultsList.tsx
+++ b/web/ui/src/routes/VaultsList.tsx
@@ -98,7 +98,7 @@ export function VaultsList() {
       <div>
         <div className="list-header">
           <h2>Vaults</h2>
-          <Link to="/vaults/new">
+          <Link to="/new">
             <button type="button">New vault</button>
           </Link>
         </div>
@@ -116,7 +116,7 @@ export function VaultsList() {
     <div>
       <div className="list-header">
         <h2>Vaults ({state.vaults.length})</h2>
-        <Link to="/vaults/new">
+        <Link to="/new">
           <button type="button">New vault</button>
         </Link>
       </div>
@@ -132,7 +132,7 @@ export function VaultsList() {
             Create your first vault to start storing tokens, secrets, and notes scoped to this hub.
           </p>
           <p style={{ marginTop: "0.75rem" }}>
-            <Link to="/vaults/new">Create a vault →</Link>
+            <Link to="/new">Create a vault →</Link>
           </p>
         </div>
       ) : (

--- a/web/ui/vite.config.ts
+++ b/web/ui/vite.config.ts
@@ -1,12 +1,13 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
-// The hub mounts this SPA at `/hub/` (see src/hub-server.ts dispatch table).
-// Build default IS the canonical mount so asset URLs resolve under the hub
-// path on tailnet — the same drift paraclaw#25 hit when its base was `/`.
-// Override with `VITE_BASE_PATH=/` for stand-alone dev served at the origin
-// root.
-const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/hub/");
+// The hub mounts this SPA at `/vault/` (primary, since hub#168-realignment) and
+// keeps `/hub/` mounted for back-compat (`/hub/permissions` lives there). Asset
+// URLs are origin-absolute and resolve under `/vault/assets/...` regardless of
+// which mount served the HTML — the same drift paraclaw#25 hit when its base
+// was `/`. Override with `VITE_BASE_PATH=/` for stand-alone dev served at the
+// origin root.
+const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/vault/");
 
 function normalizeBase(input: string): string {
   let b = input.startsWith("/") ? input : `/${input}`;
@@ -20,7 +21,7 @@ export default defineConfig({
   server: {
     port: 5174,
     proxy: {
-      // Dev server runs under /hub/ to mirror the production mount. The hub's
+      // Dev server runs under /vault/ to mirror the production mount. The hub's
       // admin + vault API lives at the origin root (/admin/*, /vaults,
       // /.well-known/*) so we only proxy those exact prefixes — everything
       // else falls through to the SPA's static assets.


### PR DESCRIPTION
## Summary

- Renames the operator-visible vault management URL from `/hub/vaults` to `/vault`, matching the `/notes`, `/claw`, `/scribe` shape Aaron called out (#168 follow-up).
- Same SPA bundle at both `/vault` (primary) and `/hub` (back-compat); runtime basename detection + per-mount route sets.
- 301 redirect for `/hub/vaults*` → `/vault*` so existing bookmarks and any cached operator-typed URLs keep working without dangling SPA routes.
- `/hub/permissions` (cross-vault grants admin) stays at `/hub/*` — it's a hub-level concern, not a vault one.
- **Plus three fixes** discovered while exercising the new flow end-to-end (operator-trap reservations, 401 UX, and an audience-mismatch blocker on per-vault Manage). Folded in rather than two-PR-coordinated since Aaron's bun-linked to this branch.

## Motivation

Aaron, in chat: *"/hub/vaults seems awkward and like it's starting to drift from our other patterns. I just go to /notes and /claw and I can configure things right there."*

The rename brings the URL to the place operators expect to find vault management, and aligns the home-page tile (now `/vault`) with the actual landing route.

## Scope discipline (what this PR does NOT do)

- The SPA source still lives in `parachute-hub/web/ui/`. Moving it to `parachute-vault` would require a fresh auth-seam design (probably a `parachute:host:vault-create` scope that the hub mints and vault accepts) — separate, larger change. Filed as #172 for the architectural follow-up.

## Audience-mismatch fix

The mint endpoint at `GET /admin/vault-admin-token/<name>` was binding every vault-admin token to a single shared audience constant (`"hub"`), but vault validates the JWT's `aud` claim against `vault.<name>` derived from its own URL-bound config (`parachute-vault/src/auth.ts` ~line 167 — `expectedAudience: vault.${vaultConfig.name}`). Result: every "Manage" click landed on a vault SPA whose token-validating fetch returned `hub JWT audience mismatch: expected "vault.boulder", got "hub"`. The public OAuth path already did the right thing — `inferAudience()` in `oauth-handlers.ts` maps `vault:<name>:<verb>` to `vault.<name>`. The hub-minted token now matches, so vault treats hub-minted and OAuth-minted tokens identically.

## Commits

1. `chore(web/ui)` — Vite build base `/vault/`; `verify-base.mjs` updated.
2. `feat(hub-server)` — mount SPA at `/vault` (vault-proxy-first under `/vault/<name>/*`); keep `/hub` mount for back-compat.
3. `feat(hub-server)` — 301 redirect `/hub/vaults*` → `/vault*` (preserves query string).
4. `feat(web/ui)` — internal nav rewires (`Link to`, `useNavigate`); runtime basename detection in `main.tsx`; conditional route sets in `App.tsx`; cross-mount nav uses `<a href>`.
5. `feat(hub)` — home tile `manageUrl` `/hub/vaults` → `/vault`.
6. `test(hub-server)` — coverage for `/vault` SPA shell, `/hub/permissions` back-compat, `/hub/vaults*` 301s. Tightens `/vault/*` SPA fallback to single-segment paths + `assets/*` so multi-segment vault-API requests on a non-existent vault 404 cleanly instead of getting masked by HTML.
7. `chore` — `0.4.0-rc.44` → `0.4.0-rc.45`; `web/ui/CLAUDE.md` documents both mounts.
8. `fix` — extend `RESERVED_VAULT_NAMES` to `{list, new, assets}` so an operator can't `POST /vaults {"name":"new"}` and silently capture `/vault/new` (the SPA's create route) or `/vault/assets/*` (the SPA's static bundle). Adds reserved-name tests + a single-segment routing test pinning proxy-vs-SPA-shell order.
9. `fix(web/ui)` — `mintVaultAdminToken` 401 redirects to `/admin/login?next=…` and hangs the promise instead of surfacing the raw "no admin session" string. Extracts `redirectToLoginAndHang<T>()` from `auth.ts` so both mints share one source of truth.
10. `fix(hub)` — vault-admin-token mint uses per-vault audience `vault.<name>` (the audience-mismatch fix above). Bumps `0.4.0-rc.45` → `0.4.0-rc.46`.

## Cookies

`parachute_hub_session` already uses `Path=/`, wide enough to cover both mounts. No change needed (`src/sessions.ts:99`).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test ./src` — **955 pass** (was 951; +4 across the three folded fixes)
- [x] `cd web/ui && bun run typecheck && bun run test && bun run build` — **47 vitest pass** (was 46); verify-base reports `/vault/`-prefixed assets
- [x] Routing-order: existing `/vault/<name>/*` proxy tests now also implicitly cover proxy-wins-over-SPA (real `dist/` resolves under default `spaDistDir`, proxy hits upstream regardless)
- [x] `/hub/vaults*` 301s to `/vault*` with query-string preserved (3 tests)
- [x] `/hub/permissions` SPA shell still served under back-compat mount
- [x] Reserved-name validation: `POST /vaults {"name":"new"}` and `{"name":"assets"}` both 400
- [x] `mintVaultAdminToken` 401 → redirect, no error surface
- [x] Per-vault audience: minting for `default` and `boulder` from one session yields `aud: "vault.default"` and `aud: "vault.boulder"`

## Follow-ups

- #172 — Move vault management SPA to the vault repo per modular UI pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)