### PR TITLE
feat(hub): relabel discovery 'Services' + rename /admin/login → /login (auth UX cleanup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.8-rc.12] - 2026-05-10
+
+Auth-UX cleanup, A/B of an A+B+C bundle (C — signed-in indicator via `/api/me` — lands separately as rc.13). Two changes addressing surface-naming friction Aaron raised after rc.11:
+
+### Changed
+
+- **Discovery page sections relabeled `Use` → `Services`.** The Use/Admin axis was a function split (use vs admin) that broke down once you noticed real services have UIs that mix use, config, and admin together. The cleaner cut is **ownership** (services own their UIs vs hub owns host admin). Heading and sub-text updated to reflect that — sub-text is now "Surfaces provided by services running on this hub." Per-service entry labels also tightened: "Browse notes" → "Notes" (and similarly for Scribe/Agent), with a one-line desc that says what the service does. Vault stays excluded from Services for the same reason as rc.11 (its content is browsed via Notes; provisioning lives under Admin).
+- **Login + logout surface rename: `/admin/login` → `/login`, `/admin/logout` → `/logout`.** The `/admin/` prefix read as "admin-only" but the handlers serve every parachute auth flow — operator login, OAuth user redirect, the future SPA sign-in. Renaming makes the URL match the surface's actual scope. Old paths 301-redirect to the new ones (with query-string preservation for `?next=…`) so cached operator URLs and OAuth-flow `next=` redirects keep working.
+
+### Added
+
+- **301 redirects** for the renamed login surface: `/admin/login → /login`, `/admin/logout → /logout`. Preserve `?next=…` query strings for the OAuth and operator-bookmark cases.
+
+### Updated to match the rename
+
+- `loginRedirect` (the unauthenticated-admin-page redirect target) now points at `/login`.
+- `handleAdminLogoutPost` final destination now redirects to `/login`.
+- Login form `action` in `admin-config-ui.ts` now POSTs to `/login`.
+- Error messages on the bearer-mint endpoints now say "sign in at /login".
+- Vite dev proxy entries for `/login` + `/logout` (was `/admin/login` + `/admin/logout`).
+- Comments in `rate-limit.ts`, `sessions.ts`, `scope-explanations.ts`, `admin-host-admin-token.ts`, `hub-server.ts` route-table.
+
+### Out of scope (rc.13)
+
+- **Signed-in indicator on hub-served surfaces.** Aaron's "signed in as X / sign out" affordance for the discovery page + admin SPA. The `/api/me` endpoint backing it is designed (per-session CSRF token included, both consumers source from one mental model) but ships in the next PR for focused review.
+
+### Test gate
+
+All test suites pass. New coverage in this PR:
+
+- `hub-server.test.ts` — 3 new redirect tests for `/admin/login → /login` (with and without `?next=…`) and `/admin/logout → /logout`.
+- `hub.test.ts` updated for the Services relabel — section heading, sub-text framing, per-entry labels, retired old "Use" assertions.
+- `admin-handlers.test.ts` updated for the `/login` final destination (logout redirect target + admin-config unauthenticated redirect target).
+
+Typecheck (both packages): clean. biome: clean.
+
+(Test-count numbers intentionally omitted — the canonical-vs-combined ambiguity is tracked at hub#219.)
+
 ## [0.5.8-rc.11] - 2026-05-10
 
 Holistic restructure of the integrated hub experience — the bigger redesign Aaron asked for after rc.10's small relabel ("clicked Vault on discovery, took me to hub management — there's confusion between use vs admin"). Discovery page split into Use / Admin; the admin SPA relocates to `/admin/*` with 301 redirects from the prior `/vault` and `/hub/*` mounts. Closes hub#231.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.8-rc.11",
+  "version": "0.5.8-rc.12",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/admin-handlers.test.ts
+++ b/src/__tests__/admin-handlers.test.ts
@@ -330,7 +330,7 @@ describe("handleAdminLogoutPost (#113)", () => {
     expect(res.headers.get("set-cookie")).toBeNull();
   });
 
-  test("clears session cookie, deletes session row, and redirects to /admin/login", async () => {
+  test("clears session cookie, deletes session row, and redirects to /login", async () => {
     const user = await createUser(harness.db, "admin", "pw");
     const session = createSession(harness.db, { userId: user.id });
     const cookie = `${CSRF_COOKIE}; ${buildSessionCookie(
@@ -338,14 +338,14 @@ describe("handleAdminLogoutPost (#113)", () => {
       Math.floor(SESSION_TTL_MS / 1000),
     )}`;
     const { body, headers } = formBody({ [CSRF_FIELD_NAME]: TEST_CSRF });
-    const req = new Request("http://hub.test/admin/logout", {
+    const req = new Request("http://hub.test/logout", {
       method: "POST",
       headers: { ...headers, cookie },
       body,
     });
     const res = await handleAdminLogoutPost(harness.db, req);
     expect(res.status).toBe(302);
-    expect(res.headers.get("location")).toBe("/admin/login");
+    expect(res.headers.get("location")).toBe("/login");
     const setCookie = res.headers.get("set-cookie") ?? "";
     expect(setCookie).toContain("parachute_hub_session=;");
     expect(setCookie).toContain("Max-Age=0");
@@ -354,24 +354,24 @@ describe("handleAdminLogoutPost (#113)", () => {
 
   test("idempotent — clears cookie even with no active session", async () => {
     const { body, headers } = formBody({ [CSRF_FIELD_NAME]: TEST_CSRF });
-    const req = new Request("http://hub.test/admin/logout", {
+    const req = new Request("http://hub.test/logout", {
       method: "POST",
       headers: { ...headers, cookie: CSRF_COOKIE },
       body,
     });
     const res = await handleAdminLogoutPost(harness.db, req);
     expect(res.status).toBe(302);
-    expect(res.headers.get("location")).toBe("/admin/login");
+    expect(res.headers.get("location")).toBe("/login");
     expect(res.headers.get("set-cookie") ?? "").toContain("parachute_hub_session=;");
   });
 });
 
 describe("handleAdminConfigGet", () => {
-  test("redirects unauthenticated requests to /admin/login", async () => {
+  test("redirects unauthenticated requests to /login", async () => {
     const req = new Request("http://hub.test/admin/config");
     const res = await handleAdminConfigGet(harness.db, req);
     expect(res.status).toBe(302);
-    expect(res.headers.get("location")).toBe("/admin/login?next=%2Fadmin%2Fconfig");
+    expect(res.headers.get("location")).toBe("/login?next=%2Fadmin%2Fconfig");
   });
 
   test("renders the empty-state when no module declares a configSchema", async () => {
@@ -426,7 +426,7 @@ describe("handleAdminConfigPost", () => {
     return formBody({ [CSRF_FIELD_NAME]: TEST_CSRF, ...values });
   }
 
-  test("redirects unauthenticated requests to /admin/login", async () => {
+  test("redirects unauthenticated requests to /login", async () => {
     const { body, headers } = postBody({ transcribe_provider: "openai" });
     const req = new Request("http://hub.test/admin/config/vault", {
       method: "POST",
@@ -439,7 +439,7 @@ describe("handleAdminConfigPost", () => {
       readManifest: fakeReadManifest,
     });
     expect(res.status).toBe(302);
-    expect(res.headers.get("location")).toContain("/admin/login");
+    expect(res.headers.get("location")).toContain("/login");
   });
 
   test("returns 400 when the CSRF token is wrong", async () => {

--- a/src/__tests__/expose-2fa-warning.test.ts
+++ b/src/__tests__/expose-2fa-warning.test.ts
@@ -81,7 +81,7 @@ describe("printPublic2FAWarning", () => {
     expect(fired).toBe(true);
     const joined = logs.join("\n");
     expect(joined).toContain("2FA is not enrolled");
-    expect(joined).toContain("https://vault.example.com/admin/login");
+    expect(joined).toContain("https://vault.example.com/login");
     expect(joined).toContain("parachute auth 2fa enroll");
   });
 
@@ -111,15 +111,13 @@ describe("printPublic2FAWarning", () => {
     expect(logs.some((l) => l.includes("2FA is not enrolled"))).toBe(true);
   });
 
-  test("embeds the supplied publicUrl into the /admin/login pointer", () => {
+  test("embeds the supplied publicUrl into the /login pointer", () => {
     const logs: string[] = [];
     printPublic2FAWarning({
       status: status({ hasTotp: false }),
       log: (l) => logs.push(l),
       publicUrl: "https://parachute.taildf9ce2.ts.net",
     });
-    expect(logs.some((l) => l.includes("https://parachute.taildf9ce2.ts.net/admin/login"))).toBe(
-      true,
-    );
+    expect(logs.some((l) => l.includes("https://parachute.taildf9ce2.ts.net/login"))).toBe(true);
   });
 });

--- a/src/__tests__/expose-cloudflare.test.ts
+++ b/src/__tests__/expose-cloudflare.test.ts
@@ -557,7 +557,7 @@ describe("exposeCloudflareUp", () => {
         expect(code).toBe(0);
         const joined = logs.join("\n");
         expect(joined).toContain("2FA is not enrolled");
-        expect(joined).toContain("https://vault.example.com/admin/login");
+        expect(joined).toContain("https://vault.example.com/login");
         expect(joined).toContain("parachute auth 2fa enroll");
       } finally {
         env.cleanup();

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -963,8 +963,8 @@ describe("expose public up", () => {
       const joined = logs.join("\n");
       expect(joined).toContain("2FA is not enrolled");
       expect(joined).toContain("parachute auth 2fa enroll");
-      // /admin/login pointer uses the canonical https://<fqdn> origin.
-      expect(joined).toContain("https://parachute.taildf9ce2.ts.net/admin/login");
+      // /login pointer uses the canonical https://<fqdn> origin.
+      expect(joined).toContain("https://parachute.taildf9ce2.ts.net/login");
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -623,6 +623,43 @@ describe("hubFetch routing", () => {
     }
   });
 
+  // Login surface rename redirects (auth-UX cleanup): /admin/login and
+  // /admin/logout 301 to /login and /logout. Path-only test — the
+  // handlers themselves are exercised through the existing
+  // handleAdminLoginGet/Post + handleAdminLogoutPost test files.
+  test("301: /admin/login → /login", async () => {
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir)(req("/admin/login"));
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("/login");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("301: /admin/login preserves the next= query param", async () => {
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir)(req("/admin/login?next=/admin/config"));
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("/login?next=/admin/config");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("301: /admin/logout → /logout", async () => {
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir)(req("/admin/logout"));
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("/logout");
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("/hub/<unknown> (no SPA mount anymore) → 404", async () => {
     const h = makeHarness();
     try {
@@ -655,8 +692,11 @@ describe("hubFetch routing", () => {
         ["/oauth/register", { method: "POST" }],
         ["/oauth/revoke", { method: "POST" }],
         ["/vaults", { method: "POST" }],
-        ["/admin/login", { method: "POST" }],
-        ["/admin/logout", { method: "POST" }],
+        // /login + /logout — canonical names since the auth-UX rename;
+        // /admin/login + /admin/logout 301-redirect to here (separate
+        // tests pin the redirects themselves).
+        ["/login", { method: "POST" }],
+        ["/logout", { method: "POST" }],
         ["/admin/config", { method: "GET" }],
         ["/admin/config/example", { method: "POST" }],
         ["/admin/host-admin-token", { method: "GET" }],

--- a/src/__tests__/hub.test.ts
+++ b/src/__tests__/hub.test.ts
@@ -29,37 +29,46 @@ describe("renderHub", () => {
     expect(html).toContain("prefers-color-scheme: dark");
   });
 
-  test("renders two sections: Use and Admin, each with its own heading + grid", () => {
-    expect(html).toContain('id="use-section"');
+  test("renders two sections: Services and Admin, each with its own heading + grid", () => {
+    expect(html).toContain('id="services-section"');
     expect(html).toContain('id="admin-section"');
-    expect(html).toContain('id="use-grid"');
+    expect(html).toContain('id="services-grid"');
     expect(html).toContain('id="admin-grid"');
-    expect(html).toContain("<h2>Use</h2>");
+    expect(html).toContain("<h2>Services</h2>");
     expect(html).toContain("<h2>Admin</h2>");
   });
 
-  test("Use section labels: Browse notes / Transcribe audio / Run agents", () => {
-    expect(html).toContain("'Browse notes'");
-    expect(html).toContain("'Transcribe audio'");
-    expect(html).toContain("'Run agents'");
+  test("Services section sub-text frames the section as service-owned surfaces", () => {
+    // Services-vs-Admin axis is OWNERSHIP (services own their UIs vs
+    // hub owns host admin), not function. The sub-text reflects that —
+    // earlier "Browse, transcribe, and run" framing put it on the
+    // function axis, which broke down once you noticed services have
+    // UIs that mix use / config / admin.
+    expect(html).toContain("Surfaces provided by services");
   });
 
-  test("Use entries use the path declared in services.json (custom mounts work)", () => {
-    // Operators may mount a service at a non-default path; the Use tile
+  test("Services entry labels: Notes / Scribe / Agent", () => {
+    expect(html).toContain("'Notes'");
+    expect(html).toContain("'Scribe'");
+    expect(html).toContain("'Agent'");
+  });
+
+  test("Services entries use the path declared in services.json (custom mounts work)", () => {
+    // Operators may mount a service at a non-default path; the tile
     // surfaces that path verbatim rather than hardcoding `/notes`/etc.
     expect(html).toContain("svc.path");
   });
 
-  test("Vault is intentionally excluded from the Use section", () => {
+  test("Vault is intentionally excluded from the Services section", () => {
     // Aaron's friction: clicking 'Vault' on discovery took him to hub
-    // management, not to vault content. Resolution: Vault has no Use
-    // entry — its content is browsed via Notes (which has its own
-    // entry). Vault provisioning lives under Admin.
+    // management, not to vault content. Resolution: Vault has no
+    // Services entry — its content is browsed via Notes (which has its
+    // own entry). Vault provisioning lives under Admin.
     expect(html).toContain("Vault deliberately omitted");
     expect(html).toContain("isVaultName");
   });
 
-  test("Use section ordering is notes → scribe → agent", () => {
+  test("Services section ordering is notes → scribe → agent", () => {
     expect(html).toContain("['notes', 'scribe', 'agent']");
   });
 

--- a/src/admin-config-ui.ts
+++ b/src/admin-config-ui.ts
@@ -61,7 +61,7 @@ ${body}
 </html>`;
 }
 
-// --- /admin/login ----------------------------------------------------------
+// --- /login ---------------------------------------------------------------
 
 export interface AdminLoginProps {
   /** Continuation path after successful login — submitted as a hidden field. */
@@ -85,7 +85,7 @@ export function renderAdminLogin(props: AdminLoginProps): string {
         <p class="subtitle">to administer this hub</p>
       </div>
       ${error}
-      <form method="POST" action="/admin/login" class="auth-form">
+      <form method="POST" action="/login" class="auth-form">
         ${renderCsrfHiddenInput(csrfToken)}
         <input type="hidden" name="next" value="${escapeAttr(next)}" />
         <label class="field">

--- a/src/admin-handlers.ts
+++ b/src/admin-handlers.ts
@@ -1,15 +1,19 @@
 /**
- * HTTP handlers for the hub admin surface — login (`/admin/login`) and the
+ * HTTP handlers for the hub admin surface — login (`/login`) and the
  * config portal (`/admin/config`, `/admin/config/<name>`). Sessions ride the
  * same `parachute_hub_session` cookie that the OAuth login mints, since PR
  * #112 widened the cookie path from `/oauth/` to `/`.
  *
+ * `/login` (was `/admin/login` pre-#231-followup) is the canonical entry
+ * for ALL parachute auth — admin operators, OAuth user flows, etc. The
+ * `/admin/login` and `/admin/logout` paths 301-redirect for back-compat.
+ *
  * Every state-changing POST is double-submit-CSRF protected
  * (`parachute_hub_csrf` cookie + `__csrf` form field, constant-time compare),
- * and every authenticated GET issues a 302 to `/admin/login?next=<path>`
- * when no session is found rather than rendering an inline login form —
- * keeps each route's intent clean and lets the operator bookmark
- * `/admin/config` without thinking about state.
+ * and every authenticated GET issues a 302 to `/login?next=<path>` when
+ * no session is found rather than rendering an inline login form — keeps
+ * each route's intent clean and lets the operator bookmark `/admin/config`
+ * without thinking about state.
  */
 import type { Database } from "bun:sqlite";
 import {
@@ -78,7 +82,7 @@ function redirect(location: string, extra: Record<string, string> = {}): Respons
 function loginRedirect(req: Request, extra: Record<string, string> = {}): Response {
   const url = new URL(req.url);
   const next = `${url.pathname}${url.search}`;
-  return redirect(`/admin/login?next=${encodeURIComponent(next)}`, extra);
+  return redirect(`/login?next=${encodeURIComponent(next)}`, extra);
 }
 
 function safeNext(raw: string | null): string {
@@ -88,7 +92,12 @@ function safeNext(raw: string | null): string {
   return raw;
 }
 
-// --- /admin/login ----------------------------------------------------------
+// --- /login ---------------------------------------------------------------
+//
+// Renamed from `/admin/login` so the surface name reflects what it is — the
+// canonical entry for ALL parachute auth (operators, OAuth user flows,
+// etc.), not an admin-only door. `/admin/login` and `/admin/logout` 301
+// to here from `hub-server.ts` for back-compat.
 
 export function handleAdminLoginGet(_db: Database, req: Request): Response {
   const url = new URL(req.url);
@@ -172,7 +181,7 @@ export interface AdminLoginDeps {
   now?: () => Date;
 }
 
-// --- /admin/logout ---------------------------------------------------------
+// --- /logout --------------------------------------------------------------
 
 /**
  * POST-only — logout is state-changing, so it rides the same double-submit
@@ -181,8 +190,8 @@ export interface AdminLoginDeps {
  * but the safety belt is already on the bus).
  *
  * Always idempotent: clearing the cookie succeeds even if there's no
- * matching session row. Returns 302 → /admin/login so the operator lands
- * back on the form ready to re-authenticate.
+ * matching session row. Returns 302 → /login so the operator lands back
+ * on the form ready to re-authenticate.
  */
 export async function handleAdminLogoutPost(db: Database, req: Request): Promise<Response> {
   const form = await req.formData();
@@ -198,7 +207,7 @@ export async function handleAdminLogoutPost(db: Database, req: Request): Promise
   }
   const sid = parseSessionCookie(req.headers.get("cookie"));
   if (sid) deleteSession(db, sid);
-  return redirect("/admin/login", { "set-cookie": buildSessionClearCookie() });
+  return redirect("/login", { "set-cookie": buildSessionClearCookie() });
 }
 
 // --- /admin/config ---------------------------------------------------------

--- a/src/admin-host-admin-token.ts
+++ b/src/admin-host-admin-token.ts
@@ -23,7 +23,7 @@
  * Both paths require already-proved local-operator identity:
  *   - operator-token mint runs as the operator's unix user.
  *   - this endpoint requires a valid `parachute_hub_session` cookie, which
- *     was set by `/admin/login` after a password check.
+ *     was set by `/login` after a password check.
  *
  * Tokens minted here are deliberately NOT persisted in the `tokens` table
  * (no refresh, no revocation tracking). They expire on their own; the SPA
@@ -62,7 +62,7 @@ export async function handleHostAdminToken(
   const sid = parseSessionCookie(req.headers.get("cookie"));
   const session = sid ? findSession(deps.db, sid) : null;
   if (!session) {
-    return jsonError(401, "unauthenticated", "no admin session — sign in at /admin/login first");
+    return jsonError(401, "unauthenticated", "no admin session — sign in at /login first");
   }
   const minted = await signAccessToken(deps.db, {
     sub: session.userId,

--- a/src/admin-vault-admin-token.ts
+++ b/src/admin-vault-admin-token.ts
@@ -55,7 +55,7 @@ export async function handleVaultAdminToken(
   const sid = parseSessionCookie(req.headers.get("cookie"));
   const session = sid ? findSession(deps.db, sid) : null;
   if (!session) {
-    return jsonError(401, "unauthenticated", "no admin session — sign in at /admin/login first");
+    return jsonError(401, "unauthenticated", "no admin session — sign in at /login first");
   }
   const scope = `vault:${vaultName}:admin`;
   // Per-vault audience: vault validates the JWT's `aud` claim against

--- a/src/commands/expose-2fa-warning.ts
+++ b/src/commands/expose-2fa-warning.ts
@@ -1,9 +1,9 @@
 /**
  * Public-exposure 2FA-enrollment warning (#186). Lands as the next layer of
- * defense after #188's `/admin/login` rate-limit floor: once the operator
- * brings up cloudflare or Tailscale Funnel, `/admin/login` is reachable from
- * the public internet on every layer admitting traffic. 2FA is the difference
- * between "password is the only wall" and "password + something-you-have."
+ * defense after #188's `/login` rate-limit floor: once the operator brings
+ * up cloudflare or Tailscale Funnel, `/login` is reachable from the public
+ * internet on every layer admitting traffic. 2FA is the difference between
+ * "password is the only wall" and "password + something-you-have."
  *
  * Why this is a warning, not a hard gate: hard-gating would surprise operators
  * mid-flow — they ran `parachute expose public` to expose, not to be told
@@ -71,8 +71,8 @@ export function printPublic2FAWarning(opts: Public2FAWarningOpts): boolean {
     return false;
   }
   log("");
-  log("⚠ 2FA is not enrolled. /admin is now reachable on the public internet");
-  log(`  (${opts.publicUrl}/admin/login). Anyone who guesses your password`);
+  log("⚠ 2FA is not enrolled. /login is now reachable on the public internet");
+  log(`  (${opts.publicUrl}/login). Anyone who guesses your password`);
   log("  is in. Strongly recommended:");
   log("");
   log("    parachute auth 2fa enroll");

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -20,6 +20,7 @@
  *   /hub/permissions                           → 301 → /admin/permissions
  *   /hub/tokens                                → 301 → /admin/tokens
  *   /hub, /hub/                                → 301 → /admin/vaults
+ *   /admin/login, /admin/logout                → 301 → /login, /logout
  *
  *   # Discovery + well-known.
  *   /, /hub.html                               → hub.html (the discovery page)
@@ -44,8 +45,8 @@
  *   /api/auth/tokens              (GET)        → paginated registry list
  *   /api/grants                   (GET)        → OAuth consent grants list
  *   /api/grants/<client_id>       (DELETE)     → revoke a single OAuth grant
- *   /admin/login                  (GET + POST) → operator password login
- *   /admin/logout                 (POST)       → end admin session
+ *   /login                        (GET + POST) → operator password login
+ *   /logout                       (POST)       → end admin session
  *   /admin/config                 (GET)        → operator config view
  *   /admin/config/<key>           (POST)       → operator config write
  *
@@ -724,6 +725,24 @@ export function hubFetch(
       });
     }
 
+    // Login surface rename: `/admin/login` and `/admin/logout` 301 to the
+    // canonical `/login` and `/logout`. The names were "admin" only by
+    // historical accident — the handlers serve every parachute auth flow
+    // (operator, OAuth user-redirect, future SPA sign-in). Renaming makes
+    // the surface name match its actual scope.
+    if (pathname === "/admin/login") {
+      return new Response("", {
+        status: 301,
+        headers: { location: `/login${url.search}` },
+      });
+    }
+    if (pathname === "/admin/logout") {
+      return new Response("", {
+        status: 301,
+        headers: { location: `/logout${url.search}` },
+      });
+    }
+
     if (pathname === "/" || pathname === "/hub.html") {
       if (!existsSync(hubHtmlPath)) {
         return new Response("hub.html not found", { status: 404 });
@@ -999,14 +1018,20 @@ export function hubFetch(
       });
     }
 
-    if (pathname === "/admin/login") {
+    // Canonical login/logout. The handlers themselves are unchanged from
+    // when they lived at /admin/login + /admin/logout; the rename surfaced
+    // via #231-followup so the URL reflects the surface's actual scope
+    // (entry point for ALL parachute auth — not admin-only). The
+    // /admin/login and /admin/logout paths 301 to here, dispatched at the
+    // top of this fn alongside the other back-compat redirects.
+    if (pathname === "/login") {
       if (!getDb) return new Response("hub db not configured", { status: 503 });
       if (req.method === "GET") return handleAdminLoginGet(getDb(), req);
       if (req.method === "POST") return handleAdminLoginPost(getDb(), req);
       return new Response("method not allowed", { status: 405 });
     }
 
-    if (pathname === "/admin/logout") {
+    if (pathname === "/logout") {
       if (!getDb) return new Response("hub db not configured", { status: 503 });
       if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
       return handleAdminLogoutPost(getDb(), req);

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -5,22 +5,29 @@ import { CONFIG_DIR } from "./config.ts";
 /**
  * Hub page served at `/` when the node is exposed.
  *
- * The page is split into two sections:
+ * The page is split into two sections, organized by **ownership**:
  *
- *   - **Use** — per-service primary human affordances. Browse notes
- *     (the Notes PWA, which is the vault-content browse path); transcribe
- *     audio (Scribe); run agents (Agent). Entries are dynamic, derived
- *     from `/.well-known/parachute.json`; only installed services show up.
- *     Vault deliberately doesn't have its own Use entry — its content is
- *     browsed via Notes, so a separate "Vault" tile would just send the
- *     operator to the admin SPA, which is exactly the friction Aaron
- *     flagged ("clicked Vault, took me to hub management").
+ *   - **Services** — surfaces provided by the modules running on this
+ *     hub. Browse notes (the Notes PWA); transcribe audio (Scribe); run
+ *     agents (Agent). Each entry points at the service's own UI; the
+ *     service owns what's behind the link (use, config, admin —
+ *     whatever it chooses to surface). Entries are dynamic, derived
+ *     from `/.well-known/parachute.json`; only installed services show
+ *     up. Vault deliberately doesn't have its own Services entry — its
+ *     content is browsed via Notes, so a separate "Vault" tile would
+ *     just send the operator to the admin SPA, which is exactly the
+ *     friction Aaron flagged ("clicked Vault, took me to hub management").
  *
- *   - **Admin** — hub-served admin SPA routes for cross-cutting host
+ *   - **Admin** — hub-owned admin surfaces for cross-cutting host
  *     concerns. Always visible: even with zero vaults installed, an
  *     operator may want to provision the first one. Three entries:
  *     Vaults (provisioning), Permissions (OAuth consent grants), Tokens
  *     (registry mint/list/revoke).
+ *
+ * The Services-vs-Admin axis is ownership, not function: services-owned
+ * UIs vs hub-owned UIs. The first cut framed it as "Use vs Admin" but
+ * that broke down once you noticed real services have UIs that mix use,
+ * config, and admin together — the cleaner cut is who's hosting the UI.
  *
  * The file stays self-contained (inline CSS + JS, no external assets) so
  * `tailscale serve` can mount it directly from disk with `--set-path=/`.
@@ -236,11 +243,11 @@ const HTML = `<!doctype html>
     <p class="tagline">Your personal-computing modules.</p>
   </header>
 
-  <section class="section" id="use-section">
-    <h2>Use</h2>
-    <p class="section-sub">Browse, transcribe, and run — the everyday surfaces.</p>
-    <div class="grid" id="use-grid" aria-live="polite">
-      <div class="empty" id="use-loading">Loading…</div>
+  <section class="section" id="services-section">
+    <h2>Services</h2>
+    <p class="section-sub">Surfaces provided by services running on this hub.</p>
+    <div class="grid" id="services-grid" aria-live="polite">
+      <div class="empty" id="services-loading">Loading…</div>
     </div>
   </section>
 
@@ -256,20 +263,20 @@ const HTML = `<!doctype html>
 </main>
 <script>
 (async () => {
-  const useGrid = document.getElementById('use-grid');
+  const servicesGrid = document.getElementById('services-grid');
   const adminGrid = document.getElementById('admin-grid');
 
-  // Use entries: per-service primary affordances. Hardcoded short→label map;
-  // path is derived from services.json so custom mounts still work.
+  // Services entries: each service's primary surface. Hardcoded short→label
+  // map; path is derived from services.json so custom mounts still work.
   // Vault deliberately omitted — its content is browsed via Notes (which
   // is its own entry below). Operators provision/admin vaults from the
   // /admin/vaults card in the Admin section.
-  const USE_LABELS = {
-    notes:  { title: 'Browse notes', desc: 'Open the Notes PWA over your vault.' },
-    scribe: { title: 'Transcribe audio', desc: 'Send audio to Scribe.' },
-    agent:  { title: 'Run agents', desc: 'Open the Agent runtime.' },
+  const SERVICE_LABELS = {
+    notes:  { title: 'Notes', desc: 'Browse your vault content.' },
+    scribe: { title: 'Scribe', desc: 'Transcribe audio.' },
+    agent:  { title: 'Agent', desc: 'Run agents on this hub.' },
   };
-  const USE_ORDER = ['notes', 'scribe', 'agent'];
+  const SERVICE_ORDER = ['notes', 'scribe', 'agent'];
 
   // Admin entries: always visible. Even a fresh hub with zero vaults wants
   // the operator to find /admin/vaults. Hardcoded — they live in the
@@ -325,9 +332,9 @@ const HTML = `<!doctype html>
     }
   }
 
-  function renderUse(services) {
+  function renderServices(services) {
     // Group services by short type. Multiple instances of the same type
-    // (e.g. two scribes) collapse into one Use entry pointing at the first
+    // (e.g. two scribes) collapse into one entry pointing at the first
     // — operators with that posture will know which one they meant.
     // Vault entries are skipped per the comment above.
     const byType = new Map();
@@ -338,22 +345,22 @@ const HTML = `<!doctype html>
     }
 
     const tiles = [];
-    for (const t of USE_ORDER) {
+    for (const t of SERVICE_ORDER) {
       const path = byType.get(t);
       if (!path) continue;
-      const labels = USE_LABELS[t];
+      const labels = SERVICE_LABELS[t];
       tiles.push({ title: labels.title, desc: labels.desc, href: path });
     }
 
-    useGrid.innerHTML = '';
+    servicesGrid.innerHTML = '';
     if (tiles.length === 0) {
       const empty = document.createElement('div');
       empty.className = 'empty';
       empty.innerHTML = 'No services installed yet. Try <code>parachute install vault</code>.';
-      useGrid.appendChild(empty);
+      servicesGrid.appendChild(empty);
       return;
     }
-    for (const tile of tiles) useGrid.appendChild(renderTile(tile));
+    for (const tile of tiles) servicesGrid.appendChild(renderTile(tile));
   }
 
   // Admin section is static — render synchronously so the operator sees it
@@ -365,9 +372,9 @@ const HTML = `<!doctype html>
     if (!wk.ok) throw new Error('well-known fetch failed: ' + wk.status);
     const doc = await wk.json();
     const services = Array.isArray(doc.services) ? doc.services : [];
-    renderUse(services);
+    renderServices(services);
   } catch (err) {
-    useGrid.innerHTML = '<div class="error">Could not load services: ' +
+    servicesGrid.innerHTML = '<div class="error">Could not load services: ' +
       (err && err.message ? err.message : String(err)) + '</div>';
   }
 })();

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -1,10 +1,13 @@
 /**
- * Per-IP rate-limit on `POST /admin/login`. Lands as a floor under brute-force
+ * Per-IP rate-limit on `POST /login`. Lands as a floor under brute-force
  * after hub#187 collapsed the public-reach matrix: with a cloudflare tunnel
- * up, `/admin/login` is now reachable from the open internet, and 2FA (#186)
+ * up, `/login` is now reachable from the open internet, and 2FA (#186)
  * is the next PR rather than this one. A 5-attempts-per-15-minute bucket per
  * IP is the standard login-form floor; it's not the primary defense, just the
  * one that turns "infinite credential grinding" into "rotate IPs".
+ *
+ * (Endpoint was `/admin/login` pre-rename; bucket logic is path-agnostic so
+ * the rename was a comment-only change here.)
  *
  * Shape: sliding window. Each key keeps the last N attempt timestamps; on a
  * new attempt we prune anything older than the window, count what remains,

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -107,7 +107,7 @@ export const FIRST_PARTY_SCOPES = Object.keys(SCOPE_EXPLANATIONS).sort();
  *   - `parachute auth rotate-operator` writes the long-lived operator token
  *     (`~/.parachute/operator.token`, mode 0600) for service accounts.
  *   - `GET /admin/host-admin-token` exchanges a valid `parachute_hub_session`
- *     cookie (set by `/admin/login` after a password check) for a
+ *     cookie (set by `/login` after a password check) for a
  *     short-lived JWT consumed by the in-tree vault-management SPA.
  *
  * Both surfaces predicate on local-operator identity that the public OAuth

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -121,7 +121,7 @@ export function parseSessionCookie(cookieHeader: string | null): string | null {
  * callers don't repeat the parse+find+null-check dance.
  *
  * Caller decides what to do on null — admin pages redirect to
- * `/admin/login?next=<path>`, OAuth's DCR endpoint falls through to
+ * `/login?next=<path>`, OAuth's DCR endpoint falls through to
  * status=`pending` (closes #199).
  */
 export function findActiveSession(

--- a/web/ui/src/lib/auth.test.ts
+++ b/web/ui/src/lib/auth.test.ts
@@ -47,7 +47,7 @@ describe("getHostAdminToken", () => {
     );
   });
 
-  it("on 401 calls window.location.replace with /admin/login?next=…", async () => {
+  it("on 401 calls window.location.replace with /login?next=…", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => new Response("", { status: 401 })),
@@ -64,9 +64,7 @@ describe("getHostAdminToken", () => {
     void auth.getHostAdminToken();
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(replace).toHaveBeenCalledWith(
-      `/admin/login?next=${encodeURIComponent("/vault/new?x=1")}`,
-    );
+    expect(replace).toHaveBeenCalledWith(`/login?next=${encodeURIComponent("/vault/new?x=1")}`);
   });
 
   it("dedupes concurrent in-flight mint requests", async () => {

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -1,13 +1,13 @@
 /**
  * Auth helper for the hub SPA. Unlike paraclaw's hub-as-issuer OAuth flow,
  * this SPA is served BY the hub itself — so it leans on the existing
- * password-gated `/admin/login` session cookie instead of running its own
- * OAuth dance.
+ * password-gated `/login` session cookie instead of running its own OAuth
+ * dance.
  *
  * Flow:
  *   1. SPA bootstrap calls `getHostAdminToken()`.
  *   2. That hits `GET /admin/host-admin-token`. The endpoint:
- *      - reads `parachute_hub_session` cookie (set by /admin/login)
+ *      - reads `parachute_hub_session` cookie (set by /login)
  *      - mints a short-lived (~10 min) JWT carrying both
  *        `parachute:host:admin` (vault provisioning, OAuth grant management)
  *        AND `parachute:host:auth` (the hub#212 Phase 2 token-registry
@@ -15,7 +15,7 @@
  *   3. Token is held in module-scoped state — NOT localStorage. Page
  *      snapshots can't carry it past a refresh, and XSS surface is the
  *      narrowest possible.
- *   4. On 401, redirect the browser to `/admin/login?next=<current path>`.
+ *   4. On 401, redirect the browser to `/login?next=<current path>`.
  *      The hub's standard login form then cookie-signs the operator and
  *      bounces back here.
  *
@@ -45,18 +45,18 @@ function tokenEndpoint(): string {
 function loginRedirectUrl(): string {
   // Round-trip the *current* SPA URL — origin + pathname + search — so the
   // post-login redirect drops the operator back where they started. Hash is
-  // intentionally dropped: the /admin/login `next=` param is server-rendered
-  // and doesn't survive a fragment round-trip cleanly.
+  // intentionally dropped: the /login `next=` param is server-rendered and
+  // doesn't survive a fragment round-trip cleanly.
   const next = `${window.location.pathname}${window.location.search}`;
-  return `/admin/login?next=${encodeURIComponent(next)}`;
+  return `/login?next=${encodeURIComponent(next)}`;
 }
 
 /**
- * Navigate to /admin/login (round-tripping the current SPA URL via `next=`)
- * and return a never-resolving Promise so the caller's continuation never
- * runs. The browser is about to tear down the page; surfacing a "session
- * expired" error to the operator gives them no useful action — the right
- * UX is "you've already left."
+ * Navigate to /login (round-tripping the current SPA URL via `next=`) and
+ * return a never-resolving Promise so the caller's continuation never runs.
+ * The browser is about to tear down the page; surfacing a "session expired"
+ * error to the operator gives them no useful action — the right UX is
+ * "you've already left."
  *
  * Shared between the host-admin mint here and the per-vault mint in
  * `lib/api.ts:mintVaultAdminToken`. Both endpoints rely on the same
@@ -73,9 +73,9 @@ export function redirectToLoginAndHang<T>(): Promise<T> {
  * (or if we don't have one yet). Concurrent callers share the in-flight
  * fetch — we don't want a burst of API calls to mint a token each.
  *
- * On 401 (no admin session), navigates the browser to /admin/login and
- * returns a never-resolving Promise so callers don't try to use a missing
- * token. Caller code does not need to check for null.
+ * On 401 (no admin session), navigates the browser to /login and returns a
+ * never-resolving Promise so callers don't try to use a missing token.
+ * Caller code does not need to check for null.
  */
 export async function getHostAdminToken(): Promise<string> {
   const now = Date.now();

--- a/web/ui/vite.config.ts
+++ b/web/ui/vite.config.ts
@@ -28,11 +28,11 @@ export default defineConfig({
       //
       // Exact-prefix proxying for /admin/login and friends — but NOT a blanket
       // /admin proxy, which would steal the SPA's own /admin/vaults route.
-      "/admin/login": {
+      "/login": {
         target: process.env.HUB_ORIGIN ?? "http://127.0.0.1:1939",
         changeOrigin: true,
       },
-      "/admin/logout": {
+      "/logout": {
         target: process.env.HUB_ORIGIN ?? "http://127.0.0.1:1939",
         changeOrigin: true,
       },


### PR DESCRIPTION
## Summary

A+B of an A+B+C bundle from the auth-UX-pathway dispatch. C (signed-in indicator via `/api/me` with per-session CSRF token) ships separately as rc.13 — split per scope review on the C surface's CSRF design needing focused review.

This PR addresses two surface-naming friction points Aaron raised after rc.11:

### A. Discovery page sections relabeled `Use` → `Services`

The Use/Admin axis was a function split (use vs admin) that broke down once you noticed real services have UIs that mix use, config, and admin together. The cleaner cut is **ownership** — services own their UIs vs hub owns host admin.

- Section heading: "Use" → "Services"
- Sub-text: "Browse, transcribe, and run — the everyday surfaces" → "Surfaces provided by services running on this hub."
- Per-entry labels tightened: "Browse notes" → "Notes" (with one-line desc "Browse your vault content"), and similarly for Scribe / Agent.
- Vault stays excluded from Services for the same reason as rc.11 — its content is browsed via Notes; provisioning lives under Admin.

### B. Login + logout surface rename

`/admin/login` → `/login`, `/admin/logout` → `/logout`. The `/admin/` prefix read as "admin-only" but the handlers serve every parachute auth flow — operator login, OAuth user-redirect, the future SPA sign-in. Renaming makes the URL match the surface's actual scope.

301 redirects from old paths preserve cached URLs and OAuth `?next=…` redirects:

```
/admin/login              → 301 → /login
/admin/login?next=...     → 301 → /login?next=... (query preserved)
/admin/logout             → 301 → /logout
```

## What's NOT in this PR (rc.13)

Signed-in indicator on hub-served surfaces — Aaron's "Signed in as X / Sign out" affordance for the discovery page + admin SPA. Design pinned for the next PR:

- New `GET /api/me` endpoint returning `{ hasSession: bool, user?: { id, displayName }, csrfToken? }`. Public, no-store. CSRF token included when signed in (per-session, expires with session) so consumers can render a logout form without a separate token-fetch round-trip.
- Discovery page (server-rendered) reads session, renders "Signed in as X" + tiny `<form method=POST action=/logout>` with the CSRF token, OR "Sign in" link.
- Admin SPA fetches `/api/me` on mount, renders the same affordance in nav, sign-out submits the form via fetch.

Both surfaces consume the same endpoint — one mental model. (Notes' equivalent is a separate parachute-notes PR.)

## Files changed

**Server:**
- `src/hub.ts` — discovery page Services rewrite + entry labels.
- `src/__tests__/hub.test.ts` — Services assertions + sub-text framing assertion.
- `src/admin-handlers.ts` — loginRedirect target, logout final destination, file header updated for the rename.
- `src/admin-config-ui.ts` — login form action.
- `src/admin-host-admin-token.ts` + `src/admin-vault-admin-token.ts` — error messages.
- `src/hub-server.ts` — handler routes (renamed paths) + 301 redirects + route-table comment.
- `src/__tests__/hub-server.test.ts` — 3 new redirect tests; updated 503 case for renamed handlers.
- `src/__tests__/admin-handlers.test.ts` — `/login` final destination assertions.
- `src/rate-limit.ts`, `src/sessions.ts`, `src/scope-explanations.ts` — comment updates.

**Web UI:**
- `web/ui/vite.config.ts` — dev proxy entries (`/login`, `/logout`).

## Versioning

- `package.json`: `0.5.8-rc.11` → `0.5.8-rc.12`.
- CHANGELOG entry under `## [0.5.8-rc.12] - 2026-05-10` framing as auth-UX cleanup A/B-of-bundle.

## Test plan

- [x] hub `bun test ./src`: all pass (was 1199; +4 net — 3 new redirect tests + handler test count adjustments).
- [x] typecheck (both packages): clean.
- [x] biome: clean.

(Test-count numbers omitted per the hub#219 canonical-vs-combined ambiguity convention.)

## Patterns check

- **Surface-naming consistency** — `/login` + `/logout` match the canonical-prefix-less shape used by `/oauth/*` and `/.well-known/*` (other auth-related public surfaces).
- **301 back-compat redirect pattern** — same shape established by hub#231 (PR #233): `new Response("", { status: 301, headers: { location: ... } })`, query-string-preserving, method-agnostic. Same test shape.
- **Discovery page section semantics** — ownership-axis framing is captured in the file header doc-comment so a future contributor adding sections has the rule: "who owns the UI behind this entry?"
- **RC versioning** — `rc.11` → `rc.12` per parachute-patterns/governance.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)