### PR TITLE
fix(hub): CORS support on /oauth/* and /.well-known/* (DCR + discovery cross-origin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,26 @@ Smoke (against `bun src/hub-server.ts --port 11939 --issuer https://parachute.ta
 
 Follow-up (filed by orchestrator): admin-configurable CORS allowlist on `/api/*` + module content routes (`/vault/*`, etc.). The wildcard posture isn't appropriate for those — they need per-operator origin allowlisting. Out of scope for this PR.
 
+## [0.5.10-rc.16] - 2026-05-20
+
+Multi-user Phase 1 — PR 5 of 5: scope-guard `vault_scope` enforcement (hub#285, design [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)). PR 4 (rc.15) wired hub to mint `vault_scope: [<assigned_vault>]` on every JWT; PR 5 adds the consumer-side surface so resource servers (vault first; scribe + notes don't need it) can refuse cross-vault access as defense-in-depth.
+
+Workspace bump only — hub itself is unchanged; the substance lives in `packages/scope-guard/`:
+
+- `@openparachute/scope-guard` 0.2.1 → 0.3.0-rc.1 (minor bump because `HubJwtClaims` gains a required field). New surfaces:
+  - **`HubJwtClaims.vaultScope: string[]`** — parsed from the `vault_scope` claim. Non-empty for non-admin users (Phase 1: single-element list naming `assigned_vault`); empty `[]` for admin users, pre-PR-4 tokens, and any malformed value. All "no pin" shapes collapse to `[]` so consumers don't distinguish absent from empty.
+  - **`enforceVaultScope(claims, requestVaultName) → boolean`** — opt-in helper. Returns true if `vaultScope` is `[]` (admin/unpinned) OR contains the target vault name; false otherwise. Consumers translate `false` to a 403 with `error: "vault_scope_mismatch"`.
+
+Defense-in-depth, not the primary gate. PR 4's `narrowVaultScopes` already produces tokens whose `scope` claim names the exact assigned vault (`vault:<assigned>:<verb>`), and vault's existing scope-string check is the primary control. `vault_scope` is the second layer for the case where a token-mint bug or third-party RS not enforcing the vocabulary correctly produces a scope string naming the wrong vault — the check kicks in before any vault data is touched.
+
+Consumer adoption: **vault** wires `enforceVaultScope` into `authenticateHubJwt` in a follow-up after this release publishes; **scribe** + **notes** + **parachute-agent** are no-touch (scopes aren't vault-named today).
+
+Token-shape compatibility: pre-PR-4 tokens lack the `vault_scope` claim entirely. The validate path surfaces those as `vaultScope: []` — admin-equivalent for vault-pin purposes. Without this back-compat, every existing operator-token would start 403-ing the moment vault wires in `enforceVaultScope`.
+
+Gate: hub `bun test ./src` → **1575 pass / 0 fail** (unchanged). scope-guard `bun test packages/scope-guard/src` → **99 pass / 0 fail / 177 expects** (+5 `vault_scope` claim-parsing cases on validate, +3 `enforceVaultScope` shape cases on the helper, +1 on-wire-null fail-open case from the post-merge reviewer-nit fold). typecheck + biome clean.
+
+(Entry backfilled retroactively in rc.17 — the merge for hub#285 didn't include a hub-side CHANGELOG block since the substance was scope-guard's own package. Adding it here so the hub CHANGELOG sequence is unbroken.)
+
 ## [0.5.10-rc.15] - 2026-05-20
 
 Multi-user Phase 1 — PR 4 of 5: OAuth vault_scope claim + consent-picker lock (hub#252, design [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)). Builds on PR 3 (rc.14) which shipped the force-change-password flow. This release wires the *OAuth issuer* side: hub-minted tokens now carry a `vault_scope` claim derived from the user's `assigned_vault`, the consent picker is locked-and-displayed for non-admin users, and the server-side defense refuses mints whose picked vault disagrees with the user's assignment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.10-rc.17] - 2026-05-20
+
+CORS support on the public OAuth surface so third-party SPAs can talk to a self-hosted hub from a foreign origin. Caught when Aaron's Gitcoin Brain UI at `https://unforced-dev.github.io` tried to OAuth-register with his hub at `https://parachute.taildf9ce2.ts.net`: the browser's preflight on `POST /oauth/register` got back a 405 without CORS headers and blocked the actual request, breaking the entire third-party-SPA story. OAuth Dynamic Client Registration (RFC 7591) is *designed* for cross-origin use — arbitrary SPAs register → authorize → exchange tokens — so wildcard CORS on the OAuth endpoints is the correct posture, not a workaround.
+
+Backend surface:
+
+- **New `src/cors.ts`** — single-source-of-truth for the CORS posture. Exports `CORS_RESPONSE_HEADERS` (the headers folded onto actual responses), `CORS_PREFLIGHT_HEADERS` (superset for OPTIONS preflights), `isCorsAllowedRoute(pathname)` (predicate matching `/oauth/*`), `corsPreflightResponse()` (204 + preflight headers), and `applyCorsHeaders(response)` (folds the response headers onto an existing Response). File-level comment lays out the matrix, the `Allow-Origin: *` + `Allow-Credentials: false` rationale, and per-header justification (Authorization + Content-Type + X-Requested-With in `Allow-Headers`; `Max-Age: 86400` for a 24h preflight cache; WWW-Authenticate in `Expose-Headers` so cross-origin SPAs can read RFC 6750 error responses).
+- **`src/hub-server.ts`** — two changes:
+  - Pre-dispatch OPTIONS preflight handler at the top of `hubFetch` (after the 301 redirects, before `/health`): `if (req.method === "OPTIONS" && isCorsAllowedRoute(pathname)) return corsPreflightResponse()`. This intercepts before the per-route handlers, so an OPTIONS to `/oauth/register` doesn't hit the POST-only handler's 405 branch — preflight is a CORS-protocol artifact, not a "real" request to the endpoint.
+  - Each `/oauth/*` route block (`/oauth/authorize`, `/oauth/authorize/approve`, `/oauth/token`, `/oauth/register`, `/oauth/revoke`) wraps its returns in `applyCorsHeaders(...)` so error branches (405 method-not-allowed, 503 db-not-configured) carry CORS too. Without that, the SPA can't read the error body — the browser shows it as an opaque network failure.
+
+Scope discipline:
+
+- **In-scope**: `/oauth/*` only. The four `/.well-known/*` documents (oauth-authorization-server, parachute.json, jwks.json, parachute-revocation.json) are *also* cross-origin endpoints but already carry their own inline CORS handling (narrower `Allow-Methods: GET, OPTIONS` since they're read-only) and predate this module. `isCorsAllowedRoute` intentionally excludes them so there's one CORS posture per route family — see the comment in `src/cors.ts`.
+- **Out-of-scope (still same-origin-only, no CORS headers)**: `/api/*` (admin Bearer surface), `/admin/*` (SPA shell), `/login` / `/logout` / `/account/*` (interactive session pages), `/vault/*` and other module content proxies. Those *do* consult cookies / minted bearers tied to the operator's hub origin; opening them cross-origin would unwire CSRF defenses for no third-party benefit. Tests in `src/__tests__/cors.test.ts` pin both directions: every `/oauth/*` route gets CORS, every listed out-of-scope route does not.
+
+Why wildcard origin (`*`) and not an allowlist: these endpoints are public by design. The OAuth protocol (RFC 6749) plus DCR (RFC 7591) put the access-control gate inside the protocol — PKCE, redirect_uri matching, the operator-driven approval flow in #74/#199 — not at the network layer. Wildcard origin is the canonical posture for OAuth authorization servers (Okta, Auth0, Keycloak); narrowing at this layer breaks legitimate third-party SPAs without preventing any attack the protocol doesn't already cover. Wildcard is safe with `Allow-Credentials: false` because none of these endpoints consult cookies — bearer tokens travel in the Authorization header, which credentials:false + origin:* allows.
+
+Gate: `bun test ./src` — **1595 pass / 0 fail / 31295 expects across 84 files** (+20 over rc.16 baseline 1575). typecheck + biome clean (root).
+
+Smoke (against `bun src/hub-server.ts --port 11939 --issuer https://parachute.taildf9ce2.ts.net`):
+
+- `OPTIONS /oauth/register` with `Origin: https://unforced-dev.github.io` → `HTTP/1.1 204 No Content` + `Access-Control-Allow-Origin: *` + `Access-Control-Allow-Methods: GET, POST, OPTIONS` + `Access-Control-Allow-Headers: Authorization, Content-Type, X-Requested-With` + `Access-Control-Max-Age: 86400`. (Was: 405 with no CORS headers — the original bug.)
+- `POST /oauth/register` with `Origin: https://unforced-dev.github.io` and a valid DCR body → `HTTP/1.1 201 Created` + `Access-Control-Allow-Origin: *` + the new client row in the response body.
+- `OPTIONS /api/me` and `OPTIONS /login` from the same third-party origin → no `Access-Control-Allow-Origin` header in the response (scope discipline preserved).
+
+Follow-up (filed by orchestrator): admin-configurable CORS allowlist on `/api/*` + module content routes (`/vault/*`, etc.). The wildcard posture isn't appropriate for those — they need per-operator origin allowlisting. Out of scope for this PR.
+
 ## [0.5.10-rc.15] - 2026-05-20
 
 Multi-user Phase 1 — PR 4 of 5: OAuth vault_scope claim + consent-picker lock (hub#252, design [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)). Builds on PR 3 (rc.14) which shipped the force-change-password flow. This release wires the *OAuth issuer* side: hub-minted tokens now carry a `vault_scope` claim derived from the user's `assigned_vault`, the consent picker is locked-and-displayed for non-admin users, and the server-side defense refuses mints whose picked vault disagrees with the user's assignment.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.10-rc.16",
+  "version": "0.5.10-rc.17",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/cors.test.ts
+++ b/src/__tests__/cors.test.ts
@@ -206,6 +206,37 @@ describe("hubFetch CORS on /oauth/*", () => {
     }
   });
 
+  test("GET /oauth/authorize response carries Access-Control-Allow-Origin: * (the sync-handler branch)", async () => {
+    // The other oauth handlers are async (`Promise<Response>`); only
+    // `handleAuthorizeGet` is sync. Folding `applyCorsHeaders` over a sync
+    // return is exercised here so a future refactor that breaks the
+    // sync-vs-async distinction (e.g. dropping the wrapper, double-wrapping,
+    // accidentally awaiting a non-Promise into a hang) is caught.
+    //
+    // 400 branch — missing required PKCE params triggers the htmlError
+    // path inside parseAuthorizeFormParams. Cleanest no-DB-seeding fixture
+    // since the params fail validation before the client lookup runs.
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db, issuer: ISSUER })(
+          new Request(
+            `${ISSUER}/oauth/authorize?client_id=test&redirect_uri=https://example.com/cb&response_type=code&state=foo`,
+            { method: "GET", headers: { origin: "https://example.com" } },
+          ),
+        );
+        expect(res.status).toBe(400);
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+        expect(res.headers.get("access-control-allow-credentials")).toBe("false");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("OPTIONS preflight on /oauth/token returns 204 + CORS", async () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/cors.test.ts
+++ b/src/__tests__/cors.test.ts
@@ -1,0 +1,433 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CORS_PREFLIGHT_HEADERS,
+  CORS_RESPONSE_HEADERS,
+  applyCorsHeaders,
+  corsPreflightResponse,
+  isCorsAllowedRoute,
+} from "../cors.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { hubFetch } from "../hub-server.ts";
+import { writeManifest } from "../services-manifest.ts";
+
+const GITCOIN_BRAIN_ORIGIN = "https://unforced-dev.github.io";
+const ISSUER = "https://parachute.taildf9ce2.ts.net";
+
+function req(path: string, init?: RequestInit): Request {
+  return new Request(`http://127.0.0.1${path}`, init);
+}
+
+function preflight(path: string, origin = GITCOIN_BRAIN_ORIGIN): Request {
+  return new Request(`http://127.0.0.1${path}`, {
+    method: "OPTIONS",
+    headers: {
+      origin,
+      "access-control-request-method": "POST",
+      "access-control-request-headers": "content-type",
+    },
+  });
+}
+
+interface Harness {
+  dir: string;
+  manifestPath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-cors-"));
+  return {
+    dir,
+    manifestPath: join(dir, "services.json"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("cors helper module", () => {
+  test("CORS_RESPONSE_HEADERS use wildcard origin and credentials=false", () => {
+    expect(CORS_RESPONSE_HEADERS["access-control-allow-origin"]).toBe("*");
+    expect(CORS_RESPONSE_HEADERS["access-control-allow-credentials"]).toBe("false");
+    // Expose-Headers surfaces RFC 6750 WWW-Authenticate so cross-origin SPAs
+    // can read OAuth error responses.
+    expect(CORS_RESPONSE_HEADERS["access-control-expose-headers"]).toContain("WWW-Authenticate");
+  });
+
+  test("CORS_PREFLIGHT_HEADERS announces GET + POST + OPTIONS and standard request headers", () => {
+    const methods = CORS_PREFLIGHT_HEADERS["access-control-allow-methods"] ?? "";
+    expect(methods).toContain("GET");
+    expect(methods).toContain("POST");
+    expect(methods).toContain("OPTIONS");
+    const headers = CORS_PREFLIGHT_HEADERS["access-control-allow-headers"] ?? "";
+    expect(headers).toContain("Authorization");
+    expect(headers).toContain("Content-Type");
+    expect(CORS_PREFLIGHT_HEADERS["access-control-max-age"]).toBe("86400");
+  });
+
+  test("isCorsAllowedRoute matches /oauth/* and nothing else", () => {
+    expect(isCorsAllowedRoute("/oauth/register")).toBe(true);
+    expect(isCorsAllowedRoute("/oauth/token")).toBe(true);
+    expect(isCorsAllowedRoute("/oauth/authorize")).toBe(true);
+    expect(isCorsAllowedRoute("/oauth/authorize/approve")).toBe(true);
+    expect(isCorsAllowedRoute("/oauth/revoke")).toBe(true);
+    // Out-of-scope surfaces. /.well-known/* handlers carry their own inline
+    // CORS posture in hub-server.ts — see the comment in cors.ts on why
+    // they're intentionally excluded from this predicate.
+    expect(isCorsAllowedRoute("/.well-known/oauth-authorization-server")).toBe(false);
+    expect(isCorsAllowedRoute("/.well-known/parachute.json")).toBe(false);
+    expect(isCorsAllowedRoute("/.well-known/jwks.json")).toBe(false);
+    expect(isCorsAllowedRoute("/api/me")).toBe(false);
+    expect(isCorsAllowedRoute("/api/users")).toBe(false);
+    expect(isCorsAllowedRoute("/admin/vaults")).toBe(false);
+    expect(isCorsAllowedRoute("/admin/host-admin-token")).toBe(false);
+    expect(isCorsAllowedRoute("/login")).toBe(false);
+    expect(isCorsAllowedRoute("/logout")).toBe(false);
+    expect(isCorsAllowedRoute("/account/change-password")).toBe(false);
+    expect(isCorsAllowedRoute("/vault/default")).toBe(false);
+    expect(isCorsAllowedRoute("/")).toBe(false);
+    // Bare /oauth doesn't match — there's no route there and the prefix
+    // intentionally requires the trailing slash so it doesn't silently widen.
+    expect(isCorsAllowedRoute("/oauth")).toBe(false);
+  });
+
+  test("corsPreflightResponse is 204 with the preflight headers and empty body", async () => {
+    const res = corsPreflightResponse();
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+    expect(res.headers.get("access-control-allow-headers")).toContain("Authorization");
+    expect(res.headers.get("access-control-max-age")).toBe("86400");
+    // 204 = no body. body should be null per the spec; reading it returns
+    // the empty string.
+    expect(await res.text()).toBe("");
+  });
+
+  test("applyCorsHeaders folds wildcard origin onto an existing JSON response", async () => {
+    const original = Response.json({ ok: true }, { status: 201 });
+    const wrapped = applyCorsHeaders(original);
+    expect(wrapped.status).toBe(201);
+    expect(wrapped.headers.get("access-control-allow-origin")).toBe("*");
+    expect(wrapped.headers.get("access-control-allow-credentials")).toBe("false");
+    expect(wrapped.headers.get("content-type")).toBe("application/json;charset=utf-8");
+    expect((await wrapped.json()) as { ok: boolean }).toEqual({ ok: true });
+  });
+
+  test("applyCorsHeaders preserves a handler's existing CORS header (no overwrite)", () => {
+    // If a handler already set Access-Control-Allow-Origin (e.g. a different
+    // posture for a specific route), we don't clobber it. Defensive; no
+    // current caller does this, but the contract should be additive.
+    const original = new Response("hi", {
+      status: 200,
+      headers: { "access-control-allow-origin": "https://specific.example" },
+    });
+    const wrapped = applyCorsHeaders(original);
+    expect(wrapped.headers.get("access-control-allow-origin")).toBe("https://specific.example");
+    expect(wrapped.headers.get("access-control-allow-credentials")).toBe("false");
+  });
+});
+
+describe("hubFetch CORS on /oauth/*", () => {
+  // The original bug: Aaron's Gitcoin Brain SPA at GITCOIN_BRAIN_ORIGIN tried
+  // to fetch /oauth/register on his hub at ISSUER. Browser preflighted with
+  // OPTIONS; preflight returned 405 (method-not-allowed from the
+  // POST-only handler) with no CORS headers, so the browser blocked the
+  // subsequent POST. These tests pin both halves of the fix.
+
+  test("OPTIONS preflight on /oauth/register from a third-party origin returns 204 + CORS", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db, issuer: ISSUER })(
+          preflight("/oauth/register"),
+        );
+        expect(res.status).toBe(204);
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+        expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+        expect(res.headers.get("access-control-allow-headers")).toContain("Content-Type");
+        expect(res.headers.get("access-control-max-age")).toBe("86400");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("POST /oauth/register response carries Access-Control-Allow-Origin: * (the actual bug)", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [] }, h.manifestPath);
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, {
+          getDb: () => db,
+          issuer: ISSUER,
+          manifestPath: h.manifestPath,
+        })(
+          new Request(`${ISSUER}/oauth/register`, {
+            method: "POST",
+            headers: { "content-type": "application/json", origin: GITCOIN_BRAIN_ORIGIN },
+            body: JSON.stringify({
+              client_name: "gitcoin-brain",
+              redirect_uris: [`${GITCOIN_BRAIN_ORIGIN}/callback`],
+            }),
+          }),
+        );
+        // Status is whatever DCR produces (typically 201 created on the
+        // public-DCR path); the CORS header is the load-bearing assertion.
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+        expect(res.headers.get("access-control-allow-credentials")).toBe("false");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("OPTIONS preflight on /oauth/authorize returns 204 + CORS", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db, issuer: ISSUER })(
+          preflight("/oauth/authorize"),
+        );
+        expect(res.status).toBe(204);
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("OPTIONS preflight on /oauth/token returns 204 + CORS", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db, issuer: ISSUER })(
+          preflight("/oauth/token"),
+        );
+        expect(res.status).toBe(204);
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+        expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("OPTIONS preflight on /oauth/revoke returns 204 + CORS", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db, issuer: ISSUER })(
+          preflight("/oauth/revoke"),
+        );
+        expect(res.status).toBe(204);
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("OPTIONS preflight on /oauth/authorize/approve returns 204 + CORS", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db, issuer: ISSUER })(
+          preflight("/oauth/authorize/approve"),
+        );
+        expect(res.status).toBe(204);
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("POST /oauth/token method-not-allowed branch still carries CORS headers", async () => {
+    // Bad-method on an in-scope path still has to ship CORS so the SPA can
+    // *read* the error response. Without it, the browser drops the response
+    // body and the SPA sees an opaque network failure instead of a clear
+    // 405.
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db, issuer: ISSUER })(
+          new Request(`${ISSUER}/oauth/token`, { method: "GET" }),
+        );
+        expect(res.status).toBe(405);
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("503 dbNotConfigured response on an oauth route still carries CORS headers", async () => {
+    // No getDb → service_unavailable. Same as method-not-allowed: the SPA
+    // needs to be able to read the error.
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir, { issuer: ISSUER })(
+        new Request(`${ISSUER}/oauth/register`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "{}",
+        }),
+      );
+      expect(res.status).toBe(503);
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("hubFetch CORS scope discipline — out-of-scope routes stay same-origin", () => {
+  // Sanity: this PR is supposed to be tightly scoped to /oauth/*. Lock in
+  // that the admin / API / login / account surfaces still respond same-
+  // origin (no wildcard CORS header). Catches any future regression where
+  // someone broadens isCorsAllowedRoute to "all /api/*" or similar.
+
+  test("OPTIONS on /api/me does not return CORS preflight 204", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db, issuer: ISSUER })(
+          preflight("/api/me"),
+        );
+        // Whatever the API surface does with OPTIONS, it must not be the
+        // CORS preflight 204+wildcard shape.
+        const acao = res.headers.get("access-control-allow-origin");
+        expect(acao).not.toBe("*");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("OPTIONS on /admin/host-admin-token does not return CORS preflight 204", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db, issuer: ISSUER })(
+          preflight("/admin/host-admin-token"),
+        );
+        const acao = res.headers.get("access-control-allow-origin");
+        expect(acao).not.toBe("*");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("OPTIONS on /login does not return CORS preflight 204", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db, issuer: ISSUER })(preflight("/login"));
+        const acao = res.headers.get("access-control-allow-origin");
+        expect(acao).not.toBe("*");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("OPTIONS on /account/change-password does not return CORS preflight 204", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db, issuer: ISSUER })(
+          preflight("/account/change-password"),
+        );
+        const acao = res.headers.get("access-control-allow-origin");
+        expect(acao).not.toBe("*");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("OPTIONS on /vault/default content proxy is not a CORS preflight 204", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [] }, h.manifestPath);
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, {
+          getDb: () => db,
+          issuer: ISSUER,
+          manifestPath: h.manifestPath,
+        })(preflight("/vault/default"));
+        const acao = res.headers.get("access-control-allow-origin");
+        expect(acao).not.toBe("*");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("the exact bug Aaron hit — preflight from unforced-dev.github.io to /oauth/register", async () => {
+    // Reproduces the exact request shape from the browser console error in
+    // the PR brief. This is the canonical regression test for the bug.
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db, issuer: ISSUER })(
+          new Request(`${ISSUER}/oauth/register`, {
+            method: "OPTIONS",
+            headers: {
+              origin: "https://unforced-dev.github.io",
+              "access-control-request-method": "POST",
+              "access-control-request-headers": "content-type",
+            },
+          }),
+        );
+        expect(res.status).toBe(204);
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+        expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+        expect(res.headers.get("access-control-allow-headers")).toContain("Content-Type");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,0 +1,168 @@
+/**
+ * CORS posture for the public OAuth + discovery surface.
+ *
+ * Background. Third-party SPAs (Aaron's Gitcoin Brain UI on
+ * `https://unforced-dev.github.io`, future user-built clients, OIDC libraries
+ * pulling discovery + JWKS) need to talk to a self-hosted hub from a foreign
+ * origin. The OAuth Dynamic Client Registration spec (RFC 7591) is *designed*
+ * for cross-origin use: any SPA registers itself, runs the auth-code flow,
+ * exchanges the code at `/oauth/token`. Without CORS headers on those
+ * endpoints, browser preflights fail and the entire third-party-SPA story is
+ * broken before it starts.
+ *
+ * The matrix:
+ *
+ *   in-scope (wildcard `Access-Control-Allow-Origin: *`):
+ *     /oauth/*                                — DCR, authorize, token, revoke
+ *     /.well-known/oauth-authorization-server — RFC 8414 metadata
+ *     /.well-known/parachute.json             — Parachute service catalog
+ *     /.well-known/jwks.json                  — RFC 7517 JWKS (public keys)
+ *     /.well-known/parachute-revocation.json  — revocation list
+ *
+ *   out-of-scope (same-origin only, no CORS headers):
+ *     /api/*                                  — admin Bearer surface
+ *     /admin/*                                — admin SPA shell
+ *     /login, /logout, /account/*             — interactive session pages
+ *     /vault/*, /<service-mount>/*            — module-level content proxy
+ *
+ * Why `*` and not an allowlist:
+ *
+ * These endpoints are public by design. The OAuth-authz spec (RFC 6749) plus
+ * DCR (RFC 7591) put the access-control gate inside the protocol (PKCE +
+ * redirect_uri matching + the operator-driven approval flow in #74/#199), not
+ * at the network layer. Wildcard origin is the canonical posture for OAuth
+ * authorization servers — see [Okta], [Auth0], [Keycloak] — because narrowing
+ * the origin list at this layer breaks legitimate third-party SPAs without
+ * preventing any attack the protocol doesn't already cover.
+ *
+ * Wildcard is safe to pair with `Allow-Credentials: false` because none of
+ * these endpoints consult cookies — bearer tokens travel in the
+ * `Authorization` header, which the wildcard-origin response *does* allow the
+ * browser to send (the credentials-mode restriction is cookie-specific).
+ *
+ * Admin/API/content routes intentionally stay same-origin-only: those *do*
+ * consult cookies / minted bearers tied to the operator's hub origin, and
+ * opening them cross-origin would unwire CSRF defenses for no third-party
+ * benefit (third parties talk to those surfaces through OAuth-issued tokens,
+ * not direct admin API access).
+ *
+ * Header rationale:
+ *
+ *   Access-Control-Allow-Origin: *
+ *     Public-by-design surface; allowlists at this layer add friction without
+ *     security (see above).
+ *
+ *   Access-Control-Allow-Credentials: false
+ *     No cookies cross this boundary. Bearer tokens in Authorization travel
+ *     fine under credentials:false + origin:*.
+ *
+ *   Access-Control-Allow-Methods: GET, POST, OPTIONS
+ *     The union of methods the in-scope route family supports. Per-route
+ *     could be narrower (e.g. /oauth/token is POST-only), but advertising the
+ *     union is the simpler shape and browsers don't enforce a per-route
+ *     check anyway — the *actual* request method gates execution at the
+ *     handler.
+ *
+ *   Access-Control-Allow-Headers: Authorization, Content-Type, X-Requested-With
+ *     The headers SPAs realistically send: bearer auth, JSON bodies, and the
+ *     X-Requested-With marker some HTTP clients add automatically. Anything
+ *     else (custom headers) lands in the preflight rejection at the browser,
+ *     which is the right shape — surface unexpected headers to the developer.
+ *
+ *   Access-Control-Max-Age: 86400
+ *     24h preflight cache. The route surface is stable (RFCs nailed down
+ *     years ago); long max-age cuts preflight chatter to ~1/day per SPA.
+ *
+ *   Access-Control-Expose-Headers: WWW-Authenticate
+ *     OAuth error responses ride in `WWW-Authenticate` (RFC 6750 §3); a
+ *     cross-origin SPA needs to read it to surface "invalid_token" /
+ *     "insufficient_scope" failure modes. Other headers (Content-Type,
+ *     Content-Length, Date, …) are CORS-safelisted by default — no need to
+ *     enumerate them.
+ *
+ * [Okta]: https://developer.okta.com/docs/concepts/api-access-management/#cors
+ * [Auth0]: https://auth0.com/docs/get-started/applications/configure-cors
+ * [Keycloak]: https://www.keycloak.org/docs/latest/server_admin/#con-web-origins-keycloak_server_administration_guide
+ */
+
+/**
+ * Headers to fold onto *actual* (non-preflight) responses for in-scope routes.
+ *
+ * Use `applyCorsHeaders(response)` when you have an existing Response object;
+ * spread these into a new Headers init when you're building one from scratch.
+ */
+export const CORS_RESPONSE_HEADERS: Readonly<Record<string, string>> = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-credentials": "false",
+  "access-control-expose-headers": "WWW-Authenticate",
+};
+
+/**
+ * Headers for the OPTIONS preflight response. Superset of the response
+ * headers — the actual request will re-send the response subset.
+ */
+export const CORS_PREFLIGHT_HEADERS: Readonly<Record<string, string>> = {
+  ...CORS_RESPONSE_HEADERS,
+  "access-control-allow-methods": "GET, POST, OPTIONS",
+  "access-control-allow-headers": "Authorization, Content-Type, X-Requested-With",
+  "access-control-max-age": "86400",
+};
+
+/**
+ * Does this pathname participate in the public-CORS surface this module owns?
+ *
+ * Matches the OAuth surface (`/oauth/...`) only. The four `/.well-known/*`
+ * documents (oauth-authorization-server, parachute.json, jwks.json,
+ * parachute-revocation.json) are *also* part of the cross-origin contract,
+ * but they each carry their own CORS handling inline in `hub-server.ts` (a
+ * narrower `Allow-Methods: GET, OPTIONS` since they're read-only) and
+ * predate this module. Including them here would mean two CORS code paths
+ * disagreeing on the method list; leaving them in their existing block keeps
+ * one CORS posture per route family.
+ *
+ * Anything else — admin/API/content/login — stays same-origin-only and must
+ * NOT pass through this predicate.
+ *
+ * Prefix-match on `/oauth/` (with trailing slash) so the bare path `/oauth`
+ * doesn't match — there's no route at `/oauth` and the prefix would
+ * accidentally widen if anyone later mounts something there.
+ */
+export function isCorsAllowedRoute(pathname: string): boolean {
+  return pathname.startsWith("/oauth/");
+}
+
+/**
+ * 204 response for an OPTIONS preflight on an in-scope route.
+ *
+ * Browsers issue this before any non-simple cross-origin request (custom
+ * Content-Type, Authorization header, non-GET/POST/HEAD method). The response
+ * body is empty by spec; the browser only reads the headers.
+ */
+export function corsPreflightResponse(): Response {
+  return new Response(null, { status: 204, headers: { ...CORS_PREFLIGHT_HEADERS } });
+}
+
+/**
+ * Fold the CORS response headers onto an existing Response.
+ *
+ * Returns a *new* Response that shares the body but has the merged Headers.
+ * Existing headers on the input response take precedence — but the CORS
+ * headers don't typically collide with anything a handler would set, so in
+ * practice this just adds three headers.
+ *
+ * Why a new Response: Response.headers is immutable post-construction. We
+ * could mutate during the handler instead, but folding at the dispatcher
+ * level keeps the per-handler code free of CORS concerns and makes "which
+ * routes are CORS-friendly" a single-source-of-truth in `isCorsAllowedRoute`.
+ */
+export function applyCorsHeaders(response: Response): Response {
+  const merged = new Headers(response.headers);
+  for (const [k, v] of Object.entries(CORS_RESPONSE_HEADERS)) {
+    if (!merged.has(k)) merged.set(k, v);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: merged,
+  });
+}

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -1283,7 +1283,9 @@ export function hubFetch(
     if (pathname === "/oauth/authorize") {
       if (!getDb) return applyCorsHeaders(dbNotConfigured());
       if (req.method === "GET") {
-        return applyCorsHeaders(await handleAuthorizeGet(getDb(), req, oauthDeps(req)));
+        // handleAuthorizeGet is sync (returns Response, not Promise<Response>).
+        // handleAuthorizePost is async — keep the await on POST only.
+        return applyCorsHeaders(handleAuthorizeGet(getDb(), req, oauthDeps(req)));
       }
       if (req.method === "POST") {
         return applyCorsHeaders(await handleAuthorizePost(getDb(), req, oauthDeps(req)));

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -133,6 +133,7 @@ import {
   handleListVaults,
 } from "./api-users.ts";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "./config.ts";
+import { applyCorsHeaders, corsPreflightResponse, isCorsAllowedRoute } from "./cors.ts";
 import { ensureCsrfToken } from "./csrf.ts";
 import { readExposeState } from "./expose-state.ts";
 import { HUB_DEFAULT_PORT, HUB_SVC, clearHubPort, writeHubPort } from "./hub-control.ts";
@@ -979,6 +980,22 @@ export function hubFetch(
       });
     }
 
+    // CORS preflight for the public OAuth + discovery surface. Browsers
+    // issue OPTIONS before any non-simple cross-origin request — third-party
+    // SPAs hitting `/oauth/register` (RFC 7591 DCR), `/oauth/token`,
+    // `/.well-known/oauth-authorization-server`, etc. Handling this above
+    // the route table means an OPTIONS to e.g. `/oauth/register` doesn't
+    // hit the method-not-allowed branch in the handler — the preflight is a
+    // CORS-protocol artifact, not a "real" request to the endpoint. The
+    // single `isCorsAllowedRoute` predicate is the source of truth for
+    // which paths carry wildcard-CORS; see `src/cors.ts` for the rationale.
+    // Out-of-scope paths (`/api/*`, `/admin/*`, `/login`, `/account/*`,
+    // `/vault/*`, generic service proxy) fall through and OPTIONS reaches
+    // whatever default the downstream handler enforces (typically 405).
+    if (req.method === "OPTIONS" && isCorsAllowedRoute(pathname)) {
+      return corsPreflightResponse();
+    }
+
     // Platform health check (Render, Fly, Kubernetes, etc.). Plain JSON,
     // no DB required — the route reports liveness, not readiness. Anything
     // more invasive (DB ping, schema check) would let a transient lock turn
@@ -1258,11 +1275,20 @@ export function hubFetch(
       return new Response(res.body, { status: res.status, headers: merged });
     }
 
+    // OAuth surface — every handler return is wrapped in `applyCorsHeaders`
+    // so third-party SPAs can fetch these endpoints cross-origin (the entire
+    // point of OAuth DCR: arbitrary SPAs register → authorize → exchange
+    // tokens). Preflight OPTIONS already returned at the top of dispatch.
+    // See `src/cors.ts` for the wildcard-origin rationale.
     if (pathname === "/oauth/authorize") {
-      if (!getDb) return dbNotConfigured();
-      if (req.method === "GET") return handleAuthorizeGet(getDb(), req, oauthDeps(req));
-      if (req.method === "POST") return handleAuthorizePost(getDb(), req, oauthDeps(req));
-      return new Response("method not allowed", { status: 405 });
+      if (!getDb) return applyCorsHeaders(dbNotConfigured());
+      if (req.method === "GET") {
+        return applyCorsHeaders(await handleAuthorizeGet(getDb(), req, oauthDeps(req)));
+      }
+      if (req.method === "POST") {
+        return applyCorsHeaders(await handleAuthorizePost(getDb(), req, oauthDeps(req)));
+      }
+      return applyCorsHeaders(new Response("method not allowed", { status: 405 }));
     }
 
     // Inline approve form for the operator-driven pending-client flow (#208).
@@ -1270,27 +1296,35 @@ export function hubFetch(
     // by handleAuthorizeGet when the operator hits a pending client. Three
     // gates inside the handler: CSRF, active session, same-origin Origin.
     if (pathname === "/oauth/authorize/approve") {
-      if (!getDb) return dbNotConfigured();
-      if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
-      return handleApproveClientPost(getDb(), req, oauthDeps(req));
+      if (!getDb) return applyCorsHeaders(dbNotConfigured());
+      if (req.method !== "POST") {
+        return applyCorsHeaders(new Response("method not allowed", { status: 405 }));
+      }
+      return applyCorsHeaders(await handleApproveClientPost(getDb(), req, oauthDeps(req)));
     }
 
     if (pathname === "/oauth/token") {
-      if (!getDb) return dbNotConfigured();
-      if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
-      return handleToken(getDb(), req, oauthDeps(req));
+      if (!getDb) return applyCorsHeaders(dbNotConfigured());
+      if (req.method !== "POST") {
+        return applyCorsHeaders(new Response("method not allowed", { status: 405 }));
+      }
+      return applyCorsHeaders(await handleToken(getDb(), req, oauthDeps(req)));
     }
 
     if (pathname === "/oauth/register") {
-      if (!getDb) return dbNotConfigured();
-      if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
-      return handleRegister(getDb(), req, oauthDeps(req));
+      if (!getDb) return applyCorsHeaders(dbNotConfigured());
+      if (req.method !== "POST") {
+        return applyCorsHeaders(new Response("method not allowed", { status: 405 }));
+      }
+      return applyCorsHeaders(await handleRegister(getDb(), req, oauthDeps(req)));
     }
 
     if (pathname === "/oauth/revoke") {
-      if (!getDb) return dbNotConfigured();
-      if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
-      return handleRevoke(getDb(), req, oauthDeps(req));
+      if (!getDb) return applyCorsHeaders(dbNotConfigured());
+      if (req.method !== "POST") {
+        return applyCorsHeaders(new Response("method not allowed", { status: 405 }));
+      }
+      return applyCorsHeaders(await handleRevoke(getDb(), req, oauthDeps(req)));
     }
 
     if (pathname === "/vaults") {


### PR DESCRIPTION
## Summary

CORS support on the public OAuth surface so third-party SPAs can talk to a self-hosted hub from a foreign origin. Caught when Aaron's Gitcoin Brain UI at `https://unforced-dev.github.io` tried to OAuth-register with his hub at `https://parachute.taildf9ce2.ts.net`: the browser's preflight on `POST /oauth/register` hit the POST-only handler's 405 branch with no CORS headers and the browser blocked the request:

```
Access to fetch at 'https://parachute.taildf9ce2.ts.net/oauth/register'
from origin 'https://unforced-dev.github.io' has been blocked by CORS
policy: Response to preflight request doesn't pass access control check:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

OAuth Dynamic Client Registration (RFC 7591) is *designed* for cross-origin use — arbitrary SPAs register → authorize → exchange tokens. Without CORS on the OAuth endpoints, the entire third-party-SPA story was broken before it started.

## Implementation

**New `src/cors.ts`** — single-source-of-truth for the CORS posture. Exports:

- `CORS_RESPONSE_HEADERS` — folded onto actual responses
- `CORS_PREFLIGHT_HEADERS` — superset for OPTIONS preflight
- `isCorsAllowedRoute(pathname)` — matches `/oauth/*`
- `corsPreflightResponse()` — 204 + preflight headers
- `applyCorsHeaders(response)` — folds headers onto an existing Response

**`src/hub-server.ts`** — two changes:

1. Pre-dispatch OPTIONS preflight at the top of `hubFetch` (after 301 redirects, before `/health`). Intercepts cross-origin preflights to in-scope routes so they return 204 + headers instead of hitting the per-route handler's 405 branch.
2. Each `/oauth/*` route block (`/oauth/authorize`, `/oauth/authorize/approve`, `/oauth/token`, `/oauth/register`, `/oauth/revoke`) wraps its returns in `applyCorsHeaders(...)` so 405 / 503 error branches *also* carry CORS — without that, the SPA can't read the error body.

## Scope

### In-scope (carries wildcard `Access-Control-Allow-Origin: *`)

- `/oauth/authorize` — auth-code flow
- `/oauth/authorize/approve` — operator approval (#208)
- `/oauth/token` — token exchange
- `/oauth/register` — RFC 7591 DCR
- `/oauth/revoke` — RFC 7009 revocation

### Already CORS-friendly (unchanged by this PR)

- `/.well-known/oauth-authorization-server` — RFC 8414 metadata
- `/.well-known/parachute.json` — service catalog
- `/.well-known/jwks.json` — JWKS
- `/.well-known/parachute-revocation.json` — revocation list

Each of these already carries wildcard CORS via inline `corsHeaders` blocks in `hub-server.ts` that predate this module — narrower `Allow-Methods: GET, OPTIONS` since they're read-only. `isCorsAllowedRoute` intentionally excludes them so we don't end up with two CORS code paths disagreeing. See the comment in `src/cors.ts` for the full reasoning.

### Out-of-scope (still same-origin-only)

- `/api/*` (admin Bearer surface)
- `/admin/*` (SPA shell)
- `/login`, `/logout`, `/account/*` (interactive session pages)
- `/vault/*` and other module content proxies

Those *do* consult cookies / minted bearers tied to the operator's hub origin; opening them cross-origin would unwire CSRF defenses for no third-party benefit (third parties hit those surfaces through OAuth-issued tokens, not direct admin API access).

## Why wildcard origin (`*`) and not an allowlist

OAuth endpoints are public by design. The protocol (RFC 6749) plus DCR (RFC 7591) put the access-control gate *inside* the protocol — PKCE, redirect_uri matching, the operator-driven approval flow in #74/#199 — not at the network layer. Wildcard origin is the canonical posture for OAuth authorization servers (Okta, Auth0, Keycloak all do the same); narrowing at this layer breaks legitimate third-party SPAs without preventing any attack the protocol doesn't already cover. Safe with `Allow-Credentials: false` because none of these endpoints consult cookies — bearer tokens travel in the Authorization header, which credentials:false + origin:* allows.

## Test plan

- [x] `bun test ./src` — **1595 pass / 0 fail / 31295 expects across 84 files** (+20 over rc.16 baseline 1575).
- [x] `bun run typecheck` — clean.
- [x] `bunx biome check .` — clean.
- [x] New test file `src/__tests__/cors.test.ts` — 20 tests covering:
  - Unit: header values, predicate matches across in-scope and out-of-scope paths, preflight shape, `applyCorsHeaders` preservation behavior
  - Integration via `hubFetch`: OPTIONS preflight on each of five `/oauth/*` routes returns 204 + headers; POST `/oauth/register` from third-party origin carries `Access-Control-Allow-Origin: *`; 405 and 503 error branches also carry CORS
  - Scope discipline: OPTIONS on `/api/me`, `/admin/host-admin-token`, `/login`, `/account/change-password`, and `/vault/default` all confirmed to NOT carry wildcard CORS
  - Exact-bug regression: OPTIONS `/oauth/register` from `Origin: https://unforced-dev.github.io` → 204 + the full preflight header set

## Smoke (local hub at http://localhost:11939 with --issuer)

```
$ curl -i -X OPTIONS -H "Origin: https://unforced-dev.github.io" \
    -H "Access-Control-Request-Method: POST" \
    -H "Access-Control-Request-Headers: Content-Type" \
    http://localhost:11939/oauth/register
HTTP/1.1 204 No Content
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: false
Access-Control-Expose-Headers: WWW-Authenticate
Access-Control-Allow-Methods: GET, POST, OPTIONS
Access-Control-Allow-Headers: Authorization, Content-Type, X-Requested-With
Access-Control-Max-Age: 86400

$ curl -i -X POST -H "Origin: https://unforced-dev.github.io" \
    -H "Content-Type: application/json" \
    -d '{"client_name":"test","redirect_uris":["https://unforced-dev.github.io/callback"]}' \
    http://localhost:11939/oauth/register
HTTP/1.1 201 Created
Content-Type: application/json
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: false
Access-Control-Expose-Headers: WWW-Authenticate
{"client_id":"f889b54a-...","status":"pending",...}
```

Out-of-scope verification: OPTIONS `/api/me` and `/login` from the same third-party origin return 503 (no admin configured) with **no** `Access-Control-Allow-Origin` header — scope discipline preserved.

## Patterns check

No new patterns; extends the existing CORS posture on `/.well-known/*` to `/oauth/*` using the same wildcard shape. The OAuth surface CORS posture is documented in the file-level docstring of `src/cors.ts` with the Okta / Auth0 / Keycloak precedent + the `Allow-Credentials: false` + wildcard-origin compatibility note.

## Follow-up

Orchestrator to file: admin-configurable CORS allowlist on `/api/*` and module content routes (`/vault/*`, etc.). The wildcard posture isn't appropriate for those — they need per-operator origin allowlisting. Out of scope for this PR.

## Versioning

- `0.5.10-rc.16` → `0.5.10-rc.17` (RC cadence per governance rule 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)