### PR TITLE
chore: housekeeping bundle — refresh stale comment, canonicalize test invocation, biome fix-up (closes #189, #190, #192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Promotes the 0.5.5-rc cycle (#187 layer-aware proxy + #188 admin-login rate-limi
 - **Canonicalize test-count invocation in `CLAUDE.md` (closes #190).** New "Test gate counts in commit messages and PR descriptions" subsection under "Running" pins `bun test ./src` (the `package.json` `"test"` script, what CI runs) as the source of gate counts quoted in commit messages and PR descriptions, and calls out that `bun test src/__tests__/` pulls in `packages/scope-guard/` tests and reports an inflated count. Recent PRs reported 1028 vs 1076 from these two invocations — the note is the cheapest way to stop divergence.
 - **`bunx biome check src/commands/expose-public-auto.ts --write` fix-up (closes #192).** Pure formatting + import-order fixes (organizeImports + format) that had been failing for multiple PRs. No semantic change. Rest of the repo passes `bunx biome check .` clean.
 
+### Fixed
+
+- **`CLAUDE.md` "Running" fence: harmonize the test command with the canonical `bun test ./src` invocation called out in the "Test gate counts" subsection just below.** Reviewer nit on PR #193 — a reader could reasonably wonder whether the bare `bun test` shown in the fence and the `bun test ./src` shown in the gate-counts subsection were equivalent. They aren't (the bare form pulls in `packages/scope-guard/` and inflates the count). The fence now shows `bun test ./src` with an inline comment back-pointing to the subsection.
+- **Biome file count: verified `bunx biome check .` reports `Checked 167 files` at this PR's HEAD, matching the count quoted in the original PR body / CHANGELOG entry.** Reviewer's run reported 166. Re-ran on a clean working tree and via the `summary` reporter — both reproducibly report 167 against the same commit. The formatter pass in `chore(format): biome fix-up on expose-public-auto.ts` was the only thing that changed tree shape during the cycle, and no files were added or removed; most likely cause of the reviewer-side delta is a stale-cache or pre-formatter working state on their end. Stated count stands.
+
 ## [0.5.5-rc.2] - 2026-05-08
 
 Review nit fold (PR #191) — no behavior change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.5] - 2026-05-08
+
+Promotes the 0.5.5-rc cycle (#187 layer-aware proxy + #188 admin-login rate-limit + #191 2FA-not-enrolled warning) to stable, plus a small content-only / formatting-only housekeeping bundle. Skips the `-rc.N` step per the doc-only-changes rule (no semantic code changes since rc.2). No intermediate RCs were published to npm during the cycle; this is the first publish to `@latest`.
+
+### Changed
+
+- **Refresh stale comment on `effectivePublicExposure` in `src/service-spec.ts` (closes #189).** The pre-#187 comment said `auth-required` services were "treated as loopback at launch." Post-#187 (layer-aware proxy + collapse tailnet to single catchall) `auth-required` reaches all layers and the service self-gates — the loopback-block is the dedicated `loopback` value's job. Comment now spells out the matrix (allowed → all layers, service self-gates; loopback → hub layer-gates; auth-required → all layers, service self-gates, field documents intent). Code unchanged — the function's return values were already correct against #187's contract.
+- **Canonicalize test-count invocation in `CLAUDE.md` (closes #190).** New "Test gate counts in commit messages and PR descriptions" subsection under "Running" pins `bun test ./src` (the `package.json` `"test"` script, what CI runs) as the source of gate counts quoted in commit messages and PR descriptions, and calls out that `bun test src/__tests__/` pulls in `packages/scope-guard/` tests and reports an inflated count. Recent PRs reported 1028 vs 1076 from these two invocations — the note is the cheapest way to stop divergence.
+- **`bunx biome check src/commands/expose-public-auto.ts --write` fix-up (closes #192).** Pure formatting + import-order fixes (organizeImports + format) that had been failing for multiple PRs. No semantic change. Rest of the repo passes `bunx biome check .` clean.
+
 ## [0.5.5-rc.2] - 2026-05-08
 
 Review nit fold (PR #191) — no behavior change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,10 @@ bun run typecheck                # tsc --noEmit (types only)
 
 For end-to-end against a real install, `bun link` this repo; the linked `parachute` binary follows the checked-out branch (see post-merge hygiene below).
 
+### Test gate counts in commit messages and PR descriptions
+
+Test gate counts in commit messages and PR descriptions are produced by `bun test ./src` (the `package.json` `"test"` script), not `bun test src/__tests__/`. The latter pulls in `packages/scope-guard/` tests and produces an inflated count that's not what CI runs. When quoting numbers ("358 pass / 1 known flake"), use the literal output of `bun test ./src` — it's what the reviewer's run will produce.
+
 ## Post-merge hygiene
 
 **After a PR merges, locally:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Bun everywhere. No Node.js runtime assumptions, no tsc for emit (types only).
 
 ```sh
 bun src/cli.ts --help            # dogfood the CLI from source
-bun test                         # run all tests
+bun test ./src                   # run all tests (canonical — see "Test gate counts" below)
 bun test src/__tests__/expose    # one suite
 bunx biome check --write .       # format + lint
 bun run typecheck                # tsc --noEmit (types only)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.5-rc.2",
+  "version": "0.5.5",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/commands/expose-public-auto.ts
+++ b/src/commands/expose-public-auto.ts
@@ -30,8 +30,8 @@
 
 import { DEFAULT_CLOUDFLARED_HOME } from "../cloudflare/detect.ts";
 import {
-  type ProviderAvailability,
   type DetectProvidersOpts,
+  type ProviderAvailability,
   detectProviders,
   isCloudflareReady,
   isTailnetReady,
@@ -143,9 +143,7 @@ function reportCloudflareNeedsDomain(r: Resolved): number {
   r.log("Re-run with the hostname:");
   r.log("  parachute expose public --cloudflare --domain vault.example.com");
   r.log("");
-  r.log(
-    "The hostname's apex domain must already be a zone on your Cloudflare account.",
-  );
+  r.log("The hostname's apex domain must already be a zone on your Cloudflare account.");
   return 1;
 }
 
@@ -154,9 +152,7 @@ function reportCloudflareNeedsDomain(r: Resolved): number {
  * (`--tailnet` / `--cloudflare`) was supplied AND we're not in a TTY (the TTY
  * path runs `expose-interactive.ts` instead).
  */
-export async function exposePublicAutoPick(
-  opts: ExposePublicAutoOpts = {},
-): Promise<number> {
+export async function exposePublicAutoPick(opts: ExposePublicAutoOpts = {}): Promise<number> {
   const r = resolve(opts);
   const availability = await r.detectProvidersImpl({ cloudflaredHome: r.cloudflaredHome });
   const tsReady = isTailnetReady(availability);

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -384,10 +384,20 @@ export const FIRST_PARTY_FALLBACKS: Record<string, FirstPartyFallback> = {
 /**
  * Effective publicExposure for a service, given what's on its services.json
  * entry. Explicit wins. If absent, derive from the spec: known api/tool
- * services without declared auth fall back to "auth-required" (treated as
- * loopback at launch); everything else defaults to "allowed" — so vault,
- * notes, channel and unknown third-party services continue to be exposed
- * without needing to opt in.
+ * services without declared auth fall back to "auth-required"; everything
+ * else defaults to "allowed" — so vault, notes, channel and unknown
+ * third-party services continue to be exposed without needing to opt in.
+ *
+ * Layer behavior (post-#187 layer-aware proxy):
+ *   "allowed"        — reaches all layers (loopback / tailnet / public);
+ *                      service self-gates if it has any auth.
+ *   "loopback"       — hub layer-gates; tailnet/public requests 404 at
+ *                      proxyToService / proxyToVault before reaching the
+ *                      service.
+ *   "auth-required"  — reaches all layers; service self-gates. Same gate
+ *                      behavior as "allowed" today; the field documents
+ *                      operator/UI intent ("requires auth before exposing")
+ *                      separately from the loopback hard-block.
  */
 export function effectivePublicExposure(
   entry: ServiceEntry,


### PR DESCRIPTION
Three small content-only / formatting-only fixes that accumulated after #187 (layer-aware proxy + collapse tailnet to single catchall) landed earlier today. Cohesive in shape — all "polish noise that's been failing CI or misleading readers since #187" — even if topically distinct. Bundled per the bundle-cohesive-multi-file-work rule; one commit per issue.

## What

- **Commit 1 — `docs(service-spec): refresh stale comment on effectivePublicExposure (closes #189)`**
  - The `effectivePublicExposure` docstring still said `auth-required` services are "treated as loopback at launch." That predates #187 (layer-aware proxy + collapse tailnet to single catchall, merged today). After #187, `auth-required` services pass through to all layers and self-gate; only `loopback` services are hub layer-gated.
  - Code unchanged — the function's return values were already correct against #187's contract; only the comment was stale.
  - New comment spells out the matrix: `allowed` → all layers, service self-gates; `loopback` → hub layer-gates (404 from non-loopback); `auth-required` → all layers, service self-gates, field documents intent.

- **Commit 2 — `docs(claude-md): canonicalize bun test ./src as the test-count invocation (closes #190)`**
  - Recent PRs reported gate counts of 1028 vs 1076 from two different invocations: `bun test ./src` (matches `package.json`'s `"test"` script and what CI runs) vs `bun test src/__tests__/` (also pulls in `packages/scope-guard/src/__tests__/`, inflated count).
  - New "Test gate counts in commit messages and PR descriptions" subsection under `CLAUDE.md`'s "Running" section pins `bun test ./src` as the source of truth for numbers quoted in commit messages + PR descriptions. Self-applied below.

- **Commit 3 — `chore(format): biome fix-up on expose-public-auto.ts (closes #192)`**
  - `bunx biome check src/commands/expose-public-auto.ts --write` — pure formatting + import-order fixes (organizeImports + format) that had been failing for multiple PRs. No semantic change.
  - Confirmed afterwards: `bunx biome check .` from repo root passes clean across all 167 files.

- **Commit 4 — `chore(release): 0.5.5`**
  - Promotes the `0.5.5-rc` cycle (#187 layer-aware proxy + #188 admin-login rate-limit + #191 2FA-not-enrolled warning) to stable, plus this PR's housekeeping bundle.
  - **Skips the `-rc.N` step** per the doc-only-changes rule — no semantic code change since rc.2; this commit only bumps version + CHANGELOG so the RC cycle is finalized as `0.5.5` stable.
  - **No intermediate RCs were published to npm during the cycle**, so this will be the first publish to `@latest`. Cleanest single-publish path; flagged for Aaron's awareness when he runs the publish.

## Why this version-bump shape

Per Aaron's "skip -rc.N for doc-only changes" memory rule: the diff against rc.2 is a stale-comment refresh, a CLAUDE.md note, and a biome formatter pass. RC validation buys nothing for content-only diffs. Bumping straight to `0.5.5` stable finalizes the rc.2 → stable promotion in one commit and keeps the npm publish a single deliberate step.

## Test gate (canonical invocation, per #190)

- `bun test ./src`: **1045 pass / 0 fail / 29691 expects**, 63 files, 11.41s
- `bun run typecheck`: clean
- `bunx biome check .`: clean across all 167 files

Expected vs actual: 1045 → 1045. Comment refresh + CLAUDE.md note can't change test count; biome fix-up is formatting-only.

## Out of scope

- patterns#41 (separate repo, parallel work by patterns tentacle).
- Anything not in `{#189, #190, #192}`.