### PR TITLE
feat(auth): parachute auth revoke-token <jti> CLI (hub#212 Phase 1 followup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.8-rc.4] - 2026-05-10
+
+Adds the operator-facing `parachute auth revoke-token <jti>` CLI — the missing companion to Phase 1's `revoked_at` column and revocation-list endpoint. Without this, end-to-end Phase 4 testing required reaching into `~/.parachute/hub/hub.db` with `sqlite3` and flipping the bit by hand. Distinct from the existing `revoke-grant` (retires OAuth *consent grants*) and `/oauth/revoke` (RFC 7009 refresh-token revocation): this revokes any *registry-row token* (CLI mints, operator mints, OAuth-issued access tokens) by jti.
+
+### Added
+
+- **`parachute auth revoke-token <jti>`** — flips `revoked_at` on the `tokens` row keyed by jti. Idempotent: re-revoking an already-revoked jti prints the existing `revoked_at` and exits 0. Not-found exits 1 with a clear "no token with jti X found in registry". On success, prints `revoked: jti=X, subject=..., scope=...` for operator audit trail.
+  - Auth gate: requires `parachute:host:auth` scope on the local `~/.parachute/operator.token` (the `auth` or `admin` scope-set covers this; narrower sets like `install`/`start`/`expose`/`vault` do not). Same gate semantics as `POST /api/auth/mint-token`.
+  - Auto-rotation banner (when the operator token is within 7d of expiry) goes to stderr; stdout stays focused on the revocation outcome.
+  - End-to-end semantics: revoke happens immediately in the local DB; the revocation list endpoint (`/.well-known/parachute-revocation.json`) picks the change up on its next 60s poll cycle; resource servers running `@openparachute/scope-guard@^0.2.0` then reject the JWT on subsequent requests.
+
+### Out of scope (deferred)
+
+- HTTP analog (`POST /api/auth/revoke-token`) — would mirror `api-mint-token.ts`'s ~80-LOC shape; deferred per the brief's <50 LOC budget for "ergonomically a few extra lines." Filed as a follow-up issue.
+- Bulk revoke (`--all-by-subject`, `--all-by-client`).
+- Revoke-by-subject convenience wrapper.
+- Admin UI revocation surface — Phase 2.
+
 ## [0.5.8-rc.3] - 2026-05-10
 
 Foundation work for [hub#212](https://github.com/ParachuteComputer/parachute-hub/issues/212) Phase 4 (RS-side revocation enforcement). Hub itself ships unchanged at the runtime surface — its own `validateAccessToken` already consults the local DB. The change here is in the workspace-vendored `@openparachute/scope-guard` package, which moves to `0.2.0` with revocation-list enforcement folded into `validateHubJwt`. Vault / scribe / parachute-agent will adopt independently in follow-up PRs once Aaron publishes scope-guard 0.2.0 to npm.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Adds the operator-facing `parachute auth revoke-token <jti>` CLI — the missing
 
 ### Added
 
-- **`parachute auth revoke-token <jti>`** — flips `revoked_at` on the `tokens` row keyed by jti. Idempotent: re-revoking an already-revoked jti prints the existing `revoked_at` and exits 0. Not-found exits 1 with a clear "no token with jti X found in registry". On success, prints `revoked: jti=X, subject=..., scope=...` for operator audit trail.
+- **`parachute auth revoke-token <jti>`** — flips `revoked_at` on the `tokens` row keyed by jti. Idempotent: re-revoking an already-revoked jti prints the existing `revoked_at` and exits 0. Not-found exits 1 with a clear "no token with jti X found in registry". On success, prints `revoked: jti=X, identity=..., scope=...` for operator audit trail. The `identity=` field surfaces `tokenRowIdentity(row)` — `userId` for OAuth-issued rows, `subject` for CLI / operator / service mints — so operators grepping on `identity=` get the right value regardless of which mint path created the token.
   - Auth gate: requires `parachute:host:auth` scope on the local `~/.parachute/operator.token` (the `auth` or `admin` scope-set covers this; narrower sets like `install`/`start`/`expose`/`vault` do not). Same gate semantics as `POST /api/auth/mint-token`.
   - Auto-rotation banner (when the operator token is within 7d of expiry) goes to stderr; stdout stays focused on the revocation outcome.
   - End-to-end semantics: revoke happens immediately in the local DB; the revocation list endpoint (`/.well-known/parachute-revocation.json`) picks the change up on its next 60s poll cycle; resource servers running `@openparachute/scope-guard@^0.2.0` then reject the JWT on subsequent requests.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.8-rc.3",
+  "version": "0.5.8-rc.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -1597,7 +1597,7 @@ describe("parachute auth revoke-token", () => {
       expect(code).toBe(0);
       expect(stderr).toBe("");
       expect(stdout).toContain(`revoked: jti=${jti}`);
-      expect(stdout).toContain("subject=");
+      expect(stdout).toContain("identity=");
       expect(stdout).toContain("scope=scribe:transcribe");
 
       // Registry row really has revoked_at set now.

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -1531,3 +1531,194 @@ describe("parachute auth mint-token", () => {
     }
   });
 });
+
+describe("parachute auth revoke-token", () => {
+  // Each test mints a fresh token via mint-token and then revokes it. Going
+  // through the public mint surface (rather than calling signAccessToken +
+  // recordTokenMint directly) keeps these tests honest about the contract:
+  // mint writes a registry row, revoke-token flips its bit, and a future
+  // round-trip through validateAccessToken would reject it. The Phase 4
+  // RS-side enforcement is exercised in scope-guard's own integration suite.
+
+  async function mintAJti(deps: AuthDeps): Promise<string> {
+    const { stdout } = await captureOutput(() =>
+      auth(["mint-token", "--scope", "scribe:transcribe"], deps),
+    );
+    const token = stdout.trim();
+    // Decode the unverified payload to recover the jti — every mint stamps one.
+    const [, payloadB64] = token.split(".");
+    const payload = JSON.parse(Buffer.from(payloadB64!, "base64url").toString("utf8")) as {
+      jti: string;
+    };
+    return payload.jti;
+  }
+
+  test("missing jti positional is a usage error", async () => {
+    const tmp = makeTmp();
+    try {
+      const { code, stderr } = await captureOutput(() =>
+        auth(["revoke-token"], { dbPath: tmp.dbPath, configDir: tmp.dir }),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("missing jti argument");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("unexpected flag is a usage error", async () => {
+    const tmp = makeTmp();
+    try {
+      const { code, stderr } = await captureOutput(() =>
+        auth(["revoke-token", "--reason", "compromise", "abc123"], {
+          dbPath: tmp.dbPath,
+          configDir: tmp.dir,
+        }),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("unexpected flag");
+      expect(stderr).toContain("--reason");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("revokes a fresh token and prints subject + scope", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const jti = await mintAJti(deps);
+      const { code, stdout, stderr } = await captureOutput(() => auth(["revoke-token", jti], deps));
+      expect(code).toBe(0);
+      expect(stderr).toBe("");
+      expect(stdout).toContain(`revoked: jti=${jti}`);
+      expect(stdout).toContain("subject=");
+      expect(stdout).toContain("scope=scribe:transcribe");
+
+      // Registry row really has revoked_at set now.
+      const db = openHubDb(tmp.dbPath);
+      try {
+        const { findTokenRowByJti } = await import("../jwt-sign.ts");
+        const row = findTokenRowByJti(db, jti);
+        expect(row?.revokedAt).not.toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("re-revoke is idempotent: exit 0, prints existing revoked_at", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const jti = await mintAJti(deps);
+      const first = await captureOutput(() => auth(["revoke-token", jti], deps));
+      expect(first.code).toBe(0);
+
+      // Capture the timestamp from the first revoke for cross-check.
+      const db = openHubDb(tmp.dbPath);
+      let firstRevokedAt: string | null;
+      try {
+        const { findTokenRowByJti } = await import("../jwt-sign.ts");
+        firstRevokedAt = findTokenRowByJti(db, jti)?.revokedAt ?? null;
+      } finally {
+        db.close();
+      }
+      expect(firstRevokedAt).not.toBeNull();
+
+      const second = await captureOutput(() => auth(["revoke-token", jti], deps));
+      expect(second.code).toBe(0);
+      expect(second.stdout).toContain("already revoked at");
+      expect(second.stdout).toContain(firstRevokedAt!);
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("unknown jti exits 1 with not-found error", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const { code, stderr } = await captureOutput(() =>
+        auth(["revoke-token", "this-jti-does-not-exist"], deps),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("no token with jti this-jti-does-not-exist found in registry");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("operator token without parachute:host:auth is rejected", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      // Replace operator.token with a narrow JWT that lacks parachute:host:auth.
+      const db = openHubDb(tmp.dbPath);
+      let narrow: string;
+      try {
+        const owner = listUsers(db)[0]!;
+        const signed = await signAccessToken(db, {
+          sub: owner.id,
+          scopes: ["scribe:transcribe"],
+          audience: "scribe",
+          clientId: OPERATOR_TOKEN_CLIENT_ID,
+          issuer: "http://127.0.0.1:1939",
+          ttlSeconds: 3600,
+        });
+        narrow = signed.token;
+      } finally {
+        db.close();
+      }
+      await writeOperatorTokenFile(narrow, tmp.dir);
+
+      const { code, stderr } = await captureOutput(() => auth(["revoke-token", "any-jti"], deps));
+      expect(code).toBe(1);
+      expect(stderr).toContain("lacks parachute:host:auth scope");
+      expect(stderr).toContain("rotate-operator");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("missing operator.token is an actionable error", async () => {
+    const tmp = makeTmp();
+    try {
+      const { code, stderr } = await captureOutput(() =>
+        auth(["revoke-token", "any-jti"], { dbPath: tmp.dbPath, configDir: tmp.dir }),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("operator.token");
+      expect(stderr).toContain("rotate-operator");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("authHelp lists revoke-token alongside mint-token", () => {
+    expect(authHelp()).toContain("revoke-token");
+    expect(authHelp()).toContain("revoke-token <jti>");
+  });
+});

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -31,6 +31,7 @@ import {
   recordTokenMint,
   revokeTokenByJti,
   signAccessToken,
+  tokenRowIdentity,
 } from "../jwt-sign.ts";
 import {
   OPERATOR_TOKEN_CLIENT_ID,
@@ -1089,9 +1090,14 @@ async function runRevokeToken(args: readonly string[], deps: AuthDeps): Promise<
       );
       return 1;
     }
-    const identity = row.userId ?? row.subject ?? "(unknown)";
+    // Use the canonical `tokenRowIdentity` helper rather than reading
+    // userId/subject inline. The label is `identity=` (not `subject=`)
+    // because for OAuth-issued rows `userId` is the user UUID and the
+    // `subject` column is NULL; calling that field "subject" in the
+    // output would mislabel the UUID for any operator grepping on it.
+    // `identity=` matches what the helper returns regardless of row type.
     console.log(
-      `revoked: jti=${jti}, subject=${identity}, scope=${row.scopes.join(" ") || "(none)"}`,
+      `revoked: jti=${jti}, identity=${tokenRowIdentity(row)}, scope=${row.scopes.join(" ") || "(none)"}`,
     );
     return 0;
   } finally {

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -26,7 +26,12 @@ import { HUB_DEFAULT_PORT, readHubPort } from "../hub-control.ts";
 import { openHubDb } from "../hub-db.ts";
 import { deriveHubOrigin } from "../hub-origin.ts";
 import { inferAudience } from "../jwt-audience.ts";
-import { recordTokenMint, signAccessToken } from "../jwt-sign.ts";
+import {
+  findTokenRowByJti,
+  recordTokenMint,
+  revokeTokenByJti,
+  signAccessToken,
+} from "../jwt-sign.ts";
 import {
   OPERATOR_TOKEN_CLIENT_ID,
   OPERATOR_TOKEN_SCOPE_SET_NAMES,
@@ -66,6 +71,7 @@ const HUB_LOCAL_SUBCOMMANDS = new Set([
   "list-users",
   "rotate-operator",
   "mint-token",
+  "revoke-token",
   "pending-clients",
   "approve-client",
   "list-grants",
@@ -94,6 +100,10 @@ Usage:
                                        operator's identity (stdout = JWT).
                                        --ttl <duration> is the deprecated
                                        alias (use --expires-in seconds).
+  parachute auth revoke-token <jti>    Mark a registry-row token revoked
+                                       by jti. Idempotent: a re-revoke
+                                       prints the existing revoked_at and
+                                       exits 0.
   parachute auth pending-clients       List OAuth clients awaiting approval
   parachute auth approve-client <id>   Approve a pending OAuth client
   parachute auth list-grants [--username <name>]
@@ -167,6 +177,15 @@ Every mint writes a row to the hub's token registry (one source of
 truth for revocation, admin UI introspection). Requires a valid
 ~/.parachute/operator.token (run \`parachute auth set-password\` or
 \`rotate-operator\` first).
+
+revoke-token flips \`revoked_at\` on a registry row by jti. The
+revocation list endpoint
+(\`/.well-known/parachute-revocation.json\`) picks the change up on
+its next 60s poll; resource servers (vault / scribe / agent) on
+scope-guard 0.2.0+ then reject the JWT. Idempotent: re-revoking an
+already-revoked jti prints the existing revoked_at and exits 0.
+Requires \`parachute:host:auth\` on the operator token (the \`auth\`
+or \`admin\` scope-set).
 
 pending-clients + approve-client gate /oauth/register against operator
 approval (closes #74). Self-served DCR registrations land as 'pending'
@@ -972,6 +991,114 @@ async function runMintToken(args: readonly string[], deps: AuthDeps): Promise<nu
   }
 }
 
+async function runRevokeToken(args: readonly string[], deps: AuthDeps): Promise<number> {
+  // Single positional: the jti. No flags. (If we grow flags later — say,
+  // --reason for an audit string — they can join here without disrupting
+  // the positional contract.)
+  const positionals = args.filter((a) => !a.startsWith("--"));
+  const flags = args.filter((a) => a.startsWith("--"));
+  if (flags.length > 0) {
+    console.error(
+      `parachute auth revoke-token: unexpected flag "${flags[0]}" (this command takes a jti positional only)`,
+    );
+    return 1;
+  }
+  if (positionals.length === 0) {
+    console.error("parachute auth revoke-token: missing jti argument");
+    console.error("usage: parachute auth revoke-token <jti>");
+    return 1;
+  }
+  if (positionals.length > 1) {
+    console.error(
+      `parachute auth revoke-token: unexpected argument "${positionals[1]}" (only one jti at a time)`,
+    );
+    return 1;
+  }
+  const jti = positionals[0]!;
+
+  const configDir = deps.configDir ?? CONFIG_DIR;
+  const issuer = resolveHubIssuer(deps.hubOrigin, configDir);
+
+  const db = deps.dbPath ? openHubDb(deps.dbPath) : openHubDb();
+  try {
+    let used: Awaited<ReturnType<typeof useOperatorTokenWithAutoRotate>>;
+    try {
+      used = await useOperatorTokenWithAutoRotate(db, { configDir, issuer });
+    } catch (err) {
+      if (err instanceof OperatorTokenExpiredError) {
+        console.error(`parachute auth revoke-token: ${err.message}`);
+        return 1;
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`parachute auth revoke-token: operator token invalid — ${msg}`);
+      console.error(
+        "run `parachute auth rotate-operator` to mint a fresh one, or check that the hub origin matches",
+      );
+      return 1;
+    }
+    if (!used) {
+      console.error(
+        "parachute auth revoke-token: no operator token found at ~/.parachute/operator.token",
+      );
+      console.error(
+        "run `parachute auth set-password` (first run) or `parachute auth rotate-operator` to mint one",
+      );
+      return 1;
+    }
+    if (used.rotated) {
+      console.error(
+        `parachute auth revoke-token: operator token within 7d of expiry — auto-rotated to ${used.rotated.expiresAt} (scope_set=${used.rotated.scopeSet})`,
+      );
+    }
+    // Scope gate: same as the HTTP /api/auth/revoke-token endpoint will use
+    // (and the same as /api/auth/mint-token uses today). Mirrors the
+    // privilege-shape of mint — both surfaces hand the operator power that
+    // a narrow non-auth scope-set token shouldn't carry. The `auth`
+    // scope-set covers this; so does `admin` (superset).
+    const tokenScope =
+      typeof used.payload.scope === "string"
+        ? used.payload.scope.split(/\s+/).filter((s) => s.length > 0)
+        : [];
+    if (!tokenScope.includes("parachute:host:auth")) {
+      console.error("parachute auth revoke-token: operator token lacks parachute:host:auth scope");
+      console.error(
+        "narrowed scope-sets without `auth` (install/start/expose/vault) can't revoke tokens — run `parachute auth rotate-operator --scope-set auth` (or `admin`) for a token that can",
+      );
+      return 1;
+    }
+
+    const row = findTokenRowByJti(db, jti);
+    if (!row) {
+      console.error(`parachute auth revoke-token: no token with jti ${jti} found in registry`);
+      return 1;
+    }
+    if (row.revokedAt) {
+      // Idempotent re-revoke. Surface the existing timestamp so an operator
+      // who's not sure whether the previous attempt landed gets a clear
+      // confirmation it did.
+      console.log(`already revoked at ${row.revokedAt}: jti=${jti}`);
+      return 0;
+    }
+    const ok = revokeTokenByJti(db, jti, new Date());
+    if (!ok) {
+      // Race: row existed, then disappeared or got revoked between our
+      // lookups. Surface as not-found rather than silently succeeding —
+      // the operator should know nothing changed under their hand.
+      console.error(
+        `parachute auth revoke-token: jti ${jti} could not be revoked (race or concurrent change)`,
+      );
+      return 1;
+    }
+    const identity = row.userId ?? row.subject ?? "(unknown)";
+    console.log(
+      `revoked: jti=${jti}, subject=${identity}, scope=${row.scopes.join(" ") || "(none)"}`,
+    );
+    return 0;
+  } finally {
+    db.close();
+  }
+}
+
 function runListUsers(deps: AuthDeps): number {
   const db = deps.dbPath ? openHubDb(deps.dbPath) : openHubDb();
   try {
@@ -1048,6 +1175,15 @@ export async function auth(args: readonly string[], deps: AuthDeps | Runner = {}
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`parachute auth mint-token: ${msg}`);
+        return 1;
+      }
+    }
+    if (sub === "revoke-token") {
+      try {
+        return await runRevokeToken(args.slice(1), normalized);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`parachute auth revoke-token: ${msg}`);
         return 1;
       }
     }


### PR DESCRIPTION
## Summary

Adds the operator-facing `parachute auth revoke-token <jti>` CLI — the missing companion to Phase 1's `revoked_at` column and revocation-list endpoint. Without this, end-to-end Phase 4 testing required reaching into `~/.parachute/hub/hub.db` with `sqlite3` and flipping the bit by hand.

Distinct from the existing `revoke-grant` (retires OAuth *consent grants*) and `/oauth/revoke` (RFC 7009 refresh-token revocation): this revokes any *registry-row token* (CLI mints, operator mints, OAuth-issued access tokens) by jti.

Refs hub#212 (Phase 1 followup; the umbrella stays open for Phase 4 RS adoption).

## Behavior

- **Idempotent**: re-revoking an already-revoked jti prints the existing `revoked_at` and exits 0.
- **Not-found**: exits 1 with `no token with jti X found in registry`.
- **Success**: prints `revoked: jti=X, subject=..., scope=...` for operator audit trail.
- **Auth gate**: requires `parachute:host:auth` on the local `~/.parachute/operator.token` (the `auth` or `admin` scope-set covers it; narrower sets like `install`/`start`/`expose`/`vault` do not). Same gate semantics as `POST /api/auth/mint-token`.
- **Auto-rotation banner** (when operator token is within 7d of expiry) goes to stderr; stdout stays focused on the revocation outcome.

## End-to-end semantics

```
parachute auth revoke-token <jti>
  → flips tokens.revoked_at in ~/.parachute/hub/hub.db (immediate)
  → /.well-known/parachute-revocation.json picks it up on next request (immediate)
  → scope-guard 0.2.0+ resource servers (vault/scribe/agent) refresh on
    their 60s poll, then reject the JWT (≤60s after revoke)
```

So end-to-end revocation latency is bounded by the 60s scope-guard cache TTL.

## What's NOT in this PR

Per the brief's tight scope:

- **HTTP analog `POST /api/auth/revoke-token`** — would mirror `api-mint-token.ts`'s ~80 LOC structure; beyond the brief's <50 LOC budget for the optional add. Filed as #220 for the next session.
- **Bulk revoke** (`--all-by-subject`, `--all-by-client`) — file as separate enhancement if needed.
- **Revoke-by-subject convenience wrapper** — same.
- **Admin UI revocation surface** — Phase 2 (task #35).

## Versions

- `package.json` (hub): `0.5.8-rc.3` → `0.5.8-rc.4`.
- CHANGELOG entry under `## [0.5.8-rc.4] - 2026-05-10`.
- scope-guard untouched (no version bump).

## Test plan

- [x] hub: **1165 pass / 0 fail** (canonical `bun test ./src` — was 1157; +8 for new revoke-token describe block: missing-jti usage error, unexpected-flag usage error, happy-path revoke + DB row check, idempotent re-revoke + timestamp match, unknown-jti not-found, narrow-scope rejection, missing operator.token, authHelp lists revoke-token).
- [x] typecheck: clean.
- [x] biome: clean.

## Patterns check

- **CLI-subcommand shape** preserved — same `runX(args, deps)` + try/catch dispatch + `HUB_LOCAL_SUBCOMMANDS` membership pattern as `mint-token`, `revoke-grant`, `rotate-operator`.
- **Auth-gate naming** preserved — same `parachute:host:auth` scope check string used in `api-mint-token.ts`'s `API_MINT_TOKEN_REQUIRED_SCOPE`. (No new constant introduced; the string literal appears in the CLI alongside the explanatory error message, mirroring how `mint-token` does its own `hub:admin` check inline. If a future PR consolidates both to share `api-mint-token.ts`'s `API_MINT_TOKEN_REQUIRED_SCOPE` constant, that's a small cleanup — not in scope here.)
- **CHANGELOG -rc bump** — RC ladder per parachute-patterns/governance.md: `rc.3` → `rc.4` for code-touching PR; doc-only would skip per the exemption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)