### PR TITLE
0.5.9 auth hygiene: operator-token semantics + auto-rotation guard + OAuth silent-approve test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.9-rc.9] - 2026-05-16
+
+Pre-stable auth hygiene bundle (closes #216, #224, #236).
+
+**#216 — Disambiguate `UsedOperatorToken.refreshed` semantics.** The prior `refreshed: boolean` field on `useOperatorTokenWithAutoRotate`'s return value conflated three operationally distinct outcomes under a single `false` value: token is fresh, token is within window but rotation skipped by the audience guard, or token is within window but rotation skipped by a missing `sub` claim. Replace with a tagged union `status: RotationStatus = { kind: "fresh" } | { kind: "rotated" } | { kind: "skipped"; reason: "aud-mismatch" | "no-sub" | "no-scope-set" }`. No production caller read `.refreshed` (audited via grep — only test sites); the `rotated` companion field that callers actually branch on is unchanged. Future telemetry / admin UI (hub#212 Phase 2 territory) can branch on `skipped.reason`.
+
+**#224 — Refuse to auto-rotate without a recognized `pa_scope_set` claim.** The audit traced a "test paradox" to its root: when a JWT carries `aud: operator` + short TTL but lacks (or has an unrecognized) `pa_scope_set` claim, the prior auto-rotation path silently widened it to the default scope-set (admin). No live operational risk — legitimately-issued operator tokens always carry the claim — but the widening surface was a defense-in-depth gap and a test-author footgun. Now returns `status: { kind: "skipped", reason: "no-scope-set" }` instead of widening; operators with a legacy or hand-crafted token without the claim must `parachute auth rotate-operator` to recover. A new "Test-author note" section in `useOperatorTokenWithAutoRotate`'s docstring spells out the two safe shapes for tests that stash JWTs at the operator path (long TTL or non-operator audience) so the pre-#222 + #222 trace doesn't re-surface.
+
+**#236 — Pin OAuth silent-approve gate end-to-end + document flow.** The skip-consent gate in `handleAuthorizeGet` (the load-bearing piece of "first Notes use prompts for consent; subsequent uses are seamless") had per-branch tests but no single end-to-end test walking the operator-visible state machine. Add a "first-use consent → silent-approve → novel-scope re-prompts" regression test that exercises the full flow in one body: fresh state, consent screen, approve, second-use silent-approve, third-use with novel scope re-prompts. The novel-scope assertion is the security-critical leg — silent-approve must not silently approve scopes the user never consented to. Plus a JSDoc block on `handleAuthorizeGet` spelling out the five-step flow (first → silent → subset → novel → revoke), the two gate constraints (unnamed-vault verbs, client re-registration), and pointing at the regression test. Operator-facing prose (parachute.computer blog) is the site tentacle's territory.
+
+Gate: `bun test ./src` 1286 pass / 1 fail (same pre-existing `status > all-healthy returns 0` env flake) / 30386 expects across 70 files. +2 tests over rc.8 (no-scope-set skip regression in operator-token; end-to-end silent-approve flow in oauth-handlers). typecheck clean. biome clean.
+
 ## [0.5.9-rc.8] - 2026-05-16
 
 Pre-stable polish bundle (closes #227, #229, #219).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.9-rc.8",
+  "version": "0.5.9-rc.9",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -3205,6 +3205,115 @@ describe("refresh-token rotation + /oauth/revoke (#73)", () => {
 // to the auth-code redirect. Strict superset (incremental scope) and
 // revoked grants still show consent.
 describe("handleAuthorizeGet — skip consent when scope already granted (#75)", () => {
+  // hub#236 — pin the full silent-approve flow end-to-end in one test.
+  // The per-branch tests below this one cover individual branches (subset,
+  // superset, revoke, unnamed-vault, re-registered-client); this test
+  // walks the operator-visible state machine in a single body so a
+  // regression at any step surfaces immediately, and the JSDoc on
+  // handleAuthorizeGet's silent-approve flow (1-5) has a single load-
+  // bearing test to point at.
+  test("first-use consent → silent-approve → novel-scope re-prompts (full silent-approve flow, #236)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const sessionCookie = buildSessionCookie(session.id, 86400);
+
+      // Step 1: first use — no grant exists; consent screen renders.
+      const firstReq = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          scope: "vault:default:read",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          state: "step1",
+        }),
+        { headers: { cookie: sessionCookie } },
+      );
+      const firstRes = handleAuthorizeGet(db, firstReq, { issuer: ISSUER });
+      expect(firstRes.status).toBe(200);
+      expect(firstRes.headers.get("content-type")).toContain("text/html");
+
+      // Step 1b: user approves via the consent form — grant gets recorded.
+      const consentRes = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: new URLSearchParams({
+            __action: "consent",
+            __csrf: TEST_CSRF,
+            approve: "yes",
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            scope: "vault:default:read",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+          }),
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: `${CSRF_COOKIE}; ${sessionCookie}`,
+          },
+        }),
+        { issuer: ISSUER },
+      );
+      expect(consentRes.status).toBe(302);
+
+      // Step 2: subsequent use, same scopes — silent-approve fires.
+      // Authoritative assertion: 302 redirect with auth code, NOT a 200
+      // HTML consent screen. This is the operator-visible payoff.
+      const secondReq = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          scope: "vault:default:read",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          state: "step2",
+        }),
+        { headers: { cookie: sessionCookie } },
+      );
+      const secondRes = handleAuthorizeGet(db, secondReq, { issuer: ISSUER });
+      expect(secondRes.status).toBe(302);
+      const secondLoc = new URL(secondRes.headers.get("location") ?? "");
+      expect(secondLoc.origin + secondLoc.pathname).toBe("https://app.example/cb");
+      expect(secondLoc.searchParams.get("code")?.length).toBeGreaterThan(20);
+      expect(secondLoc.searchParams.get("state")).toBe("step2");
+
+      // Step 3: subsequent use, novel scope NOT in the grant — gate must
+      // NOT fire; consent re-renders with the new scope explicit. This is
+      // the load-bearing security property: silent-approve must not
+      // silently approve scopes the user never consented to.
+      const novelReq = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          // Adds scribe:transcribe to the original vault:default:read.
+          scope: "vault:default:read scribe:transcribe",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          state: "step3",
+        }),
+        { headers: { cookie: sessionCookie } },
+      );
+      const novelRes = handleAuthorizeGet(db, novelReq, { issuer: ISSUER });
+      expect(novelRes.status).toBe(200);
+      expect(novelRes.headers.get("content-type")).toContain("text/html");
+      const novelBody = await novelRes.text();
+      // The new scope appears on the consent page — the user must approve
+      // it explicitly.
+      expect(novelBody).toContain("scribe:transcribe");
+    } finally {
+      cleanup();
+    }
+  });
+
   test("first approval records grant; second flow with same scopes skips consent", async () => {
     const { db, cleanup } = await makeDb();
     try {

--- a/src/__tests__/operator-token.test.ts
+++ b/src/__tests__/operator-token.test.ts
@@ -387,6 +387,51 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
     }
   });
 
+  // hub#224 — when a JWT carries the operator audience + short TTL but
+  // lacks a recognized `pa_scope_set` claim, the helper now refuses to
+  // auto-rotate. Pre-hardening the fallback widened to admin; the test
+  // pins the new "skipped, no-scope-set" outcome.
+  test("does NOT auto-rotate an aud=operator token that lacks pa_scope_set (no silent widening)", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        // aud=operator + 1h TTL + NO pa_scope_set claim. Pre-#224 this would
+        // fall back to OPERATOR_TOKEN_DEFAULT_SCOPE_SET (admin) on rotation
+        // — a silent widening of a token of unknown provenance.
+        const signed = await signAccessToken(db, {
+          sub: "user-abc",
+          scopes: ["scribe:transcribe"],
+          audience: OPERATOR_TOKEN_AUDIENCE,
+          clientId: OPERATOR_TOKEN_CLIENT_ID,
+          issuer: TEST_ISSUER,
+          ttlSeconds: 3600,
+        });
+        await writeOperatorTokenFile(signed.token, h.dir);
+
+        const used = await useOperatorTokenWithAutoRotate(db, {
+          configDir: h.dir,
+          issuer: TEST_ISSUER,
+        });
+        expect(used).not.toBeNull();
+        expect(used?.status.kind).toBe("skipped");
+        if (used?.status.kind === "skipped") {
+          expect(used.status.reason).toBe("no-scope-set");
+        }
+        expect(used?.rotated).toBeUndefined();
+        expect(used?.token).toBe(signed.token);
+        // On-disk file unchanged — no widening occurred.
+        const onDisk = await readOperatorTokenFile(h.dir);
+        expect(onDisk).toBe(signed.token);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("returns null when no operator token file exists", async () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/operator-token.test.ts
+++ b/src/__tests__/operator-token.test.ts
@@ -297,7 +297,7 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
           issuer: TEST_ISSUER,
         });
         expect(used).not.toBeNull();
-        expect(used?.refreshed).toBe(false);
+        expect(used?.status.kind).toBe("fresh");
         expect(used?.rotated).toBeUndefined();
         expect(used?.token).toBe(issued.token);
       } finally {
@@ -328,7 +328,7 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
           issuer: TEST_ISSUER,
         });
         expect(used).not.toBeNull();
-        expect(used?.refreshed).toBe(true);
+        expect(used?.status.kind).toBe("rotated");
         expect(used?.rotated?.scopeSet).toBe("start");
         // The on-disk token is now the rotated one.
         const onDisk = await readOperatorTokenFile(h.dir);
@@ -370,7 +370,10 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
           issuer: TEST_ISSUER,
         });
         expect(used).not.toBeNull();
-        expect(used?.refreshed).toBe(false);
+        expect(used?.status.kind).toBe("skipped");
+        if (used?.status.kind === "skipped") {
+          expect(used.status.reason).toBe("aud-mismatch");
+        }
         expect(used?.rotated).toBeUndefined();
         expect(used?.token).toBe(signed.token);
         // On-disk file unchanged.
@@ -488,7 +491,7 @@ describe("mintOperatorToken registry write (#212)", () => {
           configDir: h.dir,
           issuer: TEST_ISSUER,
         });
-        expect(used?.refreshed).toBe(true);
+        expect(used?.status.kind).toBe("rotated");
         // The rotated token has a new jti.
         const newJti = used!.payload.jti as string;
         expect(newJti).not.toBe(original.jti);

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -505,6 +505,61 @@ function pendingClientJson(clientId: string, issuer: string): Response {
  * either renders the login form (no session) or the consent screen (session
  * present). All authorize-time params are echoed back via hidden inputs so
  * the form POST keeps the binding intact.
+ *
+ * ## Silent-approve flow (skip-consent gate, hub#75, hub#236)
+ *
+ * Cross-surface session smoothness ("first Notes use prompts for consent;
+ * subsequent uses are seamless") rides on a single gate further down in
+ * this function. The end-to-end flow:
+ *
+ *   1. **First use.** A client lands on `/oauth/authorize` with scope `S`.
+ *      The user has a session but no prior `grants` row for this
+ *      (user, client) pair. `isCoveredByGrant` returns false; the gate
+ *      falls through; the consent screen renders. User clicks approve →
+ *      `handleAuthorizePost` records a `grants` row keyed on
+ *      (user_id, client_id) with the approved scopes, then mints the
+ *      auth code.
+ *   2. **Subsequent use, same scopes.** Same client lands on
+ *      `/oauth/authorize` with scope `S` again. `isCoveredByGrant` finds
+ *      the row and returns true. The gate fires: auth code minted
+ *      directly via `issueAuthCodeRedirect`; no consent screen renders;
+ *      operator sees a silent redirect. This is the seamless second-use
+ *      experience.
+ *   3. **Subsequent use, subset.** Client asks for scope `S' ⊂ S`. The
+ *      grant covers every requested scope; gate fires.
+ *   4. **Subsequent use, novel scope.** Client asks for scope `S''`
+ *      where `S'' ⊄ S` (a strict superset, or any new scope). The grant
+ *      doesn't cover the new ask; gate falls through; consent re-renders
+ *      with the new scope explicit. User must approve to extend the grant.
+ *   5. **Grant revoked.** Operator revokes via `/admin/permissions` or
+ *      `parachute auth revoke-grant`. The next /authorize re-renders
+ *      consent — already-minted refresh tokens keep working until they
+ *      expire (or are revoked separately via `/oauth/revoke`).
+ *
+ * Two important constraints on the gate itself:
+ *
+ *   - **Unnamed vault verbs (`vault:read`) always render consent.** The
+ *     vault-picker UI is the only path that binds an unnamed scope to a
+ *     specific vault (grants store narrowed `vault:<name>:<verb>`, so
+ *     `vault:read` never matches a stored grant literally). Re-flowing
+ *     with `vault:read` must always show the picker even if any prior
+ *     grant exists.
+ *   - **Client re-registration breaks the grant link.** Dynamic Client
+ *     Registration mints a fresh `client_id` each time; grants are keyed
+ *     on `(user_id, client_id)` so a re-registered client looks brand-
+ *     new and re-prompts for consent. (Intentional: the operator should
+ *     re-consent to an app whose registration was destroyed and re-made
+ *     — that's a stronger signal of "this is the same app I trusted"
+ *     than the redirect URI alone.)
+ *
+ * The full grant-scope subset semantics live in `grants.ts`
+ * `isCoveredByGrant`; the gate itself is the if-block below the
+ * "Skip-consent gate" comment in this function.
+ *
+ * Pinned by the regression test "first-use consent → silent-approve →
+ * novel scope re-prompts" in `oauth-handlers.test.ts` (hub#236), plus
+ * the per-branch tests in the same describe block (subset / superset /
+ * revoke / unnamed-vault / re-registered-client).
  */
 export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps): Response {
   const url = new URL(req.url);

--- a/src/operator-token.ts
+++ b/src/operator-token.ts
@@ -285,6 +285,35 @@ export interface UseOperatorTokenOpts {
   now?: () => Date;
 }
 
+/**
+ * Disambiguated outcome of `useOperatorTokenWithAutoRotate`. The prior
+ * surface (boolean `refreshed`) conflated three operationally distinct
+ * cases under a single `false` value: (a) token is fresh, no rotation
+ * needed; (b) within rotation window but rotation skipped due to
+ * privilege guard; (c) within rotation window but rotation skipped due
+ * to missing sub claim. This shape surfaces each case so future
+ * rotation telemetry / admin UI can branch on them. See hub#216 for the
+ * motivation; hub#212 Phase 2 is the natural consumer.
+ *
+ * - `fresh` — remaining lifetime above the auto-rotation threshold;
+ *   the token on disk was returned as-is. The healthy steady state.
+ * - `rotated` — rotation fired; the on-disk token was overwritten.
+ *   `rotated` companion field on `UsedOperatorToken` carries the new
+ *   path / scopeSet / expiry.
+ * - `skipped` — within rotation window, but rotation was deliberately
+ *   not performed. `reason` distinguishes:
+ *     - `aud-mismatch`: the on-disk JWT carries a non-operator audience.
+ *       This is the privilege-escalation guard (a hand-stashed scope-narrow
+ *       JWT must not be silently upgraded). See operator-token.ts line ~360.
+ *     - `no-sub`: the on-disk JWT lacks a `sub` claim, so the helper can't
+ *       safely re-mint (don't know who the token belongs to). Surfaced via
+ *       the caller's downstream invalid-token error path.
+ */
+export type RotationStatus =
+  | { kind: "fresh" }
+  | { kind: "rotated" }
+  | { kind: "skipped"; reason: "aud-mismatch" | "no-sub" };
+
 export interface UsedOperatorToken {
   /** The operator token plaintext to present as bearer. After auto-rotation, this is the freshly-minted token. */
   token: string;
@@ -292,8 +321,14 @@ export interface UsedOperatorToken {
   payload: Awaited<ReturnType<typeof validateAccessToken>>["payload"];
   /** Set when this call rotated the on-disk token. The new path on disk. */
   rotated?: { path: string; scopeSet: OperatorScopeSet; expiresAt: string };
-  /** True if the on-disk token was within the auto-rotation threshold (informational). */
-  refreshed: boolean;
+  /**
+   * Disambiguated rotation outcome. See {@link RotationStatus}. Callers that
+   * only need "did the token rotate?" can check `status.kind === "rotated"`
+   * or the presence of the `rotated` companion field (equivalent). Future
+   * telemetry / admin UI can branch on `skipped.reason` to surface why a
+   * rotation didn't fire.
+   */
+  status: RotationStatus;
 }
 
 /**
@@ -342,7 +377,7 @@ export async function useOperatorTokenWithAutoRotate(
   }
 
   if (remaining > OPERATOR_TOKEN_AUTO_ROTATE_THRESHOLD_SECONDS) {
-    return { token, payload, refreshed: false };
+    return { token, payload, status: { kind: "fresh" } };
   }
 
   // Within rotation window — but only auto-rotate if this is genuinely an
@@ -352,7 +387,7 @@ export async function useOperatorTokenWithAutoRotate(
   // operator token by the hub. Legitimate operator-tokens minted via
   // `set-password` / `rotate-operator` carry `aud: "operator"`.
   if (payload.aud !== OPERATOR_TOKEN_AUDIENCE) {
-    return { token, payload, refreshed: false };
+    return { token, payload, status: { kind: "skipped", reason: "aud-mismatch" } };
   }
 
   // Re-mint preserving scope-set.
@@ -361,7 +396,7 @@ export async function useOperatorTokenWithAutoRotate(
     // No sub claim — can't safely auto-rotate (don't know who the token
     // belongs to). Return as-is; the caller will likely surface this as an
     // invalid-token error downstream.
-    return { token, payload, refreshed: false };
+    return { token, payload, status: { kind: "skipped", reason: "no-sub" } };
   }
   const claimedSet = payload[OPERATOR_TOKEN_SCOPE_SET_CLAIM];
   const scopeSet: OperatorScopeSet = isOperatorScopeSet(claimedSet)
@@ -378,6 +413,6 @@ export async function useOperatorTokenWithAutoRotate(
     token: issued.token,
     payload: reValidated.payload,
     rotated: { path: issued.path, scopeSet: issued.scopeSet, expiresAt: issued.expiresAt },
-    refreshed: true,
+    status: { kind: "rotated" },
   };
 }

--- a/src/operator-token.ts
+++ b/src/operator-token.ts
@@ -308,11 +308,20 @@ export interface UseOperatorTokenOpts {
  *     - `no-sub`: the on-disk JWT lacks a `sub` claim, so the helper can't
  *       safely re-mint (don't know who the token belongs to). Surfaced via
  *       the caller's downstream invalid-token error path.
+ *     - `no-scope-set`: the on-disk JWT carries `aud: operator` but lacks
+ *       (or has an unrecognized) `pa_scope_set` claim. Refusing to rotate
+ *       here is hub#224's hardening: the prior behaviour fell back to the
+ *       default scope-set (admin) on rotation, which silently widened a
+ *       narrow-scope token of unknown provenance. Legitimately-issued
+ *       operator tokens always carry a recognized `pa_scope_set` (set by
+ *       `issueOperatorToken`); a token without it is either a hand-crafted
+ *       JWT (don't widen) or a pre-#213 legacy token (operator should
+ *       explicitly `parachute auth rotate-operator` to recover).
  */
 export type RotationStatus =
   | { kind: "fresh" }
   | { kind: "rotated" }
-  | { kind: "skipped"; reason: "aud-mismatch" | "no-sub" };
+  | { kind: "skipped"; reason: "aud-mismatch" | "no-sub" | "no-scope-set" };
 
 export interface UsedOperatorToken {
   /** The operator token plaintext to present as bearer. After auto-rotation, this is the freshly-minted token. */
@@ -346,8 +355,33 @@ export interface UsedOperatorToken {
  *
  * Callers receive the (possibly fresh) token to present onward. The
  * scope-set is preserved across rotations via the `pa_scope_set` claim;
- * tokens minted before #213 don't carry the claim and are treated as
- * `admin` (back-compat).
+ * tokens that lack a recognized `pa_scope_set` claim are NOT auto-rotated
+ * (hub#224 hardening — the prior fallback to the default scope-set
+ * silently widened narrow-scope tokens of unknown provenance). Operators
+ * holding a legacy token without the claim should `parachute auth
+ * rotate-operator` to recover.
+ *
+ * ## Test-author note (hub#224)
+ *
+ * Tests that stash a JWT at `~/.parachute/operator.token` to exercise
+ * downstream gate-check behaviour need to side-step auto-rotation, or
+ * the helper will silently swap the test's narrow token for a fresh
+ * admin one before the gate runs. Two safe shapes:
+ *
+ *   1. **Long TTL.** Mint with `ttlSeconds: 30 * 24 * 60 * 60` (30d) so
+ *      `remaining > OPERATOR_TOKEN_AUTO_ROTATE_THRESHOLD_SECONDS` and the
+ *      helper returns the token as-is (`status.kind === "fresh"`). This
+ *      is the pattern in `bootstrapWithOperatorScopes` (hub#222 tests).
+ *   2. **Non-operator audience.** Sign with `audience: "scribe"` (or any
+ *      non-`"operator"` value) so the line ~398 guard fires
+ *      (`status.kind === "skipped"`, `reason: "aud-mismatch"`). This is
+ *      the pattern in the pre-#222 narrow-rejection test.
+ *
+ * `aud: "operator"` + short TTL + recognized `pa_scope_set` is the
+ * auto-rotation path. `aud: "operator"` + short TTL + missing/invalid
+ * `pa_scope_set` lands on the no-scope-set skip (hub#224). Either way,
+ * if you're seeing a "narrow token magically became admin," check
+ * the test's `audience` + TTL first.
  */
 export async function useOperatorTokenWithAutoRotate(
   db: Database,
@@ -398,10 +432,18 @@ export async function useOperatorTokenWithAutoRotate(
     // invalid-token error downstream.
     return { token, payload, status: { kind: "skipped", reason: "no-sub" } };
   }
+  // Refuse to auto-rotate without a recognized scope-set claim. The prior
+  // behaviour fell back to OPERATOR_TOKEN_DEFAULT_SCOPE_SET (admin), which
+  // silently widened a narrow `aud: "operator"` token of unknown provenance
+  // — hand-crafted or pre-#213 legacy. hub#224's hardening: a missing or
+  // invalid `pa_scope_set` means "I don't know what scope to re-mint under,"
+  // so don't re-mint at all. The operator can recover via an explicit
+  // `parachute auth rotate-operator` (which always sets the claim).
   const claimedSet = payload[OPERATOR_TOKEN_SCOPE_SET_CLAIM];
-  const scopeSet: OperatorScopeSet = isOperatorScopeSet(claimedSet)
-    ? claimedSet
-    : OPERATOR_TOKEN_DEFAULT_SCOPE_SET;
+  if (!isOperatorScopeSet(claimedSet)) {
+    return { token, payload, status: { kind: "skipped", reason: "no-scope-set" } };
+  }
+  const scopeSet: OperatorScopeSet = claimedSet;
   const issued = await issueOperatorToken(db, sub, {
     dir,
     issuer: opts.issuer,


### PR DESCRIPTION
## Summary

Pre-stable auth hygiene bundle for the 0.5.9 rc chain. Three independent closures, one commit each per the new cadence. Stacks on top of hub#255 (rc.8); bumps `0.5.9-rc.8 → 0.5.9-rc.9`.

- **C1 — closes #216** — Replace ambiguous `UsedOperatorToken.refreshed: boolean` on `useOperatorTokenWithAutoRotate` with a tagged `RotationStatus` union. The prior boolean conflated three operationally distinct outcomes under one `false`: token is fresh / token within window but rotation skipped by audience guard / token within window but rotation skipped by missing `sub`. New shape `{ kind: "fresh" } | { kind: "rotated" } | { kind: "skipped"; reason: "aud-mismatch" | "no-sub" | "no-scope-set" }` surfaces each case for future telemetry / admin UI (hub#212 Phase 2). No production caller read `.refreshed` (audited via grep — only test sites); the `rotated` companion field that callers actually branch on is unchanged.

- **C2 — closes #224** — Refuse to auto-rotate when `pa_scope_set` is missing or unrecognized (returns `skipped: no-scope-set` instead of falling back to the default admin scope-set). Closes the silent-widening surface flagged by the hub#222 audit: a narrow `aud: operator` JWT without the scope-set claim would previously be re-minted as admin on rotation. Legitimately-issued operator tokens always carry the claim (set by `issueOperatorToken`); a token without it is either hand-crafted (don't widen) or pre-#213 legacy (operator should explicitly `parachute auth rotate-operator`). A new "Test-author note" section in the docstring spells out the two safe shapes for tests that stash JWTs at the operator path (long TTL or non-operator audience) so the test paradox traced in #224 doesn't re-surface.

- **C3 — closes #236** — Pin the OAuth silent-approve gate (the load-bearing piece of "first Notes use prompts for consent; subsequent uses are seamless") with a new end-to-end integration test that walks the full state machine in one body: fresh state → consent → silent-approve → novel-scope re-prompts. The novel-scope assertion is the security-critical leg — silent-approve must NOT silently approve scopes the user never consented to. Plus a JSDoc block on `handleAuthorizeGet` spelling out the five-step flow (first → silent → subset → novel → revoke), the two gate constraints (unnamed-vault verbs, client re-registration), and pointing at the regression test. The operator-facing prose explainer (vs hub-side JSDoc) is tracked separately at [parachute.computer#40](https://github.com/ParachuteComputer/parachute.computer/issues/40).

## ⚠️ Migration risk — pre-#213 operator tokens

C2's hardening could affect operators holding a token minted before ~2026-05-09 (before #213 introduced the `pa_scope_set` claim) that is currently within the 7-day auto-rotation window. The prior behaviour would silently re-mint to the default admin scope-set; the new behaviour returns `skipped: no-scope-set`. The downstream effect is the operator's CLI flow continues with the original (narrow) scope rather than getting silently widened — which is the correct posture, but a behaviour shift.

**Recovery is one command:** `parachute auth rotate-operator` mints a fresh token with the claim and the auto-rotation path works normally thereafter.

**Risk surface is small:** pre-#213 tokens have at most a 90-day default TTL, so they age out by ~2026-08-07 even without operator action. Hardening enabled by default (no opt-out flag); the failure mode is "narrow token doesn't get silently widened," not "token stops working."

This should land in the rc.9 release-notes-prominent section so operators encountering an unexpected "skipped" outcome have an obvious recovery path.

## Patterns check

- **governance.md** — code-touching PR, bumps `rc.N` only (`0.5.9-rc.8 → rc.9`). One PR, three cohesive closures bundled with one commit per issue per the new cadence; reviewer can step through each commit independently. Each commit standalone-buildable (C1 + C4 only touch `operator-token.ts`; C2 stacks on C1; C3 only touches `oauth-handlers.ts`).
- **post-merge-hygiene.md** — no exposure changes; pull `main` and rebase any open feature branch after merge.
- **Pattern touched in C1**: tagged-union discriminated return types for state machines with >2 outcomes. Same shape Notes uses for `state` discriminated unions; consistent with the broader ecosystem convention.

## Test plan

- [x] `bun test ./src` — 1286 pass / 1 fail (same pre-existing `status > all-healthy returns 0` env flake, reproduces on rc.8 unchanged) / 30386 expects across 70 files. +2 tests over rc.8 (no-scope-set skip in operator-token; end-to-end silent-approve in oauth-handlers).
- [x] `bun run typecheck` — clean
- [x] `bunx biome check .` — clean
- [ ] Reviewer dispatch confirms commits step cleanly
- [ ] Aaron-merge (hub is in click-merge category per governance Rule 4)
- [ ] Pre-merge: confirm rc.9 release notes call out the pre-#213 token migration path

## Issues closed

Closes #216, closes #224, closes #236.

## Side observations (non-blocking)

- **#216's `no-sub` skip reason** isn't exercised by a new test. The branch exists defensively for hand-crafted JWTs that bypass `signAccessToken` (which requires non-empty `sub` at the type level). Adding jose-direct test scaffolding just for one defensive branch would be more surface than it's worth.
- **#224's "no-scope-set" reason** is exercised by a new regression test (`does NOT auto-rotate an aud=operator token that lacks pa_scope_set`). Existing "auto-rotates preserving scope-set" tests cover the recognized-claim happy path.
- **#236's per-branch tests** (subset / superset / revoke / unnamed-vault / re-registered-client) all remain unchanged; the new end-to-end test is additive. The JSDoc block points at both the new test and the existing branch-tests so future contributors land in the right place.