### PR TITLE
feat(hub): multi-user Phase 1 PR 1 — users table foundation (password_changed + assigned_vault)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.10-rc.12] - 2026-05-20
+
+Multi-user Phase 1 — PR 1 of 5: users table foundation (hub#252, design [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)). Schema-only foundation that the admin-creates-user surface (PR 2), force-change-password flow (PR 3), and OAuth issuer integration (PR 4) build on. No UI surface, no API endpoints — just migration v8 + `User`-type extensions + reusable username/password validators wired through the wizard's and env-seed paths.
+
+Surface summary:
+- `src/hub-db.ts` — migration v8. Two `ALTER TABLE` on `users` (`password_changed INTEGER NOT NULL DEFAULT 0` + `assigned_vault TEXT` nullable) plus a `UPDATE users SET password_changed = 1` backfill so existing rows (wizard admin, env-seeded admin) don't get spurious force-change redirects on first sign-in.
+- `src/users.ts` — `User` gains `passwordChanged: boolean` + `assignedVault: string | null`. `CreateUserOpts` gains optional `passwordChanged` (default `false`) and `assignedVault` (default `null`); `createUser` persists both. `rowToUser` translates the 0/1 INTEGER to TS `boolean`. New `validateUsername(name)` helper (charset `[a-z0-9_-]`, length 2-32, case-insensitive reserved list `admin`/`root`/`system`/`setup`/`parachute`/`hub`, returns discriminated union with `format`/`length`/`reserved` reasons). New `validatePassword(password)` helper (12-char minimum, no complexity rules, returns discriminated union with `too_short` reason). Neither validator is wired into a caller yet — PR 2's `POST /api/users` and PR 3's `POST /account/change-password` consume them.
+- `src/commands/serve.ts` — `seedInitialAdminIfNeeded` now passes `{ passwordChanged: true }` so env-seeded admins skip the force-change-password redirect on first sign-in (they chose their password via `PARACHUTE_INITIAL_ADMIN_PASSWORD`).
+- `src/setup-wizard.ts` — `handleSetupAccountPost` now passes `{ passwordChanged: true }` to `createUser` so the wizard's first-admin (who picked their own password through the form) doesn't get the force-change-password redirect.
+
+What's NOT in PR 1 (deferred to later PRs in the chain):
+- Admin SPA `/admin/users` page + API endpoints (`GET`/`POST`/`PATCH`/`DELETE /api/users`) — PR 2.
+- `/login` force-change-password redirect + `/account/change-password` form — PR 3.
+- OAuth issuer `vault_scope` claim + per-user scope narrowing — PR 4.
+- End-to-end verification + scope-guard reach-through — PR 5.
+
+Gate: `bun test ./src` — **1497 pass / 0 fail / 31038 expects across 80 files** (+15 over rc.11 baseline 1482). SPA: `cd web/ui && bun run test` — **120 pass / 0 fail across 9 files** (unchanged — no SPA surface touched). typecheck + biome clean (root + web/ui).
+
 ## [0.5.10-rc.11] - 2026-05-20
 
 Fresh-machine connect bug + done-screen token-reveal UX. Two issues surfaced on Aaron's fresh-machine wizard testing pass, folded together.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.10-rc.11",
+  "version": "0.5.10-rc.12",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-db.test.ts
+++ b/src/__tests__/hub-db.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { hubDbPath, migrate, openHubDb } from "../hub-db.ts";
 
 interface Harness {
   configDir: string;
@@ -143,6 +143,131 @@ describe("openHubDb + migrate", () => {
             )
             .run("t1", "no-such-user", "c", "s", "2030-01-01", "2026-01-01"),
         ).toThrow();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("v8 adds password_changed + assigned_vault columns on a fresh DB", () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(h.dbPath);
+      try {
+        const versions = (
+          db.query<{ version: number }, []>("SELECT version FROM schema_version").all() ?? []
+        ).map((r) => r.version);
+        expect(versions).toContain(8);
+        // PRAGMA table_info returns the column shape; we want both new
+        // columns present with the right defaults / nullability.
+        interface ColInfo {
+          name: string;
+          type: string;
+          notnull: number;
+          dflt_value: string | null;
+        }
+        const cols = db
+          .query<ColInfo, []>(
+            "SELECT name, type, \"notnull\", dflt_value FROM pragma_table_info('users')",
+          )
+          .all();
+        const byName = new Map(cols.map((c) => [c.name, c]));
+        const pc = byName.get("password_changed");
+        expect(pc).toBeDefined();
+        expect(pc?.type).toBe("INTEGER");
+        expect(pc?.notnull).toBe(1);
+        // Default literal — SQLite returns it as a string "0".
+        expect(pc?.dflt_value).toBe("0");
+        const av = byName.get("assigned_vault");
+        expect(av).toBeDefined();
+        expect(av?.type).toBe("TEXT");
+        expect(av?.notnull).toBe(0);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("v8 backfills password_changed=1 for users that pre-date the migration", () => {
+    const h = makeHarness();
+    try {
+      // Stand up a DB at the v7 state by partially-applying migrations:
+      // open Database directly, call migrate after stripping the v8 entry
+      // would be invasive. Instead, drive the same migration shape by hand
+      // for v1-v7 then insert a row, then call migrate() to apply v8.
+      // Cleanest path: openHubDb runs everything, but we want a v7 snapshot.
+      // Approach: open with openHubDb (runs all migrations), drop the v8
+      // changes, mark v8 unapplied, insert a user with password_changed=0
+      // (simulating a row from before the backfill), then re-run migrate.
+      // SQLite doesn't have DROP COLUMN pre-3.35 universally, so we do the
+      // recreate-and-rename: drop v8's columns by recreating users without
+      // them, then delete the v8 schema_version row, then call migrate().
+      const db = openHubDb(h.dbPath);
+      try {
+        // Build a v7-shape users table and copy the v8-shape rows.
+        db.exec(`
+          CREATE TABLE users_v7 (
+            id TEXT PRIMARY KEY,
+            username TEXT UNIQUE NOT NULL,
+            password_hash TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+          );
+          INSERT INTO users_v7 (id, username, password_hash, created_at, updated_at)
+          SELECT id, username, password_hash, created_at, updated_at FROM users;
+          DROP TABLE users;
+          ALTER TABLE users_v7 RENAME TO users;
+        `);
+        db.exec("DELETE FROM schema_version WHERE version = 8");
+        // Insert a row that pre-dates v8 (no password_changed column yet).
+        db.prepare(
+          `INSERT INTO users (id, username, password_hash, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        ).run("legacy-user", "owner", "h", "2026-01-01", "2026-01-01");
+        // Now re-run migrations — v8 should ALTER the table and backfill.
+        migrate(db);
+        const row = db
+          .query<{ password_changed: number; assigned_vault: string | null }, [string]>(
+            "SELECT password_changed, assigned_vault FROM users WHERE id = ?",
+          )
+          .get("legacy-user");
+        expect(row).not.toBeNull();
+        expect(row?.password_changed).toBe(1);
+        expect(row?.assigned_vault).toBeNull();
+        const versions = (
+          db.query<{ version: number }, []>("SELECT version FROM schema_version").all() ?? []
+        ).map((r) => r.version);
+        expect(versions).toContain(8);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("v8 — fresh inserts default password_changed=0 and assigned_vault NULL", () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(h.dbPath);
+      try {
+        // Insert via the bare-columns SQL (mirrors what a pre-v8 caller
+        // would emit) to confirm the column DEFAULTs work.
+        db.prepare(
+          `INSERT INTO users (id, username, password_hash, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        ).run("u-default", "owner", "h", "2026-01-01", "2026-01-01");
+        const row = db
+          .query<{ password_changed: number; assigned_vault: string | null }, [string]>(
+            "SELECT password_changed, assigned_vault FROM users WHERE id = ?",
+          )
+          .get("u-default");
+        expect(row?.password_changed).toBe(0);
+        expect(row?.assigned_vault).toBeNull();
       } finally {
         db.close();
       }

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { seedInitialAdminIfNeeded } from "../commands/serve.ts";
 import { openHubDb } from "../hub-db.ts";
-import { userCount } from "../users.ts";
+import { getUserByUsername, userCount } from "../users.ts";
 
 describe("seedInitialAdminIfNeeded", () => {
   let dir: string;
@@ -44,6 +44,13 @@ describe("seedInitialAdminIfNeeded", () => {
     expect(log).toHaveBeenCalledTimes(1);
     expect(log.mock.calls[0]?.[0] ?? "").toContain("seeded initial admin");
     expect(log.mock.calls[0]?.[0] ?? "").toContain("ops");
+    // Multi-user Phase 1 (design 2026-05-20-multi-user-phase-1.md §wizard
+    // interaction): env-seeded admin chose their password via env vars, so
+    // skip the force-change-password redirect. `assignedVault` stays null
+    // — admin posture.
+    const seeded = getUserByUsername(db, "ops");
+    expect(seeded?.passwordChanged).toBe(true);
+    expect(seeded?.assignedVault).toBeNull();
   });
 
   test("returns 'exists' when an admin already exists, even with env vars set", async () => {

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -37,7 +37,7 @@ import {
   handleSetupVaultPost,
 } from "../setup-wizard.ts";
 import { Supervisor } from "../supervisor.ts";
-import { createUser, userCount } from "../users.ts";
+import { createUser, getUserByUsername, userCount } from "../users.ts";
 
 interface Harness {
   dir: string;
@@ -577,6 +577,13 @@ describe("handleSetupAccountPost", () => {
       const sessionCookie = setCookie(post, SESSION_COOKIE_NAME);
       expect(sessionCookie).toBeDefined();
       expect(userCount(db)).toBe(1);
+      // Multi-user Phase 1: the wizard's first admin chose their password
+      // via this very form, so skip the force-change-password redirect on
+      // first sign-in (`password_changed=1`). `assigned_vault` stays NULL
+      // — admin posture (no per-vault restriction).
+      const created = getUserByUsername(db, "ops");
+      expect(created?.passwordChanged).toBe(true);
+      expect(created?.assignedVault).toBeNull();
     } finally {
       db.close();
     }

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -33,6 +33,11 @@ function makeDb() {
 }
 
 describe("createUser", () => {
+  // Note: createUser doesn't call validatePassword directly (PR 2 wires
+  // it at the endpoint layer). These short passwords ("hunter2", "pw1",
+  // etc.) are deliberate for testing the argon2id round-trip + the
+  // INSERT shape in isolation; PR 2's endpoint tests will use full-
+  // length (12+ char) passwords against the validator-gated path.
   test("creates a user and stores an argon2id hash", async () => {
     const { db, cleanup } = makeDb();
     try {

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -4,7 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import {
+  PASSWORD_MIN_LEN,
   SingleUserModeError,
+  USERNAME_RESERVED,
   UserNotFoundError,
   UsernameTakenError,
   createUser,
@@ -13,6 +15,8 @@ import {
   listUsers,
   setPassword,
   userCount,
+  validatePassword,
+  validateUsername,
   verifyPassword,
 } from "../users.ts";
 
@@ -39,6 +43,50 @@ describe("createUser", () => {
       expect(u.passwordHash.startsWith("$argon2id$")).toBe(true);
       expect(u.createdAt).toBe(u.updatedAt);
       expect(userCount(db)).toBe(1);
+      // Default multi-user-Phase-1 shape: unchanged password, no vault pin.
+      expect(u.passwordChanged).toBe(false);
+      expect(u.assignedVault).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("passwordChanged opt-in lands the bit set (wizard / env-seed path)", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "owner", "hunter2", { passwordChanged: true });
+      expect(u.passwordChanged).toBe(true);
+      // Round-trip through getUserById so we know it's persisted, not
+      // just returned by the in-memory createUser result.
+      const fresh = getUserById(db, u.id);
+      expect(fresh?.passwordChanged).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("assignedVault opt-in persists the column (admin-creates-user path)", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "alice", "pw1", {
+        allowMulti: true,
+        assignedVault: "alice",
+      });
+      expect(u.assignedVault).toBe("alice");
+      const fresh = getUserById(db, u.id);
+      expect(fresh?.assignedVault).toBe("alice");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("assignedVault explicit null is treated the same as omitted", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "admin1", "pw1", { assignedVault: null });
+      expect(u.assignedVault).toBeNull();
+      const fresh = getUserById(db, u.id);
+      expect(fresh?.assignedVault).toBeNull();
     } finally {
       cleanup();
     }
@@ -150,5 +198,91 @@ describe("listUsers / getUserByUsername", () => {
     } finally {
       cleanup();
     }
+  });
+});
+
+describe("validateUsername", () => {
+  test("happy path — typical names", () => {
+    for (const name of ["alice", "bob_42", "user-1", "ab", "a-b-c", "x_y_z"]) {
+      const r = validateUsername(name);
+      expect(r.valid).toBe(true);
+      if (r.valid) expect(r.name).toBe(name);
+    }
+  });
+
+  test("length boundaries — 2 and 32 OK, 1 and 33 rejected", () => {
+    expect(validateUsername("ab").valid).toBe(true);
+    expect(validateUsername("a".repeat(32)).valid).toBe(true);
+    const tooShort = validateUsername("a");
+    expect(tooShort.valid).toBe(false);
+    if (!tooShort.valid) expect(tooShort.reason).toBe("length");
+    const tooLong = validateUsername("a".repeat(33));
+    expect(tooLong.valid).toBe(false);
+    if (!tooLong.valid) expect(tooLong.reason).toBe("length");
+    // Empty string is a length failure (not a format failure).
+    const empty = validateUsername("");
+    expect(empty.valid).toBe(false);
+    if (!empty.valid) expect(empty.reason).toBe("length");
+  });
+
+  test("format failures — uppercase, spaces, symbols rejected", () => {
+    for (const name of ["Alice", "bob smith", "user@domain", "name!", "user.name", "naïve"]) {
+      const r = validateUsername(name);
+      expect(r.valid).toBe(false);
+      if (!r.valid) expect(r.reason).toBe("format");
+    }
+  });
+
+  test("reserved words rejected — case-insensitive", () => {
+    for (const reserved of USERNAME_RESERVED) {
+      const r = validateUsername(reserved);
+      expect(r.valid).toBe(false);
+      if (!r.valid) expect(r.reason).toBe("reserved");
+    }
+    // Case variants — the regex pins lowercase so uppercase fails as
+    // "format" first; the case-insensitive reserved check is defense in
+    // depth. But within the lowercase-allowed set, mixed-case-spelled
+    // reserved words are blocked by the format gate (e.g. "Admin"
+    // fails format, not reserved). The regex catches case variants
+    // before reserved-check ever runs — that's correct order.
+    const mixed = validateUsername("Admin");
+    expect(mixed.valid).toBe(false);
+    if (!mixed.valid) expect(mixed.reason).toBe("format");
+  });
+
+  test("hyphens and underscores allowed; numbers allowed", () => {
+    expect(validateUsername("user_1").valid).toBe(true);
+    expect(validateUsername("user-2").valid).toBe(true);
+    expect(validateUsername("123").valid).toBe(true);
+    expect(validateUsername("_-_").valid).toBe(true);
+  });
+});
+
+describe("validatePassword", () => {
+  test("happy path — 12+ chars accepted", () => {
+    expect(validatePassword("twelvechars1").valid).toBe(true);
+    expect(validatePassword("a much longer passphrase here").valid).toBe(true);
+  });
+
+  test("boundary — exactly 12 chars accepted, 11 rejected", () => {
+    expect(PASSWORD_MIN_LEN).toBe(12);
+    expect(validatePassword("a".repeat(12)).valid).toBe(true);
+    const r = validatePassword("a".repeat(11));
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.reason).toBe("too_short");
+  });
+
+  test("empty string rejected as too_short", () => {
+    const r = validatePassword("");
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.reason).toBe("too_short");
+  });
+
+  test("no complexity rules — long but all-same-char accepted", () => {
+    // Phase 1 takes NIST 800-63B's lead: length over forced classes.
+    // Aaron settled on 12-min, no complexity. If we later want to nudge
+    // toward passphrases we'll layer it as a separate signal, not a
+    // hard gate.
+    expect(validatePassword("aaaaaaaaaaaa").valid).toBe(true);
   });
 });

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -433,7 +433,15 @@ async function runSetPassword(args: readonly string[], deps: AuthDeps): Promise<
     }
 
     try {
-      const u = await createUser(db, targetUsername, password, { allowMulti: flags.allowMulti });
+      // `passwordChanged: true` matches the wizard + env-seed paths: the
+      // CLI user typed their password at the prompt above (or supplied
+      // it via --password), so they don't need PR 3's force-change-on-
+      // first-sign-in redirect. Same reasoning as
+      // `seedInitialAdminIfNeeded` and `handleSetupAccountPost`.
+      const u = await createUser(db, targetUsername, password, {
+        allowMulti: flags.allowMulti,
+        passwordChanged: true,
+      });
       console.log(`Created hub user "${u.username}" (id=${u.id}).`);
       const issued = await issueOperatorToken(db, u.id, {
         dir: deps.configDir,

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -102,7 +102,11 @@ export async function seedInitialAdminIfNeeded(
   const username = env.PARACHUTE_INITIAL_ADMIN_USERNAME?.trim();
   const password = env.PARACHUTE_INITIAL_ADMIN_PASSWORD;
   if (!username || !password) return "needs-setup";
-  await createUser(db, username, password);
+  // Env-seeded admins chose their password via the env var; skip the
+  // multi-user-Phase-1 force-change-password redirect by landing
+  // `password_changed=true`. Same treatment as the wizard's first admin.
+  // `assignedVault` stays null — admin posture (no per-vault restriction).
+  await createUser(db, username, password, { passwordChanged: true });
   log(`parachute serve: seeded initial admin "${username}" from PARACHUTE_INITIAL_ADMIN_*`);
   return "seeded";
 }

--- a/src/hub-db.ts
+++ b/src/hub-db.ts
@@ -217,6 +217,36 @@ const MIGRATIONS: readonly Migration[] = [
       );
     `,
   },
+  {
+    version: 8,
+    sql: `
+      -- Multi-user Phase 1 (hub#252, design 2026-05-20-multi-user-phase-1.md).
+      -- Two columns on \`users\`:
+      --
+      --   * password_changed (INTEGER 0/1) — tracks whether a user has
+      --     changed their password since account creation. The admin-creates-
+      --     user flow (PR 2) lands new accounts with 0; the user's forced
+      --     change-password flow (PR 3) flips it to 1. SQLite has no native
+      --     BOOL, so 0/1 + a TS helper in users.ts handles the translation.
+      --   * assigned_vault (TEXT, nullable) — the vault instance name the
+      --     user is pinned to (Phase 1 is single-vault-per-user). NULL means
+      --     "no per-vault restriction" — the wizard's first admin and any
+      --     other admin-role user. The OAuth issuer (PR 4) reads this at
+      --     mint time to narrow the token's vault scope. No FK: vault names
+      --     resolve through services.json, not a DB row.
+      --
+      -- Backfill: every existing user pre-dates this migration. The only
+      -- accounts that could exist are the wizard's first admin (chose their
+      -- own password via the wizard form) or env-seeded admins (operator
+      -- baked the password into PARACHUTE_INITIAL_ADMIN_PASSWORD). Both
+      -- already-chosen-by-the-account-holder paths, so flip every existing
+      -- row to password_changed=1 — no spurious force-change on first sign-
+      -- in for already-bootstrapped hubs.
+      ALTER TABLE users ADD COLUMN password_changed INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE users ADD COLUMN assigned_vault TEXT;
+      UPDATE users SET password_changed = 1;
+    `,
+  },
 ];
 
 export function openHubDb(path: string = hubDbPath()): Database {

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -1089,7 +1089,12 @@ export async function handleSetupAccountPost(
     return htmlResponse(renderAccountStep({ csrfToken, username, errorMessage: fieldErr }), 400);
   }
   try {
-    const user = await createUser(deps.db, username, password);
+    // Wizard-admin chose their password through this very form; skip the
+    // multi-user-Phase-1 force-change-password redirect by landing
+    // `password_changed=true`. `assignedVault` stays null — admin posture
+    // (the wizard never asks the first admin to pin themselves to a
+    // single vault; that's a non-admin user pattern).
+    const user = await createUser(deps.db, username, password, { passwordChanged: true });
     const session = createSession(deps.db, { userId: user.id });
     const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000), {
       secure: isHttpsRequest(req),

--- a/src/users.ts
+++ b/src/users.ts
@@ -233,6 +233,11 @@ export function validateUsername(name: string): ValidateUsernameResult {
   if (name.length < USERNAME_MIN_LEN || name.length > USERNAME_MAX_LEN) {
     return { valid: false, reason: "length" };
   }
+  // The regex deliberately allows leading/trailing `_` and `-` (so
+  // `_-_`, `--alice`, `-foo`, `bar_` all pass the format gate). Stricter
+  // rules can land later if real-world users hit confusion. Vault's
+  // parallel username validator has the same shape — cross-repo parity
+  // matters more than aesthetic edge-case rejection here.
   if (!USERNAME_REGEX.test(name)) {
     return { valid: false, reason: "format" };
   }
@@ -258,6 +263,19 @@ export function validateUsername(name: string): ValidateUsernameResult {
  * form) wire the `reason` into the response.
  */
 export const PASSWORD_MIN_LEN = 12;
+
+/**
+ * Upper bound for incoming password bodies. Not enforced inside
+ * `validatePassword` itself — the validator's contract is "length floor,
+ * no complexity rules" and adding a ceiling would muddy it. Exposed as
+ * a constant so PR 2's `POST /api/users` (and PR 3's change-password
+ * form) can cap incoming bodies before argon2id touches them. Defense
+ * against a CPU-DoS shape where an unauthenticated POST submits a
+ * megabyte password and forces a long argon2id hash. 256 chars is
+ * comfortably above any human-chosen passphrase (Diceware 8-word
+ * passphrases run ~55 chars).
+ */
+export const PASSWORD_MAX_LEN = 256;
 
 export type ValidatePasswordResult = { valid: true } | { valid: false; reason: "too_short" };
 

--- a/src/users.ts
+++ b/src/users.ts
@@ -25,6 +25,25 @@ export interface User {
   passwordHash: string;
   createdAt: string;
   updatedAt: string;
+  /**
+   * Whether the user has changed their password since account creation.
+   * `false` means the user signed up with an admin-typed default password
+   * and the force-change-password flow at sign-in time should redirect
+   * them to `/account/change-password`. The wizard's first admin and env-
+   * seeded admins land as `true` (they chose their own password). Stored
+   * as `users.password_changed INTEGER 0|1` (added in migration v8).
+   */
+  passwordChanged: boolean;
+  /**
+   * The vault instance name this user is pinned to (Phase 1 multi-user is
+   * single-vault-per-user). `null` means "no per-vault restriction" — the
+   * default for admin accounts, where the OAuth issuer mints tokens for
+   * any requested vault. Non-null pins the issuer to narrow scopes to
+   * `vault:<assigned_vault>:<verb>`. No FK; vault names resolve through
+   * `services.json` at mint time. Stored as `users.assigned_vault TEXT`
+   * (added in migration v8).
+   */
+  assignedVault: string | null;
 }
 
 export class SingleUserModeError extends Error {
@@ -56,6 +75,8 @@ interface Row {
   password_hash: string;
   created_at: string;
   updated_at: string;
+  password_changed: number;
+  assigned_vault: string | null;
 }
 
 function rowToUser(r: Row): User {
@@ -65,6 +86,8 @@ function rowToUser(r: Row): User {
     passwordHash: r.password_hash,
     createdAt: r.created_at,
     updatedAt: r.updated_at,
+    passwordChanged: r.password_changed === 1,
+    assignedVault: r.assigned_vault,
   };
 }
 
@@ -72,6 +95,23 @@ export interface CreateUserOpts {
   /** Allow creating an additional user when one already exists. Off by default. */
   allowMulti?: boolean;
   now?: () => Date;
+  /**
+   * Whether the new user has already chosen their password. Default `false`
+   * — the admin-creates-user path (PR 2) lands new accounts with the bit
+   * unset so the user is force-redirected to change it on first sign-in
+   * (PR 3). The wizard's first-admin path and env-seeded admin path pass
+   * `true` (they chose their own password through the wizard form / env
+   * vars; no force-change needed).
+   */
+  passwordChanged?: boolean;
+  /**
+   * Vault instance name to pin the user to (Phase 1 single-vault). `null`
+   * (default) means "no restriction" — admin posture. The OAuth issuer
+   * (PR 4) reads this at mint time to narrow scopes. No validation here:
+   * the API endpoint (PR 2) is responsible for checking against
+   * `services.json` before passing through.
+   */
+  assignedVault?: string | null;
 }
 
 export async function createUser(
@@ -87,10 +127,14 @@ export async function createUser(
   const id = randomUUID();
   const passwordHash = await argonHash(password);
   const stamp = (opts.now?.() ?? new Date()).toISOString();
+  const passwordChanged = opts.passwordChanged === true ? 1 : 0;
+  const assignedVault = opts.assignedVault ?? null;
   try {
     db.prepare(
-      "INSERT INTO users (id, username, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
-    ).run(id, username, passwordHash, stamp, stamp);
+      `INSERT INTO users
+         (id, username, password_hash, created_at, updated_at, password_changed, assigned_vault)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(id, username, passwordHash, stamp, stamp, passwordChanged, assignedVault);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes("UNIQUE") && msg.includes("users.username")) {
@@ -98,7 +142,15 @@ export async function createUser(
     }
     throw err;
   }
-  return { id, username, passwordHash, createdAt: stamp, updatedAt: stamp };
+  return {
+    id,
+    username,
+    passwordHash,
+    createdAt: stamp,
+    updatedAt: stamp,
+    passwordChanged: passwordChanged === 1,
+    assignedVault,
+  };
 }
 
 export function getUserByUsername(db: Database, username: string): User | null {
@@ -141,4 +193,77 @@ export async function setPassword(
     .prepare("UPDATE users SET password_hash = ?, updated_at = ? WHERE id = ?")
     .run(passwordHash, stamp, userId);
   if (result.changes === 0) throw new UserNotFoundError(userId);
+}
+
+/**
+ * Username validation (multi-user Phase 1, design 2026-05-20-multi-user-phase-1.md §4).
+ *
+ * Rules — settled with Aaron pre-PR-1:
+ *   * Charset: `[a-z0-9_-]` (lowercase letters, digits, underscore, hyphen).
+ *     Lowercase-only sidesteps "Bob vs bob" case-folding bugs across every
+ *     downstream surface (URLs, log lines, the admin SPA's row keys).
+ *   * Length: 2-32 chars inclusive. Hard floor on 1-char names (no `a`,
+ *     `b`, …) because those are too easy to typo into someone else's
+ *     account; hard ceiling on 32 because URL paths and log lines stay
+ *     scannable. (Same shape vault-side scope verbs use.)
+ *   * Reserved list (case-insensitive): admin, root, system, setup,
+ *     parachute, hub. Keeps URL-shaped surfaces safe (Phase 2 may add
+ *     `/users/<username>` paths; reserving the namespace now is cheap).
+ *     Regex already pins lowercase, but the case-folded check is defense
+ *     in depth: if a future loosening lets capitals through, the reserved
+ *     check still triggers on `Admin`, `ROOT`, etc.
+ *
+ * Discriminated-union return: callers branch on `valid` rather than
+ * throwing. PR 2's `POST /api/users` returns a 400 with the `reason`
+ * surfaced in the response body.
+ */
+export const USERNAME_RESERVED = ["admin", "root", "system", "setup", "parachute", "hub"] as const;
+
+const USERNAME_REGEX = /^[a-z0-9_-]+$/;
+const USERNAME_MIN_LEN = 2;
+const USERNAME_MAX_LEN = 32;
+
+export type ValidateUsernameResult =
+  | { valid: true; name: string }
+  | { valid: false; reason: "format" | "length" | "reserved" };
+
+export function validateUsername(name: string): ValidateUsernameResult {
+  // Length check first — a 0-char string fails the regex on emptiness but
+  // "length" is the more honest diagnostic.
+  if (name.length < USERNAME_MIN_LEN || name.length > USERNAME_MAX_LEN) {
+    return { valid: false, reason: "length" };
+  }
+  if (!USERNAME_REGEX.test(name)) {
+    return { valid: false, reason: "format" };
+  }
+  // Reserved-words check is case-insensitive even though the regex already
+  // pins lowercase — see comment above.
+  const lower = name.toLowerCase();
+  if (USERNAME_RESERVED.some((r) => r === lower)) {
+    return { valid: false, reason: "reserved" };
+  }
+  return { valid: true, name };
+}
+
+/**
+ * Password validation (multi-user Phase 1, design §5).
+ *
+ * Single rule: minimum 12 characters. No complexity classes — modern
+ * guidance (NIST 800-63B) prefers passphrase length over forced-symbol
+ * mixes, and Aaron settled on 12 as the floor pre-PR-1. No max length
+ * (argon2id absorbs whatever the user submits).
+ *
+ * Same discriminated-union shape as `validateUsername` — PR 2's create-
+ * user / reset-password endpoints (and PR 3's `/account/change-password`
+ * form) wire the `reason` into the response.
+ */
+export const PASSWORD_MIN_LEN = 12;
+
+export type ValidatePasswordResult = { valid: true } | { valid: false; reason: "too_short" };
+
+export function validatePassword(password: string): ValidatePasswordResult {
+  if (password.length < PASSWORD_MIN_LEN) {
+    return { valid: false, reason: "too_short" };
+  }
+  return { valid: true };
 }


### PR DESCRIPTION
## Summary

Multi-user Phase 1 **PR 1 of 5** — schema-only foundation for the multi-user chain. No UI surface, no API endpoints, no force-change-password flow yet; those land in PRs 2 / 3 / 4 / 5.

Companion to the design doc at [`parachute.computer/design/2026-05-20-multi-user-phase-1/`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/). Master tracker: **hub#252**.

## What's in this PR

- **Migration v8** on `users` (`src/hub-db.ts`):
  - `password_changed INTEGER NOT NULL DEFAULT 0` — boolean (0/1) tracking whether the user has changed their password since account creation.
  - `assigned_vault TEXT` (nullable) — vault instance name this user is pinned to. `NULL` means admin posture (no per-vault restriction).
  - Backfill `UPDATE users SET password_changed = 1` so wizard / env-seeded admins on existing hubs don't get spurious force-change redirects.
- **`User` type + `createUser` extensions** (`src/users.ts`):
  - `User.passwordChanged: boolean` + `User.assignedVault: string | null`.
  - `CreateUserOpts` gains optional `passwordChanged` (default `false`) + `assignedVault` (default `null`).
  - `rowToUser` translates the 0/1 INTEGER → TS `boolean`.
- **`validateUsername` + `validatePassword` helpers** (`src/users.ts`):
  - `validateUsername`: charset `[a-z0-9_-]`, length 2-32, case-insensitive reserved list (`admin`, `root`, `system`, `setup`, `parachute`, `hub`). Returns discriminated union with `format` / `length` / `reserved` reasons.
  - `validatePassword`: 12-char minimum, no complexity rules (NIST 800-63B's length-over-classes guidance). Returns discriminated union with `too_short` reason.
  - Neither validator is wired into a caller yet — PR 2's `POST /api/users` and PR 3's `POST /account/change-password` will consume them. PR 1 exposes them + tests their boundaries.
- **Seed wiring**: `seedInitialAdminIfNeeded` (`src/commands/serve.ts`) and `handleSetupAccountPost` (`src/setup-wizard.ts`) now pass `{ passwordChanged: true }` so neither env-seeded admins nor the wizard's first admin land needing a forced password change.

## What's NOT in this PR (deferred to later PRs in the chain)

- Admin SPA `/admin/users` page + `GET`/`POST`/`PATCH`/`DELETE /api/users` endpoints — **PR 2**.
- `/login` force-change-password redirect + `/account/change-password` server-rendered form — **PR 3**.
- OAuth issuer per-user vault scope narrowing + `vault_scope` claim — **PR 4**.
- End-to-end verification + scope-guard reach-through smoke — **PR 5**.
- 2FA in the force-change flow — **PR 6** (per the design's 2FA section).

## Aaron's settled design pins (from the design doc)

- Per-user role default: `vault:<assigned_vault>:admin`. Stored as `assigned_vault: text`.
- Username: `[a-z0-9_-]`, 2-32, reserved-words rejected (admin/root/system/setup/parachute/hub).
- Password minimum: 12 chars, no complexity rules.
- Delete-user: hard-delete + token revocation (PR 2 wires it; PR 1 just adds the schema).
- First-admin-undeletable identified via `SELECT id FROM users ORDER BY created_at ASC LIMIT 1` (no new column needed).
- 2FA: optional in Phase 1; PR 1 doesn't add 2FA columns and doesn't touch any TOTP path.

## Test plan

- [x] `bun test ./src` — **1497 pass / 0 fail / 31038 expects across 80 files** (+15 over rc.11 baseline 1482).
- [x] `cd web/ui && bun run test` — **120 pass / 0 fail across 9 files** (unchanged — no SPA surface touched).
- [x] `bun run typecheck` clean (root + web/ui).
- [x] `bunx biome check .` clean (root + web/ui).
- [x] Smoke against `PARACHUTE_HOME=/tmp/hub-mu-pr1` with `PARACHUTE_INITIAL_ADMIN_USERNAME=seedadmin PARACHUTE_INITIAL_ADMIN_PASSWORD=longenoughtopass`:
  - Hub boots clean, all 8 migrations applied
  - Discovery `/` returns 200
  - `users` table inspected via `sqlite3 PRAGMA table_info`: `password_changed INTEGER NOT NULL DEFAULT 0` + `assigned_vault TEXT` nullable
  - Env-seeded admin row: `password_changed=1`, `assigned_vault=NULL`
- [x] Smoke against `PARACHUTE_HOME=/tmp/hub-mu-pr1-wiz` (no env vars):
  - `POST /admin/setup/account` returns 303 (success, existing flow unaffected)
  - Wizard-created admin row: `password_changed=1`, `assigned_vault=NULL`

## Versioning

Bumps to `0.5.10-rc.12` per the RC-versioning governance rule. CHANGELOG entry under `## [0.5.10-rc.12] - 2026-05-20`.

## Commits

1. `feat(hub): multi-user Phase 1 — migration v8 (password_changed + assigned_vault)` — schema + migration tests
2. `feat(hub): multi-user Phase 1 — User type + createUser opts + validators` — TS-layer schema mapping + the two reusable validators (no caller wiring)
3. `feat(hub): multi-user Phase 1 — seed env-var + wizard admins as password_changed` — `seedInitialAdminIfNeeded` + wizard account POST
4. `chore(hub): bump to 0.5.10-rc.12 — multi-user Phase 1 PR 1 (users table foundation)` — version + CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)