### PR TITLE
feat(hub): multi-user Phase 1 PR 4 — OAuth vault_scope claim + consent-picker lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.10-rc.15] - 2026-05-20
+
+Multi-user Phase 1 — PR 4 of 5: OAuth vault_scope claim + consent-picker lock (hub#252, design [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)). Builds on PR 3 (rc.14) which shipped the force-change-password flow. This release wires the *OAuth issuer* side: hub-minted tokens now carry a `vault_scope` claim derived from the user's `assigned_vault`, the consent picker is locked-and-displayed for non-admin users, and the server-side defense refuses mints whose picked vault disagrees with the user's assignment.
+
+Backend surface:
+
+- `src/jwt-sign.ts` — `SignAccessTokenOpts` gains an optional `vaultScope: string[]` field. Every minted JWT carries a `vault_scope` claim (defaults to `[]` when omitted — admins / unpinned mints; non-empty single-element list for assigned users). The claim is load-bearing for PR 5's scope-guard at vault / notes / scribe, which will consume it to enforce per-user vault narrowing downstream. Empty `[]` is the explicit "no per-user restriction" sentinel (rather than absent) so consumers never have to distinguish absent-vs-empty.
+- `src/oauth-handlers.ts`:
+  - **New `vaultScopeForUser(db, userId)` helper** — derives the claim value from `users.assigned_vault`. Null assignment (admin posture) → `[]`. Non-null → `[name]`. Read at JWT mint time on both the auth-code grant + refresh-token grant paths, so an admin-side `assigned_vault` change picks up on the user's next refresh.
+  - **`handleAuthorizeGet`** — looks up the signed-in user and threads their `assigned_vault` into `consentProps` as `lockedVault`. The consent picker renders the assigned-vault name as a read-only label with an "Assigned vault — admin-managed; you can't change this here" note, plus a hidden `vault_pick` input carrying the locked value. Admin users (assigned_vault null) keep the existing free dropdown unchanged.
+  - **`handleConsentSubmit`** — server-side defense per Aaron's pin "refuses mints whose picked vault disagrees with assigned_vault" rather than silent overwrite. Two checks for non-admin users: (1) when an unnamed `vault:<verb>` scope was disambiguated via `vault_pick`, refuse 400 if the picked vault ≠ `assigned_vault`; (2) when a named `vault:<other>:<verb>` arrived directly in the request scope, refuse 400. Wire error body is HTML with title "Vault assignment mismatch" and the description `vault_scope_mismatch: …` followed by the assigned-vault name. Admins (assigned_vault null) bypass both checks.
+  - **`signAccessToken` call sites** — both the auth-code grant (`handleTokenAuthorizationCode`) and refresh grant (`handleTokenRefresh`) now pass `vaultScope: vaultScopeForUser(db, userId)`. Re-derived at every mint (not snapshotted onto the refresh-token row) so admin-side `assigned_vault` changes take effect on the user's next refresh.
+- `src/vault-names.ts` (new) — consolidates the two pre-PR-4 private copies of the "walk services.json, emit vault instance names" helper. `oauth-handlers.ts` and `api-users.ts` both used to carry a private `listVaultNames` reading the same source; PR 4 lifts them into one place + adds `handleConsentSubmit`'s server-side defense as a third caller. Exports `listVaultNames(manifest)` for the in-memory shape (consent picker, server-side defense) and `listVaultNamesFromPath(manifestPath)` for the reads-from-disk shape (`/api/users/vaults` + `POST /api/users` validation).
+- `src/oauth-ui.ts` — `VaultPicker` interface gains optional `lockedVault: string`. New `renderVaultPicker` branch renders the locked-vault row + admin-managed note + hidden `vault_pick` input when set; CSS styles for `.vault-picker-locked` / `.vault-locked-row` / `.vault-locked-badge` / `.vault-locked-note` follow the existing chrome palette. The "approve disabled" gate is now scoped to the empty-and-not-locked case so locked-vault forms keep their Approve button enabled.
+- `src/admin-host-admin-token.ts`, `src/admin-vault-admin-token.ts`, `src/api-mint-token.ts`, `src/operator-token.ts` — every other `signAccessToken` caller updated to pass `vaultScope` explicitly. Host-admin / api-mint / operator → `[]` (no per-user pin; these are operator-driven paths). Vault-admin-token → `[vaultName]` (mirrors the per-vault scope already in the token).
+- `src/api-users.ts` — switched off the local `listVaultNames` and now imports `listVaultNamesFromPath` from the shared module. No behavior change.
+
+Tests + gates:
+
+- `src/__tests__/jwt-sign.test.ts` — 3 new tests covering `vault_scope=[]`, `vault_scope=["bob"]`, and the back-compat default (omitting `vaultScope` still emits `[]`).
+- `src/__tests__/oauth-handlers.test.ts` — 7 new tests covering: admin user sees the free dropdown; non-admin user sees the locked picker with the admin-managed note; non-admin happy path mints with `vault_scope=["default"]` and narrowed scope; admin path mints with `vault_scope=[]`; disagreeing `vault_pick` returns 400 `vault_scope_mismatch`; disagreeing named scope (e.g. `vault:other:read` for a user assigned to `default`) returns 400 `vault_scope_mismatch`; named scope matching the assigned vault passes happy path; refresh flow re-derives `vault_scope` from current `assigned_vault`.
+- `src/__tests__/vault-names.test.ts` (new) — 9 tests for the shared helper: empty manifest, single-entry-multi-path shape, per-vault-entry shape, manifest-suffix fallback for missing paths, dedup across mixed shapes, sorted output (deterministic order), `listVaultNamesFromPath` reads disk, and a cross-caller parity check pinning `listVaultNamesFromPath` ≡ `listVaultNames(readManifest(...))`.
+
+Gate: `bun test ./src` — **1574 pass / 0 fail / 31219 expects across 83 files** (+19 over rc.14 baseline 1555). SPA: `cd web/ui && bun run test` — **133 pass / 0 fail across 10 files** (unchanged — no SPA changes this PR). typecheck + biome clean (root + web/ui). SPA build clean.
+
+Smoke: see PR description.
+
+What's NOT in PR 4:
+
+- Consumer-side enforcement at vault / notes / scribe — PR 5 (scope-guard verification). The claim is *emitted* in rc.15; the *consumption* lands in rc.16 alongside the resource-server scope-guard surface.
+- Multi-vault per user (`assigned_vaults: string[]`) — Phase 2.
+- Don't-show-other-vaults UI (the Phase 2 hardening of the picker) — Phase 2. Phase 1 ships lock-the-picker per the design's decision-pin.
+
 ## [0.5.10-rc.14] - 2026-05-20
 
 Multi-user Phase 1 — PR 3 of 5: force-change-password flow (hub#252, design [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)). Builds on PR 2 (rc.13) which shipped the admin `/api/users` surface for creating accounts with `password_changed: false`. This release wires the *user* side: a session-level redirect at the login boundary that lands admin-created users on a server-rendered change-password form before they can reach the rest of the hub.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.10-rc.14",
+  "version": "0.5.10-rc.15",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/jwt-sign.test.ts
+++ b/src/__tests__/jwt-sign.test.ts
@@ -121,6 +121,65 @@ describe("signAccessToken", () => {
       cleanup();
     }
   });
+
+  // Multi-user Phase 1, PR 4 (design 2026-05-20-multi-user-phase-1.md):
+  // the `vault_scope` claim is emitted unconditionally so a downstream
+  // consumer (PR 5's scope-guard) doesn't have to distinguish "absent" from
+  // "empty." Callers pass `[]` for admin / unpinned, `[<assigned_vault>]`
+  // for non-admin pinned users.
+  test("vault_scope=[] is emitted as the empty-array claim", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const { token } = await signAccessToken(db, {
+        sub: "admin-aaron",
+        scopes: ["vault:default:read"],
+        audience: "vault.default",
+        clientId: "c",
+        issuer: "https://hub.example",
+        vaultScope: [],
+      });
+      const payload = decodeJwt(token);
+      expect(payload.vault_scope).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("vault_scope=['bob'] is emitted as the single-element claim", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const { token } = await signAccessToken(db, {
+        sub: "bob",
+        scopes: ["vault:bob:read"],
+        audience: "vault.bob",
+        clientId: "c",
+        issuer: "https://hub.example",
+        vaultScope: ["bob"],
+      });
+      const payload = decodeJwt(token);
+      expect(payload.vault_scope).toEqual(["bob"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("vault_scope defaults to [] when caller omits the field (back-compat sentinel)", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const { token } = await signAccessToken(db, {
+        sub: "operator",
+        scopes: ["parachute:host:admin"],
+        audience: "hub",
+        clientId: "c",
+        issuer: "https://hub.example",
+      });
+      const payload = decodeJwt(token);
+      // Claim is present (not undefined), set to the empty-array sentinel.
+      expect(payload.vault_scope).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
 });
 
 describe("signRefreshToken", () => {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -4802,7 +4802,12 @@ describe("handleAuthorizePost — multi-user assigned vault defense (PR 4)", () 
       expect(res.status).toBe(400);
       const html = await res.text();
       expect(html).toContain("vault_scope_mismatch");
-      expect(html).toContain("default");
+      // Echo back the picked-but-rejected vault (HTML-escaped), but DON'T
+      // leak the assigned one (post-N1 nit-fold). "your vault assignment"
+      // is the soft phrase replacing the prior `your assigned vault "..."`.
+      expect(html).toContain("&quot;other&quot;");
+      expect(html).toContain("your vault assignment");
+      expect(html).not.toContain("&quot;default&quot;");
     } finally {
       cleanup();
     }
@@ -4978,6 +4983,126 @@ describe("handleAuthorizePost — multi-user assigned vault defense (PR 4)", () 
       const refreshBody = (await refreshRes.json()) as { access_token: string };
       const refreshedValidated = await validateAccessToken(db, refreshBody.access_token, ISSUER);
       expect(refreshedValidated.payload.vault_scope).toEqual(["default"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Reviewer nit N3 (PR #283): the previous test only verified that
+  // `vault_scope` SURVIVES refresh — it didn't prove the claim is re-derived
+  // mid-session if an admin changes the user's `assigned_vault`. This test
+  // pins the actual "re-derived at refresh time" invariant by mutating the
+  // assignment between mint and refresh, then asserting the new token
+  // carries the post-mutation value. The `scope` claim itself stays
+  // narrowed to the original vault (it was set at consent time and stored
+  // on the refresh-token row); only the informational `vault_scope` claim
+  // tracks the live row.
+  test("refresh flow picks up a mid-session assigned_vault change", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const bob = await createUser(db, "bob", "pw", { assignedVault: "vault-a" });
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { verifier, challenge } = makePkce();
+
+      // Manifest fixture: both vault-a (initial assignment) and vault-b
+      // (post-admin-update assignment) are registered. PR 4 doesn't ship
+      // a PATCH endpoint, so we use the same direct UPDATE the design
+      // anticipates an admin path would call.
+      const twoVaultManifest: ServicesManifest = {
+        services: [
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/vault-a", "/vault/vault-b"],
+            health: "/health",
+            version: "0.3.0",
+          },
+        ],
+      };
+
+      // Step 1: initial OAuth dance + token mint. Asserts vault_scope=["vault-a"].
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        __csrf: TEST_CSRF,
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        vault_pick: "vault-a",
+      });
+      const consentRes = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+          },
+        }),
+        { issuer: ISSUER, loadServicesManifest: () => twoVaultManifest },
+      );
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const tokenRes = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: new URLSearchParams({
+            grant_type: "authorization_code",
+            code: code ?? "",
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            code_verifier: verifier,
+          }),
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER, loadServicesManifest: () => twoVaultManifest },
+      );
+      const tokenBody = (await tokenRes.json()) as {
+        access_token: string;
+        refresh_token: string;
+      };
+      const initial = await validateAccessToken(db, tokenBody.access_token, ISSUER);
+      expect(initial.payload.vault_scope).toEqual(["vault-a"]);
+      expect(initial.payload.scope).toBe("vault:vault-a:read");
+
+      // Step 2: admin updates bob's assigned_vault to vault-b. Direct UPDATE
+      // because Phase 1 has no PATCH endpoint; same effect a future admin
+      // path would have. The refresh path reads the live row at mint time
+      // (`vaultScopeForUser`), so the next refresh should pick up the new
+      // value.
+      db.prepare("UPDATE users SET assigned_vault = ? WHERE id = ?").run("vault-b", bob.id);
+
+      // Step 3: refresh the token. vault_scope should be ["vault-b"] (the
+      // new live value); the `scope` claim stays narrowed to the original
+      // vault (auth-code grant snapshotted it onto the refresh-token row).
+      const refreshRes = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token: tokenBody.refresh_token,
+            client_id: reg.client.clientId,
+          }),
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER, loadServicesManifest: () => twoVaultManifest },
+      );
+      expect(refreshRes.status).toBe(200);
+      const refreshBody = (await refreshRes.json()) as { access_token: string };
+      const refreshed = await validateAccessToken(db, refreshBody.access_token, ISSUER);
+      expect(refreshed.payload.vault_scope).toEqual(["vault-b"]);
+      // The `scope` claim is still bound to the original consent — the
+      // refresh-token row carries `vault:vault-a:read` and the rotation
+      // preserves it. PR 5 will be the side that enforces "your access
+      // tokens for the old vault stop working when the assignment moves";
+      // PR 4 just emits the informational claim correctly.
+      expect(refreshed.payload.scope).toBe("vault:vault-a:read");
     } finally {
       cleanup();
     }

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -4550,3 +4550,436 @@ describe("DCR first-client auto-approve window (hub#268 Item 3)", () => {
     }
   });
 });
+
+// Multi-user Phase 1, PR 4 (design 2026-05-20-multi-user-phase-1.md, hub#252):
+// non-admin users (with `assigned_vault` non-null) see the consent picker
+// locked, and the OAuth issuer mints tokens carrying `vault_scope: [<assigned>]`.
+// Server-side defense refuses any mint whose picked vault disagrees.
+describe("handleAuthorizeGet — multi-user assigned vault picker lock (PR 4)", () => {
+  test("admin user (assigned_vault null) sees the free dropdown", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const admin = await createUser(db, "admin-aaron", "pw");
+      const session = createSession(db, { userId: admin.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:read",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      // Free dropdown for admin: radio inputs present, no "Assigned vault" lock.
+      expect(html).toContain('name="vault_pick" value="default"');
+      expect(html).not.toContain("Assigned vault");
+      expect(html).not.toContain("admin-managed");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("non-admin user (assigned_vault set) sees the locked picker with admin-managed note", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const admin = await createUser(db, "admin-aaron", "pw");
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVault: "default",
+      });
+      void admin;
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:read",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("vault-picker-locked");
+      expect(html).toContain("Assigned vault");
+      expect(html).toContain("admin-managed");
+      // Hidden input carries the assigned vault as the picker value.
+      expect(html).toContain('<input type="hidden" name="vault_pick" value="default"');
+      // No free-choice radio inputs.
+      expect(html).not.toContain('type="radio" name="vault_pick"');
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("handleAuthorizePost — multi-user assigned vault defense (PR 4)", () => {
+  test("non-admin happy path: token carries vault_scope=[assigned] and narrowed scope", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { verifier, challenge } = makePkce();
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        __csrf: TEST_CSRF,
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        vault_pick: "default",
+      });
+      const consentRes = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+          },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(consentRes.status).toBe(302);
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const tokenRes = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: new URLSearchParams({
+            grant_type: "authorization_code",
+            code: code ?? "",
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            code_verifier: verifier,
+          }),
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(tokenRes.status).toBe(200);
+      const body = (await tokenRes.json()) as { access_token: string; scope: string };
+      expect(body.scope).toBe("vault:default:read");
+      const { payload } = await validateAccessToken(db, body.access_token, ISSUER);
+      expect(payload.scope).toBe("vault:default:read");
+      expect(payload.vault_scope).toEqual(["default"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("admin user (assigned_vault null) mints with vault_scope=[]", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const admin = await createUser(db, "admin-aaron", "pw");
+      const session = createSession(db, { userId: admin.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { verifier, challenge } = makePkce();
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        __csrf: TEST_CSRF,
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        vault_pick: "default",
+      });
+      const consentRes = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+          },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const tokenRes = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: new URLSearchParams({
+            grant_type: "authorization_code",
+            code: code ?? "",
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            code_verifier: verifier,
+          }),
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      const body = (await tokenRes.json()) as { access_token: string };
+      const { payload } = await validateAccessToken(db, body.access_token, ISSUER);
+      expect(payload.vault_scope).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("non-admin with disagreeing vault_pick → 400 vault_scope_mismatch", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      // The fixture also has a vault "default"; build a manifest that has
+      // two valid vault names so the mismatch isn't conflated with
+      // "unknown vault."
+      const twoVaultManifest: ServicesManifest = {
+        services: [
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/default", "/vault/other"],
+            health: "/health",
+            version: "0.3.0",
+          },
+        ],
+      };
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        __csrf: TEST_CSRF,
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        vault_pick: "other",
+      });
+      const res = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+          },
+        }),
+        { issuer: ISSUER, loadServicesManifest: () => twoVaultManifest },
+      );
+      expect(res.status).toBe(400);
+      const html = await res.text();
+      expect(html).toContain("vault_scope_mismatch");
+      expect(html).toContain("default");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("non-admin requesting named scope for the wrong vault → 400 vault_scope_mismatch", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        __csrf: TEST_CSRF,
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        // Explicit named scope targeting a vault other than bob's assigned one.
+        scope: "vault:other:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const res = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+          },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(res.status).toBe(400);
+      const html = await res.text();
+      expect(html).toContain("vault_scope_mismatch");
+      expect(html).toContain("vault:other:read");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("non-admin requesting named scope for the assigned vault → happy path", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { verifier, challenge } = makePkce();
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        __csrf: TEST_CSRF,
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        // Named scope matching bob's assigned vault — should pass.
+        scope: "vault:default:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const consentRes = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+          },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(consentRes.status).toBe(302);
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const tokenRes = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: new URLSearchParams({
+            grant_type: "authorization_code",
+            code: code ?? "",
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            code_verifier: verifier,
+          }),
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      const body = (await tokenRes.json()) as { access_token: string };
+      const { payload } = await validateAccessToken(db, body.access_token, ISSUER);
+      expect(payload.scope).toBe("vault:default:read");
+      expect(payload.vault_scope).toEqual(["default"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("refresh flow re-derives vault_scope from current assigned_vault", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { verifier, challenge } = makePkce();
+
+      // Step 1: complete the OAuth dance to obtain a refresh token.
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        __csrf: TEST_CSRF,
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        vault_pick: "default",
+      });
+      const consentRes = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+          },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const tokenRes = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: new URLSearchParams({
+            grant_type: "authorization_code",
+            code: code ?? "",
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            code_verifier: verifier,
+          }),
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      const tokenBody = (await tokenRes.json()) as {
+        access_token: string;
+        refresh_token: string;
+      };
+      const firstValidated = await validateAccessToken(db, tokenBody.access_token, ISSUER);
+      expect(firstValidated.payload.vault_scope).toEqual(["default"]);
+
+      // Step 2: refresh the token; vault_scope should still be ["default"].
+      const refreshRes = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token: tokenBody.refresh_token,
+            client_id: reg.client.clientId,
+          }),
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      const refreshBody = (await refreshRes.json()) as { access_token: string };
+      const refreshedValidated = await validateAccessToken(db, refreshBody.access_token, ISSUER);
+      expect(refreshedValidated.payload.vault_scope).toEqual(["default"]);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/__tests__/vault-names.test.ts
+++ b/src/__tests__/vault-names.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for the shared `vault-names.ts` helper (multi-user Phase 1, PR 4).
+ *
+ * The shared helper lifted the two pre-PR-4 private copies (`oauth-handlers.ts`
+ * + `api-users.ts`) into one place. These tests pin the canonical behavior so
+ * both callers — the OAuth consent picker + the admin SPA's assigned-vault
+ * dropdown + the server-side defense in `handleConsentSubmit` — see the same
+ * name set.
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ServicesManifest } from "../services-manifest.ts";
+import { listVaultNames, listVaultNamesFromPath } from "../vault-names.ts";
+
+describe("listVaultNames", () => {
+  test("returns empty list when no vault services are registered", () => {
+    const manifest: ServicesManifest = {
+      services: [
+        { name: "parachute-notes", port: 1942, paths: ["/notes"], health: "/h", version: "0.1.0" },
+        {
+          name: "parachute-scribe",
+          port: 1943,
+          paths: ["/scribe"],
+          health: "/h",
+          version: "0.1.0",
+        },
+      ],
+    };
+    expect(listVaultNames(manifest)).toEqual([]);
+  });
+
+  test("single-entry-multi-path: emits one name per `/vault/<name>` path", () => {
+    const manifest: ServicesManifest = {
+      services: [
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/work", "/vault/personal"],
+          health: "/h",
+          version: "0.1.0",
+        },
+      ],
+    };
+    expect(listVaultNames(manifest)).toEqual(["personal", "work"]);
+  });
+
+  test("per-vault entries: emits one name per `parachute-vault-<name>` entry", () => {
+    const manifest: ServicesManifest = {
+      services: [
+        {
+          name: "parachute-vault-work",
+          port: 1940,
+          paths: ["/vault/work"],
+          health: "/h",
+          version: "0.1.0",
+        },
+        {
+          name: "parachute-vault-personal",
+          port: 1941,
+          paths: ["/vault/personal"],
+          health: "/h",
+          version: "0.1.0",
+        },
+      ],
+    };
+    expect(listVaultNames(manifest)).toEqual(["personal", "work"]);
+  });
+
+  test("entry with no paths falls back to the manifest-suffix name (hub#143)", () => {
+    const manifest: ServicesManifest = {
+      services: [
+        {
+          name: "parachute-vault-archived",
+          port: 1940,
+          paths: [],
+          health: "/h",
+          version: "0.1.0",
+        },
+      ],
+    };
+    expect(listVaultNames(manifest)).toEqual(["archived"]);
+  });
+
+  test("deduplicates collisions across single-entry + per-vault shapes", () => {
+    const manifest: ServicesManifest = {
+      services: [
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/work"],
+          health: "/h",
+          version: "0.1.0",
+        },
+        {
+          name: "parachute-vault-work",
+          port: 1941,
+          paths: ["/vault/work"],
+          health: "/h",
+          version: "0.1.0",
+        },
+      ],
+    };
+    expect(listVaultNames(manifest)).toEqual(["work"]);
+  });
+
+  test("output is sorted ascending — deterministic order for both callers", () => {
+    const manifest: ServicesManifest = {
+      services: [
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/zeta", "/vault/alpha", "/vault/middle"],
+          health: "/h",
+          version: "0.1.0",
+        },
+      ],
+    };
+    expect(listVaultNames(manifest)).toEqual(["alpha", "middle", "zeta"]);
+  });
+});
+
+describe("listVaultNamesFromPath", () => {
+  test("reads from a services.json file and emits the same names", () => {
+    const dir = mkdtempSync(join(tmpdir(), "phub-vault-names-"));
+    const path = join(dir, "services.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        services: [
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/work"],
+            health: "/h",
+            version: "0.1.0",
+          },
+        ],
+      }),
+    );
+    try {
+      expect(listVaultNamesFromPath(path)).toEqual(["work"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("api-users.ts and oauth-handlers.ts read the same source through listVaultNamesFromPath / listVaultNames", () => {
+    // Cross-caller parity: the helper is the single source. Both code paths
+    // should see byte-identical output against the same services.json.
+    const dir = mkdtempSync(join(tmpdir(), "phub-vault-names-parity-"));
+    const path = join(dir, "services.json");
+    const manifest: ServicesManifest = {
+      services: [
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/work", "/vault/personal"],
+          health: "/h",
+          version: "0.1.0",
+        },
+      ],
+    };
+    writeFileSync(path, JSON.stringify(manifest));
+    try {
+      expect(listVaultNamesFromPath(path)).toEqual(listVaultNames(manifest));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/admin-host-admin-token.ts
+++ b/src/admin-host-admin-token.ts
@@ -71,6 +71,11 @@ export async function handleHostAdminToken(
     clientId: HOST_ADMIN_CLIENT_ID,
     issuer: deps.issuer,
     ttlSeconds: HOST_ADMIN_TOKEN_TTL_SECONDS,
+    // Host-admin tokens carry no per-user vault pin — the SPA Bearer talks
+    // to hub-scoped admin endpoints (vaults, grants, users, tokens), not to
+    // a single vault. Empty `vault_scope` is the "no per-user restriction"
+    // sentinel matching admin OAuth tokens.
+    vaultScope: [],
   });
   return new Response(
     JSON.stringify({

--- a/src/admin-vault-admin-token.ts
+++ b/src/admin-vault-admin-token.ts
@@ -73,6 +73,13 @@ export async function handleVaultAdminToken(
     clientId: VAULT_ADMIN_CLIENT_ID,
     issuer: deps.issuer,
     ttlSeconds: VAULT_ADMIN_TOKEN_TTL_SECONDS,
+    // The session-cookie path mints a per-vault admin Bearer for an operator
+    // who is already authenticated as an admin (post-#199 SPA path). The
+    // token names exactly one vault in its `scope`; the `vault_scope` claim
+    // mirrors that so PR 5's scope-guard side sees the same explicit pin
+    // (rather than the empty-admin sentinel that would otherwise undermine
+    // the per-vault narrowing).
+    vaultScope: [vaultName],
   });
   return new Response(
     JSON.stringify({

--- a/src/api-mint-token.ts
+++ b/src/api-mint-token.ts
@@ -191,6 +191,12 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
     clientId: API_MINT_TOKEN_CLIENT_ID,
     issuer: deps.issuer,
     ttlSeconds,
+    // Operator-driven CLI/API mint — the bearer already cleared the
+    // `parachute:host:auth` privilege gate, so there's no per-user vault
+    // pin to enforce. Empty `vault_scope` is the "no restriction"
+    // sentinel; the `scopes` themselves remain authorization-bearing as
+    // before.
+    vaultScope: [],
     ...(permissionsClaim !== undefined ? { extraClaims: { permissions: permissionsClaim } } : {}),
     ...(deps.now !== undefined ? { now: deps.now } : {}),
   });

--- a/src/api-users.ts
+++ b/src/api-users.ts
@@ -39,7 +39,6 @@ import type { Database } from "bun:sqlite";
 import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
 import { HOST_ADMIN_SCOPE } from "./admin-vaults.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
-import { readManifest } from "./services-manifest.ts";
 import {
   PASSWORD_MAX_LEN,
   type User,
@@ -52,7 +51,7 @@ import {
   validatePassword,
   validateUsername,
 } from "./users.ts";
-import { isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
+import { listVaultNamesFromPath } from "./vault-names.ts";
 
 export interface ApiUsersDeps {
   db: Database;
@@ -84,36 +83,6 @@ function toWire(u: User): UserWireShape {
     assigned_vault: u.assignedVault,
     created_at: u.createdAt,
   };
-}
-
-/**
- * Walk services.json and emit each vault instance's name (`/vault/<name>`
- * path segment or `parachute-vault-<name>` manifest suffix; see
- * `vaultInstanceNameFor`).
- *
- * Mirrors the private `listVaultNames` in `oauth-handlers.ts`. Exposed
- * here as the single source for the `/api/users/vaults` endpoint —
- * both code paths must agree on which vault names a user could be
- * pinned to so the OAuth issuer (PR 4) can validate stored
- * `assigned_vault` values against the same set.
- *
- * TODO(hub PR4): consolidate with oauth-handlers.ts:listVaultNames
- * when PR 4 lands. PR 4 already touches oauth-handlers.ts to wire the
- * `vault_scope` claim, which is the natural seam to lift this helper
- * to a shared module (well-known.ts is the likely landing site since
- * it already owns `isVaultEntry` + `vaultInstanceNameFor`).
- */
-function listVaultNames(manifestPath: string): string[] {
-  const manifest = readManifest(manifestPath);
-  const names = new Set<string>();
-  for (const svc of manifest.services) {
-    if (!isVaultEntry(svc)) continue;
-    const paths = svc.paths.length > 0 ? svc.paths : [undefined];
-    for (const path of paths) {
-      names.add(vaultInstanceNameFor(svc.name, path));
-    }
-  }
-  return Array.from(names).sort();
 }
 
 function jsonError(status: number, error: string, description: string): Response {
@@ -289,7 +258,7 @@ export async function handleCreateUser(req: Request, deps: ApiUsersDeps): Promis
   // restriction" and skips the check.
   if (assignedVault !== null) {
     const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
-    const known = new Set(listVaultNames(manifestPath));
+    const known = new Set(listVaultNamesFromPath(manifestPath));
     if (!known.has(assignedVault)) {
       return jsonError(
         400,
@@ -405,7 +374,7 @@ export async function handleListVaults(req: Request, deps: ApiUsersDeps): Promis
     return adminAuthErrorResponse(err as AdminAuthError);
   }
   const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
-  const vaults = listVaultNames(manifestPath);
+  const vaults = listVaultNamesFromPath(manifestPath);
   return new Response(JSON.stringify({ vaults }), {
     status: 200,
     headers: { "content-type": "application/json", "cache-control": "no-store" },

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -979,6 +979,7 @@ async function runMintToken(args: readonly string[], deps: AuthDeps): Promise<nu
       clientId: OPERATOR_TOKEN_CLIENT_ID,
       issuer,
       ttlSeconds,
+      vaultScope: [], // CLI-mint tokens are operator-scoped; no per-user vault pin
       ...(permissionsClaim !== undefined ? { extraClaims: { permissions: permissionsClaim } } : {}),
     });
 

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -47,6 +47,20 @@ export interface SignAccessTokenOpts {
    * or thread it from `OAuthDeps.issuer`.
    */
   issuer: string;
+  /**
+   * Per-user vault pin — the multi-user Phase 1 (design
+   * [`2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/))
+   * vault_scope claim. Non-empty for non-admin users (a single-element list
+   * naming their `assigned_vault`); empty `[]` for admin users (the "no
+   * per-user vault restriction" sentinel — admins can request any vault on
+   * the hub via the consent picker). Always emitted as a claim — defaults
+   * to `[]` when callers omit — so a downstream consumer (PR 5's
+   * scope-guard at vault / notes / scribe) can unambiguously read it
+   * without distinguishing "absent" from "empty." Phase 1 always has
+   * length ≤1; the list shape carries Phase 2 multi-vault forward without
+   * a wire-shape change.
+   */
+  vaultScope?: string[];
   /** Override the jti (defaults to random base64url(16)). Used by tests. */
   jti?: string;
   /**
@@ -60,7 +74,8 @@ export interface SignAccessTokenOpts {
    * `pa_scope_set` (which scope-set the token was minted under) so an
    * auto-rotation can preserve the operator's chosen narrowing across mints.
    * Reserved claims (`scope`, `client_id`, `sub`, `iss`, `iat`, `exp`, `aud`,
-   * `jti`) are owned by this function and overwritten if passed here.
+   * `jti`, `vault_scope`) are owned by this function and overwritten if
+   * passed here.
    */
   extraClaims?: Record<string, unknown>;
 }
@@ -85,6 +100,7 @@ export async function signAccessToken(
     ...(opts.extraClaims ?? {}),
     scope: opts.scopes.join(" "),
     client_id: opts.clientId,
+    vault_scope: opts.vaultScope ?? [],
   })
     .setProtectedHeader({ alg: SIGNING_ALGORITHM, kid: key.kid })
     .setSubject(opts.sub)

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -966,7 +966,7 @@ async function handleConsentSubmit(
     if (assignedVault !== null && pickedVault !== assignedVault) {
       return htmlError(
         "Vault assignment mismatch",
-        `vault_scope_mismatch: the picked vault "${pickedVault}" does not match your assigned vault "${assignedVault}". Ask the hub admin to update your assignment, or pick "${assignedVault}".`,
+        `vault_scope_mismatch: the picked vault "${pickedVault}" does not match your vault assignment. Ask the hub admin to update your assignment, or pick the vault shown on the consent screen.`,
         400,
       );
     }
@@ -997,7 +997,7 @@ async function handleConsentSubmit(
     if (mismatched.length > 0) {
       return htmlError(
         "Vault assignment mismatch",
-        `vault_scope_mismatch: requested scopes ${mismatched.join(", ")} target a vault other than your assigned vault "${assignedVault}".`,
+        `vault_scope_mismatch: requested scopes ${mismatched.join(", ")} target a vault other than your vault assignment.`,
         400,
       );
     }

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -80,7 +80,8 @@ import {
   findSession,
   parseSessionCookie,
 } from "./sessions.ts";
-import { getUserByUsername, verifyPassword } from "./users.ts";
+import { getUserById, getUserByUsername, verifyPassword } from "./users.ts";
+import { listVaultNames } from "./vault-names.ts";
 import { isVaultEntry, shortName, vaultInstanceNameFor } from "./well-known.ts";
 
 /** Verbs whose unnamed `vault:<verb>` form needs picker disambiguation. */
@@ -96,26 +97,6 @@ function unnamedVaultVerbs(scopes: string[]): string[] {
   return verbs;
 }
 
-/**
- * Vault instance names registered on this host, derived from services.json.
- * Walks both manifest shapes — single-entry-multi-path (`paths: ["/vault/work",
- * "/vault/personal"]`) and per-vault entries (`parachute-vault-work`) — by
- * delegating each (name, path) pair to the canonical `vaultInstanceNameFor`
- * helper. Entries with no paths still resolve to a name via the helper's
- * manifest-suffix fallback (#143).
- */
-function listVaultNames(manifest: ServicesManifest): string[] {
-  const names = new Set<string>();
-  for (const svc of manifest.services) {
-    if (!isVaultEntry(svc)) continue;
-    const paths = svc.paths.length > 0 ? svc.paths : [undefined];
-    for (const path of paths) {
-      names.add(vaultInstanceNameFor(svc.name, path));
-    }
-  }
-  return Array.from(names).sort();
-}
-
 /** Rewrite each unnamed `vault:<verb>` to `vault:<picked>:<verb>`. */
 function narrowVaultScopes(scopes: string[], pickedVault: string): string[] {
   return scopes.map((s) => {
@@ -126,6 +107,34 @@ function narrowVaultScopes(scopes: string[], pickedVault: string): string[] {
     }
     return s;
   });
+}
+
+/**
+ * Derive the `vault_scope` claim value for a given hub user. Multi-user
+ * Phase 1 (design
+ * [`2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/),
+ * §oauth-claim-shape).
+ *
+ *   - `userId` resolves to no row → `[]`. Defensive: the caller already
+ *     validated the user existed (auth-code redemption / refresh row's
+ *     user_id), but a delete-between-mint-and-now race shouldn't 500. Empty
+ *     is the safe sentinel — the scope-bearing `scope` claim is still the
+ *     gate.
+ *   - User exists with `assignedVault === null` → `[]`. Admin / unpinned
+ *     posture; the consent picker is the source of truth.
+ *   - User exists with `assignedVault === "name"` → `["name"]`. The Phase 1
+ *     single-vault pin; PR 5's scope-guard at vault/notes/scribe consumes
+ *     this to enforce that an assigned user can't request scope against any
+ *     vault other than their assigned one.
+ *
+ * Always returns an array (never undefined) so the JWT carries the claim
+ * unconditionally — readers don't have to distinguish "absent" from "empty."
+ */
+export function vaultScopeForUser(db: Database, userId: string): string[] {
+  const user = getUserById(db, userId);
+  if (!user) return [];
+  if (user.assignedVault === null) return [];
+  return [user.assignedVault];
 }
 
 export interface OAuthDeps {
@@ -714,10 +723,19 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
     return issueAuthCodeRedirect(db, parsed, requestedScopes, session.userId, deps);
   }
 
+  // Multi-user Phase 1: non-admin users (with `assigned_vault !== null`) see
+  // the picker locked to their assigned vault — they can't pick a different
+  // one. Admin users (assigned_vault === null) see the full dropdown.
+  // Defensive null-coalesce: the session points at a deleted user shouldn't
+  // 500; treat as admin posture (the broader scope-validation gate will
+  // catch any actual privilege issue).
+  const user = getUserById(db, session.userId);
+  const lockedVault = user?.assignedVault ?? null;
+
   const manifest = (deps.loadServicesManifest ?? readServicesManifest)();
   const vaultNames = listVaultNames(manifest);
   return htmlResponse(
-    renderConsent(consentProps(client, parsed, vaultNames, csrf.token)),
+    renderConsent(consentProps(client, parsed, vaultNames, csrf.token, lockedVault)),
     200,
     extra,
   );
@@ -902,6 +920,19 @@ async function handleConsentSubmit(
       params.state,
     );
   }
+  // Multi-user Phase 1 (design 2026-05-20-multi-user-phase-1.md): non-admin
+  // users (`assigned_vault !== null`) are pinned to a single vault. The
+  // consent screen renders the picker locked to that vault and any named
+  // scopes (`vault:<name>:<verb>`) requested by the client must match. The
+  // server-side defense here refuses any mint where the user's submission
+  // disagrees — Aaron pinned this as "server-side defense refuses mints
+  // whose picked vault disagrees with assigned_vault" rather than silent
+  // overwrite, so a hand-crafted POST or a misbehaving SPA can't bypass the
+  // lock. Admin users (`assigned_vault === null`) keep the existing picker-
+  // as-source-of-truth behavior.
+  const sessionUser = getUserById(db, session.userId);
+  const assignedVault = sessionUser?.assignedVault ?? null;
+
   // Vault picker (Q1 of the vault-config-and-scopes design): an unnamed
   // `vault:<verb>` scope is ambiguous about which vault it grants access to.
   // Force the operator to pick before the JWT is minted, then rewrite the
@@ -926,8 +957,52 @@ async function handleConsentSubmit(
         400,
       );
     }
+    // Server-side defense: non-admin user submitted a vault that disagrees
+    // with their `assigned_vault`. The picker rendered as locked, so a UI-
+    // path user couldn't reach this — but a hand-crafted form bypassing the
+    // locked input lands here. Refuse the mint instead of silently
+    // overwriting; the explicit error tells the operator the assignment is
+    // load-bearing.
+    if (assignedVault !== null && pickedVault !== assignedVault) {
+      return htmlError(
+        "Vault assignment mismatch",
+        `vault_scope_mismatch: the picked vault "${pickedVault}" does not match your assigned vault "${assignedVault}". Ask the hub admin to update your assignment, or pick "${assignedVault}".`,
+        400,
+      );
+    }
     scopes = narrowVaultScopes(scopes, pickedVault);
   }
+
+  // Server-side defense for named-vault scopes (`vault:<name>:<verb>`) too.
+  // A non-admin user can't request scope against any vault other than their
+  // assigned one — same invariant as the picker check above, applied to
+  // scopes that arrived already-named (e.g. a client that knows the user's
+  // vault and asked for `vault:bob:read` directly). Admins (assigned_vault
+  // null) skip this check.
+  if (assignedVault !== null) {
+    const mismatched: string[] = [];
+    for (const s of scopes) {
+      const parts = s.split(":");
+      if (
+        parts.length === 3 &&
+        parts[0] === "vault" &&
+        parts[1] &&
+        parts[2] &&
+        VAULT_VERBS.has(parts[2]) &&
+        parts[1] !== assignedVault
+      ) {
+        mismatched.push(s);
+      }
+    }
+    if (mismatched.length > 0) {
+      return htmlError(
+        "Vault assignment mismatch",
+        `vault_scope_mismatch: requested scopes ${mismatched.join(", ")} target a vault other than your assigned vault "${assignedVault}".`,
+        400,
+      );
+    }
+  }
+
   // Record (or extend) the grant so the next /oauth/authorize for this
   // (user, client) with these scopes — or any subset — can skip the consent
   // screen (#75). UNION semantics: if the user previously granted [a, b, c]
@@ -1229,6 +1304,13 @@ async function handleTokenAuthorizationCode(
     audience,
     clientId: redeemed.clientId,
     issuer: deps.issuer,
+    // vault_scope claim — Phase 1 per-user vault pin. Non-empty list for
+    // non-admin users with `assigned_vault` set; empty for admin / unpinned.
+    // The narrowing in `handleConsentSubmit` already rewrote `vault:<verb>` →
+    // `vault:<assigned_vault>:<verb>` for non-admin users, so the auth code's
+    // scopes are pre-aligned; this claim is the explicit "owned vault"
+    // signal PR 5 consumes downstream.
+    vaultScope: vaultScopeForUser(db, redeemed.userId),
     now: deps.now,
   });
   // Phase 1 (#212) registry exemption: code-grant access tokens piggyback
@@ -1342,6 +1424,14 @@ async function handleTokenRefresh(
     audience,
     clientId: row.clientId,
     issuer: deps.issuer,
+    // vault_scope claim — re-derived from the user's *current*
+    // `assigned_vault` at refresh time (not snapshotted onto the refresh-
+    // token row). An admin who changes a user's `assigned_vault` between
+    // mint and refresh sees the new value on the next refresh; existing
+    // access tokens carry their original claim until their 15-minute TTL
+    // elapses. Same posture as the design's "OAuth issuer reads
+    // `assigned_vault` at mint time, not at session-creation time" pin.
+    vaultScope: vaultScopeForUser(db, refreshUserId),
     now: deps.now,
   });
   let refresh: ReturnType<typeof signRefreshToken>;
@@ -1677,16 +1767,37 @@ function consentProps(
   params: AuthorizeFormParams,
   vaultNames: string[],
   csrfToken: string,
+  lockedVault: string | null,
 ) {
   const scopes = params.scope.split(" ").filter((s) => s.length > 0);
   const unnamedVerbs = unnamedVaultVerbs(scopes);
+  // Multi-user Phase 1 (design 2026-05-20-multi-user-phase-1.md, decision-pin
+  // "consent picker for non-admin users"): non-admin users (assigned_vault
+  // non-null) see the picker locked to their `assigned_vault` rather than a
+  // free dropdown. Phase 2 will hide other vaults entirely; Phase 1 ships
+  // lock-the-picker (the smallest diff that satisfies "user can't pick a
+  // vault they don't own"). Server-side defense in `handleConsentSubmit`
+  // refuses mints whose POST disagrees regardless of how the picker is
+  // rendered.
+  let vaultPicker: VaultPickerProps | undefined;
+  if (unnamedVerbs.length > 0) {
+    vaultPicker =
+      lockedVault !== null
+        ? { unnamedVerbs, availableVaults: vaultNames, lockedVault }
+        : { unnamedVerbs, availableVaults: vaultNames };
+  }
   return {
     params,
     clientId: client.clientId,
     clientName: client.clientName ?? client.clientId,
     scopes,
     csrfToken,
-    vaultPicker:
-      unnamedVerbs.length > 0 ? { unnamedVerbs, availableVaults: vaultNames } : undefined,
+    vaultPicker,
   };
+}
+
+interface VaultPickerProps {
+  unnamedVerbs: string[];
+  availableVaults: string[];
+  lockedVault?: string;
 }

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -89,6 +89,20 @@ export interface VaultPicker {
   unnamedVerbs: string[];
   /** Vault names registered on this host. Empty → caller can't approve. */
   availableVaults: string[];
+  /**
+   * Multi-user Phase 1 (design 2026-05-20-multi-user-phase-1.md, decision-pin
+   * "consent picker for non-admin users"): set when the signed-in user has a
+   * non-null `assigned_vault`. The picker renders the vault name as a
+   * read-only label with an admin-managed note instead of the free dropdown
+   * — the user can't choose a different vault. The form still POSTs the
+   * locked value via `vault_pick` so the server-side defense in
+   * `handleConsentSubmit` (which refuses mints whose picked vault disagrees
+   * with the user's `assigned_vault`) sees an unambiguous value.
+   *
+   * Admin users (assigned_vault === null) leave this undefined and see the
+   * full dropdown — existing behavior.
+   */
+  lockedVault?: string;
 }
 
 export interface ErrorViewProps {
@@ -171,8 +185,14 @@ export function renderConsent(props: ConsentViewProps): string {
       ? `<li class="scope scope-empty">No scopes requested — the app gets a session token only.</li>`
       : scopes.map(renderScopeRow).join("\n");
   const pickerSection = vaultPicker ? renderVaultPicker(vaultPicker) : "";
+  // Approve is disabled when the picker can't yield a valid vault. The
+  // empty-vault branch (no vaults registered) is the original case. A
+  // locked-vault picker (multi-user Phase 1) always has a valid value via
+  // the hidden input, so Approve stays enabled.
   const approveDisabled =
-    vaultPicker && vaultPicker.availableVaults.length === 0 ? " disabled" : "";
+    vaultPicker && vaultPicker.lockedVault === undefined && vaultPicker.availableVaults.length === 0
+      ? " disabled"
+      : "";
   const body = `
     <div class="card">
       <div class="card-header">
@@ -209,6 +229,32 @@ export function renderConsent(props: ConsentViewProps): string {
 
 function renderVaultPicker(picker: VaultPicker): string {
   const verbList = picker.unnamedVerbs.map((v) => `<code>vault:${escapeHtml(v)}</code>`).join(", ");
+
+  // Multi-user Phase 1: non-admin users see the picker locked to their
+  // `assigned_vault`. The form still posts via `vault_pick` so the
+  // server-side defense in `handleConsentSubmit` sees the value — but the
+  // user can't change it through the UI. A small `<input type=hidden>` and
+  // a read-only label is the smallest diff that ships the lock without
+  // disabling the broader form flow (Approve / Deny still work).
+  if (picker.lockedVault !== undefined) {
+    const locked = escapeHtml(picker.lockedVault);
+    return `
+        <section class="vault-picker vault-picker-locked">
+          <h2 class="scopes-title">Vault</h2>
+          <p class="picker-help">
+            ${verbList} apply to your assigned vault.
+          </p>
+          <div class="vault-locked-row">
+            <code class="vault-locked-name">${locked}</code>
+            <span class="vault-locked-badge">Assigned</span>
+          </div>
+          <p class="vault-locked-note">
+            Assigned vault — admin-managed; you can't change this here.
+          </p>
+          <input type="hidden" name="vault_pick" value="${locked}" />
+        </section>`;
+  }
+
   if (picker.availableVaults.length === 0) {
     return `
         <section class="vault-picker vault-picker-empty">
@@ -784,6 +830,40 @@ const STYLES = `
   }
   .vault-picker-empty .picker-help { color: ${PALETTE.danger}; }
   .vault-picker-empty .picker-help code { color: ${PALETTE.fg}; }
+  .vault-picker-locked .picker-help { color: ${PALETTE.fgMuted}; }
+  .vault-locked-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.6rem;
+    border: 1px solid ${PALETTE.border};
+    border-radius: 6px;
+    background: ${PALETTE.cardBg};
+    margin: 0.25rem 0 0.5rem;
+  }
+  .vault-locked-name {
+    font-family: ${FONT_MONO};
+    font-size: 0.9rem;
+    color: ${PALETTE.fg};
+    flex: 1;
+  }
+  .vault-locked-badge {
+    display: inline-block;
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 600;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    background: ${PALETTE.accentSoft};
+    color: ${PALETTE.accent};
+  }
+  .vault-locked-note {
+    margin: 0;
+    font-size: 0.82rem;
+    color: ${PALETTE.fgDim};
+    font-style: italic;
+  }
 
   .approve-meta {
     margin: 0 0 1.25rem;

--- a/src/operator-token.ts
+++ b/src/operator-token.ts
@@ -160,6 +160,10 @@ export async function mintOperatorToken(
     clientId: OPERATOR_TOKEN_CLIENT_ID,
     issuer: opts.issuer,
     ttlSeconds: opts.ttlSeconds ?? OPERATOR_TOKEN_TTL_SECONDS,
+    // Operator token — the hub-operator bearer. No per-user vault pin; the
+    // operator can act against any vault in this hub. Empty `vault_scope`
+    // is the "no restriction" sentinel (matches the admin OAuth shape).
+    vaultScope: [],
     extraClaims: { [OPERATOR_TOKEN_SCOPE_SET_CLAIM]: scopeSet },
     ...(opts.jti !== undefined ? { jti: opts.jti } : {}),
     ...(opts.now !== undefined ? { now: opts.now } : {}),

--- a/src/vault-names.ts
+++ b/src/vault-names.ts
@@ -1,0 +1,57 @@
+/**
+ * Vault-name list — the single source of truth for "which vault instances are
+ * registered on this hub right now."
+ *
+ * Multi-user Phase 1, PR 4 of 5 (design
+ * [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)).
+ * Consolidates the two pre-PR-4 copies that read services.json and emitted
+ * vault names — one was private inside `oauth-handlers.ts` (used by the
+ * consent vault picker + post-consent narrowing), the other was private
+ * inside `api-users.ts` (used by `GET /api/users/vaults` for the admin SPA's
+ * assigned-vault dropdown + `POST /api/users` validation). PR 4 wires a third
+ * caller — server-side defense in `handleConsentSubmit` refusing mints
+ * whose picked vault disagrees with the user's `assigned_vault` — so the
+ * two private copies became three, and a duplicated read-and-derive helper
+ * for "what vaults exist" is exactly the shape that needs a single owner.
+ *
+ * Lives next to `well-known.ts` (which already owns `isVaultEntry` +
+ * `vaultInstanceNameFor`) rather than inside it: well-known's role is the
+ * `/.well-known/parachute.json` document shape, and a free-floating list
+ * helper would muddy that file's surface. Standalone module keeps the
+ * focused-purpose contract.
+ *
+ * Walks both manifest shapes: single-entry-multi-path (`parachute-vault`
+ * with `paths: ["/vault/work", "/vault/personal"]`) and per-vault entries
+ * (`parachute-vault-work`) by delegating each (name, path) pair to
+ * `vaultInstanceNameFor`. Entries with no paths still resolve to a name via
+ * the helper's manifest-suffix fallback (hub#143).
+ */
+import { type ServicesManifest, readManifest } from "./services-manifest.ts";
+import { isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
+
+/**
+ * Emit each vault instance's name from an in-memory manifest. Sorted output
+ * keeps callers (consent picker dropdown, admin SPA dropdown, server-side
+ * defense lookup) deterministic without each having to wrap in their own
+ * `.sort()`.
+ */
+export function listVaultNames(manifest: ServicesManifest): string[] {
+  const names = new Set<string>();
+  for (const svc of manifest.services) {
+    if (!isVaultEntry(svc)) continue;
+    const paths = svc.paths.length > 0 ? svc.paths : [undefined];
+    for (const path of paths) {
+      names.add(vaultInstanceNameFor(svc.name, path));
+    }
+  }
+  return Array.from(names).sort();
+}
+
+/**
+ * Read-from-disk convenience for callers that already have a manifest path
+ * (e.g. `/api/users/vaults` reading the live `services.json`). Equivalent to
+ * `listVaultNames(readManifest(manifestPath))`.
+ */
+export function listVaultNamesFromPath(manifestPath: string): string[] {
+  return listVaultNames(readManifest(manifestPath));
+}


### PR DESCRIPTION
## Summary

Multi-user Phase 1, PR 4 of 5 (hub#252, design [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)). Builds on PR 3 (#281) which shipped the force-change-password flow. This PR wires the OAuth issuer side: hub-minted tokens now carry a `vault_scope` claim derived from the user's `assigned_vault`, the consent picker is locked-and-displayed for non-admin users, and the server-side defense refuses mints whose picked vault disagrees with the user's assignment.

## JWT claim shape change

Every hub-minted access token now carries a `vault_scope: string[]` claim:

- **Admin / unpinned users** (`assigned_vault === null`): `vault_scope: []`. The empty-array sentinel for "no per-user vault restriction" — admins can request any vault on the hub via the consent picker. Same sentinel for operator tokens, CLI-mint tokens, and host-admin SPA bearers.
- **Non-admin users** (`assigned_vault !== null`): `vault_scope: ["<assigned_vault>"]`. Phase 1 single-vault; Phase 2 widens the list shape without a wire change.

The claim is always emitted (defaults to `[]` when callers omit), so PR 5's scope-guard at vault/notes/scribe doesn't have to distinguish "absent" from "empty."

`signAccessToken` gains an optional `vaultScope` field; every existing caller updated to pass it explicitly (or relies on the `[]` default). Re-derived at every mint (not snapshotted onto the refresh-token row) so an admin-side `assigned_vault` change picks up on the user's next refresh.

## narrowVaultScopes + consent-picker lock-the-picker logic

**`handleAuthorizeGet`** looks up the signed-in user and threads their `assigned_vault` into `consentProps` as `lockedVault`. The picker renders the vault name as a read-only label with an "Assigned vault — admin-managed; you can't change this here" note plus a hidden `vault_pick` input carrying the locked value. Admins keep the existing free dropdown. Phase 1 ships lock-the-picker per the design's decision-pin; Phase 2 hardens to don't-show-other-vaults once multi-vault membership lands.

**`handleConsentSubmit`** server-side defense (per Aaron's pin: "refuses mints whose picked vault disagrees with assigned_vault" — explicit refuse, not silent overwrite). Two checks for non-admin users:

1. When an unnamed `vault:<verb>` scope was disambiguated via `vault_pick`, refuse 400 if `picked !== assigned_vault`.
2. When a named `vault:<other>:<verb>` arrives directly in the request scope, refuse 400.

Wire error body is HTML with title "Vault assignment mismatch" and the description `vault_scope_mismatch: …`. Admins (`assigned_vault === null`) bypass both checks.

## Vault-name list consolidation

PR 2 left `listVaultNames` duplicated as a private helper in both `oauth-handlers.ts` and `api-users.ts`. PR 4 adds a third caller (the server-side defense in `handleConsentSubmit`), so the duplicated read-and-derive helper now has a single owner: new `src/vault-names.ts` (next to `well-known.ts`, which already owns `isVaultEntry` + `vaultInstanceNameFor`).

Two convenience exports: `listVaultNames(manifest)` for the in-memory shape (consent picker, server-side defense) and `listVaultNamesFromPath(manifestPath)` for the reads-from-disk shape (`/api/users/vaults` + `POST /api/users` validation). Both private copies retired.

## Test plan

- [x] `bun test ./src` — 1574 pass / 0 fail / 31219 expects across 83 files (+19 over rc.14 baseline 1555).
- [x] `cd web/ui && bun run test` — 133 pass / 0 fail across 10 files (unchanged — no SPA changes this PR).
- [x] `bun run typecheck` clean (root + web/ui).
- [x] `bunx biome check src` clean (root + web/ui).
- [x] `cd web/ui && bun run build` clean.

New tests:

- `jwt-sign.test.ts` — 3 tests covering `vault_scope=[]`, `vault_scope=["bob"]`, and the back-compat default (omitting `vaultScope` still emits `[]`).
- `oauth-handlers.test.ts` — 7 tests covering: admin sees free dropdown; non-admin sees locked picker with admin-managed note; non-admin happy path (`vault_scope=["default"]` + narrowed scope); admin happy path (`vault_scope=[]`); disagreeing `vault_pick` → 400 `vault_scope_mismatch`; disagreeing named scope → 400; named scope matching assigned → happy path; refresh flow re-derives `vault_scope` from current `assigned_vault`.
- `vault-names.test.ts` (new) — 9 tests for the shared helper: empty manifest, single-entry-multi-path, per-vault-entries, manifest-suffix fallback, dedup, sorted output, `listVaultNamesFromPath` reads disk, cross-caller parity check.

## Smoke

Spun up `PARACHUTE_HOME=/tmp/hub-mu-pr4` hub on `127.0.0.1:11939`, env-seeded admin `aaron`, services.json fixture with vaults `default` + `other`.

1. **Admin host-admin token decode** — minted via `/admin/host-admin-token`. JWT payload:
   ```json
   {
     "scope": "parachute:host:admin parachute:host:auth",
     "client_id": "parachute-hub-spa",
     "vault_scope": [],
     "sub": "<aaron-uuid>",
     "iss": "http://127.0.0.1:11939",
     "aud": "hub",
     ...
   }
   ```
   `vault_scope: []` ✓.
2. **Create testuser** — `POST /api/users` with `assignedVault: "default"` → 201, row has `assigned_vault: "default"`, `password_changed: false`.
3. **OAuth flow as testuser** — `/oauth/authorize?...&scope=vault:read`. Consent page rendered with `vault-picker-locked`, "Assigned vault", "admin-managed" note, and hidden `<input type="hidden" name="vault_pick" value="default"`. No free-choice radio inputs.
4. **POST consent with `vault_pick=other`** (disagreement) → 400, body contains "Vault assignment mismatch" + `vault_scope_mismatch`. ✓
5. **POST consent with `vault_pick=default`** (happy path) → 302 to `redirect_uri?code=…`.
6. **Exchange code via `/oauth/token`** → 200 with `access_token`. JWT payload:
   ```json
   {
     "scope": "vault:default:read",
     "client_id": "<dcr-id>",
     "vault_scope": ["default"],
     "sub": "<testuser-uuid>",
     "iss": "http://127.0.0.1:11939",
     "aud": "vault.default",
     ...
   }
   ```
   `vault_scope: ["default"]` ✓, `scope` narrowed ✓.

## Cross-references

- Design: [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/) — OAuth-claim-shape section + consent-picker decision pin
- Tracker: hub#252 (broader multi-user UX issue)
- Builds on: PR 3 (#281), PR 2 (#280), PR 1 (#279)
- Followed by: PR 5 — scope-guard verification at vault / notes / scribe (consumer side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)