### PR TITLE
feat(status): reveal install-source per service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.9-rc.3] - 2026-05-12
+
+`parachute status` now reveals **where each service is running from** alongside the version/health columns (closes #243). The new `SOURCE` column classifies each row as either `bun-linked → <basename> @ <git-short-sha>` (the operator has a local checkout `bun link`'d in) or `npm (<version>)` (installed from a published package under bun globals). For bun-linked rows where `services.json`'s cached `version` lags the live `package.json` at the checkout, a `STALE: services.json cached <X>; live package.json <Y>` continuation line surfaces beneath the row.
+
+Motivation: 2026-05-11 the operator spent ~30 minutes chasing a stale `parachute-notes 0.3.11-rc.1` in `parachute status` while the actual served bundle was the freshly-built 0.3.15-rc.1. Three separate steps were needed to diagnose: check `parachute status`, check the local `package.json`, check `~/.parachute/services.json`. Now the drift is visible at a glance.
+
+Implementation: new pure helper module `src/install-source.ts` with full test-seam coverage (`bunGlobalPrefixes`, `resolveBunGlobal`, `readJson`, `readGitHead` all injectable). `src/commands/status.ts` calls `detectInstallSource` per row and `detectHubInstallSource` for the internal hub row, and renders the new column + STALE continuation line. No network. Single optional `git rev-parse --short HEAD` shell-out per bun-linked row, with a 1.5s timeout — failures degrade silently to "no SHA" rather than blocking status. The hub itself is classified the same way as the services it manages, by climbing from `import.meta.dir` to the nearest `package.json`.
+
+Out of scope (separate follow-up): fixing `parachute upgrade` so it refreshes the cached `services.json.version` on bun-linked rebuild. The STALE indicator surfaces the drift; the upgrade path that creates it is a separate issue.
+
+Gate: `bun test ./src` 1245 pass / 1 fail (pre-existing env-dependent flake in `status > all-healthy returns 0 and prints table` — the test reads the real `~/.parachute/` configDir and breaks when a stale operator PID file makes `processState` return `stopped`, present on both main and this branch) / 30242 expects across 69 files. typecheck clean. biome clean.
+
 ## [0.5.9-rc.2] - 2026-05-11
 
 Post-Pass-1 cleanup (#240 follow-up). Two cohesive changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Implementation: new pure helper module `src/install-source.ts` with full test-se
 
 Out of scope (separate follow-up): fixing `parachute upgrade` so it refreshes the cached `services.json.version` on bun-linked rebuild. The STALE indicator surfaces the drift; the upgrade path that creates it is a separate issue.
 
-Gate: `bun test ./src` 1245 pass / 1 fail (pre-existing env-dependent flake in `status > all-healthy returns 0 and prints table` — the test reads the real `~/.parachute/` configDir and breaks when a stale operator PID file makes `processState` return `stopped`, present on both main and this branch) / 30242 expects across 69 files. typecheck clean. biome clean.
+Gate: `bun test ./src` ran 1246 tests across 69 files / 30242 expects. Pass/fail varies by environment because the existing `status > all-healthy returns 0 and prints table` test reads the real `~/.parachute/` configDir rather than isolating to its temp dir (pre-existing, present on `main` — reproduced via `git stash`). Clean envs see 1246 pass / 0 fail; envs with a stale `~/.parachute/scribe/run/scribe.pid` (operator PID file pointing at a no-longer-running process) see 1245 pass / 1 fail because `processState` returns `stopped` and skips the scribe probe. Worth a follow-up to isolate the test's configDir, but unrelated to this change. typecheck clean. biome clean.
 
 ## [0.5.9-rc.2] - 2026-05-11
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.9-rc.2",
+  "version": "0.5.9-rc.3",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/install-source.test.ts
+++ b/src/__tests__/install-source.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type DetectInstallSourceDeps,
+  detectHubInstallSource,
+  detectInstallSource,
+  formatInstallSourceLabel,
+  isStale,
+} from "../install-source.ts";
+
+/**
+ * Stub helpers for the detect path. Production reads the operator's bun
+ * globals + real package.jsons; here we wire everything from a virtual
+ * filesystem so each kind (npm / bun-linked / unknown / stale) has a
+ * deterministic shape.
+ */
+function makeDeps(opts: {
+  prefixes?: readonly string[];
+  packageVersions?: Record<string, string>;
+  bunGlobalLinks?: Record<string, string>;
+  gitHeads?: Record<string, string>;
+}): DetectInstallSourceDeps {
+  const prefixes = opts.prefixes ?? ["/home/test/.bun/install/global/node_modules"];
+  return {
+    bunGlobalPrefixes: () => prefixes,
+    resolveBunGlobal: (pkg) => opts.bunGlobalLinks?.[pkg] ?? null,
+    readJson: (path) => {
+      // Path looks like `<pkgDir>/package.json` — strip suffix.
+      const pkgDirRaw = path.replace(/\/package\.json$/, "");
+      const v = opts.packageVersions?.[pkgDirRaw];
+      if (v === undefined) throw new Error(`no package.json at ${pkgDirRaw}`);
+      return { name: "@stub/pkg", version: v };
+    },
+    readGitHead: (path) => opts.gitHeads?.[path],
+  };
+}
+
+describe("detectInstallSource", () => {
+  test("classifies a bun-linked checkout (installDir outside bun globals)", () => {
+    const deps = makeDeps({
+      packageVersions: { "/Users/me/code/parachute-notes": "0.3.15-rc.1" },
+      gitHeads: { "/Users/me/code/parachute-notes": "051c404" },
+    });
+    const source = detectInstallSource(
+      { entryName: "parachute-notes", installDir: "/Users/me/code/parachute-notes" },
+      deps,
+    );
+    expect(source.kind).toBe("bun-linked");
+    expect(source.path).toBe("/Users/me/code/parachute-notes");
+    expect(source.gitHead).toBe("051c404");
+    expect(source.livePackageVersion).toBe("0.3.15-rc.1");
+  });
+
+  test("classifies an npm install (installDir under bun globals)", () => {
+    const deps = makeDeps({
+      prefixes: ["/home/test/.bun/install/global/node_modules"],
+      packageVersions: {
+        "/home/test/.bun/install/global/node_modules/@openparachute/scribe": "0.4.2-rc.1",
+      },
+    });
+    const source = detectInstallSource(
+      {
+        entryName: "parachute-scribe",
+        installDir: "/home/test/.bun/install/global/node_modules/@openparachute/scribe",
+      },
+      deps,
+    );
+    expect(source.kind).toBe("npm");
+    expect(source.livePackageVersion).toBe("0.4.2-rc.1");
+    expect(source.gitHead).toBeUndefined();
+  });
+
+  test("falls back to bun-global symlink lookup when installDir is absent", () => {
+    const deps = makeDeps({
+      bunGlobalLinks: { "@openparachute/vault": "/Users/me/code/parachute-vault" },
+      packageVersions: { "/Users/me/code/parachute-vault": "0.4.4-rc.3" },
+      gitHeads: { "/Users/me/code/parachute-vault": "8aa167b" },
+    });
+    const source = detectInstallSource({ entryName: "parachute-vault" }, deps);
+    expect(source.kind).toBe("bun-linked");
+    expect(source.path).toBe("/Users/me/code/parachute-vault");
+    expect(source.gitHead).toBe("8aa167b");
+  });
+
+  test("returns unknown when nothing resolves (no installDir, no first-party mapping)", () => {
+    const deps = makeDeps({});
+    const source = detectInstallSource({ entryName: "agent" }, deps);
+    expect(source.kind).toBe("unknown");
+    expect(source.path).toBeUndefined();
+    expect(source.gitHead).toBeUndefined();
+  });
+
+  test("omits gitHead when the bun-linked path isn't a git repo", () => {
+    const deps = makeDeps({
+      packageVersions: { "/tmp/no-git/pkg": "1.0.0" },
+      // gitHeads intentionally missing → readGitHead returns undefined.
+    });
+    const source = detectInstallSource(
+      { entryName: "third-party", installDir: "/tmp/no-git/pkg" },
+      deps,
+    );
+    expect(source.kind).toBe("bun-linked");
+    expect(source.gitHead).toBeUndefined();
+    expect(source.livePackageVersion).toBe("1.0.0");
+  });
+
+  test("omits livePackageVersion when package.json is unreadable", () => {
+    const deps = makeDeps({
+      packageVersions: {}, // every read throws
+    });
+    const source = detectInstallSource(
+      { entryName: "third-party", installDir: "/tmp/no-pkg" },
+      deps,
+    );
+    expect(source.kind).toBe("bun-linked");
+    expect(source.livePackageVersion).toBeUndefined();
+  });
+
+  test("trailing-slash prefix doesn't false-match a sibling directory", () => {
+    // Subtle: `/home/test/.bun/install/global/node_modules-other` shouldn't
+    // be classified as "under" `/home/test/.bun/install/global/node_modules`.
+    // The prefix join in `isUnderBunGlobals` adds a trailing slash precisely
+    // to avoid this — pin the behavior.
+    const deps = makeDeps({
+      prefixes: ["/home/test/.bun/install/global/node_modules"],
+      packageVersions: {
+        "/home/test/.bun/install/global/node_modules-other/pkg": "1.0.0",
+      },
+    });
+    const source = detectInstallSource(
+      {
+        entryName: "third-party",
+        installDir: "/home/test/.bun/install/global/node_modules-other/pkg",
+      },
+      deps,
+    );
+    expect(source.kind).toBe("bun-linked");
+  });
+});
+
+describe("isStale", () => {
+  test("flags drift between cached entry version and live package.json", () => {
+    expect(
+      isStale("0.3.11-rc.1", {
+        kind: "bun-linked",
+        path: "/Users/me/code/parachute-notes",
+        livePackageVersion: "0.3.15-rc.1",
+      }),
+    ).toBe(true);
+  });
+
+  test("does not flag a matching version", () => {
+    expect(
+      isStale("0.3.15-rc.1", {
+        kind: "bun-linked",
+        path: "/Users/me/code/parachute-notes",
+        livePackageVersion: "0.3.15-rc.1",
+      }),
+    ).toBe(false);
+  });
+
+  test("does not flag npm-installed services (cached version IS the source)", () => {
+    expect(
+      isStale("0.4.2-rc.1", {
+        kind: "npm",
+        path: "/path/to/global",
+        livePackageVersion: "0.4.2-rc.1",
+      }),
+    ).toBe(false);
+  });
+
+  test("does not flag when live version is unavailable", () => {
+    expect(
+      isStale("0.3.11-rc.1", {
+        kind: "bun-linked",
+        path: "/Users/me/code/parachute-notes",
+        // livePackageVersion absent — can't compute drift, don't false-flag.
+      }),
+    ).toBe(false);
+  });
+
+  test("does not flag unknown sources", () => {
+    expect(isStale("1.0.0", { kind: "unknown" })).toBe(false);
+  });
+});
+
+describe("formatInstallSourceLabel", () => {
+  test("bun-linked → basename + short SHA", () => {
+    expect(
+      formatInstallSourceLabel({
+        kind: "bun-linked",
+        path: "/Users/me/code/parachute-notes",
+        gitHead: "051c404",
+      }),
+    ).toBe("bun-linked → parachute-notes @ 051c404");
+  });
+
+  test("bun-linked without gitHead drops the @ <sha> suffix", () => {
+    expect(
+      formatInstallSourceLabel({
+        kind: "bun-linked",
+        path: "/Users/me/code/parachute-notes",
+      }),
+    ).toBe("bun-linked → parachute-notes");
+  });
+
+  test("npm with version", () => {
+    expect(
+      formatInstallSourceLabel({
+        kind: "npm",
+        path: "/some/global/dir",
+        livePackageVersion: "0.4.2-rc.1",
+      }),
+    ).toBe("npm (0.4.2-rc.1)");
+  });
+
+  test("npm without version", () => {
+    expect(formatInstallSourceLabel({ kind: "npm" })).toBe("npm");
+  });
+
+  test("unknown sources render as 'unknown'", () => {
+    expect(formatInstallSourceLabel({ kind: "unknown" })).toBe("unknown");
+  });
+});
+
+describe("detectHubInstallSource", () => {
+  test("classifies the hub based on its source location", () => {
+    // We exercise the happy path via the real hub's `src/` dir. The result
+    // depends on the test environment (CI vs. bun-linked checkout), so we
+    // only assert the kind is one of the known classifications — not the
+    // exact value. Pins the contract: never throws, always returns a known
+    // kind, never crashes on a missing git repo or globals layout.
+    const source = detectHubInstallSource(import.meta.dir);
+    expect(["bun-linked", "npm", "unknown"]).toContain(source.kind);
+  });
+
+  test("returns unknown when no package.json exists above srcDir", () => {
+    // `/private` exists on macOS but has no package.json up the chain;
+    // injected readJson always throws so the walk hits the climb-cap.
+    const source = detectHubInstallSource("/private/var/empty", {
+      readJson: () => {
+        throw new Error("no package.json");
+      },
+    });
+    expect(source.kind).toBe("unknown");
+  });
+});

--- a/src/__tests__/install-source.test.ts
+++ b/src/__tests__/install-source.test.ts
@@ -224,12 +224,15 @@ describe("formatInstallSourceLabel", () => {
 
 describe("detectHubInstallSource", () => {
   test("classifies the hub based on its source location", () => {
-    // We exercise the happy path via the real hub's `src/` dir. The result
+    // Exercise the happy path via the real hub's `src/` dir. The result
     // depends on the test environment (CI vs. bun-linked checkout), so we
     // only assert the kind is one of the known classifications — not the
-    // exact value. Pins the contract: never throws, always returns a known
-    // kind, never crashes on a missing git repo or globals layout.
-    const source = detectHubInstallSource(import.meta.dir);
+    // exact value. `readGitHead` is stubbed so the test never forks a real
+    // git process; the contract under test is "climb to package.json,
+    // classify by location against bun globals" — git is incidental.
+    const source = detectHubInstallSource(import.meta.dir, {
+      readGitHead: () => "deadbeef",
+    });
     expect(["bun-linked", "npm", "unknown"]).toContain(source.kind);
   });
 

--- a/src/__tests__/status.test.ts
+++ b/src/__tests__/status.test.ts
@@ -517,4 +517,203 @@ describe("status", () => {
       cleanup();
     }
   });
+
+  describe("install-source surface (hub#243)", () => {
+    test("renders SOURCE column header + per-row label", async () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/default"],
+            health: "/vault/default/health",
+            version: "0.4.4-rc.3",
+            installDir: "/Users/me/code/parachute-vault",
+          },
+          path,
+        );
+        const lines: string[] = [];
+        await status({
+          manifestPath: path,
+          fetchImpl: async () => new Response(null, { status: 200 }),
+          print: (l) => lines.push(l),
+          installSourceDeps: {
+            bunGlobalPrefixes: () => ["/home/test/.bun/install/global/node_modules"],
+            resolveBunGlobal: () => null,
+            readJson: (p) =>
+              p === "/Users/me/code/parachute-vault/package.json"
+                ? { name: "@openparachute/vault", version: "0.4.4-rc.3" }
+                : (() => {
+                    throw new Error("nope");
+                  })(),
+            readGitHead: () => "8aa167b",
+          },
+        });
+        expect(lines[0]).toMatch(/SOURCE/);
+        expect(lines.some((l) => l.includes("bun-linked → parachute-vault @ 8aa167b"))).toBe(true);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("STALE continuation line fires when bun-linked live version != cached version", async () => {
+      // Reproduces hub#243's motivating case: services.json says 0.3.11-rc.1
+      // but the live source has been rebuilt to 0.3.15-rc.1. Operator should
+      // see STALE in one glance from `parachute status` output.
+      const { path, cleanup } = makeTempPath();
+      try {
+        upsertService(
+          {
+            name: "parachute-notes",
+            port: 1942,
+            paths: ["/notes"],
+            health: "/notes/health",
+            version: "0.3.11-rc.1",
+            installDir: "/Users/me/code/parachute-notes",
+          },
+          path,
+        );
+        const lines: string[] = [];
+        await status({
+          manifestPath: path,
+          fetchImpl: async () => new Response(null, { status: 200 }),
+          print: (l) => lines.push(l),
+          installSourceDeps: {
+            bunGlobalPrefixes: () => ["/home/test/.bun/install/global/node_modules"],
+            resolveBunGlobal: () => null,
+            readJson: (p) =>
+              p === "/Users/me/code/parachute-notes/package.json"
+                ? { name: "@openparachute/notes", version: "0.3.15-rc.1" }
+                : (() => {
+                    throw new Error("nope");
+                  })(),
+            readGitHead: () => "051c404",
+          },
+        });
+        expect(
+          lines.some((l) =>
+            l.includes("STALE: services.json cached 0.3.11-rc.1; live package.json 0.3.15-rc.1"),
+          ),
+        ).toBe(true);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("npm-installed services render as `npm (<version>)` and never STALE", async () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        upsertService(
+          {
+            name: "parachute-scribe",
+            port: 1943,
+            paths: ["/scribe"],
+            health: "/scribe/health",
+            version: "0.4.2-rc.1",
+            installDir: "/home/test/.bun/install/global/node_modules/@openparachute/scribe",
+          },
+          path,
+        );
+        const lines: string[] = [];
+        await status({
+          manifestPath: path,
+          fetchImpl: async () => new Response(null, { status: 200 }),
+          print: (l) => lines.push(l),
+          installSourceDeps: {
+            bunGlobalPrefixes: () => ["/home/test/.bun/install/global/node_modules"],
+            resolveBunGlobal: () => null,
+            readJson: (p) =>
+              p === "/home/test/.bun/install/global/node_modules/@openparachute/scribe/package.json"
+                ? { name: "@openparachute/scribe", version: "0.4.2-rc.1" }
+                : (() => {
+                    throw new Error("nope");
+                  })(),
+            readGitHead: () => undefined,
+          },
+        });
+        expect(lines.some((l) => l.includes("npm (0.4.2-rc.1)"))).toBe(true);
+        expect(lines.some((l) => l.includes("STALE:"))).toBe(false);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("entries without installDir fall back to bun-global symlink lookup", async () => {
+      // Some services.json entries (older first-party rows, or rows written
+      // by a service that doesn't echo installDir) leave the field absent.
+      // detectInstallSource maps the entry name → first-party package and
+      // probes bun globals for the symlink. Pins that fallback path.
+      const { path, cleanup } = makeTempPath();
+      try {
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/default"],
+            health: "/vault/default/health",
+            version: "0.4.4-rc.3",
+            // No installDir.
+          },
+          path,
+        );
+        const lines: string[] = [];
+        await status({
+          manifestPath: path,
+          fetchImpl: async () => new Response(null, { status: 200 }),
+          print: (l) => lines.push(l),
+          installSourceDeps: {
+            bunGlobalPrefixes: () => ["/home/test/.bun/install/global/node_modules"],
+            resolveBunGlobal: (pkg) =>
+              pkg === "@openparachute/vault" ? "/Users/me/code/parachute-vault" : null,
+            readJson: (p) =>
+              p === "/Users/me/code/parachute-vault/package.json"
+                ? { name: "@openparachute/vault", version: "0.4.4-rc.3" }
+                : (() => {
+                    throw new Error("nope");
+                  })(),
+            readGitHead: () => "8aa167b",
+          },
+        });
+        expect(lines.some((l) => l.includes("bun-linked → parachute-vault @ 8aa167b"))).toBe(true);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("third-party row without installDir + no mapping renders as 'unknown'", async () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        upsertService(
+          {
+            name: "agent",
+            port: 1946,
+            paths: ["/agent"],
+            health: "/agent/health",
+            version: "0.1.4-rc.1",
+            // No installDir; agent isn't in FIRST_PARTY_FALLBACKS by short name,
+            // and the fallback bun-global lookup needs a known package name.
+          },
+          path,
+        );
+        const lines: string[] = [];
+        await status({
+          manifestPath: path,
+          fetchImpl: async () => new Response(null, { status: 200 }),
+          print: (l) => lines.push(l),
+          installSourceDeps: {
+            bunGlobalPrefixes: () => ["/home/test/.bun/install/global/node_modules"],
+            resolveBunGlobal: () => null,
+            readJson: () => {
+              throw new Error("not reached");
+            },
+            readGitHead: () => undefined,
+          },
+        });
+        expect(lines.some((l) => l.includes("unknown"))).toBe(true);
+      } finally {
+        cleanup();
+      }
+    });
+  });
 });

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,5 +1,12 @@
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import { HUB_SVC, readHubPort } from "../hub-control.ts";
+import {
+  type DetectInstallSourceDeps,
+  detectHubInstallSource,
+  detectInstallSource,
+  formatInstallSourceLabel,
+  isStale,
+} from "../install-source.ts";
 import { type AliveFn, defaultAlive, formatUptime, processState } from "../process-state.ts";
 import { canonicalPortForManifest, getSpec, shortNameForManifest } from "../service-spec.ts";
 import { type ServiceEntry, readManifest } from "../services-manifest.ts";
@@ -14,6 +21,19 @@ export interface StatusOpts {
   configDir?: string;
   alive?: AliveFn;
   now?: () => Date;
+  /**
+   * Test seam for install-source detection. Production reads the filesystem
+   * + shells out to git; tests inject stubs so each case (npm / bun-linked /
+   * unknown / stale) is exercised deterministically without depending on
+   * the operator's actual bun globals.
+   */
+  installSourceDeps?: DetectInstallSourceDeps;
+  /**
+   * Directory containing the running hub source. Defaults to `import.meta.dir`
+   * (the directory of this file). Tests override so the hub row's install
+   * source classification doesn't depend on the test runner's location.
+   */
+  hubSrcDir?: string;
 }
 
 export interface ProbeResult {
@@ -71,6 +91,7 @@ interface StatusRow {
   uptimeLabel: string;
   healthLabel: string;
   latencyLabel: string;
+  sourceLabel: string;
   url: string | undefined;
   healthy: boolean;
   skipped: boolean;
@@ -82,6 +103,13 @@ interface StatusRow {
    * hard-erroring on a deliberate operator port change.
    */
   driftWarning?: string;
+  /**
+   * Version-drift indicator (hub#243). Set when a bun-linked service's
+   * `services.json.version` lags the live `package.json` version at its
+   * checkout. Surfaced as a continuation line so operators can spot a
+   * stale-after-rebuild row without comparing columns by eye.
+   */
+  staleNote?: string;
 }
 
 /**
@@ -98,7 +126,13 @@ function urlForEntry(entry: ServiceEntry, short: string | undefined): string | u
   return `http://127.0.0.1:${entry.port}${first}`;
 }
 
-function hubRow(configDir: string, alive: AliveFn, nowDate: Date): StatusRow | undefined {
+function hubRow(
+  configDir: string,
+  alive: AliveFn,
+  nowDate: Date,
+  hubSrcDir: string,
+  installSourceDeps: DetectInstallSourceDeps,
+): StatusRow | undefined {
   const proc = processState(HUB_SVC, configDir, alive);
   if (proc.status === "unknown") return undefined;
   const port = readHubPort(configDir);
@@ -107,15 +141,17 @@ function hubRow(configDir: string, alive: AliveFn, nowDate: Date): StatusRow | u
   const pidLabel = proc.status === "running" && proc.pid !== undefined ? String(proc.pid) : "-";
   const uptimeLabel =
     proc.status === "running" && proc.startedAt ? formatUptime(proc.startedAt, nowDate) : "-";
+  const source = detectHubInstallSource(hubSrcDir, installSourceDeps);
   return {
     service: "parachute-hub (internal)",
     port: portLabel,
-    version: "-",
+    version: source.livePackageVersion ?? "-",
     processLabel,
     pidLabel,
     uptimeLabel,
     healthLabel: "-",
     latencyLabel: "-",
+    sourceLabel: formatInstallSourceLabel(source),
     url: port !== undefined ? `http://127.0.0.1:${port}` : undefined,
     healthy: true,
     skipped: true,
@@ -130,6 +166,8 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
   const configDir = opts.configDir ?? CONFIG_DIR;
   const alive = opts.alive ?? defaultAlive;
   const now = opts.now ?? (() => new Date());
+  const installSourceDeps = opts.installSourceDeps ?? {};
+  const hubSrcDir = opts.hubSrcDir ?? import.meta.dir;
 
   const manifest = readManifest(manifestPath);
   if (manifest.services.length === 0) {
@@ -178,6 +216,17 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
           ? `canonical port is ${canonical}`
           : undefined;
 
+      // Install-source detection (hub#243). One filesystem walk + maybe one
+      // `git rev-parse` per row. Failures degrade silently to `unknown` —
+      // status output should never error out on a missing checkout dir.
+      const detectArgs: { entryName: string; installDir?: string } = { entryName: entry.name };
+      if (entry.installDir !== undefined) detectArgs.installDir = entry.installDir;
+      const source = detectInstallSource(detectArgs, installSourceDeps);
+      const sourceLabel = formatInstallSourceLabel(source);
+      const staleNote = isStale(entry.version, source)
+        ? `STALE: services.json cached ${entry.version}; live package.json ${source.livePackageVersion}`
+        : undefined;
+
       // Only skip probe when we know the process is dead (PID file was
       // present but kill(pid, 0) failed). "unknown" status (no PID file)
       // still probes — externally-managed services should report health.
@@ -191,10 +240,12 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
           uptimeLabel,
           healthLabel: "-",
           latencyLabel: "-",
+          sourceLabel,
           url,
           healthy: false,
           skipped: true,
           driftWarning,
+          staleNote,
         };
       }
 
@@ -213,20 +264,32 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
         uptimeLabel,
         healthLabel,
         latencyLabel: `${p.latencyMs}ms`,
+        sourceLabel,
         url,
         healthy: p.healthy,
         skipped: false,
         driftWarning,
+        staleNote,
       };
     }),
   );
 
   // Hub is an internal service — not in services.json, but users notice
   // when it's dead. Only show it if we've seen it run.
-  const hub = hubRow(configDir, alive, nowDate);
+  const hub = hubRow(configDir, alive, nowDate, hubSrcDir, installSourceDeps);
   if (hub) rows.push(hub);
 
-  const header = ["SERVICE", "PORT", "VERSION", "PROCESS", "PID", "UPTIME", "HEALTH", "LATENCY"];
+  const header = [
+    "SERVICE",
+    "PORT",
+    "VERSION",
+    "PROCESS",
+    "PID",
+    "UPTIME",
+    "HEALTH",
+    "LATENCY",
+    "SOURCE",
+  ];
   const textRows = rows.map((r) => [
     r.service,
     r.port,
@@ -236,14 +299,17 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
     r.uptimeLabel,
     r.healthLabel,
     r.latencyLabel,
+    r.sourceLabel,
   ]);
   const widths = header.map((_, i) =>
     Math.max(header[i]?.length ?? 0, ...textRows.map((r) => r[i]?.length ?? 0)),
   );
   print(formatRow(header, widths));
-  // URL stays on a continuation line rather than a column. URLs are long
-  // (vault's MCP path runs ~40 chars), and a ninth column would push the
-  // table past 80 cols on every install. The "  → " prefix groups visually
+  // URL, drift, and stale notes stay on continuation lines rather than
+  // columns. URLs are long (vault's MCP path runs ~40 chars); SOURCE labels
+  // can be long for bun-linked rows. Spreading them across columns would
+  // push the table well past 80 cols on every install — continuation lines
+  // keep the table scannable. The "  → " / "  ! " prefixes group visually
   // with the row above without misleading the table widths.
   for (let i = 0; i < textRows.length; i++) {
     const cells = textRows[i];
@@ -251,10 +317,8 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
     if (!cells || !row) continue;
     print(formatRow(cells, widths));
     if (row.url) print(`  → ${row.url}`);
-    // Drift warning rides as its own continuation line. Plain ASCII (no
-    // emoji / unicode glyphs) for terminal compatibility — the same
-    // surface that prints to scripts piping `parachute status`.
     if (row.driftWarning) print(`  ! ${row.driftWarning}`);
+    if (row.staleNote) print(`  ! ${row.staleNote}`);
   }
 
   /**

--- a/src/help.ts
+++ b/src/help.ts
@@ -124,7 +124,7 @@ Examples:
 }
 
 export function statusHelp(): string {
-  return `parachute status — show installed services, process state, and health
+  return `parachute status — show installed services, process state, health, install source
 
 Usage:
   parachute status
@@ -133,11 +133,17 @@ What it does:
   Reads ~/.parachute/services.json. For each registered service:
     - checks PID file at ~/.parachute/<svc>/run/<svc>.pid → running/stopped
     - probes http://localhost:<port><health> (skipped for known-stopped processes)
+    - classifies the install source as bun-linked (local checkout) or npm
 
   Stopped services show "-" for health and don't count toward the exit
   code — they're an expected state after fresh install before \`parachute
   start\`. Running or externally-managed services that fail health checks
   do exit 1.
+
+  A "STALE: services.json cached … live package.json …" continuation line
+  appears under a row when a bun-linked service has been rebuilt but the
+  manifest's cached version hasn't caught up — re-install (\`parachute
+  install <pkg>\`) refreshes the row.
 
 Exit codes:
   0   all probed services healthy (or none running)
@@ -145,10 +151,10 @@ Exit codes:
 
 Example:
   $ parachute status
-  SERVICE          PORT  VERSION  PROCESS  PID    UPTIME  HEALTH  LATENCY
-  parachute-vault  1940  0.2.4    running  12345  2h 13m  ok      2ms
+  SERVICE          PORT  VERSION  PROCESS  PID    UPTIME  HEALTH  LATENCY  SOURCE
+  parachute-vault  1940  0.2.4    running  12345  2h 13m  ok      2ms      bun-linked → parachute-vault @ 8aa167b
     → http://127.0.0.1:1940/vault/default/mcp
-  parachute-notes  1942  0.0.1    stopped  -      -       -       -
+  parachute-notes  1942  0.0.1    stopped  -      -       -       -        npm (0.3.15-rc.1)
     → http://127.0.0.1:1942/notes
 `;
 }

--- a/src/install-source.ts
+++ b/src/install-source.ts
@@ -1,0 +1,293 @@
+/**
+ * Detects where each service is *running from* — bun-linked against a local
+ * checkout, or installed from npm — so `parachute status` can surface the
+ * provenance alongside version/health.
+ *
+ * Motivation: hub#243. After a bun-linked rebuild, `services.json`'s cached
+ * `version` field can lag the live `package.json` version, and the operator
+ * has no way to spot the drift from `status` output alone. Surfacing
+ * install-source + a STALE flag turns a three-step diagnosis into one
+ * glance.
+ *
+ * Pure read path: filesystem + (optional) one-shot `git rev-parse` per
+ * service. No network. Every external dependency is injectable via the
+ * Deps bag so tests don't touch real bun-globals or git.
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { FIRST_PARTY_FALLBACKS, shortNameForManifest } from "./service-spec.ts";
+
+export type InstallSourceKind = "bun-linked" | "npm" | "unknown";
+
+export interface InstallSource {
+  readonly kind: InstallSourceKind;
+  /**
+   * Absolute path to the source checkout (bun-linked) or the installed
+   * package dir under bun globals (npm). Undefined when `kind === "unknown"`.
+   */
+  readonly path?: string;
+  /** Short git HEAD hash for bun-linked sources where the path is a git repo. */
+  readonly gitHead?: string;
+  /**
+   * Version from the live `package.json` at `path`. For bun-linked sources
+   * this can differ from the entry's cached `services.json.version` — that's
+   * the drift case we surface.
+   */
+  readonly livePackageVersion?: string;
+}
+
+export interface DetectInstallSourceDeps {
+  /**
+   * Returns the absolute path the bun-global symlink for `packageName` points
+   * at, or null if no symlink/install exists at any known prefix. Mirrors
+   * `defaultLinkedPath` in commands/install.ts so the contracts stay aligned.
+   */
+  readonly resolveBunGlobal?: (packageName: string) => string | null;
+  /** Returns the bun-global node_modules prefixes to consider "npm-installed". */
+  readonly bunGlobalPrefixes?: () => readonly string[];
+  /** Reads + parses a JSON file. Test seam — keeps the module synchronously testable. */
+  readonly readJson?: (path: string) => unknown;
+  /** Returns the short git HEAD at `path`, or undefined if unavailable. */
+  readonly readGitHead?: (path: string) => string | undefined;
+}
+
+export function bunGlobalPrefixes(): readonly string[] {
+  const prefixes: string[] = [];
+  const fromEnv = process.env.BUN_INSTALL;
+  if (fromEnv) prefixes.push(join(fromEnv, "install", "global", "node_modules"));
+  prefixes.push(join(homedir(), ".bun", "install", "global", "node_modules"));
+  return prefixes;
+}
+
+export function defaultResolveBunGlobal(packageName: string): string | null {
+  for (const prefix of bunGlobalPrefixes()) {
+    const pkgJson = join(prefix, ...packageName.split("/"), "package.json");
+    try {
+      return dirname(realpathSync(pkgJson));
+    } catch {
+      // Try the next prefix.
+    }
+  }
+  return null;
+}
+
+export function defaultReadJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+export function defaultReadGitHead(path: string): string | undefined {
+  try {
+    const out = execFileSync("git", ["-C", path, "rev-parse", "--short", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 1500,
+    });
+    const head = out.trim();
+    return head.length > 0 ? head : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * True when `candidate` is under one of the bun-global prefixes. Both sides
+ * are realpath'd so symlinks in `candidate` (or in a parent of the prefix)
+ * don't make us miss the match. Used to classify "is this installed in bun
+ * globals" vs "is this a separate checkout that bun-link points at."
+ */
+function isUnderBunGlobals(candidate: string, prefixes: readonly string[]): boolean {
+  let cand: string;
+  try {
+    cand = realpathSync(candidate);
+  } catch {
+    cand = resolve(candidate);
+  }
+  for (const prefix of prefixes) {
+    let pre: string;
+    try {
+      pre = realpathSync(prefix);
+    } catch {
+      pre = resolve(prefix);
+    }
+    if (cand === pre) return true;
+    const withSep = pre.endsWith("/") ? pre : `${pre}/`;
+    if (cand.startsWith(withSep)) return true;
+  }
+  return false;
+}
+
+function packageNameFor(entryName: string): string | undefined {
+  const short = shortNameForManifest(entryName);
+  if (short !== undefined) {
+    const fb = FIRST_PARTY_FALLBACKS[short];
+    if (fb) return fb.package;
+  }
+  return undefined;
+}
+
+function readVersion(packageDir: string, readJson: (p: string) => unknown): string | undefined {
+  try {
+    const parsed = readJson(join(packageDir, "package.json"));
+    if (parsed && typeof parsed === "object") {
+      const v = (parsed as Record<string, unknown>).version;
+      if (typeof v === "string" && v.length > 0) return v;
+    }
+  } catch {
+    // package.json missing / malformed — leave undefined so the caller can
+    // still report kind without inventing a version.
+  }
+  return undefined;
+}
+
+export interface DetectArgs {
+  /** The services.json row name (`parachute-vault`, `agent`, etc.). */
+  readonly entryName: string;
+  /** Absolute install dir from services.json, when known. */
+  readonly installDir?: string;
+}
+
+/**
+ * Classify a service's install source. Pure: no network, single optional
+ * `git rev-parse` shell-out (mock via `readGitHead` in tests).
+ *
+ * Resolution order:
+ *   1. If `installDir` is set: realpath + compare against bun globals. Under
+ *      globals → `npm`; anywhere else → `bun-linked`.
+ *   2. Else, if we can map the entry to a first-party package name: look up
+ *      the bun-global symlink target. Bare `bun add -g <pkg>` lands under
+ *      bun globals → `npm`; `bun link` lands somewhere else → `bun-linked`.
+ *   3. Else: `unknown` — third-party rows missing `installDir` (legacy
+ *      manifest from before installDir stamping) fall here. They should be
+ *      rare and the operator's signal is "re-install to refresh."
+ */
+export function detectInstallSource(
+  args: DetectArgs,
+  deps: DetectInstallSourceDeps = {},
+): InstallSource {
+  const resolveBunGlobal = deps.resolveBunGlobal ?? defaultResolveBunGlobal;
+  const prefixes = deps.bunGlobalPrefixes ?? bunGlobalPrefixes;
+  const readJson = deps.readJson ?? defaultReadJson;
+  const readGitHead = deps.readGitHead ?? defaultReadGitHead;
+
+  const candidate =
+    args.installDir ??
+    (() => {
+      const pkg = packageNameFor(args.entryName);
+      return pkg ? resolveBunGlobal(pkg) : null;
+    })();
+
+  if (!candidate) return { kind: "unknown" };
+
+  let resolvedPath: string;
+  try {
+    resolvedPath = realpathSync(candidate);
+  } catch {
+    resolvedPath = resolve(candidate);
+  }
+
+  const underGlobals = isUnderBunGlobals(resolvedPath, prefixes());
+  const livePackageVersion = readVersion(resolvedPath, readJson);
+
+  if (underGlobals) {
+    const result: InstallSource = { kind: "npm", path: resolvedPath };
+    if (livePackageVersion !== undefined) {
+      (result as { livePackageVersion?: string }).livePackageVersion = livePackageVersion;
+    }
+    return result;
+  }
+
+  const gitHead = readGitHead(resolvedPath);
+  const result: InstallSource = { kind: "bun-linked", path: resolvedPath };
+  if (livePackageVersion !== undefined) {
+    (result as { livePackageVersion?: string }).livePackageVersion = livePackageVersion;
+  }
+  if (gitHead !== undefined) {
+    (result as { gitHead?: string }).gitHead = gitHead;
+  }
+  return result;
+}
+
+/**
+ * Detect the hub's own install source from the running process. The hub
+ * doesn't have a services.json row of its own, but `parachute status` still
+ * surfaces a row for it — so the same SOURCE column has to render. We
+ * climb from `import.meta.dir` (the location of the running source files)
+ * to the nearest `package.json`, then classify that path the same way we
+ * classify a service's `installDir`.
+ *
+ * `srcDir` is injectable so tests can drive the function without depending
+ * on `import.meta.dir` (which points at the test file, not at hub source).
+ */
+export function detectHubInstallSource(
+  srcDir: string,
+  deps: DetectInstallSourceDeps = {},
+): InstallSource {
+  // `import.meta.dir` is `<pkgDir>/src` in normal layouts.
+  const pkgDir = findNearestPackageDir(srcDir, deps.readJson ?? defaultReadJson);
+  if (!pkgDir) return { kind: "unknown" };
+  return detectInstallSource({ entryName: "parachute-hub", installDir: pkgDir }, deps);
+}
+
+function findNearestPackageDir(
+  start: string,
+  readJson: (p: string) => unknown,
+): string | undefined {
+  let current = resolve(start);
+  for (let i = 0; i < 16; i++) {
+    try {
+      readJson(join(current, "package.json"));
+      return current;
+    } catch {
+      // No package.json here — climb.
+    }
+    const parent = dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+  return undefined;
+}
+
+/**
+ * True when an entry's cached `services.json` version differs from the live
+ * `package.json` version at its bun-linked path. The single drift case the
+ * operator can act on — `parachute upgrade <svc>` for the bun-linked path
+ * doesn't refresh `services.json` on rebuild, so a freshly-built source can
+ * still report the pre-rebuild version through status.
+ *
+ * Only meaningful for `kind === "bun-linked"`. NPM-installed services
+ * don't have a "live" source separate from the cached version.
+ */
+export function isStale(entryVersion: string, source: InstallSource): boolean {
+  if (source.kind !== "bun-linked") return false;
+  if (!source.livePackageVersion) return false;
+  return source.livePackageVersion !== entryVersion;
+}
+
+/**
+ * Compact `SOURCE` cell label for the status table. Verbose-friendly, never
+ * wider than ~50 chars on typical inputs.
+ *
+ *   bun-linked: `bun-linked → <basename> @ <head>`     (head is the git short SHA)
+ *   npm:        `npm (0.3.15-rc.1)` / `npm`            (version when known)
+ *   unknown:    `unknown`
+ *
+ * The continuation `STALE` indicator is a separate line in the status
+ * renderer — keeps the column narrow.
+ */
+export function formatInstallSourceLabel(source: InstallSource): string {
+  if (source.kind === "bun-linked") {
+    const basename = source.path
+      ? (source.path.split("/").filter(Boolean).pop() ?? source.path)
+      : undefined;
+    if (basename && source.gitHead) return `bun-linked → ${basename} @ ${source.gitHead}`;
+    if (basename) return `bun-linked → ${basename}`;
+    return "bun-linked";
+  }
+  if (source.kind === "npm") {
+    if (source.livePackageVersion) return `npm (${source.livePackageVersion})`;
+    return "npm";
+  }
+  return "unknown";
+}

--- a/src/install-source.ts
+++ b/src/install-source.ts
@@ -191,22 +191,20 @@ export function detectInstallSource(
   const livePackageVersion = readVersion(resolvedPath, readJson);
 
   if (underGlobals) {
-    const result: InstallSource = { kind: "npm", path: resolvedPath };
-    if (livePackageVersion !== undefined) {
-      (result as { livePackageVersion?: string }).livePackageVersion = livePackageVersion;
-    }
-    return result;
+    return {
+      kind: "npm",
+      path: resolvedPath,
+      ...(livePackageVersion !== undefined && { livePackageVersion }),
+    };
   }
 
   const gitHead = readGitHead(resolvedPath);
-  const result: InstallSource = { kind: "bun-linked", path: resolvedPath };
-  if (livePackageVersion !== undefined) {
-    (result as { livePackageVersion?: string }).livePackageVersion = livePackageVersion;
-  }
-  if (gitHead !== undefined) {
-    (result as { gitHead?: string }).gitHead = gitHead;
-  }
-  return result;
+  return {
+    kind: "bun-linked",
+    path: resolvedPath,
+    ...(livePackageVersion !== undefined && { livePackageVersion }),
+    ...(gitHead !== undefined && { gitHead }),
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #243. `parachute status` now surfaces a new `SOURCE` column classifying each service row as either:

- `bun-linked → <basename> @ <git-short-sha>` — operator has a local checkout `bun link`'d in.
- `npm (<version>)` — installed from a published package under bun globals.

For bun-linked rows where `services.json`'s cached `version` lags the live `package.json` at the checkout, a `STALE: services.json cached <X>; live package.json <Y>` continuation line surfaces beneath the row.

## Motivation

2026-05-11 the operator spent ~30 minutes chasing a stale `parachute-notes 0.3.11-rc.1` in `parachute status` while the actual served bundle was the freshly-built `0.3.15-rc.1`. Three separate steps were needed to diagnose (`status`, `package.json`, `services.json`) plus a fourth to figure out whether the binary was bun-linked or npm-installed. The new column compresses all of that to one glance.

## Implementation

- **New pure helper `src/install-source.ts`** with full test-seam coverage — `bunGlobalPrefixes`, `resolveBunGlobal`, `readJson`, `readGitHead` are all injectable. Pure read path: filesystem + at most one `git rev-parse --short HEAD` shell-out per bun-linked row, with a 1.5s timeout. Failures degrade silently to "no SHA" / "no version" rather than blocking status. No network.

- **`src/commands/status.ts`** calls `detectInstallSource` per row and `detectHubInstallSource` for the internal hub row (which climbs from `import.meta.dir` to the nearest `package.json`). Adds `SOURCE` column to the header + per-row label; STALE rides as a continuation line beneath the row, in the same `! <note>` shape as the existing canonical-port-drift warning.

- **`statusHelp()`** updated to document the new column + STALE indicator.

### Resolution order in `detectInstallSource`

1. If services.json entry has `installDir`: realpath + compare against bun globals. Under globals → `npm`; elsewhere → `bun-linked`.
2. Else, if entry name maps to a first-party package via `shortNameForManifest`: probe bun-globals for the symlink target.
3. Else: `unknown` (third-party row with no installDir stamped — should be rare post-#56 follow-ups, since install.ts stamps installDir on every path).

## Smoke evidence

Real `services.json` on the operator's machine, after `bun link`-ing this branch:

```
SERVICE                   PORT  VERSION      PROCESS  PID    UPTIME   HEALTH  LATENCY  SOURCE
parachute-vault           1940  0.4.4-rc.3   running  15284  15h 39m  ok      31ms     bun-linked → parachute-vault @ 8aa167b
  → http://127.0.0.1:1940/vault/default/mcp
  ! STALE: services.json cached 0.4.4-rc.3; live package.json 0.4.4-rc.4
parachute-scribe          1943  0.4.2-rc.1   stopped  -      -        -       -        bun-linked → parachute-scribe @ 78c7cee
  ! STALE: services.json cached 0.4.2-rc.1; live package.json 0.4.2
parachute-notes           1942  0.3.15-rc.1  running  39790  2h 49m   ok      13ms     bun-linked → parachute-notes @ 051c404
agent                     1946  0.1.4-rc.1   stopped  -      -        -       -        bun-linked → parachute-agent @ ffa70ba
  ! STALE: services.json cached 0.1.4-rc.1; live package.json 0.1.4
parachute-hub (internal)  1939  0.5.9-rc.2   running  39443  2h 54m   -       -        bun-linked → parachute-hub @ ead85eb
```

All four bun-linked services + the bun-linked hub itself classified correctly with git SHAs. Three STALE rows caught at a glance — exactly the drift class the issue motivated.

## Out of scope

Fixing `parachute upgrade` so it refreshes the cached `services.json.version` on bun-linked rebuild. The STALE indicator surfaces the drift; the upgrade path that creates it is a separate issue (worth filing as a follow-up).

## Gate

- `bun test ./src`: **1245 pass / 1 fail / 30242 expects across 69 files**
- The 1 fail is `status > all-healthy returns 0 and prints table`, a **pre-existing env-dependent flake unrelated to this change** — the test reads the operator's real `~/.parachute/` configDir and breaks when a stale operator PID file makes `processState` return `stopped`. Reproduced on `main` via `git stash`; happens with or without this PR. Worth a follow-up to isolate the test's configDir, but not blocking.
- `bun run typecheck`: clean
- `bunx biome check .`: clean

## Patterns check

Touches the existing `status` command surface, drift-warning continuation-line convention from #195, and the `installDir` field stamping established post-#56. No new patterns introduced; the new module is hub-local with no cross-repo surface. Module-protocol files (`module-manifest.ts`, `service-spec.ts`) untouched.

## Test plan

- [x] `parachute status` correctly classifies bun-linked vs npm-installed services
- [x] STALE indicator fires when bun-linked live version differs from cached services.json version
- [x] Hub itself shows install source via `detectHubInstallSource`
- [x] `unknown` falls back gracefully when neither `installDir` nor first-party mapping resolves
- [x] No network calls; no hard failures on missing git / missing package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)