### PR TITLE
chore(release): 0.5.11 stable (rc chain → @latest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.11] - 2026-05-21
+
+Stable release. Bug-fix-only release covering issues Aaron surfaced during fresh-machine testing of 0.5.10:
+
+- **Modules on discovery page** (#292) — `runInstall` now stamps `installDir` on the services.json row (was diverged from the CLI install path) + regenerates the well-known doc after install/upgrade/uninstall. Modules installed via `/admin/modules` or the wizard now appear on `/` discovery without needing a hub restart.
+- **Approval page resolved scopes** (#294) — server-rendered approve-pending page substitutes unnamed `vault:<verb>` scopes to `vault:*:<verb>` form, matching the SPA approve page and the consent screen. Operator sees the scope shape that will actually appear in minted tokens.
+- **`parachute serve` banner** (#295) — startup line shows `http://localhost:<port>` when bound to `0.0.0.0`, with the bind address noted parenthetically. Pasting the bind address into a browser tripped Chrome's `0.0.0.0` block and surfaced as cross-origin errors.
+
+See individual rc entries below for full detail.
+
 ## [0.5.11-rc.3] - 2026-05-21
 
 **fix(serve): print localhost in banner when bound to 0.0.0.0 (operators couldn't navigate to bind address).**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.11-rc.3",
+  "version": "0.5.11",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Caps the `0.5.11-rc.1` → `rc.3` chain into `0.5.11` stable. No code changes — `package.json` version bump + CHANGELOG stable entry only.

## What's in 0.5.11

Bug-fix-only release covering issues Aaron surfaced during fresh-machine testing of 0.5.10:

- **#292 — modules on discovery page.** `runInstall` now stamps `installDir` on the services.json row (was diverged from the CLI install path) + regenerates the well-known doc after install/upgrade/uninstall. Modules installed via `/admin/modules` or the wizard now appear on `/` discovery without needing a hub restart.
- **#294 — approval page resolved scopes.** Server-rendered approve-pending page substitutes unnamed `vault:<verb>` scopes to `vault:*:<verb>` form, matching the SPA approve page and the consent screen. Operator sees the scope shape that will actually appear in minted tokens.
- **#295 — `parachute serve` banner.** Startup line shows `http://localhost:<port>` when bound to `0.0.0.0`, with the bind address noted parenthetically. Pasting the bind address into a browser tripped Chrome's `0.0.0.0` block and surfaced as cross-origin errors.

## Aaron's next action

```sh
npm publish --tag latest
```

The Render deploy on `parachute.computer/deploy/render/` advertises `@latest`, so this promotion is what makes the deploy story actually work for fresh deployers — without it the deploy page would still pull `0.5.10` and miss all three of the above fixes.

## Test plan

- [x] `bun test ./src` — 1641 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bunx biome check .` — clean
- [x] No code changes; rc.3 already validated each fix in its own PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)