### PR TITLE
feat(auth): widen mint-token CLI gate to parachute:host:auth (closes hub#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.8-rc.5] - 2026-05-10
+
+Aligns the `parachute auth mint-token` CLI gate with the HTTP companion (`POST /api/auth/mint-token`) and the new `revoke-token` CLI: all three now gate on `parachute:host:auth` rather than the historically-narrower `hub:admin`. Closes hub#222. Backwards-compatible widening — operators with `admin` scope-set tokens (the default) are unaffected; operators with the narrow `--scope-set auth` operator token gain the ability the scope-set was always meant to grant per the #214 design.
+
+### Changed
+
+- **`parachute auth mint-token` CLI** now requires `parachute:host:auth` scope on the operator token instead of `hub:admin`. Previously, the CLI's gate was tighter than the HTTP endpoint's gate (which already used `:host:auth`), making the `auth` scope-set silently insufficient for CLI mints — the very operation it's named for. The asymmetry was identified during hub#221 review (the new `revoke-token` CLI's gate); this PR closes it.
+- Error message updated: `lacks hub:admin scope` → `lacks parachute:host:auth scope`. Hint text updated to reflect that `--scope-set auth` is now sufficient (was: only `admin`).
+
+### Compatibility
+
+- **Operators with `admin` scope-set tokens** (the default from `parachute auth rotate-operator` with no `--scope-set` flag): no change. The `admin` scope-set is a superset that includes `parachute:host:auth`, so the gate still passes.
+- **Operators with `--scope-set auth` tokens**: gain CLI mint-token access (intended design, finally honoured).
+- **Operators with `--scope-set install/start/expose/vault` tokens**: still rejected. None of those carry `:host:auth`, by design.
+- **No migration needed.** Anyone whose previous workflow worked still works.
+
 ## [0.5.8-rc.4] - 2026-05-10
 
 Adds the operator-facing `parachute auth revoke-token <jti>` CLI — the missing companion to Phase 1's `revoked_at` column and revocation-list endpoint. Without this, end-to-end Phase 4 testing required reaching into `~/.parachute/hub/hub.db` with `sqlite3` and flipping the bit by hand. Distinct from the existing `revoke-grant` (retires OAuth *consent grants*) and `/oauth/revoke` (RFC 7009 refresh-token revocation): this revokes any *registry-row token* (CLI mints, operator mints, OAuth-issued access tokens) by jti.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.8-rc.4",
+  "version": "0.5.8-rc.5",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -1006,45 +1006,132 @@ describe("parachute auth mint-token", () => {
     }
   });
 
-  test("operator token without hub:admin scope is rejected (no token emitted)", async () => {
+  // Helper: stash a token with the chosen scopes at operator.token, returning
+  // the deps bag so the caller can immediately invoke mint-token. Used by
+  // every gating-scope test below to exercise the gate against a known
+  // narrow / wide token without going through `rotate-operator` (which would
+  // always mint admin-set).
+  //
+  // TTL is 30d (well beyond the 7d auto-rotation window) so the token
+  // survives the next mint-token call without being silently swapped for a
+  // fresh admin-set token by the auto-rotation path. Without this, narrow
+  // tokens would auto-rotate to admin and our gate tests would all see the
+  // post-rotation token, defeating the test entirely.
+  async function bootstrapWithOperatorScopes(
+    tmp: { dir: string; dbPath: string; cleanup: () => void },
+    scopes: readonly string[],
+  ): Promise<AuthDeps> {
+    const deps: AuthDeps = {
+      dbPath: tmp.dbPath,
+      configDir: tmp.dir,
+      isInteractive: () => false,
+    };
+    await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+    const db = openHubDb(tmp.dbPath);
+    let token: string;
+    try {
+      const owner = listUsers(db)[0]!;
+      const signed = await signAccessToken(db, {
+        sub: owner.id,
+        scopes: [...scopes],
+        audience: "operator",
+        clientId: OPERATOR_TOKEN_CLIENT_ID,
+        issuer: "http://127.0.0.1:1939",
+        ttlSeconds: 30 * 24 * 60 * 60,
+      });
+      token = signed.token;
+    } finally {
+      db.close();
+    }
+    await writeOperatorTokenFile(token, tmp.dir);
+    return deps;
+  }
+
+  // hub#222: gate widened from `hub:admin` to `parachute:host:auth`. The
+  // following tests pin the new behaviour:
+  //   - admin scope-set (which carries both) still succeeds (regression);
+  //   - `auth` scope-set (carries only `:host:auth`) NOW succeeds (gain);
+  //   - other narrow scope-sets (vault/install/etc.) still rejected;
+  //   - error message updated to name the new gate.
+
+  test("operator token with `auth` scope-set (parachute:host:auth only) mints successfully (hub#222)", async () => {
     const tmp = makeTmp();
     try {
-      const deps: AuthDeps = {
-        dbPath: tmp.dbPath,
-        configDir: tmp.dir,
-        isInteractive: () => false,
-      };
-      // Bootstrap: set-password to seed the user + signing key.
-      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
-      // Now overwrite operator.token with a valid-signature, valid-expiry
-      // JWT that lacks hub:admin — simulating someone stashing a narrow
-      // token at the operator path.
-      const db = openHubDb(tmp.dbPath);
-      let narrow: string;
-      try {
-        const owner = listUsers(db)[0]!;
-        const signed = await signAccessToken(db, {
-          sub: owner.id,
-          scopes: ["scribe:transcribe"],
-          audience: "scribe",
-          clientId: OPERATOR_TOKEN_CLIENT_ID,
-          issuer: "http://127.0.0.1:1939",
-          ttlSeconds: 3600,
-        });
-        narrow = signed.token;
-      } finally {
-        db.close();
-      }
-      await writeOperatorTokenFile(narrow, tmp.dir);
+      const deps = await bootstrapWithOperatorScopes(tmp, ["parachute:host:auth"]);
+      const { code, stdout, stderr } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "scribe:transcribe"], deps),
+      );
+      expect(code).toBe(0);
+      // Pipe purity: stdout is the JWT, stderr empty.
+      const token = stdout.trim();
+      expect(token.split(".").length).toBe(3);
+      expect(stdout).toBe(`${token}\n`);
+      expect(stderr).toBe("");
+    } finally {
+      tmp.cleanup();
+    }
+  });
 
+  test("operator token with admin scope-set still mints (regression — admin includes :host:auth as superset)", async () => {
+    const tmp = makeTmp();
+    try {
+      // The full admin scope-set carries both `hub:admin` and `parachute:host:auth`.
+      const deps = await bootstrapWithOperatorScopes(tmp, [
+        "hub:admin",
+        "parachute:host:auth",
+        "vault:admin",
+      ]);
+      const { code, stdout } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "scribe:transcribe"], deps),
+      );
+      expect(code).toBe(0);
+      expect(stdout.trim().split(".").length).toBe(3);
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("operator token without parachute:host:auth is rejected (no token emitted)", async () => {
+    const tmp = makeTmp();
+    try {
+      // Narrow non-auth token (resembles what someone might stash by mistake,
+      // or a `--scope-set vault` operator token from rotate-operator).
+      const deps = await bootstrapWithOperatorScopes(tmp, ["scribe:transcribe"]);
       const { code, stdout, stderr } = await captureOutput(() =>
         auth(["mint-token", "--scope", "scribe:transcribe"], deps),
       );
       expect(code).toBe(1);
-      expect(stderr).toContain("lacks hub:admin scope");
+      expect(stderr).toContain("lacks parachute:host:auth scope");
       expect(stderr).toContain("rotate-operator");
-      // Purity: no token written to stdout.
       expect(stdout).toBe("");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("`vault` scope-set is rejected (regression — narrow scope-sets still can't mint)", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps = await bootstrapWithOperatorScopes(tmp, ["parachute:host:vault"]);
+      const { code, stderr } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "scribe:transcribe"], deps),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("lacks parachute:host:auth scope");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("`install` scope-set is rejected (regression — narrow scope-sets still can't mint)", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps = await bootstrapWithOperatorScopes(tmp, ["parachute:host:install", "vault:read"]);
+      const { code, stderr } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "scribe:transcribe"], deps),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("lacks parachute:host:auth scope");
     } finally {
       tmp.cleanup();
     }

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -936,22 +936,26 @@ async function runMintToken(args: readonly string[], deps: AuthDeps): Promise<nu
       return 1;
     }
     // Scope gate: a valid signature + non-expired JWT at this path is not
-    // sufficient — the token must carry operator-equivalent scope. Without
-    // this, a narrowly-scoped JWT stashed at ~/.parachute/operator.token
-    // would be treated as operator-bearer and mint arbitrary tokens
-    // (privilege escalation: narrow → arbitrary). Only set-password and
-    // rotate-operator legitimately write to this path; the `admin` scope-set
-    // is the only one that carries `hub:admin`, so this gate also enforces
-    // that scope-set narrowed tokens (install/start/expose/auth/vault) cannot
-    // mint arbitrary follow-on JWTs via this path.
+    // sufficient — the token must carry mint-token authority. Without this,
+    // a narrowly-scoped JWT stashed at ~/.parachute/operator.token would be
+    // treated as operator-bearer and mint arbitrary tokens (privilege
+    // escalation: narrow → arbitrary). Only set-password and rotate-operator
+    // legitimately write to this path.
+    //
+    // Gate is `parachute:host:auth` (was `hub:admin` through 0.5.8-rc.4 — see
+    // hub#222). Both the `admin` scope-set (which includes `:host:auth` as a
+    // superset) and the `auth` scope-set (which IS `:host:auth`) qualify; the
+    // `auth` scope-set was always meant to gate auth surfaces per the #214
+    // design, but the CLI mint-token gate was historically narrower than the
+    // HTTP equivalent. This brings the two surfaces into alignment.
     const tokenScope =
       typeof used.payload.scope === "string"
         ? used.payload.scope.split(/\s+/).filter((s) => s.length > 0)
         : [];
-    if (!tokenScope.includes("hub:admin")) {
-      console.error("parachute auth mint-token: operator token lacks hub:admin scope");
+    if (!tokenScope.includes("parachute:host:auth")) {
+      console.error("parachute auth mint-token: operator token lacks parachute:host:auth scope");
       console.error(
-        "narrowed scope-sets (install/start/expose/auth/vault) can't mint follow-on tokens — run `parachute auth rotate-operator` to mint a fresh admin-set token",
+        "narrowed scope-sets without `auth` (install/start/expose/vault) can't mint follow-on tokens — run `parachute auth rotate-operator --scope-set auth` (or `admin`) for a token that can",
       );
       return 1;
     }

--- a/src/operator-token.ts
+++ b/src/operator-token.ts
@@ -52,13 +52,15 @@ export const OPERATOR_TOKEN_CLIENT_ID = "parachute-hub";
  * operator-flow's API surface; `admin` is the back-compat superset and
  * stays the default.
  *
- * Phase 1 (hub#213): the vocabulary + flag exist; CLI commands do NOT yet
- * gate on the narrower scopes. Operators can mint a `--scope-set=start`
- * token and use it as their operator.token, but commands like `install`
- * still accept it (they only check `hub:admin` today). Phase 2 (separate
- * follow-up) wires per-command enforcement so a `start` token can only
- * lifecycle-manage, not install. Until then, `--scope-set` is a tool the
- * cautious operator can opt into without breaking anyone.
+ * Per-command gating rolls out incrementally:
+ *   - Auth surfaces (hub#221 `revoke-token`, hub#222 `mint-token`) gate on
+ *     `parachute:host:auth` — both `admin` and `auth` scope-sets carry it.
+ *   - Other CLI commands (`install`, `start`, `expose`, etc.) still accept
+ *     any token with `hub:admin` and don't yet check the narrower scopes;
+ *     a future follow-up wires per-command enforcement so a `start`-set
+ *     token can only lifecycle-manage, not install. Until then,
+ *     `--scope-set` is a tool the cautious operator can opt into without
+ *     breaking anyone.
  *
  * The fine-grained `parachute:host:install/start/expose/auth/vault` scopes
  * are operator-only (non-requestable via public OAuth), like


### PR DESCRIPTION
## Summary

Aligns the `parachute auth mint-token` CLI gate with its HTTP companion (`POST /api/auth/mint-token`) and the new `revoke-token` CLI: all three now gate on `parachute:host:auth` rather than the historically-narrower `hub:admin`. The asymmetry was identified during hub#221 review of the new `revoke-token` CLI; this PR closes it.

Closes #222.

## Why

The `auth` scope-set was added in [hub#214](https://github.com/ParachuteComputer/parachute-hub/issues/214) as part of the scope-narrowing design — operators wanting to grant a CI runner narrow auth-related power without handing over an admin token. The CLI mint-token gate was historically tighter than the HTTP equivalent, so a `--scope-set auth` operator token could mint over the network but NOT from the local CLI — silently failing the very thing the scope-set was named for.

This PR brings the two surfaces into alignment:

| Scope-set on operator.token | Before | After |
|---|---|---|
| `admin` (default) | ✅ | ✅ |
| `auth` | ❌ | ✅ |
| `install` / `start` / `expose` / `vault` | ❌ | ❌ |

## Backwards compatibility

**Widening, not breaking.** No existing workflow stops working:

- Operators with `admin` scope-set tokens (the `parachute auth rotate-operator` default with no `--scope-set` flag): no change. The `admin` set is a superset that includes `parachute:host:auth`.
- Operators with `--scope-set auth` tokens: gain CLI mint access. (The HTTP endpoint already accepted them.)
- Operators with narrow `--scope-set install/start/expose/vault` tokens: still rejected — none of those carry `:host:auth`, by design.

No migration needed. Anyone whose previous workflow worked still works.

## Implementation

Three lines change in `src/commands/auth.ts`'s `runMintToken`:
- Gate scope: `"hub:admin"` → `"parachute:host:auth"`.
- Error message: `lacks hub:admin scope` → `lacks parachute:host:auth scope`.
- Hint text: now names the `auth` scope-set as a sufficient choice (was: only `admin`).

Comment block above the gate updated to explain the historical context (was-was-`hub:admin`-through-rc.4) so future readers understand why the gate matches the HTTP endpoint.

## Tests

Refactored the gating-scope test scaffolding into a `bootstrapWithOperatorScopes(tmp, scopes)` helper so the cases share one bootstrap shape. Five cases:

1. **`auth` scope-set (parachute:host:auth only) succeeds** — the gain (this PR's headline behaviour).
2. **`admin` scope-set still works** — regression for the existing default.
3. **Token without `parachute:host:auth` rejected** — narrow non-auth scope (e.g. `scribe:transcribe`); the prior "lacks hub:admin" test renamed and refocused on the new gate.
4. **`vault` scope-set rejected** — pinning that narrow scope-sets stay out.
5. **`install` scope-set rejected** — same.

The helper uses a 30d TTL deliberately — a 1h token (my first draft) tripped the within-7d auto-rotation path in `useOperatorTokenWithAutoRotate` and silently swapped the narrow test token for a fresh admin one before the gate check fired. Caught and fixed before pushing; documented in the helper's docstring so the next test author doesn't trip the same wire.

## Versions

- `package.json`: `0.5.8-rc.4` → `0.5.8-rc.5`.
- CHANGELOG entry under `## [0.5.8-rc.5] - 2026-05-10` framing the change as backwards-compatible widening.

## Test plan

- [x] hub: **1169 pass / 0 fail** (canonical `bun test ./src` from hub root — was 1165 at rc.4 tip; +5 new gating-scope tests, -1 prior test repurposed).
- [x] typecheck: clean.
- [x] biome: clean.

## Patterns check

- **CLI auth-gate pattern preserved** — same inline `tokenScope.includes(...)` shape used by `mint-token` (now consistent), `revoke-token` (set in #221), and `rotate-operator`. No new abstraction; just bringing the constant into alignment across the three surfaces.
- **Scope-set design (#214)** — this PR honours the `auth` scope-set's intended grant. The `OPERATOR_TOKEN_SCOPE_SETS` map already wired `auth: ["parachute:host:auth"]`; nothing changes there. The CLI-side check now reads what the data already said.
- **RC versioning** — `rc.4` → `rc.5` per parachute-patterns/governance.md. Code-touching PR; not doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)