### PR TITLE
fix(hub): approval UX — sign-in CTA + shareable link + named scope display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.10-rc.19] - 2026-05-20
+
+Three approval / consent UX fixes Aaron hit while testing the Gitcoin Brain UI OAuth flow against his self-hosted hub. Same session as the rc.17 / rc.18 CORS work — different layer, same posture (third-party SPA → self-hosted hub).
+
+**Issue 1 — Stale "ask the operator to run CLI" message on the unapproved-client page.** When a user lands on `/oauth/authorize` for a client that isn't yet approved AND they don't have an operator session, hub used to render:
+
+> Ask the operator to run `parachute auth approve-client <id>` from a terminal, then try again.
+
+This predated the web approval path that shipped in #277 (`/admin/approve-client/<id>` SPA route). The CLI mention is now retired in the browser path; the surface points operators at the web flow instead:
+
+  1. **Primary CTA**: "Sign in as admin to approve" → links to `/login?next=/admin/approve-client/<client_id>` so the admin lands directly on the approval page after sign-in.
+  2. **Secondary section**: "Or send this link to your hub admin" with the fully-qualified deep link `<hub_origin>/admin/approve-client/<client_id>` in a `<code>` block + a Copy-to-clipboard button (with "Copied!" feedback). The link works in any browser session — the admin opens it, hits the sign-in flow if not authed, lands on the approval page.
+
+  The authenticated-admin branch (#208's one-click approve form) is unchanged — that's the easy path when the operator is already signed in to this hub from this browser. The CLI is still available for terminal-first operators who already know `parachute auth approve-client`; we just stop pointing new users there from a browser they're already in.
+
+**Issue 2 — Consent / approval screens showed raw `vault:read` instead of the resolved `vault:<name>:read` form.** Hub narrows unnamed `vault:<verb>` scopes to `vault:<picked>:<verb>` at token-mint via the picker (or the user's `assigned_vault` for multi-user setups). But the consent screen rendered the raw OAuth request, which:
+
+  - Implied vault-wide unrestricted access (when hub *always* pins a specific vault).
+  - Surprised operators when the actual token carried a different shape than what they consented to.
+
+  Display logic now substitutes:
+
+  - **Non-admin user** (`assigned_vault` set) → `vault:<assigned>:read` on the consent row.
+  - **Admin user, single-vault hub** → `vault:<only-vault>:read` on the consent row (the picker pre-checks the only available vault, so the displayed scope matches what default-Approve will mint).
+  - **Admin user, multi-vault hub** → `vault:<TBD>:read` placeholder + an inline italic hint pointing at the picker below ("A specific vault is picked below before approving"). When the operator clicks a radio and reloads, the next render shows the chosen vault.
+  - **Operator approval page (SPA)** — pending-client admin landing: `vault:read` → `vault:*:read` with an explanation that "a specific vault is selected during sign-in via the consent picker (or the user's assigned vault for multi-user setups)." Different from the consent screen because no per-user binding has happened at this point in the flow.
+
+  `explainScope` now recognizes `vault:<name>:<verb>` and `vault:*:<verb>` via a pattern fallback so the styling + label come through. Per-vault admin (`vault:<name>:admin`) is intentionally excluded — that scope is `NON_REQUESTABLE`.
+
+**Issue 3 — Shareable admin approval link.** Covered by Issue 1's deep-link section: fully-qualified URL + Copy button (`navigator.clipboard.writeText` with a graceful fallback to range-select for older browsers / sandboxed iframes that lack the async clipboard API). Visual feedback flips the button label to "Copied!" for 1.6s.
+
+Code shape:
+
+- **`src/oauth-ui.ts`** — `ApprovePendingViewProps` gains `hubOrigin` (required, to build the fully-qualified deep link) and drops the conditional CLI hint from both branches. New `renderUnauthenticatedApproveCtas(hubOrigin, clientId)` helper renders the Sign-in CTA + shareable-link block + inline clipboard JS. `ConsentViewProps` gains optional `displayVault: string | null | undefined` (undefined → no substitution / back-compat; null → `<TBD>` placeholder; string → named substitution). New exported `substituteVaultDisplay(scope, displayVault)` does the mapping. New CSS for `.approve-actions`, `.approve-signin-cta`, `.approve-share`, `.approve-share-row`, `.approve-share-link`, `.approve-share-copy`, `.scope-pending-note`.
+- **`src/oauth-handlers.ts`** — `pendingClientResponse` threads `deps.issuer` through as `hubOrigin`. `consentProps` computes `displayVault` from `lockedVault` (non-admin → assigned vault) / `vaultNames` (admin + single-vault → that vault) / falls back to `null` (admin + multi-vault → `<TBD>` placeholder).
+- **`src/scope-explanations.ts`** — `explainScope` matches `^vault:[a-zA-Z0-9_*-]+:(read|write)$` and returns the unnamed-verb entry, so the consent UI keeps the same explanation + level styling for `vault:work:read`, `vault:*:read`, etc.
+- **`web/ui/src/routes/ApproveClient.tsx`** — `resolveScopeForDisplay(scope)` rewrites unnamed `vault:<verb>` → `vault:*:<verb>` for display; `isUnnamedVaultScope(scope)` gates whether to render the inline wildcard explanation.
+
+Gate: `bun test ./src` — **1621 pass / 0 fail / 31388 expects across 84 files** (+21 over rc.18 baseline 1600). Hub typecheck + biome clean. SPA: 135 vitest tests pass, `bun run build` ships a fresh `dist/`.
+
+Smoke (against `PARACHUTE_HOME=/tmp/hub-approval-ux` local hub):
+
+- `GET /oauth/authorize?client_id=<pending>...` in a private window (no session): page renders "Sign in as admin to approve" button (linking to `/login?next=/admin/approve-client/<id>`), a shareable code block with the fully-qualified `https://hub.../admin/approve-client/<id>` URL, and a "Copy link" button. No CLI message.
+- Clicking the Sign-in CTA hits `/login?next=...`; entering credentials lands on `/admin/approve-client/<id>` (the SPA route).
+- Consent screen for a non-admin user with `assigned_vault: "default"` requesting `vault:read` renders `<code class="scope-name">vault:default:read</code>` (not `vault:read`).
+- ApproveClient SPA for a fresh DCR with `scopes: ["vault:read", "vault:write"]` renders `vault:*:read` and `vault:*:write` with the wildcard-explanation hint.
+
+Cross-references:
+
+- #277 — web-based approval (`/admin/approve-client/<id>` SPA route) shipped earlier in the rc.18 chain. This PR points the unapproved-client surface at it.
+- #284 — related stale-`assigned_vault` followup (multi-user Phase 1 PR 4 fanout).
+
 ## [0.5.10-rc.18] - 2026-05-20
 
 Follow-up to rc.17's CORS work: switch the `/oauth/*` posture from static `Access-Control-Allow-Origin: *` + `Allow-Credentials: false` to echo-origin + `Allow-Credentials: true` + `Vary: Origin`. The rc.17 shape worked for SPAs fetching with `credentials: 'omit'`, but Aaron's Gitcoin Brain UI on `https://unforced-dev.github.io` (and most SPA frameworks by default) fetches with `credentials: 'include'`, which browsers refuse to combine with a wildcard ACAO. The browser console error was:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.10-rc.18",
+  "version": "0.5.10-rc.19",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -1022,6 +1022,58 @@ describe("handleAuthorizePost — consent submit", () => {
     }
   });
 
+  test("race-condition branch (client un-approved between GET and POST) — error points at web approval path, no CLI mention", async () => {
+    // Defensive branch in handleConsentSubmit: consent only renders for
+    // approved clients, but a row can flip back to pending between GET and
+    // POST (operator revoke / hand-crafted POST). Pre-rc.19 follow-up the
+    // error said "Run `parachute auth approve-client <id>` from a terminal";
+    // rc.19 retired every browser-visible CLI mention, so this branch now
+    // surfaces the same /admin/approve-client/<id> path the unauth GET-on-
+    // pending page advertises.
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "pending",
+      });
+      const { challenge } = makePkce();
+      const form = new URLSearchParams({
+        __action: "consent",
+        __csrf: TEST_CSRF,
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:default:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        state: "race",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+        },
+      });
+      const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(403);
+      const html = await res.text();
+      expect(html).toContain("App not yet approved");
+      // Web path advertised, with the client_id rendered inline.
+      expect(html).toContain(`/admin/approve-client/${reg.client.clientId}`);
+      expect(html).toContain("Sign in as admin");
+      // CLI mention retired from every browser-visible surface in rc.19.
+      expect(html).not.toContain("parachute auth approve-client");
+      expect(html).not.toContain("from a terminal");
+    } finally {
+      cleanup();
+    }
+  });
+
   test("rejects parachute:host:admin in form scope (defense-in-depth, #96)", async () => {
     // GET-time gate already rejects, but a hand-crafted POST could carry
     // an operator-only scope. Consent submit must independently reject.

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -2423,7 +2423,9 @@ describe("DCR approval gate (#74)", () => {
       expect(res.status).toBe(403);
       const html = await res.text();
       expect(html).toContain("App not yet approved");
-      expect(html).toContain("approve-client");
+      // /admin/approve-client/<id> deep link is the canonical recovery now
+      // (the pre-rc.19 CLI message was retired in favor of the web path).
+      expect(html).toContain(`/admin/approve-client/${encodeURIComponent(reg.client.clientId)}`);
       // No vault hint → no vault row in approve-meta. Single-vault hubs +
       // pre-vault-popover clients leave the section omitted (#244).
       expect(html).not.toContain('approve-meta-label">vault');
@@ -3916,10 +3918,13 @@ describe("inline approve button on pending /oauth/authorize (#208)", () => {
     });
   }
 
-  test("session absent → page renders WITHOUT approve form (CLI-only fallback)", async () => {
-    // Regression: pre-#208 behavior preserved when no session cookie is
-    // present. The CLI-fallback message must still be visible so an operator
-    // who arrived from a fresh browser knows what to do.
+  test("session absent → page renders Sign-in CTA + shareable deep link (no CLI message)", async () => {
+    // Approval-UX rc.19: the unauthenticated viewer no longer sees a
+    // "Ask the operator to run `parachute auth approve-client <id>`"
+    // message. The web approval path (#277) is the canonical recovery
+    // now — render a primary Sign-in CTA wired to /login?next=/admin/...
+    // and a shareable deep link the operator can send to whoever runs
+    // the hub.
     const { db, cleanup } = await makeDb();
     try {
       const reg = registerClient(db, {
@@ -3932,9 +3937,23 @@ describe("inline approve button on pending /oauth/authorize (#208)", () => {
       expect(res.status).toBe(403);
       const html = await res.text();
       expect(html).toContain("App not yet approved");
-      // CLI-fallback message present — the only way to recover without a session.
-      expect(html).toContain("approve-client");
-      // No form element pointing at the approve endpoint.
+      // Primary CTA: Sign-in link wired to land the admin directly on
+      // the approval page after authenticating.
+      expect(html).toContain("Sign in as admin to approve");
+      const expectedLoginHref = `/login?next=${encodeURIComponent(
+        `/admin/approve-client/${encodeURIComponent(reg.client.clientId)}`,
+      )}`;
+      expect(html).toContain(`href="${expectedLoginHref}"`);
+      // Secondary CTA: shareable, fully-qualified deep link + Copy button.
+      expect(html).toContain(
+        `${ISSUER}/admin/approve-client/${encodeURIComponent(reg.client.clientId)}`,
+      );
+      expect(html).toContain('id="approve-share-copy"');
+      expect(html).toContain("navigator.clipboard");
+      // Retired CLI hint must not appear anywhere in the body.
+      expect(html).not.toContain("parachute auth approve-client");
+      expect(html).not.toContain("from a terminal");
+      // No form element pointing at the approve endpoint (un-authed branch).
       expect(html).not.toContain('action="/oauth/authorize/approve"');
     } finally {
       cleanup();
@@ -3976,8 +3995,12 @@ describe("inline approve button on pending /oauth/authorize (#208)", () => {
       expect(html).toContain("MyApp");
       expect(html).toContain(reg.client.clientId);
       expect(html).toContain("https://app.example/cb");
-      // CLI fallback still visible.
-      expect(html).toContain("approve-client");
+      // Authed branch shows only the one-click Approve form — the unauth
+      // Sign-in CTA and shareable-link block do NOT render here.
+      expect(html).not.toContain("Sign in as admin to approve");
+      expect(html).not.toContain("Or send this link to your hub admin");
+      // CLI hint also gone in this branch (approval-UX rc.19).
+      expect(html).not.toContain("parachute auth approve-client");
     } finally {
       cleanup();
     }
@@ -4633,6 +4656,88 @@ describe("handleAuthorizeGet — multi-user assigned vault picker lock (PR 4)", 
       expect(html).toContain('<input type="hidden" name="vault_pick" value="default"');
       // No free-choice radio inputs.
       expect(html).not.toContain('type="radio" name="vault_pick"');
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// Approval-UX rc.19 (Issue 2 in Aaron's bundle): the consent screen now
+// renders the *resolved* scope shape — `vault:<name>:<verb>` — instead of
+// the raw OAuth request `vault:<verb>`. The raw form was confusing because
+// it implied vault-wide unrestricted access, when hub actually narrows to
+// a specific vault at token-mint via the picker (or the user's
+// assigned_vault for multi-user setups).
+describe("handleAuthorizeGet — resolved scope display (approval-UX rc.19)", () => {
+  test("non-admin user (assigned_vault set) sees vault:<assigned>:read on consent, not raw vault:read", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:read",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      // Resolved form rendered in the scope-row code block.
+      expect(html).toContain('<code class="scope-name">vault:default:read</code>');
+      // Raw unnamed form must NOT appear inside a scope row (it still
+      // appears in the hidden form-roundtrip inputs as `name="scope" value="vault:read"`).
+      expect(html).not.toContain('<code class="scope-name">vault:read</code>');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("admin user with picker — single-vault hub pre-checks and consent shows that vault", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const admin = await createUser(db, "admin-aaron", "pw");
+      const session = createSession(db, { userId: admin.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:read",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      // The fixture services manifest has a single vault named "default" — the
+      // picker pre-checks it and the consent screen renders the resolved form.
+      expect(html).toContain('<code class="scope-name">vault:default:read</code>');
     } finally {
       cleanup();
     }

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, test } from "bun:test";
 import {
   type AuthorizeFormParams,
   escapeHtml,
+  renderApprovePending,
   renderConsent,
   renderError,
   renderHiddenInputs,
   renderLogin,
   renderUnknownClient,
+  substituteVaultDisplay,
 } from "../oauth-ui.ts";
 
 const PARAMS: AuthorizeFormParams = {
@@ -272,6 +274,171 @@ describe("renderUnknownClient", () => {
     expect(html).not.toContain("'lens:dcr:'");
     // Static fallback help text still surfaces.
     expect(html).toContain("close this window");
+  });
+});
+
+describe("substituteVaultDisplay", () => {
+  test("undefined → leaves the scope untouched", () => {
+    expect(substituteVaultDisplay("vault:read", undefined)).toBe("vault:read");
+  });
+
+  test("named vault → substitutes vault:<name>:<verb>", () => {
+    expect(substituteVaultDisplay("vault:read", "work")).toBe("vault:work:read");
+    expect(substituteVaultDisplay("vault:write", "default")).toBe("vault:default:write");
+  });
+
+  test("null → renders a <TBD> placeholder for the consent picker", () => {
+    expect(substituteVaultDisplay("vault:read", null)).toBe("vault:<TBD>:read");
+  });
+
+  test("non-vault scope passes through regardless of displayVault", () => {
+    expect(substituteVaultDisplay("scribe:transcribe", "work")).toBe("scribe:transcribe");
+    expect(substituteVaultDisplay("channel:send", null)).toBe("channel:send");
+  });
+
+  test("already-named vault scope passes through (caller specified the vault)", () => {
+    expect(substituteVaultDisplay("vault:other:read", "work")).toBe("vault:other:read");
+  });
+
+  test("vault admin (vault:admin) doesn't get narrowed — admin verb stays unnamed", () => {
+    // vault:admin is a full-vault scope; we don't narrow it the same way
+    // because per-vault admin is `vault:<name>:admin` (non-requestable) and
+    // the unnamed vault:admin form is the legacy full-vault grant. Keep the
+    // displayed shape as-is so the operator sees the scope they're
+    // consenting to literally.
+    expect(substituteVaultDisplay("vault:admin", "work")).toBe("vault:admin");
+  });
+});
+
+describe("renderConsent displayVault substitution", () => {
+  test("non-admin user (lockedVault) → consent shows vault:<assigned>:<verb>", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read", "vault:write"],
+      vaultPicker: {
+        unnamedVerbs: ["read", "write"],
+        availableVaults: ["my-vault"],
+        lockedVault: "my-vault",
+      },
+      displayVault: "my-vault",
+    });
+    expect(html).toContain("vault:my-vault:read");
+    expect(html).toContain("vault:my-vault:write");
+    // Raw unnamed form (the thing this PR fixes) must NOT appear in the
+    // rendered scope-row code blocks. Scope name shows up inside
+    // `<code class="scope-name">…</code>` so check the row substring.
+    expect(html).not.toMatch(/<code class="scope-name">vault:read<\/code>/);
+    expect(html).not.toMatch(/<code class="scope-name">vault:write<\/code>/);
+  });
+
+  test("admin user, single-vault hub → picker pre-checks the only vault, consent shows it", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read"],
+      vaultPicker: { unnamedVerbs: ["read"], availableVaults: ["default"] },
+      displayVault: "default",
+    });
+    expect(html).toContain("vault:default:read");
+    expect(html).not.toMatch(/<code class="scope-name">vault:read<\/code>/);
+  });
+
+  test("admin user, multi-vault hub → displayVault=null renders <TBD> + picker hint", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read"],
+      vaultPicker: { unnamedVerbs: ["read"], availableVaults: ["work", "personal"] },
+      displayVault: null,
+    });
+    expect(html).toContain("vault:&lt;TBD&gt;:read");
+    expect(html).toContain("scope-pending-note");
+    expect(html).toContain("A specific vault is picked below");
+    // explainScope label still resolves via the verb-form lookup.
+    expect(html).toContain("Read your notes");
+  });
+
+  test("displayVault undefined preserves the legacy raw form (no substitution)", () => {
+    // The existing oauth-ui.test.ts cases call renderConsent without
+    // displayVault — confirming the back-compat shape stays.
+    const html = renderConsent({
+      params: PARAMS,
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read"],
+    });
+    expect(html).toContain("vault:read");
+  });
+});
+
+describe("renderApprovePending unauthenticated CTAs", () => {
+  const COMMON = {
+    clientName: "MyApp",
+    clientId: "client-xyz",
+    redirectUris: ["https://app.example/cb"],
+    requestedScopes: ["vault:read"],
+    hubOrigin: "https://hub.example.com",
+  };
+
+  test("renders Sign in CTA wired to /login?next=/admin/approve-client/<id>", () => {
+    const html = renderApprovePending(COMMON);
+    expect(html).toContain("Sign in as admin to approve");
+    const expectedHref = `/login?next=${encodeURIComponent("/admin/approve-client/client-xyz")}`;
+    expect(html).toContain(`href="${expectedHref}"`);
+  });
+
+  test("renders fully-qualified shareable deep link + Copy button + clipboard JS", () => {
+    const html = renderApprovePending(COMMON);
+    expect(html).toContain("https://hub.example.com/admin/approve-client/client-xyz");
+    expect(html).toContain('id="approve-share-copy"');
+    expect(html).toContain('data-link="https://hub.example.com/admin/approve-client/client-xyz"');
+    // Inline JS uses navigator.clipboard.writeText with visual feedback.
+    expect(html).toContain("navigator.clipboard");
+    expect(html).toContain("writeText");
+    expect(html).toContain("Copied!");
+  });
+
+  test("trims a trailing slash on hubOrigin so the deep link doesn't double-slash", () => {
+    const html = renderApprovePending({ ...COMMON, hubOrigin: "https://hub.example.com/" });
+    expect(html).toContain("https://hub.example.com/admin/approve-client/client-xyz");
+    expect(html).not.toContain("https://hub.example.com//admin/");
+  });
+
+  test("retired CLI hint does NOT appear in the unauthenticated branch", () => {
+    const html = renderApprovePending(COMMON);
+    expect(html).not.toContain("parachute auth approve-client");
+    expect(html).not.toContain("from a terminal");
+  });
+
+  test("escapes hostile client_id into href, data-link, and the visible deep link", () => {
+    const html = renderApprovePending({
+      ...COMMON,
+      clientId: "<img src=x onerror=alert(1)>",
+    });
+    expect(html).not.toContain("<img src=x");
+    // encodeURIComponent in both the href and the deep-link URL produces
+    // %3Cimg…; that lives inside escapeHtml-wrapped attribute values.
+    expect(html).toContain("%3Cimg");
+  });
+
+  test("admin-authenticated branch hides the unauth CTAs and renders the inline approve form", () => {
+    const html = renderApprovePending({
+      ...COMMON,
+      approveForm: { csrfToken: CSRF, returnTo: "/oauth/authorize?client_id=client-xyz" },
+    });
+    expect(html).toContain('action="/oauth/authorize/approve"');
+    expect(html).toContain("Approve and continue");
+    expect(html).not.toContain("Sign in as admin to approve");
+    expect(html).not.toContain("Or send this link to your hub admin");
+    expect(html).not.toContain("parachute auth approve-client");
   });
 });
 

--- a/src/__tests__/scope-explanations.test.ts
+++ b/src/__tests__/scope-explanations.test.ts
@@ -41,6 +41,29 @@ describe("explainScope", () => {
   test("returns null for an unknown scope", () => {
     expect(explainScope("notes:weird-thing")).toBeNull();
   });
+
+  // Approval-UX rc.19: the consent screen renders the *resolved* scope
+  // shape (`vault:<name>:read`) rather than the raw OAuth request
+  // (`vault:read`) so the operator sees the form the token will carry.
+  // explainScope falls back to the unnamed verb's entry for both the
+  // narrowed (`vault:work:read`) and wildcard-display (`vault:*:read`)
+  // forms so the consent UI keeps the same label + level styling.
+  test("named vault scopes (vault:<name>:<verb>) reuse the unnamed-verb explanation", () => {
+    expect(explainScope("vault:work:read")?.label).toBe(SCOPE_EXPLANATIONS["vault:read"]?.label);
+    expect(explainScope("vault:work:read")?.level).toBe("read");
+    expect(explainScope("vault:my-techne_2:write")?.level).toBe("write");
+  });
+
+  test("wildcard vault display form (vault:*:<verb>) explains via the unnamed verb", () => {
+    expect(explainScope("vault:*:read")?.level).toBe("read");
+    expect(explainScope("vault:*:write")?.level).toBe("write");
+  });
+
+  test("doesn't promote a per-vault admin (vault:<name>:admin) into an explained scope", () => {
+    // vault:<name>:admin is NON_REQUESTABLE — never appears on the consent
+    // screen. Explicitly not in the verb-pattern, so explainScope returns null.
+    expect(explainScope("vault:default:admin")).toBeNull();
+  });
 });
 
 describe("scopeIsAdmin", () => {

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -462,6 +462,7 @@ function pendingClientResponse(
         redirectUris: client.redirectUris,
         requestedScopes,
         ...(requestedVault !== undefined && { requestedVault }),
+        hubOrigin: deps.issuer,
         approveForm: { csrfToken: csrf.token, returnTo },
       }),
       403,
@@ -475,6 +476,7 @@ function pendingClientResponse(
       redirectUris: client.redirectUris,
       requestedScopes,
       ...(requestedVault !== undefined && { requestedVault }),
+      hubOrigin: deps.issuer,
     }),
     403,
     extra,
@@ -1786,6 +1788,23 @@ function consentProps(
         ? { unnamedVerbs, availableVaults: vaultNames, lockedVault }
         : { unnamedVerbs, availableVaults: vaultNames };
   }
+  // Named-scope display: substitute unnamed `vault:<verb>` rows with the
+  // resolved form the operator will actually consent to.
+  //   - Non-admin (lockedVault set) → render `vault:<lockedVault>:<verb>`.
+  //   - Admin with exactly one vault available → render that vault's name;
+  //     the picker pre-checks it and a default-Approve mints scope against
+  //     it, so the displayed scope matches the next state of the form.
+  //   - Admin with multiple vaults / no vaults → null sentinel; render with
+  //     a `<TBD>` placeholder + a hint pointing at the picker. Once the
+  //     operator clicks a radio the JS-free form still posts the chosen
+  //     name; the displayed scope only changes after the next page render.
+  let displayVault: string | null = null;
+  if (lockedVault !== null) {
+    displayVault = lockedVault;
+  } else if (unnamedVerbs.length > 0 && vaultNames.length === 1) {
+    const only = vaultNames[0];
+    if (only) displayVault = only;
+  }
   return {
     params,
     clientId: client.clientId,
@@ -1793,6 +1812,7 @@ function consentProps(
     scopes,
     csrfToken,
     vaultPicker,
+    displayVault,
   };
 }
 

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -885,10 +885,13 @@ async function handleConsentSubmit(
     // status here means the row was unapproved between render and submit (or
     // the form was hand-crafted). The approve UI requires a known authorize
     // URL to round-trip via `return_to`, which we don't reconstruct here —
-    // surface the static error and let the operator restart from the SPA.
+    // surface the static error pointing at the web approval path (the
+    // canonical recovery post-#277; rc.19 retired the CLI mention from
+    // every browser-visible surface so the path advertised here matches
+    // what the unauth GET-on-pending page now shows).
     return htmlError(
       "App not yet approved",
-      `This client_id is registered but has not been approved. Run \`parachute auth approve-client ${client.clientId}\` from a terminal, then try again.`,
+      `This client_id is registered but has not been approved. Sign in as admin and approve at /admin/approve-client/${client.clientId}, or send the link to your hub operator.`,
       403,
     );
   }

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -1143,23 +1143,6 @@ const STYLES = `
     color: ${PALETTE.fgDim};
     font-style: italic;
   }
-  .approve-cli-hint {
-    margin-top: 1rem;
-    padding-top: 0.85rem;
-    border-top: 1px solid ${PALETTE.borderLight};
-    color: ${PALETTE.fgMuted};
-    font-size: 0.85rem;
-  }
-  .approve-cli-hint code {
-    font-family: ${FONT_MONO};
-    font-size: 0.8rem;
-    background: ${PALETTE.bgSoft};
-    padding: 0.1rem 0.4rem;
-    border-radius: 4px;
-    color: ${PALETTE.fg};
-    word-break: break-all;
-  }
-
   .badge {
     display: inline-block;
     font-size: 0.7rem;

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -82,6 +82,28 @@ export interface ConsentViewProps {
    * vault-config-and-scopes design — force the picker, don't default).
    */
   vaultPicker?: VaultPicker;
+  /**
+   * Named-vault display: substitute unnamed `vault:<verb>` rows with
+   * `vault:<displayVault>:<verb>` in the rendered scope list so the user
+   * sees the scope shape that will actually be minted into the token. The
+   * raw `scopes` value still drives the form-roundtrip; this only changes
+   * what the operator reads.
+   *
+   * - Non-admin user (assigned_vault set): pass the assigned vault name so
+   *   the row reads `vault:my-vault:read`.
+   * - Admin user with a single vault available + the picker pre-checks the
+   *   first option: pass that name so the displayed scope matches what the
+   *   default-Approve will mint.
+   * - Admin user with multiple vaults / no obvious default: pass `null` (or
+   *   omit) and the row renders as `vault:<TBD>:read` with a tooltip
+   *   pointing at the picker. Same explanation either way.
+   *
+   * Closes the "raw scope display" leg of the approval-UX bug — silent
+   * narrowing at mint surprised operators who thought they were granting
+   * vault-wide access. Now they see the named form on the consent screen
+   * itself.
+   */
+  displayVault?: string | null;
 }
 
 export interface VaultPicker {
@@ -113,10 +135,22 @@ export interface ErrorViewProps {
 
 /**
  * Props for the "App not yet approved" view rendered when an unapproved
- * client lands on `/oauth/authorize`. When `session` is true the operator is
- * authenticated to this hub from the browser making the request, so we render
- * an inline approve form (closes #208). When false we fall back to the
- * pre-#208 CLI-only message.
+ * client lands on `/oauth/authorize`. Two-branch UI:
+ *
+ *   - Authenticated admin (operator session present + same-origin) — render
+ *     the inline approve form (closes #208). One click flips the client to
+ *     `approved` and re-enters the OAuth flow at consent.
+ *   - Unauthenticated viewer — render TWO CTAs (no terminal mention):
+ *       1. Primary: "Sign in as admin to approve" → links to
+ *          `/login?next=/admin/approve-client/<client_id>` so the admin
+ *          lands directly on the approval page after sign-in.
+ *       2. Secondary: a fully-qualified shareable deep link to
+ *          `<hub_origin>/admin/approve-client/<client_id>` with a copy
+ *          button — the operator can send it to whoever runs the hub.
+ *
+ *   The CLI fallback (`parachute auth approve-client <id>`) was retired —
+ *   the web path is the path now. Operators who want the CLI still have it
+ *   in the shell; we no longer point new users there from the browser.
  */
 export interface ApprovePendingViewProps {
   /** Display name to show — falls back to client_id when no name was supplied at DCR. */
@@ -133,6 +167,13 @@ export interface ApprovePendingViewProps {
    * #244). Single-vault hubs leave this absent and the section omits.
    */
   requestedVault?: string;
+  /**
+   * Fully-qualified hub origin used to build the shareable approval
+   * deep-link in the unauthenticated branch. Required because the link
+   * the operator copies needs to work when opened in a different browser
+   * session — only the absolute URL gets that.
+   */
+  hubOrigin: string;
   /**
    * When set, render the inline approve form. The form posts to
    * `/oauth/authorize/approve` with the CSRF token + a `return_to` URL the
@@ -179,11 +220,16 @@ export function renderLogin(props: LoginViewProps): string {
 }
 
 export function renderConsent(props: ConsentViewProps): string {
-  const { params, clientName, clientId, scopes, vaultPicker, csrfToken } = props;
+  const { params, clientName, clientId, scopes, vaultPicker, csrfToken, displayVault } = props;
+  // Substitute unnamed `vault:<verb>` rows with the resolved named form so
+  // the operator sees the scope shape that will appear in the token. Raw
+  // `scopes` keeps the wire form for the hidden form fields; only what's
+  // rendered changes. See `ConsentViewProps.displayVault`.
+  const displayedScopes = scopes.map((s) => substituteVaultDisplay(s, displayVault));
   const scopeRows =
-    scopes.length === 0
+    displayedScopes.length === 0
       ? `<li class="scope scope-empty">No scopes requested — the app gets a session token only.</li>`
-      : scopes.map(renderScopeRow).join("\n");
+      : displayedScopes.map(renderScopeRow).join("\n");
   const pickerSection = vaultPicker ? renderVaultPicker(vaultPicker) : "";
   // Approve is disabled when the picker can't yield a valid vault. The
   // empty-vault branch (no vaults registered) is the original case. A
@@ -286,21 +332,32 @@ function renderVaultPicker(picker: VaultPicker): string {
 }
 
 /**
- * "App not yet approved" page (#74). When the request carries a valid
- * operator session (#208), render the inline approve form so one click lands
- * the client as `approved` and re-enters the OAuth flow at consent. Without
- * a session, fall back to the original CLI-only message — anyone hitting
- * /oauth/authorize unauthenticated to the hub itself can't be trusted to
- * approve a DCR client from the browser, so they need to drop to a terminal
- * and run `parachute auth approve-client <id>`.
+ * "App not yet approved" page (#74). Two branches:
  *
- * The CLI fallback hint is shown in BOTH branches: a button-equipped operator
- * may still want the CLI invocation handy (different machine, scriptable
- * context). The button is the easy path; the CLI is always-available.
+ *   - **Authenticated operator with same-origin posture** (#208): render the
+ *     inline approve form so one click flips the client to `approved` and
+ *     re-enters the OAuth flow at consent.
+ *   - **Unauthenticated viewer** (Issue 1 in the approval-UX PR): render a
+ *     primary "Sign in as admin to approve" CTA wired to
+ *     `/login?next=/admin/approve-client/<id>` so the admin lands directly
+ *     on the approval page after sign-in, plus a secondary shareable
+ *     deep-link section (fully-qualified `<hub_origin>/admin/approve-client/<id>`
+ *     in a code block + Copy-to-clipboard button). The pre-rc.19 CLI hint
+ *     ("ask the operator to run `parachute auth approve-client <id>`") was
+ *     retired — the web path is the path now. CLI is still available for
+ *     terminal-first operators who already know it; we just stop pointing
+ *     new users there from a browser they're already in.
  */
 export function renderApprovePending(props: ApprovePendingViewProps): string {
-  const { clientName, clientId, redirectUris, requestedScopes, requestedVault, approveForm } =
-    props;
+  const {
+    clientName,
+    clientId,
+    redirectUris,
+    requestedScopes,
+    requestedVault,
+    hubOrigin,
+    approveForm,
+  } = props;
   const redirectList = redirectUris.map((u) => `<li><code>${escapeHtml(u)}</code></li>`).join("");
   const scopeRows =
     requestedScopes.length === 0
@@ -325,15 +382,8 @@ export function renderApprovePending(props: ApprovePendingViewProps): string {
         <input type="hidden" name="client_id" value="${escapeHtml(clientId)}" />
         <input type="hidden" name="return_to" value="${escapeHtml(approveForm.returnTo)}" />
         <button type="submit" class="btn btn-primary">Approve and continue</button>
-      </form>
-      <p class="approve-cli-hint">
-        Or run <code>parachute auth approve-client ${escapeHtml(clientId)}</code> from a terminal.
-      </p>`
-    : `
-      <p class="approve-cli-hint">
-        Ask the operator to run <code>parachute auth approve-client ${escapeHtml(clientId)}</code>
-        from a terminal, then try again.
-      </p>`;
+      </form>`
+    : renderUnauthenticatedApproveCtas(hubOrigin, clientId);
   const body = `
     <div class="card">
       <div class="card-header">
@@ -369,6 +419,111 @@ export function renderApprovePending(props: ApprovePendingViewProps): string {
       ${formSection}
     </div>`;
   return baseDocument("App not yet approved", body);
+}
+
+/**
+ * Unauthenticated branch of `renderApprovePending`. Two CTAs:
+ *
+ *   1. Primary: "Sign in as admin to approve" → links to
+ *      `/login?next=/admin/approve-client/<client_id>` so the admin lands
+ *      on the approval page after sign-in.
+ *   2. Secondary: a fully-qualified shareable deep-link to
+ *      `<hub_origin>/admin/approve-client/<client_id>` with a Copy button
+ *      so the operator can send it to whoever runs the hub.
+ *
+ * Inline JS is scoped to the Copy button only — `navigator.clipboard.writeText`
+ * with a brief "Copied!" affordance. The button degrades gracefully when
+ * scripting is unavailable (the URL is still selectable + copyable from the
+ * `<code>` block via the OS clipboard).
+ */
+function renderUnauthenticatedApproveCtas(hubOrigin: string, clientId: string): string {
+  const approvalPath = `/admin/approve-client/${encodeURIComponent(clientId)}`;
+  const loginHref = `/login?next=${encodeURIComponent(approvalPath)}`;
+  const trimmedOrigin = hubOrigin.replace(/\/+$/, "");
+  const deepLink = `${trimmedOrigin}${approvalPath}`;
+  return `
+      <div class="approve-actions">
+        <a href="${escapeHtml(loginHref)}" class="btn btn-primary approve-signin-cta">
+          Sign in as admin to approve
+        </a>
+      </div>
+      <section class="approve-share">
+        <h2 class="scopes-title">Or send this link to your hub admin</h2>
+        <p class="approve-share-help">
+          Anyone with admin access on this hub can open the link below to approve the app.
+        </p>
+        <div class="approve-share-row">
+          <code class="approve-share-link" id="approve-share-link">${escapeHtml(deepLink)}</code>
+          <button
+            type="button"
+            class="btn btn-secondary approve-share-copy"
+            id="approve-share-copy"
+            data-link="${escapeHtml(deepLink)}"
+          >Copy link</button>
+        </div>
+      </section>
+      <script>
+        (function () {
+          var btn = document.getElementById('approve-share-copy');
+          if (!btn) return;
+          var defaultLabel = btn.textContent;
+          btn.addEventListener('click', function () {
+            var link = btn.dataset.link || '';
+            var done = function (ok) {
+              btn.textContent = ok ? 'Copied!' : 'Copy failed';
+              setTimeout(function () { btn.textContent = defaultLabel; }, 1600);
+            };
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+              navigator.clipboard.writeText(link).then(function () { done(true); }, function () { done(false); });
+            } else {
+              // Fallback for browsers without async clipboard (older Safari,
+              // sandboxed iframes). Select the code block so the user can
+              // hit cmd/ctrl-C to copy manually.
+              try {
+                var range = document.createRange();
+                range.selectNode(document.getElementById('approve-share-link'));
+                var sel = window.getSelection();
+                if (sel) { sel.removeAllRanges(); sel.addRange(range); }
+                done(true);
+              } catch (e) {
+                done(false);
+              }
+            }
+          });
+        })();
+      </script>`;
+}
+
+/**
+ * Substitute an unnamed `vault:<verb>` scope with the resolved named form
+ * (`vault:<displayVault>:<verb>`) so consent / approval screens render
+ * what'll actually appear in the token rather than the raw OAuth request.
+ *
+ *   - `displayVault === undefined` → no substitution (keep input as-is).
+ *     Use this when the caller doesn't know what vault will be picked yet
+ *     and prefers the raw OAuth form. (Currently unused; reserved for the
+ *     pre-narrowing approve flow where the vault isn't known until consent.)
+ *   - `displayVault === null` → render with a `<TBD>` placeholder. Used on
+ *     the admin consent screen when the picker hasn't been touched yet, and
+ *     on the operator approval page where the vault is selected at the
+ *     per-user sign-in step, not at approve time.
+ *   - `displayVault === "name"` → render as `vault:name:verb` literally.
+ *
+ * Non-vault scopes pass through untouched. Already-named `vault:<x>:<verb>`
+ * scopes also pass through — the OAuth request already specified a vault,
+ * so there's nothing to resolve.
+ */
+export function substituteVaultDisplay(
+  scope: string,
+  displayVault: string | null | undefined,
+): string {
+  if (displayVault === undefined) return scope;
+  const parts = scope.split(":");
+  if (parts.length !== 2 || parts[0] !== "vault") return scope;
+  const verb = parts[1];
+  if (verb !== "read" && verb !== "write") return scope;
+  const vaultLabel = displayVault === null ? "<TBD>" : displayVault;
+  return `vault:${vaultLabel}:${verb}`;
 }
 
 export function renderError(props: ErrorViewProps): string {
@@ -503,7 +658,14 @@ export function renderUnknownClient(props: UnknownClientViewProps): string {
 }
 
 function renderScopeRow(scope: string): string {
-  const explanation = explainScope(scope);
+  // Special-case the `<TBD>` placeholder substituted by `substituteVaultDisplay`
+  // when the consent picker hasn't bound a vault yet — `explainScope` doesn't
+  // match it because `<` / `>` aren't in the vault-name charset, but the
+  // canonical verb-form does. Look up by the unnamed verb form so the
+  // explanation + level styling are still correct.
+  const tbdMatch = scope.match(/^vault:<TBD>:(read|write)$/);
+  const lookup = tbdMatch ? `vault:${tbdMatch[1]}` : scope;
+  const explanation = explainScope(lookup);
   if (!explanation) {
     return `<li class="scope scope-unknown">
       <code class="scope-name">${escapeHtml(scope)}</code>
@@ -512,12 +674,21 @@ function renderScopeRow(scope: string): string {
   }
   const cls = `scope scope-${explanation.level}`;
   const badge = badgeForLevel(explanation);
+  // Pending-vault hint surfaces the silent-narrowing semantics for admin
+  // operators who land on the consent screen before touching the picker.
+  // Once they pick, the form submission narrows the scope to the chosen
+  // vault — the rendered placeholder reflects that the vault is still
+  // open at this moment in the flow.
+  const pendingNote = tbdMatch
+    ? `<span class="scope-pending-note">A specific vault is picked below before approving.</span>`
+    : "";
   return `<li class="${cls}">
       <div class="scope-head">
         <code class="scope-name">${escapeHtml(scope)}</code>
         ${badge}
       </div>
       <span class="scope-label">${escapeHtml(explanation.label)}</span>
+      ${pendingNote}
     </li>`;
 }
 
@@ -915,6 +1086,63 @@ const STYLES = `
     word-break: break-all;
   }
   .approve-form { gap: 0; }
+  .approve-actions {
+    margin-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .approve-signin-cta {
+    display: inline-block;
+    text-align: center;
+    text-decoration: none;
+    line-height: 1.4;
+  }
+  .approve-signin-cta:hover {
+    background: ${PALETTE.accentHover};
+    color: ${PALETTE.cardBg};
+  }
+  .approve-share {
+    margin-top: 1.5rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid ${PALETTE.borderLight};
+  }
+  .approve-share-help {
+    margin: 0 0 0.6rem;
+    color: ${PALETTE.fgMuted};
+    font-size: 0.88rem;
+  }
+  .approve-share-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: stretch;
+    flex-wrap: wrap;
+  }
+  .approve-share-link {
+    flex: 1;
+    min-width: 0;
+    font-family: ${FONT_MONO};
+    font-size: 0.82rem;
+    background: ${PALETTE.bgSoft};
+    padding: 0.55rem 0.65rem;
+    border-radius: 6px;
+    color: ${PALETTE.fg};
+    word-break: break-all;
+    border: 1px solid ${PALETTE.border};
+  }
+  .approve-share-copy {
+    flex-shrink: 0;
+    min-height: 0;
+    padding: 0.5rem 0.9rem;
+    font-size: 0.85rem;
+  }
+  .scope-pending-note {
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 0.78rem;
+    color: ${PALETTE.fgDim};
+    font-style: italic;
+  }
   .approve-cli-hint {
     margin-top: 1rem;
     padding-top: 0.85rem;

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -159,8 +159,33 @@ export function isRequestableScope(scope: string): boolean {
   return !isNonRequestableScope(scope);
 }
 
+/**
+ * Recognize narrowed vault scopes (`vault:<name>:<verb>`) and the wildcard
+ * display form (`vault:*:<verb>`) — both render with the same explanation as
+ * the corresponding unnamed `vault:<verb>` row, since they describe the same
+ * permission scoped to a specific (or unspecified-at-mint-time) vault.
+ *
+ * The hub narrows unnamed `vault:read` → `vault:<name>:read` at consent /
+ * token-mint via the picker (Q1 of the vault-config-and-scopes design); the
+ * consent screen now surfaces that narrowed form so the user sees the scope
+ * shape that will appear in the token. `vault:*:read` is the display-only
+ * shape we use on the operator approval page where no per-user vault has
+ * been selected yet (a specific vault is chosen during sign-in).
+ *
+ * Verb-only — admin verbs on a per-vault basis (`vault:<name>:admin`) are
+ * `NON_REQUESTABLE_SCOPES` by policy and never reach the consent screen, so
+ * we don't substitute for them here. Read / write get the matching label.
+ */
+const VAULT_VERB_RE = /^vault:[a-zA-Z0-9_*-]+:(read|write)$/;
+
 export function explainScope(scope: string): ScopeExplanation | null {
-  return SCOPE_EXPLANATIONS[scope] ?? null;
+  const direct = SCOPE_EXPLANATIONS[scope];
+  if (direct) return direct;
+  if (VAULT_VERB_RE.test(scope)) {
+    const verb = scope.split(":")[2] as "read" | "write";
+    return SCOPE_EXPLANATIONS[`vault:${verb}`] ?? null;
+  }
+  return null;
 }
 
 export function scopeIsAdmin(scope: string): boolean {

--- a/web/ui/src/routes/ApproveClient.test.tsx
+++ b/web/ui/src/routes/ApproveClient.test.tsx
@@ -104,4 +104,33 @@ describe("ApproveClient", () => {
     expect(screen.getByText("network down")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
   });
+
+  // Approval-UX rc.19 (Issue 2): unnamed vault scopes get rendered as
+  // `vault:*:<verb>` on the operator approval page, with an inline
+  // explanation about how a specific vault is selected during sign-in.
+  // The pre-rc.19 shape rendered raw `vault:read`, which implied
+  // vault-wide unrestricted access — silent narrowing at mint surprised
+  // operators.
+  it("renders unnamed vault scopes as vault:*:<verb> with a wildcard explanation", async () => {
+    vi.mocked(api.getOauthClient).mockResolvedValue(
+      pendingClient({ scopes: ["vault:read", "vault:write"] }),
+    );
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("vault:*:read")).toBeInTheDocument());
+    expect(screen.getByText("vault:*:write")).toBeInTheDocument();
+    // Wildcard explanation present.
+    expect(screen.getByText(/a specific vault is selected during sign-in/i)).toBeInTheDocument();
+    // The raw unnamed form should NOT appear as a scope code element.
+    expect(screen.queryByText(/^vault:read$/)).toBeNull();
+    expect(screen.queryByText(/^vault:write$/)).toBeNull();
+  });
+
+  it("leaves named vault scopes (vault:<name>:<verb>) untouched", async () => {
+    vi.mocked(api.getOauthClient).mockResolvedValue(pendingClient({ scopes: ["vault:work:read"] }));
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("vault:work:read")).toBeInTheDocument());
+    // Already-named scopes don't carry the wildcard, so the explanation
+    // hint doesn't render.
+    expect(screen.queryByText(/a specific vault is selected during sign-in/i)).toBeNull();
+  });
 });

--- a/web/ui/src/routes/ApproveClient.tsx
+++ b/web/ui/src/routes/ApproveClient.tsx
@@ -195,10 +195,19 @@ function renderBody({ loadState, action, onApprove, onRetry }: RenderBodyProps) 
               <span className="muted">requested scopes: </span>
               {client.scopes.map((s, i) => (
                 <span key={s}>
-                  <code>{s}</code>
+                  <code>{resolveScopeForDisplay(s)}</code>
                   {i < client.scopes.length - 1 ? " " : null}
                 </span>
               ))}
+              {client.scopes.some(isUnnamedVaultScope) ? (
+                <p
+                  className="muted"
+                  style={{ marginTop: "0.4rem", fontStyle: "italic", fontSize: "0.85rem" }}
+                >
+                  <code>*</code> — a specific vault is selected during sign-in via the consent
+                  picker (or the user's assigned vault for multi-user setups).
+                </p>
+              ) : null}
             </div>
           ) : null}
           <div className="dim" style={{ marginTop: "0.25rem" }}>
@@ -228,4 +237,30 @@ function renderBody({ loadState, action, onApprove, onRetry }: RenderBodyProps) 
       </div>
     </div>
   );
+}
+
+/**
+ * Render the scope's *resolved* shape so the operator sees what'll actually
+ * appear in minted tokens, not the raw OAuth request. The hub narrows
+ * unnamed `vault:<verb>` to `vault:<name>:<verb>` at token-mint via the
+ * consent picker (or the user's assigned vault for multi-user hubs). At
+ * approve time the vault isn't bound yet, so we render the wildcard
+ * `vault:*:<verb>` form with the asterisk explained inline below the
+ * scope list — clearer than showing the unnamed form which implied
+ * vault-wide unrestricted access.
+ *
+ * Non-vault scopes (`scribe:transcribe`, `channel:send`, …) and
+ * already-named vault scopes (`vault:work:read`) pass through unchanged.
+ */
+function resolveScopeForDisplay(scope: string): string {
+  if (!isUnnamedVaultScope(scope)) return scope;
+  const verb = scope.split(":")[1];
+  return `vault:*:${verb}`;
+}
+
+function isUnnamedVaultScope(scope: string): boolean {
+  const parts = scope.split(":");
+  if (parts.length !== 2 || parts[0] !== "vault") return false;
+  const verb = parts[1];
+  return verb === "read" || verb === "write";
 }


### PR DESCRIPTION
## Summary

Three approval / consent UX bugs Aaron hit while testing the Gitcoin Brain UI OAuth flow against his self-hosted hub. Same session as the rc.17 / rc.18 CORS work — different layer, same posture (third-party SPA → self-hosted hub).

### Issue 1 — Stale "ask the operator to run CLI" message

When a viewer hits `/oauth/authorize` for a client that hasn't been approved yet AND they don't have an operator session, hub used to render:

> Ask the operator to run `parachute auth approve-client <id>` from a terminal, then try again.

This predated the web approval path that shipped in hub#277 (`/admin/approve-client/<id>` SPA route). The CLI mention is retired in the browser path. The surface now points operators at the web flow:

1. **Primary CTA**: "Sign in as admin to approve" — links to `/login?next=/admin/approve-client/<client_id>` so the admin lands directly on the approval page after sign-in.
2. **Secondary section**: "Or send this link to your hub admin" — a fully-qualified deep link (`<hub_origin>/admin/approve-client/<client_id>`) in a code block + a Copy-to-clipboard button (`navigator.clipboard.writeText` with a graceful range-select fallback for older browsers / sandboxed iframes; "Copied!" feedback for 1.6s).

The authenticated-admin branch (#208's one-click approve form) is unchanged.

### Issue 2 — Raw `vault:read` shown instead of resolved `vault:<name>:read`

Hub narrows unnamed `vault:<verb>` scopes to `vault:<picked>:<verb>` at token-mint via the consent picker (or the user's `assigned_vault` for multi-user setups). But the consent screen rendered the raw OAuth request, which implied vault-wide unrestricted access — silent narrowing at mint surprised operators.

Display logic now substitutes:

- **Non-admin user** (`assigned_vault` set) → `vault:<assigned>:read` on the consent row.
- **Admin user, single-vault hub** → `vault:<only-vault>:read` (matches the pre-checked picker default).
- **Admin user, multi-vault hub** → `vault:<TBD>:read` placeholder + an italic hint pointing at the picker below ("A specific vault is picked below before approving").
- **Operator approval page (SPA)** → `vault:*:read` with an inline wildcard explanation ("a specific vault is selected during sign-in via the consent picker (or the user's assigned vault for multi-user setups)"). Different from the consent screen because no per-user binding has happened at approve time.

`explainScope` matches `^vault:[a-zA-Z0-9_*-]+:(read|write)$` via a pattern fallback so the styling + label come through for `vault:work:read`, `vault:*:read`, etc. Per-vault admin (`vault:<name>:admin`) is intentionally excluded — that scope is `NON_REQUESTABLE`.

### Issue 3 — Shareable admin approval link

Covered by Issue 1's deep-link section.

## Test plan

- [x] `bun test ./src` — **1621 pass / 0 fail / 31388 expects across 84 files** (+21 over rc.18 baseline 1600)
- [x] `bun run typecheck` — clean
- [x] `bunx biome check .` — clean
- [x] SPA `bun run test` — 135 vitest pass
- [x] SPA `bun run build` — ships fresh `web/ui/dist/`
- [x] Smoke against `PARACHUTE_HOME=/tmp/hub-approval-ux` local hub:
  - `GET /oauth/authorize?client_id=<pending>...` in unauth posture renders "Sign in as admin to approve" + the fully-qualified deep link + Copy button + clipboard JS. **No CLI message anywhere.**
  - Sign-in CTA → `/login?next=...` (preserves next) → POST login → 302 to `/admin/approve-client/<id>`. End-to-end works.
  - Admin consent screen for `scope=vault:read+vault:write` renders `<code class="scope-name">vault:default:read</code>` (not `vault:read`) and `vault:default:write` (single-vault fixture, `displayVault=default`).

## Code shape

- `src/oauth-ui.ts` — `ApprovePendingViewProps` gains required `hubOrigin`. New `renderUnauthenticatedApproveCtas(hubOrigin, clientId)` renders the Sign-in CTA + shareable-link section + inline clipboard JS. `ConsentViewProps` gains optional `displayVault`; new exported `substituteVaultDisplay(scope, displayVault)` does the mapping. `renderScopeRow` special-cases the `<TBD>` placeholder. New CSS for the new surfaces.
- `src/oauth-handlers.ts` — `pendingClientResponse` threads `deps.issuer` through as `hubOrigin`. `consentProps` computes `displayVault` from `lockedVault` (non-admin → assigned vault) / `vaultNames` (admin + single-vault → that vault) / `null` (admin + multi-vault → `<TBD>` placeholder).
- `src/scope-explanations.ts` — verb-pattern fallback in `explainScope` recognizes `vault:<name>:<verb>` and `vault:*:<verb>`.
- `web/ui/src/routes/ApproveClient.tsx` — `resolveScopeForDisplay` rewrites unnamed `vault:<verb>` → `vault:*:<verb>`; `isUnnamedVaultScope` gates the inline wildcard explanation.

## Cross-references

- hub#277 — web-based approval (`/admin/approve-client/<id>` SPA) shipped earlier; this PR points the unapproved-client surface at it.
- hub#284 — related stale-`assigned_vault` followup (multi-user Phase 1 PR 4 fanout).

Version: `0.5.10-rc.19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)