### PR TITLE
feat(scope-guard): enforce vault_scope claim in resource-server check (hub multi-user Phase 1 PR 5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.10-rc.15",
+  "version": "0.5.10-rc.16",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/packages/scope-guard/CHANGELOG.md
+++ b/packages/scope-guard/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to `@openparachute/scope-guard` are documented here. The for
 
 The library's RC cadence is independent of `@openparachute/hub`'s — they ship from the same repo but aren't coupled in version.
 
+## 0.3.0-rc.1 — 2026-05-20
+
+Adds `vault_scope` claim surfacing + the `enforceVaultScope` defense-in-depth check (hub multi-user Phase 1 PR 5 — see [`2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)). **Additive — no behavior change for existing adopters.** A bump from `0.2.x` to `0.3.0` does NOT start rejecting any token that `0.2.x` accepted; the new helper is opt-in and the new claim is surfaced as `[]` (unrestricted) when absent.
+
+### Added
+
+- **`HubJwtClaims.vaultScope: string[]`** — parsed from the JWT's `vault_scope` claim. Non-empty for non-admin users (a single-element list naming their `assigned_vault` per Phase 1; Phase 2 widens to multi-vault without a wire-shape change). Empty `[]` for admin users, pre-PR-4 tokens, and any token where the claim is absent or malformed. The lib normalizes all three "no pin" cases to `[]` so consumers don't need to distinguish.
+- **`enforceVaultScope(claims, requestVaultName) → boolean`** — opt-in helper for resource servers. Returns `true` if `claims.vaultScope` is `[]` OR contains `requestVaultName`; returns `false` if `vaultScope` is non-empty and excludes the target. Consumers call it from inside their hub-JWT auth path (after `validateHubJwt`, before dispatching to the per-vault handler) and translate `false` to a 403 with `error: "vault_scope_mismatch"`. See `parachute-vault/src/auth.ts`'s `authenticateHubJwt` for the canonical wire-up.
+
+### Why it's a minor bump, not a patch
+
+The claim surface (`HubJwtClaims.vaultScope`) is a new required field on a public interface — adopters who structurally type the claims object (e.g. TypeScript callers that destructure `{ sub, scopes, aud, jti, clientId }`) keep working, but any caller that *constructs* a `HubJwtClaims` value (test fakes, mocks) now needs to provide `vaultScope` or it won't typecheck. That's the breaking-shape ripple that earns a minor over a patch. The runtime behavior is purely additive — the lib reads a new claim if present and surfaces `[]` if absent.
+
+### Adoption notes
+
+- **Vault**: adopt the helper inside `authenticateHubJwt` — derive the target vault from the request path, call `enforceVaultScope(claims, vaultName)`, return 403 with `vault_scope_mismatch` on false. See vault PR for the canonical pattern.
+- **Scribe**: no-touch. Scribe's surface is per-vault-orthogonal (`scribe:transcribe` / `scribe:admin` aren't vault-named); a token's `vault_scope` is informational only at scribe. If a future scribe route accepts tokens that *do* name a vault (e.g. a per-vault transcription audit log), wire in `enforceVaultScope` at that route.
+- **Notes**: no-touch. Notes is a frontend SPA; it holds the user's token and proxies through vault. The defense-in-depth check fires at vault, not at notes.
+- **Parachute-agent**: not yet adopted. Agent's `parachute:agent:*` scopes don't carry a vault pin; `vault_scope` is informational. If an agent route ever dispatches to a vault on behalf of the user, that route should call `enforceVaultScope` before forwarding.
+
+### Compatibility
+
+- **No behavior change** for any existing adopter that doesn't call `enforceVaultScope`. The lib still validates JWTs identically — the new field is additive.
+- **bundler-resolution consumers (vault, scribe, hub workspace):** unaffected.
+- **NodeNext-strict consumers (agent's tsc + vitest):** unaffected. The `.js`-extension convention from 0.2.1 carries forward.
+
 ## 0.2.1 — 2026-05-10
 
 Packaging fix. **0.2.0 is non-functional under NodeNext-strict consumers** — every non-bun adopter on `tsc + Node ESM + "moduleResolution": "nodenext"` should upgrade to 0.2.1 immediately.

--- a/packages/scope-guard/package.json
+++ b/packages/scope-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scope-guard",
-  "version": "0.2.1",
+  "version": "0.3.0-rc.1",
   "description": "Hub-issued JWT validation for Parachute resource servers (vault, scribe, parachute-agent, third-party modules).",
   "license": "AGPL-3.0",
   "type": "module",

--- a/packages/scope-guard/src/__tests__/scope.test.ts
+++ b/packages/scope-guard/src/__tests__/scope.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { hasScope } from "../scope";
+import { enforceVaultScope, hasScope } from "../scope";
 
 describe("hasScope — exact match", () => {
   test("exact string match → true", () => {
@@ -123,5 +123,49 @@ describe("hasScope — multiple grants, mixed shapes", () => {
 
   test("narrowed alongside broad — narrowed satisfies broad query", () => {
     expect(hasScope(["vault:work:write", "vault:home:read"], "vault:read")).toBe(true);
+  });
+});
+
+describe("enforceVaultScope — admin / unrestricted (empty vaultScope)", () => {
+  test("empty vaultScope passes any vault check", () => {
+    // Admin tokens and pre-PR-4 tokens both surface as `vaultScope: []`.
+    // The helper treats `[]` as "no per-user restriction" — every vault
+    // name is accepted. The scope-string check upstream remains the
+    // primary gate.
+    expect(enforceVaultScope({ vaultScope: [] }, "aaron")).toBe(true);
+    expect(enforceVaultScope({ vaultScope: [] }, "work")).toBe(true);
+    expect(enforceVaultScope({ vaultScope: [] }, "anything")).toBe(true);
+  });
+});
+
+describe("enforceVaultScope — non-admin (pinned)", () => {
+  test("vaultScope contains target → true", () => {
+    expect(enforceVaultScope({ vaultScope: ["aaron"] }, "aaron")).toBe(true);
+  });
+
+  test("vaultScope excludes target → false (the defense-in-depth case)", () => {
+    // A non-admin user with vaultScope=["aaron"] tries to reach vault
+    // "bob". Even if the token's scope string somehow named bob (token-
+    // mint bug, manual edit), this check refuses the cross-vault access.
+    expect(enforceVaultScope({ vaultScope: ["aaron"] }, "bob")).toBe(false);
+    expect(enforceVaultScope({ vaultScope: ["aaron"] }, "")).toBe(false);
+  });
+
+  test("multi-vault pin (Phase 2-shape) — any match accepts", () => {
+    // The wire shape is `string[]` so Phase 2's multi-vault membership
+    // works without a shape change. Phase 1 always has length ≤1; this
+    // test pins the forward-compat behavior.
+    expect(enforceVaultScope({ vaultScope: ["aaron", "work"] }, "aaron")).toBe(true);
+    expect(enforceVaultScope({ vaultScope: ["aaron", "work"] }, "work")).toBe(true);
+    expect(enforceVaultScope({ vaultScope: ["aaron", "work"] }, "personal")).toBe(false);
+  });
+});
+
+describe("enforceVaultScope — exact-match (no inheritance)", () => {
+  test("vault name match is case-sensitive exact-string", () => {
+    // Vault instance names are case-sensitive in services.json. The
+    // helper mirrors that — no normalization, no fuzzy match.
+    expect(enforceVaultScope({ vaultScope: ["aaron"] }, "Aaron")).toBe(false);
+    expect(enforceVaultScope({ vaultScope: ["aaron"] }, "aaron ")).toBe(false);
   });
 });

--- a/packages/scope-guard/src/__tests__/validate.test.ts
+++ b/packages/scope-guard/src/__tests__/validate.test.ts
@@ -93,14 +93,26 @@ interface SignOpts {
   omitKid?: boolean;
   kid?: string;
   /**
-   * When provided, sets the `vault_scope` claim. Empty array, undefined
-   * "absent claim entirely" (the value the option lookup uses to decide
-   * whether to include the claim), and explicit `null` are all distinct —
-   * tests need each shape to exercise the absent / empty / malformed
-   * paths the validate code handles.
+   * Typed seam for the `vault_scope` claim. Two non-array values are
+   * load-bearing here:
+   *
+   *   - `undefined` (the field omitted) → claim emitted as `[]` (default
+   *     mint-shape hub uses post-PR-4, including for admins).
+   *   - `"OMIT_CLAIM"` → claim NOT emitted at all (pre-PR-4 wire shape;
+   *     surfaces at scope-guard as `[]` for back-compat).
+   *
+   * Explicit `null` IS allowed by the type but the `??` fallback in the
+   * helper collapses it to `[]` — same as the default. The on-wire null
+   * path (a literal JSON `null` value in the JWT payload) is exercised
+   * via `vaultScopeRaw: null` instead, which bypasses the typed seam.
    */
   vaultScope?: string[] | null | "OMIT_CLAIM";
-  /** Force a malformed (non-array) `vault_scope` claim for the malformed path test. */
+  /**
+   * Force a raw value into the `vault_scope` claim, bypassing the typed
+   * `vaultScope` seam. Used to exercise the malformed-input paths the
+   * validate code normalizes to `[]`: non-array string / number /
+   * JSON-null, plus mixed arrays with non-string entries.
+   */
   vaultScopeRaw?: unknown;
 }
 
@@ -646,6 +658,12 @@ describe("createScopeGuard — vault_scope claim surfacing", () => {
     // hub never mints, (b) the scope-string check upstream is the
     // primary gate anyway. Throwing here would translate a typo into a
     // 401 instead of a clean 403 from the scope-string layer.
+    //
+    // Three shapes: string-on-wire, number-on-wire, JSON-null-on-wire.
+    // The `null` case uses `vaultScopeRaw` (not `vaultScope`) because
+    // the `signJwt` typed seam routes `null` through `?? []` — that
+    // path tests the option-API ergonomics, this path tests the actual
+    // JWT-payload-with-null-value the validate code receives.
     const guard = makeGuard();
     const tokenStr = await signJwt(kp, {
       iss: fixture.origin,
@@ -660,6 +678,13 @@ describe("createScopeGuard — vault_scope claim surfacing", () => {
     });
     const claimsNum = await guard.validateHubJwt(tokenNum);
     expect(claimsNum.vaultScope).toEqual([]);
+
+    const tokenNull = await signJwt(kp, {
+      iss: fixture.origin,
+      vaultScopeRaw: null,
+    });
+    const claimsNull = await guard.validateHubJwt(tokenNull);
+    expect(claimsNull.vaultScope).toEqual([]);
 
     guard.resetJwksCache();
   });

--- a/packages/scope-guard/src/__tests__/validate.test.ts
+++ b/packages/scope-guard/src/__tests__/validate.test.ts
@@ -92,15 +92,34 @@ interface SignOpts {
   expiresAtSeconds?: number;
   omitKid?: boolean;
   kid?: string;
+  /**
+   * When provided, sets the `vault_scope` claim. Empty array, undefined
+   * "absent claim entirely" (the value the option lookup uses to decide
+   * whether to include the claim), and explicit `null` are all distinct —
+   * tests need each shape to exercise the absent / empty / malformed
+   * paths the validate code handles.
+   */
+  vaultScope?: string[] | null | "OMIT_CLAIM";
+  /** Force a malformed (non-array) `vault_scope` claim for the malformed path test. */
+  vaultScopeRaw?: unknown;
 }
 
 async function signJwt(kp: Keypair, opts: SignOpts): Promise<string> {
   const iat = Math.floor(Date.now() / 1000);
   const exp = opts.expiresAtSeconds ?? iat + (opts.ttlSeconds ?? 60);
-  const builder = new SignJWT({
+  const payload: Record<string, unknown> = {
     scope: opts.scope ?? "vault:read",
     client_id: opts.clientId ?? "test-client",
-  })
+  };
+  if (opts.vaultScopeRaw !== undefined) {
+    payload.vault_scope = opts.vaultScopeRaw;
+  } else if (opts.vaultScope !== "OMIT_CLAIM") {
+    // Default: include `vault_scope: []` (hub's PR-4 behavior — always
+    // emit, even for admins). "OMIT_CLAIM" is the test seam for pre-PR-4
+    // tokens that lack the claim entirely.
+    payload.vault_scope = opts.vaultScope ?? [];
+  }
+  const builder = new SignJWT(payload)
     .setProtectedHeader(opts.omitKid ? { alg: "RS256" } : { alg: "RS256", kid: opts.kid ?? kp.kid })
     .setIssuer(opts.iss ?? "http://issuer.invalid")
     .setSubject(opts.sub ?? "user-1")
@@ -568,5 +587,108 @@ describe("createScopeGuard — revocation enforcement", () => {
     expect(revocationCalls).toBe(0);
     guard.resetJwksCache();
     guard.resetRevocationCache();
+  });
+});
+
+describe("createScopeGuard — vault_scope claim surfacing", () => {
+  // The vault_scope claim is hub multi-user Phase 1 PR 4's per-user vault
+  // pin. The validate-side contract is: surface what's there, normalize
+  // every "no pin" shape to `[]`, never throw on malformed input. The
+  // defense-in-depth check happens at the consumer via `enforceVaultScope`
+  // — these tests pin the claim parsing only.
+
+  test("hub-minted non-admin token (single-element array) → surfaces array", async () => {
+    const guard = makeGuard();
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      vaultScope: ["aaron"],
+      scope: "vault:aaron:read vault:aaron:write",
+    });
+    const claims = await guard.validateHubJwt(token);
+    expect(claims.vaultScope).toEqual(["aaron"]);
+    guard.resetJwksCache();
+  });
+
+  test("hub-minted admin token (explicit []) → surfaces []", async () => {
+    const guard = makeGuard();
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      vaultScope: [],
+      scope: "vault:read vault:write",
+    });
+    const claims = await guard.validateHubJwt(token);
+    expect(claims.vaultScope).toEqual([]);
+    guard.resetJwksCache();
+  });
+
+  test("pre-PR-4 token (claim absent) → surfaces [] (back-compat)", async () => {
+    // Tokens minted before PR 4 lack the claim entirely. The validate
+    // path treats that as `[]` (unrestricted) — the upstream scope-string
+    // check remains the primary gate. Without this back-compat, every
+    // operator-token and CLI-mint produced before the PR-4 cut would
+    // start 403-ing the moment a consumer wired in `enforceVaultScope`,
+    // which is the wrong tradeoff for a defense-in-depth check.
+    const guard = makeGuard();
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      vaultScope: "OMIT_CLAIM",
+      scope: "vault:read",
+    });
+    const claims = await guard.validateHubJwt(token);
+    expect(claims.vaultScope).toEqual([]);
+    guard.resetJwksCache();
+  });
+
+  test("malformed vault_scope (non-array) → surfaces [] (fail-open)", async () => {
+    // A hand-crafted or buggy token with `vault_scope: "aaron"` (string
+    // instead of array) is normalized to `[]`. The lib chooses fail-open
+    // for malformed input at this layer because (a) it's the value the
+    // hub never mints, (b) the scope-string check upstream is the
+    // primary gate anyway. Throwing here would translate a typo into a
+    // 401 instead of a clean 403 from the scope-string layer.
+    const guard = makeGuard();
+    const tokenStr = await signJwt(kp, {
+      iss: fixture.origin,
+      vaultScopeRaw: "aaron",
+    });
+    const claimsStr = await guard.validateHubJwt(tokenStr);
+    expect(claimsStr.vaultScope).toEqual([]);
+
+    const tokenNum = await signJwt(kp, {
+      iss: fixture.origin,
+      vaultScopeRaw: 42,
+    });
+    const claimsNum = await guard.validateHubJwt(tokenNum);
+    expect(claimsNum.vaultScope).toEqual([]);
+
+    guard.resetJwksCache();
+  });
+
+  test("array with non-string entries → those entries are filtered out", async () => {
+    // Mixed array: keep the strings, drop the rest. Defends against a
+    // buggy upstream that emits `["aaron", null]` from a partial lookup.
+    const guard = makeGuard();
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      vaultScopeRaw: ["aaron", null, 42, "work"],
+    });
+    const claims = await guard.validateHubJwt(token);
+    expect(claims.vaultScope).toEqual(["aaron", "work"]);
+    guard.resetJwksCache();
+  });
+
+  test("multi-vault Phase 2-shape pin → surfaces full array", async () => {
+    // Forward-compat: when Phase 2 lets a user belong to multiple vaults,
+    // the wire shape is the same `string[]`. The validate layer doesn't
+    // care about length — it surfaces what's there, the consumer's
+    // `enforceVaultScope` does the membership check.
+    const guard = makeGuard();
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      vaultScope: ["aaron", "work", "personal"],
+    });
+    const claims = await guard.validateHubJwt(token);
+    expect(claims.vaultScope).toEqual(["aaron", "work", "personal"]);
+    guard.resetJwksCache();
   });
 });

--- a/packages/scope-guard/src/index.ts
+++ b/packages/scope-guard/src/index.ts
@@ -16,7 +16,7 @@
 // transparently. Dropping the extension breaks NodeNext silently — see #225
 // for the bug that motivated 0.2.1.
 export { extractBearer, looksLikeJwt, parseScopes } from "./parse.js";
-export { hasScope } from "./scope.js";
+export { enforceVaultScope, hasScope } from "./scope.js";
 export type { JwksGetter, JwksOptions } from "./jwks.js";
 // Revocation-cache surface: the cache itself is internal — `ScopeGuard` owns
 // the lifecycle so downstream RSes don't accidentally instantiate parallel

--- a/packages/scope-guard/src/scope.ts
+++ b/packages/scope-guard/src/scope.ts
@@ -92,6 +92,18 @@ function decompose(scope: string): Decomposed | null {
  * `validateHubJwt` returns claims, *before* dispatching to the per-vault
  * handler. See `parachute-vault/src/auth.ts`'s `authenticateHubJwt` for
  * the canonical wire-up.
+ *
+ * Caller responsibility: validate `requestVaultName` is a non-empty,
+ * defined string before calling. The type signature is strict, but
+ * TypeScript can't catch a runtime `undefined` or empty string slipping
+ * through a `URL.pathname.split("/")` result or a config-derived value
+ * that wasn't checked. Passing such a value returns `false` against any
+ * non-empty `vaultScope` (secure-by-default: refuse when the target is
+ * missing), which the consumer then translates to a
+ * `vault_scope_mismatch` 403. Callers that derive `requestVaultName`
+ * from request shape should reject the request upstream with a 4xx that
+ * names the missing-target problem, rather than letting it surface here
+ * as a pin mismatch.
  */
 export function enforceVaultScope(
   claims: { vaultScope: string[] },

--- a/packages/scope-guard/src/scope.ts
+++ b/packages/scope-guard/src/scope.ts
@@ -60,6 +60,48 @@ function decompose(scope: string): Decomposed | null {
 }
 
 /**
+ * Enforce the `vault_scope` claim: does this token authorize a request
+ * targeting `requestVaultName`?
+ *
+ * The claim is the multi-user Phase 1 per-user vault pin — see
+ * [`2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/).
+ * Hub mints `vault_scope: [<assigned_vault>]` for non-admin users and
+ * `vault_scope: []` for admin / unpinned users. Pre-PR-4 tokens lack the
+ * claim entirely; the validate path surfaces those as `[]`.
+ *
+ * Decision matrix:
+ *   - `vaultScope === []` → returns `true`. No per-user restriction —
+ *     admin tokens, pre-PR-4 tokens, and any explicit "no pin" mint.
+ *     This is the unrestricted sentinel; the upstream scope-string check
+ *     (which always names the resource for hub-issued tokens) remains the
+ *     primary gate, and `vault_scope` adds nothing here.
+ *   - `vaultScope` contains `requestVaultName` → returns `true`. The user
+ *     is pinned to a list that includes the target vault.
+ *   - `vaultScope` is non-empty and excludes `requestVaultName` → returns
+ *     `false`. The user is pinned to a different vault; the request must
+ *     be refused with 403. This is the defense-in-depth case the claim
+ *     exists for — even if a scope string somehow names the wrong vault
+ *     (token-mint bug, manual edit, third-party RS not enforcing the
+ *     scope-string vocabulary correctly), this check stops cross-vault
+ *     access at the consumer.
+ *
+ * Phase 1 always has length ≤1; the list shape carries Phase 2 multi-vault
+ * forward without a wire-shape change. The check is the same either way.
+ *
+ * Consumers use this from inside their hub-JWT auth path, *after*
+ * `validateHubJwt` returns claims, *before* dispatching to the per-vault
+ * handler. See `parachute-vault/src/auth.ts`'s `authenticateHubJwt` for
+ * the canonical wire-up.
+ */
+export function enforceVaultScope(
+  claims: { vaultScope: string[] },
+  requestVaultName: string,
+): boolean {
+  if (claims.vaultScope.length === 0) return true;
+  return claims.vaultScope.includes(requestVaultName);
+}
+
+/**
  * Does `granted` satisfy `required`?
  *
  *   - Exact string match → true

--- a/packages/scope-guard/src/validate.ts
+++ b/packages/scope-guard/src/validate.ts
@@ -41,6 +41,26 @@ export interface HubJwtClaims {
   jti: string | undefined;
   /** Client id from the `client_id` claim, if present. */
   clientId: string | undefined;
+  /**
+   * Parsed `vault_scope` claim (the multi-user Phase 1 per-user vault pin —
+   * see [`2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)).
+   *
+   * Semantics:
+   *   - **Non-empty list** (e.g. `["aaron"]`) — the user is pinned to these
+   *     vault instances. Resource servers (vault, notes, scribe) refuse
+   *     requests against any other vault.
+   *   - **Empty list `[]`** — no per-user vault restriction. Admin tokens
+   *     and any pre-PR-4 hub-issued token surface as `[]`.
+   *
+   * Always present (defaults to `[]` when the claim is absent or malformed)
+   * so consumers can call `enforceVaultScope(claims, name)` without
+   * distinguishing "absent" from "empty." Hub mints non-array values
+   * never — but malformed input is treated as `[]` (no restriction)
+   * rather than throwing, since the upstream scope strings still pin
+   * the resource. The defense-in-depth check via `vault_scope` is
+   * additive, not the sole gate.
+   */
+  vaultScope: string[];
 }
 
 /** Reasons a hub JWT may fail validation. Each maps to a `HubJwtError.code`. */
@@ -250,6 +270,19 @@ export function createScopeGuard(opts: CreateScopeGuardOptions): ScopeGuard {
       const clientIdRaw = (payload as { client_id?: unknown }).client_id;
       const clientId = typeof clientIdRaw === "string" ? clientIdRaw : undefined;
 
+      // vault_scope: multi-user Phase 1 per-user vault pin (see HubJwtClaims
+      // jsdoc for full semantics). Non-array / missing / malformed values
+      // collapse to `[]` — the "no per-user restriction" sentinel. Pre-PR-4
+      // tokens lack the claim entirely; they're treated as admin-equivalent
+      // for vault-pin purposes (the upstream scope strings still pin the
+      // resource). This is the "fail-open at THIS layer, fail-closed at the
+      // scope-string layer" choice: vault_scope is defense-in-depth, not
+      // the primary gate.
+      const vaultScopeRaw = (payload as { vault_scope?: unknown }).vault_scope;
+      const vaultScope: string[] = Array.isArray(vaultScopeRaw)
+        ? vaultScopeRaw.filter((s): s is string => typeof s === "string")
+        : [];
+
       // Revocation enforcement runs LAST — only consulted if the JWT is
       // otherwise valid. Cheaper checks (signature, iss, aud, expiry) reject
       // first, so a bad signature never costs a network roundtrip. A token
@@ -277,7 +310,7 @@ export function createScopeGuard(opts: CreateScopeGuardOptions): ScopeGuard {
         }
       }
 
-      return { sub: payload.sub, scopes, aud, jti, clientId };
+      return { sub: payload.sub, scopes, aud, jti, clientId, vaultScope };
     },
 
     resetJwksCache() {


### PR DESCRIPTION
## Summary

- **scope-guard 0.2.1 → 0.3.0-rc.1** — adds `HubJwtClaims.vaultScope: string[]` (parsed from the `vault_scope` claim PR 4 ships) and `enforceVaultScope(claims, requestVaultName)` helper for resource servers to refuse cross-vault access as defense-in-depth.
- **hub 0.5.10-rc.15 → 0.5.10-rc.16** — workspace bump only; hub itself is unchanged.

Closes the last code-touching PR in the hub multi-user Phase 1 chain (PR 5 of 5). Design: [`2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/). Companion: hub#283 (PR 4).

## What changed

scope-guard surfaces:

1. **`HubJwtClaims.vaultScope: string[]`** — non-empty for non-admin users (Phase 1: single-element list naming `assigned_vault`); empty `[]` for admin users, pre-PR-4 tokens, malformed values. All "no pin" shapes collapse to `[]` so consumers don't distinguish absent from empty.
2. **`enforceVaultScope(claims, requestVaultName) → boolean`** — opt-in helper. Returns true if `vaultScope` is `[]` (admin/unpinned) OR contains the target vault name. Returns false otherwise. Consumers translate `false` to a 403 with `error: "vault_scope_mismatch"`.

Minor bump (not patch): `HubJwtClaims` gains a required field, so adopters that construct claims objects (test fakes, mocks) need to provide `vaultScope`. Runtime behavior is purely additive — no token 0.2.x accepted is rejected at 0.3.0.

## Why defense-in-depth, not primary gate

PR 4's `narrowVaultScopes` already produces tokens whose `scope` claim names the exact assigned vault (`vault:<assigned>:<verb>`). The existing scope-string check at vault is the primary gate. `vault_scope` adds a second layer for the case where a token-mint bug, manual edit, or third-party RS not enforcing the vocabulary correctly produces a scope string naming the wrong vault. The defense kicks in before any vault data is touched.

## Consumer adoption

- **vault**: adopts in a follow-up PR — wires `enforceVaultScope` into `authenticateHubJwt` with `requestVaultName = vaultConfig.name`. PR opens after this scope-guard release publishes to npm.
- **scribe**: no-touch. `scribe:transcribe` / `scribe:admin` aren't vault-named; `vault_scope` is informational only. Wire it in at a future route that accepts vault-bound tokens.
- **notes**: no-touch. Frontend SPA, no server-side JWT validation. The check fires at vault.
- **parachute-agent**: not yet adopted. Agent's `parachute:agent:*` scopes don't carry a vault pin.

## Token-shape compatibility

Pre-PR-4 tokens (every operator-token, CLI-mint, and refresh-rotation chain before PR 4) lack the `vault_scope` claim. The validate path surfaces those as `vaultScope: []` — admin-equivalent for vault-pin purposes. Without this back-compat, every existing operator-token would start 403-ing the moment vault wires in `enforceVaultScope`, which is the wrong tradeoff for a defense-in-depth check.

## Versioning

- scope-guard `0.3.0-rc.1` — minor bump, ship on `rc` dist-tag, promote to `@latest` per RC governance after Aaron's verify pass.
- hub `0.5.10-rc.16` — standard rc cadence; workspace package + tests, no hub `src/` changes.

## Tests

- hub: `bun test ./src` → 1575/1575 pass.
- scope-guard: `bun test packages/scope-guard/src` → 99/99 pass. New coverage: 5 `vault_scope` claim-parsing cases (non-admin, admin, pre-PR-4 absent, malformed, multi-vault Phase-2-shape) on validate; 3 `enforceVaultScope` shape cases (admin/unrestricted, non-admin pinned vs excluded, multi-vault, exact-match) on the helper.

## Patterns check

Touches the shared scope-guard surface ([`docs/design/2026-04-29-scope-guard-library.md`](https://github.com/ParachuteComputer/parachute-hub/blob/main/docs/design/2026-04-29-scope-guard-library.md)). No new patterns; extends `HubJwtClaims` additively. Adopts the `vault_scope_mismatch` error code shape PR 4 uses on the mint side, so failure-code vocabulary is uniform across mint + consume.

## Sequencing

1. Land this PR + Aaron publishes `@openparachute/scope-guard@0.3.0-rc.1`.
2. Vault PR (forthcoming) bumps the dep, wires `enforceVaultScope` into `authenticateHubJwt`, adds the 403 path + tests, bumps to `0.4.6-rc.4`.
3. Scribe + notes: no follow-up needed.

## Test plan

- [ ] Aaron reviews + merges
- [ ] Aaron publishes `@openparachute/scope-guard@0.3.0-rc.1` to npm (per "npm publishes are Aaron's job")
- [ ] Vault PR opens (forthcoming), consuming the new surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)