### PR TITLE
feat(hub): consumer-side of module.json uiUrl pattern (Phase D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.8-rc.15] - 2026-05-10
+
+Hub consumer-side of Phase D (module.json `uiUrl` pattern). Discovery page Services tiles are now data-driven from each service's `module.json:uiUrl` rather than from a hardcoded `SERVICE_LABELS` map. Closes the consumer side of the cross-repo Phase D rollout (patterns#52, notes#109, paraclaw#152 / agent#…).
+
+### Approach: option C, not B
+
+The brief originally leaned option B (install-time copy of `uiUrl` into `services.json`) but `upsertService` replaces the whole entry — so the field would be clobbered the first time a service boots and writes its own row. The established `loadManagementUrls` pattern for vault uses option C (read at request time from `installDir/.parachute/module.json`), which sidesteps the overwrite gap and requires no per-service runtime change. Mirrored that pattern. Trace captured in `loadServiceUiMetadata` docstring + this changelog so the C-not-B reasoning doesn't have to be rediscovered.
+
+### Added
+
+- **`uiUrl` field on `ModuleManifest`.** Same shape as `managementUrl` — leading-slash path or full http(s) URL. Validation factored into a shared `asPathOrUrl(field)` helper so the next URL-shaped manifest field doesn't copy-paste.
+- **`loadServiceUiMetadata(services, read)` in `hub-server.ts`.** Mirrors `loadManagementUrls`: reads each non-vault `installDir/.parachute/module.json` once per `/.well-known/parachute.json` request, surfaces `uiUrl` + `displayName` into per-service maps. Vaults skip — they have their own `loadManagementUrls` path. Quiet on per-entry errors (one bad manifest doesn't 500 the well-known doc).
+- **`uiUrl`, `displayName`, `tagline` fields on `WellKnownServicesEntry`.** `uiUrl` resolves relative paths against the canonical hub origin (mirrors how `url` already does it); `displayName` falls back to `services.json:displayName` when the resolver returns undefined; `tagline` rides directly from `services.json:tagline` (no installDir round-trip).
+- **`uiUrlFor` and `displayNameFor` resolver opts on `BuildWellKnownOpts`.** Synchronous so `buildWellKnown` stays a pure transform; the caller (hub-server) loads manifests once per request and passes them in.
+
+### Changed
+
+- **Discovery page (`src/hub.ts`) Services rendering is data-driven.** `SERVICE_LABELS`, `SERVICE_ORDER`, and `isVaultName()` retired. Each `doc.services[]` row with `uiUrl` renders a tile (title from `displayName` or short name, desc from `tagline`, href from `uiUrl`). Rows without `uiUrl` are intentionally skipped — vault is the canonical example (its content is browsed via Notes, which has its own row with `uiUrl: "/notes"`). Ordering is alphabetical-by-displayName per the pattern doc.
+- **Empty-state copy** updated: from "No services installed yet" to "No services with a UI declared yet" with a hint pointing at the module-json-extensibility pattern. The previous copy was misleading post-Phase-D — installed services without `uiUrl` are silent rather than broken.
+
+### Migration / no-action-needed
+
+- **No re-install required** for Aaron's existing services. Because uiUrl is read from `installDir/.parachute/module.json` at every request, the moment notes / agent ship `module.json:uiUrl` (already done in notes#109 and paraclaw#152), the next discovery refresh picks up the new tiles.
+- **No services.json schema change.** The field is intentionally NOT persisted there — would just get overwritten on next service boot.
+
+### Test gate
+
+All test suites pass. New coverage in this PR:
+
+- `module-manifest.test.ts` — 4 new tests: `uiUrl` accepts leading-slash path, accepts absolute https URL, rejects empty / non-string / no-leading-slash / non-http(s) URL, absent stays absent.
+- `well-known.test.ts` — 6 new tests: uiUrl resolver result rides into doc.services as absolute URL; absolute URL passes through verbatim; absent when resolver returns undefined; displayName resolver overrides services.json; displayName fallback; tagline rides from services.json.
+- `hub-server.test.ts` — 3 new tests: well-known surfaces uiUrl + displayName from non-vault manifests; omits uiUrl when manifest has none; vault is skipped (has its own managementUrl path).
+- `hub.test.ts` — restructured for data-driven rendering: tile shape comes from `svc.uiUrl` + `svc.displayName`; skip rule emerges from `!svc.uiUrl` not `isVaultName`; alphabetical-by-displayName ordering; empty-state copy points at the pattern doc.
+
+Typecheck (both packages): clean. biome: clean.
+
+(Test-count numbers omitted per the hub#219 canonical-vs-combined ambiguity convention.)
+
 ## [0.5.8-rc.14] - 2026-05-10
 
 Token list grouping by source — F of the auth UX pathway. The `/admin/tokens` page now distinguishes OAuth refresh tokens, operator-token mints, and CLI mints at a glance via per-row chips and a second filter dimension.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.8-rc.16] - 2026-05-10
+
+Reviewer folds on PR #238.
+
+### Security fix
+
+- **Reject protocol-relative paths in `uiUrl` / `managementUrl`** (open-redirect regression). `asPathOrUrl` previously accepted any string starting with `/`, including `"//evil.com"`. `new URL("//evil.com", "https://hub.example.com/")` resolves to `https://evil.com/` — a malicious third-party module could plant `uiUrl: "//evil.com"` in its `module.json` and turn a discovery tile into an off-origin redirect. Tightened the path-shape check to require a single leading `/` followed by at least one non-`/`. Regression tests cover both `uiUrl` and `managementUrl` since they share the helper.
+
+### Doc cleanup
+
+- Tightened `WellKnownServicesEntry.displayName` doc-comment to describe the actual fallback behavior (`module.json` first, `services.json` second).
+- Filled in `hub#238` placeholder in the C-not-B trace comment in `well-known.ts`.
+
 ## [0.5.8-rc.15] - 2026-05-10
 
 Hub consumer-side of Phase D (module.json `uiUrl` pattern). Discovery page Services tiles are now data-driven from each service's `module.json:uiUrl` rather than from a hardcoded `SERVICE_LABELS` map. Closes the consumer side of the cross-repo Phase D rollout (patterns#52, notes#109, paraclaw#152 / agent#…).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.8-rc.14",
+  "version": "0.5.8-rc.15",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.8-rc.15",
+  "version": "0.5.8-rc.16",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -246,6 +246,105 @@ describe("hubFetch routing", () => {
     }
   });
 
+  // Phase D consumer-side: each non-vault service entry's
+  // module.json:uiUrl + displayName ride through to doc.services. The
+  // discovery page (`/`) reads them to render data-driven Service tiles.
+  test("/.well-known/parachute.json surfaces uiUrl + displayName from non-vault module manifests", async () => {
+    const h = makeHarness();
+    try {
+      const notesEntry: ServiceEntry = {
+        name: "parachute-notes",
+        port: 5173,
+        paths: ["/notes"],
+        health: "/health",
+        version: "0.0.1",
+        installDir: "/fake/notes",
+      };
+      writeManifest({ services: [notesEntry] }, h.manifestPath);
+      const res = await hubFetch(h.dir, {
+        manifestPath: h.manifestPath,
+        readModuleManifest: async () => ({
+          name: "notes",
+          manifestName: "parachute-notes",
+          kind: "frontend",
+          port: 5173,
+          paths: ["/notes"],
+          health: "/health",
+          uiUrl: "/notes",
+          displayName: "Notes",
+        }),
+      })(req("/.well-known/parachute.json"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        services: Array<{ name: string; uiUrl?: string; displayName?: string }>;
+      };
+      const svc = body.services.find((s) => s.name === "parachute-notes");
+      expect(svc?.uiUrl).toMatch(/\/notes$/);
+      expect(svc?.displayName).toBe("Notes");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/.well-known/parachute.json omits uiUrl when the non-vault manifest has none", async () => {
+    const h = makeHarness();
+    try {
+      const notesEntry: ServiceEntry = {
+        name: "parachute-notes",
+        port: 5173,
+        paths: ["/notes"],
+        health: "/health",
+        version: "0.0.1",
+        installDir: "/fake/notes",
+      };
+      writeManifest({ services: [notesEntry] }, h.manifestPath);
+      const res = await hubFetch(h.dir, {
+        manifestPath: h.manifestPath,
+        readModuleManifest: async () => ({
+          name: "notes",
+          manifestName: "parachute-notes",
+          kind: "frontend",
+          port: 5173,
+          paths: ["/notes"],
+          health: "/health",
+          // no uiUrl declared — discovery page will skip the tile.
+        }),
+      })(req("/.well-known/parachute.json"));
+      const body = (await res.json()) as { services: Array<{ uiUrl?: string }> };
+      expect(body.services[0]).not.toHaveProperty("uiUrl");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/.well-known/parachute.json: uiUrl resolver is skipped for vault entries (loadManagementUrls handles vault)", async () => {
+    const h = makeHarness();
+    try {
+      const vaultWithDir: ServiceEntry = { ...vaultEntry("default"), installDir: "/fake/vault" };
+      writeManifest({ services: [vaultWithDir] }, h.manifestPath);
+      // The fake module.json declares uiUrl, but vault is supposed to be
+      // skipped by loadServiceUiMetadata (it has its own managementUrl
+      // path). So doc.services[vault] should NOT carry uiUrl.
+      const res = await hubFetch(h.dir, {
+        manifestPath: h.manifestPath,
+        readModuleManifest: async () => ({
+          name: "vault",
+          manifestName: "parachute-vault",
+          kind: "api",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/health",
+          uiUrl: "/should-be-ignored",
+        }),
+      })(req("/.well-known/parachute.json"));
+      const body = (await res.json()) as { services: Array<{ name: string; uiUrl?: string }> };
+      const vaultSvc = body.services.find((s) => s.name === "parachute-vault");
+      expect(vaultSvc).not.toHaveProperty("uiUrl");
+    } finally {
+      h.cleanup();
+    }
+  });
+
   // The bug this PR fixes: `parachute vault create techne` updates
   // services.json but the old code only re-derived parachute.json on
   // `parachute expose`. With the dynamic build, the second GET reflects

--- a/src/__tests__/hub.test.ts
+++ b/src/__tests__/hub.test.ts
@@ -47,29 +47,33 @@ describe("renderHub", () => {
     expect(html).toContain("Surfaces provided by services");
   });
 
-  test("Services entry labels: Notes / Scribe / Agent", () => {
-    expect(html).toContain("'Notes'");
-    expect(html).toContain("'Scribe'");
-    expect(html).toContain("'Agent'");
+  test("Services tiles are data-driven from each service's uiUrl + displayName", () => {
+    // Phase D consumer-side: SERVICE_LABELS / SERVICE_ORDER hardcoding
+    // retired. Each well-known services[] row carries displayName + uiUrl
+    // (sourced from module.json via hub-server's loadServiceUiMetadata);
+    // tiles render directly from those.
+    expect(html).toContain("svc.uiUrl");
+    expect(html).toContain("svc.displayName");
+    // No more hardcoded short→label map.
+    expect(html).not.toContain("'Notes', desc:");
+    expect(html).not.toContain("['notes', 'scribe', 'agent']");
   });
 
-  test("Services entries use the path declared in services.json (custom mounts work)", () => {
-    // Operators may mount a service at a non-default path; the tile
-    // surfaces that path verbatim rather than hardcoding `/notes`/etc.
-    expect(html).toContain("svc.path");
+  test("Services skip rule emerges from data, not name-checks (vault has no uiUrl)", () => {
+    // The previous `isVaultName` hardcoded skip is gone — vault doesn't
+    // declare uiUrl, so it naturally doesn't render. Other API-only
+    // modules (current or future) get the same treatment for free.
+    expect(html).toContain("if (!svc || !svc.uiUrl) continue;");
+    // The function definition is gone (the comment may still mention the
+    // name as historical context — we only care about the active code).
+    expect(html).not.toContain("function isVaultName");
   });
 
-  test("Vault is intentionally excluded from the Services section", () => {
-    // Aaron's friction: clicking 'Vault' on discovery took him to hub
-    // management, not to vault content. Resolution: Vault has no
-    // Services entry — its content is browsed via Notes (which has its
-    // own entry). Vault provisioning lives under Admin.
-    expect(html).toContain("Vault deliberately omitted");
-    expect(html).toContain("isVaultName");
-  });
-
-  test("Services section ordering is notes → scribe → agent", () => {
-    expect(html).toContain("['notes', 'scribe', 'agent']");
+  test("Services tiles sort alphabetically by displayName", () => {
+    // Per the module-json-extensibility pattern doc — default ordering
+    // until a `displayOrder` field surfaces. localeCompare keeps the
+    // ordering stable across locales for ASCII labels.
+    expect(html).toContain("a.title.localeCompare(b.title)");
   });
 
   test("Admin section is hardcoded (always visible) with three entries", () => {
@@ -86,9 +90,13 @@ describe("renderHub", () => {
     expect(html).toContain("Admin section is static");
   });
 
-  test("Use section empty state hints at install", () => {
-    expect(html).toContain("No services installed yet");
-    expect(html).toContain("parachute install vault");
+  test("Services section empty state guides operators to declare uiUrl", () => {
+    // Empty state under Phase D means "no installed service has declared
+    // uiUrl yet" — different shape from pre-D ("none installed at all").
+    // Hint points at the pattern doc since the fix is in module.json,
+    // not at install time.
+    expect(html).toContain("No services with a UI declared yet");
+    expect(html).toContain("module-json-extensibility");
   });
 
   test("Use section error state surfaces the underlying message", () => {

--- a/src/__tests__/module-manifest.test.ts
+++ b/src/__tests__/module-manifest.test.ts
@@ -126,6 +126,32 @@ describe("validateModuleManifest", () => {
     ).toThrow(/http:.*https:/);
   });
 
+  test("uiUrl accepts a leading-slash path (Phase D)", () => {
+    const m = validateModuleManifest({ ...VALID, uiUrl: "/notes" }, "x");
+    expect(m.uiUrl).toBe("/notes");
+  });
+
+  test("uiUrl accepts an absolute https URL", () => {
+    const m = validateModuleManifest({ ...VALID, uiUrl: "https://app.example.com/" }, "x");
+    expect(m.uiUrl).toBe("https://app.example.com/");
+  });
+
+  test("uiUrl rejects empty / non-string / non-url-or-path (mirrors managementUrl)", () => {
+    expect(() => validateModuleManifest({ ...VALID, uiUrl: "" }, "x")).toThrow(/uiUrl/);
+    expect(() => validateModuleManifest({ ...VALID, uiUrl: 7 }, "x")).toThrow(/uiUrl/);
+    expect(() => validateModuleManifest({ ...VALID, uiUrl: "no-slash" }, "x")).toThrow(
+      /path starting with "\/" or a full http\(s\) URL/,
+    );
+    expect(() => validateModuleManifest({ ...VALID, uiUrl: "ftp://example.com" }, "x")).toThrow(
+      /http:.*https:/,
+    );
+  });
+
+  test("uiUrl absent stays absent", () => {
+    const m = validateModuleManifest(VALID, "x");
+    expect(m.uiUrl).toBeUndefined();
+  });
+
   test("managementUrl absent stays absent", () => {
     const m = validateModuleManifest(VALID, "x");
     expect(m.managementUrl).toBeUndefined();

--- a/src/__tests__/module-manifest.test.ts
+++ b/src/__tests__/module-manifest.test.ts
@@ -152,6 +152,28 @@ describe("validateModuleManifest", () => {
     expect(m.uiUrl).toBeUndefined();
   });
 
+  // Open-redirect regression: protocol-relative paths like "//evil.com" pass
+  // a naive `startsWith("/")` check but `new URL("//evil.com", base)` resolves
+  // to the foreign origin. A malicious third-party module could plant such a
+  // value in module.json:uiUrl and turn a discovery tile into an off-origin
+  // redirect. Both uiUrl and managementUrl are validated by the shared
+  // asPathOrUrl helper, so cover both.
+  test("uiUrl rejects protocol-relative paths (open-redirect regression)", () => {
+    expect(() => validateModuleManifest({ ...VALID, uiUrl: "//evil.com" }, "x")).toThrow(/uiUrl/);
+    expect(() => validateModuleManifest({ ...VALID, uiUrl: "//evil.com/path" }, "x")).toThrow(
+      /uiUrl/,
+    );
+  });
+
+  test("managementUrl rejects protocol-relative paths (open-redirect regression)", () => {
+    expect(() => validateModuleManifest({ ...VALID, managementUrl: "//evil.com" }, "x")).toThrow(
+      /managementUrl/,
+    );
+    expect(() =>
+      validateModuleManifest({ ...VALID, managementUrl: "//evil.com/admin" }, "x"),
+    ).toThrow(/managementUrl/);
+  });
+
   test("managementUrl absent stays absent", () => {
     const m = validateModuleManifest(VALID, "x");
     expect(m.managementUrl).toBeUndefined();

--- a/src/__tests__/well-known.test.ts
+++ b/src/__tests__/well-known.test.ts
@@ -302,6 +302,75 @@ describe("buildWellKnown", () => {
     expect(doc.notes).toEqual([{ url: "https://x.example/notes", version: "0.0.1" }]);
   });
 
+  // Phase D consumer-side: services entries surface uiUrl + displayName +
+  // tagline so the discovery page can render data-driven Service tiles.
+  test("uiUrl resolver result rides into doc.services entry as absolute URL", () => {
+    const doc = buildWellKnown({
+      services: [notes],
+      canonicalOrigin: "https://x.example",
+      uiUrlFor: () => "/notes",
+    });
+    const svc = doc.services.find((s) => s.name === "parachute-notes");
+    expect(svc?.uiUrl).toBe("https://x.example/notes");
+  });
+
+  test("uiUrl absolute URL passes through verbatim", () => {
+    const doc = buildWellKnown({
+      services: [notes],
+      canonicalOrigin: "https://x.example",
+      uiUrlFor: () => "https://notes.example.com/app",
+    });
+    const svc = doc.services.find((s) => s.name === "parachute-notes");
+    expect(svc?.uiUrl).toBe("https://notes.example.com/app");
+  });
+
+  test("uiUrl absent when the resolver returns undefined (vault case)", () => {
+    const doc = buildWellKnown({
+      services: [vault, notes],
+      canonicalOrigin: "https://x.example",
+      uiUrlFor: (e) => (e.name === "parachute-notes" ? "/notes" : undefined),
+    });
+    const vaultSvc = doc.services.find((s) => s.name === "parachute-vault");
+    const notesSvc = doc.services.find((s) => s.name === "parachute-notes");
+    expect(vaultSvc).not.toHaveProperty("uiUrl");
+    expect(notesSvc?.uiUrl).toBe("https://x.example/notes");
+  });
+
+  test("displayName resolver overrides services.json displayName", () => {
+    const notesWithName: ServiceEntry = { ...notes, displayName: "FromServicesJson" };
+    const doc = buildWellKnown({
+      services: [notesWithName],
+      canonicalOrigin: "https://x.example",
+      displayNameFor: () => "FromModuleJson",
+    });
+    const svc = doc.services.find((s) => s.name === "parachute-notes");
+    expect(svc?.displayName).toBe("FromModuleJson");
+  });
+
+  test("displayName falls back to services.json when resolver returns undefined", () => {
+    const notesWithName: ServiceEntry = { ...notes, displayName: "FromServicesJson" };
+    const doc = buildWellKnown({
+      services: [notesWithName],
+      canonicalOrigin: "https://x.example",
+      displayNameFor: () => undefined,
+    });
+    const svc = doc.services.find((s) => s.name === "parachute-notes");
+    expect(svc?.displayName).toBe("FromServicesJson");
+  });
+
+  test("tagline rides through from services.json (no resolver needed)", () => {
+    const notesWithTagline: ServiceEntry = {
+      ...notes,
+      tagline: "Notes PWA backed by your vault.",
+    };
+    const doc = buildWellKnown({
+      services: [notesWithTagline],
+      canonicalOrigin: "https://x.example",
+    });
+    const svc = doc.services.find((s) => s.name === "parachute-notes");
+    expect(svc?.tagline).toBe("Notes PWA backed by your vault.");
+  });
+
   test("falls back to / for empty paths", () => {
     const entry: ServiceEntry = { ...vault, paths: [] };
     const doc = buildWellKnown({

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -543,6 +543,50 @@ async function loadManagementUrls(
 }
 
 /**
+ * For each NON-vault `ServiceEntry` with a known `installDir`, read its
+ * `.parachute/module.json` and surface the optional `uiUrl` and
+ * `displayName`. Returns two `name → value` maps keyed by services.json
+ * entry name. Mirrors `loadManagementUrls` (vault is the analog there;
+ * non-vault services are the analog here — vaults are user-facing via
+ * Notes, not their own UI).
+ *
+ * Why read at request time and not from services.json: services own the
+ * write side of services.json (`upsertService` replaces the whole entry
+ * on every boot), so any install-time copy of `uiUrl` / `displayName`
+ * would be clobbered the first time the service writes its own entry.
+ * Reading from `installDir/module.json` at request time avoids the gap
+ * and matches the established `managementUrl` precedent.
+ *
+ * Quiet on per-entry errors: a malformed module.json on one service
+ * shouldn't 500 the entire well-known doc — its row just renders without
+ * a Services tile. The validator already throws structured errors from
+ * `readModuleManifest`; logging them once here is the right floor.
+ */
+async function loadServiceUiMetadata(
+  services: readonly ServiceEntry[],
+  read: (installDir: string) => Promise<ModuleManifest | null>,
+): Promise<{ uiUrls: Map<string, string>; displayNames: Map<string, string> }> {
+  const uiUrls = new Map<string, string>();
+  const displayNames = new Map<string, string>();
+  await Promise.all(
+    services.map(async (s) => {
+      // Skip vaults — they have their own loadManagementUrls path and no
+      // operator-facing user UI of their own (content browses via Notes).
+      if (isVaultEntry(s) || !s.installDir) return;
+      try {
+        const m = await read(s.installDir);
+        if (m?.uiUrl) uiUrls.set(s.name, m.uiUrl);
+        if (m?.displayName) displayNames.set(s.name, m.displayName);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`well-known: skipping uiUrl/displayName for ${s.name}: ${msg}`);
+      }
+    }),
+  );
+  return { uiUrls, displayNames };
+}
+
+/**
  * Resolve the SPA bundle dir. We anchor to this file's location so a
  * `bun src/hub-server.ts` from any cwd still finds `<repo>/web/ui/dist/`.
  * Tests / production override via `HubFetchDeps.spaDistDir`.
@@ -804,14 +848,17 @@ export function hubFetch(
       try {
         const manifest = readManifest(manifestPath);
         const canonicalOrigin = configuredIssuer ?? new URL(req.url).origin;
-        const managementUrlByName = await loadManagementUrls(
-          manifest.services,
-          deps?.readModuleManifest ?? defaultReadModuleManifest,
-        );
+        const readManifestFn = deps?.readModuleManifest ?? defaultReadModuleManifest;
+        const [managementUrlByName, serviceUiMeta] = await Promise.all([
+          loadManagementUrls(manifest.services, readManifestFn),
+          loadServiceUiMetadata(manifest.services, readManifestFn),
+        ]);
         const doc = buildWellKnown({
           services: manifest.services,
           canonicalOrigin,
           managementUrlFor: (entry) => managementUrlByName.get(entry.name),
+          uiUrlFor: (entry) => serviceUiMeta.uiUrls.get(entry.name),
+          displayNameFor: (entry) => serviceUiMeta.displayNames.get(entry.name),
         });
         return new Response(JSON.stringify(doc), {
           headers: { "content-type": "application/json", ...corsHeaders },

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -380,17 +380,17 @@ const HTML_TEMPLATE = `<!doctype html>
   const servicesGrid = document.getElementById('services-grid');
   const adminGrid = document.getElementById('admin-grid');
 
-  // Services entries: each service's primary surface. Hardcoded short→label
-  // map; path is derived from services.json so custom mounts still work.
-  // Vault deliberately omitted — its content is browsed via Notes (which
-  // is its own entry below). Operators provision/admin vaults from the
-  // /admin/vaults card in the Admin section.
-  const SERVICE_LABELS = {
-    notes:  { title: 'Notes', desc: 'Browse your vault content.' },
-    scribe: { title: 'Scribe', desc: 'Transcribe audio.' },
-    agent:  { title: 'Agent', desc: 'Run agents on this hub.' },
-  };
-  const SERVICE_ORDER = ['notes', 'scribe', 'agent'];
+  // Services entries are now data-driven from /.well-known/parachute.json.
+  // Each services[] row carries (since hub#... — Phase D consumer side):
+  //   - displayName: human label (sourced from module.json:displayName).
+  //   - uiUrl: where the user-facing UI lives (sourced from module.json:uiUrl).
+  //     A row WITHOUT uiUrl declines to render a tile — the module is
+  //     either API-only (vault, scribe-without-UI) or surfaces its UI
+  //     through a sibling (vault → Notes).
+  // The previous SERVICE_LABELS / SERVICE_ORDER / isVaultName hardcoding
+  // is retired: vault has no uiUrl, so the "skip vault" rule emerges
+  // from data rather than a name check; ordering is alphabetical-by-
+  // displayName per the module-json-extensibility pattern doc.
 
   // Admin entries: always visible. Even a fresh hub with zero vaults wants
   // the operator to find /admin/vaults. Hardcoded — they live in the
@@ -405,10 +405,6 @@ const HTML_TEMPLATE = `<!doctype html>
     return manifestName.replace(/^parachute-/, '');
   }
 
-  function isVaultName(name) {
-    return name === 'parachute-vault' || name.startsWith('parachute-vault-');
-  }
-
   function renderTile({ title, desc, href }) {
     const a = document.createElement('a');
     a.className = 'card';
@@ -419,10 +415,12 @@ const HTML_TEMPLATE = `<!doctype html>
     t.textContent = title;
     a.appendChild(t);
 
-    const d = document.createElement('p');
-    d.className = 'card-desc';
-    d.textContent = desc;
-    a.appendChild(d);
+    if (desc) {
+      const d = document.createElement('p');
+      d.className = 'card-desc';
+      d.textContent = desc;
+      a.appendChild(d);
+    }
 
     const meta = document.createElement('div');
     meta.className = 'card-meta';
@@ -447,30 +445,38 @@ const HTML_TEMPLATE = `<!doctype html>
   }
 
   function renderServices(services) {
-    // Group services by short type. Multiple instances of the same type
-    // (e.g. two scribes) collapse into one entry pointing at the first
-    // — operators with that posture will know which one they meant.
-    // Vault entries are skipped per the comment above.
-    const byType = new Map();
+    // Render one tile per service that declares a uiUrl. Entries without
+    // uiUrl are intentionally omitted — vault is the canonical example
+    // (its content is browsed via Notes, which has its own uiUrl row).
+    // Multiple entries with the same shortName collapse into one tile;
+    // operators with two scribe instances pick the first arbitrarily,
+    // and they'd know which they meant.
+    const byShort = new Map();
     for (const svc of services) {
-      if (isVaultName(svc.name)) continue;
-      const t = shortName(svc.name);
-      if (!byType.has(t)) byType.set(t, svc.path);
+      if (!svc || !svc.uiUrl) continue;
+      const key = shortName(svc.name);
+      if (byShort.has(key)) continue;
+      byShort.set(key, {
+        title: svc.displayName || key,
+        desc: svc.tagline || '',
+        href: svc.uiUrl,
+      });
     }
 
-    const tiles = [];
-    for (const t of SERVICE_ORDER) {
-      const path = byType.get(t);
-      if (!path) continue;
-      const labels = SERVICE_LABELS[t];
-      tiles.push({ title: labels.title, desc: labels.desc, href: path });
-    }
+    // Alphabetical-by-displayName per the module-json-extensibility pattern.
+    // Stable for shared-prefix labels (Notes, Notes-Lite would sort that way).
+    const tiles = Array.from(byShort.values()).sort((a, b) =>
+      a.title.localeCompare(b.title),
+    );
 
     servicesGrid.innerHTML = '';
     if (tiles.length === 0) {
       const empty = document.createElement('div');
       empty.className = 'empty';
-      empty.innerHTML = 'No services installed yet. Try <code>parachute install vault</code>.';
+      empty.innerHTML =
+        'No services with a UI declared yet. Modules surface their UIs by ' +
+        'declaring <code>uiUrl</code> in <code>module.json</code> ' +
+        '(see the module-json-extensibility pattern).';
       servicesGrid.appendChild(empty);
       return;
     }

--- a/src/module-manifest.ts
+++ b/src/module-manifest.ts
@@ -115,6 +115,27 @@ export interface ModuleManifest {
    */
   readonly managementUrl?: string;
   /**
+   * Where the module's primary user-facing UI lives. Hub renders a tile on
+   * the discovery page (`/`) Services section when set (see
+   * `parachute-patterns/patterns/module-json-extensibility.md` and the
+   * `loadUiUrls` resolver in `hub-server.ts`).
+   *
+   * Two shapes — same rules as `managementUrl`:
+   *   - A relative path (e.g. `"/notes"`, `"/agent"`) — hub resolves
+   *     against the canonical hub origin.
+   *   - A full absolute URL — hub uses verbatim.
+   *
+   * Absent = no Services tile rendered (the module is API-only or surfaces
+   * its UI via a sibling module — e.g. vault content browses through Notes,
+   * so vault has no `uiUrl`).
+   *
+   * Read at every discovery render via `installDir/.parachute/module.json`
+   * (mirrors how `managementUrl` is sourced for vaults). Not persisted in
+   * services.json — that file's "services own the write side" semantics
+   * would clobber any install-time copy on the next service boot.
+   */
+  readonly uiUrl?: string;
+  /**
    * When `true`, the hub's `/<svc>/*` proxy strips the matched mount prefix
    * before forwarding (so the backend sees `/health` rather than
    * `/<name>/health`). Default `false` matches the prefix-aware convention
@@ -374,6 +395,7 @@ export function validateModuleManifest(raw: unknown, where: string): ModuleManif
   const dependencies = asDependencies(m.dependencies, where);
   const configSchema = asConfigSchema(m.configSchema, where);
   const managementUrl = asManagementUrl(m.managementUrl, where);
+  const uiUrl = asUiUrl(m.uiUrl, where);
   let stripPrefix: boolean | undefined;
   if (m.stripPrefix !== undefined) {
     if (typeof m.stripPrefix !== "boolean") {
@@ -396,6 +418,9 @@ export function validateModuleManifest(raw: unknown, where: string): ModuleManif
   if (managementUrl !== undefined) {
     (out as { managementUrl?: string }).managementUrl = managementUrl;
   }
+  if (uiUrl !== undefined) {
+    (out as { uiUrl?: string }).uiUrl = uiUrl;
+  }
   if (stripPrefix !== undefined) {
     (out as { stripPrefix?: boolean }).stripPrefix = stripPrefix;
   }
@@ -403,26 +428,35 @@ export function validateModuleManifest(raw: unknown, where: string): ModuleManif
 }
 
 function asManagementUrl(v: unknown, where: string): string | undefined {
+  return asPathOrUrl(v, where, "managementUrl");
+}
+
+function asUiUrl(v: unknown, where: string): string | undefined {
+  return asPathOrUrl(v, where, "uiUrl");
+}
+
+/**
+ * Validate a "path or http(s) URL" field. Both `managementUrl` and `uiUrl`
+ * follow the same shape per the module-json-extensibility pattern doc;
+ * factored so the next URL-shaped field doesn't have to copy-paste.
+ */
+function asPathOrUrl(v: unknown, where: string, field: string): string | undefined {
   if (v === undefined) return undefined;
   if (typeof v !== "string" || v.length === 0) {
-    throw new ModuleManifestError(
-      `${where}: "managementUrl" must be a non-empty string if present`,
-    );
+    throw new ModuleManifestError(`${where}: "${field}" must be a non-empty string if present`);
   }
   // Two valid shapes: a path starting with "/" or a full http(s) URL.
   if (v.startsWith("/")) return v;
   try {
     const u = new URL(v);
     if (u.protocol !== "http:" && u.protocol !== "https:") {
-      throw new ModuleManifestError(
-        `${where}: "managementUrl" absolute form must use http: or https:`,
-      );
+      throw new ModuleManifestError(`${where}: "${field}" absolute form must use http: or https:`);
     }
     return v;
   } catch (err) {
     if (err instanceof ModuleManifestError) throw err;
     throw new ModuleManifestError(
-      `${where}: "managementUrl" must be a path starting with "/" or a full http(s) URL`,
+      `${where}: "${field}" must be a path starting with "/" or a full http(s) URL`,
     );
   }
 }

--- a/src/module-manifest.ts
+++ b/src/module-manifest.ts
@@ -445,8 +445,12 @@ function asPathOrUrl(v: unknown, where: string, field: string): string | undefin
   if (typeof v !== "string" || v.length === 0) {
     throw new ModuleManifestError(`${where}: "${field}" must be a non-empty string if present`);
   }
-  // Two valid shapes: a path starting with "/" or a full http(s) URL.
-  if (v.startsWith("/")) return v;
+  // Two valid shapes: an absolute path starting with a single "/" or a full
+  // http(s) URL. Reject protocol-relative forms like "//evil.com" — they
+  // start with "/" but `new URL("//evil.com", base)` resolves to the foreign
+  // origin, which would let a malicious module render an off-origin tile and
+  // turn the discovery page into an open-redirect surface.
+  if (v.startsWith("/") && !v.startsWith("//")) return v;
   try {
     const u = new URL(v);
     if (u.protocol !== "http:" && u.protocol !== "https:") {

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -26,6 +26,14 @@ export interface WellKnownVaultEntry {
  * to iterate without having to know every service's shortName ahead of time.
  * `infoUrl` points at the service's `/.parachute/info` endpoint (relative to
  * its mount path) which the hub fetches client-side for displayName/tagline.
+ *
+ * `displayName` and `uiUrl` are both optional — the discovery page renders
+ * a Services tile when `uiUrl` is present, falling back to the manifest
+ * short name when `displayName` is absent. Both are sourced via hub-server's
+ * `loadUiUrls`/`loadManagementUrls`-style readers from the module's
+ * `installDir/.parachute/module.json`, NOT from services.json (which gets
+ * overwritten on service boot per the "services own the write side"
+ * contract — see hub#... commit message for the C-not-B trace).
  */
 export interface WellKnownServicesEntry {
   name: string;
@@ -33,6 +41,12 @@ export interface WellKnownServicesEntry {
   path: string;
   version: string;
   infoUrl: string;
+  /** Human-readable label for the discovery page, sourced from `module.json:displayName`. */
+  displayName?: string;
+  /** Where the service's primary user-facing UI lives, sourced from `module.json:uiUrl`. */
+  uiUrl?: string;
+  /** One-line subtitle for the discovery tile, sourced from `services.json:tagline`. */
+  tagline?: string;
 }
 
 /**
@@ -107,6 +121,19 @@ export interface BuildWellKnownOpts {
    * in. Returning `undefined` means "no admin SPA" and hub renders no link.
    */
   managementUrlFor?: (entry: ServiceEntry) => string | undefined;
+  /**
+   * Optional resolver mapping a `ServiceEntry` to its `module.json:uiUrl`,
+   * if any. Same shape as `managementUrlFor`. Returning `undefined` means
+   * "no user-facing UI" and discovery omits the Services tile (e.g. vault
+   * has no `uiUrl` — its content browses through Notes).
+   */
+  uiUrlFor?: (entry: ServiceEntry) => string | undefined;
+  /**
+   * Optional resolver mapping a `ServiceEntry` to its `module.json:displayName`.
+   * Hub-server reads this at request time; falls back to the entry's own
+   * `displayName` (from services.json) when absent.
+   */
+  displayNameFor?: (entry: ServiceEntry) => string | undefined;
 }
 
 /** Join a base origin and a path without double slashes — "/" stays "/". */
@@ -131,7 +158,29 @@ export function buildWellKnown(opts: BuildWellKnownOpts): WellKnownDocument {
     for (const path of pathsToEmit) {
       const url = new URL(path, `${base}/`).toString();
       const infoUrl = new URL(joinInfoPath(path), `${base}/`).toString();
-      doc.services.push({ name: s.name, url, path, version: s.version, infoUrl });
+      const entry: WellKnownServicesEntry = {
+        name: s.name,
+        url,
+        path,
+        version: s.version,
+        infoUrl,
+      };
+      const displayName = opts.displayNameFor?.(s) ?? s.displayName;
+      if (displayName !== undefined) entry.displayName = displayName;
+      // Tagline rides on services.json (set by service-spec at install or
+      // by the service's own boot-time upsert). Read directly from the
+      // entry — no installDir round-trip needed since it's already
+      // persisted server-side and reasonably stable across reboots.
+      if (s.tagline !== undefined) entry.tagline = s.tagline;
+      // Resolve uiUrl: relative path → absolute URL against `base`; full
+      // http(s) URL → verbatim. Same rule managementUrl uses.
+      const uiUrlRaw = opts.uiUrlFor?.(s);
+      if (uiUrlRaw !== undefined) {
+        entry.uiUrl = /^https?:\/\//i.test(uiUrlRaw)
+          ? uiUrlRaw
+          : new URL(uiUrlRaw, `${base}/`).toString();
+      }
+      doc.services.push(entry);
       if (isVault) {
         const managementUrl = opts.managementUrlFor?.(s);
         const entry: WellKnownVaultEntry = {

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -33,7 +33,7 @@ export interface WellKnownVaultEntry {
  * `loadUiUrls`/`loadManagementUrls`-style readers from the module's
  * `installDir/.parachute/module.json`, NOT from services.json (which gets
  * overwritten on service boot per the "services own the write side"
- * contract — see hub#... commit message for the C-not-B trace).
+ * contract — see hub#238 commit message for the C-not-B trace).
  */
 export interface WellKnownServicesEntry {
   name: string;
@@ -41,7 +41,11 @@ export interface WellKnownServicesEntry {
   path: string;
   version: string;
   infoUrl: string;
-  /** Human-readable label for the discovery page, sourced from `module.json:displayName`. */
+  /**
+   * Human-readable label for the discovery page. Sourced from
+   * `module.json:displayName` when available; falls back to
+   * `services.json:displayName` written at install time.
+   */
   displayName?: string;
   /** Where the service's primary user-facing UI lives, sourced from `module.json:uiUrl`. */
   uiUrl?: string;


### PR DESCRIPTION
## Summary

Discovery page Services tiles now render data-driven from each service's `module.json:uiUrl` rather than from a hardcoded `SERVICE_LABELS` map. Closes the consumer side of the cross-repo Phase D rollout (patterns#52, notes#109, paraclaw#152).

## Approach: option C, not B

The brief originally leaned **option B** — install-time copy of `uiUrl` into `services.json`. While surveying I traced `upsertService(entry)`: it replaces the whole entry on service boot, so any install-time copy gets clobbered the first time the service writes its row. Surfaced the gap; team-lead approved **option C** (mirror the established `loadManagementUrls` pattern: read `installDir/.parachute/module.json` at request time).

Smaller PR, no clobber risk, no re-install required for Aaron — the moment notes/agent ship `module.json:uiUrl` (already done upstream), the next discovery refresh picks up tiles.

## Changes

**Added**
- `ModuleManifest.uiUrl` (path or absolute http(s) URL — same shape as `managementUrl`). Validation factored into shared `asPathOrUrl(field)` helper.
- `loadServiceUiMetadata(services, read)` in `hub-server.ts`. Mirrors `loadManagementUrls`. Reads each non-vault `installDir/.parachute/module.json` once per `/.well-known/parachute.json` request, surfaces `uiUrl` + `displayName`. Vault skipped (has its own `loadManagementUrls` path). Quiet on per-entry errors.
- `WellKnownServicesEntry` gains `uiUrl`, `displayName`, `tagline`. `uiUrl` resolves relative paths against canonical hub origin.
- `BuildWellKnownOpts.uiUrlFor` + `displayNameFor` resolver opts (sync — caller does the async loading once).

**Changed**
- `src/hub.ts` Services rendering: `SERVICE_LABELS`, `SERVICE_ORDER`, `isVaultName()` retired. Each `doc.services[]` row with `uiUrl` renders a tile (title from `displayName` or short name, desc from `tagline`, href from `uiUrl`). Rows without `uiUrl` skip — vault is the canonical example (its content is browsed via Notes). Ordering alphabetical-by-displayName.
- Empty-state copy: "No services with a UI declared yet" + pattern doc hint (replaces stale "no services installed").

## Test plan

- [x] `bun test ./src` (canonical) — 1232/0 (was 1220 at rc.14; +12: 4 module-manifest, 6 well-known, 3 hub-server; net rebalance in hub.test for the data-driven rewrite)
- [x] `bun run typecheck` — clean (both packages)
- [x] `bunx biome check .` — clean
- [x] Smoke: with notes installed (already shipping `module.json:uiUrl: "/notes"`), discovery renders the Notes tile dynamically; with vault only (no `uiUrl`), discovery shows empty state.

## Patterns check

- **module-json-extensibility** (patterns#52): conforms — `uiUrl` is the next field added under the same shape as `managementUrl`. Validation goes through the shared `asPathOrUrl` helper rather than copy-pasted ad-hoc.
- **services own the write side** (services.json contract): conforms — `uiUrl` is intentionally NOT persisted in services.json. The "Why C, not B" trace in CHANGELOG + `loadServiceUiMetadata` docstring captures the rationale so the next reader doesn't re-derive it.
- **alphabetical-by-displayName ordering**: conforms (replaces the old `SERVICE_ORDER` hardcoded array).

## Migration

None. No re-install needed. Discovery picks up new tiles the moment downstream services land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)