### PR TITLE
feat(oauth): emit per-vault services catalog keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.9-rc.4] - 2026-05-12
+
+`buildServicesCatalog` (the helper that populates the `services` map in `/oauth/token` responses) now emits **per-vault `vault:<name>` keys** alongside the legacy collapsed `vault` key when there are multiple vaults to disambiguate (closes #247).
+
+**Motivation.** Notes' multi-vault popover (notes#115) shipped, and the deferred Phase 2 work from `buildServicesCatalog`'s docstring is now blocking real use. On Aaron's 4-vault hub (default + boulder + gitcoin + techne), every connect-vault flow in Notes was getting the same `services.vault.url = /vault/default` regardless of which vault the OAuth grant actually narrowed to — so multiple VaultRecords collided in Notes' store (vaultId is URL-derived) and only one entry showed in Manage Vaults despite multiple OAuth grants.
+
+**What changed.** When the token's scopes admit a single vault on a single-vault hub, the catalog is unchanged — `services.vault.url` only. When the token's scopes narrow to a specific vault (`vault:boulder:write`) or when multiple vaults are admitted on a multi-vault hub, per-vault keys are added:
+
+```json
+{
+  "services": {
+    "vault": { "url": "https://hub.example/vault/default", "version": "0.4.4" },
+    "vault:default": { "url": "https://hub.example/vault/default", "version": "0.4.4" },
+    "vault:boulder": { "url": "https://hub.example/vault/boulder", "version": "0.4.4" },
+    "vault:gitcoin": { "url": "https://hub.example/vault/gitcoin", "version": "0.4.4" },
+    "vault:techne":  { "url": "https://hub.example/vault/techne",  "version": "0.4.4" }
+  }
+}
+```
+
+**Backwards compat.** The collapsed `vault` key is never removed — pre-popover clients keep working without changes. Per-vault keys are purely additive. On a per-vault-narrowed token (e.g. `vault:boulder:write`), the collapsed `vault` key points at the only admitted vault (boulder), so legacy single-vault clients on a multi-vault hub happen to land on the correctly-scoped URL too.
+
+**Emit rule.** Per-vault keys fire when (a) there are >1 admitted vault paths to disambiguate, OR (b) the token carries any per-vault-narrowed scope (`vault:<name>:<verb>`). The latter is an explicit consumer signal that the per-vault key matters even on single-vault hubs — so a Notes consumer reading `services["vault:default"]` works uniformly regardless of hub vault count.
+
+Both manifest shapes for multi-vault are handled: the modern single-row-multi-path layout (`parachute-vault` with `paths: ["/vault/default", "/vault/boulder", ...]` — what Aaron's hub uses) and the legacy per-vault-row layout (`parachute-vault-<name>` rows).
+
+**Notes-side follow-up (separate PR).** `OAuthCallback` in `parachute-notes` will be updated to prefer `token.services?.["vault:<name>"]?.url` over `token.services?.vault?.url` when the token's `vault` claim is set. That change lands after this PR merges and the next `@openparachute/hub` is on npm; tracked as a Notes-side issue.
+
+Gate: `bun test ./src` 1253 pass / 1 fail (pre-existing env flake — same as rc.3) / 30250 expects across 69 files. +8 tests over rc.3 (multi-vault catalog coverage). typecheck clean. biome clean.
+
 ## [0.5.9-rc.3] - 2026-05-12
 
 `parachute status` now reveals **where each service is running from** alongside the version/health columns (closes #243). The new `SOURCE` column classifies each row as either `bun-linked → <basename> @ <git-short-sha>` (the operator has a local checkout `bun link`'d in) or `npm (<version>)` (installed from a published package under bun globals). For bun-linked rows where `services.json`'s cached `version` lags the live `package.json` at the checkout, a `STALE: services.json cached <X>; live package.json <Y>` continuation line surfaces beneath the row.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.9-rc.3",
+  "version": "0.5.9-rc.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -1034,9 +1034,14 @@ describe("handleToken — full OAuth dance", () => {
 
       // closes #81 — services catalog tells the client where vault lives so
       // notes doesn't have to re-probe /.well-known/parachute.json. A
-      // vault:read token only sees the vault entry.
+      // `vault:default:read` token sees both the collapsed `vault` key
+      // (backwards compat) AND the per-vault `vault:default` key (closes
+      // #247 — pre-#247 only the collapsed key was emitted; consumers on
+      // multi-vault hubs were forced to assume `/vault/default` and
+      // collided).
       expect(tokenBody.services).toEqual({
         vault: { url: `${ISSUER}/vault/default`, version: "0.3.0" },
+        "vault:default": { url: `${ISSUER}/vault/default`, version: "0.3.0" },
       });
 
       // closes #215 reviewer F2 — Phase 1 code-grant access-token registry
@@ -1543,6 +1548,156 @@ describe("handleToken — full OAuth dance", () => {
     };
     expect(buildServicesCatalog(customManifest, ISSUER, ["vault:read"])).toEqual({
       vault: { url: `${ISSUER}/vault/work`, version: "0.3.0" },
+    });
+  });
+
+  // closes #247 — multi-vault correctness. Pre-#247 every vault collapsed
+  // under the single `vault` key, so Notes' OAuthCallback always wrote
+  // VaultRecord URL = paths[0] of the first vault row regardless of which
+  // vault the token actually granted. Per-vault `vault:<name>` keys let
+  // consumers route each grant to the correct vault URL.
+  describe("services catalog — multi-vault per-vault keys (#247)", () => {
+    // Real shape from a multi-vault hub: one `parachute-vault` row with N
+    // paths, each path naming an instance. Aaron's setup verbatim (4
+    // vaults: default, boulder, gitcoin, techne).
+    const multiVaultManifest: ServicesManifest = {
+      services: [
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default", "/vault/boulder", "/vault/gitcoin", "/vault/techne"],
+          health: "/health",
+          version: "0.4.4",
+        },
+      ],
+    };
+
+    test("single-vault hub with broad scope: only collapsed `vault` key (unchanged)", () => {
+      // Per-vault keys are noise on single-vault hubs — no disambiguation
+      // is needed. Backwards compat for pre-popover clients matters here.
+      expect(buildServicesCatalog(FIXTURE_MANIFEST, ISSUER, ["vault:read"])).toEqual({
+        vault: { url: `${ISSUER}/vault/default`, version: "0.3.0" },
+      });
+    });
+
+    test("single-vault hub with per-vault-narrowed scope: emits per-vault key too", () => {
+      // A `vault:default:read` token is an explicit consumer signal that
+      // the per-vault key matters — emit it even on a single-vault hub so
+      // the consumer's `services["vault:default"]` lookup works uniformly
+      // regardless of how many vaults the hub has.
+      expect(buildServicesCatalog(FIXTURE_MANIFEST, ISSUER, ["vault:default:read"])).toEqual({
+        vault: { url: `${ISSUER}/vault/default`, version: "0.3.0" },
+        "vault:default": { url: `${ISSUER}/vault/default`, version: "0.3.0" },
+      });
+    });
+
+    test("multi-vault hub with broad scope: emits every per-vault key + collapsed `vault`", () => {
+      // Broad `vault:read` admits every vault on the hub. Per-#247
+      // guidance: emit per-vault keys for all admitted vaults so the
+      // consumer (Notes popover) can pick its target by name without
+      // re-probing /.well-known/parachute.json.
+      expect(buildServicesCatalog(multiVaultManifest, ISSUER, ["vault:read"])).toEqual({
+        // Collapsed key still emitted (first admitted path); backwards compat.
+        vault: { url: `${ISSUER}/vault/default`, version: "0.4.4" },
+        "vault:default": { url: `${ISSUER}/vault/default`, version: "0.4.4" },
+        "vault:boulder": { url: `${ISSUER}/vault/boulder`, version: "0.4.4" },
+        "vault:gitcoin": { url: `${ISSUER}/vault/gitcoin`, version: "0.4.4" },
+        "vault:techne": { url: `${ISSUER}/vault/techne`, version: "0.4.4" },
+      });
+    });
+
+    test("multi-vault hub with per-vault scope: only that vault's per-vault key", () => {
+      // Aaron's "Connect boulder" flow: token has `vault:boulder:write`,
+      // scope admits only boulder. Pre-#247 the catalog said `vault.url =
+      // /vault/default` (WRONG), so Notes stored a /vault/default record
+      // with scope `vault:boulder:write` — collision city as more vaults
+      // got connected. Post-#247 the consumer reads
+      // `services["vault:boulder"].url` which correctly says /vault/boulder.
+      expect(buildServicesCatalog(multiVaultManifest, ISSUER, ["vault:boulder:write"])).toEqual({
+        // Collapsed `vault` points at boulder too — the only admitted
+        // vault — so legacy consumers happen to land on the right URL even
+        // though they have no per-vault awareness.
+        vault: { url: `${ISSUER}/vault/boulder`, version: "0.4.4" },
+        "vault:boulder": { url: `${ISSUER}/vault/boulder`, version: "0.4.4" },
+      });
+    });
+
+    test("multi-vault hub with mixed scopes: per-vault keys for each narrowed vault", () => {
+      // A token granting both `vault:boulder:read` and `vault:gitcoin:write`
+      // admits exactly those two vaults; default and techne aren't reachable.
+      expect(
+        buildServicesCatalog(multiVaultManifest, ISSUER, [
+          "vault:boulder:read",
+          "vault:gitcoin:write",
+        ]),
+      ).toEqual({
+        vault: { url: `${ISSUER}/vault/boulder`, version: "0.4.4" },
+        "vault:boulder": { url: `${ISSUER}/vault/boulder`, version: "0.4.4" },
+        "vault:gitcoin": { url: `${ISSUER}/vault/gitcoin`, version: "0.4.4" },
+      });
+    });
+
+    test("multi-vault hub: broad + per-vault scopes coexist; broad opens all vaults", () => {
+      // A token that carries BOTH `vault:read` (broad) AND
+      // `vault:boulder:write` (narrow) should land in the broad bucket
+      // because the broad scope is more permissive — narrowing one verb
+      // can't take away access the unnamed scope already granted.
+      expect(
+        buildServicesCatalog(multiVaultManifest, ISSUER, ["vault:read", "vault:boulder:write"]),
+      ).toEqual({
+        vault: { url: `${ISSUER}/vault/default`, version: "0.4.4" },
+        "vault:default": { url: `${ISSUER}/vault/default`, version: "0.4.4" },
+        "vault:boulder": { url: `${ISSUER}/vault/boulder`, version: "0.4.4" },
+        "vault:gitcoin": { url: `${ISSUER}/vault/gitcoin`, version: "0.4.4" },
+        "vault:techne": { url: `${ISSUER}/vault/techne`, version: "0.4.4" },
+      });
+    });
+
+    test("legacy per-vault rows (parachute-vault-<name>) also produce per-vault keys", () => {
+      // Older multi-vault layout — one row per vault — should produce the
+      // same catalog shape as the single-row-multi-path layout. The
+      // `vaultInstanceNameFor` helper handles both via its
+      // manifest-suffix fallback.
+      const legacyManifest: ServicesManifest = {
+        services: [
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/default"],
+            health: "/health",
+            version: "0.4.4",
+          },
+          {
+            name: "parachute-vault-work",
+            port: 1941,
+            paths: ["/vault/work"],
+            health: "/health",
+            version: "0.4.4",
+          },
+        ],
+      };
+      expect(buildServicesCatalog(legacyManifest, ISSUER, ["vault:read"])).toEqual({
+        vault: { url: `${ISSUER}/vault/default`, version: "0.4.4" },
+        "vault:default": { url: `${ISSUER}/vault/default`, version: "0.4.4" },
+        "vault:work": { url: `${ISSUER}/vault/work`, version: "0.4.4" },
+      });
+    });
+
+    test("non-vault services unaffected — only one key per service, no per-instance variant", () => {
+      // The per-vault-key expansion is vault-specific. scribe / notes /
+      // third-party rows still emit one key per service.
+      expect(
+        buildServicesCatalog(FIXTURE_MANIFEST, ISSUER, [
+          "vault:default:read",
+          "scribe:transcribe",
+          "notes:read",
+        ]),
+      ).toEqual({
+        vault: { url: `${ISSUER}/vault/default`, version: "0.3.0" },
+        "vault:default": { url: `${ISSUER}/vault/default`, version: "0.3.0" },
+        scribe: { url: `${ISSUER}/scribe`, version: "0.3.0-rc.1" },
+        notes: { url: `${ISSUER}/notes`, version: "0.3.0" },
+      });
     });
   });
 });

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -158,41 +158,129 @@ export type ServicesCatalog = Record<string, ServicesCatalogEntry>;
  * version, so OAuth clients don't have to re-probe `/.well-known/parachute.json`
  * to know where vault lives.
  *
- * URL source: `entry.paths[0]` from services.json verbatim — never hardcode
+ * URL source: `entry.paths[*]` from services.json verbatim — never hardcode
  * `/vault/default`. Users who installed with `parachute install vault
  * --vault-name work` have `paths: ["/vault/work"]` in their manifest, and the
  * catalog URL must follow that. The custom-vault-name regression test in
- * oauth-handlers.test.ts pins this.
+ * oauth-handlers.test.ts pins this for single-vault.
  *
  * Filtering: only services for which the token has at least one scope are
  * included. A scope `vault:read` admits the `vault` service; a token with only
  * `scribe:transcribe` gets a catalog with no vault entry. The check is on the
  * audience prefix (`<aud>:<verb>`) — same shape `inferAudience` uses.
  *
- * Multi-vault: Phase 1 collapses every vault entry under the single key
- * `vault`, first matching `parachute-vault*` row wins. Per-vault keys
- * (`services.vault.work.url` or `services["vault:work"].url`) are deferred
- * to a future design once notes ships its vault picker; multi-vault clients
- * need to probe `/.well-known/parachute.json` for the full vaults array
- * until then.
+ * Multi-vault (closes #247): emits per-vault keys `vault:<name>` alongside
+ * the collapsed `vault` key. A scope `vault:boulder:write` admits only
+ * boulder → emits `vault:boulder` (and the legacy `vault` key, pointing at
+ * boulder so it resolves consistently). A broad scope `vault:read` admits
+ * every vault on the hub → emits `vault:<name>` for each vault path plus
+ * the legacy `vault` key (pointing at `entry.paths[0]` of the first vault,
+ * unchanged from Phase 1). Notes' OAuthCallback (notes#115 ships the
+ * picker; per-vault consumer change is the post-#247 Notes-side PR) reads
+ * `services["vault:<name>"]` so it stops collapsing multi-vault grants
+ * onto a single VaultRecord URL.
+ *
+ * Pre-popover clients still see `services.vault` and behave unchanged —
+ * that key never goes away. Per-vault keys are additive.
  */
 export function buildServicesCatalog(
   manifest: ServicesManifest,
   issuer: string,
   scopes: readonly string[],
 ): ServicesCatalog {
+  // Two scope-derived sets:
+  //   - audiences: bare service prefix (`vault`, `scribe`) → admits the
+  //     collapsed key + every per-vault key.
+  //   - namedVaults: per-vault narrowed scopes (`vault:<name>:<verb>`) →
+  //     admits only `vault:<name>` and the collapsed `vault`.
+  //
+  // A token with both `vault:read` and `vault:boulder:write` should land in
+  // the "any vault" bucket — the bare scope is permissive, the named one
+  // is informational. Detect this via the bare-prefix presence; the named
+  // scope's per-vault narrowing still works for clients that prefer it.
   const audiences = new Set<string>();
+  const namedVaults = new Set<string>();
   for (const s of scopes) {
+    const parts = s.split(":");
+    if (
+      parts.length === 3 &&
+      parts[0] === "vault" &&
+      parts[1] &&
+      parts[2] &&
+      VAULT_VERBS.has(parts[2])
+    ) {
+      namedVaults.add(parts[1]);
+      audiences.add("vault");
+      continue;
+    }
     const colon = s.indexOf(":");
     if (colon > 0) audiences.add(s.slice(0, colon));
   }
+  const broadVaultScope =
+    audiences.has("vault") &&
+    scopes.some((s) => {
+      const parts = s.split(":");
+      return (
+        parts.length === 2 &&
+        parts[0] === "vault" &&
+        parts[1] !== undefined &&
+        VAULT_VERBS.has(parts[1])
+      );
+    });
+
+  // Count total admitted vault paths across the manifest. Per-vault keys
+  // are only worth emitting when there are >1 admitted vaults to
+  // disambiguate (or when the token's own scopes are per-vault narrowed —
+  // a per-vault scope is an explicit consumer signal that the per-vault
+  // key matters even on a single-vault hub). The check is on admitted
+  // paths, not raw vault rows: a broad token on a multi-path vault row
+  // sees N paths; a per-vault token sees only its own.
+  let admittedVaultPathCount = 0;
+  if (audiences.has("vault")) {
+    for (const entry of manifest.services) {
+      if (!isVaultEntry(entry)) continue;
+      const paths = entry.paths.length > 0 ? entry.paths : ["/"];
+      for (const path of paths) {
+        const instance = vaultInstanceNameFor(entry.name, path);
+        if (broadVaultScope || namedVaults.has(instance)) admittedVaultPathCount++;
+      }
+    }
+  }
+  const emitPerVaultKeys = admittedVaultPathCount > 1 || namedVaults.size > 0;
+
   const base = issuer.replace(/\/$/, "");
   const catalog: ServicesCatalog = {};
   for (const entry of manifest.services) {
-    const path = entry.paths[0] ?? "/";
-    const key = isVaultEntry(entry) ? "vault" : shortName(entry.name);
+    if (isVaultEntry(entry)) {
+      if (!audiences.has("vault")) continue;
+      // Walk every path the row exposes. Real multi-vault on the hub is a
+      // single `parachute-vault` row with N paths (one per vault instance);
+      // legacy per-vault rows (`parachute-vault-<name>`) are handled by the
+      // same loop because each contributes one path.
+      const paths = entry.paths.length > 0 ? entry.paths : ["/"];
+      for (const path of paths) {
+        const instance = vaultInstanceNameFor(entry.name, path);
+        const admit = broadVaultScope || namedVaults.has(instance);
+        if (!admit) continue;
+        if (emitPerVaultKeys) {
+          const perVaultKey = `vault:${instance}`;
+          if (!catalog[perVaultKey]) {
+            catalog[perVaultKey] = { url: `${base}${path}`, version: entry.version };
+          }
+        }
+        // Collapsed `vault` key stays for backwards compat. First admitted
+        // vault wins (deterministic — `entry.paths[0]` for a broad scope,
+        // or the only admitted instance for a per-vault scope).
+        if (!catalog.vault) {
+          catalog.vault = { url: `${base}${path}`, version: entry.version };
+        }
+      }
+      continue;
+    }
+    const key = shortName(entry.name);
     if (!audiences.has(key)) continue;
-    if (catalog[key]) continue; // first vault wins; deterministic for clients
+    if (catalog[key]) continue;
+    const path = entry.paths[0] ?? "/";
     catalog[key] = { url: `${base}${path}`, version: entry.version };
   }
   return catalog;


### PR DESCRIPTION
## Summary

Closes #247. `buildServicesCatalog` (`src/oauth-handlers.ts`) now emits per-vault `vault:<name>` keys in `/oauth/token` responses alongside the legacy collapsed `vault` key, so multi-vault hubs no longer collapse every grant onto a single vault URL.

## Motivation

Notes' multi-vault popover (notes#115) shipped, exposing the Phase 1 limitation that was deferred when popover wasn't ready. On Aaron's 4-vault hub, every connect-vault flow returned `services.vault.url = /vault/default` regardless of which vault the OAuth grant actually narrowed to. Notes' VaultRecord vaultId is URL-derived, so multiple OAuth grants collided onto a single record in Notes' store — Manage Vaults showed only one entry despite connecting boulder, gitcoin, techne.

## Catalog shape (after #247)

```json
{
  "services": {
    "vault": { "url": "https://hub.example/vault/default", "version": "0.4.4" },
    "vault:default": { "url": "https://hub.example/vault/default", "version": "0.4.4" },
    "vault:boulder": { "url": "https://hub.example/vault/boulder", "version": "0.4.4" },
    "vault:gitcoin": { "url": "https://hub.example/vault/gitcoin", "version": "0.4.4" },
    "vault:techne":  { "url": "https://hub.example/vault/techne",  "version": "0.4.4" }
  }
}
```

## Emit rule

Per-vault keys fire when **either**:

- (a) there are >1 admitted vault paths to disambiguate, **OR**
- (b) the token carries any per-vault-narrowed scope (`vault:<name>:<verb>`).

The (b) case is the explicit consumer signal — a Notes consumer reading `services["vault:default"]` works uniformly regardless of how many vaults the hub has. Single-vault hubs with a broad scope still get exactly the pre-#247 catalog (no per-vault key emitted — would be noise with no disambiguation value).

## Backwards compatibility

The collapsed `vault` key is **preserved unconditionally**. Pre-popover Notes clients keep working without changes. Per-vault keys are purely additive — never replace, never override the collapsed key.

On a per-vault-narrowed token (e.g. `vault:boulder:write`), the collapsed `vault` key points at the narrowed vault, so legacy single-vault clients on a multi-vault hub happen to land on the correctly-scoped URL too.

## Both multi-vault layouts handled

- Modern single-row-multi-path (`parachute-vault` with `paths: ["/vault/default", "/vault/boulder", ...]`) — what Aaron's hub uses.
- Legacy per-vault rows (`parachute-vault-<name>`).

Same code path via `vaultInstanceNameFor` from `well-known.ts`.

## Notes-side follow-up (separate PR)

`OAuthCallback` in `parachute-notes` will be updated to prefer `token.services?.["vault:<name>"]?.url` over the legacy collapsed key when the token's `vault` claim is set. **That change lands after this PR merges** and the next `@openparachute/hub` is on npm. Tracked as a Notes-side issue/PR; not bundled into this PR per the team's serial-PR convention (different concerns, different repo).

## Tests

Eight new tests under `services catalog — multi-vault per-vault keys (#247)`:

- Single-vault + broad scope → unchanged (pre-#247 shape).
- Single-vault + per-vault-narrowed scope → emits both `vault` and `vault:default`.
- Multi-vault (single-row, 4 paths — Aaron's layout) + broad scope → every per-vault key emitted alongside collapsed `vault`.
- Multi-vault + per-vault scope (`vault:boulder:write`) → only `vault:boulder`; collapsed `vault` also narrows to boulder's URL.
- Multi-vault + mixed narrowed scopes for two distinct vaults.
- Multi-vault + broad + narrowed → broad wins (more permissive).
- Legacy per-vault rows → same catalog shape via `vaultInstanceNameFor` fallback.
- Non-vault services unaffected — single key per service.

The existing full-OAuth-dance test at `oauth-handlers.test.ts:1038` (`authorize → token → validate JWT`) also updated: a `vault:default:read` token now sees both `vault` and `vault:default` in the catalog. Comment cites #247 for the contract change.

## Patterns check

- **Module protocol** untouched. Catalog shape change is purely on the OAuth wire surface.
- **OAuth scopes** semantics unchanged. Per-vault-narrowed scopes (`vault:<name>:<verb>`) still derive audience `vault.<name>` per `jwt-audience.ts`; this PR just makes the catalog reflect the narrowing the audience derivation already does.
- **Backwards compat** — pre-popover clients keep working. The collapsed `vault` key never goes away.

## Gate

- `bun test ./src`: **1253 pass / 1 fail / 30250 expects across 69 files**
- +8 tests over rc.3 baseline (1245 → 1253).
- The 1 fail is the same pre-existing env-dependent flake in `status > all-healthy returns 0 and prints table` — operator's stale `~/.parachute/scribe/run/scribe.pid` makes `processState` return `stopped`, present on `main` (verified via `git stash`). Unrelated to this change.
- `bun run typecheck`: clean
- `bunx biome check .`: clean

## Test plan

- [x] Multi-vault hub with broad scope emits every per-vault key.
- [x] Multi-vault hub with per-vault scope only emits that vault's per-vault key.
- [x] Single-vault hub with broad scope unchanged from pre-#247.
- [x] Single-vault hub with per-vault-narrowed scope emits per-vault key (explicit consumer signal).
- [x] Legacy per-vault rows (`parachute-vault-<name>`) produce same catalog shape as single-row-multi-path.
- [x] Non-vault services (scribe / notes / third-party) unaffected.
- [x] Pre-popover clients reading `services.vault.url` continue working unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)