### PR TITLE
chore: bump scope-guard to 0.1.0 stable + correct CHANGELOG date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
-## 0.5.0 — 2026-05-04
+## 0.5.0 — 2026-05-05
 
 First clean stable promotion to `@latest` since the package was renamed from `@openparachute/cli` in 0.3.0. The previous `@latest` (`0.3.0-rc.1`) was an RC promoted to `@latest` in the early pre-launch rush — that violated the "RC versioning before `@latest`" rule from governance. **This release corrects the governance posture by promoting a non-RC stable to `@latest`.**
 

--- a/packages/scope-guard/CHANGELOG.md
+++ b/packages/scope-guard/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to `@openparachute/scope-guard` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
+
+The library's RC cadence is independent of `@openparachute/hub`'s — they ship from the same repo but aren't coupled in version.
+
+## 0.1.0 — 2026-05-05
+
+First stable release. Promoted from `0.1.0-rc.1` after the API surface stabilised across the vault → scribe → parachute-agent migration sequence.
+
+### Added
+
+- **`createScopeGuard({ hubOrigin, jwks?, jwksGetter? })`** — factory bound to a hub origin. Holds the JWKS getter so the cache lives across requests. `hubOrigin` accepts a string or a resolver function (the function form lets consumers layer their own env-var precedence, e.g. parachute-agent's `PARACHUTE_AGENT_HUB_ORIGIN` over `PARACHUTE_HUB_ORIGIN`).
+- **`guard.validateHubJwt(token, { expectedAudience? })`** — JWKS-backed verify. Pins `iss` to the configured hub origin (without that, anyone could mint a token against any RSA key and pass JWKS verification). Strict-checks `aud` (RFC 7519 string-or-array) when supplied. Throws `HubJwtError` with a coarse `code` on failure.
+- **`HubJwtError.code`** taxonomy — `signature | issuer | expired | kid | jwks | audience | shape`. Single error class; consumers branch on `code` rather than catching subclasses.
+- **`hasScope(granted, required)`** — generic `<resource>:<verb>` and `<resource>:<name>:<verb>` matcher with `admin ⊇ write ⊇ read` inheritance. The library is the engine, not the dictionary; per-service scope vocabularies and cross-resource catch-alls stay in each service.
+- **`parseScopes(raw)` / `extractBearer(authHeader)` / `looksLikeJwt(token)`** — string helpers every consumer reaches for.
+- **JWKS cache controls** — defaults: 5min `cacheMaxAge`, 30s `cooldown`. Override via the `jwks` option, or inject a `jwksGetter` directly to bypass the cache entirely (tests and non-default JWKS topologies).
+- **`guard.resetJwksCache()`** — drops the cached JWKS getter for the bound origin. Tests use this to switch fake JWKS endpoints between cases.
+
+### Design notes
+
+- The library lives as a sub-package of `parachute-hub` because the hub owns the JWT-issuance side and the scope vocabulary. It's published independently to npm as `@openparachute/scope-guard`.
+- See [`parachute-hub/docs/design/2026-04-29-scope-guard-library.md`](https://github.com/ParachuteComputer/parachute-hub/blob/main/docs/design/2026-04-29-scope-guard-library.md) for full rationale, alternatives considered, and the migration sequence.

--- a/packages/scope-guard/package.json
+++ b/packages/scope-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scope-guard",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0",
   "description": "Hub-issued JWT validation for Parachute resource servers (vault, scribe, parachute-agent, third-party modules).",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Two corrections in one PR ahead of Aaron's `@latest` publish round.

### 1. scope-guard `0.1.0-rc.1` → `0.1.0`

Aaron wants every package on stable scope-guard, not RC.

- `packages/scope-guard/package.json`: version bump.
- `packages/scope-guard/CHANGELOG.md` **(new)**: first CHANGELOG for the sub-package, with the 0.1.0 entry promoting the rc.1 surface (createScopeGuard / validateHubJwt / hasScope / parseScopes / extractBearer / looksLikeJwt / HubJwtError taxonomy / JWKS cache controls).

The library's RC cadence is independent of `@openparachute/hub`'s, so the stable promotion is its own beat — and the publish order Aaron will run is scope-guard first (so dependent repos resolve), then hub.

#### Hub root pin

The team-lead brief mentioned updating a hub root `dependencies["@openparachute/scope-guard"]` pin. There isn't one — the hub is the **issuer** side (it mints the JWTs); scope-guard is the **consumer** library, depended on by vault / scribe / parachute-agent. Hub root `package.json` `dependencies` is `@node-rs/argon2` + `jose` only. No pin to update.

### 2. Hub CHANGELOG date `2026-05-04` → `2026-05-05`

Reverts the date fix from #175 — Aaron confirmed May 5th is the correct publish date.

## Hub stays at 0.5.0

This PR does **not** bump the hub version. The 0.5.0 stable promotion already merged in #175.

## Gates (on `dd50f62`)

- **Host typecheck**: clean.
- **Host tests**: **960 pass / 0 fail / 2510 expects across 61 files** (~11s).
- **scope-guard typecheck**: clean.
- **scope-guard tests**: **64 pass / 0 fail across 4 files**.
- **web/ui typecheck**: clean.
- **web/ui tests**: **47 pass / 0 fail across 5 files**.

Lint baseline + web/ui build unchanged from #175 (no source files touched).

## Commits

`dd50f62` chore: bump scope-guard to 0.1.0 stable + correct CHANGELOG date

## Test plan

- [ ] CI green (host typecheck + tests + scope-guard + web/ui).
- [ ] Aaron: `cd packages/scope-guard && npm publish --tag latest` (with 2FA) — `npm view @openparachute/scope-guard dist-tags` shows `latest: 0.1.0`.
- [ ] Aaron: `npm publish --tag latest` from root — `npm view @openparachute/hub dist-tags` shows `latest: 0.5.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)