### PR TITLE
fix(scope-guard): add .js extensions to relative imports for NodeNext consumers (0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.8-rc.6] - 2026-05-10
+
+Workspace consumes `@openparachute/scope-guard@0.2.1` — a packaging fix for NodeNext-strict consumers (agent's tsc + vitest). Hub itself is unaffected at runtime: hub's auth paths never go through scope-guard (they use the local `validateAccessToken` against the on-box DB), and the workspace consumes scope-guard via Bun's bundler resolution, which already resolved 0.2.0's extensionless imports correctly. Test gate unchanged.
+
+### Changed
+
+- **`@openparachute/scope-guard` 0.2.0 → 0.2.1** — adds explicit `.js` extensions to relative imports in published `dist/`. See `packages/scope-guard/CHANGELOG.md` for the full surface change. **Vault and scribe auto-pick the new patch on next `bun install` (their pin is `^0.2.0`); no downstream PR needed.** Agent updates its exact-pin separately.
+
 ## [0.5.8-rc.5] - 2026-05-10
 
 Aligns the `parachute auth mint-token` CLI gate with the HTTP companion (`POST /api/auth/mint-token`) and the new `revoke-token` CLI: all three now gate on `parachute:host:auth` rather than the historically-narrower `hub:admin`. Closes hub#222. Backwards-compatible widening — operators with `admin` scope-set tokens (the default) are unaffected; operators with the narrow `--scope-set auth` operator token gain the ability the scope-set was always meant to grant per the #214 design.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.8-rc.5",
+  "version": "0.5.8-rc.6",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/packages/scope-guard/CHANGELOG.md
+++ b/packages/scope-guard/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to `@openparachute/scope-guard` are documented here. The for
 
 The library's RC cadence is independent of `@openparachute/hub`'s — they ship from the same repo but aren't coupled in version.
 
+## 0.2.1 — 2026-05-10
+
+Packaging fix. **0.2.0 is non-functional under NodeNext-strict consumers** — every non-bun adopter on `tsc + Node ESM + "moduleResolution": "nodenext"` should upgrade to 0.2.1 immediately.
+
+### Fixed
+
+- **Relative imports in published `dist/` now carry explicit `.js` extensions.** Source imports like `from "./validate"` were emitted into dist verbatim by tsc, which works for bun + `"moduleResolution": "bundler"` (vault, scribe, hub workspace) but breaks NodeNext: `Cannot find module ".../dist/parse"`. Type information collapses to `any`/`unknown` at the consumer; downstream paths that touch `HubJwtError.code` then fail TS18046 ("'err' is of type 'unknown'"). Added `.js` to every relative import in `src/index.ts` and `src/validate.ts` (the only non-test source files with relative imports); tsc now emits the extensions verbatim and NodeNext resolution succeeds.
+
+### Compatibility
+
+- **No behaviour change.** Every API surface is identical to 0.2.0. This is a pure packaging fix.
+- **bundler-resolution consumers (vault, scribe, hub workspace):** unaffected. Bun resolves `.js` back to `.ts` transparently; the explicit extension is a no-op for them.
+- **NodeNext-strict consumers (agent's tsc + vitest):** 0.2.0 was unusable; 0.2.1 works.
+- **Vault and scribe** (currently on `^0.2.0`) auto-pick 0.2.1 on next `bun install` — no PR needed downstream.
+- **Agent** updates its `minimumReleaseAgeExclude` pin from `0.2.0` to `0.2.1` (still exact-version-pinned per their governance).
+
+### Forward-looking note
+
+The internal convention going forward: relative imports in scope-guard source MUST carry `.js` extensions. The `index.ts` header comment now spells this out so the next contributor doesn't re-introduce the bug. Long-term, we'd add an `eslint-plugin-import` `extensions` rule (or biome equivalent if/when one ships) to mechanically enforce — out of scope for 0.2.1.
+
 ## 0.2.0 — 2026-05-10
 
 Adds enforcement of the hub's revocation list (hub#212 Phase 4 RS-side foundation). **This is a behaviour-breaking minor for adopters**: any vault / scribe / parachute-agent / third-party RS that bumps from `0.1.x` will start rejecting JWTs whose `jti` appears in `<hub-origin>/.well-known/parachute-revocation.json`. Adopt only after testing against a revoked-token fixture (or equivalent integration test).

--- a/packages/scope-guard/package.json
+++ b/packages/scope-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scope-guard",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Hub-issued JWT validation for Parachute resource servers (vault, scribe, parachute-agent, third-party modules).",
   "license": "AGPL-3.0",
   "type": "module",

--- a/packages/scope-guard/src/index.ts
+++ b/packages/scope-guard/src/index.ts
@@ -8,9 +8,16 @@
  * See README.md for the full API rundown and design.
  */
 
-export { extractBearer, looksLikeJwt, parseScopes } from "./parse";
-export { hasScope } from "./scope";
-export type { JwksGetter, JwksOptions } from "./jwks";
+// Note: relative imports MUST carry `.js` extensions even though the source
+// files are `.ts`. tsc emits the extension verbatim into dist, and NodeNext-
+// strict consumers (e.g. agent's tsc + vitest under Node ESM) require the
+// extension to resolve compiled JS modules. Bun + bundler-resolution
+// consumers (vault, scribe, hub workspace) resolve `.js` back to `.ts`
+// transparently. Dropping the extension breaks NodeNext silently — see #225
+// for the bug that motivated 0.2.1.
+export { extractBearer, looksLikeJwt, parseScopes } from "./parse.js";
+export { hasScope } from "./scope.js";
+export type { JwksGetter, JwksOptions } from "./jwks.js";
 // Revocation-cache surface: the cache itself is internal — `ScopeGuard` owns
 // the lifecycle so downstream RSes don't accidentally instantiate parallel
 // caches with diverging policies. The seam exposed here is `RevocationFetcher`
@@ -22,7 +29,7 @@ export {
   defaultRevocationFetcher,
   type RevocationFetcher,
   type RevocationListBody,
-} from "./revocation-cache";
+} from "./revocation-cache.js";
 export {
   createScopeGuard,
   HubJwtError,
@@ -31,4 +38,4 @@ export {
   type HubJwtErrorCode,
   type ScopeGuard,
   type ValidateHubJwtOptions,
-} from "./validate";
+} from "./validate.js";

--- a/packages/scope-guard/src/validate.ts
+++ b/packages/scope-guard/src/validate.ts
@@ -1,11 +1,11 @@
 import { type JWTPayload, jwtVerify } from "jose";
-import { type JwksGetter, type JwksOptions, getOrCreateJwksGetter, resetCache } from "./jwks";
-import { parseScopes } from "./parse";
+import { type JwksGetter, type JwksOptions, getOrCreateJwksGetter, resetCache } from "./jwks.js";
+import { parseScopes } from "./parse.js";
 import {
   type RevocationCache,
   type RevocationFetcher,
   createRevocationCache,
-} from "./revocation-cache";
+} from "./revocation-cache.js";
 
 /**
  * Hub-issued JWT validation, factored out of vault/scribe/parachute-agent's


### PR DESCRIPTION
## Summary

scope-guard 0.2.0's published `dist/` used extensionless relative imports (`from "./validate"`, etc.). Bun + bundler-resolution consumers (vault, scribe, hub workspace) resolve fine; **NodeNext-strict consumers (agent's tsc + vitest under Node ESM) break** with `Cannot find module ".../dist/parse"`. Type information collapses to `any`/`unknown` at the consumer; downstream paths that touch `HubJwtError.code` then fail TS18046.

This PR adds explicit `.js` extensions to every relative import in `packages/scope-guard/src/index.ts` and `packages/scope-guard/src/validate.ts` (the only non-test files with relative imports — `__tests__/` is excluded from dist per `tsconfig.json`). tsc emits the extension verbatim. NodeNext now resolves; bundler resolution is unaffected (the explicit extension is a no-op there).

Aaron approved option A (republish 0.2.1 with `.js` extensions in source) over the alternatives.

## Versions

- `packages/scope-guard/package.json`: **0.2.0 → 0.2.1** — patch bump, pure packaging fix, zero behavior change.
- `package.json` (hub): **0.5.8-rc.5 → 0.5.8-rc.6** — workspace consumes scope-guard transparently; hub itself never goes through scope-guard at runtime (its auth paths use the local `validateAccessToken` against the on-box DB), so this is structurally inert at the hub surface.

## Compatibility matrix

| Consumer | Before (0.2.0) | After (0.2.1) | Action needed |
|---|---|---|---|
| **bun + bundler resolution** (vault, scribe, hub workspace) | works | works | none — auto-picks via `^0.2.0` on next install |
| **NodeNext + tsc + vitest** (agent) | broken | works | bump exact-pin from 0.2.0 to 0.2.1 |

## What's NOT in this PR

- **Vault / scribe re-bumps.** Their pin is `^0.2.0`; bun resolves to 0.2.1 on next install. No PR needed downstream.
- **Other ergonomic packaging improvements.** Only fixing the breakage that blocks agent.
- **README updates.** CHANGELOG carries the substance.

## Forward-looking note

Internal convention going forward: relative imports in scope-guard source MUST carry `.js` extensions. Header comment in `index.ts` documents this so the next contributor doesn't re-introduce the bug. Long-term, an `eslint-plugin-import` `extensions` rule (or biome equivalent if/when one ships) would mechanically enforce — out of scope for 0.2.1; capturing as known good cleanup.

## Test plan

- [x] hub: **1169 pass / 0 fail** (canonical `bun test ./src` — unchanged from rc.5; this is purely a packaging fix).
- [x] scope-guard: **88 pass / 0 fail** (unchanged).
- [x] typecheck (both packages): clean.
- [x] biome: clean.
- [x] Verified: `dist/*.js` now contains `from "./X.js"` for every relative import (eyeballed `dist/index.js` and `dist/validate.js` after a fresh `bun run build`).

## Patterns check

- **scope-guard library shape** — public API surface unchanged (every export from `index.ts` still exists with the same signature). The diff is purely the `.js` suffix on import specifiers.
- **RC versioning** — hub bumps `rc.5` → `rc.6` per parachute-patterns/governance.md (code-touching PR, not doc-only). scope-guard takes its own `0.2.0` → `0.2.1` patch (the library's RC cadence is independent of hub's, per scope-guard's README).
- **Zero behavior change** at the API boundary — the failure was a packaging-layer bug; the fix is a packaging-layer fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)