### PR TITLE
feat(oauth-ui): surface vault hint in approve-pending UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.9-rc.6] - 2026-05-12
+
+`/oauth/authorize`'s approve-pending UI (the page operators see when a DCR-registered client lands on the authorize endpoint before being approved) now surfaces the **vault hint** from the authorize URL (closes #244). Notes' VaultPopover (notes#115) passes `vault=<name>` on `/oauth/authorize` when kicking the OAuth flow for a specific vault; before this PR hub silently ignored it in the rendered page. On a multi-vault hub (4 vaults: boulder, default, gitcoin, techne) the operator had no way to tell which vault they were approving for. Single-vault hubs unaffected — the row omits when the hint is absent.
+
+Surface: `ApprovePendingViewProps` in `src/oauth-ui.ts` gets a new optional `requestedVault?: string` field. `renderApprovePending` renders a `vault: <name>` row in the existing `approve-meta` section, between `client_id` and `redirect_uris`, when the field is set. `handleAuthorizeGet` in `src/oauth-handlers.ts` reads the `vault` query param from the authorize URL and threads it through to both `renderApprovePending` call sites (with-session inline-form path + no-session CLI-only path). Empty-string `vault=` values normalize to undefined so the UI never renders a blank label.
+
+Gate: `bun test ./src` 1279 pass / 1 fail (same pre-existing env flake) / 30288 expects across 70 files. +2 tests over rc.5 (with-vault-hint render, empty-string-param normalize). typecheck clean. biome clean.
+
 ## [0.5.9-rc.5] - 2026-05-12
 
 Cookie-based POST endpoints (`/oauth/authorize/approve`, `/oauth/register` auto-approve, the DCR auto-approve path) now accept requests from any **hub-bound origin**, not just the configured `issuer` URL (closes #245). Previously, an operator hitting hub admin at `http://localhost:1939/login` then submitting the approve form got "Cross-origin request rejected" because Origin (loopback) didn't match issuer (tailnet). Same failure mode for tailnet→tailnet flows where Tailscale Serve stripped the Origin/Referer headers — the strict check returned false and 403'd a legitimate operator path.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.9-rc.5",
+  "version": "0.5.9-rc.6",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -2231,6 +2231,76 @@ describe("DCR approval gate (#74)", () => {
       const html = await res.text();
       expect(html).toContain("App not yet approved");
       expect(html).toContain("approve-client");
+      // No vault hint → no vault row in approve-meta. Single-vault hubs +
+      // pre-vault-popover clients leave the section omitted (#244).
+      expect(html).not.toContain('approve-meta-label">vault');
+    } finally {
+      cleanup();
+    }
+  });
+
+  // closes #244 — vault hint surfaced in approve-pending UI. Notes#115
+  // passes `vault=<name>` on `/oauth/authorize` for per-vault grants; hub's
+  // approve page now displays it alongside the other client metadata so a
+  // multi-vault operator can tell which vault they're approving for.
+  test("authorize: pending client with vault hint → approve UI renders 'vault: <name>'", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "pending",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:read",
+          vault: "boulder",
+        }),
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(403);
+      const html = await res.text();
+      expect(html).toContain("App not yet approved");
+      // The vault hint surfaces as a labeled row in the approve-meta block.
+      expect(html).toContain('approve-meta-label">vault');
+      expect(html).toContain("boulder");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("authorize: pending client with empty vault param → no vault row", async () => {
+    // Defensive: `vault=` with empty value normalizes to undefined so the
+    // UI doesn't render a blank vault label. Easy to hit if a client builds
+    // the URL via URLSearchParams.set("vault", someMaybeEmptyVar).
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "pending",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:read",
+          vault: "",
+        }),
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(403);
+      const html = await res.text();
+      expect(html).toContain("App not yet approved");
+      expect(html).not.toContain('approve-meta-label">vault');
     } finally {
       cleanup();
     }

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -431,6 +431,12 @@ function pendingClientResponse(
   const requestedScopes = (authorizeUrl.searchParams.get("scope") ?? "")
     .split(" ")
     .filter((s) => s.length > 0);
+  // Vault hint (closes #244): Notes' VaultPopover (notes#115) sets this on
+  // the authorize URL when kicking OAuth for a specific vault. Empty-string
+  // values normalize to undefined so the approve UI omits the row rather
+  // than rendering a blank vault label.
+  const vaultParam = authorizeUrl.searchParams.get("vault");
+  const requestedVault = vaultParam && vaultParam.length > 0 ? vaultParam : undefined;
   const session = findActiveSession(db, req, deps.now ?? (() => new Date()));
   const sameOrigin = isSameOriginRequest(req, resolveBoundOrigins(deps));
   const csrf = ensureCsrfToken(req);
@@ -443,6 +449,7 @@ function pendingClientResponse(
         clientId: client.clientId,
         redirectUris: client.redirectUris,
         requestedScopes,
+        ...(requestedVault !== undefined && { requestedVault }),
         approveForm: { csrfToken: csrf.token, returnTo },
       }),
       403,
@@ -455,6 +462,7 @@ function pendingClientResponse(
       clientId: client.clientId,
       redirectUris: client.redirectUris,
       requestedScopes,
+      ...(requestedVault !== undefined && { requestedVault }),
     }),
     403,
     extra,

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -112,6 +112,14 @@ export interface ApprovePendingViewProps {
   /** Scopes parsed from the original `/oauth/authorize?scope=` query param. */
   requestedScopes: string[];
   /**
+   * Vault hint from the original `/oauth/authorize?vault=<name>` query param,
+   * passed by Notes' VaultPopover (notes#115) when kicking the OAuth flow for
+   * a specific vault. Rendered alongside scopes so the operator can tell
+   * which vault they're approving access for on a multi-vault hub (closes
+   * #244). Single-vault hubs leave this absent and the section omits.
+   */
+  requestedVault?: string;
+  /**
    * When set, render the inline approve form. The form posts to
    * `/oauth/authorize/approve` with the CSRF token + a `return_to` URL the
    * server will redirect to after the approve commits — the original
@@ -245,12 +253,25 @@ function renderVaultPicker(picker: VaultPicker): string {
  * context). The button is the easy path; the CLI is always-available.
  */
 export function renderApprovePending(props: ApprovePendingViewProps): string {
-  const { clientName, clientId, redirectUris, requestedScopes, approveForm } = props;
+  const { clientName, clientId, redirectUris, requestedScopes, requestedVault, approveForm } =
+    props;
   const redirectList = redirectUris.map((u) => `<li><code>${escapeHtml(u)}</code></li>`).join("");
   const scopeRows =
     requestedScopes.length === 0
       ? `<li class="scope scope-empty">No scopes requested — the app gets a session token only.</li>`
       : requestedScopes.map(renderScopeRow).join("\n");
+  // Vault hint (closes #244): Notes' VaultPopover (notes#115) passes
+  // `vault=<name>` on `/oauth/authorize` for per-vault grants. Surface it
+  // alongside scopes so a multi-vault operator can tell which vault they're
+  // approving for. Missing on single-vault hubs / pre-vault-popover clients —
+  // section omits when absent.
+  const vaultRow = requestedVault
+    ? `
+        <p class="approve-meta-row">
+          <span class="approve-meta-label">vault</span>
+          <code class="approve-meta-value">${escapeHtml(requestedVault)}</code>
+        </p>`
+    : "";
   const formSection = approveForm
     ? `
       <form method="POST" action="/oauth/authorize/approve" class="auth-form approve-form">
@@ -289,7 +310,7 @@ export function renderApprovePending(props: ApprovePendingViewProps): string {
         <p class="approve-meta-row">
           <span class="approve-meta-label">client_id</span>
           <code class="approve-meta-value">${escapeHtml(clientId)}</code>
-        </p>
+        </p>${vaultRow}
         <div class="approve-meta-row approve-meta-row-block">
           <span class="approve-meta-label">redirect_uris</span>
           <ul class="approve-redirect-list">${redirectList}</ul>


### PR DESCRIPTION
## Summary

Closes #244. Hub's approve-pending UI (`renderApprovePending` in `src/oauth-ui.ts`) now surfaces the `vault=<name>` query param from `/oauth/authorize` as a `vault: <name>` row in the existing `approve-meta` section.

## Motivation

Notes' VaultPopover (notes#115) passes `vault=<name>` on `/oauth/authorize` when kicking the OAuth flow for a specific vault. The token-exchange path's `pendingClientJson` already carries the surrounding metadata, but the HTML-rendered approve UI silently ignored the hint. On Aaron's 4-vault hub (boulder/default/gitcoin/techne) there was no way to tell which vault a given approve flow was targeting.

## What changed

- **`ApprovePendingViewProps`** (`src/oauth-ui.ts`) — new optional `requestedVault?: string` field. Docstring cites notes#115 + hub#244.
- **`renderApprovePending`** — renders a `vault: <name>` row in the existing `approve-meta` section (between `client_id` and `redirect_uris`) when the field is set. XSS-safe via `escapeHtml`. Omits the row when the field is undefined.
- **`handleAuthorizeGet`** (`src/oauth-handlers.ts`) — reads the `vault` query param from the authorize URL and threads it through to both `renderApprovePending` call sites (with-session inline-form path + no-session CLI-only path). Empty-string `vault=` normalizes to undefined so the UI never renders a blank label.

## Tests

Two new tests in `src/__tests__/oauth-handlers.test.ts` under the existing "DCR approval gate (#74)" describe block:

- `vault=boulder` → approve UI HTML contains `approve-meta-label">vault` and `boulder`. Pins the rendering surface.
- `vault=` (empty) → no vault row in the rendered HTML. Pins the normalize-empty-to-undefined contract.

The existing pending-client test (line 2220 pre-PR) was updated to assert NO vault row when the hint is absent, locking in the single-vault default.

## Single-vault hubs unaffected

When the `vault` param is absent (or empty), `renderApprovePending` doesn't render the row at all. Pre-vault-popover clients and single-vault hubs see the same UI as before this PR.

## Patterns check

No new patterns introduced. The change extends an existing rendered surface; HTML escapes via the established `escapeHtml` helper. No schema changes, no module-protocol changes, no OAuth wire-level changes (the `vault` query param has been a documented Notes#115 convention since the popover shipped).

## Gate

- `bun test ./src`: **1279 pass / 1 fail / 30288 expects across 70 files**
- +2 tests over rc.5 baseline.
- The 1 fail is the same pre-existing env-dependent flake in `status > all-healthy returns 0 and prints table` (operator's stale scribe PID file). Unrelated.
- `bun run typecheck`: clean
- `bunx biome check .`: clean

## Test plan

- [x] Multi-vault operator hitting `/oauth/authorize?vault=boulder&...` sees "vault: boulder" in approve UI.
- [x] Single-vault hub (no `vault=` param) sees no vault row — UI unchanged from pre-#244.
- [x] Empty `vault=` value omits the row (no blank label).
- [x] HTML-escaped vault name (XSS defense — though VaultPopover-source names are filesystem-safe identifiers, the escape is defense-in-depth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)