### PR TITLE
fix(hub-server): proxy dispatch edge cases — trailing-slash matcher + FIRST_PARTY_FALLBACKS stripPrefix (closes #196, #197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.6-rc.1] - 2026-05-08
+
+Bundled fix for two `proxyToService` / `proxyToVault` dispatch edge cases that hub#187's tests missed. Both surfaced during operator diagnostics on Aaron's box (2026-05-08); both make the hub silently 404 a real on-box backend.
+
+### Fixed
+
+- **Trailing-slash mount paths now match sub-paths in `findServiceUpstream` / `findVaultUpstream` (closes #197).** A services.json entry written with `paths: ["/notes/"]` (trailing slash) used to match only the exact pathname `/notes/` and never any sub-path, because `pathname.startsWith("/notes//")` is always false (URLs don't have double slashes). Operator-visible symptom on Aaron's box: notes blank screen — the SPA shell loaded at `/notes/` but every `/notes/assets/*.js` request 404'd from hub. Fix: normalize trailing slashes (`path.replace(/\/+$/, "") || "/"`) before the equality + prefix check, in both matchers. The `|| "/"` branch keeps a bare-root mount `"/"` stable rather than collapsing to the empty string. The reported `match.mount` is the normalized form so callers computing `pathname.slice(match.mount.length)` (the stripPrefix path) get a consistent answer regardless of how the entry was written on disk.
+- **`proxyToService` / `proxyToVault` honor `stripPrefix` from `FIRST_PARTY_FALLBACKS` when the on-disk entry omits it (closes #196).** Scribe v0.4.0 doesn't write `stripPrefix: true` to its services.json entry — the declaration only lives in hub's `SCRIBE_FALLBACK.manifest.stripPrefix` (`src/service-spec.ts`). Pre-#187 this didn't matter because the per-service `tailscale serve` plan baked the path into the target URL (`/scribe → http://127.0.0.1:1943/scribe`); post-#187 routing went through hub which wasn't consulting the fallback registry. Result: `/scribe/health` got forwarded verbatim to scribe, scribe served bare paths and 404'd. Fix: new `stripPrefixFor(entry)` helper consulted by both proxies — explicit on-entry wins, otherwise consult `FIRST_PARTY_FALLBACKS` keyed by short name (same shape as how `effectivePublicExposure` already handles fallback derivation in service-spec.ts), default `false` (preserving existing keep-prefix default for unknown / third-party services). Scribe-side companion is parachute-scribe#40 (canonical-port-on-boot regression — different diagnostic, same operator). `proxyToVault` gets the same shape for symmetry; no first-party vault fallback declares `stripPrefix` today, so this is a no-op in practice.
+
+### Added
+
+- **Tests: `findServiceUpstream` / `findVaultUpstream` trailing-slash regression coverage (`src/__tests__/hub-server.test.ts`).** Two unit tests pin the new normalization (one each for service and vault matchers), plus a hubFetch end-to-end test that drives a `/notes/assets/index-XXX.js` request through a `paths: ["/notes/"]` entry to a fixture upstream and asserts the path is forwarded verbatim. A bare-root `paths: ["/"]` test pins the `|| "/"` branch's stability without changing the existing exact-match-only contract for catchall mounts.
+- **Tests: hubFetch end-to-end coverage for the FIRST_PARTY_FALLBACKS stripPrefix derivation (`src/__tests__/hub-server.test.ts`).** Three tests cover the three precedence rungs: (1) `parachute-scribe` entry without `stripPrefix` resolves to the SCRIBE_FALLBACK's `stripPrefix: true` and the backend sees the bare `/health` path; (2) explicit `stripPrefix: false` on the entry overrides the fallback (full path forwarded); (3) third-party service whose manifestName isn't in FIRST_PARTY_FALLBACKS gets the default keep-prefix behavior (no accidental strip).
+
+### Why this lands now
+
+Both edge cases broke real operator setups today during diagnostics on Aaron's box. Filed as #196 / #197 alongside two further tactical issues (#194 `notes-serve` `Bun.resolveSync` from hub cwd, #195 port collision validation) — those are bigger fixes / separate PRs. This bundle sticks to the two regressions whose root cause is hub#187 missing edge cases in proxy dispatch, so the fix is small and surgical.
+
 ## [0.5.5] - 2026-05-08
 
 Promotes the 0.5.5-rc cycle (#187 layer-aware proxy + #188 admin-login rate-limit + #191 2FA-not-enrolled warning) to stable, plus a small content-only / formatting-only housekeeping bundle. Skips the `-rc.N` step per the doc-only-changes rule (no semantic code changes since rc.2). No intermediate RCs were published to npm during the cycle; this is the first publish to `@latest`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.5",
+  "version": "0.5.6-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -746,6 +746,31 @@ describe("findVaultUpstream (#144)", () => {
     expect(m?.mount).toBe("/vault/inner");
     expect(m?.port).toBe(1941);
   });
+
+  // #197: a services.json entry written with a trailing slash on the mount
+  // path (e.g. `paths: ["/vault/default/"]`) used to only match the exact
+  // pathname `/vault/default/` and silently drop every sub-path because
+  // `pathname.startsWith("/vault/default//")` is always false. Normalize
+  // trailing slashes before comparison so sub-paths route correctly.
+  test("trailing-slash mount path matches sub-paths (#197)", () => {
+    const trailing: ServiceEntry = {
+      name: "parachute-vault",
+      port: 1940,
+      paths: ["/vault/default/"],
+      health: "/vault/default/health",
+      version: "0.4.0",
+    };
+    const exact = findVaultUpstream([trailing], "/vault/default");
+    expect(exact?.port).toBe(1940);
+    // mount is reported normalized (trailing slash stripped) so callers
+    // computing `pathname.slice(match.mount.length)` get the same answer
+    // regardless of how the entry was written on disk.
+    expect(exact?.mount).toBe("/vault/default");
+
+    const sub = findVaultUpstream([trailing], "/vault/default/notes/abc");
+    expect(sub?.port).toBe(1940);
+    expect(sub?.mount).toBe("/vault/default");
+  });
 });
 
 describe("hubFetch /vault/<name>/* dynamic proxy (#144)", () => {
@@ -1143,6 +1168,62 @@ describe("findServiceUpstream (#182)", () => {
     ];
     expect(findServiceUpstream(services, "/scribe-admin")).toBeUndefined();
     expect(findServiceUpstream(services, "/scribe-admin/foo")).toBeUndefined();
+  });
+
+  // #197: a services.json entry written with a trailing slash on the mount
+  // path (e.g. `paths: ["/notes/"]`) used to only match the exact pathname
+  // `/notes/` and silently drop every sub-path because
+  // `pathname.startsWith("/notes//")` is always false. Notes blank-screen
+  // on Aaron's box (2026-05-08) was the operator-visible symptom: the SPA
+  // shell loaded but every `/notes/assets/*.js` 404'd. Normalize trailing
+  // slashes before comparison.
+  test("trailing-slash mount path matches sub-paths (#197)", () => {
+    const services: ServiceEntry[] = [
+      {
+        name: "parachute-notes",
+        port: 1942,
+        paths: ["/notes/"],
+        health: "/notes/health",
+        version: "0.1.0",
+      },
+    ];
+    const exact = findServiceUpstream(services, "/notes");
+    expect(exact?.port).toBe(1942);
+    // mount is reported normalized (trailing slash stripped) so callers
+    // computing `pathname.slice(match.mount.length)` (the stripPrefix path)
+    // get the same answer regardless of how the entry was written on disk.
+    expect(exact?.mount).toBe("/notes");
+
+    const asset = findServiceUpstream(services, "/notes/assets/index-XXX.js");
+    expect(asset?.port).toBe(1942);
+    expect(asset?.mount).toBe("/notes");
+    expect(asset?.entry.name).toBe("parachute-notes");
+  });
+
+  test('mount path "/" survives normalization without collapsing to empty string (#197)', () => {
+    // Edge case: `"/".replace(/\/+$/, "")` yields the empty string; the
+    // `|| "/"` branch keeps it stable so an exact-`/` request still matches.
+    // Pre-fix this branch wasn't reachable (legacy `paths: ["/"]` entries
+    // are already remapped to `/<shortname>` in-memory by services-manifest;
+    // the test pins the lookup-level behavior so a future regression in the
+    // remap layer doesn't silently 404 every catchall request).
+    //
+    // Sub-path matching for `/`-mounted entries is intentionally not asserted
+    // here — that would change the existing "exact match only" behavior
+    // captured in `pathname === path || pathname.startsWith(path + '/')`,
+    // which never matched `/anything` when `path === "/"` (since `"//"` is
+    // not a real URL prefix).
+    const services: ServiceEntry[] = [
+      {
+        name: "catchall",
+        port: 1950,
+        paths: ["/"],
+        health: "/health",
+        version: "0.1.0",
+      },
+    ];
+    expect(findServiceUpstream(services, "/")?.port).toBe(1950);
+    expect(findServiceUpstream(services, "/")?.mount).toBe("/");
   });
 });
 
@@ -1623,6 +1704,160 @@ describe("hubFetch /<svc>/* generic proxy dispatch (#182)", () => {
       // /vault/* and confirming no fallthrough to the vault upstream.
       const elsewhere = await fetcher(req("/totally/not/a/vault"));
       expect(elsewhere.status).toBe(404);
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("trailing-slash entry routes sub-paths end-to-end (#197)", async () => {
+    // Operator-symptom regression: notes blank-screen on Aaron's box
+    // (2026-05-08). services.json had `paths: ["/notes/"]` (trailing slash),
+    // which used to make the matcher return undefined for every sub-path
+    // because `pathname.startsWith("/notes//")` is always false. Hub
+    // returned 404 for `/notes/assets/*.js` even though the SPA shell
+    // loaded fine, breaking the page silently.
+    const h = makeHarness();
+    const upstream = startUpstream("notes");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-notes",
+              port: upstream.port,
+              paths: ["/notes/"],
+              health: "/notes/health",
+              version: "0.1.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(req("/notes/assets/index-XXX.js"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { tag: string; pathname: string };
+      expect(body.tag).toBe("notes");
+      // Path is forwarded verbatim — no stripPrefix on the notes entry, so
+      // backend sees the full mount-prefixed path.
+      expect(body.pathname).toBe("/notes/assets/index-XXX.js");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("FIRST_PARTY_FALLBACKS supplies stripPrefix when entry omits it (#196)", async () => {
+    // Operator-symptom regression: scribe `/scribe/health` 404 on Aaron's
+    // box (2026-05-08). Scribe v0.4.0 doesn't write `stripPrefix: true` to
+    // its services.json entry; the declaration only lives in hub's
+    // SCRIBE_FALLBACK manifest. Pre-#187 this didn't matter because the
+    // per-service `tailscale serve` plan baked the path into the target
+    // URL; post-#187 routing went through hub which wasn't consulting the
+    // fallback registry. Result: hub forwarded `/scribe/health` verbatim
+    // to scribe at :1943, scribe served bare paths and 404'd. Fix: hub-
+    // side fallback merge in `stripPrefixFor`.
+    //
+    // Use a `parachute-scribe` manifestName so `shortNameForManifest`
+    // resolves to "scribe" → SCRIBE_FALLBACK (which declares
+    // `stripPrefix: true`). The entry itself omits stripPrefix to mirror
+    // what scribe v0.4.0 actually writes today.
+    const h = makeHarness();
+    const upstream = startUpstream("scribe");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-scribe",
+              port: upstream.port,
+              paths: ["/scribe"],
+              health: "/scribe/health",
+              version: "0.4.0",
+              // stripPrefix intentionally omitted — must be derived from
+              // FIRST_PARTY_FALLBACKS.scribe.manifest.stripPrefix.
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(req("/scribe/health"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { tag: string; pathname: string };
+      expect(body.tag).toBe("scribe");
+      // The mount prefix is stripped — backend sees the bare `/health`
+      // route that scribe v0.4.0 actually serves.
+      expect(body.pathname).toBe("/health");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("explicit stripPrefix:false on entry overrides FIRST_PARTY_FALLBACKS (#196)", async () => {
+    // Explicit-on-entry must win, even when the fallback would default to
+    // stripping. Documents the precedence ordering: explicit > fallback >
+    // false. Without this, an operator who deliberately writes
+    // `"stripPrefix": false` couldn't opt out of the fallback's strip.
+    const h = makeHarness();
+    const upstream = startUpstream("scribe");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-scribe",
+              port: upstream.port,
+              paths: ["/scribe"],
+              health: "/scribe/health",
+              version: "0.4.0",
+              stripPrefix: false,
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(req("/scribe/health"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { pathname: string };
+      // Explicit false wins — full path forwarded.
+      expect(body.pathname).toBe("/scribe/health");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("third-party service without fallback does not strip (#196)", async () => {
+    // Default behavior contract: a service whose manifestName isn't in
+    // FIRST_PARTY_FALLBACKS and whose entry omits stripPrefix gets the
+    // pre-#196 keep-prefix behavior. No accidental strip on third-party
+    // installs.
+    const h = makeHarness();
+    const upstream = startUpstream("third-party");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "third-party-service",
+              port: upstream.port,
+              paths: ["/third"],
+              health: "/third/health",
+              version: "0.1.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(req("/third/health"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { pathname: string };
+      expect(body.pathname).toBe("/third/health");
     } finally {
       upstream.stop();
       h.cleanup();

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -67,7 +67,11 @@ import {
   handleToken,
 } from "./oauth-handlers.ts";
 import { clearPid, writePid } from "./process-state.ts";
-import { effectivePublicExposure } from "./service-spec.ts";
+import {
+  FIRST_PARTY_FALLBACKS,
+  effectivePublicExposure,
+  shortNameForManifest,
+} from "./service-spec.ts";
 import { type ServiceEntry, readManifest } from "./services-manifest.ts";
 import { getAllPublicKeys } from "./signing-keys.ts";
 import { buildWellKnown, isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
@@ -137,9 +141,16 @@ export function findVaultUpstream(
   for (const s of services) {
     if (!isVaultEntry(s)) continue;
     for (const path of s.paths) {
-      if (pathname === path || pathname.startsWith(`${path}/`)) {
-        if (!best || path.length > best.mount.length) {
-          best = { port: s.port, mount: path, entry: s };
+      // Normalize trailing slashes before comparison (#197). A services.json
+      // entry written with `paths: ["/vault/default/"]` would otherwise only
+      // match the exact pathname `/vault/default/` and never any sub-path,
+      // because `pathname.startsWith("/vault/default//")` is always false.
+      // The "|| '/'" branch keeps a bare-root mount "/" stable rather than
+      // collapsing it to an empty string.
+      const norm = path.replace(/\/+$/, "") || "/";
+      if (pathname === norm || pathname.startsWith(`${norm}/`)) {
+        if (!best || norm.length > best.mount.length) {
+          best = { port: s.port, mount: norm, entry: s };
         }
       }
     }
@@ -295,7 +306,14 @@ async function proxyToVault(req: Request, manifestPath: string): Promise<Respons
   if (effectivePublicExposure(match.entry) === "loopback" && layerOf(req) !== "loopback") {
     return new Response("not found", { status: 404 });
   }
-  return proxyRequest(req, match.port, "vault");
+  // Symmetry with proxyToService (#196): honor `stripPrefix` with FIRST_-
+  // PARTY_FALLBACKS as a fallback source. No first-party vault fallback
+  // declares stripPrefix today (vault expects the full `/vault/<name>/*`
+  // path), so this is a no-op in practice — but reading the same shape in
+  // both proxies keeps the dispatch surface consistent for future readers.
+  const stripPrefix = stripPrefixFor(match.entry);
+  const targetPath = stripPrefix ? url.pathname.slice(match.mount.length) || "/" : undefined;
+  return proxyRequest(req, match.port, "vault", targetPath);
 }
 
 /**
@@ -314,9 +332,18 @@ export function findServiceUpstream(
   for (const s of services) {
     if (isVaultEntry(s)) continue;
     for (const path of s.paths) {
-      if (pathname === path || pathname.startsWith(`${path}/`)) {
-        if (!best || path.length > best.mount.length) {
-          best = { port: s.port, mount: path, entry: s };
+      // Normalize trailing slashes before comparison (#197). A services.json
+      // entry written with `paths: ["/notes/"]` would otherwise only match
+      // the exact pathname `/notes/` and never `/notes/assets/index.js` —
+      // `pathname.startsWith("/notes//")` is always false because URLs
+      // don't have double slashes. Result: SPA shell loads but every asset
+      // 404s (notes blank-screen on Aaron's box, 2026-05-08).
+      // The "|| '/'" branch keeps a bare-root mount "/" stable rather than
+      // collapsing it to an empty string.
+      const norm = path.replace(/\/+$/, "") || "/";
+      if (pathname === norm || pathname.startsWith(`${norm}/`)) {
+        if (!best || norm.length > best.mount.length) {
+          best = { port: s.port, mount: norm, entry: s };
         }
       }
     }
@@ -364,10 +391,32 @@ async function proxyToService(req: Request, manifestPath: string): Promise<Respo
   if (effectivePublicExposure(match.entry) === "loopback" && layerOf(req) !== "loopback") {
     return new Response("not found", { status: 404 });
   }
-  const targetPath = match.entry.stripPrefix
-    ? url.pathname.slice(match.mount.length) || "/"
-    : undefined;
+  // Consult FIRST_PARTY_FALLBACKS as a fallback for `stripPrefix` (#196).
+  // Scribe v0.4.0 doesn't write `stripPrefix: true` to its services.json
+  // entry — the declaration only lives in hub's SCRIBE_FALLBACK manifest.
+  // Pre-#187 this didn't matter because the per-service tailscale serve
+  // plan baked the path into the target URL; post-#187 routing went through
+  // hub which wasn't consulting the fallback registry. Same shape as how
+  // `effectivePublicExposure` already handles fallback derivation in
+  // service-spec.ts. Explicit-on-entry still wins; absent → fallback →
+  // false (preserving existing keep-prefix default for unknown services).
+  const stripPrefix = stripPrefixFor(match.entry);
+  const targetPath = stripPrefix ? url.pathname.slice(match.mount.length) || "/" : undefined;
   return proxyRequest(req, match.port, match.entry.name, targetPath);
+}
+
+/**
+ * Resolve effective `stripPrefix` for a service entry. Explicit on-entry
+ * wins; otherwise consult `FIRST_PARTY_FALLBACKS` keyed by short name (so
+ * scribe's vendored fallback supplies `stripPrefix: true` even when scribe's
+ * own boot doesn't write it). Defaults to `false` — keep the prefix —
+ * matching the pre-#196 dispatch behavior for unknown / third-party services.
+ */
+function stripPrefixFor(entry: ServiceEntry): boolean {
+  if (entry.stripPrefix !== undefined) return entry.stripPrefix;
+  const short = shortNameForManifest(entry.name);
+  const fb = short !== undefined ? FIRST_PARTY_FALLBACKS[short] : undefined;
+  return fb?.manifest.stripPrefix ?? false;
 }
 
 export interface HubFetchDeps {


### PR DESCRIPTION
## Summary

Bundled fix for two `proxyToService` / `proxyToVault` dispatch edge cases that hub#187's tests missed. Both surfaced today (2026-05-08) during operator diagnostics on Aaron's box; both make the hub silently 404 a real on-box backend.

- **#197 — trailing-slash mount paths fail to match sub-paths.** A services.json entry with `paths: [\"/notes/\"]` matched only the exact pathname `/notes/` and never any sub-path because `pathname.startsWith(\"/notes//\")` is always false. Operator-visible symptom on Aaron's box: notes blank screen — the SPA shell loaded at `/notes/` but every `/notes/assets/*.js` 404'd from hub. Fix: normalize trailing slashes (`path.replace(/\/+$/, \"\") || \"/\"`) before equality + prefix check, in both `findServiceUpstream` and `findVaultUpstream`. The `|| \"/\"` branch keeps a bare-root mount stable rather than collapsing to the empty string.
- **#196 — `stripPrefix` not honored when the service doesn't write it.** `proxyToService` read `stripPrefix` from the on-disk services.json entry only. Scribe v0.4.0 doesn't write `stripPrefix: true` to its entry — the declaration only lives in hub's `SCRIBE_FALLBACK.manifest.stripPrefix`. Pre-#187 this didn't matter (per-service tailscale-serve baked the path into the target URL); post-#187 routing went through hub which wasn't consulting the fallback registry. Operator-visible symptom: `/scribe/health` → 404 from hub even though scribe was up at :1943 serving `/health`. Fix: new `stripPrefixFor(entry)` helper consulted by both proxies — explicit on-entry wins, otherwise consult `FIRST_PARTY_FALLBACKS` keyed by short name (same shape as `effectivePublicExposure`'s existing fallback derivation), default `false`. `proxyToVault` gets the same shape for symmetry (no-op in practice — vault entries don't strip).

## Diagnostic context

Filed today alongside two further tactical issues (out of scope for this PR):
- #194 — `notes-serve` `Bun.resolveSync` from hub cwd fails for bun-linked notes (silent 502 on tailnet)
- #195 — port collision: scribe + agent both at 1944 in services.json

Cross-repo companion: parachute-scribe#40 (scribe v0.4.0 rewrites services.json port to 1944 on boot, ignoring canonical 1943) — different diagnostic, same operator-day.

## Operator state

Aaron's `~/.parachute/services.json` has tactical workarounds (notes installDir, scribe stripPrefix, agent port 1945). After this PR merges they become unnecessary but safe to leave in place.

## Test plan

- [x] `bun test ./src` — 1052 pass / 0 fail (was 1045 baseline; +7 new tests)
- [x] `bun run typecheck` — clean
- [x] `bunx biome check .` — clean
- [ ] Reviewer dispatch (team-lead's job, not the tentacle's)

New regression tests in `src/__tests__/hub-server.test.ts`:
- `findServiceUpstream` / `findVaultUpstream`: trailing-slash sub-path matching
- `findServiceUpstream`: bare-root `paths: [\"/\"]` survives normalization (pins `|| \"/\"` branch stability)
- hubFetch e2e: `paths: [\"/notes/\"]` + `/notes/assets/index-XXX.js` round-trip with path forwarded verbatim
- hubFetch e2e: `parachute-scribe` entry without `stripPrefix` resolves to SCRIBE_FALLBACK's `stripPrefix: true` (backend sees bare `/health`)
- hubFetch e2e: explicit `stripPrefix: false` on the entry overrides the fallback (precedence ordering)
- hubFetch e2e: third-party service without a fallback gets default keep-prefix (no accidental strip)

## Patterns check

- **proxy dispatch shape (`hub-server.ts`)** — touches the surface introduced by hub#182 (services.json-driven dispatch) and extended by hub#187 (layer-aware proxy). Conforms to existing patterns; no new pattern established. The fallback-merge for `stripPrefix` mirrors how `effectivePublicExposure` already derives `auth-required` from `FIRST_PARTY_FALLBACKS` in `service-spec.ts`.
- **FIRST_PARTY_FALLBACKS as transitional vendored-manifest fallback** (per workspace CLAUDE.md) — this PR uses the registry exactly as documented: a fallback for first-party services that haven't yet shipped their own `.parachute/module.json`. No new entries added, no scope creep on the registry's role.
- **RC versioning before `@latest`** — bumped to `0.5.6-rc.1` per pre-1.0 RC convention. Code-touching PR, no skip-rc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)