### PR TITLE
docs(hub): rename admin-config-ui.ts → admin-login-ui.ts (closes #241) + add architecture-surfaces table to CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.9-rc.2] - 2026-05-11
+
+Post-Pass-1 cleanup (#240 follow-up). Two cohesive changes:
+
+1. **`admin-config-ui.ts` → `admin-login-ui.ts` rename (closes #241).** #240 retired the legacy `/admin/config` server-rendered portal and trimmed this file from 534 → 257 LOC; what's left is `renderAdminLogin` + `renderAdminError` + shared chrome. The filename now matches the content. Mechanical rename: single importer (`src/admin-handlers.ts`) updated; cross-file docstring references in `web/ui/CLAUDE.md` and `web/ui/src/styles.css` refreshed; the file's own preamble rewritten to drop the stale "config portal lived here" history (kept a one-line note pointing at #240 + #241 for archeology).
+
+2. **`## Architecture surfaces` table added to `parachute-hub/CLAUDE.md`.** Pass 2 audit confirmed the hub's HTTP surface area is structurally coherent post-#240 — six distinct layers (discovery / login / SPA / OAuth / API / well-known), each matched to its audience's constraints. The table is the at-a-glance reference; the route-by-route detail stays in `src/hub-server.ts`'s header docstring (the executable source of truth). Lets future tentacles + reviewers orient without reverse-engineering the dispatcher.
+
 ## [0.5.9-rc.1] - 2026-05-11
 
 Integration-debt cleanup after the SPA-rework chain that landed 2026-05-10 (#233 admin SPA mount, #234 `/login` rename, #235 signed-in indicator, #237 token UI). The rework migrated three admin surfaces (vaults/permissions/tokens) into the SPA but left two legacy server-rendered admin pages dangling; this PR closes the immediate friction.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,23 @@ parachute vault <args>    →  exec parachute-vault (transparent)        (src/co
 
 The flat shape matters: each command is a self-contained module in `src/commands/`, wired through `src/cli.ts`'s argv parser. No framework, no plugin system, no global state beyond a handful of pure module constants.
 
+### Architecture surfaces
+
+The hub serves six distinct kinds of HTTP surface. Each is the shape it is because of its audience's constraints (JS availability, auth posture, cross-origin behavior). The full route table is the header docstring in [`src/hub-server.ts`](./src/hub-server.ts); this is the layered summary.
+
+| Layer | Shape | Audience | Why this shape |
+|---|---|---|---|
+| Discovery (`/`, `/hub.html`) | server-rendered HTML | unauthenticated visitors | Pre-auth entry; session-aware "Signed in as X" hydrates from cookie. Must work without JS so a brand-new operator can hit the box and see the discovery page. |
+| `/login`, `/logout` | server-rendered HTML | pre-auth | The form on `/login` posts to itself, redirects on success. SPA-rendering would force a JS load just to show two text inputs, and gate first-visit auth on bundle delivery. |
+| `/admin/*` | SPA (`web/ui`) | post-auth admin | Vaults, permissions, tokens, approve-client. Mounted at `/admin` so the SPA's react-router basename + service worker boundary are clean. Per-route Bearer minted from the session cookie at `/admin/host-admin-token`. |
+| `/oauth/*` | server-rendered HTML + JSON | third-party OAuth clients | `/oauth/authorize` is a cross-origin redirect target — must stand alone without the SPA shell. `/oauth/token`, `/oauth/register`, `/oauth/revoke` are spec-shaped JSON per RFCs 6749 / 7591 / 7009. |
+| `/api/*` | JSON, Bearer-gated (except `/api/me`) | SPA + cross-cutting consumers | Internal API for the admin SPA. Snake-case wire shape mirrors DB columns; host-admin Bearer comes from `/admin/host-admin-token`, mint-and-cache pattern in `web/ui/src/lib/auth.ts`. |
+| `/.well-known/*` | JSON + wildcard CORS | public discovery | RFC 8414 metadata, JWKS, services catalog, revocation list. Wildcard CORS because cross-origin browser fetches (Notes, future SPAs, resource servers polling revocation) need to read them. |
+
+Two cross-cutting back-compat surfaces sit above this table:
+- 301 redirects from legacy admin URLs (`/hub/*`, `/vault`, `/admin/login`, `/admin/config`) to the canonical `/admin/*` or `/login` surfaces. Listed at the top of `hub-server.ts`'s dispatch order so they preempt anything below.
+- Generic services.json-driven proxy (`/<service-mount>/*`) — the last fallthrough, used for non-vault modules like notes/scribe/agent.
+
 ### Shared surfaces
 
 - **`src/service-spec.ts`** — `SERVICE_SPECS` is the registry: which npm package backs each short name, what to run on install/start, the canonical seed entry. Adding a new service = one entry here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ The flat shape matters: each command is a self-contained module in `src/commands
 
 ### Architecture surfaces
 
-The hub serves six distinct kinds of HTTP surface. Each is the shape it is because of its audience's constraints (JS availability, auth posture, cross-origin behavior). The full route table is the header docstring in [`src/hub-server.ts`](./src/hub-server.ts); this is the layered summary.
+The hub serves six distinct kinds of operator-facing HTTP surface. Each is the shape it is because of its audience's constraints (JS availability, auth posture, cross-origin behavior). Content-routing surfaces (per-vault + generic services-proxy paths) sit outside the table; they're listed below it. The full route table is the header docstring in [`src/hub-server.ts`](./src/hub-server.ts); this is the layered summary.
 
 | Layer | Shape | Audience | Why this shape |
 |---|---|---|---|
@@ -32,9 +32,10 @@ The hub serves six distinct kinds of HTTP surface. Each is the shape it is becau
 | `/api/*` | JSON, Bearer-gated (except `/api/me`) | SPA + cross-cutting consumers | Internal API for the admin SPA. Snake-case wire shape mirrors DB columns; host-admin Bearer comes from `/admin/host-admin-token`, mint-and-cache pattern in `web/ui/src/lib/auth.ts`. |
 | `/.well-known/*` | JSON + wildcard CORS | public discovery | RFC 8414 metadata, JWKS, services catalog, revocation list. Wildcard CORS because cross-origin browser fetches (Notes, future SPAs, resource servers polling revocation) need to read them. |
 
-Two cross-cutting back-compat surfaces sit above this table:
-- 301 redirects from legacy admin URLs (`/hub/*`, `/vault`, `/admin/login`, `/admin/config`) to the canonical `/admin/*` or `/login` surfaces. Listed at the top of `hub-server.ts`'s dispatch order so they preempt anything below.
-- Generic services.json-driven proxy (`/<service-mount>/*`) — the last fallthrough, used for non-vault modules like notes/scribe/agent.
+Three surface types sit outside the operator-facing table:
+- 301 back-compat redirects from legacy admin URLs (`/hub/*`, `/vault`, `/admin/login`, `/admin/config`) to the canonical `/admin/*` or `/login` surfaces. Listed at the top of `hub-server.ts`'s dispatch order so they preempt anything below.
+- Per-vault content proxy (`/vault/<name>/*`) — routes to the vault backend on its services.json port. User-facing vault data (Notes PWA, MCP endpoints, etc.), not admin-scoped; vaults own their own user surfaces, the hub just stitches the path prefix.
+- Generic services.json-driven proxy (`/<service-mount>/*`) — the last fallthrough, longest-prefix match against services.json. Used for non-vault modules like notes / scribe / agent.
 
 ### Shared surfaces
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.9-rc.1",
+  "version": "0.5.9-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/admin-handlers.ts
+++ b/src/admin-handlers.ts
@@ -11,7 +11,7 @@
  * (`parachute_hub_csrf` cookie + `__csrf` form field, constant-time compare).
  */
 import type { Database } from "bun:sqlite";
-import { renderAdminError, renderAdminLogin } from "./admin-config-ui.ts";
+import { renderAdminError, renderAdminLogin } from "./admin-login-ui.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
 import { checkAndRecord, clientIpFromRequest } from "./rate-limit.ts";
 import {

--- a/src/admin-login-ui.ts
+++ b/src/admin-login-ui.ts
@@ -1,9 +1,14 @@
 /**
- * Branded HTML for the hub admin login + generic error pages. Same privacy
- * posture as `oauth-ui.ts` (no third-party fonts, inline CSS, no JS). The
- * legacy server-rendered `/admin/config` portal lived here too; it was
- * retired post-SPA-rework (hub#231) — the admin SPA is the operator surface
- * now, and module config is a follow-up driven by per-module SPAs.
+ * Branded HTML for the hub's pre-auth surfaces: the `/login` form and the
+ * generic admin error page surfaced when CSRF or rate-limit gates fire on
+ * `/login` and `/logout`. Same privacy posture as `oauth-ui.ts` (no third-
+ * party fonts, inline CSS, no JS) — these pages are pre-auth and have to
+ * stand alone without the SPA shell.
+ *
+ * History: this file was `admin-config-ui.ts` and held the server-rendered
+ * `/admin/config` module-config portal (hub#46). #240 retired the portal
+ * post-SPA-rework; the file shed everything except the two renderers below.
+ * Renamed to `admin-login-ui.ts` in #241 so the filename matches the content.
  *
  * Pure functions — DB, sessions live in `admin-handlers.ts`.
  */

--- a/web/ui/CLAUDE.md
+++ b/web/ui/CLAUDE.md
@@ -118,7 +118,7 @@ usually means the postinstall hasn't run yet, or fired with
 
 `src/styles.css` is the single source of truth for the SPA's palette,
 typography, and components. The tokens (`--accent`, `--bg`, etc.) are
-lifted from `src/oauth-ui.ts` and `src/admin-config-ui.ts` so the SPA
+lifted from `src/oauth-ui.ts` and `src/admin-login-ui.ts` so the SPA
 stays visually continuous with the password-login → consent flow the
 operator just walked through. Don't drift them without updating both
 server-rendered surfaces.

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -1,5 +1,5 @@
 /*
- * Brand tokens lifted from src/oauth-ui.ts + src/admin-config-ui.ts so the
+ * Brand tokens lifted from src/oauth-ui.ts + src/admin-login-ui.ts so the
  * SPA stays visually continuous with the password-login → consent flow the
  * operator will have just walked through. Don't drift these without
  * updating both server-rendered surfaces.


### PR DESCRIPTION
## Summary

Post-#240 cleanup, bundled per team-lead's Pass 2 verdict ("structurally coherent; carry on"). Two cohesive pieces:

1. **`admin-config-ui.ts` → `admin-login-ui.ts` rename (closes #241).** #240 retired the legacy `/admin/config` server-rendered portal and trimmed this file from 534 → 257 LOC; what's left is `renderAdminLogin` + `renderAdminError` + shared chrome. Filename now matches content. Touched: single importer in `src/admin-handlers.ts`, plus two cross-file docstring references in `web/ui/CLAUDE.md` and `web/ui/src/styles.css`. The file's own preamble rewritten to drop the stale "config portal lived here" history (kept a one-line archeology note pointing at #240 + #241).
2. **New `## Architecture surfaces` section in `parachute-hub/CLAUDE.md`.** Six-layer summary table (discovery / login / SPA / OAuth / API / well-known) from Pass 2's audit, with a one-sentence rationale per layer's shape. The at-a-glance reference; route-by-route detail stays in `src/hub-server.ts`'s header docstring (the executable source of truth).

## Why bundled

Both pieces close the same loop: the rename makes the on-disk filename match the post-#240 reality; the CLAUDE.md table makes the layered architecture explicit so future tentacles + reviewers don't have to reverse-engineer `hub-server.ts` to understand the shape.

## Net

+39 / -9 LOC. Mostly the new architecture-surfaces table.

## Gate

- `bun run typecheck` (hub + SPA): clean
- `bun test ./src`: **1222 pass / 0 fail / 30207 expects** (unchanged from #240's post-merge baseline — rename is pure mechanical)
- SPA `bun run test`: **103 pass / 0 fail** (unchanged)
- `bunx biome check .`: clean
- `git grep admin-config-ui` post-rename: returns only two intentional historical references (the file's own "History:" preamble note + the historical #240 CHANGELOG entry). Both correct.

## Patterns

No pattern changes. Per [`governance.md`](../parachute-patterns/blob/main/patterns/governance.md) rule 2: doc-only PRs could skip RC bump, but this also touches `src/admin-login-ui.ts` (the rename's content edit) and `src/admin-handlers.ts` (the import update), so it's a code-touching PR. Bumped `0.5.9-rc.1` → `0.5.9-rc.2`.

## Test plan

- [x] hub backend `bun test ./src`
- [x] SPA `bun run test`
- [x] hub + SPA typecheck
- [x] biome
- [x] `git grep admin-config-ui` post-rename verified (only historical refs remain)