### PR TITLE
feat(upgrade): allow hub as self-upgrade target (closes #251) (0.5.9-rc.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.9-rc.7] - 2026-05-16
+
+`parachute upgrade hub` now works — the dispatcher can self-upgrade (closes #251). Before this PR, `parachute upgrade hub` failed with `unknown service "hub". known: vault, notes, scribe, channel` because `resolveTargets` only consulted `FIRST_PARTY_FALLBACKS`, which deliberately excludes hub itself (hub isn't a fallback-registry entry — it's the dispatcher, and `FIRST_PARTY_FALLBACKS` is a transitional vendored-manifest fallback for committed-core modules per the workspace governance note). Users on a pre-0.5 install had no path back to current via the same dispatcher they already had; they had to `bun add -g @openparachute/hub@latest` by hand.
+
+**Fix.** Special-case `hub` in `src/commands/upgrade.ts` `resolveTargets`:
+
+- `parachute upgrade hub` synthesizes a `ResolvedTarget` keyed by the new `HUB_PACKAGE` constant (`@openparachute/hub`) exported from `hub-control.ts`. No services.json row is required (hub isn't in services.json); `findGlobalInstall("@openparachute/hub")` is the sole locate path and works the same for npm-installed and `bun link` checkouts.
+- The sweep path (`parachute upgrade` with no arg) now upgrades hub first, then every services.json entry. Hub-first ordering avoids a downstream service restart racing the dispatcher swap mid-sweep. The empty-manifest path no longer errors — hub is always upgradeable, even on a fresh install where no other services exist.
+- `unknown service` error message includes `hub` in the known list so the help is consistent with `parachute logs` (which has always accepted `hub`).
+
+**Restart.** Reuses the existing `lifecycle.restart(HUB_SVC, …)` path, which routes through `startHubSvc` / `stopHubSvc` (the hub's own lifecycle seams via `ensureHubRunning` / `stopHub`). No new restart code; the CLI process running the upgrade is separate from the daemon being upgraded, so killing+respawning the daemon doesn't kill the in-flight upgrade flow.
+
+**Help text.** `parachute upgrade --help` mentions hub explicitly + notes the closed issue.
+
+Gate: `bun test ./src` 1284 pass / 1 fail (same pre-existing `status > all-healthy returns 0` env flake — reproduces on rc.6 with no diff applied) / 30302 expects across 70 files. +5 tests over rc.6 (hub-as-target npm path, empty-manifest hub upgrade, hub-as-target bun-linked path, hub --tag forwarding, sweep-includes-hub ordering; existing partial-failure sweep test updated to seed hub). typecheck clean. biome clean.
+
 ## [0.5.9-rc.6] - 2026-05-12
 
 `/oauth/authorize`'s approve-pending UI (the page operators see when a DCR-registered client lands on the authorize endpoint before being approved) now surfaces the **vault hint** from the authorize URL (closes #244). Notes' VaultPopover (notes#115) passes `vault=<name>` on `/oauth/authorize` when kicking the OAuth flow for a specific vault; before this PR hub silently ignored it in the rendered page. On a multi-vault hub (4 vaults: boulder, default, gitcoin, techne) the operator had no way to tell which vault they were approving for. Single-vault hubs unaffected — the row omits when the hint is absent.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.9-rc.6",
+  "version": "0.5.9-rc.7",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/upgrade.test.ts
+++ b/src/__tests__/upgrade.test.ts
@@ -85,12 +85,12 @@ function seedVault(manifestPath: string, installDir: string, version = "0.4.0"):
 }
 
 describe("parachute upgrade", () => {
-  test("errors cleanly when no services installed", async () => {
+  test("errors cleanly when targeting a service that's not installed", async () => {
     const h = makeHarness();
     try {
       const logs: string[] = [];
       const m = makeRunner();
-      const code = await upgrade(undefined, {
+      const code = await upgrade("vault", {
         manifestPath: h.manifestPath,
         configDir: h.configDir,
         runner: m.runner,
@@ -105,7 +105,7 @@ describe("parachute upgrade", () => {
     }
   });
 
-  test("errors cleanly on unknown service", async () => {
+  test("errors cleanly on unknown service, lists hub in the known set", async () => {
     const h = makeHarness();
     try {
       seedVault(h.manifestPath, join(h.installRoot, "vault"));
@@ -120,7 +120,9 @@ describe("parachute upgrade", () => {
         log: (l) => logs.push(l),
       });
       expect(code).toBe(1);
-      expect(logs.join("\n")).toMatch(/unknown service/);
+      const joined = logs.join("\n");
+      expect(joined).toMatch(/unknown service/);
+      expect(joined).toMatch(/\bhub\b/);
     } finally {
       h.cleanup();
     }
@@ -472,11 +474,249 @@ describe("parachute upgrade", () => {
     }
   });
 
+  test("hub as target: npm-installed path runs bun add -g @openparachute/hub@<tag> + restart", async () => {
+    const h = makeHarness();
+    try {
+      // Hub is not in services.json — it's an internal service. The upgrade
+      // command must still accept `hub` as a target, locate its global install,
+      // run `bun add -g @openparachute/hub@latest`, and restart.
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.8" });
+
+      const seenCmd: string[][] = [];
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          seenCmd.push([...cmd]);
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.9" });
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          // Not a git checkout — drives the npm-install branch.
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "fatal: not a git repository\n" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      let restartedShort: string | undefined;
+      const logs: string[] = [];
+      const code = await upgrade("hub", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        restartFn: async (svc) => {
+          restartedShort = svc;
+          return 0;
+        },
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(restartedShort).toBe("hub");
+      const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
+      expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@latest"]);
+      const joined = logs.join("\n");
+      expect(joined).toMatch(/hub: npm-installed/);
+      expect(joined).toMatch(/0\.5\.8 → 0\.5\.9/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("hub as target works even with empty services.json (closes #251)", async () => {
+    // The dispatcher must be able to self-upgrade on a brand-new install where
+    // services.json doesn't exist yet — that's the worst-case bootstrap path
+    // and was the failure mode in #251.
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.8" });
+
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.9" });
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      let restartedShort: string | undefined;
+      const code = await upgrade("hub", {
+        manifestPath: h.manifestPath, // file doesn't exist
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        restartFn: async (svc) => {
+          restartedShort = svc;
+          return 0;
+        },
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(restartedShort).toBe("hub");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("hub as target: bun-linked checkout follows the linked path", async () => {
+    const h = makeHarness();
+    try {
+      const checkoutDir = join(h.installRoot, "parachute-hub-checkout");
+      writePackageJson(checkoutDir, { name: "@openparachute/hub", version: "0.5.9-rc.7" });
+
+      let headCalls = 0;
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          if (cmd[0] === "git" && cmd[1] === "pull") return 0;
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 0, stdout: "true" };
+          }
+          if (cmd[1] === "status") return { code: 0, stdout: "" };
+          if (cmd[1] === "rev-parse" && cmd[2] === "HEAD") {
+            headCalls++;
+            return { code: 0, stdout: headCalls === 1 ? "old" : "new" };
+          }
+          if (cmd[1] === "diff") return { code: 0, stdout: "src/foo.ts" };
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      let restartedShort: string | undefined;
+      const logs: string[] = [];
+      const code = await upgrade("hub", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(checkoutDir, "package.json") : null,
+        restartFn: async (svc) => {
+          restartedShort = svc;
+          return 0;
+        },
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(restartedShort).toBe("hub");
+      expect(logs.join("\n")).toMatch(/hub: bun-linked checkout/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("hub as target: --tag is forwarded to bun add -g for the hub package", async () => {
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.8" });
+
+      const seenCmd: string[][] = [];
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          seenCmd.push([...cmd]);
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      await upgrade("hub", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        restartFn: async () => 0,
+        tag: "rc",
+        log: () => {},
+      });
+      const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
+      expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@rc"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("sweep includes hub: hub upgraded alongside services.json entries", async () => {
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      const vaultDir = join(h.installRoot, "vault");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.8" });
+      writePackageJson(vaultDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, vaultDir);
+
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            const pkg = cmd[3] ?? "";
+            if (pkg.startsWith("@openparachute/hub")) {
+              writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.9" });
+            }
+            if (pkg.startsWith("@openparachute/vault")) {
+              writePackageJson(vaultDir, { name: "@openparachute/vault", version: "0.5.0" });
+            }
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      const restartCalls: string[] = [];
+      const code = await upgrade(undefined, {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) => {
+          if (pkg === "@openparachute/hub") return join(hubInstallDir, "package.json");
+          if (pkg === "@openparachute/vault") return join(vaultDir, "package.json");
+          return null;
+        },
+        restartFn: async (svc) => {
+          restartCalls.push(svc);
+          return 0;
+        },
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      // Hub goes first so its dispatcher upgrade isn't preempted.
+      expect(restartCalls).toEqual(["hub", "vault"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("sweep (no svc): partial failure — later targets still run; first failure code wins", async () => {
     const h = makeHarness();
     try {
+      const hubInstallDir = join(h.installRoot, "hub");
       const vaultDir = join(h.installRoot, "vault");
       const notesDir = join(h.installRoot, "notes");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.8" });
       writePackageJson(vaultDir, { name: "@openparachute/vault", version: "0.4.0" });
       writePackageJson(notesDir, { name: "@openparachute/notes", version: "0.0.1" });
       seedVault(h.manifestPath, vaultDir);
@@ -492,6 +732,7 @@ describe("parachute upgrade", () => {
         h.manifestPath,
       );
 
+      // hub is npm-installed and succeeds (no version bump → skip restart).
       // vault is npm-installed (no git); bun add -g fails with 7
       // notes is npm-installed and succeeds with version bump
       const runner: UpgradeRunner = {
@@ -521,6 +762,7 @@ describe("parachute upgrade", () => {
         configDir: h.configDir,
         runner,
         findGlobalInstall: (pkg) => {
+          if (pkg === "@openparachute/hub") return join(hubInstallDir, "package.json");
           if (pkg === "@openparachute/vault") return join(vaultDir, "package.json");
           if (pkg === "@openparachute/notes") return join(notesDir, "package.json");
           return null;
@@ -532,6 +774,7 @@ describe("parachute upgrade", () => {
         log: (l) => logs.push(l),
       });
       expect(code).toBe(7);
+      // Hub skipped restart (version unchanged), notes restarted after version bump.
       expect(restartCalls).toEqual(["notes"]);
       expect(logs.join("\n")).toMatch(/vault: bun add -g failed \(exit 7\)/);
     } finally {

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -38,6 +38,7 @@ import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
+import { HUB_PACKAGE, HUB_SVC } from "../hub-control.ts";
 import { ModuleManifestError } from "../module-manifest.ts";
 import {
   type ServiceSpec,
@@ -149,16 +150,38 @@ function resolve(opts: UpgradeOpts): Resolved {
   };
 }
 
+/**
+ * Synthetic services.json row for the hub. The hub isn't in services.json
+ * (it's an implementation detail of `parachute expose`, not a user-facing
+ * service), so callers passing `hub` as the upgrade target need a fabricated
+ * `ResolvedTarget`. Only `installDir` is read downstream — left undefined so
+ * `findGlobalInstall("@openparachute/hub")` is the sole locate path, which
+ * works the same for npm installs and `bun link` checkouts.
+ */
+function hubTarget(): ResolvedTarget {
+  const entry: ServiceEntry = {
+    name: HUB_PACKAGE,
+    port: 0,
+    paths: [],
+    health: "",
+    version: "",
+  };
+  return { short: HUB_SVC, entry, spec: undefined, packageName: HUB_PACKAGE };
+}
+
 async function resolveTargets(
   svc: string | undefined,
   manifestPath: string,
 ): Promise<{ targets: ResolvedTarget[] } | { error: string }> {
   const manifest = readManifest(manifestPath);
-  if (manifest.services.length === 0) {
-    return { error: "No services installed yet. Try: parachute install <service>" };
-  }
 
   if (svc !== undefined) {
+    if (svc === HUB_SVC) return { targets: [hubTarget()] };
+
+    if (manifest.services.length === 0) {
+      return { error: "No services installed yet. Try: parachute install <service>" };
+    }
+
     const firstPartySpec = getSpec(svc);
     if (firstPartySpec) {
       const entry = manifest.services.find((s) => s.name === firstPartySpec.manifestName);
@@ -183,10 +206,15 @@ async function resolveTargets(
         throw err;
       }
     }
-    return { error: `unknown service "${svc}". known: ${knownServices().join(", ")}` };
+    return {
+      error: `unknown service "${svc}". known: ${[HUB_SVC, ...knownServices()].join(", ")}`,
+    };
   }
 
-  const targets: ResolvedTarget[] = [];
+  // Sweep mode: hub first, then everything in services.json. Hub-first means a
+  // dispatcher upgrade can't be undermined mid-sweep by a service upgrade that
+  // restarts hub for reasons unrelated to its own code change.
+  const targets: ResolvedTarget[] = [hubTarget()];
   for (const entry of manifest.services) {
     const short = shortNameForManifest(entry.name);
     if (short) {
@@ -209,7 +237,6 @@ async function resolveTargets(
       }
     }
   }
-  if (targets.length === 0) return { error: "No upgradeable services in services.json." };
   return { targets };
 }
 

--- a/src/help.ts
+++ b/src/help.ts
@@ -348,8 +348,9 @@ What it does:
   Re-running on an up-to-date install is a fast no-op.
 
 Examples:
-  parachute upgrade                 sweep every installed service
+  parachute upgrade                 sweep hub + every installed service
   parachute upgrade vault           just vault
+  parachute upgrade hub             upgrade the dispatcher itself (closes #251)
   parachute upgrade vault --tag rc  pin the rc dist-tag (npm path only)
 `;
 }

--- a/src/hub-control.ts
+++ b/src/hub-control.ts
@@ -27,6 +27,7 @@ import { WELL_KNOWN_DIR } from "./well-known.ts";
  */
 
 export const HUB_SVC = "hub";
+export const HUB_PACKAGE = "@openparachute/hub";
 export const HUB_DEFAULT_PORT = 1939;
 /**
  * Default fallback range is 1 — the hub binds 1939 or fails. Walking up would


### PR DESCRIPTION
## Summary

Closes #251 — `parachute upgrade hub` returned `unknown service "hub". known: vault, notes, scribe, channel` because `resolveTargets` only consulted `FIRST_PARTY_FALLBACKS`, which deliberately excludes hub itself. Users on a pre-0.5 install had no path back to current via the same dispatcher they already had; they had to `bun add -g @openparachute/hub@latest` by hand.

## What changed

- **`src/commands/upgrade.ts`** — special-case `hub` in `resolveTargets`:
  - `parachute upgrade hub` synthesizes a `ResolvedTarget` keyed by the new `HUB_PACKAGE` constant (`@openparachute/hub`) exported from `hub-control.ts`. No services.json row is required (hub isn't in services.json); `findGlobalInstall("@openparachute/hub")` is the sole locate path and works the same for npm-installed and `bun link` checkouts.
  - The sweep path (`parachute upgrade` with no arg) now upgrades hub first, then every services.json entry. Hub-first avoids a downstream service restart racing the dispatcher swap mid-sweep.
  - Empty-manifest path no longer errors — hub is always upgradeable, even on a fresh install where no other services exist.
  - `unknown service` error message lists `hub` alongside the rest, matching `parachute logs` which has always accepted `hub`.

- **`src/hub-control.ts`** — new exported `HUB_PACKAGE = "@openparachute/hub"` constant alongside `HUB_SVC`. Single source of truth for the hub's npm package name.

- **`src/help.ts`** — upgrade help mentions `parachute upgrade hub` explicitly + notes the closed issue.

## What did NOT change

- **`FIRST_PARTY_FALLBACKS`** stays untouched. That registry is the transitional vendored-manifest fallback for committed-core modules per the workspace `CLAUDE.md`; hub is the dispatcher, not a fallback entry. Special-case in upgrade.ts is the right surgical fix (Option 1 in the issue) rather than tangling the fallback registry (Option 2).

- **Lifecycle restart code.** Reuses the existing `lifecycle.restart(HUB_SVC, …)` path through `startHubSvc` / `stopHubSvc` (hub's own lifecycle seams via `ensureHubRunning` / `stopHub`). The CLI process running the upgrade is separate from the daemon being upgraded, so the daemon respawn doesn't kill the in-flight upgrade flow.

## Test plan

`bun test ./src`:

- **1284 pass / 1 fail / 30302 expects across 70 files.**
- The 1 fail is the same pre-existing `status > all-healthy returns 0 and prints table` env flake (reproduces on rc.6 with no diff applied — verified).
- +5 tests over rc.6 in `src/__tests__/upgrade.test.ts`:
  - `hub as target: npm-installed path runs bun add -g @openparachute/hub@<tag> + restart`
  - `hub as target works even with empty services.json (closes #251)` — the brand-new-install bootstrap case
  - `hub as target: bun-linked checkout follows the linked path`
  - `hub as target: --tag is forwarded to bun add -g for the hub package`
  - `sweep includes hub: hub upgraded alongside services.json entries` — asserts hub-first restart order
- Existing partial-failure sweep test updated to seed hub (so the test still measures vault-fails-then-notes-succeeds rather than tripping on hub).
- typecheck clean. biome clean.

- [ ] `parachute upgrade hub` on a real install — bun-linked path
- [ ] `parachute upgrade hub` on a real install — npm path (with `--tag rc`)
- [ ] `parachute upgrade` (no arg) sweep upgrades hub first, then services
- [ ] `parachute upgrade hub --help` shows the new example line

## Versioning

`0.5.9-rc.6` → `0.5.9-rc.7`. Per governance Rule 2, RC chain stays on the same patch number; promote to `0.5.9` stable when Aaron says ready.

## Patterns

- **Governance Rule 1** (no auto-merge) — reviewer dispatch + verification, then Aaron clicks merge (hub is not in the team-lead delegated-merge set).
- **Governance Rule 2** (RC versioning) — `0.5.9-rc.7` bump.
- **Governance Rule 3** (patterns check) — touches the upgrade pattern; conforms to the existing seam (`runner`, `findGlobalInstall`, `restartFn` injection points all preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)