### PR TITLE
feat(manifest): validate ports on upsertService write (closes #205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.7-rc.4] - 2026-05-08
+
+Symmetric write-time port-collision gate on `services-manifest.ts:upsertService`. Closes the asymmetry left after #204: read-time `validateManifest` rejects duplicate ports, but the write side happily landed corrupt state on disk and only the next read surfaced the fault. Defense-in-depth — the boot-overwrite root causes are fixed in parachute-scribe#41 + parachute-agent#146 — but "shouldn't happen" isn't "can't happen."
+
+### Fixed
+
+- **`upsertService` rejects writes that would land a duplicate port in `services.json` (closes #205).** New `assertNoDuplicatePorts(entries, where)` helper extracted out of `validateManifest` so both read and write paths apply the same gate without the write side re-validating every entry's shape (the merged manifest's entries are already typed `ServiceEntry`; what's interesting is the property of the merged set, not any individual entry). After the in-memory upsert merge but before `writeManifest`, the helper runs across `current.services`; if two distinct services would share a port the call throws `ServicesManifestError` with the same message shape as the read path (`<path>: duplicate port 1944 — claimed by both "parachute-scribe" and "agent". Edit services.json to give each service a unique port.`). The previous shape would write the corrupt manifest, leave bad state on disk, and only surface the fault on the next `readManifest` (`parachute status` / `parachute start` / per-request hub-server reads). Same multi-vault carve-out as the read side: `parachute-vault*` rows sharing a port is intentional — one process serves N vault instances on a single port at distinct mount paths — and only fires when at least one of the conflicting names isn't a `parachute-vault*` row. The update path (in-place replace by name when the row already exists) runs the gate after the replace, so moving a row to a free port succeeds and moving a row to a colliding port is rejected with on-disk state left coherent.
+
+### Added
+
+- **Tests: `upsertService` write-time duplicate-port rejection coverage (`src/__tests__/services-manifest.test.ts`, new `upsertService duplicate-port rejection (hub#205)` describe block).** Five new cases. Add a service at a non-conflicting port → succeeds (and the persisted file matches); add a service at a port already claimed by a non-vault service → throws `ServicesManifestError` with port + both names in the message AND the existing row stays put (no corrupt write); add a `parachute-vault-*` row at a port already used by another `parachute-vault-*` row → succeeds (multi-vault carve-out); UPDATE an existing entry's port to a free port → succeeds; UPDATE an existing entry's port to a colliding port → throws and on-disk state stays coherent (scribe at 1944, agent at 1945, scribe-trying-to-move-to-1945 rejected before any write).
+
+### Out of scope
+
+- **`assignServicePort` `.env` PORT preservation (flagged on hub#204 + patterns#45 reviews).** Different layer — `assignServicePort` writes to a service's `.env` file, not `services.json` — and a meaningful separate concern (operator-edited PORT preservation across re-installs is a deliberate behavior; what the reviewer flagged is a stale-`.env`-vs-fresh-`services.json` reconciliation question). Filed as hub#206 for design discussion; this PR stays scoped to #205's write-time validation of `services.json`.
+
 ## [0.5.7-rc.3] - 2026-05-08
 
 Hub-side defense-in-depth on the silent-port-collision class fixed upstream in parachute-scribe#41 + parachute-agent#146. `services.json` parsing now hard-rejects two distinct services on the same port; `parachute status` flags canonical-port drift inline so an operator-visible warning replaces a silent miswire.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.7-rc.3",
+  "version": "0.5.7-rc.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/services-manifest.test.ts
+++ b/src/__tests__/services-manifest.test.ts
@@ -432,6 +432,137 @@ describe("services-manifest", () => {
       }
     });
   });
+
+  // Write-time port collision rejection (hub#205). The read-time gate above
+  // catches duplicate ports on the next `readManifest`, but without a
+  // matching write-side check `upsertService` happily writes a corrupt
+  // manifest to disk and only the next read surfaces the fault. A buggy
+  // service boot calling `upsertService({ name: "agent", port: 1944 })`
+  // while scribe is already at 1944 must fail before `writeManifest` runs.
+  // Same multi-vault carve-out applies.
+  describe("upsertService duplicate-port rejection (hub#205)", () => {
+    const scribe: ServiceEntry = {
+      name: "parachute-scribe",
+      port: 1944,
+      paths: ["/scribe"],
+      health: "/scribe/health",
+      version: "0.4.0",
+    };
+    const agent: ServiceEntry = {
+      name: "agent",
+      port: 1944,
+      paths: ["/agent"],
+      health: "/agent/health",
+      version: "0.1.0",
+    };
+
+    test("succeeds when adding a service at a non-conflicting port", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        upsertService(scribe, path);
+        const m = upsertService({ ...agent, port: 1945 }, path);
+        expect(m.services).toHaveLength(2);
+        expect(m.services.map((s) => s.port).sort()).toEqual([1944, 1945]);
+        // And it actually wrote: a fresh read sees both rows.
+        expect(readManifest(path).services).toHaveLength(2);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("throws ServicesManifestError when adding a service at a port already claimed by a non-vault service", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        upsertService(scribe, path);
+        expect(() => upsertService(agent, path)).toThrow(ServicesManifestError);
+        // Error names the colliding port and both services so an operator
+        // scanning logs knows which two rows to reconcile.
+        expect(() => upsertService(agent, path)).toThrow(/duplicate port 1944/);
+        expect(() => upsertService(agent, path)).toThrow(/parachute-scribe/);
+        expect(() => upsertService(agent, path)).toThrow(/agent/);
+        // Crucially: services.json was NOT corrupted on the failed write.
+        // The pre-existing row stays, and the agent row never lands.
+        const m = readManifest(path);
+        expect(m.services).toHaveLength(1);
+        expect(m.services[0]?.name).toBe("parachute-scribe");
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("succeeds when adding a vault row at a port already used by another vault row (multi-vault carve-out)", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        const vaultDefault: ServiceEntry = {
+          name: "parachute-vault-default",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.4.0",
+        };
+        const vaultTechne: ServiceEntry = {
+          name: "parachute-vault-techne",
+          port: 1940,
+          paths: ["/vault/techne"],
+          health: "/vault/techne/health",
+          version: "0.4.0",
+        };
+        upsertService(vaultDefault, path);
+        const m = upsertService(vaultTechne, path);
+        expect(m.services).toHaveLength(2);
+        expect(m.services.map((s) => s.port)).toEqual([1940, 1940]);
+        // And persisted: a fresh read sees both vault rows on the same port,
+        // confirming readManifest's multi-vault carve-out matches the write
+        // side's.
+        expect(readManifest(path).services).toHaveLength(2);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("succeeds when UPDATING an existing entry's port to a non-conflicting port", () => {
+      // The update path (idx >= 0 in upsertService) replaces the row in-place
+      // before the duplicate-port check. Updating an entry's port to a value
+      // that collides with a DIFFERENT row must still throw, but moving an
+      // entry to a free port must succeed — including off canonical, which is
+      // a legitimate operator move (e.g., to dodge a third-party clash).
+      const { path, cleanup } = makeTempPath();
+      try {
+        upsertService(scribe, path); // port 1944
+        upsertService({ ...agent, port: 1945 }, path); // port 1945
+        // Move scribe from 1944 to 1948 (free): succeeds.
+        const m = upsertService({ ...scribe, port: 1948 }, path);
+        expect(m.services).toHaveLength(2);
+        const scribeRow = m.services.find((s) => s.name === "parachute-scribe");
+        expect(scribeRow?.port).toBe(1948);
+        // Fresh read: persisted state matches.
+        const persisted = readManifest(path);
+        expect(persisted.services.find((s) => s.name === "parachute-scribe")?.port).toBe(1948);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("throws when UPDATING an existing entry's port to one that collides with another row", () => {
+      // Companion to the above: the update path must NOT bypass the gate
+      // when the moved row's new port now collides with a different row.
+      const { path, cleanup } = makeTempPath();
+      try {
+        upsertService(scribe, path); // port 1944
+        upsertService({ ...agent, port: 1945 }, path); // port 1945
+        // Move scribe to 1945, where agent already lives: must throw.
+        expect(() => upsertService({ ...scribe, port: 1945 }, path)).toThrow(ServicesManifestError);
+        expect(() => upsertService({ ...scribe, port: 1945 }, path)).toThrow(/duplicate port 1945/);
+        // And the on-disk state stayed coherent — scribe at 1944, agent at
+        // 1945 — because the gate fires before writeManifest.
+        const persisted = readManifest(path);
+        expect(persisted.services.find((s) => s.name === "parachute-scribe")?.port).toBe(1944);
+        expect(persisted.services.find((s) => s.name === "agent")?.port).toBe(1945);
+      } finally {
+        cleanup();
+      }
+    });
+  });
 });
 
 describe("claw → agent migration", () => {

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -149,28 +149,30 @@ function isVaultName(name: string): boolean {
   return name === "parachute-vault" || name.startsWith("parachute-vault-");
 }
 
-function validateManifest(raw: unknown, where: string): ServicesManifest {
-  if (!raw || typeof raw !== "object") {
-    throw new ServicesManifestError(`${where}: root must be an object`);
-  }
-  const services = (raw as Record<string, unknown>).services;
-  if (!Array.isArray(services)) {
-    throw new ServicesManifestError(`${where}: "services" must be an array`);
-  }
-  const entries = services.map((s, i) => validateEntry(s, `${where} services[${i}]`));
-  // Reject manifests where two distinct services share a port. Without this
-  // gate, both services land in services.json, the OS lets only one bind,
-  // and the hub reverse-proxy quietly routes everyone to whichever service
-  // won the race. That's exactly how parachute-hub#195 (scribe + agent both
-  // at 1944) produced a silent /agent → scribe miswire. The underlying
-  // overwrite bugs are fixed in parachute-scribe#41 + parachute-agent#146;
-  // this is the hub-side gate so the same class can't recur silently.
-  //
-  // Multi-vault is the deliberate exception: one parachute-vault process
-  // serves N vault instances on a single port at distinct mount paths, so
-  // multiple `parachute-vault*` rows sharing a port is intentional, not a
-  // collision. The check fires only when the conflicting names aren't
-  // both vault rows.
+/**
+ * Reject manifests where two distinct services share a port. Without this
+ * gate, both services land in services.json, the OS lets only one bind,
+ * and the hub reverse-proxy quietly routes everyone to whichever service
+ * won the race. That's exactly how parachute-hub#195 (scribe + agent both
+ * at 1944) produced a silent /agent → scribe miswire. The underlying
+ * overwrite bugs are fixed in parachute-scribe#41 + parachute-agent#146;
+ * this is the hub-side gate so the same class can't recur silently.
+ *
+ * Multi-vault is the deliberate exception: one parachute-vault process
+ * serves N vault instances on a single port at distinct mount paths, so
+ * multiple `parachute-vault*` rows sharing a port is intentional, not a
+ * collision. The check fires only when the conflicting names aren't
+ * both vault rows.
+ *
+ * Pulled out of `validateManifest` so the write side (`upsertService`) can
+ * apply the same gate after merging without re-validating every entry's
+ * shape — the merged manifest's entries are already typed `ServiceEntry`,
+ * but a duplicate-port collision is a property of the merged set, not of
+ * any individual entry. Read-side path runs this after `validateEntry`
+ * across the array; write-side path runs this on the post-merge entries.
+ * Both surface the same `ServicesManifestError` shape.
+ */
+function assertNoDuplicatePorts(entries: ServiceEntry[], where: string): void {
   const portsSeen = new Map<number, string>();
   for (const entry of entries) {
     const prev = portsSeen.get(entry.port);
@@ -181,6 +183,18 @@ function validateManifest(raw: unknown, where: string): ServicesManifest {
     }
     if (prev === undefined) portsSeen.set(entry.port, entry.name);
   }
+}
+
+function validateManifest(raw: unknown, where: string): ServicesManifest {
+  if (!raw || typeof raw !== "object") {
+    throw new ServicesManifestError(`${where}: root must be an object`);
+  }
+  const services = (raw as Record<string, unknown>).services;
+  if (!Array.isArray(services)) {
+    throw new ServicesManifestError(`${where}: "services" must be an array`);
+  }
+  const entries = services.map((s, i) => validateEntry(s, `${where} services[${i}]`));
+  assertNoDuplicatePorts(entries, where);
   return { services: entries };
 }
 
@@ -259,6 +273,14 @@ export function upsertService(
   } else {
     current.services.push(entry);
   }
+  // Symmetric port-collision gate (closes hub#205). Read-time validation
+  // (`validateManifest` → `assertNoDuplicatePorts`) catches duplicates the
+  // next time `services.json` is read, but without this write-side check the
+  // bad state lives on disk for that window. A buggy service boot calling
+  // `upsertService({ name: "agent", port: 1944 })` while scribe is already
+  // at 1944 would otherwise succeed and corrupt the manifest. Same
+  // multi-vault carve-out as the read path.
+  assertNoDuplicatePorts(current.services, path);
   writeManifest(current, path);
   return current;
 }


### PR DESCRIPTION
## Summary

Closes the asymmetric gap from #204: read-time `validateManifest` rejects duplicate ports, but `upsertService` (the write side) doesn't validate the merged manifest before `writeManifest`. A buggy service boot calling `upsertService({ name: "agent", port: 1944 })` while scribe is already at 1944 would otherwise succeed, corrupt `services.json`, and only surface on the next `readManifest`. The bad state lives on disk for that window — small but non-zero.

This PR pulls the per-port duplicate check out of `validateManifest` into a shared `assertNoDuplicatePorts(entries, where)` helper and runs it on the post-merge entries inside `upsertService`, before `writeManifest`. Same `ServicesManifestError` shape, same multi-vault carve-out (multiple `parachute-vault*` rows on a single port is intentional — one process, N vault instances, distinct mount paths). Update path is gated too: moving a row to a free port succeeds, moving to a colliding port is rejected with on-disk state left coherent.

Defense-in-depth: the boot-overwrite root causes are fixed in parachute-scribe#41 + parachute-agent#146, so `upsertService` shouldn't be called with duplicate ports unless something new regresses. But "shouldn't" isn't "can't" — symmetric write-time validation closes the window.

## Why two paths, one gate

Pulling the helper out (rather than re-calling `validateManifest` on the merged in-memory shape) avoids re-validating every entry's shape on the write side, where the merged manifest's entries are already typed `ServiceEntry`. The interesting property — duplicate-port collision — is a property of the merged set, not of any individual entry, so a small dedicated helper is the cleaner shape. Both call sites (`validateManifest` after `validateEntry` across the array; `upsertService` after the in-place merge) feed the same helper and surface the same error message format.

## Versioning

- Bumps `0.5.7-rc.3` → `0.5.7-rc.4`. Patch-level RC bump per pre-1.0 RC governance — code-touching, no API change.
- CHANGELOG entry under `[0.5.7-rc.4] - 2026-05-08`.

## Out of scope

- **`assignServicePort` `.env` PORT preservation** (flagged on hub#204 + patterns#45 reviews). Different layer — `assignServicePort` writes a service's `.env` file, not `services.json` — and a meaningful separate concern (operator-edited PORT preservation across re-installs is deliberate; the question is stale-`.env`-vs-fresh-`services.json` reconciliation post the services.json-wins direction). Filed as hub#206 for design discussion. Per the spawn brief's judgment call: keeping this PR scoped to #205's write-time validation of `services.json` rather than folding a separate concern.
- hub#201 (cross-origin DCR design) — bigger work, separate.
- hub#203 (recovery tool / `parachute doctor`) — separate, deferred.

## Test plan

Canonical gate (`bun test ./src`): **1088 pass / 0 fail** (was 1083 / 0; +5 new tests). 29788 expect() calls. Typecheck clean (`tsc --noEmit`). Biome check clean (167 files, no fixes applied).

New regression block in `src/__tests__/services-manifest.test.ts` → `upsertService duplicate-port rejection (hub#205)`:

- [x] `upsertService` succeeds when adding a service at a non-conflicting port (and the persisted file matches).
- [x] `upsertService` throws `ServicesManifestError` when adding a service at a port already claimed by a non-vault service — error names port + both names — and the existing row stays put (no corrupt write).
- [x] `upsertService` succeeds when adding a `parachute-vault-*` row at a port already used by another `parachute-vault-*` row (multi-vault carve-out matches the read side's).
- [x] `upsertService` succeeds when UPDATING an existing entry's port to a non-conflicting port (in-place replace + post-replace gate); persisted state matches.
- [x] `upsertService` throws when UPDATING an existing entry's port to one that collides with another row; on-disk state stays coherent (rejected before `writeManifest`).

## Refs

- #195 — original collision report.
- #204 — read-time validation + canonical-port drift warning (this PR's read-side counterpart).
- #205 — this PR.
- #206 — follow-up: `assignServicePort` `.env` ↔ `services.json` reconciliation.
- parachute-scribe#41 + parachute-agent#146 — upstream root-cause fixes (boot respects services.json port). This PR is hub-side defense-in-depth on the same class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)