### PR TITLE
polish(hub): supervisor lifecycle hardening (closes #263 #264 #265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.10-rc.8] - 2026-05-20
+
+Supervisor lifecycle hardening bundle (closes hub#263, #264, #265). Three follow-up items from the hub#262 reviewer pass, all on the supervisor's stop/upgrade code path. One PR, two logical commits + the rc.8 bump.
+
+**Item 1 (#263) + Item 2 (#264) — `Supervisor.stop()` now awaits child exit with SIGKILL escalation.** Previously `stop()` sent SIGTERM and returned synchronously. No correctness bug on Render (the OS reaps children when hub exits as PID 1), but children's final log lines never made it through hub's stdout pipe before the platform tore the container down — the last 100ms of vault's logs (often the most diagnostic) vanished from Render's log viewer. And a wedged module that ignored SIGTERM would leak until the container itself was recycled. Same code path, one fix: send SIGTERM, `await Promise.race([proc.exited, setTimeout(killTimeoutMs)])`, escalate to SIGKILL if the timeout wins, then await exit either way. Default 5s timeout (configurable via `SupervisorOpts.killTimeoutMs` so tests can use a small value). `restart()` is simplified — `stop()` already awaits exit, so the post-stop `await entry.proc.exited` block is now redundant.
+
+**Item 3 (#265) — test for upgrade-on-unsupervised-module path.** The upgrade endpoint in `api-modules-ops.ts` has a branch where `bun add -g` succeeds but `supervisor.restart(short)` returns undefined (module is in services.json but never spawned — e.g. seeded by a pre-supervisor `parachute install`). The branch correctly marks the operation `failed` with a "try install first" log line, but it had no test. Added one: writes a services.json row, skips `supervisor.start()`, POSTs `/api/modules/vault/upgrade`, polls the operation, asserts `status: "failed"` + the canonical message.
+
+Surface summary:
+- `src/supervisor.ts` — new `killTimeoutMs` opt (default 5000); `stop()` awaits race(exited, timeout) with SIGKILL escalation; `restart()` simplified.
+- `src/__tests__/supervisor.test.ts` — existing operator-stop test rewritten to await the new async stop; +2 new tests (SIGKILL escalation, well-behaved await-before-return).
+- `src/__tests__/api-modules-ops.test.ts` — +1 new test (upgrade on installed-but-not-supervised).
+
+Gate: `bun test ./src` — **1418 pass / 0 fail / 30746 expects across 79 files**. +3 over rc.7 (1415 → 1418). typecheck + biome clean.
+
+No smoke — these are correctness fixes provable by tests. The SIGKILL escalation is exercised end-to-end in the test by feeding a fake child whose `kill()` only resolves `exited` on SIGKILL.
+
 ## [0.5.10-rc.7] - 2026-05-19
 
 Post-wizard polish bundle (hub#268). Three related items caught while walking the rc.6 wizard on a fresh machine. One PR, three logical commits + the rc.7 bump.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.10-rc.7",
+  "version": "0.5.10-rc.8",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-modules-ops.test.ts
+++ b/src/__tests__/api-modules-ops.test.ts
@@ -415,6 +415,71 @@ describe("POST /api/modules/:short/upgrade", () => {
     await new Promise((r) => setTimeout(r, 10));
     expect(calls).toContainEqual(["bun", "add", "-g", "@openparachute/vault@latest"]);
   });
+
+  test("fails with 'try install first' when module is installed but never supervised", async () => {
+    // Module has a services.json row (e.g. seeded by `parachute install`
+    // pre-supervisor era) but the supervisor never spawned it.
+    // `bun add -g` succeeds, then `supervisor.restart()` returns
+    // undefined because there's no entry in the Map. The operation
+    // should land in `failed` with the canonical "try install first"
+    // message rather than silently succeed (hub#265).
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/vault/default"],
+        health: "/vault/default/health",
+        version: "0.4.5",
+      },
+    ]);
+    const { supervisor, spawns } = makeIdleSupervisor();
+    // Intentionally do NOT call supervisor.start(...) — that's the
+    // path under test.
+
+    const { run, calls } = alwaysOkRun();
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const deps = {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+      supervisor,
+      run,
+    };
+    const res = await handleUpgrade(
+      postReq("/api/modules/vault/upgrade", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      deps,
+    );
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { operation_id: string };
+    // Give the async runUpgrade chain a tick to settle.
+    await new Promise((r) => setTimeout(r, 10));
+
+    // bun add was still attempted (it's the first step).
+    expect(calls).toContainEqual(["bun", "add", "-g", "@openparachute/vault@latest"]);
+    // No supervisor spawn ever happened — confirms the missing
+    // supervisor entry is what we exercised, not some other branch.
+    expect(spawns).toEqual([]);
+
+    // Poll the operation: status `failed`, message points the
+    // operator at the install path.
+    const opRes = await handleOperationGet(
+      getReq(`/api/modules/operations/${body.operation_id}`, {
+        authorization: `Bearer ${bearer}`,
+      }),
+      body.operation_id,
+      deps,
+    );
+    const op = (await opRes.json()) as {
+      status: string;
+      error?: string;
+      log: string[];
+    };
+    expect(op.status).toBe("failed");
+    expect(op.error).toMatch(/supervisor restart found no module/);
+    expect(op.log.join(" ")).toMatch(/try install first/);
+  });
 });
 
 describe("POST /api/modules/:short/uninstall", () => {

--- a/src/__tests__/supervisor.test.ts
+++ b/src/__tests__/supervisor.test.ts
@@ -328,7 +328,8 @@ describe("Supervisor.stop", () => {
 
     // The exited-resolver awaited the same promise stop() did; if
     // stop returned without awaiting, this flag could still be false.
-    // (Both promise chains fire from the same resolveExit call.)
+    // (Both promise chains fire from the same resolveExit call.
+    // Microtask ordering guarantees they both run before await returns.)
     expect(exitObservedBeforeReturn).toBe(true);
     expect(signals).toEqual(["SIGTERM"]);
     expect(sup.get("vault")?.status).toBe("stopped");

--- a/src/__tests__/supervisor.test.ts
+++ b/src/__tests__/supervisor.test.ts
@@ -248,16 +248,89 @@ describe("Supervisor.stop", () => {
     });
     await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
 
-    await sup.stop("vault");
+    // stop() now awaits proc.exited (with SIGKILL escalation on
+    // timeout) — kick it off, observe the SIGTERM landed, then
+    // resolve exited so the await completes.
+    const stopPromise = sup.stop("vault");
     expect(proc.killed).toBe(true);
     expect(proc.killSignal).toBe("SIGTERM");
 
     proc.closeStreams();
     proc.resolveExit(0);
-    await tick();
+    await stopPromise;
 
     // No second spawn — stop is an intentional exit.
     expect(spawner.calls).toHaveLength(1);
+    expect(sup.get("vault")?.status).toBe("stopped");
+  });
+
+  test("escalates to SIGKILL when child ignores SIGTERM past killTimeoutMs", async () => {
+    // Child that refuses to exit on SIGTERM. The fake records every
+    // signal it receives; the supervisor should send SIGTERM,
+    // observe no exit, then send SIGKILL after the timeout.
+    const proc = makeFakeProc(101);
+    const signals: (NodeJS.Signals | number | undefined)[] = [];
+    proc.kill = (signal) => {
+      signals.push(signal);
+      // Only SIGKILL actually terminates this fake child — SIGTERM
+      // gets logged and ignored, simulating the wedged-module shape.
+      if (signal === "SIGKILL") proc.resolveExit(null);
+    };
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(proc);
+    const outputs: string[] = [];
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      restartDelayMs: 0,
+      sleep: () => Promise.resolve(),
+      killTimeoutMs: 5, // Short timeout so the test doesn't pause for 5s.
+      output: (line) => outputs.push(line),
+    });
+    await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+
+    proc.closeStreams();
+    await sup.stop("vault");
+
+    // SIGTERM first, then SIGKILL after the timeout.
+    expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(outputs.some((l) => l.includes("escalating to SIGKILL"))).toBe(true);
+    expect(sup.get("vault")?.status).toBe("stopped");
+  });
+
+  test("stop awaits child exit before returning (no SIGKILL needed)", async () => {
+    // Well-behaved child: exits ~10ms after SIGTERM. stop() should
+    // return only after the exit promise resolves, not immediately
+    // post-SIGTERM. This is the log-flush guarantee that motivated
+    // the await in the first place (hub#263).
+    const proc = makeFakeProc(101);
+    proc.kill = (signal) => {
+      signals.push(signal);
+      // Simulate the child taking a few ms to flush + exit.
+      setTimeout(() => proc.resolveExit(0), 5);
+    };
+    const signals: (NodeJS.Signals | number | undefined)[] = [];
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(proc);
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      restartDelayMs: 0,
+      sleep: () => Promise.resolve(),
+      killTimeoutMs: 1000, // Plenty of headroom for the 5ms simulated exit.
+    });
+    await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+
+    proc.closeStreams();
+    let exitObservedBeforeReturn = false;
+    void proc.exited.then(() => {
+      exitObservedBeforeReturn = true;
+    });
+    await sup.stop("vault");
+
+    // The exited-resolver awaited the same promise stop() did; if
+    // stop returned without awaiting, this flag could still be false.
+    // (Both promise chains fire from the same resolveExit call.)
+    expect(exitObservedBeforeReturn).toBe(true);
+    expect(signals).toEqual(["SIGTERM"]);
     expect(sup.get("vault")?.status).toBe("stopped");
   });
 });

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -241,12 +241,13 @@ export class Supervisor {
           }
           try {
             await proc.exited;
+            // SIGKILL cannot be caught; OS reaps the child promptly.
           } catch {
             // exited rejection is non-fatal — we're stopping anyway.
           }
         }
       } finally {
-        if (timer !== undefined) clearTimeout(timer);
+        clearTimeout(timer!);
       }
     }
     entry.state = { ...entry.state, status: "stopped" };

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -81,6 +81,17 @@ export interface SupervisorOpts {
    */
   readonly restartDelayMs?: number;
   /**
+   * Max time to wait for a child to exit after SIGTERM before
+   * escalating to SIGKILL, in ms. Default 5000 — long enough for a
+   * well-behaved module to flush its log buffer + drop its listeners,
+   * short enough that a wedged child doesn't keep `stop()` (and the
+   * container shutdown path that calls it) hanging indefinitely.
+   *
+   * Tests pass a short timeout (1–10ms) to exercise the SIGKILL
+   * escalation path without real waiting.
+   */
+  readonly killTimeoutMs?: number;
+  /**
    * Where prefixed child output goes. Default `process.stdout.write`.
    * Tests inject a collector so they can assert on the multiplexed
    * stream without spelunking stdout.
@@ -123,6 +134,7 @@ export interface SupervisedProc {
 const DEFAULT_MAX_RESTARTS = 3;
 const DEFAULT_RESTART_WINDOW_MS = 60_000;
 const DEFAULT_RESTART_DELAY_MS = 500;
+const DEFAULT_KILL_TIMEOUT_MS = 5_000;
 
 /**
  * Per-module supervisor. Owns the spawn → watch → restart loop.
@@ -143,6 +155,7 @@ export class Supervisor {
       maxRestarts: opts.maxRestarts ?? DEFAULT_MAX_RESTARTS,
       restartWindowMs: opts.restartWindowMs ?? DEFAULT_RESTART_WINDOW_MS,
       restartDelayMs: opts.restartDelayMs ?? DEFAULT_RESTART_DELAY_MS,
+      killTimeoutMs: opts.killTimeoutMs ?? DEFAULT_KILL_TIMEOUT_MS,
       output: opts.output ?? ((line) => process.stdout.write(line)),
       spawnFn: opts.spawnFn ?? defaultSpawnFn,
       now: opts.now ?? Date.now,
@@ -177,19 +190,63 @@ export class Supervisor {
   }
 
   /**
-   * Stop a supervised module. Sends SIGTERM, marks the state
-   * `stopped`, and detaches the exit watcher so a normal termination
-   * isn't seen as a crash. Idempotent on already-stopped modules.
+   * Stop a supervised module. Sends SIGTERM, awaits the child's exit
+   * (so the log-pump drains the final flush before our stdout closes),
+   * and escalates to SIGKILL if the child doesn't exit within
+   * `killTimeoutMs`. Marks the state `stopped` and detaches the exit
+   * watcher so a normal termination isn't seen as a crash. Idempotent
+   * on already-stopped modules.
+   *
+   * The await matters in two places:
+   *   - Container shutdown (hub PID 1 receiving SIGTERM from Render):
+   *     without it, children's final log lines never make it through
+   *     hub's stdout pipe before the platform reaps the pod.
+   *   - `restart()`: a fresh spawn that races a still-listening prior
+   *     PID will fail with EADDRINUSE.
+   *
+   * The SIGKILL escalation handles a wedged module (e.g. a broken
+   * native binding ignoring SIGTERM). Without it, `stop()` would hang
+   * forever and a re-deploy would leak the orphaned child until the
+   * container itself was recycled.
    */
   async stop(short: string): Promise<ModuleState | undefined> {
     const entry = this.modules.get(short);
     if (!entry) return undefined;
     entry.stopRequested = true;
-    if (entry.proc) {
+    const proc = entry.proc;
+    if (proc) {
       try {
-        entry.proc.kill("SIGTERM");
+        proc.kill("SIGTERM");
       } catch {
         // Process may already be dead — fall through.
+      }
+      // Race the child's exit against the kill timeout. If the timer
+      // wins, escalate to SIGKILL. Either way we end up awaiting the
+      // exit promise so the log pump drains.
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<"timeout">((resolve) => {
+        timer = setTimeout(() => resolve("timeout"), this.opts.killTimeoutMs);
+      });
+      try {
+        const winner = await Promise.race([proc.exited.then(() => "exited" as const), timeout]);
+        if (winner === "timeout") {
+          this.opts.output(
+            `[supervisor] ${entry.req.short} did not exit ${this.opts.killTimeoutMs}ms after SIGTERM — escalating to SIGKILL.\n`,
+          );
+          try {
+            proc.kill("SIGKILL");
+          } catch {
+            // Process may already be dead between the timeout firing
+            // and us reaching kill() — fall through to the await.
+          }
+          try {
+            await proc.exited;
+          } catch {
+            // exited rejection is non-fatal — we're stopping anyway.
+          }
+        }
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
       }
     }
     entry.state = { ...entry.state, status: "stopped" };
@@ -217,16 +274,10 @@ export class Supervisor {
     if (!entry) return undefined;
     const req = entry.req;
     entry.state = { ...entry.state, status: "restarting" };
+    // stop() now awaits the prior process's exit (with SIGKILL
+    // escalation) before returning, so the fresh spawn below doesn't
+    // race on EADDRINUSE — no separate await needed here.
     await this.stop(short);
-    // Wait for the prior process to actually exit so the new spawn
-    // doesn't race on EADDRINUSE.
-    if (entry.proc) {
-      try {
-        await entry.proc.exited;
-      } catch {
-        // exited promise rejection is non-fatal — we're stopping anyway.
-      }
-    }
     // Drop the entry so `start` treats this as a clean spawn.
     this.modules.delete(short);
     return this.start(req);


### PR DESCRIPTION
## Summary

Three supervisor-lifecycle follow-ups from the hub#262 reviewer pass, bundled into one cohesive PR because Items 1+2 are literally the same code path.

- **#263** — `Supervisor.stop()` now awaits the child's `exited` promise before returning, so the log-pump drains the child's final flush before hub's stdout pipe closes. Fixes the "last 100ms of vault's logs vanish from Render's log viewer" symptom — no correctness bug on Render (hub is PID 1, OS reaps children), but a real diagnostic-visibility loss.
- **#264** — same code path now escalates to SIGKILL if the child doesn't exit within `killTimeoutMs` (default 5000ms, configurable for tests). Fixes the wedged-module leak (a broken native binding that ignores SIGTERM would have leaked until the container itself was recycled).
- **#265** — regression test for the `handleUpgrade` branch where `bun add -g` succeeds but `supervisor.restart(short)` returns undefined (module is in services.json but never supervised). The branch correctly marks the operation `failed` with a "try install first" message; now it has a test guarding that behavior.

## Item 1 + 2 (bundled): stop() awaits child exit with SIGKILL escalation

The two issues are the same code path — implementing Option A from #263 naturally hands off to #264's escalation. New shape:

```ts
proc.kill("SIGTERM");
const winner = await Promise.race([
  proc.exited.then(() => "exited"),
  setTimeout(killTimeoutMs).then(() => "timeout"),
]);
if (winner === "timeout") {
  proc.kill("SIGKILL");
  await proc.exited;
}
```

New `SupervisorOpts.killTimeoutMs` (default `5_000`) so tests can pass a small value (5ms) to exercise the SIGKILL path without real waiting.

`restart()` simplified — it had its own `await entry.proc.exited` after `stop()` returned, which is now redundant since `stop()` does the awaiting.

## Item 3: test upgrade-on-unsupervised path

Pre-supervisor `parachute install` runs could leave a services.json row without a corresponding supervisor entry. Hitting `POST /api/modules/vault/upgrade` in that state was supposed to mark the operation `failed` with "try install first" — verified now by a test.

## Test plan

- [x] `bun test ./src` — **1418 pass / 0 fail / 30746 expects across 79 files**. +3 over rc.7.
- [x] `bun run typecheck` clean.
- [x] `bunx biome check .` clean.
- [x] Existing supervisor tests still pass (operator-stop test was rewritten to handle the new async shape).
- [x] New SIGKILL-escalation test: fake child whose `kill()` only resolves `exited` on SIGKILL — verifies SIGTERM → 5ms timeout → SIGKILL escalation lands.
- [x] New await-before-return test: well-behaved child exits ~5ms after SIGTERM — verifies `stop()` doesn't return until exit resolves (the log-flush guarantee).
- [x] New upgrade-on-unsupervised test: manifests services.json row, skips `supervisor.start()`, POSTs upgrade, polls op, asserts `failed` + "try install first" message + `spawns === []` (confirms we hit the right branch).
- No smoke — these are correctness fixes provable by tests. The fake-child harness exercises the full SIGTERM/SIGKILL flow end-to-end.

## Versioning

`0.5.10-rc.8`. Same chain as rc.7 per pre-1.0 RC governance.

Closes #263, closes #264, closes #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)