### PR TITLE
fix(hub): parachute restart hub detects orphan bun proc on bound port (#287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.1] - 2026-05-21
+
+**fix(hub): `parachute restart hub` detects orphan bun proc on bound port.**
+
+When the `hub.port` file is missing or stale but a bun process is still holding port 1939, `parachute restart hub` previously reported `hub wasn't running.` while the orphan continued occupying the port — the subsequent `parachute start hub` then failed with `hub: port 1939 unavailable.` The only recovery was a manual `lsof` + `kill`. Surfaced during fresh-machine CORS testing 2026-05-20 (hub#287).
+
+`stopHub` now falls back to probing the canonical hub port (1939) via `lsof -ti :<port> -sTCP:LISTEN` when the pidfile is absent or its PID is dead. If a process is bound, it's treated as an orphan hub: the operator sees `Detected orphan hub process holding port 1939 (PID 12345); stopping it.` and `stopHub` runs the standard SIGTERM → SIGKILL escalation against the adopted PID. `parachute restart hub` therefore now works end-to-end against the stale-pidfile case — the bug repro from hub#287 — without manual cleanup.
+
+`ensureHubRunning`'s port-unavailable error also now names the holder when `lsof` can resolve a PID, pointing the operator at `parachute restart hub` (the orphan-aware path) rather than the bare `lsof -iTCP:1939` hint.
+
+Implementation:
+
+- `src/hub-control.ts` — new `defaultPidOnPort` helper wrapping `lsof -ti :<port> -sTCP:LISTEN` (macOS + Linux; Windows out of scope for v0.6). New `PidOnPortFn` type + injectable `pidOnPort` seam on both `EnsureHubOpts` and `StopHubOpts` so tests don't shell out. `stopHub` now resolves its target PID in two stages: pidfile-first (existing behavior when the file is present + live), then port-probe fallback when the pidfile is missing or stale. Orphan adoption emits a clear stderr line before signalling. `ensureHubRunning`'s port-unavailable throw is enhanced to name the holder + recommend `parachute restart hub` when a PID is resolvable.
+- `src/__tests__/hub-control.test.ts` — pidOnPort stub added to existing stop/start tests (so the real `lsof` against the actually-running local hub on 1939 doesn't bleed into the test harness). Four new tests for hub#287: stale pidfile + orphan-on-port adoption; missing pidfile + orphan-on-port adoption; no orphan reported + no pidfile (genuine no-op); orphan PID reported but already dead (race-window cleanup).
+
+Cross-platform note: `lsof` is the de facto orphan-PID probe on macOS + Linux and ships by default on both. Windows is out of scope for the v0.6 cloud-deploy + owner-operated targets; if/when Windows lands, the seam is already injectable per the `PidOnPortFn` interface.
+
+Tests:
+
+- hub: 1728 pass (1723 before; +4 hub#287 stopHub orphan-adoption tests in `src/__tests__/hub-control.test.ts`, +1 hub#287 ensureHubRunning orphan-hint test).
+- web/ui: 148 pass (unchanged).
+- typecheck + biome: clean.
+
 ## [0.5.12-rc.2] - 2026-05-21
 
 **feat(hub): runtime-settable hub_origin via admin SPA.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
-## [0.5.13-rc.1] - 2026-05-21
+## [0.5.12-rc.3] - 2026-05-21
 
 **fix(hub): `parachute restart hub` detects orphan bun proc on bound port.**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.1",
+  "version": "0.5.12-rc.3",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.12-rc.2",
+  "version": "0.5.13-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-control.test.ts
+++ b/src/__tests__/hub-control.test.ts
@@ -95,10 +95,12 @@ describe("ensureHubRunning", () => {
     }
   });
 
-  test("default fallback is 1 slot: fails when 1939 is taken", async () => {
+  test("default fallback is 1 slot: fails when 1939 is taken (no pid resolvable)", async () => {
     // Canonical layout pins hub to 1939. Walking up would collide with the
     // next service's slot, so the default is to fail and let the user unblock
-    // the port — not quietly land somewhere else.
+    // the port — not quietly land somewhere else. When `lsof` can't name a
+    // PID (Windows, lsof missing, permission), fall back to the classic
+    // lsof-iTCP hint.
     const h = makeHarness();
     try {
       const spawner = makeSpawner(7777);
@@ -109,9 +111,33 @@ describe("ensureHubRunning", () => {
           spawner,
           alive: () => true,
           probe: probeTaken(new Set([1939])),
+          pidOnPort: () => undefined,
           readyWaitMs: 0,
         }),
       ).rejects.toThrow(/lsof -iTCP:1939/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("fails with orphan-PID hint when lsof names the holder (hub#287)", async () => {
+    // When `lsof` can resolve the orphan PID holding the canonical port,
+    // we surface it + recommend `parachute restart hub` (which now detects
+    // and kills the orphan) rather than the bare lsof hint.
+    const h = makeHarness();
+    try {
+      const spawner = makeSpawner(7777);
+      await expect(
+        ensureHubRunning({
+          configDir: h.configDir,
+          wellKnownDir: h.wellKnownDir,
+          spawner,
+          alive: () => true,
+          probe: probeTaken(new Set([1939])),
+          pidOnPort: () => 4242,
+          readyWaitMs: 0,
+        }),
+      ).rejects.toThrow(/PID 4242 is already listening.*parachute restart hub/);
     } finally {
       h.cleanup();
     }
@@ -193,6 +219,7 @@ describe("ensureHubRunning", () => {
           spawner,
           alive: () => true,
           probe: async () => false,
+          pidOnPort: () => undefined,
           readyWaitMs: 0,
           fallbackRange: 3,
         }),
@@ -264,6 +291,7 @@ describe("stopHub", () => {
         alive: () => aliveNow,
         sleep: async () => {},
         now: () => 0,
+        pidOnPort: () => undefined,
       });
       expect(stopped).toBe(true);
       expect(signals).toEqual(["SIGTERM"]);
@@ -293,6 +321,7 @@ describe("stopHub", () => {
         now: () => t,
         killWaitMs: 100,
         pollIntervalMs: 10,
+        pidOnPort: () => undefined,
       });
       expect(stopped).toBe(true);
       expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
@@ -301,7 +330,7 @@ describe("stopHub", () => {
     }
   });
 
-  test("no-op + cleans port file when no pid recorded", async () => {
+  test("no-op + cleans port file when no pid recorded and port is free", async () => {
     const h = makeHarness();
     try {
       writeHubPort(1939, h.configDir);
@@ -313,6 +342,7 @@ describe("stopHub", () => {
         alive: () => true,
         sleep: async () => {},
         now: () => 0,
+        pidOnPort: () => undefined,
       });
       expect(stopped).toBe(false);
       expect(readHubPort(h.configDir)).toBeUndefined();
@@ -321,7 +351,7 @@ describe("stopHub", () => {
     }
   });
 
-  test("stale pid (process already gone) clears state without killing", async () => {
+  test("stale pid (process already gone) + port free clears state without killing", async () => {
     const h = makeHarness();
     try {
       writePid("hub", 77, h.configDir);
@@ -335,10 +365,123 @@ describe("stopHub", () => {
         alive: () => false,
         sleep: async () => {},
         now: () => 0,
+        pidOnPort: () => undefined,
       });
       expect(stopped).toBe(false);
       expect(killCalled).toBe(false);
       expect(existsSync(pidPath("hub", h.configDir))).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // hub#287: orphan-detection paths. The bug shape is "hub.port is missing
+  // or stale, but a bun process is still holding 1939, so `parachute stop
+  // hub` says 'wasn't running' and the next `parachute start hub` fails
+  // with EADDRINUSE." Three variations exercised below.
+
+  test("hub#287: stale hub.port + orphan bound to canonical port → adopts + kills", async () => {
+    // Pidfile names a dead process; lsof reveals a *different* PID is the
+    // actual orphan holder. stopHub clears the stale pidfile, adopts the
+    // orphan, and SIGTERMs it.
+    const h = makeHarness();
+    try {
+      writePid("hub", 77, h.configDir);
+      writeHubPort(1939, h.configDir);
+      const killedPids: number[] = [];
+      const log: string[] = [];
+      let orphanAlive = true;
+      const stopped = await stopHub({
+        configDir: h.configDir,
+        kill: (pid, _sig) => {
+          killedPids.push(pid);
+          orphanAlive = false;
+        },
+        // Stale recorded pid (77) is dead; orphan PID (4242) is alive.
+        alive: (pid) => (pid === 77 ? false : orphanAlive),
+        sleep: async () => {},
+        now: () => 0,
+        pidOnPort: () => 4242,
+        log: (l) => log.push(l),
+      });
+      expect(stopped).toBe(true);
+      expect(killedPids).toEqual([4242]);
+      expect(existsSync(pidPath("hub", h.configDir))).toBe(false);
+      expect(readHubPort(h.configDir)).toBeUndefined();
+      const out = log.join("\n");
+      expect(out).toMatch(/Detected orphan hub process holding port 1939 \(PID 4242\)/);
+      expect(out).toMatch(/✓ orphan hub process \(PID 4242\) stopped/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("hub#287: missing hub.port + orphan bound to canonical port → adopts + kills", async () => {
+    // No pidfile, no port file — but lsof finds a bun proc on 1939.
+    // stopHub adopts and kills it (this is the exact repro Aaron filed).
+    const h = makeHarness();
+    try {
+      const killedPids: number[] = [];
+      const log: string[] = [];
+      let orphanAlive = true;
+      const stopped = await stopHub({
+        configDir: h.configDir,
+        kill: (pid, _sig) => {
+          killedPids.push(pid);
+          orphanAlive = false;
+        },
+        alive: () => orphanAlive,
+        sleep: async () => {},
+        now: () => 0,
+        pidOnPort: () => 9999,
+        log: (l) => log.push(l),
+      });
+      expect(stopped).toBe(true);
+      expect(killedPids).toEqual([9999]);
+      expect(log.join("\n")).toMatch(/Detected orphan hub process holding port 1939 \(PID 9999\)/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("hub#287: no orphan reported and no pidfile → genuine no-op", async () => {
+    // The "hub really wasn't running" path stays clean — no false orphan
+    // adoption when lsof returns nothing.
+    const h = makeHarness();
+    try {
+      const stopped = await stopHub({
+        configDir: h.configDir,
+        kill: () => {
+          throw new Error("must not be called");
+        },
+        alive: () => true,
+        sleep: async () => {},
+        now: () => 0,
+        pidOnPort: () => undefined,
+      });
+      expect(stopped).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("hub#287: orphan PID reported but already dead → treated as no-op", async () => {
+    // Race window: lsof said port was held but the orphan exited before
+    // we could signal it. alive() returns false, so we don't try to kill
+    // a phantom — clean exit as "wasn't running".
+    const h = makeHarness();
+    try {
+      const stopped = await stopHub({
+        configDir: h.configDir,
+        kill: () => {
+          throw new Error("must not be called");
+        },
+        alive: () => false,
+        sleep: async () => {},
+        now: () => 0,
+        pidOnPort: () => 1234,
+      });
+      expect(stopped).toBe(false);
     } finally {
       h.cleanup();
     }

--- a/src/hub-control.ts
+++ b/src/hub-control.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { dirname, join } from "node:path";
@@ -83,11 +84,51 @@ export type HubPortProbe = (port: number) => Promise<boolean>;
 export type KillFn = (pid: number, signal: NodeJS.Signals | number) => void;
 export type SleepFn = (ms: number) => Promise<void>;
 
+/**
+ * Find the PID of the process currently bound to `port` on the local host.
+ * Returns undefined when nothing is listening (or when we couldn't determine
+ * a PID — `lsof` missing, permission errors, etc.; the caller treats that
+ * as "no orphan to adopt").
+ *
+ * The signature is injectable so tests can stub orphan detection without
+ * shelling out to `lsof`. Production callers use `defaultPidOnPort` which
+ * wraps `lsof -ti :<port> -sTCP:LISTEN`. macOS + Linux ship `lsof` by
+ * default; Windows is out of scope for v0.6 — see hub#287.
+ */
+export type PidOnPortFn = (port: number) => number | undefined;
+
 export const defaultKill: KillFn = (pid, signal) => {
   process.kill(pid, signal);
 };
 
 export const defaultSleep: SleepFn = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Default orphan-PID probe: `lsof -ti :<port> -sTCP:LISTEN` returns the
+ * single PID listening on `port`, one per line. We take the first numeric
+ * line — multiple PIDs would be unusual for a TCP LISTEN socket and would
+ * still resolve to a valid target. Any failure (lsof not installed, no
+ * output, garbage) returns undefined so callers fall through to the
+ * "port held by something we can't see" path.
+ */
+export const defaultPidOnPort: PidOnPortFn = (port) => {
+  try {
+    const result = spawnSync("lsof", ["-ti", `:${port}`, "-sTCP:LISTEN"], {
+      encoding: "utf8",
+      timeout: 2000,
+    });
+    if (result.status !== 0) return undefined;
+    const first = result.stdout
+      .split("\n")
+      .map((s) => s.trim())
+      .find((s) => s.length > 0);
+    if (first === undefined) return undefined;
+    const pid = Number.parseInt(first, 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 /**
  * True if `port` accepts a listen() on 127.0.0.1. We bind-then-close to
@@ -112,6 +153,14 @@ export interface EnsureHubOpts {
   alive?: AliveFn;
   probe?: HubPortProbe;
   sleep?: SleepFn;
+  /**
+   * Look up the PID listening on `port`. Production default uses `lsof`;
+   * tests inject a stub. Used to report which orphan process is holding
+   * the canonical hub port when the bind probe fails — so the operator
+   * has a concrete PID to point `parachute restart hub` at, not just an
+   * "unavailable" error. See hub#287.
+   */
+  pidOnPort?: PidOnPortFn;
   /** Starting port (default 1939). First port that probe()s true wins. */
   startPort?: number;
   /** How many ports to try before giving up (default 20). */
@@ -150,6 +199,7 @@ export async function ensureHubRunning(opts: EnsureHubOpts = {}): Promise<Ensure
   const alive = opts.alive ?? defaultAlive;
   const probe = opts.probe ?? defaultPortProbe;
   const sleep = opts.sleep ?? defaultSleep;
+  const pidOnPort = opts.pidOnPort ?? defaultPidOnPort;
   const startPort = opts.startPort ?? HUB_DEFAULT_PORT;
   const fallbackRange = opts.fallbackRange ?? HUB_PORT_FALLBACK_RANGE;
   const reservedPorts = new Set(opts.reservedPorts ?? []);
@@ -175,8 +225,18 @@ export async function ensureHubRunning(opts: EnsureHubOpts = {}): Promise<Ensure
     }
   }
   if (chosenPort === undefined) {
+    // Port is held by *something*. If we can name the PID (lsof on macOS /
+    // Linux), point the operator at `parachute restart hub` — which now
+    // detects and kills the orphan even when hub.port is missing or stale
+    // (hub#287). Without a PID, fall back to the classic lsof hint.
     const range =
       fallbackRange === 1 ? `${startPort}` : `${startPort}..${startPort + fallbackRange - 1}`;
+    const orphanPid = fallbackRange === 1 ? pidOnPort(startPort) : undefined;
+    if (orphanPid !== undefined) {
+      throw new Error(
+        `hub: port ${range} unavailable — PID ${orphanPid} is already listening. Run \`parachute restart hub\` to clean up and restart, or \`kill ${orphanPid}\` then \`parachute start hub\`.`,
+      );
+    }
     throw new Error(
       `hub: port ${range} unavailable. Run \`lsof -iTCP:${startPort}\` to find what's using it, or pass --hub-port to override.`,
     );
@@ -215,6 +275,20 @@ export interface StopHubOpts {
   /** How long SIGTERM gets before SIGKILL. */
   killWaitMs?: number;
   pollIntervalMs?: number;
+  /**
+   * Look up the PID listening on a port. Defaults to `lsof -ti :<port>`
+   * (macOS + Linux). Used by `stopHub` for orphan adoption when hub.port
+   * is missing/stale but something is still bound to the canonical hub
+   * port — see hub#287. Tests inject a stub.
+   */
+  pidOnPort?: PidOnPortFn;
+  /**
+   * Canonical hub port to probe for orphan adoption. Defaults to
+   * `HUB_DEFAULT_PORT` (1939). The `hub.port` file is the primary source
+   * when present; this is the fallback when the file is missing or its
+   * PID is dead but the port is still bound.
+   */
+  canonicalPort?: number;
   log?: (line: string) => void;
 }
 
@@ -226,15 +300,39 @@ export async function stopHub(opts: StopHubOpts = {}): Promise<boolean> {
   const now = opts.now ?? Date.now;
   const killWaitMs = opts.killWaitMs ?? 5_000;
   const pollIntervalMs = opts.pollIntervalMs ?? 100;
+  const pidOnPort = opts.pidOnPort ?? defaultPidOnPort;
+  const canonicalPort = opts.canonicalPort ?? HUB_DEFAULT_PORT;
   const log = opts.log ?? (() => {});
 
-  const pid = readPid(HUB_SVC, configDir);
-  if (pid === undefined) {
-    clearHubPort(configDir);
-    return false;
-  }
-  if (!alive(pid)) {
+  // Resolve target PID: prefer the recorded pidfile (always-correct when
+  // present + live), but fall back to probing the canonical hub port for
+  // orphan processes. hub#287 — a stale or missing hub.port left
+  // `parachute stop hub` / `parachute restart hub` blind to a bun proc
+  // still holding 1939, leaving the operator stuck with EADDRINUSE on
+  // the next `start`.
+  let pid = readPid(HUB_SVC, configDir);
+  let killedOrphan = false;
+
+  if (pid !== undefined && !alive(pid)) {
+    // Stale pidfile — clear it. Fall through to the port-probe below in
+    // case the *port* is still held by an orphan (different PID than the
+    // stale one we just cleared).
     clearPid(HUB_SVC, configDir);
+    pid = undefined;
+  }
+
+  if (pid === undefined) {
+    const orphanPid = pidOnPort(canonicalPort);
+    if (orphanPid !== undefined && alive(orphanPid)) {
+      log(
+        `Detected orphan hub process holding port ${canonicalPort} (PID ${orphanPid}); stopping it.`,
+      );
+      pid = orphanPid;
+      killedOrphan = true;
+    }
+  }
+
+  if (pid === undefined) {
     clearHubPort(configDir);
     return false;
   }
@@ -263,5 +361,6 @@ export async function stopHub(opts: StopHubOpts = {}): Promise<boolean> {
 
   clearPid(HUB_SVC, configDir);
   clearHubPort(configDir);
+  if (killedOrphan) log(`✓ orphan hub process (PID ${pid}) stopped.`);
   return true;
 }


### PR DESCRIPTION
## Summary

Closes #287.

When `hub.port` is missing or stale but a bun process is still holding port 1939, `parachute restart hub` previously reported `hub wasn't running.` while the orphan continued occupying the port. The subsequent `parachute start hub` then failed with `hub: port 1939 unavailable.` The only recovery was a manual `lsof` + `kill`. Surfaced during Aaron's fresh-machine CORS testing 2026-05-20.

## Fix

`stopHub` now falls back to probing the canonical hub port via `lsof -ti :<port> -sTCP:LISTEN` when the pidfile is absent or its PID is dead. If a process is bound, it's adopted as an orphan hub:

```
Detected orphan hub process holding port 1939 (PID 12345); stopping it.
✓ orphan hub process (PID 12345) stopped.
```

`stopHub` then runs the standard SIGTERM → SIGKILL escalation against the adopted PID. Because `restart = stop + start`, `parachute restart hub` now works end-to-end against the stale-pidfile case without manual cleanup.

`ensureHubRunning`'s port-unavailable error also now names the holder when `lsof` can resolve a PID, pointing the operator at `parachute restart hub` (the orphan-aware path) rather than the bare `lsof -iTCP:1939` hint.

## Implementation

- `src/hub-control.ts` — new `defaultPidOnPort` helper wrapping `lsof -ti :<port> -sTCP:LISTEN`. New `PidOnPortFn` type + injectable `pidOnPort` seam on both `EnsureHubOpts` and `StopHubOpts` so tests don't shell out. `stopHub` resolves its target PID in two stages: pidfile-first (existing behavior when present + live), then port-probe fallback when the pidfile is missing or stale. `ensureHubRunning`'s port-unavailable throw enhanced to surface the orphan PID + recommend `parachute restart hub`.
- `src/__tests__/hub-control.test.ts` — pidOnPort stub added to existing stop/start tests (the real `lsof` against the actually-running local hub on 1939 was bleeding into the test harness). Four new tests for hub#287: stale pidfile + orphan-on-port adoption; missing pidfile + orphan-on-port adoption; no orphan + no pidfile (genuine no-op); orphan PID reported but already dead (race-window cleanup). One new `ensureHubRunning` test for the orphan-PID-named error path.

## Cross-platform

`lsof` is the de facto orphan-PID probe on macOS + Linux and ships by default on both. Windows is out of scope for the v0.6 cloud-deploy + owner-operated targets; if/when Windows lands, the `PidOnPortFn` seam is already injectable for a platform-specific probe.

## Versioning

`0.5.12-rc.2` → `0.5.13-rc.1`. CHANGELOG entry under `## [0.5.13-rc.1] - 2026-05-21`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test ./src` — 1728 pass (1723 before, +5)
- [x] `cd web/ui && bun run test` — 148 pass (unchanged)
- [x] `bunx biome check src/` — clean
- [x] Smoke verified end-to-end against real `lsof` on a spawned bun listener: orphan detected, killed, port unreachable after `stopHub` returned `true`.
- [x] Inverse smoke (nothing bound on port): `stopHub` returns `false` with zero log lines (genuine no-op preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)