### PR TITLE
feat(admin): rate-limit POST /admin/login (closes #185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.4-rc.1] - 2026-05-08
+
+### Added
+
+- **Per-IP rate-limit on `POST /admin/login` (5 attempts / 15-minute sliding window).** Lands as a brute-force floor under `/admin/login`, which became reachable from every layer (loopback / tailnet / public) when 0.5.3-rc.1 collapsed the access-control matrix into the hub. On a cloudflare-fronted hub, that means the open internet — until #186 ships 2FA-on-login, this is the only thing slowing credential grinding. New module `src/rate-limit.ts` keeps a sliding-window timestamp list per IP and is wired into `handleAdminLoginPost` *after* CSRF (so cross-site junk doesn't burn slots) but *before* credential check (so 401s, missing-user, and eventually 2FA failures all count toward the same bucket — auth-stage independent). Exhaustion returns `429 Too Many Requests` with a `Retry-After` header pointing at the bucket-reset moment in seconds. Layer-independent: a buggy script hammering loopback gets 429'd just like a public attacker; tailnet logins all share the loopback bucket since `tailscale serve` proxies from `127.0.0.1`, which is acceptable because brute-force isn't the threat model on an authed-tailnet ingress. (#185)
+- **`clientIpFromRequest` IP-extraction helper (`src/rate-limit.ts`).** Priority order: `CF-Connecting-IP` (cloudflared sets this on every forwarded request, with the actual client IP rather than the cloudflare edge); `X-Forwarded-For` first hop (defensive fallback for any non-cloudflare proxy fronting hub); fall through to `UNKNOWN_IP_SENTINEL` so the limiter always has a key (direct-loopback callers all share one bucket, intended bound). No `Forwarded` (RFC 7239) parser today — `X-Forwarded-For` covers the operator-deploy reality and `Forwarded` is rare in this niche; can add when the first deployment needs it. (#185)
+- **Storage shape: in-memory `Map<ip, timestamps[]>` for the lifetime of the hub process.** Persistence isn't worth a SQLite write per attempt — process restart is itself a defense (the attacker loses progress against any one bucket). Memory is bounded by an opportunistic prune on every check; sentinel-bucket sharing keeps direct-loopback noise to one entry. (#185)
+- **`AdminLoginDeps` test seam on `handleAdminLoginPost`.** Production callers omit it (real clock); tests inject `now` so rate-limit assertions don't race wall-clock time. Kept narrow — login doesn't share the wider `AdminDeps` because it doesn't load services / module manifests. (#185)
+
+### Why this lands now
+
+Pre-#187, `/admin/login` was loopback-only on a tailnet/funnel-only deployment (the route lived on the hub which only listened on `127.0.0.1`). Post-#187 the access-control matrix moved into the hub itself, and every layer that admits requests at all admits `/admin/*`. For operators on cloudflare-only exposure that means a public-internet brute-force surface. 2FA (#186) is the primary defense and ships next; the rate-limit floor lands first because it's small, well-bounded, and gets some of the way there for operators who upgrade before the 2FA PR lands.
+
 ## [0.5.3-rc.2] - 2026-05-08
 
 Review nit fold (PR #187) — no behavior change beyond test coverage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.4-rc.2] - 2026-05-08
+
+Review nit fold (PR #188) — no behavior change.
+
+### Changed
+
+- **Drop unreachable `pruned.length === 0` branch in `checkAndRecord`'s deny path (`src/rate-limit.ts`).** The deny branch only fires when `pruned.length >= MAX_ATTEMPTS`, so the `if (pruned.length === 0) buckets.delete(key)` arm was structurally unreachable; the `else buckets.set(key, pruned)` arm was the only path that ever ran. Replaced the if/else with an unconditional `buckets.set(key, pruned)` plus a comment explaining the deny-bucket-is-still-full intent so a future reader doesn't reintroduce a confused `delete` arm.
+- **Document the `Math.max(1, ...)` clamp on `retryAfterSeconds` as defense-in-depth.** The unclamped value is provably `>= 1` in the deny branch (every retained timestamp is strictly inside the window, so `resetAtMs - now > 0` strictly, so `Math.ceil(positiveMs / 1000) >= 1`). The clamp stays as a belt-and-suspenders floor in case the filter logic is ever loosened. JSDoc on `RateLimitResult.retryAfterSeconds` updated to reflect this.
+
+### Added
+
+- **Test: `retryAfterSeconds === 1` at the 1-ms-remaining boundary (`src/__tests__/rate-limit.test.ts`).** Pins the minimum natural value the `Math.ceil((resetAtMs - now) / 1000)` calculation produces in the deny branch, which is what the existing clamp would catch if the filter logic regressed.
+- **Test: sweep `now` from t0 across the full window in 100ms steps and assert every denied response has `retryAfterSeconds >= 1`.** Belt-and-suspenders invariant check that the deny branch never produces a sub-1 unclamped value.
+
 ## [0.5.4-rc.1] - 2026-05-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.3-rc.2",
+  "version": "0.5.4-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.4-rc.1",
+  "version": "0.5.4-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/admin-handlers.test.ts
+++ b/src/__tests__/admin-handlers.test.ts
@@ -13,6 +13,7 @@ import {
 import { CSRF_COOKIE_NAME, CSRF_FIELD_NAME } from "../csrf.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import type { ConfigSchema, ModuleManifest } from "../module-manifest.ts";
+import { __resetForTests as resetRateLimit } from "../rate-limit.ts";
 import type { ServicesManifest } from "../services-manifest.ts";
 import { SESSION_TTL_MS, buildSessionCookie, createSession, findSession } from "../sessions.ts";
 import { createUser } from "../users.ts";
@@ -106,6 +107,10 @@ function fakeReadManifest(installDir: string): Promise<ModuleManifest | null> {
 let harness: Harness;
 beforeEach(() => {
   harness = makeHarness();
+  // Per-test rate-limit state — login tests share the UNKNOWN_IP sentinel
+  // bucket since they don't set CF-Connecting-IP, so without a reset the
+  // 6th test in this file would 429 spuriously.
+  resetRateLimit();
 });
 afterEach(() => {
   harness.cleanup();
@@ -221,6 +226,93 @@ describe("handleAdminLoginPost", () => {
     const res = await handleAdminLoginPost(harness.db, req);
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe("/admin/config");
+  });
+
+  // hub#185 — per-IP rate-limit (5 attempts / 15 min) on POST /admin/login.
+  test("6 rapid POSTs from same IP get 200/401×4/429 and the 429 carries Retry-After", async () => {
+    await createUser(harness.db, "admin", "correct-pw");
+    const buildReq = (password: string) => {
+      const { body, headers } = formBody({
+        [CSRF_FIELD_NAME]: TEST_CSRF,
+        username: "admin",
+        password,
+        next: "/admin/config",
+      });
+      return new Request("http://hub.test/admin/login", {
+        method: "POST",
+        headers: { ...headers, cookie: CSRF_COOKIE, "cf-connecting-ip": "203.0.113.42" },
+        body,
+      });
+    };
+    // First attempt: correct password → 302. Counts as attempt #1.
+    const first = await handleAdminLoginPost(harness.db, buildReq("correct-pw"));
+    expect(first.status).toBe(302);
+    // Attempts 2–5: wrong password → 401 each.
+    for (let i = 2; i <= 5; i++) {
+      const r = await handleAdminLoginPost(harness.db, buildReq("wrong"));
+      expect(r.status).toBe(401);
+    }
+    // Attempt 6: rate-limit fires before credential check → 429 + Retry-After.
+    const denied = await handleAdminLoginPost(harness.db, buildReq("wrong"));
+    expect(denied.status).toBe(429);
+    const retryAfter = denied.headers.get("retry-after");
+    expect(retryAfter).not.toBeNull();
+    const seconds = Number(retryAfter);
+    expect(seconds).toBeGreaterThan(0);
+    // Window is 15 min = 900s, so retry-after sits in (0, 900].
+    expect(seconds).toBeLessThanOrEqual(900);
+  });
+
+  test("rate-limit is per-IP: a different IP can still log in after another's bucket fills", async () => {
+    await createUser(harness.db, "admin", "pw");
+    const buildReq = (ip: string, password: string) => {
+      const { body, headers } = formBody({
+        [CSRF_FIELD_NAME]: TEST_CSRF,
+        username: "admin",
+        password,
+        next: "/admin/config",
+      });
+      return new Request("http://hub.test/admin/login", {
+        method: "POST",
+        headers: { ...headers, cookie: CSRF_COOKIE, "cf-connecting-ip": ip },
+        body,
+      });
+    };
+    // Exhaust ip-a's bucket with 5 wrong-password attempts, then confirm 429.
+    for (let i = 0; i < 5; i++) {
+      await handleAdminLoginPost(harness.db, buildReq("203.0.113.7", "wrong"));
+    }
+    const aDenied = await handleAdminLoginPost(harness.db, buildReq("203.0.113.7", "wrong"));
+    expect(aDenied.status).toBe(429);
+    // Different IP: fresh bucket, correct credentials → 302.
+    const bOk = await handleAdminLoginPost(harness.db, buildReq("198.51.100.99", "pw"));
+    expect(bOk.status).toBe(302);
+  });
+
+  test("rate-limit fires before credential check (denied request never touches DB)", async () => {
+    // No user exists in the harness DB. First 5 attempts should be 401
+    // ("Invalid credentials" — no such user). 6th should be 429 with the
+    // rate-limit body, NOT a credential-failure body.
+    const buildReq = () => {
+      const { body, headers } = formBody({
+        [CSRF_FIELD_NAME]: TEST_CSRF,
+        username: "ghost",
+        password: "x",
+        next: "/admin/config",
+      });
+      return new Request("http://hub.test/admin/login", {
+        method: "POST",
+        headers: { ...headers, cookie: CSRF_COOKIE, "cf-connecting-ip": "203.0.113.99" },
+        body,
+      });
+    };
+    for (let i = 0; i < 5; i++) {
+      const r = await handleAdminLoginPost(harness.db, buildReq());
+      expect(r.status).toBe(401);
+    }
+    const denied = await handleAdminLoginPost(harness.db, buildReq());
+    expect(denied.status).toBe(429);
+    expect(await denied.text()).toContain("Too many login attempts");
   });
 });
 

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  MAX_ATTEMPTS,
+  UNKNOWN_IP_SENTINEL,
+  WINDOW_MS,
+  __resetForTests,
+  checkAndRecord,
+  clientIpFromRequest,
+} from "../rate-limit.ts";
+
+afterEach(() => {
+  __resetForTests();
+});
+
+describe("checkAndRecord — bucket fill / drain", () => {
+  test("admits the first MAX_ATTEMPTS attempts; denies the next one with Retry-After", () => {
+    const now = new Date("2026-05-08T12:00:00Z");
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+      const r = checkAndRecord("ip-a", now);
+      expect(r.allowed).toBe(true);
+      expect(r.retryAfterSeconds).toBeUndefined();
+    }
+    const denied = checkAndRecord("ip-a", now);
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterSeconds).toBeDefined();
+    // 5 attempts at the same instant; window length 15 min = 900s. Reset is
+    // exactly WINDOW_MS later, so retry-after === WINDOW_MS / 1000.
+    expect(denied.retryAfterSeconds).toBe(WINDOW_MS / 1000);
+  });
+
+  test("bucket drains: attempt is admitted again once the window passes", () => {
+    const t0 = new Date("2026-05-08T12:00:00Z");
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+      checkAndRecord("ip-a", t0);
+    }
+    const stillDenied = checkAndRecord("ip-a", new Date(t0.getTime() + WINDOW_MS - 1000));
+    expect(stillDenied.allowed).toBe(false);
+
+    // Advance past the window — all five timestamps fall off, slot opens.
+    const past = new Date(t0.getTime() + WINDOW_MS + 1000);
+    const allowed = checkAndRecord("ip-a", past);
+    expect(allowed.allowed).toBe(true);
+  });
+
+  test("partial drain: oldest entry falling off opens exactly one slot", () => {
+    const t0 = new Date("2026-05-08T12:00:00Z");
+    // Spread 5 attempts 1 minute apart so they fall off the window
+    // individually rather than as a cohort.
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+      checkAndRecord("ip-a", new Date(t0.getTime() + i * 60_000));
+    }
+    // Right at the 5th-minute mark, all 5 are in window → denied.
+    const denied = checkAndRecord("ip-a", new Date(t0.getTime() + 5 * 60_000));
+    expect(denied.allowed).toBe(false);
+
+    // Step past WINDOW_MS from the *first* attempt (t0) → that one falls
+    // off, so we should be admitted.
+    const partial = new Date(t0.getTime() + WINDOW_MS + 1000);
+    const r = checkAndRecord("ip-a", partial);
+    expect(r.allowed).toBe(true);
+  });
+
+  test("denied attempts do not push the reset further into the future", () => {
+    const t0 = new Date("2026-05-08T12:00:00Z");
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+      checkAndRecord("ip-a", t0);
+    }
+    // Five denials over 30 seconds. The reset moment must be anchored to the
+    // 5 admitted attempts at t0, NOT to the latest denial.
+    for (let i = 1; i <= 5; i++) {
+      checkAndRecord("ip-a", new Date(t0.getTime() + i * 6000));
+    }
+    const finalCheck = checkAndRecord("ip-a", new Date(t0.getTime() + 30_000));
+    expect(finalCheck.allowed).toBe(false);
+    // 30 seconds elapsed; expected ~870s remaining. Tolerance ±2s for
+    // ceil-rounding edge.
+    const expected = Math.ceil((WINDOW_MS - 30_000) / 1000);
+    expect(finalCheck.retryAfterSeconds).toBe(expected);
+  });
+
+  test("Retry-After is always at least 1 second at the boundary", () => {
+    const t0 = new Date("2026-05-08T12:00:00Z");
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+      checkAndRecord("ip-a", t0);
+    }
+    // Exactly at the moment the oldest attempt would fall off — clamp to 1.
+    const r = checkAndRecord("ip-a", new Date(t0.getTime() + WINDOW_MS));
+    // At exactly WINDOW_MS, the oldest is gone → admitted, not denied.
+    expect(r.allowed).toBe(true);
+  });
+});
+
+describe("checkAndRecord — multi-IP independence", () => {
+  test("exhausting one IP's bucket does not affect another IP", () => {
+    const now = new Date("2026-05-08T12:00:00Z");
+    for (let i = 0; i < MAX_ATTEMPTS; i++) checkAndRecord("ip-a", now);
+    expect(checkAndRecord("ip-a", now).allowed).toBe(false);
+
+    // Different IP — fresh bucket.
+    expect(checkAndRecord("ip-b", now).allowed).toBe(true);
+    expect(checkAndRecord("ip-c", now).allowed).toBe(true);
+  });
+
+  test("IPv4 / IPv6 / sentinel are all distinct keys", () => {
+    const now = new Date("2026-05-08T12:00:00Z");
+    for (let i = 0; i < MAX_ATTEMPTS; i++) checkAndRecord("203.0.113.7", now);
+    expect(checkAndRecord("203.0.113.7", now).allowed).toBe(false);
+    expect(checkAndRecord("2001:db8::42", now).allowed).toBe(true);
+    expect(checkAndRecord(UNKNOWN_IP_SENTINEL, now).allowed).toBe(true);
+  });
+});
+
+describe("clientIpFromRequest — header priority", () => {
+  test("CF-Connecting-IP wins over X-Forwarded-For", () => {
+    const req = new Request("http://hub.test/admin/login", {
+      headers: {
+        "cf-connecting-ip": "203.0.113.7",
+        "x-forwarded-for": "198.51.100.99, 10.0.0.1",
+      },
+    });
+    expect(clientIpFromRequest(req)).toBe("203.0.113.7");
+  });
+
+  test("X-Forwarded-For first hop is used when CF-Connecting-IP is absent", () => {
+    const req = new Request("http://hub.test/admin/login", {
+      headers: { "x-forwarded-for": "198.51.100.99, 10.0.0.1, 10.0.0.2" },
+    });
+    expect(clientIpFromRequest(req)).toBe("198.51.100.99");
+  });
+
+  test("X-Forwarded-For with whitespace is trimmed", () => {
+    const req = new Request("http://hub.test/admin/login", {
+      headers: { "x-forwarded-for": "  198.51.100.99  , 10.0.0.1" },
+    });
+    expect(clientIpFromRequest(req)).toBe("198.51.100.99");
+  });
+
+  test("falls through to UNKNOWN_IP_SENTINEL when no headers are set", () => {
+    const req = new Request("http://hub.test/admin/login");
+    expect(clientIpFromRequest(req)).toBe(UNKNOWN_IP_SENTINEL);
+  });
+
+  test("empty / whitespace-only header values are treated as absent", () => {
+    const req = new Request("http://hub.test/admin/login", {
+      headers: { "cf-connecting-ip": "   ", "x-forwarded-for": "" },
+    });
+    expect(clientIpFromRequest(req)).toBe(UNKNOWN_IP_SENTINEL);
+  });
+
+  test("empty CF-Connecting-IP falls through to X-Forwarded-For first hop", () => {
+    const req = new Request("http://hub.test/admin/login", {
+      headers: { "cf-connecting-ip": "", "x-forwarded-for": "198.51.100.99" },
+    });
+    expect(clientIpFromRequest(req)).toBe("198.51.100.99");
+  });
+});

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -88,6 +88,40 @@ describe("checkAndRecord — bucket fill / drain", () => {
     // At exactly WINDOW_MS, the oldest is gone → admitted, not denied.
     expect(r.allowed).toBe(true);
   });
+
+  test("Retry-After natural value is always >= 1 in the deny branch (1ms-remaining case)", () => {
+    // The `Math.max(1, ...)` clamp at rate-limit.ts:90 is defense-in-depth:
+    // the deny branch requires `pruned.length >= MAX_ATTEMPTS`, which means
+    // every retained timestamp is strictly inside the window, so
+    // `resetAtMs - now > 0` strictly, so `Math.ceil(positive / 1000) >= 1`.
+    // This test pins that invariant: at `WINDOW_MS - 1ms` after the cohort,
+    // 1ms remains until the oldest falls off → unclamped value is
+    // `Math.ceil(1 / 1000) = 1`, the minimum natural value.
+    const t0 = new Date("2026-05-08T12:00:00Z");
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+      checkAndRecord("ip-a", t0);
+    }
+    const denied = checkAndRecord("ip-a", new Date(t0.getTime() + WINDOW_MS - 1));
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterSeconds).toBe(1);
+  });
+
+  test("Retry-After is >= 1 across every denied step from t0 to the boundary", () => {
+    // Belt-and-suspenders sweep: walk `now` from t0 up to (but not including)
+    // the boundary in 100ms steps and assert every denied response has
+    // `retryAfterSeconds >= 1`. Locks in the "natural value never drops to
+    // zero in the deny branch" invariant the clamp guards.
+    const t0 = new Date("2026-05-08T12:00:00Z");
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+      checkAndRecord("ip-a", t0);
+    }
+    for (let dt = 0; dt < WINDOW_MS; dt += 100) {
+      const r = checkAndRecord("ip-a", new Date(t0.getTime() + dt));
+      expect(r.allowed).toBe(false);
+      expect(r.retryAfterSeconds).toBeDefined();
+      expect(r.retryAfterSeconds as number).toBeGreaterThanOrEqual(1);
+    }
+  });
 });
 
 describe("checkAndRecord — multi-IP independence", () => {

--- a/src/admin-handlers.ts
+++ b/src/admin-handlers.ts
@@ -31,6 +31,7 @@ import { restart as lifecycleRestart } from "./commands/lifecycle.ts";
 import { CONFIG_DIR } from "./config.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
 import type { ModuleManifest } from "./module-manifest.ts";
+import { checkAndRecord, clientIpFromRequest } from "./rate-limit.ts";
 import {
   type ServicesManifest,
   readManifest as readServicesManifest,
@@ -106,7 +107,11 @@ export function handleAdminLoginGet(_db: Database, req: Request): Response {
   return htmlResponse(renderAdminLogin({ next, csrfToken: csrf.token }), 200, extra);
 }
 
-export async function handleAdminLoginPost(db: Database, req: Request): Promise<Response> {
+export async function handleAdminLoginPost(
+  db: Database,
+  req: Request,
+  deps: AdminLoginDeps = {},
+): Promise<Response> {
   const form = await req.formData();
   const formCsrf = form.get(CSRF_FIELD_NAME);
   if (!verifyCsrfToken(req, typeof formCsrf === "string" ? formCsrf : null)) {
@@ -116,6 +121,24 @@ export async function handleAdminLoginPost(db: Database, req: Request): Promise<
         message: "The form's CSRF token did not match. Reload the page and try again.",
       }),
       400,
+    );
+  }
+  // Rate-limit gate fires *after* CSRF (so a junk cross-site POST doesn't
+  // burn a bucket slot for the victim's IP) but *before* credential check.
+  // Every legitimate login attempt — wrong password, missing user, eventually
+  // failed-2FA (#186) — counts toward the same bucket so an attacker can't
+  // partition the cooldown across stages.
+  const clientIp = clientIpFromRequest(req);
+  const now = deps.now ? deps.now() : new Date();
+  const gate = checkAndRecord(clientIp, now);
+  if (!gate.allowed) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Too many login attempts",
+        message: `Too many login attempts from this IP. Try again in ${gate.retryAfterSeconds ?? 1} seconds.`,
+      }),
+      429,
+      { "retry-after": String(gate.retryAfterSeconds ?? 1) },
     );
   }
   const username = String(form.get("username") ?? "");
@@ -145,6 +168,17 @@ export async function handleAdminLoginPost(db: Database, req: Request): Promise<
   const session = createSession(db, { userId: user.id });
   const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
   return redirect(next, { "set-cookie": cookie });
+}
+
+/**
+ * Test-injection seam for `handleAdminLoginPost`. Production callers omit
+ * `deps`; tests pass a deterministic clock so the rate-limit assertions
+ * don't race wall-clock time. Kept narrow — login doesn't share the wider
+ * `AdminDeps` because it doesn't load services / module manifests.
+ */
+export interface AdminLoginDeps {
+  /** Test seam — defaults to real clock. */
+  now?: () => Date;
 }
 
 // --- /admin/logout ---------------------------------------------------------

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -48,8 +48,11 @@ export interface RateLimitResult {
   allowed: boolean;
   /**
    * Seconds until the bucket reset (oldest in-window timestamp falls off).
-   * Only set when `allowed` is false. Always >= 1 to give a non-zero
-   * `Retry-After` header value even at the boundary.
+   * Only set when `allowed` is false. Always >= 1: the deny branch only
+   * fires when the oldest in-window timestamp is strictly inside the
+   * window, so `Math.ceil(positiveMs / 1000) >= 1` naturally. The
+   * `Math.max(1, ...)` clamp inside `checkAndRecord` is a defense-in-depth
+   * floor in case the filter logic is ever loosened.
    */
   retryAfterSeconds?: number;
 }
@@ -84,15 +87,21 @@ export function checkAndRecord(key: string, now: Date): RateLimitResult {
   if (pruned.length >= MAX_ATTEMPTS) {
     // Reset moment = oldest in-window attempt + WINDOW_MS. `pruned[0]` is
     // the oldest because timestamps are appended in order. Subtract `now`
-    // for seconds-until-reset; clamp to >= 1 so Retry-After never reads 0
-    // at the exact boundary.
+    // for seconds-until-reset. The unclamped value is provably >= 1 in this
+    // branch (see below), but `Math.max(1, ...)` stays as a defense-in-depth
+    // floor so Retry-After never reads 0 if the filter logic is ever
+    // loosened. Reasoning: the deny branch requires `pruned.length >=
+    // MAX_ATTEMPTS`, which implies every entry survived the `t > cutoff`
+    // filter, i.e. `pruned[0] > now - WINDOW_MS` strictly, i.e. `resetAtMs -
+    // now > 0` strictly, i.e. `Math.ceil(positive / 1000) >= 1`.
     const resetAtMs = (pruned[0] ?? now.getTime()) + WINDOW_MS;
     const retryAfterSeconds = Math.max(1, Math.ceil((resetAtMs - now.getTime()) / 1000));
-    // Persist the prune so the bucket doesn't carry stale entries forward
-    // past their window. (Skipping this would leak a tiny amount of memory
-    // when an attacker stops hitting a denied IP.)
-    if (pruned.length === 0) buckets.delete(key);
-    else buckets.set(key, pruned);
+    // Denied attempt: the bucket is still full (>= MAX_ATTEMPTS in-window
+    // entries), so unconditionally re-store the pruned slice. Persisting the
+    // prune keeps stale entries from leaking forward past their window. We
+    // do NOT delete here — that branch is structurally unreachable in deny
+    // because deny requires a non-empty `pruned`.
+    buckets.set(key, pruned);
     return { allowed: false, retryAfterSeconds };
   }
 

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -1,0 +1,154 @@
+/**
+ * Per-IP rate-limit on `POST /admin/login`. Lands as a floor under brute-force
+ * after hub#187 collapsed the public-reach matrix: with a cloudflare tunnel
+ * up, `/admin/login` is now reachable from the open internet, and 2FA (#186)
+ * is the next PR rather than this one. A 5-attempts-per-15-minute bucket per
+ * IP is the standard login-form floor; it's not the primary defense, just the
+ * one that turns "infinite credential grinding" into "rotate IPs".
+ *
+ * Shape: sliding window. Each key keeps the last N attempt timestamps; on a
+ * new attempt we prune anything older than the window, count what remains,
+ * decide allow / deny, and (on allow) append the current timestamp. Sliding
+ * gives an exact `Retry-After` (seconds until the *oldest* in-window
+ * timestamp falls off) rather than the rough next-refill of a token bucket.
+ *
+ * Storage: process-local `Map`. Persistence isn't worth a SQLite write per
+ * attempt — process restart is itself a defense (the attacker loses all
+ * progress against any one bucket). Memory is bounded by an opportunistic
+ * sweep of empty buckets every time we touch the map, so an attacker
+ * cycling through IPs can't grow the map without also leaving timestamps in
+ * each.
+ *
+ * Auth-stage independence: callers MUST gate via `checkAndRecord` *before*
+ * the credential check. A 2FA (or password) failure should count toward the
+ * same bucket as a wrong password — an attacker who knows the password
+ * shouldn't get unlimited grinding against backup codes.
+ *
+ * Layer-independent: the limiter applies on every layer (loopback included).
+ * A buggy script hammering loopback gets 429'd just like a public attacker.
+ * The one wrinkle is `tailscale serve` proxying from `127.0.0.1`, so all
+ * tailnet logins share the loopback bucket — acceptable because tailnet is
+ * authed at the network layer and brute-force isn't the threat model there.
+ *
+ * Testable: inject the clock via `now` so the tests can advance time
+ * deterministically without `setTimeout`. Module-level state is exported via
+ * `__resetForTests` so the test file can reset between cases without
+ * recreating the module.
+ */
+
+/** Window length: 15 minutes. */
+export const WINDOW_MS = 15 * 60 * 1000;
+/** Attempts allowed per window. 6th attempt within the window is denied. */
+export const MAX_ATTEMPTS = 5;
+/** Sentinel for the IP-extraction priority chain when nothing parsed. */
+export const UNKNOWN_IP_SENTINEL = "unknown";
+
+export interface RateLimitResult {
+  /** True if the attempt is admitted; caller proceeds to credential check. */
+  allowed: boolean;
+  /**
+   * Seconds until the bucket reset (oldest in-window timestamp falls off).
+   * Only set when `allowed` is false. Always >= 1 to give a non-zero
+   * `Retry-After` header value even at the boundary.
+   */
+  retryAfterSeconds?: number;
+}
+
+/**
+ * Module-level state. `Map<key, attemptsTimestampsMs[]>`. Each array holds
+ * raw `Date.now()`-style millisecond timestamps for in-window attempts.
+ */
+const buckets: Map<string, number[]> = new Map();
+
+/**
+ * Record an attempt and return whether it's admitted. `key` is typically a
+ * client IP from `clientIpFromRequest`. `now` is injected for testability;
+ * production callers pass `new Date()`.
+ *
+ * Behavior:
+ *   - Prune timestamps older than `now - WINDOW_MS`.
+ *   - If remaining count >= MAX_ATTEMPTS, deny with `retryAfterSeconds`
+ *     pointing at the oldest in-window timestamp's age-out moment. The
+ *     denied attempt is NOT recorded — we don't want a flood of denials
+ *     pushing the reset further into the future. The window stays anchored
+ *     to the actual 5 admitted attempts.
+ *   - Otherwise admit, append the current timestamp, return allowed.
+ */
+export function checkAndRecord(key: string, now: Date): RateLimitResult {
+  const cutoff = now.getTime() - WINDOW_MS;
+  const existing = buckets.get(key) ?? [];
+  // Drop anything that fell out of the window. Mutating a copy keeps the
+  // semantics clear: `pruned` is always the in-window slice.
+  const pruned = existing.filter((t) => t > cutoff);
+
+  if (pruned.length >= MAX_ATTEMPTS) {
+    // Reset moment = oldest in-window attempt + WINDOW_MS. `pruned[0]` is
+    // the oldest because timestamps are appended in order. Subtract `now`
+    // for seconds-until-reset; clamp to >= 1 so Retry-After never reads 0
+    // at the exact boundary.
+    const resetAtMs = (pruned[0] ?? now.getTime()) + WINDOW_MS;
+    const retryAfterSeconds = Math.max(1, Math.ceil((resetAtMs - now.getTime()) / 1000));
+    // Persist the prune so the bucket doesn't carry stale entries forward
+    // past their window. (Skipping this would leak a tiny amount of memory
+    // when an attacker stops hitting a denied IP.)
+    if (pruned.length === 0) buckets.delete(key);
+    else buckets.set(key, pruned);
+    return { allowed: false, retryAfterSeconds };
+  }
+
+  pruned.push(now.getTime());
+  buckets.set(key, pruned);
+  return { allowed: true };
+}
+
+/**
+ * Test-only escape hatch. Production code never calls this; the test file
+ * uses it between cases so module-level state doesn't leak across tests.
+ */
+export function __resetForTests(): void {
+  buckets.clear();
+}
+
+/**
+ * Extract the client IP from request headers, in priority order:
+ *   1. `CF-Connecting-IP` — cloudflared sets this on every forwarded request,
+ *      and it's the actual client IP (not the cloudflare edge). This is the
+ *      authoritative source on cloudflare-fronted hubs.
+ *   2. `X-Forwarded-For` first hop — defensive fallback for any non-cloudflare
+ *      proxy fronting hub. The first comma-separated value is the original
+ *      client; later values are intermediate proxies.
+ *   3. `Forwarded` (RFC 7239) — not parsed; covered by the comment in the
+ *      issue's IP-priority list as deferred. `X-Forwarded-For` covers the
+ *      operator-deploy reality (every common reverse proxy sets it).
+ *   4. Fall through to `UNKNOWN_IP_SENTINEL`. Hub binds `127.0.0.1`, so the
+ *      "request remote addr" case the spec mentions doesn't materialize at
+ *      this layer (Bun's `requestIP` is on `Server`, not `Request`, and
+ *      everything reaching here is either loopback or proxy-injected). The
+ *      sentinel ensures the limiter always has a key — all sentinel
+ *      requests share one bucket, which is the intended bound for
+ *      direct-loopback callers (curl from the same host).
+ *
+ * Returns a trimmed string. Empty / whitespace-only header values are
+ * treated as absent.
+ */
+export function clientIpFromRequest(req: Request): string {
+  const cfConnectingIp = trimOrNull(req.headers.get("cf-connecting-ip"));
+  if (cfConnectingIp) return cfConnectingIp;
+
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) {
+    // First hop only. RFC 7239 / X-Forwarded-For convention is
+    // `client, proxy1, proxy2`; the leftmost entry is the original client.
+    const first = xff.split(",")[0];
+    const trimmed = trimOrNull(first ?? "");
+    if (trimmed) return trimmed;
+  }
+
+  return UNKNOWN_IP_SENTINEL;
+}
+
+function trimOrNull(s: string | null | undefined): string | null {
+  if (s == null) return null;
+  const t = s.trim();
+  return t.length > 0 ? t : null;
+}


### PR DESCRIPTION
## Summary

Lands a 5-attempts-per-15-minute per-IP floor under brute-force on `POST /admin/login`. Closes #185.

#187 was the architectural prerequisite: when it collapsed the tailnet/cloudflare access-control matrix into the hub, `/admin/login` started reaching every layer that admits requests at all. On a cloudflare-fronted hub that means the open internet. 2FA on login (#186) is the primary defense and ships as the next PR — this one lands first because it's small and well-bounded, and gets some of the way there for operators who upgrade before #186.

## Surface

- **`src/rate-limit.ts`** (new) — sliding-window timestamps per IP in a process-local `Map`.
  - `checkAndRecord(key: string, now: Date): RateLimitResult` — gate + record. Returns `{ allowed, retryAfterSeconds? }`. Denied attempts are NOT recorded; the window stays anchored to the 5 admitted attempts so a flood of denials can't push the reset further out.
  - `clientIpFromRequest(req: Request): string` — IP-extraction priority:
    1. `CF-Connecting-IP` (cloudflared sets this on every forwarded request — the actual client IP, not the cloudflare edge)
    2. `X-Forwarded-For` first hop (defensive fallback for any non-cloudflare proxy fronting hub)
    3. `UNKNOWN_IP_SENTINEL` so the limiter always has a key (direct-loopback callers all share one bucket — intended bound)

- **`src/admin-handlers.ts:handleAdminLoginPost`** — wires the gate **after** CSRF (so cross-site junk doesn't burn slots) but **before** the credential check. Auth-stage independent: 401s (wrong password), missing-user, and eventually 2FA failures (#186) all count toward the same bucket so an attacker who knows the password can't grind backup codes. Exhaustion returns:

  ```
  HTTP/1.1 429 Too Many Requests
  Retry-After: <seconds>
  Content-Type: text/html
  ```

- **`AdminLoginDeps`** test seam — narrow shape with just `{ now?: () => Date }`. Production callers omit it; tests inject for deterministic time control.

## Layer-independence

Rate-limit applies on every layer (loopback included). A buggy script hammering loopback should also get 429'd. `tailscale serve` proxies from `127.0.0.1`, so all tailnet logins share the loopback bucket — acceptable because tailnet is authed at the network layer and brute-force isn't the threat model there.

## Storage

In-memory `Map<ip, timestamps[]>` for the lifetime of the hub process. Persistence isn't worth a SQLite write per attempt — process restart is itself a defense (the attacker loses progress against any one bucket). Memory is bounded by an opportunistic prune on every check; sentinel-bucket sharing keeps direct-loopback noise to one entry.

## Tests

- **Unit** (`src/__tests__/rate-limit.test.ts`, 13 cases):
  - Bucket fills (5 ok, 6th 429); drains across the window; partial drain releases exactly one slot; denied attempts don't push the reset further out; `Retry-After` sanity.
  - Multi-IP independence; IPv4/IPv6/sentinel as distinct keys.
  - IP-extraction priority order; whitespace handling; empty-header fall-through.

- **Integration** (`src/__tests__/admin-handlers.test.ts`, 3 cases):
  - 6 rapid POSTs from same IP → `200/401/401/401/401/429` with `Retry-After` set.
  - Per-IP isolation: exhausting one IP's bucket doesn't affect another's.
  - Gate-fires-before-credential-check: 6 POSTs from a non-existent user yield `401×5/429` with the rate-limit body, not a credential-failure body.

## Version

`0.5.3-rc.2` → `0.5.4-rc.1`. New patch cycle, fresh RC. CHANGELOG entry under `[0.5.4-rc.1] - 2026-05-08`.

## Test plan

- [x] `bun test ./src` — 1028 pass, 0 fail.
- [x] `bun run typecheck` — clean.
- [x] `bunx biome check src/rate-limit.ts src/admin-handlers.ts src/__tests__/rate-limit.test.ts src/__tests__/admin-handlers.test.ts` — clean. (Note: 2 pre-existing biome errors on main in `src/commands/expose-public-auto.ts` — out of scope for this PR; can file as a follow-up.)
- [x] Manual smoke: started hub on port 19390, GET'd `/admin/login` to mint a CSRF cookie + token, then POSTed 6× with the cookie+token. Result: `401/401/401/401/401/429` with `retry-after: 900` on the 429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)