### PR TITLE
fix(auth): host-admin-token SPA bearer also carries parachute:host:auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.8-rc.9] - 2026-05-10
+
+End-to-end bugfix surfaced from manual testing of `/hub/tokens` (Phase 2 admin UI from rc.8): the SPA's session-bearer (minted by `GET /admin/host-admin-token`) carried only `parachute:host:admin`, but the new admin endpoints (`/api/auth/mint-token`, `/api/auth/revoke-token`, `/api/auth/tokens`) gate on `parachute:host:auth`. SPA failed with `Couldn't load tokens: bearer token lacks parachute:host:auth` on first load.
+
+### Fixed
+
+- **`HOST_ADMIN_SCOPES`** in `src/admin-host-admin-token.ts` now includes both `parachute:host:admin` AND `parachute:host:auth`. Brings the SPA's session-bearer in line with the `--scope-set admin` operator-token semantics from hub#214 / #222 (admin = superset of all narrower scope-sets, including `auth`). Both scopes are already in `NON_REQUESTABLE_SCOPES`, so the security envelope is unchanged — the SPA bearer is still mintable only via the local cookie path.
+
+### Added
+
+- **End-to-end regression test** in `src/__tests__/admin-host-admin-token.test.ts`: mints a JWT through the SPA cookie flow, then exercises `GET /api/auth/tokens` with that bearer and asserts 200 (was 403 pre-fix). The Phase 2 backend tests minted operator-style tokens with `:host:auth` directly — they didn't exercise the full SPA session flow, leaving this gap. New test pins it.
+
+### Why this slipped past Phase 2 reviews
+
+The new admin endpoints' tests minted bearer tokens with the right scope directly via `mintOperatorToken({ scopeSet: "admin" })`. None walked the path the SPA actually takes — cookie → host-admin-token → `:host:admin`-only JWT → admin endpoint. The dual-scope semantics that the operator-side already had via the `admin` scope-set wasn't mirrored to the SPA-side mint until manual end-to-end testing surfaced the mismatch. Regression test now covers the full flow so a future shape divergence here can't reach production.
+
+### Test gate
+
+- hub: 1194 pass / 0 fail (was 1193; +1 for the new regression test).
+- typecheck + biome: clean.
+
 ## [0.5.8-rc.8] - 2026-05-10
 
 Phase 2 of hub#212: admin UI for token management at `/hub/tokens`. Operators get a browser surface for the registry that backed `parachute auth mint-token`, `parachute auth revoke-token`, and the new HTTP endpoints from rc.7. Refs hub#212 (umbrella stays open through Phase 6).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.8-rc.8",
+  "version": "0.5.8-rc.9",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/admin-host-admin-token.test.ts
+++ b/src/__tests__/admin-host-admin-token.test.ts
@@ -2,9 +2,12 @@
  * Tests for the SPA's session→bearer mint endpoint. Covers:
  *   - 401 when no admin session cookie is present.
  *   - 401 when the cookie names a deleted/expired session.
- *   - 200 + JWT carrying parachute:host:admin when the session is valid.
+ *   - 200 + JWT carrying parachute:host:admin AND parachute:host:auth.
  *   - Token validates against the hub's own keys and the configured issuer.
  *   - Method-not-allowed on POST.
+ *   - End-to-end regression: the minted JWT actually unlocks the new
+ *     `/api/auth/tokens` endpoint (hub#212 Phase 2 backend) — the bug from
+ *     end-to-end testing that motivated adding `parachute:host:auth` here.
  */
 import type { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -12,9 +15,11 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { HOST_ADMIN_TOKEN_TTL_SECONDS, handleHostAdminToken } from "../admin-host-admin-token.ts";
+import { handleApiTokens } from "../api-tokens.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { validateAccessToken } from "../jwt-sign.ts";
 import { SESSION_TTL_MS, buildSessionCookie, createSession, deleteSession } from "../sessions.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
 import { createUser } from "../users.ts";
 
 const ISSUER = "https://hub.test";
@@ -82,8 +87,9 @@ describe("handleHostAdminToken", () => {
     expect(res.status).toBe(405);
   });
 
-  test("200 mints a JWT carrying parachute:host:admin and the configured issuer", async () => {
+  test("200 mints a JWT carrying parachute:host:admin + parachute:host:auth and the configured issuer", async () => {
     const { cookie, userId } = await withSession();
+    rotateSigningKey(harness.db);
     const req = new Request(`${ISSUER}/admin/host-admin-token`, {
       headers: { cookie },
     });
@@ -96,7 +102,10 @@ describe("handleHostAdminToken", () => {
       expires_at: string;
       scopes: string[];
     };
-    expect(body.scopes).toEqual(["parachute:host:admin"]);
+    // Both scopes — the SPA now needs `:host:auth` for the hub#212 Phase 2
+    // token-registry endpoints alongside the existing `:host:admin` for
+    // vault provisioning + grant management.
+    expect(body.scopes).toEqual(["parachute:host:admin", "parachute:host:auth"]);
     expect(body.token.length).toBeGreaterThan(20);
 
     // expires_at is roughly TTL_SECONDS in the future.
@@ -110,6 +119,45 @@ describe("handleHostAdminToken", () => {
     expect(validated.payload.sub).toBe(userId);
     expect(validated.payload.iss).toBe(ISSUER);
     const scopeClaim = (validated.payload as { scope?: string }).scope ?? "";
-    expect(scopeClaim.split(/\s+/)).toContain("parachute:host:admin");
+    const scopes = scopeClaim.split(/\s+/);
+    expect(scopes).toContain("parachute:host:admin");
+    expect(scopes).toContain("parachute:host:auth");
+  });
+
+  // Regression for the end-to-end bug that motivated adding `:host:auth`
+  // here: the SPA's session-bearer was rejected by `/api/auth/tokens` (and
+  // its peers) because it carried `:host:admin` only. This test mints
+  // through the SPA path and exercises one of the new endpoints
+  // end-to-end — the Phase 2 backend tests only minted operator-style
+  // tokens with `:host:auth` directly, leaving the SPA-flow gap uncaught.
+  test("regression: the minted SPA bearer is accepted by /api/auth/tokens", async () => {
+    const { cookie } = await withSession();
+    rotateSigningKey(harness.db);
+
+    // Step 1: SPA grabs its bearer via the cookie path.
+    const mintRes = await handleHostAdminToken(
+      new Request(`${ISSUER}/admin/host-admin-token`, { headers: { cookie } }),
+      { db: harness.db, issuer: ISSUER },
+    );
+    expect(mintRes.status).toBe(200);
+    const { token } = (await mintRes.json()) as { token: string };
+
+    // Step 2: SPA hits /api/auth/tokens with that bearer. Pre-fix this
+    // returned 403 `bearer token lacks parachute:host:auth`; post-fix it
+    // returns 200 with the (empty-by-default) tokens list.
+    const tokensRes = await handleApiTokens(
+      new Request(`${ISSUER}/api/auth/tokens`, {
+        method: "GET",
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      { db: harness.db, issuer: ISSUER },
+    );
+    expect(tokensRes.status).toBe(200);
+    const tokensBody = (await tokensRes.json()) as {
+      tokens: unknown[];
+      next_cursor: string | null;
+    };
+    expect(Array.isArray(tokensBody.tokens)).toBe(true);
+    expect(tokensBody.next_cursor).toBeNull();
   });
 });

--- a/src/admin-host-admin-token.ts
+++ b/src/admin-host-admin-token.ts
@@ -1,15 +1,23 @@
 /**
  * `GET /admin/host-admin-token` — exchange a valid admin session cookie for a
- * short-lived JWT carrying `parachute:host:admin`.
+ * short-lived JWT carrying both `parachute:host:admin` and
+ * `parachute:host:auth` (the same superset an `--scope-set admin` operator
+ * token holds).
  *
- * Why this exists: the hub's vault-management SPA (served under `/hub/`)
- * needs a Bearer to call admin endpoints like `POST /vaults`, but
- * `parachute:host:admin` is in `NON_REQUESTABLE_SCOPES` — the public
- * `/oauth/authorize` endpoint refuses to mint it so third-party apps can't
- * acquire cross-vault provisioning capability via consent.
+ * Why this exists: the hub's admin SPA (served under `/hub/`) needs a Bearer
+ * to call:
+ *   - `parachute:host:admin` surfaces — `POST /vaults` (vault provisioning),
+ *     `/api/grants` (OAuth consent grant management).
+ *   - `parachute:host:auth` surfaces — `GET /api/auth/tokens`,
+ *     `POST /api/auth/mint-token`, `POST /api/auth/revoke-token` (the token
+ *     registry endpoints from hub#212 Phase 2).
+ *
+ * Both scopes are in `NON_REQUESTABLE_SCOPES` — the public `/oauth/authorize`
+ * endpoint refuses to mint either, so third-party apps can't acquire these
+ * capabilities via consent. This local mint path is the SPA's only way in.
  *
  * The local mint path now has two surfaces:
- *   1. `parachute auth ...` — operator-token file (~1y, on-disk, mode 0600).
+ *   1. `parachute auth ...` — operator-token file (90d, on-disk, mode 0600).
  *   2. THIS endpoint — short-lived JWT (10 min) handed to the SPA in memory.
  *
  * Both paths require already-proved local-operator identity:
@@ -20,6 +28,13 @@
  * Tokens minted here are deliberately NOT persisted in the `tokens` table
  * (no refresh, no revocation tracking). They expire on their own; the SPA
  * re-fetches when the JWT is about to lapse.
+ *
+ * Background on the dual-scope shape: prior to hub#212 Phase 2 this endpoint
+ * minted `parachute:host:admin` only. The Phase 2 admin endpoints
+ * (`/api/auth/*`) gate on `parachute:host:auth`, which the SPA's bearer
+ * lacked — `/hub/tokens` failed with `bearer token lacks parachute:host:auth`
+ * on first end-to-end load. Adding `:host:auth` here brings the SPA bearer
+ * in line with the admin scope-set semantics from hub#214 / #222.
  */
 import type { Database } from "bun:sqlite";
 import { signAccessToken } from "./jwt-sign.ts";
@@ -29,7 +44,7 @@ import { findSession, parseSessionCookie } from "./sessions.ts";
 export const HOST_ADMIN_TOKEN_TTL_SECONDS = 10 * 60;
 const HOST_ADMIN_AUDIENCE = "hub";
 const HOST_ADMIN_CLIENT_ID = "parachute-hub-spa";
-export const HOST_ADMIN_SCOPES = ["parachute:host:admin"] as const;
+export const HOST_ADMIN_SCOPES = ["parachute:host:admin", "parachute:host:auth"] as const;
 
 export interface MintHostAdminTokenDeps {
   db: Database;

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -8,8 +8,10 @@
  *   1. SPA bootstrap calls `getHostAdminToken()`.
  *   2. That hits `GET /admin/host-admin-token`. The endpoint:
  *      - reads `parachute_hub_session` cookie (set by /admin/login)
- *      - mints a short-lived (~10 min) JWT carrying `parachute:host:admin`
- *        and returns it as JSON.
+ *      - mints a short-lived (~10 min) JWT carrying both
+ *        `parachute:host:admin` (vault provisioning, OAuth grant management)
+ *        AND `parachute:host:auth` (the hub#212 Phase 2 token-registry
+ *        endpoints at /api/auth/*) and returns it as JSON.
  *   3. Token is held in module-scoped state — NOT localStorage. Page
  *      snapshots can't carry it past a refresh, and XSS surface is the
  *      narrowest possible.
@@ -17,8 +19,8 @@
  *      The hub's standard login form then cookie-signs the operator and
  *      bounces back here.
  *
- * The narrow `parachute:host:admin` scope is in `NON_REQUESTABLE_SCOPES`
- * server-side, so the public `/oauth/authorize` flow refuses to mint it.
+ * Both `:host:admin` and `:host:auth` are in `NON_REQUESTABLE_SCOPES`
+ * server-side, so the public `/oauth/authorize` flow refuses to mint either.
  * Only this session-cookie path can — see hub#scope-explanations.ts.
  */
 


### PR DESCRIPTION
## Summary

End-to-end bugfix surfaced from manual testing of `/hub/tokens` (Phase 2 admin UI shipped in rc.8). The SPA's session-bearer (minted by `GET /admin/host-admin-token`) carried only `parachute:host:admin`, but the new admin endpoints from rc.7 (`/api/auth/mint-token`, `/api/auth/revoke-token`, `/api/auth/tokens`) gate on `parachute:host:auth`. SPA failed with `Couldn't load tokens: bearer token lacks parachute:host:auth` on first load.

## The fix

`HOST_ADMIN_SCOPES` in `src/admin-host-admin-token.ts:33` now includes both:

```diff
-export const HOST_ADMIN_SCOPES = ["parachute:host:admin"] as const;
+export const HOST_ADMIN_SCOPES = ["parachute:host:admin", "parachute:host:auth"] as const;
```

Mirrors the `--scope-set admin` operator-token semantics from hub#214 / #222 — admin is the superset of all narrower scope-sets, including `auth`. Both scopes were already in `NON_REQUESTABLE_SCOPES`, so the security envelope is unchanged: the SPA bearer is still mintable only via the local cookie path.

## Why this slipped past Phase 2 reviews

The new endpoints' tests minted operator-style tokens with `:host:auth` directly via `mintOperatorToken({ scopeSet: "admin" })`. None walked the path the SPA actually takes:

```
cookie → /admin/host-admin-token → JWT (with old scope set) → /api/auth/tokens → 403
```

The dual-scope semantics that the operator-side already had via the `admin` scope-set wasn't mirrored to the SPA-side mint until manual end-to-end testing surfaced it. Classic blind-spot between unit-tested-with-operator-tokens and real-world-uses-cookie-mint.

## Regression test

New end-to-end test in `src/__tests__/admin-host-admin-token.test.ts`:

1. Mint a JWT through the SPA cookie flow (`handleHostAdminToken` with a real session cookie).
2. Hit `/api/auth/tokens` with that bearer.
3. Assert 200 (was 403 pre-fix).

Plus the existing scopes-list assertion in the happy-path test now checks for both scopes.

## SPA-side doc update

Updated the comment in `web/ui/src/lib/auth.ts` to mention both scopes (consume side; the SPA only reads `token` and `expires_at` from the response, never the scopes list, so no behavioral change there — just a stale comment refresh).

## Versioning

- `package.json`: `0.5.8-rc.8` → `0.5.8-rc.9`.
- CHANGELOG entry under `## [0.5.8-rc.9] - 2026-05-10` framing as end-to-end bugfix; explicit "why this slipped" note.

## Test plan

- [x] hub `bun test ./src`: **1194 pass / 0 fail** (was 1193; +1 for the new regression test).
- [x] typecheck: clean.
- [x] biome: clean.

## Patterns check

- **`NON_REQUESTABLE_SCOPES` posture preserved** — both `:host:admin` and `:host:auth` were already on the deny-list for public OAuth. The cookie-mint path is the only way either gets issued. Nothing changes about who can request what via OAuth.
- **End-to-end regression coverage added** — closes the "tested-with-operator-tokens vs real-world-cookie-mint" blind spot. Same family of gap as the auto-rotation TTL trap from #224 — flagging here in case worth a broader test-design audit later (not in scope for this PR).
- **RC versioning** — `rc.8` → `rc.9` per parachute-patterns/governance.md (code-touching fix; not doc-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)