### PR TITLE
feat(hub): multi-user Phase 1 PR 2 — admin /admin/users page + API (create/list/delete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.10-rc.13] - 2026-05-20
+
+Multi-user Phase 1 — PR 2 of 5: admin `/admin/users` page + API (hub#252, design [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)). Builds on PR 1's `users` table foundation (rc.12): wires the `validateUsername` / `validatePassword` validators into a four-endpoint admin surface, adds the SPA route, and adds the FK-aware delete-user helper that keeps token audit rows intact while letting the parent users row drop.
+
+Backend surface:
+
+- `src/api-users.ts` (new) — four endpoints, all `parachute:host:admin`-gated (same gate as `/api/grants`, `/vaults`, destructive `/api/modules/:short/*`). Snake-case wire shape; `password_hash` is **never** returned.
+  - **`GET /api/users`** — list users sorted by `created_at ASC` (consistent with first-admin selector). Returns `{ users: [{ id, username, password_changed, assigned_vault, created_at }, …] }`.
+  - **`POST /api/users`** — body `{ username, password, assignedVault?: string | null }`. Order of checks: 413 `password_too_long` if `password.length > PASSWORD_MAX_LEN` (256) — fires **before** argon2id touches the body, mitigating the CPU-DoS shape; 400 `invalid_username` (length / format / reserved); 400 `invalid_password` (< 12 chars); 400 `assigned_vault_not_found` if the vault isn't in services.json; 409 `username_taken` case-insensitive; 201 with `{ user: {…} }` on success. Admin-created users land with `password_changed: false` so PR 3's `/login` force-redirect catches them on first sign-in.
+  - **`DELETE /api/users/:id`** — 404 unknown id; 403 `first_admin_undeletable` when the target row is the earliest `created_at` (safety rail to prevent self-locking the hub); 204 on success. Delete flow: revoke all the user's tokens (`tokens.revoked_at = now`), null out `tokens.user_id` (and backfill `subject` with the username so the audit trail isn't anchored to a vanished PK), drop their `sessions` + `grants` (non-cascading FKs), then drop the users row. All wrapped in a single transaction.
+  - **`GET /api/users/vaults`** — sorted vault-instance-name list from services.json (`vaultInstanceNameFor` + `isVaultEntry`). Feeds the SPA's assigned-vault dropdown. Mirrors the (private) `listVaultNames` in `oauth-handlers.ts` so PR 4's issuer-side validation reads from the same source.
+- `src/users.ts` — adds `getUserByUsernameCI(db, username)` (case-insensitive lookup; `COLLATE NOCASE` — defense in depth against legacy mixed-case rows shadowing the validator-pinned lowercase form) and `deleteUser(db, userId)` (the FK-aware sweep above; returns `false` for unknown ids so the API layer can 404-or-204 by race).
+- `src/hub-server.ts` — route table extended (`/api/users`, `/api/users/vaults`, `/api/users/<id>`); per-id route falls through after the literal `vaults` segment is pre-empted so `vaults` can't be mistaken for an id.
+
+Frontend surface:
+
+- `web/ui/src/routes/Users.tsx` (new) — three-section page. (1) Users table with columns Username · Assigned vault · Password set · Created · Actions; `assigned_vault: null` renders as `—` (tooltip explains "no per-vault restriction (admin-level access)"); `password_changed: false` renders as "pending first login"; first row carries a "first admin" badge and a disabled Delete button with tooltip "First admin can't be deleted (would self-lock the hub)". (2) Collapsible Create-user form below the table — username + password + assigned-vault dropdown (`"No restriction (admin-level access)"` is the first option mapping to `null`; subsequent options are vault names from `/api/users/vaults`); client-side validates username regex + length and password ≥ 12 chars before posting (server is authoritative — the client check is fast feedback). On success the form clears and a banner says "User &lt;name&gt; created. They'll be prompted to change their password on first sign-in." (3) Delete confirmation inline dialog mirroring `Permissions.tsx`'s revoke pattern — click → confirm → DELETE → table refresh.
+- `web/ui/src/lib/api.ts` — `listUsers()`, `createUser(input)`, `deleteUser(id)`, `listUserVaults()`. `deleteUser`'s 403 path deliberately does **not** clear the cached bearer (403 here is "first_admin_undeletable" policy, not auth failure — clearing the token wouldn't help).
+- `web/ui/src/App.tsx` — `/users` route mounted; `Users` link added to the nav between Modules and Permissions; subtitle helper recognises `/users`.
+
+Tests + gates:
+
+- `src/__tests__/api-users.test.ts` (new) — 28 tests covering: auth boundary (401 / 403) on every endpoint, GET happy path (no hash leakage, snake-case shape, created_at order), POST happy paths (with and without `assigned_vault`), every POST validation branch (username length / format / reserved, password too short, 413 with elapsed-time floor ≤ 200ms to assert the cap fires before argon2id), 409 conflict case-insensitive, 400 `assigned_vault_not_found`, DELETE 404 unknown id, DELETE 403 first-admin-undeletable, DELETE 204 with token revocation + user_id NULL + subject backfilled with username, GET `/api/users/vaults` with empty and populated services.json.
+- `src/__tests__/users.test.ts` — `getUserByUsernameCI` + `deleteUser` unit coverage (3 + 2 tests).
+- `web/ui/src/routes/Users.test.tsx` (new) — 13 tests covering: loading state, empty state, list with sample data, listUsers failure, first-admin Delete disabled + tooltip, delete confirm dialog (cancel + confirm + error), create form hidden by default, vault dropdown options include the synthetic No-restriction entry, create happy path posts the right body and refreshes the list, client-side rejects 11-char password, 409 conflict surface.
+- `src/App.test.tsx` — nav-link-order assertion updated to include the new Users link.
+
+Gate: `bun test ./src` — **1530 pass / 0 fail / 31120 expects across 81 files** (+33 over rc.12 baseline 1497). SPA: `cd web/ui && bun run test` — **133 pass / 0 fail across 10 files** (+13 over rc.12 baseline 120). typecheck + biome clean (root + web/ui). SPA build clean (`vite build` + `verify-base.mjs` green).
+
+Smoke: spun up a hub against `PARACHUTE_HOME=/tmp/hub-mu-pr2`, walked the wizard, opened `/admin/users` — first admin in the list with Delete disabled. Created `testuser` with `verylongpassword123` and assigned vault → user appeared with "pending first login" status. `curl -X DELETE` against the first admin returned 403 `first_admin_undeletable`. UI-deleted `testuser` → row removed, no errors. `curl -X POST` with a 300-char password returned 413 `password_too_long`.
+
+What's NOT in PR 2 (deferred to later PRs in the chain):
+
+- `/login` force-change-password redirect + `/account/change-password` form — PR 3.
+- OAuth issuer `vault_scope` claim + per-user scope narrowing — PR 4.
+- End-to-end verification + scope-guard reach-through — PR 5.
+- Edit-existing-user (reassign vault, reset password) — Phase 2 (Phase 1's admin recovery shape is "delete + re-create").
+- 2FA enrollment inline on first sign-in — Phase 1.5 PR 6 (optional, design §2FA-orientation).
+
 ## [0.5.10-rc.12] - 2026-05-20
 
 Multi-user Phase 1 — PR 1 of 5: users table foundation (hub#252, design [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)). Schema-only foundation that the admin-creates-user surface (PR 2), force-change-password flow (PR 3), and OAuth issuer integration (PR 4) build on. No UI surface, no API endpoints — just migration v8 + `User`-type extensions + reusable username/password validators wired through the wizard's and env-seed paths.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.10-rc.12",
+  "version": "0.5.10-rc.13",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-users.test.ts
+++ b/src/__tests__/api-users.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Tests for `/api/users*` (multi-user Phase 1, PR 2). Covers:
+ *
+ *   - Auth boundary: every endpoint requires a bearer carrying
+ *     `parachute:host:admin`.
+ *   - GET happy path (list, no hash leakage).
+ *   - POST happy path + every validator branch (bad username
+ *     format/length/reserved, password too short, password > 256 chars
+ *     returns 413 BEFORE argon2id touches it, conflict 409 case-
+ *     insensitive, assigned_vault missing-from-services.json returns
+ *     400 `assigned_vault_not_found`).
+ *   - DELETE happy path with token revocation; first-admin-undeletable
+ *     returns 403; 404 on unknown id.
+ *   - GET /api/users/vaults returns the same name set the OAuth issuer
+ *     would resolve against.
+ *   - 405 on wrong methods.
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  handleCreateUser,
+  handleDeleteUser,
+  handleListUsers,
+  handleListVaults,
+} from "../api-users.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { findTokenRowByJti, recordTokenMint, signAccessToken } from "../jwt-sign.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "https://hub.test";
+const HOST_ADMIN_SCOPE = "parachute:host:admin";
+
+interface Harness {
+  db: Database;
+  manifestPath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(servicesJson?: string): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-api-users-"));
+  const db = openHubDb(hubDbPath(dir));
+  const manifestPath = join(dir, "services.json");
+  // Default manifest — empty services list; tests that want a vault can
+  // override by passing servicesJson.
+  writeFileSync(manifestPath, servicesJson ?? JSON.stringify({ services: [] }));
+  return {
+    db,
+    manifestPath,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+function manifestWithVaults(...names: string[]): string {
+  // Single-entry shape: one `parachute-vault` service with N paths.
+  const paths = names.map((n) => `/vault/${n}`);
+  return JSON.stringify({
+    services: [
+      {
+        name: "parachute-vault",
+        port: 4101,
+        paths,
+        health: "/health",
+        version: "0.0.0-test",
+      },
+    ],
+  });
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+interface MintedBearer {
+  bearer: string;
+  jti: string;
+  userId: string;
+}
+
+async function makeAdminBearer(
+  scopes = [HOST_ADMIN_SCOPE],
+  username = "operator",
+): Promise<MintedBearer> {
+  const user = await createUser(harness.db, username, "any-password", {
+    allowMulti: true,
+    passwordChanged: true,
+  });
+  const minted = await signAccessToken(harness.db, {
+    sub: user.id,
+    scopes,
+    audience: "hub",
+    clientId: "parachute-hub-spa",
+    issuer: ISSUER,
+    ttlSeconds: 600,
+  });
+  return { bearer: minted.token, jti: minted.jti, userId: user.id };
+}
+
+function req(path: string, init: RequestInit = {}): Request {
+  return new Request(`${ISSUER}${path}`, init);
+}
+
+function withBearer(path: string, bearer: string, init: RequestInit = {}): Request {
+  const headers = new Headers(init.headers ?? {});
+  headers.set("authorization", `Bearer ${bearer}`);
+  return new Request(`${ISSUER}${path}`, { ...init, headers });
+}
+
+function deps(): {
+  db: Database;
+  issuer: string;
+  manifestPath: string;
+} {
+  return { db: harness.db, issuer: ISSUER, manifestPath: harness.manifestPath };
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/users — list users
+// ---------------------------------------------------------------------------
+
+describe("handleListUsers", () => {
+  test("401 with no Authorization header", async () => {
+    const res = await handleListUsers(req("/api/users"), deps());
+    expect(res.status).toBe(401);
+  });
+
+  test("403 when bearer lacks parachute:host:admin", async () => {
+    const { bearer } = await makeAdminBearer(["other:scope"]);
+    const res = await handleListUsers(withBearer("/api/users", bearer), deps());
+    expect(res.status).toBe(403);
+  });
+
+  test("405 on POST", async () => {
+    const { bearer } = await makeAdminBearer();
+    const res = await handleListUsers(withBearer("/api/users", bearer, { method: "POST" }), deps());
+    // The handler itself is GET-only; the hub-server dispatcher routes
+    // POSTs to handleCreateUser. We assert the handler's own contract.
+    expect(res.status).toBe(405);
+  });
+
+  test("lists users in created_at ASC order, omitting password_hash", async () => {
+    const { bearer } = await makeAdminBearer();
+    await createUser(harness.db, "alice", "alice-strong-password", {
+      allowMulti: true,
+    });
+    const res = await handleListUsers(withBearer("/api/users", bearer), deps());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    const body = (await res.json()) as {
+      users: Array<Record<string, unknown>>;
+    };
+    expect(body.users.length).toBe(2);
+    // First admin (operator) created first → first row.
+    expect(body.users[0]?.username).toBe("operator");
+    expect(body.users[1]?.username).toBe("alice");
+    // Hash never leaks.
+    for (const u of body.users) {
+      expect(u).not.toHaveProperty("password_hash");
+      expect(u).not.toHaveProperty("passwordHash");
+      // Snake-case wire shape.
+      expect(u).toHaveProperty("id");
+      expect(u).toHaveProperty("username");
+      expect(u).toHaveProperty("password_changed");
+      expect(u).toHaveProperty("assigned_vault");
+      expect(u).toHaveProperty("created_at");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/users — create user
+// ---------------------------------------------------------------------------
+
+describe("handleCreateUser", () => {
+  async function post(
+    bearer: string,
+    body: Record<string, unknown> | string,
+    headers: Record<string, string> = {},
+  ): Promise<Response> {
+    const init: RequestInit = {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${bearer}`,
+        ...headers,
+      },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    };
+    return await handleCreateUser(req("/api/users", init), deps());
+  }
+
+  test("401 with no Authorization header", async () => {
+    const res = await handleCreateUser(req("/api/users", { method: "POST", body: "{}" }), deps());
+    expect(res.status).toBe(401);
+  });
+
+  test("403 when bearer lacks parachute:host:admin", async () => {
+    const { bearer } = await makeAdminBearer(["other:scope"]);
+    const res = await post(bearer, { username: "x", password: "y" });
+    expect(res.status).toBe(403);
+  });
+
+  test("happy path returns 201 + user with password_changed=false, no hash", async () => {
+    const { bearer } = await makeAdminBearer();
+    const res = await post(bearer, {
+      username: "alice",
+      password: "alice-strong-passphrase",
+      assignedVault: null,
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { user: Record<string, unknown> };
+    expect(body.user.username).toBe("alice");
+    expect(body.user.password_changed).toBe(false);
+    expect(body.user.assigned_vault).toBeNull();
+    expect(body.user).not.toHaveProperty("password_hash");
+  });
+
+  test("rejects non-JSON content-type", async () => {
+    const { bearer } = await makeAdminBearer();
+    const res = await post(bearer, "not-json", { "content-type": "text/plain" });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_request");
+  });
+
+  test("rejects malformed JSON body", async () => {
+    const { bearer } = await makeAdminBearer();
+    const res = await post(bearer, "{not valid");
+    expect(res.status).toBe(400);
+  });
+
+  test("400 invalid_username when username too short (length reason)", async () => {
+    const { bearer } = await makeAdminBearer();
+    const res = await post(bearer, {
+      username: "a",
+      password: "strong-passphrase-123",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("invalid_username");
+    expect(body.error_description).toMatch(/2-32/);
+  });
+
+  test("400 invalid_username when username has bad characters (format reason)", async () => {
+    const { bearer } = await makeAdminBearer();
+    const res = await post(bearer, {
+      username: "Alice",
+      password: "strong-passphrase-123",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("invalid_username");
+    expect(body.error_description).toMatch(/lowercase/);
+  });
+
+  test("400 invalid_username when username is reserved", async () => {
+    const { bearer } = await makeAdminBearer();
+    const res = await post(bearer, {
+      username: "admin",
+      password: "strong-passphrase-123",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_username");
+  });
+
+  test("400 invalid_password when password is too short (< 12 chars)", async () => {
+    const { bearer } = await makeAdminBearer();
+    const res = await post(bearer, {
+      username: "alice",
+      password: "short",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_password");
+  });
+
+  test("413 password_too_long when password > 256 chars (before argon2id touches it)", async () => {
+    const { bearer } = await makeAdminBearer();
+    const huge = "a".repeat(300);
+    const t0 = Date.now();
+    const res = await post(bearer, { username: "alice", password: huge });
+    const elapsed = Date.now() - t0;
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("password_too_long");
+    // Sanity check the cap fires before argon2id — a 300-char argon2id
+    // hash is well into the hundreds of ms; the cap-and-reject path
+    // should complete in <50ms on any sane runner. Floor of 200ms here
+    // keeps the check noise-tolerant.
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  test("409 username_taken with case-insensitive match against existing rows", async () => {
+    const { bearer } = await makeAdminBearer();
+    await post(bearer, {
+      username: "alice",
+      password: "alice-strong-passphrase",
+    });
+    // Lowercase rejection — exact match.
+    let res = await post(bearer, {
+      username: "alice",
+      password: "alice-strong-passphrase",
+    });
+    expect(res.status).toBe(409);
+    let body = (await res.json()) as { error: string };
+    expect(body.error).toBe("username_taken");
+    // Mixed-case rejection — the validator pins lowercase anyway, so
+    // the case-insensitive check only matters if a legacy row was hand-
+    // inserted with capitals. We verify the lookup is case-folding by
+    // bypassing the validator with the lowercase exact form.
+    res = await post(bearer, {
+      username: "alice",
+      password: "alice-strong-passphrase",
+    });
+    expect(res.status).toBe(409);
+    body = (await res.json()) as { error: string };
+    expect(body.error).toBe("username_taken");
+  });
+
+  test("400 assigned_vault_not_found when vault is not in services.json", async () => {
+    const { bearer } = await makeAdminBearer();
+    const res = await post(bearer, {
+      username: "alice",
+      password: "alice-strong-passphrase",
+      assignedVault: "ghost-vault",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("assigned_vault_not_found");
+  });
+
+  test("happy path with assigned_vault that exists in services.json", async () => {
+    harness.cleanup();
+    harness = makeHarness(manifestWithVaults("home"));
+    const { bearer } = await makeAdminBearer();
+    const res = await post(bearer, {
+      username: "alice",
+      password: "alice-strong-passphrase",
+      assignedVault: "home",
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { user: Record<string, unknown> };
+    expect(body.user.assigned_vault).toBe("home");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/users/:id — hard-delete user
+// ---------------------------------------------------------------------------
+
+describe("handleDeleteUser", () => {
+  test("401 with no Authorization header", async () => {
+    const res = await handleDeleteUser(
+      req("/api/users/some-id", { method: "DELETE" }),
+      "some-id",
+      deps(),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("403 when bearer lacks parachute:host:admin", async () => {
+    const { bearer } = await makeAdminBearer(["other:scope"]);
+    const res = await handleDeleteUser(
+      withBearer("/api/users/some-id", bearer, { method: "DELETE" }),
+      "some-id",
+      deps(),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("405 on GET", async () => {
+    const { bearer } = await makeAdminBearer();
+    const res = await handleDeleteUser(
+      withBearer("/api/users/some-id", bearer, { method: "GET" }),
+      "some-id",
+      deps(),
+    );
+    expect(res.status).toBe(405);
+  });
+
+  test("404 when user does not exist", async () => {
+    const { bearer } = await makeAdminBearer();
+    const res = await handleDeleteUser(
+      withBearer("/api/users/no-such-id", bearer, { method: "DELETE" }),
+      "no-such-id",
+      deps(),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  test("403 first_admin_undeletable when deleting the earliest user", async () => {
+    const { bearer, userId } = await makeAdminBearer();
+    const res = await handleDeleteUser(
+      withBearer(`/api/users/${userId}`, bearer, { method: "DELETE" }),
+      userId,
+      deps(),
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("first_admin_undeletable");
+    // The user row still exists (delete refused).
+    const stillThere = await handleListUsers(withBearer("/api/users", bearer), deps());
+    const list = (await stillThere.json()) as { users: Array<{ id: string }> };
+    expect(list.users.map((u) => u.id)).toContain(userId);
+  });
+
+  test("204 deletes a non-first user and revokes their tokens", async () => {
+    const { bearer } = await makeAdminBearer();
+    // Create a second user (non-first) + mint a token on their behalf.
+    const second = await createUser(harness.db, "alice", "alice-strong-passphrase", {
+      allowMulti: true,
+      passwordChanged: true,
+    });
+    const minted = await signAccessToken(harness.db, {
+      sub: second.id,
+      scopes: ["vault:home:read"],
+      audience: "vault",
+      clientId: "notes-client",
+      issuer: ISSUER,
+      ttlSeconds: 600,
+    });
+    // `signAccessToken` mints the JWT but doesn't write a `tokens` row.
+    // Production paths that mint a registry-row token call
+    // `recordTokenMint` immediately afterwards; mirror that here so the
+    // delete-user revocation has something to flip + null.
+    recordTokenMint(harness.db, {
+      jti: minted.jti,
+      createdVia: "operator_mint",
+      subject: second.username,
+      userId: second.id,
+      clientId: "notes-client",
+      scopes: ["vault:home:read"],
+      expiresAt: minted.expiresAt,
+    });
+    expect(findTokenRowByJti(harness.db, minted.jti)?.revokedAt).toBeNull();
+
+    const res = await handleDeleteUser(
+      withBearer(`/api/users/${second.id}`, bearer, { method: "DELETE" }),
+      second.id,
+      deps(),
+    );
+    expect(res.status).toBe(204);
+
+    // User row is gone.
+    const listRes = await handleListUsers(withBearer("/api/users", bearer), deps());
+    const list = (await listRes.json()) as { users: Array<{ id: string }> };
+    expect(list.users.map((u) => u.id)).not.toContain(second.id);
+
+    // Token row stays for audit but is now revoked + user_id NULLed +
+    // subject backfilled with the username.
+    const row = findTokenRowByJti(harness.db, minted.jti);
+    expect(row).not.toBeNull();
+    expect(row?.revokedAt).not.toBeNull();
+    expect(row?.userId).toBeNull();
+    expect(row?.subject).toBe("alice");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/users/vaults — vault-name list for the assigned-vault dropdown
+// ---------------------------------------------------------------------------
+
+describe("handleListVaults", () => {
+  test("401 with no Authorization header", async () => {
+    const res = await handleListVaults(req("/api/users/vaults"), deps());
+    expect(res.status).toBe(401);
+  });
+
+  test("403 when bearer lacks parachute:host:admin", async () => {
+    const { bearer } = await makeAdminBearer(["other:scope"]);
+    const res = await handleListVaults(withBearer("/api/users/vaults", bearer), deps());
+    expect(res.status).toBe(403);
+  });
+
+  test("405 on POST", async () => {
+    const { bearer } = await makeAdminBearer();
+    const res = await handleListVaults(
+      withBearer("/api/users/vaults", bearer, { method: "POST" }),
+      deps(),
+    );
+    expect(res.status).toBe(405);
+  });
+
+  test("returns empty list when no vaults are registered", async () => {
+    const { bearer } = await makeAdminBearer();
+    const res = await handleListVaults(withBearer("/api/users/vaults", bearer), deps());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { vaults: string[] };
+    expect(body.vaults).toEqual([]);
+  });
+
+  test("returns sorted vault names from services.json", async () => {
+    harness.cleanup();
+    harness = makeHarness(manifestWithVaults("home", "work", "scratch"));
+    const { bearer } = await makeAdminBearer();
+    const res = await handleListVaults(withBearer("/api/users/vaults", bearer), deps());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { vaults: string[] };
+    expect(body.vaults).toEqual(["home", "scratch", "work"]);
+  });
+});

--- a/src/__tests__/api-users.test.ts
+++ b/src/__tests__/api-users.test.ts
@@ -300,30 +300,41 @@ describe("handleCreateUser", () => {
     expect(elapsed).toBeLessThan(200);
   });
 
-  test("409 username_taken with case-insensitive match against existing rows", async () => {
+  test("409 username_taken on exact-duplicate POST", async () => {
     const { bearer } = await makeAdminBearer();
     await post(bearer, {
       username: "alice",
       password: "alice-strong-passphrase",
     });
-    // Lowercase rejection — exact match.
-    let res = await post(bearer, {
+    const res = await post(bearer, {
       username: "alice",
       password: "alice-strong-passphrase",
     });
     expect(res.status).toBe(409);
-    let body = (await res.json()) as { error: string };
+    const body = (await res.json()) as { error: string };
     expect(body.error).toBe("username_taken");
-    // Mixed-case rejection — the validator pins lowercase anyway, so
-    // the case-insensitive check only matters if a legacy row was hand-
-    // inserted with capitals. We verify the lookup is case-folding by
-    // bypassing the validator with the lowercase exact form.
-    res = await post(bearer, {
+  });
+
+  test("409 username_taken shadows a hand-inserted mixed-case legacy row (CI path)", async () => {
+    // Insert a mixed-case row directly — bypasses the validator's
+    // lowercase-only gate so we can prove the CI shadowing check
+    // (`getUserByUsernameCI` / `COLLATE NOCASE`) actually fires. The
+    // exact-duplicate test above can't exercise this path because the
+    // validator rejects "Alice" with `invalid_username` (format) long
+    // before the CI lookup runs.
+    const stamp = "2026-05-20T00:00:00.000Z";
+    harness.db
+      .prepare(
+        "INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed, assigned_vault) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      )
+      .run("legacy-id", "Alice", "$argon2id$fake", stamp, stamp, 1, null);
+    const { bearer } = await makeAdminBearer();
+    const res = await post(bearer, {
       username: "alice",
       password: "alice-strong-passphrase",
     });
     expect(res.status).toBe(409);
-    body = (await res.json()) as { error: string };
+    const body = (await res.json()) as { error: string };
     expect(body.error).toBe("username_taken");
   });
 

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -10,8 +10,10 @@ import {
   UserNotFoundError,
   UsernameTakenError,
   createUser,
+  deleteUser,
   getUserById,
   getUserByUsername,
+  getUserByUsernameCI,
   listUsers,
   setPassword,
   userCount,
@@ -200,6 +202,61 @@ describe("listUsers / getUserByUsername", () => {
       expect(getUserByUsername(db, "nobody")).toBeNull();
       await createUser(db, "owner", "pw");
       expect(getUserByUsername(db, "owner")?.username).toBe("owner");
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("getUserByUsernameCI", () => {
+  test("matches exact lowercase username", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      await createUser(db, "alice", "alice-strong-passphrase");
+      expect(getUserByUsernameCI(db, "alice")?.username).toBe("alice");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("matches case-insensitively (defense in depth for legacy mixed-case rows)", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      await createUser(db, "alice", "alice-strong-passphrase");
+      expect(getUserByUsernameCI(db, "Alice")?.username).toBe("alice");
+      expect(getUserByUsernameCI(db, "ALICE")?.username).toBe("alice");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("returns null when no row matches", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      expect(getUserByUsernameCI(db, "ghost")).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("deleteUser", () => {
+  test("returns false when user does not exist", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      expect(deleteUser(db, "no-such-id")).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("returns true and drops the row", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "alice", "alice-strong-passphrase");
+      expect(deleteUser(db, u.id)).toBe(true);
+      expect(getUserById(db, u.id)).toBeNull();
+      expect(userCount(db)).toBe(0);
     } finally {
       cleanup();
     }

--- a/src/api-users.ts
+++ b/src/api-users.ts
@@ -96,6 +96,12 @@ function toWire(u: User): UserWireShape {
  * both code paths must agree on which vault names a user could be
  * pinned to so the OAuth issuer (PR 4) can validate stored
  * `assigned_vault` values against the same set.
+ *
+ * TODO(hub PR4): consolidate with oauth-handlers.ts:listVaultNames
+ * when PR 4 lands. PR 4 already touches oauth-handlers.ts to wire the
+ * `vault_scope` claim, which is the natural seam to lift this helper
+ * to a shared module (well-known.ts is the likely landing site since
+ * it already owns `isVaultEntry` + `vaultInstanceNameFor`).
  */
 function listVaultNames(manifestPath: string): string[] {
   const manifest = readManifest(manifestPath);
@@ -212,7 +218,7 @@ async function parseCreateBody(req: Request): Promise<ParseOk | ParseErr> {
       ok: false,
       status: 413,
       error: "password_too_long",
-      description: `password length must be ≤ ${PASSWORD_MAX_LEN} characters (got ${password.length})`,
+      description: `password length must be ≤ ${PASSWORD_MAX_LEN} characters`,
     };
   }
   // `assigned_vault` is optional — omitted (undefined) or explicit null

--- a/src/api-users.ts
+++ b/src/api-users.ts
@@ -1,0 +1,418 @@
+/**
+ * `/api/users*` — admin endpoints for managing hub user accounts.
+ *
+ * Multi-user Phase 1, PR 2 of 5. Design:
+ * [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/).
+ * Tracker: hub#252. Builds on PR 1 (hub#279) which shipped migration v8 +
+ * the `validateUsername` / `validatePassword` validators this layer wires
+ * through.
+ *
+ * Surfaces:
+ *
+ *   GET    /api/users             list users (host:admin)
+ *   POST   /api/users             create user (host:admin)
+ *   DELETE /api/users/:id         hard-delete user (host:admin)
+ *   GET    /api/users/vaults      vault-name list for the assigned-vault
+ *                                 dropdown (host:admin)
+ *
+ * Wire shape is snake_case (matches `/api/grants`, `/api/auth/tokens`).
+ * Responses never include `password_hash` — hashes never leave the DB.
+ *
+ * Phase 1 deliberately ships only list / create / delete. Editing a user
+ * (reassign vault, reset password) is Phase 2 work — Phase 1's admin
+ * recovery shape is "delete + re-create" per the design doc's §6.
+ *
+ * Auth: every endpoint requires a bearer token carrying the
+ * `parachute:host:admin` scope. Same gate as `/api/grants`, `/vaults`,
+ * and the destructive `/api/modules/:short/*` actions. The SPA mints
+ * one via `/admin/host-admin-token` from the session cookie; the SPA's
+ * `lib/auth.ts` caches it in module-scoped memory (never `localStorage`).
+ *
+ * First-admin-undeletable: enforced server-side via
+ * `SELECT id FROM users ORDER BY created_at ASC LIMIT 1`. Per design §7
+ * the safety rail is absolute — Phase 1 has no role model, so the
+ * first-created admin is *the* admin by construction. A malicious or
+ * buggy SPA bypassing the row-level disabled-button can't get past
+ * the API check.
+ */
+import type { Database } from "bun:sqlite";
+import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
+import { HOST_ADMIN_SCOPE } from "./admin-vaults.ts";
+import { SERVICES_MANIFEST_PATH } from "./config.ts";
+import { readManifest } from "./services-manifest.ts";
+import {
+  PASSWORD_MAX_LEN,
+  type User,
+  UsernameTakenError,
+  createUser,
+  deleteUser,
+  getUserById,
+  getUserByUsernameCI,
+  listUsers,
+  validatePassword,
+  validateUsername,
+} from "./users.ts";
+import { isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
+
+export interface ApiUsersDeps {
+  db: Database;
+  /** Hub origin — JWT `iss` validation. */
+  issuer: string;
+  /** Override services.json path. Defaults to `~/.parachute/services.json`. */
+  manifestPath?: string;
+}
+
+/**
+ * Wire shape for a user row. Mirrors the DB columns but renames for
+ * snake_case-on-the-wire camelCase-in-TS: `password_changed`,
+ * `assigned_vault`, `created_at`. **`password_hash` is never present**
+ * — it's the one column that must not leak.
+ */
+export interface UserWireShape {
+  id: string;
+  username: string;
+  password_changed: boolean;
+  assigned_vault: string | null;
+  created_at: string;
+}
+
+function toWire(u: User): UserWireShape {
+  return {
+    id: u.id,
+    username: u.username,
+    password_changed: u.passwordChanged,
+    assigned_vault: u.assignedVault,
+    created_at: u.createdAt,
+  };
+}
+
+/**
+ * Walk services.json and emit each vault instance's name (`/vault/<name>`
+ * path segment or `parachute-vault-<name>` manifest suffix; see
+ * `vaultInstanceNameFor`).
+ *
+ * Mirrors the private `listVaultNames` in `oauth-handlers.ts`. Exposed
+ * here as the single source for the `/api/users/vaults` endpoint —
+ * both code paths must agree on which vault names a user could be
+ * pinned to so the OAuth issuer (PR 4) can validate stored
+ * `assigned_vault` values against the same set.
+ */
+function listVaultNames(manifestPath: string): string[] {
+  const manifest = readManifest(manifestPath);
+  const names = new Set<string>();
+  for (const svc of manifest.services) {
+    if (!isVaultEntry(svc)) continue;
+    const paths = svc.paths.length > 0 ? svc.paths : [undefined];
+    for (const path of paths) {
+      names.add(vaultInstanceNameFor(svc.name, path));
+    }
+  }
+  return Array.from(names).sort();
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** GET /api/users — list users, ordered by `created_at ASC`. */
+export async function handleListUsers(req: Request, deps: ApiUsersDeps): Promise<Response> {
+  if (req.method !== "GET") {
+    return jsonError(405, "method_not_allowed", "use GET");
+  }
+  try {
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+  } catch (err) {
+    return adminAuthErrorResponse(err as AdminAuthError);
+  }
+  const users = listUsers(deps.db).map(toWire);
+  return new Response(JSON.stringify({ users }), {
+    status: 200,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+interface CreateUserBody {
+  username: string;
+  password: string;
+  assignedVault: string | null;
+}
+
+interface ParseOk {
+  ok: true;
+  body: CreateUserBody;
+}
+interface ParseErr {
+  ok: false;
+  status: number;
+  error: string;
+  description: string;
+}
+
+async function parseCreateBody(req: Request): Promise<ParseOk | ParseErr> {
+  const ctype = req.headers.get("content-type") ?? "";
+  if (!ctype.toLowerCase().includes("application/json")) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      description: "Content-Type must be application/json",
+    };
+  }
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      description: `invalid JSON body: ${msg}`,
+    };
+  }
+  if (!raw || typeof raw !== "object") {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      description: "request body must be a JSON object",
+    };
+  }
+  const obj = raw as Record<string, unknown>;
+  const username = obj.username;
+  if (typeof username !== "string" || username.length === 0) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      description: '"username" must be a non-empty string',
+    };
+  }
+  const password = obj.password;
+  if (typeof password !== "string" || password.length === 0) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      description: '"password" must be a non-empty string',
+    };
+  }
+  // Cap incoming password length BEFORE any validator or argon2id touches
+  // it. Argon2id over an arbitrarily-large body is a CPU-DoS shape: a
+  // 1MB password would burn ~seconds of single-thread time. The
+  // `PASSWORD_MAX_LEN` const from PR 1 (256 chars) is comfortably above
+  // any human passphrase (Diceware 8-word is ~55 chars). 413 is the
+  // canonical RFC 7231 status for "request entity too large" — the
+  // body itself is in-bounds but a specific field exceeds policy.
+  if (password.length > PASSWORD_MAX_LEN) {
+    return {
+      ok: false,
+      status: 413,
+      error: "password_too_long",
+      description: `password length must be ≤ ${PASSWORD_MAX_LEN} characters (got ${password.length})`,
+    };
+  }
+  // `assigned_vault` is optional — omitted (undefined) or explicit null
+  // both mean "no restriction (admin-level access)." Empty string is
+  // rejected as a confused client send (would otherwise persist as ""
+  // and never resolve in services.json).
+  let assignedVault: string | null = null;
+  if (Object.hasOwn(obj, "assignedVault")) {
+    const v = obj.assignedVault;
+    if (v === null) {
+      assignedVault = null;
+    } else if (typeof v === "string" && v.length > 0) {
+      assignedVault = v;
+    } else if (typeof v !== "undefined") {
+      return {
+        ok: false,
+        status: 400,
+        error: "invalid_request",
+        description: '"assignedVault" must be a non-empty string or null',
+      };
+    }
+  }
+  return { ok: true, body: { username, password, assignedVault } };
+}
+
+/** POST /api/users — create user. */
+export async function handleCreateUser(req: Request, deps: ApiUsersDeps): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonError(405, "method_not_allowed", "use POST");
+  }
+  try {
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+  } catch (err) {
+    return adminAuthErrorResponse(err as AdminAuthError);
+  }
+  const parsed = await parseCreateBody(req);
+  if (!parsed.ok) {
+    return jsonError(parsed.status, parsed.error, parsed.description);
+  }
+  const { username, password, assignedVault } = parsed.body;
+
+  // PR 1's username validator — charset + length + reserved-word check.
+  const u = validateUsername(username);
+  if (!u.valid) {
+    const description = describeUsernameReason(u.reason);
+    return jsonError(400, "invalid_username", description);
+  }
+  // PR 1's password validator — 12-char floor only.
+  const p = validatePassword(password);
+  if (!p.valid) {
+    return jsonError(
+      400,
+      "invalid_password",
+      "password must be at least 12 characters (passphrase-friendly; no complexity rules)",
+    );
+  }
+
+  // Case-insensitive uniqueness check — the validator pins lowercase
+  // for new inputs, but a legacy mixed-case row in the DB shouldn't be
+  // shadowed by an accidental same-letters-different-case new user.
+  if (getUserByUsernameCI(deps.db, username) !== null) {
+    return jsonError(409, "username_taken", `username "${username}" is already in use`);
+  }
+
+  // Validate `assigned_vault` against the live services.json vault list.
+  // A stale name (vault since removed) is rejected at create time per
+  // design §security/`assigned_vault validation`. NULL means "no
+  // restriction" and skips the check.
+  if (assignedVault !== null) {
+    const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
+    const known = new Set(listVaultNames(manifestPath));
+    if (!known.has(assignedVault)) {
+      return jsonError(
+        400,
+        "assigned_vault_not_found",
+        `assigned_vault "${assignedVault}" is not registered in services.json`,
+      );
+    }
+  }
+
+  // Persist. The admin-created path lands `passwordChanged: false` so the
+  // user gets force-redirected through `/account/change-password` on
+  // first sign-in (PR 3). The wizard's first-admin path and the env-
+  // seed path both set `passwordChanged: true` explicitly — neither of
+  // those touches this endpoint. `allowMulti: true` because Phase 1 is
+  // the whole point — `createUser`'s single-user guard would otherwise
+  // 500 here once the first admin exists.
+  try {
+    const created = await createUser(deps.db, username, password, {
+      allowMulti: true,
+      passwordChanged: false,
+      assignedVault,
+    });
+    return new Response(JSON.stringify({ user: toWire(created) }), {
+      status: 201,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (err) {
+    // Race: another POST landed between our CI check and createUser's
+    // INSERT and snagged the username. Surface as the same 409.
+    if (err instanceof UsernameTakenError) {
+      return jsonError(409, "username_taken", err.message);
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    return jsonError(500, "server_error", `failed to create user: ${msg}`);
+  }
+}
+
+/** DELETE /api/users/:id — hard-delete + token revocation + session/grant cleanup. */
+export async function handleDeleteUser(
+  req: Request,
+  userId: string,
+  deps: ApiUsersDeps,
+): Promise<Response> {
+  if (req.method !== "DELETE") {
+    return jsonError(405, "method_not_allowed", "use DELETE");
+  }
+  try {
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+  } catch (err) {
+    return adminAuthErrorResponse(err as AdminAuthError);
+  }
+  const target = getUserById(deps.db, userId);
+  if (!target) {
+    return jsonError(404, "not_found", `no user with id "${userId}"`);
+  }
+
+  // First-admin-undeletable. The earliest-created row is the wizard or
+  // env-seeded admin by construction — Phase 1 has no role model, so
+  // the first admin is *the* admin. Deleting them would self-lock the
+  // hub. Per design §7 the API returns 403 with `first_admin_undeletable`
+  // (the design doc says 409; aligning to 403 here because the resource
+  // exists and the request is forbidden by policy rather than blocked
+  // by a state conflict — RFC 7231 §6.5.3 fits cleaner than §6.5.8.
+  // Either is defensible; the wire `error` string is the part the SPA
+  // matches on for the "first admin can't be deleted" surface).
+  const firstAdminRow = deps.db
+    .query<{ id: string }, []>("SELECT id FROM users ORDER BY created_at ASC LIMIT 1")
+    .get();
+  if (firstAdminRow && firstAdminRow.id === userId) {
+    return jsonError(
+      403,
+      "first_admin_undeletable",
+      "the first-created admin cannot be deleted (would self-lock the hub)",
+    );
+  }
+
+  // `deleteUser` (users.ts) atomically revokes the user's tokens
+  // (`tokens.revoked_at = now`, then NULLs `user_id` so the FK doesn't
+  // block the parent delete; backfills `subject` with the username so
+  // the audit trail isn't anchored to a vanished primary key), drops
+  // their sessions + grants (both have non-cascading FKs on user_id),
+  // and finally deletes the users row. Idempotent — false return path
+  // happens only if the row vanished between `getUserById` and this
+  // call, which we treat as a race-tolerant 204.
+  const removed = deleteUser(deps.db, userId);
+  if (!removed) {
+    // Race: row deleted by a concurrent request. Operator's intent
+    // (no such user) is already satisfied — same shape as the grant-
+    // revoke race in `admin-grants.ts`.
+    return new Response(null, { status: 204 });
+  }
+  console.log(`user deleted: id=${userId} username=${target.username}`);
+  return new Response(null, { status: 204 });
+}
+
+/**
+ * GET /api/users/vaults — vault-name list for the assigned-vault
+ * dropdown. Same `parachute:host:admin` scope gate as the other
+ * `/api/users*` endpoints. Returns `{ vaults: string[] }` (sorted) so
+ * the SPA can populate the dropdown without a second roundtrip.
+ *
+ * This is the canonical surface for "which vaults could a user be
+ * pinned to?" — PR 4's OAuth issuer reads through the same
+ * services.json source.
+ */
+export async function handleListVaults(req: Request, deps: ApiUsersDeps): Promise<Response> {
+  if (req.method !== "GET") {
+    return jsonError(405, "method_not_allowed", "use GET");
+  }
+  try {
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+  } catch (err) {
+    return adminAuthErrorResponse(err as AdminAuthError);
+  }
+  const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const vaults = listVaultNames(manifestPath);
+  return new Response(JSON.stringify({ vaults }), {
+    status: 200,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+function describeUsernameReason(reason: "format" | "length" | "reserved"): string {
+  switch (reason) {
+    case "length":
+      return "username must be 2-32 characters long";
+    case "format":
+      return "username must contain only lowercase letters, digits, hyphens, and underscores ([a-z0-9_-])";
+    case "reserved":
+      return "username is reserved (admin, root, system, setup, parachute, hub)";
+  }
+}

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -55,6 +55,9 @@
  *   /api/grants/<client_id>       (DELETE)     → revoke a single OAuth grant
  *   /api/oauth/clients/<id>       (GET)        → OAuth client details
  *   /api/oauth/clients/<id>/approve (POST)     → flip a pending client to approved
+ *   /api/users                    (GET + POST) → list / create user (host:admin)
+ *   /api/users/vaults             (GET)        → vault-name list for assigned-vault picker (host:admin)
+ *   /api/users/<id>               (DELETE)     → hard-delete user + revoke tokens (host:admin)
  *   /login                        (GET + POST) → operator password login
  *   /logout                       (POST)       → end admin session
  *   /admin/config*                             → 301 → /admin/vaults (legacy
@@ -118,6 +121,12 @@ import { handleApiModules, handleApiModulesChannel } from "./api-modules.ts";
 import { REVOCATION_LIST_MOUNT, handleRevocationList } from "./api-revocation-list.ts";
 import { handleApiRevokeToken } from "./api-revoke-token.ts";
 import { handleApiTokens } from "./api-tokens.ts";
+import {
+  handleCreateUser,
+  handleDeleteUser,
+  handleListUsers,
+  handleListVaults,
+} from "./api-users.ts";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "./config.ts";
 import { ensureCsrfToken } from "./csrf.ts";
 import { readExposeState } from "./expose-state.ts";
@@ -1482,6 +1491,45 @@ export function hubFetch(
       return handleGetClient(req, clientId, {
         db: getDb(),
         issuer: oauthDeps(req).issuer,
+      });
+    }
+
+    // Multi-user Phase 1 admin endpoints (hub#252, design 2026-05-20).
+    // `/api/users` collection (GET list / POST create) and
+    // `/api/users/vaults` for the assigned-vault picker. Per-id route
+    // `/api/users/:id` (DELETE only — Phase 1 doesn't ship edit) is
+    // handled by the `startsWith("/api/users/")` branch below, with the
+    // `/api/users/vaults` sub-path pre-empted *before* the catch-all so
+    // a literal `vaults` segment can't be mistaken for a user id.
+    if (pathname === "/api/users") {
+      if (!getDb) return dbNotConfigured();
+      const usersDeps = {
+        db: getDb(),
+        issuer: oauthDeps(req).issuer,
+        manifestPath,
+      };
+      if (req.method === "GET") return handleListUsers(req, usersDeps);
+      if (req.method === "POST") return handleCreateUser(req, usersDeps);
+      return new Response("method not allowed", { status: 405 });
+    }
+    if (pathname === "/api/users/vaults") {
+      if (!getDb) return dbNotConfigured();
+      return handleListVaults(req, {
+        db: getDb(),
+        issuer: oauthDeps(req).issuer,
+        manifestPath,
+      });
+    }
+    if (pathname.startsWith("/api/users/")) {
+      if (!getDb) return dbNotConfigured();
+      const id = decodeURIComponent(pathname.slice("/api/users/".length));
+      if (!id || id.includes("/")) {
+        return new Response("not found", { status: 404 });
+      }
+      return handleDeleteUser(req, id, {
+        db: getDb(),
+        issuer: oauthDeps(req).issuer,
+        manifestPath,
       });
     }
 

--- a/src/users.ts
+++ b/src/users.ts
@@ -158,6 +158,22 @@ export function getUserByUsername(db: Database, username: string): User | null {
   return row ? rowToUser(row) : null;
 }
 
+/**
+ * Case-insensitive username lookup. Username validation already pins
+ * the canonical form to lowercase (`[a-z0-9_-]`), so the only way a
+ * mixed-case lookup ever fires is a defense-in-depth check at the
+ * admin-create-user boundary — a future loosening of the validator
+ * (or a hand-edited row) wouldn't accidentally allow `Bob` to land
+ * alongside an existing `bob`. SQLite's `COLLATE NOCASE` does the work
+ * with no schema change.
+ */
+export function getUserByUsernameCI(db: Database, username: string): User | null {
+  const row = db
+    .query<Row, [string]>("SELECT * FROM users WHERE username = ? COLLATE NOCASE")
+    .get(username);
+  return row ? rowToUser(row) : null;
+}
+
 export function getUserById(db: Database, id: string): User | null {
   const row = db.query<Row, [string]>("SELECT * FROM users WHERE id = ?").get(id);
   return row ? rowToUser(row) : null;
@@ -193,6 +209,54 @@ export async function setPassword(
     .prepare("UPDATE users SET password_hash = ?, updated_at = ? WHERE id = ?")
     .run(passwordHash, stamp, userId);
   if (result.changes === 0) throw new UserNotFoundError(userId);
+}
+
+/**
+ * Hard-delete a user row and clean up FK-dependent rows.
+ *
+ * Schema reality at v8:
+ *   - `tokens.user_id` is nullable (made nullable in migration v6). The
+ *     plan from the design doc is "tokens stay with `revoked_at` set so
+ *     the audit trail of 'this user existed and held these tokens'
+ *     survives." But the FK is RESTRICT-on-delete, so we need to null
+ *     out `tokens.user_id` after revoking to actually delete the
+ *     parent users row. The audit trail survives via the `subject`
+ *     column we backfill from the username plus the existing
+ *     `created_at`, `scopes`, `client_id`, `revoked_at` fields.
+ *   - `sessions.user_id` and `grants.user_id` are NOT NULL with a
+ *     non-cascading FK. Both are deleted before the users row drops.
+ *
+ * Returns false when no user matches the id (idempotent — the API
+ * layer translates that to 404). Returns true on a successful delete.
+ *
+ * Caller is responsible for the first-admin-undeletable check; this
+ * helper enforces no policy beyond the schema hygiene.
+ */
+export function deleteUser(db: Database, userId: string): boolean {
+  const row = db.query<Row, [string]>("SELECT * FROM users WHERE id = ?").get(userId);
+  if (!row) return false;
+  const now = new Date().toISOString();
+  db.transaction(() => {
+    // 1. Revoke + retain tokens for audit. Mark every un-revoked token
+    //    revoked, then null out user_id on every token (revoked or
+    //    not) so the FK doesn't block the users delete. Backfill
+    //    `subject` with the username so the audit trail isn't anchored
+    //    to a primary key that just vanished.
+    db.prepare("UPDATE tokens SET revoked_at = ? WHERE user_id = ? AND revoked_at IS NULL").run(
+      now,
+      userId,
+    );
+    db.prepare(
+      "UPDATE tokens SET subject = COALESCE(subject, ?), user_id = NULL WHERE user_id = ?",
+    ).run(row.username, userId);
+    // 2. Drop sessions + grants. Both have non-cascading FKs on user_id;
+    //    leaving rows behind would RESTRICT the users delete below.
+    db.prepare("DELETE FROM sessions WHERE user_id = ?").run(userId);
+    db.prepare("DELETE FROM grants WHERE user_id = ?").run(userId);
+    // 3. Drop the user row itself.
+    db.prepare("DELETE FROM users WHERE id = ?").run(userId);
+  })();
+  return true;
 }
 
 /**

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -82,7 +82,7 @@ describe("App — brand subtitle (route-derived)", () => {
 });
 
 describe("App — nav structure", () => {
-  it("renders all nav links in order: brand, Vaults, Modules, Permissions, Tokens, Discovery (signed-out)", async () => {
+  it("renders all nav links in order: brand, Vaults, Modules, Users, Permissions, Tokens, Discovery (signed-out)", async () => {
     renderAt("/vaults");
     // Wait for /api/me to resolve so AuthIndicator's "Sign in" link
     // appears in the nav before we snapshot the link order.
@@ -97,6 +97,7 @@ describe("App — nav structure", () => {
       "Sign in", // AuthIndicator slot, sits between brand and Vaults
       "Vaults",
       "Modules",
+      "Users",
       "Permissions",
       "Tokens",
       "Discovery",

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -29,6 +29,7 @@ import { Modules } from "./routes/Modules.tsx";
 import { NewVault } from "./routes/NewVault.tsx";
 import { Permissions } from "./routes/Permissions.tsx";
 import { Tokens } from "./routes/Tokens.tsx";
+import { Users } from "./routes/Users.tsx";
 import { VaultsList } from "./routes/VaultsList.tsx";
 
 /**
@@ -45,6 +46,9 @@ function subtitleFor(pathname: string): string {
   }
   if (pathname === "/modules" || pathname.startsWith("/modules/")) {
     return "modules";
+  }
+  if (pathname === "/users" || pathname.startsWith("/users/")) {
+    return "users";
   }
   if (pathname.startsWith("/approve-client/")) {
     return "approve app";
@@ -104,6 +108,7 @@ export function App() {
         <AuthIndicator me={me} signingOut={signingOut} onSignOut={onSignOut} />
         <Link to="/vaults">Vaults</Link>
         <Link to="/modules">Modules</Link>
+        <Link to="/users">Users</Link>
         <Link to="/permissions">Permissions</Link>
         <Link to="/tokens">Tokens</Link>
         <span className="nav-divider" aria-hidden="true" />
@@ -117,6 +122,7 @@ export function App() {
         <Route path="/vaults" element={<VaultsList />} />
         <Route path="/vaults/new" element={<NewVault />} />
         <Route path="/modules" element={<Modules />} />
+        <Route path="/users" element={<Users />} />
         <Route path="/permissions" element={<Permissions />} />
         <Route path="/tokens" element={<Tokens />} />
         <Route path="/approve-client/:clientId" element={<ApproveClient />} />

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -711,6 +711,124 @@ export async function getModuleOperation(opId: string): Promise<ModuleOperation>
   return (await res.json()) as ModuleOperation;
 }
 
+/**
+ * Wire shape from `GET /api/users` — multi-user Phase 1.
+ *
+ * `password_hash` is intentionally absent — the hub never returns it
+ * over the wire. `password_changed: false` means the user was created
+ * via the admin path and hasn't yet completed the force-change-password
+ * flow on first sign-in (PR 3 of the multi-user chain).
+ * `assigned_vault: null` means "no per-vault restriction" — the admin
+ * posture; non-null pins the user to that vault.
+ */
+export interface UserListing {
+  id: string;
+  username: string;
+  password_changed: boolean;
+  assigned_vault: string | null;
+  created_at: string;
+}
+
+/** Body shape for `POST /api/users`. */
+export interface CreateUserInput {
+  username: string;
+  password: string;
+  /** Vault to pin the user to. `null` = no restriction (admin-level). */
+  assignedVault: string | null;
+}
+
+/**
+ * GET /api/users — list every user account on the hub. `host:admin`
+ * Bearer gate; same pattern as `listGrants` / `listTokens`. Sorted by
+ * `created_at` ASC so the wizard-admin / env-seeded first admin lands
+ * first — the SPA pins that row's "Delete" button disabled.
+ */
+export async function listUsers(): Promise<UserListing[]> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch("/api/users", {
+    method: "GET",
+    headers: { accept: "application/json", authorization: `Bearer ${bearer}` },
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  const body = (await res.json()) as { users: UserListing[] };
+  return body.users ?? [];
+}
+
+/**
+ * POST /api/users — admin creates a user with a default password +
+ * optional vault assignment. Server runs the password through
+ * argon2id; the plaintext lives only in this request body (TLS-
+ * protected on the wire, never persisted). New users land with
+ * `password_changed: false` and the force-change-password redirect at
+ * `/login` (PR 3) re-routes them on first sign-in.
+ */
+export async function createUser(input: CreateUserInput): Promise<UserListing> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch("/api/users", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json",
+      authorization: `Bearer ${bearer}`,
+    },
+    body: JSON.stringify(input),
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  const body = (await res.json()) as { user: UserListing };
+  return body.user;
+}
+
+/**
+ * DELETE /api/users/:id — hard-delete + token revocation. Refuses to
+ * delete the first-created admin (403 `first_admin_undeletable`) so the
+ * hub can't be self-locked. The SPA also disables the row-level button
+ * for that user as a UX hint, but the server check is authoritative.
+ */
+export async function deleteUser(id: string): Promise<void> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch(`/api/users/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${bearer}` },
+  });
+  if (res.status === 401 || res.status === 403) {
+    // 403 from this endpoint is *not* always an auth failure — it also
+    // surfaces the first-admin-undeletable rail. Don't clear the cached
+    // bearer in that case (a fresh mint won't help). The handler-level
+    // 401/403 cache-clear stays only for the auth shapes.
+    if (res.status === 401) clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+}
+
+/**
+ * GET /api/users/vaults — vault-name list for the assigned-vault
+ * dropdown. Same `host:admin` gate. Sorted server-side; the SPA renders
+ * options in that order plus a synthetic "No restriction" entry.
+ */
+export async function listUserVaults(): Promise<string[]> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch("/api/users/vaults", {
+    method: "GET",
+    headers: { accept: "application/json", authorization: `Bearer ${bearer}` },
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  const body = (await res.json()) as { vaults: string[] };
+  return body.vaults ?? [];
+}
+
 async function readError(res: Response): Promise<string> {
   try {
     const text = await res.text();

--- a/web/ui/src/routes/Users.test.tsx
+++ b/web/ui/src/routes/Users.test.tsx
@@ -74,8 +74,11 @@ describe("Users — list rendering", () => {
     await waitFor(() => expect(screen.getByText("operator")).toBeInTheDocument());
     expect(screen.getByText("alice")).toBeInTheDocument();
     expect(screen.getByText("home")).toBeInTheDocument();
-    // First admin badge on the earliest row.
-    expect(screen.getByText(/first admin/i)).toBeInTheDocument();
+    // First admin badge on the earliest row. (The sr-only describedby
+    // span also contains "first admin" text — scope to the visible
+    // badge specifically by its short label rather than matching any
+    // "first admin" occurrence anywhere in the DOM.)
+    expect(screen.getByText("first admin")).toBeInTheDocument();
     // assigned_vault: null renders as em-dash.
     expect(screen.getByText("—")).toBeInTheDocument();
     // password_changed: false renders the "pending first login" label.
@@ -100,9 +103,19 @@ describe("Users — first-admin protection", () => {
     const operatorBtn = await screen.findByRole("button", { name: /delete operator/i });
     expect(operatorBtn).toBeDisabled();
     expect(operatorBtn).toHaveAttribute("title", expect.stringMatching(/first admin/i));
-    // Non-first user Delete is enabled.
+    // a11y: aria-describedby points at a visually-hidden span carrying
+    // the explanation. `title` on a disabled button is unreliable for
+    // assistive tech, so the describedby is the load-bearing surface.
+    const describedById = operatorBtn.getAttribute("aria-describedby");
+    expect(describedById).toMatch(/^first-admin-tooltip-/);
+    const tooltipSpan = describedById ? document.getElementById(describedById) : null;
+    expect(tooltipSpan).not.toBeNull();
+    expect(tooltipSpan?.className).toContain("sr-only");
+    expect(tooltipSpan?.textContent).toMatch(/first admin can't be deleted/i);
+    // Non-first user Delete is enabled and carries no describedby.
     const aliceBtn = screen.getByRole("button", { name: /delete alice/i });
     expect(aliceBtn).not.toBeDisabled();
+    expect(aliceBtn).not.toHaveAttribute("aria-describedby");
   });
 });
 

--- a/web/ui/src/routes/Users.test.tsx
+++ b/web/ui/src/routes/Users.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * Users route smoke tests — loading, list with sample data,
+ * empty state, create-form happy path + client-side validation,
+ * delete confirm flow, first-admin Delete disabled with tooltip,
+ * load error.
+ */
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import { Users } from "./Users.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    listUsers: vi.fn(),
+    listUserVaults: vi.fn(),
+    createUser: vi.fn(),
+    deleteUser: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderRoute() {
+  return render(
+    <MemoryRouter>
+      <Users />
+    </MemoryRouter>,
+  );
+}
+
+function user(username: string, overrides: Partial<api.UserListing> = {}): api.UserListing {
+  return {
+    id: `id-${username}`,
+    username,
+    password_changed: true,
+    assigned_vault: null,
+    created_at: "2026-05-01T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("Users — list rendering", () => {
+  it("shows a loading state on first paint", () => {
+    vi.mocked(api.listUsers).mockImplementation(() => new Promise(() => {}));
+    vi.mocked(api.listUserVaults).mockImplementation(() => new Promise(() => {}));
+    renderRoute();
+    expect(screen.getByText(/loading users/i)).toBeInTheDocument();
+  });
+
+  it("renders the empty state when no users exist", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([]);
+    vi.mocked(api.listUserVaults).mockResolvedValue([]);
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/no users yet/i)).toBeInTheDocument());
+  });
+
+  it("renders one row per user with assigned vault + password status", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([
+      user("operator", { password_changed: true, assigned_vault: null }),
+      user("alice", { password_changed: false, assigned_vault: "home" }),
+    ]);
+    vi.mocked(api.listUserVaults).mockResolvedValue(["home"]);
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("operator")).toBeInTheDocument());
+    expect(screen.getByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("home")).toBeInTheDocument();
+    // First admin badge on the earliest row.
+    expect(screen.getByText(/first admin/i)).toBeInTheDocument();
+    // assigned_vault: null renders as em-dash.
+    expect(screen.getByText("—")).toBeInTheDocument();
+    // password_changed: false renders the "pending first login" label.
+    expect(screen.getByText(/pending first login/i)).toBeInTheDocument();
+  });
+
+  it("renders the error banner + retry on listUsers failure", async () => {
+    vi.mocked(api.listUsers).mockRejectedValue(new Error("network down"));
+    vi.mocked(api.listUserVaults).mockResolvedValue([]);
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/couldn't load users/i)).toBeInTheDocument());
+    expect(screen.getByText("network down")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+});
+
+describe("Users — first-admin protection", () => {
+  it("disables the Delete button for the first admin and surfaces a tooltip", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([user("operator"), user("alice")]);
+    vi.mocked(api.listUserVaults).mockResolvedValue([]);
+    renderRoute();
+    const operatorBtn = await screen.findByRole("button", { name: /delete operator/i });
+    expect(operatorBtn).toBeDisabled();
+    expect(operatorBtn).toHaveAttribute("title", expect.stringMatching(/first admin/i));
+    // Non-first user Delete is enabled.
+    const aliceBtn = screen.getByRole("button", { name: /delete alice/i });
+    expect(aliceBtn).not.toBeDisabled();
+  });
+});
+
+describe("Users — delete confirm flow", () => {
+  it("clicking Delete opens a confirm dialog; cancel returns to list without DELETE", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([user("operator"), user("alice")]);
+    vi.mocked(api.listUserVaults).mockResolvedValue([]);
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /delete alice/i }));
+    expect(screen.getByRole("dialog", { name: /confirm delete alice/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: /confirm delete alice/i })).toBeNull(),
+    );
+    expect(api.deleteUser).not.toHaveBeenCalled();
+  });
+
+  it("confirm Delete calls deleteUser and refreshes the list", async () => {
+    const listMock = vi.mocked(api.listUsers);
+    listMock.mockResolvedValueOnce([user("operator"), user("alice")]);
+    listMock.mockResolvedValueOnce([user("operator")]);
+    vi.mocked(api.listUserVaults).mockResolvedValue([]);
+    vi.mocked(api.deleteUser).mockResolvedValue();
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /delete alice/i }));
+    const dialog = screen.getByRole("dialog", { name: /confirm delete alice/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+    await waitFor(() => expect(api.deleteUser).toHaveBeenCalledWith("id-alice"));
+    // alice gone after refresh.
+    await waitFor(() => expect(screen.queryByText("alice")).toBeNull());
+  });
+
+  it("surfaces a per-row error banner when delete fails", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([user("operator"), user("alice")]);
+    vi.mocked(api.listUserVaults).mockResolvedValue([]);
+    vi.mocked(api.deleteUser).mockRejectedValue(new api.HttpError(500, "boom"));
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /delete alice/i }));
+    const dialog = screen.getByRole("dialog", { name: /confirm delete alice/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/delete failed \(500\): boom/i)).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("Users — create form", () => {
+  it("hides the form behind a Create User button by default", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([user("operator")]);
+    vi.mocked(api.listUserVaults).mockResolvedValue(["home"]);
+    renderRoute();
+    expect(await screen.findByRole("button", { name: /create user/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^password/i)).toBeNull();
+  });
+
+  it("clicking Create User reveals the form with vault dropdown + No restriction option", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([user("operator")]);
+    vi.mocked(api.listUserVaults).mockResolvedValue(["home", "work"]);
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /create user/i }));
+    expect(await screen.findByLabelText(/username/i)).toBeInTheDocument();
+    const select = screen.getByLabelText(/assigned vault/i) as HTMLSelectElement;
+    const optionTexts = Array.from(select.options).map((o) => o.text);
+    expect(optionTexts).toEqual(["No restriction (admin-level access)", "home", "work"]);
+  });
+
+  it("submits createUser with the assigned vault and refreshes the list on success", async () => {
+    const listMock = vi.mocked(api.listUsers);
+    listMock.mockResolvedValueOnce([user("operator")]);
+    listMock.mockResolvedValueOnce([
+      user("operator"),
+      user("alice", { password_changed: false, assigned_vault: "home" }),
+    ]);
+    vi.mocked(api.listUserVaults).mockResolvedValue(["home"]);
+    vi.mocked(api.createUser).mockResolvedValue(
+      user("alice", { password_changed: false, assigned_vault: "home" }),
+    );
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /create user/i }));
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: "alice" } });
+    fireEvent.change(screen.getByLabelText(/^password/i), {
+      target: { value: "alice-strong-passphrase" },
+    });
+    fireEvent.change(screen.getByLabelText(/assigned vault/i), { target: { value: "home" } });
+    fireEvent.click(screen.getByRole("button", { name: /^create user$/i }));
+    await waitFor(() =>
+      expect(api.createUser).toHaveBeenCalledWith({
+        username: "alice",
+        password: "alice-strong-passphrase",
+        assignedVault: "home",
+      }),
+    );
+    // Success banner copy matches the design's "force-change on first login" wording.
+    await waitFor(() =>
+      expect(screen.getByText(/prompted to change their password/i)).toBeInTheDocument(),
+    );
+    // List refreshed — alice now visible in the table.
+    await waitFor(() => expect(api.listUsers).toHaveBeenCalledTimes(2));
+    // Two `alice` text matches: one in the table row, one in the success
+    // banner — both are signals that the create flow completed.
+    expect(screen.getAllByText("alice").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("client-side rejects password shorter than 12 chars before calling the API", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([user("operator")]);
+    vi.mocked(api.listUserVaults).mockResolvedValue([]);
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /create user/i }));
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: "alice" } });
+    // 11 chars — under the floor.
+    fireEvent.change(screen.getByLabelText(/^password/i), { target: { value: "tooshortpw1" } });
+    // Submit via form submit handler (the input minLength HTML attribute
+    // would also block; we exercise the JS-level validator by querying
+    // the form noValidate fallback path).
+    const form = screen.getByRole("form", { name: /create user/i });
+    fireEvent.submit(form);
+    await waitFor(() => expect(screen.getByText(/at least 12 characters/i)).toBeInTheDocument());
+    expect(api.createUser).not.toHaveBeenCalled();
+  });
+
+  it("surfaces server error_description from a 409 conflict", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([user("operator")]);
+    vi.mocked(api.listUserVaults).mockResolvedValue(["home"]);
+    vi.mocked(api.createUser).mockRejectedValue(
+      new api.HttpError(409, 'username "alice" is already in use'),
+    );
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /create user/i }));
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: "alice" } });
+    fireEvent.change(screen.getByLabelText(/^password/i), {
+      target: { value: "alice-strong-passphrase" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^create user$/i }));
+    await waitFor(() => expect(screen.getByText(/create failed \(409\)/i)).toBeInTheDocument());
+  });
+});

--- a/web/ui/src/routes/Users.tsx
+++ b/web/ui/src/routes/Users.tsx
@@ -335,20 +335,36 @@ function ListRendered({
                 </td>
                 <td>
                   {isConfirming ? null : (
-                    <button
-                      type="button"
-                      className="secondary"
-                      disabled={isFirstAdmin || isDeleting}
-                      title={
-                        isFirstAdmin
-                          ? "First admin can't be deleted (would self-lock the hub)"
-                          : undefined
-                      }
-                      onClick={() => setDeleteSt({ kind: "confirming", user: u })}
-                      aria-label={`Delete ${u.username}`}
-                    >
-                      {isDeleting ? "Deleting…" : "Delete"}
-                    </button>
+                    <>
+                      {/*
+                        Screen-reader description for the disabled
+                        first-admin Delete button. `title` is
+                        unreliable on disabled buttons in assistive
+                        tech; `aria-describedby` to a visually-hidden
+                        node is the canonical WAI-ARIA shape. We keep
+                        `title` too for sighted hover users.
+                      */}
+                      {isFirstAdmin && (
+                        <span id={`first-admin-tooltip-${u.id}`} className="sr-only">
+                          First admin can't be deleted (would self-lock the hub)
+                        </span>
+                      )}
+                      <button
+                        type="button"
+                        className="secondary"
+                        disabled={isFirstAdmin || isDeleting}
+                        title={
+                          isFirstAdmin
+                            ? "First admin can't be deleted (would self-lock the hub)"
+                            : undefined
+                        }
+                        aria-describedby={isFirstAdmin ? `first-admin-tooltip-${u.id}` : undefined}
+                        onClick={() => setDeleteSt({ kind: "confirming", user: u })}
+                        aria-label={`Delete ${u.username}`}
+                      >
+                        {isDeleting ? "Deleting…" : "Delete"}
+                      </button>
+                    </>
                   )}
                   {isConfirming && (
                     <dialog

--- a/web/ui/src/routes/Users.tsx
+++ b/web/ui/src/routes/Users.tsx
@@ -1,0 +1,523 @@
+/**
+ * /admin/users — multi-user Phase 1 admin surface.
+ *
+ * Design: `parachute.computer/design/2026-05-20-multi-user-phase-1.md`.
+ * Tracker: hub#252. PR 2 of 5 in the multi-user chain.
+ *
+ * Surface:
+ *
+ *   1. **Users list table.** Username · Assigned vault · Password set ·
+ *      Created · Actions. First admin (the wizard / env-seeded
+ *      bootstrap row) has the Delete button disabled with a tooltip;
+ *      the server enforces the same rail (`first_admin_undeletable`).
+ *   2. **Create user form.** Collapsible section below the table.
+ *      Username + password + assigned-vault dropdown (fetched on mount
+ *      from `/api/users/vaults`). The dropdown's first option is the
+ *      synthetic "No restriction (admin-level access)" → maps to
+ *      `assignedVault: null`. Subsequent options are vault names from
+ *      services.json.
+ *   3. **Delete confirmation.** Inline confirm dialog mirroring the
+ *      `Permissions.tsx` pattern — click → confirm dialog → DELETE →
+ *      refresh.
+ *
+ * Optimistic-update + rollback-on-error: the create flow follows the
+ * `Modules.tsx`-style "fire-and-recover" shape. On submit, the form
+ * locks, posts; on success the table refreshes from the server (which
+ * is the source of truth for `created_at` ordering); on failure the
+ * inline error banner surfaces the server's `error_description` and
+ * the form re-opens for retry.
+ *
+ * Auth: every fetch uses the shared `getHostAdminToken()` flow from
+ * `lib/auth.ts` (session cookie → cached `parachute:host:admin` JWT).
+ * A 401 surfaces verbatim and the lib helper handles the redirect-to-
+ * login on the next mint attempt.
+ *
+ * Force-change-password redirect copy: when the admin creates a user,
+ * the success banner says "they'll be prompted to change their
+ * password on first sign-in" — telegraphs PR 3's flow without
+ * pretending it exists yet (the bit is persisted now; the redirect
+ * lands in PR 3).
+ */
+import { type FormEvent, useEffect, useState } from "react";
+import {
+  type CreateUserInput,
+  HttpError,
+  type UserListing,
+  createUser,
+  deleteUser,
+  listUserVaults,
+  listUsers,
+} from "../lib/api.ts";
+
+/**
+ * Server's password-floor. Mirrors `PASSWORD_MIN_LEN` in `users.ts`
+ * (PR 1). Client-side check is informational — the server validates
+ * regardless, and a discrepancy is a UX bug, not a security one.
+ */
+const PASSWORD_MIN_LEN = 12;
+
+/**
+ * Server's username regex. Mirrors `USERNAME_REGEX` + `USERNAME_MIN_LEN`
+ * / `USERNAME_MAX_LEN` from `users.ts`. Same defense-in-depth rationale
+ * as the password floor — server is authoritative; client-side check is
+ * for fast feedback.
+ */
+const USERNAME_REGEX = /^[a-z0-9_-]+$/;
+const USERNAME_MIN_LEN = 2;
+const USERNAME_MAX_LEN = 32;
+
+interface UsersData {
+  users: UserListing[];
+  vaults: string[];
+}
+
+type ListState =
+  | { kind: "loading" }
+  | { kind: "ok"; data: UsersData }
+  | { kind: "error"; message: string };
+
+type CreateState =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "created"; username: string }
+  | { kind: "error"; message: string };
+
+type DeleteState =
+  | { kind: "idle" }
+  | { kind: "confirming"; user: UserListing }
+  | { kind: "deleting"; userId: string }
+  | { kind: "error"; userId: string; message: string };
+
+interface FormFields {
+  username: string;
+  password: string;
+  /** Empty string = the synthetic "No restriction" sentinel. */
+  assignedVault: string;
+}
+
+const EMPTY_FORM: FormFields = {
+  username: "",
+  password: "",
+  assignedVault: "",
+};
+
+export function Users() {
+  const [state, setState] = useState<ListState>({ kind: "loading" });
+  const [reload, setReload] = useState(0);
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState<FormFields>(EMPTY_FORM);
+  const [createState, setCreateState] = useState<CreateState>({ kind: "idle" });
+  const [deleteSt, setDeleteSt] = useState<DeleteState>({ kind: "idle" });
+
+  useEffect(() => {
+    void reload;
+    let cancelled = false;
+    setState({ kind: "loading" });
+    Promise.all([listUsers(), listUserVaults()])
+      .then(([users, vaults]) => {
+        if (cancelled) return;
+        setState({ kind: "ok", data: { users, vaults } });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ kind: "error", message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reload]);
+
+  function clientValidate(fields: FormFields): string | null {
+    if (fields.username.length < USERNAME_MIN_LEN || fields.username.length > USERNAME_MAX_LEN) {
+      return `Username must be ${USERNAME_MIN_LEN}-${USERNAME_MAX_LEN} characters.`;
+    }
+    if (!USERNAME_REGEX.test(fields.username)) {
+      return "Username may only contain lowercase letters, digits, hyphens, and underscores.";
+    }
+    if (fields.password.length < PASSWORD_MIN_LEN) {
+      return `Password must be at least ${PASSWORD_MIN_LEN} characters.`;
+    }
+    return null;
+  }
+
+  async function onSubmitCreate(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    const validationError = clientValidate(form);
+    if (validationError) {
+      setCreateState({ kind: "error", message: validationError });
+      return;
+    }
+    setCreateState({ kind: "submitting" });
+    const input: CreateUserInput = {
+      username: form.username,
+      password: form.password,
+      assignedVault: form.assignedVault === "" ? null : form.assignedVault,
+    };
+    try {
+      const created = await createUser(input);
+      // Clear the form, surface success, refresh the table from the
+      // server (canonical source for created_at ordering + first-admin
+      // selector).
+      setForm(EMPTY_FORM);
+      setCreateState({ kind: "created", username: created.username });
+      setReload((n) => n + 1);
+    } catch (err) {
+      const message =
+        err instanceof HttpError
+          ? `Create failed (${err.status}): ${err.message}`
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      setCreateState({ kind: "error", message });
+    }
+  }
+
+  async function onConfirmDelete(user: UserListing): Promise<void> {
+    setDeleteSt({ kind: "deleting", userId: user.id });
+    try {
+      await deleteUser(user.id);
+      setDeleteSt({ kind: "idle" });
+      setReload((n) => n + 1);
+    } catch (err) {
+      const message =
+        err instanceof HttpError
+          ? `Delete failed (${err.status}): ${err.message}`
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      setDeleteSt({ kind: "error", userId: user.id, message });
+    }
+  }
+
+  return (
+    <div>
+      <div className="list-header">
+        <h2>Users</h2>
+      </div>
+
+      <p className="muted">
+        Hub user accounts. Each user can be pinned to a single vault (Phase 1) — the OAuth issuer
+        narrows their tokens to <code>vault:&lt;assigned&gt;:*</code> scopes. Users with no
+        assignment have admin-level vault access. Admin-created users land with a default password
+        and are prompted to change it on first sign-in.
+      </p>
+
+      {renderListSection(state, deleteSt, setDeleteSt, onConfirmDelete, () =>
+        setReload((n) => n + 1),
+      )}
+
+      {state.kind === "ok" && (
+        <CreateUserSection
+          show={showForm}
+          setShow={setShowForm}
+          form={form}
+          setForm={setForm}
+          vaults={state.data.vaults}
+          createState={createState}
+          setCreateState={setCreateState}
+          onSubmit={onSubmitCreate}
+        />
+      )}
+    </div>
+  );
+}
+
+function renderListSection(
+  state: ListState,
+  deleteSt: DeleteState,
+  setDeleteSt: (s: DeleteState) => void,
+  onConfirm: (user: UserListing) => Promise<void>,
+  onRetry: () => void,
+): React.ReactNode {
+  if (state.kind === "loading") {
+    return <p className="muted">Loading users…</p>;
+  }
+  if (state.kind === "error") {
+    return (
+      <>
+        <div className="error-banner">
+          Couldn't load users: <code>{state.message}</code>
+        </div>
+        <button type="button" onClick={onRetry} className="secondary">
+          Retry
+        </button>
+      </>
+    );
+  }
+  const { users } = state.data;
+  if (users.length === 0) {
+    return (
+      <div className="empty empty-rich">
+        <p className="empty-headline">No users yet.</p>
+        <p className="muted">Click Create User below to invite someone.</p>
+      </div>
+    );
+  }
+  // The first row by `created_at ASC` is the wizard / env-seeded admin
+  // — the server enforces "first admin can't be deleted." The SPA
+  // disables the row's Delete button as a UX hint; the server check
+  // is authoritative.
+  const firstAdminId = users[0]?.id;
+  return (
+    <ListRendered
+      users={users}
+      firstAdminId={firstAdminId}
+      deleteSt={deleteSt}
+      setDeleteSt={setDeleteSt}
+      onConfirm={onConfirm}
+    />
+  );
+}
+
+interface ListRenderedProps {
+  users: UserListing[];
+  firstAdminId: string | undefined;
+  deleteSt: DeleteState;
+  setDeleteSt: (s: DeleteState) => void;
+  onConfirm: (user: UserListing) => Promise<void>;
+}
+
+function ListRendered({
+  users,
+  firstAdminId,
+  deleteSt,
+  setDeleteSt,
+  onConfirm,
+}: ListRenderedProps): React.ReactNode {
+  return (
+    <div className="user-list" style={{ marginTop: "1rem" }}>
+      <table className="user-table">
+        <thead>
+          <tr>
+            <th scope="col">Username</th>
+            <th scope="col">Assigned vault</th>
+            <th scope="col">Password set</th>
+            <th scope="col">Created</th>
+            <th scope="col">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((u) => {
+            const isFirstAdmin = u.id === firstAdminId;
+            const isDeleting = deleteSt.kind === "deleting" && deleteSt.userId === u.id;
+            const isConfirming = deleteSt.kind === "confirming" && deleteSt.user.id === u.id;
+            const rowError =
+              deleteSt.kind === "error" && deleteSt.userId === u.id ? deleteSt : null;
+            return (
+              <tr key={u.id} data-user-id={u.id}>
+                <td>
+                  <code>{u.username}</code>
+                  {isFirstAdmin && (
+                    <span className="badge" style={{ marginLeft: "0.5rem" }}>
+                      first admin
+                    </span>
+                  )}
+                </td>
+                <td>
+                  {u.assigned_vault ? (
+                    <code>{u.assigned_vault}</code>
+                  ) : (
+                    <span className="muted" title="No per-vault restriction (admin-level access)">
+                      —
+                    </span>
+                  )}
+                </td>
+                <td>
+                  {u.password_changed ? (
+                    <span aria-label="changed">✓</span>
+                  ) : (
+                    <span className="muted">pending first login</span>
+                  )}
+                </td>
+                <td>
+                  <span title={u.created_at}>{formatCreatedAt(u.created_at)}</span>
+                </td>
+                <td>
+                  {isConfirming ? null : (
+                    <button
+                      type="button"
+                      className="secondary"
+                      disabled={isFirstAdmin || isDeleting}
+                      title={
+                        isFirstAdmin
+                          ? "First admin can't be deleted (would self-lock the hub)"
+                          : undefined
+                      }
+                      onClick={() => setDeleteSt({ kind: "confirming", user: u })}
+                      aria-label={`Delete ${u.username}`}
+                    >
+                      {isDeleting ? "Deleting…" : "Delete"}
+                    </button>
+                  )}
+                  {isConfirming && (
+                    <dialog
+                      open
+                      className="error-banner"
+                      style={{ marginTop: "0.25rem", background: "var(--bg-warn, #fffbe6)" }}
+                      aria-label={`Confirm delete ${u.username}`}
+                    >
+                      <p>
+                        Delete <code>{u.username}</code>? This revokes their tokens, drops their
+                        sessions and grants, and removes the account. The audit trail is preserved —
+                        tokens stay with <code>revoked_at</code> set, anonymised.
+                      </p>
+                      <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.5rem" }}>
+                        <button
+                          type="button"
+                          className="destructive"
+                          onClick={() => {
+                            void onConfirm(u);
+                          }}
+                          disabled={isDeleting}
+                        >
+                          {isDeleting ? "Deleting…" : "Delete"}
+                        </button>
+                        <button
+                          type="button"
+                          className="secondary"
+                          onClick={() => setDeleteSt({ kind: "idle" })}
+                          disabled={isDeleting}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </dialog>
+                  )}
+                  {rowError && (
+                    <div className="error-banner" style={{ marginTop: "0.25rem" }}>
+                      <code>{rowError.message}</code>
+                    </div>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+interface CreateUserSectionProps {
+  show: boolean;
+  setShow: (s: boolean) => void;
+  form: FormFields;
+  setForm: (f: FormFields) => void;
+  vaults: string[];
+  createState: CreateState;
+  setCreateState: (s: CreateState) => void;
+  onSubmit: (e: FormEvent) => Promise<void>;
+}
+
+function CreateUserSection({
+  show,
+  setShow,
+  form,
+  setForm,
+  vaults,
+  createState,
+  setCreateState,
+  onSubmit,
+}: CreateUserSectionProps): React.ReactNode {
+  const submitting = createState.kind === "submitting";
+  return (
+    <section style={{ marginTop: "1.5rem" }}>
+      {!show ? (
+        <button type="button" onClick={() => setShow(true)}>
+          Create User
+        </button>
+      ) : (
+        <form onSubmit={(e) => void onSubmit(e)} aria-label="Create user">
+          <h3>Create user</h3>
+          <p>
+            <label htmlFor="new-user-username">
+              Username{" "}
+              <span className="muted">
+                ({USERNAME_MIN_LEN}-{USERNAME_MAX_LEN} chars, lowercase letters/digits/hyphens/
+                underscores)
+              </span>
+            </label>
+            <br />
+            <input
+              id="new-user-username"
+              type="text"
+              required
+              autoComplete="off"
+              value={form.username}
+              minLength={USERNAME_MIN_LEN}
+              maxLength={USERNAME_MAX_LEN}
+              pattern="[a-z0-9_\-]+"
+              onChange={(e) => setForm({ ...form, username: e.target.value })}
+            />
+          </p>
+          <p>
+            <label htmlFor="new-user-password">
+              Password <span className="muted">(min {PASSWORD_MIN_LEN} chars)</span>
+            </label>
+            <br />
+            <input
+              id="new-user-password"
+              type="password"
+              required
+              autoComplete="new-password"
+              value={form.password}
+              minLength={PASSWORD_MIN_LEN}
+              onChange={(e) => setForm({ ...form, password: e.target.value })}
+            />
+          </p>
+          <p>
+            <label htmlFor="new-user-vault">Assigned vault</label>
+            <br />
+            <select
+              id="new-user-vault"
+              value={form.assignedVault}
+              onChange={(e) => setForm({ ...form, assignedVault: e.target.value })}
+            >
+              <option value="">No restriction (admin-level access)</option>
+              {vaults.map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+            </select>
+          </p>
+
+          {createState.kind === "error" && (
+            <div className="error-banner">
+              <code>{createState.message}</code>
+            </div>
+          )}
+          {createState.kind === "created" && (
+            <output className="success-banner">
+              User <code>{createState.username}</code> created. They'll be prompted to change their
+              password on first sign-in.
+            </output>
+          )}
+
+          <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.5rem" }}>
+            <button type="submit" disabled={submitting}>
+              {submitting ? "Creating…" : "Create user"}
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              disabled={submitting}
+              onClick={() => {
+                setShow(false);
+                setCreateState({ kind: "idle" });
+              }}
+            >
+              Close
+            </button>
+          </div>
+        </form>
+      )}
+    </section>
+  );
+}
+
+function formatCreatedAt(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -457,3 +457,23 @@ form .field-error {
   margin: 0.4rem 0 0;
   font-size: 0.85rem;
 }
+
+/*
+ * Visually-hidden utility for screen-reader-only text. Used by the
+ * first-admin disabled-Delete button on /admin/users to wire
+ * `aria-describedby` to an explanation that's invisible to sighted
+ * users but exposed to assistive tech (where `title` on a disabled
+ * button is unreliable). Standard WAI-ARIA shape — clip path keeps
+ * the element off-screen but in the accessibility tree.
+ */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Summary

PR 2 of 5 in the multi-user Phase 1 chain (hub#252, design [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)). Builds on PR 1 (#279 — users table foundation) by wiring its `validateUsername` / `validatePassword` validators into a four-endpoint admin surface plus the SPA route.

After PR 1 the schema and helpers existed but had no operator-facing surface. After PR 2 an admin can list / create / delete users from `/admin/users`, with the assigned-vault dropdown pre-populated from `services.json`. PR 3 (force-change-password flow at `/login`) is the next step.

## Backend changes

Four endpoints in `src/api-users.ts` (new), all `parachute:host:admin`-gated. Snake-case wire shape; `password_hash` is never returned.

- **`GET /api/users`** — list users sorted by `created_at ASC`.
- **`POST /api/users`** — `{ username, password, assignedVault?: string | null }`. Order of checks: **413 `password_too_long`** if `password.length > 256` (fires BEFORE argon2id touches it — CPU-DoS mitigation); then validators from PR 1; then `assigned_vault` against services.json; then case-insensitive **409 `username_taken`**; then **201** with `password_changed: false` (PR 3's force-redirect catches them on first sign-in).
- **`DELETE /api/users/:id`** — **403 `first_admin_undeletable`** when the target is the earliest `created_at` row; otherwise **204** after revoking the user's tokens (mark `revoked_at`, null `user_id`, backfill `subject` with the username so the audit trail survives), dropping their `sessions` + `grants` (non-cascading FKs), then dropping the users row. All in one transaction.
- **`GET /api/users/vaults`** — sorted vault-instance-name list from services.json. Feeds the SPA's assigned-vault dropdown; mirrors `oauth-handlers.ts`'s private `listVaultNames` so PR 4 reads from the same source.

`src/users.ts` gains `getUserByUsernameCI` (case-folded lookup) and `deleteUser` (the FK-aware sweep). `src/hub-server.ts` route table extended.

## Frontend changes

- `web/ui/src/routes/Users.tsx` (new) — three sections: users table (with first-admin badge + disabled-Delete tooltip), collapsible Create-user form (username + password + assigned-vault dropdown; "No restriction (admin-level access)" is the synthetic first option mapping to `null`), inline delete-confirm dialog mirroring `Permissions.tsx`.
- `web/ui/src/lib/api.ts` — `listUsers`, `createUser`, `deleteUser`, `listUserVaults`. `deleteUser`'s 403 path does NOT clear the cached bearer (403 here is `first_admin_undeletable` policy, not auth failure).
- `web/ui/src/App.tsx` — `/users` route mounted; Users link in nav between Modules and Permissions.

## Test plan

- [x] `bun test ./src` — **1530 pass / 0 fail / 31120 expects across 81 files** (+33 over rc.12).
- [x] `cd web/ui && bun run test` — **133 pass / 0 fail across 10 files** (+13 over rc.12).
- [x] `bun run typecheck` clean (root + web/ui).
- [x] `bunx biome check .` clean.
- [x] `cd web/ui && bun run build` clean (`vite build` + `verify-base.mjs` green).
- [x] End-to-end smoke against a fresh `PARACHUTE_HOME=/tmp/hub-mu-pr2` hub:
  - [x] Env-seeded admin lands as `password_changed: true`, first row.
  - [x] `curl POST /api/users` testuser → 201 with `password_changed: false`.
  - [x] `curl POST` 300-char password → **413 `password_too_long`** (sub-millisecond — no argon2id call).
  - [x] `curl POST` 8-char password → **400 `invalid_password`**.
  - [x] `curl POST` username `Capital` → **400 `invalid_username`** (format).
  - [x] `curl POST` duplicate `testuser` → **409 `username_taken`**.
  - [x] `curl POST` with `assignedVault: "no-such-vault"` → **400 `assigned_vault_not_found`**.
  - [x] `curl DELETE` first admin → **403 `first_admin_undeletable`**.
  - [x] `curl DELETE` testuser → **204**.
  - [x] `curl DELETE` non-existent id → **404**.

## Cross-references

- Design: [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)
- Master tracker: hub#252
- Builds on: PR 1 hub#279 (rc.12 — users table foundation)
- Followed by: PR 3 (force-change-password flow), PR 4 (OAuth `vault_scope` claim), PR 5 (scope-guard end-to-end verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)