### PR TITLE
feat(hub): multi-user Phase 1 PR 3 — force-change-password flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.10-rc.14] - 2026-05-20
+
+Multi-user Phase 1 — PR 3 of 5: force-change-password flow (hub#252, design [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)). Builds on PR 2 (rc.13) which shipped the admin `/api/users` surface for creating accounts with `password_changed: false`. This release wires the *user* side: a session-level redirect at the login boundary that lands admin-created users on a server-rendered change-password form before they can reach the rest of the hub.
+
+Backend surface:
+
+- `src/admin-handlers.ts` — `loginRedirectTarget(user, next)` helper: when `user.passwordChanged === false`, return `/account/change-password?next=<encoded original-next>` (or the bare path when next is the post-login default); otherwise return `next` (today's behavior). The `/login` POST mints the session cookie as normal and 302s to the helper's target. **Session-level redirect, not token-level** — the user IS authenticated, they're just expected to change their admin-typed default before continuing. Per design §sign-in flow change.
+- `src/api-account.ts` (new) — `/account/*` user-self-service surface.
+  - **`GET /account/change-password`** — server-rendered HTML form. Requires an active session (otherwise 302 → `/login?next=/account/change-password`). Renders the "first-time login" heading when `password_changed === false`; renders the "Change your password" heading when `true` (direct-nav path: any signed-in user can rotate their password — the redirect at `/login` is the *only* flag-gated behavior). Falls back to `/login` if the session points at a deleted user.
+  - **`POST /account/change-password`** — `application/x-www-form-urlencoded` body with `current_password`, `new_password`, `new_password_confirm`, `next`. Order of checks: 401 (no session) → 400 (CSRF) → 400 (missing field) → 413 (new > `PASSWORD_MAX_LEN`, **before** argon2id touches it; same CPU-DoS defense as `/api/users` POST) → 400 `invalid_password` (PR 1's 12-char validator) → 400 `password_mismatch` (new ≠ confirm) → 401 `invalid_credentials` (verifyPassword) → 400 `password_unchanged` (new === current, *after* verify so we don't leak that a guessed new matches an unverified current) → 302 to `next` with `password_changed = 1`. On error the page re-renders with an inline error banner; the session cookie is untouched (the user stays signed in). Session cookies on other devices stay valid through their natural 24h expiry — Phase 2 adds explicit "sign out everywhere" per the design's trade-off discussion.
+  - **`markPasswordChanged(db, userId, now?)`** — idempotent UPDATE that flips the flag and bumps `updated_at`. Lives next to the POST handler for now; lift into `users.ts` when PR 4 (or a Phase 2 admin-reset path) adds a second call site.
+- `src/account-change-password-ui.ts` (new) — pure renderer for the two-mode form. Same chrome family as `admin-login-ui.ts` (`/login`): inline CSS, no third-party fonts, no SPA bundle. Form works without JS; an inline `<script>` adds fast-feedback validation (mirroring the three server checks: min length, confirm match, current ≠ new).
+- `src/hub-server.ts` — route table extended (`/account/change-password` GET + POST). Dispatch placed adjacent to `/login` and `/logout` since the three surfaces share the session-cookie posture.
+
+Tests + gates:
+
+- `src/__tests__/api-account.test.ts` (new) — 18 tests covering: GET no-session 302 (with `next` preservation through `/login`), GET first-time vs rotate mode by flag, GET against stale-user session, POST happy path (hash updates, flag flips, 302 to next, default lands on `/admin/vaults`), every POST validation branch (no session, CSRF mismatch, wrong current, too short, too long with elapsed-time floor < 200ms asserting cap fires before argon2id, mismatch confirm, unchanged after verify), failure-re-render keeps session cookie. `markPasswordChanged` unit tests for the happy path + idempotent re-call.
+- `src/__tests__/admin-handlers.test.ts` — 4 new `loginRedirectTarget` tests: passwordChanged=false with next= encodes the original destination into the change-password URL, no-next= → bare `/account/change-password`, passwordChanged=true → existing behavior unchanged, unsafe next= can't leak through the encoder. Updated 6 existing login-POST tests to pass `passwordChanged: true` on `createUser` (matches wizard-admin posture; old tests pre-dated the force-change behavior and would otherwise land on the change-password URL).
+
+Gate: `bun test ./src` — **1553 pass / 0 fail / 31176 expects across 82 files** (+23 over rc.13 baseline 1530). SPA: `cd web/ui && bun run test` — **133 pass / 0 fail across 10 files** (unchanged — no SPA changes this PR). typecheck + biome clean (root + web/ui). SPA build clean.
+
+Smoke: see PR description.
+
+What's NOT in PR 3:
+
+- OAuth issuer `vault_scope` claim + per-user scope narrowing — PR 4.
+- End-to-end verification + scope-guard reach-through — PR 5.
+- 2FA enrollment inline on first sign-in — Phase 1.5 PR 6 (optional, design §2FA-orientation).
+- Admin-reset-another-user's-password — Phase 2 (design §6: Phase 1's recovery shape is delete + re-create).
+- "Sign out everywhere" / cross-session invalidation on password change — Phase 2 self-service profile page.
+
 ## [0.5.10-rc.13] - 2026-05-20
 
 Multi-user Phase 1 — PR 2 of 5: admin `/admin/users` page + API (hub#252, design [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)). Builds on PR 1's `users` table foundation (rc.12): wires the `validateUsername` / `validatePassword` validators into a four-endpoint admin surface, adds the SPA route, and adds the FK-aware delete-user helper that keeps token audit rows intact while letting the parent users row drop.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.10-rc.13",
+  "version": "0.5.10-rc.14",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/admin-handlers.test.ts
+++ b/src/__tests__/admin-handlers.test.ts
@@ -151,7 +151,7 @@ describe("handleAdminLoginPost", () => {
   });
 
   test("redirects to next= and sets session cookie on success", async () => {
-    await createUser(harness.db, "admin", "pw");
+    await createUser(harness.db, "admin", "pw", { passwordChanged: true });
     const { body, headers } = formBody({
       [CSRF_FIELD_NAME]: TEST_CSRF,
       username: "admin",
@@ -170,7 +170,7 @@ describe("handleAdminLoginPost", () => {
   });
 
   test("ignores an absolute-URL next= from the form", async () => {
-    await createUser(harness.db, "admin", "pw");
+    await createUser(harness.db, "admin", "pw", { passwordChanged: true });
     const { body, headers } = formBody({
       [CSRF_FIELD_NAME]: TEST_CSRF,
       username: "admin",
@@ -193,7 +193,7 @@ describe("handleAdminLoginPost", () => {
     // alongside scheme-absolute URLs; this test pins the POST path
     // explicitly so future refactors of the redirect builder don't quietly
     // re-open the open-redirect.
-    await createUser(harness.db, "admin", "pw");
+    await createUser(harness.db, "admin", "pw", { passwordChanged: true });
     const { body, headers } = formBody({
       [CSRF_FIELD_NAME]: TEST_CSRF,
       username: "admin",
@@ -214,7 +214,7 @@ describe("handleAdminLoginPost", () => {
     // Post-SPA-rework default: when the form omits `next`, login lands on
     // the SPA's vault list. Previously the legacy `/admin/config` portal
     // was the default; that page is retired and 301s to /admin/vaults.
-    await createUser(harness.db, "admin", "pw");
+    await createUser(harness.db, "admin", "pw", { passwordChanged: true });
     const { body, headers } = formBody({
       [CSRF_FIELD_NAME]: TEST_CSRF,
       username: "admin",
@@ -232,7 +232,7 @@ describe("handleAdminLoginPost", () => {
 
   // hub#185 — per-IP rate-limit (5 attempts / 15 min) on POST /admin/login.
   test("6 rapid POSTs from same IP get 200/401×4/429 and the 429 carries Retry-After", async () => {
-    await createUser(harness.db, "admin", "correct-pw");
+    await createUser(harness.db, "admin", "correct-pw", { passwordChanged: true });
     const buildReq = (password: string) => {
       const { body, headers } = formBody({
         [CSRF_FIELD_NAME]: TEST_CSRF,
@@ -266,7 +266,7 @@ describe("handleAdminLoginPost", () => {
   });
 
   test("rate-limit is per-IP: a different IP can still log in after another's bucket fills", async () => {
-    await createUser(harness.db, "admin", "pw");
+    await createUser(harness.db, "admin", "pw", { passwordChanged: true });
     const buildReq = (ip: string, password: string) => {
       const { body, headers } = formBody({
         [CSRF_FIELD_NAME]: TEST_CSRF,
@@ -315,6 +315,116 @@ describe("handleAdminLoginPost", () => {
     const denied = await handleAdminLoginPost(harness.db, buildReq());
     expect(denied.status).toBe(429);
     expect(await denied.text()).toContain("Too many login attempts");
+  });
+});
+
+describe("loginRedirectTarget — force-change-password (multi-user PR 3)", () => {
+  // Multi-user Phase 1 PR 3: when a user's `password_changed === false`, the
+  // login POST redirects to `/account/change-password` instead of `next`.
+  // Session cookie is still minted (the user IS authenticated). When the
+  // user has `password_changed === true`, today's behavior is unchanged.
+  //
+  // We exercise the live POST handler rather than the helper directly so
+  // the test pins the wire-shape behavior — the helper is an
+  // implementation detail.
+
+  test("password_changed=false redirects to /account/change-password (admin-created user)", async () => {
+    // Admin-created users land with passwordChanged=false. PR 2's
+    // /api/users POST is the canonical entry; here we just exercise the
+    // helper directly to stay focused on the login redirect.
+    await createUser(harness.db, "admin", "admin-original-pw", {
+      passwordChanged: true, // wizard admin
+    });
+    await createUser(harness.db, "newbie", "default-pw", {
+      allowMulti: true,
+      passwordChanged: false, // PR-2 admin-created shape
+    });
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "newbie",
+      password: "default-pw",
+      next: "/admin/permissions",
+    });
+    const req = new Request("http://hub.test/login", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAdminLoginPost(harness.db, req);
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    // The change-password target preserves the original `next` so the
+    // user lands where they intended after picking a new password.
+    expect(location.startsWith("/account/change-password")).toBe(true);
+    expect(location).toContain(encodeURIComponent("/admin/permissions"));
+    // Session cookie IS minted — the user is signed in. The redirect is
+    // session-level, not "block sign-in entirely."
+    expect(res.headers.get("set-cookie") ?? "").toContain("parachute_hub_session=");
+  });
+
+  test("password_changed=false with no next= redirects to bare /account/change-password", async () => {
+    await createUser(harness.db, "newbie", "default-pw", { passwordChanged: false });
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "newbie",
+      password: "default-pw",
+    });
+    const req = new Request("http://hub.test/login", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAdminLoginPost(harness.db, req);
+    expect(res.status).toBe(302);
+    // No `?next=` suffix when the user's intended destination was the
+    // post-login default — keeps the URL clean.
+    expect(res.headers.get("location")).toBe("/account/change-password");
+  });
+
+  test("password_changed=true honors the original next= (existing behavior unchanged)", async () => {
+    // Wizard admins and env-seeded admins land passwordChanged=true; the
+    // pre-PR-3 redirect shape must keep working.
+    await createUser(harness.db, "admin", "pw", { passwordChanged: true });
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "admin",
+      password: "pw",
+      next: "/admin/tokens",
+    });
+    const req = new Request("http://hub.test/login", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAdminLoginPost(harness.db, req);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/admin/tokens");
+  });
+
+  test("password_changed=false defense-in-depth: unsafe next= is sanitized before encoding", async () => {
+    // safeNext rewrites unsafe next values to /admin/vaults BEFORE the
+    // redirect-target helper runs. The change-password URL should never
+    // carry an attacker-shaped redirect — even on the force-change path.
+    await createUser(harness.db, "newbie", "default-pw", { passwordChanged: false });
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "newbie",
+      password: "default-pw",
+      next: "https://evil.example/pwn",
+    });
+    const req = new Request("http://hub.test/login", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAdminLoginPost(harness.db, req);
+    expect(res.status).toBe(302);
+    // safeNext rewrote next to /admin/vaults (the post-login default),
+    // and loginRedirectTarget treats that as "no specific next" → bare
+    // /account/change-password. Either way, evil.example never appears.
+    const location = res.headers.get("location") ?? "";
+    expect(location.startsWith("/account/change-password")).toBe(true);
+    expect(location).not.toContain("evil.example");
   });
 });
 

--- a/src/__tests__/admin-handlers.test.ts
+++ b/src/__tests__/admin-handlers.test.ts
@@ -316,6 +316,31 @@ describe("handleAdminLoginPost", () => {
     expect(denied.status).toBe(429);
     expect(await denied.text()).toContain("Too many login attempts");
   });
+
+  test("password too long (> PASSWORD_MAX_LEN) → 413, fires before argonVerify (PR-3 fold N1)", async () => {
+    // Fold N1: an unauthenticated POST submitting a megabyte password
+    // would otherwise burn a full argon2id verify on arbitrary input.
+    // The cap fires before getUserByUsername / verifyPassword — pin with
+    // an elapsed-time floor of 200ms.
+    await createUser(harness.db, "admin", "correct-pw", { passwordChanged: true });
+    const huge = "z".repeat(5000);
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "admin",
+      password: huge,
+      next: "/admin/vaults",
+    });
+    const req = new Request("http://hub.test/login", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const t0 = Date.now();
+    const res = await handleAdminLoginPost(harness.db, req);
+    const elapsed = Date.now() - t0;
+    expect(res.status).toBe(413);
+    expect(elapsed).toBeLessThan(200);
+  });
 });
 
 describe("loginRedirectTarget — force-change-password (multi-user PR 3)", () => {

--- a/src/__tests__/api-account.test.ts
+++ b/src/__tests__/api-account.test.ts
@@ -330,6 +330,38 @@ describe("POST /account/change-password", () => {
     expect(elapsed).toBeLessThan(200);
   });
 
+  test("current_password too long (> PASSWORD_MAX_LEN) → 413, fires before argonVerify (PR-3 fold N1)", async () => {
+    // Fold N1: a session-authenticated caller could otherwise submit a
+    // huge `current_password` and burn argon2id verify cycles on
+    // arbitrary input. The cap should reject before verifyPassword
+    // touches the body — pin with elapsed-time floor < 200ms.
+    const { cookie } = await sessionCookieFor(harness.db, "newbie", "old-default-pw", {
+      passwordChanged: false,
+    });
+    const huge = "x".repeat(5000);
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      current_password: huge,
+      new_password: "user-chosen-strong-passphrase",
+      new_password_confirm: "user-chosen-strong-passphrase",
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const t0 = Date.now();
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    const elapsed = Date.now() - t0;
+    expect(res.status).toBe(413);
+    const html = await res.text();
+    expect(html).toContain("Current password must be");
+    // Pin: cap-and-reject < 200ms even on a noisy runner. An argon2id
+    // verify of the (correct length but mistyped) current password would
+    // push elapsed into the hundreds of ms.
+    expect(elapsed).toBeLessThan(200);
+  });
+
   test("new !== confirm → 400 password_mismatch", async () => {
     const { cookie } = await sessionCookieFor(harness.db, "newbie", "old-default-pw");
     const { body, headers } = formBody({

--- a/src/__tests__/api-account.test.ts
+++ b/src/__tests__/api-account.test.ts
@@ -1,0 +1,431 @@
+/**
+ * `/account/change-password` GET + POST — multi-user Phase 1 PR 3.
+ *
+ * Coverage:
+ *   - GET without session → 302 /login (with `next` preserved)
+ *   - GET with session, passwordChanged=false → 200 with "First-time" heading
+ *   - GET with session, passwordChanged=true → 200 with "Change your password" heading
+ *   - POST without session → 401
+ *   - POST without CSRF → 400
+ *   - POST happy path: hash updated + password_changed flips to 1
+ *   - POST wrong current → 401
+ *   - POST new too short (< 12) → 400
+ *   - POST new too long (> PASSWORD_MAX_LEN) → 413 with timing pin
+ *   - POST new !== confirm → 400
+ *   - POST new === current → 400 (after verify, to avoid leaking that
+ *     `new_password` matches any *attempted* current)
+ *   - POST with passwordChanged=false: flag flips AND the page works
+ *     normally (the only flag-gated behavior is the /login redirect)
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  handleAccountChangePasswordGet,
+  handleAccountChangePasswordPost,
+  markPasswordChanged,
+} from "../api-account.ts";
+import { CSRF_COOKIE_NAME, CSRF_FIELD_NAME } from "../csrf.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
+import { createUser, getUserById, verifyPassword } from "../users.ts";
+
+const TEST_CSRF = "csrf-account-test-token";
+const CSRF_COOKIE = `${CSRF_COOKIE_NAME}=${TEST_CSRF}`;
+
+interface Harness {
+  db: Database;
+  configDir: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const configDir = mkdtempSync(join(tmpdir(), "phub-api-account-"));
+  const db = openHubDb(hubDbPath(configDir));
+  return {
+    db,
+    configDir,
+    cleanup: () => {
+      db.close();
+      rmSync(configDir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function sessionCookieFor(
+  db: Database,
+  username: string,
+  password: string,
+  opts: { passwordChanged?: boolean; allowMulti?: boolean } = {},
+): Promise<{ userId: string; cookie: string }> {
+  const user = await createUser(db, username, password, {
+    passwordChanged: opts.passwordChanged ?? false,
+    allowMulti: opts.allowMulti ?? false,
+  });
+  const session = createSession(db, { userId: user.id });
+  const cookie = `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`;
+  return { userId: user.id, cookie };
+}
+
+function formBody(values: Record<string, string>): {
+  body: string;
+  headers: Record<string, string>;
+} {
+  const params = new URLSearchParams();
+  for (const [k, v] of Object.entries(values)) params.append(k, v);
+  return {
+    body: params.toString(),
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+describe("GET /account/change-password", () => {
+  test("no session → 302 /login with next preserved", () => {
+    const req = new Request("http://hub.test/account/change-password");
+    const res = handleAccountChangePasswordGet(req, { db: harness.db });
+    expect(res.status).toBe(302);
+    const loc = res.headers.get("location") ?? "";
+    expect(loc.startsWith("/login?next=")).toBe(true);
+    // The encoded next should bring the user back to this page.
+    expect(decodeURIComponent(loc.split("?next=")[1] ?? "")).toBe("/account/change-password");
+  });
+
+  test("no session with a downstream next= bounces through /login carrying both legs", () => {
+    const req = new Request("http://hub.test/account/change-password?next=%2Fadmin%2Fpermissions");
+    const res = handleAccountChangePasswordGet(req, { db: harness.db });
+    expect(res.status).toBe(302);
+    const loc = res.headers.get("location") ?? "";
+    // After /login the user should land at /account/change-password?next=/admin/permissions.
+    // The location header carries that as a percent-encoded `next` param;
+    // decode twice (once for the outer `?next=`, once for the inner
+    // `?next=` inside the change-password target).
+    const outerNext = decodeURIComponent(loc.split("?next=")[1] ?? "");
+    expect(outerNext.startsWith("/account/change-password")).toBe(true);
+    expect(decodeURIComponent(outerNext)).toContain("/admin/permissions");
+  });
+
+  test("passwordChanged=false renders the first-time heading", async () => {
+    const { cookie } = await sessionCookieFor(harness.db, "newbie", "default-pw", {
+      passwordChanged: false,
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      headers: { cookie },
+    });
+    const res = handleAccountChangePasswordGet(req, { db: harness.db });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("First-time login");
+    // form posts back to the same path
+    expect(html).toContain('action="/account/change-password"');
+    // signed-in-as label includes the username
+    expect(html).toContain("newbie");
+  });
+
+  test("passwordChanged=true renders the rotate heading (direct nav is allowed)", async () => {
+    // Per design §"Direct navigation": a user with the flag flipped can
+    // still navigate here to rotate their password. The redirect at /login
+    // is the only flag-gated behavior.
+    const { cookie } = await sessionCookieFor(harness.db, "admin", "admin-pw", {
+      passwordChanged: true,
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      headers: { cookie },
+    });
+    const res = handleAccountChangePasswordGet(req, { db: harness.db });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Change your password");
+    expect(html).not.toContain("First-time login");
+  });
+
+  test("session pointing at non-existent user → 302 /login (graceful logout)", async () => {
+    // Defends against the race where a session row outlives the user it
+    // points at (a delete-user via SQL shell, a corrupted restore, etc.).
+    // The on-disk FK normally guards against this state, so forge it
+    // explicitly with `PRAGMA foreign_keys=OFF` around the INSERT.
+    const sessionId = "test-stale-session-id-base64url-padding";
+    harness.db.exec("PRAGMA foreign_keys = OFF");
+    try {
+      harness.db
+        .prepare("INSERT INTO sessions (id, user_id, expires_at, created_at) VALUES (?, ?, ?, ?)")
+        .run(
+          sessionId,
+          "nonexistent-user-uuid",
+          new Date(Date.now() + 60_000).toISOString(),
+          new Date().toISOString(),
+        );
+    } finally {
+      harness.db.exec("PRAGMA foreign_keys = ON");
+    }
+    const cookie = `${CSRF_COOKIE}; ${buildSessionCookie(sessionId, Math.floor(SESSION_TTL_MS / 1000))}`;
+    const req = new Request("http://hub.test/account/change-password", {
+      headers: { cookie },
+    });
+    const res = handleAccountChangePasswordGet(req, { db: harness.db });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/login");
+  });
+});
+
+describe("POST /account/change-password", () => {
+  test("no session → 401", async () => {
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      current_password: "default-pw",
+      new_password: "long-enough-passphrase",
+      new_password_confirm: "long-enough-passphrase",
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    expect(res.status).toBe(401);
+  });
+
+  test("CSRF mismatch → 400", async () => {
+    const { cookie } = await sessionCookieFor(harness.db, "newbie", "default-pw");
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: "wrong-token",
+      current_password: "default-pw",
+      new_password: "long-enough-passphrase",
+      new_password_confirm: "long-enough-passphrase",
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    expect(res.status).toBe(400);
+  });
+
+  test("happy path: hash updates, password_changed flips to 1, 302 to next", async () => {
+    const { userId, cookie } = await sessionCookieFor(harness.db, "newbie", "old-default-pw", {
+      passwordChanged: false,
+    });
+    const before = getUserById(harness.db, userId);
+    expect(before?.passwordChanged).toBe(false);
+    const oldHash = before?.passwordHash;
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      current_password: "old-default-pw",
+      new_password: "user-chosen-strong-passphrase",
+      new_password_confirm: "user-chosen-strong-passphrase",
+      next: "/admin/permissions",
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/admin/permissions");
+
+    const after = getUserById(harness.db, userId);
+    expect(after?.passwordChanged).toBe(true);
+    expect(after?.passwordHash).not.toBe(oldHash);
+    expect(after).toBeTruthy();
+    if (after) {
+      expect(await verifyPassword(after, "user-chosen-strong-passphrase")).toBe(true);
+      expect(await verifyPassword(after, "old-default-pw")).toBe(false);
+    }
+  });
+
+  test("missing next defaults to /admin/vaults", async () => {
+    const { cookie } = await sessionCookieFor(harness.db, "newbie", "old-default-pw", {
+      passwordChanged: false,
+    });
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      current_password: "old-default-pw",
+      new_password: "user-chosen-strong-passphrase",
+      new_password_confirm: "user-chosen-strong-passphrase",
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/admin/vaults");
+  });
+
+  test("wrong current_password → 401, no state change", async () => {
+    const { userId, cookie } = await sessionCookieFor(harness.db, "newbie", "old-default-pw", {
+      passwordChanged: false,
+    });
+    const oldHash = getUserById(harness.db, userId)?.passwordHash;
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      current_password: "this-is-not-the-pw",
+      new_password: "user-chosen-strong-passphrase",
+      new_password_confirm: "user-chosen-strong-passphrase",
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    expect(res.status).toBe(401);
+    const after = getUserById(harness.db, userId);
+    expect(after?.passwordChanged).toBe(false);
+    expect(after?.passwordHash).toBe(oldHash ?? "");
+  });
+
+  test("new password too short (< 12) → 400 invalid_password", async () => {
+    const { cookie } = await sessionCookieFor(harness.db, "newbie", "old-default-pw");
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      current_password: "old-default-pw",
+      new_password: "short",
+      new_password_confirm: "short",
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    expect(res.status).toBe(400);
+    const html = await res.text();
+    expect(html).toContain("at least 12");
+  });
+
+  test("new password too long (> PASSWORD_MAX_LEN) → 413, fires before argon2id", async () => {
+    const { cookie } = await sessionCookieFor(harness.db, "newbie", "old-default-pw");
+    const huge = "a".repeat(300);
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      current_password: "old-default-pw",
+      new_password: huge,
+      new_password_confirm: huge,
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const t0 = Date.now();
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    const elapsed = Date.now() - t0;
+    expect(res.status).toBe(413);
+    // Same timing-pin pattern PR 2 uses on /api/users — the cap should
+    // reject in < 200ms even on a noisy runner; an argon2id verify of the
+    // current password would push elapsed into the hundreds of ms.
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  test("new !== confirm → 400 password_mismatch", async () => {
+    const { cookie } = await sessionCookieFor(harness.db, "newbie", "old-default-pw");
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      current_password: "old-default-pw",
+      new_password: "user-chosen-strong-passphrase",
+      new_password_confirm: "user-chosen-strong-passphraze", // typo
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    expect(res.status).toBe(400);
+    const html = await res.text();
+    expect(html).toContain("do not match");
+  });
+
+  test("new === current → 400 password_unchanged (after verify-current passes)", async () => {
+    const { cookie } = await sessionCookieFor(harness.db, "newbie", "same-old-password");
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      current_password: "same-old-password",
+      new_password: "same-old-password",
+      new_password_confirm: "same-old-password",
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    expect(res.status).toBe(400);
+    const html = await res.text();
+    expect(html).toContain("differ from your current");
+  });
+
+  test("missing required field → 400", async () => {
+    const { cookie } = await sessionCookieFor(harness.db, "newbie", "old-default-pw");
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      current_password: "old-default-pw",
+      // new_password omitted
+      new_password_confirm: "long-enough-passphrase",
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    expect(res.status).toBe(400);
+  });
+
+  test("re-render after failure keeps the user signed in (no session-clear)", async () => {
+    const { cookie } = await sessionCookieFor(harness.db, "newbie", "old-default-pw");
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      current_password: "wrong",
+      new_password: "long-enough-passphrase",
+      new_password_confirm: "long-enough-passphrase",
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    expect(res.status).toBe(401);
+    // The error re-renders the page; the failure must not clear the
+    // session cookie (the user is still signed in, just typed the wrong
+    // current password).
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).not.toContain("Max-Age=0");
+  });
+});
+
+describe("markPasswordChanged", () => {
+  test("flips password_changed from 0 to 1 and bumps updated_at", async () => {
+    const user = await createUser(harness.db, "newbie", "pw", { passwordChanged: false });
+    const before = getUserById(harness.db, user.id);
+    expect(before?.passwordChanged).toBe(false);
+    const beforeStamp = before?.updatedAt ?? "";
+    // Pin the clock so the assertion is deterministic.
+    const fixed = new Date(Date.parse(beforeStamp) + 1000);
+    markPasswordChanged(harness.db, user.id, () => fixed);
+    const after = getUserById(harness.db, user.id);
+    expect(after?.passwordChanged).toBe(true);
+    expect(after?.updatedAt).toBe(fixed.toISOString());
+  });
+
+  test("idempotent — running against an already-true row stays true", async () => {
+    const user = await createUser(harness.db, "admin", "pw", { passwordChanged: true });
+    markPasswordChanged(harness.db, user.id);
+    const after = getUserById(harness.db, user.id);
+    expect(after?.passwordChanged).toBe(true);
+  });
+});

--- a/src/account-change-password-ui.ts
+++ b/src/account-change-password-ui.ts
@@ -100,9 +100,12 @@ export interface RenderChangePasswordProps {
   next: string;
   /** Inline error to surface above the form after a failed POST. */
   errorMessage?: string;
+  // NOTE: unused in Phase 1 (POST always redirects on success). Reserved
+  // for Phase 2 self-service profile flow that may rotate-in-place and
+  // re-render with a success banner.
   /** Render a success banner — used by the rotate flow when the user
    *  re-renders the form after a successful change (Phase 2; for now
-   *  the POST 200 path returns a JSON ok and the handler redirects). */
+   *  the POST success path always redirects so this never fires). */
   successMessage?: string;
 }
 

--- a/src/account-change-password-ui.ts
+++ b/src/account-change-password-ui.ts
@@ -1,0 +1,376 @@
+/**
+ * Server-rendered HTML for `/account/change-password` — the user's
+ * self-service password rotation surface, and the landing page for the
+ * force-change-password redirect from `/login` (multi-user Phase 1 PR 3,
+ * design 2026-05-20-multi-user-phase-1.md §sign-in flow change).
+ *
+ * Two modes share the page:
+ *
+ *  - **first-time login** (`mode: "first-time"`): the just-logged-in user
+ *    has `password_changed: false`. Heading reads "First-time login: please
+ *    choose a new password" and the page explains why the redirect fired
+ *    (the admin typed the default; you should pick your own).
+ *  - **rotate** (`mode: "rotate"`): a signed-in user navigated here on
+ *    their own to change their password. Heading reads "Change your
+ *    password" — no force-redirect framing.
+ *
+ * The handler decides which mode to render at request time by reading
+ * the user's `passwordChanged` flag; this file is the pure renderer.
+ *
+ * Same chrome family as `admin-login-ui.ts` (`/login`) — inline CSS,
+ * no third-party fonts, no SPA bundle. The page works without JS;
+ * client-side validation is a fast-feedback layer on top of the server-
+ * side `validatePassword` + match-confirm + current-≠-new checks.
+ */
+import { renderCsrfHiddenInput } from "./csrf.ts";
+import { escapeHtml } from "./oauth-ui.ts";
+import { PASSWORD_MIN_LEN } from "./users.ts";
+
+// --- shared chrome --------------------------------------------------------
+//
+// Palette + font stack mirror `admin-login-ui.ts` so the change-password
+// surface visually belongs to the same "Parachute pre-auth + thin-auth"
+// surface family as /login. A small Phase-2 polish opportunity is to
+// extract this into a shared `auth-ui-chrome.ts`; for now duplication is
+// cheap and keeps the surfaces independently editable.
+
+const PALETTE = {
+  bg: "#faf8f4",
+  bgSoft: "#f3f0ea",
+  fg: "#2c2a26",
+  fgMuted: "#6b6860",
+  fgDim: "#9a9690",
+  accent: "#4a7c59",
+  accentHover: "#3d6849",
+  accentSoft: "rgba(74, 124, 89, 0.08)",
+  border: "#e4e0d8",
+  borderLight: "#ece9e2",
+  cardBg: "#ffffff",
+  danger: "#a3392b",
+  dangerSoft: "rgba(163, 57, 43, 0.08)",
+  success: "#3d6849",
+  successSoft: "rgba(61, 104, 73, 0.08)",
+} as const;
+
+const FONT_SERIF = `Georgia, "Times New Roman", serif`;
+const FONT_SANS = `-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`;
+const FONT_MONO = `ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", monospace`;
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}
+
+function baseDocument(title: string, body: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>${escapeHtml(title)}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="referrer" content="no-referrer" />
+  <style>${STYLES}</style>
+</head>
+<body>
+  <main>
+${body}
+  </main>
+</body>
+</html>`;
+}
+
+function header(): string {
+  return `
+        <div class="brand">
+          <span class="brand-mark">⌬</span>
+          <span class="brand-name">Parachute</span>
+          <span class="brand-tag">account</span>
+        </div>`;
+}
+
+// --- /account/change-password ---------------------------------------------
+
+export type ChangePasswordMode = "first-time" | "rotate";
+
+export interface RenderChangePasswordProps {
+  mode: ChangePasswordMode;
+  csrfToken: string;
+  /** The signed-in user's display name (for the "signed in as <X>" line). */
+  username: string;
+  /** Where the POST handler should redirect on success (same-origin path). */
+  next: string;
+  /** Inline error to surface above the form after a failed POST. */
+  errorMessage?: string;
+  /** Render a success banner — used by the rotate flow when the user
+   *  re-renders the form after a successful change (Phase 2; for now
+   *  the POST 200 path returns a JSON ok and the handler redirects). */
+  successMessage?: string;
+}
+
+export function renderChangePassword(props: RenderChangePasswordProps): string {
+  const { mode, csrfToken, username, next, errorMessage, successMessage } = props;
+  const error = errorMessage ? `<p class="error-banner">${escapeHtml(errorMessage)}</p>` : "";
+  const success = successMessage
+    ? `<p class="success-banner">${escapeHtml(successMessage)}</p>`
+    : "";
+
+  const title =
+    mode === "first-time" ? "First-time login: choose a new password" : "Change your password";
+  const subtitle =
+    mode === "first-time"
+      ? "An admin set a default password for your account. Please pick your own before continuing — only you should know it."
+      : "Pick a new password for your account.";
+
+  const body = `
+    <div class="card">
+      <div class="card-header">
+        ${header()}
+        <h1>${escapeHtml(title)}</h1>
+        <p class="subtitle">${escapeHtml(subtitle)}</p>
+        <p class="signed-in">Signed in as <strong>${escapeHtml(username)}</strong>.</p>
+      </div>
+      ${success}
+      ${error}
+      <form method="POST" action="/account/change-password" class="auth-form" id="change-form">
+        ${renderCsrfHiddenInput(csrfToken)}
+        <input type="hidden" name="next" value="${escapeAttr(next)}" />
+        <label class="field">
+          <span class="field-label">Current password</span>
+          <input type="password" name="current_password" autocomplete="current-password"
+            autofocus required />
+        </label>
+        <label class="field">
+          <span class="field-label">New password</span>
+          <input type="password" name="new_password" autocomplete="new-password"
+            required minlength="${PASSWORD_MIN_LEN}" id="new-password" />
+          <span class="field-hint">at least ${PASSWORD_MIN_LEN} characters — a passphrase is fine</span>
+        </label>
+        <label class="field">
+          <span class="field-label">Confirm new password</span>
+          <input type="password" name="new_password_confirm" autocomplete="new-password"
+            required minlength="${PASSWORD_MIN_LEN}" id="new-password-confirm" />
+          <span class="field-hint" id="confirm-hint"></span>
+        </label>
+        <button type="submit" class="btn btn-primary">Change password</button>
+      </form>
+    </div>
+    <script>${CLIENT_VALIDATION_JS}</script>`;
+  const pageTitle =
+    mode === "first-time" ? "First-time login — Parachute" : "Change password — Parachute";
+  return baseDocument(pageTitle, body);
+}
+
+// --- client-side validation -----------------------------------------------
+//
+// Fast-feedback only — the server-side handler is the authority. Mirrors
+// the three server checks: minimum length, new === confirm, current ≠ new.
+// Without JS the form posts normally and the server re-renders with an
+// inline error message; with JS the user sees "passwords don't match" or
+// "new password must differ from current" inline before submitting.
+
+const CLIENT_VALIDATION_JS = `
+(function () {
+  var form = document.getElementById("change-form");
+  if (!form) return;
+  var newPw = document.getElementById("new-password");
+  var confirm = document.getElementById("new-password-confirm");
+  var current = form.querySelector('input[name="current_password"]');
+  var hint = document.getElementById("confirm-hint");
+  function check() {
+    if (!hint) return;
+    if (!confirm || !newPw || !current) return;
+    if (confirm.value.length === 0) { hint.textContent = ""; return; }
+    if (confirm.value !== newPw.value) {
+      hint.textContent = "Passwords do not match";
+      hint.style.color = "${PALETTE.danger}";
+    } else if (current.value.length > 0 && current.value === newPw.value) {
+      hint.textContent = "New password must differ from current";
+      hint.style.color = "${PALETTE.danger}";
+    } else {
+      hint.textContent = "Passwords match";
+      hint.style.color = "${PALETTE.success}";
+    }
+  }
+  if (newPw) newPw.addEventListener("input", check);
+  if (confirm) confirm.addEventListener("input", check);
+  if (current) current.addEventListener("input", check);
+  form.addEventListener("submit", function (e) {
+    if (!newPw || !confirm || !current) return;
+    if (newPw.value !== confirm.value) {
+      e.preventDefault();
+      if (hint) {
+        hint.textContent = "Passwords do not match";
+        hint.style.color = "${PALETTE.danger}";
+      }
+      return;
+    }
+    if (current.value === newPw.value) {
+      e.preventDefault();
+      if (hint) {
+        hint.textContent = "New password must differ from current";
+        hint.style.color = "${PALETTE.danger}";
+      }
+      return;
+    }
+  });
+})();
+`;
+
+// --- styles ---------------------------------------------------------------
+//
+// Mirrors `admin-login-ui.ts` STYLES. If/when a shared `auth-ui-chrome.ts`
+// lands these two should merge.
+
+const STYLES = `
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: ${FONT_SANS};
+    background: ${PALETTE.bg};
+    color: ${PALETTE.fg};
+    line-height: 1.55;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  main {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 1.5rem;
+  }
+  .card {
+    width: 100%;
+    max-width: 30rem;
+    background: ${PALETTE.cardBg};
+    border: 1px solid ${PALETTE.border};
+    border-radius: 12px;
+    padding: 2rem 1.75rem;
+    box-shadow: 0 1px 2px rgba(44, 42, 38, 0.04), 0 8px 24px rgba(44, 42, 38, 0.06);
+  }
+  .card-header { margin-bottom: 1.5rem; }
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: ${PALETTE.accent};
+    font-weight: 500;
+    font-size: 0.95rem;
+    margin-bottom: 1.25rem;
+  }
+  .brand-mark { font-size: 1.1rem; line-height: 1; }
+  .brand-name { letter-spacing: 0.01em; }
+  .brand-tag {
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 0.7rem;
+    color: ${PALETTE.fgMuted};
+    border: 1px solid ${PALETTE.borderLight};
+    padding: 0.05rem 0.4rem;
+    border-radius: 999px;
+  }
+  h1 {
+    font-family: ${FONT_SERIF};
+    font-weight: 400;
+    font-size: 1.6rem;
+    line-height: 1.2;
+    margin: 0 0 0.4rem;
+    color: ${PALETTE.fg};
+  }
+  .subtitle { margin: 0; color: ${PALETTE.fgMuted}; font-size: 0.95rem; }
+  .signed-in {
+    margin: 0.75rem 0 0;
+    color: ${PALETTE.fgMuted};
+    font-size: 0.85rem;
+    font-family: ${FONT_MONO};
+  }
+  .signed-in strong { color: ${PALETTE.fg}; font-weight: 500; }
+
+  .auth-form { display: flex; flex-direction: column; gap: 0.9rem; }
+  .field { display: flex; flex-direction: column; gap: 0.35rem; }
+  .field-label {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: ${PALETTE.fgMuted};
+    letter-spacing: 0.01em;
+    font-family: ${FONT_MONO};
+  }
+  .field-hint {
+    font-size: 0.78rem;
+    color: ${PALETTE.fgMuted};
+    font-family: ${FONT_MONO};
+  }
+  input[type=text], input[type=password] {
+    font: inherit;
+    width: 100%;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid ${PALETTE.border};
+    border-radius: 6px;
+    background: ${PALETTE.bg};
+    color: ${PALETTE.fg};
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  input[type=text]:focus, input[type=password]:focus {
+    outline: none;
+    border-color: ${PALETTE.accent};
+    background: ${PALETTE.cardBg};
+    box-shadow: 0 0 0 3px ${PALETTE.accentSoft};
+  }
+
+  .btn {
+    font: inherit;
+    font-weight: 500;
+    padding: 0.65rem 1.25rem;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+    min-height: 2.5rem;
+  }
+  .btn-primary {
+    background: ${PALETTE.accent};
+    color: ${PALETTE.cardBg};
+    margin-top: 0.4rem;
+  }
+  .btn-primary:hover { background: ${PALETTE.accentHover}; }
+
+  .error-banner {
+    background: ${PALETTE.dangerSoft};
+    border: 1px solid ${PALETTE.danger};
+    border-radius: 6px;
+    color: ${PALETTE.danger};
+    padding: 0.6rem 0.8rem;
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+  }
+  .success-banner {
+    background: ${PALETTE.successSoft};
+    border: 1px solid ${PALETTE.success};
+    border-radius: 6px;
+    color: ${PALETTE.success};
+    padding: 0.6rem 0.8rem;
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+  }
+
+  @media (max-width: 480px) {
+    main { padding: 0.75rem; }
+    .card { padding: 1.5rem 1.25rem; border-radius: 10px; }
+    h1 { font-size: 1.4rem; }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    body { background: #1a1815; color: #e8e4dc; }
+    .card { background: #25221d; border-color: #3a362f; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3); }
+    h1 { color: #f0ece4; }
+    .subtitle, .field-label, .field-hint, .signed-in { color: #a8a29a; }
+    .signed-in strong { color: #f0ece4; }
+    input[type=text], input[type=password] {
+      background: #1f1c18; border-color: #3a362f; color: #e8e4dc;
+    }
+    input[type=text]:focus, input[type=password]:focus {
+      background: #25221d;
+    }
+    .brand-tag { border-color: #3a362f; color: #a8a29a; }
+  }
+`;

--- a/src/admin-handlers.ts
+++ b/src/admin-handlers.ts
@@ -23,7 +23,7 @@ import {
   deleteSession,
   parseSessionCookie,
 } from "./sessions.ts";
-import { getUserByUsername, verifyPassword } from "./users.ts";
+import { type User, getUserByUsername, verifyPassword } from "./users.ts";
 
 function htmlResponse(body: string, status = 200, extra: Record<string, string> = {}): Response {
   return new Response(body, {
@@ -44,11 +44,53 @@ function redirect(location: string, extra: Record<string, string> = {}): Respons
  */
 const POST_LOGIN_DEFAULT = "/admin/vaults";
 
+/**
+ * Force-change-password landing. Multi-user Phase 1 PR 3: when a user
+ * signs in with `password_changed === false` (admin-created account
+ * with the admin's default password), the login POST 302s here instead
+ * of `next`. The original `next` rides along as a query param so the
+ * change-password POST can land them at their intended destination
+ * after they pick a new password.
+ *
+ * Session-level redirect, not token-level — the cookie is minted as
+ * normal; only the redirect target changes. The user IS signed in,
+ * they're just expected to change their password before doing anything
+ * else (the `/account/change-password` page is reachable, the SPA
+ * isn't gated). Design §sign-in flow change.
+ */
+const FORCE_CHANGE_PASSWORD_PATH = "/account/change-password";
+
 function safeNext(raw: string | null): string {
   if (!raw) return POST_LOGIN_DEFAULT;
   // Only allow same-origin paths — never honor an absolute URL or scheme.
   if (!raw.startsWith("/") || raw.startsWith("//")) return POST_LOGIN_DEFAULT;
   return raw;
+}
+
+/**
+ * Pick the post-login redirect target for a freshly-authenticated user.
+ *
+ * **The only place `password_changed` gates a flow.** Per design §sign-
+ * in flow change, force-change is a session-level redirect at the login
+ * boundary — once changed, no per-request scope check is needed and
+ * no token claim carries the bit forward.
+ *
+ * When `password_changed === false`:
+ *   - redirect to `/account/change-password`
+ *   - preserve the user's intended `next` as a query param so the
+ *     change-password POST can finish the trip
+ *
+ * When `password_changed === true`: return `next` (today's behavior).
+ */
+export function loginRedirectTarget(user: User, next: string): string {
+  if (user.passwordChanged) return next;
+  // Preserve the operator's intended destination; the change-password
+  // POST will read this and 302 there after the change lands.
+  // Only encode `next` if it isn't already the post-change default —
+  // keeps the URL clean for the common case (no `next` param specified
+  // at login time → no `?next=` on the change-password URL).
+  if (next === POST_LOGIN_DEFAULT) return FORCE_CHANGE_PASSWORD_PATH;
+  return `${FORCE_CHANGE_PASSWORD_PATH}?next=${encodeURIComponent(next)}`;
 }
 
 // --- /login ---------------------------------------------------------------
@@ -128,7 +170,15 @@ export async function handleAdminLoginPost(
   const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000), {
     secure: isHttpsRequest(req),
   });
-  return redirect(next, { "set-cookie": cookie });
+  // Multi-user Phase 1 PR 3 — `password_changed === false` (admin-created
+  // user, hasn't picked their own password yet) lands at
+  // `/account/change-password` instead of `next`. The session cookie is
+  // minted as normal — the user IS authenticated, they're just expected
+  // to change the admin-typed default before continuing. Their original
+  // `next` rides along on the change-password URL so the post-change
+  // POST can land them at their intended destination.
+  const target = loginRedirectTarget(user, next);
+  return redirect(target, { "set-cookie": cookie });
 }
 
 /**

--- a/src/admin-handlers.ts
+++ b/src/admin-handlers.ts
@@ -23,7 +23,7 @@ import {
   deleteSession,
   parseSessionCookie,
 } from "./sessions.ts";
-import { type User, getUserByUsername, verifyPassword } from "./users.ts";
+import { PASSWORD_MAX_LEN, type User, getUserByUsername, verifyPassword } from "./users.ts";
 
 function htmlResponse(body: string, status = 200, extra: Record<string, string> = {}): Response {
   return new Response(body, {
@@ -150,6 +150,22 @@ export async function handleAdminLoginPost(
     return htmlResponse(
       renderAdminLogin({ next, csrfToken, errorMessage: "Username and password are required." }),
       400,
+    );
+  }
+  // Cap incoming password length BEFORE getUserByUsername / argon2id
+  // verify touches it. An unauthenticated POST submitting a megabyte
+  // password would otherwise force a full argon2id hash on arbitrary
+  // input — CPU-DoS shape. 413 fires before any DB or hash work; same
+  // `PASSWORD_MAX_LEN` constant `/api/users` and `/account/change-
+  // password` use (PR-3 fold N1: applied uniformly across the auth
+  // surface family).
+  if (password.length > PASSWORD_MAX_LEN) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Password too long",
+        message: `Password must be ≤ ${PASSWORD_MAX_LEN} characters.`,
+      }),
+      413,
     );
   }
   const user = getUserByUsername(db, username);

--- a/src/api-account.ts
+++ b/src/api-account.ts
@@ -46,6 +46,7 @@
  * trade-off discussion in §security/force-change-password.
  */
 import type { Database } from "bun:sqlite";
+import { hash as argonHash } from "@node-rs/argon2";
 import { type ChangePasswordMode, renderChangePassword } from "./account-change-password-ui.ts";
 import { renderAdminError } from "./admin-login-ui.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
@@ -53,8 +54,8 @@ import { isHttpsRequest } from "./request-protocol.ts";
 import { findActiveSession } from "./sessions.ts";
 import {
   PASSWORD_MAX_LEN,
+  UserNotFoundError,
   getUserById,
-  setPassword,
   validatePassword,
   verifyPassword,
 } from "./users.ts";
@@ -164,16 +165,23 @@ export function handleAccountChangePasswordGet(req: Request, deps: ApiAccountDep
  * §scope-section ordering):
  *   1. Session (else 401 — no body to validate without an identity).
  *   2. CSRF (else 400 — same wire shape as `/login` POST CSRF failure).
- *   3. `new_password.length > PASSWORD_MAX_LEN` → 413 BEFORE argon2id
- *      touches it. Defensive against CPU-DoS through a megabyte body.
- *   4. `validatePassword(new_password)` → 400 `invalid_password`
+ *   3. Required-field presence (else 400).
+ *   4. `current_password.length > PASSWORD_MAX_LEN` → 413 BEFORE argon2id
+ *      verify touches it. Session-gated, so the CPU-DoS surface is
+ *      narrower than the unauthenticated `/login` POST, but the cap is
+ *      cheap insurance against a megabyte-current-password submission
+ *      (PR-3 fold N1).
+ *   5. `new_password.length > PASSWORD_MAX_LEN` → 413 BEFORE argon2id
+ *      hash touches it.
+ *   6. `validatePassword(new_password)` → 400 `invalid_password`
  *      (12-char floor; same validator the create-user path uses).
- *   5. `new_password !== confirm` → 400 `password_mismatch`.
- *   6. `verifyPassword(user, current_password)` → 401 `invalid_credentials`.
- *      Runs argon2id so order matters — 5 happens first to avoid burning
+ *   7. `new_password !== confirm` → 400 `password_mismatch`.
+ *   8. `verifyPassword(user, current_password)` → 401 `invalid_credentials`.
+ *      Runs argon2id so order matters — 7 happens first to avoid burning
  *      a hash on an obviously-broken input.
- *   7. `new_password === current_password` → 400 `password_unchanged`.
- *   8. `setPassword` + `markPasswordChanged` → 302 → next.
+ *   9. `new_password === current_password` → 400 `password_unchanged`.
+ *  10. Hash new + atomic UPDATE (password_hash + password_changed=1 +
+ *      updated_at) in one transaction (PR-3 fold N2) → 302 → next.
  *
  * Re-render shape on validation failure: the page comes back with an
  * inline error banner (matching `/login`'s POST failure shape), HTTP
@@ -239,6 +247,26 @@ export async function handleAccountChangePasswordPost(
         errorMessage: "All three fields are required.",
       }),
       400,
+    );
+  }
+
+  // Cap `currentPassword` length BEFORE argon2id verify touches it. The
+  // session-authenticated caller would otherwise be able to submit a
+  // megabyte body and force a full argon2id hash on arbitrary input
+  // (CPU-DoS shape — same flavor as the unauthenticated /api/users POST
+  // mitigates with the new-password cap below, but session-gated here
+  // since change-password sits behind /login). Same 413 + shape as the
+  // new-password cap; same `PASSWORD_MAX_LEN` constant.
+  if (currentPassword.length > PASSWORD_MAX_LEN) {
+    return htmlResponse(
+      renderChangePassword({
+        mode,
+        csrfToken,
+        username: user.username,
+        next,
+        errorMessage: `Current password must be ≤ ${PASSWORD_MAX_LEN} characters.`,
+      }),
+      413,
     );
   }
 
@@ -325,28 +353,57 @@ export async function handleAccountChangePasswordPost(
     );
   }
 
-  // Persist new hash + flip the changed flag. Two statements (could be
-  // a single UPDATE; kept separate so `setPassword`'s contract — "just
-  // updates the hash" — stays clean and the `markPasswordChanged`
-  // helper is reusable from the admin-reset path if Phase 2 ever wants
-  // to call it independently).
+  // Persist new hash + flip the changed flag, atomically.
+  //
+  // Hash OUTSIDE the transaction. `db.transaction()` on bun:sqlite is
+  // sync — argon2id's async hash promise inside the closure would
+  // silently break atomicity (same constraint the OAuth token-rotate
+  // path documents in oauth-handlers.ts). Hash first, then run both
+  // UPDATEs inside the tx so a mid-write process crash can't land us
+  // with a fresh hash but a stale flag (benign in this direction — one
+  // extra force-redirect on next login — but trivially avoidable).
   const now = deps.now ?? (() => new Date());
-  await setPassword(deps.db, user.id, newPassword, now);
-  markPasswordChanged(deps.db, user.id, now);
+  const passwordHash = await argonHash(newPassword);
+  const stamp = now().toISOString();
+  try {
+    deps.db.transaction(() => {
+      const result = deps.db
+        .prepare(
+          "UPDATE users SET password_hash = ?, password_changed = 1, updated_at = ? WHERE id = ?",
+        )
+        .run(passwordHash, stamp, user.id);
+      if (result.changes === 0) throw new UserNotFoundError(user.id);
+    })();
+  } catch (err) {
+    // The user row vanished between the session-resolve check above and
+    // the UPDATE. Surface as 401 + "account not found" — same shape as
+    // the stale-session-id branch at the top of this handler.
+    if (err instanceof UserNotFoundError) {
+      return htmlResponse(
+        renderAdminError({
+          title: "Account not found",
+          message: "The signed-in account no longer exists. Please sign in again.",
+        }),
+        401,
+      );
+    }
+    throw err;
+  }
 
+  // Ops-visibility headers (no downstream consumer): surface password-
+  // change events to hub log grep / monitoring without changing the
+  // response body. Safe to remove if not in use. `x-parachute-password-
+  // changed: 1` is the event marker; `x-secure-context` records whether
+  // the request arrived over HTTPS (matches the cookie's `Secure`
+  // attribute decision so a log line at the same path tells the
+  // operator the transport posture without re-checking the cookie).
+  // No new session cookie set — the existing one stays valid. The user
+  // remains signed in, just with a fresh hash. (Other devices' sessions
+  // also stay valid; Phase 2 adds "sign out everywhere" per the
+  // design's session-invalidation discussion.)
   return redirect(next, {
-    // No new session cookie — the existing one stays valid. The user
-    // remains signed in, just with a fresh hash. (Other devices'
-    // sessions also stay valid; Phase 2 adds "sign out everywhere"
-    // per the design's session-invalidation discussion.)
     "x-parachute-password-changed": "1",
-    // For tests + ops visibility; not load-bearing.
     "cache-control": "no-store",
-    // Force the new HTTPS-or-HTTP CSRF cookie to remain — no-op if not
-    // present, but mirrors the `/login` POST's posture of not stomping
-    // on session/CSRF cookies on the success redirect.
-    // (Intentionally not setting set-cookie — the existing cookies
-    // ride through.)
     "x-secure-context": isHttpsRequest(req) ? "https" : "http",
   });
 }
@@ -355,11 +412,23 @@ export async function handleAccountChangePasswordPost(
  * Flip `users.password_changed` from 0 to 1 for the given user.
  * Idempotent — running against an already-`true` row is a no-op.
  *
- * Lives here (not in `users.ts`) because the only call sites are the
- * change-password POST handler and the admin-reset-password path (PR 4
- * may add the latter; today there is no reset). When that second call
- * site exists, lift this into `users.ts` next to `setPassword` for
- * shared use.
+ * **Not used by the change-password POST itself** — that path inlines
+ * the password_changed=1 flip into the same UPDATE that writes the new
+ * hash, so the two writes commit atomically inside one transaction
+ * (folds N2 of PR #281). This standalone helper is retained for two
+ * call sites that don't co-occur with a hash rewrite:
+ *
+ *   1. Test scaffolding that flips the bit without rotating the hash.
+ *   2. Phase 2's admin-reset path, where the operator-side rewrite of
+ *      the hash flips `password_changed` back to 0 (so the user is
+ *      forced through change-password on next login) — there's no
+ *      `markPasswordChanged` call on that flow, but a future
+ *      "skip-force-change for this re-issued password" flow would
+ *      want it.
+ *
+ * Lives here (not in `users.ts`) because the only current call site is
+ * the test scaffolding; lift into `users.ts` next to `setPassword` when
+ * Phase 2 grows a production caller.
  */
 export function markPasswordChanged(
   db: Database,

--- a/src/api-account.ts
+++ b/src/api-account.ts
@@ -1,0 +1,374 @@
+/**
+ * `/account/*` — signed-in user self-service surfaces.
+ *
+ * Multi-user Phase 1, PR 3 of 5 (force-change-password flow). Design:
+ * [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/).
+ * Tracker: hub#252. Builds on PR 2 (hub#280) which shipped the admin
+ * `/api/users` surface for creating accounts that land with
+ * `password_changed: false`.
+ *
+ * This file handles the *user* side of the change-password flow:
+ *
+ *   GET  /account/change-password    — server-rendered HTML form
+ *   POST /account/change-password    — verify current + set new + flip flag
+ *
+ * Auth posture: any user with a valid session cookie can reach both
+ * endpoints. The `/login` POST handler (separately) does the
+ * force-redirect when `password_changed === false` — that's the *only*
+ * surface that branches on the flag. The page itself is a regular
+ * signed-in surface (per design §sign-in flow change "Direct
+ * navigation"): a user with `password_changed: true` can still
+ * navigate here to rotate their password, and the POST works for any
+ * signed-in user against their own account.
+ *
+ * Force-change is **session-level, not token-level** (design
+ * §security/force-change-password as session-level). Tokens minted
+ * before the change stay valid until revoked; the redirect is the
+ * interactive sign-in boundary. PR 4's OAuth issuer doesn't read the
+ * flag at mint time.
+ *
+ * Wire shape: GET returns HTML (server-rendered). POST accepts
+ * `application/x-www-form-urlencoded` (matches the form submission;
+ * no fetch/JSON layer — keeps the page operational without JS, same
+ * posture as `/login` and `/admin/setup/account`). On success the
+ * POST returns 302 → `next` (or `/admin/vaults` if absent). On error
+ * the POST re-renders the form with an inline error banner — same
+ * pattern as `handleAdminLoginPost`.
+ *
+ * Other-session invalidation: skipped for Phase 1. Sessions are a
+ * single `id` column with a `user_id` FK; a one-liner
+ * `DELETE FROM sessions WHERE user_id = ? AND id != ?` would force
+ * re-auth on other devices, but it also breaks tabs open elsewhere
+ * without explicit user intent. Phase 2's self-service profile page
+ * adds a deliberate "sign out everywhere" action (design §2 "Phase
+ * 2"). Until then the user's existing other-device sessions stay
+ * valid through to natural 24h expiry — matches the design doc's
+ * trade-off discussion in §security/force-change-password.
+ */
+import type { Database } from "bun:sqlite";
+import { type ChangePasswordMode, renderChangePassword } from "./account-change-password-ui.ts";
+import { renderAdminError } from "./admin-login-ui.ts";
+import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
+import { isHttpsRequest } from "./request-protocol.ts";
+import { findActiveSession } from "./sessions.ts";
+import {
+  PASSWORD_MAX_LEN,
+  getUserById,
+  setPassword,
+  validatePassword,
+  verifyPassword,
+} from "./users.ts";
+
+export interface ApiAccountDeps {
+  db: Database;
+  /** Test seam — defaults to real clock. */
+  now?: () => Date;
+}
+
+/**
+ * Where to land after a successful password change when no `next` param
+ * is present. Matches `POST_LOGIN_DEFAULT` in `admin-handlers.ts` — the
+ * admin SPA's vault list. Kept as a local const (not imported) so this
+ * file doesn't accidentally couple to admin-handlers' internals; if the
+ * default ever diverges the two should reconcile via a shared config.
+ */
+const POST_CHANGE_DEFAULT = "/admin/vaults";
+
+function safeNext(raw: string | null | undefined): string {
+  if (!raw) return POST_CHANGE_DEFAULT;
+  // Only allow same-origin paths — never honor an absolute URL or scheme.
+  // Same shape as `safeNext` in admin-handlers.ts. The
+  // change-password GET should never redirect *back* to /login for a
+  // signed-in user, but if a malicious form somehow shipped an
+  // absolute URL we'd want it ignored here too.
+  if (!raw.startsWith("/") || raw.startsWith("//")) return POST_CHANGE_DEFAULT;
+  return raw;
+}
+
+function htmlResponse(body: string, status = 200, extra: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/html; charset=utf-8", ...extra },
+  });
+}
+
+function redirect(location: string, extra: Record<string, string> = {}): Response {
+  return new Response(null, { status: 302, headers: { location, ...extra } });
+}
+
+/**
+ * Compute the change-password mode from the user's `passwordChanged`
+ * flag. Pure — both handlers below read the user, branch on this, and
+ * render. Keeping it a free function keeps the GET / POST handlers
+ * symmetric: the GET picks the mode for the initial render, the POST
+ * picks the same mode if it has to re-render with an error.
+ */
+function modeFor(passwordChanged: boolean): ChangePasswordMode {
+  return passwordChanged ? "rotate" : "first-time";
+}
+
+/**
+ * GET /account/change-password — render the form.
+ *
+ * Auth: requires an active session. Without one, 302 to /login with
+ * `?next=/account/change-password` so the user lands back here after
+ * signing in. **Critically, this redirect fires regardless of the
+ * `password_changed` flag** — a session-less user has no flag to
+ * branch on, and they can't reach the change-password page until
+ * they've signed in once.
+ *
+ * The page renders for *any* signed-in user — including users whose
+ * `password_changed` is already `true`. That's the direct-navigation
+ * path: a user manually visits to rotate their password (design §sign-
+ * in flow change "Direct navigation").
+ */
+export function handleAccountChangePasswordGet(req: Request, deps: ApiAccountDeps): Response {
+  const session = findActiveSession(deps.db, req);
+  if (!session) {
+    // Echo `next` so post-login lands back here. Same safe-next discipline
+    // as `/login` — strip any unsafe path before re-emitting.
+    const url = new URL(req.url);
+    const requestedNext = url.searchParams.get("next");
+    const safeNextValue = safeNext(requestedNext);
+    const querySuffix =
+      safeNextValue !== POST_CHANGE_DEFAULT ? `?next=${encodeURIComponent(safeNextValue)}` : "";
+    const nextParam = encodeURIComponent(`/account/change-password${querySuffix}`);
+    return redirect(`/login?next=${nextParam}`);
+  }
+  const user = getUserById(deps.db, session.userId);
+  if (!user) {
+    // Session points at a deleted user — clear posture is "log them out."
+    // Hand back to /login; the stale session row will time out on its own.
+    return redirect("/login");
+  }
+  const url = new URL(req.url);
+  const next = safeNext(url.searchParams.get("next"));
+  const csrf = ensureCsrfToken(req);
+  const extra: Record<string, string> = csrf.setCookie ? { "set-cookie": csrf.setCookie } : {};
+  return htmlResponse(
+    renderChangePassword({
+      mode: modeFor(user.passwordChanged),
+      csrfToken: csrf.token,
+      username: user.username,
+      next,
+    }),
+    200,
+    extra,
+  );
+}
+
+/**
+ * POST /account/change-password — verify current + apply new.
+ *
+ * Order of checks (matches the design doc's §sign-in flow change /
+ * §scope-section ordering):
+ *   1. Session (else 401 — no body to validate without an identity).
+ *   2. CSRF (else 400 — same wire shape as `/login` POST CSRF failure).
+ *   3. `new_password.length > PASSWORD_MAX_LEN` → 413 BEFORE argon2id
+ *      touches it. Defensive against CPU-DoS through a megabyte body.
+ *   4. `validatePassword(new_password)` → 400 `invalid_password`
+ *      (12-char floor; same validator the create-user path uses).
+ *   5. `new_password !== confirm` → 400 `password_mismatch`.
+ *   6. `verifyPassword(user, current_password)` → 401 `invalid_credentials`.
+ *      Runs argon2id so order matters — 5 happens first to avoid burning
+ *      a hash on an obviously-broken input.
+ *   7. `new_password === current_password` → 400 `password_unchanged`.
+ *   8. `setPassword` + `markPasswordChanged` → 302 → next.
+ *
+ * Re-render shape on validation failure: the page comes back with an
+ * inline error banner (matching `/login`'s POST failure shape), HTTP
+ * status reflects the class (400 / 401 / 413). On success: 302 to
+ * `next` — the session cookie is unchanged (the user is still signed
+ * in; only the password hash and the flag moved).
+ */
+export async function handleAccountChangePasswordPost(
+  req: Request,
+  deps: ApiAccountDeps,
+): Promise<Response> {
+  const session = findActiveSession(deps.db, req);
+  if (!session) {
+    // No session means no identity — there's no useful re-render here.
+    // Same shape as the admin-API endpoints: 401 with a brief HTML
+    // response, the operator's flow recovers by signing in again.
+    return htmlResponse(
+      renderAdminError({
+        title: "Not signed in",
+        message: "Please sign in before changing your password.",
+      }),
+      401,
+    );
+  }
+  const user = getUserById(deps.db, session.userId);
+  if (!user) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Account not found",
+        message: "The signed-in account no longer exists. Please sign in again.",
+      }),
+      401,
+    );
+  }
+
+  const form = await req.formData();
+  const formCsrf = form.get(CSRF_FIELD_NAME);
+  if (!verifyCsrfToken(req, typeof formCsrf === "string" ? formCsrf : null)) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Invalid form submission",
+        message: "The form's CSRF token did not match. Reload the page and try again.",
+      }),
+      400,
+    );
+  }
+  const csrfToken = typeof formCsrf === "string" ? formCsrf : "";
+
+  const currentPassword = String(form.get("current_password") ?? "");
+  const newPassword = String(form.get("new_password") ?? "");
+  const confirmPassword = String(form.get("new_password_confirm") ?? "");
+  const next = safeNext(String(form.get("next") ?? ""));
+  const mode = modeFor(user.passwordChanged);
+
+  // Required-field check before any expensive work.
+  if (!currentPassword || !newPassword || !confirmPassword) {
+    return htmlResponse(
+      renderChangePassword({
+        mode,
+        csrfToken,
+        username: user.username,
+        next,
+        errorMessage: "All three fields are required.",
+      }),
+      400,
+    );
+  }
+
+  // Cap new-password length BEFORE argon2id touches it. 413 fires before
+  // any validator or hash call so a megabyte body burns ~0ms server CPU.
+  // Same pattern as PR 2's `/api/users` POST.
+  if (newPassword.length > PASSWORD_MAX_LEN) {
+    return htmlResponse(
+      renderChangePassword({
+        mode,
+        csrfToken,
+        username: user.username,
+        next,
+        errorMessage: `New password must be ≤ ${PASSWORD_MAX_LEN} characters.`,
+      }),
+      413,
+    );
+  }
+
+  // 12-char minimum (PR 1 validator). Floors only; no complexity rules.
+  const validity = validatePassword(newPassword);
+  if (!validity.valid) {
+    return htmlResponse(
+      renderChangePassword({
+        mode,
+        csrfToken,
+        username: user.username,
+        next,
+        errorMessage: "New password must be at least 12 characters (a passphrase is fine).",
+      }),
+      400,
+    );
+  }
+
+  // Confirm-matches check before the argon2id verify — fast feedback for
+  // a transposed-character mistake, and avoids one hash call on the
+  // common typo path.
+  if (newPassword !== confirmPassword) {
+    return htmlResponse(
+      renderChangePassword({
+        mode,
+        csrfToken,
+        username: user.username,
+        next,
+        errorMessage: "New password and confirmation do not match.",
+      }),
+      400,
+    );
+  }
+
+  // Verify current password. Argon2id verify is the expensive op; we
+  // gated above so it only fires once per legitimate-shape submission.
+  const currentOk = await verifyPassword(user, currentPassword);
+  if (!currentOk) {
+    return htmlResponse(
+      renderChangePassword({
+        mode,
+        csrfToken,
+        username: user.username,
+        next,
+        errorMessage: "Current password is incorrect.",
+      }),
+      401,
+    );
+  }
+
+  // Refuse same-as-current. We check after verify so a 401 ("wrong
+  // current password") takes precedence over "your current password
+  // happens to equal your new attempt but isn't even your real current
+  // password" — a 400 here when current is wrong would leak that the
+  // typed `new_password` matches *some* attempted prior. With verify-
+  // first, this branch only fires when current is correct AND new
+  // equals current — the real "didn't actually change anything" case.
+  if (newPassword === currentPassword) {
+    return htmlResponse(
+      renderChangePassword({
+        mode,
+        csrfToken,
+        username: user.username,
+        next,
+        errorMessage: "New password must differ from your current password.",
+      }),
+      400,
+    );
+  }
+
+  // Persist new hash + flip the changed flag. Two statements (could be
+  // a single UPDATE; kept separate so `setPassword`'s contract — "just
+  // updates the hash" — stays clean and the `markPasswordChanged`
+  // helper is reusable from the admin-reset path if Phase 2 ever wants
+  // to call it independently).
+  const now = deps.now ?? (() => new Date());
+  await setPassword(deps.db, user.id, newPassword, now);
+  markPasswordChanged(deps.db, user.id, now);
+
+  return redirect(next, {
+    // No new session cookie — the existing one stays valid. The user
+    // remains signed in, just with a fresh hash. (Other devices'
+    // sessions also stay valid; Phase 2 adds "sign out everywhere"
+    // per the design's session-invalidation discussion.)
+    "x-parachute-password-changed": "1",
+    // For tests + ops visibility; not load-bearing.
+    "cache-control": "no-store",
+    // Force the new HTTPS-or-HTTP CSRF cookie to remain — no-op if not
+    // present, but mirrors the `/login` POST's posture of not stomping
+    // on session/CSRF cookies on the success redirect.
+    // (Intentionally not setting set-cookie — the existing cookies
+    // ride through.)
+    "x-secure-context": isHttpsRequest(req) ? "https" : "http",
+  });
+}
+
+/**
+ * Flip `users.password_changed` from 0 to 1 for the given user.
+ * Idempotent — running against an already-`true` row is a no-op.
+ *
+ * Lives here (not in `users.ts`) because the only call sites are the
+ * change-password POST handler and the admin-reset-password path (PR 4
+ * may add the latter; today there is no reset). When that second call
+ * site exists, lift this into `users.ts` next to `setPassword` for
+ * shared use.
+ */
+export function markPasswordChanged(
+  db: Database,
+  userId: string,
+  now: () => Date = () => new Date(),
+): void {
+  const stamp = now().toISOString();
+  db.prepare("UPDATE users SET password_changed = 1, updated_at = ? WHERE id = ?").run(
+    stamp,
+    userId,
+  );
+}

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -60,6 +60,10 @@
  *   /api/users/<id>               (DELETE)     → hard-delete user + revoke tokens (host:admin)
  *   /login                        (GET + POST) → operator password login
  *   /logout                       (POST)       → end admin session
+ *   /account/change-password      (GET + POST) → user self-service change-password
+ *                                                 (force-redirect target for users
+ *                                                 with password_changed=false; also
+ *                                                 reachable directly to rotate)
  *   /admin/config*                             → 301 → /admin/vaults (legacy
  *                                                portal retired post-SPA-rework)
  *
@@ -106,6 +110,7 @@ import {
 import { handleHostAdminToken } from "./admin-host-admin-token.ts";
 import { handleVaultAdminToken } from "./admin-vault-admin-token.ts";
 import { handleCreateVault } from "./admin-vaults.ts";
+import { handleAccountChangePasswordGet, handleAccountChangePasswordPost } from "./api-account.ts";
 import { handleApiMe } from "./api-me.ts";
 import { handleApiMintToken } from "./api-mint-token.ts";
 import {
@@ -1550,6 +1555,24 @@ export function hubFetch(
       if (!getDb) return dbNotConfigured();
       if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
       return handleAdminLogoutPost(getDb(), req);
+    }
+
+    // Multi-user Phase 1 PR 3 — user self-service change-password surface
+    // (hub#252, design §sign-in flow change). Both GET (render form) and
+    // POST (apply change) require a session cookie. The handler itself
+    // does the session check + 302 to /login when missing — same posture
+    // as the rest of /account/* will use as Phase 2 broadens this prefix.
+    //
+    // This route is intentionally NOT gated by `password_changed === false`
+    // — that's only the *redirect* path from /login. A signed-in user with
+    // `password_changed: true` can still navigate here to rotate their
+    // password (design §"Direct navigation").
+    if (pathname === "/account/change-password") {
+      if (!getDb) return dbNotConfigured();
+      const accountDeps = { db: getDb() };
+      if (req.method === "GET") return handleAccountChangePasswordGet(req, accountDeps);
+      if (req.method === "POST") return handleAccountChangePasswordPost(req, accountDeps);
+      return new Response("method not allowed", { status: 405 });
     }
 
     // Legacy `/admin/config` (server-rendered module-config portal, #46)


### PR DESCRIPTION
## Summary

Multi-user Phase 1, PR 3 of 5 (hub#252, design [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)). Builds on PR 2 (#280) which ships admin-creates-user landing accounts with `password_changed: false`. This PR is the user-side: a session-level redirect at the login boundary, plus a server-rendered change-password form.

Three commits:

1. `/login` POST: when `user.passwordChanged === false`, 302 to `/account/change-password` (preserving the original `next` as a query param) instead of the existing destination. Session cookie is still minted — the user IS authenticated, they're just expected to change the admin-typed default before continuing.
2. `/account/change-password` GET + POST: server-rendered HTML form (matches the chrome family of `/login`). Two render modes — "first-time login" when `passwordChanged === false`, "Change your password" otherwise (direct-nav path). The redirect at `/login` is the *only* flag-gated behavior; the page itself is reachable for any signed-in user who wants to rotate their password.
3. rc bump to `0.5.10-rc.14` + CHANGELOG.

## Key design points

- **Session-level redirect, not token-level** — the flag is read once at the login boundary; once flipped no per-request scope check or token claim carries it forward. Vault / notes / scribe don't learn about the flag. (Design §sign-in flow change, §security/force-change-password.)
- **POST check order**: session (401) → CSRF (400) → field presence (400) → new > `PASSWORD_MAX_LEN` (413, **before** argon2id touches it; same CPU-DoS defense `/api/users` POST uses) → `validatePassword` (400, 12-char floor from PR 1) → new ≠ confirm (400) → `verifyPassword` on current (401) → new === current (400 — **after** verify so a wrong-current attempt doesn't leak that the typed new matches some attempted current) → `setPassword` + `markPasswordChanged` + 302.
- **Form picks the rendered shape**: server-rendered HTML matches the existing `/login` posture (no SPA bundle for the auth surface family). Inline `<script>` adds fast-feedback validation but the server is authoritative.
- **Other-session invalidation: skipped for Phase 1.** A one-liner `DELETE FROM sessions WHERE user_id = ? AND id != ?` would force re-auth on other devices, but it also breaks tabs without explicit user intent. Phase 2's self-service profile page adds an explicit "sign out everywhere" action; until then existing other-device sessions stay valid through natural 24h expiry, matching the design doc's trade-off discussion in §security/force-change-password.

## Form rendering — server vs SPA

Picked **server-rendered HTML** to match `/login`'s posture (the existing pre-auth + thin-auth surface family — see hub `CLAUDE.md`'s architecture-surfaces table). The form has to be reachable as soon as the user is force-redirected from `/login`, before any SPA shell ever loads; matching `/login`'s shape avoids inventing a third pattern for the auth surface family.

## Test plan

- [x] `bun test ./src` — **1553 pass / 0 fail / 31176 expects across 82 files** (+23 over rc.13's 1530).
- [x] `cd web/ui && bun run test` — **133 pass / 0 fail across 10 files** (unchanged from PR 2 baseline; no SPA changes this PR).
- [x] `bun run typecheck` clean.
- [x] `bunx biome check .` clean.
- [x] `cd web/ui && bun run build` clean.

## Smoke

Spun up hub with `PARACHUTE_HOME=/tmp/hub-mu-pr3` + env-seeded admin `aaron`, walked end-to-end:

| Step | Result |
|---|---|
| Login as `aaron` (passwordChanged=true from env seed) | 302 → `/admin/vaults` (no redirect) ✓ |
| `POST /api/users` create `testuser` with `longenoughpassword123` | 201, `password_changed=false` ✓ |
| Login as `testuser` (fresh cookies) | 302 → `/account/change-password` ✓ |
| Session cookie minted on the force-redirect | ✓ (the user IS authenticated) |
| `GET /account/change-password` | 200, "First-time login" heading, "Signed in as testuser" label ✓ |
| POST `current=longenoughpassword123` + new `user-chosen-strong-password` | 302 → `/admin/vaults` ✓ |
| DB: `password_changed=1`, hash differs | ✓ |
| Login as `testuser` with NEW password | 302 → `/admin/vaults` (no force-redirect) ✓ |
| Login as `testuser` with OLD password | 401 ✓ |
| Direct-nav `GET /account/change-password` (passwordChanged=1 now) | 200, "Change your password" heading ✓ |
| POST with wrong current_password | 401, "Current password is incorrect" inline error ✓ |

## Open questions

- The 413-too-long timing test asserts `< 200ms`. On the slowest CI box this could flake; same floor PR 2 uses on `/api/users`, so consistent.
- `markPasswordChanged` is local to `api-account.ts` for Phase 1 (single call site). When PR 4 lands the admin-reset path or Phase 2 lands the profile page, lift this into `users.ts` next to `setPassword`.
- Direct-nav rotate uses POST 302 → `next` (defaults to `/admin/vaults`). A Phase-2 polish opportunity is rendering the page again with a success banner instead of redirecting (the renderer already has `successMessage` plumbed through), but the design doc's flow text describes redirect-on-success so we match it for now.

## Cross-references

- Design: [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)
- Tracker: hub#252
- Builds on: PR 1 (#279, schema + validators) and PR 2 (#280, admin /api/users)
- Next in chain: PR 4 (OAuth issuer `vault_scope` claim + per-user scope narrowing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)