### PR TITLE
feat(ui): /admin/tokens source filter pills + per-row chips (auth UX F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.8-rc.14] - 2026-05-10
+
+Token list grouping by source — F of the auth UX pathway. The `/admin/tokens` page now distinguishes OAuth refresh tokens, operator-token mints, and CLI mints at a glance via per-row chips and a second filter dimension.
+
+### Added
+
+- **`?created_via=` query param on `GET /api/auth/tokens`.** Accepts `oauth_refresh | operator_mint | cli_mint`; composes with the existing `?revoked=` and `?subject=` filters. Invalid value → 400. `ListTokensFilter` gains a typed `createdVia?: TokenCreatedVia` field; `listTokens` translates it into a `WHERE created_via = ?` clause.
+- **Source filter pills on `/admin/tokens`.** Second filter row alongside the existing Status pills: "All sources / OAuth / Operator / CLI mint". Both dimensions compose. Filter state lives in the URL via `useSearchParams` (`?status=live&source=oauth_refresh`) so refresh + share preserve the operator's view; the default `all` value strips the param to keep the URL minimal.
+- **Per-row source chip.** Each token row shows a small colored tag — OAuth (subtle blue), Operator (subtle gold), CLI (subtle sage, palette-aligned with the existing `.tag` accent base). Tooltip exposes the raw `created_via` value for operators who care about the canonical name.
+- **Filter-aware empty state.** When no rows match the active filter, the empty message switches to "No tokens match the current filter" with a hint to widen via the pills. The original "No tokens." copy stays for the truly-empty registry case.
+
+### Changed
+
+- `web/ui/src/lib/api.ts`: `ListTokensOpts` gains `createdVia?: AdminTokenCreatedVia` (new exported type mirroring `TokenCreatedVia`); `listTokens()` serializes it to `created_via=…`.
+
+### Test gate
+
+All test suites pass. New coverage in this PR:
+
+- `api-tokens.test.ts` — 4 new tests: `?created_via=cli_mint` narrows correctly, `?created_via=operator_mint` narrows correctly, `?created_via=cli_mint` composes with `?revoked=false`, `?created_via=invalid` → 400.
+- `Tokens.test.tsx` — 7 new tests across 2 describes: source pill clicks call `listTokens` with the right `createdVia`; status + source compose; "All sources" clears the source filter; OAuth/Operator/CLI rows render the correct chip with the matching `source-…` class; filter-aware empty state appears when filters are active.
+
+Typecheck (both packages): clean. biome: clean. UI build + verify-base: clean.
+
+(Test-count numbers omitted per the hub#219 canonical-vs-combined ambiguity convention.)
+
 ## [0.5.8-rc.13] - 2026-05-10
 
 Auth-UX cleanup, C of the A+B+C bundle (A+B shipped as rc.12). Adds the signed-in indicator to hub-served surfaces — discovery page (server-rendered) and the admin SPA. Both consume a single new endpoint (`GET /api/me`) that returns session identity + a per-session CSRF token, so the sign-out form can be rendered without a separate token-fetch step.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.8-rc.13",
+  "version": "0.5.8-rc.14",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-tokens.test.ts
+++ b/src/__tests__/api-tokens.test.ts
@@ -44,6 +44,8 @@ interface SeedOpts {
   revokedAt?: Date | null;
   /** Override created_at — drives ORDER BY. Tests use ascending real timestamps. */
   createdAt?: Date;
+  /** Mint provenance for the registry row. Defaults to `cli_mint`. */
+  createdVia?: "cli_mint" | "operator_mint";
 }
 
 async function seed(
@@ -54,6 +56,7 @@ async function seed(
   const scopes = opts.scopes ?? ["scribe:transcribe"];
   const subject = opts.subject ?? userId;
   const createdAt = opts.createdAt ?? new Date();
+  const createdVia = opts.createdVia ?? "cli_mint";
   const signed = await signAccessToken(db, {
     sub: subject,
     scopes,
@@ -65,7 +68,7 @@ async function seed(
   });
   recordTokenMint(db, {
     jti: signed.jti,
-    createdVia: "cli_mint",
+    createdVia,
     subject,
     clientId: "parachute-hub",
     scopes,
@@ -409,6 +412,118 @@ describe("GET /api/auth/tokens (admin token list — Phase 2 backend)", () => {
         const jtisTheirs = bodyTheirs.tokens.map((t) => t.jti);
         expect(jtisTheirs).toContain(theirs);
         expect(jtisTheirs).not.toContain(mine);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("?created_via=cli_mint narrows to CLI-minted rows", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        // mintOperatorToken seeds an operator_mint row already.
+        const cliJti = await seed(db, userId, { createdVia: "cli_mint" });
+        const opJti = await seed(db, userId, { createdVia: "operator_mint" });
+
+        const resp = await handleApiTokens(
+          getRequest("?created_via=cli_mint", { authorization: `Bearer ${op.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as {
+          tokens: Array<{ jti: string; created_via: string }>;
+        };
+        const jtis = body.tokens.map((t) => t.jti);
+        expect(jtis).toContain(cliJti);
+        expect(jtis).not.toContain(opJti);
+        // Every returned row reports created_via=cli_mint (sanity).
+        expect(body.tokens.every((t) => t.created_via === "cli_mint")).toBe(true);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("?created_via=operator_mint narrows to operator-token rows", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const cliJti = await seed(db, userId, { createdVia: "cli_mint" });
+        const opJti = await seed(db, userId, { createdVia: "operator_mint" });
+
+        const resp = await handleApiTokens(
+          getRequest("?created_via=operator_mint", { authorization: `Bearer ${op.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as {
+          tokens: Array<{ jti: string; created_via: string }>;
+        };
+        const jtis = body.tokens.map((t) => t.jti);
+        expect(jtis).toContain(opJti);
+        expect(jtis).not.toContain(cliJti);
+        expect(body.tokens.every((t) => t.created_via === "operator_mint")).toBe(true);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("?created_via composes with ?revoked", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const liveCli = await seed(db, userId, { createdVia: "cli_mint" });
+        const deadCli = await seed(db, userId, {
+          createdVia: "cli_mint",
+          revokedAt: new Date(),
+        });
+        const liveOp = await seed(db, userId, { createdVia: "operator_mint" });
+
+        const resp = await handleApiTokens(
+          getRequest("?revoked=false&created_via=cli_mint", {
+            authorization: `Bearer ${op.token}`,
+          }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as { tokens: Array<{ jti: string }> };
+        const jtis = body.tokens.map((t) => t.jti);
+        expect(jtis).toContain(liveCli);
+        expect(jtis).not.toContain(deadCli); // wrong revoked status
+        expect(jtis).not.toContain(liveOp); // wrong created_via
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("?created_via=invalid → 400", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiTokens(
+          getRequest("?created_via=bogus", { authorization: `Bearer ${op.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(400);
       } finally {
         db.close();
       }

--- a/src/__tests__/api-tokens.test.ts
+++ b/src/__tests__/api-tokens.test.ts
@@ -420,6 +420,12 @@ describe("GET /api/auth/tokens (admin token list — Phase 2 backend)", () => {
     }
   });
 
+  // No dedicated `?created_via=oauth_refresh` filter test — the WHERE clause
+  // is identical for all three created_via values (parameterized SQL), and
+  // seeding an `oauth_refresh` row requires calling `signRefreshToken` (the
+  // OAuth grant path) rather than the test helper's `cli_mint`/`operator_mint`
+  // arms. The two value-specific tests below pin the filter logic;
+  // `oauth_refresh` would add no new coverage.
   test("?created_via=cli_mint narrows to CLI-minted rows", async () => {
     const h = makeHarness();
     try {

--- a/src/api-tokens.ts
+++ b/src/api-tokens.ts
@@ -42,6 +42,11 @@
  *     rows) or `subject` (CLI / operator / service mint rows). The
  *     consumer doesn't need to know which column to query; the helper
  *     handles both.
+ *   - `created_via=<value>` — narrow by mint provenance. One of
+ *     `oauth_refresh` (OAuth refresh-token rotation), `operator_mint`
+ *     (operator-token rotation via `parachute auth rotate-operator`),
+ *     or `cli_mint` (CLI / `POST /api/auth/mint-token`). Powers the
+ *     admin UI's "by source" filter pills (hub#212 Phase F).
  *
  * Why bearer-gated rather than session-cookie-gated: matches the rest
  * of `/api/auth/*` (mint-token, revoke-token), so an automation client
@@ -51,7 +56,7 @@
  * `/vaults` and `/api/grants` calls.
  */
 import type { Database } from "bun:sqlite";
-import { listTokens, validateAccessToken } from "./jwt-sign.ts";
+import { type TokenCreatedVia, listTokens, validateAccessToken } from "./jwt-sign.ts";
 
 /** Scope required on the bearer token to call this endpoint. */
 export const API_TOKENS_REQUIRED_SCOPE = "parachute:host:auth";
@@ -139,11 +144,30 @@ export async function handleApiTokens(req: Request, deps: ApiTokensDeps): Promis
   const subjectParam = url.searchParams.get("subject");
   const subject =
     typeof subjectParam === "string" && subjectParam.length > 0 ? subjectParam : undefined;
+  const createdViaParam = url.searchParams.get("created_via");
+  let createdVia: TokenCreatedVia | undefined;
+  if (
+    createdViaParam === "oauth_refresh" ||
+    createdViaParam === "operator_mint" ||
+    createdViaParam === "cli_mint"
+  ) {
+    createdVia = createdViaParam;
+  } else if (createdViaParam !== null) {
+    return jsonError(
+      400,
+      "invalid_request",
+      "created_via must be one of: oauth_refresh | operator_mint | cli_mint",
+    );
+  }
   const cursor = url.searchParams.get("cursor");
 
   // 5. Query.
   const page = listTokens(deps.db, {
-    filter: { ...(revoked ? { revoked } : {}), ...(subject ? { subject } : {}) },
+    filter: {
+      ...(revoked ? { revoked } : {}),
+      ...(subject ? { subject } : {}),
+      ...(createdVia ? { createdVia } : {}),
+    },
     cursor,
   });
 

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -271,11 +271,13 @@ export function listActiveRevocations(db: Database, now: Date): string[] {
  * Filter for `listTokens`. `revoked` defaults to "all"; `subject` matches
  * either the OAuth `user_id` or the non-OAuth `subject` column (so the
  * caller doesn't need to know which mint path created the row to filter
- * by identity).
+ * by identity); `createdVia` narrows by mint provenance (OAuth refresh,
+ * operator-token mint, CLI / api-mint-token).
  */
 export interface ListTokensFilter {
   revoked?: "true" | "false" | "all";
   subject?: string;
+  createdVia?: TokenCreatedVia;
 }
 
 /**
@@ -344,6 +346,10 @@ export function listTokens(
   if (typeof filter.subject === "string" && filter.subject.length > 0) {
     wheres.push("(user_id = ? OR subject = ?)");
     params.push(filter.subject, filter.subject);
+  }
+  if (filter.createdVia) {
+    wheres.push("created_via = ?");
+    params.push(filter.createdVia);
   }
   if (cursorCreatedAt !== undefined && cursorJti !== undefined) {
     // "strictly older than (cursor.created_at, cursor.jti)" under the

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -342,12 +342,17 @@ export interface AdminTokensPage {
   next_cursor: string | null;
 }
 
+/** Mint-provenance values surfaced by the registry. Mirrors `TokenCreatedVia` server-side. */
+export type AdminTokenCreatedVia = "oauth_refresh" | "operator_mint" | "cli_mint";
+
 /** Filter knobs for `listTokens`. */
 export interface ListTokensOpts {
   /** "true" → only revoked; "false" → only un-revoked; "all" or omit → both. */
   revoked?: "true" | "false" | "all";
   /** Exact match against either `user_id` (OAuth rows) or `subject` (mint rows). */
   subject?: string;
+  /** Narrow by mint provenance (oauth_refresh / operator_mint / cli_mint). */
+  createdVia?: AdminTokenCreatedVia;
   /** Cursor from a previous page's `next_cursor`. */
   cursor?: string;
 }
@@ -360,6 +365,7 @@ export async function listTokens(opts: ListTokensOpts = {}): Promise<AdminTokens
   const params = new URLSearchParams();
   if (opts.revoked) params.set("revoked", opts.revoked);
   if (opts.subject) params.set("subject", opts.subject);
+  if (opts.createdVia) params.set("created_via", opts.createdVia);
   if (opts.cursor) params.set("cursor", opts.cursor);
   const query = params.toString();
   const url = query ? `/api/auth/tokens?${query}` : "/api/auth/tokens";

--- a/web/ui/src/routes/Tokens.test.tsx
+++ b/web/ui/src/routes/Tokens.test.tsx
@@ -135,8 +135,8 @@ describe("Tokens — list rendering", () => {
   });
 });
 
-describe("Tokens — filter pills", () => {
-  it("clicking a filter pill calls listTokens with the right ?revoked= value", async () => {
+describe("Tokens — filter pills (status + source, hub#212 Phase F)", () => {
+  it("clicking a status pill calls listTokens with the right ?revoked= value", async () => {
     vi.mocked(api.listTokens).mockResolvedValue({ tokens: [], next_cursor: null });
     renderRoute();
     // Initial call with default `all`.
@@ -147,6 +147,127 @@ describe("Tokens — filter pills", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /^revoked only$/i, pressed: false }));
     await waitFor(() => expect(api.listTokens).toHaveBeenCalledWith({ revoked: "true" }));
+  });
+
+  it("clicking a source pill calls listTokens with the right createdVia value", async () => {
+    vi.mocked(api.listTokens).mockResolvedValue({ tokens: [], next_cursor: null });
+    renderRoute();
+    await waitFor(() => expect(api.listTokens).toHaveBeenCalledWith({ revoked: "all" }));
+
+    fireEvent.click(screen.getByRole("button", { name: /^oauth$/i, pressed: false }));
+    await waitFor(() =>
+      expect(api.listTokens).toHaveBeenCalledWith({
+        revoked: "all",
+        createdVia: "oauth_refresh",
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^operator$/i, pressed: false }));
+    await waitFor(() =>
+      expect(api.listTokens).toHaveBeenCalledWith({
+        revoked: "all",
+        createdVia: "operator_mint",
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^cli mint$/i, pressed: false }));
+    await waitFor(() =>
+      expect(api.listTokens).toHaveBeenCalledWith({
+        revoked: "all",
+        createdVia: "cli_mint",
+      }),
+    );
+  });
+
+  it("status + source filters compose: live + OAuth", async () => {
+    vi.mocked(api.listTokens).mockResolvedValue({ tokens: [], next_cursor: null });
+    renderRoute();
+    await waitFor(() => expect(api.listTokens).toHaveBeenCalledWith({ revoked: "all" }));
+
+    fireEvent.click(screen.getByRole("button", { name: /^live only$/i, pressed: false }));
+    fireEvent.click(screen.getByRole("button", { name: /^oauth$/i, pressed: false }));
+    await waitFor(() =>
+      expect(api.listTokens).toHaveBeenCalledWith({
+        revoked: "false",
+        createdVia: "oauth_refresh",
+      }),
+    );
+  });
+
+  it("clicking 'All sources' clears the source filter", async () => {
+    vi.mocked(api.listTokens).mockResolvedValue({ tokens: [], next_cursor: null });
+    renderRoute();
+    await waitFor(() => expect(api.listTokens).toHaveBeenCalledWith({ revoked: "all" }));
+
+    fireEvent.click(screen.getByRole("button", { name: /^operator$/i, pressed: false }));
+    await waitFor(() =>
+      expect(api.listTokens).toHaveBeenCalledWith({
+        revoked: "all",
+        createdVia: "operator_mint",
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^all sources$/i, pressed: false }));
+    // Back to default — no createdVia in the call.
+    await waitFor(() => expect(api.listTokens).toHaveBeenLastCalledWith({ revoked: "all" }));
+  });
+});
+
+describe("Tokens — source chip per row (hub#212 Phase F)", () => {
+  // Note: the filter pills also use the labels "OAuth" / "Operator" / "CLI mint",
+  // so a bare `getByText` would multi-match. Each test waits for the row to
+  // render then picks the chip via its `tag` class — the filter pills are
+  // <button> with `secondary`, the chips are <span> with `tag source-…`.
+  function findRowChip(label: string): HTMLElement | null {
+    const matches = screen.getAllByText(label);
+    return matches.find((el) => el.classList.contains("tag")) ?? null;
+  }
+
+  it("OAuth row shows 'OAuth' chip with source-oauth class", async () => {
+    vi.mocked(api.listTokens).mockResolvedValue({
+      tokens: [tokenRow("oauthrowAAAAAAAAAXXXX", { created_via: "oauth_refresh" })],
+      next_cursor: null,
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/oauthrow…XXXX/)).toBeInTheDocument());
+    const chip = findRowChip("OAuth");
+    expect(chip).not.toBeNull();
+    expect(chip?.className).toContain("source-oauth");
+  });
+
+  it("Operator row shows 'Operator' chip with source-operator class", async () => {
+    vi.mocked(api.listTokens).mockResolvedValue({
+      tokens: [tokenRow("oprowAAAAAAAAAXXXX", { created_via: "operator_mint" })],
+      next_cursor: null,
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/oprowAAA…XXXX/)).toBeInTheDocument());
+    const chip = findRowChip("Operator");
+    expect(chip).not.toBeNull();
+    expect(chip?.className).toContain("source-operator");
+  });
+
+  it("CLI mint row shows 'CLI' chip with source-cli class", async () => {
+    vi.mocked(api.listTokens).mockResolvedValue({
+      tokens: [tokenRow("clirowAAAAAAAAAXXXX", { created_via: "cli_mint" })],
+      next_cursor: null,
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/clirowAA…XXXX/)).toBeInTheDocument());
+    const chip = findRowChip("CLI");
+    expect(chip).not.toBeNull();
+    expect(chip?.className).toContain("source-cli");
+  });
+
+  it("renders 'No tokens match the current filter' empty state when filters are active", async () => {
+    vi.mocked(api.listTokens).mockResolvedValue({ tokens: [], next_cursor: null });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/no tokens\./i)).toBeInTheDocument());
+
+    // Activate a filter; the empty state should switch wording.
+    fireEvent.click(screen.getByRole("button", { name: /^operator$/i, pressed: false }));
+    await waitFor(() =>
+      expect(screen.getByText(/no tokens match the current filter/i)).toBeInTheDocument(),
+    );
   });
 });
 

--- a/web/ui/src/routes/Tokens.test.tsx
+++ b/web/ui/src/routes/Tokens.test.tsx
@@ -30,9 +30,11 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-function renderRoute() {
+function renderRoute(initialEntry = "/") {
+  // initialEntry lets the URL param tests (Phase F) drive
+  // `useSearchParams` from a deep-link state without going through a click.
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <Tokens />
     </MemoryRouter>,
   );
@@ -192,6 +194,38 @@ describe("Tokens — filter pills (status + source, hub#212 Phase F)", () => {
         createdVia: "oauth_refresh",
       }),
     );
+  });
+
+  it("URL deep-link: /admin/tokens?source=operator_mint loads with Operator pill active", async () => {
+    // Operator visits the page with a pre-set filter (bookmark, share link,
+    // post-refresh restore). useSearchParams reads the initial URL; the
+    // pill state + initial listTokens call both reflect it.
+    vi.mocked(api.listTokens).mockResolvedValue({ tokens: [], next_cursor: null });
+    renderRoute("/?source=operator_mint");
+    await waitFor(() =>
+      expect(api.listTokens).toHaveBeenCalledWith({
+        revoked: "all",
+        createdVia: "operator_mint",
+      }),
+    );
+    // The Operator pill carries aria-pressed=true, the others don't.
+    expect(screen.getByRole("button", { name: /^operator$/i, pressed: true })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^all sources$/i, pressed: false }),
+    ).toBeInTheDocument();
+  });
+
+  it("URL deep-link: status + source compose on initial load", async () => {
+    vi.mocked(api.listTokens).mockResolvedValue({ tokens: [], next_cursor: null });
+    renderRoute("/?status=live&source=cli_mint");
+    await waitFor(() =>
+      expect(api.listTokens).toHaveBeenCalledWith({
+        revoked: "false",
+        createdVia: "cli_mint",
+      }),
+    );
+    expect(screen.getByRole("button", { name: /^live only$/i, pressed: true })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^cli mint$/i, pressed: true })).toBeInTheDocument();
   });
 
   it("clicking 'All sources' clears the source filter", async () => {

--- a/web/ui/src/routes/Tokens.tsx
+++ b/web/ui/src/routes/Tokens.tsx
@@ -19,7 +19,9 @@
  * before posting.
  */
 import { type FormEvent, useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import {
+  type AdminTokenCreatedVia,
   type AdminTokenListing,
   HttpError,
   type ListTokensOpts,
@@ -30,6 +32,10 @@ import {
 } from "../lib/api.ts";
 
 type FilterValue = "all" | "live" | "revoked";
+
+/** Source filter values. `all` is the default; the other three map 1:1 to
+ * `created_via` on the wire. */
+type SourceFilter = "all" | AdminTokenCreatedVia;
 
 type ListState =
   | { kind: "loading" }
@@ -65,7 +71,14 @@ const EMPTY_FORM: MintFormFields = {
 };
 
 export function Tokens() {
-  const [filter, setFilter] = useState<FilterValue>("all");
+  // Filter state lives in the URL via react-router's `useSearchParams` so
+  // refresh + share preserve the operator's view. Default value when the
+  // param is absent (or unrecognized) is `all` for both dimensions —
+  // matches the "show everything" UX from before this filter pair existed.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filter = readStatusFilter(searchParams.get("status"));
+  const sourceFilter = readSourceFilter(searchParams.get("source"));
+
   const [list, setList] = useState<ListState>({ kind: "loading" });
   const [reload, setReload] = useState(0);
   const [mint, setMint] = useState<MintState>({ kind: "idle" });
@@ -74,15 +87,28 @@ export function Tokens() {
   const [showForm, setShowForm] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
 
+  /**
+   * Update one filter dimension while preserving the other (and any
+   * unrelated query params). Strips the param entirely when set to the
+   * default `all` value — keeps the URL minimal in the common case.
+   */
+  function setFilterParam(key: "status" | "source", value: string): void {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (value === "all") next.delete(key);
+        else next.set(key, value);
+        return next;
+      },
+      { replace: true },
+    );
+  }
+
   useEffect(() => {
     void reload;
     let cancelled = false;
     setList({ kind: "loading" });
-    const opts: ListTokensOpts = {};
-    if (filter === "live") opts.revoked = "false";
-    else if (filter === "revoked") opts.revoked = "true";
-    else opts.revoked = "all";
-    listTokens(opts)
+    listTokens(buildListOpts(filter, sourceFilter))
       .then((page) => {
         if (cancelled) return;
         setList({ kind: "ok", tokens: page.tokens, nextCursor: page.next_cursor });
@@ -95,7 +121,7 @@ export function Tokens() {
     return () => {
       cancelled = true;
     };
-  }, [reload, filter]);
+  }, [reload, filter, sourceFilter]);
 
   async function loadMore(): Promise<void> {
     if (list.kind !== "ok" || !list.nextCursor) return;
@@ -105,10 +131,10 @@ export function Tokens() {
     // attribute on the button is the primary defense; this state guard is
     // belt-and-suspenders for fast-finger keyboard activation.
     if (loadingMore) return;
-    const opts: ListTokensOpts = { cursor: list.nextCursor };
-    if (filter === "live") opts.revoked = "false";
-    else if (filter === "revoked") opts.revoked = "true";
-    else opts.revoked = "all";
+    const opts: ListTokensOpts = {
+      ...buildListOpts(filter, sourceFilter),
+      cursor: list.nextCursor,
+    };
     setLoadingMore(true);
     try {
       const page = await listTokens(opts);
@@ -342,9 +368,9 @@ export function Tokens() {
         </div>
       ) : null}
 
-      <div style={{ marginTop: "1rem", marginBottom: "1rem", display: "flex", gap: "0.5rem" }}>
-        <span className="muted" style={{ marginRight: "0.5rem" }}>
-          Filter:
+      <div style={{ marginTop: "1rem", marginBottom: "0.5rem", display: "flex", gap: "0.5rem" }}>
+        <span className="muted" style={{ marginRight: "0.5rem", minWidth: "4rem" }}>
+          Status:
         </span>
         {(
           [
@@ -356,9 +382,32 @@ export function Tokens() {
           <button
             key={opt.value}
             type="button"
-            onClick={() => setFilter(opt.value)}
+            onClick={() => setFilterParam("status", opt.value)}
             className={filter === opt.value ? undefined : "secondary"}
             aria-pressed={filter === opt.value}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+      <div style={{ marginBottom: "1rem", display: "flex", gap: "0.5rem" }}>
+        <span className="muted" style={{ marginRight: "0.5rem", minWidth: "4rem" }}>
+          Source:
+        </span>
+        {(
+          [
+            { value: "all", label: "All sources" },
+            { value: "oauth_refresh", label: "OAuth" },
+            { value: "operator_mint", label: "Operator" },
+            { value: "cli_mint", label: "CLI mint" },
+          ] as const
+        ).map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => setFilterParam("source", opt.value)}
+            className={sourceFilter === opt.value ? undefined : "secondary"}
+            aria-pressed={sourceFilter === opt.value}
           >
             {opt.label}
           </button>
@@ -373,6 +422,7 @@ export function Tokens() {
         onLoadMore: loadMore,
         onRetry: () => setReload((n) => n + 1),
         loadingMore,
+        filtersActive: filter !== "all" || sourceFilter !== "all",
       })}
     </div>
   );
@@ -386,6 +436,8 @@ interface RenderListProps {
   onLoadMore: () => Promise<void>;
   onRetry: () => void;
   loadingMore: boolean;
+  /** True when either filter dimension is narrowed; drives empty-state copy. */
+  filtersActive: boolean;
 }
 
 function renderList({
@@ -396,6 +448,7 @@ function renderList({
   onLoadMore,
   onRetry,
   loadingMore,
+  filtersActive,
 }: RenderListProps) {
   if (list.kind === "loading") {
     return <p className="muted">Loading…</p>;
@@ -413,6 +466,17 @@ function renderList({
     );
   }
   if (list.tokens.length === 0) {
+    if (filtersActive) {
+      return (
+        <div className="empty empty-rich">
+          <p className="empty-headline">No tokens match the current filter.</p>
+          <p className="muted">
+            Try widening the Status or Source pills above. The default "Show all / All sources" view
+            shows every registry row.
+          </p>
+        </div>
+      );
+    }
     return (
       <div className="empty empty-rich">
         <p className="empty-headline">No tokens.</p>
@@ -438,8 +502,11 @@ function renderList({
               <div className="name">
                 <code title={t.jti}>{truncateJti(t.jti)}</code>
                 <span className={`tag${status === "live" ? "" : " muted"}`}>{status}</span>
-                <span className="muted" style={{ fontSize: "0.85rem" }}>
-                  {t.created_via}
+                <span
+                  className={`tag source-${sourceClassFor(t.created_via)}`}
+                  title={`created_via: ${t.created_via}`}
+                >
+                  {sourceLabelFor(t.created_via)}
                 </span>
               </div>
               <div className="dim" style={{ marginTop: "0.25rem" }}>
@@ -558,6 +625,60 @@ function tokenStatus(t: AdminTokenListing): "live" | "expired" | "revoked" {
   const exp = new Date(t.expires_at).getTime();
   if (!Number.isNaN(exp) && exp < Date.now()) return "expired";
   return "live";
+}
+
+/** Status filter parser. Unknown / missing → `all`. */
+function readStatusFilter(raw: string | null): FilterValue {
+  if (raw === "live" || raw === "revoked" || raw === "all") return raw;
+  return "all";
+}
+
+/** Source filter parser. Unknown / missing → `all`. */
+function readSourceFilter(raw: string | null): SourceFilter {
+  if (raw === "oauth_refresh" || raw === "operator_mint" || raw === "cli_mint" || raw === "all") {
+    return raw;
+  }
+  return "all";
+}
+
+/** Translate the two filter dimensions into the wire-shape opts for `listTokens`. */
+function buildListOpts(filter: FilterValue, sourceFilter: SourceFilter): ListTokensOpts {
+  const opts: ListTokensOpts = {};
+  if (filter === "live") opts.revoked = "false";
+  else if (filter === "revoked") opts.revoked = "true";
+  else opts.revoked = "all";
+  if (sourceFilter !== "all") opts.createdVia = sourceFilter;
+  return opts;
+}
+
+/** Short label for the per-row source chip. Falls back to the raw value
+ * for any future created_via values not yet known here. */
+function sourceLabelFor(createdVia: string): string {
+  switch (createdVia) {
+    case "oauth_refresh":
+      return "OAuth";
+    case "operator_mint":
+      return "Operator";
+    case "cli_mint":
+      return "CLI";
+    default:
+      return createdVia;
+  }
+}
+
+/** CSS class suffix for the per-row source chip — drives the colored
+ * variant. Unknown values fall back to muted styling. */
+function sourceClassFor(createdVia: string): string {
+  switch (createdVia) {
+    case "oauth_refresh":
+      return "oauth";
+    case "operator_mint":
+      return "operator";
+    case "cli_mint":
+      return "cli";
+    default:
+      return "unknown";
+  }
 }
 
 function truncateJti(jti: string): string {

--- a/web/ui/src/routes/Tokens.tsx
+++ b/web/ui/src/routes/Tokens.tsx
@@ -100,6 +100,9 @@ export function Tokens() {
         else next.set(key, value);
         return next;
       },
+      // `replace`, not push: filter changes shouldn't flood browser history.
+      // Back-button from the table goes to the previous app route, not back
+      // through every filter state the operator clicked through.
       { replace: true },
     );
   }

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -255,6 +255,41 @@ h2 {
   color: var(--fg-muted);
 }
 
+/* Source chips on the /admin/tokens row — distinguish OAuth refresh
+   tokens from operator mints from CLI mints at a glance. Subtle,
+   palette-aligned; the chip is for orientation, not visual weight.
+   Built on the existing `.tag` base via a `source-<kind>` modifier. */
+.tag.source-oauth {
+  background: rgba(74, 124, 198, 0.12); /* subtle blue */
+  color: #3b6aa6;
+}
+.tag.source-operator {
+  background: rgba(198, 152, 74, 0.14); /* subtle gold */
+  color: #8a5e1f;
+}
+.tag.source-cli {
+  background: rgba(74, 124, 89, 0.14); /* sage — close to .tag accent base */
+  color: #2f5a3f;
+}
+.tag.source-unknown {
+  background: var(--bg-soft);
+  color: var(--fg-muted);
+}
+@media (prefers-color-scheme: dark) {
+  .tag.source-oauth {
+    background: rgba(122, 156, 220, 0.14);
+    color: #9bb6d8;
+  }
+  .tag.source-operator {
+    background: rgba(220, 180, 110, 0.14);
+    color: #d4b27a;
+  }
+  .tag.source-cli {
+    background: rgba(122, 176, 138, 0.14);
+    color: #8fc49e;
+  }
+}
+
 .vault-row {
   display: flex;
   align-items: center;

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -288,6 +288,13 @@ h2 {
     background: rgba(122, 176, 138, 0.14);
     color: #8fc49e;
   }
+  .tag.source-unknown {
+    /* Future-proof fallback for any created_via value the SPA's switch
+       doesn't yet know. Mirrors `.tag.muted` in dark mode — same
+       relationship to the page background as the light-mode rule above. */
+    background: rgba(232, 228, 220, 0.06);
+    color: #a8a49a;
+  }
 }
 
 .vault-row {


### PR DESCRIPTION
## Summary

Phase F of the auth UX pathway. The `/admin/tokens` page now distinguishes OAuth refresh tokens, operator-token mints, and CLI mints — both via a per-row chip and a second filter dimension that composes with the existing status pills.

Operators landing on the page no longer face a wall of similar-looking rows; the source dimension is surfaced in the UI so OAuth-issued tokens vs operator mints vs CLI mints are immediately visually distinct.

## What's in the PR

### Backend (`?created_via=` filter)

- `ListTokensFilter` in `src/jwt-sign.ts` gains `createdVia?: TokenCreatedVia`; `listTokens` translates it to a `WHERE created_via = ?` clause.
- `GET /api/auth/tokens` accepts `?created_via=oauth_refresh|operator_mint|cli_mint`. Composes with `?revoked=…` and `?subject=…`. Invalid value → 400.
- Type-checked at the wire boundary so a typo'd value can't slip into a SQL clause.

### UI

- **Two filter rows.** Existing Status pills (Show all / Live only / Revoked only) plus new Source pills (All sources / OAuth / Operator / CLI mint). Both dimensions compose.
- **URL-driven filter state** via `useSearchParams` (`?status=live&source=oauth_refresh`). Refresh + share preserve the operator's view. Default `all` strips the param to keep URLs minimal.
- **Per-row source chip** alongside the status pill. Subtle palette: OAuth blue, Operator gold, CLI sage (light + dark mode variants). Tooltip exposes the raw `created_via` string for operators who care about the canonical name.
- **Filter-aware empty state.** When no rows match the active filter, the empty message switches to "No tokens match the current filter" with a hint to widen via the pills. Original "No tokens." copy stays for the truly-empty registry case.

## Versioning

- `package.json`: `0.5.8-rc.13` → `0.5.8-rc.14`.
- CHANGELOG entry under `## [0.5.8-rc.14] - 2026-05-10`.

## Test plan

- [x] hub `bun test ./src`: all pass (was 1216 at rc.13; +4 — `?created_via=` filter narrows for cli_mint and operator_mint, composes with `?revoked=`, invalid → 400).
- [x] web/ui `bun run test`: all pass (was 88; +7 across 2 describes — source pill clicks call `listTokens` with the right `createdVia`; status + source compose; "All sources" clears the filter; OAuth/Operator/CLI rows render the correct chip with the matching `source-…` class; filter-aware empty state appears when filters are active).
- [x] typecheck (both packages): clean.
- [x] biome: clean.
- [x] UI build + `verify-base`: clean (asserts `/admin/`-prefixed assets).

(Test-count numbers omitted per the hub#219 canonical-vs-combined ambiguity convention.)

## Patterns check

- **`useSearchParams` for filter state** — first SPA route to use this pattern. Clean fit; no extra state-management library needed.
- **`.tag.source-…` modifier on the existing `.tag` base** — reuses the established chip primitive rather than inventing a new component. Dark-mode variants follow the existing `prefers-color-scheme: dark` block.
- **Filter compose semantics on the wire** — `created_via` joins `revoked` and `subject` as just-another-AND-clause in `listTokens`'s WHERE composition. No special handling.
- **RC versioning** — `rc.13` → `rc.14` per parachute-patterns/governance.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)