### PR TITLE
fix(lifecycle): graceful-degradation for installDir-less third-party rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## 0.5.1-rc.1 — 2026-05-05
+
+### Fixed
+
+- **`parachute restart|stop|logs <svc>` against installDir-less third-party rows.** A services.json entry whose name isn't a first-party short and whose row was written before the `installDir` contract (PR #84) used to hit the generic `unknown service "<svc>"` path — misleading, since the row exists; just with a stale shape. `lifecycle.resolveTargets` now returns the entry with `spec: undefined` for that case so `stop`/`logs` work via pidfile/logfile semantics keyed by short name. `start` still has to fail (no startCmd to invoke), but with an actionable message: *"services.json entry has no installDir, so the start command can't be resolved. Re-run `parachute install <path-to-X>` to refresh its registration, or upgrade the module to a version that self-registers with installDir."* The genuinely-unknown path (no first-party fallback AND no row in services.json) still surfaces `unknown service`. This is a third-party graceful-degradation fix, **not** a promotion-to-first-party — the committed-core line (vault/notes/scribe/hub) drawn 2026-04-25 is unchanged, and the FIRST_PARTY_FALLBACKS constant (renamed from SERVICE_SPECS in #70) stays a fallback for the four pre-manifest first-party packages, not a registry to grow. Compatible with the third-party-via-installDir path added in #84.
+
 ## 0.5.0 — 2026-05-05
 
 First clean stable promotion to `@latest` since the package was renamed from `@openparachute/cli` in 0.3.0. The previous `@latest` (`0.3.0-rc.1`) was an RC promoted to `@latest` in the early pre-launch rush — that violated the "RC versioning before `@latest`" rule from governance. **This release corrects the governance posture by promoting a non-RC stable to `@latest`.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.0",
+  "version": "0.5.1-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -517,9 +517,13 @@ describe("parachute start", () => {
     }
   });
 
-  test("third-party with no installDir errors as unknown service", async () => {
-    // A row whose name isn't a known short name AND has no installDir is
-    // unmanageable — we have no way to find a spec for it.
+  test("start: installDir-less third-party row surfaces an actionable error", async () => {
+    // A services.json row whose name isn't first-party AND has no installDir
+    // can't yield a startCmd. Pre-fix this hit the generic "unknown service"
+    // path (misleading — the row exists, just with stale shape). Post-fix
+    // resolveTargets returns the entry with spec=undefined and start prints
+    // an actionable message that points at the real fix (re-install or
+    // upgrade-the-module).
     const h = makeHarness();
     try {
       upsertService(
@@ -539,7 +543,30 @@ describe("parachute start", () => {
         log: (l) => lines.push(l),
       });
       expect(code).toBe(1);
-      expect(lines.join("\n")).toMatch(/unknown service "mystery"/);
+      const out = lines.join("\n");
+      expect(out).toMatch(/services\.json entry has no installDir/);
+      expect(out).toMatch(/parachute install <path-to-mystery>/);
+      expect(out).not.toMatch(/unknown service/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("start: name absent from services.json still errors as unknown service", async () => {
+    // The genuinely-unknown path: no first-party fallback, no row in
+    // services.json. Distinguish from the above (row exists but lacks
+    // installDir) so the error message is right-shaped for each.
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const lines: string[] = [];
+      const code = await start("ghost", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => lines.push(l),
+      });
+      expect(code).toBe(1);
+      expect(lines.join("\n")).toMatch(/unknown service "ghost"/);
     } finally {
       h.cleanup();
     }
@@ -721,6 +748,45 @@ describe("parachute stop", () => {
       h.cleanup();
     }
   });
+
+  test("third-party row without installDir: stops via pidfile", async () => {
+    // Graceful-degradation path: an installed-but-stale third-party row
+    // (no installDir field — pre-installDir-contract self-registration)
+    // should still be stoppable. stop only needs the short name to find
+    // the pidfile; spec resolution isn't on the critical path for stop.
+    const h = makeHarness();
+    try {
+      upsertService(
+        {
+          name: "mystery",
+          port: 1944,
+          paths: ["/mystery"],
+          health: "/mystery/health",
+          version: "0.0.1",
+        },
+        h.manifestPath,
+      );
+      writePid("mystery", 4242, h.configDir);
+      const killed: Array<[number, string | number]> = [];
+      let aliveCall = 0;
+      const code = await stop("mystery", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        kill: (pid, sig) => killed.push([pid, sig]),
+        alive: () => {
+          aliveCall++;
+          return aliveCall === 1;
+        },
+        sleep: async () => {},
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(killed).toEqual([[4242, "SIGTERM"]]);
+      expect(readPid("mystery", h.configDir)).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
 });
 
 describe("parachute restart", () => {
@@ -818,6 +884,37 @@ describe("parachute logs", () => {
       });
       expect(code).toBe(0);
       expect(lines).toEqual(["agent line 1", "agent line 2"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("third-party row without installDir: tails by short name", async () => {
+    // Graceful-degradation path: log file is keyed by short name, written by
+    // start. installDir is irrelevant for tailing — the entry just needs to
+    // exist in services.json.
+    const h = makeHarness();
+    try {
+      upsertService(
+        {
+          name: "mystery",
+          port: 1944,
+          paths: ["/mystery"],
+          health: "/mystery/health",
+          version: "0.0.1",
+        },
+        h.manifestPath,
+      );
+      const p = ensureLogPath("mystery", h.configDir);
+      writeFileSync(p, "mystery line 1\nmystery line 2\n");
+      const lines: string[] = [];
+      const code = await logs("mystery", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => lines.push(l),
+      });
+      expect(code).toBe(0);
+      expect(lines).toEqual(["mystery line 1", "mystery line 2"]);
     } finally {
       h.cleanup();
     }

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -268,13 +268,19 @@ async function resolveTargets(
       }
       return { targets: [{ short: svc, entry, spec: firstPartySpec }] };
     }
-    // Third-party: match a services.json row by name. Third-party rows
-    // carry `installDir`; without it we have no way to resolve a spec.
+    // Third-party: match a services.json row by name. Rows with `installDir`
+    // resolve a full spec from the on-disk module.json. Rows without it are
+    // still managed (stop/logs use pidfile/logfile semantics keyed by short
+    // name), but with `spec: undefined` — `start` will surface an
+    // installDir-specific error downstream rather than reject up front.
     const entry = manifest.services.find((s) => s.name === svc);
-    if (entry?.installDir) {
-      const { spec, error } = await specForEntry(svc, entry);
-      if (error) return { error: `${svc}: invalid module.json — ${error}` };
-      return { targets: [{ short: svc, entry, spec }] };
+    if (entry) {
+      if (entry.installDir) {
+        const { spec, error } = await specForEntry(svc, entry);
+        if (error) return { error: `${svc}: invalid module.json — ${error}` };
+        return { targets: [{ short: svc, entry, spec }] };
+      }
+      return { targets: [{ short: svc, entry, spec: undefined }] };
     }
     return {
       error: `unknown service "${svc}". known: ${knownServices().join(", ")}`,
@@ -323,7 +329,17 @@ export async function start(svc: string | undefined, opts: LifecycleOpts = {}): 
 
     const cmd = spec?.startCmd?.(entry);
     if (!cmd || cmd.length === 0) {
-      r.log(`${short}: lifecycle not yet supported for this service.`);
+      // Distinguish the missing-installDir case from "spec resolved but has
+      // no startCmd" — the former is fixable by re-registering the module,
+      // the latter is a hub-level limitation. Third-party rows hit the first
+      // branch when their self-registration predates the installDir contract.
+      if (!getSpec(short) && !entry.installDir) {
+        r.log(
+          `${short}: services.json entry has no installDir, so the start command can't be resolved. Re-run \`parachute install <path-to-${short}>\` to refresh its registration, or upgrade the module to a version that self-registers with installDir.`,
+        );
+      } else {
+        r.log(`${short}: lifecycle not yet supported for this service.`);
+      }
       failures++;
       continue;
     }
@@ -487,13 +503,14 @@ export async function logs(svc: string, opts: LogsOpts = {}): Promise<number> {
 
   // logs only needs a valid short name to find the log file. First-party
   // wins via the spec lookup; third-party rows match by `entry.name`; the
-  // internal hub is a known short outside of services.json. We don't need
-  // the full spec here — we just need to confirm the name maps to
-  // something the CLI manages.
+  // internal hub is a known short outside of services.json. installDir is
+  // irrelevant here — the log file is keyed by short name and exists once
+  // the service has run, regardless of how it was registered. We just need
+  // to confirm the name maps to something the CLI manages.
   const isFirstParty = getSpec(svc) !== undefined;
   if (!isFirstParty && svc !== HUB_SVC) {
     const entry = readManifest(manifestPath).services.find((s) => s.name === svc);
-    if (!entry?.installDir) {
+    if (!entry) {
       log(`unknown service "${svc}". known: ${[HUB_SVC, ...knownServices()].join(", ")}`);
       return 1;
     }

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -214,8 +214,10 @@ interface ResolvedTarget {
    * Lifecycle spec resolved at request time. First-party comes from
    * `getSpec(short)`; third-party comes from
    * `getSpecFromInstallDir(entry.installDir, ...)`. May be undefined when
-   * a row has neither — lifecycle prints "lifecycle not yet supported"
-   * for that service rather than crashing the whole sweep.
+   * a row has neither — `start` prints the actionable "no installDir"
+   * re-install message for an installDir-less third-party row, or
+   * "lifecycle not yet supported" otherwise; `stop`/`logs` keep working
+   * via pidfile/logfile semantics keyed by `short`.
    */
   spec: ServiceSpec | undefined;
 }
@@ -248,6 +250,13 @@ async function specForEntry(
  * `module.json` (which is what install copied to `entry.name` for
  * third-party). First-party are addressed by their short name (vault,
  * notes, …) and matched via `shortNameForManifest`.
+ *
+ * Named-path detail: a third-party row whose name matches but lacks
+ * `installDir` resolves to the entry with `spec: undefined` (rather than
+ * an "unknown service" error). `stop`/`logs` handle the spec-less case
+ * via pidfile/logfile semantics; `start` surfaces an actionable
+ * re-install hint downstream. The genuinely-unknown path (no first-party
+ * fallback AND no row in services.json) still errors as `unknown service`.
  */
 async function resolveTargets(
   svc: string | undefined,


### PR DESCRIPTION
## Summary

- `parachute restart|stop|logs <svc>` against an installed-but-stale third-party row (no `installDir` field) used to bail with the generic `unknown service "<svc>"` error in `resolveTargets`. Misleading: the row exists, the service may be running, but stop/logs don't need a spec at all and start could give a far more actionable error.
- Fix at lifecycle resolution + per-command: `resolveTargets` returns the entry with `spec: undefined` when installDir is missing; `stop`/`logs` work via pidfile/logfile semantics keyed by short name; `start` surfaces an actionable "re-install or upgrade-the-module" hint.
- Bumps to `0.5.1-rc.1` per pre-1.0 RC governance.

## Background

Reported as `parachute restart agent` failing with `unknown service "agent". known: vault, notes, scribe, channel` while parachute-agent was running fine on `:1944` and registered in `services.json`. Diagnosis: agent's self-registration row is missing the `installDir` field that the third-party resolution path requires (`lifecycle.ts:resolveTargets` → `entry?.installDir` check bails). The row looked like:

```json
{"name": "agent", "port": 1944, "paths": ["/agent"], "health": "/api/health", "version": "0.1.1", ...}
```

Two fix paths were considered:

(a) **parachute-agent self-registers `installDir`.** The proper fix; lives in the agent repo. **Filed against parachute-agent separately** — not in this PR.

(b) **Hub-side graceful degradation.** What this PR ships: hub stops being hostile when a third-party module's self-registration omits `installDir`.

(b) is worth doing as defense-in-depth even with (a) shipped, because operators today run a mix of module versions and other third-party modules may have similar gaps in the future.

## What this is **not**

This is **not** a promotion of parachute-agent to first-party. The committed-core line drawn 2026-04-25 in `/Users/parachute/ParachuteComputer/CLAUDE.md` (vault/notes/scribe/hub) is unchanged. `FIRST_PARTY_FALLBACKS` (renamed from `SERVICE_SPECS` in #70) stays a fallback for the four pre-manifest first-party packages, not a registry to grow. The third-party-via-installDir path (#84) stays the canonical path for non-first-party modules.

The earlier proposal to add `AGENT_FALLBACK` was rejected as it would have reversed three settled architectural decisions: the committed-core line (2026-04-25), the SERVICE_SPECS-gate removal (#70), and the third-party-via-installDir contract (#84).

## Behavior changes

| Scenario | Pre-fix | Post-fix |
|---|---|---|
| `restart` on installDir-less row | `unknown service` (exit 1) | stop branch graceful via pidfile, start surfaces actionable hint |
| `stop` on installDir-less row | `unknown service` (exit 1) | stops via pidfile, exit 0 |
| `logs` on installDir-less row | `unknown service` (exit 1) | tails by short name (or "no logs yet"), exit 0 |
| `start` on installDir-less row | `unknown service` (exit 1) | actionable: "re-run `parachute install <path-to-X>` or upgrade the module" (exit 1) |
| `restart` on truly unknown name | `unknown service` (exit 1) | `unknown service` (exit 1) — unchanged |

Smoke against the bun-linked checkout:

```sh
$ bun src/cli.ts restart agent
agent wasn't running.
agent: services.json entry has no installDir, so the start command can't be resolved. Re-run \`parachute install <path-to-agent>\` to refresh its registration, or upgrade the module to a version that self-registers with installDir.

$ bun src/cli.ts restart ghost
unknown service "ghost". known: vault, notes, scribe, channel
```

## Patterns check

- **Module manifest contract** ([`parachute-patterns/patterns/module-protocol.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-protocol.md)): unchanged. `installDir` remains the canonical mechanism for third-party module lifecycle resolution; this PR just makes the hub more forgiving when a third-party module self-registers without it.
- **First-party vs third-party boundary** (committed-core line, 2026-04-25): unchanged. parachute-agent stays third-party.
- **Pre-1.0 RC governance** ([`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md)): conforms — `0.5.0` → `0.5.1-rc.1`, post-merge \`npm publish --tag rc\`, deliberate \`npm dist-tag add @latest\` for promotion.
- No new patterns established or changed.

## Test plan

- [x] `bun test ./src` — 963 pass, 0 fail (existing test renamed + 3 new tests added)
- [x] `bun run typecheck` — clean
- [x] `bunx biome check src/commands/lifecycle.ts src/__tests__/lifecycle.test.ts CHANGELOG.md package.json` — clean (the 2 pre-existing errors in `expose-public-auto.ts` are unchanged baseline; not in this PR's scope)
- [x] Smoke against bun-linked checkout: `restart agent` (graceful-degradation path), `restart ghost` (truly-unknown path), `logs agent` (no-logfile graceful response)

## Reviewer hints

- The architectural-weight discussion lives in the SendMessage exchange that produced this PR. Short version: don't grow `FIRST_PARTY_FALLBACKS`; treat third-party rows without `installDir` as a graceful-degradation case at the hub, and file the proper fix against the third-party module separately.
- One follow-up that's *not* in scope here: parachute-agent self-registration should write `installDir`. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)