### PR TITLE
hub#258: Dockerfile + render.yaml + env-driven boot for Render self-host (0.5.10-rc.1)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,50 @@
+# Keep the build context small — Docker uploads everything not listed here
+# to the daemon on every build.
+
+# VCS + editor noise
+.git
+.gitignore
+.github
+.vscode
+.idea
+*.swp
+*.swo
+
+# Install artifacts (re-installed inside the builder stage)
+node_modules
+**/node_modules
+.bun
+
+# Build artifacts (the builder stage rebuilds the SPA)
+web/ui/dist
+web/ui/tsconfig.tsbuildinfo
+**/dist
+**/*.tsbuildinfo
+coverage
+
+# Local runtime state — never want this baked into an image
+.parachute
+parachute-home
+*.db
+*.db-journal
+*.log
+
+# Docs / launch artifacts — not needed at runtime
+docs
+LAUNCH_SMOKE.md
+RELEASE-NOTES-*.md
+WAKE-UP-*.md
+BETA-EMAIL-*.md
+CHANGELOG.md
+
+# Test snapshots / fixtures that aren't needed in the image
+**/__snapshots__
+**/*.test.ts.snap
+
+# OS junk
+.DS_Store
+Thumbs.db
+
+# Don't ship the Dockerfile itself into the image
+Dockerfile
+.dockerignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.10-rc.2] - 2026-05-18
+
+Reviewer nits folded — render.yaml comments + DB close on stop + CONFIG_DIR note.
+
+- **`render.yaml`** — comment the `plan: starter` line (persistent disks
+  aren't on Render's free tier; Render auto-resizes online if you want to
+  upgrade later). Also comment the `PARACHUTE_HUB_ORIGIN` env entry with
+  the issuer-claim caveat (leave blank to derive from request origin on
+  first boot; set BEFORE issuing OAuth tokens — tokens minted with one
+  issuer claim won't validate against another).
+- **`src/commands/serve.ts`** — `stop()` now closes the hub DB handle in
+  addition to stopping the Bun server, so test harnesses don't leak the
+  underlying SQLite handle across runs. Return type widened to
+  `() => Promise<void>`; `src/cli.ts` SIGINT/SIGTERM handler awaits it.
+- **`src/commands/serve.ts`** — added a note above the `CONFIG_DIR` /
+  `WELL_KNOWN_DIR` imports documenting that they're evaluated at
+  module-load time from `process.env.PARACHUTE_HOME`; the `env` seam on
+  `serve()` cannot reroute them. Tests should set `PARACHUTE_HOME`
+  before importing for path isolation.
+
+Gate: `bun test ./src` 1307 pass / 1 fail (same pre-existing
+`status > all-healthy returns 0` env flake). typecheck clean. biome clean.
+
 ## [0.5.10-rc.1] - 2026-05-18
 
 Render self-host foundation (closes #258). Three sub-changes ship together so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.10-rc.1] - 2026-05-18
+
+Render self-host foundation (closes #258). Three sub-changes ship together so
+the container-deploy path arrives in one revert-able PR:
+
+- **`Dockerfile`** — multi-stage `oven/bun:1.3-alpine` build. Stage 1 installs
+  with `--frozen-lockfile --ignore-scripts`, then runs `bun run build:spa`
+  explicitly so the install layer stays source-independent. Stage 2 copies the
+  built SPA + `node_modules` + source, declares `PARACHUTE_HOME=/parachute` as
+  the persistent-disk mount, exposes 1939, runs as non-root `bun` user under
+  `tini` for clean signal handling, and entrypoints `bun src/cli.ts serve`.
+  `.dockerignore` prunes the build context (node_modules, .git, dist, OS
+  junk, CHANGELOG, etc.) so layer caches stay tight.
+- **`render.yaml`** — Render Blueprint. One web service backed by the
+  Dockerfile, persistent 1 GB disk mounted at `/parachute` (`PARACHUTE_HOME`),
+  `/health` health check, and `sync: false` placeholders for the public
+  origin + admin seed env vars so a fresh deploy prompts the operator for
+  each via the dashboard rather than baking secrets into the repo.
+- **`parachute serve` foreground entrypoint** — new subcommand for the
+  container-supervisor shape. Reads `PORT` (default 1939), `PARACHUTE_HUB_ORIGIN`,
+  and `PARACHUTE_BIND_HOST` from env; binds the hub HTTP listener on
+  `0.0.0.0` by default; auto-writes the static `hub.html` on a fresh disk
+  so `/` serves a discovery page without `parachute expose` having to run
+  first.
+- **Env-driven first-boot seed + `/admin/setup` placeholder + pre-admin
+  503 gate.** `parachute serve` reads `PARACHUTE_INITIAL_ADMIN_USERNAME` +
+  `PARACHUTE_INITIAL_ADMIN_PASSWORD` on first boot; when no admin row
+  exists and both are set, seeds the admin via `createUser`, logs
+  `seeded initial admin "<name>" from PARACHUTE_INITIAL_ADMIN_*` to stdout,
+  and proceeds. Boot-time idempotent — once an admin exists the env vars
+  are ignored, so leaving them set across restarts is safe. When no admin
+  and no seed, the hub still comes up and a placeholder page lives at
+  `/admin/setup` pointing at the env-var path; admin-onboarding-coupled
+  surfaces (`/login`, `/logout`, `/admin/*` except `/admin/setup`,
+  `/api/*`) return `{error: "setup_required", setup_url: "/admin/setup"}`
+  until an admin is configured. `/health`, `/`, `/.well-known/*`,
+  `/oauth/*`, and content proxies (`/vault/*`, generic `/<service>/*`)
+  pass through the gate untouched — third-party OAuth and JWKS-driven
+  verification don't depend on admin onboarding. Once any admin exists,
+  the gate is a no-op. The real wizard ships in hub#259.
+
+`hub-server.ts` also gains a `/health` route (200 JSON with status +
+service + version) that's been advertised in the issue but wasn't
+actually wired before, plus env-aware `parseArgs` so `bun src/hub-server.ts`
+works without any flags when `PORT` / `PARACHUTE_HUB_ORIGIN` /
+`PARACHUTE_BIND_HOST` are set (the container path).
+
+Gate: `bun test ./src` 1307 pass / 1 fail (same pre-existing
+`status > all-healthy returns 0` env flake carried since 0.5.9-rc.8) /
+30443 expects across 72 files. +19 over 0.5.9 (5 in `serve.test.ts`,
+9 in `setup-gate.test.ts`, 5 incremental coverage in `hub-server.test.ts`).
+typecheck clean. biome clean.
+
 ## [0.5.9] - 2026-05-17
 
 Stable release. Promotes from `0.5.9-rc.9` after pre-stable polish + auth-hygiene

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,4 +89,9 @@ EXPOSE 1939
 USER bun
 
 ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["bun", "src/hub-server.ts"]
+# `parachute serve` is the container-shape entrypoint: foreground hub, env-
+# driven config, env-driven first-boot admin seed. The bare
+# `bun src/hub-server.ts` path also works (and supports env via parseArgs)
+# but skips the seedInitialAdminIfNeeded step, so the container would never
+# auto-create the admin from PARACHUTE_INITIAL_ADMIN_*.
+CMD ["bun", "src/cli.ts", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,92 @@
+# syntax=docker/dockerfile:1.7
+#
+# Parachute Hub container image.
+#
+# Stage 1 (`builder`) installs dependencies (including web/ui's React SPA
+# devDeps via the workspace postinstall) and produces the built SPA in
+# `web/ui/dist`. Stage 2 copies the source + the built SPA + production
+# `node_modules` into a slim runtime layer.
+#
+# Bun reads `src/cli.ts` directly — no separate transpile step. The
+# entrypoint runs the hub HTTP server on `${PORT}` (default 1939), with
+# `PARACHUTE_HOME` pointed at the persistent disk (default `/parachute`).
+#
+# Operator-facing env vars:
+#   PORT                              — bind port (Render injects this)
+#   PARACHUTE_BIND_HOST               — bind hostname; container default
+#                                       `0.0.0.0` (set below). Override only
+#                                       if you're putting another reverse
+#                                       proxy in front inside the container.
+#   PARACHUTE_HOME                    — config root (mount the disk here)
+#   PARACHUTE_HUB_ORIGIN              — canonical https://… origin for OAuth
+#   PARACHUTE_INITIAL_ADMIN_USERNAME  — first-boot admin username (optional)
+#   PARACHUTE_INITIAL_ADMIN_PASSWORD  — first-boot admin password (optional)
+
+ARG BUN_VERSION=1.3
+FROM oven/bun:${BUN_VERSION}-alpine AS builder
+
+WORKDIR /app
+
+# Copy manifests first so Docker layer-caches the install step across
+# source-only changes. Includes the scope-guard workspace package and the
+# web/ui frontend workspace.
+COPY package.json bun.lock ./
+COPY packages/scope-guard/package.json packages/scope-guard/
+COPY web/ui/package.json web/ui/bun.lock web/ui/
+
+# Install with the lockfile pinned. `--frozen-lockfile` matches CI; the
+# top-level install's `postinstall` triggers `bun run build:spa` which
+# needs the web/ui devDeps, so install everything (no --production).
+RUN bun install --frozen-lockfile --ignore-scripts
+
+# Copy the rest of the source. `.dockerignore` already prunes
+# node_modules, .git, dist artifacts, etc.
+COPY . .
+
+# Build the SPA explicitly (postinstall was skipped above via
+# --ignore-scripts to keep the install layer source-independent).
+RUN bun run build:spa
+
+# ---- Runtime stage --------------------------------------------------------
+
+FROM oven/bun:${BUN_VERSION}-alpine AS runtime
+
+WORKDIR /app
+
+# tini reaps zombies + forwards signals so `docker stop` / Render redeploys
+# shut the hub down cleanly instead of getting SIGKILLed after the grace
+# period.
+RUN apk add --no-cache tini
+
+# Bring over installed deps + the built SPA + source. The image runs the
+# hub from source via Bun (no separate build artifact for src/).
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/packages ./packages
+COPY --from=builder /app/web/ui/dist ./web/ui/dist
+COPY --from=builder /app/src ./src
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/LICENSE ./LICENSE
+COPY --from=builder /app/README.md ./README.md
+
+# Default PARACHUTE_HOME points at the persistent-disk mount. The boot
+# script ensures the directory exists before the hub starts, so a fresh
+# Render disk doesn't 500 on first request.
+ENV PARACHUTE_HOME=/parachute \
+    PORT=1939 \
+    PARACHUTE_BIND_HOST=0.0.0.0 \
+    NODE_ENV=production
+
+# Render mounts the persistent disk at $PARACHUTE_HOME; declare the volume
+# so a `docker run` without a bind mount still gets an anonymous volume
+# rather than writing under the image layer.
+VOLUME ["/parachute"]
+
+EXPOSE 1939
+
+# Run as the non-root `bun` user that the base image already provides.
+# The persistent disk needs to be readable+writable by uid/gid 1000; both
+# Render disks and standard bind mounts default to a mode that works.
+USER bun
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["bun", "src/hub-server.ts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,15 @@ ENV PARACHUTE_HOME=/parachute \
     PARACHUTE_BIND_HOST=0.0.0.0 \
     NODE_ENV=production
 
+# Pre-create the persistent-disk mount point and hand it to the non-root
+# `bun` user (uid 1000). Docker creates a VOLUME mount with root:root
+# permissions inheriting the image layer's owner; without this chown the
+# first `mkdirSync('/parachute/well-known')` from `parachute serve` fails
+# with EACCES. Render's disks come up pre-owned per Render's docs but
+# anonymous-volume `docker run` and bind-mount paths both need this seed
+# directory to exist with the right uid.
+RUN mkdir -p /parachute && chown -R bun:bun /parachute
+
 # Render mounts the persistent disk at $PARACHUTE_HOME; declare the volume
 # so a `docker run` without a bind mount still gets an anonymous volume
 # rather than writing under the image layer.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.10-rc.1",
+  "version": "0.5.10-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.9",
+  "version": "0.5.10-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/render.yaml
+++ b/render.yaml
@@ -20,6 +20,8 @@ services:
   - type: web
     name: parachute-hub
     runtime: docker
+    # Starter plan ($7/mo) required: persistent disks are NOT available on Render's free tier.
+    # Render auto-resizes plans online if you need to upgrade later.
     plan: starter
     # Health check at /health — implemented at the very top of hub's
     # request dispatch so a wedged DB or busted services.json can't
@@ -59,6 +61,10 @@ services:
       #
       # `sync: false` because each operator's Render deploy has a
       # different hostname; the dashboard prompts on first deploy.
+      #
+      # Leave blank to derive the OAuth issuer claim from request origin on first boot.
+      # Set this to your custom domain BEFORE issuing OAuth tokens to clients — tokens minted
+      # with one issuer claim won't validate against another.
       - key: PARACHUTE_HUB_ORIGIN
         sync: false
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,80 @@
+# Render Blueprint for self-hosting @openparachute/hub.
+#
+# Layout: one `web` service (the hub HTTP server) backed by a persistent
+# disk at /parachute. Notes is served by hub via the `notes-serve.ts`
+# shim once installed — no separate Render service for it. Vault gets its
+# own Render Blueprint (separate repo).
+#
+# To use: connect a fresh Render account to a fork of this repo and click
+# "New Blueprint" → point at this file. Render will provision the
+# service + disk and start the build. Set the admin-seed env vars in the
+# Render dashboard (marked `sync: false`) or use the web wizard at
+# `/admin/setup` after the first deploy.
+#
+# Custom domains: add the domain on the Render service page, then set
+# PARACHUTE_HUB_ORIGIN to `https://<your-domain>`. The OAuth issuer claim
+# is baked from this value, so issued tokens are only valid against the
+# canonical origin.
+
+services:
+  - type: web
+    name: parachute-hub
+    runtime: docker
+    plan: starter
+    # Health check at /health — implemented at the very top of hub's
+    # request dispatch so a wedged DB or busted services.json can't
+    # cascade into a Render restart loop.
+    healthCheckPath: /health
+    autoDeploy: true
+    disk:
+      name: parachute-home
+      mountPath: /parachute
+      # 1 GiB covers the hub.db + per-vault data for a single operator.
+      # Bump in the Render dashboard if you're hosting multiple
+      # high-traffic vaults; Render resizes online (no redeploy).
+      sizeGB: 1
+    envVars:
+      # The persistent disk mount. Hub honors this for `~/.parachute/`,
+      # so hub.db, services.json, well-known/, and per-service dirs all
+      # land on the persistent volume rather than the ephemeral
+      # container filesystem.
+      - key: PARACHUTE_HOME
+        value: /parachute
+
+      # Container listens on whatever port Render injects via $PORT.
+      # Render's HTTP forwarder maps the public 443 → this port.
+      - key: PORT
+        value: 1939
+
+      # Bind to all interfaces inside the container so Render's HTTP
+      # forwarder can reach us — the on-box `parachute expose` default
+      # of 127.0.0.1 only works behind a same-host reverse proxy.
+      - key: PARACHUTE_BIND_HOST
+        value: 0.0.0.0
+
+      # Canonical public origin baked into the OAuth issuer claim and
+      # token aud claims. MUST match the custom domain you attach to
+      # this service — issued tokens become invalid if the value drifts
+      # from the actual request origin.
+      #
+      # `sync: false` because each operator's Render deploy has a
+      # different hostname; the dashboard prompts on first deploy.
+      - key: PARACHUTE_HUB_ORIGIN
+        sync: false
+
+      # First-boot admin seed. Optional — if unset, the hub still comes
+      # up and routes non-/.well-known requests to /admin/setup so the
+      # operator can bootstrap via the web wizard.
+      #
+      # `sync: false` so secrets never land in source control. Setting
+      # these is a one-time act; once an admin exists in hub.db, the
+      # seed code path is a no-op even if the env vars stay set.
+      - key: PARACHUTE_INITIAL_ADMIN_USERNAME
+        sync: false
+      - key: PARACHUTE_INITIAL_ADMIN_PASSWORD
+        sync: false
+
+      # Run with a sensible Node-style production hint. Bun honors this
+      # for any libraries that branch on NODE_ENV.
+      - key: NODE_ENV
+        value: production

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -9,6 +9,7 @@ import { findServiceUpstream, findVaultUpstream, hubFetch, layerOf } from "../hu
 import { pidPath } from "../process-state.ts";
 import { type ServiceEntry, writeManifest } from "../services-manifest.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
 
 interface Harness {
   dir: string;
@@ -909,6 +910,11 @@ describe("hubFetch routing", () => {
     try {
       const db = openHubDb(hubDbPath(h.dir));
       try {
+        // Seed an admin so the pre-admin setup gate (hub#258) doesn't
+        // 503 the request before the OAuth method-allow check runs.
+        // OAuth routing semantics are what this test pins; the setup
+        // gate has its own coverage in src/__tests__/setup-gate.test.ts.
+        await createUser(db, "owner", "pw");
         const res = await hubFetch(h.dir, { getDb: () => db })(
           req("/oauth/token", { method: "GET" }),
         );
@@ -926,6 +932,7 @@ describe("hubFetch routing", () => {
     try {
       const db = openHubDb(hubDbPath(h.dir));
       try {
+        await createUser(db, "owner", "pw");
         const res = await hubFetch(h.dir, {
           getDb: () => db,
           issuer: "https://hub.example",
@@ -939,6 +946,162 @@ describe("hubFetch routing", () => {
         expect(res.status).toBe(201);
         const body = (await res.json()) as Record<string, unknown>;
         expect(typeof body.client_id).toBe("string");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // Platform health check (hub#258). Returns 200 JSON regardless of DB
+  // state — Render et al. poll this every few seconds and a transient DB
+  // open shouldn't cascade into a restart loop. The body advertises the
+  // running version so a deploy verifier can confirm the rolled-out
+  // image is the one it expected.
+  test("/health returns 200 JSON without invoking the db", async () => {
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir, {
+        getDb: () => {
+          throw new Error("getDb must not be called by /health");
+        },
+      })(req("/health"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      expect(res.headers.get("cache-control")).toBe("no-store");
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.status).toBe("ok");
+      expect(body.service).toBe("parachute-hub");
+      expect(typeof body.version).toBe("string");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // First-boot setup placeholder (hub#258). When no admin exists the page
+  // is the bootstrap onboarding surface; once an admin exists it 301s to
+  // /login so a stale bookmark still lands somewhere useful.
+  test("/admin/setup renders placeholder HTML when no admin exists", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db })(req("/admin/setup"));
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toContain("text/html");
+        const body = await res.text();
+        expect(body).toContain("first-boot setup");
+        expect(body).toContain("PARACHUTE_INITIAL_ADMIN_USERNAME");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/admin/setup 301s to /login when an admin already exists", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        await createUser(db, "owner", "pw");
+        const res = await hubFetch(h.dir, { getDb: () => db })(req("/admin/setup"));
+        expect(res.status).toBe(301);
+        expect(res.headers.get("location")).toBe("/login");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // Pre-admin lockout (hub#258). When no admin row exists, operator-
+  // facing surfaces (admin/api/login) 503 with a JSON body pointing at
+  // /admin/setup. Public surfaces (health, well-known, /, oauth, vault,
+  // /admin/setup itself) stay open so the container is reachable and
+  // OAuth third parties aren't held hostage by admin onboarding.
+  test("pre-admin lockout: /admin/vaults returns 503 setup_required", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db })(req("/admin/vaults"));
+        expect(res.status).toBe(503);
+        const body = (await res.json()) as Record<string, unknown>;
+        expect(body.error).toBe("setup_required");
+        expect(body.setup_url).toBe("/admin/setup");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("pre-admin lockout: /api/me returns 503 setup_required", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db })(req("/api/me"));
+        expect(res.status).toBe(503);
+        const body = (await res.json()) as Record<string, unknown>;
+        expect(body.error).toBe("setup_required");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("pre-admin lockout: /login is gated, /admin/setup + /health + well-known stay open", async () => {
+    const h = makeHarness();
+    try {
+      writeFileSync(join(h.dir, "hub.html"), "<html>discovery</html>");
+      writeManifest({ services: [] }, h.manifestPath);
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const handler = hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath });
+        // /login gated
+        const loginRes = await handler(req("/login"));
+        expect(loginRes.status).toBe(503);
+        // /admin/setup open
+        const setupRes = await handler(req("/admin/setup"));
+        expect(setupRes.status).toBe(200);
+        // /health open
+        const healthRes = await handler(req("/health"));
+        expect(healthRes.status).toBe(200);
+        // / open
+        const rootRes = await handler(req("/"));
+        expect(rootRes.status).toBe(200);
+        // /.well-known/parachute.json open
+        const wkRes = await handler(req("/.well-known/parachute.json"));
+        expect(wkRes.status).toBe(200);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("pre-admin lockout falls away once an admin exists", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        // Before: /api/me 503s under the lockout.
+        const before = await hubFetch(h.dir, { getDb: () => db })(req("/api/me"));
+        expect(before.status).toBe(503);
+        // After seeding an admin: dispatch resumes normal handling.
+        await createUser(db, "owner", "pw");
+        const after = await hubFetch(h.dir, { getDb: () => db })(req("/api/me"));
+        // /api/me with no session returns `hasSession: false` 200, not 503.
+        expect(after.status).toBe(200);
       } finally {
         db.close();
       }

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { seedInitialAdminIfNeeded } from "../commands/serve.ts";
+import { openHubDb } from "../hub-db.ts";
+import { userCount } from "../users.ts";
+
+describe("seedInitialAdminIfNeeded", () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "parachute-serve-"));
+    dbPath = join(dir, "hub.db");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("returns 'needs-setup' on fresh state with no env vars", async () => {
+    const db = openHubDb(dbPath);
+    const result = await seedInitialAdminIfNeeded(db, {}, () => {});
+    expect(result).toBe("needs-setup");
+    expect(userCount(db)).toBe(0);
+  });
+
+  test("seeds an admin from PARACHUTE_INITIAL_ADMIN_* on fresh state", async () => {
+    const db = openHubDb(dbPath);
+    const log = mock<(line: string) => void>(() => {});
+    const result = await seedInitialAdminIfNeeded(
+      db,
+      {
+        PARACHUTE_INITIAL_ADMIN_USERNAME: "ops",
+        PARACHUTE_INITIAL_ADMIN_PASSWORD: "correct horse battery staple",
+      },
+      log,
+    );
+    expect(result).toBe("seeded");
+    expect(userCount(db)).toBe(1);
+    // The log line carries the username so operators can grep container
+    // logs to verify the seed fired.
+    expect(log).toHaveBeenCalledTimes(1);
+    expect((log.mock.calls[0]?.[0] ?? "")).toContain("seeded initial admin");
+    expect((log.mock.calls[0]?.[0] ?? "")).toContain("ops");
+  });
+
+  test("returns 'exists' when an admin already exists, even with env vars set", async () => {
+    // Seed once.
+    const db = openHubDb(dbPath);
+    await seedInitialAdminIfNeeded(
+      db,
+      {
+        PARACHUTE_INITIAL_ADMIN_USERNAME: "ops",
+        PARACHUTE_INITIAL_ADMIN_PASSWORD: "first-pw",
+      },
+      () => {},
+    );
+
+    // Same env on a second boot must NOT clobber the existing admin —
+    // the seed is first-boot only. (Container restart with the env still
+    // set from the Render dashboard is the canonical second-boot.)
+    const result = await seedInitialAdminIfNeeded(
+      db,
+      {
+        PARACHUTE_INITIAL_ADMIN_USERNAME: "ops",
+        PARACHUTE_INITIAL_ADMIN_PASSWORD: "different-pw",
+      },
+      () => {},
+    );
+    expect(result).toBe("exists");
+    expect(userCount(db)).toBe(1);
+  });
+
+  test("treats whitespace-only username as missing (needs-setup)", async () => {
+    const db = openHubDb(dbPath);
+    const result = await seedInitialAdminIfNeeded(
+      db,
+      {
+        PARACHUTE_INITIAL_ADMIN_USERNAME: "   ",
+        PARACHUTE_INITIAL_ADMIN_PASSWORD: "pw",
+      },
+      () => {},
+    );
+    expect(result).toBe("needs-setup");
+    expect(userCount(db)).toBe(0);
+  });
+
+  test("requires both username and password — half-set env is needs-setup", async () => {
+    const db = openHubDb(dbPath);
+    const result = await seedInitialAdminIfNeeded(
+      db,
+      { PARACHUTE_INITIAL_ADMIN_USERNAME: "ops" },
+      () => {},
+    );
+    expect(result).toBe("needs-setup");
+    expect(userCount(db)).toBe(0);
+  });
+});

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -42,8 +42,8 @@ describe("seedInitialAdminIfNeeded", () => {
     // The log line carries the username so operators can grep container
     // logs to verify the seed fired.
     expect(log).toHaveBeenCalledTimes(1);
-    expect((log.mock.calls[0]?.[0] ?? "")).toContain("seeded initial admin");
-    expect((log.mock.calls[0]?.[0] ?? "")).toContain("ops");
+    expect(log.mock.calls[0]?.[0] ?? "").toContain("seeded initial admin");
+    expect(log.mock.calls[0]?.[0] ?? "").toContain("ops");
   });
 
   test("returns 'exists' when an admin already exists, even with env vars set", async () => {

--- a/src/__tests__/setup-gate.test.ts
+++ b/src/__tests__/setup-gate.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Pre-admin setup gate (hub#258). When the hub boots with no admin row
+ * (the fresh container case), admin-onboarding-coupled surfaces 503
+ * with `{error: "setup_required", setup_url: "/admin/setup"}` so
+ * callers can branch on the shape rather than scrape an HTML page.
+ *
+ * Gated routes (require an admin to be useful): `/login`, `/logout`,
+ * `/admin/*` (except `/admin/setup`), `/api/*`.
+ *
+ * Routes that pass through (platform health, public discovery, OAuth
+ * third-party flows, content proxies, the setup page itself):
+ *
+ *   /health, /, /hub.html, /.well-known/*, /admin/setup,
+ *   /oauth/*, /vault/*, /<service>/*
+ *
+ * Once an admin row exists, the gate is a no-op — the rest of dispatch
+ * runs as normal. The `/admin/setup` route 301s to /login at that
+ * point so a stale bookmark still lands somewhere.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { hubFetch } from "../hub-server.ts";
+import { writeManifest } from "../services-manifest.ts";
+import { createUser } from "../users.ts";
+
+interface Harness {
+  dir: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "setup-gate-"));
+  // Minimal hub.html so the `/` route resolves without a 404.
+  writeFileSync(join(dir, "hub.html"), "<html>discovery</html>");
+  writeManifest({ services: [] }, join(dir, "services.json"));
+  return {
+    dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+function req(path: string, init: RequestInit = {}): Request {
+  return new Request(`http://127.0.0.1:1939${path}`, init);
+}
+
+describe("setup gate (no admin yet)", () => {
+  let h: Harness;
+  beforeEach(() => {
+    h = makeHarness();
+  });
+  afterEach(() => h.cleanup());
+
+  test("503s gated admin/api routes with setup_required body", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      // `/api/me` is a representative gated route — admin SPA bootstrap
+      // can't function without an operator identity behind it.
+      const res = await hubFetch(h.dir, { getDb: () => db })(req("/api/me"));
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("setup_required");
+      expect(body.setup_url).toBe("/admin/setup");
+      expect(typeof body.error_description).toBe("string");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("503s /login when no admin exists", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const res = await hubFetch(h.dir, { getDb: () => db })(req("/login"));
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("setup_required");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("/oauth/register passes through the gate (third-party DCR doesn't need admin)", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const res = await hubFetch(h.dir, {
+        getDb: () => db,
+        issuer: "https://hub.example",
+      })(
+        req("/oauth/register", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ redirect_uris: ["https://app.example/cb"] }),
+        }),
+      );
+      // Either 201 (registered) or 4xx (validation rejection) — the
+      // point is NOT 503-setup_required. OAuth surfaces operate
+      // independently of the admin-onboarding state.
+      expect(res.status).not.toBe(503);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("/health passes through the gate", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const res = await hubFetch(h.dir, { getDb: () => db })(req("/health"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.status).toBe("ok");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("/.well-known/jwks.json passes through the gate", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const res = await hubFetch(h.dir, { getDb: () => db })(req("/.well-known/jwks.json"));
+      // Empty keys array is the no-rotation-yet shape, but the route is
+      // reachable — not gated to 503.
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { keys: unknown[] };
+      expect(Array.isArray(body.keys)).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("/ passes through the gate (renders discovery page)", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const res = await hubFetch(h.dir, { getDb: () => db })(req("/"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("/admin/setup renders the placeholder HTML", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const res = await hubFetch(h.dir, { getDb: () => db })(req("/admin/setup"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
+      const html = await res.text();
+      // Spot-check the env-var seed is documented — it's the canonical
+      // bootstrap path for containers and we don't want a future
+      // refactor to silently strip it.
+      expect(html).toContain("PARACHUTE_INITIAL_ADMIN_USERNAME");
+      expect(html).toContain("PARACHUTE_INITIAL_ADMIN_PASSWORD");
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe("setup gate (admin exists)", () => {
+  let h: Harness;
+  beforeEach(() => {
+    h = makeHarness();
+  });
+  afterEach(() => h.cleanup());
+
+  test("no-ops once an admin row exists — operator routes resume normal dispatch", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      await createUser(db, "owner", "pw");
+      // /oauth/token rejects GET with 405 in normal dispatch (it's a
+      // POST-only endpoint). If the gate were still firing this would
+      // come back 503; the 405 confirms regular dispatch resumed.
+      const res = await hubFetch(h.dir, { getDb: () => db })(
+        req("/oauth/token", { method: "GET" }),
+      );
+      expect(res.status).toBe(405);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("/admin/setup 301s to /login once an admin exists", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      await createUser(db, "owner", "pw");
+      const res = await hubFetch(h.dir, { getDb: () => db })(req("/admin/setup"));
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("/login");
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -602,16 +602,17 @@ async function main(argv: string[]): Promise<number> {
         return 1;
       }
       // `serve` returns once Bun.serve is bound; the listener keeps the
-      // event loop alive until SIGINT/SIGTERM, at which point the
-      // container supervisor reaps us.
-      await serve();
-      // Park the event loop indefinitely — Bun.serve's reference keeps the
-      // process alive but the await above resolves immediately. Return
-      // wrapped in a Promise that only settles on signal.
+      // event loop alive until SIGINT/SIGTERM, at which point we stop the
+      // server cleanly and exit. Container supervisor (tini, Render, Docker)
+      // reaps us once the event loop drains.
+      const { stop: stopServer } = await serve();
       await new Promise<void>((resolve) => {
-        const stop = () => resolve();
-        process.on("SIGINT", stop);
-        process.on("SIGTERM", stop);
+        const handler = () => {
+          stopServer();
+          resolve();
+        };
+        process.on("SIGINT", handler);
+        process.on("SIGTERM", handler);
       });
       return 0;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -607,8 +607,8 @@ async function main(argv: string[]): Promise<number> {
       // reaps us once the event loop drains.
       const { stop: stopServer } = await serve();
       await new Promise<void>((resolve) => {
-        const handler = () => {
-          stopServer();
+        const handler = async () => {
+          await stopServer();
           resolve();
         };
         process.on("SIGINT", handler);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { exposePublic, exposeTailnet } from "./commands/expose.ts";
 import { install } from "./commands/install.ts";
 import { logs, restart, start, stop } from "./commands/lifecycle.ts";
 import { migrate } from "./commands/migrate.ts";
+import { serve } from "./commands/serve.ts";
 import { setup } from "./commands/setup.ts";
 import { status } from "./commands/status.ts";
 import { upgrade } from "./commands/upgrade.ts";
@@ -24,6 +25,7 @@ import {
   logsHelp,
   migrateHelp,
   restartHelp,
+  serveHelp,
   setupHelp,
   startHelp,
   statusHelp,
@@ -587,6 +589,31 @@ async function main(argv: string[]): Promise<number> {
         return 1;
       }
       return await migrate({ dryRun, yes });
+    }
+
+    case "serve": {
+      if (isHelpFlag(rest[0])) {
+        console.log(serveHelp());
+        return 0;
+      }
+      if (rest.length > 0) {
+        console.error(`parachute serve: unexpected argument "${rest[0]}"`);
+        console.error("usage: parachute serve");
+        return 1;
+      }
+      // `serve` returns once Bun.serve is bound; the listener keeps the
+      // event loop alive until SIGINT/SIGTERM, at which point the
+      // container supervisor reaps us.
+      await serve();
+      // Park the event loop indefinitely — Bun.serve's reference keeps the
+      // process alive but the await above resolves immediately. Return
+      // wrapped in a Promise that only settles on signal.
+      await new Promise<void>((resolve) => {
+        const stop = () => resolve();
+        process.on("SIGINT", stop);
+        process.on("SIGTERM", stop);
+      });
+      return 0;
     }
 
     case "auth":

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -28,8 +28,8 @@ import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { CONFIG_DIR } from "../config.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
-import { writeHubFile } from "../hub.ts";
 import { hubFetch } from "../hub-server.ts";
+import { writeHubFile } from "../hub.ts";
 import { createUser, userCount } from "../users.ts";
 import { WELL_KNOWN_DIR } from "../well-known.ts";
 
@@ -108,6 +108,10 @@ export async function serve(opts: ServeOpts = {}): Promise<{
   const envPort = parsePort(env.PORT);
   const port = opts.port ?? envPort ?? DEFAULT_PORT;
   const issuer = (opts.issuer ?? env.PARACHUTE_HUB_ORIGIN)?.replace(/\/+$/, "") || undefined;
+  // Containers default to 0.0.0.0 so the platform's HTTP forwarder can
+  // reach us; the `--hostname` flag / PARACHUTE_BIND_HOST is the escape
+  // hatch for setups that want loopback-only inside a sidecar.
+  const hostname = env.PARACHUTE_BIND_HOST || "0.0.0.0";
 
   // Ensure the well-known dir exists, and seed a static hub.html so `/`
   // serves something coherent on a fresh disk (the dynamic path through
@@ -129,11 +133,7 @@ export async function serve(opts: ServeOpts = {}): Promise<{
 
   const server = Bun.serve({
     port,
-    // Cloud hosts (Render, Fly, anything behind a public HTTP forwarder)
-    // need the listener bound to all interfaces. The on-box `parachute
-    // expose` flow that binds 127.0.0.1 is a separate entrypoint
-    // (hub-server.ts's `import.meta.main` path) and stays loopback-only.
-    hostname: "0.0.0.0",
+    hostname,
     fetch: hubFetch(WELL_KNOWN_DIR, {
       getDb: () => db,
       issuer,
@@ -142,7 +142,7 @@ export async function serve(opts: ServeOpts = {}): Promise<{
   });
 
   log(
-    `parachute serve: listening on http://0.0.0.0:${port} (PARACHUTE_HOME=${CONFIG_DIR}, db=${dbPath}, issuer=${issuer ?? "<request-origin>"}, admin=${adminBootstrap})`,
+    `parachute serve: listening on http://${hostname}:${port} (PARACHUTE_HOME=${CONFIG_DIR}, db=${dbPath}, issuer=${issuer ?? "<request-origin>"}, admin=${adminBootstrap})`,
   );
 
   return {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -26,6 +26,8 @@
 
 import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
+// NOTE: CONFIG_DIR/WELL_KNOWN_DIR are evaluated at import time from process.env.PARACHUTE_HOME.
+// The `env` parameter on `serve()` cannot reroute them — set PARACHUTE_HOME before importing for path isolation.
 import { CONFIG_DIR } from "../config.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { hubFetch } from "../hub-server.ts";
@@ -100,7 +102,7 @@ export async function seedInitialAdminIfNeeded(
  */
 export async function serve(opts: ServeOpts = {}): Promise<{
   result: ServeResult;
-  stop: () => void;
+  stop: () => Promise<void>;
 }> {
   const env = opts.env ?? process.env;
   const log = opts.log ?? ((line) => console.log(line));
@@ -147,6 +149,9 @@ export async function serve(opts: ServeOpts = {}): Promise<{
 
   return {
     result: { port, ...(issuer !== undefined ? { issuer } : {}), adminBootstrap },
-    stop: () => server.stop(),
+    stop: async () => {
+      await server.stop();
+      db.close();
+    },
   };
 }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,0 +1,152 @@
+/**
+ * `parachute serve` — long-running hub HTTP server, foregrounded.
+ *
+ * The on-box CLI flow (`parachute expose`) spawns hub-server detached and
+ * tracks it via pidfile. Container hosts (Docker, Render) need the inverse
+ * shape: the hub process IS PID 1 of the container, lives in the
+ * foreground, and exits with the container.
+ *
+ * This subcommand wires that path:
+ *
+ *   - Reads `PORT` (default 1939) and `PARACHUTE_HUB_ORIGIN` (the canonical
+ *     public origin Render exposes via custom domain) from env.
+ *   - Auto-writes `hub.html` into `~/.parachute/well-known/` so `/` serves a
+ *     real discovery page on a fresh disk without the operator having to
+ *     run `parachute expose` first.
+ *   - Seeds an initial admin from `PARACHUTE_INITIAL_ADMIN_USERNAME` +
+ *     `PARACHUTE_INITIAL_ADMIN_PASSWORD` on first boot when no admin
+ *     exists, so the wizard isn't a hard precondition.
+ *   - Starts the hub-server fetch loop bound to `0.0.0.0` (container hosts
+ *     need to accept the platform's HTTP forwarder, not just localhost).
+ *
+ * Stays out of pidfile/log-rotation logic — those are for the detached
+ * `parachute start hub` flow. A container supervisor (Docker, systemd,
+ * Render) owns process lifecycle; this command only owns the fetch loop.
+ */
+
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { CONFIG_DIR } from "../config.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { writeHubFile } from "../hub.ts";
+import { hubFetch } from "../hub-server.ts";
+import { createUser, userCount } from "../users.ts";
+import { WELL_KNOWN_DIR } from "../well-known.ts";
+
+export interface ServeOpts {
+  /** Override PORT (test-only). Real callers thread env via process.env. */
+  port?: number;
+  /** Override PARACHUTE_HUB_ORIGIN (test-only). */
+  issuer?: string;
+  /** Override the env source (test-only). */
+  env?: NodeJS.ProcessEnv;
+  /** Logger seam (test-only). */
+  log?: (line: string) => void;
+}
+
+export interface ServeResult {
+  port: number;
+  issuer?: string;
+  /**
+   * "seeded" — initial admin created from env vars.
+   * "exists" — admin row already present, env vars ignored.
+   * "needs-setup" — no admin and no env-var seed; wizard mode (the
+   * setup-placeholder redirect in hub-server.ts takes over).
+   */
+  adminBootstrap: "seeded" | "exists" | "needs-setup";
+}
+
+const DEFAULT_PORT = 1939;
+
+function parsePort(raw: string | undefined): number | undefined {
+  if (raw === undefined || raw === "") return undefined;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n <= 0 || n > 65535) {
+    throw new Error(`PORT must be 1..65535, got "${raw}"`);
+  }
+  return n;
+}
+
+/**
+ * Seed the initial admin from env vars when no admin exists. Returns the
+ * bootstrap state so the caller can log it for operator visibility.
+ *
+ * Boot-time idempotent: if an admin already exists, we leave it alone —
+ * `PARACHUTE_INITIAL_ADMIN_*` is a first-boot seed, not a reset switch.
+ * That keeps a container restart with the env vars still set from
+ * clobbering an admin who has since rotated their password.
+ */
+export async function seedInitialAdminIfNeeded(
+  db: ReturnType<typeof openHubDb>,
+  env: NodeJS.ProcessEnv,
+  log: (line: string) => void = () => {},
+): Promise<"seeded" | "exists" | "needs-setup"> {
+  if (userCount(db) > 0) return "exists";
+  const username = env.PARACHUTE_INITIAL_ADMIN_USERNAME?.trim();
+  const password = env.PARACHUTE_INITIAL_ADMIN_PASSWORD;
+  if (!username || !password) return "needs-setup";
+  await createUser(db, username, password);
+  log(`parachute serve: seeded initial admin "${username}" from PARACHUTE_INITIAL_ADMIN_*`);
+  return "seeded";
+}
+
+/**
+ * Run the hub fetch loop in the foreground. Resolves when `Bun.serve` is
+ * bound; the returned `stop()` shuts the server down for tests.
+ *
+ * The CLI dispatcher calls this without awaiting completion — `Bun.serve`
+ * runs the listener and the runtime keeps the process alive until a
+ * signal. Tests pass `port: 0` so the kernel picks an ephemeral port.
+ */
+export async function serve(opts: ServeOpts = {}): Promise<{
+  result: ServeResult;
+  stop: () => void;
+}> {
+  const env = opts.env ?? process.env;
+  const log = opts.log ?? ((line) => console.log(line));
+
+  const envPort = parsePort(env.PORT);
+  const port = opts.port ?? envPort ?? DEFAULT_PORT;
+  const issuer = (opts.issuer ?? env.PARACHUTE_HUB_ORIGIN)?.replace(/\/+$/, "") || undefined;
+
+  // Ensure the well-known dir exists, and seed a static hub.html so `/`
+  // serves something coherent on a fresh disk (the dynamic path through
+  // `hubFetch` takes over once a DB row exists; the disk file is the
+  // signed-out fallback).
+  if (!existsSync(WELL_KNOWN_DIR)) mkdirSync(WELL_KNOWN_DIR, { recursive: true });
+  const hubHtmlPath = join(WELL_KNOWN_DIR, "hub.html");
+  if (!existsSync(hubHtmlPath)) writeHubFile(hubHtmlPath);
+
+  const dbPath = hubDbPath();
+  const db = openHubDb(dbPath);
+  const adminBootstrap = await seedInitialAdminIfNeeded(db, env, log);
+
+  if (adminBootstrap === "needs-setup") {
+    log(
+      "parachute serve: no admin account configured. Set PARACHUTE_INITIAL_ADMIN_USERNAME + PARACHUTE_INITIAL_ADMIN_PASSWORD, or visit /admin/setup once the hub is reachable.",
+    );
+  }
+
+  const server = Bun.serve({
+    port,
+    // Cloud hosts (Render, Fly, anything behind a public HTTP forwarder)
+    // need the listener bound to all interfaces. The on-box `parachute
+    // expose` flow that binds 127.0.0.1 is a separate entrypoint
+    // (hub-server.ts's `import.meta.main` path) and stays loopback-only.
+    hostname: "0.0.0.0",
+    fetch: hubFetch(WELL_KNOWN_DIR, {
+      getDb: () => db,
+      issuer,
+      loopbackPort: port,
+    }),
+  });
+
+  log(
+    `parachute serve: listening on http://0.0.0.0:${port} (PARACHUTE_HOME=${CONFIG_DIR}, db=${dbPath}, issuer=${issuer ?? "<request-origin>"}, admin=${adminBootstrap})`,
+  );
+
+  return {
+    result: { port, ...(issuer !== undefined ? { issuer } : {}), adminBootstrap },
+    stop: () => server.stop(),
+  };
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -17,6 +17,7 @@ Usage:
   parachute logs <service> [-f]     print service logs; -f to tail
   parachute expose tailnet [off]    HTTPS across your tailnet (supported)
   parachute expose public  [off]    HTTPS on the public internet (exploratory)
+  parachute serve                   run hub HTTP server foregrounded (for containers)
   parachute migrate [--dry-run]     archive legacy files at ecosystem root
   parachute auth <cmd>              identity (set password, manage 2FA)
   parachute vault <args...>         vault-specific ops (tokens, 2fa, config, init,
@@ -367,6 +368,47 @@ Log file:
   ~/.parachute/<service>/logs/<service>.log
 
 If no log file exists yet, prints a hint to \`parachute start <service>\`.
+`;
+}
+
+export function serveHelp(): string {
+  return `parachute serve — run the hub HTTP server foregrounded
+
+Usage:
+  parachute serve
+
+The container shape. The on-box CLI flow (\`parachute expose\`) spawns the
+hub-server detached and tracks it via pidfile; \`parachute serve\` is the
+inverse — the hub IS the foreground process, lives as long as its
+supervisor wants it to, and exits on signal. Built for Docker / Render /
+systemd, but works fine for a foregrounded local debug too.
+
+Environment:
+  PORT                              bind port (default 1939). Render injects
+                                    this; honor it so the platform's HTTP
+                                    forwarder lands on the right socket.
+  PARACHUTE_HOME                    config root (default ~/.parachute).
+                                    Point at a persistent disk in containers.
+  PARACHUTE_HUB_ORIGIN              canonical https://… origin baked into
+                                    OAuth issuer + token aud claims. Set to
+                                    the public hostname Render / Cloudflare
+                                    serves.
+  PARACHUTE_INITIAL_ADMIN_USERNAME  on first boot when no admin row exists,
+  PARACHUTE_INITIAL_ADMIN_PASSWORD  seed an admin from these. Boot-time
+                                    idempotent — ignored once an admin
+                                    exists, so leaving them set across
+                                    restarts is safe.
+
+If no admin exists and the seed env vars aren't set, the hub still comes
+up — visit \`/admin/setup\` to bootstrap via the placeholder wizard.
+
+Examples:
+  parachute serve                          # foreground, defaults
+  PORT=8080 PARACHUTE_HOME=/parachute parachute serve
+  docker run -e PARACHUTE_INITIAL_ADMIN_USERNAME=ops \\
+             -e PARACHUTE_INITIAL_ADMIN_PASSWORD=… \\
+             -v parachute-data:/parachute \\
+             parachute-hub:0.5.10 serve
 `;
 }
 

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -85,6 +85,7 @@ import type { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import pkg from "../package.json" with { type: "json" };
 import { handleApproveClient, handleGetClient } from "./admin-clients.ts";
 import { handleListGrants, handleRevokeGrant } from "./admin-grants.ts";
 import {
@@ -103,12 +104,7 @@ import { handleApiTokens } from "./api-tokens.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import { ensureCsrfToken } from "./csrf.ts";
 import { readExposeState } from "./expose-state.ts";
-import {
-  HUB_DEFAULT_PORT,
-  HUB_SVC,
-  clearHubPort,
-  writeHubPort,
-} from "./hub-control.ts";
+import { HUB_DEFAULT_PORT, HUB_SVC, clearHubPort, writeHubPort } from "./hub-control.ts";
 import { hubDbPath, openHubDb } from "./hub-db.ts";
 import { type RenderHubOpts, renderHub } from "./hub.ts";
 import { pemToJwk } from "./jwks.ts";
@@ -136,7 +132,6 @@ import { type ServiceEntry, readManifest } from "./services-manifest.ts";
 import { findActiveSession } from "./sessions.ts";
 import { getAllPublicKeys } from "./signing-keys.ts";
 import { getUserById, userCount } from "./users.ts";
-import pkg from "../package.json" with { type: "json" };
 import {
   WELL_KNOWN_DIR,
   buildWellKnown,
@@ -763,6 +758,93 @@ async function serveSpa(spaDistDir: string, pathname: string, mount: SpaMount): 
   });
 }
 
+/**
+ * Routes that fall through the pre-admin lockout (503 → /admin/setup).
+ *
+ * Gated (operator-facing) when no admin row exists:
+ *   - `/admin/*` (except `/admin/setup`) — vault admin, permissions, tokens
+ *   - `/api/*`                            — host-admin API surface
+ *   - `/login`, `/logout`                 — pointless without an account
+ *
+ * Open through the gate (so the container is reachable and discoverable
+ * the moment it boots, even before an admin is seeded):
+ *   - `/health`                           — platform liveness check
+ *   - `/.well-known/*`                    — public discovery + JWKS
+ *   - `/admin/setup`                      — the setup placeholder itself
+ *   - `/` and `/hub.html`                 — static discovery page
+ *   - `/oauth/*`                          — third-party OAuth surface; clients
+ *                                            can register/refresh independent
+ *                                            of admin onboarding
+ *   - `/vault/*`, `/<service>/*`          — content proxies; service-level auth
+ *                                            handles its own failure modes
+ *
+ * The function is called only when an admin row is missing; in the
+ * normal-running case (any admin row exists) this gate is a no-op and the
+ * regular dispatch continues.
+ */
+function shouldGateForSetup(pathname: string): boolean {
+  if (pathname === "/login" || pathname === "/logout") return true;
+  if (pathname === "/admin/setup") return false;
+  if (pathname === "/admin" || pathname.startsWith("/admin/")) return true;
+  if (pathname.startsWith("/api/")) return true;
+  return false;
+}
+
+/**
+ * Minimal first-boot setup page. The real wizard (form + submit + admin
+ * row create) ships in hub#259. For now this is a static, single-screen
+ * HTML doc that tells the operator how to seed an admin via env vars and
+ * restart. No external assets — the body sits inline so a fresh container
+ * with no SPA bundle still serves something coherent.
+ */
+function renderSetupPlaceholder(): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Parachute Hub — first-boot setup</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+           max-width: 36rem; margin: 4rem auto; padding: 0 1.5rem; line-height: 1.55;
+           color: #1a1a1a; background: #fafafa; }
+    h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+    p.lede { color: #555; margin-top: 0; }
+    code, pre { background: #f0eee7; border-radius: 4px; padding: 0.1rem 0.35rem;
+                font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.95em; }
+    pre { padding: 0.75rem 1rem; overflow-x: auto; }
+    .note { background: #fff8e1; border-left: 3px solid #d4a017; padding: 0.75rem 1rem;
+            margin: 1.5rem 0; font-size: 0.92em; }
+  </style>
+</head>
+<body>
+  <h1>Parachute Hub — first-boot setup</h1>
+  <p class="lede">No admin account exists yet on this hub. Set the seed env
+  vars below and restart the container to bootstrap the first operator.</p>
+
+  <h2>Option 1 — env-var seed (recommended for containers)</h2>
+  <p>Set these on the container and restart:</p>
+  <pre>PARACHUTE_INITIAL_ADMIN_USERNAME=ops
+PARACHUTE_INITIAL_ADMIN_PASSWORD=&lt;a strong password&gt;</pre>
+  <p>On boot the hub will create the admin row, then ignore the env vars
+  on every subsequent restart — they're a first-boot seed, not a reset
+  switch. Rotate the password later via <code>parachute auth set-password</code>
+  inside the container, or via the admin UI.</p>
+
+  <h2>Option 2 — CLI from inside the container</h2>
+  <pre>docker exec -it &lt;container&gt; parachute auth set-password \\
+  --username ops --password '&lt;…&gt;'</pre>
+
+  <div class="note">
+    The full web-based setup wizard (browser form, no env vars or shell
+    needed) is tracked in <code>hub#259</code> and will replace this
+    placeholder when it ships.
+  </div>
+</body>
+</html>
+`;
+}
+
 // Canonical 503 body for "getDb is unset, hub is unconfigured." Shape matches
 // the OAuth error vocabulary used by /api/auth/* (`service_unavailable`) so a
 // consumer never has to branch on content-type to extract a message. See
@@ -817,16 +899,6 @@ export function hubFetch(
   return async (req) => {
     const url = new URL(req.url);
     const pathname = url.pathname;
-
-    // Liveness probe. First so a wedged DB or busted services.json can't
-    // make Render restart the container — health is process-level, not
-    // app-state. JSON payload is small enough to keep the response cheap
-    // under k8s/Render's tight probe budgets.
-    if (pathname === "/health") {
-      return new Response(JSON.stringify({ ok: true }), {
-        headers: { "content-type": "application/json" },
-      });
-    }
 
     // 301 back-compat for the pre-hub#231 admin-SPA mounts:
     //
@@ -896,6 +968,73 @@ export function hubFetch(
         status: 301,
         headers: { location: `/logout${url.search}` },
       });
+    }
+
+    // Platform health check (Render, Fly, Kubernetes, etc.). Plain JSON,
+    // no DB required — the route reports liveness, not readiness. Anything
+    // more invasive (DB ping, schema check) would let a transient lock turn
+    // into a restart loop on the platform side. 200 always while the
+    // process is up.
+    if (pathname === "/health") {
+      return new Response(
+        JSON.stringify({ status: "ok", service: "parachute-hub", version: pkg.version }),
+        {
+          headers: {
+            "content-type": "application/json",
+            "cache-control": "no-store",
+          },
+        },
+      );
+    }
+
+    // First-boot setup placeholder. Real wizard ships in hub#259. When no
+    // admin exists, render a minimal HTML page pointing operators at the
+    // env-var seed path. When an admin already exists, 301 to /login —
+    // the route doesn't disappear after setup so a stale bookmark still
+    // lands somewhere useful.
+    if (pathname === "/admin/setup") {
+      if (getDb) {
+        const db = getDb();
+        if (userCount(db) > 0) {
+          return new Response("", {
+            status: 301,
+            headers: { location: "/login" },
+          });
+        }
+      }
+      return new Response(renderSetupPlaceholder(), {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+
+    // Pre-admin lockout. When the hub has booted with no admin row (the
+    // fresh-container case before PARACHUTE_INITIAL_ADMIN_* is set or
+    // /admin/setup is walked), every operator-facing surface that requires
+    // identity is meaningless — auth flows can't validate, the SPA can't
+    // mint a host-admin token, OAuth can't issue codes. Route those to a
+    // 503 that points at /admin/setup. Health, well-known, /admin/setup
+    // itself, and the static discovery page (/) ran above and are
+    // unaffected; OAuth + admin + api endpoints fall here.
+    //
+    // `shouldGateForSetup` runs first so non-gated paths (well-known, /,
+    // /health, /admin/setup) never touch getDb — keeping the
+    // existing OPTIONS-preflight contract that those routes are db-free.
+    if (getDb && shouldGateForSetup(pathname) && userCount(getDb()) === 0) {
+      return new Response(
+        JSON.stringify({
+          error: "setup_required",
+          error_description:
+            "no admin configured. Visit /admin/setup, or set PARACHUTE_INITIAL_ADMIN_USERNAME + PARACHUTE_INITIAL_ADMIN_PASSWORD and restart.",
+          setup_url: "/admin/setup",
+        }),
+        {
+          status: 503,
+          headers: {
+            "content-type": "application/json",
+            "cache-control": "no-store",
+          },
+        },
+      );
     }
 
     if (pathname === "/" || pathname === "/hub.html") {

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -103,7 +103,12 @@ import { handleApiTokens } from "./api-tokens.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import { ensureCsrfToken } from "./csrf.ts";
 import { readExposeState } from "./expose-state.ts";
-import { HUB_SVC, clearHubPort, writeHubPort } from "./hub-control.ts";
+import {
+  HUB_DEFAULT_PORT,
+  HUB_SVC,
+  clearHubPort,
+  writeHubPort,
+} from "./hub-control.ts";
 import { hubDbPath, openHubDb } from "./hub-db.ts";
 import { type RenderHubOpts, renderHub } from "./hub.ts";
 import { pemToJwk } from "./jwks.ts";
@@ -130,18 +135,38 @@ import {
 import { type ServiceEntry, readManifest } from "./services-manifest.ts";
 import { findActiveSession } from "./sessions.ts";
 import { getAllPublicKeys } from "./signing-keys.ts";
-import { getUserById } from "./users.ts";
-import { buildWellKnown, isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
+import { getUserById, userCount } from "./users.ts";
+import pkg from "../package.json" with { type: "json" };
+import {
+  WELL_KNOWN_DIR,
+  buildWellKnown,
+  isVaultEntry,
+  vaultInstanceNameFor,
+} from "./well-known.ts";
 
 interface Args {
   port: number;
+  hostname: string;
   wellKnownDir: string;
   dbPath: string;
   issuer: string | undefined;
 }
 
-function parseArgs(argv: string[]): Args {
+/**
+ * Parse hub-server flags. Container hosts (Render, Docker) configure us
+ * entirely via env vars — no flags. The `parachute expose` spawn path passes
+ * everything as flags. Flags beat env, env beats defaults.
+ *
+ *   PORT                       — bind port (Render injects this)
+ *   PARACHUTE_BIND_HOST        — bind hostname; default 127.0.0.1 to keep
+ *                                the historical loopback posture safe.
+ *                                Containers should set 0.0.0.0.
+ *   PARACHUTE_HUB_ORIGIN       — canonical https://… origin used as the
+ *                                OAuth issuer claim.
+ */
+function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): Args {
   let port: number | undefined;
+  let hostname: string | undefined;
   let wellKnownDir: string | undefined;
   let dbPath: string | undefined;
   let issuer: string | undefined;
@@ -150,11 +175,11 @@ function parseArgs(argv: string[]): Args {
     if (a === "--port") {
       const v = argv[++i];
       if (!v) throw new Error("--port requires a value");
-      const n = Number.parseInt(v, 10);
-      if (!Number.isInteger(n) || n <= 0 || n > 65535) {
-        throw new Error(`--port must be 1..65535, got "${v}"`);
-      }
-      port = n;
+      port = parsePort(v);
+    } else if (a === "--hostname") {
+      const v = argv[++i];
+      if (!v) throw new Error("--hostname requires a value");
+      hostname = v;
     } else if (a === "--well-known-dir") {
       const v = argv[++i];
       if (!v) throw new Error("--well-known-dir requires a value");
@@ -171,9 +196,22 @@ function parseArgs(argv: string[]): Args {
       throw new Error(`unknown argument: ${a}`);
     }
   }
-  if (port === undefined) throw new Error("--port is required");
-  if (wellKnownDir === undefined) throw new Error("--well-known-dir is required");
-  return { port, wellKnownDir, dbPath: dbPath ?? hubDbPath(), issuer };
+  if (port === undefined && env.PORT) port = parsePort(env.PORT);
+  if (port === undefined) port = HUB_DEFAULT_PORT;
+  if (hostname === undefined) hostname = env.PARACHUTE_BIND_HOST || "127.0.0.1";
+  if (wellKnownDir === undefined) wellKnownDir = WELL_KNOWN_DIR;
+  if (issuer === undefined && env.PARACHUTE_HUB_ORIGIN) {
+    issuer = env.PARACHUTE_HUB_ORIGIN.replace(/\/+$/, "");
+  }
+  return { port, hostname, wellKnownDir, dbPath: dbPath ?? hubDbPath(), issuer };
+}
+
+function parsePort(v: string): number {
+  const n = Number.parseInt(v, 10);
+  if (!Number.isInteger(n) || n <= 0 || n > 65535) {
+    throw new Error(`port must be 1..65535, got "${v}"`);
+  }
+  return n;
 }
 
 /**
@@ -780,6 +818,16 @@ export function hubFetch(
     const url = new URL(req.url);
     const pathname = url.pathname;
 
+    // Liveness probe. First so a wedged DB or busted services.json can't
+    // make Render restart the container — health is process-level, not
+    // app-state. JSON payload is small enough to keep the response cheap
+    // under k8s/Render's tight probe budgets.
+    if (pathname === "/health") {
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+
     // 301 back-compat for the pre-hub#231 admin-SPA mounts:
     //
     //   `/vault`            → `/admin/vaults`
@@ -1237,7 +1285,7 @@ export function hubFetch(
 }
 
 if (import.meta.main) {
-  const { port, wellKnownDir, dbPath, issuer } = parseArgs(process.argv.slice(2));
+  const { port, hostname, wellKnownDir, dbPath, issuer } = parseArgs(process.argv.slice(2));
   let cachedDb: Database | undefined;
   const getDb = () => {
     if (!cachedDb) cachedDb = openHubDb(dbPath);
@@ -1245,7 +1293,7 @@ if (import.meta.main) {
   };
   Bun.serve({
     port,
-    hostname: "127.0.0.1",
+    hostname,
     fetch: hubFetch(wellKnownDir, { getDb, issuer, loopbackPort: port }),
   });
   // Register PID + port from the running hub itself so any startup path
@@ -1269,7 +1317,7 @@ if (import.meta.main) {
   });
   process.on("exit", cleanup);
   console.log(
-    `parachute-hub listening on http://127.0.0.1:${port} (dir=${wellKnownDir}, db=${dbPath}${
+    `parachute-hub listening on http://${hostname}:${port} (dir=${wellKnownDir}, db=${dbPath}${
       issuer ? `, issuer=${issuer}` : ""
     })`,
   );


### PR DESCRIPTION
Closes #258 — Phase 1 of the Render self-host arc.

## Summary

Lays the container-deploy groundwork so a fresh Render account can run hub via Blueprint:

- **`Dockerfile`** (multi-stage, Bun-based) — installs with `--frozen-lockfile`, builds the admin SPA, copies into a slim runtime stage, runs as non-root `bun` user under `tini`, declares `/parachute` as the persistent-disk mount with bun-owned permissions, entrypoints `bun src/cli.ts serve`.
- **`.dockerignore`** — prunes build context (node_modules, .git, dist, OS junk, etc.).
- **`render.yaml`** — Render Blueprint declaring one web service + 1 GB persistent disk at `/parachute` + `/health` health check + `sync: false` placeholders for `PARACHUTE_HUB_ORIGIN` and the admin seed env vars.
- **`parachute serve`** subcommand — foreground hub entrypoint for containers. Reads `PORT` / `PARACHUTE_HUB_ORIGIN` / `PARACHUTE_BIND_HOST` from env; binds `0.0.0.0` by default; auto-writes static `hub.html` so `/` serves a coherent discovery page on a fresh disk; orchestrates the admin seed; calls `Bun.serve().stop()` on SIGINT/SIGTERM for clean shutdown.
- **Env-driven first-admin seed** — when `PARACHUTE_INITIAL_ADMIN_USERNAME` + `PARACHUTE_INITIAL_ADMIN_PASSWORD` are both set on first boot with no admin row, `seedInitialAdminIfNeeded` creates the admin. Boot-time idempotent — once an admin exists the env vars are ignored, safe to leave set across restarts.
- **`/admin/setup` placeholder page** — minimal HTML doc documenting both bootstrap paths (env-var seed + `parachute auth set-password`). 301s to `/login` once an admin exists.
- **Pre-admin lockout** — when no admin row exists, admin-onboarding-coupled surfaces (`/login`, `/logout`, `/admin/*` except `/admin/setup`, `/api/*`) return `503 {error: "setup_required", setup_url: "/admin/setup"}`. `/health`, `/`, `/.well-known/*`, `/oauth/*`, content proxies pass through — third-party OAuth + JWKS-driven verification don't depend on admin onboarding. Gate is a no-op once any admin row exists.
- **`/health` route** — 200 JSON with `{status, service, version}` at the top of dispatch so platform health checks never observe app-state degradation.

## RC bump

Per Rule 4 (RC versioning), bumped `0.5.9` → `0.5.10-rc.1`. Same `0.5.10` patch number will hold across the rc chain until Aaron promotes to stable.

## Commit chain

1. `feat(deploy): Dockerfile + .dockerignore + parachute serve foreground entrypoint`
2. `feat(deploy): render.yaml Blueprint for one-click Render self-host`
3. `feat(boot): env-driven first-admin seed + /admin/setup placeholder + pre-admin lockout`
4. `chore: release 0.5.10-rc.1`
5. `polish: Dockerfile CMD uses parachute serve + cli serve calls stop() on signal`
6. `fix(docker): chown /parachute to bun uid for non-root volume writes`

## Pattern check

- **Module Protocol** (`parachute-patterns/patterns/module-protocol.md`) — Dockerfile + `parachute serve` give hub a deployment shape that runs in any OCI-compliant host. Existing on-box `parachute expose` flow is unaffected; both entrypoints coexist. No protocol change.
- **OAuth scopes** — unchanged; OAuth surfaces deliberately pass through the new pre-admin gate.
- **Naming** — Render service name `parachute-hub` aligns with the rest of the ecosystem; persistent disk name `parachute-home` mirrors the `PARACHUTE_HOME` env contract.

## Test plan

- [x] `bun test ./src` — 1307 pass / 1 fail (pre-existing `status > all-healthy returns 0` env flake carried since 0.5.9-rc.8) / 30443 expects across 72 files. +19 over 0.5.9.
- [x] `bun run typecheck` clean.
- [x] `bunx biome check .` clean.
- [x] `docker build` succeeds end-to-end (multi-stage, ~120 MB final image).
- [x] **Smoke A — seeded admin:** `docker run -e PARACHUTE_INITIAL_ADMIN_USERNAME=ops -e PARACHUTE_INITIAL_ADMIN_PASSWORD=…` → `/health` returns 200 JSON, `/api/me` returns `{hasSession: false}` (gate disabled because admin row exists), logs show `seeded initial admin "ops"`.
- [x] **Smoke B — no seed:** `docker run` without env vars → `/health` returns 200, `/api/me` returns 503 with `setup_required` + `setup_url`, `/admin/setup` returns 200 placeholder HTML, logs show `no admin account configured … visit /admin/setup`.
- [ ] End-to-end Render Blueprint deploy (Aaron to drive on a test Render account; out of band for this PR).

## Out of scope (follow-ups)

- The setup wizard itself (form + submit + admin row create) — tracked at hub#259.
- Vault Dockerfile — vault#339 (parallel).
- The `/deploy` page on parachute.computer — site#42 (chains after this).
- Scribe / agent / notes Dockerfiles — separate phases.

## Reviewer note

Found ~75 lines of unrelated uncommitted local changes in `src/hub-server.ts` on entry (env-aware `parseArgs`, hostname flag, `/health` route — all hub#258-shaped). Folded into commit 1 with attribution in the message; flagging here so the reviewer knows that portion of the diff predates this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)