### PR TITLE
feat(hub#260): admin module mgmt API + supervisor + container-mode runtime install (Phase 1A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.10-rc.3] - 2026-05-18
+
+Admin module management for v0.6 Render self-host (closes #260, Phase 1A). The cloud-deployed hub starts empty; this PR makes vault / notes / scribe installable from the SPA so a friend who clicks Deploy can stand up the full stack without leaving the browser.
+
+**Per-module child supervisor.** New `src/supervisor.ts` attaches each module as a Bun.spawn child, line-prefixes their stdout/stderr into hub's own (so Render's log viewer shows `[vault] …` alongside `[scribe] …`), and restarts on crash with a sliding-window budget (3 in 60s by default; then `crashed`). Idempotent `start()`, explicit `restart()`, `list()`/`get()` for the API surface. The on-box `parachute start <svc>` path stays on `commands/lifecycle.ts` — different ownership.
+
+**Boot-time auto-start.** `parachute serve` reads services.json after admin-seed and hands each registered module to the supervisor. Empty services.json (fresh container) is a no-op — hub HTTP server still comes up so the operator can install via UI. Per-module `.env` is layered under `PARACHUTE_HUB_ORIGIN` (live env wins on collision).
+
+**Module management API.** Six endpoints under `/api/modules/*`, all bearer-gated on `parachute:host:auth`:
+
+- `GET /api/modules` — curated catalog (vault/notes/scribe) joined with services.json + supervisor state + npm `@latest` probe (3s timeout, 5min cache). Returns `supervisor_available: false` under CLI mode so the SPA disables actions cleanly.
+- `POST /api/modules/:short/install` — async. `bun add -g @openparachute/<svc>@latest` → seed services.json → supervisor.start. Returns 202 + `{operation_id}`. Idempotent: already-running short-circuits to `succeeded`.
+- `POST /api/modules/:short/restart` — sync. supervisor.restart. Returns the new state.
+- `POST /api/modules/:short/upgrade` — async. `bun add @latest` → supervisor.restart.
+- `POST /api/modules/:short/uninstall` — sync. Stop child → remove services.json row → `bun remove -g`. Each step idempotent.
+- `GET /api/modules/operations/:id` — poll an async op (`pending` → `running` → `succeeded`|`failed`). The SPA polls every 1s.
+
+Curated-only for v0.6 — `parseModulesPath` refuses non-vault/notes/scribe shorts. Channel is exploration, not committed-core; marketplace is Phase 2.
+
+**`/admin/modules` SPA page.** New `web/ui/src/routes/Modules.tsx`. Lists every curated module with status badge (`running` / `stopped` / `crashed` / `starting` / `restarting` / not-installed), version pair (installed → latest), and per-row action buttons. Async ops show inline progress + the operation log; sync errors stay on the row banner until the next action.
+
+**Container plumbing.** Dockerfile sets `BUN_INSTALL=/parachute/modules` so modules installed via `bun add` land on the persistent disk and survive container restarts. The runtime stage chowns `/parachute` to uid 1000 (the non-root `bun` user) so the volume is writable on first boot. render.yaml carries the env defaults Render injects on Deploy.
+
+Surface summary:
+- 6 new modules: `src/supervisor.ts`, `src/commands/serve-boot.ts`, `src/api-modules.ts`, `src/api-modules-ops.ts`, `web/ui/src/routes/Modules.tsx`, `web/ui/src/routes/Modules.test.tsx`.
+- 6 modules edited: `src/commands/serve.ts` (boot-spawn wiring), `src/hub-server.ts` (HubFetchDeps.supervisor + 6 route additions), `web/ui/src/lib/api.ts` (6 new client helpers), `web/ui/src/App.tsx` (nav + route), `Dockerfile` (BUN_INSTALL + chown), `render.yaml` (env defaults).
+
+Gate: `bun test ./src` 1347 pass / 1 fail (pre-existing `status > all-healthy returns 0` env flake) / 30555 expects across 76 files. +40 over rc.2 (12 supervisor + 6 serve-boot + 8 api-modules + 14 api-modules-ops). `cd web/ui && bun run test` 115 pass / 0 fail (+10 Modules.test.tsx). typecheck clean. biome clean.
+
+Container smoke deferred to the operator's Render dashboard verification — local docker build was not exercised in this PR (no docker daemon available). The supervisor + boot-spawn + module-mgmt-API layers are unit-tested against stubbed spawn/run seams; the Render-side smoke (build image → install vault via UI → restart container → verify persistence) is the final v0.6 gate before promotion to stable.
+
+Phase 1B (real-time module status updates, per-module log streaming in the SPA) is deferred to a follow-up PR — this one is already ~1300 LOC across both server + SPA.
+
 ## [0.5.10-rc.2] - 2026-05-18
 
 Reviewer nits folded — render.yaml comments + DB close on stop + CONFIG_DIR note.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.10-rc.4] - 2026-05-18
+
+Fold reviewer security nit on hub#262: destructive POST endpoints (`install` / `restart` / `upgrade` / `uninstall`) now require `parachute:host:admin` (was `parachute:host:auth`). The `:auth` scope reads the catalog; `:admin` mutates it. SPA path unaffected (host-admin token carries both scopes); narrow `--scope-set auth` automation tokens now correctly get 403 on destructive operations. Also drops dead `existsSync` import. +1 test asserting the 403 path.
+
 ## [0.5.10-rc.3] - 2026-05-18
 
 Admin module management for v0.6 Render self-host (closes #260, Phase 1A). The cloud-deployed hub starts empty; this PR makes vault / notes / scribe installable from the SPA so a friend who clicks Deploy can stand up the full stack without leaving the browser.

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,15 @@
 #   PARACHUTE_HUB_ORIGIN              — canonical https://… origin for OAuth
 #   PARACHUTE_INITIAL_ADMIN_USERNAME  — first-boot admin username (optional)
 #   PARACHUTE_INITIAL_ADMIN_PASSWORD  — first-boot admin password (optional)
+#   BUN_INSTALL                       — root for runtime-installed modules.
+#                                       Pinned to `/parachute/modules` (under
+#                                       the persistent disk) so vault/notes/
+#                                       scribe installed via /admin/modules
+#                                       survive container restarts. Without
+#                                       this, `bun add @openparachute/<svc>`
+#                                       would write to bun's per-user prefix
+#                                       on the ephemeral image layer and
+#                                       vanish on every redeploy.
 
 ARG BUN_VERSION=1.3
 FROM oven/bun:${BUN_VERSION}-alpine AS builder
@@ -71,19 +80,29 @@ COPY --from=builder /app/README.md ./README.md
 # Default PARACHUTE_HOME points at the persistent-disk mount. The boot
 # script ensures the directory exists before the hub starts, so a fresh
 # Render disk doesn't 500 on first request.
+#
+# BUN_INSTALL pins runtime-installed modules under the persistent disk
+# (`/parachute/modules`) so vault / notes / scribe installed via
+# /admin/modules survive container restarts. Bun's `bun add -g <pkg>`
+# resolves to `$BUN_INSTALL/install/global/node_modules/<pkg>`; module
+# discovery in src/install-source.ts already honors this env var, so
+# the supervisor finds children at the new path without code changes.
 ENV PARACHUTE_HOME=/parachute \
     PORT=1939 \
     PARACHUTE_BIND_HOST=0.0.0.0 \
+    BUN_INSTALL=/parachute/modules \
     NODE_ENV=production
 
-# Pre-create the persistent-disk mount point and hand it to the non-root
-# `bun` user (uid 1000). Docker creates a VOLUME mount with root:root
-# permissions inheriting the image layer's owner; without this chown the
-# first `mkdirSync('/parachute/well-known')` from `parachute serve` fails
-# with EACCES. Render's disks come up pre-owned per Render's docs but
-# anonymous-volume `docker run` and bind-mount paths both need this seed
-# directory to exist with the right uid.
-RUN mkdir -p /parachute && chown -R bun:bun /parachute
+# Pre-create the persistent-disk mount point AND the BUN_INSTALL subdir,
+# then hand both to the non-root `bun` user (uid 1000). Docker creates
+# a VOLUME mount with root:root permissions inheriting the image layer's
+# owner; without this chown the first `mkdirSync('/parachute/well-known')`
+# from `parachute serve` (or `bun add` writing into
+# `/parachute/modules/install/global/...`) fails with EACCES. Render's
+# disks come up pre-owned per Render's docs but anonymous-volume
+# `docker run` and bind-mount paths both need this seed directory to
+# exist with the right uid.
+RUN mkdir -p /parachute/modules && chown -R bun:bun /parachute
 
 # Render mounts the persistent disk at $PARACHUTE_HOME; declare the volume
 # so a `docker run` without a bind mount still gets an anonymous volume

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.10-rc.2",
+  "version": "0.5.10-rc.3",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.10-rc.3",
+  "version": "0.5.10-rc.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/render.yaml
+++ b/render.yaml
@@ -54,6 +54,18 @@ services:
       - key: PARACHUTE_BIND_HOST
         value: 0.0.0.0
 
+      # Pin Bun's global-install root to the persistent disk so modules
+      # installed at runtime via /admin/modules (hub#260) survive
+      # container restarts. `bun add @openparachute/<svc>` resolves the
+      # package to `$BUN_INSTALL/install/global/node_modules/<pkg>`;
+      # module discovery in src/install-source.ts honors this env var,
+      # so the supervisor finds installed children at the new path.
+      # Without this, bun installs to its per-user prefix on the
+      # ephemeral image layer and every redeploy nukes user-installed
+      # modules.
+      - key: BUN_INSTALL
+        value: /parachute/modules
+
       # Canonical public origin baked into the OAuth issuer claim and
       # token aud claims. MUST match the custom domain you attach to
       # this service — issued tokens become invalid if the value drifts

--- a/src/__tests__/api-modules-ops.test.ts
+++ b/src/__tests__/api-modules-ops.test.ts
@@ -1,0 +1,494 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  API_MODULES_OPS_REQUIRED_SCOPE,
+  _resetOperationsRegistryForTests,
+  handleInstall,
+  handleOperationGet,
+  handleRestart,
+  handleUninstall,
+  handleUpgrade,
+  parseModulesPath,
+} from "../api-modules-ops.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { recordTokenMint, signAccessToken } from "../jwt-sign.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { type SpawnRequest, type SupervisedProc, Supervisor } from "../supervisor.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "http://127.0.0.1:1939";
+
+interface Harness {
+  dir: string;
+  manifestPath: string;
+  db: ReturnType<typeof openHubDb>;
+  userId: string;
+  cleanup: () => void;
+}
+
+async function makeHarness(): Promise<Harness> {
+  const dir = mkdtempSync(join(tmpdir(), "phub-api-modules-ops-"));
+  const db = openHubDb(hubDbPath(dir));
+  rotateSigningKey(db);
+  const user = await createUser(db, "owner", "pw");
+  return {
+    dir,
+    manifestPath: join(dir, "services.json"),
+    db,
+    userId: user.id,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function mintBearer(h: Harness, scopes: string[]): Promise<string> {
+  const signed = await signAccessToken(h.db, {
+    sub: h.userId,
+    scopes,
+    audience: "parachute-hub",
+    clientId: "parachute-hub",
+    issuer: ISSUER,
+    ttlSeconds: 3600,
+  });
+  recordTokenMint(h.db, {
+    jti: signed.jti,
+    createdVia: "operator_mint",
+    subject: h.userId,
+    clientId: "parachute-hub",
+    scopes,
+    expiresAt: signed.expiresAt,
+  });
+  return signed.token;
+}
+
+function postReq(path: string, headers: Record<string, string>): Request {
+  return new Request(`http://localhost${path}`, { method: "POST", headers });
+}
+
+function getReq(path: string, headers: Record<string, string>): Request {
+  return new Request(`http://localhost${path}`, { method: "GET", headers });
+}
+
+function makeIdleSupervisor(): {
+  supervisor: Supervisor;
+  spawns: SpawnRequest[];
+} {
+  const spawns: SpawnRequest[] = [];
+  const spawnFn = (req: SpawnRequest): SupervisedProc => {
+    spawns.push(req);
+    // The fake's `exited` resolves when kill() is called, mirroring a
+    // well-behaved child that exits on SIGTERM. Without this, the
+    // supervisor's `restart()` awaits forever after the stop signal.
+    let resolveExit!: (c: number | null) => void;
+    const exited = new Promise<number | null>((r) => {
+      resolveExit = r;
+    });
+    return {
+      pid: 7777,
+      exited,
+      stdout: null,
+      stderr: null,
+      kill: () => resolveExit(0),
+    };
+  };
+  return { supervisor: new Supervisor({ spawnFn }), spawns };
+}
+
+function writeManifest(path: string, services: unknown[]): void {
+  writeFileSync(path, JSON.stringify({ services }));
+}
+
+/** Run a no-op shell — production calls `bun add`/`bun remove`; tests don't. */
+function alwaysOkRun(): {
+  run: (cmd: readonly string[]) => Promise<number>;
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  return {
+    calls,
+    run: async (cmd) => {
+      calls.push([...cmd]);
+      return 0;
+    },
+  };
+}
+
+describe("parseModulesPath", () => {
+  test("recognizes curated short + action", () => {
+    expect(parseModulesPath("/api/modules/vault/install")).toEqual({
+      short: "vault",
+      rest: "install",
+    });
+    expect(parseModulesPath("/api/modules/scribe/upgrade")).toEqual({
+      short: "scribe",
+      rest: "upgrade",
+    });
+  });
+
+  test("rejects non-curated shorts (no marketplace yet)", () => {
+    // Channel exists in FIRST_PARTY_FALLBACKS but is exploration, not
+    // in CURATED_MODULES — the v0.6 surface refuses to drive it via
+    // /api/modules.
+    expect(parseModulesPath("/api/modules/channel/install")).toBeUndefined();
+    expect(parseModulesPath("/api/modules/random/install")).toBeUndefined();
+  });
+
+  test("rejects malformed paths", () => {
+    expect(parseModulesPath("/api/modules/")).toBeUndefined();
+    expect(parseModulesPath("/api/modules/vault")).toBeUndefined();
+    expect(parseModulesPath("/something/else")).toBeUndefined();
+  });
+});
+
+describe("POST /api/modules/:short/install", () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+    _resetOperationsRegistryForTests();
+  });
+  afterEach(() => h.cleanup());
+
+  test("returns 401 on missing bearer", async () => {
+    const { supervisor } = makeIdleSupervisor();
+    const res = await handleInstall(postReq("/api/modules/vault/install", {}), "vault", {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+      supervisor,
+      run: async () => 0,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("returns 403 on bearer without parachute:host:auth scope", async () => {
+    const { supervisor } = makeIdleSupervisor();
+    const bearer = await mintBearer(h, ["scribe:transcribe"]);
+    const res = await handleInstall(
+      postReq("/api/modules/vault/install", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run: async () => 0,
+      },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("202 + operation_id, runs bun add + seeds services.json + spawns", async () => {
+    const { supervisor, spawns } = makeIdleSupervisor();
+    const { run, calls } = alwaysOkRun();
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleInstall(
+      postReq("/api/modules/vault/install", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run,
+      },
+    );
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { operation_id: string };
+    expect(body.operation_id).toBeDefined();
+
+    // Wait a microtask for the async install to settle. The
+    // alwaysOkRun returns immediately, so the chain
+    // bun-add → seed → spawn happens within one microtask
+    // batch — give it two ticks to be safe.
+    await new Promise((r) => setTimeout(r, 10));
+
+    // `bun add` was called with the @latest spec.
+    expect(calls).toContainEqual(["bun", "add", "-g", "@openparachute/vault@latest"]);
+    // services.json now has the vault row (the seed-on-missing path).
+    const manifest = JSON.parse(readFileSync(h.manifestPath, "utf8")) as {
+      services: Array<{ name: string }>;
+    };
+    expect(manifest.services.some((s) => s.name === "parachute-vault")).toBe(true);
+    // Supervisor was handed the spawn.
+    expect(spawns.find((s) => s.short === "vault")?.cmd).toEqual(["parachute-vault", "serve"]);
+  });
+
+  test("idempotent: already-installed + running returns succeeded immediately", async () => {
+    // Pre-seed services.json + supervisor state.
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/vault/default"],
+        health: "/vault/default/health",
+        version: "0.4.5",
+      },
+    ]);
+    const { supervisor } = makeIdleSupervisor();
+    await supervisor.start({ short: "vault", cmd: ["parachute-vault", "serve"] });
+
+    const { run, calls } = alwaysOkRun();
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleInstall(
+      postReq("/api/modules/vault/install", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run,
+      },
+    );
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { operation_id: string };
+
+    // bun add was NOT called — short-circuit hit.
+    expect(calls).toEqual([]);
+
+    // The operation record is already in succeeded state.
+    const opRes = await handleOperationGet(
+      getReq(`/api/modules/operations/${body.operation_id}`, {
+        authorization: `Bearer ${bearer}`,
+      }),
+      body.operation_id,
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run,
+      },
+    );
+    const op = (await opRes.json()) as { status: string };
+    expect(op.status).toBe("succeeded");
+  });
+
+  test("failed bun-add surfaces failed status on the operation", async () => {
+    const { supervisor } = makeIdleSupervisor();
+    // Run returns 1 + findGlobalInstall returns null = real failure.
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const deps = {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+      supervisor,
+      run: async () => 1,
+      findGlobalInstall: () => null,
+    };
+    const res = await handleInstall(
+      postReq("/api/modules/vault/install", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      deps,
+    );
+    const body = (await res.json()) as { operation_id: string };
+    await new Promise((r) => setTimeout(r, 10));
+    const opRes = await handleOperationGet(
+      getReq(`/api/modules/operations/${body.operation_id}`, {
+        authorization: `Bearer ${bearer}`,
+      }),
+      body.operation_id,
+      deps,
+    );
+    const op = (await opRes.json()) as { status: string; error?: string };
+    expect(op.status).toBe("failed");
+    expect(op.error).toMatch(/bun add -g exited 1/);
+  });
+});
+
+describe("POST /api/modules/:short/restart", () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+    _resetOperationsRegistryForTests();
+  });
+  afterEach(() => h.cleanup());
+
+  test("404 not_supervised when module isn't running", async () => {
+    const { supervisor } = makeIdleSupervisor();
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleRestart(
+      postReq("/api/modules/vault/restart", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run: async () => 0,
+      },
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("not_supervised");
+  });
+
+  test("returns new state on success", async () => {
+    const { supervisor } = makeIdleSupervisor();
+    await supervisor.start({ short: "vault", cmd: ["parachute-vault", "serve"] });
+
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleRestart(
+      postReq("/api/modules/vault/restart", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run: async () => 0,
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { short: string; state: { status: string } };
+    expect(body.short).toBe("vault");
+    // restart sets the state to either restarting or running depending
+    // on timing — either is acceptable here as long as it's not crashed/stopped.
+    expect(["restarting", "running", "starting"]).toContain(body.state.status);
+  });
+});
+
+describe("POST /api/modules/:short/upgrade", () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+    _resetOperationsRegistryForTests();
+  });
+  afterEach(() => h.cleanup());
+
+  test("202 + bun add @latest + restart on already-running module", async () => {
+    const { supervisor } = makeIdleSupervisor();
+    await supervisor.start({ short: "vault", cmd: ["parachute-vault", "serve"] });
+
+    const { run, calls } = alwaysOkRun();
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleUpgrade(
+      postReq("/api/modules/vault/upgrade", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run,
+      },
+    );
+    expect(res.status).toBe(202);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(calls).toContainEqual(["bun", "add", "-g", "@openparachute/vault@latest"]);
+  });
+});
+
+describe("POST /api/modules/:short/uninstall", () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+    _resetOperationsRegistryForTests();
+  });
+  afterEach(() => h.cleanup());
+
+  test("stops child + removes services.json row + runs bun remove", async () => {
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/vault/default"],
+        health: "/vault/default/health",
+        version: "0.4.5",
+      },
+    ]);
+    const { supervisor } = makeIdleSupervisor();
+    await supervisor.start({ short: "vault", cmd: ["parachute-vault", "serve"] });
+
+    const { run, calls } = alwaysOkRun();
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleUninstall(
+      postReq("/api/modules/vault/uninstall", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run,
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { short: string; log: string[] };
+    expect(body.short).toBe("vault");
+    // The log captures each step's outcome.
+    expect(body.log.join(" ")).toMatch(/supervisor stopped/);
+    expect(body.log.join(" ")).toMatch(/removed parachute-vault from services.json/);
+
+    // services.json row is gone.
+    const manifest = JSON.parse(readFileSync(h.manifestPath, "utf8")) as {
+      services: Array<{ name: string }>;
+    };
+    expect(manifest.services.some((s) => s.name === "parachute-vault")).toBe(false);
+    // bun remove was called.
+    expect(calls).toContainEqual(["bun", "remove", "-g", "@openparachute/vault"]);
+  });
+
+  test("idempotent on never-installed module", async () => {
+    const { supervisor } = makeIdleSupervisor();
+    const { run } = alwaysOkRun();
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleUninstall(
+      postReq("/api/modules/vault/uninstall", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run,
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { log: string[] };
+    expect(body.log.join(" ")).toMatch(/not supervised/);
+    expect(body.log.join(" ")).toMatch(/not in services.json/);
+  });
+});
+
+describe("GET /api/modules/operations/:id", () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+    _resetOperationsRegistryForTests();
+  });
+  afterEach(() => h.cleanup());
+
+  test("404 on unknown id", async () => {
+    const { supervisor } = makeIdleSupervisor();
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleOperationGet(
+      getReq("/api/modules/operations/no-such-id", { authorization: `Bearer ${bearer}` }),
+      "no-such-id",
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run: async () => 0,
+      },
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/__tests__/api-modules-ops.test.ts
+++ b/src/__tests__/api-modules-ops.test.ts
@@ -165,7 +165,7 @@ describe("POST /api/modules/:short/install", () => {
     expect(res.status).toBe(401);
   });
 
-  test("returns 403 on bearer without parachute:host:auth scope", async () => {
+  test("returns 403 on bearer without parachute:host:admin scope", async () => {
     const { supervisor } = makeIdleSupervisor();
     const bearer = await mintBearer(h, ["scribe:transcribe"]);
     const res = await handleInstall(
@@ -181,6 +181,31 @@ describe("POST /api/modules/:short/install", () => {
       },
     );
     expect(res.status).toBe(403);
+  });
+
+  test("returns 403 on bearer with only :host:auth (not :host:admin) — destructive ops elevated", async () => {
+    // `:host:auth` is the read-only catalog scope (`GET /api/modules`).
+    // Destructive POSTs are admin-only. Mint a token that carries
+    // *only* `:auth` and confirm install is refused — the boundary
+    // that keeps automation callers from uninstalling vault.
+    const { supervisor } = makeIdleSupervisor();
+    const bearer = await mintBearer(h, ["parachute:host:auth"]);
+    const res = await handleInstall(
+      postReq("/api/modules/vault/install", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run: async () => 0,
+      },
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("insufficient_scope");
+    expect(body.error_description).toContain("parachute:host:admin");
   });
 
   test("202 + operation_id, runs bun add + seeds services.json + spawns", async () => {

--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  API_MODULES_REQUIRED_SCOPE,
+  _clearLatestVersionCacheForTests,
+  handleApiModules,
+} from "../api-modules.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { recordTokenMint, signAccessToken } from "../jwt-sign.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { type SpawnRequest, type SupervisedProc, Supervisor } from "../supervisor.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "http://127.0.0.1:1939";
+
+interface Harness {
+  dir: string;
+  manifestPath: string;
+  db: ReturnType<typeof openHubDb>;
+  userId: string;
+  cleanup: () => void;
+}
+
+async function makeHarness(): Promise<Harness> {
+  const dir = mkdtempSync(join(tmpdir(), "phub-api-modules-"));
+  const db = openHubDb(hubDbPath(dir));
+  rotateSigningKey(db);
+  const user = await createUser(db, "owner", "pw");
+  return {
+    dir,
+    manifestPath: join(dir, "services.json"),
+    db,
+    userId: user.id,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function mintBearer(h: Harness, scopes: string[]): Promise<string> {
+  const signed = await signAccessToken(h.db, {
+    sub: h.userId,
+    scopes,
+    audience: "parachute-hub",
+    clientId: "parachute-hub",
+    issuer: ISSUER,
+    ttlSeconds: 3600,
+  });
+  recordTokenMint(h.db, {
+    jti: signed.jti,
+    createdVia: "operator_mint",
+    subject: h.userId,
+    clientId: "parachute-hub",
+    scopes,
+    expiresAt: signed.expiresAt,
+  });
+  return signed.token;
+}
+
+function writeManifest(path: string, services: unknown[]): void {
+  writeFileSync(path, JSON.stringify({ services }));
+}
+
+function getReq(headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/api/modules", {
+    method: "GET",
+    headers,
+  });
+}
+
+function postReq(): Request {
+  return new Request("http://localhost/api/modules", {
+    method: "POST",
+  });
+}
+
+function makeIdleSupervisor(): {
+  supervisor: Supervisor;
+  spawnFn: (req: SpawnRequest) => SupervisedProc;
+} {
+  // Test fake: never resolves `exited` so the supervisor's crash-watch
+  // loop stays quiet for the test's lifetime.
+  const spawnFn: (req: SpawnRequest) => SupervisedProc = () => ({
+    pid: 12345,
+    exited: new Promise(() => {}),
+    stdout: null,
+    stderr: null,
+    kill: () => {},
+  });
+  return { supervisor: new Supervisor({ spawnFn }), spawnFn };
+}
+
+describe("GET /api/modules", () => {
+  let h: Harness;
+
+  beforeEach(async () => {
+    h = await makeHarness();
+    _clearLatestVersionCacheForTests();
+  });
+  afterEach(() => h.cleanup());
+
+  test("405 on non-GET", async () => {
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(postReq(), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: async () => null,
+    });
+    expect(res.status).toBe(405);
+    // Bearer's not even consulted on method-mismatch — that's fine,
+    // 405 short-circuits before auth so we keep the surface defensive.
+    expect(bearer).toBeDefined();
+  });
+
+  test("401 with no Authorization header", async () => {
+    const res = await handleApiModules(getReq(), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: async () => null,
+    });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("unauthenticated");
+  });
+
+  test("403 when bearer lacks parachute:host:auth", async () => {
+    // A bearer with a narrow scope (`scribe:transcribe`) is valid per
+    // signature but must not reach this surface. Insufficient_scope is
+    // the spec-shaped error.
+    const bearer = await mintBearer(h, ["scribe:transcribe"]);
+    const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: async () => null,
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("insufficient_scope");
+  });
+
+  test("200 + curated list on fresh container (empty services.json)", async () => {
+    // The v0.6 hot path: brand-new Render container, no services.json
+    // yet. UI must render "install vault / notes / scribe" cards even
+    // though nothing's installed.
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: async () => "0.9.9",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      modules: Array<{
+        short: string;
+        available: boolean;
+        installed: boolean;
+        latest_version: string | null;
+      }>;
+      supervisor_available: boolean;
+    };
+    // Curated order is preserved: vault → notes → scribe.
+    expect(body.modules.map((m) => m.short)).toEqual(["vault", "notes", "scribe"]);
+    expect(body.modules.every((m) => m.available)).toBe(true);
+    expect(body.modules.every((m) => !m.installed)).toBe(true);
+    expect(body.modules.every((m) => m.latest_version === "0.9.9")).toBe(true);
+    // Supervisor wasn't injected → flag reflects that.
+    expect(body.supervisor_available).toBe(false);
+  });
+
+  test("surfaces installed_version from services.json", async () => {
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/vault/default"],
+        health: "/vault/default/health",
+        version: "0.4.5",
+        installDir: "/parachute/modules/node_modules/@openparachute/vault",
+      },
+    ]);
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: async () => "0.5.0",
+    });
+    const body = (await res.json()) as {
+      modules: Array<{
+        short: string;
+        installed: boolean;
+        installed_version: string | null;
+        latest_version: string | null;
+        install_dir: string | null;
+      }>;
+    };
+    const vault = body.modules.find((m) => m.short === "vault");
+    expect(vault?.installed).toBe(true);
+    expect(vault?.installed_version).toBe("0.4.5");
+    expect(vault?.latest_version).toBe("0.5.0");
+    expect(vault?.install_dir).toBe("/parachute/modules/node_modules/@openparachute/vault");
+    // The other curated rows stay installed:false — the test installed
+    // only vault, so notes + scribe still render as available-but-not-installed.
+    const notes = body.modules.find((m) => m.short === "notes");
+    expect(notes?.installed).toBe(false);
+    expect(notes?.installed_version).toBeNull();
+  });
+
+  test("includes supervisor status + pid when a supervisor is injected", async () => {
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/vault/default"],
+        health: "/vault/default/health",
+        version: "0.4.5",
+      },
+    ]);
+    const { supervisor } = makeIdleSupervisor();
+    await supervisor.start({ short: "vault", cmd: ["parachute-vault", "serve"] });
+
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      supervisor,
+      fetchLatestVersion: async () => null,
+    });
+    const body = (await res.json()) as {
+      modules: Array<{ short: string; supervisor_status: string | null; pid: number | null }>;
+      supervisor_available: boolean;
+    };
+    const vault = body.modules.find((m) => m.short === "vault");
+    expect(vault?.supervisor_status).toBe("running");
+    expect(vault?.pid).toBe(12345);
+    // Modules without a supervisor entry get null status — the UI
+    // disables Restart/Stop for those since there's no live process.
+    const notes = body.modules.find((m) => m.short === "notes");
+    expect(notes?.supervisor_status).toBeNull();
+    expect(notes?.pid).toBeNull();
+    expect(body.supervisor_available).toBe(true);
+  });
+
+  test("npm probe failure → latest_version is null but response still 200", async () => {
+    // The whole point of the probe-is-opportunistic posture: a flaky
+    // npm registry must not break the page render. The UI handles
+    // null gracefully.
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: async () => null,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      modules: Array<{ short: string; latest_version: string | null }>;
+    };
+    expect(body.modules.every((m) => m.latest_version === null)).toBe(true);
+  });
+
+  test("caches latest_version across requests within the TTL", async () => {
+    // Second back-to-back request must not re-hit the registry. The
+    // UI may poll this endpoint; we don't want it to slam npm.
+    let calls = 0;
+    const probe = async (_pkg: string): Promise<string | null> => {
+      calls++;
+      return "0.5.0";
+    };
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const deps = {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: probe,
+      cacheTtlMs: 60_000,
+    };
+    await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), deps);
+    const callsAfterFirst = calls;
+    await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), deps);
+    expect(callsAfterFirst).toBeGreaterThan(0);
+    expect(calls).toBe(callsAfterFirst);
+  });
+});

--- a/src/__tests__/serve-boot.test.ts
+++ b/src/__tests__/serve-boot.test.ts
@@ -4,11 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { bootSupervisedModules } from "../commands/serve-boot.ts";
 import { type ServiceEntry, writeManifest } from "../services-manifest.ts";
-import {
-  type SpawnRequest,
-  Supervisor,
-  type SupervisedProc,
-} from "../supervisor.ts";
+import { type SpawnRequest, type SupervisedProc, Supervisor } from "../supervisor.ts";
 
 interface Harness {
   dir: string;
@@ -150,10 +146,7 @@ describe("bootSupervisedModules", () => {
   test("hubOrigin wins over a stale .env entry on collision", async () => {
     writeManifest({ services: [VAULT_ENTRY] }, h.manifestPath);
     mkdirSync(join(h.dir, "vault"), { recursive: true });
-    writeFileSync(
-      join(h.dir, "vault", ".env"),
-      "PARACHUTE_HUB_ORIGIN=http://stale.local\n",
-    );
+    writeFileSync(join(h.dir, "vault", ".env"), "PARACHUTE_HUB_ORIGIN=http://stale.local\n");
 
     const recorder = makeRecorder();
     const sup = new Supervisor({ spawnFn: recorder.spawn });

--- a/src/__tests__/serve-boot.test.ts
+++ b/src/__tests__/serve-boot.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { bootSupervisedModules } from "../commands/serve-boot.ts";
+import { type ServiceEntry, writeManifest } from "../services-manifest.ts";
+import {
+  type SpawnRequest,
+  Supervisor,
+  type SupervisedProc,
+} from "../supervisor.ts";
+
+interface Harness {
+  dir: string;
+  manifestPath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "serve-boot-"));
+  const manifestPath = join(dir, "services.json");
+  return {
+    dir,
+    manifestPath,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+function makeFakeProc(pid: number): SupervisedProc & { resolveExit: (c: number | null) => void } {
+  let resolveExit!: (c: number | null) => void;
+  const exited = new Promise<number | null>((r) => {
+    resolveExit = r;
+  });
+  return {
+    pid,
+    exited,
+    stdout: null,
+    stderr: null,
+    kill: () => {},
+    resolveExit,
+  };
+}
+
+function makeRecorder(): {
+  spawn: (req: SpawnRequest) => SupervisedProc;
+  calls: SpawnRequest[];
+} {
+  const calls: SpawnRequest[] = [];
+  let nextPid = 1000;
+  return {
+    calls,
+    spawn: (req) => {
+      calls.push(req);
+      nextPid++;
+      return makeFakeProc(nextPid);
+    },
+  };
+}
+
+const VAULT_ENTRY: ServiceEntry = {
+  name: "parachute-vault",
+  port: 1940,
+  paths: ["/vault/default"],
+  health: "/vault/default/health",
+  version: "0.4.5",
+};
+
+const NOTES_ENTRY: ServiceEntry = {
+  name: "parachute-notes",
+  port: 1941,
+  paths: ["/notes"],
+  health: "/notes/health",
+  version: "0.3.15",
+};
+
+describe("bootSupervisedModules", () => {
+  let h: Harness;
+  beforeEach(() => {
+    h = makeHarness();
+  });
+  afterEach(() => h.cleanup());
+
+  test("spawns one supervisor child per first-party services.json row", async () => {
+    writeManifest({ services: [VAULT_ENTRY, NOTES_ENTRY] }, h.manifestPath);
+    const recorder = makeRecorder();
+    const sup = new Supervisor({ spawnFn: recorder.spawn });
+
+    const results = await bootSupervisedModules(sup, {
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.status === "started")).toBe(true);
+    expect(recorder.calls).toHaveLength(2);
+    const shorts = recorder.calls.map((c) => c.short).sort();
+    expect(shorts).toEqual(["notes", "vault"]);
+  });
+
+  test("empty services.json is a no-op", async () => {
+    writeManifest({ services: [] }, h.manifestPath);
+    const recorder = makeRecorder();
+    const sup = new Supervisor({ spawnFn: recorder.spawn });
+
+    const results = await bootSupervisedModules(sup, {
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+    });
+
+    expect(results).toEqual([]);
+    expect(recorder.calls).toEqual([]);
+  });
+
+  test("forwards PARACHUTE_HUB_ORIGIN to child env when set", async () => {
+    writeManifest({ services: [VAULT_ENTRY] }, h.manifestPath);
+    const recorder = makeRecorder();
+    const sup = new Supervisor({ spawnFn: recorder.spawn });
+
+    await bootSupervisedModules(sup, {
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+      hubOrigin: "https://hub.example",
+    });
+
+    expect(recorder.calls[0]?.env?.PARACHUTE_HUB_ORIGIN).toBe("https://hub.example");
+  });
+
+  test("merges per-module .env file into child env", async () => {
+    writeManifest({ services: [VAULT_ENTRY] }, h.manifestPath);
+    // Write a per-module .env at <configDir>/<short>/.env — what the
+    // on-box flow's install-time scribe-key prompt produces.
+    mkdirSync(join(h.dir, "vault"), { recursive: true });
+    writeFileSync(
+      join(h.dir, "vault", ".env"),
+      "SCRIBE_AUTH_TOKEN=secret-token\nSCRIBE_URL=http://127.0.0.1:3200\n",
+    );
+
+    const recorder = makeRecorder();
+    const sup = new Supervisor({ spawnFn: recorder.spawn });
+
+    await bootSupervisedModules(sup, {
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+    });
+
+    expect(recorder.calls[0]?.env?.SCRIBE_AUTH_TOKEN).toBe("secret-token");
+    expect(recorder.calls[0]?.env?.SCRIBE_URL).toBe("http://127.0.0.1:3200");
+  });
+
+  test("hubOrigin wins over a stale .env entry on collision", async () => {
+    writeManifest({ services: [VAULT_ENTRY] }, h.manifestPath);
+    mkdirSync(join(h.dir, "vault"), { recursive: true });
+    writeFileSync(
+      join(h.dir, "vault", ".env"),
+      "PARACHUTE_HUB_ORIGIN=http://stale.local\n",
+    );
+
+    const recorder = makeRecorder();
+    const sup = new Supervisor({ spawnFn: recorder.spawn });
+
+    await bootSupervisedModules(sup, {
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+      hubOrigin: "https://live.example",
+    });
+
+    // The live hub-origin from the runtime env beats the on-disk
+    // stale value — that's the resolveHubOrigin precedence carried
+    // over from lifecycle.ts.
+    expect(recorder.calls[0]?.env?.PARACHUTE_HUB_ORIGIN).toBe("https://live.example");
+  });
+
+  test("rows with no resolvable startCmd are skipped with reason", async () => {
+    // A third-party services.json entry that ALSO doesn't match a
+    // first-party fallback AND has no installDir → no spec.
+    const orphan: ServiceEntry = {
+      name: "@third-party/unknown",
+      port: 4000,
+      paths: ["/unknown"],
+      health: "/unknown/health",
+      version: "0.1.0",
+    };
+    writeManifest({ services: [orphan] }, h.manifestPath);
+    const recorder = makeRecorder();
+    const sup = new Supervisor({ spawnFn: recorder.spawn });
+    const logs: string[] = [];
+
+    const results = await bootSupervisedModules(sup, {
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+      log: (l) => logs.push(l),
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("skipped");
+    expect(results[0]?.reason).toBe("no-spec");
+    expect(recorder.calls).toEqual([]);
+    expect(logs.some((l) => l.includes("no startCmd resolvable"))).toBe(true);
+  });
+});

--- a/src/__tests__/supervisor.test.ts
+++ b/src/__tests__/supervisor.test.ts
@@ -1,0 +1,408 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { type SpawnRequest, type SupervisedProc, Supervisor } from "../supervisor.ts";
+
+/**
+ * Fake subprocess with controllable exited promise + injectable stdout
+ * / stderr. The test drives `resolveExit(code)` to simulate the child
+ * exiting (clean or crash) and `emit(stream, bytes)` to push log
+ * output through the line-buffered tap.
+ */
+interface FakeProc extends SupervisedProc {
+  resolveExit(code: number | null): void;
+  emitStdout(chunk: string): void;
+  emitStderr(chunk: string): void;
+  closeStreams(): void;
+  killed: boolean;
+  killSignal?: NodeJS.Signals | number;
+}
+
+function makeFakeProc(pid: number): FakeProc {
+  let resolveExit!: (code: number | null) => void;
+  const exited = new Promise<number | null>((resolve) => {
+    resolveExit = resolve;
+  });
+
+  const stdoutController = makeStreamController();
+  const stderrController = makeStreamController();
+
+  return {
+    pid,
+    exited,
+    stdout: stdoutController.stream,
+    stderr: stderrController.stream,
+    kill(signal) {
+      this.killed = true;
+      this.killSignal = signal;
+    },
+    killed: false,
+    resolveExit: (code) => resolveExit(code),
+    emitStdout: (chunk) => stdoutController.push(chunk),
+    emitStderr: (chunk) => stderrController.push(chunk),
+    closeStreams: () => {
+      stdoutController.close();
+      stderrController.close();
+    },
+  };
+}
+
+function makeStreamController(): {
+  stream: ReadableStream<Uint8Array>;
+  push: (s: string) => void;
+  close: () => void;
+} {
+  let controller: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  const enc = new TextEncoder();
+  return {
+    stream,
+    push: (s) => controller.enqueue(enc.encode(s)),
+    close: () => {
+      try {
+        controller.close();
+      } catch {
+        // already closed
+      }
+    },
+  };
+}
+
+/**
+ * Programmable spawner. Hand it a queue of FakeProc instances, one per
+ * expected spawn call (or one shared if every spawn uses the same
+ * fake). Tests drive lifecycle by calling resolveExit on the returned
+ * proc.
+ */
+function makeQueueSpawner(): {
+  spawn: (req: SpawnRequest) => SupervisedProc;
+  enqueue: (proc: FakeProc) => void;
+  calls: SpawnRequest[];
+} {
+  const queue: FakeProc[] = [];
+  const calls: SpawnRequest[] = [];
+  return {
+    enqueue: (proc) => queue.push(proc),
+    calls,
+    spawn: (req) => {
+      calls.push(req);
+      const next = queue.shift();
+      if (!next) throw new Error(`unexpected spawn for ${req.short}`);
+      return next;
+    },
+  };
+}
+
+function tick(ms = 10): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe("Supervisor.start + status transitions", () => {
+  test("transitions starting → running after spawn", async () => {
+    const proc = makeFakeProc(123);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(proc);
+    const sup = new Supervisor({ spawnFn: spawner.spawn });
+
+    const state = await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+    expect(state.status).toBe("running");
+    expect(state.pid).toBe(123);
+    expect(state.startedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(spawner.calls).toHaveLength(1);
+    expect(spawner.calls[0]?.short).toBe("vault");
+
+    // Cleanup: resolve the exited promise so the watcher doesn't dangle.
+    proc.closeStreams();
+    sup.stop("vault");
+    proc.resolveExit(0);
+  });
+
+  test("is idempotent on a running module — second start returns existing state", async () => {
+    const proc = makeFakeProc(123);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(proc);
+    const sup = new Supervisor({ spawnFn: spawner.spawn });
+
+    await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+    await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+    // Only one spawn — the second start short-circuited.
+    expect(spawner.calls).toHaveLength(1);
+
+    proc.closeStreams();
+    sup.stop("vault");
+    proc.resolveExit(0);
+  });
+});
+
+describe("Supervisor restart-on-crash", () => {
+  test("restarts a crashed module within the budget", async () => {
+    const first = makeFakeProc(101);
+    const second = makeFakeProc(102);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(first);
+    spawner.enqueue(second);
+
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      restartDelayMs: 0,
+      sleep: () => Promise.resolve(),
+    });
+    await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+
+    // First child crashes.
+    first.closeStreams();
+    first.resolveExit(1);
+    // Let the handleExit microtask run + the spawn happen.
+    await tick();
+
+    expect(spawner.calls).toHaveLength(2);
+    const state = sup.get("vault");
+    expect(state?.status).toBe("running");
+    expect(state?.pid).toBe(102);
+    expect(state?.restartsInWindow).toBe(1);
+    expect(state?.lastExitCode).toBe(1);
+
+    second.closeStreams();
+    sup.stop("vault");
+    second.resolveExit(0);
+  });
+
+  test("gives up after maxRestarts crashes in window, marks crashed", async () => {
+    const procs = Array.from({ length: 3 }, (_, i) => makeFakeProc(200 + i));
+    const spawner = makeQueueSpawner();
+    for (const p of procs) spawner.enqueue(p);
+
+    const outputs: string[] = [];
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      maxRestarts: 3,
+      restartDelayMs: 0,
+      sleep: () => Promise.resolve(),
+      output: (line) => outputs.push(line),
+    });
+    await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+
+    // Crash 3 times in quick succession.
+    for (const p of procs) {
+      p.closeStreams();
+      p.resolveExit(2);
+      await tick();
+    }
+
+    const state = sup.get("vault");
+    expect(state?.status).toBe("crashed");
+    expect(state?.restartsInWindow).toBe(3);
+    expect(spawner.calls).toHaveLength(3); // initial + 2 restarts; 3rd crash trips the budget.
+    expect(outputs.some((l) => l.includes("giving up"))).toBe(true);
+  });
+
+  test("crashes outside the window drop off and budget resets", async () => {
+    const procs = Array.from({ length: 3 }, (_, i) => makeFakeProc(300 + i));
+    const spawner = makeQueueSpawner();
+    for (const p of procs) spawner.enqueue(p);
+
+    let nowVal = 1_000_000;
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      maxRestarts: 2,
+      restartWindowMs: 5_000,
+      restartDelayMs: 0,
+      sleep: () => Promise.resolve(),
+      now: () => nowVal,
+    });
+    await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+
+    // First crash at t=0.
+    procs[0]?.closeStreams();
+    procs[0]?.resolveExit(1);
+    await tick();
+    expect(sup.get("vault")?.restartsInWindow).toBe(1);
+
+    // Advance past the window; the first crash falls out before the
+    // second is counted.
+    nowVal += 10_000;
+    procs[1]?.closeStreams();
+    procs[1]?.resolveExit(1);
+    await tick();
+    // Budget reset — this crash is alone in its window.
+    expect(sup.get("vault")?.restartsInWindow).toBe(1);
+    expect(sup.get("vault")?.status).toBe("running");
+
+    procs[2]?.closeStreams();
+    sup.stop("vault");
+    procs[2]?.resolveExit(0);
+  });
+});
+
+describe("Supervisor.stop", () => {
+  test("operator stop is not a crash — does not restart", async () => {
+    const proc = makeFakeProc(101);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(proc);
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      restartDelayMs: 0,
+      sleep: () => Promise.resolve(),
+    });
+    await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+
+    await sup.stop("vault");
+    expect(proc.killed).toBe(true);
+    expect(proc.killSignal).toBe("SIGTERM");
+
+    proc.closeStreams();
+    proc.resolveExit(0);
+    await tick();
+
+    // No second spawn — stop is an intentional exit.
+    expect(spawner.calls).toHaveLength(1);
+    expect(sup.get("vault")?.status).toBe("stopped");
+  });
+});
+
+describe("Supervisor.restart", () => {
+  test("stops the current process and spawns fresh", async () => {
+    const first = makeFakeProc(101);
+    const second = makeFakeProc(102);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(first);
+    spawner.enqueue(second);
+
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      restartDelayMs: 0,
+      sleep: () => Promise.resolve(),
+    });
+    await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+
+    // Kick off restart; we need to resolve the first proc's exited so
+    // the awaitable in restart() doesn't hang.
+    const restartPromise = sup.restart("vault");
+    first.closeStreams();
+    first.resolveExit(0);
+    const state = await restartPromise;
+
+    expect(state?.status).toBe("running");
+    expect(state?.pid).toBe(102);
+    expect(spawner.calls).toHaveLength(2);
+
+    second.closeStreams();
+    sup.stop("vault");
+    second.resolveExit(0);
+  });
+});
+
+describe("Supervisor output multiplexing", () => {
+  test("prefixes child stdout lines with [short]", async () => {
+    const proc = makeFakeProc(101);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(proc);
+    const outputs: string[] = [];
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      output: (line) => outputs.push(line),
+    });
+    await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+
+    proc.emitStdout("listening on 1940\n");
+    proc.emitStdout("ready\n");
+    // Allow the async stream reader to flush.
+    await tick(20);
+
+    expect(outputs).toContain("[vault] listening on 1940\n");
+    expect(outputs).toContain("[vault] ready\n");
+
+    proc.closeStreams();
+    sup.stop("vault");
+    proc.resolveExit(0);
+  });
+
+  test("line-buffers split chunks so partial lines don't break the prefix", async () => {
+    const proc = makeFakeProc(101);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(proc);
+    const outputs: string[] = [];
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      output: (line) => outputs.push(line),
+    });
+    await sup.start({ short: "scribe", cmd: ["bun", "scribe.ts"] });
+
+    // Single line arriving in two chunks should still be one prefixed
+    // line — not "[scribe] listening" + "[scribe]  on 3200\n".
+    proc.emitStdout("listening");
+    await tick(10);
+    proc.emitStdout(" on 3200\n");
+    await tick(20);
+
+    expect(outputs).toContain("[scribe] listening on 3200\n");
+
+    proc.closeStreams();
+    sup.stop("scribe");
+    proc.resolveExit(0);
+  });
+
+  test("multiple children interleave without prefix collisions", async () => {
+    const vault = makeFakeProc(101);
+    const scribe = makeFakeProc(102);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(vault);
+    spawner.enqueue(scribe);
+    const outputs: string[] = [];
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      output: (line) => outputs.push(line),
+    });
+    await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+    await sup.start({ short: "scribe", cmd: ["bun", "scribe.ts"] });
+
+    vault.emitStdout("vault-line-1\n");
+    scribe.emitStdout("scribe-line-1\n");
+    vault.emitStderr("vault-err\n");
+    await tick(20);
+
+    expect(outputs).toContain("[vault] vault-line-1\n");
+    expect(outputs).toContain("[scribe] scribe-line-1\n");
+    expect(outputs).toContain("[vault] vault-err\n");
+
+    vault.closeStreams();
+    scribe.closeStreams();
+    sup.stop("vault");
+    sup.stop("scribe");
+    vault.resolveExit(0);
+    scribe.resolveExit(0);
+  });
+});
+
+describe("Supervisor.list + get", () => {
+  test("list returns snapshot of all supervised modules", async () => {
+    const vault = makeFakeProc(101);
+    const scribe = makeFakeProc(102);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(vault);
+    spawner.enqueue(scribe);
+    const sup = new Supervisor({ spawnFn: spawner.spawn });
+
+    await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+    await sup.start({ short: "scribe", cmd: ["bun", "scribe.ts"] });
+
+    const states = sup.list();
+    expect(states).toHaveLength(2);
+    const shorts = states.map((s) => s.short).sort();
+    expect(shorts).toEqual(["scribe", "vault"]);
+
+    vault.closeStreams();
+    scribe.closeStreams();
+    sup.stop("vault");
+    sup.stop("scribe");
+    vault.resolveExit(0);
+    scribe.resolveExit(0);
+  });
+
+  test("get returns undefined for an unknown module", () => {
+    const sup = new Supervisor({ spawnFn: () => makeFakeProc(0) });
+    expect(sup.get("nothing")).toBeUndefined();
+  });
+});

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -23,21 +23,34 @@
  * the source of truth post-restart. The UI re-polls /api/modules to
  * re-derive what's actually installed.
  *
- * Bearer-gated on `parachute:host:auth` like the rest of the
- * /api/modules surface.
+ * Bearer-gated on `parachute:host:admin` (destructive ops). Diverges
+ * from the read-only `/api/modules` GET which sits on the broader
+ * `:host:auth` scope: reading the catalog is part of the auth
+ * surface, mutating it is admin-only. A `:auth`-only automation token
+ * gets 403 here; the SPA's host-admin mint
+ * (`/admin/host-admin-token`) carries both scopes so the UI path is
+ * unaffected.
  */
 
 import type { Database } from "bun:sqlite";
 import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
 import { CURATED_MODULES, type CuratedModuleShort } from "./api-modules.ts";
 import { validateAccessToken } from "./jwt-sign.ts";
 import { FIRST_PARTY_FALLBACKS, type ServiceSpec, composeServiceSpec } from "./service-spec.ts";
 import { findService, readManifest, removeService } from "./services-manifest.ts";
 import type { ModuleState, SpawnRequest, Supervisor } from "./supervisor.ts";
 
-/** Scope required for every POST + operation-poll endpoint here. */
-export const API_MODULES_OPS_REQUIRED_SCOPE = "parachute:host:auth";
+/**
+ * Scope required for every POST + operation-poll endpoint here.
+ *
+ * `:host:admin` (not `:host:auth`) because install / upgrade /
+ * uninstall change the running set of system components — destructive
+ * by definition. The SPA mints both scopes through
+ * `/admin/host-admin-token` so its bearer carries this; an automation
+ * caller minted with `--scope-set auth` gets 403 from these endpoints,
+ * which is the intended security boundary.
+ */
+export const API_MODULES_OPS_REQUIRED_SCOPE = "parachute:host:admin";
 
 export type OperationKind = "install" | "upgrade" | "restart" | "uninstall";
 export type OperationStatus = "pending" | "running" | "succeeded" | "failed";
@@ -517,8 +530,3 @@ function acceptedOp(opId: string): Response {
     headers: { "content-type": "application/json" },
   });
 }
-
-// Suppress unused-import warning — kept around for the future
-// install-dir surface where we'll need to existsSync the bun globals
-// prefix before reporting "installed."
-void existsSync;

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -1,0 +1,524 @@
+/**
+ * `/api/modules/:short/*` POST endpoints + `/api/modules/operations/:id`
+ * — module lifecycle operations driven from the admin SPA.
+ *
+ * Two operation classes:
+ *
+ *   - **Synchronous** (restart, uninstall): handler runs the work
+ *     inline and returns the new state in the response body. Fast
+ *     enough that the UI just shows a spinner for the request
+ *     round-trip — no operation_id needed.
+ *
+ *   - **Asynchronous** (install, upgrade): handler kicks off work via
+ *     `Bun.spawn` for `bun add` and returns 202 + `{operation_id}`
+ *     immediately. The UI polls `GET /api/modules/operations/:id`
+ *     every ~1s until the operation reaches a terminal state. This
+ *     decouples the npm download (which can take 10-60s on a slow
+ *     link) from the request timeout.
+ *
+ * Operation state lives in an in-memory registry — a singleton Map
+ * keyed by uuid. State is transient by design: a hub restart drops
+ * pending ops, which is the correct behavior because the underlying
+ * `bun add` is no longer running and the supervisor's own state is
+ * the source of truth post-restart. The UI re-polls /api/modules to
+ * re-derive what's actually installed.
+ *
+ * Bearer-gated on `parachute:host:auth` like the rest of the
+ * /api/modules surface.
+ */
+
+import type { Database } from "bun:sqlite";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { CURATED_MODULES, type CuratedModuleShort } from "./api-modules.ts";
+import { validateAccessToken } from "./jwt-sign.ts";
+import { FIRST_PARTY_FALLBACKS, type ServiceSpec, composeServiceSpec } from "./service-spec.ts";
+import { findService, readManifest, removeService } from "./services-manifest.ts";
+import type { ModuleState, SpawnRequest, Supervisor } from "./supervisor.ts";
+
+/** Scope required for every POST + operation-poll endpoint here. */
+export const API_MODULES_OPS_REQUIRED_SCOPE = "parachute:host:auth";
+
+export type OperationKind = "install" | "upgrade" | "restart" | "uninstall";
+export type OperationStatus = "pending" | "running" | "succeeded" | "failed";
+
+export interface Operation {
+  id: string;
+  kind: OperationKind;
+  short: string;
+  status: OperationStatus;
+  /** Sparse log of progress events surfaced to the UI ("running bun add…", etc). */
+  log: string[];
+  /** Error message when status is `failed`. Mirrored from the underlying throw. */
+  error?: string;
+  startedAt: string;
+  finishedAt?: string;
+}
+
+interface OperationsRegistry {
+  create(kind: OperationKind, short: string): Operation;
+  get(id: string): Operation | undefined;
+  /** Append a log line + (optionally) advance status. */
+  update(id: string, patch: Partial<Pick<Operation, "status" | "error">>, logLine?: string): void;
+}
+
+/**
+ * Process-local operations registry. One Map for the lifetime of
+ * `parachute serve`. Tests opt into a fresh registry per case via
+ * `_resetOperationsRegistryForTests`.
+ */
+class InMemoryOperationsRegistry implements OperationsRegistry {
+  private readonly ops = new Map<string, Operation>();
+  private readonly clock: () => Date;
+
+  constructor(clock: () => Date = () => new Date()) {
+    this.clock = clock;
+  }
+
+  create(kind: OperationKind, short: string): Operation {
+    const op: Operation = {
+      id: randomUUID(),
+      kind,
+      short,
+      status: "pending",
+      log: [],
+      startedAt: this.clock().toISOString(),
+    };
+    this.ops.set(op.id, op);
+    return op;
+  }
+
+  get(id: string): Operation | undefined {
+    return this.ops.get(id);
+  }
+
+  update(id: string, patch: Partial<Pick<Operation, "status" | "error">>, logLine?: string): void {
+    const op = this.ops.get(id);
+    if (!op) return;
+    if (patch.status) op.status = patch.status;
+    if (patch.error !== undefined) op.error = patch.error;
+    if (logLine) op.log.push(logLine);
+    if (patch.status === "succeeded" || patch.status === "failed") {
+      op.finishedAt = this.clock().toISOString();
+    }
+  }
+}
+
+const defaultRegistry = new InMemoryOperationsRegistry();
+
+/** Reset the singleton operations registry — tests call between cases. */
+export function _resetOperationsRegistryForTests(): void {
+  // The Map underneath is private; re-create the singleton by replacing
+  // every entry. Cheaper than re-exporting a mutable reference.
+  const r = defaultRegistry as unknown as { ops: Map<string, Operation> };
+  r.ops.clear();
+}
+
+export interface RunOpts {
+  /** stdio-inheriting Bun.spawn wrapper for `bun add` / `bun remove`. */
+  run?: (cmd: readonly string[]) => Promise<number>;
+}
+
+export interface ApiModulesOpsDeps {
+  db: Database;
+  issuer: string;
+  manifestPath: string;
+  configDir: string;
+  supervisor: Supervisor;
+  /**
+   * Override the operations registry (test seam). Production uses the
+   * process-singleton; tests inject one with a deterministic clock so
+   * `startedAt`/`finishedAt` are stable.
+   */
+  registry?: OperationsRegistry;
+  /**
+   * Override the shell runner (test seam). Production spawns `bun add`
+   * / `bun remove` for real; tests stub to a fast in-memory function
+   * that returns a chosen exit code without touching the filesystem.
+   */
+  run?: (cmd: readonly string[]) => Promise<number>;
+  /** Override the cwd for the install dir lookup (BUN_INSTALL-aware). */
+  bunInstallDir?: string;
+  /**
+   * Override `findGlobalInstall`. Production probes bun's globals
+   * (BUN_INSTALL-aware via `${BUN_INSTALL}/install/global/...`); tests
+   * inject a fake. Returns the path to the installed package.json or
+   * null when not found.
+   */
+  findGlobalInstall?: (pkg: string) => string | null;
+}
+
+interface PathMatch {
+  short: CuratedModuleShort;
+  rest: string;
+}
+
+/**
+ * Parse `/api/modules/<short>/<rest>` into the canonical short name +
+ * the action suffix. Rejects unknown shorts to keep arbitrary
+ * services.json names from driving the install pathway (curated-only
+ * for v0.6).
+ */
+export function parseModulesPath(pathname: string): PathMatch | undefined {
+  const prefix = "/api/modules/";
+  if (!pathname.startsWith(prefix)) return undefined;
+  const tail = pathname.slice(prefix.length);
+  const slash = tail.indexOf("/");
+  if (slash <= 0) return undefined;
+  const short = tail.slice(0, slash);
+  const rest = tail.slice(slash + 1);
+  if (!CURATED_MODULES.includes(short as CuratedModuleShort)) return undefined;
+  return { short: short as CuratedModuleShort, rest };
+}
+
+async function authorize(req: Request, deps: ApiModulesOpsDeps): Promise<Response | undefined> {
+  const auth = req.headers.get("authorization");
+  if (!auth || !auth.startsWith("Bearer ")) {
+    return jsonError(401, "unauthenticated", "Authorization: Bearer <token> required");
+  }
+  const bearer = auth.slice("Bearer ".length).trim();
+  if (!bearer) return jsonError(401, "unauthenticated", "empty bearer token");
+  try {
+    const validated = await validateAccessToken(deps.db, bearer, deps.issuer);
+    if (typeof validated.payload.sub !== "string" || validated.payload.sub.length === 0) {
+      return jsonError(401, "unauthenticated", "bearer token has no sub claim");
+    }
+    const scopes =
+      typeof validated.payload.scope === "string"
+        ? validated.payload.scope.split(/\s+/).filter((s) => s.length > 0)
+        : [];
+    if (!scopes.includes(API_MODULES_OPS_REQUIRED_SCOPE)) {
+      return jsonError(
+        403,
+        "insufficient_scope",
+        `bearer token lacks ${API_MODULES_OPS_REQUIRED_SCOPE}`,
+      );
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return jsonError(401, "unauthenticated", `bearer token invalid — ${msg}`);
+  }
+  return undefined;
+}
+
+function specFor(short: CuratedModuleShort): ServiceSpec {
+  const fb = FIRST_PARTY_FALLBACKS[short];
+  // Curated set is a const; every entry has a fallback. The non-null
+  // assertion is safe because CURATED_MODULES is a tuple-literal
+  // intersected with the FIRST_PARTY_FALLBACKS key set.
+  if (!fb) throw new Error(`internal: no fallback for curated ${short}`);
+  return composeServiceSpec({
+    packageName: fb.package,
+    manifest: fb.manifest,
+    extras: fb.extras,
+  });
+}
+
+function defaultRun(cmd: readonly string[]): Promise<number> {
+  const proc = Bun.spawn([...cmd], { stdio: ["ignore", "inherit", "inherit"] });
+  return proc.exited;
+}
+
+/**
+ * Spawn the supervised child for `short`, using the spec's startCmd
+ * and the current services.json entry (so notes' port-derived
+ * startCmd resolves correctly).
+ */
+async function spawnSupervised(
+  short: CuratedModuleShort,
+  spec: ServiceSpec,
+  deps: ApiModulesOpsDeps,
+): Promise<ModuleState | undefined> {
+  const manifest = readManifest(deps.manifestPath);
+  const entry = manifest.services.find((s) => s.name === spec.manifestName);
+  if (!entry) return undefined;
+  const cmd = spec.startCmd?.(entry);
+  if (!cmd || cmd.length === 0) return undefined;
+  const req: SpawnRequest = {
+    short,
+    cmd,
+    ...(entry.installDir ? { cwd: entry.installDir } : {}),
+  };
+  return deps.supervisor.start(req);
+}
+
+/**
+ * POST /api/modules/:short/install — async.
+ *
+ * Schedules a `bun add @openparachute/<svc>@latest` followed by
+ * services.json seed + supervisor spawn. Returns 202 + operation_id
+ * immediately; the UI polls /api/modules/operations/:id.
+ *
+ * Idempotent: if the module is already installed AND its supervisor
+ * state is running, the operation completes immediately with status
+ * `succeeded` and a "already running" log line. The UI doesn't have
+ * to special-case "this was a no-op."
+ */
+export async function handleInstall(
+  req: Request,
+  short: CuratedModuleShort,
+  deps: ApiModulesOpsDeps,
+): Promise<Response> {
+  if (req.method !== "POST") return jsonError(405, "method_not_allowed", "use POST");
+  const authFail = await authorize(req, deps);
+  if (authFail) return authFail;
+
+  const registry = deps.registry ?? defaultRegistry;
+  const op = registry.create("install", short);
+
+  // Idempotent short-circuit: already installed + running → mark
+  // succeeded synchronously so the UI's "operation finished"
+  // pathway works the same as a fresh install.
+  const spec = specFor(short);
+  const existing = findService(spec.manifestName, deps.manifestPath);
+  const state = deps.supervisor.get(short);
+  if (existing && state?.status === "running") {
+    registry.update(op.id, { status: "succeeded" }, `${short} already installed + running`);
+    return acceptedOp(op.id);
+  }
+
+  // Kick off the async work. We DON'T await — the response goes back
+  // immediately + the work runs in the background. Errors get logged
+  // to the operation; nothing throws back to the request handler.
+  void runInstall(op.id, short, spec, deps).catch((err) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    registry.update(op.id, { status: "failed", error: msg }, `install failed: ${msg}`);
+  });
+
+  return acceptedOp(op.id);
+}
+
+async function runInstall(
+  opId: string,
+  short: CuratedModuleShort,
+  spec: ServiceSpec,
+  deps: ApiModulesOpsDeps,
+): Promise<void> {
+  const registry = deps.registry ?? defaultRegistry;
+  const run = deps.run ?? defaultRun;
+  registry.update(opId, { status: "running" }, `running bun add -g ${spec.package}@latest`);
+  const code = await run(["bun", "add", "-g", `${spec.package}@latest`]);
+  if (code !== 0) {
+    // Bun 1.2.x lockfile-recovery noise: probe the global prefix
+    // before treating non-zero as fatal. Mirrors the same defense in
+    // commands/install.ts.
+    const findGlobalInstall = deps.findGlobalInstall;
+    const probed = findGlobalInstall?.(spec.package) ?? null;
+    if (!probed) {
+      registry.update(
+        opId,
+        { status: "failed", error: `bun add -g exited ${code}` },
+        `bun add -g ${spec.package}@latest failed (exit ${code})`,
+      );
+      return;
+    }
+    registry.update(opId, {}, `bun add reported exit ${code} but package landed at ${probed}`);
+  }
+
+  // Seed services.json if absent (the install flow does this for the
+  // CLI; we replicate the seed-only piece here so the supervisor's
+  // boot path can spawn next time).
+  if (spec.seedEntry) {
+    const existing = findService(spec.manifestName, deps.manifestPath);
+    if (!existing) {
+      const entry = spec.seedEntry();
+      const { upsertService } = await import("./services-manifest.ts");
+      upsertService(entry, deps.manifestPath);
+      registry.update(opId, {}, `seeded services.json entry for ${short}`);
+    }
+  }
+
+  // Spawn the child via the supervisor. Boot-spawn semantics apply.
+  const state = await spawnSupervised(short, spec, deps);
+  if (!state) {
+    registry.update(
+      opId,
+      { status: "failed", error: "module installed but spawn failed (no startCmd resolved)" },
+      `${short}: install succeeded but no startCmd resolvable from services.json`,
+    );
+    return;
+  }
+  registry.update(opId, { status: "succeeded" }, `${short} installed + spawned (pid ${state.pid})`);
+}
+
+/**
+ * POST /api/modules/:short/restart — synchronous.
+ *
+ * Routes through `supervisor.restart(short)` which does stop → await
+ * exit → start with the same SpawnRequest. Returns the new state in
+ * the body — the UI's spinner can clear as soon as the response
+ * arrives, no operation poll needed.
+ */
+export async function handleRestart(
+  req: Request,
+  short: CuratedModuleShort,
+  deps: ApiModulesOpsDeps,
+): Promise<Response> {
+  if (req.method !== "POST") return jsonError(405, "method_not_allowed", "use POST");
+  const authFail = await authorize(req, deps);
+  if (authFail) return authFail;
+
+  const state = await deps.supervisor.restart(short);
+  if (!state) {
+    return jsonError(
+      404,
+      "not_supervised",
+      `${short} is not currently supervised — install it first`,
+    );
+  }
+  return jsonOk({ short, state });
+}
+
+/**
+ * POST /api/modules/:short/upgrade — async.
+ *
+ * Runs `bun add -g @openparachute/<svc>@latest` then restarts the
+ * supervised child. Same operation-poll pattern as install.
+ */
+export async function handleUpgrade(
+  req: Request,
+  short: CuratedModuleShort,
+  deps: ApiModulesOpsDeps,
+): Promise<Response> {
+  if (req.method !== "POST") return jsonError(405, "method_not_allowed", "use POST");
+  const authFail = await authorize(req, deps);
+  if (authFail) return authFail;
+
+  const registry = deps.registry ?? defaultRegistry;
+  const op = registry.create("upgrade", short);
+  const spec = specFor(short);
+
+  void runUpgrade(op.id, short, spec, deps).catch((err) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    registry.update(op.id, { status: "failed", error: msg }, `upgrade failed: ${msg}`);
+  });
+  return acceptedOp(op.id);
+}
+
+async function runUpgrade(
+  opId: string,
+  short: CuratedModuleShort,
+  spec: ServiceSpec,
+  deps: ApiModulesOpsDeps,
+): Promise<void> {
+  const registry = deps.registry ?? defaultRegistry;
+  const run = deps.run ?? defaultRun;
+  registry.update(opId, { status: "running" }, `running bun add -g ${spec.package}@latest`);
+  const code = await run(["bun", "add", "-g", `${spec.package}@latest`]);
+  if (code !== 0) {
+    const findGlobalInstall = deps.findGlobalInstall;
+    const probed = findGlobalInstall?.(spec.package) ?? null;
+    if (!probed) {
+      registry.update(
+        opId,
+        { status: "failed", error: `bun add -g exited ${code}` },
+        `bun add -g ${spec.package}@latest failed (exit ${code})`,
+      );
+      return;
+    }
+    registry.update(opId, {}, `bun add reported exit ${code} but package landed at ${probed}`);
+  }
+
+  const state = await deps.supervisor.restart(short);
+  if (!state) {
+    registry.update(
+      opId,
+      { status: "failed", error: "upgrade installed but supervisor restart found no module" },
+      `${short}: upgraded but supervisor had no live entry — try install first`,
+    );
+    return;
+  }
+  registry.update(
+    opId,
+    { status: "succeeded" },
+    `${short} upgraded + restarted (pid ${state.pid})`,
+  );
+}
+
+/**
+ * POST /api/modules/:short/uninstall — synchronous.
+ *
+ * Stops the supervised child, removes the services.json row, runs
+ * `bun remove -g <pkg>`. Returns the final state for UI confirmation.
+ * Idempotent: missing supervisor entry / missing services.json row /
+ * missing global install are all handled gracefully (the operation
+ * succeeds with a per-step "already gone" log).
+ */
+export async function handleUninstall(
+  req: Request,
+  short: CuratedModuleShort,
+  deps: ApiModulesOpsDeps,
+): Promise<Response> {
+  if (req.method !== "POST") return jsonError(405, "method_not_allowed", "use POST");
+  const authFail = await authorize(req, deps);
+  if (authFail) return authFail;
+
+  const spec = specFor(short);
+  const log: string[] = [];
+
+  // 1. Stop the supervised child (idempotent — null on missing).
+  const stopped = await deps.supervisor.stop(short);
+  log.push(stopped ? `${short} supervisor stopped` : `${short} not supervised`);
+
+  // 2. Drop the services.json row (idempotent — readManifest is empty if missing).
+  const before = readManifest(deps.manifestPath);
+  if (before.services.some((s) => s.name === spec.manifestName)) {
+    removeService(spec.manifestName, deps.manifestPath);
+    log.push(`removed ${spec.manifestName} from services.json`);
+  } else {
+    log.push(`${spec.manifestName} not in services.json`);
+  }
+
+  // 3. bun remove -g (idempotent on missing — bun returns 0).
+  const run = deps.run ?? defaultRun;
+  const code = await run(["bun", "remove", "-g", spec.package]);
+  log.push(`bun remove -g ${spec.package} exited ${code}`);
+
+  return jsonOk({ short, log });
+}
+
+/**
+ * GET /api/modules/operations/:id — poll operation status.
+ */
+export async function handleOperationGet(
+  req: Request,
+  opId: string,
+  deps: ApiModulesOpsDeps,
+): Promise<Response> {
+  if (req.method !== "GET") return jsonError(405, "method_not_allowed", "use GET");
+  const authFail = await authorize(req, deps);
+  if (authFail) return authFail;
+
+  const registry = deps.registry ?? defaultRegistry;
+  const op = registry.get(opId);
+  if (!op) {
+    return jsonError(404, "not_found", `no operation with id ${opId}`);
+  }
+  return jsonOk(op);
+}
+
+function jsonError(status: number, code: string, description: string): Response {
+  return new Response(JSON.stringify({ error: code, error_description: description }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function jsonOk(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function acceptedOp(opId: string): Response {
+  return new Response(JSON.stringify({ operation_id: opId }), {
+    status: 202,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// Suppress unused-import warning — kept around for the future
+// install-dir surface where we'll need to existsSync the bun globals
+// prefix before reporting "installed."
+void existsSync;

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -1,0 +1,266 @@
+/**
+ * `GET /api/modules` — admin SPA's module-management surface.
+ *
+ * Combines three sources into a single per-module row:
+ *
+ *   - **Curated availability** — vault, notes, scribe (the v0.6 release
+ *     bar). The Phase-2 marketplace will broaden this; for now it's
+ *     hardcoded so the admin UI has a stable "what can I install?" list
+ *     even on a fresh container where services.json is empty.
+ *   - **Installed state** — services.json reads (version, installDir).
+ *   - **Supervisor state** — per-module run status (`running` / `stopped`
+ *     / `crashed` / `starting` / `restarting`) + pid. Absent when the
+ *     hub is in CLI mode (no supervisor injected through HubFetchDeps).
+ *
+ * Bearer-gated on `parachute:host:auth` to match the rest of `/api/auth/*`
+ * and `/api/grants` — the admin SPA mints this scope via
+ * `/admin/host-admin-token` and threads it as `Authorization: Bearer`.
+ *
+ * The `latest_version` field is opportunistic: an npm registry probe with
+ * a short timeout. On failure it's null and the UI just shows "check
+ * later" — we don't fail the whole request because one network blip
+ * shouldn't keep the page from rendering installed modules.
+ */
+
+import type { Database } from "bun:sqlite";
+import { validateAccessToken } from "./jwt-sign.ts";
+import { FIRST_PARTY_FALLBACKS } from "./service-spec.ts";
+import { readManifest } from "./services-manifest.ts";
+import type { ModuleState, Supervisor } from "./supervisor.ts";
+
+/** Scope required on the bearer token to call this endpoint. */
+export const API_MODULES_REQUIRED_SCOPE = "parachute:host:auth";
+
+/**
+ * Curated module short-names for v0.6 Render self-host. Marketplace is
+ * Phase 2 — until then, the admin UI offers exactly these three. Order
+ * is the recommended install order (vault before notes, scribe last).
+ */
+export const CURATED_MODULES = ["vault", "notes", "scribe"] as const;
+export type CuratedModuleShort = (typeof CURATED_MODULES)[number];
+
+export interface ApiModulesDeps {
+  db: Database;
+  issuer: string;
+  manifestPath: string;
+  supervisor?: Supervisor;
+  /**
+   * NPM @latest probe. Returns the version string or null on failure /
+   * timeout. Default is the real npm registry; tests inject a fake so
+   * they don't hit the network.
+   */
+  fetchLatestVersion?: (pkg: string) => Promise<string | null>;
+  /**
+   * Module-level cache TTL for `latest_version` probes, in ms. Default
+   * 5 minutes — long enough that a tab refresh doesn't slam npm,
+   * short enough that an `npm publish` shows up by the next minute the
+   * operator clicks Upgrade. Test seam: pass 0 to disable caching.
+   */
+  cacheTtlMs?: number;
+  /** Test seam over wall-clock. */
+  now?: () => number;
+}
+
+interface ModuleWireShape {
+  short: string;
+  package: string;
+  display_name: string;
+  tagline: string;
+  available: boolean;
+  installed: boolean;
+  installed_version: string | null;
+  latest_version: string | null;
+  supervisor_status: ModuleState["status"] | null;
+  pid: number | null;
+  /**
+   * The path on disk where the module is installed, if known. Surfaces
+   * the BUN_INSTALL or bun-link install location for operator debug —
+   * the UI can show "installed at /parachute/modules/node_modules/..."
+   * so a vanished disk is obvious.
+   */
+  install_dir: string | null;
+}
+
+interface ModulesResponse {
+  modules: ModuleWireShape[];
+  /**
+   * Whether the supervisor is wired into this hub. `false` under
+   * `parachute expose` / on-box CLI; the UI greys out install/start
+   * actions because the supervisor's the only path that drives them
+   * (the on-box `parachute start <svc>` flow lives outside hub).
+   */
+  supervisor_available: boolean;
+}
+
+interface CachedVersion {
+  value: string | null;
+  fetchedAt: number;
+}
+
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
+const latestVersionCache = new Map<string, CachedVersion>();
+
+/**
+ * Default `fetchLatestVersion`. Hits the npm registry's package
+ * metadata endpoint with a 3s AbortController timeout. Returns null on
+ * any failure (timeout, network, parse, missing dist-tag) — the UI
+ * tolerates a missing latest_version, so we keep the response shape
+ * stable even when the registry is flaky.
+ */
+export async function defaultFetchLatestVersion(pkg: string): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 3_000);
+  try {
+    const url = `https://registry.npmjs.org/${encodeURIComponent(pkg)}/latest`;
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { version?: unknown };
+    return typeof body.version === "string" ? body.version : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function handleApiModules(req: Request, deps: ApiModulesDeps): Promise<Response> {
+  if (req.method !== "GET") {
+    return jsonError(405, "method_not_allowed", "use GET");
+  }
+
+  // Bearer presence + parsing.
+  const auth = req.headers.get("authorization");
+  if (!auth || !auth.startsWith("Bearer ")) {
+    return jsonError(401, "unauthenticated", "Authorization: Bearer <token> required");
+  }
+  const bearer = auth.slice("Bearer ".length).trim();
+  if (!bearer) {
+    return jsonError(401, "unauthenticated", "empty bearer token");
+  }
+
+  // Bearer validation.
+  let bearerScopes: string[];
+  try {
+    const validated = await validateAccessToken(deps.db, bearer, deps.issuer);
+    if (typeof validated.payload.sub !== "string" || validated.payload.sub.length === 0) {
+      return jsonError(401, "unauthenticated", "bearer token has no sub claim");
+    }
+    bearerScopes =
+      typeof validated.payload.scope === "string"
+        ? validated.payload.scope.split(/\s+/).filter((s) => s.length > 0)
+        : [];
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return jsonError(401, "unauthenticated", `bearer token invalid — ${msg}`);
+  }
+
+  if (!bearerScopes.includes(API_MODULES_REQUIRED_SCOPE)) {
+    return jsonError(403, "insufficient_scope", `bearer token lacks ${API_MODULES_REQUIRED_SCOPE}`);
+  }
+
+  // Load installed state from services.json. Missing file = empty manifest
+  // (fresh container), which is the v0.6 hot path — readManifest already
+  // returns { services: [] } for a missing file, so no extra branching.
+  const manifest = readManifest(deps.manifestPath);
+  const installedByShort = new Map<string, { version: string; installDir?: string }>();
+  for (const entry of manifest.services) {
+    // The installed-by-short map is keyed on `short` for join against
+    // the curated list. shortNameForManifest reads from
+    // FIRST_PARTY_FALLBACKS — we walk that table directly to derive the
+    // mapping, since `entry.name` is the long manifestName and we want
+    // the canonical short here without re-importing the helper.
+    for (const short of CURATED_MODULES) {
+      const fb = FIRST_PARTY_FALLBACKS[short];
+      if (fb?.manifest.manifestName === entry.name) {
+        const value: { version: string; installDir?: string } = { version: entry.version };
+        if (entry.installDir !== undefined) value.installDir = entry.installDir;
+        installedByShort.set(short, value);
+      }
+    }
+  }
+
+  // Supervisor state — per-module run status snapshot.
+  const supervisor = deps.supervisor;
+  const stateByShort = new Map<string, ModuleState>();
+  if (supervisor) {
+    for (const state of supervisor.list()) {
+      stateByShort.set(state.short, state);
+    }
+  }
+
+  // Resolve npm @latest in parallel — short timeout per request, cache
+  // shared across requests so a fast UI poll doesn't slam the registry.
+  const fetchLatest = deps.fetchLatestVersion ?? defaultFetchLatestVersion;
+  const cacheTtl = deps.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+  const now = deps.now ?? Date.now;
+
+  const latestByShort = new Map<string, string | null>();
+  await Promise.all(
+    CURATED_MODULES.map(async (short) => {
+      const fb = FIRST_PARTY_FALLBACKS[short];
+      if (!fb) {
+        latestByShort.set(short, null);
+        return;
+      }
+      const pkg = fb.package;
+      const cached = latestVersionCache.get(pkg);
+      if (cached && cacheTtl > 0 && now() - cached.fetchedAt < cacheTtl) {
+        latestByShort.set(short, cached.value);
+        return;
+      }
+      const value = await fetchLatest(pkg);
+      latestVersionCache.set(pkg, { value, fetchedAt: now() });
+      latestByShort.set(short, value);
+    }),
+  );
+
+  // Compose the wire shape. Curated order is the recommended install order;
+  // installed modules outside the curated list (uncommon — only third-party)
+  // are appended at the end with `available: false`.
+  const modules: ModuleWireShape[] = [];
+  for (const short of CURATED_MODULES) {
+    const fb = FIRST_PARTY_FALLBACKS[short];
+    if (!fb) continue;
+    const installed = installedByShort.get(short);
+    const state = stateByShort.get(short);
+    modules.push({
+      short,
+      package: fb.package,
+      display_name: fb.manifest.displayName ?? fb.manifest.name,
+      tagline: fb.manifest.tagline ?? "",
+      available: true,
+      installed: installed !== undefined,
+      installed_version: installed?.version ?? null,
+      latest_version: latestByShort.get(short) ?? null,
+      supervisor_status: state?.status ?? null,
+      pid: state?.pid ?? null,
+      install_dir: installed?.installDir ?? null,
+    });
+  }
+
+  const body: ModulesResponse = {
+    modules,
+    supervisor_available: supervisor !== undefined,
+  };
+
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function jsonError(status: number, code: string, description: string): Response {
+  return new Response(JSON.stringify({ error: code, error_description: description }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * Reset the in-memory `latest_version` cache. Tests call this between
+ * runs to prevent state leakage across test cases; production never
+ * needs it (the cache is per-process and short-TTL anyway).
+ */
+export function _clearLatestVersionCacheForTests(): void {
+  latestVersionCache.clear();
+}

--- a/src/commands/serve-boot.ts
+++ b/src/commands/serve-boot.ts
@@ -96,7 +96,12 @@ export async function bootSupervisedModules(
     const env: Record<string, string> = { ...fileEnv };
     if (opts.hubOrigin) env[HUB_ORIGIN_ENV] = opts.hubOrigin;
 
-    const req: { short: string; cmd: readonly string[]; cwd?: string; env?: Record<string, string> } = {
+    const req: {
+      short: string;
+      cmd: readonly string[];
+      cwd?: string;
+      env?: Record<string, string>;
+    } = {
       short,
       cmd,
     };
@@ -114,10 +119,7 @@ export async function bootSupervisedModules(
   return results;
 }
 
-async function resolveSpec(
-  short: string,
-  entry: ServiceEntry,
-): Promise<ServiceSpec | undefined> {
+async function resolveSpec(short: string, entry: ServiceEntry): Promise<ServiceSpec | undefined> {
   const firstParty = getSpec(short);
   if (firstParty) return firstParty;
   if (!entry.installDir) return undefined;

--- a/src/commands/serve-boot.ts
+++ b/src/commands/serve-boot.ts
@@ -1,0 +1,131 @@
+/**
+ * Container-mode module boot helpers, separated from `serve.ts` so
+ * tests can drive the supervisor wiring without standing up
+ * `Bun.serve`.
+ *
+ * `bootSupervisedModules` reads services.json, resolves each
+ * first-party module's `startCmd` from `SERVICE_SPECS`, and calls
+ * `Supervisor.start` for each. Third-party modules with `installDir`
+ * but no first-party fallback are also picked up via the same
+ * `getSpecFromInstallDir` path that `commands/lifecycle.ts` uses, so
+ * a hub-installed `@third-party/foo` boots the same way `vault` does.
+ *
+ * Idempotent: re-calling boot when modules are already running is a
+ * no-op (supervisor's own idempotent `start`). Missing-startCmd rows
+ * are logged + skipped, not fatal — the operator may have installed a
+ * module that doesn't expose a daemon (e.g. CLI-only).
+ */
+
+import { join } from "node:path";
+import { readEnvFileValues } from "../env-file.ts";
+import { HUB_ORIGIN_ENV } from "../hub-origin.ts";
+import { ModuleManifestError } from "../module-manifest.ts";
+import {
+  type ServiceSpec,
+  getSpec,
+  getSpecFromInstallDir,
+  shortNameForManifest,
+} from "../service-spec.ts";
+import { type ServiceEntry, readManifest } from "../services-manifest.ts";
+import type { Supervisor } from "../supervisor.ts";
+
+export interface BootOpts {
+  /** Path to services.json. */
+  readonly manifestPath: string;
+  /** Config dir ($PARACHUTE_HOME). Used to read per-module .env. */
+  readonly configDir: string;
+  /** Canonical OAuth issuer / hub origin. Forwarded to child env as PARACHUTE_HUB_ORIGIN. */
+  readonly hubOrigin?: string;
+  /** Logger seam. */
+  readonly log?: (line: string) => void;
+}
+
+export interface BootedModule {
+  readonly short: string;
+  readonly entryName: string;
+  readonly status: "started" | "skipped";
+  readonly reason?: string;
+}
+
+/**
+ * Walk services.json, spawn every manageable module via the
+ * supervisor. Returns a per-module decision log so the caller can
+ * surface a startup summary.
+ */
+export async function bootSupervisedModules(
+  supervisor: Supervisor,
+  opts: BootOpts,
+): Promise<BootedModule[]> {
+  const log = opts.log ?? (() => {});
+  const manifest = readManifest(opts.manifestPath);
+  const results: BootedModule[] = [];
+
+  for (const entry of manifest.services) {
+    const short = shortNameForManifest(entry.name) ?? entry.name;
+    const spec = await resolveSpec(short, entry);
+    if (!spec) {
+      // Row exists but no first-party fallback and no installDir-derived
+      // manifest. `parachute start` would print the same hint; the
+      // container path just logs + carries on.
+      log(`[supervisor] ${short}: no startCmd resolvable (services.json entry exists, no spec).`);
+      results.push({
+        short,
+        entryName: entry.name,
+        status: "skipped",
+        reason: "no-spec",
+      });
+      continue;
+    }
+
+    const cmd = spec.startCmd?.(entry);
+    if (!cmd || cmd.length === 0) {
+      log(`[supervisor] ${short}: spec resolved but no startCmd — skipping (CLI-only module).`);
+      results.push({
+        short,
+        entryName: entry.name,
+        status: "skipped",
+        reason: "no-start-cmd",
+      });
+      continue;
+    }
+
+    // Per-module .env layers under HUB_ORIGIN (hub-origin wins on
+    // collision — it's the canonical issuer source, and a stale .env
+    // shouldn't override the live `parachute serve` env).
+    const fileEnv = readEnvFileValues(join(opts.configDir, short, ".env"));
+    const env: Record<string, string> = { ...fileEnv };
+    if (opts.hubOrigin) env[HUB_ORIGIN_ENV] = opts.hubOrigin;
+
+    const req: { short: string; cmd: readonly string[]; cwd?: string; env?: Record<string, string> } = {
+      short,
+      cmd,
+    };
+    // Third-party modules ship clean relative startCmds — cwd:
+    // installDir makes them resolve. First-party fallbacks use
+    // absolute / PATH binaries so cwd is a no-op there.
+    if (entry.installDir) req.cwd = entry.installDir;
+    if (Object.keys(env).length > 0) req.env = env;
+
+    await supervisor.start(req);
+    log(`[supervisor] ${short}: started (cmd=${cmd.join(" ")}).`);
+    results.push({ short, entryName: entry.name, status: "started" });
+  }
+
+  return results;
+}
+
+async function resolveSpec(
+  short: string,
+  entry: ServiceEntry,
+): Promise<ServiceSpec | undefined> {
+  const firstParty = getSpec(short);
+  if (firstParty) return firstParty;
+  if (!entry.installDir) return undefined;
+  try {
+    const spec = await getSpecFromInstallDir(entry.installDir, entry.name);
+    return spec ?? undefined;
+  } catch (err) {
+    if (err instanceof ModuleManifestError) return undefined;
+    throw err;
+  }
+}

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -26,14 +26,18 @@
 
 import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
-// NOTE: CONFIG_DIR/WELL_KNOWN_DIR are evaluated at import time from process.env.PARACHUTE_HOME.
-// The `env` parameter on `serve()` cannot reroute them — set PARACHUTE_HOME before importing for path isolation.
-import { CONFIG_DIR } from "../config.ts";
+// NOTE: CONFIG_DIR/WELL_KNOWN_DIR/SERVICES_MANIFEST_PATH are evaluated at
+// import time from process.env.PARACHUTE_HOME. The `env` parameter on
+// `serve()` cannot reroute them — set PARACHUTE_HOME before importing for
+// path isolation.
+import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { hubFetch } from "../hub-server.ts";
 import { writeHubFile } from "../hub.ts";
+import { Supervisor } from "../supervisor.ts";
 import { createUser, userCount } from "../users.ts";
 import { WELL_KNOWN_DIR } from "../well-known.ts";
+import { bootSupervisedModules } from "./serve-boot.ts";
 
 export interface ServeOpts {
   /** Override PORT (test-only). Real callers thread env via process.env. */
@@ -44,6 +48,15 @@ export interface ServeOpts {
   env?: NodeJS.ProcessEnv;
   /** Logger seam (test-only). */
   log?: (line: string) => void;
+  /**
+   * Inject a pre-built Supervisor (test-only). Production constructs
+   * one internally with default options; tests pass in a Supervisor
+   * with stubbed spawn/sleep/now so the boot path doesn't try to
+   * `Bun.spawn` real children.
+   */
+  supervisor?: Supervisor;
+  /** Skip the services.json boot pass (test-only). */
+  skipModuleBoot?: boolean;
 }
 
 export interface ServeResult {
@@ -56,6 +69,8 @@ export interface ServeResult {
    * setup-placeholder redirect in hub-server.ts takes over).
    */
   adminBootstrap: "seeded" | "exists" | "needs-setup";
+  /** The supervisor instance — exposed so callers (tests) can introspect / drive it. */
+  supervisor: Supervisor;
 }
 
 const DEFAULT_PORT = 1939;
@@ -133,6 +148,36 @@ export async function serve(opts: ServeOpts = {}): Promise<{
     );
   }
 
+  const supervisor = opts.supervisor ?? new Supervisor();
+
+  // Boot already-installed modules from services.json. In a container,
+  // this is the path that re-spawns vault / notes / scribe after a
+  // restart — the persistent disk preserved both the install (in
+  // `$BUN_INSTALL/install/global/node_modules`) and the row that says
+  // "this module is registered + active." Idempotent: the supervisor
+  // skips modules that are already running.
+  if (!opts.skipModuleBoot) {
+    try {
+      const booted = await bootSupervisedModules(supervisor, {
+        manifestPath: SERVICES_MANIFEST_PATH,
+        configDir: CONFIG_DIR,
+        ...(issuer !== undefined ? { hubOrigin: issuer } : {}),
+        log,
+      });
+      const startedCount = booted.filter((b) => b.status === "started").length;
+      if (startedCount > 0) {
+        log(`parachute serve: supervisor booted ${startedCount} module(s) from services.json.`);
+      }
+    } catch (err) {
+      // A malformed services.json or a single module-spec read failure
+      // shouldn't keep the hub HTTP server from coming up — the
+      // operator can still hit /admin/modules to remediate.
+      log(
+        `parachute serve: module boot failed (${err instanceof Error ? err.message : String(err)}). The hub HTTP server is still starting; visit /admin/modules to remediate.`,
+      );
+    }
+  }
+
   const server = Bun.serve({
     port,
     hostname,
@@ -140,6 +185,7 @@ export async function serve(opts: ServeOpts = {}): Promise<{
       getDb: () => db,
       issuer,
       loopbackPort: port,
+      supervisor,
     }),
   });
 
@@ -148,8 +194,19 @@ export async function serve(opts: ServeOpts = {}): Promise<{
   );
 
   return {
-    result: { port, ...(issuer !== undefined ? { issuer } : {}), adminBootstrap },
+    result: {
+      port,
+      ...(issuer !== undefined ? { issuer } : {}),
+      adminBootstrap,
+      supervisor,
+    },
     stop: async () => {
+      // Stop supervised children first so they get a clean SIGTERM
+      // before the HTTP server (which they may depend on for hub-issued
+      // tokens) goes away.
+      for (const state of supervisor.list()) {
+        await supervisor.stop(state.short);
+      }
       await server.stop();
       db.close();
     },

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -42,6 +42,11 @@
  *   /admin/vault-admin-token/<n>  (GET)        → per-vault bearer mint (cookie-gated)
  *   /api/me                       (GET)        → who-am-I (session+CSRF or hasSession:false)
  *   /api/modules                  (GET)        → curated + installed module catalog (host:auth)
+ *   /api/modules/:short/install   (POST)       → bun add + spawn (async op)
+ *   /api/modules/:short/restart   (POST)       → supervisor restart (sync)
+ *   /api/modules/:short/upgrade   (POST)       → bun add @latest + restart (async op)
+ *   /api/modules/:short/uninstall (POST)       → stop child + bun remove + drop row (sync)
+ *   /api/modules/operations/:id   (GET)        → poll async op status
  *   /api/auth/mint-token          (POST)       → CLI/automation token mint (bearer)
  *   /api/auth/revoke-token        (POST)       → revoke registry-row token by jti
  *   /api/auth/tokens              (GET)        → paginated registry list
@@ -99,11 +104,19 @@ import { handleVaultAdminToken } from "./admin-vault-admin-token.ts";
 import { handleCreateVault } from "./admin-vaults.ts";
 import { handleApiMe } from "./api-me.ts";
 import { handleApiMintToken } from "./api-mint-token.ts";
+import {
+  handleInstall,
+  handleOperationGet,
+  handleRestart,
+  handleUninstall,
+  handleUpgrade,
+  parseModulesPath,
+} from "./api-modules-ops.ts";
 import { handleApiModules } from "./api-modules.ts";
 import { REVOCATION_LIST_MOUNT, handleRevocationList } from "./api-revocation-list.ts";
 import { handleApiRevokeToken } from "./api-revoke-token.ts";
 import { handleApiTokens } from "./api-tokens.ts";
-import { SERVICES_MANIFEST_PATH } from "./config.ts";
+import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "./config.ts";
 import { ensureCsrfToken } from "./csrf.ts";
 import { readExposeState } from "./expose-state.ts";
 import { HUB_DEFAULT_PORT, HUB_SVC, clearHubPort, writeHubPort } from "./hub-control.ts";
@@ -1295,6 +1308,68 @@ export function hubFetch(
       };
       if (deps?.supervisor !== undefined) modulesDeps.supervisor = deps.supervisor;
       return handleApiModules(req, modulesDeps);
+    }
+
+    // Module operation poll surface — pre-empts the /api/modules/:short/*
+    // routes below so `/api/modules/operations/<uuid>` doesn't accidentally
+    // match a parseModulesPath("/operations") and fall through.
+    if (pathname.startsWith("/api/modules/operations/")) {
+      if (!getDb) return dbNotConfigured();
+      if (!deps?.supervisor) {
+        return new Response(
+          JSON.stringify({
+            error: "supervisor_unavailable",
+            error_description:
+              "module operations require `parachute serve` (supervisor mode); on-box CLI uses `parachute install/upgrade/restart`",
+          }),
+          { status: 503, headers: { "content-type": "application/json" } },
+        );
+      }
+      const opId = decodeURIComponent(pathname.slice("/api/modules/operations/".length));
+      if (!opId || opId.includes("/")) return new Response("not found", { status: 404 });
+      return handleOperationGet(req, opId, {
+        db: getDb(),
+        issuer: oauthDeps(req).issuer,
+        manifestPath: deps?.manifestPath ?? SERVICES_MANIFEST_PATH,
+        configDir: CONFIG_DIR,
+        supervisor: deps.supervisor,
+      });
+    }
+
+    // Per-module action endpoints: /api/modules/:short/{install,restart,upgrade,uninstall}.
+    if (pathname.startsWith("/api/modules/")) {
+      if (!getDb) return dbNotConfigured();
+      if (!deps?.supervisor) {
+        return new Response(
+          JSON.stringify({
+            error: "supervisor_unavailable",
+            error_description:
+              "module operations require `parachute serve` (supervisor mode); on-box CLI uses `parachute install/upgrade/restart`",
+          }),
+          { status: 503, headers: { "content-type": "application/json" } },
+        );
+      }
+      const match = parseModulesPath(pathname);
+      if (!match) return new Response("not found", { status: 404 });
+      const opsDeps = {
+        db: getDb(),
+        issuer: oauthDeps(req).issuer,
+        manifestPath: deps?.manifestPath ?? SERVICES_MANIFEST_PATH,
+        configDir: CONFIG_DIR,
+        supervisor: deps.supervisor,
+      };
+      switch (match.rest) {
+        case "install":
+          return handleInstall(req, match.short, opsDeps);
+        case "restart":
+          return handleRestart(req, match.short, opsDeps);
+        case "upgrade":
+          return handleUpgrade(req, match.short, opsDeps);
+        case "uninstall":
+          return handleUninstall(req, match.short, opsDeps);
+        default:
+          return new Response("not found", { status: 404 });
+      }
     }
 
     if (pathname === "/api/auth/mint-token") {

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -131,6 +131,7 @@ import {
 import { type ServiceEntry, readManifest } from "./services-manifest.ts";
 import { findActiveSession } from "./sessions.ts";
 import { getAllPublicKeys } from "./signing-keys.ts";
+import type { Supervisor } from "./supervisor.ts";
 import { getUserById, userCount } from "./users.ts";
 import {
   WELL_KNOWN_DIR,
@@ -563,6 +564,15 @@ export interface HubFetchDeps {
    * legitimate access).
    */
   loadExposeHubOrigin?: () => string | undefined;
+  /**
+   * Container-mode child supervisor. When present (under `parachute serve`),
+   * `/api/modules/*` handlers drive install/restart/upgrade/uninstall through
+   * it. Absent under the on-box CLI path (`parachute expose`) where
+   * `commands/lifecycle.ts` owns the detached-pidfile lifecycle instead —
+   * the module-mgmt API in that mode returns 503 with a hint to use the
+   * CLI commands directly.
+   */
+  supervisor?: Supervisor;
 }
 
 /**

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -41,6 +41,7 @@
  *   /admin/host-admin-token       (GET)        → SPA bearer mint (cookie-gated)
  *   /admin/vault-admin-token/<n>  (GET)        → per-vault bearer mint (cookie-gated)
  *   /api/me                       (GET)        → who-am-I (session+CSRF or hasSession:false)
+ *   /api/modules                  (GET)        → curated + installed module catalog (host:auth)
  *   /api/auth/mint-token          (POST)       → CLI/automation token mint (bearer)
  *   /api/auth/revoke-token        (POST)       → revoke registry-row token by jti
  *   /api/auth/tokens              (GET)        → paginated registry list
@@ -98,6 +99,7 @@ import { handleVaultAdminToken } from "./admin-vault-admin-token.ts";
 import { handleCreateVault } from "./admin-vaults.ts";
 import { handleApiMe } from "./api-me.ts";
 import { handleApiMintToken } from "./api-mint-token.ts";
+import { handleApiModules } from "./api-modules.ts";
 import { REVOCATION_LIST_MOUNT, handleRevocationList } from "./api-revocation-list.ts";
 import { handleApiRevokeToken } from "./api-revoke-token.ts";
 import { handleApiTokens } from "./api-tokens.ts";
@@ -1282,6 +1284,17 @@ export function hubFetch(
     if (pathname === "/api/me") {
       if (!getDb) return dbNotConfigured();
       return handleApiMe(req, { db: getDb() });
+    }
+
+    if (pathname === "/api/modules") {
+      if (!getDb) return dbNotConfigured();
+      const modulesDeps: Parameters<typeof handleApiModules>[1] = {
+        db: getDb(),
+        issuer: oauthDeps(req).issuer,
+        manifestPath: deps?.manifestPath ?? SERVICES_MANIFEST_PATH,
+      };
+      if (deps?.supervisor !== undefined) modulesDeps.supervisor = deps.supervisor;
+      return handleApiModules(req, modulesDeps);
     }
 
     if (pathname === "/api/auth/mint-token") {

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -1,0 +1,359 @@
+/**
+ * Per-module child supervisor for container-mode hub.
+ *
+ * The on-box flow (`parachute start <svc>`) spawns module daemons
+ * detached + unref'd, writes a pidfile, and walks away — process
+ * lifecycle becomes the operator's problem (launchd, systemd, or a
+ * follow-up `parachute restart`). That shape doesn't work in a
+ * container:
+ *
+ *   - There's no external supervisor watching the children. If vault
+ *     crashes, nothing brings it back.
+ *   - Render's log viewer only surfaces hub's stdout. A detached child
+ *     whose stdout goes to `~/.parachute/<svc>/logs/<svc>.log` is
+ *     invisible to the operator clicking through the dashboard.
+ *
+ * This supervisor solves both. It spawns each module attached (no
+ * `detached: true`, no `unref()`), pipes their stdout/stderr through a
+ * line-prefixing tap into hub's own stdout (`[vault] …`,
+ * `[scribe] …`), watches `proc.exited`, and restarts crashed children
+ * up to a small budget before giving up + marking the module
+ * `crashed`. The budget keeps a wedged-on-boot module from chewing
+ * forever; once it's exhausted the operator sees the crash via /api/modules
+ * (or, post-1B, the per-module log view).
+ *
+ * Out of scope for this module: spawning the hub HTTP server itself
+ * (that's `Bun.serve` in the same process), driving the on-box
+ * `parachute start <svc>` path (still uses `commands/lifecycle.ts`),
+ * persisting child state to disk (transient — re-derived from
+ * services.json on boot).
+ */
+
+export type ModuleStatus = "starting" | "running" | "stopped" | "crashed" | "restarting";
+
+export interface ModuleState {
+  /** Short name (vault / notes / scribe / …). */
+  readonly short: string;
+  /** Last-observed lifecycle phase. */
+  readonly status: ModuleStatus;
+  /** PID of the current Bun.spawn child, if any. */
+  readonly pid?: number;
+  /** ISO timestamp of the most recent spawn. */
+  readonly startedAt?: string;
+  /** Crash count within the current restart window. Resets after the window passes without a crash. */
+  readonly restartsInWindow: number;
+  /** ISO timestamp of the most recent crash, or undefined if never crashed. */
+  readonly lastCrashAt?: string;
+  /** Exit code of the most recent crash. */
+  readonly lastExitCode?: number | null;
+}
+
+export interface SpawnRequest {
+  /** Short name — used as the log prefix and the supervisor map key. */
+  readonly short: string;
+  /** argv passed to `Bun.spawn`. */
+  readonly cmd: readonly string[];
+  /** Optional cwd for the child. */
+  readonly cwd?: string;
+  /**
+   * Optional env merged on top of `process.env`. The supervisor doesn't
+   * mutate `process.env`; the merge happens at spawn time.
+   */
+  readonly env?: Record<string, string>;
+}
+
+export interface SupervisorOpts {
+  /**
+   * Max crashes within `restartWindowMs` before the supervisor gives up
+   * and marks the module `crashed`. Default 3 — enough to ride out a
+   * transient race (DB lock, port still releasing), few enough to stop
+   * a wedged-on-boot module from looping forever.
+   */
+  readonly maxRestarts?: number;
+  /**
+   * Sliding window for the restart budget, in ms. A crash older than
+   * this falls out of the count. Default 60_000 (1 minute).
+   */
+  readonly restartWindowMs?: number;
+  /**
+   * Delay between a crash being observed and the restart spawn, in ms.
+   * Default 500 — gives sockets time to release on EADDRINUSE.
+   */
+  readonly restartDelayMs?: number;
+  /**
+   * Where prefixed child output goes. Default `process.stdout.write`.
+   * Tests inject a collector so they can assert on the multiplexed
+   * stream without spelunking stdout.
+   */
+  readonly output?: (line: string) => void;
+  /**
+   * Test seam over `Bun.spawn`. Returns a Subprocess-shaped handle.
+   */
+  readonly spawnFn?: SpawnFn;
+  /**
+   * Test seam over wall-clock. Production passes `Date.now`.
+   */
+  readonly now?: () => number;
+  /**
+   * Test seam over `setTimeout`. Production resolves a real Promise
+   * with `setTimeout`. Tests stub to advance time deterministically.
+   */
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Subprocess-shaped seam. Production passes through to `Bun.spawn`;
+ * tests construct a fake that exposes a controllable `exited` Promise
+ * and pipe-able stdout/stderr.
+ */
+export type SpawnFn = (req: SpawnRequest) => SupervisedProc;
+
+/**
+ * The minimal Subprocess shape the supervisor depends on. Bun's real
+ * `Subprocess` matches this; the test fake mirrors it.
+ */
+export interface SupervisedProc {
+  readonly pid: number;
+  readonly exited: Promise<number | null>;
+  readonly stdout: ReadableStream<Uint8Array> | null;
+  readonly stderr: ReadableStream<Uint8Array> | null;
+  kill(signal?: NodeJS.Signals | number): void;
+}
+
+const DEFAULT_MAX_RESTARTS = 3;
+const DEFAULT_RESTART_WINDOW_MS = 60_000;
+const DEFAULT_RESTART_DELAY_MS = 500;
+
+/**
+ * Per-module supervisor. Owns the spawn → watch → restart loop.
+ *
+ * Single-process semantics: instances of `Supervisor` aren't safe to
+ * share across processes (the underlying Subprocess handles are
+ * process-local). Hub creates one Supervisor per `parachute serve`
+ * boot and threads it into the API handlers.
+ */
+export class Supervisor {
+  private readonly opts: Required<Omit<SupervisorOpts, "spawnFn">> & {
+    readonly spawnFn: SpawnFn;
+  };
+  private readonly modules = new Map<string, ModuleEntry>();
+
+  constructor(opts: SupervisorOpts = {}) {
+    this.opts = {
+      maxRestarts: opts.maxRestarts ?? DEFAULT_MAX_RESTARTS,
+      restartWindowMs: opts.restartWindowMs ?? DEFAULT_RESTART_WINDOW_MS,
+      restartDelayMs: opts.restartDelayMs ?? DEFAULT_RESTART_DELAY_MS,
+      output: opts.output ?? ((line) => process.stdout.write(line)),
+      spawnFn: opts.spawnFn ?? defaultSpawnFn,
+      now: opts.now ?? Date.now,
+      sleep: opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms))),
+    };
+  }
+
+  /**
+   * Spawn a module under supervision. Idempotent: re-spawning an
+   * already-running module is a no-op (returns the existing state).
+   * Re-spawning a previously-crashed module clears the crash budget
+   * and starts fresh.
+   */
+  async start(req: SpawnRequest): Promise<ModuleState> {
+    const existing = this.modules.get(req.short);
+    if (existing && (existing.state.status === "running" || existing.state.status === "starting")) {
+      return existing.state;
+    }
+    // Crashed → operator intent is "try again." Wipe the budget.
+    const entry: ModuleEntry = {
+      req,
+      state: {
+        short: req.short,
+        status: "starting",
+        restartsInWindow: 0,
+      },
+      crashStamps: [],
+    };
+    this.modules.set(req.short, entry);
+    this.spawnAndWatch(entry);
+    return entry.state;
+  }
+
+  /**
+   * Stop a supervised module. Sends SIGTERM, marks the state
+   * `stopped`, and detaches the exit watcher so a normal termination
+   * isn't seen as a crash. Idempotent on already-stopped modules.
+   */
+  async stop(short: string): Promise<ModuleState | undefined> {
+    const entry = this.modules.get(short);
+    if (!entry) return undefined;
+    entry.stopRequested = true;
+    if (entry.proc) {
+      try {
+        entry.proc.kill("SIGTERM");
+      } catch {
+        // Process may already be dead — fall through.
+      }
+    }
+    entry.state = { ...entry.state, status: "stopped" };
+    return entry.state;
+  }
+
+  /** Snapshot of every supervised module's current state. */
+  list(): ModuleState[] {
+    return Array.from(this.modules.values(), (e) => e.state);
+  }
+
+  /** Snapshot of a single module's state, or undefined if not supervised. */
+  get(short: string): ModuleState | undefined {
+    return this.modules.get(short)?.state;
+  }
+
+  /**
+   * Restart a supervised module: stop, wait for exit, start with the
+   * same SpawnRequest. Used by the `/api/modules/:name/restart`
+   * handler. The on-box `parachute restart <svc>` path stays on
+   * `commands/lifecycle.ts` — different surface, different ownership.
+   */
+  async restart(short: string): Promise<ModuleState | undefined> {
+    const entry = this.modules.get(short);
+    if (!entry) return undefined;
+    const req = entry.req;
+    entry.state = { ...entry.state, status: "restarting" };
+    await this.stop(short);
+    // Wait for the prior process to actually exit so the new spawn
+    // doesn't race on EADDRINUSE.
+    if (entry.proc) {
+      try {
+        await entry.proc.exited;
+      } catch {
+        // exited promise rejection is non-fatal — we're stopping anyway.
+      }
+    }
+    // Drop the entry so `start` treats this as a clean spawn.
+    this.modules.delete(short);
+    return this.start(req);
+  }
+
+  private spawnAndWatch(entry: ModuleEntry): void {
+    const proc = this.opts.spawnFn(entry.req);
+    entry.proc = proc;
+    entry.state = {
+      ...entry.state,
+      status: "running",
+      pid: proc.pid,
+      startedAt: new Date(this.opts.now()).toISOString(),
+    };
+    this.pipeOutput(entry.req.short, proc);
+    void proc.exited.then((exitCode) => this.handleExit(entry, exitCode));
+  }
+
+  private async handleExit(entry: ModuleEntry, exitCode: number | null): Promise<void> {
+    // Operator-driven stop: not a crash, don't restart.
+    if (entry.stopRequested) {
+      entry.state = {
+        ...entry.state,
+        status: "stopped",
+        pid: undefined,
+        lastExitCode: exitCode,
+      };
+      return;
+    }
+
+    const now = this.opts.now();
+    // Drop crashes older than the window before counting.
+    const cutoff = now - this.opts.restartWindowMs;
+    entry.crashStamps = entry.crashStamps.filter((t) => t >= cutoff);
+    entry.crashStamps.push(now);
+
+    if (entry.crashStamps.length >= this.opts.maxRestarts) {
+      this.opts.output(
+        `[supervisor] ${entry.req.short} crashed ${entry.crashStamps.length}x within ${this.opts.restartWindowMs}ms — giving up.\n`,
+      );
+      entry.state = {
+        ...entry.state,
+        status: "crashed",
+        pid: undefined,
+        lastCrashAt: new Date(now).toISOString(),
+        lastExitCode: exitCode,
+        restartsInWindow: entry.crashStamps.length,
+      };
+      return;
+    }
+
+    entry.state = {
+      ...entry.state,
+      status: "restarting",
+      pid: undefined,
+      lastCrashAt: new Date(now).toISOString(),
+      lastExitCode: exitCode,
+      restartsInWindow: entry.crashStamps.length,
+    };
+    this.opts.output(
+      `[supervisor] ${entry.req.short} exited (code=${exitCode ?? "?"}); restart ${entry.crashStamps.length}/${this.opts.maxRestarts} in window.\n`,
+    );
+    await this.opts.sleep(this.opts.restartDelayMs);
+    // Operator may have called stop() during the sleep — re-check.
+    if (entry.stopRequested) return;
+    this.spawnAndWatch(entry);
+  }
+
+  /**
+   * Tap a child's stdout + stderr into the supervisor's `output`
+   * callback (hub's stdout by default), prefixing each line with the
+   * module's short name. Line-buffered: partial chunks accumulate
+   * until a newline arrives so multi-byte log lines don't get
+   * scrambled across modules.
+   */
+  private pipeOutput(short: string, proc: SupervisedProc): void {
+    const prefix = `[${short}] `;
+    if (proc.stdout) void pumpLines(proc.stdout, prefix, this.opts.output);
+    if (proc.stderr) void pumpLines(proc.stderr, prefix, this.opts.output);
+  }
+}
+
+interface ModuleEntry {
+  req: SpawnRequest;
+  state: ModuleState;
+  proc?: SupervisedProc;
+  crashStamps: number[];
+  stopRequested?: boolean;
+}
+
+async function pumpLines(
+  stream: ReadableStream<Uint8Array>,
+  prefix: string,
+  output: (line: string) => void,
+): Promise<void> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      // Flush every complete line; keep the partial tail buffered.
+      let nl = buf.indexOf("\n");
+      while (nl !== -1) {
+        const line = buf.slice(0, nl + 1);
+        output(prefix + line);
+        buf = buf.slice(nl + 1);
+        nl = buf.indexOf("\n");
+      }
+    }
+    // Flush any trailing partial line so we don't drop a module's
+    // last log message (it's likely the most important one — the
+    // exit cause).
+    if (buf.length > 0) output(`${prefix + buf}\n`);
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+const defaultSpawnFn: SpawnFn = (req) => {
+  const spawnOpts: Parameters<typeof Bun.spawn>[1] = {
+    stdio: ["ignore", "pipe", "pipe"],
+  };
+  if (req.cwd) spawnOpts.cwd = req.cwd;
+  if (req.env) spawnOpts.env = { ...process.env, ...req.env };
+  const proc = Bun.spawn([...req.cmd], spawnOpts);
+  return proc as unknown as SupervisedProc;
+};

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -28,6 +28,7 @@ vi.mock("./lib/api.ts", async (orig) => {
     listVaults: vi.fn().mockResolvedValue([]),
     listGrants: vi.fn().mockResolvedValue([]),
     listTokens: vi.fn().mockResolvedValue({ tokens: [], next_cursor: null }),
+    listModules: vi.fn().mockResolvedValue({ modules: [], supervisor_available: false }),
     // App's useEffect hits getMe() on mount. Default mock = signed-out so
     // the AuthIndicator renders the deterministic "Sign in" link rather
     // than racing on a real fetch. Per-test overrides via mockResolvedValue.
@@ -69,6 +70,11 @@ describe("App — brand subtitle (route-derived)", () => {
     expect(screen.getByText(/tokens/i, { selector: ".sub" })).toBeInTheDocument();
   });
 
+  it("/modules renders 'modules'", () => {
+    renderAt("/modules");
+    expect(screen.getByText(/modules/i, { selector: ".sub" })).toBeInTheDocument();
+  });
+
   it("origin root (/) falls back to 'vaults' (the SPA's home)", () => {
     renderAt("/");
     expect(screen.getByText(/vaults/i, { selector: ".sub" })).toBeInTheDocument();
@@ -76,7 +82,7 @@ describe("App — brand subtitle (route-derived)", () => {
 });
 
 describe("App — nav structure", () => {
-  it("renders all nav links in order: brand, Vaults, Permissions, Tokens, Discovery (signed-out)", async () => {
+  it("renders all nav links in order: brand, Vaults, Modules, Permissions, Tokens, Discovery (signed-out)", async () => {
     renderAt("/vaults");
     // Wait for /api/me to resolve so AuthIndicator's "Sign in" link
     // appears in the nav before we snapshot the link order.
@@ -90,6 +96,7 @@ describe("App — nav structure", () => {
       expect.stringMatching(/parachute admin/i),
       "Sign in", // AuthIndicator slot, sits between brand and Vaults
       "Vaults",
+      "Modules",
       "Permissions",
       "Tokens",
       "Discovery",
@@ -221,6 +228,11 @@ describe("App — route rendering", () => {
   it("/tokens renders Tokens (heading 'Tokens')", () => {
     renderAt("/tokens");
     expect(screen.getByRole("heading", { name: /^tokens$/i })).toBeInTheDocument();
+  });
+
+  it("/modules renders Modules (heading 'Modules')", async () => {
+    renderAt("/modules");
+    expect(await screen.findByRole("heading", { name: /^modules$/i })).toBeInTheDocument();
   });
 
   it("origin root (/) renders VaultsList (the SPA's home)", async () => {

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -25,6 +25,7 @@ import { type ReactNode, useEffect, useState } from "react";
 import { Link, Route, Routes, useLocation } from "react-router-dom";
 import { type MeResponse, getMe, signOut } from "./lib/api.ts";
 import { ApproveClient } from "./routes/ApproveClient.tsx";
+import { Modules } from "./routes/Modules.tsx";
 import { NewVault } from "./routes/NewVault.tsx";
 import { Permissions } from "./routes/Permissions.tsx";
 import { Tokens } from "./routes/Tokens.tsx";
@@ -41,6 +42,9 @@ function subtitleFor(pathname: string): string {
   }
   if (pathname === "/tokens" || pathname.startsWith("/tokens/")) {
     return "tokens";
+  }
+  if (pathname === "/modules" || pathname.startsWith("/modules/")) {
+    return "modules";
   }
   if (pathname.startsWith("/approve-client/")) {
     return "approve app";
@@ -99,6 +103,7 @@ export function App() {
         </Link>
         <AuthIndicator me={me} signingOut={signingOut} onSignOut={onSignOut} />
         <Link to="/vaults">Vaults</Link>
+        <Link to="/modules">Modules</Link>
         <Link to="/permissions">Permissions</Link>
         <Link to="/tokens">Tokens</Link>
         <span className="nav-divider" aria-hidden="true" />
@@ -111,6 +116,7 @@ export function App() {
         <Route path="/" element={<VaultsList />} />
         <Route path="/vaults" element={<VaultsList />} />
         <Route path="/vaults/new" element={<NewVault />} />
+        <Route path="/modules" element={<Modules />} />
         <Route path="/permissions" element={<Permissions />} />
         <Route path="/tokens" element={<Tokens />} />
         <Route path="/approve-client/:clientId" element={<ApproveClient />} />

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -529,6 +529,152 @@ export async function approveOauthClient(clientId: string): Promise<ApproveClien
   return (await res.json()) as ApproveClientResult;
 }
 
+/**
+ * One row from `GET /api/modules`. Mirrors the snake_case wire shape
+ * from `src/api-modules.ts`.
+ */
+export interface ModuleListing {
+  short: string;
+  package: string;
+  display_name: string;
+  tagline: string;
+  available: boolean;
+  installed: boolean;
+  installed_version: string | null;
+  latest_version: string | null;
+  supervisor_status: "starting" | "running" | "stopped" | "crashed" | "restarting" | null;
+  pid: number | null;
+  install_dir: string | null;
+}
+
+/** Top-level shape from `GET /api/modules`. */
+export interface ModulesCatalog {
+  modules: ModuleListing[];
+  /**
+   * When false, install/restart/upgrade/uninstall actions are disabled
+   * — the hub is in CLI mode (no supervisor wired) and the operator
+   * should use `parachute install/upgrade/restart` from a shell.
+   */
+  supervisor_available: boolean;
+}
+
+/**
+ * GET /api/modules — read-side module catalog. Combines availability +
+ * installed-version + supervisor state + npm @latest. Same Bearer
+ * pattern as `listGrants` / `listTokens`.
+ */
+export async function listModules(): Promise<ModulesCatalog> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch("/api/modules", {
+    method: "GET",
+    headers: { accept: "application/json", authorization: `Bearer ${bearer}` },
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as ModulesCatalog;
+}
+
+/** Operation kinds returned by `POST /api/modules/:short/*`. */
+export type ModuleOperationKind = "install" | "upgrade" | "restart" | "uninstall";
+export type ModuleOperationStatus = "pending" | "running" | "succeeded" | "failed";
+
+export interface ModuleOperation {
+  id: string;
+  kind: ModuleOperationKind;
+  short: string;
+  status: ModuleOperationStatus;
+  log: string[];
+  error?: string;
+  startedAt: string;
+  finishedAt?: string;
+}
+
+/** Sync action response shape (restart, uninstall). */
+export interface ModuleActionResult {
+  short: string;
+  state?: { status: string; pid?: number };
+  log?: string[];
+}
+
+async function postModuleAction(short: string, action: ModuleOperationKind): Promise<Response> {
+  const bearer = await getHostAdminToken();
+  return await fetch(`/api/modules/${encodeURIComponent(short)}/${action}`, {
+    method: "POST",
+    headers: { accept: "application/json", authorization: `Bearer ${bearer}` },
+  });
+}
+
+/**
+ * POST /api/modules/:short/install — async. Returns the operation_id;
+ * caller polls `getModuleOperation` until status is terminal.
+ */
+export async function installModule(short: string): Promise<string> {
+  const res = await postModuleAction(short, "install");
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  const body = (await res.json()) as { operation_id: string };
+  return body.operation_id;
+}
+
+/** POST /api/modules/:short/upgrade — async. Same shape as install. */
+export async function upgradeModule(short: string): Promise<string> {
+  const res = await postModuleAction(short, "upgrade");
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  const body = (await res.json()) as { operation_id: string };
+  return body.operation_id;
+}
+
+/** POST /api/modules/:short/restart — synchronous. */
+export async function restartModule(short: string): Promise<ModuleActionResult> {
+  const res = await postModuleAction(short, "restart");
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as ModuleActionResult;
+}
+
+/** POST /api/modules/:short/uninstall — synchronous. */
+export async function uninstallModule(short: string): Promise<ModuleActionResult> {
+  const res = await postModuleAction(short, "uninstall");
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as ModuleActionResult;
+}
+
+/**
+ * GET /api/modules/operations/:id — poll for a long-running operation
+ * kicked off by install or upgrade. Returns 404 (HttpError) when the
+ * id is unknown / expired.
+ */
+export async function getModuleOperation(opId: string): Promise<ModuleOperation> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch(`/api/modules/operations/${encodeURIComponent(opId)}`, {
+    method: "GET",
+    headers: { accept: "application/json", authorization: `Bearer ${bearer}` },
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as ModuleOperation;
+}
+
 async function readError(res: Response): Promise<string> {
   try {
     const text = await res.text();

--- a/web/ui/src/routes/Modules.test.tsx
+++ b/web/ui/src/routes/Modules.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * Modules route smoke tests — catalog rendering, status badges,
+ * install kick-off + op polling → terminal, restart/uninstall sync
+ * paths, supervisor-unavailable disabled state.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import { Modules } from "./Modules.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    listModules: vi.fn(),
+    installModule: vi.fn(),
+    restartModule: vi.fn(),
+    upgradeModule: vi.fn(),
+    uninstallModule: vi.fn(),
+    getModuleOperation: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function renderRoute() {
+  return render(
+    <MemoryRouter>
+      <Modules />
+    </MemoryRouter>,
+  );
+}
+
+function moduleRow(short: string, overrides: Partial<api.ModuleListing> = {}): api.ModuleListing {
+  return {
+    short,
+    package: `@openparachute/${short}`,
+    display_name: short.charAt(0).toUpperCase() + short.slice(1),
+    tagline: `the ${short} module`,
+    available: true,
+    installed: false,
+    installed_version: null,
+    latest_version: "1.0.0",
+    supervisor_status: null,
+    pid: null,
+    install_dir: null,
+    ...overrides,
+  };
+}
+
+describe("Modules — catalog rendering", () => {
+  it("shows a loading state on first paint", () => {
+    vi.mocked(api.listModules).mockImplementation(() => new Promise(() => {}));
+    renderRoute();
+    expect(screen.getByText(/loading modules/i)).toBeInTheDocument();
+  });
+
+  it("renders one row per module with display name + tagline", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [moduleRow("vault"), moduleRow("notes"), moduleRow("scribe")],
+      supervisor_available: true,
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    expect(screen.getByText("Notes")).toBeInTheDocument();
+    expect(screen.getByText("Scribe")).toBeInTheDocument();
+    // Tagline copy from the listing flows through to the row.
+    expect(screen.getByText("the vault module")).toBeInTheDocument();
+  });
+
+  it("badges 'not installed' for available-but-uninstalled rows", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [moduleRow("vault")],
+      supervisor_available: true,
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    expect(screen.getByText(/not installed/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Running' badge + installed version for an installed+running row", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [
+        moduleRow("vault", {
+          installed: true,
+          installed_version: "0.4.5",
+          latest_version: "0.4.5",
+          supervisor_status: "running",
+          pid: 9876,
+        }),
+      ],
+      supervisor_available: true,
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    expect(screen.getByText(/running/i)).toBeInTheDocument();
+    expect(screen.getByText("v0.4.5")).toBeInTheDocument();
+  });
+});
+
+describe("Modules — supervisor unavailable", () => {
+  it("disables actions + shows the CLI-mode banner", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [
+        moduleRow("vault", {
+          installed: true,
+          installed_version: "0.4.5",
+          supervisor_status: null,
+        }),
+      ],
+      supervisor_available: false,
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    // CLI-mode banner copy.
+    expect(screen.getByText(/parachute serve/)).toBeInTheDocument();
+    // Restart button present but disabled.
+    const restartBtn = screen.getByRole("button", { name: /restart/i });
+    expect(restartBtn).toBeDisabled();
+  });
+});
+
+describe("Modules — install flow", () => {
+  it("kicks off install and starts polling the operation", async () => {
+    // Real timers — we just want to observe the kick-off and the poll
+    // wiring. End-to-end poll → terminal → refresh is covered by the
+    // server-side api-modules-ops tests; here we verify the SPA wires
+    // installModule + getModuleOperation correctly.
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [moduleRow("vault")],
+      supervisor_available: true,
+    });
+    vi.mocked(api.installModule).mockResolvedValue("op-abc");
+    vi.mocked(api.getModuleOperation).mockResolvedValue({
+      id: "op-abc",
+      kind: "install",
+      short: "vault",
+      status: "running",
+      log: ["running bun add"],
+      startedAt: "2026-05-18T00:00:00Z",
+    });
+
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /install/i }));
+
+    await waitFor(() => expect(api.installModule).toHaveBeenCalledWith("vault"));
+    // Poll fires within ~1s — give waitFor 2s to be safe.
+    await waitFor(() => expect(api.getModuleOperation).toHaveBeenCalledWith("op-abc"), {
+      timeout: 2000,
+    });
+  });
+});
+
+describe("Modules — restart sync flow", () => {
+  it("calls restartModule then refreshes catalog", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [
+        moduleRow("vault", {
+          installed: true,
+          installed_version: "0.4.5",
+          latest_version: "0.4.5",
+          supervisor_status: "running",
+        }),
+      ],
+      supervisor_available: true,
+    });
+    vi.mocked(api.restartModule).mockResolvedValue({ short: "vault" });
+
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /restart/i }));
+    await waitFor(() => expect(api.restartModule).toHaveBeenCalledWith("vault"));
+    await waitFor(() => expect(api.listModules).toHaveBeenCalledTimes(2));
+  });
+
+  it("surfaces an inline error on restart failure", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [
+        moduleRow("vault", {
+          installed: true,
+          installed_version: "0.4.5",
+          latest_version: "0.4.5",
+          supervisor_status: "running",
+        }),
+      ],
+      supervisor_available: true,
+    });
+    vi.mocked(api.restartModule).mockRejectedValue(
+      new api.HttpError(503, "supervisor_unavailable"),
+    );
+
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /restart/i }));
+    await waitFor(() => expect(screen.getByText(/supervisor_unavailable/)).toBeInTheDocument());
+  });
+});
+
+describe("Modules — uninstall sync flow", () => {
+  it("confirms then calls uninstallModule", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [
+        moduleRow("vault", {
+          installed: true,
+          installed_version: "0.4.5",
+          latest_version: "0.4.5",
+          supervisor_status: "running",
+        }),
+      ],
+      supervisor_available: true,
+    });
+    vi.mocked(api.uninstallModule).mockResolvedValue({ short: "vault" });
+    // Auto-confirm the window.confirm dialog so the uninstall fires.
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /uninstall/i }));
+    await waitFor(() => expect(api.uninstallModule).toHaveBeenCalledWith("vault"));
+    confirmSpy.mockRestore();
+  });
+
+  it("does not call uninstallModule when the operator cancels confirm", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [
+        moduleRow("vault", {
+          installed: true,
+          installed_version: "0.4.5",
+          latest_version: "0.4.5",
+          supervisor_status: "running",
+        }),
+      ],
+      supervisor_available: true,
+    });
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /uninstall/i }));
+    // Give the click handler a tick.
+    await Promise.resolve();
+    expect(api.uninstallModule).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+});

--- a/web/ui/src/routes/Modules.tsx
+++ b/web/ui/src/routes/Modules.tsx
@@ -1,0 +1,376 @@
+/**
+ * /admin/modules — admin UI for installing / restarting / upgrading /
+ * uninstalling Parachute modules at runtime.
+ *
+ * The v0.6 release bar: a friend can fork + click Deploy to Render +
+ * land here + install vault / notes / scribe via UI in under 5 minutes.
+ *
+ * Two response shapes off the API:
+ *   - Restart / uninstall are synchronous — the POST returns the new
+ *     state and we re-fetch the catalog.
+ *   - Install / upgrade are async — the POST returns an operation_id
+ *     and we poll GET /api/modules/operations/:id every second until
+ *     terminal. The op's `log` array drives a small progress banner.
+ *
+ * `supervisor_available: false` is the on-box CLI path (no `parachute
+ * serve`). Actions get disabled and a small banner tells the operator
+ * to use `parachute install/upgrade/restart` from their shell instead.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type ModuleListing,
+  type ModuleOperation,
+  type ModulesCatalog,
+  getModuleOperation,
+  installModule,
+  listModules,
+  restartModule,
+  uninstallModule,
+  upgradeModule,
+} from "../lib/api.ts";
+
+type CatalogState =
+  | { kind: "loading" }
+  | { kind: "ok"; catalog: ModulesCatalog }
+  | { kind: "error"; message: string };
+
+interface PendingOp {
+  kind: "install" | "upgrade";
+  operationId: string;
+  short: string;
+  log: string[];
+  status: ModuleOperation["status"];
+  error?: string;
+}
+
+const POLL_INTERVAL_MS = 1000;
+
+export function Modules() {
+  const [catalog, setCatalog] = useState<CatalogState>({ kind: "loading" });
+  const [pendingOps, setPendingOps] = useState<PendingOp[]>([]);
+  // Per-module disabled state for the sync actions, so a fast-finger
+  // operator can't fire restart twice in flight.
+  const [syncBusy, setSyncBusy] = useState<Record<string, boolean>>({});
+  // Surfaces a sync action's error message inline on the row.
+  const [syncError, setSyncError] = useState<Record<string, string>>({});
+
+  const refreshCatalog = useCallback(async () => {
+    try {
+      const next = await listModules();
+      setCatalog({ kind: "ok", catalog: next });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setCatalog({ kind: "error", message: msg });
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshCatalog();
+  }, [refreshCatalog]);
+
+  // Poll any pending async operations. One interval per page mount,
+  // batched against all current pendingOps each tick so an operator
+  // who kicks off install on every module sees a single timer driving
+  // them all.
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  useEffect(() => {
+    if (pendingOps.length === 0) {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+      return;
+    }
+    if (pollRef.current) return;
+    pollRef.current = setInterval(() => {
+      void Promise.all(
+        pendingOps.map(async (p) => {
+          try {
+            const op = await getModuleOperation(p.operationId);
+            setPendingOps((prev) =>
+              prev.map((q) =>
+                q.operationId === op.id
+                  ? { ...q, log: op.log, status: op.status, error: op.error }
+                  : q,
+              ),
+            );
+            if (op.status === "succeeded" || op.status === "failed") {
+              // Terminal — drop after a beat so the operator can see
+              // the final log line, then refresh the catalog.
+              setTimeout(() => {
+                setPendingOps((prev) => prev.filter((q) => q.operationId !== op.id));
+                void refreshCatalog();
+              }, 1500);
+            }
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            setPendingOps((prev) =>
+              prev.map((q) =>
+                q.operationId === p.operationId ? { ...q, status: "failed", error: msg } : q,
+              ),
+            );
+          }
+        }),
+      );
+    }, POLL_INTERVAL_MS);
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [pendingOps, refreshCatalog]);
+
+  async function onInstall(short: string) {
+    try {
+      const operationId = await installModule(short);
+      setPendingOps((prev) => [
+        ...prev,
+        { kind: "install", operationId, short, log: [], status: "pending" },
+      ]);
+    } catch (err) {
+      setSyncError((prev) => ({
+        ...prev,
+        [short]: err instanceof Error ? err.message : String(err),
+      }));
+    }
+  }
+
+  async function onUpgrade(short: string) {
+    try {
+      const operationId = await upgradeModule(short);
+      setPendingOps((prev) => [
+        ...prev,
+        { kind: "upgrade", operationId, short, log: [], status: "pending" },
+      ]);
+    } catch (err) {
+      setSyncError((prev) => ({
+        ...prev,
+        [short]: err instanceof Error ? err.message : String(err),
+      }));
+    }
+  }
+
+  async function onRestart(short: string) {
+    if (syncBusy[short]) return;
+    setSyncBusy((prev) => ({ ...prev, [short]: true }));
+    setSyncError((prev) => {
+      const next = { ...prev };
+      delete next[short];
+      return next;
+    });
+    try {
+      await restartModule(short);
+      await refreshCatalog();
+    } catch (err) {
+      setSyncError((prev) => ({
+        ...prev,
+        [short]: err instanceof Error ? err.message : String(err),
+      }));
+    } finally {
+      setSyncBusy((prev) => ({ ...prev, [short]: false }));
+    }
+  }
+
+  async function onUninstall(short: string) {
+    if (syncBusy[short]) return;
+    if (
+      !window.confirm(
+        `Uninstall ${short}? The container will stop the service, remove the package, and drop its services.json entry. The persistent disk's data dir is left intact.`,
+      )
+    ) {
+      return;
+    }
+    setSyncBusy((prev) => ({ ...prev, [short]: true }));
+    setSyncError((prev) => {
+      const next = { ...prev };
+      delete next[short];
+      return next;
+    });
+    try {
+      await uninstallModule(short);
+      await refreshCatalog();
+    } catch (err) {
+      setSyncError((prev) => ({
+        ...prev,
+        [short]: err instanceof Error ? err.message : String(err),
+      }));
+    } finally {
+      setSyncBusy((prev) => ({ ...prev, [short]: false }));
+    }
+  }
+
+  if (catalog.kind === "loading") {
+    return <div className="empty">Loading modules…</div>;
+  }
+  if (catalog.kind === "error") {
+    if (catalog.message.includes("setup_required")) {
+      return (
+        <div className="empty">
+          Hub not yet configured. <a href="/admin/setup">Finish first-boot setup</a> first.
+        </div>
+      );
+    }
+    return (
+      <div className="empty">
+        Failed to load modules: {catalog.message}.{" "}
+        <button type="button" onClick={() => void refreshCatalog()}>
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const { modules, supervisor_available } = catalog.catalog;
+
+  return (
+    <section className="modules">
+      <h1>Modules</h1>
+      <p className="muted">
+        Install, upgrade, and manage Parachute modules. Available modules are pinned for the v0.6
+        release; the marketplace is on the roadmap.
+      </p>
+
+      {!supervisor_available && (
+        <div className="banner banner-info">
+          This hub is running outside container mode (no supervisor wired). Module install / restart
+          / upgrade is available only under <code>parachute serve</code>. On-box installs use{" "}
+          <code>parachute install vault</code> etc. from a shell instead.
+        </div>
+      )}
+
+      {pendingOps.length > 0 && (
+        <div className="banner">
+          <strong>In progress:</strong>
+          <ul>
+            {pendingOps.map((p) => (
+              <li key={p.operationId}>
+                <code>{p.short}</code> · {p.kind} · status: {p.status}
+                {p.error ? ` · error: ${p.error}` : null}
+                {p.log.length > 0 && (
+                  <details>
+                    <summary>{p.log.length} log line(s)</summary>
+                    <pre>{p.log.join("\n")}</pre>
+                  </details>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <ul className="module-list">
+        {modules.map((mod) => (
+          <ModuleRow
+            key={mod.short}
+            module={mod}
+            supervisorAvailable={supervisor_available}
+            syncBusy={Boolean(syncBusy[mod.short])}
+            errorMessage={syncError[mod.short]}
+            onInstall={() => void onInstall(mod.short)}
+            onUpgrade={() => void onUpgrade(mod.short)}
+            onRestart={() => void onRestart(mod.short)}
+            onUninstall={() => void onUninstall(mod.short)}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+interface ModuleRowProps {
+  module: ModuleListing;
+  supervisorAvailable: boolean;
+  syncBusy: boolean;
+  errorMessage: string | undefined;
+  onInstall: () => void;
+  onUpgrade: () => void;
+  onRestart: () => void;
+  onUninstall: () => void;
+}
+
+function ModuleRow({
+  module: mod,
+  supervisorAvailable,
+  syncBusy,
+  errorMessage,
+  onInstall,
+  onUpgrade,
+  onRestart,
+  onUninstall,
+}: ModuleRowProps) {
+  const canAct = supervisorAvailable && !syncBusy;
+  const upgradeAvailable =
+    mod.installed && mod.installed_version !== mod.latest_version && mod.latest_version !== null;
+
+  return (
+    <li className="module-row" data-short={mod.short}>
+      <header>
+        <h2>
+          {mod.display_name} <span className="muted">({mod.short})</span>
+        </h2>
+        <span className={`status status-${mod.supervisor_status ?? "absent"}`}>
+          {statusLabel(mod)}
+        </span>
+      </header>
+      {mod.tagline ? <p className="tagline">{mod.tagline}</p> : null}
+
+      <dl className="meta">
+        <dt>Package</dt>
+        <dd>
+          <code>{mod.package}</code>
+        </dd>
+        {mod.installed && (
+          <>
+            <dt>Installed</dt>
+            <dd>
+              v{mod.installed_version ?? "unknown"}
+              {upgradeAvailable && <span className="badge">v{mod.latest_version} available</span>}
+            </dd>
+          </>
+        )}
+        {!mod.installed && mod.latest_version && (
+          <>
+            <dt>Latest on npm</dt>
+            <dd>v{mod.latest_version}</dd>
+          </>
+        )}
+        {mod.pid && (
+          <>
+            <dt>PID</dt>
+            <dd>{mod.pid}</dd>
+          </>
+        )}
+      </dl>
+
+      <div className="actions">
+        {!mod.installed && (
+          <button type="button" disabled={!canAct} onClick={onInstall}>
+            Install
+          </button>
+        )}
+        {mod.installed && (
+          <>
+            <button type="button" disabled={!canAct} onClick={onRestart}>
+              Restart
+            </button>
+            <button type="button" disabled={!canAct || !upgradeAvailable} onClick={onUpgrade}>
+              {upgradeAvailable ? `Upgrade to v${mod.latest_version}` : "Up to date"}
+            </button>
+            <button type="button" className="destructive" disabled={!canAct} onClick={onUninstall}>
+              Uninstall
+            </button>
+          </>
+        )}
+      </div>
+
+      {errorMessage && <div className="error">{errorMessage}</div>}
+    </li>
+  );
+}
+
+function statusLabel(mod: ModuleListing): string {
+  if (!mod.installed) return "not installed";
+  if (!mod.supervisor_status) return "not supervised";
+  return mod.supervisor_status;
+}


### PR DESCRIPTION
## Summary

Phase 1A of hub#260 — the v0.6 Render self-host release bar. A friend who clicks Deploy to Render lands on `/admin/setup`, finishes admin bootstrap, navigates to `/admin/modules`, and installs vault / notes / scribe via three button clicks. No shell, no `parachute install`.

Closes hub#260 Phase 1A (1B = real-time status + per-module log view, splits to a follow-up).

## What this PR builds

**Per-module child supervisor** (`src/supervisor.ts`) — attaches each module via `Bun.spawn`, line-prefixes stdout/stderr into hub's own (`[vault] …`, `[scribe] …` — Render's log viewer surfaces them all), restarts on crash with a sliding-window budget (3 in 60s default → `crashed`), idempotent `start()` / explicit `restart()` / `list()` / `get()` for the API surface.

**Boot-time auto-start** (`src/commands/serve-boot.ts`) — `parachute serve` reads services.json after admin-seed and hands each registered module to the supervisor. Per-module `.env` merged under `PARACHUTE_HUB_ORIGIN` (live env wins on collision).

**Module management HTTP API** (`src/api-modules.ts` + `src/api-modules-ops.ts`):
- `GET /api/modules` — curated catalog (vault/notes/scribe) joined with services.json + supervisor state + npm `@latest` probe (3s timeout, 5min cache).
- `POST /api/modules/:short/install` (async, returns 202 + `operation_id`)
- `POST /api/modules/:short/restart` (sync)
- `POST /api/modules/:short/upgrade` (async)
- `POST /api/modules/:short/uninstall` (sync)
- `GET /api/modules/operations/:id` (poll)

All bearer-gated on `parachute:host:auth`. The SPA mints via `/admin/host-admin-token`. Curated-only — `parseModulesPath` refuses non-curated shorts; marketplace = Phase 2.

**`/admin/modules` SPA page** (`web/ui/src/routes/Modules.tsx`) — module rows with status badge, version pair, action buttons. Async ops show inline progress + operation log; sync errors stay on the row banner.

**Container plumbing** (Dockerfile + render.yaml) — `BUN_INSTALL=/parachute/modules` so modules persist across container restarts. The runtime stage chowns `/parachute` to uid 1000 (non-root `bun` user) for first-boot writes.

## Surface

- 6 new files
- 6 modified files
- ~1300 LOC net additions

## Test plan

`bun test ./src`:

- **1347 pass / 1 fail / 30555 expects across 76 files.**
- The 1 fail is the same pre-existing `status > all-healthy returns 0 and prints table` env flake — reproduces on `main` with no diff. Unrelated.
- +40 tests over `0.5.10-rc.2`: 12 supervisor + 6 serve-boot + 8 api-modules + 14 api-modules-ops.

`cd web/ui && bun run test`:
- 115 pass / 0 fail (+10 in Modules.test.tsx: catalog rendering, supervisor unavailable, install kick-off + poll wiring, restart sync flow, uninstall confirm flow).

- typecheck clean.
- biome clean (201 files, no fixes applied).

- [ ] Container smoke (deferred to operator Render verification): docker build → empty disk → install vault via `/admin/modules` → vault running on 1940 → docker stop → docker start → vault re-spawned from persistent disk → docker logs shows `[vault] …` prefixed lines.
- [ ] Manual `parachute serve` smoke locally: empty services.json → SPA renders catalog → install vault button (will require local module install path — defer to first real deploy).

Local Docker daemon is not available in this work session so the build-and-run smoke is deferred to Aaron's Render verification before promoting to stable. The supervisor + boot-spawn + module-mgmt-API layers are unit-tested against stubbed spawn/run seams; the Render-side smoke is the v0.6 release gate.

## Out of scope (Phase 1B — follow-up PR)

- Real-time module status updates in the SPA (currently a manual refresh after each action).
- Per-module log streaming in the SPA (today: hub stdout multiplex carries it; the SPA doesn't tail it).

## Out of scope (Phase 2)

- Module config UI / schema-driven forms.
- Marketplace beyond curated vault/notes/scribe.
- Multi-user permissions on module mgmt.

## Patterns check

- **Governance Rule 1** (no auto-merge) — Aaron clicks merge for hub PRs.
- **Governance Rule 2** (RC versioning) — `0.5.10-rc.2` → `0.5.10-rc.3`. RC chain continues; promote to `0.5.10` stable when ready.
- **Governance Rule 3** (patterns check) — this PR introduces a new "container-mode runtime install" pattern (supervised children + persistent BUN_INSTALL + module-mgmt API). Worth documenting in parachute-patterns/ after a follow-up settles Phase 1B. Filing a follow-up issue to capture it.
- **Module protocol** — services.json + module.json contracts unchanged; the supervisor reads `startCmd` from existing `SERVICE_SPECS` / `getSpecFromInstallDir`. No new contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)