### PR TITLE
chore(scope-guard): 0.3.0 stable (rc chain → @latest)

### DIFF
--- a/packages/scope-guard/CHANGELOG.md
+++ b/packages/scope-guard/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `@openparachute/scope-guard` are documented here. The for
 
 The library's RC cadence is independent of `@openparachute/hub`'s — they ship from the same repo but aren't coupled in version.
 
+## [0.3.0] - 2026-05-20
+
+Stable release. Multi-user Phase 1 vault scope enforcement.
+
+- **`vault_scope` claim required field** on `HubJwtClaims` (#285): tokens now carry a `vault_scope: string[]` claim. `[]` = unrestricted (admin); `["vault-name"]` = pinned to that vault. Back-compat: absent claim → `[]` (pre-PR-4 tokens still work).
+- **`enforceVaultScope(claims, requestVaultName)` helper** (#285): resource servers (vault, notes, scribe) call this to refuse cross-vault access when a token's `vault_scope` doesn't include the requested vault. Returns `true` if `vault_scope` is empty OR `requestVaultName` is in it.
+- **Defensive parsing** (#285): malformed `vault_scope` (non-array, null, mixed types) → fallback to `[]`. Primary security gate is the scope-string check; `vault_scope` is defense-in-depth.
+
+Adopters: vault@0.4.6 consumes this version. Notes and scribe pass through unchanged (no vault-bound tokens at the consumer side).
+
 ## 0.3.0-rc.1 — 2026-05-20
 
 Adds `vault_scope` claim surfacing + the `enforceVaultScope` defense-in-depth check (hub multi-user Phase 1 PR 5 — see [`2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/)). **Additive — no behavior change for existing adopters.** A bump from `0.2.x` to `0.3.0` does NOT start rejecting any token that `0.2.x` accepted; the new helper is opt-in and the new claim is surfaced as `[]` (unrestricted) when absent.

--- a/packages/scope-guard/package.json
+++ b/packages/scope-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scope-guard",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0",
   "description": "Hub-issued JWT validation for Parachute resource servers (vault, scribe, parachute-agent, third-party modules).",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Caps the `0.3.0-rc.1` chain into `0.3.0` stable. No code changes — `packages/scope-guard/package.json` version + `CHANGELOG.md` entry only.

## Why now

`vault@0.4.6` stable depends on `@openparachute/scope-guard` at `@latest` for the `vault_scope` claim enforcement (multi-user Phase 1). The rc has been published to `@rc`; vault can't publish cleanly to `@latest` until scope-guard is also on `@latest` at a matching version.

## Diff

- `packages/scope-guard/package.json`: `0.3.0-rc.1` → `0.3.0`
- `packages/scope-guard/CHANGELOG.md`: stable entry added at the top; existing rc.1 entry preserved below

## Independence from PR #290

This PR touches only `packages/scope-guard/`. PR #290 (hub stable promotion) touches `package.json` at repo root + hub source. No file overlap — landed in a parallel worktree branch (`ag-unforced-dev-scope-guard`) to avoid blocking on PR #290's per-repo serial slot.

## Tests

```
cd packages/scope-guard && bun test src
# 99 pass, 0 fail, 177 expect() calls
```

## Aaron's next action (after merge)

```
cd packages/scope-guard && npm publish --tag latest
```

Separate publish from hub's own — this is just the workspace sub-package.