### PR TITLE
feat(hub): layer-aware proxy + collapse tailnet to single catchall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.3-rc.2] - 2026-05-08
+
+Review nit fold (PR #187) — no behavior change beyond test coverage.
+
+### Changed
+
+- **`layerOf` matches `Tailscale-Funnel-Request: ?1` by value, not presence.** The structured-header value is the contract per `tailscale.com/ipnlocal/serve.go`; comparing on value (rather than `!== null`) makes the classifier's intent explicit and prevents a future loosening from accidentally accepting any value. CF-Ray / CF-Connecting-IP stay on presence-checks (open-string identifiers, no canonical value).
+- **`warnLegacyRoot` typed as `void`; unused binding dropped at the call site.** The function has been warning-only since the path-rewrite was removed in 0.5.3-rc.1; `const services = warnLegacyRoot(...)` implied a transform that wasn't happening. Caller now uses `manifest.services` directly downstream.
+
+### Added
+
+- **Test: unknown third-party service (no `FIRST_PARTY_FALLBACKS` row, no explicit `publicExposure`) defaults to `"allowed"` and reaches the public layer.** Regression-guards anyone tightening `effectivePublicExposure`'s default toward `"loopback"` — that would silently 404 every third-party module installed via `module.json` on tailnet/public exposure.
+
 ## [0.5.3-rc.1] - 2026-05-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.3-rc.1] - 2026-05-08
+
+### Added
+
+- **Hub-side request-layer detection (`layerOf`).** Every request reaching `127.0.0.1:1939` is classified into `loopback` / `tailnet` / `public` by inspecting the proxy headers each trusted forwarder injects: `Tailscale-User-Login` (tailnet, authed via `tailscale serve`), `Tailscale-Funnel-Request: ?1` (public, Tailscale Funnel — verified against `serve.go addTailscaleIdentityHeaders`), `CF-Ray` / `CF-Connecting-IP` (public, cloudflared tunnel), or none of the above (loopback). Spoofing isn't a concern: hub binds 127.0.0.1, so external requests can't reach the listener except via these forwarders. Drives the new `publicExposure` enforcement below.
+- **`publicExposure: "loopback"` enforcement on `/<svc>/*` and `/vault/<name>/*` dispatch.** `effectivePublicExposure(entry)` was already exposed by `service-spec.ts`; `proxyToService` and `proxyToVault` now consult it and 404 when the layer mismatches (loopback service hit from tailnet/public). `allowed` and `auth-required` pass through; the service does its own auth. **Hub-owned routes (`/`, `/admin/*`, `/api/*`, `/hub/*`, `/oauth/*`, `/.well-known/*`, `/vault/*` SPA mount, `POST /vaults`) are NOT layer-blocked** — they reach all layers and rely on app-level auth (admin session cookie + 2FA, OAuth, per-route logic). This is the access-control matrix the redirected single-ingress design committed to.
+
+### Changed
+
+- **`parachute expose tailnet up` collapses to a single tailscale rule.** Pre-collapse the planner emitted one mount per service: hub root, well-known, four OAuth proxies, `/vault/`, plus one per non-vault service — eight mounts for a baseline vault+notes install. New shape: `tailscale serve --bg --https=443 --set-path=/ http://127.0.0.1:<hubPort>/` and the hub does all internal dispatch. `parachute expose public` (Tailscale Funnel) emits the symmetric single rule. Closes the symmetry gap with the cloudflare side that shipped in #178 on 0.5.2; the access-control matrix now lives uniformly in the hub regardless of which forwarder admitted the request.
+- **`partitionByExposure` removed from the tailnet plan layer.** Its job (filtering loopback/auth-required services off the tailscale plan) is moot now that every service rides the catchall. The hub gates per request via `effectivePublicExposure` + `layerOf`. Operator-visible "X is loopback-only" warnings at expose time are gone — the equivalent operator signal is hub returning 404 for those routes from non-loopback callers.
+- **Legacy `paths: ["/"]` entries warn but no longer get rewritten in-memory.** Pre-collapse the planner remapped them to `/<shortname>` so they didn't collide with the hub's tailscale `/` mount. With one catchall, the collision is hub-side; the warning still fires so operators know to re-install. (No services in the wild have ever shipped this shape on a release version.)
+
+### Migration / impact
+
+- Operators with `parachute expose tailnet` already up: re-run after upgrading. The teardown-then-bringup sweep in `exposeUp` handles old multi-mount state correctly via the recorded `entries[]` in `expose-state.json`.
+- Operators with `publicExposure: "loopback"` services in `services.json`: behavior is materially equivalent (those routes were unreachable from tailnet/public before because the plan withheld them; now they're 404 because the hub gate fires). `auth-required` services that lacked an actual auth gate: were withheld pre-collapse, now reach all layers and rely on the service to gate. **Verify your service is actually auth-gating before relying on this** (#185 tracks rate-limiting on `/admin/login` since `/admin` is now public-reachable with cloudflare/funnel exposure; #186 tracks an `expose public` warning when 2FA isn't enrolled).
+- Tailnet exposure now matches cloudflare: one ingress rule, all policy in hub.
+
 ## [0.5.2] - 2026-05-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.3-rc.1",
+  "version": "0.5.3-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.2",
+  "version": "0.5.3-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -112,7 +112,11 @@ function seedServices(path: string): void {
 const allServicesUp = async () => true;
 
 describe("expose tailnet up", () => {
-  test("mounts hub proxy at /, one proxy per service, plus well-known proxy", async () => {
+  test("emits exactly one catchall mount: / → http://127.0.0.1:<hubPort>/", async () => {
+    // Single-rule symmetry with cloudflare ingress (#178). Hub does all
+    // internal dispatch (UI, OAuth, well-known, vault SPA + per-vault proxy,
+    // generic /<svc>/* services dispatch) so the tailscale plan stays at
+    // one mount regardless of how many services are installed.
     const h = makeHarness();
     try {
       seedServices(h.manifestPath);
@@ -136,47 +140,20 @@ describe("expose tailnet up", () => {
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      // 4 baseline (hub + wk + vault + notes) + 4 OAuth proxies (vault present).
-      expect(serveCalls).toHaveLength(8);
+      // Exactly one bringup: `/ → http://127.0.0.1:<hubPort>/`.
+      expect(serveCalls).toHaveLength(1);
       // Tailnet mode never uses funnel — neither the old flag nor the new subcommand.
       expect(serveCalls.every((c) => !c.includes("--funnel"))).toBe(true);
       expect(calls.every((c) => c[1] !== "funnel")).toBe(true);
 
-      const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path="))).sort();
-      // Vault paths consolidate to a single `/vault/` mount → hub (#144);
-      // the hub then picks the specific vault instance per request from
-      // services.json. Notes (and other non-vault services) keep their
-      // direct mount.
-      expect(mounts).toEqual([
-        "--set-path=/",
-        "--set-path=/.well-known/oauth-authorization-server",
-        "--set-path=/.well-known/parachute.json",
-        "--set-path=/notes",
-        "--set-path=/oauth/authorize",
-        "--set-path=/oauth/register",
-        "--set-path=/oauth/token",
-        "--set-path=/vault/",
-      ]);
+      const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path=")));
+      expect(mounts).toEqual(["--set-path=/"]);
 
-      // Hub + well-known now point at localhost HTTP, not a file path.
-      // Target path mirrors mount exactly so tailscale's strip-then-forward
-      // is a no-op; otherwise SPAs at /<mount>/ redirect-loop.
-      const hubCall = serveCalls.find((c) => c.includes("--set-path=/"));
-      expect(hubCall?.[hubCall.length - 1]).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
-
-      const wkCall = serveCalls.find((c) => c.includes("--set-path=/.well-known/parachute.json"));
-      expect(wkCall?.[wkCall.length - 1]).toMatch(
-        /^http:\/\/127\.0\.0\.1:\d+\/\.well-known\/parachute\.json$/,
-      );
-
-      // Non-vault service targets include the mount path so tailscale's
-      // strip-then-forward is a no-op against base-aware backends.
-      const notesCall = serveCalls.find((c) => c.includes("--set-path=/notes"));
-      expect(notesCall?.[notesCall.length - 1]).toBe("http://127.0.0.1:5173/notes");
-      // Vault mount targets the hub's loopback port (the hub re-proxies to
-      // the right vault backend on each request) — port is dynamic per test.
-      const vaultCall = serveCalls.find((c) => c.includes("--set-path=/vault/"));
-      expect(vaultCall?.[vaultCall.length - 1]).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/vault\/$/);
+      // Hub catchall target is the hub loopback root with trailing slash so
+      // tailscale's strip-then-forward is a no-op (mount and target match
+      // byte-for-byte).
+      const hubCall = serveCalls[0] ?? [];
+      expect(hubCall[hubCall.length - 1]).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
 
       expect(existsSync(h.wellKnownPath)).toBe(true);
       expect(existsSync(h.hubPath)).toBe(true);
@@ -186,9 +163,9 @@ describe("expose tailnet up", () => {
       const state = readExposeState(h.statePath);
       expect(state?.layer).toBe("tailnet");
       expect(state?.mode).toBe("path");
-      expect(state?.entries).toHaveLength(8);
-      // All entries are proxy now — no file-backed tailscale serve.
-      expect(state?.entries.every((e) => e.kind === "proxy")).toBe(true);
+      expect(state?.entries).toHaveLength(1);
+      expect(state?.entries[0]?.mount).toBe("/");
+      expect(state?.entries[0]?.kind).toBe("proxy");
     } finally {
       h.cleanup();
     }
@@ -224,10 +201,11 @@ describe("expose tailnet up", () => {
     }
   });
 
-  test("trailing-slash mount preserves trailing slash in target URL", async () => {
-    // Aaron hit ERR_TOO_MANY_REDIRECTS on /notes/ because tailscale strips
-    // the prefix, Vite (base=/notes) redirects back to /notes/, tailscale
-    // strips again, loop. Pinning target = mount byte-for-byte breaks that.
+  test("hub catchall target ends in `/` so tailscale strip-then-forward is a no-op", async () => {
+    // Aaron hit ERR_TOO_MANY_REDIRECTS on /notes/ pre-collapse because
+    // tailscale strips the prefix and Vite (base=/notes) redirects back to
+    // /notes/. Mount and target byte-equal breaks that loop. Now that there's
+    // one catchall, the same rule applies to the hub root: `/ → http://…/`.
     const h = makeHarness();
     try {
       upsertService(
@@ -258,15 +236,20 @@ describe("expose tailnet up", () => {
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      const notesCall = serveCalls.find((c) => c.includes("--set-path=/notes/"));
-      expect(notesCall).toBeDefined();
-      expect(notesCall?.[notesCall.length - 1]).toBe("http://127.0.0.1:5173/notes/");
+      expect(serveCalls).toHaveLength(1);
+      const call = serveCalls[0] ?? [];
+      expect(call).toContain("--set-path=/");
+      expect(call[call.length - 1]).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
     } finally {
       h.cleanup();
     }
   });
 
-  test("legacy paths:[/] entry is remapped to /<shortname> with warning", async () => {
+  test("legacy paths:[/] entry warns operator (no rewrite — hub dispatches per request)", async () => {
+    // Pre-collapse this remapped to /<shortname>; now the hub does dispatch
+    // per services.json, so a paths:["/"] entry would still collide with the
+    // hub UI but the failure surface is hub-side, not tailscale-plan-side.
+    // Keep the warn so operators know to re-install.
     const h = makeHarness();
     try {
       upsertService(
@@ -290,16 +273,12 @@ describe("expose tailnet up", () => {
       });
       expect(code).toBe(0);
 
+      // Plan is still exactly one catchall regardless of the legacy entry.
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path="))).sort();
-      // Even with the legacy `/` remap, the vault rolls into the consolidated
-      // `/vault/` mount → hub. The remap warning still fires; the mount shape
-      // just doesn't reflect the original `/<shortname>` since #144.
-      expect(mounts).toContain("--set-path=/vault/");
-      expect(mounts).toContain("--set-path=/");
-      expect(mounts.filter((m) => m === "--set-path=/")).toHaveLength(1);
+      expect(serveCalls).toHaveLength(1);
+      expect(serveCalls[0]).toContain("--set-path=/");
 
       expect(logs.join("\n")).toMatch(/parachute-vault claims "\/"; hub page lives there/);
     } finally {
@@ -435,11 +414,12 @@ describe("expose tailnet up", () => {
       expect(joined).toMatch(/parachute-notes \(port 5173\) is not responding/);
       expect(joined).toMatch(/parachute start notes/);
       expect(joined).not.toMatch(/parachute-vault.*not responding/);
-      // Bringup still happened — 4 service entries + 4 OAuth proxies got staged.
+      // Bringup still happened — single hub catchall regardless of which
+      // services responded to the probe.
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      expect(serveCalls).toHaveLength(8);
+      expect(serveCalls).toHaveLength(1);
     } finally {
       h.cleanup();
     }
@@ -484,7 +464,10 @@ describe("expose tailnet up", () => {
     }
   });
 
-  test("emits 4 OAuth proxies targeting the hub origin (hub IS the IdP)", async () => {
+  test("hub catchall serves OAuth + well-known internally — no separate mount per endpoint", async () => {
+    // OAuth (hub IS the IdP) and well-known (parachute.json + JWKS +
+    // oauth-authorization-server metadata) are dispatched by the hub from
+    // the single catchall. State + bringup carry exactly one entry.
     const h = makeHarness();
     try {
       seedServices(h.manifestPath);
@@ -507,26 +490,10 @@ describe("expose tailnet up", () => {
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      const oauthTargets = new Map<string, string>();
-      for (const c of serveCalls) {
-        const mount = c.find((a) => a.startsWith("--set-path="))?.slice("--set-path=".length);
-        if (
-          mount &&
-          (mount.startsWith("/oauth/") || mount === "/.well-known/oauth-authorization-server")
-        ) {
-          oauthTargets.set(mount, c[c.length - 1] ?? "");
-        }
-      }
-      expect(oauthTargets.get("/.well-known/oauth-authorization-server")).toMatch(
-        /^http:\/\/127\.0\.0\.1:\d+\/\.well-known\/oauth-authorization-server$/,
-      );
-      expect(oauthTargets.get("/oauth/authorize")).toMatch(
-        /^http:\/\/127\.0\.0\.1:\d+\/oauth\/authorize$/,
-      );
-      expect(oauthTargets.get("/oauth/token")).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/oauth\/token$/);
-      expect(oauthTargets.get("/oauth/register")).toMatch(
-        /^http:\/\/127\.0\.0\.1:\d+\/oauth\/register$/,
-      );
+      // Single catchall — no per-endpoint OAuth or well-known mounts.
+      expect(serveCalls).toHaveLength(1);
+      const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path=")));
+      expect(mounts).toEqual(["--set-path=/"]);
 
       const state = readExposeState(h.statePath);
       expect(state?.hubOrigin).toBe("https://parachute.taildf9ce2.ts.net");
@@ -535,7 +502,10 @@ describe("expose tailnet up", () => {
     }
   });
 
-  test("emits OAuth proxies even when no vault is installed (hub IS the IdP)", async () => {
+  test("plan is one catchall regardless of which services are installed", async () => {
+    // Pre-collapse this varied: with vault installed we got more mounts than
+    // without. Now the count is constant — the hub dispatches from
+    // services.json per request, so the tailscale plan doesn't enumerate.
     const h = makeHarness();
     try {
       upsertService(
@@ -567,15 +537,7 @@ describe("expose tailnet up", () => {
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      // Hub + well-known + notes + 4 OAuth proxies = 7. The hub serves OAuth
-      // regardless of which services are installed.
-      expect(serveCalls).toHaveLength(7);
-      const oauthMounts = serveCalls
-        .map((c) => c.find((a) => a.startsWith("--set-path=")))
-        .filter(
-          (m): m is string => !!m && (m.includes("/oauth/") || m.endsWith("authorization-server")),
-        );
-      expect(oauthMounts).toHaveLength(4);
+      expect(serveCalls).toHaveLength(1);
     } finally {
       h.cleanup();
     }
@@ -821,8 +783,9 @@ describe("expose public up", () => {
       const funnelCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "funnel" && c.includes("--bg"),
       );
-      // 4 baseline mounts + 4 OAuth proxies (vault seeded).
-      expect(funnelCalls).toHaveLength(8);
+      // Single hub catchall — public mode shape now matches tailnet (#178
+      // landed the cloudflare-side single-rule; this closes tailnet).
+      expect(funnelCalls).toHaveLength(1);
       // Never emit the legacy `serve --funnel` shape.
       expect(calls.every((c) => !c.includes("--funnel"))).toBe(true);
       expect(calls.every((c) => !(c[1] === "serve" && c.includes("--bg")))).toBe(true);
@@ -830,7 +793,7 @@ describe("expose public up", () => {
       const state = readExposeState(h.statePath);
       expect(state?.layer).toBe("public");
       expect(state?.funnel).toBe(true);
-      expect(state?.entries).toHaveLength(8);
+      expect(state?.entries).toHaveLength(1);
 
       expect(logs.join("\n")).toMatch(/Public exposure active/);
     } finally {
@@ -1023,15 +986,21 @@ describe("expose public off", () => {
   });
 });
 
-describe("expose publicExposure filter", () => {
-  // Launch-blocker: services without auth should never be mounted on
-  // tailnet/funnel. The filter reads `publicExposure` from each entry (or
-  // derives a safe default from the service spec) and withholds non-"allowed"
-  // services from the tailscale serve plan.
-  test("explicit loopback keeps the service off the serve plan", async () => {
+describe("expose plan is layer-agnostic — gating moved to hub", () => {
+  // Pre-collapse the tailscale plan partitioned services by publicExposure
+  // and withheld loopback/auth-required entries. Now the plan is always one
+  // catchall to the hub, which gates per request via `effectivePublicExposure`
+  // + `layerOf` (see hub-server.ts). These tests confirm the plan stays
+  // single-rule regardless of services' exposure declarations; per-request
+  // gating is exercised in hub-server.test.ts.
+
+  test("plan stays one catchall when a loopback-only service is installed", async () => {
+    // Pre-collapse, scribe (publicExposure: "loopback") was withheld from the
+    // plan with an operator-visible warning. Now scribe is on the plan via
+    // the hub catchall — the hub returns 404 to non-loopback callers per
+    // hub-server's `proxyToService` layer-gate. Plan stays one mount.
     const h = makeHarness();
     try {
-      // Vault is mounted as usual; scribe declares loopback and is withheld.
       upsertService(
         {
           name: "parachute-vault",
@@ -1056,7 +1025,6 @@ describe("expose publicExposure filter", () => {
       );
       const { runner, calls } = makeRunner();
       const { spawner } = makeHubSpawner(1111);
-      const logs: string[] = [];
       const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
@@ -1067,41 +1035,29 @@ describe("expose publicExposure filter", () => {
         configDir: h.configDir,
         hubEnsureOpts: hubEnsureOpts(spawner),
         servicePortProbe: allServicesUp,
-        log: (l) => logs.push(l),
+        log: () => {},
       });
       expect(code).toBe(0);
-
       const serveCalls = calls.filter(
         (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      const mounts = serveCalls.map((c) => c.find((a) => a.startsWith("--set-path=")));
-      // Vault rolls into the consolidated `/vault/` mount → hub (#144);
-      // its 4 OAuth proxies, hub, and well-known are still individually
-      // mounted. /scribe is loopback-only and absent.
-      expect(mounts).toContain("--set-path=/vault/");
-      expect(mounts).not.toContain("--set-path=/scribe");
+      expect(serveCalls).toHaveLength(1);
+      expect(serveCalls[0]).toContain("--set-path=/");
 
-      // Operator-visible notice explaining the withhold.
-      expect(logs.join("\n")).toMatch(
-        /parachute-scribe is loopback-only — loopback-only by service declaration/,
-      );
-
-      // State file reflects the reduced plan so teardown doesn't trip on
-      // entries that were never brought up.
+      // State carries one entry — hub catchall. No /scribe or /vault/* in state.
       const state = readExposeState(h.statePath);
-      expect(state?.entries.some((e) => e.mount === "/scribe")).toBe(false);
+      expect(state?.entries).toHaveLength(1);
+      expect(state?.entries[0]?.mount).toBe("/");
     } finally {
       h.cleanup();
     }
   });
 
-  test("explicit auth-required behaves like loopback at launch", async () => {
-    // auth-required is the future-looking declaration for a service that
-    // wants auth but hasn't confirmed it's configured. Today the CLI treats
-    // it identically to loopback — still no funnel/tailnet exposure.
+  test("plan stays one catchall regardless of mix of publicExposure values", async () => {
+    // Mix: allowed, loopback, auth-required, and absent. Plan is one mount.
     const h = makeHarness();
     try {
-      seedServices(h.manifestPath); // vault + notes, both allowed by default
+      seedServices(h.manifestPath); // vault + notes
       upsertService(
         {
           name: "parachute-channel",
@@ -1113,40 +1069,6 @@ describe("expose publicExposure filter", () => {
         },
         h.manifestPath,
       );
-      const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
-      const logs: string[] = [];
-      const code = await exposeTailnet("up", {
-        runner,
-        manifestPath: h.manifestPath,
-        statePath: h.statePath,
-        wellKnownPath: h.wellKnownPath,
-        hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
-        configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
-        servicePortProbe: allServicesUp,
-        log: (l) => logs.push(l),
-      });
-      expect(code).toBe(0);
-      const mounts = calls
-        .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
-        .map((c) => c.find((a) => a.startsWith("--set-path=")));
-      expect(mounts).not.toContain("--set-path=/channel");
-      expect(logs.join("\n")).toMatch(/parachute-channel is loopback-only — auth-required/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("missing publicExposure + spec kind=api, hasAuth=false → loopback default (scribe)", async () => {
-    // Scribe today has no auth gate; its ServiceSpec says so (kind: "api",
-    // hasAuth: false). With publicExposure absent we should still withhold.
-    // This is the safe-by-default case for services that haven't yet been
-    // updated to declare their exposure.
-    const h = makeHarness();
-    try {
-      seedServices(h.manifestPath);
       upsertService(
         {
           name: "parachute-scribe",
@@ -1160,51 +1082,6 @@ describe("expose publicExposure filter", () => {
       );
       const { runner, calls } = makeRunner();
       const { spawner } = makeHubSpawner(1111);
-      const logs: string[] = [];
-      const code = await exposeTailnet("up", {
-        runner,
-        manifestPath: h.manifestPath,
-        statePath: h.statePath,
-        wellKnownPath: h.wellKnownPath,
-        hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
-        configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
-        servicePortProbe: allServicesUp,
-        log: (l) => logs.push(l),
-      });
-      expect(code).toBe(0);
-      const mounts = calls
-        .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
-        .map((c) => c.find((a) => a.startsWith("--set-path=")));
-      expect(mounts).not.toContain("--set-path=/scribe");
-      // Reason text points operators at the missing auth gate.
-      expect(logs.join("\n")).toMatch(
-        /parachute-scribe is loopback-only — auth-required: service has no auth gate/,
-      );
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("missing publicExposure on a known auth'd api service (vault) still exposes", async () => {
-    // vault's ServiceSpec has hasAuth: true, so the absence of publicExposure
-    // should not hide it — the back-compat path for every vault entry written
-    // before this field existed.
-    const h = makeHarness();
-    try {
-      upsertService(
-        {
-          name: "parachute-vault",
-          port: 1940,
-          paths: ["/vault/default"],
-          health: "/vault/default/health",
-          version: "0.2.4",
-        },
-        h.manifestPath,
-      );
-      const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
@@ -1218,53 +1095,10 @@ describe("expose publicExposure filter", () => {
         log: () => {},
       });
       expect(code).toBe(0);
-      const mounts = calls
-        .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
-        .map((c) => c.find((a) => a.startsWith("--set-path=")));
-      // Vault → consolidated `/vault/` mount (#144).
-      expect(mounts).toContain("--set-path=/vault/");
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("unknown third-party service without publicExposure defaults to allowed", async () => {
-    // A service not in SERVICE_SPECS has no kind/hasAuth signal. We err on
-    // the side of preserving current behavior (back-compat) so operators'
-    // existing exposures don't silently stop working on upgrade. If the
-    // third-party wants to opt out, they can write publicExposure: "loopback"
-    // into their services.json entry.
-    const h = makeHarness();
-    try {
-      upsertService(
-        {
-          name: "parachute-rando",
-          port: 1947,
-          paths: ["/rando"],
-          health: "/rando/health",
-          version: "0.0.1",
-        },
-        h.manifestPath,
+      const serveCalls = calls.filter(
+        (c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"),
       );
-      const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
-      const code = await exposeTailnet("up", {
-        runner,
-        manifestPath: h.manifestPath,
-        statePath: h.statePath,
-        wellKnownPath: h.wellKnownPath,
-        hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
-        configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
-        servicePortProbe: allServicesUp,
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      const mounts = calls
-        .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
-        .map((c) => c.find((a) => a.startsWith("--set-path=")));
-      expect(mounts).toContain("--set-path=/rando");
+      expect(serveCalls).toHaveLength(1);
     } finally {
       h.cleanup();
     }
@@ -1595,12 +1429,15 @@ describe("expose teardown tolerance for already-gone entries", () => {
   });
 });
 
-describe("expose vault mount consolidation (#144)", () => {
-  // Pre-#144: tailscale plan emitted one mount per vault path. New vault →
-  // had to re-run `parachute expose` to get a tailnet route. Post-#144: a
-  // single `/vault/` → hub mount, hub does the per-request lookup.
+describe("expose: vault routing fully internal to hub", () => {
+  // Pre-#144: one tailscale mount per vault path. #144 collapsed those to a
+  // single `/vault/ → hub` mount. This PR collapses one step further: vault
+  // routing is just a slice of the hub catchall now. Hub's `proxyToVault`
+  // (in hub-server.ts) still dispatches per services.json on each request,
+  // so `parachute vault create <name>` is reachable without re-expose; the
+  // tailscale plan just no longer carries a vault-specific entry.
 
-  test("single vault, single path → exactly one /vault/ mount, no per-instance entry", async () => {
+  test("single vault, single path → still one catchall, no /vault/* tailscale rule", async () => {
     const h = makeHarness();
     try {
       upsertService(
@@ -1631,59 +1468,16 @@ describe("expose vault mount consolidation (#144)", () => {
       const mounts = calls
         .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
         .map((c) => c.find((a) => a.startsWith("--set-path=")));
-      expect(mounts).toContain("--set-path=/vault/");
-      expect(mounts).not.toContain("--set-path=/vault/default");
+      expect(mounts).toEqual(["--set-path=/"]);
     } finally {
       h.cleanup();
     }
   });
 
-  test("multi-path single ServiceEntry still emits exactly one /vault/ mount", async () => {
-    // The current vault manifest shape: one ServiceEntry whose `paths` lists
-    // every instance. The plan must collapse them all to the hub-routed
-    // `/vault/` instead of one mount per instance.
-    const h = makeHarness();
-    try {
-      upsertService(
-        {
-          name: "parachute-vault",
-          port: 1940,
-          paths: ["/vault/default", "/vault/techne"],
-          health: "/vault/default/health",
-          version: "0.4.0",
-        },
-        h.manifestPath,
-      );
-      const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
-      const code = await exposeTailnet("up", {
-        runner,
-        manifestPath: h.manifestPath,
-        statePath: h.statePath,
-        wellKnownPath: h.wellKnownPath,
-        hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
-        configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
-        servicePortProbe: allServicesUp,
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      const mounts = calls
-        .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
-        .map((c) => c.find((a) => a.startsWith("--set-path=")));
-      const vaultMounts = mounts.filter((m) => m?.startsWith("--set-path=/vault"));
-      expect(vaultMounts).toEqual(["--set-path=/vault/"]);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("multiple separate vault ServiceEntries still emit exactly one /vault/ mount", async () => {
-    // Pathological but representable: someone might install a second
-    // parachute-vault-archive backend alongside the bare parachute-vault.
-    // Both fold into the single `/vault/` mount; hub disambiguates per
-    // request.
+  test("multiple separate vault ServiceEntries → still one catchall", async () => {
+    // Pathological but representable: a second parachute-vault-archive
+    // alongside the bare parachute-vault. Both reachable via the hub
+    // catchall; hub picks the backend per request.
     const h = makeHarness();
     try {
       upsertService(
@@ -1724,48 +1518,7 @@ describe("expose vault mount consolidation (#144)", () => {
       const mounts = calls
         .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
         .map((c) => c.find((a) => a.startsWith("--set-path=")));
-      const vaultMounts = mounts.filter((m) => m?.startsWith("--set-path=/vault"));
-      expect(vaultMounts).toEqual(["--set-path=/vault/"]);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("no vault installed → no /vault/ mount in the plan", async () => {
-    const h = makeHarness();
-    try {
-      upsertService(
-        {
-          name: "parachute-notes",
-          port: 5173,
-          paths: ["/notes"],
-          health: "/notes/health",
-          version: "0.0.1",
-        },
-        h.manifestPath,
-      );
-      const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
-      const code = await exposeTailnet("up", {
-        runner,
-        manifestPath: h.manifestPath,
-        statePath: h.statePath,
-        wellKnownPath: h.wellKnownPath,
-        hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
-        configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
-        servicePortProbe: allServicesUp,
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      const mounts = calls
-        .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
-        .map((c) => c.find((a) => a.startsWith("--set-path=")));
-      expect(mounts).not.toContain("--set-path=/vault/");
-      // /notes is still individually mounted — non-vault services keep
-      // their direct route.
-      expect(mounts).toContain("--set-path=/notes");
+      expect(mounts).toEqual(["--set-path=/"]);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -1887,6 +1887,49 @@ describe("hubFetch publicExposure layer-gate (proxyToService)", () => {
       h.cleanup();
     }
   });
+
+  test("unknown third-party service (no SERVICE_SPECS row, no publicExposure) → defaults to allowed, reaches public layer", async () => {
+    // Third-party modules installed via `module.json` aren't in
+    // FIRST_PARTY_FALLBACKS, so effectivePublicExposure has no spec to
+    // derive from. The contract documented on effectivePublicExposure is
+    // "default to 'allowed'", which means the gate must NOT fire from the
+    // public layer for an unknown service that didn't opt into a stricter
+    // exposure. Regression-guards anyone tightening the default to
+    // "loopback" without realizing it would silently 404 every
+    // third-party module on tailnet/public.
+    const h = makeHarness();
+    const upstream = startUpstream("unknown-thirdparty");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-unknown-thirdparty",
+              port: upstream.port,
+              paths: ["/parachute-unknown-thirdparty"],
+              health: "/parachute-unknown-thirdparty/health",
+              version: "0.1.0",
+              // publicExposure absent — exercises the unknown-spec default path
+              // kind absent — no SERVICE_SPECS / FIRST_PARTY_FALLBACKS row matches
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const r = req("/parachute-unknown-thirdparty/health", {
+        headers: { "CF-Ray": "abc123" },
+      });
+      const res = await fetcher(r);
+      // Default "allowed" → no gate. Forwarded to upstream.
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { tag: string };
+      expect(body.tag).toBe("unknown-thirdparty");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
 });
 
 describe("hubFetch publicExposure layer-gate (proxyToVault)", () => {

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { HUB_SVC, hubPortPath } from "../hub-control.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
-import { findServiceUpstream, findVaultUpstream, hubFetch } from "../hub-server.ts";
+import { findServiceUpstream, findVaultUpstream, hubFetch, layerOf } from "../hub-server.ts";
 import { pidPath } from "../process-state.ts";
 import { type ServiceEntry, writeManifest } from "../services-manifest.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
@@ -1623,6 +1623,375 @@ describe("hubFetch /<svc>/* generic proxy dispatch (#182)", () => {
       // /vault/* and confirming no fallthrough to the vault upstream.
       const elsewhere = await fetcher(req("/totally/not/a/vault"));
       expect(elsewhere.status).toBe(404);
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+});
+
+describe("layerOf — classify trust layer from proxy headers", () => {
+  // Hub binds 127.0.0.1:1939; only trusted forwarders (cloudflared,
+  // tailscaled-serve, tailscaled-funnel) reach the listener. Spoofing isn't
+  // a concern. layerOf inspects the headers each forwarder injects.
+
+  test("no proxy headers → loopback (direct localhost call)", () => {
+    expect(layerOf(req("/"))).toBe("loopback");
+  });
+
+  test("Tailscale-User-Login → tailnet (authed via tailscale serve)", () => {
+    // Set verbatim per Tailscale docs / serve.go addTailscaleIdentityHeaders.
+    const r = req("/", { headers: { "Tailscale-User-Login": "alice@example.com" } });
+    expect(layerOf(r)).toBe("tailnet");
+  });
+
+  test("Tailscale-Funnel-Request: ?1 → public (Tailscale Funnel)", () => {
+    // Tailscale Funnel sets this header on every funneled connection per
+    // serve.go; mutually exclusive with Tailscale-User-Login.
+    const r = req("/", { headers: { "Tailscale-Funnel-Request": "?1" } });
+    expect(layerOf(r)).toBe("public");
+  });
+
+  test("CF-Ray → public (Cloudflare tunnel)", () => {
+    const r = req("/", { headers: { "CF-Ray": "abc123-DEN" } });
+    expect(layerOf(r)).toBe("public");
+  });
+
+  test("CF-Connecting-IP → public (Cloudflare tunnel — alt header shape)", () => {
+    const r = req("/", { headers: { "CF-Connecting-IP": "203.0.113.42" } });
+    expect(layerOf(r)).toBe("public");
+  });
+
+  test("Cloudflare wins over tailscale headers (cloudflared-then-serve hop, defensive)", () => {
+    // If a node ran both forwarders chained, the outer-most public layer
+    // wins. Defensive — not a recommended deployment shape.
+    const r = req("/", {
+      headers: { "CF-Ray": "abc", "Tailscale-User-Login": "alice@example.com" },
+    });
+    expect(layerOf(r)).toBe("public");
+  });
+
+  test("Tailscale-Funnel-Request wins over Tailscale-User-Login (defensive)", () => {
+    // serve.go can't actually set both — funnel returns early. Defensive.
+    const r = req("/", {
+      headers: {
+        "Tailscale-Funnel-Request": "?1",
+        "Tailscale-User-Login": "alice@example.com",
+      },
+    });
+    expect(layerOf(r)).toBe("public");
+  });
+});
+
+describe("hubFetch publicExposure layer-gate (proxyToService)", () => {
+  // The hub's only layer-gate. effectivePublicExposure(entry) === "loopback"
+  // → 404 on tailnet/public; pass through on loopback. "allowed" /
+  // "auth-required" reach all layers (service does its own auth gate).
+
+  function startUpstream(replyTag: string): { port: number; stop: () => void } {
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: () =>
+        new Response(JSON.stringify({ tag: replyTag }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    });
+    return { port: server.port as number, stop: () => server.stop(true) };
+  }
+
+  test("publicExposure: loopback + tailnet header → 404 (gate hides the route)", async () => {
+    const h = makeHarness();
+    const upstream = startUpstream("loopback-only");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "loopback-only",
+              port: upstream.port,
+              paths: ["/loopback-only"],
+              health: "/loopback-only/health",
+              version: "0.1.0",
+              publicExposure: "loopback",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const r = req("/loopback-only/anything", {
+        headers: { "Tailscale-User-Login": "alice@example.com" },
+      });
+      const res = await fetcher(r);
+      expect(res.status).toBe(404);
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("publicExposure: loopback + public header → 404 (gate hides the route)", async () => {
+    const h = makeHarness();
+    const upstream = startUpstream("loopback-only");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "loopback-only",
+              port: upstream.port,
+              paths: ["/loopback-only"],
+              health: "/loopback-only/health",
+              version: "0.1.0",
+              publicExposure: "loopback",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const r = req("/loopback-only/anything", { headers: { "CF-Ray": "abc123" } });
+      const res = await fetcher(r);
+      expect(res.status).toBe(404);
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("publicExposure: loopback + no headers → reaches upstream (loopback layer)", async () => {
+    const h = makeHarness();
+    const upstream = startUpstream("loopback-only");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "loopback-only",
+              port: upstream.port,
+              paths: ["/loopback-only"],
+              health: "/loopback-only/health",
+              version: "0.1.0",
+              publicExposure: "loopback",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(req("/loopback-only/health"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { tag: string };
+      expect(body.tag).toBe("loopback-only");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("publicExposure: allowed + tailnet header → reaches upstream (no gate)", async () => {
+    const h = makeHarness();
+    const upstream = startUpstream("allowed");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "allowed",
+              port: upstream.port,
+              paths: ["/allowed"],
+              health: "/allowed/health",
+              version: "0.1.0",
+              publicExposure: "allowed",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const r = req("/allowed/health", {
+        headers: { "Tailscale-User-Login": "alice@example.com" },
+      });
+      const res = await fetcher(r);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { tag: string };
+      expect(body.tag).toBe("allowed");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("publicExposure: auth-required + public header → reaches upstream (service self-gates)", async () => {
+    // The service does its own auth check; the hub passes through.
+    const h = makeHarness();
+    const upstream = startUpstream("auth-required");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "auth-required",
+              port: upstream.port,
+              paths: ["/auth-required"],
+              health: "/auth-required/health",
+              version: "0.1.0",
+              publicExposure: "auth-required",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const r = req("/auth-required/health", { headers: { "CF-Ray": "abc123" } });
+      const res = await fetcher(r);
+      expect(res.status).toBe(200);
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("scribe (kind=api, hasAuth=false default) → loopback gate fires from public layer", async () => {
+    // Spec-derived default for scribe is "auth-required" (NOT loopback —
+    // see effectivePublicExposure in service-spec.ts). So the hub passes
+    // through; this test confirms the spec-default isn't accidentally
+    // loopback-gating well-known services.
+    const h = makeHarness();
+    const upstream = startUpstream("scribe");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-scribe",
+              port: upstream.port,
+              paths: ["/scribe"],
+              health: "/scribe/health",
+              version: "0.1.0",
+              // publicExposure absent — exercises spec-derived default
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const r = req("/scribe/health", { headers: { "CF-Ray": "abc123" } });
+      const res = await fetcher(r);
+      // auth-required → pass through; service does its own gate.
+      expect(res.status).toBe(200);
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+});
+
+describe("hubFetch publicExposure layer-gate (proxyToVault)", () => {
+  // Same gate, applied to /vault/<name>/* dispatch. A vault entry that
+  // declares publicExposure: "loopback" is hidden from non-loopback callers.
+
+  function startVaultUpstream(replyTag: string): { port: number; stop: () => void } {
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: () =>
+        new Response(JSON.stringify({ tag: replyTag }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    });
+    return { port: server.port as number, stop: () => server.stop(true) };
+  }
+
+  test("vault publicExposure: loopback + tailnet header → 404", async () => {
+    const h = makeHarness();
+    const upstream = startVaultUpstream("vault-private");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault-private",
+              port: upstream.port,
+              paths: ["/vault/private"],
+              health: "/vault/private/health",
+              version: "0.4.0",
+              publicExposure: "loopback",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const r = req("/vault/private/health", {
+        headers: { "Tailscale-User-Login": "alice@example.com" },
+      });
+      const res = await fetcher(r);
+      expect(res.status).toBe(404);
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("vault publicExposure: loopback + no headers → reaches vault backend", async () => {
+    const h = makeHarness();
+    const upstream = startVaultUpstream("vault-private");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault-private",
+              port: upstream.port,
+              paths: ["/vault/private"],
+              health: "/vault/private/health",
+              version: "0.4.0",
+              publicExposure: "loopback",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(req("/vault/private/health"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { tag: string };
+      expect(body.tag).toBe("vault-private");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("vault publicExposure: allowed + tailnet header → reaches backend", async () => {
+    const h = makeHarness();
+    const upstream = startVaultUpstream("vault-public");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: upstream.port,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+              publicExposure: "allowed",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const r = req("/vault/default/health", {
+        headers: { "Tailscale-User-Login": "alice@example.com" },
+      });
+      const res = await fetcher(r);
+      expect(res.status).toBe(200);
     } finally {
       upstream.stop();
       h.cleanup();

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -17,9 +17,9 @@ import {
   stopHub,
 } from "../hub-control.ts";
 import { deriveHubOrigin } from "../hub-origin.ts";
-import { HUB_MOUNT, HUB_PATH, writeHubFile } from "../hub.ts";
+import { HUB_PATH, writeHubFile } from "../hub.ts";
 import { type AliveFn, processState } from "../process-state.ts";
-import { effectivePublicExposure, shortNameForManifest } from "../service-spec.ts";
+import { shortNameForManifest } from "../service-spec.ts";
 import { type ServiceEntry, readManifest } from "../services-manifest.ts";
 import { type ServeEntry, bringupCommand, teardownCommand } from "../tailscale/commands.ts";
 import { getFqdn, isTailscaleInstalled } from "../tailscale/detect.ts";
@@ -29,7 +29,6 @@ import {
   WELL_KNOWN_MOUNT,
   WELL_KNOWN_PATH,
   buildWellKnown,
-  isVaultEntry,
   shortName,
   writeWellKnownFile,
 } from "../well-known.ts";
@@ -39,17 +38,24 @@ import { restart } from "./lifecycle.ts";
  * Two exposure layers share a single tailscale serve config on this node.
  * Public layer adds `--funnel` to each handler; everything else is identical.
  *
- * Funnel constraint: Tailscale allows at most three public HTTPS ports per
- * node (443, 8443, 10000). Path-routing packs every service onto a single
- * port — that's why we default to one `--https=443` and mount services under
- * `/vault`, `/notes`, etc. rather than giving each service its own port or
- * subdomain. Subdomain-per-service requires the Tailscale Services feature
- * (virtual-IP advertisement) and is deferred.
+ * Single-rule shape: tailnet bringup emits exactly one `tailscale serve`
+ * mount — `/ → http://127.0.0.1:<hubPort>/`. The hub does all internal
+ * routing per request: hub UI, OAuth, well-known, vault SPA + per-vault
+ * proxy, and generic services.json-driven `/<svc>/*` dispatch. Layer
+ * detection (loopback / tailnet / public) and `publicExposure` enforcement
+ * also live in the hub (`layerOf` + `effectivePublicExposure`), so this
+ * plan layer no longer partitions services up-front. Cloudflare ingress
+ * shipped the same shape on 0.5.2 in #178; this closes the symmetry.
  *
- * Hub + well-known entries are HTTP proxies to an internal Bun.serve (see
- * `hub-control.ts`). They used to be `--set-path=<mount> <file>` entries but
- * macOS `tailscaled` runs sandboxed and can't read arbitrary files; proxy
- * mode is the only reliable shape.
+ * Funnel constraint, mostly historical now: Tailscale allows at most three
+ * public HTTPS ports per node (443, 8443, 10000). With one rule there is
+ * one port — symbolic but the constraint is what motivated path-routing
+ * over subdomain-per-service in the first place.
+ *
+ * Hub mount is an HTTP proxy to the internal Bun.serve (see `hub-control.ts`).
+ * Used to be `--set-path=<mount> <file>` entries but macOS `tailscaled` runs
+ * sandboxed and can't read arbitrary files; proxy mode is the only reliable
+ * shape.
  */
 
 export interface ExposeOpts {
@@ -104,166 +110,53 @@ export interface ExposeOpts {
 const HUB_DEPENDENT_SHORTS = ["vault"] as const;
 
 /**
- * OAuth paths the hub serves natively. The mount path is what clients see;
- * the target is the hub's loopback origin (where `hub-server.ts` is
- * listening). tailscale strips the mount before forwarding, so the target
- * must include the same path so the hub-server router sees the full URL.
- *
- * Pre-cli#58 (PR (c)) these were proxied to vault's `/vault/<name>/oauth/*`
- * handlers; after PR (c) the hub IS the OAuth IdP and vault validates
- * hub-issued JWTs (vault#169).
+ * Single tailscale serve mount: `/ → http://127.0.0.1:<hubPort>/`. The hub
+ * dispatches everything internally (hub page, /admin, /api, /hub SPA, /oauth,
+ * /.well-known, /vault SPA + proxy, /vaults POST, generic /<svc>/*), so the
+ * tailscale plan stays at this single rule regardless of how many services
+ * are installed. `publicExposure: "loopback"` enforcement happens inside the
+ * hub via `layerOf` — see `proxyToService` / `proxyToVault` in hub-server.ts.
  */
-const OAUTH_PATHS = [
-  "/.well-known/oauth-authorization-server",
-  "/oauth/authorize",
-  "/oauth/token",
-  "/oauth/register",
-] as const;
+const HUB_CATCHALL_MOUNT = "/";
 
 /**
- * Single tailscale serve mount that catches every `/vault/<name>/...` request
- * and routes it through the hub. The hub then reads services.json on each
- * request to pick the right vault backend (#144). Consolidating to one mount
- * means `parachute vault create techne` is reachable on the tailnet without
- * re-running `parachute expose` — only the hub-internal lookup needs to know
- * about the new path.
- *
- * Trailing slash distinguishes the mount from `/vaults` (the create-vault
- * POST endpoint, an exact-match on hub).
+ * Warn (but don't rewrite) for legacy `paths: ["/"]` entries. Pre-#144 these
+ * were remapped to `/<shortname>` so they didn't collide with the hub page
+ * at `/`. Now that the entire tailnet is one catchall to the hub, the hub
+ * dispatches by services.json `paths[]` per request — a `paths: ["/"]` entry
+ * still wouldn't route correctly, but the failure is hub-side rather than a
+ * tailscale plan collision. Emit the warning so operators know to re-install.
  */
-const VAULT_MOUNT = "/vault/";
-
-/**
- * Remap legacy `paths: ["/"]` entries to `/<shortname>` so they don't collide
- * with the hub page at `/`. Emits a warning per remapped service. This is the
- * transitional path for services installed before the vault PR that writes
- * `paths: ["/vault/<default>"]` — once `parachute install` is re-run those
- * entries update themselves and this branch goes dormant.
- */
-function remapLegacyRoot(
+function warnLegacyRoot(
   services: readonly ServiceEntry[],
   log: (line: string) => void,
-): ServiceEntry[] {
-  return services.map((s) => {
-    const first = s.paths[0];
-    if (first !== "/") return s;
+): readonly ServiceEntry[] {
+  for (const s of services) {
+    if (s.paths[0] !== "/") continue;
     const sn = shortName(s.name);
-    const remapped = `/${sn}`;
     log(
-      `note: ${s.name} claims "/"; hub page lives there — exposing at "${remapped}" instead. Re-run \`parachute install ${sn}\` to update services.json.`,
+      `note: ${s.name} claims "/"; hub page lives there — re-run \`parachute install ${sn}\` to update services.json.`,
     );
-    return { ...s, paths: [remapped, ...s.paths.slice(1)] };
-  });
+  }
+  return services;
 }
 
 /**
- * Partition services into ones that will be mounted on the layer versus ones
- * that stay loopback-only. "allowed" services go on the serve plan; every
- * other effective exposure state (explicit loopback, explicit auth-required,
- * spec-default auth-required) is withheld. Hidden services still appear in
- * services.json so on-box callers reach them at http://127.0.0.1:<port>.
+ * Build the tailscale plan: one rule, `/ → http://127.0.0.1:<hubPort>/`.
+ * Hub does internal dispatch (UI, OAuth, well-known, vault SPA + per-vault
+ * proxy, generic /<svc>/* services.json dispatch) and per-request layer
+ * gating for `publicExposure: "loopback"` services. See `layerOf` in
+ * `hub-server.ts` for the access-control matrix.
  */
-interface ExposurePartition {
-  exposed: ServiceEntry[];
-  hidden: Array<{ entry: ServiceEntry; reason: string }>;
-}
-
-function partitionByExposure(services: readonly ServiceEntry[]): ExposurePartition {
-  const exposed: ServiceEntry[] = [];
-  const hidden: Array<{ entry: ServiceEntry; reason: string }> = [];
-  for (const s of services) {
-    const eff = effectivePublicExposure(s);
-    if (eff === "allowed") {
-      exposed.push(s);
-      continue;
-    }
-    // Explicit declaration tells the user exactly what the service asked for;
-    // a spec-derived default points at the usual cause (no auth configured).
-    let reason: string;
-    if (s.publicExposure === "loopback") {
-      reason = "loopback-only by service declaration";
-    } else if (s.publicExposure === "auth-required") {
-      reason = "auth-required: service reports auth is not yet configured";
-    } else {
-      reason = "auth-required: service has no auth gate — set the service's auth token to expose";
-    }
-    hidden.push({ entry: s, reason });
-  }
-  return { exposed, hidden };
-}
-
-/**
- * Compose the tailscale serve target URL for a service rooted at `mount`.
- *
- * `tailscale serve --set-path=<mount> <target>` strips `<mount>` from the
- * incoming request path before forwarding. So if the backend expects
- * requests to keep arriving at `<mount>/...` (every SPA with a configured
- * base path, plus vault's `/vault/<name>/` API root) the target URL must
- * include the same mount path — otherwise the backend sees requests at `/`,
- * emits a redirect back to its real base, tailscale strips again, and the
- * client loops on `ERR_TOO_MANY_REDIRECTS`.
- *
- * The rule of thumb is: mount and target path must match byte-for-byte
- * (including trailing slash state), so tailscale's strip-then-forward is a
- * no-op and the backend sees the full path it expects.
- */
-function serviceProxyTarget(port: number, mount: string): string {
-  return `http://127.0.0.1:${port}${mount}`;
-}
-
-function planEntries(services: readonly ServiceEntry[], hubPort: number): ServeEntry[] {
-  const entries: ServeEntry[] = [];
-  entries.push({
-    kind: "proxy",
-    mount: HUB_MOUNT,
-    target: serviceProxyTarget(hubPort, HUB_MOUNT),
-    service: "hub",
-  });
-  let anyVault = false;
-  for (const s of services) {
-    if (isVaultEntry(s)) {
-      // Vault paths route through the single `/vault/` → hub mount below so
-      // `parachute vault create <name>` is reachable on the tailnet without
-      // a re-expose. Hub does the per-request services.json lookup (#144).
-      anyVault = true;
-      continue;
-    }
-    const mount = s.paths[0] ?? `/${shortName(s.name)}`;
-    entries.push({
+function planEntries(hubPort: number): ServeEntry[] {
+  return [
+    {
       kind: "proxy",
-      mount,
-      target: serviceProxyTarget(s.port, mount),
-      service: s.name,
-    });
-  }
-  if (anyVault) {
-    entries.push({
-      kind: "proxy",
-      mount: VAULT_MOUNT,
-      target: serviceProxyTarget(hubPort, VAULT_MOUNT),
-      service: "vault",
-    });
-  }
-  entries.push({
-    kind: "proxy",
-    mount: WELL_KNOWN_MOUNT,
-    target: serviceProxyTarget(hubPort, WELL_KNOWN_MOUNT),
-    service: "well-known",
-  });
-
-  // The hub is the OAuth IdP — mount the four endpoints at the canonical
-  // origin and proxy them to the hub's loopback. tailscale strips the mount
-  // before forwarding, so the target keeps the same path (matches the
-  // `serviceProxyTarget` rule of thumb in the doc above).
-  for (const oauthPath of OAUTH_PATHS) {
-    entries.push({
-      kind: "proxy",
-      mount: oauthPath,
-      target: serviceProxyTarget(hubPort, oauthPath),
-      service: "hub:oauth",
-    });
-  }
-  return entries;
+      mount: HUB_CATCHALL_MOUNT,
+      target: `http://127.0.0.1:${hubPort}/`,
+      service: "hub",
+    },
+  ];
 }
 
 async function runEach(
@@ -366,12 +259,11 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
     }
   }
 
-  const allServices = remapLegacyRoot(manifest.services, log);
-  // Split out loopback/auth-required services before planning the serve routes.
-  // Hidden services keep their /127.0.0.1:<port> accessibility for on-box
-  // callers (e.g., vault's transcription-worker dialing scribe); they just
-  // don't land on tailnet/funnel.
-  const { exposed: services, hidden } = partitionByExposure(allServices);
+  // Plan no longer partitions services — every service goes through the
+  // single hub catchall, and hub gates per request (`publicExposure` +
+  // `layerOf` in hub-server.ts). Just surface the legacy `paths: ["/"]`
+  // warning so operators know to re-install.
+  const services = warnLegacyRoot(manifest.services, log);
 
   /**
    * Probe each service port before wiring tailscale up. A service that's
@@ -428,14 +320,11 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
     else log(`✓ hub already running (pid ${hub.pid}, port ${hub.port}).`);
   }
 
-  const entries = planEntries(services, hubPort);
+  const entries = planEntries(hubPort);
   log(`Exposing under ${canonicalOrigin} (${layerLabel(layer)}, path-routing, port ${port}):`);
   for (const e of entries) {
     const suffix = e.kind === "proxy" ? `→ ${e.target}  (${e.service})` : `→ ${e.target}`;
     log(`  ${e.mount.padEnd(30, " ")} ${suffix}`);
-  }
-  for (const { entry: hiddenSvc, reason } of hidden) {
-    log(`  (${hiddenSvc.name} is loopback-only — ${reason})`);
   }
 
   const cmds = entries.map((e) => bringupCommand(e, { port, funnel }));

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -127,10 +127,7 @@ const HUB_CATCHALL_MOUNT = "/";
  * still wouldn't route correctly, but the failure is hub-side rather than a
  * tailscale plan collision. Emit the warning so operators know to re-install.
  */
-function warnLegacyRoot(
-  services: readonly ServiceEntry[],
-  log: (line: string) => void,
-): readonly ServiceEntry[] {
+function warnLegacyRoot(services: readonly ServiceEntry[], log: (line: string) => void): void {
   for (const s of services) {
     if (s.paths[0] !== "/") continue;
     const sn = shortName(s.name);
@@ -138,7 +135,6 @@ function warnLegacyRoot(
       `note: ${s.name} claims "/"; hub page lives there — re-run \`parachute install ${sn}\` to update services.json.`,
     );
   }
-  return services;
 }
 
 /**
@@ -262,8 +258,10 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
   // Plan no longer partitions services — every service goes through the
   // single hub catchall, and hub gates per request (`publicExposure` +
   // `layerOf` in hub-server.ts). Just surface the legacy `paths: ["/"]`
-  // warning so operators know to re-install.
-  const services = warnLegacyRoot(manifest.services, log);
+  // warning so operators know to re-install. `warnLegacyRoot` is
+  // side-effect-only (warning to `log`); use `manifest.services` directly
+  // downstream.
+  warnLegacyRoot(manifest.services, log);
 
   /**
    * Probe each service port before wiring tailscale up. A service that's
@@ -273,7 +271,7 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
    */
   const portProbe = opts.servicePortProbe ?? (async (p: number) => !(await defaultPortProbe(p)));
   const probeResults = await Promise.all(
-    services.map(async (s) => ({ svc: s, up: await portProbe(s.port) })),
+    manifest.services.map(async (s) => ({ svc: s, up: await portProbe(s.port) })),
   );
   for (const { svc, up } of probeResults) {
     if (up) continue;
@@ -286,7 +284,7 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
   // Kept for manual debugging / inspection only — the hub server now builds
   // /.well-known/parachute.json dynamically from services.json at request time
   // (#135), so this on-disk copy is no longer load-bearing for any consumer.
-  const wellKnownDoc = buildWellKnown({ services, canonicalOrigin });
+  const wellKnownDoc = buildWellKnown({ services: manifest.services, canonicalOrigin });
   writeWellKnownFile(wellKnownDoc, wellKnownFilePath);
   log(`Wrote ${wellKnownFilePath}`);
   writeHubFile(hubFilePath);
@@ -308,7 +306,7 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
     hubPort = existing;
   } else {
     const hub = await ensureHubRunning({
-      reservedPorts: services.map((s) => s.port),
+      reservedPorts: manifest.services.map((s) => s.port),
       ...(opts.hubEnsureOpts ?? {}),
       configDir,
       wellKnownDir,

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -195,7 +195,13 @@ export type RequestLayer = "loopback" | "tailnet" | "public";
 export function layerOf(req: Request): RequestLayer {
   const h = req.headers;
   if (h.get("cf-ray") !== null || h.get("cf-connecting-ip") !== null) return "public";
-  if (h.get("tailscale-funnel-request") !== null) return "public";
+  // Match the structured-header value (`?1`) rather than mere presence:
+  // serve.go only ever emits `?1`, so insisting on the canonical value keeps
+  // the classifier's intent obvious to a future reader (don't loosen this to
+  // `!== null` — Tailscale's contract is the value, not the header name).
+  // CF-Ray / CF-Connecting-IP are open-string identifiers with no canonical
+  // value to compare against, hence the presence-check above.
+  if (h.get("tailscale-funnel-request") === "?1") return "public";
   if (h.get("tailscale-user-login") !== null) return "tailnet";
   return "loopback";
 }

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -67,6 +67,7 @@ import {
   handleToken,
 } from "./oauth-handlers.ts";
 import { clearPid, writePid } from "./process-state.ts";
+import { effectivePublicExposure } from "./service-spec.ts";
 import { type ServiceEntry, readManifest } from "./services-manifest.ts";
 import { getAllPublicKeys } from "./signing-keys.ts";
 import { buildWellKnown, isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
@@ -144,6 +145,59 @@ export function findVaultUpstream(
     }
   }
   return best;
+}
+
+/**
+ * The trust layer a request arrived through. Hub binds `127.0.0.1:1939`, so
+ * every request reaches it via one of three trusted forwarders (or directly
+ * over loopback). The forwarder injects characteristic headers that we use to
+ * classify; nothing else can reach the listener, so spoofing isn't a concern.
+ *
+ *   "loopback" — direct localhost call (CLI, on-box service, dev shell).
+ *   "tailnet"  — `tailscale serve` forwarding an authed tailnet user.
+ *   "public"   — `tailscale funnel` (public-over-tailnet, unauthed) OR a
+ *                cloudflared tunnel forwarding from the public internet.
+ *
+ * Used to gate `publicExposure: "loopback"` services on the generic
+ * `/<svc>/*` dispatch (the hub's only layer-gate). Hub-owned paths (`/`,
+ * `/admin/*`, `/api/*`, `/hub/*`, `/oauth/*`, `/.well-known/*`, `/vault/*`,
+ * `/vaults`) reach all layers and rely on app-level auth (admin session
+ * cookie + 2FA, OAuth, per-service tokens) — they are NOT layer-blocked.
+ */
+export type RequestLayer = "loopback" | "tailnet" | "public";
+
+/**
+ * Classify the trust layer for an incoming request by inspecting proxy
+ * headers. Order matters: cloudflared headers come first because cloudflared
+ * could in principle be deployed alongside tailscale on the same node.
+ *
+ * Header reference (verified against tailscale serve.go on 2026-05-08):
+ *   - `Tailscale-User-Login` is set ONLY by `tailscale serve` for an authed
+ *     tailnet user. Tagged-source nodes don't get it. Funnel never sets it.
+ *   - `Tailscale-Funnel-Request: ?1` is set ONLY by Tailscale Funnel.
+ *     Mutually exclusive with `Tailscale-User-Login` (the serve.go path
+ *     returns early when funneled).
+ *   - `CF-Ray` and `CF-Connecting-IP` are set by Cloudflare's edge for
+ *     anything proxied through a cloudflared tunnel.
+ *
+ * Spoofing isn't a concern: hub binds `127.0.0.1:1939`, so external requests
+ * can't reach the listener except via these trusted forwarders. Tailscale
+ * specifically strips the same headers from incoming requests before
+ * re-injecting them, so even a malicious tailnet peer can't impersonate a
+ * different user. We could mirror that strip-on-arrival defense, but it's
+ * belt-and-braces given the bind shape.
+ *
+ * Default to "loopback" when no proxy headers are present — that's the
+ * direct-localhost case. Funnel without `Tailscale-Funnel-Request` would
+ * also fall here, but Tailscale always sets the header on funneled
+ * requests, so this branch only fires for true loopback callers.
+ */
+export function layerOf(req: Request): RequestLayer {
+  const h = req.headers;
+  if (h.get("cf-ray") !== null || h.get("cf-connecting-ip") !== null) return "public";
+  if (h.get("tailscale-funnel-request") !== null) return "public";
+  if (h.get("tailscale-user-login") !== null) return "tailnet";
+  return "loopback";
 }
 
 /**
@@ -229,6 +283,12 @@ async function proxyToVault(req: Request, manifestPath: string): Promise<Respons
   const url = new URL(req.url);
   const match = findVaultUpstream(services, url.pathname);
   if (!match) return undefined;
+  // Layer-gate on `publicExposure: "loopback"` — hide the entry from non-
+  // loopback callers as if it doesn't exist. "allowed" / "auth-required"
+  // pass through; the service does its own auth.
+  if (effectivePublicExposure(match.entry) === "loopback" && layerOf(req) !== "loopback") {
+    return new Response("not found", { status: 404 });
+  }
   return proxyRequest(req, match.port, "vault");
 }
 
@@ -290,6 +350,14 @@ async function proxyToService(req: Request, manifestPath: string): Promise<Respo
   const url = new URL(req.url);
   const match = findServiceUpstream(services, url.pathname);
   if (!match) return undefined;
+  // Layer-gate on `publicExposure: "loopback"`. From the perspective of a
+  // tailnet/public caller, a loopback-only service must be indistinguishable
+  // from "not installed" — 404, not 403, so we don't leak the existence of
+  // the route. "allowed" / "auth-required" pass through; the service does
+  // its own auth.
+  if (effectivePublicExposure(match.entry) === "loopback" && layerOf(req) !== "loopback") {
+    return new Response("not found", { status: 404 });
+  }
   const targetPath = match.entry.stripPrefix
     ? url.pathname.slice(match.mount.length) || "/"
     : undefined;


### PR DESCRIPTION
## Summary

Three interlocking changes — bundled because they only make sense together:

1. **Hub-side layer detection (`layerOf`).** Classify every request reaching `127.0.0.1:1939` as `loopback` / `tailnet` / `public` by inspecting trusted-forwarder headers. Header set verified against [tailscale serve.go's `addTailscaleIdentityHeaders`](https://github.com/tailscale/tailscale/blob/main/ipn/ipnlocal/serve.go) — `Tailscale-User-Login` is set ONLY by tailscale serve for an authed user; `Tailscale-Funnel-Request: ?1` is set ONLY by Tailscale Funnel; `CF-Ray` / `CF-Connecting-IP` mark cloudflared. No headers → loopback.

2. **`publicExposure: "loopback"` enforcement on `/<svc>/*` and `/vault/<name>/*`.** `effectivePublicExposure(entry)` (already in `service-spec.ts:392`) is now wired into `proxyToService` and `proxyToVault` in `hub-server.ts`. `loopback` → 404 from non-loopback layers. `allowed` / `auth-required` → reach all layers, service self-gates. **Hub-owned routes are NOT layer-blocked** — they reach uniformly across all layers and rely on app-level auth.

3. **Tailnet collapses to one rule.** `parachute expose tailnet|public` now emits exactly `tailscale serve --bg --https=443 --set-path=/ http://127.0.0.1:<hubPort>/`. The hub does all internal dispatch. Symmetric with cloudflare ingress that shipped in #178 on 0.5.2.

## Access-control matrix

| Path / class | Loopback | Tailnet | Public | Gated by |
|---|---|---|---|---|
| `/admin/*`, `/api/*`, `/hub/*` | ✓ | ✓ | ✓ | session cookie + host-admin-token (password + 2FA) |
| Service `publicExposure: "allowed"` | ✓ | ✓ | ✓ | service's own auth |
| Service `publicExposure: "loopback"` | ✓ | ✗ | ✗ | hub layer-gate |
| Service `publicExposure: "auth-required"` | ✓ | ✓ | ✓ | service's own auth |
| `/oauth/*`, `/.well-known/*`, `/`, `/vault/*` | ✓ | ✓ | ✓ | per-route logic |

## Why bundled

The three changes have to land together: detection without enforcement is dead code; enforcement without collapse leaves the gap that motivated the redirect; collapse without detection-and-enforcement removes per-mount filtering with nothing to replace it.

## References

- **#178** — cloudflare side already shipped on 0.5.2 (`e48a8ed feat(expose): cloudflare ingress → single hub catchall`). This PR closes the symmetry on tailnet.
- **#185** — rate-limit `/admin/login` (brute-force mitigation, since `/admin` is now public-reachable). Filed as follow-up; out of scope here.
- **#186** — `parachute expose public` warning if 2FA isn't enrolled. Filed as follow-up; out of scope here.

## Test plan

- [x] `bun run typecheck` clean.
- [x] `bunx biome check src/hub-server.ts src/commands/expose.ts src/__tests__/expose.test.ts src/__tests__/hub-server.test.ts` clean (pre-existing biome errors elsewhere unrelated).
- [x] `bun test src/__tests__/`: 1075/1075 pass (was 1059; +16 layer-gate tests in `hub-server.test.ts`).
  - Layer classification tested for all four header shapes (Tailscale-User-Login, Tailscale-Funnel-Request, CF-Ray, CF-Connecting-IP) + headerless + defensive precedence.
  - `publicExposure: "loopback"` gate fires from tailnet header → 404; from public headers → 404; from no headers → reaches upstream.
  - `publicExposure: "allowed"` and `auth-required` pass through from all layers.
  - `expose.test.ts` rewritten: every multi-mount expectation collapsed to single-catchall assertion (`expect(serveCalls).toHaveLength(1); expect(mounts).toEqual(["--set-path=/"])`).
- [x] **Live smoke** (spawn hub on `:19500` with two stub upstreams):
  - `loopback-only` + no headers → 200 (hub forwards)
  - `loopback-only` + `Tailscale-User-Login` → 404 (gate)
  - `loopback-only` + `Tailscale-Funnel-Request: ?1` → 404 (gate)
  - `loopback-only` + `CF-Ray` → 404 (gate)
  - `allowed-svc` + `Tailscale-User-Login` → 200 (no gate)
  - `allowed-svc` + `CF-Ray` → 200 (no gate)
  - `/admin/login` + `Tailscale-User-Login` → 200 (admin/login NOT layer-gated)
  - `/.well-known/parachute.json` + `Tailscale-User-Login` → 200 (well-known reaches all layers)
- [x] **Live dry-run** of `exposeTailnet` planner with vault + notes + scribe + agent installed: emits exactly one `tailscale serve --bg --https=443 --set-path=/ http://127.0.0.1:1939/` regardless of service count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)