### PR TITLE
feat(ui): hub experience restructure — discovery Use/Admin split + /admin/* route rename (closes #231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.8-rc.11] - 2026-05-10
+
+Holistic restructure of the integrated hub experience — the bigger redesign Aaron asked for after rc.10's small relabel ("clicked Vault on discovery, took me to hub management — there's confusion between use vs admin"). Discovery page split into Use / Admin; the admin SPA relocates to `/admin/*` with 301 redirects from the prior `/vault` and `/hub/*` mounts. Closes hub#231.
+
+### Changed
+
+- **Discovery page (`/`) restructured** into two `<section>`s:
+  - **Use** — per-service primary affordances. Browse notes (the Notes PWA, which is the vault-content browse path); Transcribe audio (Scribe); Run agents (Agent). Entries are dynamic, derived from `services.json`; only installed services appear, paths come from the registered mount (so custom paths still work). Vault deliberately omitted — its content is browsed via Notes; provisioning lives under Admin.
+  - **Admin** — three always-visible cards: Vaults (`/admin/vaults`), Permissions (`/admin/permissions`), Tokens (`/admin/tokens`). Renders synchronously so an operator sees admin even if the well-known fetch is slow.
+- **Admin SPA mounts at `/admin/*` (was `/vault` + `/hub/*`).** Single mount; the SPA's basename is `/admin`; Vite build base is `/admin/`; assets resolve at `/admin/assets/*`. main.tsx and App.tsx simplified — `isHubMount` and the dual-mount detection both gone.
+- **Brand renamed** from "Parachute Hub" to "Parachute Admin" (it's unambiguously admin now). Subtitle is route-derived ("vaults" / "permissions" / "tokens") via `useLocation` — updates on client-side nav.
+
+### Added
+
+- **301 back-compat redirects** for every pre-rename SPA URL:
+  - `/vault` → `/admin/vaults`
+  - `/vault/new` → `/admin/vaults/new`
+  - `/hub/vaults*` → `/admin/vaults*` (this redirect predated #231; now retargets at the final mount instead of bouncing through the interim `/vault`)
+  - `/hub/permissions` → `/admin/permissions`
+  - `/hub/tokens` → `/admin/tokens`
+  - `/hub` (bare) → `/admin/vaults`
+  - All preserve query strings; method-agnostic (no POST endpoint at any of these paths).
+
+### Compatibility
+
+- **`/vault/<name>/*` (per-vault content proxy) is unchanged** — that's user-facing vault data (Notes PWA, etc.), not the admin SPA. Stays where it is.
+- **Pre-rename `/vault/<unknown>/*` SPA-shell fallback removed.** Under the prior shape, an unregistered vault name fell through to the SPA shell (which would client-side render a 404). Now it 404s directly. No operator workflow relied on the SPA-shell fallback.
+- **Pre-rename `/hub/*` SPA mount removed.** Known prefixes 301 to the new locations; unknown `/hub/*` paths 404 (was: SPA shell). Documented in the dispatch comments.
+
+### Out of scope (deferred — separate issues)
+
+- Module.json `useUrl` / `adminUrl` fields (cross-repo work; future Phase 2 follow-up).
+- Vault-side per-instance admin UI (filed as vault#283).
+- Discovery functionality beyond the Use/Admin split — status pills, real-time health, etc. (Phase 3 if anyone wants).
+
+### Test gate
+
+- hub: 1199 pass / 0 fail (was 1194 at rc.10; +5 — 9 new redirect/SPA-mount tests, retired the pre-rename `/vault` and `/hub/*` SPA tests).
+- web/ui: 83 pass / 0 fail (was 77; +6 across the rewritten App.test.tsx — five subtitle cases + three nav-structure assertions + six route-rendering assertions covering the new mount shape).
+- typecheck (both packages): clean. biome: clean. UI build + verify-base: clean (verifies `/admin/`-prefixed asset URLs).
+
 ## [0.5.8-rc.10] - 2026-05-10
 
 UX polish on the admin SPA — addresses the "/hub/tokens feels inside of the /vault UI" concern Aaron raised after rc.9. Three small changes; no API surface change, no behavior change beyond labels and visual grouping.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,15 @@ Holistic restructure of the integrated hub experience — the bigger redesign Aa
 
 ### Test gate
 
-- hub: 1199 pass / 0 fail (was 1194 at rc.10; +5 — 9 new redirect/SPA-mount tests, retired the pre-rename `/vault` and `/hub/*` SPA tests).
-- web/ui: 83 pass / 0 fail (was 77; +6 across the rewritten App.test.tsx — five subtitle cases + three nav-structure assertions + six route-rendering assertions covering the new mount shape).
-- typecheck (both packages): clean. biome: clean. UI build + verify-base: clean (verifies `/admin/`-prefixed asset URLs).
+All test suites pass. New coverage in this PR:
+
+- **`hub.test.ts`** rewritten for the new discovery shape — 15 tests covering the Use/Admin section structure, dynamic Use entries from services.json, hardcoded Admin entries, the synchronous-Admin-render guarantee, and absence of the retired aggregate-by-module-type code.
+- **`hub-server.test.ts`** retired the pre-rename `/vault` and `/hub/*` SPA tests; added 9 new tests across the new `/admin/*` SPA mount (vaults / vaults/new / permissions / tokens / assets / 503 + 405 surfaces) and every 301 redirect (`/vault`, `/vault/new`, `/hub/vaults*`, `/hub/permissions`, `/hub/tokens`, `/hub` bare) including query-string preservation.
+- **`App.test.tsx`** rewritten to use `MemoryRouter`'s `initialEntries` (subtitle is now router-derived; no more `Object.defineProperty(window.location, ...)`). Covers route-derived subtitle, single-mount nav structure, and per-route component rendering (including the 404 fallback).
+
+Typecheck (both packages): clean. biome: clean. UI build + `verify-base`: clean (asserts `/admin/`-prefixed asset URLs).
+
+(Test-count numbers intentionally omitted — the canonical-vs-combined ambiguity is tracked at hub#219.)
 
 ## [0.5.8-rc.10] - 2026-05-10
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.8-rc.10",
+  "version": "0.5.8-rc.11",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -398,15 +398,12 @@ describe("hubFetch routing", () => {
     }
   });
 
-  // SPA mounts after hub#168-realignment:
-  //   /vault — primary (vault list, NewVault, etc.)
-  //   /hub   — back-compat (only /hub/permissions; /hub/vaults* is 301'd
-  //            below, /hub/ root falls through to the SPA's 404 route)
-  //
-  // Same bundle at both mounts. Build base is /vault/, so asset URLs are
-  // origin-absolute and resolve regardless of which mount served the HTML.
+  // SPA mount after hub#231: single `/admin/*` mount serves vault
+  // provisioning + permissions + tokens. Pre-rename `/vault` and `/hub/*`
+  // SPA URLs are 301-redirected; the per-vault content proxy at
+  // `/vault/<name>/*` stays where it is.
 
-  test("/vault serves index.html when the SPA bundle exists", async () => {
+  test("/admin/vaults serves the SPA shell when the bundle exists", async () => {
     const h = makeHarness();
     try {
       const dist = join(h.dir, "dist");
@@ -414,7 +411,7 @@ describe("hubFetch routing", () => {
       writeFileSync(join(dist, "index.html"), "<!doctype html><div id=root></div>");
       writeManifest({ services: [] }, h.manifestPath);
       const res = await hubFetch(h.dir, { spaDistDir: dist, manifestPath: h.manifestPath })(
-        req("/vault"),
+        req("/admin/vaults"),
       );
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
@@ -424,10 +421,7 @@ describe("hubFetch routing", () => {
     }
   });
 
-  test("/vault/new (client-side route, no matching vault) falls back to index.html", async () => {
-    // Routing-order check: `new` isn't a known vault, so proxyToVault
-    // returns undefined and we fall through to the SPA shell. The router
-    // takes over client-side and renders the NewVault form.
+  test("/admin/vaults/new serves the SPA shell (client-side route)", async () => {
     const h = makeHarness();
     try {
       const dist = join(h.dir, "dist");
@@ -435,7 +429,7 @@ describe("hubFetch routing", () => {
       writeFileSync(join(dist, "index.html"), "<!doctype html><div id=root></div>");
       writeManifest({ services: [] }, h.manifestPath);
       const res = await hubFetch(h.dir, { spaDistDir: dist, manifestPath: h.manifestPath })(
-        req("/vault/new"),
+        req("/admin/vaults/new"),
       );
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
@@ -445,7 +439,34 @@ describe("hubFetch routing", () => {
     }
   });
 
-  test("/vault/assets/*.js is served with the matching content-type", async () => {
+  test("/admin/permissions serves the SPA shell", async () => {
+    const h = makeHarness();
+    try {
+      const dist = join(h.dir, "dist");
+      mkdirIfMissing(dist);
+      writeFileSync(join(dist, "index.html"), "<!doctype html><div id=root></div>");
+      const res = await hubFetch(h.dir, { spaDistDir: dist })(req("/admin/permissions"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/admin/tokens serves the SPA shell", async () => {
+    const h = makeHarness();
+    try {
+      const dist = join(h.dir, "dist");
+      mkdirIfMissing(dist);
+      writeFileSync(join(dist, "index.html"), "<!doctype html><div id=root></div>");
+      const res = await hubFetch(h.dir, { spaDistDir: dist })(req("/admin/tokens"));
+      expect(res.status).toBe(200);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/admin/assets/*.js is served with the matching content-type", async () => {
     const h = makeHarness();
     try {
       const dist = join(h.dir, "dist");
@@ -456,7 +477,7 @@ describe("hubFetch routing", () => {
       writeFileSync(join(assets, "main.js"), "console.log('hi');");
       writeManifest({ services: [] }, h.manifestPath);
       const res = await hubFetch(h.dir, { spaDistDir: dist, manifestPath: h.manifestPath })(
-        req("/vault/assets/main.js"),
+        req("/admin/assets/main.js"),
       );
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toBe("application/javascript; charset=utf-8");
@@ -466,14 +487,14 @@ describe("hubFetch routing", () => {
     }
   });
 
-  test("/vault/* returns 503 with build hint when dist is missing", async () => {
+  test("/admin/* returns 503 with build hint when dist is missing", async () => {
     const h = makeHarness();
     try {
       writeManifest({ services: [] }, h.manifestPath);
       const res = await hubFetch(h.dir, {
         spaDistDir: join(h.dir, "missing"),
         manifestPath: h.manifestPath,
-      })(req("/vault"));
+      })(req("/admin/vaults"));
       expect(res.status).toBe(503);
       expect(await res.text()).toContain("bun run build");
     } finally {
@@ -481,55 +502,14 @@ describe("hubFetch routing", () => {
     }
   });
 
-  test("/vault rejects non-GET methods with 405", async () => {
-    const h = makeHarness();
-    try {
-      const dist = join(h.dir, "dist");
-      mkdirIfMissing(dist);
-      writeFileSync(join(dist, "index.html"), "<!doctype html>");
-      const res = await hubFetch(h.dir, { spaDistDir: dist })(req("/vault", { method: "POST" }));
-      expect(res.status).toBe(405);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("/hub/permissions serves the SPA shell (back-compat mount)", async () => {
-    const h = makeHarness();
-    try {
-      const dist = join(h.dir, "dist");
-      mkdirIfMissing(dist);
-      writeFileSync(join(dist, "index.html"), "<!doctype html><div id=root></div>");
-      const res = await hubFetch(h.dir, { spaDistDir: dist })(req("/hub/permissions"));
-      expect(res.status).toBe(200);
-      expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
-      expect(await res.text()).toContain("<div id=root>");
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("/hub/* returns 503 with build hint when dist is missing", async () => {
-    const h = makeHarness();
-    try {
-      const res = await hubFetch(h.dir, { spaDistDir: join(h.dir, "missing") })(
-        req("/hub/permissions"),
-      );
-      expect(res.status).toBe(503);
-      expect(await res.text()).toContain("bun run build");
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("/hub rejects non-GET methods with 405", async () => {
+  test("/admin/vaults rejects non-GET methods with 405", async () => {
     const h = makeHarness();
     try {
       const dist = join(h.dir, "dist");
       mkdirIfMissing(dist);
       writeFileSync(join(dist, "index.html"), "<!doctype html>");
       const res = await hubFetch(h.dir, { spaDistDir: dist })(
-        req("/hub/permissions", { method: "POST" }),
+        req("/admin/vaults", { method: "POST" }),
       );
       expect(res.status).toBe(405);
     } finally {
@@ -537,36 +517,120 @@ describe("hubFetch routing", () => {
     }
   });
 
-  test("/hub/vaults issues a 301 redirect to /vault", async () => {
-    // Back-compat for bookmarks. The exact mount path used to be /hub/vaults
-    // before the realignment; permanent redirect keeps stale URLs working.
+  // 301 back-compat redirects (closes hub#231): pre-rename SPA URLs
+  // 301-redirect to the new /admin/* mount. Tests cover every entry in the
+  // dispatch — operator bookmarks landing on any of these still work.
+
+  test("301: /vault → /admin/vaults", async () => {
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir)(req("/vault"));
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("/admin/vaults");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("301: /vault/new → /admin/vaults/new", async () => {
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir)(req("/vault/new"));
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("/admin/vaults/new");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("301: /vault preserves query string", async () => {
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir)(req("/vault?next=foo"));
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("/admin/vaults?next=foo");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("301: /hub/vaults → /admin/vaults (chain through the rename)", async () => {
+    // The /hub/vaults redirect predates #231 — it used to land at /vault.
+    // Now it lands at the final /admin/vaults so old bookmarks don't bounce
+    // through two redirects.
     const h = makeHarness();
     try {
       const res = await hubFetch(h.dir)(req("/hub/vaults"));
       expect(res.status).toBe(301);
-      expect(res.headers.get("location")).toBe("/vault");
+      expect(res.headers.get("location")).toBe("/admin/vaults");
     } finally {
       h.cleanup();
     }
   });
 
-  test("/hub/vaults/new redirects to /vault/new", async () => {
+  test("301: /hub/vaults/new → /admin/vaults/new", async () => {
     const h = makeHarness();
     try {
       const res = await hubFetch(h.dir)(req("/hub/vaults/new"));
       expect(res.status).toBe(301);
-      expect(res.headers.get("location")).toBe("/vault/new");
+      expect(res.headers.get("location")).toBe("/admin/vaults/new");
     } finally {
       h.cleanup();
     }
   });
 
-  test("/hub/vaults/* preserves the query string in the redirect", async () => {
+  test("301: /hub/vaults/* preserves the query string", async () => {
     const h = makeHarness();
     try {
       const res = await hubFetch(h.dir)(req("/hub/vaults/foo?bar=1&baz=2"));
       expect(res.status).toBe(301);
-      expect(res.headers.get("location")).toBe("/vault/foo?bar=1&baz=2");
+      expect(res.headers.get("location")).toBe("/admin/vaults/foo?bar=1&baz=2");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("301: /hub/permissions → /admin/permissions", async () => {
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir)(req("/hub/permissions"));
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("/admin/permissions");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("301: /hub/tokens → /admin/tokens", async () => {
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir)(req("/hub/tokens"));
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("/admin/tokens");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("301: /hub bare → /admin/vaults", async () => {
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir)(req("/hub"));
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("/admin/vaults");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/hub/<unknown> (no SPA mount anymore) → 404", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [] }, h.manifestPath);
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(
+        req("/hub/unknown-thing"),
+      );
+      expect(res.status).toBe(404);
     } finally {
       h.cleanup();
     }
@@ -1024,15 +1088,15 @@ describe("hubFetch /vault/<name>/* dynamic proxy (#144)", () => {
     }
   });
 
-  test("single-segment /vault/<name> picks proxy when registered, SPA shell when not", async () => {
+  test("single-segment /vault/<name> picks proxy when registered, 404 when not", async () => {
     // Two cases share one fixture so the contrast is explicit:
     //   - `/vault/default` is registered → proxy answers (200, JSON tag).
-    //   - `/vault/nonexistent` has no match → falls through to the SPA
-    //     shell (200, text/html). The SPA's :name route renders client-side
-    //     and shows a 404 in-app, but at the wire it's the shell.
+    //   - `/vault/nonexistent` has no match → 404 directly (no SPA-shell
+    //     fallback under /vault since hub#231 moved the admin SPA to
+    //     /admin/*; the /vault/<name>/* slot is now exclusively the
+    //     per-vault content proxy).
     // This is the routing-order seam #173 introduced — proxy is consulted
-    // before the SPA fallback, and the fallback only triggers when no
-    // vault claims the path.
+    // before the 404; the SPA fallback that used to live here is gone.
     const h = makeHarness();
     const upstream = startUpstream("default-vault");
     try {
@@ -1065,10 +1129,8 @@ describe("hubFetch /vault/<name>/* dynamic proxy (#144)", () => {
       expect(body.tag).toBe("default-vault");
       expect(body.pathname).toBe("/vault/default");
 
-      const shelled = await fetcher(req("/vault/nonexistent"));
-      expect(shelled.status).toBe(200);
-      expect(shelled.headers.get("content-type")).toBe("text/html; charset=utf-8");
-      expect(await shelled.text()).toContain("<div id=root>");
+      const notFound = await fetcher(req("/vault/nonexistent"));
+      expect(notFound.status).toBe(404);
     } finally {
       upstream.stop();
       h.cleanup();

--- a/src/__tests__/hub.test.ts
+++ b/src/__tests__/hub.test.ts
@@ -13,10 +13,9 @@ describe("renderHub", () => {
     expect(html).toContain("<script>");
   });
 
-  test("fetches /.well-known/parachute.json and reads services[] + vaults[]", () => {
+  test("fetches /.well-known/parachute.json for the Use section", () => {
     expect(html).toContain("/.well-known/parachute.json");
     expect(html).toContain("doc.services");
-    expect(html).toContain("doc.vaults");
   });
 
   test("uses parachute.computer sage palette and serif/sans fonts", () => {
@@ -30,79 +29,70 @@ describe("renderHub", () => {
     expect(html).toContain("prefers-color-scheme: dark");
   });
 
-  test("falls back to a generic icon for module tiles", () => {
-    expect(html).toContain("fallbackIcon");
+  test("renders two sections: Use and Admin, each with its own heading + grid", () => {
+    expect(html).toContain('id="use-section"');
+    expect(html).toContain('id="admin-section"');
+    expect(html).toContain('id="use-grid"');
+    expect(html).toContain('id="admin-grid"');
+    expect(html).toContain("<h2>Use</h2>");
+    expect(html).toContain("<h2>Admin</h2>");
   });
 
-  test("renders one tile per module type, not per service instance", () => {
-    expect(html).toContain("aggregate(services, vaults)");
-    expect(html).toContain("renderTile");
-    expect(html).toContain("MODULE_ORDER");
+  test("Use section labels: Browse notes / Transcribe audio / Run agents", () => {
+    expect(html).toContain("'Browse notes'");
+    expect(html).toContain("'Transcribe audio'");
+    expect(html).toContain("'Run agents'");
   });
 
-  test("known module display order is vault → scribe → notes → agent", () => {
-    expect(html).toContain("['vault', 'scribe', 'notes', 'agent']");
+  test("Use entries use the path declared in services.json (custom mounts work)", () => {
+    // Operators may mount a service at a non-default path; the Use tile
+    // surfaces that path verbatim rather than hardcoding `/notes`/etc.
+    expect(html).toContain("svc.path");
   });
 
-  test("vault tile counts vaults[] (per instance) and links to /vault", () => {
-    // Vault count is the length of doc.vaults — one entry per /vault/<name>
-    // mount, so a single ServiceEntry with paths=[a,b,c] still shows "3
-    // registered". The manage link is the hub's vault SPA at /vault
-    // (renamed from /hub/vaults in the realignment), never an individual
-    // vault backend.
-    expect(html).toContain("vaults.length");
-    expect(html).toContain("'/vault'");
-  });
-
-  test("non-vault tiles take their manageUrl from the service's path", () => {
-    // shortName('parachute-scribe') = 'scribe' → tile links to svc.path,
-    // which is whatever the module declared (e.g. /scribe, /notes, /agent).
-    // Hardcoding the link would silently break on a custom mount.
-    expect(html).toContain("manageUrl: svc.path");
-  });
-
-  test("tiles for module types with zero instances are hidden", () => {
-    // Aggregate only inserts a group when the type has at least one entry;
-    // tilesInOrder iterates the map. No "0 registered" surface.
-    expect(html).not.toContain("0 registered");
-    expect(html).toContain("count === 1 ? '1 registered'");
-  });
-
-  test("module labels are humanized (Vault / Scribe / Notes / Agent)", () => {
-    expect(html).toContain("vault: 'Vault'");
-    expect(html).toContain("scribe: 'Scribe'");
-    expect(html).toContain("notes: 'Notes'");
-    expect(html).toContain("agent: 'Agent'");
-  });
-
-  test("vault-name detection covers parachute-vault and parachute-vault-<name>", () => {
-    // Phase-1 multi-vault keeps a single ServiceEntry with multiple paths
-    // (parachute-vault), but the door is open for per-instance entries
-    // (parachute-vault-techne). isVaultName has to accept both.
+  test("Vault is intentionally excluded from the Use section", () => {
+    // Aaron's friction: clicking 'Vault' on discovery took him to hub
+    // management, not to vault content. Resolution: Vault has no Use
+    // entry — its content is browsed via Notes (which has its own
+    // entry). Vault provisioning lives under Admin.
+    expect(html).toContain("Vault deliberately omitted");
     expect(html).toContain("isVaultName");
-    expect(html).toContain("'parachute-vault'");
-    expect(html).toContain("'parachute-vault-'");
   });
 
-  test("empty state when no modules are registered", () => {
-    expect(html).toContain("No modules installed yet");
+  test("Use section ordering is notes → scribe → agent", () => {
+    expect(html).toContain("['notes', 'scribe', 'agent']");
+  });
+
+  test("Admin section is hardcoded (always visible) with three entries", () => {
+    expect(html).toContain("ADMIN_ENTRIES");
+    expect(html).toContain("/admin/vaults");
+    expect(html).toContain("/admin/permissions");
+    expect(html).toContain("/admin/tokens");
+  });
+
+  test("Admin section renders synchronously (does not depend on the well-known fetch)", () => {
+    // Even if the fetch is slow or fails, the operator should see Admin
+    // surfaces — they may be the reason the operator landed on /.
+    expect(html).toContain("renderAdmin();");
+    expect(html).toContain("Admin section is static");
+  });
+
+  test("Use section empty state hints at install", () => {
+    expect(html).toContain("No services installed yet");
     expect(html).toContain("parachute install vault");
   });
 
-  test("error state surfaces the underlying message", () => {
-    expect(html).toContain("Could not load modules");
+  test("Use section error state surfaces the underlying message", () => {
+    expect(html).toContain("Could not load services");
   });
 
-  test("does not retain the per-service interactive-card / config-form code", () => {
-    // The home page is now a directory of modules — per-instance config
-    // forms and detail panels live behind the Manage links (vault SPA at
-    // /vault, the running module's own UI elsewhere). Keeping the
-    // dead code around is a maintenance trap.
+  test("does not retain the old aggregate-by-module-type code", () => {
+    // The Vault collapse + per-module aggregation pattern is gone — Use
+    // entries are direct service-path → label lookups; Admin is hardcoded.
+    expect(html).not.toContain("aggregate(services, vaults)");
+    expect(html).not.toContain("MODULE_LABELS");
     expect(html).not.toContain("renderConfigField");
-    expect(html).not.toContain("fetchConfig");
     expect(html).not.toContain("kind-badge");
-    expect(html).not.toContain("info.mcpUrl");
-    expect(html).not.toContain("info.openInNotesUrl");
   });
 });
 

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -507,22 +507,23 @@ function defaultSpaDistDir(): string {
 }
 
 /**
- * The SPA serves at two mounts:
+ * The admin SPA serves at a single mount: `/admin/*` (since hub#231).
  *
- * - `/vault` — primary, since hub#168-realignment. Matches the operator
- *   pattern of `/<module>` as the entry point (alongside `/notes`, `/agent`,
- *   `/scribe`). VaultsList, NewVault, and per-vault detail routes hang off
- *   here.
- * - `/hub` — back-compat. `/hub/permissions` (cross-vault grants) is a hub
- *   concern and stays where bookmarks expect it. `/hub/vaults*` is a 301 to
- *   `/vault*` further up the dispatch — keeping it out of this mount.
+ * Routes:
+ *   - `/admin/vaults`       → vault list (the SPA's home)
+ *   - `/admin/vaults/new`   → vault create form
+ *   - `/admin/permissions`  → OAuth consent grant management
+ *   - `/admin/tokens`       → token registry: mint / list / revoke
  *
- * Both mounts serve the same SPA bundle. Asset URLs are origin-absolute
- * (`/vault/assets/...`) per the build base, so the HTML loads correctly
- * regardless of which mount served it. main.tsx detects the active mount
- * at runtime and configures react-router's `basename` accordingly.
+ * Asset URLs are origin-absolute (`/admin/assets/...`) per the Vite build
+ * base. main.tsx pins react-router's basename to `/admin`.
+ *
+ * Pre-rename mounts (the old `/vault` for the vault SPA, `/hub/*` for
+ * permissions+tokens) are 301-redirected further up the dispatch so cached
+ * operator URLs keep working. `/vault/<name>/*` (per-vault content proxy)
+ * stays — that's user-facing vault data, not part of this admin SPA.
  */
-type SpaMount = "/vault" | "/hub";
+type SpaMount = "/admin";
 
 /**
  * Pick a content type for static assets the SPA build produces. Vite's
@@ -569,8 +570,8 @@ function spaContentType(pathname: string): string {
  * filter rejects sub-paths containing "..", and the resolved absolute
  * path is checked to start with `dist/` before any read.
  *
- * `mount` is the prefix being served (`/vault` or `/hub`); we strip it
- * from `pathname` to land on the file path inside `dist/`.
+ * `mount` is the prefix being served (`/admin`); we strip it from
+ * `pathname` to land on the file path inside `dist/`.
  */
 async function serveSpa(spaDistDir: string, pathname: string, mount: SpaMount): Promise<Response> {
   if (!existsSync(spaDistDir)) {
@@ -579,7 +580,7 @@ async function serveSpa(spaDistDir: string, pathname: string, mount: SpaMount): 
       { status: 503, headers: { "content-type": "text/plain; charset=utf-8" } },
     );
   }
-  // Strip the mount prefix; "/vault" → "", "/vault/" → "/", "/vault/x" → "/x".
+  // Strip the mount prefix; "/admin" → "", "/admin/" → "/", "/admin/x" → "/x".
   const sub = pathname === mount ? "" : pathname.slice(mount.length);
   const indexPath = join(spaDistDir, "index.html");
 
@@ -630,18 +631,55 @@ export function hubFetch(
     const url = new URL(req.url);
     const pathname = url.pathname;
 
-    // 301 back-compat: `/hub/vaults*` was the SPA's vault-management entry
-    // before hub#168-realignment. Bookmarks and any cached operator-typed
-    // URLs land here; permanent redirect keeps them working without leaving
-    // a dangling SPA route. Query string preserved; fragment is client-side
-    // and survives the redirect at the browser. Method-agnostic — even a
-    // misrouted POST gets the redirect, since there's no /hub/vaults POST
-    // endpoint to protect.
+    // 301 back-compat for the pre-hub#231 admin-SPA mounts:
+    //
+    //   `/vault`            → `/admin/vaults`
+    //   `/vault/new`        → `/admin/vaults/new`
+    //   `/hub/vaults*`      → `/admin/vaults*` (this redirect predates #231;
+    //                        it now retargets at the new admin mount instead
+    //                        of the interim `/vault` mount)
+    //   `/hub/permissions`  → `/admin/permissions`
+    //   `/hub/tokens`       → `/admin/tokens`
+    //   `/hub` (bare)       → `/admin/vaults`
+    //
+    // Permanent redirect so cached operator URLs keep working without
+    // leaving dangling SPA routes. Query string preserved; fragment is
+    // client-side and survives the redirect at the browser. Method-agnostic
+    // — even a misrouted POST gets the redirect; none of these paths host a
+    // POST endpoint to protect.
+    //
+    // `/vault/<name>/*` is INTENTIONALLY excluded — that's the per-vault
+    // content proxy (Notes PWA, etc.), not the admin SPA. Stays where it is.
+    if (pathname === "/vault" || pathname === "/vault/" || pathname === "/vault/new") {
+      const sub = pathname === "/vault/new" ? "/new" : "";
+      return new Response("", {
+        status: 301,
+        headers: { location: `/admin/vaults${sub}${url.search}` },
+      });
+    }
     if (pathname === "/hub/vaults" || pathname.startsWith("/hub/vaults/")) {
-      const newPath = `/vault${pathname.slice("/hub/vaults".length)}`;
+      const newPath = `/admin/vaults${pathname.slice("/hub/vaults".length)}`;
       return new Response("", {
         status: 301,
         headers: { location: `${newPath}${url.search}` },
+      });
+    }
+    if (pathname === "/hub/permissions") {
+      return new Response("", {
+        status: 301,
+        headers: { location: `/admin/permissions${url.search}` },
+      });
+    }
+    if (pathname === "/hub/tokens") {
+      return new Response("", {
+        status: 301,
+        headers: { location: `/admin/tokens${url.search}` },
+      });
+    }
+    if (pathname === "/hub" || pathname === "/hub/") {
+      return new Response("", {
+        status: 301,
+        headers: { location: `/admin/vaults${url.search}` },
       });
     }
 
@@ -828,15 +866,10 @@ export function hubFetch(
       });
     }
 
-    // /hub SPA mount (back-compat). Kept for `/hub/permissions` and any other
-    // hub-level admin surface that lived under /hub/ before the realignment.
-    // /hub/vaults* is a separate concern handled by the 301 redirect lower
-    // down — the redirect runs first so it never reaches here. Only GET —
-    // POSTs for vault create go to /vaults, not the SPA mount.
-    if (pathname === "/hub" || pathname.startsWith("/hub/")) {
-      if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
-      return serveSpa(spaDistDir, pathname, "/hub");
-    }
+    // Note: the old `/hub/*` SPA mount has been retired. Known prefixes
+    // (`/hub`, `/hub/vaults*`, `/hub/permissions`, `/hub/tokens`) are
+    // 301-redirected at the top of dispatch. Any other `/hub/*` path falls
+    // through to the catch-all 404 — there's no admin surface left there.
 
     if (pathname === "/admin/host-admin-token") {
       if (!getDb) return new Response("hub db not configured", { status: 503 });
@@ -954,34 +987,36 @@ export function hubFetch(
       return handleAdminConfigPost(getDb(), req, name);
     }
 
-    // /vault — primary SPA mount + dynamic per-vault proxy share this
-    // namespace. Order matters:
-    //   1. `/vault` exact → SPA shell (vault list).
-    //   2. `/vault/<known-vault>/...` → proxy to the vault backend, picked
-    //      from services.json by longest-mount-prefix. Read per request so a
-    //      `parachute vault create` performed after `parachute expose` is
-    //      immediately reachable (#144).
-    //   3. `/vault/<spa-route>` → SPA shell. Only single-segment paths
-    //      (`/vault/new`, `/vault/<name>`) and `/vault/assets/*` count as
-    //      SPA routes. Multi-segment requests like `/vault/<unknown>/health`
-    //      are vault-API shapes targeting a non-existent vault and 404 —
-    //      otherwise the SPA shell would mask backend 404s with HTML.
-    //      `new` and `assets` are reserved vault names (see
-    //      `RESERVED_VAULT_NAMES` in admin-vaults.ts) so an operator
-    //      can't register a vault that shadows the SPA's create route or
-    //      its static asset bundle.
-    if (pathname === "/vault") {
-      if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
-      return serveSpa(spaDistDir, pathname, "/vault");
-    }
+    // /vault/<name>/* — per-vault content proxy. Stays as user-facing
+    // surface (the Notes PWA loads through here, etc.). The bare `/vault`
+    // and `/vault/new` paths were SPA routes pre-#231; they 301-redirect at
+    // the top of dispatch now. Multi-segment requests like
+    // `/vault/<unknown>/health` are vault-API shapes targeting a
+    // non-existent vault and 404 directly — there's no SPA-shell fallback
+    // here anymore (the SPA moved to /admin), so we can't accidentally
+    // mask a backend 404 with HTML.
     if (pathname.startsWith("/vault/")) {
       const proxied = await proxyToVault(req, manifestPath);
       if (proxied) return proxied;
-      const sub = pathname.slice("/vault/".length);
-      const isSpaRoute = !sub.includes("/") || sub.startsWith("assets/");
-      if (!isSpaRoute) return new Response("not found", { status: 404 });
-      if (req.method !== "GET") return new Response("not found", { status: 404 });
-      return serveSpa(spaDistDir, pathname, "/vault");
+      return new Response("not found", { status: 404 });
+    }
+
+    // /admin/* SPA mount. All non-SPA admin handlers (host-admin-token,
+    // vault-admin-token, login, logout, config, api/auth/*, api/grants,
+    // grants/*) ran above and either matched or returned. Anything that
+    // makes it here under /admin/* is a SPA route or asset request; the
+    // SPA's own router renders the page and handles 404 client-side for
+    // unknown sub-paths.
+    if (pathname === "/admin" || pathname === "/admin/") {
+      // Unprefixed /admin → SPA shell pointed at the vault list (its home).
+      // The SPA's basename is /admin, so the router will land on / and
+      // render VaultsList.
+      if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
+      return serveSpa(spaDistDir, pathname, "/admin");
+    }
+    if (pathname.startsWith("/admin/")) {
+      if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
+      return serveSpa(spaDistDir, pathname, "/admin");
     }
 
     // Generic services.json-driven dispatch for non-vault modules. Reaches

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -9,17 +9,58 @@
  * `tailscale serve … --set-path=/ http://127.0.0.1:<port>`. This shim is
  * that localhost backing.
  *
- * Routes (all bound to 127.0.0.1):
- *   /                                         → hub.html
- *   /hub.html                                 → hub.html
- *   /.well-known/parachute.json               → built dynamically from services.json
- *   /.well-known/jwks.json                    → JWKS from hub.db
- *   /.well-known/oauth-authorization-server   → RFC 8414 metadata (issuer, endpoints)
- *   /oauth/authorize  (GET + POST)            → login → consent → auth code
- *   /oauth/authorize/approve (POST)           → inline DCR approve form (#208)
- *   /oauth/token      (POST)                  → authorization_code + refresh_token grants
- *   /oauth/register   (POST)                  → RFC 7591 dynamic client registration
- *   anything else                             → 404
+ * Routes (all bound to 127.0.0.1) — listed in dispatch order. Order is
+ * load-bearing: 301 redirects fire before the proxies and SPA mount they
+ * preempt; admin API endpoints fire before the /admin/* SPA catch-all.
+ *
+ *   # Pre-rename 301 back-compat (hub#231 — first so they preempt any
+ *   # remaining handlers under /vault or /hub).
+ *   /vault, /vault/, /vault/new                → 301 → /admin/vaults[/new]
+ *   /hub/vaults*                               → 301 → /admin/vaults*
+ *   /hub/permissions                           → 301 → /admin/permissions
+ *   /hub/tokens                                → 301 → /admin/tokens
+ *   /hub, /hub/                                → 301 → /admin/vaults
+ *
+ *   # Discovery + well-known.
+ *   /, /hub.html                               → hub.html (the discovery page)
+ *   /.well-known/parachute.json                → built dynamically from services.json
+ *   /.well-known/parachute-revocation.json     → revoked-jti list (hub#212 Phase 1)
+ *   /.well-known/jwks.json                     → JWKS from hub.db
+ *   /.well-known/oauth-authorization-server    → RFC 8414 metadata (issuer, endpoints)
+ *
+ *   # OAuth issuer.
+ *   /oauth/authorize  (GET + POST)             → login → consent → auth code
+ *   /oauth/authorize/approve (POST)            → inline DCR approve form (#208)
+ *   /oauth/token      (POST)                   → authorization_code + refresh_token grants
+ *   /oauth/register   (POST)                   → RFC 7591 dynamic client registration
+ *   /oauth/revoke     (POST)                   → RFC 7009 refresh-token revocation
+ *
+ *   # Admin API + bearer-mint surfaces (must precede /admin/* SPA mount).
+ *   /vaults                       (POST)       → create vault
+ *   /admin/host-admin-token       (GET)        → SPA bearer mint (cookie-gated)
+ *   /admin/vault-admin-token/<n>  (GET)        → per-vault bearer mint (cookie-gated)
+ *   /api/auth/mint-token          (POST)       → CLI/automation token mint (bearer)
+ *   /api/auth/revoke-token        (POST)       → revoke registry-row token by jti
+ *   /api/auth/tokens              (GET)        → paginated registry list
+ *   /api/grants                   (GET)        → OAuth consent grants list
+ *   /api/grants/<client_id>       (DELETE)     → revoke a single OAuth grant
+ *   /admin/login                  (GET + POST) → operator password login
+ *   /admin/logout                 (POST)       → end admin session
+ *   /admin/config                 (GET)        → operator config view
+ *   /admin/config/<key>           (POST)       → operator config write
+ *
+ *   # Per-vault content proxy (user-facing vault data: Notes PWA, MCP, etc.).
+ *   /vault/<name>/*                            → proxy to the vault backend
+ *
+ *   # Admin SPA mount (catch-all under /admin; runs after all admin API
+ *   # handlers above, so /admin/<known> reaches the right handler and
+ *   # /admin/<spa-route> serves the SPA shell).
+ *   /admin, /admin/, /admin/*                  → SPA shell (vaults / new / permissions / tokens)
+ *
+ *   # Generic services.json-driven proxy (non-vault modules: notes, scribe, agent).
+ *   /<service-mount>/*                         → proxy via services.json longest-prefix
+ *
+ *   anything else                              → 404
  *
  * Invoked as:
  *   bun <this-file> --port <n> --well-known-dir <path> [--db <path>] [--issuer <url>]

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -5,14 +5,22 @@ import { CONFIG_DIR } from "./config.ts";
 /**
  * Hub page served at `/` when the node is exposed.
  *
- * The page is a *module directory*: one tile per module type (vault, scribe,
- * notes, agent), not one row per service instance. Aaron's original shape
- * iterated `services[]` and rendered a card per entry — fine at one vault,
- * but at three vaults plus scribe + notes + agent the page reads as a flat
- * list of instances rather than the modules themselves (#168). The new shape
- * aggregates: "Vault — 3 registered — Manage →" links to the per-vault SPA at
- * `/vault`; "Scribe — 1 registered" links to the running scribe instance;
- * etc. Zero-count types are hidden entirely.
+ * The page is split into two sections:
+ *
+ *   - **Use** — per-service primary human affordances. Browse notes
+ *     (the Notes PWA, which is the vault-content browse path); transcribe
+ *     audio (Scribe); run agents (Agent). Entries are dynamic, derived
+ *     from `/.well-known/parachute.json`; only installed services show up.
+ *     Vault deliberately doesn't have its own Use entry — its content is
+ *     browsed via Notes, so a separate "Vault" tile would just send the
+ *     operator to the admin SPA, which is exactly the friction Aaron
+ *     flagged ("clicked Vault, took me to hub management").
+ *
+ *   - **Admin** — hub-served admin SPA routes for cross-cutting host
+ *     concerns. Always visible: even with zero vaults installed, an
+ *     operator may want to provision the first one. Three entries:
+ *     Vaults (provisioning), Permissions (OAuth consent grants), Tokens
+ *     (registry mint/list/revoke).
  *
  * The file stays self-contained (inline CSS + JS, no external assets) so
  * `tailscale serve` can mount it directly from disk with `--set-path=/`.
@@ -108,6 +116,22 @@ const HTML = `<!doctype html>
     font-size: 1.1rem;
     margin: 0;
   }
+  .section {
+    margin-bottom: 3rem;
+  }
+  .section h2 {
+    font-family: var(--serif);
+    font-weight: 400;
+    font-size: 1.5rem;
+    color: var(--fg);
+    margin: 0 0 0.4rem;
+    letter-spacing: -0.005em;
+  }
+  .section .section-sub {
+    color: var(--fg-muted);
+    font-size: 0.92rem;
+    margin: 0 0 1.25rem;
+  }
   .grid {
     display: grid;
     gap: 1.25rem;
@@ -117,12 +141,12 @@ const HTML = `<!doctype html>
     background: var(--card-bg);
     border: 1px solid var(--border);
     border-radius: 12px;
-    padding: 1.75rem;
+    padding: 1.5rem;
     text-decoration: none;
     color: inherit;
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.5rem;
     transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
     opacity: 0;
     animation: fadeUp 0.4s ease forwards;
@@ -131,46 +155,22 @@ const HTML = `<!doctype html>
   .card:nth-child(2) { animation-delay: 0.06s; }
   .card:nth-child(3) { animation-delay: 0.1s; }
   .card:nth-child(4) { animation-delay: 0.14s; }
-  .card:nth-child(5) { animation-delay: 0.18s; }
-  .card:nth-child(n+6) { animation-delay: 0.22s; }
   .card:hover {
     border-color: var(--accent-light);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
     transform: translateY(-2px);
   }
-  .card-head {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
-  .icon {
-    width: 2.25rem;
-    height: 2.25rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--accent-soft);
-    border-radius: 8px;
-    color: var(--accent);
-    font-size: 1.25rem;
-    flex-shrink: 0;
-    overflow: hidden;
-  }
-  .icon img, .icon svg {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-  }
   .card-title {
     font-family: var(--serif);
-    font-size: 1.5rem;
+    font-size: 1.4rem;
     font-weight: 400;
     margin: 0;
     line-height: 1.1;
+    color: var(--fg);
   }
-  .card-count {
+  .card-desc {
     color: var(--fg-muted);
-    font-size: 0.95rem;
+    font-size: 0.92rem;
     margin: 0;
     flex-grow: 1;
   }
@@ -178,7 +178,7 @@ const HTML = `<!doctype html>
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-top: 0.25rem;
+    margin-top: 0.5rem;
     font-size: 0.8rem;
     color: var(--fg-dim);
   }
@@ -186,14 +186,14 @@ const HTML = `<!doctype html>
     font-family: ui-monospace, 'SF Mono', Monaco, monospace;
     color: var(--fg-muted);
   }
-  .manage {
+  .arrow {
     color: var(--accent);
     font-weight: 500;
   }
   .empty, .error {
     text-align: center;
     color: var(--fg-muted);
-    padding: 3rem 1rem;
+    padding: 1.5rem 1rem;
     border: 1px dashed var(--border);
     border-radius: 12px;
   }
@@ -225,7 +225,7 @@ const HTML = `<!doctype html>
   }
   @media (max-width: 640px) {
     main { padding: 2.5rem 1rem 4rem; }
-    .card { padding: 1.5rem; }
+    .card { padding: 1.25rem; }
   }
 </style>
 </head>
@@ -235,144 +235,140 @@ const HTML = `<!doctype html>
     <h1>Parachute</h1>
     <p class="tagline">Your personal-computing modules.</p>
   </header>
-  <section id="modules" class="grid" aria-live="polite">
-    <div class="empty" id="loading">Loading modules\u2026</div>
+
+  <section class="section" id="use-section">
+    <h2>Use</h2>
+    <p class="section-sub">Browse, transcribe, and run — the everyday surfaces.</p>
+    <div class="grid" id="use-grid" aria-live="polite">
+      <div class="empty" id="use-loading">Loading…</div>
+    </div>
   </section>
+
+  <section class="section" id="admin-section">
+    <h2>Admin</h2>
+    <p class="section-sub">Manage this hub — vaults, permissions, tokens.</p>
+    <div class="grid" id="admin-grid"></div>
+  </section>
+
   <footer>
     <a href="/.well-known/parachute.json">discovery</a>
   </footer>
 </main>
 <script>
 (async () => {
-  const root = document.getElementById('modules');
-  const fallbackIcon = \`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="9"/></svg>\`;
+  const useGrid = document.getElementById('use-grid');
+  const adminGrid = document.getElementById('admin-grid');
 
-  // Display order for known module types. Unknown short-names append after,
-  // so a third-party module mounted at /foo still gets a tile.
-  const MODULE_ORDER = ['vault', 'scribe', 'notes', 'agent'];
-  const MODULE_LABELS = {
-    vault: 'Vault',
-    scribe: 'Scribe',
-    notes: 'Notes',
-    agent: 'Agent',
+  // Use entries: per-service primary affordances. Hardcoded short→label map;
+  // path is derived from services.json so custom mounts still work.
+  // Vault deliberately omitted — its content is browsed via Notes (which
+  // is its own entry below). Operators provision/admin vaults from the
+  // /admin/vaults card in the Admin section.
+  const USE_LABELS = {
+    notes:  { title: 'Browse notes', desc: 'Open the Notes PWA over your vault.' },
+    scribe: { title: 'Transcribe audio', desc: 'Send audio to Scribe.' },
+    agent:  { title: 'Run agents', desc: 'Open the Agent runtime.' },
   };
+  const USE_ORDER = ['notes', 'scribe', 'agent'];
 
-  function isVaultName(name) {
-    return name === 'parachute-vault' || name.startsWith('parachute-vault-');
-  }
+  // Admin entries: always visible. Even a fresh hub with zero vaults wants
+  // the operator to find /admin/vaults. Hardcoded — they live in the
+  // hub-served SPA, not in services.json.
+  const ADMIN_ENTRIES = [
+    { title: 'Vaults', desc: 'Create and manage vaults on this hub.', href: '/admin/vaults' },
+    { title: 'Permissions', desc: 'OAuth consent grants per app.', href: '/admin/permissions' },
+    { title: 'Tokens', desc: 'Mint and revoke access tokens.', href: '/admin/tokens' },
+  ];
 
   function shortName(manifestName) {
     return manifestName.replace(/^parachute-/, '');
   }
 
-  function labelFor(type) {
-    if (MODULE_LABELS[type]) return MODULE_LABELS[type];
-    return type.charAt(0).toUpperCase() + type.slice(1);
+  function isVaultName(name) {
+    return name === 'parachute-vault' || name.startsWith('parachute-vault-');
   }
 
-  // Aggregate services + vaults into one entry per module type. Vault is
-  // special-cased because its count comes from doc.vaults[] (one entry per
-  // vault instance / mount path) and its manage link goes to the hub's
-  // per-vault SPA at /vault — not to any single vault backend.
-  function aggregate(services, vaults) {
-    const groups = new Map();
-    if (vaults.length > 0) {
-      groups.set('vault', {
-        type: 'vault',
-        label: 'Vault',
-        count: vaults.length,
-        manageUrl: '/vault',
-      });
-    }
-    for (const svc of services) {
-      if (isVaultName(svc.name)) continue;
-      const t = shortName(svc.name);
-      const existing = groups.get(t);
-      if (existing) {
-        existing.count += 1;
-      } else {
-        groups.set(t, {
-          type: t,
-          label: labelFor(t),
-          count: 1,
-          manageUrl: svc.path,
-        });
-      }
-    }
-    return groups;
-  }
-
-  function tilesInOrder(groups) {
-    const out = [];
-    for (const t of MODULE_ORDER) {
-      const g = groups.get(t);
-      if (g) out.push(g);
-    }
-    const known = new Set(MODULE_ORDER);
-    const extras = [...groups.values()]
-      .filter((g) => !known.has(g.type))
-      .sort((a, b) => a.type.localeCompare(b.type));
-    return out.concat(extras);
-  }
-
-  function renderTile(group) {
+  function renderTile({ title, desc, href }) {
     const a = document.createElement('a');
     a.className = 'card';
-    a.href = group.manageUrl;
+    a.href = href;
 
-    const head = document.createElement('div');
-    head.className = 'card-head';
+    const t = document.createElement('h3');
+    t.className = 'card-title';
+    t.textContent = title;
+    a.appendChild(t);
 
-    const icon = document.createElement('div');
-    icon.className = 'icon';
-    icon.innerHTML = fallbackIcon;
-
-    const title = document.createElement('h2');
-    title.className = 'card-title';
-    title.textContent = group.label;
-
-    head.appendChild(icon);
-    head.appendChild(title);
-    a.appendChild(head);
-
-    const count = document.createElement('p');
-    count.className = 'card-count';
-    count.textContent = group.count === 1 ? '1 registered' : group.count + ' registered';
-    a.appendChild(count);
+    const d = document.createElement('p');
+    d.className = 'card-desc';
+    d.textContent = desc;
+    a.appendChild(d);
 
     const meta = document.createElement('div');
     meta.className = 'card-meta';
     const path = document.createElement('span');
     path.className = 'path';
-    path.textContent = group.manageUrl;
-    const manage = document.createElement('span');
-    manage.className = 'manage';
-    manage.textContent = 'Manage \u2192';
+    path.textContent = href;
+    const arrow = document.createElement('span');
+    arrow.className = 'arrow';
+    arrow.textContent = '→';
     meta.appendChild(path);
-    meta.appendChild(manage);
+    meta.appendChild(arrow);
     a.appendChild(meta);
 
     return a;
   }
+
+  function renderAdmin() {
+    adminGrid.innerHTML = '';
+    for (const entry of ADMIN_ENTRIES) {
+      adminGrid.appendChild(renderTile(entry));
+    }
+  }
+
+  function renderUse(services) {
+    // Group services by short type. Multiple instances of the same type
+    // (e.g. two scribes) collapse into one Use entry pointing at the first
+    // — operators with that posture will know which one they meant.
+    // Vault entries are skipped per the comment above.
+    const byType = new Map();
+    for (const svc of services) {
+      if (isVaultName(svc.name)) continue;
+      const t = shortName(svc.name);
+      if (!byType.has(t)) byType.set(t, svc.path);
+    }
+
+    const tiles = [];
+    for (const t of USE_ORDER) {
+      const path = byType.get(t);
+      if (!path) continue;
+      const labels = USE_LABELS[t];
+      tiles.push({ title: labels.title, desc: labels.desc, href: path });
+    }
+
+    useGrid.innerHTML = '';
+    if (tiles.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'empty';
+      empty.innerHTML = 'No services installed yet. Try <code>parachute install vault</code>.';
+      useGrid.appendChild(empty);
+      return;
+    }
+    for (const tile of tiles) useGrid.appendChild(renderTile(tile));
+  }
+
+  // Admin section is static — render synchronously so the operator sees it
+  // even if the well-known fetch is slow or fails.
+  renderAdmin();
 
   try {
     const wk = await fetch('/.well-known/parachute.json', { credentials: 'omit' });
     if (!wk.ok) throw new Error('well-known fetch failed: ' + wk.status);
     const doc = await wk.json();
     const services = Array.isArray(doc.services) ? doc.services : [];
-    const vaults = Array.isArray(doc.vaults) ? doc.vaults : [];
-
-    const groups = aggregate(services, vaults);
-    const tiles = tilesInOrder(groups);
-
-    if (tiles.length === 0) {
-      root.innerHTML = '<div class="empty">No modules installed yet. Try <code>parachute install vault</code>.</div>';
-      return;
-    }
-    root.innerHTML = '';
-    for (const g of tiles) root.appendChild(renderTile(g));
+    renderUse(services);
   } catch (err) {
-    root.innerHTML = '<div class="error">Could not load modules: ' + (err && err.message ? err.message : String(err)) + '</div>';
+    useGrid.innerHTML = '<div class="error">Could not load services: ' +
+      (err && err.message ? err.message : String(err)) + '</div>';
   }
 })();
 </script>

--- a/web/ui/scripts/verify-base.mjs
+++ b/web/ui/scripts/verify-base.mjs
@@ -1,8 +1,9 @@
 // Regression check mirroring paraclaw's verify-base: the canonical-mount
-// default build must produce asset URLs prefixed with `/vault/`. If
-// `vite.config.ts`'s `base` ever drifts back to `/` or to the old `/hub/`,
-// the bundle HTML loses the right prefix and assets 404 under the SPA mount —
-// the same silent failure paraclaw#25 codified in mount-path-convention.md.
+// default build must produce asset URLs prefixed with `/admin/`. If
+// `vite.config.ts`'s `base` ever drifts back to `/` or to the old `/vault/` /
+// `/hub/`, the bundle HTML loses the right prefix and assets 404 under the
+// SPA mount — the same silent failure paraclaw#25 codified in
+// mount-path-convention.md.
 //
 // Skipped when VITE_BASE_PATH is set explicitly (legitimate override).
 
@@ -10,21 +11,21 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const override = process.env.VITE_BASE_PATH;
-if (override && override !== "/vault/") {
+if (override && override !== "/admin/") {
   console.log(`verify-base: VITE_BASE_PATH=${override} (override) — skipping default-mount check.`);
   process.exit(0);
 }
 
 const html = readFileSync(resolve("dist/index.html"), "utf8");
-const wantPrefix = "/vault/assets/";
+const wantPrefix = "/admin/assets/";
 const hasMounted = html.includes(`src="${wantPrefix}`) || html.includes(`href="${wantPrefix}`);
 if (!hasMounted) {
   console.error(
-    "✖ verify-base: dist/index.html is missing /vault/-prefixed asset URLs.\n" +
-      "  This means vite's `base` resolved to something other than `/vault/`.\n" +
-      "  Check web/ui/vite.config.ts (default should be `/vault/`) and any\n" +
+    "✖ verify-base: dist/index.html is missing /admin/-prefixed asset URLs.\n" +
+      "  This means vite's `base` resolved to something other than `/admin/`.\n" +
+      "  Check web/ui/vite.config.ts (default should be `/admin/`) and any\n" +
       "  VITE_BASE_PATH env var leaking into the build environment.",
   );
   process.exit(1);
 }
-console.log("verify-base: ✓ dist/index.html references /vault/-prefixed assets.");
+console.log("verify-base: ✓ dist/index.html references /admin/-prefixed assets.");

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -1,84 +1,79 @@
 /**
- * App-level smoke tests — brand subtitle reflects the active mount; nav
- * has the right groups + dividers.
+ * App-level smoke tests — brand subtitle reflects the active route; nav
+ * has the right groups + dividers; routes render the expected components.
  *
- * Note: `isHubMount` is computed at module-load time from
- * `window.location.pathname`. To test both branches we re-import the
- * module after mutating jsdom's location. Vitest's `vi.resetModules()`
- * + dynamic import gives us a fresh evaluation per test.
+ * Subtitle is now derived from the router's pathname (via `useLocation`),
+ * so tests drive route changes via `MemoryRouter`'s `initialEntries` —
+ * no `window.location` munging needed.
  */
 import { render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-afterEach(() => {
-  vi.resetModules();
+import { App } from "./App.tsx";
+import type * as api from "./lib/api.ts";
+
+// Stub all API helpers — App pulls in VaultsList / Permissions / Tokens
+// at module-load time, and each of those calls into lib/api.ts on mount.
+// Without stubs, jsdom would attempt real fetches and the route tests
+// would race against unmounted state.
+vi.mock("./lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    listVaults: vi.fn().mockResolvedValue([]),
+    listGrants: vi.fn().mockResolvedValue([]),
+    listTokens: vi.fn().mockResolvedValue({ tokens: [], next_cursor: null }),
+  };
 });
 
-async function renderAtPath(pathname: string) {
-  // jsdom's `window.location` is read-only via assignment; replace via
-  // `Object.defineProperty` so the module sees the new pathname when
-  // re-evaluated.
-  Object.defineProperty(window, "location", {
-    value: { ...window.location, pathname },
-    writable: true,
-  });
-  vi.resetModules();
-  const { App } = await import("./App.tsx");
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function renderAt(pathname: string) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={[pathname]}>
       <App />
     </MemoryRouter>,
   );
 }
 
-describe("App — brand subtitle", () => {
-  it("/vault* renders 'vault provisioning'", async () => {
-    await renderAtPath("/vault");
-    expect(screen.getByText(/vault provisioning/i)).toBeInTheDocument();
-    expect(screen.queryByText(/host admin/i)).toBeNull();
+describe("App — brand subtitle (route-derived)", () => {
+  it("/vaults renders 'vaults'", () => {
+    renderAt("/vaults");
+    expect(screen.getByText(/vaults/i, { selector: ".sub" })).toBeInTheDocument();
   });
 
-  it("/vault/new also renders 'vault provisioning'", async () => {
-    await renderAtPath("/vault/new");
-    expect(screen.getByText(/vault provisioning/i)).toBeInTheDocument();
+  it("/vaults/new renders 'vaults' (sub-route still under vaults)", () => {
+    renderAt("/vaults/new");
+    expect(screen.getByText(/vaults/i, { selector: ".sub" })).toBeInTheDocument();
   });
 
-  it("/hub* renders 'host admin'", async () => {
-    await renderAtPath("/hub/tokens");
-    expect(screen.getByText(/host admin/i)).toBeInTheDocument();
-    expect(screen.queryByText(/vault provisioning/i)).toBeNull();
+  it("/permissions renders 'permissions'", () => {
+    renderAt("/permissions");
+    expect(screen.getByText(/permissions/i, { selector: ".sub" })).toBeInTheDocument();
   });
 
-  it("/hub/permissions also renders 'host admin'", async () => {
-    await renderAtPath("/hub/permissions");
-    expect(screen.getByText(/host admin/i)).toBeInTheDocument();
+  it("/tokens renders 'tokens'", () => {
+    renderAt("/tokens");
+    expect(screen.getByText(/tokens/i, { selector: ".sub" })).toBeInTheDocument();
   });
 
-  // Bare `/hub` path — `isHubMount` explicitly handles this case alongside
-  // `pathname.startsWith("/hub/")`. Pinning here so a future change to the
-  // detection that breaks the bare-prefix path can't slip through.
-  it("/hub (bare path, no trailing route) also renders 'host admin'", async () => {
-    await renderAtPath("/hub");
-    expect(screen.getByText(/host admin/i)).toBeInTheDocument();
-    expect(screen.queryByText(/vault provisioning/i)).toBeNull();
-  });
-
-  it("origin root falls back to vault-provisioning subtitle", async () => {
-    await renderAtPath("/");
-    expect(screen.getByText(/vault provisioning/i)).toBeInTheDocument();
+  it("origin root (/) falls back to 'vaults' (the SPA's home)", () => {
+    renderAt("/");
+    expect(screen.getByText(/vaults/i, { selector: ".sub" })).toBeInTheDocument();
   });
 });
 
 describe("App — nav structure", () => {
-  it("renders all four nav links in order: Vaults, Permissions, Tokens, Discovery", async () => {
-    await renderAtPath("/vault");
+  it("renders all nav links in order: brand, Vaults, Permissions, Tokens, Discovery", () => {
+    renderAt("/vaults");
     const nav = screen.getByRole("navigation");
     const links = within(nav).getAllByRole("link");
-    // Brand link is index 0; the four nav items follow.
     const labels = links.map((a) => a.textContent?.trim());
     expect(labels).toEqual([
-      expect.stringMatching(/parachute hub/i),
+      expect.stringMatching(/parachute admin/i),
       "Vaults",
       "Permissions",
       "Tokens",
@@ -86,15 +81,59 @@ describe("App — nav structure", () => {
     ]);
   });
 
-  it("renders two visual dividers between nav groups", async () => {
-    const { container } = await renderAtPath("/vault");
-    // Two `.nav-divider` spans: one between Vaults and Permissions, one
-    // between Tokens and Discovery. aria-hidden so screen readers skip
-    // them as decorative.
+  it("renders one visual divider between SPA-internal links and Discovery", () => {
+    // Single mount = single SPA section. The remaining divider separates
+    // in-SPA `<Link>` nav from the cross-mount Discovery `<a href>` (which
+    // leaves the SPA basename).
+    const { container } = renderAt("/vaults");
     const dividers = container.querySelectorAll(".nav-divider");
-    expect(dividers).toHaveLength(2);
+    expect(dividers).toHaveLength(1);
     for (const d of dividers) {
       expect(d.getAttribute("aria-hidden")).toBe("true");
     }
+  });
+
+  it("brand label is 'Parachute Admin' (renamed from 'Parachute Hub' in #231)", () => {
+    renderAt("/vaults");
+    expect(screen.getByText(/parachute admin/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^parachute hub/i)).toBeNull();
+  });
+});
+
+describe("App — route rendering", () => {
+  it("/vaults renders VaultsList (heading 'Vaults')", async () => {
+    renderAt("/vaults");
+    expect(await screen.findByRole("heading", { name: /^vaults/i })).toBeInTheDocument();
+  });
+
+  it("/vaults/new renders NewVault (form input for vault name)", () => {
+    renderAt("/vaults/new");
+    // NewVault's form has a name input — surfaces immediately on mount.
+    expect(screen.getByLabelText(/vault name/i)).toBeInTheDocument();
+  });
+
+  it("/permissions renders Permissions (heading 'Permissions')", () => {
+    renderAt("/permissions");
+    expect(screen.getByRole("heading", { name: /^permissions$/i })).toBeInTheDocument();
+  });
+
+  it("/tokens renders Tokens (heading 'Tokens')", () => {
+    renderAt("/tokens");
+    expect(screen.getByRole("heading", { name: /^tokens$/i })).toBeInTheDocument();
+  });
+
+  it("origin root (/) renders VaultsList (the SPA's home)", async () => {
+    renderAt("/");
+    expect(await screen.findByRole("heading", { name: /^vaults/i })).toBeInTheDocument();
+  });
+
+  it("unknown path renders 404 with link back to vaults", () => {
+    renderAt("/this-does-not-exist");
+    const empty = screen.getByText(/404/).closest(".empty");
+    expect(empty).not.toBeNull();
+    // Scope the link query to the 404 body — the brand link in the nav
+    // also matches /vaults/i and would otherwise multi-match.
+    const backLink = within(empty as HTMLElement).getByRole("link", { name: /vaults/i });
+    expect(backLink).toHaveAttribute("href", "/vaults");
   });
 });

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,90 +1,80 @@
 /**
- * Parachute Hub admin SPA.
+ * Parachute Admin SPA.
  *
- * This bundle is the operator-facing browser UI for the **hub**. Two
- * concerns live under one roof, served at two mounts on the same hub:
+ * Hub-served browser UI for cross-cutting host concerns:
  *
- *   - **`/vault/*`** — vault provisioning. Lists every vault registered
- *     with the hub (`/.well-known/parachute.json`); operators create new
- *     vaults via `/vault/new`. This is NOT a per-vault admin UI; vaults
- *     own their own surfaces (the MCP endpoint for AI clients, the Notes
- *     PWA for human content browsing). Per-vault admin (config, schemas)
- *     doesn't have a hub-served UI today; if/when it does, it'll be
- *     vault-served — analogous to how the agent has its own admin.
+ *   - **`/admin/vaults`** — vault provisioning. List + create. Per-vault
+ *     content (the Notes PWA, etc.) lives at `/vault/<name>/*` and is NOT
+ *     part of this SPA — vaults own their own user-facing surfaces.
+ *   - **`/admin/permissions`** — OAuth consent grant management.
+ *   - **`/admin/tokens`** — token registry: mint, list, revoke.
  *
- *   - **`/hub/*`** — cross-cutting host concerns. `/hub/permissions`
- *     manages the OAuth consent skip-list; `/hub/tokens` manages the
- *     hub's token registry (mint / list / revoke). These are operator
- *     state about the hub itself, not about any single vault.
+ * Single mount at `/admin/*` (as of hub#231). The prior dual mounts
+ * (`/vault` for the vault SPA, `/hub/*` for permissions+tokens) are
+ * 301-redirected in `hub-server.ts` so cached URLs keep working.
  *
- * The active mount picks the route table — we don't render every route
- * under both basenames since the concerns are unrelated. Cross-mount
- * navigation uses plain `<a href>` because react-router's `<Link>`
- * resolves against the active basename.
+ * Cross-surface navigation off the SPA (e.g. to `/` or `/vault/<name>/`)
+ * uses plain `<a href>` since react-router's `<Link>` resolves against
+ * the SPA basename.
  *
- * The brand subtitle reflects the active mount so an operator who lands
- * deep in either tree knows which surface they're on.
+ * The discovery page at `/` (see `src/hub.ts`) is the operator's
+ * entry point — its Use section links to per-service surfaces; its
+ * Admin section links here.
  */
-import { Link, Route, Routes } from "react-router-dom";
+import { Link, Route, Routes, useLocation } from "react-router-dom";
 import { NewVault } from "./routes/NewVault.tsx";
 import { Permissions } from "./routes/Permissions.tsx";
 import { Tokens } from "./routes/Tokens.tsx";
 import { VaultsList } from "./routes/VaultsList.tsx";
 
-const isHubMount =
-  typeof window !== "undefined" &&
-  (window.location.pathname === "/hub" || window.location.pathname.startsWith("/hub/"));
-
-const subtitle = isHubMount ? "host admin" : "vault provisioning";
+/**
+ * Subtitle reflects the active route's section so a deep-link operator
+ * knows where they are without reading the URL bar. Updates on
+ * client-side navigation via the router's pathname.
+ */
+function subtitleFor(pathname: string): string {
+  if (pathname === "/permissions" || pathname.startsWith("/permissions/")) {
+    return "permissions";
+  }
+  if (pathname === "/tokens" || pathname.startsWith("/tokens/")) {
+    return "tokens";
+  }
+  return "vaults";
+}
 
 export function App() {
+  const { pathname } = useLocation();
+  const subtitle = subtitleFor(pathname);
+
   return (
     <div className="page">
       <nav className="nav">
-        <a href="/vault" className="brand">
-          Parachute Hub <span className="sub">{subtitle}</span>
-        </a>
-        {/* Group 1 — vault provisioning (lives under /vault). */}
-        <a href="/vault">Vaults</a>
+        <Link to="/vaults" className="brand">
+          Parachute Admin <span className="sub">{subtitle}</span>
+        </Link>
+        <Link to="/vaults">Vaults</Link>
+        <Link to="/permissions">Permissions</Link>
+        <Link to="/tokens">Tokens</Link>
         <span className="nav-divider" aria-hidden="true" />
-        {/* Group 2 — host admin (lives under /hub). */}
-        <a href="/hub/permissions">Permissions</a>
-        <a href="/hub/tokens">Tokens</a>
-        <span className="nav-divider" aria-hidden="true" />
-        {/* Group 3 — top-level: the public discovery page at /. */}
         <a href="/" title="Hub discovery page (top-level)">
           Discovery
         </a>
       </nav>
 
       <Routes>
-        {isHubMount ? (
-          <>
-            <Route path="/permissions" element={<Permissions />} />
-            <Route path="/tokens" element={<Tokens />} />
-            <Route
-              path="*"
-              element={
-                <div className="empty">
-                  404 — back to <a href="/vault">vaults</a>.
-                </div>
-              }
-            />
-          </>
-        ) : (
-          <>
-            <Route path="/" element={<VaultsList />} />
-            <Route path="/new" element={<NewVault />} />
-            <Route
-              path="*"
-              element={
-                <div className="empty">
-                  404 — back to <Link to="/">vaults</Link>.
-                </div>
-              }
-            />
-          </>
-        )}
+        <Route path="/" element={<VaultsList />} />
+        <Route path="/vaults" element={<VaultsList />} />
+        <Route path="/vaults/new" element={<NewVault />} />
+        <Route path="/permissions" element={<Permissions />} />
+        <Route path="/tokens" element={<Tokens />} />
+        <Route
+          path="*"
+          element={
+            <div className="empty">
+              404 — back to <Link to="/vaults">vaults</Link>.
+            </div>
+          }
+        />
       </Routes>
     </div>
   );

--- a/web/ui/src/main.tsx
+++ b/web/ui/src/main.tsx
@@ -7,17 +7,15 @@ import "./styles.css";
 const root = document.getElementById("root");
 if (!root) throw new Error("#root not found");
 
-// Dual-mount basename detection. The SPA serves at /vault (primary, since
-// hub#168-realignment) and /hub (back-compat for /hub/permissions). The
-// bundle is identical at both — `import.meta.env.BASE_URL` points at the
-// build base (/vault/) regardless of which mount served us — but react-
-// router needs the *runtime* mount so <Link to="/"> resolves under the
-// right one. Without this, a user landing at /hub/permissions would have
-// the router try to strip /vault from a /hub URL and refuse to render.
+// Single-mount basename detection. As of hub#231 the admin SPA mounts at
+// /admin/* exclusively — the prior /vault and /hub mounts are 301-redirected
+// in `hub-server.ts` so any cached operator URL keeps working. react-router
+// needs the *runtime* basename so <Link to="/vaults"> resolves to
+// /admin/vaults; without this it would try to navigate to /vaults at the
+// origin root and 404.
 function detectBasename(): string {
   const path = window.location.pathname;
-  if (path === "/hub" || path.startsWith("/hub/")) return "/hub";
-  if (path === "/vault" || path.startsWith("/vault/")) return "/vault";
+  if (path === "/admin" || path.startsWith("/admin/")) return "/admin";
   // Stand-alone dev served at origin root (VITE_BASE_PATH=/).
   return "";
 }

--- a/web/ui/src/routes/NewVault.tsx
+++ b/web/ui/src/routes/NewVault.tsx
@@ -120,7 +120,7 @@ export function NewVault() {
           >
             {state.kind === "submitting" ? "Creating…" : "Create vault"}
           </button>
-          <Link to="/" className="muted">
+          <Link to="/vaults" className="muted">
             Cancel
           </Link>
         </div>

--- a/web/ui/src/routes/VaultsList.test.tsx
+++ b/web/ui/src/routes/VaultsList.test.tsx
@@ -57,7 +57,10 @@ describe("VaultsList", () => {
     vi.mocked(api.listVaults).mockResolvedValue([]);
     renderList();
     await waitFor(() => expect(screen.getByText(/no vaults yet/i)).toBeInTheDocument());
-    expect(screen.getByRole("link", { name: /create a vault/i })).toHaveAttribute("href", "/new");
+    expect(screen.getByRole("link", { name: /create a vault/i })).toHaveAttribute(
+      "href",
+      "/vaults/new",
+    );
   });
 
   it("renders one row per vault with name + version + URL", async () => {

--- a/web/ui/src/routes/VaultsList.tsx
+++ b/web/ui/src/routes/VaultsList.tsx
@@ -98,7 +98,7 @@ export function VaultsList() {
       <div>
         <div className="list-header">
           <h2>Vaults</h2>
-          <Link to="/new">
+          <Link to="/vaults/new">
             <button type="button">New vault</button>
           </Link>
         </div>
@@ -116,7 +116,7 @@ export function VaultsList() {
     <div>
       <div className="list-header">
         <h2>Vaults ({state.vaults.length})</h2>
-        <Link to="/new">
+        <Link to="/vaults/new">
           <button type="button">New vault</button>
         </Link>
       </div>
@@ -132,7 +132,7 @@ export function VaultsList() {
             Create your first vault to start storing tokens, secrets, and notes scoped to this hub.
           </p>
           <p style={{ marginTop: "0.75rem" }}>
-            <Link to="/new">Create a vault →</Link>
+            <Link to="/vaults/new">Create a vault →</Link>
           </p>
         </div>
       ) : (

--- a/web/ui/vite.config.ts
+++ b/web/ui/vite.config.ts
@@ -1,13 +1,12 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
-// The hub mounts this SPA at `/vault/` (primary, since hub#168-realignment) and
-// keeps `/hub/` mounted for back-compat (`/hub/permissions` lives there). Asset
-// URLs are origin-absolute and resolve under `/vault/assets/...` regardless of
-// which mount served the HTML — the same drift paraclaw#25 hit when its base
-// was `/`. Override with `VITE_BASE_PATH=/` for stand-alone dev served at the
-// origin root.
-const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/vault/");
+// As of hub#231 the hub mounts this SPA at `/admin/` exclusively. Asset URLs
+// are origin-absolute and resolve under `/admin/assets/...`; pre-rename
+// `/vault` and `/hub/*` paths are 301-redirected by `hub-server.ts` so cached
+// operator URLs keep working. Override with `VITE_BASE_PATH=/` for stand-alone
+// dev served at the origin root.
+const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/admin/");
 
 function normalizeBase(input: string): string {
   let b = input.startsWith("/") ? input : `/${input}`;
@@ -21,11 +20,35 @@ export default defineConfig({
   server: {
     port: 5174,
     proxy: {
-      // Dev server runs under /vault/ to mirror the production mount. The hub's
-      // admin + vault API lives at the origin root (/admin/*, /vaults,
-      // /.well-known/*) so we only proxy those exact prefixes — everything
-      // else falls through to the SPA's static assets.
-      "/admin": {
+      // Dev server runs under /admin/ to mirror the production mount. The hub
+      // serves a few non-SPA paths under the same prefix (`/admin/login`,
+      // `/admin/host-admin-token`, etc.) and the vault APIs at the origin root
+      // (`/vaults`, `/.well-known/*`). Proxy those to the running hub so the
+      // dev SPA hits real auth + data instead of 404ing on every fetch.
+      //
+      // Exact-prefix proxying for /admin/login and friends — but NOT a blanket
+      // /admin proxy, which would steal the SPA's own /admin/vaults route.
+      "/admin/login": {
+        target: process.env.HUB_ORIGIN ?? "http://127.0.0.1:1939",
+        changeOrigin: true,
+      },
+      "/admin/logout": {
+        target: process.env.HUB_ORIGIN ?? "http://127.0.0.1:1939",
+        changeOrigin: true,
+      },
+      "/admin/host-admin-token": {
+        target: process.env.HUB_ORIGIN ?? "http://127.0.0.1:1939",
+        changeOrigin: true,
+      },
+      "/admin/vault-admin-token": {
+        target: process.env.HUB_ORIGIN ?? "http://127.0.0.1:1939",
+        changeOrigin: true,
+      },
+      "/admin/config": {
+        target: process.env.HUB_ORIGIN ?? "http://127.0.0.1:1939",
+        changeOrigin: true,
+      },
+      "/api": {
         target: process.env.HUB_ORIGIN ?? "http://127.0.0.1:1939",
         changeOrigin: true,
       },


### PR DESCRIPTION
## Summary

Holistic restructure of the integrated hub experience after Aaron's "clicked Vault on discovery, took me to hub management — there's confusion between use vs admin" friction.

Three coupled pieces in one PR — they only land coherently together (the discovery page links at the new `/admin/*` routes; the SPA mount is what the redirects target; the redirects exist because of the SPA mount move).

Closes #231.

## Three pieces

### 1. Discovery page (`/`) — Use vs Admin

`src/hub.ts` rewritten. Two `<section>`s with their own `<h2>`:

- **Use** — per-service primary affordances. Hardcoded labels (Browse notes / Transcribe audio / Run agents), path derived from `services.json` (so custom mounts still work). Only installed services appear. **Vault deliberately omitted** — its content is browsed via Notes (which is its own entry); a separate Vault tile would just send the operator to admin, which is exactly the friction Aaron flagged.
- **Admin** — hardcoded, always visible: Vaults (`/admin/vaults`), Permissions (`/admin/permissions`), Tokens (`/admin/tokens`). Renders synchronously so the operator sees admin even if the well-known fetch is slow.

`hub.test.ts` rewritten for the new shape (15 tests).

### 2. Route rename: `/admin/*` (closes #231)

| Old | New |
|---|---|
| `/vault` (SPA shell — vault list) | `/admin/vaults` |
| `/vault/new` | `/admin/vaults/new` |
| `/hub/permissions` | `/admin/permissions` |
| `/hub/tokens` | `/admin/tokens` |

- **Vite base** flipped `/vault/` → `/admin/`. Assets at `/admin/assets/*`. `verify-base.mjs` updated.
- **Per-prefix dev proxies** for `/admin/login`, `/admin/host-admin-token`, `/admin/vault-admin-token`, `/admin/config`, `/admin/logout`, `/api` — explicit list, NOT a blanket `/admin` proxy (which would steal SPA routes).
- **`main.tsx`** simplified to single-basename detection (`/admin`).
- **`App.tsx`** restructured: brand "Parachute Hub" → "Parachute Admin"; subtitle route-derived via `useLocation`; routes `/`, `/vaults`, `/vaults/new`, `/permissions`, `/tokens`. Single nav-divider (between SPA-internal `<Link>` nav and the cross-mount Discovery `<a href>`).
- **`VaultsList` + `NewVault`** `<Link>` paths updated.
- **`hub-server.ts`**: added `/admin/*` SPA mount at end of dispatch (after all `/admin/<known-handler>` API routes); removed old `/hub/*` SPA mount and `/vault` exact + `/vault/<unknown>` SPA-shell fallback.

### 3. 301 back-compat redirects

Every pre-rename SPA URL has a permanent redirect so cached operator URLs keep working:

```
/vault           → /admin/vaults
/vault/new       → /admin/vaults/new
/hub/vaults*     → /admin/vaults*    (retargeted from interim /vault)
/hub/permissions → /admin/permissions
/hub/tokens      → /admin/tokens
/hub (bare)      → /admin/vaults
```

All preserve query strings; method-agnostic (no POST endpoint at any of these paths). `/vault/<name>/*` (per-vault content proxy) is **intentionally unchanged** — that's user-facing vault data (Notes PWA loads through there), not the admin SPA.

## Three decisions worth a reviewer eyeball

1. **`/hub` bare → `/admin/vaults`** (not `/admin`). Skip the unhelpful intermediate; `/admin` itself just aliases the vaults page. If we ever want a separate `/admin` landing page, easy to add then.
2. **Brand link target → `/vaults`**. When you're on `/permissions` and click "Parachute Admin", you go to `/vaults`. Vaults is the canonical SPA home.
3. **Pre-rename `/vault/<unknown>` SPA-shell fallback removed → 404s directly.** Under the prior shape, an unregistered vault name fell through to the SPA shell (which would client-side render a 404). Now it 404s at the wire. Behavior change is intentional per the new dispatch shape; no operator workflow relied on the SPA-shell fallback.

## Versioning

- `package.json`: `0.5.8-rc.10` → `0.5.8-rc.11`.
- CHANGELOG entry under `## [0.5.8-rc.11] - 2026-05-10` framing as holistic restructure.

## Test plan

- [x] hub `bun test ./src`: **1199 pass / 0 fail** (was 1194; +5 net — 9 new redirect/SPA-mount tests, retired the pre-rename `/vault` and `/hub/*` SPA tests).
- [x] web/ui `bun run test`: **83 pass / 0 fail** (was 77; +6 across rewritten `App.test.tsx` — uses `MemoryRouter`'s `initialEntries` now since subtitle is router-derived, no more `Object.defineProperty(window.location, ...)` dance).
- [x] typecheck (both packages): clean.
- [x] biome: clean.
- [x] UI build + `verify-base`: clean (asserts `/admin/`-prefixed asset URLs).

## Patterns check

- **Mount-aware routing pattern preserved** — single mount now, but the basename-detection seam in `main.tsx` is the same shape; future cross-mount work has a clear extension point.
- **`/hub` denylist comment in `hub-server.ts`** updated to call out that the `/hub/*` SPA mount is gone — known prefixes 301, unknown `/hub/*` 404s.
- **Discovery page CSS reused** — same `.card` / animation / palette tokens; `.section` and `.section-sub` are the only new classes (small, scoped, mirror existing `--border` / `--fg-muted` tokens).
- **No new design system** — all UI changes use existing classes from `web/ui/src/styles.css` and the discovery page's existing inline CSS.
- **RC versioning** — `rc.10` → `rc.11` per parachute-patterns/governance.md.

## Out of scope

- Module.json `useUrl` / `adminUrl` fields (cross-repo work; future Phase 2 follow-up).
- Vault-side per-instance admin UI (filed as vault#283).
- Discovery functionality beyond Use/Admin split (status pills, real-time health) — Phase 3 if anyone wants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)