### PR TITLE
feat(ui): hub admin SPA relabel + nav grouping (UX polish post-Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.8-rc.10] - 2026-05-10
+
+UX polish on the admin SPA — addresses the "/hub/tokens feels inside of the /vault UI" concern Aaron raised after rc.9. Three small changes; no API surface change, no behavior change beyond labels and visual grouping.
+
+### Changed
+
+- **Brand subtitle is now context-aware.** "Parachute Hub <span>vault management</span>" was a misnomer — the SPA is cross-vault provisioning under `/vault/*`, not per-vault management. Subtitle now derives from the active mount:
+  - `/vault/*` → "vault provisioning"
+  - `/hub/*` → "host admin"
+  - origin root → falls back to "vault provisioning"
+- **Nav links are visually grouped.** Three logical clusters separated by thin vertical dividers (decorative, `aria-hidden="true"`):
+  - **Vaults** (vault provisioning)
+  - **Permissions, Tokens** (host admin)
+  - **Discovery** (top-level)
+  
+  No new entries; just hierarchy. New `.nav-divider` CSS class — single rule, mirrors the existing `--border` token.
+- **Header doc-comment in `App.tsx`** explaining what this SPA is and isn't:
+  - It IS hub admin: cross-vault provisioning + cross-cutting host concerns.
+  - It is NOT a vault-internal admin UI — vault has its own MCP endpoint for AI clients and the Notes PWA for human content browsing.
+  - Per-instance vault admin (config / schemas) doesn't have a UI today; if/when it does, it'll be vault-served (analogous to agent's own admin).
+
+### Added
+
+- **`web/ui/src/App.test.tsx`** — first test file for `App`. Five subtitle cases (every mount path) + two nav-structure assertions (link order + divider presence + `aria-hidden`).
+
+### Out of scope (deferred — separate issues)
+
+- URL renames (`/vault` → `/admin/vaults`, `/hub/permissions` → `/admin/permissions`).
+- Vault-side per-instance admin UI.
+
+### Test gate
+
+- web/ui: 76 pass / 0 fail (was 69; +7 across the App test file).
+- hub: 1194 pass / 0 fail (unchanged — no backend touched).
+- typecheck (both packages): clean. biome: clean. UI build + verify-base: clean.
+
 ## [0.5.8-rc.9] - 2026-05-10
 
 End-to-end bugfix surfaced from manual testing of `/hub/tokens` (Phase 2 admin UI from rc.8): the SPA's session-bearer (minted by `GET /admin/host-admin-token`) carried only `parachute:host:admin`, but the new admin endpoints (`/api/auth/mint-token`, `/api/auth/revoke-token`, `/api/auth/tokens`) gate on `parachute:host:auth`. SPA failed with `Couldn't load tokens: bearer token lacks parachute:host:auth` on first load.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ UX polish on the admin SPA — addresses the "/hub/tokens feels inside of the /v
 
 ### Added
 
-- **`web/ui/src/App.test.tsx`** — first test file for `App`. Five subtitle cases (every mount path) + two nav-structure assertions (link order + divider presence + `aria-hidden`).
+- **`web/ui/src/App.test.tsx`** — first test file for `App`. Eight new tests: six subtitle cases (covering `/vault`, `/vault/new`, `/hub/tokens`, `/hub/permissions`, bare `/hub`, and origin root) plus two nav-structure assertions (link order + divider presence with `aria-hidden`).
 
 ### Out of scope (deferred — separate issues)
 
@@ -34,7 +34,7 @@ UX polish on the admin SPA — addresses the "/hub/tokens feels inside of the /v
 
 ### Test gate
 
-- web/ui: 76 pass / 0 fail (was 69; +7 across the App test file).
+- web/ui: 77 pass / 0 fail (was 69; +8 across the App test file).
 - hub: 1194 pass / 0 fail (unchanged — no backend touched).
 - typecheck (both packages): clean. biome: clean. UI build + verify-base: clean.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.8-rc.9",
+  "version": "0.5.8-rc.10",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -55,6 +55,15 @@ describe("App — brand subtitle", () => {
     expect(screen.getByText(/host admin/i)).toBeInTheDocument();
   });
 
+  // Bare `/hub` path — `isHubMount` explicitly handles this case alongside
+  // `pathname.startsWith("/hub/")`. Pinning here so a future change to the
+  // detection that breaks the bare-prefix path can't slip through.
+  it("/hub (bare path, no trailing route) also renders 'host admin'", async () => {
+    await renderAtPath("/hub");
+    expect(screen.getByText(/host admin/i)).toBeInTheDocument();
+    expect(screen.queryByText(/vault provisioning/i)).toBeNull();
+  });
+
   it("origin root falls back to vault-provisioning subtitle", async () => {
     await renderAtPath("/");
     expect(screen.getByText(/vault provisioning/i)).toBeInTheDocument();

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * App-level smoke tests — brand subtitle reflects the active mount; nav
+ * has the right groups + dividers.
+ *
+ * Note: `isHubMount` is computed at module-load time from
+ * `window.location.pathname`. To test both branches we re-import the
+ * module after mutating jsdom's location. Vitest's `vi.resetModules()`
+ * + dynamic import gives us a fresh evaluation per test.
+ */
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+async function renderAtPath(pathname: string) {
+  // jsdom's `window.location` is read-only via assignment; replace via
+  // `Object.defineProperty` so the module sees the new pathname when
+  // re-evaluated.
+  Object.defineProperty(window, "location", {
+    value: { ...window.location, pathname },
+    writable: true,
+  });
+  vi.resetModules();
+  const { App } = await import("./App.tsx");
+  return render(
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>,
+  );
+}
+
+describe("App — brand subtitle", () => {
+  it("/vault* renders 'vault provisioning'", async () => {
+    await renderAtPath("/vault");
+    expect(screen.getByText(/vault provisioning/i)).toBeInTheDocument();
+    expect(screen.queryByText(/host admin/i)).toBeNull();
+  });
+
+  it("/vault/new also renders 'vault provisioning'", async () => {
+    await renderAtPath("/vault/new");
+    expect(screen.getByText(/vault provisioning/i)).toBeInTheDocument();
+  });
+
+  it("/hub* renders 'host admin'", async () => {
+    await renderAtPath("/hub/tokens");
+    expect(screen.getByText(/host admin/i)).toBeInTheDocument();
+    expect(screen.queryByText(/vault provisioning/i)).toBeNull();
+  });
+
+  it("/hub/permissions also renders 'host admin'", async () => {
+    await renderAtPath("/hub/permissions");
+    expect(screen.getByText(/host admin/i)).toBeInTheDocument();
+  });
+
+  it("origin root falls back to vault-provisioning subtitle", async () => {
+    await renderAtPath("/");
+    expect(screen.getByText(/vault provisioning/i)).toBeInTheDocument();
+  });
+});
+
+describe("App — nav structure", () => {
+  it("renders all four nav links in order: Vaults, Permissions, Tokens, Discovery", async () => {
+    await renderAtPath("/vault");
+    const nav = screen.getByRole("navigation");
+    const links = within(nav).getAllByRole("link");
+    // Brand link is index 0; the four nav items follow.
+    const labels = links.map((a) => a.textContent?.trim());
+    expect(labels).toEqual([
+      expect.stringMatching(/parachute hub/i),
+      "Vaults",
+      "Permissions",
+      "Tokens",
+      "Discovery",
+    ]);
+  });
+
+  it("renders two visual dividers between nav groups", async () => {
+    const { container } = await renderAtPath("/vault");
+    // Two `.nav-divider` spans: one between Vaults and Permissions, one
+    // between Tokens and Discovery. aria-hidden so screen readers skip
+    // them as decorative.
+    const dividers = container.querySelectorAll(".nav-divider");
+    expect(dividers).toHaveLength(2);
+    for (const d of dividers) {
+      expect(d.getAttribute("aria-hidden")).toBe("true");
+    }
+  });
+});

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,29 +1,57 @@
+/**
+ * Parachute Hub admin SPA.
+ *
+ * This bundle is the operator-facing browser UI for the **hub**. Two
+ * concerns live under one roof, served at two mounts on the same hub:
+ *
+ *   - **`/vault/*`** — vault provisioning. Lists every vault registered
+ *     with the hub (`/.well-known/parachute.json`); operators create new
+ *     vaults via `/vault/new`. This is NOT a per-vault admin UI; vaults
+ *     own their own surfaces (the MCP endpoint for AI clients, the Notes
+ *     PWA for human content browsing). Per-vault admin (config, schemas)
+ *     doesn't have a hub-served UI today; if/when it does, it'll be
+ *     vault-served — analogous to how the agent has its own admin.
+ *
+ *   - **`/hub/*`** — cross-cutting host concerns. `/hub/permissions`
+ *     manages the OAuth consent skip-list; `/hub/tokens` manages the
+ *     hub's token registry (mint / list / revoke). These are operator
+ *     state about the hub itself, not about any single vault.
+ *
+ * The active mount picks the route table — we don't render every route
+ * under both basenames since the concerns are unrelated. Cross-mount
+ * navigation uses plain `<a href>` because react-router's `<Link>`
+ * resolves against the active basename.
+ *
+ * The brand subtitle reflects the active mount so an operator who lands
+ * deep in either tree knows which surface they're on.
+ */
 import { Link, Route, Routes } from "react-router-dom";
 import { NewVault } from "./routes/NewVault.tsx";
 import { Permissions } from "./routes/Permissions.tsx";
 import { Tokens } from "./routes/Tokens.tsx";
 import { VaultsList } from "./routes/VaultsList.tsx";
 
-// Same SPA bundle, two mounts: /vault (primary, vault management) and
-// /hub (back-compat + cross-cutting auth state — /hub/permissions and
-// /hub/tokens). The active mount picks the route table — we don't render
-// every route under both basenames since they are unrelated concerns.
-// Cross-mount navigation uses plain <a href> because <Link> resolves
-// against the active basename.
 const isHubMount =
   typeof window !== "undefined" &&
   (window.location.pathname === "/hub" || window.location.pathname.startsWith("/hub/"));
+
+const subtitle = isHubMount ? "host admin" : "vault provisioning";
 
 export function App() {
   return (
     <div className="page">
       <nav className="nav">
         <a href="/vault" className="brand">
-          Parachute Hub <span className="sub">vault management</span>
+          Parachute Hub <span className="sub">{subtitle}</span>
         </a>
+        {/* Group 1 — vault provisioning (lives under /vault). */}
         <a href="/vault">Vaults</a>
+        <span className="nav-divider" aria-hidden="true" />
+        {/* Group 2 — host admin (lives under /hub). */}
         <a href="/hub/permissions">Permissions</a>
         <a href="/hub/tokens">Tokens</a>
+        <span className="nav-divider" aria-hidden="true" />
+        {/* Group 3 — top-level: the public discovery page at /. */}
         <a href="/" title="Hub discovery page (top-level)">
           Discovery
         </a>

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -132,6 +132,16 @@ code {
   text-decoration: none;
   color: var(--fg);
 }
+/* Visual grouping between nav sections — vault provisioning, host admin,
+   top-level discovery. Subtle 1px vertical line; flex layout takes care
+   of spacing via the parent `.nav { gap: 1rem }`. */
+.nav .nav-divider {
+  display: inline-block;
+  width: 1px;
+  height: 1.1em;
+  background: var(--border);
+  align-self: center;
+}
 
 h2 {
   margin: 0 0 1rem;


### PR DESCRIPTION
## Summary

UX polish addressing Aaron's "`/hub/tokens` feels inside of the `/vault` UI" concern after rc.9. Three small changes; no API surface change, no behavior change beyond labels and visual grouping.

## Changes

### 1. Brand subtitle is context-aware

`web/ui/src/App.tsx`'s brand subtitle was hardcoded to "vault management" — a misnomer, since the SPA is cross-vault provisioning under `/vault/*`, not per-vault management. Now derived from the active mount:

| Path | Subtitle |
|---|---|
| `/vault/*` | "vault provisioning" |
| `/hub/*` | "host admin" |
| origin root | "vault provisioning" (vault is the canonical home) |

### 2. Nav links visually grouped

Three logical clusters separated by thin vertical dividers:

```
Parachute Hub <subtitle>     Vaults  |  Permissions  Tokens  |  Discovery
                             ──────  ──────────────────────  ─────────
                             vault   host admin              top-level
                             prov.
```

Dividers are decorative `<span class="nav-divider" aria-hidden="true">` — single CSS rule mirroring the existing `--border` token, no new design system primitive. No new nav entries; just hierarchy.

### 3. Header doc-comment explains the SPA's role

Added a doc-comment at the top of `App.tsx`:
- This SPA IS hub admin (cross-vault provisioning + cross-cutting host concerns).
- It is NOT a vault-internal admin UI — vault has its own MCP endpoint for AI clients and the Notes PWA for human content browsing.
- Per-instance vault admin (config / schemas) doesn't have a hub-served UI today; if/when it does, it'll be vault-served (analogous to agent's own admin).

## Out of scope (deferred per team-lead)

- URL renames (`/vault` → `/admin/vaults`, `/hub/permissions` → `/admin/permissions`, etc.) — separate issue, deferred.
- Vault-side per-instance admin UI — separate vault issue, deferred.
- Restructuring the SPA further (separate bundles, etc.).

## Versions

- `package.json`: `0.5.8-rc.9` → `0.5.8-rc.10`.
- CHANGELOG entry under `## [0.5.8-rc.10] - 2026-05-10` framing as UX polish post-Phase 2.

## Test plan

- [x] web/ui: **76 pass / 0 fail** (was 69; +7 across the new `App.test.tsx` file — five subtitle cases covering every mount path, plus two nav-structure assertions for link order + divider presence + `aria-hidden`).
- [x] hub: **1194 pass / 0 fail** (unchanged — no backend touched).
- [x] typecheck (both packages): clean.
- [x] biome: clean.
- [x] UI build + `verify-base` post-build check: clean.

## Patterns check

- **Mount-aware routing semantics preserved** — `isHubMount` constant unchanged; just used in one more place (subtitle derivation).
- **No new design system** — the `.nav-divider` class is one rule (~7 lines) mirroring the existing `--border` token. Same posture as Tokens.tsx and Permissions.tsx — reuse, don't invent.
- **Doc-comment shape** matches the existing pattern of "this file does X, intentionally not Y, see Z for the related concern" used in `admin-host-admin-token.ts`, `api-mint-token.ts`, etc.
- **First test file for `App`** — fills a meaningful gap. The mount-aware routing was previously tested only indirectly via per-route tests; subtitle derivation and nav structure now have direct coverage.
- **RC versioning** — `rc.9` → `rc.10` per parachute-patterns/governance.md (code-touching PR; not doc-only).

## Test-design note for the App tests

`isHubMount` is computed at module-load time from `window.location.pathname`. To exercise both branches the tests use `Object.defineProperty(window, "location", ...)` + `vi.resetModules()` + dynamic import — gives a fresh module evaluation per test. Captured in the file's docstring so the next App test author doesn't rebuild this from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)