### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
+
+## 0.5.0 — 2026-05-05
+
+First clean stable promotion to `@latest` since the package was renamed from `@openparachute/cli` in 0.3.0. The previous `@latest` (`0.3.0-rc.1`) was an RC promoted to `@latest` in the early pre-launch rush — that violated the "RC versioning before `@latest`" rule from governance. **This release corrects the governance posture by promoting a non-RC stable to `@latest`.**
+
+### Added
+
+- **Vault-management SPA** at `/vault` (`web/ui/`, Vite + React + TypeScript). Phase 1 ships list + create with single-emit `pvt_*` token banner. Mount-aware `basename` swaps route sets between `/vault/*` (vault list / new / detail) and `/hub/*` (cross-vault permissions). (#157, #161, #163, #173)
+- **Per-vault grants admin UI** at `/hub/permissions` — operator-controlled view of which client/scope grants are recorded in the hub's grants table, with revoke. (#162, #165)
+- **Native OAuth issuance** at `/oauth/authorize`, `/oauth/token`, `/oauth/revoke` with refresh-token rotation, RFC 7009 revocation, scope-validation, branded consent UI, declared-scope advertising in AS metadata, refresh-rotation hardening, and skip-consent-when-already-granted shortcut. (#66, #69, #70, #76, #79, #82, #99, #101, #104, #106, #107, #108, #115, #118, #119, #120, #150)
+- **`parachute:host:admin` scope** for the unified `parachute setup` walk-through, locked behind a session-cookie path so the public OAuth flow can't request it. (#95, #96, #98, #110, #112)
+- **Create-vault flow + OAuth scope picker** during the host-setup walkthrough. (#95)
+- **Config portal** rendering each module's `configSchema` as a form, with a writeable surface back to the running module. (#114)
+- **`parachute upgrade <service>`** for both bun-linked dev installs and npm-installed services. (#117)
+- **Dynamic `/.well-known/parachute.json`** built from `services.json` on every request, with plural-array shape for every kind (vaults, notes, agent, etc.). (#105, #135, #138, #142)
+- **Dynamic `/vault/<name>/*` proxy routing** so newly-created vaults are reachable on tailnet immediately, without `parachute expose` re-runs. (#144, #145)
+- **Native Cloudflare Tunnel** support for `parachute expose public`, with `--tunnel-name` flag for stable public URLs. (#29, #32, #151, #153)
+- **`@openparachute/scope-guard`** sub-package: hub-issued JWT validation library shared between vault, scribe, and (soon) parachute-agent. JWKS-backed verify, audience strict-check, generic `<resource>:<verb>` / `<resource>:<name>:<verb>` scope matcher with `admin ⊇ write ⊇ read` inheritance, single `HubJwtError.code` taxonomy. Independent RC cadence from the hub. (#121, #152)
+- **Vault-admin-token mint** at `/admin/vault-admin-token` returning a per-vault-audience JWT (`aud: vault.<name>`); SPA auto-mints + refreshes on 401. (#173)
+- **`RESERVED_VAULT_NAMES`** extension to block `new` and `assets` from being used as a vault short-name (would shadow `/vault/new` SPA route or `/vault/assets/*` Vite asset pattern). (#173)
+- **Home page tile-per-module-type** collapse — `/` renders a single tile per module rather than per-instance, with deep links into each module's surface. (#170)
+- **Third-party modules via `installDir` + `module.json`** so non-first-party modules (currently parachute-agent, formerly paraclaw) can install through `parachute install <local-path>` and participate in the hub's scope/manifest registry. (#83, #84, #90)
+- **services.json `claw` → `agent` migration** at read-time. Legacy entries with `name: "claw"` and `paths[0] === "/claw"` are silently rewritten to `name: "agent"` with `paths: ["/agent"]` (and any `/claw/*` paths/health rerouted in lockstep). Idempotent, narrow trigger. (#174)
+
+### Changed
+
+- **`@openparachute/cli` → `@openparachute/hub`** (rename completed in 0.3.0-rc.1). The bin name `parachute` is unchanged. The "CLI" framing was always partial — the package now bundles the daemon (`:1939` discovery, OAuth issuance, vault management SPA), and `parachute` is one of its surfaces.
+- **`/hub/vaults` → `/vault`** for module-pattern symmetry. The SPA now mounts at the same shape every other module uses (`/<short-name>/*`). Old `/hub/vaults*` URLs 301-redirect. (#173)
+- **`SERVICE_SPECS` → `FIRST_PARTY_FALLBACKS`** semantic shift — the constant is now a fallback for first-party packages (vault, notes, scribe, channel) rather than a gating list. Modules install through `<installDir>/.parachute/module.json` first; the fallback only kicks in for the four packages that pre-date the manifest convention. (#70)
+- **Homepage `MODULE_ORDER` + `MODULE_LABELS`** rename `claw` / `Claw` → `agent` / `Agent` to match the renamed daemon. (#174)
+- **Detached lifecycle process group**: `parachute start|stop|restart` now SIGTERMs the whole process group, so wrapped start commands (`pnpm exec`, `tsx`, etc.) actually restart instead of orphaning. (#88, #93)
+- **`parachute start|stop|restart|logs hub`** now manages the hub itself the same way it manages every other module — no more separate command surface. (#166, #167)
+- **`bun link` detection in `parachute install`**: the bun global node_modules tree is checked for an existing symlink before `bun add -g` runs, so locally-developed services don't 404 against npm. (#89, #94)
+- **`scope-registry`** uses `installDir` from `services.json` to locate `module.json`, fixing third-party module scope reads. (#90)
+- **`parachute install`** uses `manifest.name` (not `manifestName`) as the `services.json` key, log line, and auto-start short-name — fixes the divergence regression where modules whose npm package name differed from their short name (e.g. paraclaw shipping `name: "claw"` + `manifestName: "paraclaw"`) installed under the wrong key. (#85, #86)
+
+### Fixed
+
+- `vault-admin-token` audience mismatch — hub minted with broad `aud: vault` while resource servers strict-checked `aud: vault.<name>`. Now mints with the per-vault audience the resource server expects. (#173)
+- `iss` claim is now set on every hub-issued JWT. (#77, #79)
+- `client_secret` is now enforced on `/oauth/token` for confidential clients. (#101)
+- `recordGrant` is now transaction-wrapped, with audit logging on the skip-consent shortcut. (#119, #120, #150)
+- `/.well-known/parachute.json` emits one `vaults` entry per path for multi-path vault services. (#142)
+- "Manual hub" detection bug + vault-name unification regression. (#143, #148, #149)
+
+### Deprecated
+
+- **Legacy `~/.parachute/services.json` shape** with `name: "claw"` + `paths: ["/claw"]` rows is auto-migrated to `name: "agent"` + `paths: ["/agent"]` on read. The migration is idempotent and silent; no operator action required beyond reinstalling parachute-agent (formerly paraclaw) from npm.
+
+### Retired
+
+- `src/deploy/` was moved to the separate `parachute-cloud` repo. The hub no longer contains the `parachute deploy` provider integration. (#146, #147)
+
+### Security
+
+- Refresh-token rotation now invalidates the prior token on use; rotation hardening covered the pre-launch surface. (#106, #107, #108, #115)
+- Operator-approval gate added to Dynamic Client Registration so unauthenticated DCR can't silently mint clients. (#104)
+
+### Governance
+
+- This release corrects the pre-launch RC-on-`@latest` posture by promoting a non-RC stable. Future RC versions will land on the `rc` dist-tag (`npm publish --tag rc`); promotion to `@latest` is a deliberate `npm dist-tag add` step.
+
+## 0.3.0 — 2026-04-26
+
+- **Renamed `@openparachute/cli` → `@openparachute/hub`** to reflect that the package is no longer just a CLI. The `parachute` binary is one surface; the long-running daemon (discovery on `:1939`, OAuth issuance, vault SPA) is another. (#60, #61, #62)
+- See [release notes for 0.3.0](https://github.com/ParachuteComputer/parachute-hub/releases/tag/v0.3.0) for the full pre-rename changelog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
-## 0.5.0 — 2026-05-05
+## 0.5.0 — 2026-05-04
 
 First clean stable promotion to `@latest` since the package was renamed from `@openparachute/cli` in 0.3.0. The previous `@latest` (`0.3.0-rc.1`) was an RC promoted to `@latest` in the early pre-launch rush — that violated the "RC versioning before `@latest`" rule from governance. **This release corrects the governance posture by promoting a non-RC stable to `@latest`.**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.0-rc.1",
+  "version": "0.5.0",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -155,19 +155,16 @@ describe("cli per-subcommand help", () => {
     // is set up" output — proving the skip flag bypassed auto-pick and went
     // straight to the Funnel path. If we regressed and skip-flag tumbled
     // into auto-pick, we'd see the auto-pick neither-ready report instead.
-    const proc = Bun.spawn(
-      [process.execPath, CLI, "expose", "public", "--skip-provider-check"],
-      {
-        stdout: "pipe",
-        stderr: "pipe",
-        env: {
-          ...process.env,
-          PATH: "",
-          HOME: "/tmp/parachute-hub-nonexistent-home",
-          PARACHUTE_HOME: "/tmp/parachute-hub-nonexistent-home",
-        },
+    const proc = Bun.spawn([process.execPath, CLI, "expose", "public", "--skip-provider-check"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        PATH: "",
+        HOME: "/tmp/parachute-hub-nonexistent-home",
+        PARACHUTE_HOME: "/tmp/parachute-hub-nonexistent-home",
       },
-    );
+    });
     const [stdout, code] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
     expect(code).toBe(1);
     expect(stdout).toMatch(/tailscale is not installed or not on PATH/);

--- a/src/__tests__/services-manifest.test.ts
+++ b/src/__tests__/services-manifest.test.ts
@@ -264,10 +264,7 @@ describe("claw → agent migration", () => {
         health: "/scribe/health",
         version: "0.1.0",
       };
-      writeFileSync(
-        path,
-        `${JSON.stringify({ services: [vault, claw, scribe] }, null, 2)}\n`,
-      );
+      writeFileSync(path, `${JSON.stringify({ services: [vault, claw, scribe] }, null, 2)}\n`);
       const got = readManifest(path);
       expect(got.services).toHaveLength(3);
       expect(got.services[0]).toEqual(vault);

--- a/web/ui/src/routes/NewVault.tsx
+++ b/web/ui/src/routes/NewVault.tsx
@@ -158,8 +158,8 @@ function CreatedView({
           <h3>Your vault token (shown once)</h3>
           <p className="muted">
             This is the only time the hub will show this token. Copy it and store it somewhere safe
-            — a password manager, the operator's notes, parachute-agent's secrets store. If you lose it,
-            you'll need to mint a new one from the vault directly.
+            — a password manager, the operator's notes, parachute-agent's secrets store. If you lose
+            it, you'll need to mint a new one from the vault directly.
           </p>
           <div className="token-box">
             <code>{result.token}</code>


### PR DESCRIPTION
## Summary

Final-stable bump: `0.5.0-rc.1` → `0.5.0`. First clean stable on the `@latest` dist-tag since `@openparachute/cli` was renamed to `@openparachute/hub` in 0.3.0.

After Aaron merges this and runs `npm publish --tag latest` from his shell, `npm view @openparachute/hub dist-tags` should show `latest: 0.5.0`.

## Governance correction

The current `@latest` is `0.3.0-rc.1` — an RC promoted to `@latest` in the pre-launch rush. That violated `parachute-patterns/patterns/governance.md`'s **"RC versioning before `@latest`"** rule.

This release fixes the posture by promoting a non-RC stable to `@latest`. From here forward:

- RC versions (`0.X.Y-rc.N`) land on the `rc` dist-tag via `npm publish --tag rc`.
- Promotion to `@latest` is a deliberate `npm dist-tag add @openparachute/hub@<version> latest` step after validation.

## Changes

- `package.json`: `0.5.0-rc.1` → `0.5.0`.
- `CHANGELOG.md` (new file): full 0.5.0 entry summarising work since 0.3.0-rc.1 (the previous `@latest`). Highlights:
  - Vault management SPA at `/vault` (#157, #161, #163, #173) + home tile collapse (#170).
  - Per-vault grants admin UI at `/hub/permissions` (#162, #165).
  - Native OAuth issuance + branded consent UI + DCR operator gate + RFC 7009 revocation + refresh rotation hardening (#66, #69, #70, #76, #79, #82, #99, #101, #104, #106-#108, #115, #118-#120, #150).
  - `parachute:host:admin` scope + unified `parachute setup` (#95-#98, #110, #112).
  - Config portal (#114), `parachute upgrade` (#117), dynamic well-known (#105, #135, #138, #142), dynamic vault proxy (#144, #145), Cloudflare Tunnel expose (#29, #32, #151, #153).
  - `@openparachute/scope-guard` sub-package (#121, #152).
  - Vault-admin-token audience fix (#173) + `RESERVED_VAULT_NAMES` extension (#173).
  - Third-party module install via `<installDir>/.parachute/module.json` (#83, #84, #90).
  - claw → agent rename + services.json migration (#174).
  - Many smaller fixes (#85, #88, #89, #93, #94, #143, #148, #149, #166, #167).

### Folded lint-baseline restoration

Three biome `format` slip-throughs found while running gates fresh:

- `web/ui/src/routes/NewVault.tsx` — the `paraclaw` → `parachute-agent` user-copy fold from #174 pushed line 161 over biome's print width (single line wrapped at "If you lose / it,").
- `src/__tests__/services-manifest.test.ts` — the new claw-migration test (PR #174) had a `writeFileSync(path, ...)` call wrapped where biome wants it inline.
- `src/__tests__/cli.test.ts` — earlier expose-merge slip in the `--skip-provider-check` smoke; `Bun.spawn(...)` arg-block formatting drifted.

Lint state after this PR: **2 errors in `src/commands/expose-public-auto.ts`** (organizeImports + format), which is the long-standing baseline. None of my contributions remain in the lint diff.

## Gates (on `0246894`, post-bump)

- **Host typecheck**: clean.
- **Host tests**: **960 pass / 0 fail / 2510 expects across 61 files** (~12s).
- **web/ui typecheck**: clean. **47 pass / 0 fail across 5 files**.
- **web/ui build**: clean. `verify-base.mjs` confirms `/vault/`-prefixed assets. 247.44 kB JS / 4.90 kB CSS / 78.03 kB gzipped JS — unchanged from main.
- **scope-guard tests**: **64 pass / 0 fail across 4 files**, typecheck clean.
- **Lint baseline**: 2 errors in 162 files (`src/commands/expose-public-auto.ts` — pre-existing).

### Note on `status.test.ts`

First gate run hit one local-only failure: `status > all-healthy returns 0 and prints table` skipped the scribe health probe. Root cause: a stale PID file at `~/.parachute/scribe/run/scribe.pid` (PID 45692, dead). The test doesn't pass `configDir`, so `processState` reads the global `~/.parachute/`, sees the dead PID file, returns "stopped", and the probe is short-circuited. Cleared the stale PID; test green; full suite green. CI is unaffected (clean home). Filing as a follow-up: `status` test isolation should pass `configDir` to the temp dir.

## Test plan

- [ ] CI green (typecheck + tests on host + web/ui + scope-guard).
- [ ] Aaron: `npm publish --tag latest` (with 2FA).
- [ ] Aaron: `npm view @openparachute/hub dist-tags` shows `latest: 0.5.0`.
- [ ] Aaron: post-publish, `parachute --version` from a fresh `bunx @openparachute/hub@latest --version` prints `0.5.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)