### PR TITLE
fix(serve): print localhost in startup banner when bound to 0.0.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.11-rc.3] - 2026-05-21
+
+**fix(serve): print localhost in banner when bound to 0.0.0.0 (operators couldn't navigate to bind address).**
+
+Aaron hit this on rc.2 testing: `parachute serve` printed `listening on http://0.0.0.0:1939` and pasting that URL into Chrome failed (browser refuses to navigate to `0.0.0.0`; even when it resolves, mixing the bind-address origin with other URLs like `localhost:1939` trips cross-origin checks). `0.0.0.0` is a kernel-side meta-address ("listen on all interfaces") — not an operator-usable URL.
+
+Fix shape:
+
+- Extracted `formatListeningBanner(...)` in `src/commands/serve.ts`. When the bind hostname is `0.0.0.0`, the banner now prints `http://localhost:<port>` with a parenthetical `(bound on all interfaces: 0.0.0.0:<port>)` so operators get a navigable URL while still seeing the actual bind address for diagnostic purposes.
+- When the operator has explicitly chosen a hostname via `PARACHUTE_BIND_HOST` (e.g. `127.0.0.1`, a LAN IP), the banner prints that hostname directly with no parenthetical — the operator knows what they wired.
+- Bind behaviour is unchanged: `Bun.serve({ hostname })` still receives the original `0.0.0.0` / `PARACHUTE_BIND_HOST` value, so containers + LAN exposure paths keep working exactly as before. Banner-only cosmetic fix.
+
+Tests added in `src/__tests__/serve.test.ts`:
+- `0.0.0.0` → banner displays `localhost` + parenthetical bind disclosure (URL precedes disclosure precedes contextual block).
+- `127.0.0.1` → banner displays the loopback verbatim, no bind disclosure.
+- `192.168.1.10` → banner displays the LAN IP verbatim, no bind disclosure.
+- Contextual block carries `PARACHUTE_HOME`, db, issuer, admin state; undefined issuer renders as `<request-origin>`.
+
 ## [0.5.11-rc.2] - 2026-05-20
 
 **fix(approve-pending): substitute unnamed vault scopes with wildcard form (matches SPA + consent).**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.11-rc.2",
+  "version": "0.5.11-rc.3",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { seedInitialAdminIfNeeded } from "../commands/serve.ts";
+import { formatListeningBanner, seedInitialAdminIfNeeded } from "../commands/serve.ts";
 import { openHubDb } from "../hub-db.ts";
 import { getUserByUsername, userCount } from "../users.ts";
 
@@ -103,5 +103,62 @@ describe("seedInitialAdminIfNeeded", () => {
     );
     expect(result).toBe("needs-setup");
     expect(userCount(db)).toBe(0);
+  });
+});
+
+describe("formatListeningBanner", () => {
+  const base = {
+    port: 1939,
+    configDir: "/home/op/.parachute",
+    dbPath: "/home/op/.parachute/hub.db",
+    issuer: undefined,
+    adminBootstrap: "exists",
+  };
+
+  test("hostname 0.0.0.0 → display localhost + bound note", () => {
+    // Chrome refuses to navigate to `0.0.0.0`, and mixing it with
+    // `localhost` trips cross-origin errors. Operators paste the URL
+    // straight from the banner, so the printed URL must be navigable.
+    const line = formatListeningBanner({ ...base, hostname: "0.0.0.0" });
+    expect(line).toContain("listening on http://localhost:1939");
+    expect(line).toContain("(bound on all interfaces: 0.0.0.0:1939)");
+    // The bind disclosure should sit between the URL and the contextual
+    // PARACHUTE_HOME / db / issuer block, so an operator scanning the
+    // banner sees the URL first and the bind note second.
+    const urlIdx = line.indexOf("http://localhost:1939");
+    const boundIdx = line.indexOf("(bound on all interfaces");
+    const homeIdx = line.indexOf("PARACHUTE_HOME=");
+    expect(urlIdx).toBeLessThan(boundIdx);
+    expect(boundIdx).toBeLessThan(homeIdx);
+  });
+
+  test("hostname 127.0.0.1 (operator-chosen loopback) → display verbatim, no bound note", () => {
+    const line = formatListeningBanner({ ...base, hostname: "127.0.0.1" });
+    expect(line).toContain("listening on http://127.0.0.1:1939");
+    expect(line).not.toContain("bound on all interfaces");
+  });
+
+  test("hostname 192.168.x.x (operator-chosen LAN IP) → display verbatim, no bound note", () => {
+    const line = formatListeningBanner({ ...base, hostname: "192.168.1.10" });
+    expect(line).toContain("listening on http://192.168.1.10:1939");
+    expect(line).not.toContain("bound on all interfaces");
+  });
+
+  test("contextual block carries PARACHUTE_HOME, db, issuer, admin state", () => {
+    const line = formatListeningBanner({
+      ...base,
+      hostname: "0.0.0.0",
+      issuer: "https://hub.example.com",
+      adminBootstrap: "seeded",
+    });
+    expect(line).toContain("PARACHUTE_HOME=/home/op/.parachute");
+    expect(line).toContain("db=/home/op/.parachute/hub.db");
+    expect(line).toContain("issuer=https://hub.example.com");
+    expect(line).toContain("admin=seeded");
+  });
+
+  test("issuer undefined renders as <request-origin> placeholder", () => {
+    const line = formatListeningBanner({ ...base, hostname: "0.0.0.0" });
+    expect(line).toContain("issuer=<request-origin>");
   });
 });

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -75,6 +75,31 @@ export interface ServeResult {
 
 const DEFAULT_PORT = 1939;
 
+/**
+ * Build the startup banner line.
+ *
+ * `0.0.0.0` is a bind-host meta-address — the kernel uses it to mean "listen
+ * on all interfaces," but Chrome and other browsers refuse to navigate to it
+ * (and any cross-resource fetch that mixes `0.0.0.0` with `localhost` trips
+ * cross-origin checks). Operators who paste the banner URL into a browser
+ * need the loopback form. When the operator has explicitly chosen a
+ * hostname via `PARACHUTE_BIND_HOST` (e.g. `127.0.0.1`, a LAN IP), we
+ * honour their choice and print it directly — they know what they wired.
+ */
+export function formatListeningBanner(args: {
+  hostname: string;
+  port: number;
+  configDir: string;
+  dbPath: string;
+  issuer?: string;
+  adminBootstrap: string;
+}): string {
+  const { hostname, port, configDir, dbPath, issuer, adminBootstrap } = args;
+  const displayHost = hostname === "0.0.0.0" ? "localhost" : hostname;
+  const boundNote = hostname === "0.0.0.0" ? ` (bound on all interfaces: 0.0.0.0:${port})` : "";
+  return `parachute serve: listening on http://${displayHost}:${port}${boundNote} (PARACHUTE_HOME=${configDir}, db=${dbPath}, issuer=${issuer ?? "<request-origin>"}, admin=${adminBootstrap})`;
+}
+
 function parsePort(raw: string | undefined): number | undefined {
   if (raw === undefined || raw === "") return undefined;
   const n = Number.parseInt(raw, 10);
@@ -194,7 +219,14 @@ export async function serve(opts: ServeOpts = {}): Promise<{
   });
 
   log(
-    `parachute serve: listening on http://${hostname}:${port} (PARACHUTE_HOME=${CONFIG_DIR}, db=${dbPath}, issuer=${issuer ?? "<request-origin>"}, admin=${adminBootstrap})`,
+    formatListeningBanner({
+      hostname,
+      port,
+      configDir: CONFIG_DIR,
+      dbPath,
+      issuer,
+      adminBootstrap,
+    }),
   );
 
   return {


### PR DESCRIPTION
## Summary

Aaron hit this on rc.2 testing: `parachute serve` printed `listening on http://0.0.0.0:1939` and pasting that URL into Chrome failed. `0.0.0.0` is a kernel-side meta-address ("listen on all interfaces"); browsers refuse to navigate to it, and mixing it with other origins (like `localhost:1939`) trips cross-origin / connection errors. Operators need to see a navigable URL in the banner.

## Fix

- Extracted `formatListeningBanner(...)` in `src/commands/serve.ts` for testability.
- When the bind hostname is `0.0.0.0`, the banner prints `http://localhost:<port>` with a parenthetical `(bound on all interfaces: 0.0.0.0:<port>)` — operator-usable URL up front, bind address noted for diagnostics.
- When the operator has explicitly chosen a hostname via `PARACHUTE_BIND_HOST` (`127.0.0.1`, LAN IP, etc.), the banner prints that hostname directly with no parenthetical. They know what they wired.
- Bind behaviour is unchanged: `Bun.serve({ hostname })` still receives the original `0.0.0.0` / `PARACHUTE_BIND_HOST` value, so container + LAN exposure paths keep working. Banner-only cosmetic fix.

Skipped the optional defensive redirect (hub redirecting incoming `Host: 0.0.0.0` requests to `localhost`) — banner fix alone solves the immediate UX, and a redirect would need to be careful around container-platform health checks that may use unusual Host headers.

## Smoke

Default (no `PARACHUTE_BIND_HOST`):

```
parachute serve: listening on http://localhost:11939 (bound on all interfaces: 0.0.0.0:11939) (PARACHUTE_HOME=..., db=..., issuer=<request-origin>, admin=needs-setup)
```

With `PARACHUTE_BIND_HOST=127.0.0.1`:

```
parachute serve: listening on http://127.0.0.1:11940 (PARACHUTE_HOME=..., db=..., issuer=<request-origin>, admin=needs-setup)
```

## Test plan

- [x] `bun test src/__tests__/serve.test.ts` — 10 pass (5 new banner tests + 5 existing seed-admin tests)
- [x] `bun test ./src` (hub-only gate) — 1641 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` on changed files — clean
- [x] Live smoke: default 0.0.0.0 → `http://localhost:11939` + bound note; PARACHUTE_BIND_HOST=127.0.0.1 → `http://127.0.0.1:11940` no bound note

## Patterns check

No pattern boundary touched. Operator-facing banner text only.

## Versioning

`0.5.11-rc.2` → `0.5.11-rc.3` (continuing rc chain per [governance rule 2](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md)).