### PR TITLE
feat(expose): warn when 2FA not enrolled before public exposure (closes #186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.5-rc.2] - 2026-05-08
+
+Review nit fold (PR #191) — no behavior change.
+
+### Added
+
+- **Test: malformed `config.yaml` → `is2FAEnrolled()` returns `false` (`src/__tests__/expose-2fa-warning.test.ts`).** Pins the safer-fail contract — junk YAML doesn't match the regex, the probe resolves to `hasTotp: false`, and the public-exposure warning fires rather than silently suppressing. Guards against a future refactor of `auth-status.ts` quietly inverting the default.
+
 ## [0.5.5-rc.1] - 2026-05-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.5-rc.1] - 2026-05-08
+
+### Added
+
+- **`parachute expose public` warns when 2FA is not enrolled.** Lands as the next layer of defense after #188's `/admin/login` rate-limit floor. `/admin/login` became reachable across all layers (loopback / tailnet / public) when 0.5.3-rc.1 collapsed the access-control matrix into the hub; on cloudflare or Tailscale Funnel, that's the open internet, where 2FA is the difference between "password is the only wall" and "password + something-you-have." Both bringup paths (`expose-cloudflare.ts` and the public branch of `expose.ts`) now check `readVaultAuthStatus().hasTotp` after the tunnel is up but before returning, and print a contextual warning + the one-line `parachute auth 2fa enroll` remediation when 2FA is absent. Warning-only by design — hard-gating would surprise operators mid-flow; the tunnel is up regardless. Tailnet exposure is moot (tailscale-authed at the proxy) so the warning is public-layer only. (#186)
+- **`is2FAEnrolled()` + `printPublic2FAWarning()` helper module (`src/commands/expose-2fa-warning.ts`).** Wraps the existing `readVaultAuthStatus().hasTotp` probe in a focused, testable surface. Source-of-truth is vault's `config.yaml` `totp_secret` field — the hub's `users` table has no TOTP column today (it'll gain one when hub-admin login verifies TOTP against vault). The hub already forwards `parachute auth 2fa enroll` to `parachute-vault` (see `commands/auth.ts` `VAULT_FORWARDED_SUBCOMMANDS`), so the read-side stays consistent with the write-side.
+- **`vaultHome` and `vaultAuthStatus` test seams on `ExposeCloudflareOpts` and `ExposeOpts`.** Production callers omit; tests inject either a tmp `vaultHome` (so the probe reads a controlled `config.yaml`) or a pre-computed `VaultAuthStatus` (so the probe is bypassed entirely). Mirrors the pattern `expose-auth-preflight.ts` already uses for the interactive wizard.
+
+### Why this lands now
+
+Rate-limit floor (#188) caps brute-force throughput at 5 attempts / 15-minute sliding window per IP. 2FA is the primary defense once an attacker is past the floor — without TOTP, a leaked password is full admin access. The expose-public moment is the natural surfacing point: it's the only place where the operator's previously-loopback `/admin/login` becomes a public-internet target, and they're already paying attention to security copy from `printAuthGuidance` / the tailnet-public note.
+
+The warning lands ahead of hub-admin TOTP verification on `POST /admin/login` itself — that's a follow-up. Today's flow nudges operators to enroll in vault now so they're ready when verification ships, and so any operator on cloudflare-fronted hub today has the strongest practical defense available.
+
 ## [0.5.4-rc.2] - 2026-05-08
 
 Review nit fold (PR #188) — no behavior change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.5-rc.1",
+  "version": "0.5.5-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.4-rc.2",
+  "version": "0.5.5-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/expose-2fa-warning.test.ts
+++ b/src/__tests__/expose-2fa-warning.test.ts
@@ -53,6 +53,21 @@ describe("is2FAEnrolled", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  test("malformed config.yaml → not enrolled (safer fail mode, fires warning)", () => {
+    // The probe parses config.yaml with a line-anchored regex (no YAML
+    // dependency), so junk content simply doesn't match `totp_secret: "..."`
+    // and resolves to `hasTotp: false` — which fires the public-exposure
+    // warning rather than silently suppressing it. Pin that contract so a
+    // future refactor of auth-status.ts can't quietly invert it.
+    const dir = mkdtempSync(join(tmpdir(), "pcli-2fa-warn-"));
+    try {
+      writeFileSync(join(dir, "config.yaml"), "totp_secret: [unbalanced\n  ::: not yaml\n");
+      expect(is2FAEnrolled({ vaultHome: dir })).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("printPublic2FAWarning", () => {

--- a/src/__tests__/expose-2fa-warning.test.ts
+++ b/src/__tests__/expose-2fa-warning.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { is2FAEnrolled, printPublic2FAWarning } from "../commands/expose-2fa-warning.ts";
+import type { VaultAuthStatus } from "../vault/auth-status.ts";
+
+function status(partial: Partial<VaultAuthStatus> = {}): VaultAuthStatus {
+  return {
+    hasOwnerPassword: false,
+    hasTotp: false,
+    tokenCount: 0,
+    vaultNames: [],
+    ...partial,
+  };
+}
+
+describe("is2FAEnrolled", () => {
+  test("returns true when status carries hasTotp: true", () => {
+    expect(is2FAEnrolled({ status: status({ hasTotp: true }) })).toBe(true);
+  });
+
+  test("returns false when status carries hasTotp: false", () => {
+    expect(is2FAEnrolled({ status: status({ hasTotp: false }) })).toBe(false);
+  });
+
+  test("reads totp_secret from vaultHome's config.yaml when status not supplied", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pcli-2fa-warn-"));
+    try {
+      writeFileSync(join(dir, "config.yaml"), 'totp_secret: "JBSWY3DPEHPK3PXP"\n');
+      expect(is2FAEnrolled({ vaultHome: dir })).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("missing config.yaml → not enrolled (false)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pcli-2fa-warn-"));
+    try {
+      // No config.yaml written.
+      expect(is2FAEnrolled({ vaultHome: dir })).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("empty totp_secret value → not enrolled (matches vault's readGlobalConfig)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pcli-2fa-warn-"));
+    try {
+      writeFileSync(join(dir, "config.yaml"), 'totp_secret: ""\n');
+      expect(is2FAEnrolled({ vaultHome: dir })).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("printPublic2FAWarning", () => {
+  test("not enrolled → fires warning, returns true", () => {
+    const logs: string[] = [];
+    const fired = printPublic2FAWarning({
+      status: status({ hasTotp: false }),
+      log: (l) => logs.push(l),
+      publicUrl: "https://vault.example.com",
+    });
+    expect(fired).toBe(true);
+    const joined = logs.join("\n");
+    expect(joined).toContain("2FA is not enrolled");
+    expect(joined).toContain("https://vault.example.com/admin/login");
+    expect(joined).toContain("parachute auth 2fa enroll");
+  });
+
+  test("enrolled → suppressed, returns false, logs nothing", () => {
+    const logs: string[] = [];
+    const fired = printPublic2FAWarning({
+      status: status({ hasTotp: true }),
+      log: (l) => logs.push(l),
+      publicUrl: "https://vault.example.com",
+    });
+    expect(fired).toBe(false);
+    expect(logs).toEqual([]);
+  });
+
+  test("password-also-missing case still fires (warning is layer-independent of password state)", () => {
+    // The wide-open state (no password, no 2FA) hits this branch too — the
+    // hub's own `printAuthGuidance` (cloudflare) and `runAuthPreflight`
+    // (interactive wizard) cover the password remediation; this warning is
+    // strictly about 2FA.
+    const logs: string[] = [];
+    const fired = printPublic2FAWarning({
+      status: status({ hasOwnerPassword: false, hasTotp: false }),
+      log: (l) => logs.push(l),
+      publicUrl: "https://vault.example.com",
+    });
+    expect(fired).toBe(true);
+    expect(logs.some((l) => l.includes("2FA is not enrolled"))).toBe(true);
+  });
+
+  test("embeds the supplied publicUrl into the /admin/login pointer", () => {
+    const logs: string[] = [];
+    printPublic2FAWarning({
+      status: status({ hasTotp: false }),
+      log: (l) => logs.push(l),
+      publicUrl: "https://parachute.taildf9ce2.ts.net",
+    });
+    expect(logs.some((l) => l.includes("https://parachute.taildf9ce2.ts.net/admin/login"))).toBe(
+      true,
+    );
+  });
+});

--- a/src/__tests__/expose-cloudflare.test.ts
+++ b/src/__tests__/expose-cloudflare.test.ts
@@ -511,6 +511,107 @@ describe("exposeCloudflareUp", () => {
       env.cleanup();
     }
   });
+
+  // 2FA-enrollment warning (#186). The cloudflare path is always public —
+  // every successful bringup makes /admin/login reachable on the open
+  // internet, where 2FA is the primary defense beyond #188's rate-limit floor.
+  describe("2FA-enrollment warning", () => {
+    test("not enrolled → warning fires after the success block", async () => {
+      const env = makeEnv();
+      try {
+        const uuid = "cccccccc-0000-0000-0000-000000000003";
+        const { runner } = queueRunner([
+          { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
+          { code: 0, stdout: "[]", stderr: "" },
+          {
+            code: 0,
+            stdout: `Tunnel credentials written to ${env.cloudflaredHome}/${uuid}.json.\nCreated tunnel parachute with id ${uuid}\n`,
+            stderr: "",
+          },
+          { code: 0, stdout: "", stderr: "" },
+        ]);
+        const { spawner } = fakeSpawner(42100);
+        const logs: string[] = [];
+
+        const code = await exposeCloudflareUp("vault.example.com", {
+          runner,
+          spawner,
+          alive: () => false,
+          kill: () => {},
+          log: (l) => logs.push(l),
+          manifestPath: env.manifestPath,
+          statePath: env.statePath,
+          configPath: env.configPath,
+          logPath: env.logPath,
+          cloudflaredHome: env.cloudflaredHome,
+          // No password, no 2FA — fully wide open. The warning should still
+          // fire; password-recovery copy already lives in `printAuthGuidance`.
+          vaultAuthStatus: {
+            hasOwnerPassword: false,
+            hasTotp: false,
+            tokenCount: 0,
+            vaultNames: [],
+          },
+        });
+
+        expect(code).toBe(0);
+        const joined = logs.join("\n");
+        expect(joined).toContain("2FA is not enrolled");
+        expect(joined).toContain("https://vault.example.com/admin/login");
+        expect(joined).toContain("parachute auth 2fa enroll");
+      } finally {
+        env.cleanup();
+      }
+    });
+
+    test("enrolled → warning suppressed (no '2FA is not enrolled' line)", async () => {
+      const env = makeEnv();
+      try {
+        const uuid = "dddddddd-0000-0000-0000-000000000004";
+        const { runner } = queueRunner([
+          { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
+          { code: 0, stdout: "[]", stderr: "" },
+          {
+            code: 0,
+            stdout: `Tunnel credentials written to ${env.cloudflaredHome}/${uuid}.json.\nCreated tunnel parachute with id ${uuid}\n`,
+            stderr: "",
+          },
+          { code: 0, stdout: "", stderr: "" },
+        ]);
+        const { spawner } = fakeSpawner(42101);
+        const logs: string[] = [];
+
+        const code = await exposeCloudflareUp("vault.example.com", {
+          runner,
+          spawner,
+          alive: () => false,
+          kill: () => {},
+          log: (l) => logs.push(l),
+          manifestPath: env.manifestPath,
+          statePath: env.statePath,
+          configPath: env.configPath,
+          logPath: env.logPath,
+          cloudflaredHome: env.cloudflaredHome,
+          vaultAuthStatus: {
+            hasOwnerPassword: true,
+            hasTotp: true,
+            tokenCount: 1,
+            vaultNames: ["default"],
+          },
+        });
+
+        expect(code).toBe(0);
+        const joined = logs.join("\n");
+        expect(joined).not.toContain("2FA is not enrolled");
+        // The existing `printAuthGuidance` 2FA-recommend bullet is unrelated
+        // to the new contextual warning and stays in place — assert it on a
+        // shape that doesn't collide with the warning text.
+        expect(joined).toContain("(recommended) TOTP + backup codes");
+      } finally {
+        env.cleanup();
+      }
+    });
+  });
 });
 
 describe("exposeCloudflareOff", () => {

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -570,6 +570,41 @@ describe("expose tailnet up", () => {
       h.cleanup();
     }
   });
+
+  // 2FA warning is public-layer only (#186). Tailnet ingress is
+  // tailscale-authed at the proxy, so /admin/login isn't on the open
+  // internet — the warning is moot here even when 2FA is unset.
+  test("tailnet bringup does NOT fire the 2FA warning even when not enrolled", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      const { runner } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const logs: string[] = [];
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        log: (l) => logs.push(l),
+        vaultAuthStatus: {
+          hasOwnerPassword: false,
+          hasTotp: false,
+          tokenCount: 0,
+          vaultNames: [],
+        },
+      });
+      expect(code).toBe(0);
+      expect(logs.join("\n")).not.toContain("2FA is not enrolled");
+    } finally {
+      h.cleanup();
+    }
+  });
 });
 
 describe("expose tailnet off", () => {
@@ -891,6 +926,77 @@ describe("expose public up", () => {
       expect(offs).toHaveLength(1);
       const state = readExposeState(h.statePath);
       expect(state?.layer).toBe("public");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // 2FA-enrollment warning (#186). Funnel exposure makes /admin/login
+  // reachable on the open internet just like cloudflare; the warning lives in
+  // a shared helper (`expose-2fa-warning.ts`) wired into both paths.
+  test("2FA not enrolled → warning fires on the public layer", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      const { runner } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const logs: string[] = [];
+      const code = await exposePublic("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        log: (l) => logs.push(l),
+        vaultAuthStatus: {
+          hasOwnerPassword: true,
+          hasTotp: false,
+          tokenCount: 0,
+          vaultNames: ["default"],
+        },
+      });
+      expect(code).toBe(0);
+      const joined = logs.join("\n");
+      expect(joined).toContain("2FA is not enrolled");
+      expect(joined).toContain("parachute auth 2fa enroll");
+      // /admin/login pointer uses the canonical https://<fqdn> origin.
+      expect(joined).toContain("https://parachute.taildf9ce2.ts.net/admin/login");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("2FA enrolled → warning suppressed on the public layer", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      const { runner } = makeRunner();
+      const { spawner } = makeHubSpawner(1111);
+      const logs: string[] = [];
+      const code = await exposePublic("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubEnsureOpts: hubEnsureOpts(spawner),
+        servicePortProbe: allServicesUp,
+        log: (l) => logs.push(l),
+        vaultAuthStatus: {
+          hasOwnerPassword: true,
+          hasTotp: true,
+          tokenCount: 1,
+          vaultNames: ["default"],
+        },
+      });
+      expect(code).toBe(0);
+      expect(logs.join("\n")).not.toContain("2FA is not enrolled");
     } finally {
       h.cleanup();
     }

--- a/src/commands/expose-2fa-warning.ts
+++ b/src/commands/expose-2fa-warning.ts
@@ -1,0 +1,82 @@
+/**
+ * Public-exposure 2FA-enrollment warning (#186). Lands as the next layer of
+ * defense after #188's `/admin/login` rate-limit floor: once the operator
+ * brings up cloudflare or Tailscale Funnel, `/admin/login` is reachable from
+ * the public internet on every layer admitting traffic. 2FA is the difference
+ * between "password is the only wall" and "password + something-you-have."
+ *
+ * Why this is a warning, not a hard gate: hard-gating would surprise operators
+ * mid-flow — they ran `parachute expose public` to expose, not to be told
+ * "set up 2FA first." A loud, contextual warning + a clear one-line
+ * remediation is the right shape; the operator decides whether to act now or
+ * later. The tunnel is up regardless.
+ *
+ * Why the source-of-truth is vault's `config.yaml`: 2FA enrollment lives in
+ * `parachute-vault` (the hub forwards `parachute auth 2fa enroll` to vault —
+ * see `commands/auth.ts` `VAULT_FORWARDED_SUBCOMMANDS`). The hub's `users`
+ * table has no TOTP column today; it will gain one when hub-admin login
+ * verifies TOTP against vault. Until then, "is 2FA enrolled?" maps cleanly
+ * to "does vault's config.yaml carry a non-empty `totp_secret`?", which is
+ * exactly what `readVaultAuthStatus().hasTotp` returns.
+ *
+ * If vault isn't installed at all (rare for the cloudflare path — it requires
+ * a vault entry — but possible on the tailnet/funnel path): `hasTotp` comes
+ * back `false` and the warning still fires. The remediation
+ * `parachute auth 2fa enroll` then surfaces vault's "install vault first"
+ * error, which is the right next step regardless.
+ */
+
+import { type VaultAuthStatus, readVaultAuthStatus } from "../vault/auth-status.ts";
+
+export interface Public2FAWarningOpts {
+  /** Pre-computed status to skip on-disk probe (tests). Production omits. */
+  status?: VaultAuthStatus;
+  /** Forwarded to {@link readVaultAuthStatus} when `status` is not supplied. */
+  vaultHome?: string;
+  /** Sink for the warning lines. Defaults to console.log. */
+  log?: (line: string) => void;
+  /** Public URL the operator just brought up — embedded in the warning. */
+  publicUrl: string;
+}
+
+/**
+ * `true` when `totp_secret` is present and non-empty in vault's config.yaml,
+ * `false` otherwise (missing vault, missing config.yaml, empty value).
+ *
+ * Source-of-truth note: TOTP storage is the vault's, not the hub's. See the
+ * module-level doc comment.
+ */
+export function is2FAEnrolled(
+  opts: { vaultHome?: string; status?: VaultAuthStatus } = {},
+): boolean {
+  const status =
+    opts.status ?? readVaultAuthStatus(opts.vaultHome ? { vaultHome: opts.vaultHome } : {});
+  return status.hasTotp;
+}
+
+/**
+ * Print a 2FA-enrollment warning to `log` when not enrolled. No-op when
+ * enrolled. Returns `true` if the warning fired, `false` if suppressed —
+ * primarily to make integration tests assert the branch without scraping log
+ * text.
+ */
+export function printPublic2FAWarning(opts: Public2FAWarningOpts): boolean {
+  const log = opts.log ?? ((line: string) => console.log(line));
+  if (
+    is2FAEnrolled({
+      ...(opts.vaultHome ? { vaultHome: opts.vaultHome } : {}),
+      ...(opts.status ? { status: opts.status } : {}),
+    })
+  ) {
+    return false;
+  }
+  log("");
+  log("⚠ 2FA is not enrolled. /admin is now reachable on the public internet");
+  log(`  (${opts.publicUrl}/admin/login). Anyone who guesses your password`);
+  log("  is in. Strongly recommended:");
+  log("");
+  log("    parachute auth 2fa enroll");
+  log("");
+  log("  Adds TOTP + backup codes. Takes 30 seconds.");
+  return true;
+}

--- a/src/commands/expose-cloudflare.ts
+++ b/src/commands/expose-cloudflare.ts
@@ -30,6 +30,8 @@ import { SERVICES_MANIFEST_PATH } from "../config.ts";
 import { type AliveFn, defaultAlive } from "../process-state.ts";
 import { readManifest } from "../services-manifest.ts";
 import { type Runner, defaultRunner } from "../tailscale/run.ts";
+import type { VaultAuthStatus } from "../vault/auth-status.ts";
+import { printPublic2FAWarning } from "./expose-2fa-warning.ts";
 
 const AUTH_DOC_URL =
   "https://github.com/ParachuteComputer/parachute-vault/blob/main/docs/auth-model.md";
@@ -106,6 +108,18 @@ export interface ExposeCloudflareOpts {
   /** Override `~/.cloudflared` for tests and `$HOME`-free environments. */
   cloudflaredHome?: string;
   now?: () => Date;
+  /**
+   * Override `~/.parachute/vault` for the 2FA-enrollment probe. Tests
+   * point at a tmp dir; production omits and the probe defaults to the
+   * resolved vault home. (#186)
+   */
+  vaultHome?: string;
+  /**
+   * Pre-computed vault auth status, primarily for tests. When set,
+   * `printPublic2FAWarning` consults this instead of reading
+   * `<vaultHome>/config.yaml` from disk. (#186)
+   */
+  vaultAuthStatus?: VaultAuthStatus;
 }
 
 interface Resolved {
@@ -121,6 +135,8 @@ interface Resolved {
   logPath: string;
   cloudflaredHome: string;
   now: () => Date;
+  vaultHome: string | undefined;
+  vaultAuthStatus: VaultAuthStatus | undefined;
 }
 
 function resolve(opts: ExposeCloudflareOpts): Resolved {
@@ -139,6 +155,8 @@ function resolve(opts: ExposeCloudflareOpts): Resolved {
     logPath: opts.logPath ?? paths.logPath,
     cloudflaredHome: opts.cloudflaredHome ?? DEFAULT_CLOUDFLARED_HOME,
     now: opts.now ?? (() => new Date()),
+    vaultHome: opts.vaultHome,
+    vaultAuthStatus: opts.vaultAuthStatus,
   };
 }
 
@@ -313,6 +331,15 @@ export async function exposeCloudflareUp(
   r.log("Point a claude.ai / ChatGPT connector at:");
   r.log(`  ${vaultUrl}`);
   printAuthGuidance(r.log, vaultUrl);
+  // 2FA-enrollment warning when /admin/login is now reachable on the public
+  // internet but the operator hasn't enrolled TOTP. Cloudflare exposure is
+  // always public; tailnet/funnel mirrors this in `expose.ts`. See #186.
+  printPublic2FAWarning({
+    log: r.log,
+    publicUrl: baseUrl,
+    ...(r.vaultHome !== undefined ? { vaultHome: r.vaultHome } : {}),
+    ...(r.vaultAuthStatus !== undefined ? { status: r.vaultAuthStatus } : {}),
+  });
   return 0;
 }
 

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -24,6 +24,7 @@ import { type ServiceEntry, readManifest } from "../services-manifest.ts";
 import { type ServeEntry, bringupCommand, teardownCommand } from "../tailscale/commands.ts";
 import { getFqdn, isTailscaleInstalled } from "../tailscale/detect.ts";
 import { type Runner, defaultRunner } from "../tailscale/run.ts";
+import type { VaultAuthStatus } from "../vault/auth-status.ts";
 import {
   WELL_KNOWN_DIR,
   WELL_KNOWN_MOUNT,
@@ -32,6 +33,7 @@ import {
   shortName,
   writeWellKnownFile,
 } from "../well-known.ts";
+import { printPublic2FAWarning } from "./expose-2fa-warning.ts";
 import { restart } from "./lifecycle.ts";
 
 /**
@@ -98,6 +100,18 @@ export interface ExposeOpts {
    * spawning real child processes.
    */
   restartService?: (short: string) => Promise<number>;
+  /**
+   * Override `~/.parachute/vault` for the 2FA-enrollment probe on the public
+   * (Funnel) layer. Tests point at a tmp dir; production omits and the probe
+   * defaults to the resolved vault home. (#186)
+   */
+  vaultHome?: string;
+  /**
+   * Pre-computed vault auth status, primarily for tests. When set,
+   * `printPublic2FAWarning` consults this instead of reading
+   * `<vaultHome>/config.yaml` from disk. (#186)
+   */
+  vaultAuthStatus?: VaultAuthStatus;
 }
 
 /**
@@ -356,6 +370,20 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
   }
   log(`  Discovery: ${canonicalOrigin}${WELL_KNOWN_MOUNT}`);
   log(`  OAuth issuer: ${hubOrigin}`);
+
+  // 2FA-enrollment warning, public-layer only. /admin/login became reachable
+  // from every layer when 0.5.3-rc.1 collapsed the access-control matrix into
+  // the hub; on Funnel that means the open internet, where 2FA is the
+  // defense beyond #188's rate-limit floor. Tailnet exposure stays
+  // tailscale-authed at the ingress so the warning is moot there. See #186.
+  if (layer === "public") {
+    printPublic2FAWarning({
+      log,
+      publicUrl: canonicalOrigin,
+      ...(opts.vaultHome !== undefined ? { vaultHome: opts.vaultHome } : {}),
+      ...(opts.vaultAuthStatus !== undefined ? { status: opts.vaultAuthStatus } : {}),
+    });
+  }
 
   // Auto-restart services that cache the hub origin. Aaron hit this on launch
   // day: after `expose public` first-run, vault kept its stale (loopback)


### PR DESCRIPTION
## Summary

Adds a contextual 2FA-enrollment warning to both `parachute expose public` bringup paths (cloudflare and Tailscale Funnel) when vault's `config.yaml` has no `totp_secret`. Lands as the next layer of defense after #188's rate-limit floor — once cloudflare/funnel exposes `/admin/login` on the open internet, 2FA is the difference between *password is the only wall* and *password + something-you-have*.

Closes #186. Architectural prereq #187 made `/admin/login` reachable across all layers; #188 added the rate-limit floor; this is the 2FA layer of the same defense-in-depth stack.

## The access-control matrix this complements

From #187's commit, the matrix that this warning targets:

| Layer | `/admin/login` reachable? | Defense |
|---|---|---|
| loopback | yes | password (local-only attacker model) |
| tailnet | yes | password + tailscale identity at proxy |
| **public** (cloudflare/funnel) | **yes** | **password + #188 rate-limit floor + #186 (this PR) 2FA warning** |

## What this PR does

1. **New helper module** `src/commands/expose-2fa-warning.ts` exporting `is2FAEnrolled()` and `printPublic2FAWarning()`. Source-of-truth is vault's `config.yaml` `totp_secret` — the hub's `users` table has no TOTP column today (will gain one when hub-admin login verifies TOTP against vault). The hub already forwards `parachute auth 2fa enroll` to `parachute-vault`, so the read-side stays consistent with the existing write-side.
2. **`exposeCloudflareUp`** (`src/commands/expose-cloudflare.ts`) calls `printPublic2FAWarning(...)` after `printAuthGuidance(...)`. Cloudflare exposure is always public, so the call is unconditional.
3. **`exposeUp`** (`src/commands/expose.ts`) calls `printPublic2FAWarning(...)` after the success message **only when `layer === "public"`**. Tailnet exposure is tailscale-authed at the proxy so the warning is moot there.
4. **Test seams**: `vaultHome` and `vaultAuthStatus` added to `ExposeCloudflareOpts` and `ExposeOpts`. Production callers omit; tests inject either a tmp `vaultHome` (real disk read) or a pre-computed `VaultAuthStatus` (probe bypass). Mirrors the pattern `expose-auth-preflight.ts` already uses.

## Why warning-only (not a hard gate)

The spec calls this out explicitly. Hard-gating would surprise operators mid-flow — they ran `parachute expose public` to expose, not to be told "set up 2FA first." A loud, contextual warning + a clear one-line remediation (`parachute auth 2fa enroll`) is the right shape; the operator decides whether to act now or later. The tunnel is up regardless.

## Test plan

- [x] Unit: `is2FAEnrolled` returns `true` when `totp_secret` set, `false` otherwise (4 tests covering: status injection, real-disk read, missing config.yaml, empty value).
- [x] Unit: `printPublic2FAWarning` fires when not enrolled, suppresses when enrolled, embeds the supplied `publicUrl` correctly (4 tests).
- [x] Integration (cloudflare): warning fires when `vaultAuthStatus` reports no TOTP; suppressed when enrolled. Existing `printAuthGuidance` 2FA-recommend bullet stays in place.
- [x] Integration (`exposeUp`): public-layer warning fires when not enrolled; suppressed when enrolled; tailnet bringup never fires the warning even with no TOTP.
- [x] Smoke: invoked the helper end-to-end against real disk. With `~/.parachute/vault/config.yaml` carrying `totp_secret` (Aaron's actual state) → suppressed. With tmp `vaultHome` (no config.yaml) → warning fires verbatim with the correct URL embedded.
- [x] All 1044 tests pass via `bun test ./src` (canonical invocation per #190; was 1030 pre-PR).
- [x] `bun run typecheck` clean.
- [x] `bunx biome check` clean for files touched by this PR. (Two pre-existing biome errors in `src/commands/expose-public-auto.ts` are unrelated to this change and out of scope.)

## Out of scope

- Hub-admin TOTP verification on `POST /admin/login` itself — follow-up PR. Today's flow nudges operators to enroll in vault now so they're ready when verification ships.
- Two stale-comment follow-ups (#189 stale `effectivePublicExposure` comment, patterns#41 stale parachute-cli link).
- Test-script canonicalization (#190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)