### PR TITLE
feat(ui): /hub/tokens admin route — list + mint + revoke (hub#212 Phase 2 UI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.8-rc.8] - 2026-05-10
+
+Phase 2 of hub#212: admin UI for token management at `/hub/tokens`. Operators get a browser surface for the registry that backed `parachute auth mint-token`, `parachute auth revoke-token`, and the new HTTP endpoints from rc.7. Refs hub#212 (umbrella stays open through Phase 6).
+
+### Added
+
+- **`/hub/tokens` route** in the SPA. Three actions:
+  - **List** — paginated, status-filtered (Show all / Live only / Revoked only) view of every registry row. Each row surfaces jti (truncated, full on hover), identity (`user_id ?? subject`), scope, status pill (live / expired / revoked), `created_via` provenance, dates, and an expandable `<details>` for the `permissions` JSON.
+  - **Mint** — inline form (toggle from page header). Fields: scope (required), audience (optional, inferred from scope on the hub side), expires_in (seconds), subject (defaults to operator's sub), permissions (JSON object, validated client-side). On success, the JWT is shown ONCE in a `mint-banner` with copy-to-clipboard and a clear "this is the only time" warning — no DB-side recovery.
+  - **Revoke** — per-row button (live tokens only) → confirm dialog → `POST /api/auth/revoke-token`. Mirrors the Permissions page's revoke flow exactly.
+- **Three new API helpers in `web/ui/src/lib/api.ts`** — `listTokens(opts)`, `mintToken(input)`, `revokeToken(jti)`. All follow the established Bearer + clearCachedToken-on-401/403 pattern from `createVault` / `listGrants`. Types match the rc.7 wire shape verbatim (snake_case, parsed `permissions`).
+- **Cursor pagination via "Load more" button** at the bottom of the list. Appends the next page in place; clears the button when `next_cursor` goes null.
+
+### Changed
+
+- **`web/ui/src/App.tsx`** — added `/hub/tokens` route alongside `/hub/permissions`. Renamed the local `isPermissionsMount` constant to `isHubMount` (now the mount hosts more than one route). Nav adds a "Tokens" link.
+
+### Visual posture
+
+- Reused every existing CSS class — `.vault-row`, `.tag` / `.tag.muted`, `.list-header`, `.empty-rich`, `.error-banner`, `.section`, `.mint-banner`, `.field-error`. Zero new CSS, zero new design system.
+
+### Test gate
+
+- hub: 1193 pass / 0 fail (unchanged from rc.7 — purely additive UI work).
+- web UI: 66 pass / 0 fail (was 47 pre-existing; +19 across list rendering, status pills, filter pills, mint form validation + happy path, revoke confirm flow, "Load more" pagination, and one end-to-end integration that walks mint → see in list → revoke → see status update).
+- typecheck (both): clean. biome: clean. UI build verified — `dist/index.html` carries `/vault/`-prefixed asset URLs per the post-build regression check.
+
 ## [0.5.8-rc.7] - 2026-05-10
 
 Two new HTTP endpoints — backend foundation for hub#212 Phase 2 (admin UI for token management). Closes hub#220. The admin UI itself ships in a follow-up rc.8 PR; these endpoints have standalone value for any operator-tooling that wants programmatic registry access.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.8-rc.7",
+  "version": "0.5.8-rc.8",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,14 +1,16 @@
 import { Link, Route, Routes } from "react-router-dom";
 import { NewVault } from "./routes/NewVault.tsx";
 import { Permissions } from "./routes/Permissions.tsx";
+import { Tokens } from "./routes/Tokens.tsx";
 import { VaultsList } from "./routes/VaultsList.tsx";
 
 // Same SPA bundle, two mounts: /vault (primary, vault management) and
-// /hub (back-compat, /hub/permissions only). The active mount picks the
-// route table — we don't render every route under both basenames since
-// they are unrelated concerns. Cross-mount navigation uses plain <a href>
-// because <Link> resolves against the active basename.
-const isPermissionsMount =
+// /hub (back-compat + cross-cutting auth state — /hub/permissions and
+// /hub/tokens). The active mount picks the route table — we don't render
+// every route under both basenames since they are unrelated concerns.
+// Cross-mount navigation uses plain <a href> because <Link> resolves
+// against the active basename.
+const isHubMount =
   typeof window !== "undefined" &&
   (window.location.pathname === "/hub" || window.location.pathname.startsWith("/hub/"));
 
@@ -21,15 +23,17 @@ export function App() {
         </a>
         <a href="/vault">Vaults</a>
         <a href="/hub/permissions">Permissions</a>
+        <a href="/hub/tokens">Tokens</a>
         <a href="/" title="Hub discovery page (top-level)">
           Discovery
         </a>
       </nav>
 
       <Routes>
-        {isPermissionsMount ? (
+        {isHubMount ? (
           <>
             <Route path="/permissions" element={<Permissions />} />
+            <Route path="/tokens" element={<Tokens />} />
             <Route
               path="*"
               element={

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -250,6 +250,140 @@ export function resolveManagementUrl(vaultUrl: string, managementUrl: string): s
   return `${base}${tail}`;
 }
 
+/**
+ * One row from `GET /api/auth/tokens`. Matches the wire shape from
+ * `src/api-tokens.ts` exactly — snake_case fields, parsed `permissions`
+ * (object, not raw JSON string — hub layer parses).
+ */
+export interface AdminTokenListing {
+  jti: string;
+  user_id: string | null;
+  subject: string | null;
+  client_id: string;
+  scopes: string[];
+  expires_at: string;
+  revoked_at: string | null;
+  created_at: string;
+  created_via: string;
+  permissions: Record<string, unknown> | null;
+}
+
+/** One page of tokens. `next_cursor` is null when we've walked to the end. */
+export interface AdminTokensPage {
+  tokens: AdminTokenListing[];
+  next_cursor: string | null;
+}
+
+/** Filter knobs for `listTokens`. */
+export interface ListTokensOpts {
+  /** "true" → only revoked; "false" → only un-revoked; "all" or omit → both. */
+  revoked?: "true" | "false" | "all";
+  /** Exact match against either `user_id` (OAuth rows) or `subject` (mint rows). */
+  subject?: string;
+  /** Cursor from a previous page's `next_cursor`. */
+  cursor?: string;
+}
+
+/**
+ * GET /api/auth/tokens — paginated list of registry rows. Same Bearer
+ * pattern as `createVault` / `listGrants`.
+ */
+export async function listTokens(opts: ListTokensOpts = {}): Promise<AdminTokensPage> {
+  const params = new URLSearchParams();
+  if (opts.revoked) params.set("revoked", opts.revoked);
+  if (opts.subject) params.set("subject", opts.subject);
+  if (opts.cursor) params.set("cursor", opts.cursor);
+  const query = params.toString();
+  const url = query ? `/api/auth/tokens?${query}` : "/api/auth/tokens";
+
+  const bearer = await getHostAdminToken();
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${bearer}`,
+    },
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  return (await res.json()) as AdminTokensPage;
+}
+
+/** Body shape for `POST /api/auth/mint-token`. Matches the hub-side handler. */
+export interface MintTokenInput {
+  scope: string;
+  audience?: string;
+  expires_in?: number;
+  subject?: string;
+  permissions?: Record<string, unknown>;
+}
+
+/** Successful mint response. The `token` is shown ONCE in the UI; never persisted. */
+export interface MintedToken {
+  jti: string;
+  token: string;
+  expires_at: string;
+  scope: string;
+  permissions?: Record<string, unknown>;
+}
+
+/**
+ * POST /api/auth/mint-token — mint a scope-narrow access token. Same
+ * Bearer pattern; the minted JWT comes back in the response body and
+ * is the operator's only chance to copy it (no DB-side recovery).
+ */
+export async function mintToken(input: MintTokenInput): Promise<MintedToken> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch("/api/auth/mint-token", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json",
+      authorization: `Bearer ${bearer}`,
+    },
+    body: JSON.stringify(input),
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  return (await res.json()) as MintedToken;
+}
+
+/**
+ * POST /api/auth/revoke-token — flip `revoked_at` on the registry row
+ * keyed by jti. Idempotent: re-revoking returns the original
+ * `revoked_at`. UI surfaces this as a confirm-then-POST flow per row.
+ */
+export async function revokeToken(jti: string): Promise<{ jti: string; revoked_at: string }> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch("/api/auth/revoke-token", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json",
+      authorization: `Bearer ${bearer}`,
+    },
+    body: JSON.stringify({ jti }),
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  return (await res.json()) as { jti: string; revoked_at: string };
+}
+
 async function readError(res: Response): Promise<string> {
   try {
     const text = await res.text();

--- a/web/ui/src/routes/Tokens.test.tsx
+++ b/web/ui/src/routes/Tokens.test.tsx
@@ -1,0 +1,453 @@
+/**
+ * Tokens route smoke tests — list rendering, status pills, filter pills,
+ * mint flow (form open → submit → mint-banner with copy → list refresh),
+ * revoke confirm flow (cancel + confirm), revoke failure, "Load more"
+ * cursor pagination, integration happy-path (mint → see in list →
+ * revoke → see status update).
+ */
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import { Tokens } from "./Tokens.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    listTokens: vi.fn(),
+    mintToken: vi.fn(),
+    revokeToken: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderRoute() {
+  return render(
+    <MemoryRouter>
+      <Tokens />
+    </MemoryRouter>,
+  );
+}
+
+const FUTURE = "2030-01-01T00:00:00.000Z";
+const PAST = "2020-01-01T00:00:00.000Z";
+
+const tokenRow = (
+  jti: string,
+  overrides: Partial<api.AdminTokenListing> = {},
+): api.AdminTokenListing => ({
+  jti,
+  user_id: "user-uuid",
+  subject: null,
+  client_id: "parachute-hub",
+  scopes: ["scribe:transcribe"],
+  expires_at: FUTURE,
+  revoked_at: null,
+  created_at: "2026-05-10T12:00:00.000Z",
+  created_via: "cli_mint",
+  permissions: null,
+  ...overrides,
+});
+
+describe("Tokens — list rendering", () => {
+  it("renders the empty state when no tokens exist", async () => {
+    vi.mocked(api.listTokens).mockResolvedValue({ tokens: [], next_cursor: null });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/no tokens\./i)).toBeInTheDocument());
+  });
+
+  it("renders one row per token with truncated jti, identity, scope, dates", async () => {
+    // JTIs need to be > 14 chars to actually trigger truncation.
+    vi.mocked(api.listTokens).mockResolvedValue({
+      tokens: [
+        tokenRow("aaaaaaaaXXXXXXXbbbb", { scopes: ["vault:work:read"] }),
+        tokenRow("zzzzzzzzYYYYYYYwwww", {
+          scopes: ["scribe:transcribe"],
+          subject: "operator",
+          user_id: null,
+        }),
+      ],
+      next_cursor: null,
+    });
+    renderRoute();
+    // Truncated jtis appear (8 chars + ellipsis + last 4).
+    await waitFor(() => expect(screen.getByText(/aaaaaaaa…bbbb/)).toBeInTheDocument());
+    expect(screen.getByText(/zzzzzzzz…wwww/)).toBeInTheDocument();
+    // Identity rendering: user_id when present, subject as fallback.
+    expect(screen.getByText("user-uuid")).toBeInTheDocument();
+    expect(screen.getByText("operator")).toBeInTheDocument();
+    // Scopes show as code tags.
+    expect(screen.getByText("vault:work:read")).toBeInTheDocument();
+    expect(screen.getByText("scribe:transcribe")).toBeInTheDocument();
+  });
+
+  it("renders status pills: live / expired / revoked", async () => {
+    vi.mocked(api.listTokens).mockResolvedValue({
+      tokens: [
+        tokenRow("aliveeeeAAAAAAAXXXX", { expires_at: FUTURE, revoked_at: null }),
+        tokenRow("expirexpirEEEEEEEEEXXXX", { expires_at: PAST, revoked_at: null }),
+        tokenRow("revokedRRRRRRRRRRRXXXX", {
+          expires_at: FUTURE,
+          revoked_at: "2026-05-10T13:00:00.000Z",
+        }),
+      ],
+      next_cursor: null,
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/aliveeee…XXXX/)).toBeInTheDocument());
+    // Status pill text appears for each.
+    expect(screen.getByText("live")).toBeInTheDocument();
+    expect(screen.getByText("expired")).toBeInTheDocument();
+    expect(screen.getByText("revoked")).toBeInTheDocument();
+  });
+
+  it("revoke button only renders for live tokens (not expired or revoked)", async () => {
+    vi.mocked(api.listTokens).mockResolvedValue({
+      tokens: [
+        tokenRow("aliveeeeAAAAAAAXXXX"),
+        tokenRow("expirexpirEEEEEEEEEXXXX", { expires_at: PAST }),
+        tokenRow("revokedRRRRRRRRRRRXXXX", { revoked_at: "2026-05-10T13:00:00.000Z" }),
+      ],
+      next_cursor: null,
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/aliveeee…XXXX/)).toBeInTheDocument());
+    // Three rows; only one Revoke button (for the live token).
+    const revokeButtons = screen.getAllByRole("button", { name: /^revoke /i });
+    expect(revokeButtons).toHaveLength(1);
+  });
+
+  it("renders the error banner + retry on listTokens failure", async () => {
+    vi.mocked(api.listTokens).mockRejectedValue(new Error("network down"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/couldn't load tokens/i)).toBeInTheDocument());
+    expect(screen.getByText("network down")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+});
+
+describe("Tokens — filter pills", () => {
+  it("clicking a filter pill calls listTokens with the right ?revoked= value", async () => {
+    vi.mocked(api.listTokens).mockResolvedValue({ tokens: [], next_cursor: null });
+    renderRoute();
+    // Initial call with default `all`.
+    await waitFor(() => expect(api.listTokens).toHaveBeenCalledWith({ revoked: "all" }));
+
+    fireEvent.click(screen.getByRole("button", { name: /^live only$/i, pressed: false }));
+    await waitFor(() => expect(api.listTokens).toHaveBeenCalledWith({ revoked: "false" }));
+
+    fireEvent.click(screen.getByRole("button", { name: /^revoked only$/i, pressed: false }));
+    await waitFor(() => expect(api.listTokens).toHaveBeenCalledWith({ revoked: "true" }));
+  });
+});
+
+describe("Tokens — mint form", () => {
+  beforeEach(() => {
+    vi.mocked(api.listTokens).mockResolvedValue({ tokens: [], next_cursor: null });
+  });
+
+  it("Mint new token toggle opens + cancels the form", async () => {
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /mint new token/i }));
+    // Form labels visible.
+    expect(screen.getByLabelText(/scope \(space-separated\)/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+    await waitFor(() => expect(screen.queryByLabelText(/scope \(space-separated\)/i)).toBeNull());
+  });
+
+  it("client-side validation: empty scope on submit shows field-error", async () => {
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /mint new token/i }));
+    // Required attribute should block native submit, but we test the post-validation
+    // path by bypassing the required check via direct form submit.
+    const form = screen.getByLabelText(/scope \(space-separated\)/i).closest("form");
+    expect(form).not.toBeNull();
+    // Set an empty value and dispatch submit. JSDOM honors `required`, so we
+    // need to remove it for the test — but the simpler signal is "mintToken
+    // was not called when scope is empty." Verify by submitting after removing
+    // required.
+    const scopeInput = screen.getByLabelText(/scope \(space-separated\)/i) as HTMLInputElement;
+    scopeInput.removeAttribute("required");
+    fireEvent.submit(form!);
+    await waitFor(() => expect(screen.getByText(/scope is required/i)).toBeInTheDocument());
+    expect(api.mintToken).not.toHaveBeenCalled();
+  });
+
+  it("client-side validation: malformed permissions JSON shows field-error", async () => {
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /mint new token/i }));
+    fireEvent.change(screen.getByLabelText(/scope \(space-separated\)/i), {
+      target: { value: "scribe:transcribe" },
+    });
+    fireEvent.change(screen.getByLabelText(/permissions/i), {
+      target: { value: "not json {[" },
+    });
+    fireEvent.submit(screen.getByLabelText(/scope \(space-separated\)/i).closest("form")!);
+    await waitFor(() =>
+      expect(screen.getByText(/permissions is not valid JSON/i)).toBeInTheDocument(),
+    );
+    expect(api.mintToken).not.toHaveBeenCalled();
+  });
+
+  it("client-side validation: permissions array (not object) shows field-error", async () => {
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /mint new token/i }));
+    fireEvent.change(screen.getByLabelText(/scope \(space-separated\)/i), {
+      target: { value: "scribe:transcribe" },
+    });
+    fireEvent.change(screen.getByLabelText(/permissions/i), {
+      target: { value: '["array", "not object"]' },
+    });
+    fireEvent.submit(screen.getByLabelText(/scope \(space-separated\)/i).closest("form")!);
+    await waitFor(() =>
+      expect(screen.getByText(/permissions must be a JSON object/i)).toBeInTheDocument(),
+    );
+    expect(api.mintToken).not.toHaveBeenCalled();
+  });
+
+  it("client-side validation: non-integer expires_in shows field-error", async () => {
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /mint new token/i }));
+    fireEvent.change(screen.getByLabelText(/scope \(space-separated\)/i), {
+      target: { value: "scribe:transcribe" },
+    });
+    fireEvent.change(screen.getByLabelText(/expires in/i), {
+      target: { value: "not-a-number" },
+    });
+    fireEvent.submit(screen.getByLabelText(/scope \(space-separated\)/i).closest("form")!);
+    await waitFor(() =>
+      expect(screen.getByText(/expires_in must be a positive integer/i)).toBeInTheDocument(),
+    );
+    expect(api.mintToken).not.toHaveBeenCalled();
+  });
+
+  it("happy path: submits scope-only mint, shows mint-banner with the JWT, refreshes list", async () => {
+    vi.mocked(api.mintToken).mockResolvedValue({
+      jti: "newjtiabcdef",
+      token: "header.payload.signature",
+      expires_at: FUTURE,
+      scope: "scribe:transcribe",
+    });
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /mint new token/i }));
+    fireEvent.change(screen.getByLabelText(/scope \(space-separated\)/i), {
+      target: { value: "scribe:transcribe" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^mint$/i }));
+
+    await waitFor(() => expect(api.mintToken).toHaveBeenCalledWith({ scope: "scribe:transcribe" }));
+    // Mint-banner shows the JWT once.
+    await waitFor(() => expect(screen.getByText("header.payload.signature")).toBeInTheDocument());
+    expect(screen.getByText(/this is the only time/i)).toBeInTheDocument();
+    // List was refreshed (listTokens called twice — initial + post-mint).
+    expect(vi.mocked(api.listTokens).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("happy path: full form (scope + audience + expires_in + subject + permissions) round-trips", async () => {
+    vi.mocked(api.mintToken).mockResolvedValue({
+      jti: "fulljtiXXXX",
+      token: "h.p.s",
+      expires_at: FUTURE,
+      scope: "vault:default:write",
+      permissions: { vault: { default: { write_tags: ["health"] } } },
+    });
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /mint new token/i }));
+    fireEvent.change(screen.getByLabelText(/scope \(space-separated\)/i), {
+      target: { value: "vault:default:write" },
+    });
+    fireEvent.change(screen.getByLabelText(/audience/i), {
+      target: { value: "vault.default" },
+    });
+    fireEvent.change(screen.getByLabelText(/expires in/i), {
+      target: { value: "3600" },
+    });
+    fireEvent.change(screen.getByLabelText(/subject/i), {
+      target: { value: "robot" },
+    });
+    fireEvent.change(screen.getByLabelText(/permissions/i), {
+      target: { value: '{"vault":{"default":{"write_tags":["health"]}}}' },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^mint$/i }));
+
+    await waitFor(() =>
+      expect(api.mintToken).toHaveBeenCalledWith({
+        scope: "vault:default:write",
+        audience: "vault.default",
+        expires_in: 3600,
+        subject: "robot",
+        permissions: { vault: { default: { write_tags: ["health"] } } },
+      }),
+    );
+  });
+
+  it("server error on mint surfaces in the form (no mint-banner)", async () => {
+    vi.mocked(api.mintToken).mockRejectedValue(new api.HttpError(403, "insufficient_scope"));
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /mint new token/i }));
+    fireEvent.change(screen.getByLabelText(/scope \(space-separated\)/i), {
+      target: { value: "scribe:transcribe" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^mint$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/mint failed \(403\): insufficient_scope/i)).toBeInTheDocument(),
+    );
+    // No mint-banner.
+    expect(screen.queryByText(/this is the only time/i)).toBeNull();
+  });
+});
+
+describe("Tokens — revoke flow", () => {
+  it("revoke button opens confirm dialog; cancel returns to list without POST", async () => {
+    vi.mocked(api.listTokens).mockResolvedValue({
+      tokens: [tokenRow("revokemeRRRRRRRXXXX")],
+      next_cursor: null,
+    });
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /^revoke revokeme…XXXX$/i }));
+    expect(
+      screen.getByRole("dialog", { name: /confirm revoke revokeme…XXXX/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: /confirm revoke/i })).toBeNull(),
+    );
+    expect(api.revokeToken).not.toHaveBeenCalled();
+  });
+
+  it("confirm revoke calls POST then refreshes the list", async () => {
+    const listMock = vi.mocked(api.listTokens);
+    listMock.mockResolvedValueOnce({
+      tokens: [tokenRow("revokemeRRRRRRRXXXX")],
+      next_cursor: null,
+    });
+    listMock.mockResolvedValueOnce({
+      tokens: [tokenRow("revokemeRRRRRRRXXXX", { revoked_at: "2026-05-10T14:00:00.000Z" })],
+      next_cursor: null,
+    });
+    vi.mocked(api.revokeToken).mockResolvedValue({
+      jti: "revokemeRRRRRRRXXXX",
+      revoked_at: "2026-05-10T14:00:00.000Z",
+    });
+
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /^revoke revokeme…XXXX$/i }));
+    const dialog = screen.getByRole("dialog", { name: /confirm revoke revokeme…XXXX/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: /^revoke$/i }));
+
+    await waitFor(() => expect(api.revokeToken).toHaveBeenCalledWith("revokemeRRRRRRRXXXX"));
+    // List refreshed; status pill switches to revoked.
+    await waitFor(() => expect(screen.getByText("revoked")).toBeInTheDocument());
+  });
+
+  it("surfaces a per-row error banner when revoke fails", async () => {
+    vi.mocked(api.listTokens).mockResolvedValue({
+      tokens: [tokenRow("revokemeRRRRRRRXXXX")],
+      next_cursor: null,
+    });
+    vi.mocked(api.revokeToken).mockRejectedValue(new api.HttpError(404, "not_found"));
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /^revoke revokeme…XXXX$/i }));
+    const dialog = screen.getByRole("dialog", { name: /confirm revoke revokeme…XXXX/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: /^revoke$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/revoke failed \(404\): not_found/i)).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("Tokens — pagination", () => {
+  it("Load more appends next page; clears button when next_cursor goes null", async () => {
+    const listMock = vi.mocked(api.listTokens);
+    listMock.mockResolvedValueOnce({
+      tokens: [tokenRow("page1aaaPPPPPPPXXXX")],
+      next_cursor: "cursor-1",
+    });
+    listMock.mockResolvedValueOnce({
+      tokens: [tokenRow("page2bbbPPPPPPPYYYY")],
+      next_cursor: null,
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/page1aaa…XXXX/)).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /load more/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /load more/i }));
+    await waitFor(() => expect(screen.getByText(/page2bbb…YYYY/)).toBeInTheDocument());
+    // Both rows now present; Load more button gone (next_cursor was null).
+    expect(screen.getByText(/page1aaa…XXXX/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /load more/i })).toBeNull();
+    // Second call passed the cursor.
+    expect(listMock).toHaveBeenLastCalledWith({ cursor: "cursor-1", revoked: "all" });
+  });
+});
+
+describe("Tokens — integration: mint → see in list → revoke → see status update", () => {
+  it("walks the full happy-path loop", async () => {
+    const listMock = vi.mocked(api.listTokens);
+    // Page 1 (initial): empty registry.
+    listMock.mockResolvedValueOnce({ tokens: [], next_cursor: null });
+    // Page 2 (after mint): one live row.
+    listMock.mockResolvedValueOnce({
+      tokens: [tokenRow("integratioNIIIIIIIIIIonXX", { scopes: ["scribe:transcribe"] })],
+      next_cursor: null,
+    });
+    // Page 3 (after revoke): one revoked row.
+    listMock.mockResolvedValueOnce({
+      tokens: [
+        tokenRow("integratioNIIIIIIIIIIonXX", {
+          scopes: ["scribe:transcribe"],
+          revoked_at: "2026-05-10T14:00:00.000Z",
+        }),
+      ],
+      next_cursor: null,
+    });
+    vi.mocked(api.mintToken).mockResolvedValue({
+      jti: "integratioNIIIIIIIIIIonXX",
+      token: "h.p.s",
+      expires_at: FUTURE,
+      scope: "scribe:transcribe",
+    });
+    vi.mocked(api.revokeToken).mockResolvedValue({
+      jti: "integratioNIIIIIIIIIIonXX",
+      revoked_at: "2026-05-10T14:00:00.000Z",
+    });
+
+    renderRoute();
+    // Step 1: empty state visible.
+    await waitFor(() => expect(screen.getByText(/no tokens\./i)).toBeInTheDocument());
+
+    // Step 2: open form, fill scope, mint.
+    fireEvent.click(screen.getByRole("button", { name: /mint new token/i }));
+    fireEvent.change(screen.getByLabelText(/scope \(space-separated\)/i), {
+      target: { value: "scribe:transcribe" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^mint$/i }));
+
+    // Step 3: mint-banner appears with the once-shown JWT.
+    await waitFor(() => expect(screen.getByText("h.p.s")).toBeInTheDocument());
+
+    // Step 4: list refreshed to show the new live row.
+    await waitFor(() => expect(screen.getByText(/integrat…onXX/)).toBeInTheDocument());
+    expect(screen.getByText("live")).toBeInTheDocument();
+
+    // Step 5: open revoke confirm, confirm.
+    fireEvent.click(screen.getByRole("button", { name: /^revoke integrat…onXX$/i }));
+    const dialog = screen.getByRole("dialog", { name: /confirm revoke integrat…onXX/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: /^revoke$/i }));
+
+    // Step 6: status pill switches to revoked; row stays.
+    await waitFor(() => expect(screen.getByText("revoked")).toBeInTheDocument());
+  });
+});

--- a/web/ui/src/routes/Tokens.test.tsx
+++ b/web/ui/src/routes/Tokens.test.tsx
@@ -368,6 +368,42 @@ describe("Tokens — revoke flow", () => {
   });
 });
 
+describe("Tokens — client_id rendering (F2)", () => {
+  it("renders client_id alongside identity for OAuth-style rows", async () => {
+    vi.mocked(api.listTokens).mockResolvedValue({
+      tokens: [
+        tokenRow("oauthrowAAAAAAAAAXXXX", {
+          client_id: "oauth-app-foo",
+          user_id: "shared-user-uuid",
+          subject: null,
+        }),
+      ],
+      next_cursor: null,
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("shared-user-uuid")).toBeInTheDocument());
+    // client_id appears as code text following "client:" label.
+    expect(screen.getByText("oauth-app-foo")).toBeInTheDocument();
+    expect(screen.getByText(/client:/)).toBeInTheDocument();
+  });
+
+  it("renders parachute-hub client_id for CLI/operator-mint rows", async () => {
+    vi.mocked(api.listTokens).mockResolvedValue({
+      tokens: [
+        tokenRow("clirowAAAAAAAAAXXXX", {
+          client_id: "parachute-hub",
+          user_id: null,
+          subject: "operator",
+        }),
+      ],
+      next_cursor: null,
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("operator")).toBeInTheDocument());
+    expect(screen.getByText("parachute-hub")).toBeInTheDocument();
+  });
+});
+
 describe("Tokens — pagination", () => {
   it("Load more appends next page; clears button when next_cursor goes null", async () => {
     const listMock = vi.mocked(api.listTokens);
@@ -390,6 +426,46 @@ describe("Tokens — pagination", () => {
     expect(screen.queryByRole("button", { name: /load more/i })).toBeNull();
     // Second call passed the cursor.
     expect(listMock).toHaveBeenLastCalledWith({ cursor: "cursor-1", revoked: "all" });
+  });
+
+  it("Load more is disabled while the next-page fetch is in flight (F1)", async () => {
+    const listMock = vi.mocked(api.listTokens);
+    listMock.mockResolvedValueOnce({
+      tokens: [tokenRow("page1aaaPPPPPPPXXXX")],
+      next_cursor: "cursor-1",
+    });
+    // Hold the second call open so we can inspect button state during the
+    // in-flight window — the whole point of F1 is "user double-clicks; we
+    // don't refire the fetch and overwrite each other's appended pages."
+    let resolveSecond: (page: api.AdminTokensPage) => void = () => {};
+    listMock.mockReturnValueOnce(
+      new Promise<api.AdminTokensPage>((resolve) => {
+        resolveSecond = resolve;
+      }),
+    );
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/page1aaa…XXXX/)).toBeInTheDocument());
+
+    const loadMoreBtn = screen.getByRole("button", { name: /^load more$/i });
+    expect(loadMoreBtn).not.toBeDisabled();
+    fireEvent.click(loadMoreBtn);
+
+    // While the second fetch is pending: button text flips to "Loading…"
+    // AND it's disabled — so a second click can't refire the fetch.
+    await waitFor(() => expect(screen.getByRole("button", { name: /^loading…$/i })).toBeDisabled());
+    fireEvent.click(screen.getByRole("button", { name: /^loading…$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^loading…$/i }));
+    // Two extra clicks during the in-flight window — listTokens still only
+    // called twice total (initial + the one in-flight), not four times.
+    expect(listMock).toHaveBeenCalledTimes(2);
+
+    // Resolve the in-flight call. Button reverts to enabled "Load more"
+    // (or vanishes if next_cursor is null — here we set null to verify
+    // the cleanup path).
+    resolveSecond({ tokens: [tokenRow("page2bbbPPPPPPPYYYY")], next_cursor: null });
+    await waitFor(() => expect(screen.getByText(/page2bbb…YYYY/)).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: /^load more$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^loading…$/i })).toBeNull();
   });
 });
 

--- a/web/ui/src/routes/Tokens.tsx
+++ b/web/ui/src/routes/Tokens.tsx
@@ -1,0 +1,544 @@
+/**
+ * /hub/tokens — admin UI over the hub's token registry.
+ *
+ * Three actions:
+ *   1. List rows from `GET /api/auth/tokens` with status filter (all /
+ *      live / revoked) and "Load more" cursor pagination.
+ *   2. Mint a new token via `POST /api/auth/mint-token` (inline form;
+ *      reveals the JWT once via a mint-banner with copy-to-clipboard).
+ *   3. Revoke per-row via `POST /api/auth/revoke-token` with a confirm
+ *      step (mirrors Permissions' revoke flow).
+ *
+ * Auth is the shared `parachute_hub_session` cookie → host-admin JWT
+ * dance from `lib/auth.ts`. The page itself only needs to render — the
+ * lib helpers handle the redirect-to-login on session expiry.
+ *
+ * `permissions` arrives parsed (object, not raw JSON string) thanks to
+ * the hub-side parsing introduced in hub#226 F1; the form input is a
+ * textarea that the operator types as JSON, validated client-side
+ * before posting.
+ */
+import { type FormEvent, useEffect, useState } from "react";
+import {
+  type AdminTokenListing,
+  HttpError,
+  type ListTokensOpts,
+  type MintedToken,
+  listTokens,
+  mintToken,
+  revokeToken,
+} from "../lib/api.ts";
+
+type FilterValue = "all" | "live" | "revoked";
+
+type ListState =
+  | { kind: "loading" }
+  | { kind: "ok"; tokens: AdminTokenListing[]; nextCursor: string | null }
+  | { kind: "error"; message: string };
+
+type MintState =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "minted"; token: MintedToken }
+  | { kind: "error"; message: string };
+
+type RevokeState =
+  | { kind: "idle" }
+  | { kind: "confirming"; jti: string }
+  | { kind: "revoking"; jti: string }
+  | { kind: "error"; jti: string; message: string };
+
+interface MintFormFields {
+  scope: string;
+  audience: string;
+  expiresIn: string;
+  subject: string;
+  permissions: string;
+}
+
+const EMPTY_FORM: MintFormFields = {
+  scope: "",
+  audience: "",
+  expiresIn: "",
+  subject: "",
+  permissions: "",
+};
+
+export function Tokens() {
+  const [filter, setFilter] = useState<FilterValue>("all");
+  const [list, setList] = useState<ListState>({ kind: "loading" });
+  const [reload, setReload] = useState(0);
+  const [mint, setMint] = useState<MintState>({ kind: "idle" });
+  const [form, setForm] = useState<MintFormFields>(EMPTY_FORM);
+  const [revoke, setRevoke] = useState<RevokeState>({ kind: "idle" });
+  const [showForm, setShowForm] = useState(false);
+
+  useEffect(() => {
+    void reload;
+    let cancelled = false;
+    setList({ kind: "loading" });
+    const opts: ListTokensOpts = {};
+    if (filter === "live") opts.revoked = "false";
+    else if (filter === "revoked") opts.revoked = "true";
+    else opts.revoked = "all";
+    listTokens(opts)
+      .then((page) => {
+        if (cancelled) return;
+        setList({ kind: "ok", tokens: page.tokens, nextCursor: page.next_cursor });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setList({ kind: "error", message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reload, filter]);
+
+  async function loadMore(): Promise<void> {
+    if (list.kind !== "ok" || !list.nextCursor) return;
+    const opts: ListTokensOpts = { cursor: list.nextCursor };
+    if (filter === "live") opts.revoked = "false";
+    else if (filter === "revoked") opts.revoked = "true";
+    else opts.revoked = "all";
+    try {
+      const page = await listTokens(opts);
+      setList({
+        kind: "ok",
+        tokens: [...list.tokens, ...page.tokens],
+        nextCursor: page.next_cursor,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setList({ kind: "error", message });
+    }
+  }
+
+  async function onSubmitMint(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    const scope = form.scope.trim();
+    if (scope.length === 0) {
+      setMint({ kind: "error", message: "scope is required" });
+      return;
+    }
+    let permissions: Record<string, unknown> | undefined;
+    if (form.permissions.trim().length > 0) {
+      try {
+        const parsed = JSON.parse(form.permissions) as unknown;
+        if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+          setMint({
+            kind: "error",
+            message: 'permissions must be a JSON object (e.g. {"vault":{"default":...}})',
+          });
+          return;
+        }
+        permissions = parsed as Record<string, unknown>;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setMint({ kind: "error", message: `permissions is not valid JSON — ${msg}` });
+        return;
+      }
+    }
+    let expiresIn: number | undefined;
+    if (form.expiresIn.trim().length > 0) {
+      const n = Number(form.expiresIn);
+      if (!Number.isInteger(n) || n <= 0) {
+        setMint({ kind: "error", message: "expires_in must be a positive integer (seconds)" });
+        return;
+      }
+      expiresIn = n;
+    }
+
+    setMint({ kind: "submitting" });
+    try {
+      const minted = await mintToken({
+        scope,
+        ...(form.audience.trim() ? { audience: form.audience.trim() } : {}),
+        ...(expiresIn !== undefined ? { expires_in: expiresIn } : {}),
+        ...(form.subject.trim() ? { subject: form.subject.trim() } : {}),
+        ...(permissions ? { permissions } : {}),
+      });
+      setMint({ kind: "minted", token: minted });
+      setForm(EMPTY_FORM);
+      setShowForm(false);
+      setReload((n) => n + 1);
+    } catch (err) {
+      const message =
+        err instanceof HttpError
+          ? `mint failed (${err.status}): ${err.message}`
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      setMint({ kind: "error", message });
+    }
+  }
+
+  async function onConfirmRevoke(jti: string): Promise<void> {
+    setRevoke({ kind: "revoking", jti });
+    try {
+      await revokeToken(jti);
+      setRevoke({ kind: "idle" });
+      setReload((n) => n + 1);
+    } catch (err) {
+      const message =
+        err instanceof HttpError
+          ? `revoke failed (${err.status}): ${err.message}`
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      setRevoke({ kind: "error", jti, message });
+    }
+  }
+
+  function copyTokenToClipboard(token: string): void {
+    if (typeof navigator !== "undefined" && navigator.clipboard) {
+      void navigator.clipboard.writeText(token);
+    }
+  }
+
+  return (
+    <div>
+      <div className="list-header">
+        <h2>Tokens</h2>
+        <button type="button" onClick={() => setShowForm((s) => !s)}>
+          {showForm ? "Hide form" : "Mint new token"}
+        </button>
+      </div>
+
+      <p className="muted">
+        The hub's token registry. Every CLI / OAuth / operator-mint writes a row here. Revoking
+        flips <code>revoked_at</code>; resource servers on{" "}
+        <code>@openparachute/scope-guard@^0.2.0</code> reject within ~60s of the next poll.
+      </p>
+
+      {mint.kind === "minted" ? (
+        <div className="mint-banner">
+          <h3>Minted</h3>
+          <p>
+            Your new access token (jti: <code>{mint.token.jti}</code>):
+          </p>
+          <div className="token-box">
+            <code>{mint.token.token}</code>
+          </div>
+          <p className="warn">
+            This is the only time the JWT is shown. Copy it now — there is no DB-side recovery.
+          </p>
+          <div className="actions">
+            <button type="button" onClick={() => copyTokenToClipboard(mint.token.token)}>
+              Copy
+            </button>
+            <button type="button" className="secondary" onClick={() => setMint({ kind: "idle" })}>
+              Dismiss
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {showForm ? (
+        <div className="section">
+          <form onSubmit={onSubmitMint}>
+            <div className="row">
+              <label htmlFor="mint-scope">Scope (space-separated)</label>
+              <input
+                id="mint-scope"
+                type="text"
+                value={form.scope}
+                onChange={(e) => setForm({ ...form, scope: e.target.value })}
+                placeholder="e.g. scribe:transcribe vault:default:read"
+                required
+              />
+              <div className="field-hint">
+                Space-separated <code>resource:verb</code> or <code>resource:name:verb</code>{" "}
+                tuples. The hub rejects non-requestable scopes (admin, host:*) per the
+                privilege-diffusion guard.
+              </div>
+            </div>
+
+            <div className="row">
+              <label htmlFor="mint-audience">Audience (optional)</label>
+              <input
+                id="mint-audience"
+                type="text"
+                value={form.audience}
+                onChange={(e) => setForm({ ...form, audience: e.target.value })}
+                placeholder="inferred from scope when blank"
+              />
+              <div className="field-hint">
+                Inferred from scope if omitted. <code>vault:&lt;name&gt;:&lt;verb&gt;</code> →{" "}
+                <code>vault.&lt;name&gt;</code>; otherwise the first colon-prefixed scope's
+                namespace; fallback <code>hub</code>.
+              </div>
+            </div>
+
+            <div className="row">
+              <label htmlFor="mint-expires-in">Expires in (seconds, optional)</label>
+              <input
+                id="mint-expires-in"
+                type="text"
+                inputMode="numeric"
+                value={form.expiresIn}
+                onChange={(e) => setForm({ ...form, expiresIn: e.target.value })}
+                placeholder="default 90d (7776000)"
+              />
+            </div>
+
+            <div className="row">
+              <label htmlFor="mint-subject">Subject (optional)</label>
+              <input
+                id="mint-subject"
+                type="text"
+                value={form.subject}
+                onChange={(e) => setForm({ ...form, subject: e.target.value })}
+                placeholder="defaults to operator's sub"
+              />
+            </div>
+
+            <div className="row">
+              <label htmlFor="mint-permissions">Permissions (JSON object, optional)</label>
+              <textarea
+                id="mint-permissions"
+                value={form.permissions}
+                onChange={(e) => setForm({ ...form, permissions: e.target.value })}
+                placeholder='e.g. {"vault":{"default":{"write_tags":["health"]}}}'
+                rows={3}
+                style={{ width: "100%", fontFamily: "monospace", fontSize: "0.9rem" }}
+              />
+            </div>
+
+            {mint.kind === "error" ? (
+              <div className="field-error">
+                <code>{mint.message}</code>
+              </div>
+            ) : null}
+
+            <div className="actions">
+              <button type="submit" disabled={mint.kind === "submitting"}>
+                {mint.kind === "submitting" ? "Minting…" : "Mint"}
+              </button>
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => {
+                  setShowForm(false);
+                  setForm(EMPTY_FORM);
+                  setMint({ kind: "idle" });
+                }}
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : null}
+
+      <div style={{ marginTop: "1rem", marginBottom: "1rem", display: "flex", gap: "0.5rem" }}>
+        <span className="muted" style={{ marginRight: "0.5rem" }}>
+          Filter:
+        </span>
+        {(
+          [
+            { value: "all", label: "Show all" },
+            { value: "live", label: "Live only" },
+            { value: "revoked", label: "Revoked only" },
+          ] as const
+        ).map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => setFilter(opt.value)}
+            className={filter === opt.value ? undefined : "secondary"}
+            aria-pressed={filter === opt.value}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {renderList({
+        list,
+        revoke,
+        setRevoke,
+        onConfirm: onConfirmRevoke,
+        onLoadMore: loadMore,
+        onRetry: () => setReload((n) => n + 1),
+      })}
+    </div>
+  );
+}
+
+interface RenderListProps {
+  list: ListState;
+  revoke: RevokeState;
+  setRevoke: (s: RevokeState) => void;
+  onConfirm: (jti: string) => Promise<void>;
+  onLoadMore: () => Promise<void>;
+  onRetry: () => void;
+}
+
+function renderList({ list, revoke, setRevoke, onConfirm, onLoadMore, onRetry }: RenderListProps) {
+  if (list.kind === "loading") {
+    return <p className="muted">Loading…</p>;
+  }
+  if (list.kind === "error") {
+    return (
+      <>
+        <div className="error-banner">
+          Couldn't load tokens: <code>{list.message}</code>
+        </div>
+        <button type="button" onClick={onRetry} className="secondary">
+          Retry
+        </button>
+      </>
+    );
+  }
+  if (list.tokens.length === 0) {
+    return (
+      <div className="empty empty-rich">
+        <p className="empty-headline">No tokens.</p>
+        <p className="muted">
+          Every CLI mint, OAuth grant, and operator-token rotation lands here. Mint one with the
+          form above, or via <code>parachute auth mint-token</code>.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {list.tokens.map((t) => {
+        const status = tokenStatus(t);
+        const isRevoking = revoke.kind === "revoking" && revoke.jti === t.jti;
+        const isConfirming = revoke.kind === "confirming" && revoke.jti === t.jti;
+        const rowError = revoke.kind === "error" && revoke.jti === t.jti ? revoke : null;
+        const identity = t.user_id ?? t.subject ?? "(unknown)";
+        return (
+          <div key={t.jti} className="vault-row">
+            <div className="body">
+              <div className="name">
+                <code title={t.jti}>{truncateJti(t.jti)}</code>
+                <span className={`tag${status === "live" ? "" : " muted"}`}>{status}</span>
+                <span className="muted" style={{ fontSize: "0.85rem" }}>
+                  {t.created_via}
+                </span>
+              </div>
+              <div className="dim" style={{ marginTop: "0.25rem" }}>
+                <span className="muted">identity: </span>
+                <code>{identity}</code>
+              </div>
+              <div className="dim" style={{ marginTop: "0.25rem" }}>
+                <span className="muted">scope: </span>
+                {t.scopes.map((s, i) => (
+                  <span key={s}>
+                    <code>{s}</code>
+                    {i < t.scopes.length - 1 ? " " : null}
+                  </span>
+                ))}
+              </div>
+              <div className="dim" style={{ marginTop: "0.25rem", fontSize: "0.82rem" }}>
+                <span className="muted">created </span>
+                <code title={t.created_at}>{formatDate(t.created_at)}</code>
+                <span className="muted"> · expires </span>
+                <code title={t.expires_at}>{formatDate(t.expires_at)}</code>
+                {t.revoked_at ? (
+                  <>
+                    <span className="muted"> · revoked </span>
+                    <code title={t.revoked_at}>{formatDate(t.revoked_at)}</code>
+                  </>
+                ) : null}
+              </div>
+              {t.permissions ? (
+                <details style={{ marginTop: "0.35rem" }}>
+                  <summary className="muted" style={{ cursor: "pointer", fontSize: "0.85rem" }}>
+                    permissions
+                  </summary>
+                  <pre style={{ fontSize: "0.82rem", marginTop: "0.25rem" }}>
+                    {JSON.stringify(t.permissions, null, 2)}
+                  </pre>
+                </details>
+              ) : null}
+              {rowError ? (
+                <div className="error-banner" style={{ marginTop: "0.5rem" }}>
+                  <code>{rowError.message}</code>
+                </div>
+              ) : null}
+              {isConfirming ? (
+                <dialog
+                  open
+                  className="error-banner"
+                  style={{ marginTop: "0.5rem", background: "var(--bg-warn, #fffbe6)" }}
+                  aria-label={`Confirm revoke ${truncateJti(t.jti)}`}
+                >
+                  <p>
+                    Revoke <code>{truncateJti(t.jti)}</code>? Resource servers reject within ~60s of
+                    the next revocation-list poll. This cannot be undone.
+                  </p>
+                  <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.5rem" }}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void onConfirm(t.jti);
+                      }}
+                      disabled={isRevoking}
+                    >
+                      {isRevoking ? "Revoking…" : "Revoke"}
+                    </button>
+                    <button
+                      type="button"
+                      className="secondary"
+                      onClick={() => setRevoke({ kind: "idle" })}
+                      disabled={isRevoking}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </dialog>
+              ) : null}
+            </div>
+            {!isConfirming && status === "live" ? (
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => setRevoke({ kind: "confirming", jti: t.jti })}
+                aria-label={`Revoke ${truncateJti(t.jti)}`}
+              >
+                Revoke
+              </button>
+            ) : null}
+          </div>
+        );
+      })}
+
+      {list.nextCursor ? (
+        <div style={{ marginTop: "1rem" }}>
+          <button
+            type="button"
+            className="secondary"
+            onClick={() => {
+              void onLoadMore();
+            }}
+          >
+            Load more
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function tokenStatus(t: AdminTokenListing): "live" | "expired" | "revoked" {
+  if (t.revoked_at) return "revoked";
+  const exp = new Date(t.expires_at).getTime();
+  if (!Number.isNaN(exp) && exp < Date.now()) return "expired";
+  return "live";
+}
+
+function truncateJti(jti: string): string {
+  if (jti.length <= 14) return jti;
+  return `${jti.slice(0, 8)}…${jti.slice(-4)}`;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}

--- a/web/ui/src/routes/Tokens.tsx
+++ b/web/ui/src/routes/Tokens.tsx
@@ -72,6 +72,7 @@ export function Tokens() {
   const [form, setForm] = useState<MintFormFields>(EMPTY_FORM);
   const [revoke, setRevoke] = useState<RevokeState>({ kind: "idle" });
   const [showForm, setShowForm] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
 
   useEffect(() => {
     void reload;
@@ -98,10 +99,17 @@ export function Tokens() {
 
   async function loadMore(): Promise<void> {
     if (list.kind !== "ok" || !list.nextCursor) return;
+    // Guard against double-clicks: a second invocation while the first
+    // request is in flight would close over the same `list.tokens` and
+    // overwrite the first call's appended page on resolve. The `disabled`
+    // attribute on the button is the primary defense; this state guard is
+    // belt-and-suspenders for fast-finger keyboard activation.
+    if (loadingMore) return;
     const opts: ListTokensOpts = { cursor: list.nextCursor };
     if (filter === "live") opts.revoked = "false";
     else if (filter === "revoked") opts.revoked = "true";
     else opts.revoked = "all";
+    setLoadingMore(true);
     try {
       const page = await listTokens(opts);
       setList({
@@ -112,6 +120,8 @@ export function Tokens() {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       setList({ kind: "error", message });
+    } finally {
+      setLoadingMore(false);
     }
   }
 
@@ -362,6 +372,7 @@ export function Tokens() {
         onConfirm: onConfirmRevoke,
         onLoadMore: loadMore,
         onRetry: () => setReload((n) => n + 1),
+        loadingMore,
       })}
     </div>
   );
@@ -374,9 +385,18 @@ interface RenderListProps {
   onConfirm: (jti: string) => Promise<void>;
   onLoadMore: () => Promise<void>;
   onRetry: () => void;
+  loadingMore: boolean;
 }
 
-function renderList({ list, revoke, setRevoke, onConfirm, onLoadMore, onRetry }: RenderListProps) {
+function renderList({
+  list,
+  revoke,
+  setRevoke,
+  onConfirm,
+  onLoadMore,
+  onRetry,
+  loadingMore,
+}: RenderListProps) {
   if (list.kind === "loading") {
     return <p className="muted">Loading…</p>;
   }
@@ -425,6 +445,12 @@ function renderList({ list, revoke, setRevoke, onConfirm, onLoadMore, onRetry }:
               <div className="dim" style={{ marginTop: "0.25rem" }}>
                 <span className="muted">identity: </span>
                 <code>{identity}</code>
+                {t.client_id ? (
+                  <>
+                    <span className="muted"> · client: </span>
+                    <code>{t.client_id}</code>
+                  </>
+                ) : null}
               </div>
               <div className="dim" style={{ marginTop: "0.25rem" }}>
                 <span className="muted">scope: </span>
@@ -514,11 +540,12 @@ function renderList({ list, revoke, setRevoke, onConfirm, onLoadMore, onRetry }:
           <button
             type="button"
             className="secondary"
+            disabled={loadingMore}
             onClick={() => {
               void onLoadMore();
             }}
           >
-            Load more
+            {loadingMore ? "Loading…" : "Load more"}
           </button>
         </div>
       ) : null}


### PR DESCRIPTION
## Summary

Phase 2 UI consumer for hub#212. Operators get a browser surface at `/hub/tokens` for the registry that backed `parachute auth mint-token` (hub#221), `parachute auth revoke-token` (hub#221), and the new HTTP endpoints from rc.7 (#226).

Builds atop the merged contract from #226 — no moving target. Refs #212 (umbrella stays open through Phase 6).

## Three actions, browser-side

### 1. List

Paginated, status-filtered (Show all / Live only / Revoked only) view of every registry row. Each row surfaces:
- jti (truncated to `xxxxxxxx…YYYY`, full on hover)
- identity (`user_id ?? subject ?? "(unknown)"`)
- scope (inline as code tags)
- status pill — `live` (default `.tag`) / `expired` (muted) / `revoked` (muted)
- `created_via` provenance
- created / expires / revoked-when-applicable dates
- expandable `<details>` for `permissions` (collapsed by default — most rows have null permissions)

Cursor pagination via "Load more" button at the bottom; appends in place; clears button when `next_cursor` goes null.

### 2. Mint

Inline form (toggle from page header). Fields:
- **scope** (required) — space-separated `<resource>:<verb>` or `<resource>:<name>:<verb>` tuples. Hub rejects non-requestable scopes (admin, host:*) per the privilege-diffusion guard.
- **audience** (optional) — inferred from scope on the hub side if blank.
- **expires_in** (optional, seconds) — defaults to hub's 90d.
- **subject** (optional) — defaults to operator's sub.
- **permissions** (optional, JSON object) — validated client-side before posting.

On success: `mint-banner` (same pattern NewVault uses for vault `pvt_*` token reveals) shows the JWT ONCE with copy-to-clipboard and a clear "this is the only time the JWT is shown" warning. Refreshes the list.

### 3. Revoke

Per-row button (live tokens only — expired/revoked rows don't render the button). Inline confirm dialog: "Revoke this token? Resource servers reject within ~60s of the next revocation-list poll. This cannot be undone." → `POST /api/auth/revoke-token` → list refresh.

Mirrors the `Permissions` page's revoke flow exactly.

## Visual posture per brief

Reused every existing CSS class — `.vault-row`, `.tag` / `.tag.muted`, `.list-header`, `.empty-rich`, `.error-banner`, `.section`, `.mint-banner`, `.field-error`. **Zero new CSS, zero new design system.**

## Files touched

- **NEW** `web/ui/src/routes/Tokens.tsx` (~440 LOC) — the route.
- **NEW** `web/ui/src/routes/Tokens.test.tsx` (~330 LOC) — 19 tests across 6 describe blocks.
- `web/ui/src/lib/api.ts` — three new helpers + types (`listTokens`, `mintToken`, `revokeToken`, plus `AdminTokenListing`, `AdminTokensPage`, `MintTokenInput`, `MintedToken`, `ListTokensOpts`).
- `web/ui/src/App.tsx` — added `/hub/tokens` route alongside `/hub/permissions`. Renamed local `isPermissionsMount` → `isHubMount`. Nav adds a "Tokens" link.

## What's NOT in this PR

- Bulk revoke / revoke-by-subject UI surfaces — file as separate enhancements if they surface a need.
- `?limit=N` query param exposure (the backend already hardcodes 50; UI doesn't need to override).
- Edit-token UI — tokens are immutable once issued; only revocable.
- Cross-mount nav from `/vault` → `/hub/tokens` — the existing nav handles this via `<a href>`; no new component needed.

## Versioning

- `package.json`: `0.5.8-rc.7` → `0.5.8-rc.8`.
- CHANGELOG entry under `## [0.5.8-rc.8] - 2026-05-10` framing as Phase 2 admin UI; cross-references rc.7 backend foundation.

## Test plan

- [x] hub `bun test ./src`: **1193 pass / 0 fail** (unchanged — UI work is purely additive).
- [x] web/ui `bun run test`: **66 pass / 0 fail** (was 47; +19 new across:
  - **list rendering** (5): empty state, row surface (truncated jti / identity / scope), status pills (live/expired/revoked), revoke-button-only-for-live regression, error banner + retry.
  - **filter pills** (1): clicking each pill calls `listTokens` with the right `?revoked=` value.
  - **mint form** (7): toggle open/cancel, validation × 4 (empty scope, malformed JSON, JSON array, non-integer expires_in), happy path scope-only, happy path full-form round-trip with all fields, server error surface.
  - **revoke flow** (3): confirm dialog cancel doesn't POST, confirm-revoke POSTs + refreshes list with status-pill switch, per-row error banner on failure.
  - **pagination** (1): "Load more" appends next page + clears button when `next_cursor` goes null.
  - **integration** (1): mint via UI form → see in list as live → revoke → see status update to revoked. End-to-end happy path through every state machine).
- [x] hub typecheck + biome: clean.
- [x] UI typecheck + build: clean. `verify-base.mjs` post-build check passes (`dist/index.html` carries `/vault/`-prefixed asset URLs per the codified regression check).

## Patterns check

- **Mount-aware routing** (per `web/ui/CLAUDE.md`) — added `/hub/tokens` under the `/hub` mount alongside `/permissions`. Renamed `isPermissionsMount` to `isHubMount` since the mount now hosts more than one route.
- **State-machine rendering** — `ListState` / `MintState` / `RevokeState` discriminated unions, mirroring `Permissions.tsx` and `VaultsList.tsx`. No state library; pure `useState`.
- **Bearer + clearCachedToken-on-401/403** — every new helper in `lib/api.ts` follows the pattern set by `createVault` / `listGrants` / `revokeGrant`.
- **Identity field semantics** — `tokenRowIdentity` from hub#221 honored client-side as `user_id ?? subject ?? "(unknown)"`. Inline duplication (1 line) accepted vs importing a hub-side helper into the SPA bundle.
- **Mint-banner pattern** — same shape as NewVault's `pvt_*` token reveal. Single-emit, copy + dismiss, "only time" warning.
- **RC versioning** — `rc.7` → `rc.8` per parachute-patterns/governance.md.

## Implementation notes worth a reviewer eyeball

1. **Two test-design wrinkles caught + fixed before push**:
   - JTI test data needs to be 16+ chars to actually trigger `truncateJti`. First draft used 12-char strings; assertions for `xxxxxxxx…YYYY` couldn't match the un-truncated form.
   - Filter pill text initially collided with status pill text (`live`, `revoked` overloaded). Renamed filter buttons to "Show all" / "Live only" / "Revoked only" — UX-cleaner anyway, since the filter and the status are conceptually different.

2. **Permissions display** uses `<details>` collapsed by default. Most rows have null permissions; expanding heavy JSON inline for every row would be visual noise. Operator-driven progressive disclosure.

3. **Toggle button text** says "Hide form" when the form is open (was "Cancel" in first draft, but that collided with the form's own Cancel button). Distinct labels for distinct actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)