### PR TITLE
fix(hub): server-rendered approve-pending shows resolved scopes (matches SPA + consent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.11-rc.2] - 2026-05-20
+
+**fix(approve-pending): substitute unnamed vault scopes with wildcard form (matches SPA + consent).**
+
+Aaron hit this on rc.1 testing: the server-rendered `ApprovePendingView` (the "App not yet approved — Sign in as admin to approve" page on `/oauth/authorize` for a pending client) showed raw OAuth scopes like `vault:read` and `vault:write` rather than the resolved `vault:*:read` / `vault:*:write` form. The SPA's `/admin/approve-client/<id>` view (hub#289) already substituted correctly; this brings the server-rendered version in line.
+
+Root cause: `renderApprovePending` rendered `requestedScopes` directly with no display-time substitution. Both branches (unauth viewer with sign-in CTA + authenticated admin with inline approve form) got the raw scope shape.
+
+Fix shape:
+
+- Documented the `'*'` mode on `substituteVaultDisplay(scope, displayVault)` — the literal string `'*'` renders unnamed `vault:<verb>` scopes as `vault:*:<verb>`. Already-named vault scopes (`vault:work:read`) and non-vault scopes (`scribe:transcribe`, `channel:send`) pass through unchanged.
+- `renderApprovePending` now maps requested scopes through `substituteVaultDisplay(s, '*')` before rendering.
+- Surfaces an inline explanation below the scope list when any scope renders with `*`: "a specific vault is selected during sign-in via the consent picker (or the user's assigned vault for multi-user setups). The `*` shows the unbound shape." Omitted when all scopes are non-vault or already-named. Mirrors the SPA's pattern in `ApproveClient.tsx`.
+
+Tests added in `src/__tests__/oauth-ui.test.ts`:
+- `substituteVaultDisplay` `'*'` mode: substitutes unnamed → wildcard, leaves non-vault + already-named pass-through.
+- `renderApprovePending` renders `vault:*:read` / `vault:*:write` (not raw) for unnamed input.
+- Wildcard explanation surfaces when any scope is unnamed-vault; absent for all-non-vault, all-already-named, and empty-scope inputs.
+- Authenticated admin branch gets the same substitution + explanation.
+
+Cross-reference: hub#289 (the SPA + consent renderer that already did this).
+
 ## [0.5.11-rc.1] - 2026-05-20
 
 **fix: regenerate well-known after install/upgrade/uninstall so discovery page reflects current state.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.11-rc.1",
+  "version": "0.5.11-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -462,6 +462,103 @@ describe("renderApprovePending unauthenticated CTAs", () => {
   });
 });
 
+describe("renderApprovePending scope display (wildcard substitution)", () => {
+  const COMMON = {
+    clientName: "MyApp",
+    clientId: "client-xyz",
+    redirectUris: ["https://app.example/cb"],
+    hubOrigin: "https://hub.example.com",
+  };
+
+  test("unnamed vault scopes render with the wildcard form (vault:*:<verb>)", () => {
+    // The bug Aaron hit on rc.1: the server-rendered approve-pending page
+    // showed raw `vault:read` / `vault:write` rather than the resolved
+    // `vault:*:<verb>` form the SPA already used. Both the unauth viewer
+    // and the authenticated admin branch get the substituted display so
+    // they match the SPA's `/admin/approve-client/<id>` view.
+    const html = renderApprovePending({
+      ...COMMON,
+      requestedScopes: ["vault:read", "vault:write"],
+    });
+    expect(html).toMatch(/<code class="scope-name">vault:\*:read<\/code>/);
+    expect(html).toMatch(/<code class="scope-name">vault:\*:write<\/code>/);
+    // Raw unnamed form must NOT appear in the rendered scope-row code
+    // blocks any more — that was the bug.
+    expect(html).not.toMatch(/<code class="scope-name">vault:read<\/code>/);
+    expect(html).not.toMatch(/<code class="scope-name">vault:write<\/code>/);
+  });
+
+  test("wildcard explanation surfaces below the scope list when any scope renders with `*`", () => {
+    const html = renderApprovePending({
+      ...COMMON,
+      requestedScopes: ["vault:read"],
+    });
+    // The `<p class="scope-wildcard-note">…` element is what's conditional;
+    // `.scope-wildcard-note` as a CSS class name is always present in the
+    // stylesheet, so match the rendered element specifically.
+    expect(html).toMatch(/<p class="scope-wildcard-note">/);
+    expect(html).toContain("a specific vault is selected during sign-in");
+    expect(html).toContain("unbound shape");
+  });
+
+  test("wildcard explanation is omitted when no scope renders with `*`", () => {
+    // All-non-vault: explanation absent.
+    const nonVault = renderApprovePending({
+      ...COMMON,
+      requestedScopes: ["scribe:transcribe", "channel:send"],
+    });
+    expect(nonVault).not.toMatch(/<p class="scope-wildcard-note">/);
+    expect(nonVault).not.toContain("unbound shape");
+
+    // Already-named vault: explanation absent (vault already specified).
+    const named = renderApprovePending({
+      ...COMMON,
+      requestedScopes: ["vault:work:read"],
+    });
+    expect(named).not.toMatch(/<p class="scope-wildcard-note">/);
+    expect(named).not.toContain("unbound shape");
+
+    // Empty scopes: explanation absent (no scope rows at all).
+    const empty = renderApprovePending({ ...COMMON, requestedScopes: [] });
+    expect(empty).not.toMatch(/<p class="scope-wildcard-note">/);
+  });
+
+  test("already-named vault scopes still render as-is (no double substitution)", () => {
+    const html = renderApprovePending({
+      ...COMMON,
+      requestedScopes: ["vault:work:read"],
+    });
+    expect(html).toMatch(/<code class="scope-name">vault:work:read<\/code>/);
+    // Pre-existing named scopes don't get mangled by the wildcard substitution.
+    expect(html).not.toMatch(/vault:\*:work/);
+  });
+
+  test("mixed scopes render the wildcard explanation when ANY scope is unnamed-vault", () => {
+    const html = renderApprovePending({
+      ...COMMON,
+      requestedScopes: ["scribe:transcribe", "vault:read"],
+    });
+    expect(html).toMatch(/<code class="scope-name">scribe:transcribe<\/code>/);
+    expect(html).toMatch(/<code class="scope-name">vault:\*:read<\/code>/);
+    expect(html).toMatch(/<p class="scope-wildcard-note">/);
+  });
+
+  test("authenticated admin branch also gets the wildcard substitution + explanation", () => {
+    // Both branches of the page render through the same scope-display path
+    // — the inline-form admin viewer sees the same resolved scopes as the
+    // unauth viewer with the sign-in CTA.
+    const html = renderApprovePending({
+      ...COMMON,
+      requestedScopes: ["vault:read", "vault:write"],
+      approveForm: { csrfToken: CSRF, returnTo: "/oauth/authorize?client_id=client-xyz" },
+    });
+    expect(html).toContain('action="/oauth/authorize/approve"');
+    expect(html).toMatch(/<code class="scope-name">vault:\*:read<\/code>/);
+    expect(html).toMatch(/<code class="scope-name">vault:\*:write<\/code>/);
+    expect(html).toMatch(/<p class="scope-wildcard-note">/);
+  });
+});
+
 describe("CSS / styling guarantees", () => {
   test("does not load fonts from a third-party CDN (privacy)", () => {
     const html = renderLogin({ params: PARAMS, csrfToken: CSRF });

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -308,6 +308,26 @@ describe("substituteVaultDisplay", () => {
     // consenting to literally.
     expect(substituteVaultDisplay("vault:admin", "work")).toBe("vault:admin");
   });
+
+  test("'*' → renders the wildcard display form (vault:*:<verb>)", () => {
+    // Approve-time rendering: no vault has been picked yet (the consent
+    // picker hasn't run), but rendering the raw `vault:read` form implies
+    // unrestricted full-vault access. The wildcard signals "scope will be
+    // narrowed to a specific vault at consent" — mirrors the SPA's
+    // `/admin/approve-client/<id>` view.
+    expect(substituteVaultDisplay("vault:read", "*")).toBe("vault:*:read");
+    expect(substituteVaultDisplay("vault:write", "*")).toBe("vault:*:write");
+  });
+
+  test("'*' → non-vault scopes still pass through unchanged", () => {
+    expect(substituteVaultDisplay("scribe:transcribe", "*")).toBe("scribe:transcribe");
+    expect(substituteVaultDisplay("channel:send", "*")).toBe("channel:send");
+  });
+
+  test("'*' → already-named vault scopes pass through (caller specified the vault)", () => {
+    expect(substituteVaultDisplay("vault:work:read", "*")).toBe("vault:work:read");
+    expect(substituteVaultDisplay("vault:other:write", "*")).toBe("vault:other:write");
+  });
 });
 
 describe("renderConsent displayVault substitution", () => {

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -359,10 +359,30 @@ export function renderApprovePending(props: ApprovePendingViewProps): string {
     approveForm,
   } = props;
   const redirectList = redirectUris.map((u) => `<li><code>${escapeHtml(u)}</code></li>`).join("");
+  // Substitute unnamed `vault:<verb>` rows with the wildcard display form
+  // (`vault:*:<verb>`) so the operator sees the shape that will appear in
+  // the token after consent narrows the scope to a specific vault. At
+  // approve time no vault has been picked yet — the SPA's
+  // `/admin/approve-client/<id>` view uses the same wildcard treatment
+  // (see `resolveScopeForDisplay` in `web/ui/src/routes/ApproveClient.tsx`).
+  const displayedScopes = requestedScopes.map((s) => substituteVaultDisplay(s, "*"));
   const scopeRows =
-    requestedScopes.length === 0
+    displayedScopes.length === 0
       ? `<li class="scope scope-empty">No scopes requested — the app gets a session token only.</li>`
-      : requestedScopes.map(renderScopeRow).join("\n");
+      : displayedScopes.map(renderScopeRow).join("\n");
+  // Wildcard explanation: surface the "the asterisk means the vault is
+  // picked later" hint below the scope list when at least one row carries
+  // `vault:*:<verb>`. Mirrors the SPA's inline note on
+  // `/admin/approve-client/<id>`. Omitted when no scope renders with `*`
+  // (all scopes are either non-vault or already-named).
+  const wildcardNote = displayedScopes.some((s) => /^vault:\*:(read|write)$/.test(s))
+    ? `
+        <p class="scope-wildcard-note">
+          <code>*</code> — a specific vault is selected during sign-in via the consent
+          picker (or the user's assigned vault for multi-user setups). The
+          <code>*</code> shows the unbound shape.
+        </p>`
+    : "";
   // Vault hint (closes #244): Notes' VaultPopover (notes#115) passes
   // `vault=<name>` on `/oauth/authorize` for per-vault grants. Surface it
   // alongside scopes so a multi-vault operator can tell which vault they're
@@ -414,7 +434,7 @@ export function renderApprovePending(props: ApprovePendingViewProps): string {
       </section>
       <section class="scopes">
         <h2 class="scopes-title">Permissions requested</h2>
-        <ul class="scope-list">${scopeRows}</ul>
+        <ul class="scope-list">${scopeRows}</ul>${wildcardNote}
       </section>
       ${formSection}
     </div>`;
@@ -1149,6 +1169,21 @@ const STYLES = `
     font-size: 0.78rem;
     color: ${PALETTE.fgDim};
     font-style: italic;
+  }
+  .scope-wildcard-note {
+    margin: 0.6rem 0 0;
+    font-size: 0.82rem;
+    color: ${PALETTE.fgDim};
+    font-style: italic;
+    line-height: 1.45;
+  }
+  .scope-wildcard-note code {
+    font-family: ${FONT_MONO};
+    font-style: normal;
+    background: ${PALETTE.bgSoft};
+    padding: 0.05rem 0.3rem;
+    border-radius: 4px;
+    color: ${PALETTE.fgMuted};
   }
   .badge {
     display: inline-block;

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -507,6 +507,13 @@ function renderUnauthenticatedApproveCtas(hubOrigin: string, clientId: string): 
  *     the admin consent screen when the picker hasn't been touched yet, and
  *     on the operator approval page where the vault is selected at the
  *     per-user sign-in step, not at approve time.
+ *   - `displayVault === "*"` → render with a literal asterisk placeholder
+ *     (`vault:*:verb`). Used on the server-rendered approve-pending page
+ *     and the SPA's `/admin/approve-client/<id>` view: at approve time the
+ *     vault isn't bound yet (no consent picker has run), so the asterisk
+ *     signals "wildcard — a specific vault is selected later in the flow."
+ *     Callers that render this form should also surface the inline
+ *     explanation below the scope list (see `renderApprovePending`).
  *   - `displayVault === "name"` → render as `vault:name:verb` literally.
  *
  * Non-vault scopes pass through untouched. Already-named `vault:<x>:<verb>`


### PR DESCRIPTION
## Summary

Aaron hit this on rc.1 testing: the server-rendered `ApprovePendingView` (the unauth "App not yet approved — Sign in as admin to approve" page on `/oauth/authorize` for a pending client) showed raw OAuth scopes like `vault:read` and `vault:write` instead of the resolved `vault:*:read` / `vault:*:write` wildcard form. The SPA's `/admin/approve-client/<id>` view (hub#289) already substituted correctly, and so did the post-sign-in `renderConsent`; this brings the third surface — the server-rendered approve-pending page — in line with the other two.

## Root cause

`renderApprovePending` in `src/oauth-ui.ts` mapped `requestedScopes` straight into `renderScopeRow` with no display-time substitution. Both branches of the page got the raw shape:

- Unauthenticated viewer (with the "Sign in as admin to approve" CTA) — showed `vault:read` / `vault:write`.
- Authenticated admin viewer (with the inline one-click Approve form) — same raw display.

Meanwhile the consent screen already substituted via `substituteVaultDisplay(s, displayVault)` and the SPA used `resolveScopeForDisplay(s)` to render `vault:*:<verb>`. Three surfaces, two doing it right, one missing.

## Fix

- **`substituteVaultDisplay`**: documented the existing `'*'` mode in JSDoc — the literal string `'*'` falls through the current implementation cleanly to render `vault:*:<verb>` for unnamed vault scopes. Non-vault scopes (`scribe:transcribe`, `channel:send`) and already-named vault scopes (`vault:work:read`) still pass through unchanged.
- **`renderApprovePending`**: now maps `requestedScopes` through `substituteVaultDisplay(s, '*')` before rendering, so unnamed `vault:read` displays as `vault:*:read`. Both branches share the same scope-display path.
- **Inline wildcard explanation**: when any scope renders with `*`, the page surfaces an inline note below the scope list — "a specific vault is selected during sign-in via the consent picker (or the user's assigned vault for multi-user setups). The `*` shows the unbound shape." Omitted when no scope carries the wildcard (all-non-vault, all-already-named, empty-scope). Mirrors the SPA's pattern in `ApproveClient.tsx:202-210`.
- **CSS**: new `.scope-wildcard-note` style block, visually continuous with the existing `.scope-pending-note` (consent-picker hint) — same fgDim / italic posture.

No SPA changes — this is server-rendered only. The SPA + consent renderer already had the substituted display.

## Commit shape

- `6d49625` — `substituteVaultDisplay`: doc the `'*'` mode + pin with tests.
- `040219d` — `renderApprovePending` integration + CSS + tests for the new behavior.
- `bef5aec` — rc bump to `0.5.11-rc.2` + CHANGELOG.

## Test plan

- [x] `bun test ./src` — 1636 pass, 0 fail, 31437 expect() calls (was 1627; +9 new in `oauth-ui.test.ts`).
- [x] `bun run typecheck` — clean.
- [x] `bunx biome check .` — clean.
- [x] Smoke against a fresh `PARACHUTE_HOME=/tmp/hub-scope-render-smoke`:
  - Registered a DCR client (status `pending`) with `scope: "vault:read vault:write"` via `POST /oauth/register`.
  - Hit `/oauth/authorize?client_id=<id>&...&scope=vault%3Aread%20vault%3Awrite&...` unauthenticated.
  - Page renders status 403 with "App not yet approved".
  - Permissions show `<code class="scope-name">vault:*:read</code>` + `<code class="scope-name">vault:*:write</code>` (raw `vault:read` / `vault:write` absent from `scope-name` blocks).
  - Inline `<p class="scope-wildcard-note">` element present with the "unbound shape" copy.
  - "Sign in as admin to approve" CTA renders below.

## Cross-reference

- hub#289 — the approval-UX PR that added the SPA's `resolveScopeForDisplay` + `displayVault` substitution on the consent renderer. This PR brings the third surface (the server-rendered approve-pending page) in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)