### PR TITLE
feat(auth): hub token registry + mint API + revocation list endpoint (hub#212 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.8-rc.2] - 2026-05-09
+
+Token registry + mint API + revocation list endpoint — Phase 1 of the hub-as-sole-AS migration tracked in [#212](https://github.com/ParachuteComputer/parachute-hub/issues/212). Five components, all hub-side, additive (no breaking changes to existing surfaces). Closes Phase 1 and absorbs Phase 5 (CLI relocation — the canonical `parachute auth mint-token` already exists per #179, this PR extends it).
+
+### Added
+
+- **Token registry: `tokens` table v6 migration (Component 1).** Generalizes the OAuth-refresh-only `tokens` table into a unified registry across every issued JWT class. Three new columns: `permissions TEXT` (JSON, fine-grained constraints per the auth-architecture research doc §11.3), `created_via TEXT NOT NULL DEFAULT 'oauth_refresh'` (provenance: `oauth_refresh` / `cli_mint` / `operator_mint`), `subject TEXT` (non-user identity for service / operator mints — operator-mint rows store `"operator"` here while leaving `user_id` NULL). The `user_id` column drops its NOT NULL constraint (CLI/operator mints aren't tied to a hub user; OAuth-refresh rows still set it). SQLite has no `ALTER COLUMN` to drop NOT NULL, so the migration uses the recreate-and-rename pattern inside the migration transaction (atomic; nothing references `tokens` so the drop is safe). Existing rows backfill `created_via='oauth_refresh'` automatically via the column default. New indexes: `tokens_revoked` (powers the revocation-list filter), `tokens_subject` (lookup by non-user mint). Existing indexes (`tokens_user`, `tokens_active_refresh`, `tokens_family`) recreated post-rename. Pre-Phase-1 tokens (already issued before this migration) stay valid but unregistered; they expire on their own (15-min access tokens drained within the hour; pre-#213 365d operator tokens cap at their original expiry).
+- **`POST /api/auth/mint-token` HTTP endpoint (Component 3).** New file `src/api-mint-token.ts`. Companion to the CLI for automation that doesn't have local CLI access. Auth: `Authorization: Bearer <token>` whose `scope` claim contains `parachute:host:auth` (the new narrow scope from #213). Body shape: `{ scope, audience?, expires_in?, subject?, permissions? }` — same semantics as the CLI's `--scope` / `--aud` / `--expires-in` / `--sub` / `--permissions` flags. Returns `{ jti, token, expires_at, scope, permissions? }`. 401 / 403 / 400 / 405 surfaces match the OAuth error vocabulary. Wired into `hub-server.ts` dispatch. Every mint writes a registry row identical to the CLI path (`created_via='cli_mint'`).
+- **`GET /.well-known/parachute-revocation.json` revocation list endpoint (Component 5).** New file `src/api-revocation-list.ts`. Public endpoint (no auth — the list is harmless to expose; opaque jtis only). Returns `{ generated_at, jtis: [...] }` filtered to `revoked_at IS NOT NULL AND expires_at > now`. Already-expired jtis are filtered out (consumers' own `exp` check rejects them anyway; listing is noise). `Cache-Control: public, max-age=60` matches the polling cadence Phase 4 will wire on the resource-server side. Wildcard CORS posture identical to `/.well-known/jwks.json` — resource servers fetch this cross-origin.
+- **`recordTokenMint(db, opts)` helper in `src/jwt-sign.ts`.** The non-OAuth-refresh mint path; writes a registry row with the chosen `created_via` and `subject`. Used by `parachute auth mint-token`, the new HTTP endpoint, and the operator-mint paths.
+- **`revokeTokenByJti(db, jti, now)` helper in `src/jwt-sign.ts`.** Idempotent revocation: returns `true` when a row was updated (was un-revoked before), `false` when no row matches or the row was already revoked. Powers the future `/admin/tokens` admin UI revoke action (Phase 2) and any other explicit-revoke surface.
+- **`listActiveRevocations(db, now)` helper in `src/jwt-sign.ts`.** Returns the snapshot of currently-revoked-and-not-yet-expired jtis. Powers the revocation list endpoint.
+- **`tokenRowIdentity(row)` helper in `src/jwt-sign.ts`.** Returns the canonical "who is this token for" string — `userId ?? subject ?? ""`. Collapses the OAuth-vs-non-OAuth distinction for callers that don't care.
+- **`TokenCreatedVia` type exported from `src/jwt-sign.ts`** — `"oauth_refresh" | "cli_mint" | "operator_mint"`.
+
+### Changed
+
+- **`parachute auth mint-token` extended (Component 2).** New flags:
+  - `--permissions <JSON>` — JSON object encoding fine-grained constraints beyond OAuth scope. Round-trips into the JWT's `permissions` claim. Validated to be a JSON object (not a primitive, not an array); malformed JSON or non-object payloads are rejected with a usage error.
+  - `--expires-in <integer-seconds>` — canonical lifetime flag. Matches OAuth's `expires_in` claim semantics (the JWT `exp` is `iat + expires_in`). Integer-seconds only; values like `1d` go through the legacy `--ttl` flag.
+  - `--ttl` is now the **deprecated alias**: still works, still accepts the duration-string form (`90d` / `24h` / `30m` / `60s`), but emits a one-line stderr deprecation notice on use (`--ttl is deprecated; use --expires-in <seconds> instead (will be removed in 0.6.0)`). Passing both `--ttl` and `--expires-in` together is a usage error.
+  - Help text rewritten with the multi-scope syntax, the `--permissions` example, and the deprecation note.
+  - Every successful mint writes a `tokens` registry row (`created_via='cli_mint'`, `subject=<--sub or operator's sub>`, `user_id NULL` per the design — CLI mints aren't user-tied at the row level).
+- **Operator-token mints write to the registry (Component 4).** `mintOperatorToken` now calls `recordTokenMint(...)` after signing — `created_via='operator_mint'`, `subject="operator"`, `user_id NULL`. Auto-rotation rows from #213's `useOperatorTokenWithAutoRotate` get registered too. Both the original and the rotated row exist (the original isn't auto-revoked on rotation; it stays valid until its own `exp`). A future "revoke prior on rotation" toggle is a Phase 2 candidate; for now we accept the slightly larger registry for the simpler invariant.
+- **`signRefreshToken` explicitly stamps `created_via='oauth_refresh'`.** Previously the column didn't exist; v6's column default would handle pre-existing rows but new inserts go through this path now. Belt-and-suspenders with the migration default.
+- **`RefreshTokenRow.userId` is now `string | null`.** Reflects the v6 schema. OAuth callsites (`oauth-handlers.ts:1054`, line 1069 — refresh-token rotation path) add a runtime guard: if `findRefreshToken` returns a row with `userId === null` (shouldn't happen because `findRefreshToken` filters by `refresh_token_hash IS NOT NULL`, and only OAuth-refresh rows have a hash), surface a clean `invalid_grant` rather than letting the type-system lie cascade. Defense-in-depth; the runtime path is unreachable on a correct schema but the guard makes the contract explicit.
+- **`SignAccessTokenOpts.extraClaims` now used for the `permissions` claim too.** Previously only `pa_scope_set` rode this seam (#213). The `extraClaims` shape is unchanged; it just has more callers now.
+
+### Migration / impact
+
+- **Operators upgrading from 0.5.7-rc.* or 0.5.7 stable:** the v6 migration runs automatically on next `openHubDb()`. Existing OAuth refresh-token rows are backfilled with `created_via='oauth_refresh'`; their `permissions` and `subject` stay NULL. No data loss, no downtime.
+- **Operators with operator.token files from 0.5.7 or earlier:** still valid (the JWT carries its own `exp`, signed by hub's existing keys, validated by `validateAccessToken`). They don't have a registry row, but that's harmless — `validateAccessToken` only consults the registry to check `revoked_at`, and a missing row is treated as not-revoked. The next `parachute auth rotate-operator` (or the auto-rotation from #213) will register the new token.
+- **OAuth refresh-token rotation:** unchanged behavior. The new `userId` nullability guard is defense-in-depth; the runtime path is unreachable on correctly-shaped rows.
+- **Pre-existing access tokens:** still valid until expiry. The 15-minute default TTL means any pre-Phase-1 access tokens drain within the hour after deploy.
+
+### Out of scope (deferred to later phases of #212)
+
+- **Phase 2: admin UI `/admin/tokens` route** — list / revoke / inspect rows. Daytime work.
+- **Phase 4: vault / agent / scribe revocation-list consumers** — fetch `/.well-known/parachute-revocation.json` on a 60s TTL and reject any presented JWT whose `jti` appears. Resource-server side; this PR ships the issuer-side endpoint only.
+- **Phase 5: `parachute vault tokens create` → `parachute auth mint-token`** — partially absorbed into this PR (the canonical CLI path already exists; the `vault tokens create` path becomes a removable alias). Final cutover deferred to a Phase 5 cleanup PR.
+- **Phase 6: `pvt_*` deprecation in vault** — vault-side; out of scope here.
+- **Per-CLI-command scope-set enforcement (Phase 2 of #213)** — separate followup.
+
+### Tests
+
+`bun test ./src`: **1153 pass / 0 fail** (was 1118 / 0 on the 0.5.8-rc.1 tip). 35 new cases:
+
+- `src/__tests__/jwt-sign.test.ts` (+7): v6 schema shape via `PRAGMA table_info(tokens)`, `recordTokenMint` round-trip, duplicate-jti throws `RefreshTokenInsertError`, `revokeTokenByJti` idempotency + flips `revoked_at`, `listActiveRevocations` filters by `revoked_at AND expires_at>now`, `tokenRowIdentity` returns `userId ?? subject`, `signRefreshToken` stamps `created_via='oauth_refresh'`.
+- `src/__tests__/auth.test.ts` (+9): every mint writes registry row (`created_via='cli_mint'`), `--permissions` JSON object round-trips into JWT + registry, `--permissions` malformed JSON rejected, `--permissions` non-object (array) rejected, `--expires-in` (canonical) sets JWT TTL, `--expires-in` non-integer rejected, `--expires-in` over 365d cap rejected, `--ttl` deprecation notice on stderr but still works, both `--ttl` and `--expires-in` together rejected.
+- `src/__tests__/operator-token.test.ts` (+2): `mintOperatorToken` writes registry row (`created_via='operator_mint'`, `subject='operator'`, `user_id NULL`), auto-rotation writes a fresh row for the rotated token while leaving the original row in place.
+- `src/__tests__/api-mint-token.test.ts` (+11, new file): 401 no auth, 401 non-Bearer, 401 invalid bearer, 403 bearer without `parachute:host:auth`, happy path with admin operator token (registry row written, JWT round-trips), happy path with `--scope-set=auth` narrow operator token, `permissions` round-trip, 400 missing scope, 400 expires_in over cap, 400 permissions non-object, 405 non-POST.
+- `src/__tests__/api-revocation-list.test.ts` (+6, new file): empty list initially, returns revoked jti, filters out already-expired, OAuth-refresh rows participate (cross-class revocation), 405 non-GET, `revokeTokenByJti` idempotency.
+
+`bunx biome check .`: 171 files, no findings. `bun run typecheck`: clean.
+
 ## [0.5.8-rc.1] - 2026-05-09
 
 Operator-token hardening — first slice of the hub-as-sole-AS migration arc tracked in #212. This PR is scoped to #213's three pieces; the broader registry + revocation infrastructure lands in 0.5.8-rc.2 (#212 Phase 1).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.8-rc.1",
+  "version": "0.5.8-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-mint-token.test.ts
+++ b/src/__tests__/api-mint-token.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleApiMintToken } from "../api-mint-token.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { signAccessToken, validateAccessToken } from "../jwt-sign.ts";
+import { mintOperatorToken } from "../operator-token.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+
+interface Harness {
+  dir: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-api-mint-"));
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+const ISSUER = "http://127.0.0.1:1939";
+
+async function bootstrap(
+  dir: string,
+): Promise<{ db: ReturnType<typeof openHubDb>; userId: string }> {
+  const db = openHubDb(hubDbPath(dir));
+  rotateSigningKey(db);
+  const u = await createUser(db, "owner", "pw");
+  return { db, userId: u.id };
+}
+
+function jsonRequest(body: unknown, headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/api/auth/mint-token", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
+  test("401 when no Authorization header", async () => {
+    const h = makeHarness();
+    try {
+      const { db } = await bootstrap(h.dir);
+      try {
+        const resp = await handleApiMintToken(jsonRequest({ scope: "vault:read" }), {
+          db,
+          issuer: ISSUER,
+        });
+        expect(resp.status).toBe(401);
+        const body = (await resp.json()) as { error: string };
+        expect(body.error).toBe("unauthenticated");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("401 when Authorization is not Bearer", async () => {
+    const h = makeHarness();
+    try {
+      const { db } = await bootstrap(h.dir);
+      try {
+        const resp = await handleApiMintToken(
+          jsonRequest({ scope: "vault:read" }, { authorization: "Basic xyz" }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(401);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("401 when bearer fails signature/issuer validation", async () => {
+    const h = makeHarness();
+    try {
+      const { db } = await bootstrap(h.dir);
+      try {
+        const resp = await handleApiMintToken(
+          jsonRequest({ scope: "vault:read" }, { authorization: "Bearer not-a-real-jwt" }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(401);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("403 when bearer scope lacks parachute:host:auth", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        // Hand-mint a JWT with hub:admin only — covers the operator-bearer
+        // happy path for OTHER routes but is intentionally insufficient for
+        // /api/auth/mint-token (we want a narrow `parachute:host:auth` gate).
+        const narrow = await signAccessToken(db, {
+          sub: userId,
+          scopes: ["hub:admin"],
+          audience: "hub",
+          clientId: "parachute-hub",
+          issuer: ISSUER,
+          ttlSeconds: 3600,
+        });
+        const resp = await handleApiMintToken(
+          jsonRequest({ scope: "vault:read" }, { authorization: `Bearer ${narrow.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(403);
+        const body = (await resp.json()) as { error: string };
+        expect(body.error).toBe("insufficient_scope");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("happy path: admin operator-token mints a scope-narrow JWT + writes registry row", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiMintToken(
+          jsonRequest(
+            { scope: "scribe:transcribe", expires_in: 3600 },
+            { authorization: `Bearer ${op.token}` },
+          ),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as {
+          jti: string;
+          token: string;
+          expires_at: string;
+          scope: string;
+        };
+        expect(body.token.split(".")).toHaveLength(3);
+        expect(body.scope).toBe("scribe:transcribe");
+        expect(typeof body.jti).toBe("string");
+        // Round-trip the minted JWT through hub validation.
+        const validated = await validateAccessToken(db, body.token, ISSUER);
+        expect(validated.payload.scope).toBe("scribe:transcribe");
+        expect(validated.payload.aud).toBe("scribe");
+        expect(validated.payload.jti).toBe(body.jti);
+        // Registry row was written.
+        const row = db
+          .query<{ jti: string; created_via: string; subject: string }, [string]>(
+            "SELECT jti, created_via, subject FROM tokens WHERE jti = ?",
+          )
+          .get(body.jti);
+        expect(row).not.toBeNull();
+        expect(row?.created_via).toBe("cli_mint");
+        // Default subject = bearer's sub = the userId.
+        expect(row?.subject).toBe(userId);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("happy path: --scope-set=auth narrow operator token also passes the scope gate", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, {
+          issuer: ISSUER,
+          scopeSet: "auth",
+        });
+        const resp = await handleApiMintToken(
+          jsonRequest({ scope: "vault:read" }, { authorization: `Bearer ${op.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(200);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("permissions object round-trips into JWT + registry row", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const permissions = { vault: { default: { write_tags: ["health"] } } };
+        const resp = await handleApiMintToken(
+          jsonRequest(
+            { scope: "vault:default:write", permissions },
+            { authorization: `Bearer ${op.token}` },
+          ),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as { token: string; jti: string; permissions: unknown };
+        expect(body.permissions).toEqual(permissions);
+        const validated = await validateAccessToken(db, body.token, ISSUER);
+        expect(validated.payload.permissions).toEqual(permissions);
+        const row = db
+          .query<{ permissions: string }, [string]>("SELECT permissions FROM tokens WHERE jti = ?")
+          .get(body.jti);
+        expect(JSON.parse(row!.permissions)).toEqual(permissions);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("400 when scope is missing", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiMintToken(
+          jsonRequest({}, { authorization: `Bearer ${op.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(400);
+        const body = (await resp.json()) as { error: string; error_description: string };
+        expect(body.error).toBe("invalid_request");
+        expect(body.error_description).toContain("scope");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("400 when expires_in exceeds 365d cap", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiMintToken(
+          jsonRequest(
+            { scope: "vault:read", expires_in: 366 * 86400 },
+            { authorization: `Bearer ${op.token}` },
+          ),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(400);
+        const body = (await resp.json()) as { error_description: string };
+        expect(body.error_description).toContain("365d cap");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("400 when permissions is not an object", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiMintToken(
+          jsonRequest(
+            { scope: "vault:read", permissions: ["not", "an", "object"] },
+            { authorization: `Bearer ${op.token}` },
+          ),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(400);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("405 on non-POST", async () => {
+    const h = makeHarness();
+    try {
+      const { db } = await bootstrap(h.dir);
+      try {
+        const req = new Request("http://localhost/api/auth/mint-token", { method: "GET" });
+        const resp = await handleApiMintToken(req, { db, issuer: ISSUER });
+        expect(resp.status).toBe(405);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/api-mint-token.test.ts
+++ b/src/__tests__/api-mint-token.test.ts
@@ -293,6 +293,76 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
     }
   });
 
+  // closes #215 reviewer F1 — privilege-diffusion guard.
+  test("400 invalid_scope when minting parachute:host:auth (non-requestable)", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiMintToken(
+          jsonRequest({ scope: "parachute:host:auth" }, { authorization: `Bearer ${op.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(400);
+        const body = (await resp.json()) as { error: string; error_description: string };
+        expect(body.error).toBe("invalid_scope");
+        expect(body.error_description).toContain("parachute:host:auth");
+        expect(body.error_description).toContain("not requestable");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("400 invalid_scope when multi-scope includes a non-requestable", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiMintToken(
+          jsonRequest(
+            { scope: "vault:default:write parachute:host:admin" },
+            { authorization: `Bearer ${op.token}` },
+          ),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(400);
+        const body = (await resp.json()) as { error: string; error_description: string };
+        expect(body.error).toBe("invalid_scope");
+        expect(body.error_description).toContain("parachute:host:admin");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("400 invalid_scope when minting vault:<name>:admin (regex non-requestable)", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiMintToken(
+          jsonRequest({ scope: "vault:work:admin" }, { authorization: `Bearer ${op.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(400);
+        const body = (await resp.json()) as { error: string };
+        expect(body.error).toBe("invalid_scope");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("405 on non-POST", async () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/api-revocation-list.test.ts
+++ b/src/__tests__/api-revocation-list.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleRevocationList } from "../api-revocation-list.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { recordTokenMint, revokeTokenByJti, signRefreshToken } from "../jwt-sign.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+
+interface Harness {
+  dir: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-revocation-"));
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe("GET /.well-known/parachute-revocation.json (hub#212 Phase 1)", () => {
+  test("empty list when nothing revoked", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const req = new Request("http://localhost/.well-known/parachute-revocation.json");
+        const resp = handleRevocationList(req, { db });
+        expect(resp.status).toBe(200);
+        expect(resp.headers.get("content-type")).toBe("application/json");
+        expect(resp.headers.get("cache-control")).toBe("public, max-age=60");
+        const body = (await resp.json()) as { generated_at: string; jtis: string[] };
+        expect(body.jtis).toEqual([]);
+        expect(typeof body.generated_at).toBe("string");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("returns revoked jti after revokeTokenByJti", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const futureExpiry = new Date(Date.now() + 86400_000).toISOString();
+        recordTokenMint(db, {
+          jti: "jti-revoked-1",
+          createdVia: "cli_mint",
+          subject: "operator",
+          clientId: "parachute-hub",
+          scopes: ["scribe:transcribe"],
+          expiresAt: futureExpiry,
+        });
+        recordTokenMint(db, {
+          jti: "jti-active-1",
+          createdVia: "cli_mint",
+          subject: "operator",
+          clientId: "parachute-hub",
+          scopes: ["vault:read"],
+          expiresAt: futureExpiry,
+        });
+        revokeTokenByJti(db, "jti-revoked-1", new Date());
+
+        const req = new Request("http://localhost/.well-known/parachute-revocation.json");
+        const resp = handleRevocationList(req, { db });
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as { jtis: string[] };
+        expect(body.jtis).toEqual(["jti-revoked-1"]);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("filters out already-expired revoked jtis", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const past = new Date(Date.now() - 86400_000).toISOString();
+        const future = new Date(Date.now() + 86400_000).toISOString();
+        // Revoked but expired — should NOT appear in the list (consumers'
+        // own exp check would reject it anyway; listing it is noise).
+        recordTokenMint(db, {
+          jti: "jti-expired-revoked",
+          createdVia: "cli_mint",
+          subject: "operator",
+          clientId: "parachute-hub",
+          scopes: ["vault:read"],
+          expiresAt: past,
+        });
+        recordTokenMint(db, {
+          jti: "jti-active-revoked",
+          createdVia: "cli_mint",
+          subject: "operator",
+          clientId: "parachute-hub",
+          scopes: ["vault:read"],
+          expiresAt: future,
+        });
+        revokeTokenByJti(db, "jti-expired-revoked", new Date());
+        revokeTokenByJti(db, "jti-active-revoked", new Date());
+
+        const req = new Request("http://localhost/.well-known/parachute-revocation.json");
+        const resp = handleRevocationList(req, { db });
+        const body = (await resp.json()) as { jtis: string[] };
+        expect(body.jtis).toEqual(["jti-active-revoked"]);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("OAuth-refresh rows participate in the same revocation surface", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const u = await createUser(db, "owner", "pw");
+        // signRefreshToken writes a row with created_via='oauth_refresh';
+        // revoking by jti must surface it the same way as cli_mint rows.
+        const refresh = signRefreshToken(db, {
+          jti: "jti-oauth-refresh-1",
+          userId: u.id,
+          clientId: "parachute-hub",
+          scopes: ["vault:read"],
+        });
+        expect(refresh.familyId).toBeDefined();
+        revokeTokenByJti(db, "jti-oauth-refresh-1", new Date());
+
+        const req = new Request("http://localhost/.well-known/parachute-revocation.json");
+        const resp = handleRevocationList(req, { db });
+        const body = (await resp.json()) as { jtis: string[] };
+        expect(body.jtis).toContain("jti-oauth-refresh-1");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("rejects non-GET methods with 405", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const req = new Request("http://localhost/.well-known/parachute-revocation.json", {
+          method: "POST",
+        });
+        const resp = handleRevocationList(req, { db });
+        expect(resp.status).toBe(405);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("revokeTokenByJti is idempotent — second call returns false", () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const future = new Date(Date.now() + 86400_000).toISOString();
+        recordTokenMint(db, {
+          jti: "jti-once",
+          createdVia: "cli_mint",
+          subject: "operator",
+          clientId: "parachute-hub",
+          scopes: ["vault:read"],
+          expiresAt: future,
+        });
+        const now = new Date();
+        expect(revokeTokenByJti(db, "jti-once", now)).toBe(true);
+        expect(revokeTokenByJti(db, "jti-once", now)).toBe(false);
+        expect(revokeTokenByJti(db, "jti-does-not-exist", now)).toBe(false);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -1287,4 +1287,224 @@ describe("parachute auth mint-token", () => {
       tmp.cleanup();
     }
   });
+
+  // closes #212 Phase 1 — registry write, --permissions, --expires-in,
+  // --ttl deprecation notice.
+  test("every successful mint writes a tokens registry row (created_via=cli_mint)", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const { code, stdout } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "scribe:transcribe"], deps),
+      );
+      expect(code).toBe(0);
+      const token = stdout.trim();
+      const db = openHubDb(tmp.dbPath);
+      try {
+        const validated = await validateAccessToken(db, token);
+        const jti = validated.payload.jti as string;
+        const row = db
+          .query<{ jti: string; created_via: string; subject: string | null }, [string]>(
+            "SELECT jti, created_via, subject FROM tokens WHERE jti = ?",
+          )
+          .get(jti);
+        expect(row).not.toBeNull();
+        expect(row?.created_via).toBe("cli_mint");
+        // Default subject = operator's sub (the hub user id).
+        expect(typeof row?.subject).toBe("string");
+        expect(row?.subject?.length).toBeGreaterThan(0);
+      } finally {
+        db.close();
+      }
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("--permissions JSON object round-trips into JWT + registry row", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const permissions = '{"vault":{"default":{"write_tags":["health"]}}}';
+      const { code, stdout } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "vault:default:write", "--permissions", permissions], deps),
+      );
+      expect(code).toBe(0);
+      const token = stdout.trim();
+      const db = openHubDb(tmp.dbPath);
+      try {
+        const validated = await validateAccessToken(db, token);
+        expect(validated.payload.permissions).toEqual({
+          vault: { default: { write_tags: ["health"] } },
+        });
+        const jti = validated.payload.jti as string;
+        const row = db
+          .query<{ permissions: string }, [string]>("SELECT permissions FROM tokens WHERE jti = ?")
+          .get(jti);
+        expect(JSON.parse(row!.permissions)).toEqual({
+          vault: { default: { write_tags: ["health"] } },
+        });
+      } finally {
+        db.close();
+      }
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("--permissions with malformed JSON is rejected", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const { code, stderr } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "vault:read", "--permissions", "{not-json}"], deps),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("not valid JSON");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("--permissions with non-object JSON (array) is rejected", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const { code, stderr } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "vault:read", "--permissions", "[1,2,3]"], deps),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("must be a JSON object");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("--expires-in (canonical) sets the JWT TTL in seconds", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const { code, stdout } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "scribe:transcribe", "--expires-in", "7200"], deps),
+      );
+      expect(code).toBe(0);
+      const token = stdout.trim();
+      const db = openHubDb(tmp.dbPath);
+      try {
+        const validated = await validateAccessToken(db, token);
+        const exp = validated.payload.exp as number;
+        const iat = validated.payload.iat as number;
+        expect(exp - iat).toBe(7200);
+      } finally {
+        db.close();
+      }
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("--expires-in with non-integer value rejected", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const { code, stderr } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "vault:read", "--expires-in", "1d"], deps),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("integer seconds count");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("--expires-in over 365d cap rejected", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const { code, stderr } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "vault:read", "--expires-in", String(366 * 86400)], deps),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("365d cap");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("--ttl emits deprecation notice on stderr but still works", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const { code, stdout, stderr } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "scribe:transcribe", "--ttl", "1h"], deps),
+      );
+      expect(code).toBe(0);
+      expect(stdout.trim().split(".").length).toBe(3);
+      expect(stderr).toContain("--ttl is deprecated");
+      expect(stderr).toContain("--expires-in");
+      expect(stderr).toContain("0.6.0");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("passing both --ttl and --expires-in is an error", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const { code, stderr } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "vault:read", "--ttl", "1h", "--expires-in", "3600"], deps),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("--ttl");
+      expect(stderr).toContain("--expires-in");
+    } finally {
+      tmp.cleanup();
+    }
+  });
 });

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -1488,6 +1488,29 @@ describe("parachute auth mint-token", () => {
     }
   });
 
+  // closes #215 reviewer F1 — privilege-diffusion guard on the CLI mint path.
+  test("CLI mint-token rejects parachute:host:auth (non-requestable scope)", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const { code, stdout, stderr } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "parachute:host:auth"], deps),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("not requestable");
+      expect(stderr).toContain("parachute:host:auth");
+      // No token leaked to stdout.
+      expect(stdout).toBe("");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
   test("passing both --ttl and --expires-in is an error", async () => {
     const tmp = makeTmp();
     try {

--- a/src/__tests__/jwt-sign.test.ts
+++ b/src/__tests__/jwt-sign.test.ts
@@ -9,8 +9,13 @@ import {
   REFRESH_TOKEN_TTL_MS,
   RefreshTokenInsertError,
   findRefreshToken,
+  findTokenRowByJti,
+  listActiveRevocations,
+  recordTokenMint,
+  revokeTokenByJti,
   signAccessToken,
   signRefreshToken,
+  tokenRowIdentity,
   validateAccessToken,
 } from "../jwt-sign.ts";
 import { getActiveSigningKey, rotateSigningKey } from "../signing-keys.ts";
@@ -354,6 +359,206 @@ describe("validateAccessToken", () => {
       const enc = (o: object) => Buffer.from(JSON.stringify(o)).toString("base64url");
       const fake = `${enc(header)}.${enc(payload)}.sig`;
       await expect(validateAccessToken(db, fake)).rejects.toThrow(/missing kid/);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// closes #212 Phase 1 — unified token registry helpers (recordTokenMint,
+// revokeTokenByJti, listActiveRevocations) and the v6 schema shape.
+describe("token registry (hub#212 Phase 1)", () => {
+  test("v6 schema: tokens has user_id NULLABLE + permissions/created_via/subject", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      // SQLite PRAGMA table_info reports column nullability + defaults; the
+      // bun:sqlite driver maps the row shape onto our type. The columns are
+      // (cid, name, type, notnull, dflt_value, pk) per SQLite docs.
+      type ColInfo = {
+        cid: number;
+        name: string;
+        type: string;
+        notnull: number;
+        dflt_value: string | null;
+        pk: number;
+      };
+      const cols = db.query<ColInfo, []>("PRAGMA table_info(tokens)").all();
+      const byName = new Map(cols.map((c) => [c.name, c]));
+      // Pre-v6: user_id NOT NULL. Post-v6: user_id NULLABLE.
+      expect(byName.get("user_id")?.notnull).toBe(0);
+      // New columns.
+      expect(byName.has("permissions")).toBe(true);
+      expect(byName.has("created_via")).toBe(true);
+      expect(byName.has("subject")).toBe(true);
+      // created_via has the back-compat default for pre-v6 rows.
+      expect(byName.get("created_via")?.dflt_value).toMatch(/oauth_refresh/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("recordTokenMint inserts a registry row matching the inputs", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const expiresAt = new Date(Date.now() + 86400_000).toISOString();
+      recordTokenMint(db, {
+        jti: "jti-cli-1",
+        createdVia: "cli_mint",
+        subject: "operator",
+        clientId: "parachute-hub",
+        scopes: ["vault:read", "scribe:transcribe"],
+        expiresAt,
+        permissions: '{"vault":{"default":{"read_tags":["public"]}}}',
+      });
+      const row = findTokenRowByJti(db, "jti-cli-1");
+      expect(row).not.toBeNull();
+      expect(row?.userId).toBeNull();
+      expect(row?.subject).toBe("operator");
+      expect(row?.createdVia).toBe("cli_mint");
+      expect(row?.scopes).toEqual(["vault:read", "scribe:transcribe"]);
+      expect(row?.expiresAt).toBe(expiresAt);
+      expect(row?.permissions).toBe('{"vault":{"default":{"read_tags":["public"]}}}');
+      expect(row?.revokedAt).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("recordTokenMint with a duplicate jti throws RefreshTokenInsertError", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const expiresAt = new Date(Date.now() + 86400_000).toISOString();
+      recordTokenMint(db, {
+        jti: "jti-dup",
+        createdVia: "operator_mint",
+        subject: "operator",
+        clientId: "parachute-hub",
+        scopes: ["hub:admin"],
+        expiresAt,
+      });
+      expect(() =>
+        recordTokenMint(db, {
+          jti: "jti-dup",
+          createdVia: "cli_mint",
+          subject: "operator",
+          clientId: "parachute-hub",
+          scopes: ["vault:read"],
+          expiresAt,
+        }),
+      ).toThrow(RefreshTokenInsertError);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("revokeTokenByJti flips revoked_at; second call returns false (idempotent)", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const expiresAt = new Date(Date.now() + 86400_000).toISOString();
+      recordTokenMint(db, {
+        jti: "jti-rev",
+        createdVia: "cli_mint",
+        subject: "operator",
+        clientId: "parachute-hub",
+        scopes: ["vault:read"],
+        expiresAt,
+      });
+      const now = new Date();
+      expect(revokeTokenByJti(db, "jti-rev", now)).toBe(true);
+      expect(revokeTokenByJti(db, "jti-rev", now)).toBe(false);
+      const row = findTokenRowByJti(db, "jti-rev");
+      expect(row?.revokedAt).toBe(now.toISOString());
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("listActiveRevocations filters by revoked_at AND expires_at>now", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const past = new Date(Date.now() - 86400_000).toISOString();
+      const future = new Date(Date.now() + 86400_000).toISOString();
+      // Two revoked rows: one expired, one active.
+      recordTokenMint(db, {
+        jti: "jti-revoked-expired",
+        createdVia: "cli_mint",
+        subject: "operator",
+        clientId: "parachute-hub",
+        scopes: ["vault:read"],
+        expiresAt: past,
+      });
+      recordTokenMint(db, {
+        jti: "jti-revoked-active",
+        createdVia: "cli_mint",
+        subject: "operator",
+        clientId: "parachute-hub",
+        scopes: ["vault:read"],
+        expiresAt: future,
+      });
+      // One non-revoked active row (control — must NOT appear).
+      recordTokenMint(db, {
+        jti: "jti-not-revoked",
+        createdVia: "cli_mint",
+        subject: "operator",
+        clientId: "parachute-hub",
+        scopes: ["vault:read"],
+        expiresAt: future,
+      });
+      const now = new Date();
+      revokeTokenByJti(db, "jti-revoked-expired", now);
+      revokeTokenByJti(db, "jti-revoked-active", now);
+      const list = listActiveRevocations(db, now);
+      expect(list).toEqual(["jti-revoked-active"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("tokenRowIdentity returns userId when present, else subject", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      rotateSigningKey(db);
+      const u = await createUser(db, "owner", "pw");
+      // OAuth refresh row: userId set, subject NULL.
+      const refresh = signRefreshToken(db, {
+        jti: "jti-oauth",
+        userId: u.id,
+        clientId: "parachute-hub",
+        scopes: ["vault:read"],
+      });
+      expect(refresh.familyId).toBeDefined();
+      const oauthRow = findTokenRowByJti(db, "jti-oauth")!;
+      expect(tokenRowIdentity(oauthRow)).toBe(u.id);
+
+      // CLI mint row: userId NULL, subject set.
+      recordTokenMint(db, {
+        jti: "jti-cli",
+        createdVia: "cli_mint",
+        subject: "operator",
+        clientId: "parachute-hub",
+        scopes: ["vault:read"],
+        expiresAt: new Date(Date.now() + 86400_000).toISOString(),
+      });
+      const cliRow = findTokenRowByJti(db, "jti-cli")!;
+      expect(tokenRowIdentity(cliRow)).toBe("operator");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("signRefreshToken explicitly stamps created_via='oauth_refresh'", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      rotateSigningKey(db);
+      const u = await createUser(db, "owner", "pw");
+      signRefreshToken(db, {
+        jti: "jti-oauth-stamped",
+        userId: u.id,
+        clientId: "parachute-hub",
+        scopes: ["vault:read"],
+      });
+      const row = findTokenRowByJti(db, "jti-oauth-stamped");
+      expect(row?.createdVia).toBe("oauth_refresh");
     } finally {
       cleanup();
     }

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { getClient, registerClient } from "../clients.ts";
 import { CSRF_COOKIE_NAME } from "../csrf.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
-import { validateAccessToken } from "../jwt-sign.ts";
+import { findTokenRowByJti, validateAccessToken } from "../jwt-sign.ts";
 import {
   authorizationServerMetadata,
   buildServicesCatalog,
@@ -1038,6 +1038,28 @@ describe("handleToken — full OAuth dance", () => {
       expect(tokenBody.services).toEqual({
         vault: { url: `${ISSUER}/vault/default`, version: "0.3.0" },
       });
+
+      // closes #215 reviewer F2 — Phase 1 code-grant access-token registry
+      // exemption pinning. The access token and refresh token share `jti`
+      // by design (signRefreshToken({ jti: access.jti, ... }) at the mint
+      // site), so the `tokens` row keyed by the access-token jti IS the
+      // shared row — refresh_token_hash is non-null, created_via is
+      // 'oauth_refresh'. We deliberately don't write a separate per-jti
+      // access-token row; revocation acts on the shared jti / family,
+      // bounded by the 15-min access TTL.
+      expect(payload.jti).toBeTruthy();
+      const row = findTokenRowByJti(db, payload.jti as string);
+      expect(row).not.toBeNull();
+      expect(row?.createdVia).toBe("oauth_refresh");
+      expect(row?.familyId).toBeTruthy();
+      // Verify the registry has exactly one row for this code-grant
+      // (not two — no separate access-token row).
+      const rowCount = (
+        db
+          .query<{ n: number }, [string]>("SELECT COUNT(*) as n FROM tokens WHERE jti = ?")
+          .get(payload.jti as string) ?? { n: 0 }
+      ).n;
+      expect(rowCount).toBe(1);
     } finally {
       cleanup();
     }

--- a/src/__tests__/operator-token.test.ts
+++ b/src/__tests__/operator-token.test.ts
@@ -429,3 +429,88 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
     }
   });
 });
+
+// closes #212 Phase 1 — operator-mint paths write to the unified token
+// registry so they show up in the revocation list and admin UI alongside
+// OAuth refresh tokens and CLI mints.
+describe("mintOperatorToken registry write (#212)", () => {
+  test("writes a tokens row with created_via='operator_mint', subject='operator', user_id NULL", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const minted = await mintOperatorToken(db, "user-abc", {
+          issuer: TEST_ISSUER,
+          scopeSet: "start",
+        });
+        const row = db
+          .query<
+            {
+              jti: string;
+              user_id: string | null;
+              subject: string | null;
+              created_via: string;
+              scopes: string;
+              expires_at: string;
+            },
+            [string]
+          >(
+            "SELECT jti, user_id, subject, created_via, scopes, expires_at FROM tokens WHERE jti = ?",
+          )
+          .get(minted.jti);
+        expect(row).not.toBeNull();
+        expect(row?.user_id).toBeNull();
+        expect(row?.subject).toBe("operator");
+        expect(row?.created_via).toBe("operator_mint");
+        expect(row?.scopes).toBe("parachute:host:start");
+        expect(row?.expires_at).toBe(minted.expiresAt);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("auto-rotation writes a fresh registry row for the rotated token", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const original = await issueOperatorToken(db, "user-abc", {
+          dir: h.dir,
+          issuer: TEST_ISSUER,
+          ttlSeconds: 24 * 60 * 60, // within rotation window
+        });
+        const used = await useOperatorTokenWithAutoRotate(db, {
+          configDir: h.dir,
+          issuer: TEST_ISSUER,
+        });
+        expect(used?.refreshed).toBe(true);
+        // The rotated token has a new jti.
+        const newJti = used!.payload.jti as string;
+        expect(newJti).not.toBe(original.jti);
+        const row = db
+          .query<{ jti: string; created_via: string }, [string]>(
+            "SELECT jti, created_via FROM tokens WHERE jti = ?",
+          )
+          .get(newJti);
+        expect(row).not.toBeNull();
+        expect(row?.created_via).toBe("operator_mint");
+        // Both the original and the rotated row exist (the original isn't
+        // auto-revoked — it stays valid until its own exp). Phase 2 may add
+        // a "revoke prior on rotation" toggle; for now we keep both.
+        const origRow = db
+          .query<{ jti: string }, [string]>("SELECT jti FROM tokens WHERE jti = ?")
+          .get(original.jti);
+        expect(origRow).not.toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/api-mint-token.ts
+++ b/src/api-mint-token.ts
@@ -1,0 +1,222 @@
+/**
+ * `POST /api/auth/mint-token` — HTTP companion to `parachute auth mint-token`.
+ *
+ * Same arg/return shape as the CLI; just the network path. Used by:
+ *
+ *   - automation that doesn't have CLI access (CI runners, cloud agents)
+ *     but does hold an operator-bearer with `parachute:host:auth` scope;
+ *   - the future admin SPA when the operator wants to mint a one-shot
+ *     scope-narrow token without dropping to a terminal.
+ *
+ * Auth: `Authorization: Bearer <token>` where `token`'s `scope` claim
+ * contains `parachute:host:auth`. The operator's local operator.token
+ * (admin scope-set) covers this; a narrow `--scope-set=auth` operator
+ * token also covers this.
+ *
+ * Why a separate endpoint instead of extending /admin/host-admin-token:
+ * that endpoint is session-cookie-gated for the SPA's needs and only
+ * mints `parachute:host:admin`. This endpoint is bearer-gated for
+ * automation and mints arbitrary scope/permissions tuples per request.
+ *
+ * Every successful mint writes a row to the `tokens` registry
+ * (`created_via='cli_mint'` — same provenance as the CLI path, since
+ * HTTP mint is just CLI-by-network). Powers the
+ * `/.well-known/parachute-revocation.json` endpoint.
+ */
+import type { Database } from "bun:sqlite";
+import { inferAudience } from "./jwt-audience.ts";
+import { recordTokenMint, signAccessToken, validateAccessToken } from "./jwt-sign.ts";
+
+/** Default lifetime when --expires-in / `expires_in` is omitted. Matches the CLI. */
+export const API_MINT_TOKEN_DEFAULT_TTL_SECONDS = 90 * 24 * 60 * 60;
+/** Hard cap. Matches the CLI's --expires-in upper bound. */
+export const API_MINT_TOKEN_MAX_TTL_SECONDS = 365 * 24 * 60 * 60;
+/** Scope required on the bearer token to call this endpoint. */
+export const API_MINT_TOKEN_REQUIRED_SCOPE = "parachute:host:auth";
+/** client_id stamped on minted tokens. Matches the CLI flow's value. */
+export const API_MINT_TOKEN_CLIENT_ID = "parachute-hub";
+
+export interface ApiMintTokenDeps {
+  db: Database;
+  /** Hub origin — written into the JWT `iss` of minted tokens AND used to validate the bearer. */
+  issuer: string;
+  /** Test seam for time. */
+  now?: () => Date;
+}
+
+interface MintTokenRequest {
+  scope?: unknown;
+  audience?: unknown;
+  expires_in?: unknown;
+  subject?: unknown;
+  permissions?: unknown;
+}
+
+export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonError(405, "method_not_allowed", "use POST");
+  }
+
+  // 1. Bearer presence + parsing.
+  const auth = req.headers.get("authorization");
+  if (!auth || !auth.startsWith("Bearer ")) {
+    return jsonError(401, "unauthenticated", "Authorization: Bearer <token> required");
+  }
+  const bearer = auth.slice("Bearer ".length).trim();
+  if (!bearer) {
+    return jsonError(401, "unauthenticated", "empty bearer token");
+  }
+
+  // 2. Bearer validation (signature, issuer, expiry, revocation).
+  let bearerSub: string;
+  let bearerScopes: string[];
+  try {
+    const validated = await validateAccessToken(deps.db, bearer, deps.issuer);
+    const sub = validated.payload.sub;
+    if (typeof sub !== "string" || sub.length === 0) {
+      return jsonError(401, "unauthenticated", "bearer token has no sub claim");
+    }
+    bearerSub = sub;
+    bearerScopes =
+      typeof validated.payload.scope === "string"
+        ? validated.payload.scope.split(/\s+/).filter((s) => s.length > 0)
+        : [];
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return jsonError(401, "unauthenticated", `bearer token invalid — ${msg}`);
+  }
+
+  // 3. Scope gate.
+  if (!bearerScopes.includes(API_MINT_TOKEN_REQUIRED_SCOPE)) {
+    return jsonError(
+      403,
+      "insufficient_scope",
+      `bearer token lacks ${API_MINT_TOKEN_REQUIRED_SCOPE}`,
+    );
+  }
+
+  // 4. Body parsing.
+  let body: MintTokenRequest;
+  try {
+    body = (await req.json()) as MintTokenRequest;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return jsonError(400, "invalid_request", `body must be valid JSON — ${msg}`);
+  }
+  if (typeof body !== "object" || body === null) {
+    return jsonError(400, "invalid_request", "body must be a JSON object");
+  }
+
+  // 5. Required + typed field extraction.
+  if (typeof body.scope !== "string" || body.scope.trim().length === 0) {
+    return jsonError(400, "invalid_request", "scope is required and must be a non-empty string");
+  }
+  const scopes = body.scope.split(/\s+/).filter((s) => s.length > 0);
+  if (scopes.length === 0) {
+    return jsonError(400, "invalid_request", "scope must contain at least one scope");
+  }
+
+  let audience: string;
+  if (body.audience === undefined) {
+    audience = inferAudience(scopes);
+  } else if (typeof body.audience === "string" && body.audience.length > 0) {
+    audience = body.audience;
+  } else {
+    return jsonError(400, "invalid_request", "audience must be a non-empty string when present");
+  }
+
+  let ttlSeconds = API_MINT_TOKEN_DEFAULT_TTL_SECONDS;
+  if (body.expires_in !== undefined) {
+    if (typeof body.expires_in !== "number" || !Number.isFinite(body.expires_in)) {
+      return jsonError(400, "invalid_request", "expires_in must be a positive integer (seconds)");
+    }
+    if (!Number.isInteger(body.expires_in) || body.expires_in <= 0) {
+      return jsonError(400, "invalid_request", "expires_in must be a positive integer (seconds)");
+    }
+    if (body.expires_in > API_MINT_TOKEN_MAX_TTL_SECONDS) {
+      return jsonError(
+        400,
+        "invalid_request",
+        `expires_in exceeds 365d cap (${API_MINT_TOKEN_MAX_TTL_SECONDS} seconds)`,
+      );
+    }
+    ttlSeconds = body.expires_in;
+  }
+
+  let subject: string;
+  if (body.subject === undefined) {
+    subject = bearerSub;
+  } else if (typeof body.subject === "string" && body.subject.length > 0) {
+    subject = body.subject;
+  } else {
+    return jsonError(400, "invalid_request", "subject must be a non-empty string when present");
+  }
+
+  let permissionsClaim: Record<string, unknown> | undefined;
+  let permissionsCanonical: string | undefined;
+  if (body.permissions !== undefined) {
+    if (
+      typeof body.permissions !== "object" ||
+      body.permissions === null ||
+      Array.isArray(body.permissions)
+    ) {
+      return jsonError(400, "invalid_request", "permissions must be a JSON object");
+    }
+    permissionsClaim = body.permissions as Record<string, unknown>;
+    permissionsCanonical = JSON.stringify(permissionsClaim);
+  }
+
+  // 6. Mint + register.
+  const minted = await signAccessToken(deps.db, {
+    sub: subject,
+    scopes,
+    audience,
+    clientId: API_MINT_TOKEN_CLIENT_ID,
+    issuer: deps.issuer,
+    ttlSeconds,
+    ...(permissionsClaim !== undefined ? { extraClaims: { permissions: permissionsClaim } } : {}),
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  });
+
+  recordTokenMint(deps.db, {
+    jti: minted.jti,
+    createdVia: "cli_mint",
+    subject,
+    // user_id intentionally omitted — CLI-mint rows store subject only,
+    // matching the CLI path's shape (so HTTP and CLI mints look identical
+    // in the registry). The bearer's user identity is implicit via the
+    // bearer's own user_id (which is in its own tokens row).
+    clientId: API_MINT_TOKEN_CLIENT_ID,
+    scopes,
+    expiresAt: minted.expiresAt,
+    ...(permissionsCanonical !== undefined ? { permissions: permissionsCanonical } : {}),
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  });
+
+  return new Response(
+    JSON.stringify({
+      jti: minted.jti,
+      token: minted.token,
+      expires_at: minted.expiresAt,
+      scope: scopes.join(" "),
+      ...(permissionsClaim !== undefined ? { permissions: permissionsClaim } : {}),
+    }),
+    {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+        "cache-control": "no-store",
+      },
+    },
+  );
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/src/api-mint-token.ts
+++ b/src/api-mint-token.ts
@@ -26,6 +26,7 @@
 import type { Database } from "bun:sqlite";
 import { inferAudience } from "./jwt-audience.ts";
 import { recordTokenMint, signAccessToken, validateAccessToken } from "./jwt-sign.ts";
+import { isNonRequestableScope } from "./scope-explanations.ts";
 
 /** Default lifetime when --expires-in / `expires_in` is omitted. Matches the CLI. */
 export const API_MINT_TOKEN_DEFAULT_TTL_SECONDS = 90 * 24 * 60 * 60;
@@ -114,6 +115,22 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
   const scopes = body.scope.split(/\s+/).filter((s) => s.length > 0);
   if (scopes.length === 0) {
     return jsonError(400, "invalid_request", "scope must contain at least one scope");
+  }
+
+  // Privilege-diffusion guard: mint paths cannot themselves mint tokens
+  // carrying non-requestable scopes (parachute:host:admin, the host:*
+  // narrow scopes, vault:<name>:admin). Holder of `parachute:host:auth`
+  // can mint vault/scribe/agent verb scopes for downstream services, but
+  // cannot mint another `:auth` (or any other non-requestable) without
+  // forced re-auth via the operator.token rotation path. Same set the
+  // public OAuth flow already rejects.
+  const blocked = scopes.filter((s) => isNonRequestableScope(s));
+  if (blocked.length > 0) {
+    return jsonError(
+      400,
+      "invalid_scope",
+      `scope ${blocked.join(", ")} is not requestable via mint-token; use OAuth flow or operator rotation`,
+    );
   }
 
   let audience: string;

--- a/src/api-revocation-list.ts
+++ b/src/api-revocation-list.ts
@@ -1,0 +1,59 @@
+/**
+ * `GET /.well-known/parachute-revocation.json` — public list of revoked,
+ * not-yet-expired token jtis. Resource servers (vault, scribe, agent)
+ * fetch this on a 60s TTL and reject any presented JWT whose jti appears.
+ *
+ * Public endpoint (no auth). The list itself is harmless to expose: it's
+ * a list of opaque IDs whose only utility is "this token shouldn't be
+ * accepted." A leaked list doesn't enable any new attack — at worst, an
+ * attacker learns which compromise the operator already cleaned up.
+ *
+ * Already-expired jtis are filtered out: every consumer checks `exp`
+ * itself, so listing expired tokens just bloats the response. The
+ * revocation list exists for *unexpired* tokens whose validity got cut
+ * short. Once `exp` passes, a row falls off the list naturally.
+ *
+ * Caching: 60s `Cache-Control: max-age=60` matches the consumer's
+ * polling cadence (Phase 4 wires the 60s TTL on the resource-server
+ * side). Shorter cache = revocation propagates faster but burns more
+ * CPU on this endpoint; 60s is the published convergence target.
+ */
+import type { Database } from "bun:sqlite";
+import { listActiveRevocations } from "./jwt-sign.ts";
+
+export const REVOCATION_LIST_MOUNT = "/.well-known/parachute-revocation.json";
+/** Consumer cache TTL in seconds. Resource servers should poll on this cadence. */
+export const REVOCATION_LIST_CACHE_SECONDS = 60;
+
+export interface RevocationListDeps {
+  db: Database;
+  /** Test seam for time. */
+  now?: () => Date;
+}
+
+interface RevocationListBody {
+  generated_at: string;
+  jtis: string[];
+}
+
+export function handleRevocationList(req: Request, deps: RevocationListDeps): Response {
+  if (req.method !== "GET") {
+    return new Response(JSON.stringify({ error: "method_not_allowed" }), {
+      status: 405,
+      headers: { "content-type": "application/json" },
+    });
+  }
+  const now = deps.now?.() ?? new Date();
+  const jtis = listActiveRevocations(deps.db, now);
+  const body: RevocationListBody = {
+    generated_at: now.toISOString(),
+    jtis,
+  };
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": `public, max-age=${REVOCATION_LIST_CACHE_SECONDS}`,
+    },
+  });
+}

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -26,7 +26,7 @@ import { HUB_DEFAULT_PORT, readHubPort } from "../hub-control.ts";
 import { openHubDb } from "../hub-db.ts";
 import { deriveHubOrigin } from "../hub-origin.ts";
 import { inferAudience } from "../jwt-audience.ts";
-import { signAccessToken } from "../jwt-sign.ts";
+import { recordTokenMint, signAccessToken } from "../jwt-sign.ts";
 import {
   OPERATOR_TOKEN_CLIENT_ID,
   OPERATOR_TOKEN_SCOPE_SET_NAMES,
@@ -87,9 +87,12 @@ Usage:
                                        Mint a fresh ~/.parachute/operator.token
                                        (set = install|start|expose|auth|vault|admin,
                                        default admin)
-  parachute auth mint-token --scope <scope> [--aud <aud>] [--ttl <duration>] [--sub <sub>]
+  parachute auth mint-token --scope <scope> [--aud <aud>] [--expires-in <seconds>]
+                                            [--sub <sub>] [--permissions <json>]
                                        Mint a scope-narrow JWT against the
-                                       operator's identity (stdout = JWT)
+                                       operator's identity (stdout = JWT).
+                                       --ttl <duration> is the deprecated
+                                       alias (use --expires-in seconds).
   parachute auth pending-clients       List OAuth clients awaiting approval
   parachute auth approve-client <id>   Approve a pending OAuth client
   parachute auth list-grants [--username <name>]
@@ -141,9 +144,28 @@ identity, signed with the same key as OAuth-issued tokens. Pipeable:
 \`parachute auth mint-token --scope scribe:transcribe | pbcopy\`. The
 audience defaults via the same inference rule the OAuth flow uses
 (named \`vault:<name>:<verb>\` → \`vault.<name>\`, otherwise the first
-colon-prefixed scope's namespace, fallback \`hub\`). TTL defaults to 90d,
-caps at 365d. Requires a valid ~/.parachute/operator.token (run
-\`parachute auth set-password\` or \`rotate-operator\` first).
+colon-prefixed scope's namespace, fallback \`hub\`). Lifetime defaults
+to 90d, caps at 365d.
+
+--scope accepts space-separated multi-scope (e.g.
+\`--scope "vault:default:read agent:wovenboulder:invoke"\`).
+
+--expires-in is the canonical lifetime flag — integer seconds (e.g.
+\`--expires-in 86400\` for 1 day). The legacy \`--ttl\` flag accepts a
+duration suffix (\`90d\` / \`24h\` / \`30m\` / \`60s\`) and is supported as
+a deprecated alias; passing it emits a one-line stderr deprecation
+notice. \`--ttl\` will be removed in 0.6.0.
+
+--permissions accepts a JSON object encoding fine-grained constraints
+beyond OAuth scope (e.g.
+\`--permissions '{"vault":{"default":{"write_tags":["health"]}}}'\`).
+Carried in the JWT as the \`permissions\` claim per the convergence
+section of the auth-architecture research doc.
+
+Every mint writes a row to the hub's token registry (one source of
+truth for revocation, admin UI introspection). Requires a valid
+~/.parachute/operator.token (run \`parachute auth set-password\` or
+\`rotate-operator\` first).
 
 pending-clients + approve-client gate /oauth/register against operator
 approval (closes #74). Self-served DCR registrations land as 'pending'
@@ -657,7 +679,11 @@ interface MintTokenFlags {
   scope?: string;
   aud?: string;
   ttl?: string;
+  expiresIn?: string;
   sub?: string;
+  permissions?: string;
+  /** True when --ttl was used (deprecated alias). Triggers a one-line stderr warning. */
+  ttlDeprecationSeen?: boolean;
   error?: string;
 }
 
@@ -665,7 +691,10 @@ function parseMintTokenFlags(args: readonly string[]): MintTokenFlags {
   let scope: string | undefined;
   let aud: string | undefined;
   let ttl: string | undefined;
+  let expiresIn: string | undefined;
   let sub: string | undefined;
+  let permissions: string | undefined;
+  let ttlDeprecationSeen = false;
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === "--scope") {
@@ -686,9 +715,18 @@ function parseMintTokenFlags(args: readonly string[]): MintTokenFlags {
       const v = args[++i];
       if (!v) return { error: "--ttl requires a value" };
       ttl = v;
+      ttlDeprecationSeen = true;
     } else if (a?.startsWith("--ttl=")) {
       ttl = a.slice("--ttl=".length);
       if (!ttl) return { error: "--ttl requires a value" };
+      ttlDeprecationSeen = true;
+    } else if (a === "--expires-in") {
+      const v = args[++i];
+      if (!v) return { error: "--expires-in requires a value" };
+      expiresIn = v;
+    } else if (a?.startsWith("--expires-in=")) {
+      expiresIn = a.slice("--expires-in=".length);
+      if (!expiresIn) return { error: "--expires-in requires a value" };
     } else if (a === "--sub") {
       const v = args[++i];
       if (!v) return { error: "--sub requires a value" };
@@ -696,11 +734,21 @@ function parseMintTokenFlags(args: readonly string[]): MintTokenFlags {
     } else if (a?.startsWith("--sub=")) {
       sub = a.slice("--sub=".length);
       if (!sub) return { error: "--sub requires a value" };
+    } else if (a === "--permissions") {
+      const v = args[++i];
+      if (!v) return { error: "--permissions requires a value" };
+      permissions = v;
+    } else if (a?.startsWith("--permissions=")) {
+      permissions = a.slice("--permissions=".length);
+      if (!permissions) return { error: "--permissions requires a value" };
     } else {
       return { error: `unknown flag "${a}"` };
     }
   }
-  return { scope, aud, ttl, sub };
+  if (ttl !== undefined && expiresIn !== undefined) {
+    return { error: "pass --expires-in OR --ttl, not both (--ttl is the deprecated alias)" };
+  }
+  return { scope, aud, ttl, expiresIn, sub, permissions, ttlDeprecationSeen };
 }
 
 const MINT_TOKEN_TTL_DEFAULT_SECONDS = 90 * 24 * 60 * 60;
@@ -708,9 +756,9 @@ const MINT_TOKEN_TTL_MAX_SECONDS = 365 * 24 * 60 * 60;
 
 /**
  * Parse a Go-ish duration string: integer + one of d/h/m/s. Caps at 365d.
- * `90d` → 7776000. We don't honor Go's stdlib `time.ParseDuration` exactly
- * (no `d` there), so this is a small custom parser to keep the operator
- * surface obvious.
+ * `90d` → 7776000. Used by the deprecated --ttl alias. The canonical
+ * --expires-in flag takes a raw integer seconds value (per OAuth's
+ * `expires_in` claim semantics — see `parseExpiresIn`).
  */
 function parseTtl(input: string): { seconds: number } | { error: string } {
   const m = /^(\d+)(d|h|m|s)$/.exec(input);
@@ -726,6 +774,29 @@ function parseTtl(input: string): { seconds: number } | { error: string } {
   return { seconds };
 }
 
+/**
+ * Parse the canonical --expires-in flag value as an integer seconds count.
+ * Matches OAuth's `expires_in` claim semantics — the JWT `exp` is
+ * `iat + expires_in`. Caps at 365d like the deprecated --ttl path.
+ */
+function parseExpiresIn(input: string): { seconds: number } | { error: string } {
+  if (!/^\d+$/.test(input)) {
+    return {
+      error: `invalid --expires-in "${input}" — expected an integer seconds count (e.g. 86400 = 1 day)`,
+    };
+  }
+  const seconds = Number.parseInt(input, 10);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return { error: `invalid --expires-in "${input}" — must be > 0` };
+  }
+  if (seconds > MINT_TOKEN_TTL_MAX_SECONDS) {
+    return {
+      error: `--expires-in "${input}" exceeds 365d cap (${MINT_TOKEN_TTL_MAX_SECONDS} seconds)`,
+    };
+  }
+  return { seconds };
+}
+
 async function runMintToken(args: readonly string[], deps: AuthDeps): Promise<number> {
   const flags = parseMintTokenFlags(args);
   if (flags.error) {
@@ -735,7 +806,7 @@ async function runMintToken(args: readonly string[], deps: AuthDeps): Promise<nu
   if (!flags.scope) {
     console.error("parachute auth mint-token: --scope is required");
     console.error(
-      "usage: parachute auth mint-token --scope <scope> [--aud <aud>] [--ttl <duration>] [--sub <sub>]",
+      "usage: parachute auth mint-token --scope <scope> [--aud <aud>] [--expires-in <seconds>] [--sub <sub>] [--permissions <json>]",
     );
     return 1;
   }
@@ -746,14 +817,47 @@ async function runMintToken(args: readonly string[], deps: AuthDeps): Promise<nu
     return 1;
   }
 
+  let permissions: string | undefined;
+  if (flags.permissions !== undefined) {
+    try {
+      // Parse to validate well-formedness — round-trip through JSON.stringify
+      // so we hand the JWT a canonicalized payload (no operator-introduced
+      // whitespace, no comments, no trailing commas).
+      const parsed = JSON.parse(flags.permissions) as unknown;
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        console.error(
+          'parachute auth mint-token: --permissions must be a JSON object (e.g. \'{"vault":{"default":{"write_tags":["health"]}}}\')',
+        );
+        return 1;
+      }
+      permissions = JSON.stringify(parsed);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`parachute auth mint-token: --permissions is not valid JSON — ${msg}`);
+      return 1;
+    }
+  }
+
   let ttlSeconds = MINT_TOKEN_TTL_DEFAULT_SECONDS;
-  if (flags.ttl) {
+  if (flags.expiresIn) {
+    const parsed = parseExpiresIn(flags.expiresIn);
+    if ("error" in parsed) {
+      console.error(`parachute auth mint-token: ${parsed.error}`);
+      return 1;
+    }
+    ttlSeconds = parsed.seconds;
+  } else if (flags.ttl) {
     const parsed = parseTtl(flags.ttl);
     if ("error" in parsed) {
       console.error(`parachute auth mint-token: ${parsed.error}`);
       return 1;
     }
     ttlSeconds = parsed.seconds;
+  }
+  if (flags.ttlDeprecationSeen) {
+    console.error(
+      "parachute auth mint-token: --ttl is deprecated; use --expires-in <seconds> instead (will be removed in 0.6.0)",
+    );
   }
 
   const configDir = deps.configDir ?? CONFIG_DIR;
@@ -818,6 +922,7 @@ async function runMintToken(args: readonly string[], deps: AuthDeps): Promise<nu
 
     const audience = flags.aud ?? inferAudience(scopes);
     const subjectForMint = flags.sub ?? operatorSub;
+    const permissionsClaim = permissions !== undefined ? JSON.parse(permissions) : undefined;
 
     const minted = await signAccessToken(db, {
       sub: subjectForMint,
@@ -826,7 +931,24 @@ async function runMintToken(args: readonly string[], deps: AuthDeps): Promise<nu
       clientId: OPERATOR_TOKEN_CLIENT_ID,
       issuer,
       ttlSeconds,
+      ...(permissionsClaim !== undefined ? { extraClaims: { permissions: permissionsClaim } } : {}),
     });
+
+    // Write a registry row (hub#212 Phase 1). Powers the revocation list
+    // endpoint and admin UI introspection. Per design: CLI-mint rows have
+    // user_id NULL; the subject column carries the chosen mint subject
+    // (--sub overrides operator-sub). The JWT is its own access token,
+    // not a refresh token, so refresh_token_hash + family_id stay NULL.
+    recordTokenMint(db, {
+      jti: minted.jti,
+      createdVia: "cli_mint",
+      subject: subjectForMint,
+      clientId: OPERATOR_TOKEN_CLIENT_ID,
+      scopes,
+      expiresAt: minted.expiresAt,
+      ...(permissions !== undefined ? { permissions } : {}),
+    });
+
     console.log(minted.token);
     return 0;
   } finally {

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -36,6 +36,7 @@ import {
   issueOperatorToken,
   useOperatorTokenWithAutoRotate,
 } from "../operator-token.ts";
+import { isNonRequestableScope } from "../scope-explanations.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 import {
   SingleUserModeError,
@@ -814,6 +815,21 @@ async function runMintToken(args: readonly string[], deps: AuthDeps): Promise<nu
   const scopes = flags.scope.split(/\s+/).filter((s) => s.length > 0);
   if (scopes.length === 0) {
     console.error("parachute auth mint-token: --scope must contain at least one scope");
+    return 1;
+  }
+
+  // Privilege-diffusion guard: mint paths cannot themselves mint tokens
+  // carrying non-requestable scopes (parachute:host:admin, the host:*
+  // narrow scopes, vault:<name>:admin). Holder of `parachute:host:auth`
+  // can mint vault/scribe/agent verb scopes for downstream services, but
+  // cannot mint another `:auth` (or any other non-requestable) without
+  // forced re-auth via the operator.token rotation path. Same set the
+  // public OAuth flow already rejects.
+  const blocked = scopes.filter((s) => isNonRequestableScope(s));
+  if (blocked.length > 0) {
+    console.error(
+      `parachute auth mint-token: scope ${blocked.join(", ")} is not requestable via mint-token; use OAuth flow or operator rotation`,
+    );
     return 1;
   }
 

--- a/src/hub-db.ts
+++ b/src/hub-db.ts
@@ -130,6 +130,69 @@ const MIGRATIONS: readonly Migration[] = [
       CREATE INDEX tokens_family ON tokens (family_id) WHERE family_id IS NOT NULL;
     `,
   },
+  {
+    version: 6,
+    sql: `
+      -- Token registry generalization (closes hub#212 Phase 1). Until v6 the
+      -- tokens table only held OAuth refresh tokens; v6 generalizes it to a
+      -- single registry across every issued JWT class (refresh, access,
+      -- operator, mint-token). Three structural changes:
+      --
+      --   1. user_id becomes NULLABLE. OAuth-issued rows still set it to the
+      --      caller's user (canonical identity field). CLI-minted /
+      --      operator-minted rows leave user_id NULL and put the operator/
+      --      service name in the new \`subject\` column.
+      --   2. Three new columns: \`permissions\` (JSON, custom claim per
+      --      auth-architecture-shape.md §11.3), \`created_via\` (provenance
+      --      tag: oauth_refresh / cli_mint / operator_mint), \`subject\`
+      --      (non-user identity for service / operator mints).
+      --   3. Existing rows backfill \`created_via='oauth_refresh'\` because
+      --      the table was OAuth-refresh-only before v6.
+      --
+      -- SQLite has no ALTER COLUMN to drop NOT NULL, so we use the
+      -- recreate-and-rename pattern. Inside the migration transaction the
+      -- whole swap is atomic; concurrent reads (there are none — hub is
+      -- single-writer) wouldn't see a half-state. FKs from tokens → users
+      -- stay enforced for non-NULL user_id values; nothing references
+      -- tokens, so the drop is safe.
+      CREATE TABLE tokens_new (
+        jti TEXT PRIMARY KEY,
+        user_id TEXT REFERENCES users(id),
+        client_id TEXT NOT NULL,
+        scopes TEXT NOT NULL,
+        refresh_token_hash TEXT,
+        family_id TEXT,
+        expires_at TEXT NOT NULL,
+        revoked_at TEXT,
+        created_at TEXT NOT NULL,
+        permissions TEXT,
+        created_via TEXT NOT NULL DEFAULT 'oauth_refresh',
+        subject TEXT
+      );
+      INSERT INTO tokens_new (
+        jti, user_id, client_id, scopes, refresh_token_hash, family_id,
+        expires_at, revoked_at, created_at,
+        permissions, created_via, subject
+      )
+      SELECT
+        jti, user_id, client_id, scopes, refresh_token_hash, family_id,
+        expires_at, revoked_at, created_at,
+        NULL, 'oauth_refresh', NULL
+      FROM tokens;
+      DROP TABLE tokens;
+      ALTER TABLE tokens_new RENAME TO tokens;
+      -- Recreate indexes (DROP TABLE took them with it).
+      CREATE INDEX tokens_user ON tokens (user_id) WHERE user_id IS NOT NULL;
+      CREATE INDEX tokens_active_refresh ON tokens (refresh_token_hash)
+        WHERE refresh_token_hash IS NOT NULL AND revoked_at IS NULL;
+      CREATE INDEX tokens_family ON tokens (family_id) WHERE family_id IS NOT NULL;
+      -- New: revocation list endpoint queries on (revoked_at, expires_at).
+      CREATE INDEX tokens_revoked ON tokens (revoked_at)
+        WHERE revoked_at IS NOT NULL;
+      -- Subject lookup for non-user mints (operator name, service name).
+      CREATE INDEX tokens_subject ON tokens (subject) WHERE subject IS NOT NULL;
+    `,
+  },
 ];
 
 export function openHubDb(path: string = hubDbPath()): Database {

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -51,6 +51,8 @@ import {
 import { handleHostAdminToken } from "./admin-host-admin-token.ts";
 import { handleVaultAdminToken } from "./admin-vault-admin-token.ts";
 import { handleCreateVault } from "./admin-vaults.ts";
+import { handleApiMintToken } from "./api-mint-token.ts";
+import { REVOCATION_LIST_MOUNT, handleRevocationList } from "./api-revocation-list.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import { HUB_SVC, clearHubPort, writeHubPort } from "./hub-control.ts";
 import { hubDbPath, openHubDb } from "./hub-db.ts";
@@ -694,6 +696,30 @@ export function hubFetch(
       }
     }
 
+    if (pathname === REVOCATION_LIST_MOUNT) {
+      // Revocation list (hub#212 Phase 1). Public — same CORS posture as
+      // jwks.json since resource servers (vault/scribe/agent) fetch it
+      // cross-origin on the 60s polling cadence wired in Phase 4.
+      const corsHeaders = {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "GET, OPTIONS",
+      };
+      if (req.method === "OPTIONS") {
+        return new Response(null, { status: 204, headers: corsHeaders });
+      }
+      if (!getDb) {
+        return new Response('{"error":"revocation list unavailable: db not configured"}', {
+          status: 503,
+          headers: { "content-type": "application/json", ...corsHeaders },
+        });
+      }
+      const resp = handleRevocationList(req, { db: getDb() });
+      // Layer the wildcard CORS over whatever cache-control the handler set.
+      const merged = new Headers(resp.headers);
+      for (const [k, v] of Object.entries(corsHeaders)) merged.set(k, v);
+      return new Response(resp.body, { status: resp.status, headers: merged });
+    }
+
     if (pathname === "/.well-known/jwks.json") {
       // JWKS is also a cross-origin fetch target (browser-side OAuth
       // libraries pull this to verify access tokens). Same wildcard CORS
@@ -835,6 +861,14 @@ export function hubFetch(
         db: getDb(),
         issuer: oauthDeps(req).issuer,
         knownVaultNames,
+      });
+    }
+
+    if (pathname === "/api/auth/mint-token") {
+      if (!getDb) return new Response("hub db not configured", { status: 503 });
+      return handleApiMintToken(req, {
+        db: getDb(),
+        issuer: oauthDeps(req).issuer,
       });
     }
 

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -865,7 +865,12 @@ export function hubFetch(
     }
 
     if (pathname === "/api/auth/mint-token") {
-      if (!getDb) return new Response("hub db not configured", { status: 503 });
+      if (!getDb) {
+        return Response.json(
+          { error: "service_unavailable", error_description: "hub db not configured" },
+          { status: 503 },
+        );
+      }
       return handleApiMintToken(req, {
         db: getDb(),
         issuer: oauthDeps(req).issuer,

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -113,6 +113,15 @@ export interface SignRefreshTokenOpts {
   now?: () => Date;
 }
 
+/**
+ * Provenance of a `tokens` row — which mint path wrote it. Drives the
+ * unified token registry semantics introduced in v6 (hub#212 Phase 1):
+ * one table for refresh tokens, one for CLI-minted access tokens, one
+ * for operator tokens. Different mint paths = different rows; revocation
+ * lookup + revocation list are uniform across all of them.
+ */
+export type TokenCreatedVia = "oauth_refresh" | "cli_mint" | "operator_mint";
+
 export interface SignedRefreshToken {
   /** Opaque token to return to the client. NOT recoverable from the DB. */
   token: string;
@@ -147,8 +156,8 @@ export function signRefreshToken(db: Database, opts: SignRefreshTokenOpts): Sign
   const familyId = opts.familyId ?? randomUUID();
   try {
     db.prepare(
-      `INSERT INTO tokens (jti, user_id, client_id, scopes, refresh_token_hash, family_id, expires_at, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO tokens (jti, user_id, client_id, scopes, refresh_token_hash, family_id, expires_at, created_at, created_via)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'oauth_refresh')`,
     ).run(
       opts.jti,
       opts.userId,
@@ -166,6 +175,96 @@ export function signRefreshToken(db: Database, opts: SignRefreshTokenOpts): Sign
     );
   }
   return { token, refreshTokenHash, familyId, expiresAt };
+}
+
+export interface RecordTokenMintOpts {
+  /** Same as the issued JWT's jti — keys the row. */
+  jti: string;
+  /** Provenance tag — drives admin UI grouping and the registry semantics. */
+  createdVia: Exclude<TokenCreatedVia, "oauth_refresh">;
+  /** Subject identity for non-user mints. Operator-mint rows pass "operator"; service-mint rows pass the service short name. */
+  subject: string;
+  /** Optional user_id when the mint was performed against a hub user (the mint-token CLI flow defaults to the operator's user). NULL for purely service-tied mints. */
+  userId?: string;
+  clientId: string;
+  scopes: string[];
+  /** ISO-8601 expiry. Same value as the JWT's `exp`. */
+  expiresAt: string;
+  /** Optional JSON-encoded permissions claim (per auth-architecture-shape.md §11.3). */
+  permissions?: string;
+  now?: () => Date;
+}
+
+/**
+ * Write a `tokens` row for a non-OAuth-refresh mint. The OAuth refresh
+ * path goes through `signRefreshToken` (which already inserts); this path
+ * is for CLI mint-token, the new POST /api/auth/mint-token endpoint, and
+ * operator-token mints (rotate-operator + the auto-rotation helper from
+ * #213).
+ *
+ * Every issued JWT must have a row in this table going forward — that's
+ * the contract the revocation list endpoint depends on. Pre-Phase-1
+ * tokens (already issued before this migration) are unregistered but
+ * harmless: they expire on their own (15-min access tokens drained
+ * within the hour; 365d operator tokens cap at their original expiry,
+ * with the new 90d auto-rotation taking over once an operator runs the
+ * CLI again).
+ */
+export function recordTokenMint(db: Database, opts: RecordTokenMintOpts): void {
+  const now = opts.now?.() ?? new Date();
+  try {
+    db.prepare(
+      `INSERT INTO tokens (
+        jti, user_id, client_id, scopes, expires_at, created_at,
+        permissions, created_via, subject
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      opts.jti,
+      opts.userId ?? null,
+      opts.clientId,
+      opts.scopes.join(" "),
+      opts.expiresAt,
+      now.toISOString(),
+      opts.permissions ?? null,
+      opts.createdVia,
+      opts.subject,
+    );
+  } catch (err) {
+    throw new RefreshTokenInsertError(
+      `failed to insert token registry row (jti=${opts.jti}, created_via=${opts.createdVia}): ${err instanceof Error ? err.message : String(err)}`,
+      err,
+    );
+  }
+}
+
+/**
+ * Mark a `tokens` row revoked by jti. Idempotent: a row already revoked
+ * keeps its existing `revoked_at`. Returns true when a row was updated
+ * (was un-revoked before), false when no row matches or the row was
+ * already revoked. Used by the new admin revoke path, the operator-mint
+ * rotation cleanup, and any future explicit-revoke surface.
+ */
+export function revokeTokenByJti(db: Database, jti: string, now: Date): boolean {
+  const res = db
+    .prepare("UPDATE tokens SET revoked_at = ? WHERE jti = ? AND revoked_at IS NULL")
+    .run(now.toISOString(), jti);
+  return Number(res.changes) > 0;
+}
+
+/**
+ * Snapshot of currently-revoked-and-not-yet-expired jtis. Powers the
+ * `/.well-known/parachute-revocation.json` endpoint. Already-expired jtis
+ * are filtered out (no need to advertise the obvious — every consumer
+ * checks `exp` itself; the revocation list exists for *unexpired*
+ * tokens whose validity got cut short).
+ */
+export function listActiveRevocations(db: Database, now: Date): string[] {
+  const rows = db
+    .query<{ jti: string }, [string]>(
+      "SELECT jti FROM tokens WHERE revoked_at IS NOT NULL AND expires_at > ? ORDER BY jti",
+    )
+    .all(now.toISOString());
+  return rows.map((r) => r.jti);
 }
 
 export interface ValidatedAccessToken {
@@ -218,9 +317,29 @@ export async function validateAccessToken(
  * decides what to do with `revokedAt` — the rotation path treats a revoked
  * row as theft (RFC 6819 §5.2.2.3).
  */
+/**
+ * Generic shape of a `tokens` row, post-v6. Covers OAuth refresh tokens
+ * (`createdVia === "oauth_refresh"`, `userId` set, `subject` null) and
+ * the new non-OAuth mint paths (`createdVia === "cli_mint" |
+ * "operator_mint"`, may have `userId` set if minted against a hub user,
+ * `subject` always set to the operator/service name).
+ *
+ * `identity` is the canonical "who is this token for" — `userId ??
+ * subject`. Use it when you don't care about the OAuth-vs-non distinction.
+ */
 export interface RefreshTokenRow {
   jti: string;
-  userId: string;
+  /**
+   * Hub user id when the row was OAuth-issued or minted against a hub
+   * user. Null for service-tied mints (where `subject` carries the
+   * service name).
+   */
+  userId: string | null;
+  /**
+   * Non-user subject: operator name, service short name, agent id. Null
+   * for OAuth refresh-token rows (those use `userId` directly).
+   */
+  subject: string | null;
   clientId: string;
   scopes: string[];
   /** Family identifier — shared across rotated descendants (#73). */
@@ -228,29 +347,49 @@ export interface RefreshTokenRow {
   expiresAt: string;
   revokedAt: string | null;
   createdAt: string;
+  /** Provenance tag — drives admin UI grouping. v6 onward this is set on every row. */
+  createdVia: TokenCreatedVia;
+  /** JSON-encoded fine-grained constraints (auth-architecture-shape.md §11.3). */
+  permissions: string | null;
+}
+
+/**
+ * Convenience: returns the canonical identity string for a tokens row,
+ * collapsing the OAuth-vs-non-OAuth distinction. OAuth rows return
+ * `userId`; CLI/operator-minted rows return `subject`. At least one is
+ * always set post-v6.
+ */
+export function tokenRowIdentity(row: RefreshTokenRow): string {
+  return row.userId ?? row.subject ?? "";
 }
 
 interface TokenRowDb {
   jti: string;
-  user_id: string;
+  user_id: string | null;
   client_id: string;
   scopes: string;
   family_id: string | null;
   expires_at: string;
   revoked_at: string | null;
   created_at: string;
+  permissions: string | null;
+  created_via: string;
+  subject: string | null;
 }
 
 function rowToRefreshToken(row: TokenRowDb): RefreshTokenRow {
   return {
     jti: row.jti,
     userId: row.user_id,
+    subject: row.subject,
     clientId: row.client_id,
     scopes: row.scopes.split(" ").filter((s) => s.length > 0),
     familyId: row.family_id ?? row.jti,
     expiresAt: row.expires_at,
     revokedAt: row.revoked_at,
     createdAt: row.created_at,
+    createdVia: (row.created_via as TokenCreatedVia) ?? "oauth_refresh",
+    permissions: row.permissions,
   };
 }
 

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -1019,6 +1019,18 @@ async function handleTokenRefresh(
   if (row.clientId !== clientId) {
     return jsonResponse({ error: "invalid_grant", error_description: "client_id mismatch" }, 400);
   }
+  // Refresh-token rows always have a non-null user_id (the caller's hub
+  // user). Post-v6 the column is nullable to accommodate non-OAuth mints
+  // (operator/cli mints), but those rows have no `refresh_token_hash` so
+  // `findRefreshToken` can't return them. Defensive: surface a clean
+  // invalid_grant if a hand-crafted row shows up here without a user.
+  if (!row.userId) {
+    return jsonResponse(
+      { error: "invalid_grant", error_description: "refresh_token has no associated user" },
+      400,
+    );
+  }
+  const refreshUserId: string = row.userId;
   const now = deps.now?.() ?? new Date();
   if (row.revokedAt) {
     // Replay of an already-rotated refresh token. Per RFC 6819 §5.2.2.3 the
@@ -1053,7 +1065,7 @@ async function handleTokenRefresh(
   // (#107).
   const audience = inferAudience(row.scopes);
   const access = await signAccessToken(db, {
-    sub: row.userId,
+    sub: refreshUserId,
     scopes: row.scopes,
     audience,
     clientId: row.clientId,
@@ -1066,7 +1078,7 @@ async function handleTokenRefresh(
       db.prepare("UPDATE tokens SET revoked_at = ? WHERE jti = ?").run(now.toISOString(), row.jti);
       return signRefreshToken(db, {
         jti: access.jti,
-        userId: row.userId,
+        userId: refreshUserId,
         clientId: row.clientId,
         scopes: row.scopes,
         familyId: row.familyId,

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -966,6 +966,13 @@ async function handleTokenAuthorizationCode(
     issuer: deps.issuer,
     now: deps.now,
   });
+  // Phase 1 (#212) registry exemption: code-grant access tokens piggyback
+  // on the paired refresh token's `tokens` row (they share `jti` by
+  // design). We don't write a separate access-token row — revocation acts
+  // on the shared jti / family, and the 15-min access TTL bounds the
+  // window before per-jti re-validation is needed. A separate per-jti
+  // access-token row would double registry write volume on every OAuth
+  // grant + every refresh rotation; not worth the trade today.
   const refresh = signRefreshToken(db, {
     jti: access.jti,
     userId: redeemed.userId,

--- a/src/operator-token.ts
+++ b/src/operator-token.ts
@@ -27,7 +27,7 @@ import type { Database } from "bun:sqlite";
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { configDir } from "./config.ts";
-import { signAccessToken, validateAccessToken } from "./jwt-sign.ts";
+import { recordTokenMint, signAccessToken, validateAccessToken } from "./jwt-sign.ts";
 
 export const OPERATOR_TOKEN_FILENAME = "operator.token";
 /** Default operator-token lifetime — 90 days, was 365d through 0.5.7 (#213). */
@@ -157,6 +157,22 @@ export async function mintOperatorToken(
     ttlSeconds: opts.ttlSeconds ?? OPERATOR_TOKEN_TTL_SECONDS,
     extraClaims: { [OPERATOR_TOKEN_SCOPE_SET_CLAIM]: scopeSet },
     ...(opts.jti !== undefined ? { jti: opts.jti } : {}),
+    ...(opts.now !== undefined ? { now: opts.now } : {}),
+  });
+  // Register every operator-mint with the unified token registry (hub#212
+  // Phase 1). Per design: operator-mint rows have user_id NULL; the
+  // subject column carries the canonical "operator" identity string.
+  // (Storing user_id here would require an FK-valid users row, which the
+  // operator-mint path doesn't always have access to in test fixtures —
+  // and conceptually the operator is a role, not a hub user.) Powers the
+  // revocation list endpoint.
+  recordTokenMint(db, {
+    jti: minted.jti,
+    createdVia: "operator_mint",
+    subject: "operator",
+    clientId: OPERATOR_TOKEN_CLIENT_ID,
+    scopes,
+    expiresAt: minted.expiresAt,
     ...(opts.now !== undefined ? { now: opts.now } : {}),
   });
   return { ...minted, scopeSet };

--- a/src/operator-token.ts
+++ b/src/operator-token.ts
@@ -19,9 +19,12 @@
  * with an explicit re-auth message — auto-rotating from a dead token would
  * defeat the lifetime cap (security: forces a manual re-auth touch).
  *
- * The hub doesn't track operator-token jtis for revocation today (planned
- * for hub#212 Phase 1), so a leaked file stays valid until its TTL elapses.
- * Treat operator.token like an SSH private key.
+ * Operator-token jtis are tracked in the hub `tokens` registry as of
+ * hub#212 Phase 1 (created_via='operator_mint'); per-jti revocation is
+ * enforced via validateAccessToken's row.revokedAt check. A leaked file
+ * still stays valid until either its TTL elapses or the operator
+ * explicitly revokes the jti — treat operator.token like an SSH private
+ * key.
  */
 import type { Database } from "bun:sqlite";
 import { promises as fs } from "node:fs";


### PR DESCRIPTION
## Summary

Phase 1 of the hub-as-sole-AS migration tracked in [hub#212](https://github.com/ParachuteComputer/parachute-hub/issues/212). Five components, all hub-side, additive (no breaking changes to existing surfaces). Absorbs Phase 5 (CLI relocation) since the canonical `parachute auth mint-token` already exists per #179 — this PR extends it rather than relocating it.

Companion auth-architecture context: `parachute-patterns/research/auth-architecture-shape.md` §11.

## Components

### C1 — `tokens` table v6 migration

Generalizes the OAuth-refresh-only `tokens` table into a unified registry across every issued JWT class.

- New columns: `permissions TEXT` (JSON, fine-grained constraints per the research doc §11.3), `created_via TEXT NOT NULL DEFAULT 'oauth_refresh'` (provenance: `oauth_refresh` / `cli_mint` / `operator_mint`), `subject TEXT` (non-user identity for service / operator mints — operator-mint rows store `"operator"` here while leaving `user_id` NULL).
- `user_id` drops NOT NULL. CLI/operator mints aren't tied to a hub user; OAuth-refresh rows still set it.
- SQLite has no `ALTER COLUMN` to drop NOT NULL, so the migration uses the recreate-and-rename pattern inside the migration transaction (atomic; nothing references `tokens` so the drop is safe). Existing rows backfill `created_via='oauth_refresh'` automatically via the column default.
- New indexes: `tokens_revoked` (powers revocation-list filter), `tokens_subject` (lookup by non-user mint). Existing indexes recreated post-rename.
- Pre-Phase-1 tokens (already issued before this migration) stay valid but unregistered; they expire on their own. Documented in CHANGELOG migration/impact.

### C2 — `parachute auth mint-token` extended

- `--permissions <JSON>` — JSON object encoding fine-grained constraints beyond OAuth scope. Round-trips into the JWT's `permissions` claim. Validated to be a JSON object (not primitive, not array); malformed JSON or non-object payloads rejected.
- `--expires-in <integer-seconds>` — canonical lifetime flag. Matches OAuth's `expires_in` claim semantics. Integer-seconds only.
- `--ttl <duration>` is now the deprecated alias: still works, still accepts duration-string form (`90d` / `24h` / `30m` / `60s`), emits a one-line stderr deprecation notice. Passing both `--ttl` and `--expires-in` together is a usage error.
- Help text rewritten with multi-scope syntax, `--permissions` example, deprecation note.
- Every successful mint writes a `tokens` registry row (`created_via='cli_mint'`, `subject=<--sub or operator's sub>`, `user_id NULL` per the design).

### C3 — `POST /api/auth/mint-token` HTTP endpoint

New file `src/api-mint-token.ts`. Companion to the CLI for automation that doesn't have local CLI access.

- **Auth:** `Authorization: Bearer <token>` whose `scope` claim contains `parachute:host:auth` (the new narrow scope from #213).
- **Body:** `{ scope, audience?, expires_in?, subject?, permissions? }`. Same semantics as the CLI flags.
- **Returns:** `{ jti, token, expires_at, scope, permissions? }`.
- 401 / 403 / 400 / 405 surfaces match the OAuth error vocabulary.
- Wired into `hub-server.ts` dispatch. Every mint writes a registry row identical to the CLI path.

### C4 — operator.token mints register

`mintOperatorToken` now calls `recordTokenMint(...)` after signing — `created_via='operator_mint'`, `subject="operator"`, `user_id NULL`. Auto-rotation rows from #213's `useOperatorTokenWithAutoRotate` get registered too. Both the original and the rotated row exist until their own `exp`; "revoke prior on rotation" deferred to Phase 2.

### C5 — `GET /.well-known/parachute-revocation.json`

New file `src/api-revocation-list.ts`. Public endpoint (no auth — list is harmless to expose; opaque jtis only).

- Returns `{ generated_at, jtis: [...] }` filtered to `revoked_at IS NOT NULL AND expires_at > now`. Already-expired jtis filtered out.
- `Cache-Control: public, max-age=60` matches the polling cadence Phase 4 will wire on the resource-server side.
- Wildcard CORS posture identical to `/.well-known/jwks.json`.

## New helpers in `src/jwt-sign.ts`

- `recordTokenMint(db, opts)` — non-OAuth-refresh mint path; writes a registry row.
- `revokeTokenByJti(db, jti, now)` — idempotent revoke; returns true on first call, false on already-revoked / not-found.
- `listActiveRevocations(db, now)` — snapshot of revoked-and-not-yet-expired jtis. Powers the revocation list endpoint.
- `tokenRowIdentity(row)` — returns `userId ?? subject ?? ""`. Collapses OAuth-vs-non distinction.
- `TokenCreatedVia` type exported.

## Migration / impact

- **Operators upgrading from 0.5.7-rc.* / 0.5.7 / 0.5.8-rc.1:** v6 migration runs automatically on next `openHubDb()`. Existing OAuth refresh-token rows backfill `created_via='oauth_refresh'`; their `permissions` and `subject` stay NULL. No data loss, no downtime.
- **Operators with operator.token from before this PR:** still valid (the JWT carries its own `exp`, signed by hub's existing keys). They don't have a registry row, but `validateAccessToken` only consults the registry to check `revoked_at` — a missing row is treated as not-revoked. Next `rotate-operator` (or auto-rotation from #213) registers the new token.
- **OAuth refresh-token rotation:** unchanged behavior. The new `userId` nullability guard in `oauth-handlers.ts` is defense-in-depth; the runtime path is unreachable on correctly-shaped rows.
- **Pre-existing access tokens:** still valid until expiry. The 15-minute default TTL means any pre-Phase-1 access tokens drain within the hour after deploy.

## Out of scope (deferred to later phases of #212)

- **Phase 2: admin UI `/admin/tokens`** — list / revoke / inspect. Daytime work.
- **Phase 4: vault / agent / scribe revocation-list consumers** — fetch the new endpoint on a 60s TTL and reject jtis that appear. Resource-server side; this PR ships the issuer-side endpoint only.
- **Phase 5: `parachute vault tokens create` → `parachute auth mint-token`** — partially absorbed (canonical CLI path already exists). Final cutover deferred.
- **Phase 6: `pvt_*` deprecation in vault** — vault-side; out of scope.
- **Per-CLI-command scope-set enforcement (Phase 2 of #213)** — separate followup.

## Versioning

`0.5.8-rc.1` shipped at #214. This is the second code-touching PR of the cycle, so `0.5.8-rc.1 → 0.5.8-rc.2`. CHANGELOG date `2026-05-09` per the project's local-frame convention (lesson from #214).

## Test plan

- [x] `bun test ./src` — **1153 pass / 0 fail** (was 1118 / 0 on the 0.5.8-rc.1 tip). 35 new cases:
  - `src/__tests__/jwt-sign.test.ts` (+7): v6 schema shape via `PRAGMA table_info(tokens)`, `recordTokenMint` round-trip, duplicate-jti throws, `revokeTokenByJti` idempotency + flips `revoked_at`, `listActiveRevocations` filters, `tokenRowIdentity` returns `userId ?? subject`, `signRefreshToken` stamps `created_via='oauth_refresh'`.
  - `src/__tests__/auth.test.ts` (+9): registry write on every mint, `--permissions` JSON round-trip, `--permissions` malformed JSON / non-object rejected, `--expires-in` happy path / non-integer / over-cap rejected, `--ttl` deprecation notice still works, both `--ttl` and `--expires-in` together rejected.
  - `src/__tests__/operator-token.test.ts` (+2): operator-mint registry row, auto-rotation writes a fresh row.
  - `src/__tests__/api-mint-token.test.ts` (+11, new file): 401 no auth / non-Bearer / invalid bearer, 403 missing scope, happy path with admin operator-token (+ `--scope-set=auth`), permissions round-trip, 400 missing scope / over-cap / non-object permissions, 405 non-POST.
  - `src/__tests__/api-revocation-list.test.ts` (+6, new file): empty list, populated after revoke, expiry filter, OAuth-refresh rows participate, 405 non-GET, idempotency.
- [x] `bunx biome check .` — 171 files, no findings.
- [x] `bun run typecheck` — clean.

## Cross-references

- Phase 1 of [hub#212](https://github.com/ParachuteComputer/parachute-hub/issues/212) — does NOT close (5 more phases). Issue body's Phase 1 checkbox should be marked complete; Phase 5 should also be marked since this PR absorbs the canonical CLI surface.
- Builds on #214 (operator.token hardening — 90d default + scope-set vocabulary + 0600 perms). The new `parachute:host:auth` scope from #214 is the gate on the new HTTP endpoint.
- Auth-architecture research doc: `parachute-patterns/research/auth-architecture-shape.md` §11 (the convergence section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)