### PR TITLE
fix(install): stop writing PORT to service .env (services.json is authoritative) (closes #206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.7-rc.6] - 2026-05-08
+
+Stop writing `PORT=` to service `.env` files at install time. Services.json is authoritative for service ports — services follow a 4-tier `resolvePort` ladder (services.json → service config → bare PORT env → compiled-in canonical default) per parachute-scribe#41 / parachute-agent#146 / parachute-agent#148, codified at the ecosystem level in parachute-patterns#45 — so the duplicate `.env` PORT was at best dead weight and at worst a source of drift on re-install. Existing `.env` files keep their stale PORT (harmless — service-side `resolvePort` reads services.json first; the bare PORT env tier is the lowest priority). Closes #206.
+
+### Fixed
+
+- **`assignServicePort` no longer writes `PORT=<port>` to the service's `.env` (closes #206).** Pre-#206 the install path read the service's `.env`, preserved any pre-existing PORT (`source: "preserved"`), and otherwise wrote `PORT=<assigned>` into the file via `parseEnvFile` / `upsertEnvLine` / `writeEnvFile`. Post-#206 the function is a thin wrapper over `assignPort`: it picks a port (canonical → unassigned reservation → past-range with warning) and returns `{ port, source, warning? }`. The `.env` is not read, not created, not mutated. Operators who edit `services.json` to fix a duplicate-port collision (e.g. after the read-time #204 / write-time #205 gates flag one) no longer get re-stamped by a stale `.env` PORT on the next `parachute install`. The `installDir`-stamping, services.json seed/update, and auto-wire / scribe-provider code paths in `commands/install.ts` are unchanged — they still drive services.json to the freshly-assigned port. The "Wrote PORT=… to <envPath>" log line goes away with the write; the assigned port surfaces via the existing "✓ <name> registered on port <n>" line and any fallback warning. Picked option A from the hub#206 design conversation; alternatives B (warn on disagreement, keep `.env` precedence) and C (interactive reconcile) added behavioral surface for what's now a pure-historical concern — services.json wins, full stop.
+
+### Added
+
+- **Tests: `assignServicePort` rewritten to pin the new contract (`src/__tests__/port-assign.test.ts`, new `assignServicePort (hub#206 — services.json is authoritative)` describe block, 4 cases).** Returns canonical when free (no .env created); does NOT preserve a pre-existing PORT in `.env` (the function returns the canonical assignment AND leaves the file bit-for-bit identical — no PORT rewrite, no other-line mutation); returns fallback port + warning when canonical is occupied (`.env` still bit-for-bit untouched); third-party with no canonical gets the first reservation slot, no `.env` created. The pre-#206 `.env` round-trip cases (`preserves an existing PORT`, `writes PORT into a fresh .env`, `writes a fallback PORT`, `ignores a non-numeric PORT`, `preserves surrounding lines on rewrite`) are intentionally gone — they tested behavior that no longer exists.
+- **Tests: `install.test.ts` cases asserting `.env` PORT now invert (3 updated cases).** `install reflects canonical port in services.json without writing PORT to .env (hub#206)` — services.json carries 1940; if `<configDir>/vault/.env` exists at all, it doesn't have a PORT line. `install does NOT preserve a pre-existing PORT in .env across re-installs (hub#206)` — pre-existing `PORT=1947` in `.env` is left bit-for-bit untouched, services.json gets the freshly-assigned canonical 1940 (the operator's now-stale `.env` PORT is harmless because the boot-time ladder reads services.json first). `install falls back inside the canonical range when the slot is occupied (hub#206 — no .env write)` — services.json carries the fallback 1944, `.env` stays absent / has no PORT line, the canonical-is-in-use warning still surfaces.
+
+### Doc
+
+- **`port-assign.ts` / `service-spec.ts` / `help.ts` doc comments rewritten.** Pre-#206 wording ("CLI is the port authority… writes `PORT=<port>` into `~/.parachute/<svc>/.env`… idempotent, an existing PORT in .env wins") was load-bearing for the old behavior; the new wording explains that `services.json` is the single source of truth at boot per the 4-tier ladder, that operator override is now "edit services.json" (or `parachute config` once that lands), and that pre-#206 stale `.env` PORT lines on existing operator machines are harmless and untouched.
+
+### Migration
+
+- **Nothing for operators to do.** Stale `PORT=` lines in existing `~/.parachute/<svc>/.env` files are ignored by services that follow the documented 4-tier ladder (scribe ≥ #41, agent ≥ #146 / #148, future modules per parachute-patterns#45). They can be left alone or trimmed by hand; either is fine. Future `parachute install` runs will not re-add or rewrite them.
+
+### Out of scope
+
+- **`parachute doctor` (issue hub#203).** Recovery / self-repair tool for misconfigured `services.json` is its own design discussion and explicitly deferred indefinitely per the 2026-05-08 design call. This PR doesn't touch it.
+- **The DCR doc in patterns#46.** Separate parallel work on the patterns repo, not in scope here.
+
 ## [0.5.7-rc.5] - 2026-05-08
 
 Inline "Approve this app" form on the pending-DCR-client page when the request carries an authenticated operator session. Closes the cross-origin SPA recovery gap left by #199/#200's same-origin DCR auto-approve: a fresh client_id minted by an SPA on a different origin (notes-on-tailnet talking to hub-on-localhost, or any first-load with cleared browser state) lands `pending`, hits "App not yet approved" on `/oauth/authorize`, and previously had no in-flow recovery — operator had to drop to a terminal and run `parachute auth approve-client <id>`. Now: one click in the same browser tab approves and re-enters the OAuth flow at consent. Picked over A2 (SameSite=None auto-approve) and A3 (popup-relay) per the 2026-05-08 design conversation — boring, secure, honest UX.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.7-rc.5",
+  "version": "0.5.7-rc.6",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -264,9 +264,11 @@ describe("install", () => {
 
   test("CLI overrides a non-canonical port written by init when canonical is free", async () => {
     // Pre-#53 the CLI deferred to whatever port the service's init wrote
-    // (e.g. 5173, Vite's dev default for notes). With CLI-as-port-authority
-    // the canonical slot wins when free: the manifest is updated and the
-    // .env carries PORT=<canonical> so the next daemon boot binds it.
+    // (e.g. 5173, Vite's dev default for notes). With hub-as-port-authority
+    // the canonical slot wins when free: services.json is updated to the
+    // canonical port (post-hub#206 the install path no longer touches .env;
+    // services.json is the single source of truth at boot per the 4-tier
+    // resolvePort ladder in scribe/agent).
     const { path, configDir, cleanup } = makeTempPath();
     try {
       const logs: string[] = [];
@@ -1047,11 +1049,14 @@ describe("install", () => {
     }
   });
 
-  // CLI-as-port-authority (#53). Install assigns the service's port up front
-  // and writes `PORT=<port>` into `<configDir>/<svc>/.env`. lifecycle.start
-  // merges that .env into spawn env, so the next daemon boot binds the port
-  // the CLI picked.
-  test("install writes PORT=<canonical> to .env when the slot is free", async () => {
+  // Hub-as-port-authority (#53), services.json-is-authoritative (#206).
+  // Install picks the service's port up front and reflects it in
+  // services.json. Pre-#206 it also wrote `PORT=<port>` into the service's
+  // `.env`; post-#206 it doesn't — services.json is the single source of
+  // truth at boot per the 4-tier resolvePort ladder in scribe#41 / agent#146
+  // / agent#148, so the duplicate `.env` PORT was at best dead weight and
+  // at worst a source of drift on re-install.
+  test("install reflects canonical port in services.json without writing PORT to .env (hub#206)", async () => {
     const { path, configDir, cleanup } = makeTempPath();
     try {
       const code = await install("vault", {
@@ -1064,34 +1069,38 @@ describe("install", () => {
         log: () => {},
       });
       expect(code).toBe(0);
-      const envText = readFileSync(join(configDir, "vault", ".env"), "utf8");
-      expect(envText).toContain("PORT=1940");
+      // services.json is authoritative — that's where the port lives.
+      const entry = findService("parachute-vault", path);
+      expect(entry?.port).toBe(1940);
+      // .env should NOT have a PORT line. The directory may not even
+      // exist (nothing in this test path writes to the service's config
+      // dir); if it does, the file shouldn't carry PORT.
+      const envPath = join(configDir, "vault", ".env");
+      if (existsSync(envPath)) {
+        expect(readFileSync(envPath, "utf8")).not.toMatch(/^PORT=/m);
+      }
     } finally {
       cleanup();
     }
   });
 
-  test("install preserves a pre-existing PORT in .env across re-installs", async () => {
+  test("install does NOT preserve a pre-existing PORT in .env across re-installs (hub#206)", async () => {
+    // Pre-#206 a stale `.env` PORT survived a re-install: an operator
+    // who edited services.json to fix a duplicate would get re-stamped
+    // by the .env on the next `parachute install`. Post-#206 services.json
+    // is authoritative; the install path leaves `.env` alone but
+    // services.json reflects the freshly-assigned port. The stale `.env`
+    // PORT is harmless because the boot-time resolvePort ladder reads
+    // services.json before falling through to the bare PORT env tier.
     const { path, configDir, cleanup } = makeTempPath();
     try {
-      // First install assigns canonical 1940.
-      await install("vault", {
-        runner: async () => 0,
-        manifestPath: path,
-        configDir,
-        startService: async () => 0,
-        isLinked: () => false,
-        portProbe: async () => false,
-        log: () => {},
-      });
-      // Hand-edit .env to use a custom port (operator override).
       const envPath = join(configDir, "vault", ".env");
-      const original = readFileSync(envPath, "utf8");
-      const edited = original.replace("PORT=1940", "PORT=1947");
-      const { writeFileSync } = await import("node:fs");
-      writeFileSync(envPath, edited);
+      const { mkdirSync, writeFileSync } = await import("node:fs");
+      mkdirSync(join(configDir, "vault"), { recursive: true });
+      // Pre-existing .env with an operator-edited (now-stale) PORT.
+      const before = "PORT=1947\nOTHER=keepme\n";
+      writeFileSync(envPath, before);
 
-      // Second install must preserve the operator's choice, not stomp it.
       await install("vault", {
         runner: async () => 0,
         manifestPath: path,
@@ -1101,13 +1110,20 @@ describe("install", () => {
         portProbe: async () => false,
         log: () => {},
       });
-      expect(readFileSync(envPath, "utf8")).toContain("PORT=1947");
+
+      // services.json gets the freshly-assigned canonical port (1940),
+      // NOT the stale 1947 from .env.
+      const entry = findService("parachute-vault", path);
+      expect(entry?.port).toBe(1940);
+      // .env is bit-for-bit untouched: the stale PORT stays, OTHER stays,
+      // and we did NOT rewrite the file with a new PORT line.
+      expect(readFileSync(envPath, "utf8")).toBe(before);
     } finally {
       cleanup();
     }
   });
 
-  test("install falls back inside the canonical range when the slot is occupied", async () => {
+  test("install falls back inside the canonical range when the slot is occupied (hub#206 — no .env write)", async () => {
     const { path, configDir, cleanup } = makeTempPath();
     try {
       // Pretend something else is on 1940.
@@ -1133,11 +1149,14 @@ describe("install", () => {
       });
       expect(code).toBe(0);
       // First reservation slot is 1944.
-      const envText = readFileSync(join(configDir, "vault", ".env"), "utf8");
-      expect(envText).toContain("PORT=1944");
       const entry = findService("parachute-vault", path);
       expect(entry?.port).toBe(1944);
       expect(logs.join("\n")).toMatch(/canonical port 1940 is in use/);
+      // .env is not touched.
+      const envPath = join(configDir, "vault", ".env");
+      if (existsSync(envPath)) {
+        expect(readFileSync(envPath, "utf8")).not.toMatch(/^PORT=/m);
+      }
     } finally {
       cleanup();
     }

--- a/src/__tests__/port-assign.test.ts
+++ b/src/__tests__/port-assign.test.ts
@@ -74,103 +74,92 @@ describe("assignPort (pure)", () => {
   });
 });
 
-describe("assignServicePort (.env round-trip)", () => {
-  test("preserves an existing PORT in .env (idempotent re-install)", () => {
-    const { dir, cleanup } = makeTempDir();
-    try {
-      const envPath = join(dir, ".env");
-      writeFileSync(envPath, "PORT=1944\nOTHER=keepme\n");
-      const result = assignServicePort({
-        envPath,
-        canonical: 1940,
-        // Even though canonical is free, the existing .env wins.
-        occupied: [],
-      });
-      expect(result.port).toBe(1944);
-      expect(result.source).toBe("preserved");
-      expect(result.written).toBe(false);
-      // File untouched — no rewrite means OTHER stays as-is.
-      const text = readFileSync(envPath, "utf8");
-      expect(text).toContain("PORT=1944");
-      expect(text).toContain("OTHER=keepme");
-    } finally {
-      cleanup();
-    }
-  });
+describe("assignServicePort (hub#206 — services.json is authoritative)", () => {
+  // Post-hub#206 assignServicePort is a thin wrapper over assignPort: the
+  // install path no longer touches the service's .env, since services.json
+  // is the single source of truth and the duplicate state caused drift on
+  // re-install. These tests pin the new contract:
+  //   1. The function returns the assigned port + source/warning.
+  //   2. It does not write to .env. Pre-existing .env files are untouched
+  //      (no PORT line added, no PORT line removed, no other lines mutated).
+  //   3. There's no "preserved" source — a stale .env PORT does NOT survive
+  //      a re-install (operators edit services.json now).
 
-  test("writes PORT into a fresh .env when canonical is free", () => {
+  test("returns canonical when free, does not touch .env", () => {
     const { dir, cleanup } = makeTempDir();
     try {
       const envPath = join(dir, "subdir", ".env");
       const result = assignServicePort({
-        envPath,
         canonical: 1940,
         occupied: [],
       });
       expect(result.port).toBe(1940);
       expect(result.source).toBe("canonical");
-      expect(result.written).toBe(true);
       expect(result.warning).toBeUndefined();
-      expect(existsSync(envPath)).toBe(true);
-      expect(readFileSync(envPath, "utf8")).toContain("PORT=1940");
+      // No .env file gets created — subdir doesn't even exist.
+      expect(existsSync(envPath)).toBe(false);
     } finally {
       cleanup();
     }
   });
 
-  test("writes a fallback PORT and surfaces the warning when canonical is occupied", () => {
+  test("does NOT preserve a pre-existing PORT in .env (services.json is authoritative)", () => {
+    // Pre-hub#206 a stale `.env` PORT survived a re-install — operators
+    // editing services.json would get re-stamped by the .env. Post-#206
+    // services.json wins; the .env PORT is ignored at install time and
+    // also at boot (per the 4-tier ladder in scribe/agent).
     const { dir, cleanup } = makeTempDir();
     try {
       const envPath = join(dir, ".env");
+      const before = "PORT=1944\nOTHER=keepme\n";
+      writeFileSync(envPath, before);
       const result = assignServicePort({
-        envPath,
+        canonical: 1940,
+        occupied: [],
+      });
+      // We assigned the canonical port, NOT the stale 1944 from .env.
+      expect(result.port).toBe(1940);
+      expect(result.source).toBe("canonical");
+      // The .env file is bit-for-bit untouched — PORT line and other lines
+      // both stay. (No new PORT line written, no existing PORT rewritten.)
+      const after = readFileSync(envPath, "utf8");
+      expect(after).toBe(before);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("returns fallback port and warning when canonical is occupied; .env untouched", () => {
+    const { dir, cleanup } = makeTempDir();
+    try {
+      const envPath = join(dir, ".env");
+      // Pre-existing .env with non-PORT content.
+      const before = "FOO=bar\n";
+      writeFileSync(envPath, before);
+      const result = assignServicePort({
         canonical: 1940,
         occupied: [1940],
       });
       expect(result.port).toBe(1944);
       expect(result.source).toBe("fallback-in-range");
-      expect(result.written).toBe(true);
       expect(result.warning).toMatch(/canonical port 1940 is in use/);
-      expect(readFileSync(envPath, "utf8")).toContain("PORT=1944");
+      // .env stays bit-for-bit identical.
+      expect(readFileSync(envPath, "utf8")).toBe(before);
     } finally {
       cleanup();
     }
   });
 
-  test("ignores a non-numeric PORT and assigns a fresh one", () => {
+  test("third-party (no canonical) gets first reservation slot; no .env created", () => {
     const { dir, cleanup } = makeTempDir();
     try {
       const envPath = join(dir, ".env");
-      writeFileSync(envPath, "PORT=garbage\n");
       const result = assignServicePort({
-        envPath,
-        canonical: 1940,
         occupied: [],
       });
-      expect(result.port).toBe(1940);
-      expect(result.written).toBe(true);
-      // The garbage value got upserted to a real number.
-      expect(readFileSync(envPath, "utf8")).toContain("PORT=1940");
-    } finally {
-      cleanup();
-    }
-  });
-
-  test("preserves surrounding lines on rewrite", () => {
-    const { dir, cleanup } = makeTempDir();
-    try {
-      const envPath = join(dir, ".env");
-      writeFileSync(envPath, "FOO=bar\nBAZ=qux\n");
-      const result = assignServicePort({
-        envPath,
-        canonical: 1940,
-        occupied: [],
-      });
-      expect(result.written).toBe(true);
-      const text = readFileSync(envPath, "utf8");
-      expect(text).toContain("FOO=bar");
-      expect(text).toContain("BAZ=qux");
-      expect(text).toContain("PORT=1940");
+      expect(result.port).toBe(1944);
+      expect(result.source).toBe("fallback-in-range");
+      expect(existsSync(envPath)).toBe(false);
     } finally {
       cleanup();
     }

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -598,7 +598,7 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
   } else if (entry && entry.port !== portResult.port) {
     // init wrote an entry on the canonical port but the CLI assigned a
     // different one (collision). Reflect the CLI's choice so the hub and
-    // status views stay consistent with the .env we just wrote.
+    // status views stay consistent with the canonical-port assignment.
     upsertService({ ...entry, port: portResult.port }, manifestPath);
     entry = findService(entryName, manifestPath);
     log(

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -545,28 +545,26 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
     }
   }
 
-  // CLI-as-port-authority (#53): pick the service's port now and persist it
-  // via `~/.parachute/<svc>/.env`. lifecycle.start merges that .env into the
-  // spawn env (PR #50), so the next daemon boot binds the port we picked.
-  // Idempotent — an existing PORT in .env wins, so re-installs and
-  // user-edited ports survive across upgrades. Compiled-in service-side
-  // fallbacks (vault → 1940 etc.) stay; this just adds a CLI-managed
-  // override.
+  // Hub-as-port-authority (#53): pick the service's port now and reflect it
+  // in services.json. Pre-hub#206 the install path also wrote `PORT=<port>`
+  // into the service's `.env`; post-#206 (option A) services.json is the
+  // single source of truth — services follow the 4-tier resolvePort ladder
+  // (services.json → service config → bare PORT env → compiled-in default,
+  // per parachute-scribe#41 / parachute-agent#146 / parachute-agent#148 /
+  // parachute-patterns#45), so the duplicate `.env` PORT was at best dead
+  // weight and at worst a source of drift on re-install. Existing `.env`
+  // PORT lines on operator machines stay where they are — harmless — and
+  // future installs no longer touch them.
   const preInitEntry = findService(entryName, manifestPath);
   const probe = opts.portProbe ?? defaultPortProbe;
   const occupied = await collectOccupiedPorts(manifestPath, entryName, preInitEntry?.port, probe);
-  const envPath = join(configDir, short, ".env");
   const canonicalPort = spec.seedEntry?.().port ?? preInitEntry?.port;
   const portResult = assignServicePort({
-    envPath,
     canonical: canonicalPort,
     occupied,
   });
   if (portResult.warning) {
     log(`⚠ ${portResult.warning}`);
-  }
-  if (portResult.written) {
-    log(`Wrote PORT=${portResult.port} to ${envPath}.`);
   }
 
   // Find-or-seed the manifest entry. Re-read after the seed write so a silent

--- a/src/help.ts
+++ b/src/help.ts
@@ -44,9 +44,9 @@ Services:
 What it does:
   1. bun add -g @openparachute/<service>[@<tag>]
   2. run any service-specific init (e.g. \`parachute-vault init\`)
-  3. assign a canonical port (1939–1949) and write \`PORT=<port>\` into
-     \`~/.parachute/<service>/.env\`. Idempotent — an existing PORT wins, so
-     re-installs and operator-edited ports survive across upgrades.
+  3. assign a canonical port (1939–1949) and reflect it in
+     \`~/.parachute/services.json\` — the single source of truth at boot
+     (services follow a 4-tier resolvePort ladder; services.json wins).
   4. verify the service registered itself in ~/.parachute/services.json
   5. for scribe in a TTY: prompt for transcription provider + API key
      (or take \`--scribe-provider\` / \`--scribe-key\`)

--- a/src/port-assign.ts
+++ b/src/port-assign.ts
@@ -1,23 +1,32 @@
-import { parseEnvFile, upsertEnvLine, writeEnvFile } from "./env-file.ts";
 import { CANONICAL_PORT_MAX, CANONICAL_PORT_MIN, PORT_RESERVATIONS } from "./service-spec.ts";
 
 /**
- * The CLI is the port authority for Parachute services. At install time it
- * picks a port for each service, writes `PORT=<port>` into the service's
- * `~/.parachute/<svc>/.env`, and reflects the chosen port in services.json.
- * Services keep a compiled-in fallback (e.g. vault → 1940) so a stand-alone
- * `bun run` still works, but the CLI's PORT env var wins on installs it
- * manages.
+ * The hub is the port authority for Parachute services. At install time it
+ * picks a port for each service and reflects the chosen port in
+ * `services.json`. That manifest is the single source of truth at boot
+ * (parachute-scribe#41 / parachute-agent#146 / parachute-agent#148): each
+ * service reads `services.json` first and only falls through to lower-tier
+ * sources (its own config, the bare `PORT` env, the compiled-in canonical
+ * default) when the manifest doesn't pin a port. So writing PORT into the
+ * service's `.env` is no longer load-bearing — services.json wins.
+ *
+ * Pre-hub#206, install also wrote `PORT=<port>` into `~/.parachute/<svc>/.env`
+ * and preserved any pre-existing value across re-installs ("operator-edited
+ * port survives upgrade"). Post-#206 (option A from the design discussion):
+ * we stop writing PORT to `.env` entirely. The duplicate state was at best
+ * dead weight and at worst a source of drift — operators editing
+ * `services.json` would get re-stamped by a stale `.env` PORT on the next
+ * `parachute install`. Existing `.env` PORT lines stay where they are
+ * (harmless — service-side resolvePort reads services.json first; the bare
+ * PORT env tier is the lowest priority).
  *
  * Why up-front assignment instead of detect-on-collision-at-boot:
  *   - Two services racing to bind the same port produces an opaque "address in
- *     use" deep inside one of them. Assigning at install lets the CLI keep
+ *     use" deep inside one of them. Assigning at install lets the hub keep
  *     a single coherent picture of who owns what.
  *   - The hub's reverse-proxy targets are computed from services.json. If a
  *     service silently falls back to a different port at runtime, the hub
  *     proxies to a dead port and the user sees a 502 with no explanation.
- *   - Re-installs stay idempotent: the existing `PORT=` in .env wins, so a
- *     user who edited their port keeps it across upgrades.
  */
 
 export type AssignmentSource = "canonical" | "fallback-in-range" | "fallback-out-of-range";
@@ -72,8 +81,6 @@ export function assignPort(
 }
 
 export interface AssignServicePortOpts {
-  /** Path to the service's `.env` file. */
-  readonly envPath: string;
   /** Canonical default for this service, or undefined for third-party. */
   readonly canonical?: number;
   /** Ports we already know to be taken. */
@@ -82,41 +89,27 @@ export interface AssignServicePortOpts {
 
 export interface AssignServicePortResult {
   readonly port: number;
-  /** "preserved" when an existing PORT in .env was kept; otherwise the
-   *  source from `assignPort`. */
-  readonly source: "preserved" | AssignmentSource;
-  /** True when we wrote PORT into .env on this call. */
-  readonly written: boolean;
+  readonly source: AssignmentSource;
   /** Warning to surface to the user, if any. */
   readonly warning?: string;
 }
 
 /**
- * Reconcile a service's PORT with its `.env`. Idempotent:
- *   - If PORT is already set in .env, preserve it (`source: "preserved"`).
- *     Re-installs and user-edited ports survive across upgrades.
- *   - Otherwise call `assignPort` and write `PORT=<port>` into .env.
+ * Assign a port for a service at install time.
  *
- * Reads only the value of PORT from .env; everything else is round-tripped
- * untouched via `parseEnvFile` / `upsertEnvLine` / `writeEnvFile`.
+ * As of hub#206 this is a thin wrapper over `assignPort`: services.json is
+ * the source of truth for service ports (parachute-scribe#41 /
+ * parachute-agent#146 / parachute-agent#148 / parachute-patterns#45), so the
+ * install path no longer touches the service's `.env`. The wrapper still
+ * exists to give the install path a stable seam — `collectOccupiedPorts`
+ * feeds into the same shape regardless of how the underlying picker
+ * evolves — and to keep the warning return path centralized.
  */
 export function assignServicePort(opts: AssignServicePortOpts): AssignServicePortResult {
-  const env = parseEnvFile(opts.envPath);
-  const existing = env.values.PORT;
-  if (existing !== undefined && /^[1-9]\d{0,4}$/.test(existing)) {
-    const port = Number(existing);
-    if (port > 0 && port < 65536) {
-      return { port, source: "preserved", written: false };
-    }
-  }
-
   const assignment = assignPort(opts.canonical, opts.occupied);
-  const nextLines = upsertEnvLine(env.lines, "PORT", String(assignment.port));
-  writeEnvFile(opts.envPath, nextLines);
   const result: AssignServicePortResult = {
     port: assignment.port,
     source: assignment.source,
-    written: true,
   };
   if (assignment.warning) {
     return { ...result, warning: assignment.warning };

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -19,20 +19,29 @@ import type { ServiceEntry } from "./services-manifest.ts";
  * (see hub-control.ts) — if something else is on 1939 we fail loudly rather
  * than walking up into a service's slot.
  *
- * **CLI is the port authority.** `parachute install <svc>` picks the port at
- * install time and writes `PORT=<port>` into `~/.parachute/<svc>/.env`.
- * lifecycle.start merges that .env into the spawn env, so the next daemon
- * boot binds the port the CLI assigned. Algorithm (see port-assign.ts):
+ * **Hub is the port authority.** `parachute install <svc>` picks the port
+ * at install time and reflects it in `services.json`. Algorithm (see
+ * port-assign.ts):
  *
  *   1. Prefer the canonical slot (`spec.seedEntry().port`).
  *   2. On collision, walk the unassigned range (1944–1949 today).
  *   3. Range exhausted: assign past 1949 with a warning.
  *
- * Idempotent: an existing `PORT=` in .env wins, so re-installs and
- * operator-edited ports survive across upgrades. Services keep their
- * compiled-in fallbacks (vault → 1940 etc.) so a stand-alone `bun run`
- * still works without a CLI-managed .env, but the CLI's PORT wins on any
- * install it manages.
+ * `services.json` is the single source of truth at boot: each service
+ * follows a 4-tier resolvePort ladder (services.json → service config →
+ * bare PORT env → compiled-in canonical default), per parachute-scribe#41,
+ * parachute-agent#146, parachute-agent#148, and parachute-patterns#45.
+ * Pre-hub#206 the install path also wrote `PORT=<port>` into the service's
+ * `~/.parachute/<svc>/.env`; post-#206 it doesn't — services.json wins,
+ * the duplicate `.env` PORT was at best dead weight and at worst a source
+ * of drift on re-install (a stale `.env` PORT would re-stamp services.json
+ * even after an operator had fixed it).
+ *
+ * Operator override is now "edit services.json" (or `parachute config`
+ * once that lands), not "edit `.env`". Pre-#206 stale `.env` PORT lines on
+ * existing operator machines stay where they are — harmless, since the
+ * boot-time ladder reads services.json before falling through to the bare
+ * PORT env tier — and future installs no longer touch them.
  *
  * **No speculative reservations.** Future first-party modules claim a slot
  * the moment they ship, not before — pre-reservation for unbuilt things has


### PR DESCRIPTION
## Summary

Stops `parachute install <svc>` from writing `PORT=<port>` into the service's `~/.parachute/<svc>/.env`. `services.json` is the single source of truth at boot per the 4-tier `resolvePort` ladder shipped in parachute-scribe#41 / parachute-agent#146 / parachute-agent#148 (codified at the ecosystem level in parachute-patterns#45), so the duplicate `.env` PORT was at best dead weight and at worst a source of drift on re-install: an operator who fixed a duplicate-port collision in `services.json` (e.g. after the read-time hub#204 / write-time hub#205 gates flagged one) would get re-stamped by a stale `.env` PORT on the next `parachute install`.

This is **option A** from the hub#206 design conversation. Alternatives B (warn on disagreement, keep `.env` precedence) and C (interactive reconcile, prompt or pick services.json non-interactively) added behavioral surface for what's now a pure-historical concern — services.json wins, full stop.

## What changed

- **`src/port-assign.ts` — `assignServicePort` is now a thin wrapper over `assignPort`.** Picks a port (canonical → unassigned reservation → past-range with warning) and returns `{ port, source, warning? }`. The `.env` is not read, not created, not mutated. The pre-#206 `parseEnvFile` / `upsertEnvLine` / `writeEnvFile` round-trip and the `source: \"preserved\"` path are removed.
- **`src/commands/install.ts` — drops `envPath` from the `assignServicePort` call and the \"Wrote PORT=… to <envPath>\" log line.** The seed / port-update path still drives `services.json` to the freshly-assigned port; `installDir`-stamping, auto-wire, and scribe-provider setup are unchanged.
- **Doc rewrites in `service-spec.ts`, `port-assign.ts`, `help.ts`.** Pre-#206 wording (\"CLI is the port authority… writes `PORT=<port>` into `~/.parachute/<svc>/.env`… idempotent, existing PORT in .env wins\") was load-bearing for the old behavior. New wording explains services.json is the single source of truth at boot per the 4-tier ladder, that operator override is now \"edit services.json\" (or `parachute config` once that lands), and that pre-#206 stale `.env` PORT lines on existing operator machines are harmless and untouched.

## Tests

- **`src/__tests__/port-assign.test.ts` rewritten.** New `assignServicePort (hub#206 — services.json is authoritative)` describe block, 4 cases pinning the new contract:
  - Returns canonical when free; no `.env` created.
  - Does **not** preserve a pre-existing PORT in `.env` — returns the canonical assignment AND leaves the file bit-for-bit identical (no PORT rewrite, no other-line mutation).
  - Returns fallback port + warning when canonical is occupied; `.env` still bit-for-bit untouched.
  - Third-party (no canonical) gets first reservation slot; no `.env` created.

  Pre-#206 round-trip cases (`preserves an existing PORT`, `writes PORT into a fresh .env`, `writes a fallback PORT`, `ignores a non-numeric PORT`, `preserves surrounding lines on rewrite`) intentionally removed — they tested behavior that no longer exists.

- **`src/__tests__/install.test.ts` PORT-in-`.env` cases inverted (3 updates).**
  - `install reflects canonical port in services.json without writing PORT to .env (hub#206)` — services.json carries 1940; if `<configDir>/vault/.env` exists at all, it doesn't have a PORT line.
  - `install does NOT preserve a pre-existing PORT in .env across re-installs (hub#206)` — pre-existing `PORT=1947` in `.env` is left bit-for-bit untouched, services.json gets the freshly-assigned canonical 1940 (the operator's now-stale `.env` PORT is harmless because the boot-time ladder reads services.json first).
  - `install falls back inside the canonical range when the slot is occupied (hub#206 — no .env write)` — services.json carries the fallback 1944, `.env` stays absent / has no PORT line, the canonical-is-in-use warning still surfaces.

## Gate

- `bun test ./src`: **1100 pass / 0 fail** / 29829 expect() calls / 63 files / 11.35s.
- `bun run typecheck`: clean (`tsc --noEmit`).
- `bunx biome check --write .`: clean (no fixes applied).

## Migration

Nothing for operators to do. Stale `PORT=` lines in existing `~/.parachute/<svc>/.env` files are ignored by services that follow the documented 4-tier ladder (scribe ≥ #41, agent ≥ #146 / #148, future modules per parachute-patterns#45). They can be left alone or trimmed by hand; either is fine. Future `parachute install` runs will not re-add or rewrite them.

## Patterns check

- Touches the **services.json-wins / 4-tier resolvePort ladder** convention codified in parachute-patterns#45. This PR aligns hub's install path with the pattern: services.json is authoritative, `.env` PORT is no longer written. No pattern change required — the doc already reflects this end-state and pre-#206 hub was the last write-side leak.
- No change to **port reservations**, **manifest schema**, **OAuth scopes**, or any other cross-cutting pattern.

## Refs

- Closes #206.
- Builds on hub#204 (read-time port-collision rejection) + hub#205 (write-time port-collision rejection on `upsertService`) — both flagged this `.env`-vs-services.json drift on review.
- parachute-scribe#41 / parachute-agent#146 / parachute-agent#148 — boot respects services.json port (the upstream half of services.json-wins).
- parachute-patterns#45 — services.json-wins direction at the ecosystem level.

## Out of scope

- **`parachute doctor` (issue hub#203).** Deferred indefinitely per the 2026-05-08 design call. Not touched here.
- **DCR doc in patterns#46.** Separate parallel work on the patterns repo.

## Test plan

- [x] `bun test ./src` — 1100 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bunx biome check .` — clean
- [ ] After merge: bun-link the hub, run `parachute install vault` on a fresh `~/.parachute` and verify `~/.parachute/vault/.env` has no PORT line and `~/.parachute/services.json` has `parachute-vault` at port 1940
- [ ] After merge: with a pre-existing `~/.parachute/vault/.env` containing `PORT=1947`, run `parachute install vault` and verify `.env` is bit-for-bit unchanged AND `services.json` reflects the freshly-assigned canonical 1940 (operator override is now \"edit services.json\")
- [ ] After merge: with a duplicate-port collision in `services.json` and an operator-edited fix in place, verify `parachute install` does NOT re-stamp the stale `.env` PORT back into services.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)