### PR TITLE
chore(release): claw → agent rename + services.json migration for 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.4.0-rc.46",
+  "version": "0.5.0-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/packages/scope-guard/README.md
+++ b/packages/scope-guard/README.md
@@ -1,6 +1,6 @@
 # @openparachute/scope-guard
 
-Hub-issued JWT validation for Parachute resource servers (vault, scribe, paraclaw, third-party modules).
+Hub-issued JWT validation for Parachute resource servers (vault, scribe, parachute-agent, third-party modules).
 
 The Parachute hub mints OAuth access tokens as RS256 JWTs and publishes its public keys at `/.well-known/jwks.json`. This library is the consumer-side mirror: every resource server uses the same verifier so the trust kernel doesn't drift between modules.
 
@@ -43,7 +43,7 @@ async function enforceAuth(req: Request, vaultName: string) {
 
 ## Design
 
-See [`parachute-hub/docs/design/2026-04-29-scope-guard-library.md`](https://github.com/ParachuteComputer/parachute-hub/blob/main/docs/design/2026-04-29-scope-guard-library.md) for full rationale, alternatives considered, and the migration sequence (vault → scribe → paraclaw).
+See [`parachute-hub/docs/design/2026-04-29-scope-guard-library.md`](https://github.com/ParachuteComputer/parachute-hub/blob/main/docs/design/2026-04-29-scope-guard-library.md) for full rationale, alternatives considered, and the migration sequence (vault → scribe → parachute-agent).
 
 The lib lives as a sub-package of `parachute-hub` because the hub owns the JWT-issuance side and the scope vocabulary. It's published independently to npm as `@openparachute/scope-guard`.
 

--- a/packages/scope-guard/package.json
+++ b/packages/scope-guard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openparachute/scope-guard",
   "version": "0.1.0-rc.1",
-  "description": "Hub-issued JWT validation for Parachute resource servers (vault, scribe, paraclaw, third-party modules).",
+  "description": "Hub-issued JWT validation for Parachute resource servers (vault, scribe, parachute-agent, third-party modules).",
   "license": "AGPL-3.0",
   "type": "module",
   "publishConfig": {

--- a/packages/scope-guard/src/__tests__/scope.test.ts
+++ b/packages/scope-guard/src/__tests__/scope.test.ts
@@ -67,8 +67,8 @@ describe("hasScope — narrowed inheritance", () => {
 });
 
 describe("hasScope — cross-resource never matches", () => {
-  test("vault:admin does NOT satisfy claw:read", () => {
-    expect(hasScope(["vault:admin"], "claw:read")).toBe(false);
+  test("vault:admin does NOT satisfy agent:read", () => {
+    expect(hasScope(["vault:admin"], "agent:read")).toBe(false);
   });
 
   test("vault:admin does NOT satisfy scribe:read", () => {

--- a/packages/scope-guard/src/validate.ts
+++ b/packages/scope-guard/src/validate.ts
@@ -3,7 +3,7 @@ import { type JwksGetter, type JwksOptions, getOrCreateJwksGetter, resetCache } 
 import { parseScopes } from "./parse";
 
 /**
- * Hub-issued JWT validation, factored out of vault/scribe/paraclaw's
+ * Hub-issued JWT validation, factored out of vault/scribe/parachute-agent's
  * near-identical implementations.
  *
  * Trust model:
@@ -67,8 +67,9 @@ export interface CreateScopeGuardOptions {
   /**
    * The hub's origin. Either a literal string or a resolver function — the
    * function form lets consumers layer their own env-var precedence (e.g.
-   * paraclaw's `PARACLAW_HUB_ORIGIN` over `PARACHUTE_HUB_ORIGIN`). Trailing
-   * slashes are stripped so the canonical form matches what the hub mints.
+   * parachute-agent's `PARACHUTE_AGENT_HUB_ORIGIN` over
+   * `PARACHUTE_HUB_ORIGIN`). Trailing slashes are stripped so the canonical
+   * form matches what the hub mints.
    */
   hubOrigin: string | (() => string);
 

--- a/src/__tests__/hub.test.ts
+++ b/src/__tests__/hub.test.ts
@@ -40,8 +40,8 @@ describe("renderHub", () => {
     expect(html).toContain("MODULE_ORDER");
   });
 
-  test("known module display order is vault → scribe → notes → claw", () => {
-    expect(html).toContain("['vault', 'scribe', 'notes', 'claw']");
+  test("known module display order is vault → scribe → notes → agent", () => {
+    expect(html).toContain("['vault', 'scribe', 'notes', 'agent']");
   });
 
   test("vault tile counts vaults[] (per instance) and links to /vault", () => {
@@ -56,7 +56,7 @@ describe("renderHub", () => {
 
   test("non-vault tiles take their manageUrl from the service's path", () => {
     // shortName('parachute-scribe') = 'scribe' → tile links to svc.path,
-    // which is whatever the module declared (e.g. /scribe, /notes, /claw).
+    // which is whatever the module declared (e.g. /scribe, /notes, /agent).
     // Hardcoding the link would silently break on a custom mount.
     expect(html).toContain("manageUrl: svc.path");
   });
@@ -68,11 +68,11 @@ describe("renderHub", () => {
     expect(html).toContain("count === 1 ? '1 registered'");
   });
 
-  test("module labels are humanized (Vault / Scribe / Notes / Claw)", () => {
+  test("module labels are humanized (Vault / Scribe / Notes / Agent)", () => {
     expect(html).toContain("vault: 'Vault'");
     expect(html).toContain("scribe: 'Scribe'");
     expect(html).toContain("notes: 'Notes'");
-    expect(html).toContain("claw: 'Claw'");
+    expect(html).toContain("agent: 'Agent'");
   });
 
   test("vault-name detection covers parachute-vault and parachute-vault-<name>", () => {

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -1399,16 +1399,16 @@ describe("install", () => {
   });
 
   test("third-party with diverging name/manifestName keys services.json by name (hub#85)", async () => {
-    // Repro for parachute-hub#85: paraclaw ships `name: "claw",
-    // manifestName: "paraclaw"`. Install used to seed services.json under
-    // `paraclaw` (the npm label) while lifecycle looks up by `claw` (the
-    // canonical short) → "unknown service". Fix: services.json key is
-    // always `manifest.name` for third-party.
+    // Repro for parachute-hub#85: parachute-agent ships `name: "agent",
+    // manifestName: "parachute-agent"`. Install used to seed services.json
+    // under `parachute-agent` (the npm label) while lifecycle looks up by
+    // `agent` (the canonical short) → "unknown service". Fix: services.json
+    // key is always `manifest.name` for third-party.
     const { path, configDir, cleanup } = makeTempPath();
     try {
       const startCalls: string[] = [];
       const logs: string[] = [];
-      const code = await install("paraclaw", {
+      const code = await install("parachute-agent", {
         runner: async () => 0,
         manifestPath: path,
         configDir,
@@ -1420,29 +1420,29 @@ describe("install", () => {
         portProbe: async () => false,
         log: (l) => logs.push(l),
         readManifest: async () => ({
-          name: "claw",
-          manifestName: "paraclaw",
+          name: "agent",
+          manifestName: "parachute-agent",
           kind: "api",
           port: 1945,
-          paths: ["/claw"],
-          health: "/claw/health",
+          paths: ["/agent"],
+          health: "/agent/health",
           startCmd: ["bun", "server.ts"],
         }),
-        findGlobalInstall: () => "/fake/prefix/paraclaw/package.json",
+        findGlobalInstall: () => "/fake/prefix/parachute-agent/package.json",
       });
       expect(code).toBe(0);
       // services.json is keyed by `name`, not `manifestName`.
-      expect(findService("claw", path)?.name).toBe("claw");
-      expect(findService("paraclaw", path)).toBeUndefined();
+      expect(findService("agent", path)?.name).toBe("agent");
+      expect(findService("parachute-agent", path)).toBeUndefined();
       // Auto-start receives the canonical short name (= manifest.name).
-      expect(startCalls).toEqual(["claw"]);
+      expect(startCalls).toEqual(["agent"]);
       // Log lines speak in the canonical short name too. Port comes from
       // assignServicePort (third-party gets the first unassigned canonical
       // slot, currently 1944), not the manifest's port hint.
       const joined = logs.join("\n");
-      expect(joined).toMatch(/Seeded services\.json entry for claw/);
-      expect(joined).toMatch(/claw registered on port \d+/);
-      expect(joined).not.toMatch(/Seeded services\.json entry for paraclaw/);
+      expect(joined).toMatch(/Seeded services\.json entry for agent/);
+      expect(joined).toMatch(/agent registered on port \d+/);
+      expect(joined).not.toMatch(/Seeded services\.json entry for parachute-agent/);
     } finally {
       cleanup();
     }

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -494,14 +494,14 @@ describe("parachute start", () => {
     // gets cwd=installDir so manifest-declared relative paths work.
     const h = makeHarness();
     try {
-      const installDir = join(h.configDir, "_pkg-claw");
-      seedThirdParty(h.manifestPath, h.configDir, "claw", {
+      const installDir = join(h.configDir, "_pkg-agent");
+      seedThirdParty(h.manifestPath, h.configDir, "agent", {
         installDir,
         startCmd: ["bun", "web/server/src/server.ts"],
         port: 1944,
       });
       const spawner = makeSpawner([8080]);
-      const code = await start("claw", {
+      const code = await start("agent", {
         configDir: h.configDir,
         manifestPath: h.manifestPath,
         spawner,
@@ -511,7 +511,7 @@ describe("parachute start", () => {
       expect(spawner.calls).toHaveLength(1);
       expect(spawner.calls[0]?.cmd).toEqual(["bun", "web/server/src/server.ts"]);
       expect(spawner.calls[0]?.cwd).toBe(installDir);
-      expect(readPid("claw", h.configDir)).toBe(8080);
+      expect(readPid("agent", h.configDir)).toBe(8080);
     } finally {
       h.cleanup();
     }
@@ -549,8 +549,8 @@ describe("parachute start", () => {
     const h = makeHarness();
     try {
       seedVault(h.manifestPath);
-      const installDir = join(h.configDir, "_pkg-claw");
-      seedThirdParty(h.manifestPath, h.configDir, "claw", {
+      const installDir = join(h.configDir, "_pkg-agent");
+      seedThirdParty(h.manifestPath, h.configDir, "agent", {
         installDir,
         startCmd: ["bun", "server.ts"],
         port: 1944,
@@ -803,21 +803,21 @@ describe("parachute logs", () => {
   test("third-party module name with installDir is recognised", async () => {
     const h = makeHarness();
     try {
-      const installDir = join(h.configDir, "_pkg-claw");
-      seedThirdParty(h.manifestPath, h.configDir, "claw", {
+      const installDir = join(h.configDir, "_pkg-agent");
+      seedThirdParty(h.manifestPath, h.configDir, "agent", {
         installDir,
         startCmd: ["bun", "server.ts"],
       });
-      const p = ensureLogPath("claw", h.configDir);
-      writeFileSync(p, "claw line 1\nclaw line 2\n");
+      const p = ensureLogPath("agent", h.configDir);
+      writeFileSync(p, "agent line 1\nagent line 2\n");
       const lines: string[] = [];
-      const code = await logs("claw", {
+      const code = await logs("agent", {
         configDir: h.configDir,
         manifestPath: h.manifestPath,
         log: (l) => lines.push(l),
       });
       expect(code).toBe(0);
-      expect(lines).toEqual(["claw line 1", "claw line 2"]);
+      expect(lines).toEqual(["agent line 1", "agent line 2"]);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -121,8 +121,8 @@ describe("authorizationServerMetadata", () => {
       "vault:admin",
       "hub:admin",
       "parachute:host:admin", // declared but operator-only — must still be filtered
-      "claw:read",
-      "claw:write",
+      "agent:read",
+      "agent:write",
       "mymodule:do-thing",
     ]);
     const res = authorizationServerMetadata({
@@ -132,8 +132,8 @@ describe("authorizationServerMetadata", () => {
     const body = (await res.json()) as Record<string, unknown>;
     const scopesSupported = body.scopes_supported as string[];
     // Third-party scopes show up
-    expect(scopesSupported).toContain("claw:read");
-    expect(scopesSupported).toContain("claw:write");
+    expect(scopesSupported).toContain("agent:read");
+    expect(scopesSupported).toContain("agent:write");
     expect(scopesSupported).toContain("mymodule:do-thing");
     // First-party still advertised — no regression
     expect(scopesSupported).toContain("vault:read");

--- a/src/__tests__/scope-registry.test.ts
+++ b/src/__tests__/scope-registry.test.ts
@@ -140,7 +140,7 @@ describe("loadDeclaredScopes", () => {
   test("readModuleScopes receives installDir from services.json (closes #85 follow-up)", () => {
     // Regression: scope-registry was looking up by services.json `name` in
     // bun-globals. For third-party modules where name (canonical short like
-    // "claw") differs from the npm package name on disk ("nanoclaw" for
+    // "agent") differs from the npm package name on disk ("nanoagent" for
     // forks), that lookup fails and the module's scopes are never declared.
     // installDir from hub#84 is the correct path source.
     const { manifestPath, cleanup } = tmp();
@@ -150,12 +150,12 @@ describe("loadDeclaredScopes", () => {
         JSON.stringify({
           services: [
             {
-              name: "claw",
+              name: "agent",
               port: 1944,
-              paths: ["/claw"],
+              paths: ["/agent"],
               health: "/api/health",
               version: "0.0.0-linked",
-              installDir: "/Users/test/ParachuteComputer/paraclaw",
+              installDir: "/Users/test/ParachuteComputer/parachute-agent",
             },
           ],
         }),
@@ -165,15 +165,15 @@ describe("loadDeclaredScopes", () => {
         manifestPath,
         readModuleScopes: (pkg, installDir) => {
           calls.push({ pkg, installDir });
-          return pkg === "claw" ? ["claw:read", "claw:write", "claw:admin"] : null;
+          return pkg === "agent" ? ["agent:read", "agent:write", "agent:admin"] : null;
         },
       });
       expect(calls).toEqual([
-        { pkg: "claw", installDir: "/Users/test/ParachuteComputer/paraclaw" },
+        { pkg: "agent", installDir: "/Users/test/ParachuteComputer/parachute-agent" },
       ]);
-      expect(declared.has("claw:read")).toBe(true);
-      expect(declared.has("claw:write")).toBe(true);
-      expect(declared.has("claw:admin")).toBe(true);
+      expect(declared.has("agent:read")).toBe(true);
+      expect(declared.has("agent:write")).toBe(true);
+      expect(declared.has("agent:admin")).toBe(true);
     } finally {
       cleanup();
     }

--- a/src/__tests__/services-manifest.test.ts
+++ b/src/__tests__/services-manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -192,6 +192,123 @@ describe("services-manifest", () => {
       expect(() => upsertService({ ...vault, installDir: 42 as unknown as string }, path)).toThrow(
         /installDir/,
       );
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("claw → agent migration", () => {
+  // Paraclaw was renamed to parachute-agent across the ecosystem (npm
+  // package, mount path, short name). Operators who upgraded hub but
+  // still have the old paraclaw row in services.json otherwise see a
+  // tile labelled "Claw" and a hub route at `/claw` while their newly
+  // upgraded daemon listens on `/agent`. The migration runs on
+  // readManifest, rewrites the row in-place, and writes back.
+  const claw: ServiceEntry = {
+    name: "claw",
+    port: 1944,
+    paths: ["/claw"],
+    health: "/claw/health",
+    version: "0.1.0",
+  };
+  const agent: ServiceEntry = {
+    name: "agent",
+    port: 1944,
+    paths: ["/agent"],
+    health: "/agent/health",
+    version: "0.1.0",
+  };
+
+  test("rewrites name + paths + health when both name=claw and paths[0]=/claw", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writeFileSync(path, `${JSON.stringify({ services: [claw] }, null, 2)}\n`);
+      const got = readManifest(path);
+      expect(got.services).toEqual([agent]);
+      // Persisted: a second read sees the migrated shape directly, no
+      // re-migration required.
+      const reread = JSON.parse(readFileSync(path, "utf8")) as {
+        services: ServiceEntry[];
+      };
+      expect(reread.services[0]?.name).toBe("agent");
+      expect(reread.services[0]?.paths).toEqual(["/agent"]);
+      expect(reread.services[0]?.health).toBe("/agent/health");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("idempotent: an already-agent entry is not rewritten and not rewritten on re-read", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writeFileSync(path, `${JSON.stringify({ services: [agent] }, null, 2)}\n`);
+      const beforeMtime = statSync(path).mtimeMs;
+      const got = readManifest(path);
+      expect(got.services).toEqual([agent]);
+      // No write back when nothing changed: mtime stays put.
+      const afterMtime = statSync(path).mtimeMs;
+      expect(afterMtime).toBe(beforeMtime);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("mixed manifest: vault and scribe are untouched, only claw migrates", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const scribe: ServiceEntry = {
+        name: "parachute-scribe",
+        port: 1943,
+        paths: ["/scribe"],
+        health: "/scribe/health",
+        version: "0.1.0",
+      };
+      writeFileSync(
+        path,
+        `${JSON.stringify({ services: [vault, claw, scribe] }, null, 2)}\n`,
+      );
+      const got = readManifest(path);
+      expect(got.services).toHaveLength(3);
+      expect(got.services[0]).toEqual(vault);
+      expect(got.services[1]).toEqual(agent);
+      expect(got.services[2]).toEqual(scribe);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("preserves nested /claw paths when present (e.g. /claw/api)", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const clawNested: ServiceEntry = {
+        name: "claw",
+        port: 1944,
+        paths: ["/claw", "/claw/api"],
+        health: "/claw/api/health",
+        version: "0.1.0",
+      };
+      writeFileSync(path, `${JSON.stringify({ services: [clawNested] }, null, 2)}\n`);
+      const got = readManifest(path);
+      expect(got.services[0]?.paths).toEqual(["/agent", "/agent/api"]);
+      expect(got.services[0]?.health).toBe("/agent/api/health");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("leaves a row alone if name is claw but mount is something else (deliberate third-party reuse)", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const oddClaw: ServiceEntry = {
+        name: "claw",
+        port: 9000,
+        paths: ["/something-else"],
+        health: "/something-else/health",
+        version: "0.1.0",
+      };
+      writeFileSync(path, `${JSON.stringify({ services: [oddClaw] }, null, 2)}\n`);
+      expect(readManifest(path).services).toEqual([oddClaw]);
     } finally {
       cleanup();
     }

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -3,7 +3,7 @@
  *
  * The hub's first authenticated, mutating endpoint. Until now the hub has
  * been a pure issuer; Phase 1 of the vault-config-and-scopes design (D1)
- * lifts vault provisioning into a hub UI surface so paraclaw / hub-admin
+ * lifts vault provisioning into a hub UI surface so parachute-agent / hub-admin
  * pages can mint a vault without shelling out to a terminal.
  *
  * Wire shape:

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -291,7 +291,7 @@ function defaultSpaDistDir(): string {
  * The SPA serves at two mounts:
  *
  * - `/vault` — primary, since hub#168-realignment. Matches the operator
- *   pattern of `/<module>` as the entry point (alongside `/notes`, `/claw`,
+ *   pattern of `/<module>` as the entry point (alongside `/notes`, `/agent`,
  *   `/scribe`). VaultsList, NewVault, and per-vault detail routes hang off
  *   here.
  * - `/hub` — back-compat. `/hub/permissions` (cross-vault grants) is a hub

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -6,9 +6,9 @@ import { CONFIG_DIR } from "./config.ts";
  * Hub page served at `/` when the node is exposed.
  *
  * The page is a *module directory*: one tile per module type (vault, scribe,
- * notes, claw), not one row per service instance. Aaron's original shape
+ * notes, agent), not one row per service instance. Aaron's original shape
  * iterated `services[]` and rendered a card per entry — fine at one vault,
- * but at three vaults plus scribe + notes + claw the page reads as a flat
+ * but at three vaults plus scribe + notes + agent the page reads as a flat
  * list of instances rather than the modules themselves (#168). The new shape
  * aggregates: "Vault — 3 registered — Manage →" links to the per-vault SPA at
  * `/vault`; "Scribe — 1 registered" links to the running scribe instance;
@@ -249,12 +249,12 @@ const HTML = `<!doctype html>
 
   // Display order for known module types. Unknown short-names append after,
   // so a third-party module mounted at /foo still gets a tile.
-  const MODULE_ORDER = ['vault', 'scribe', 'notes', 'claw'];
+  const MODULE_ORDER = ['vault', 'scribe', 'notes', 'agent'];
   const MODULE_LABELS = {
     vault: 'Vault',
     scribe: 'Scribe',
     notes: 'Notes',
-    claw: 'Claw',
+    agent: 'Agent',
   };
 
   function isVaultName(name) {

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -233,7 +233,7 @@ export function authorizationServerMetadata(deps: OAuthDeps): Response {
   const iss = deps.issuer;
   // Advertise the full declared-scope set — FIRST_PARTY ∪ each registered
   // module's `scopes.defines` — so standards-following clients discover
-  // third-party scopes (e.g. paraclaw's `claw:*`) the same way they discover
+  // third-party scopes (e.g. parachute-agent's `agent:*`) the same way they discover
   // first-party ones. The token-issuance path already consults
   // `loadDeclaredScopes` (see #90); metadata had to follow or the issuer's
   // public advertisement would be a strict subset of what it'll actually

--- a/src/scope-registry.ts
+++ b/src/scope-registry.ts
@@ -73,8 +73,8 @@ export function findUnknownScopes(
  *   1. If `installDir` is provided (hub#84 stamps this on every services.json
  *      row at install time), read directly from there. This is the canonical
  *      path — services.json's `name` is the manifest's canonical short
- *      (e.g. "claw"), which doesn't match the npm package name on disk
- *      (e.g. "nanoclaw" for forks). bun-globals lookup-by-name fails for
+ *      (e.g. "agent"), which doesn't match the npm package name on disk
+ *      (e.g. "nanoagent" for forks). bun-globals lookup-by-name fails for
  *      that case; installDir is the source of truth.
  *   2. Fall back to `<bun-globals>/<packageName>/.parachute/module.json`
  *      for entries without installDir (older installs, or services that

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -136,7 +136,47 @@ export function readManifest(path: string = SERVICES_MANIFEST_PATH): ServicesMan
       `failed to parse ${path}: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
-  return validateManifest(raw, path);
+  const validated = validateManifest(raw, path);
+  const migrated = migrateClawToAgent(validated);
+  if (migrated.changed) writeManifest(migrated.manifest, path);
+  return migrated.manifest;
+}
+
+/**
+ * Migrate legacy `claw` entries to `agent` in-place. Paraclaw was renamed
+ * to parachute-agent across the ecosystem (npm package, mount path, short
+ * name); operators who upgraded hub but still have the old paraclaw row
+ * in services.json would otherwise see a tile labelled "Claw" and a hub
+ * route at `/claw` while their newly-upgraded daemon listens on `/agent`.
+ *
+ * Idempotent. Only rewrites when both `name === "claw"` AND the first path
+ * is `/claw` — narrow enough that a deliberately-named third-party module
+ * (e.g. `name: "claw"` on a different mount) is left alone. Health and any
+ * `/claw`-rooted paths are rewritten in lockstep.
+ */
+function migrateClawToAgent(manifest: ServicesManifest): {
+  manifest: ServicesManifest;
+  changed: boolean;
+} {
+  let changed = false;
+  const services = manifest.services.map((entry) => {
+    if (entry.name !== "claw" || entry.paths[0] !== "/claw") return entry;
+    changed = true;
+    const next: ServiceEntry = {
+      ...entry,
+      name: "agent",
+      paths: entry.paths.map((p) => rewriteClawPath(p)),
+      health: rewriteClawPath(entry.health),
+    };
+    return next;
+  });
+  return { manifest: { services }, changed };
+}
+
+function rewriteClawPath(p: string): string {
+  if (p === "/claw") return "/agent";
+  if (p.startsWith("/claw/")) return `/agent${p.slice("/claw".length)}`;
+  return p;
 }
 
 export function writeManifest(

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -39,7 +39,7 @@ export interface WellKnownServicesEntry {
  * Canonical `/.well-known/parachute.json` shape.
  *
  * Two parts:
- *   - `vaults: []`, `notes: []`, `claw: []`, … — every kind is a plural
+ *   - `vaults: []`, `notes: []`, `agent: []`, … — every kind is a plural
  *     array, so consumers always read `notes[0]` if they want "the one" and
  *     the multi-install case is visible at every call site (closes #92).
  *   - `services: []` — flat list the hub page iterates. Scales to N frontends
@@ -122,7 +122,7 @@ export function buildWellKnown(opts: BuildWellKnownOpts): WellKnownDocument {
     // Vault services are mounted at one path per vault instance — a single
     // ServiceEntry with `paths: ["/vault/default", "/vault/techne"]` represents
     // two distinct vault instances behind the same backend. Iterate each path
-    // so consumers (paraclaw vault picker, hub page) see every instance
+    // so consumers (parachute-agent vault picker, hub page) see every instance
     // (closes #141). Non-vault services keep the legacy paths[0] semantic;
     // multi-path on those is treated as aliases rather than separate
     // installs.

--- a/web/ui/src/routes/NewVault.tsx
+++ b/web/ui/src/routes/NewVault.tsx
@@ -158,7 +158,7 @@ function CreatedView({
           <h3>Your vault token (shown once)</h3>
           <p className="muted">
             This is the only time the hub will show this token. Copy it and store it somewhere safe
-            — a password manager, the operator's notes, paraclaw's secrets store. If you lose it,
+            — a password manager, the operator's notes, parachute-agent's secrets store. If you lose it,
             you'll need to mint a new one from the vault directly.
           </p>
           <div className="token-box">


### PR DESCRIPTION
## Summary

Pre-publish cleanup pass for the **0.5.0** hub release, coordinated with the parachute-agent (formerly paraclaw) cross-ecosystem rename.

- **Hub homepage tile.** `src/hub.ts` MODULE_ORDER and MODULE_LABELS rename `claw` / `Claw` → `agent` / `Agent`. Operators land on `/` and see a tile labelled "Agent" matching the renamed daemon.
- **services.json migration.** Read-time idempotent rewrite in `src/services-manifest.ts:readManifest()`: when an entry has `name: "claw"` AND `paths[0] === "/claw"`, the row is rewritten to `name: "agent"` with `paths: ["/agent"]` and any `/claw`-rooted paths/health updated in lockstep. Idempotent (no write when nothing changes); narrow trigger leaves a deliberately-named third-party module on a different mount alone.
- **Test fixtures + active-comment sweep.** lifecycle.test.ts third-party scaffolding, install.test.ts hub#85 regression, scope-registry.test.ts, oauth-handlers.test.ts, scope-guard scope.test.ts, and inline comments in scope-registry.ts / well-known.ts / hub-server.ts / oauth-handlers.ts / admin-vaults.ts. scope-guard `package.json` description and README intro updated. Historical issue refs (`paraclaw#18`, `paraclaw#25`) and design-doc mentions left for the cross-repo doc sweep.
- **NewVault token-banner copy.** `web/ui/src/routes/NewVault.tsx:161` user-facing recommendation reads `parachute-agent's secrets store` instead of `paraclaw's secrets store`. (Folded after team-lead review — the only user-visible string in the SPA that named the old binary.)
- **Version**: 0.4.0-rc.46 → **0.5.0-rc.1**. Pre-1.0 minor jump to mark the post-rename release; skips past the 0.4.0-rc state held for the vault SPA arc.

> Note for reviewers: the team-lead brief assumed `SERVICE_SPECS` had a `claw` entry needing rewrite. There is no such entry — paraclaw has always been third-party (lives via `<installDir>/.parachute/module.json`), and the hub-side surface that hardcodes the short name is the homepage tile order in `src/hub.ts` and the services.json shape that operators carry locally. The migration handles the second; the rename handles the first.

## Operator-facing migration

When an operator upgrades hub on a box that still has the old paraclaw row in `~/.parachute/services.json`, the next read of services.json silently rewrites the row in place: `name: "claw"` → `name: "agent"`, `paths: ["/claw"]` → `paths: ["/agent"]`, `/claw/health` → `/agent/health`. Once the operator also upgrades paraclaw → parachute-agent, the daemon serves on `/agent` and hub routing matches. No CLI step required from the operator beyond the parachute-agent reinstall.

## Cross-repo coordination

This PR depends on parachute-agent landing the rename of repo / package / binary / mount. Patterns + paraclaw + site repos are doing the wider doc scrub in parallel.

## Patterns check (governance rule)

- **mount-aware-routing** (`paraclaw#25`): N/A — no mount changes here.
- **module-protocol**: this PR formalises a small adoption of the *read-time idempotent migration* shape inside `readManifest()`. No new pattern established; just applying the existing migration discipline (narrow trigger, write-only-when-changed, test the idempotent re-read) to a new field.
- No other patterns established or changed.

## Commits

1. `cb50dfb` chore(hub): rename claw → agent in homepage MODULE_ORDER + labels
2. `b2b122c` chore: sweep test fixtures + active comments paraclaw → parachute-agent
3. `bec617d` feat(services-manifest): migrate legacy claw entries to agent on read
4. `92d5895` chore(release): bump 0.4.0-rc.46 → 0.5.0-rc.1
5. `f62165b` chore(web/ui): rename paraclaw → parachute-agent in NewVault token-banner copy

## Gates (post-bump, including NewVault fold)

- **Host typecheck**: clean.
- **Host tests**: **960 pass** / 0 fail / 2510 expects across 61 files (~11s). +5 vs main: the new services.json migration tests (claw → agent rewrite, idempotent agent no-op, mixed manifest only-claw-migrates, nested `/claw/api` paths preserved, claw-on-non-/claw-mount left alone).
- **web/ui typecheck**: clean. **47 pass** / 0 fail across 5 files.
- **web/ui build**: clean. `verify-base.mjs` confirms `/vault/`-prefixed assets. 247.44 kB JS / 4.90 kB CSS / 78.03 kB gzipped JS — unchanged from main.
- **scope-guard tests**: **64 pass** / 0 fail across 4 files.
- **Lint baseline**: 3 errors in 162 files (biome `format` in `src/commands/expose-public-auto.ts`). Pre-existing on main, unchanged here.

## Skipped

- **hub#169** (bun-link installDir gap): optional per brief, not blocking @latest. Aaron's running with the manual workaround. Defer to post-publish.
- **Historical issue refs and design docs**: `paraclaw#18`, `paraclaw#25`, and `docs/design/2026-04-29-*.md` mentions of paraclaw. The patterns tentacle is sweeping the wider doc set in parallel.

## Test plan

- [ ] CI green (typecheck + tests on host + web/ui + scope-guard).
- [ ] Local smoke: bun-linked checkout, `parachute install vault` from a fresh `~/.parachute/`; visit `/` and confirm tile reads "Vault" (no regression).
- [ ] Migration smoke: hand-craft a `~/.parachute/services.json` with the legacy claw-shape entry, run any `parachute` command (e.g. `parachute status`), confirm services.json is rewritten with `name: "agent"` + `paths: ["/agent"]`, second run is a no-op (mtime stable).
- [ ] Mint a vault from `/vault/new` in a browser; confirm the token banner copy reads "parachute-agent's secrets store".

🤖 Generated with [Claude Code](https://claude.com/claude-code)