### PR TITLE
feat(auth): signed-in indicator on hub-served surfaces via /api/me + per-session CSRF (auth UX C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.8-rc.13] - 2026-05-10
+
+Auth-UX cleanup, C of the A+B+C bundle (A+B shipped as rc.12). Adds the signed-in indicator to hub-served surfaces — discovery page (server-rendered) and the admin SPA. Both consume a single new endpoint (`GET /api/me`) that returns session identity + a per-session CSRF token, so the sign-out form can be rendered without a separate token-fetch step.
+
+### Added
+
+- **`GET /api/me`** (`src/api-me.ts`). Public, session-cookie-aware. Returns:
+  - `{ hasSession: false }` when no active session.
+  - `{ hasSession: true, user: { id, displayName }, csrf }` when signed in. The `csrf` token is reused from the existing `parachute_hub_csrf` cookie if present, or freshly minted (with Set-Cookie attached). Same value the existing login form embeds — submit it back as `__csrf` against `/logout` (or any future state-changing endpoint).
+  - `cache-control: no-store` (response varies per session).
+  - No CORS — same-origin only; hub-served UIs are same-origin.
+- **Discovery page server-rendered indicator** (`src/hub.ts`). `renderHub({ session })` accepts an optional session (displayName + csrfToken). When present, the header carries "Signed in as &lt;name&gt;" plus an inline `<form method="POST" action="/logout">` with the CSRF token embedded — works without JS. When absent, renders a "Sign in" link to `/login?next=/`. The `/` handler in `hub-server.ts` reads the cookie + user via `findActiveSession` + `getUserById` and passes through; without a configured DB, falls back to the static disk-file (signed-out shape).
+- **SPA indicator** (`web/ui/src/App.tsx`). `useEffect` fetches `/api/me` on mount; renders an `AuthIndicator` in the nav (after the brand). Sign-out button POSTs to `/logout` via `signOut(csrf)` in `lib/api.ts` — form-encoded body so the existing logout handler's `req.formData()` parse works without a handler change. On success, navigates to `/` so the operator immediately sees the freshly-rendered signed-out header.
+- **Two new SPA helpers in `web/ui/src/lib/api.ts`**: `getMe()` returning `MeResponse` (discriminated union: `MeSignedIn | MeSignedOut`); `signOut(csrf)` returning `Promise<void>`.
+
+### Changed
+
+- `src/hub.ts` `renderHub()` signature: now accepts optional `RenderHubOpts { session? }`. Existing call site (`writeHubFile`) emits the signed-out shape — that disk file is the static fallback for the no-DB case.
+- `src/hub-server.ts` `/` and `/hub.html` handler: prefers the dynamic render path when a DB is configured; falls back to the static disk file otherwise. Adds `<header>` CSS for the `.auth-indicator` block (absolute-positioned top-right; falls below title on narrow viewports).
+
+### Test gate
+
+All test suites pass. New coverage in this PR:
+
+- `api-me.test.ts` — 7 tests: 405 on non-GET, no-session minimal payload, deleted-session-row treated as not-signed-in, full payload with user + CSRF, cookie minted + Set-Cookie when absent, cookie reused when present, distinct tokens across requests with no cookie.
+- `hub.test.ts` — 4 new tests for the indicator (default-no-session emits "Sign in" affordance, session arg emits "Signed in as ..." + inline POST form, displayName escaping, CSRF token escaping in the value attribute).
+- `hub-server.test.ts` — 2 new tests for the dynamic `/` handler (no-session-cookie renders the "Sign in" affordance via the dynamic path; active session renders "Signed in as &lt;name&gt;" + sign-out form + Set-Cookie for the freshly-minted CSRF token).
+- `App.test.tsx` — 5 new auth-indicator tests (renders nothing on first paint then "Sign in" once `/api/me` resolves; sign-in link points at `/login?next=...`; signed-in payload renders "Signed in as ..." + sign-out button; sign-out POST + navigate-to-`/`; "Signing out…" disabled state during in-flight POST). Plus updated nav-structure test for the new "Sign in" slot in the link order.
+
+Typecheck (both packages): clean. biome: clean. UI build + verify-base: clean.
+
+(Test-count numbers omitted per the hub#219 canonical-vs-combined ambiguity convention.)
+
 ## [0.5.8-rc.12] - 2026-05-10
 
 Auth-UX cleanup, A/B of an A+B+C bundle (C — signed-in indicator via `/api/me` — lands separately as rc.13). Two changes addressing surface-naming friction Aaron raised after rc.11:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.8-rc.12",
+  "version": "0.5.8-rc.13",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-me.test.ts
+++ b/src/__tests__/api-me.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for `GET /api/me` — the public who-am-I endpoint that powers the
+ * signed-in indicator on hub-served surfaces (discovery server-rendered
+ * + admin SPA fetched). Covers:
+ *   - Method gate (non-GET → 405).
+ *   - No session → minimal `{ hasSession: false }`, no CSRF, no Set-Cookie.
+ *   - Active session → full payload with displayName + CSRF.
+ *   - Session-cookie present but row deleted → `{ hasSession: false }`.
+ *   - CSRF cookie reused when present, minted + Set-Cookie when absent.
+ *   - CSRF token bound to the cookie (consumer can submit it back).
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleApiMe } from "../api-me.ts";
+import { CSRF_COOKIE_NAME, buildCsrfCookie, generateCsrfToken } from "../csrf.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession, deleteSession } from "../sessions.ts";
+import { createUser } from "../users.ts";
+
+interface Harness {
+  db: Database;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-api-me-"));
+  const db = openHubDb(hubDbPath(dir));
+  return {
+    db,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+async function withSession(): Promise<{ cookie: string; userId: string; sid: string }> {
+  const user = await createUser(harness.db, "aaron", "pw");
+  const session = createSession(harness.db, { userId: user.id });
+  const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+  return { cookie, userId: user.id, sid: session.id };
+}
+
+describe("handleApiMe", () => {
+  test("405 on non-GET", async () => {
+    const req = new Request("http://hub.test/api/me", { method: "POST" });
+    const res = handleApiMe(req, { db: harness.db });
+    expect(res.status).toBe(405);
+  });
+
+  test("no session cookie → { hasSession: false }, no CSRF, no Set-Cookie", async () => {
+    const req = new Request("http://hub.test/api/me");
+    const res = handleApiMe(req, { db: harness.db });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(res.headers.get("set-cookie")).toBeNull();
+    const body = (await res.json()) as { hasSession: boolean; user?: unknown; csrf?: string };
+    expect(body.hasSession).toBe(false);
+    expect(body.user).toBeUndefined();
+    expect(body.csrf).toBeUndefined();
+  });
+
+  test("session cookie pointing at deleted session → { hasSession: false }", async () => {
+    const { cookie, sid } = await withSession();
+    deleteSession(harness.db, sid);
+    const req = new Request("http://hub.test/api/me", { headers: { cookie } });
+    const res = handleApiMe(req, { db: harness.db });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { hasSession: boolean };
+    expect(body.hasSession).toBe(false);
+  });
+
+  test("active session → full payload with user + CSRF token", async () => {
+    const { cookie, userId } = await withSession();
+    const req = new Request("http://hub.test/api/me", { headers: { cookie } });
+    const res = handleApiMe(req, { db: harness.db });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    const body = (await res.json()) as {
+      hasSession: boolean;
+      user?: { id: string; displayName: string };
+      csrf?: string;
+    };
+    expect(body.hasSession).toBe(true);
+    expect(body.user?.id).toBe(userId);
+    expect(body.user?.displayName).toBe("aaron");
+    expect(typeof body.csrf).toBe("string");
+    expect((body.csrf ?? "").length).toBeGreaterThan(20);
+  });
+
+  test("active session + no CSRF cookie → mints token + Set-Cookie attached", async () => {
+    const { cookie } = await withSession();
+    const req = new Request("http://hub.test/api/me", { headers: { cookie } });
+    const res = handleApiMe(req, { db: harness.db });
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(`${CSRF_COOKIE_NAME}=`);
+    // The token in the JSON body must match the value being set in the
+    // cookie — that's the consumer's contract for submitting it back.
+    const body = (await res.json()) as { csrf?: string };
+    const cookieValueMatch = setCookie.match(new RegExp(`${CSRF_COOKIE_NAME}=([A-Za-z0-9_-]+)`));
+    expect(cookieValueMatch?.[1]).toBe(body.csrf);
+  });
+
+  test("active session + CSRF cookie already present → reuses token, no Set-Cookie", async () => {
+    const { cookie } = await withSession();
+    const csrfToken = generateCsrfToken();
+    const csrfCookie = buildCsrfCookie(csrfToken).split(";")[0]!; // just `name=value`
+    const combinedCookie = `${cookie}; ${csrfCookie}`;
+    const req = new Request("http://hub.test/api/me", { headers: { cookie: combinedCookie } });
+    const res = handleApiMe(req, { db: harness.db });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("set-cookie")).toBeNull();
+    const body = (await res.json()) as { csrf?: string };
+    expect(body.csrf).toBe(csrfToken);
+  });
+
+  test("two distinct requests (no CSRF cookie either way) get distinct freshly-minted tokens", async () => {
+    // Pin that the CSRF token is request-randomized when no cookie is
+    // present. Two requests from the same session, neither carrying a
+    // CSRF cookie, get two different tokens. Real consumers carry the
+    // first response's Set-Cookie back on subsequent requests, so this
+    // path is operationally rare — but the entropy property is still
+    // load-bearing for the no-cookie cold-start case.
+    const { cookie } = await withSession();
+    const resA = handleApiMe(new Request("http://hub.test/api/me", { headers: { cookie } }), {
+      db: harness.db,
+    });
+    const resB = handleApiMe(new Request("http://hub.test/api/me", { headers: { cookie } }), {
+      db: harness.db,
+    });
+    const bodyA = (await resA.json()) as { csrf?: string };
+    const bodyB = (await resB.json()) as { csrf?: string };
+    expect(bodyA.csrf).toBeDefined();
+    expect(bodyB.csrf).toBeDefined();
+    expect(bodyA.csrf).not.toBe(bodyB.csrf);
+  });
+});

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -57,13 +57,65 @@ describe("hubFetch routing", () => {
     }
   });
 
-  test("/hub.html serves the same file as /", async () => {
+  test("/hub.html serves the same file as / (no DB → static fallback)", async () => {
     const h = makeHarness();
     try {
       writeFileSync(join(h.dir, "hub.html"), "<html>x</html>");
       const res = await hubFetch(h.dir)(req("/hub.html"));
       expect(res.status).toBe(200);
       expect(await res.text()).toBe("<html>x</html>");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/ renders the signed-out indicator dynamically when DB is configured but no session cookie (rc.13)", async () => {
+    // The dynamic path takes over from the static disk file the moment a
+    // DB is configured. With no session cookie, we still render — just
+    // with the "Sign in" affordance.
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db })(req("/"));
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+        const body = await res.text();
+        expect(body).toContain('class="auth-indicator"');
+        expect(body).toContain("Sign in");
+        expect(body).not.toContain("Signed in as");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/ renders 'Signed in as <name>' + sign-out form when session cookie is active (rc.13)", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const { createUser } = await import("../users.ts");
+        const { createSession, buildSessionCookie, SESSION_TTL_MS } = await import(
+          "../sessions.ts"
+        );
+        const user = await createUser(db, "aaron", "pw");
+        const session = createSession(db, { userId: user.id });
+        const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+        const res = await hubFetch(h.dir, { getDb: () => db })(req("/", { headers: { cookie } }));
+        expect(res.status).toBe(200);
+        const body = await res.text();
+        expect(body).toContain("Signed in as");
+        expect(body).toContain("aaron");
+        expect(body).toContain('action="/logout"');
+        expect(body).toContain('name="__csrf"');
+        // CSRF cookie was minted on the response (no prior cookie present).
+        expect(res.headers.get("set-cookie") ?? "").toContain("parachute_hub_csrf=");
+      } finally {
+        db.close();
+      }
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/hub.test.ts
+++ b/src/__tests__/hub.test.ts
@@ -103,6 +103,52 @@ describe("renderHub", () => {
     expect(html).not.toContain("renderConfigField");
     expect(html).not.toContain("kind-badge");
   });
+
+  test("default render (no session) emits the 'Sign in' affordance", () => {
+    expect(html).toContain('class="auth-indicator"');
+    expect(html).toContain("Sign in");
+    expect(html).toContain('href="/login?next=/"');
+    // No POST form, no CSRF input — those only appear when signed in.
+    expect(html).not.toContain('action="/logout"');
+    expect(html).not.toContain("__csrf");
+  });
+});
+
+describe("renderHub — signed-in indicator (rc.13)", () => {
+  test("session user → 'Signed in as <name>' + inline POST form with CSRF", () => {
+    const html = renderHub({
+      session: { displayName: "aaron", csrfToken: "csrf-token-xyz" },
+    });
+    expect(html).toContain('class="auth-indicator"');
+    expect(html).toContain("Signed in as");
+    expect(html).toContain("aaron");
+    // Inline POST form for sign-out — CSRF token embedded as the
+    // existing `__csrf` field name (matches /logout's expectations).
+    expect(html).toContain('method="POST" action="/logout"');
+    expect(html).toContain('name="__csrf"');
+    expect(html).toContain('value="csrf-token-xyz"');
+    expect(html).toContain("Sign out");
+    // No "Sign in" affordance when signed in.
+    expect(html).not.toContain('href="/login?next=/"');
+  });
+
+  test("displayName with HTML special chars is escaped", () => {
+    // Username field allows alphanumerics historically, but the
+    // displayName field on the wire is forward-compatible with profile
+    // names that may contain &, <, >. Escape at render time.
+    const html = renderHub({
+      session: { displayName: "<aaron>&friends", csrfToken: "tok" },
+    });
+    expect(html).toContain("&lt;aaron&gt;&amp;friends");
+    expect(html).not.toContain("<aaron>&friends");
+  });
+
+  test("CSRF token with HTML special chars is escaped in the value attribute", () => {
+    const html = renderHub({
+      session: { displayName: "aaron", csrfToken: 'token"with"quotes' },
+    });
+    expect(html).toContain('value="token&quot;with&quot;quotes"');
+  });
 });
 
 describe("writeHubFile", () => {

--- a/src/api-me.ts
+++ b/src/api-me.ts
@@ -1,0 +1,120 @@
+/**
+ * `GET /api/me` — public who-am-I endpoint for hub-served surfaces.
+ *
+ * Reads the `parachute_hub_session` cookie. If present and active, returns
+ * the user identity AND a CSRF token bound to the existing CSRF cookie (or
+ * a freshly-minted one). Otherwise returns the minimal `{ hasSession: false }`
+ * payload.
+ *
+ * Public — no auth required (returns "not signed in" rather than 401 when
+ * no session, so the SPA / discovery page can render a consistent affordance
+ * regardless of auth state). No CORS — same-origin only; hub-served UIs
+ * are same-origin.
+ *
+ * Response shape:
+ *
+ *   { hasSession: false }
+ *   { hasSession: true, user: { id, displayName }, csrf: "<token>" }
+ *
+ * `displayName` is the user's `username` today — there's no separate
+ * display-name field on the User shape. Surfaced under a different key
+ * here so a future profile-name migration can land without breaking
+ * SPA / discovery consumers.
+ *
+ * Why include the CSRF token only when signed in: there's nothing to
+ * sign-out (or otherwise mutate) without a session. Minting a token in
+ * the unsigned-in case would just bloat the response and prime a cookie
+ * the consumer has no use for.
+ *
+ * Why a dedicated endpoint rather than reusing `/admin/config`:
+ * `/admin/config` redirects to /login when unauthenticated, which is
+ * exactly the wrong UX for an unconditionally-fetched "show sign-in
+ * affordance" call. `/api/me` cleanly returns either state without a
+ * bounce.
+ *
+ * The CSRF token returned here is the same token any same-session
+ * `<form>` would carry — the consumer (SPA fetch POST or
+ * server-rendered discovery form) submits it back as `__csrf` against
+ * the existing logout / mutation handlers.
+ */
+import type { Database } from "bun:sqlite";
+import { ensureCsrfToken } from "./csrf.ts";
+import { findActiveSession } from "./sessions.ts";
+import { getUserById } from "./users.ts";
+
+export interface ApiMeDeps {
+  db: Database;
+}
+
+interface SignedInUser {
+  id: string;
+  displayName: string;
+}
+
+interface ApiMeResponse {
+  hasSession: boolean;
+  user?: SignedInUser;
+  csrf?: string;
+}
+
+export function handleApiMe(req: Request, deps: ApiMeDeps): Response {
+  if (req.method !== "GET") {
+    return jsonError(405, "method_not_allowed", "use GET");
+  }
+
+  const session = findActiveSession(deps.db, req);
+  if (!session) {
+    return ok({ hasSession: false });
+  }
+
+  const user = getUserById(deps.db, session.userId);
+  if (!user) {
+    // Session row points at a deleted user — treat as not signed in.
+    // The session row should be cleaned up by some future sweep, but
+    // surfacing a stale identity to the UI would be worse than a
+    // momentary "signed out" affordance.
+    return ok({ hasSession: false });
+  }
+
+  // Mint a CSRF token (or reuse the existing cookie's). When this is the
+  // first request to set the cookie, attach Set-Cookie so the browser
+  // stores it for future logout submission.
+  const csrf = ensureCsrfToken(req);
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    // Don't cache — session can change at any time (login, logout,
+    // expiry). The endpoint is cheap; revalidate on every request.
+    "cache-control": "no-store",
+  };
+  if (csrf.setCookie) headers["set-cookie"] = csrf.setCookie;
+
+  const body: ApiMeResponse = {
+    hasSession: true,
+    user: {
+      id: user.id,
+      displayName: user.username,
+    },
+    csrf: csrf.token,
+  };
+  return new Response(JSON.stringify(body), { status: 200, headers });
+}
+
+function ok(body: ApiMeResponse): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": "no-store",
+    },
+  });
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/src/api-me.ts
+++ b/src/api-me.ts
@@ -51,11 +51,16 @@ interface SignedInUser {
   displayName: string;
 }
 
-interface ApiMeResponse {
-  hasSession: boolean;
-  user?: SignedInUser;
-  csrf?: string;
-}
+/**
+ * Discriminated union mirroring the client-side `MeResponse` shape in
+ * `web/ui/src/lib/api.ts`. The two early returns below (no-session,
+ * deleted-user) construct the `false` arm; the success path constructs
+ * the `true` arm. Typing it as a union (rather than an interface with
+ * optional fields) means the compiler refuses any future construction
+ * that mixes states — e.g. `{ hasSession: false, user: staleUser }`
+ * fails at the type-check, not just at code-review.
+ */
+type ApiMeResponse = { hasSession: false } | { hasSession: true; user: SignedInUser; csrf: string };
 
 export function handleApiMe(req: Request, deps: ApiMeDeps): Response {
   if (req.method !== "GET") {

--- a/src/csrf.ts
+++ b/src/csrf.ts
@@ -19,9 +19,12 @@
  * pre-login and post-login forms, and it works no matter how many tabs the
  * operator has open.
  *
- * The cookie is HttpOnly (the form doesn't need JS to read it; the server
- * embeds the value at render time), SameSite=Lax (matches the session
- * cookie), Secure, and Path=/ (covers every admin form, OAuth or otherwise).
+ * The cookie is HttpOnly: consumers receive the token value via either the
+ * server-rendered HTML form (cookie + embedded value, classic double-submit)
+ * or via the JSON body of `/api/me` (cookie alongside body — same pattern,
+ * just JSON instead of HTML). Neither path needs JS to read the cookie
+ * directly. SameSite=Lax (matches the session cookie), Secure, and Path=/
+ * (covers every admin form, OAuth flow, and `/api/me` consumer).
  *
  * Token entropy: 32 random bytes, base64url-encoded — same shape as session
  * IDs. No HMAC needed: the value is opaque to the client and only ever

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -40,6 +40,7 @@
  *   /vaults                       (POST)       → create vault
  *   /admin/host-admin-token       (GET)        → SPA bearer mint (cookie-gated)
  *   /admin/vault-admin-token/<n>  (GET)        → per-vault bearer mint (cookie-gated)
+ *   /api/me                       (GET)        → who-am-I (session+CSRF or hasSession:false)
  *   /api/auth/mint-token          (POST)       → CLI/automation token mint (bearer)
  *   /api/auth/revoke-token        (POST)       → revoke registry-row token by jti
  *   /api/auth/tokens              (GET)        → paginated registry list
@@ -93,13 +94,16 @@ import {
 import { handleHostAdminToken } from "./admin-host-admin-token.ts";
 import { handleVaultAdminToken } from "./admin-vault-admin-token.ts";
 import { handleCreateVault } from "./admin-vaults.ts";
+import { handleApiMe } from "./api-me.ts";
 import { handleApiMintToken } from "./api-mint-token.ts";
 import { REVOCATION_LIST_MOUNT, handleRevocationList } from "./api-revocation-list.ts";
 import { handleApiRevokeToken } from "./api-revoke-token.ts";
 import { handleApiTokens } from "./api-tokens.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
+import { ensureCsrfToken } from "./csrf.ts";
 import { HUB_SVC, clearHubPort, writeHubPort } from "./hub-control.ts";
 import { hubDbPath, openHubDb } from "./hub-db.ts";
+import { type RenderHubOpts, renderHub } from "./hub.ts";
 import { pemToJwk } from "./jwks.ts";
 import {
   type ModuleManifest,
@@ -121,7 +125,9 @@ import {
   shortNameForManifest,
 } from "./service-spec.ts";
 import { type ServiceEntry, readManifest } from "./services-manifest.ts";
+import { findActiveSession } from "./sessions.ts";
 import { getAllPublicKeys } from "./signing-keys.ts";
+import { getUserById } from "./users.ts";
 import { buildWellKnown, isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
 
 interface Args {
@@ -744,6 +750,31 @@ export function hubFetch(
     }
 
     if (pathname === "/" || pathname === "/hub.html") {
+      // When a DB is configured, render the discovery page dynamically so
+      // the header carries a "Signed in as <name>" affordance for the
+      // active session. Without a DB, fall back to the static disk file
+      // (signed-out shape) — the disk file is what `parachute expose`
+      // wrote out, used when the hub-server is running without state.
+      if (getDb) {
+        const db = getDb();
+        const session = findActiveSession(db, req);
+        let renderOpts: RenderHubOpts = {};
+        const headers: Record<string, string> = {
+          "content-type": "text/html; charset=utf-8",
+        };
+        if (session) {
+          const user = getUserById(db, session.userId);
+          if (user) {
+            const csrf = ensureCsrfToken(req);
+            renderOpts = {
+              session: { displayName: user.username, csrfToken: csrf.token },
+            };
+            if (csrf.setCookie) headers["set-cookie"] = csrf.setCookie;
+          }
+        }
+        return new Response(renderHub(renderOpts), { headers });
+      }
+      // No DB configured → fall back to static file (signed-out only).
       if (!existsSync(hubHtmlPath)) {
         return new Response("hub.html not found", { status: 404 });
       }
@@ -957,6 +988,16 @@ export function hubFetch(
         issuer: oauthDeps(req).issuer,
         knownVaultNames,
       });
+    }
+
+    if (pathname === "/api/me") {
+      if (!getDb) {
+        return Response.json(
+          { error: "service_unavailable", error_description: "hub db not configured" },
+          { status: 503 },
+        );
+      }
+      return handleApiMe(req, { db: getDb() });
     }
 
     if (pathname === "/api/auth/mint-token") {

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { CONFIG_DIR } from "./config.ts";
+import { CSRF_FIELD_NAME } from "./csrf.ts";
 
 /**
  * Hub page served at `/` when the node is exposed.
@@ -36,21 +37,85 @@ import { CONFIG_DIR } from "./config.ts";
 export const HUB_PATH = join(CONFIG_DIR, "well-known", "hub.html");
 export const HUB_MOUNT = "/";
 
-export function renderHub(): string {
-  return HTML;
+export interface RenderHubSession {
+  /** displayName from /api/me semantics — username today, profile field later. */
+  displayName: string;
+  /** Per-session CSRF token; embedded in the inline sign-out form. */
+  csrfToken: string;
 }
 
+export interface RenderHubOpts {
+  /**
+   * When set, renders "Signed in as <displayName>" + an inline sign-out
+   * form. When omitted (or null), renders a "Sign in" link. Pass through
+   * from `findActiveSession` + `ensureCsrfToken` in the hub-server `/`
+   * handler — the static-disk write path (`writeHubFile`) emits the
+   * signed-out shape, since that file gets served only when the
+   * dynamic path can't (`!getDb`).
+   */
+  session?: RenderHubSession | null;
+}
+
+export function renderHub(opts: RenderHubOpts = {}): string {
+  return buildHtml(opts);
+}
+
+/**
+ * Write the static signed-out HTML to disk. Used by `parachute expose` so
+ * `tailscale serve --set-path=/` has a file to back. The dynamic
+ * session-aware path runs through `hub-server.ts`'s `/` handler whenever
+ * a DB is configured; this disk file is the fallback when it isn't.
+ */
 export function writeHubFile(path: string = HUB_PATH): string {
   if (!existsSync(dirname(path))) {
     mkdirSync(dirname(path), { recursive: true });
   }
+  const html = renderHub();
   const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
-  writeFileSync(tmp, HTML);
+  writeFileSync(tmp, html);
   renameSync(tmp, path);
   return path;
 }
 
-const HTML = `<!doctype html>
+function buildHtml({ session }: RenderHubOpts): string {
+  const authBlock = session
+    ? renderSignedIn(session.displayName, session.csrfToken)
+    : renderSignedOut();
+  return HTML_TEMPLATE.replace("<!--AUTH-INDICATOR-->", authBlock);
+}
+
+function renderSignedIn(displayName: string, csrfToken: string): string {
+  // Inline POST form so sign-out works without JS. Submit button is
+  // styled as a text link via `.auth-signout` so the visual weight
+  // matches the surrounding "Signed in as <name>" text.
+  return `<div class="auth-indicator">
+      <span class="muted">Signed in as <strong>${escapeHtml(displayName)}</strong></span>
+      <form method="POST" action="/logout" class="auth-signout-form">
+        <input type="hidden" name="${CSRF_FIELD_NAME}" value="${escapeAttr(csrfToken)}" />
+        <button type="submit" class="auth-signout">Sign out</button>
+      </form>
+    </div>`;
+}
+
+function renderSignedOut(): string {
+  return `<div class="auth-indicator">
+      <a href="/login?next=/" class="auth-signin">Sign in</a>
+    </div>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}
+
+const HTML_TEMPLATE = `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8" />
@@ -109,6 +174,50 @@ const HTML = `<!doctype html>
   header {
     text-align: center;
     margin-bottom: 3.5rem;
+    position: relative;
+  }
+  /* Auth indicator: small text + sign-in/out affordance, top-right of the
+     header. Doesn't crowd the centered title; falls below the title on
+     narrow viewports via the media query at the bottom of this stylesheet. */
+  .auth-indicator {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--fg-muted);
+  }
+  .auth-indicator .muted {
+    color: var(--fg-muted);
+  }
+  .auth-indicator strong {
+    font-weight: 600;
+    color: var(--fg);
+  }
+  .auth-signout-form {
+    margin: 0;
+    display: inline;
+  }
+  .auth-signout, .auth-signin {
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--accent);
+    font: inherit;
+    cursor: pointer;
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+  .auth-signout:hover, .auth-signin:hover {
+    color: var(--accent-hover);
+  }
+  a.auth-signin {
+    /* Anchor needs explicit reset since the a element has its own
+       color/decoration. */
+    border-bottom: none;
   }
   h1 {
     font-family: var(--serif);
@@ -233,12 +342,17 @@ const HTML = `<!doctype html>
   @media (max-width: 640px) {
     main { padding: 2.5rem 1rem 4rem; }
     .card { padding: 1.25rem; }
+    /* Auth indicator drops below the title on narrow viewports so the
+       header doesn't crowd. */
+    header { padding-top: 1.75rem; }
+    .auth-indicator { font-size: 0.8rem; }
   }
 </style>
 </head>
 <body>
 <main>
   <header>
+    <!--AUTH-INDICATOR-->
     <h1>Parachute</h1>
     <p class="tagline">Your personal-computing modules.</p>
   </header>

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -6,12 +6,16 @@
  * so tests drive route changes via `MemoryRouter`'s `initialEntries` —
  * no `window.location` munging needed.
  */
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { App } from "./App.tsx";
-import type * as api from "./lib/api.ts";
+// Runtime import (not `import type`) because the auth-indicator tests
+// call `vi.mocked(api.getMe).mockResolvedValue(...)` at runtime to drive
+// per-test fixtures. The mock above replaces the live module's exports
+// with vi.fn()s — `api.getMe` resolves to that vi.fn at call time.
+import * as api from "./lib/api.ts";
 
 // Stub all API helpers — App pulls in VaultsList / Permissions / Tokens
 // at module-load time, and each of those calls into lib/api.ts on mount.
@@ -24,6 +28,11 @@ vi.mock("./lib/api.ts", async (orig) => {
     listVaults: vi.fn().mockResolvedValue([]),
     listGrants: vi.fn().mockResolvedValue([]),
     listTokens: vi.fn().mockResolvedValue({ tokens: [], next_cursor: null }),
+    // App's useEffect hits getMe() on mount. Default mock = signed-out so
+    // the AuthIndicator renders the deterministic "Sign in" link rather
+    // than racing on a real fetch. Per-test overrides via mockResolvedValue.
+    getMe: vi.fn().mockResolvedValue({ hasSession: false }),
+    signOut: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -67,13 +76,19 @@ describe("App — brand subtitle (route-derived)", () => {
 });
 
 describe("App — nav structure", () => {
-  it("renders all nav links in order: brand, Vaults, Permissions, Tokens, Discovery", () => {
+  it("renders all nav links in order: brand, Vaults, Permissions, Tokens, Discovery (signed-out)", async () => {
     renderAt("/vaults");
+    // Wait for /api/me to resolve so AuthIndicator's "Sign in" link
+    // appears in the nav before we snapshot the link order.
     const nav = screen.getByRole("navigation");
+    await waitFor(() =>
+      expect(within(nav).getByRole("link", { name: /^sign in$/i })).toBeInTheDocument(),
+    );
     const links = within(nav).getAllByRole("link");
     const labels = links.map((a) => a.textContent?.trim());
     expect(labels).toEqual([
       expect.stringMatching(/parachute admin/i),
+      "Sign in", // AuthIndicator slot, sits between brand and Vaults
       "Vaults",
       "Permissions",
       "Tokens",
@@ -97,6 +112,92 @@ describe("App — nav structure", () => {
     renderAt("/vaults");
     expect(screen.getByText(/parachute admin/i)).toBeInTheDocument();
     expect(screen.queryByText(/^parachute hub/i)).toBeNull();
+  });
+});
+
+describe("App — auth indicator (rc.13)", () => {
+  it("renders nothing on first paint, then 'Sign in' once /api/me resolves to signed-out", async () => {
+    vi.mocked(api.getMe).mockResolvedValue({ hasSession: false });
+    renderAt("/vaults");
+    // First paint shouldn't have the link yet (`me === null` until effect resolves).
+    // The `await waitFor` proves the link appears asynchronously.
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: /^sign in$/i })).toBeInTheDocument(),
+    );
+  });
+
+  it("Sign in link points at /login?next=<current path>", async () => {
+    vi.mocked(api.getMe).mockResolvedValue({ hasSession: false });
+    renderAt("/permissions");
+    const link = await screen.findByRole("link", { name: /^sign in$/i });
+    // jsdom's window.location.pathname is "/" by default since MemoryRouter
+    // doesn't touch real window.location. So the next= encodes "/" not
+    // /permissions. Pinning the actual encoded value here.
+    expect(link.getAttribute("href")).toBe(`/login?next=${encodeURIComponent("/")}`);
+  });
+
+  it("renders 'Signed in as <displayName>' + Sign out button when /api/me has a session", async () => {
+    vi.mocked(api.getMe).mockResolvedValue({
+      hasSession: true,
+      user: { id: "u1", displayName: "aaron" },
+      csrf: "csrf-token-abc",
+    });
+    renderAt("/vaults");
+    await waitFor(() => expect(screen.getByText(/signed in as/i)).toBeInTheDocument());
+    expect(screen.getByText("aaron")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^sign out$/i })).toBeInTheDocument();
+    // The "Sign in" link must NOT also appear when signed in.
+    expect(screen.queryByRole("link", { name: /^sign in$/i })).toBeNull();
+  });
+
+  it("clicking Sign out POSTs the CSRF token via signOut() and navigates to /", async () => {
+    vi.mocked(api.getMe).mockResolvedValue({
+      hasSession: true,
+      user: { id: "u1", displayName: "aaron" },
+      csrf: "csrf-token-abc",
+    });
+    vi.mocked(api.signOut).mockResolvedValue();
+    // Stub window.location so we can observe the navigation without
+    // actually navigating jsdom away from the test page.
+    const original = window.location;
+    Object.defineProperty(window, "location", {
+      value: { ...original, href: original.href },
+      writable: true,
+    });
+
+    try {
+      renderAt("/vaults");
+      const signOutBtn = await screen.findByRole("button", { name: /^sign out$/i });
+      fireEvent.click(signOutBtn);
+      await waitFor(() => expect(api.signOut).toHaveBeenCalledWith("csrf-token-abc"));
+      // Navigation target is `/` (discovery) so the operator sees the
+      // signed-out affordance immediately on the freshly-rebuilt header.
+      await waitFor(() => expect(window.location.href).toBe("/"));
+    } finally {
+      Object.defineProperty(window, "location", { value: original, writable: true });
+    }
+  });
+
+  it("Sign out button shows 'Signing out…' and disables during the in-flight POST", async () => {
+    vi.mocked(api.getMe).mockResolvedValue({
+      hasSession: true,
+      user: { id: "u1", displayName: "aaron" },
+      csrf: "csrf-token-abc",
+    });
+    let resolveSignOut: () => void = () => {};
+    vi.mocked(api.signOut).mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveSignOut = resolve;
+      }),
+    );
+    renderAt("/vaults");
+    const signOutBtn = await screen.findByRole("button", { name: /^sign out$/i });
+    fireEvent.click(signOutBtn);
+    // While the POST is pending, the button is disabled with "Signing out…".
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^signing out…$/i })).toBeDisabled(),
+    );
+    resolveSignOut();
   });
 });
 

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -21,7 +21,9 @@
  * entry point — its Use section links to per-service surfaces; its
  * Admin section links here.
  */
+import { type ReactNode, useEffect, useState } from "react";
 import { Link, Route, Routes, useLocation } from "react-router-dom";
+import { type MeResponse, getMe, signOut } from "./lib/api.ts";
 import { NewVault } from "./routes/NewVault.tsx";
 import { Permissions } from "./routes/Permissions.tsx";
 import { Tokens } from "./routes/Tokens.tsx";
@@ -45,6 +47,45 @@ function subtitleFor(pathname: string): string {
 export function App() {
   const { pathname } = useLocation();
   const subtitle = subtitleFor(pathname);
+  const [me, setMe] = useState<MeResponse | null>(null);
+  const [signingOut, setSigningOut] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getMe()
+      .then((res) => {
+        if (cancelled) return;
+        setMe(res);
+      })
+      .catch(() => {
+        // Network failure — leave `me` null. Nav indicator stays in
+        // the loading-collapsed state (renders nothing); the rest of
+        // the SPA still works since the per-page admin Bearer mint
+        // does its own redirect-to-login on 401.
+        if (cancelled) return;
+        setMe({ hasSession: false });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function onSignOut(csrf: string): Promise<void> {
+    setSigningOut(true);
+    try {
+      await signOut(csrf);
+      // Land on discovery so the operator immediately sees the
+      // signed-out affordance (and the freshly-rebuilt session-less
+      // header). Full navigation, not Link — we're leaving the SPA.
+      window.location.href = "/";
+    } catch {
+      // Logout failed — stay put and clear the spinner; the operator
+      // can retry. Realistically the only failure surface is CSRF
+      // mismatch (cookie cleared in another tab) or the server being
+      // down, both of which a reload will resolve.
+      setSigningOut(false);
+    }
+  }
 
   return (
     <div className="page">
@@ -52,6 +93,7 @@ export function App() {
         <Link to="/vaults" className="brand">
           Parachute Admin <span className="sub">{subtitle}</span>
         </Link>
+        <AuthIndicator me={me} signingOut={signingOut} onSignOut={onSignOut} />
         <Link to="/vaults">Vaults</Link>
         <Link to="/permissions">Permissions</Link>
         <Link to="/tokens">Tokens</Link>
@@ -77,5 +119,45 @@ export function App() {
         />
       </Routes>
     </div>
+  );
+}
+
+interface AuthIndicatorProps {
+  me: MeResponse | null;
+  signingOut: boolean;
+  onSignOut: (csrf: string) => Promise<void>;
+}
+
+/**
+ * Nav-mounted "Signed in as <name> · Sign out" affordance. Renders nothing
+ * until /api/me resolves (avoids flicker between an empty state and the
+ * filled one). When signed out, renders a "Sign in" link.
+ */
+function AuthIndicator({ me, signingOut, onSignOut }: AuthIndicatorProps): ReactNode {
+  if (me === null) return null; // first-paint, before /api/me resolves
+  if (!me.hasSession) {
+    return (
+      <a href={`/login?next=${encodeURIComponent(window.location.pathname)}`} className="auth-spa">
+        Sign in
+      </a>
+    );
+  }
+  return (
+    <span className="auth-spa">
+      <span className="muted">
+        Signed in as <strong>{me.user.displayName}</strong>
+      </span>{" "}
+      ·{" "}
+      <button
+        type="button"
+        className="auth-spa-signout"
+        disabled={signingOut}
+        onClick={() => {
+          void onSignOut(me.csrf);
+        }}
+      >
+        {signingOut ? "Signing out…" : "Sign out"}
+      </button>
+    </span>
   );
 }

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -237,6 +237,74 @@ export async function revokeGrant(clientId: string): Promise<void> {
 }
 
 /**
+ * `/api/me` wire shape. Matches `src/api-me.ts` verbatim — snake-case-free
+ * because the field names are short and the JS consumers benefit more from
+ * camelCase here than from a literal mirror.
+ */
+export interface MeSignedIn {
+  hasSession: true;
+  user: { id: string; displayName: string };
+  /** Per-session CSRF token; submit as `__csrf` against /logout etc. */
+  csrf: string;
+}
+export interface MeSignedOut {
+  hasSession: false;
+}
+export type MeResponse = MeSignedIn | MeSignedOut;
+
+/**
+ * GET /api/me — public who-am-I. No Bearer needed (session-cookie aware
+ * directly on the hub). Returns minimal `{ hasSession: false }` when no
+ * session, full `{ hasSession: true, user, csrf }` when signed in.
+ *
+ * Used by App.tsx on mount to render the "Signed in as <name> · Sign out"
+ * affordance in the nav, and by the sign-out flow to source the CSRF
+ * token for the POST to /logout.
+ */
+export async function getMe(): Promise<MeResponse> {
+  const res = await fetch("/api/me", {
+    method: "GET",
+    headers: { accept: "application/json" },
+    credentials: "same-origin",
+  });
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  return (await res.json()) as MeResponse;
+}
+
+/**
+ * POST /logout — sign out the current session. Submits the CSRF token
+ * as form-encoded `__csrf` (matches the existing logout handler's
+ * `req.formData()` parser; sending JSON would require a handler change).
+ *
+ * On success, the browser is left without a session cookie; callers
+ * typically navigate to / (discovery) to land on the signed-out
+ * affordance immediately.
+ */
+export async function signOut(csrfToken: string): Promise<void> {
+  const body = new URLSearchParams({ __csrf: csrfToken });
+  const res = await fetch("/logout", {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      // Don't follow the 302 the handler returns — the SPA navigates
+      // itself after success so the post-logout target is in our hands,
+      // not the server's.
+      accept: "text/html, application/json",
+    },
+    credentials: "same-origin",
+    body,
+    redirect: "manual",
+  });
+  // The handler returns 302 → /login on success. `redirect: "manual"`
+  // surfaces that as a network-level "opaqueredirect" with status 0;
+  // any 2xx or 302 is a success signal here. 4xx is a real error.
+  if (res.status === 0 || res.ok || res.status === 302) return;
+  throw new HttpError(res.status, await readError(res));
+}
+
+/**
  * Resolve a vault's `managementUrl` against the vault's mounted URL.
  * Absolute URL → returned verbatim. Path → joined onto `vaultUrl` after
  * stripping the trailing slash so we don't double-slash.

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -143,6 +143,39 @@ code {
   align-self: center;
 }
 
+/* SPA auth indicator — "Signed in as <name> · Sign out" or "Sign in".
+   Sits in the nav, after brand's margin-right:auto pushes everything
+   right. The brand keeps the layout balance; auth lands in the
+   right-aligned cluster with Vaults/Permissions/Tokens/Discovery.
+   Sign-out button is styled as an inline text link so the visual
+   weight matches the surrounding muted "Signed in as <name>" text. */
+.nav .auth-spa {
+  font-size: 0.85rem;
+  color: var(--fg-muted);
+}
+.nav .auth-spa strong {
+  font-weight: 600;
+  color: var(--fg);
+}
+.nav .auth-spa-signout {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+.nav .auth-spa-signout:hover:not(:disabled) {
+  color: var(--accent-hover);
+}
+.nav .auth-spa-signout:disabled {
+  color: var(--fg-dim);
+  cursor: not-allowed;
+}
+
 h2 {
   margin: 0 0 1rem;
   font-size: 1.4rem;


### PR DESCRIPTION
## Summary

C of the A+B+C auth UX cleanup (A+B shipped as rc.12, design pinned in #234's PR description). Adds the "Signed in as X / Sign out" affordance to discovery (server-rendered) and the admin SPA, both consuming a single new `GET /api/me` endpoint that returns session identity plus a per-session CSRF token.

The CSRF token is the same value any same-session form would carry — sign-out submits it back as `__csrf` against the existing `/logout` handler. **No relaxation of CSRF protection.**

## Three pieces

### 1. `GET /api/me`

`src/api-me.ts` (~110 LOC). Public, session-cookie-aware, same-origin.

- `{ hasSession: false }` when no active session.
- `{ hasSession: true, user: { id, displayName }, csrf }` when signed in. CSRF token reused from existing `parachute_hub_csrf` cookie or freshly minted with Set-Cookie attached.
- `cache-control: no-store`. No CORS.
- Why a dedicated endpoint and not `/admin/config`: the latter redirects to /login when unauthenticated, which is exactly the wrong UX for an unconditionally-fetched "show sign-in affordance" call.

### 2. Discovery page server-rendered indicator

`src/hub.ts`. `renderHub({ session })` accepts an optional session arg.

- **Signed in:** header carries `Signed in as <displayName>` + inline `<form method="POST" action="/logout">` with the CSRF token embedded as `__csrf`. **Works without JS.**
- **Signed out:** header shows "Sign in" link to `/login?next=/`.

`hub-server.ts`'s `/` handler reads the cookie via `findActiveSession` + `getUserById`, mints CSRF via `ensureCsrfToken`, passes through to `renderHub`. Falls back to the static disk file when no DB is configured.

### 3. SPA indicator + sign-out

`web/ui/src/App.tsx`. `useEffect` fetches `/api/me` on mount; renders `<AuthIndicator>` in nav (between brand and Vaults).

- **Signed in:** `Signed in as <displayName> · Sign out`. Sign-out POSTs form-encoded `__csrf=<token>` to `/logout` via `signOut(csrf)` helper. On success, full navigation to `/` so the operator sees the freshly-rendered signed-out header.
- **Signed out:** "Sign in" link to `/login?next=<current-path>`.
- **First paint:** renders nothing — avoids flicker between empty state and filled state.

Two new helpers in `web/ui/src/lib/api.ts`: `getMe()` returning `MeResponse` (discriminated union: `MeSignedIn | MeSignedOut`); `signOut(csrf)` returning `Promise<void>`.

## Three impl choices worth a reviewer eyeball

1. **CSRF surface choice — extend `/api/me`, not relax `/logout`.** Sign-out form posts the CSRF token as form-encoded body so the existing handler's `req.formData()` parse works as-is. Both consumers (discovery + SPA) source their token from `/api/me`.

2. **`signOut()` uses `redirect: "manual"`** so the SPA's fetch doesn't follow the handler's 302 → /login. The SPA then explicitly navigates to `/` (discovery) for a coherent post-logout landing.

3. **Static disk file fallback preserved.** Without a configured DB, `/` still serves the on-disk `hub.html` (which `parachute expose` writes out as the signed-out shape). Dynamic path only kicks in when DB is available — `parachute expose` doesn't need any changes.

## Versioning

- `package.json`: `0.5.8-rc.12` → `0.5.8-rc.13`.
- CHANGELOG entry under `## [0.5.8-rc.13] - 2026-05-10` with explicit cross-ref to rc.12 for the A+B half.

## Test plan

- [x] hub `bun test ./src`: all pass (was 1203 at rc.12; +13).
  - `api-me.test.ts` — 7 cases (405 / no-session / deleted-session / full-payload / fresh-mint Set-Cookie / cookie-reuse / two-distinct-no-cookie tokens differ).
  - `hub-server.test.ts` — 2 new (no-session dynamic-render, signed-in dynamic-render with CSRF Set-Cookie).
  - `hub.test.ts` — 4 new (default no-session emits Sign in, session arg emits inline POST form, displayName escaping, CSRF token escaping in value attr).
- [x] web/ui `bun run test`: all pass (was 83; +5).
  - `App.test.tsx` — 5 new (renders nothing on first paint then Sign in; Sign in href; Signed in as … + Sign out button when session; sign-out POST + navigation to /; Signing out… disabled state during in-flight POST). Plus updated nav-structure test for new "Sign in" link in the link-order snapshot.
- [x] typecheck (both packages): clean.
- [x] biome: clean.
- [x] UI build + `verify-base`: clean.

## Patterns check

- **CSRF discipline preserved** — same double-submit-cookie pattern (`parachute_hub_csrf` cookie + `__csrf` form field, `verifyCsrfToken` constant-time compare). No new auth surface; just a new way to source the token client-side.
- **Same-origin only** — `/api/me` has no CORS headers; hub-served UIs are same-origin. If a future cross-origin consumer needs me-info, that's a separate `/.well-known/me` design conversation.
- **State-machine rendering** in `AuthIndicator` matches Permissions/Tokens conventions (`me === null` → first paint; discriminated union for the resolved cases).
- **Session-bound TTL** — CSRF cookie outlives the 24h session by design (30d), but the token returned by `/api/me` only ever applies to the current session via the `verifyCsrfToken` cookie compare. A logout invalidates the session, so a stale token can't replay against a fresh session.
- **RC versioning** — `rc.12` → `rc.13` per parachute-patterns/governance.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)