### PR TITLE
feat(hub): admin SPA module-config form — Phase 1 critical-path (hub#260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.12-rc.4] - 2026-05-21
+
+**feat(hub): admin SPA module-config form (hub#260) — Phase 1 critical-path.**
+
+The admin SPA at `/admin/modules/<short>/config` now renders a generic per-module configuration form, driven entirely by each module's own `/.parachute/config/schema` declaration. Friends deploying via Render can now configure scribe (transcription provider, cleanup provider, port, etc.) from the browser without dropping to a terminal — the last UI gap on the v0.6 single-container Phase 1 critical path.
+
+Architecture — Option A (hub mints `<short>:admin` token at proxy time):
+
+The SPA's session-derived bearer carries `parachute:host:admin`, but modules enforce per-module scopes on `/.parachute/config*` (e.g. scribe requires `scribe:admin`). Two choices to bridge the gap:
+
+- **Option A** (this PR): hub mints a short-lived (60s TTL) `<short>:admin` JWT on each proxied request, drops the SPA bearer, and forwards with the minted token. Audit-friendly (each proxy mint is one signed JWT), keeps modules ignorant of hub's session model, and reuses the existing `signAccessToken` pipeline. The minted token is NOT recorded in the tokens registry — it's a one-shot proxy artifact.
+- Option B (rejected): modules treat `parachute:host:admin` as a master scope that overrides all per-module scopes. Centralizes hub's vocabulary in every module's auth gate; couples module auth surfaces to hub's session model; harder to audit (no clear "who is acting on this module right now" trail).
+
+Renderer — hand-rolled, NOT `@rjsf/core`:
+
+The brief recommended `@rjsf/core` (industry-standard React JSON Schema Form library). The decision here is to hand-roll a focused renderer for the schema vocabulary Parachute modules actually use today: `string` / `number` / `integer` / `boolean`, `enum`, `default`, `title`, `description`, `minimum` / `maximum`, `writeOnly`. Rationale:
+
+- Bundle savings: @rjsf + ajv + plugins is ~250 KB; the SPA build today ships 301 KB total. The library would double our bundle.
+- Schema vocabulary: scribe's schema (the only module with a live schema today) uses none of @rjsf's heavy-hitter features (oneOf / anyOf / dependencies / conditionals). Hand-rolling matches the actual scribe schema shape exactly.
+- Growth path: if/when a module ships a schema feature the hand-roll doesn't cover, lift in @rjsf at that point. Today's call is "no debt, no library."
+
+writeOnly UX (Draft-07 secret-handling, forward-looking):
+
+scribe's current schema has no `writeOnly` fields, but the next module that needs a config-side secret (e.g. agent with API keys) will. The renderer implements the canonical pattern:
+
+- `writeOnly: true` string → `<input type="password">` with `autocomplete="new-password"`.
+- The module's `GET /.parachute/config` response omits writeOnly keys by convention. SPA infers "stored value exists" from "schema marks writeOnly AND value absent in GET response" and shows a `••••••••` placeholder.
+- Hint copy: "Leave blank to keep the current value." A blank password input the user didn't touch has `dirty: false` and is NOT included in the PUT payload — the module preserves its stored secret.
+- A user-typed value flips `dirty: true` and IS included; the module overwrites the stored secret.
+
+The pattern works for every module that ships a writeOnly field on the same `dirty-only-PUT` shape, no per-module branches needed.
+
+Form-state shape:
+
+- `draft`: user's edited values per field (keyed by property name).
+- `dirty`: per-field "did the user touch this?" gate.
+- Submit builds the PUT payload from `{name: draft[name] for name if dirty[name]}` — *only changed fields*. This is what makes the writeOnly preserve-on-blank semantics safe across all field types, not just secrets: a user who edits two fields and submits doesn't accidentally re-send the other 10 fields' current values back to the module (no churn on the underlying config.json, no "did the value just change?" noise in restart-required signals).
+
+Implementation:
+
+- `src/api-modules-config.ts` (new) — `handleApiModulesConfig` + `parseModulesConfigPath`. GET schema, GET values, PUT values. Validates `parachute:host:admin` on the SPA bearer; mints a `<short>:admin` JWT via `signAccessToken` for proxy use; forwards to `http://127.0.0.1:<modulePort>/.parachute/config[/schema]` (honors per-module `stripPrefix`); pipes the response body verbatim so module-side validation errors reach the SPA with their original `{error, message, errors[]}` shape. Special-case: upstream 404 on a GET surfaces as `no_config_schema` (not the raw 404) so the SPA can render a "module has no operator-editable config" empty state distinct from "module not installed."
+- `src/hub-server.ts` — dispatcher entry ahead of the install/restart/upgrade/uninstall switch (those routes use `parseModulesPath` which doesn't match the `/config` suffix shape).
+- `web/ui/src/routes/ModuleConfig.tsx` (new) — the SPA page. Switch-based renderer per schema property type. Five terminal states: loading / no_schema / not_installed / error / ok. writeOnly handling per-field.
+- `web/ui/src/lib/api.ts` — three new fetch helpers (`getModuleConfigSchema`, `getModuleConfigValues`, `putModuleConfigValues`) + four new exported types (`ConfigSchemaProperty`, `ModuleConfigSchema`, `ModuleConfigValues`, `ModuleConfigPutResult`).
+- `web/ui/src/App.tsx` — `/modules/:short/config` route mount + subtitle disambiguation for the per-module sub-page.
+- `web/ui/src/routes/Modules.tsx` — "Configure" link per installed module row. Stays enabled even when supervisor is offline (config endpoints are served by the module itself, not the supervisor).
+- `web/ui/src/styles.css` — minimal styles for the new page + `.btn` rule so the Configure `<Link>` looks like the sibling action buttons.
+
+Tests:
+
+- `src/__tests__/api-modules-config.test.ts` (new, 18 tests) — path parser shape coverage; 401 / 403 / 405 auth boundary; not-installed → 404; mint-and-forward (decodes the JWT the fake upstream receives + asserts scope=`<short>:admin`, audience=`<short>`, iss=hub, ttl=60s); GET schema / GET values / PUT body forwarding; 4xx verbatim; upstream 404 → `no_config_schema`; upstream unreachable → 502; stripPrefix true (scribe-shape) vs false (notes-shape) → correct upstream path.
+- `web/ui/src/routes/ModuleConfig.test.tsx` (new, 12 tests) — loading / no_schema / not_installed / error states; scribe golden fixture renders per-property correctly; submit sends only dirty fields; empty-submit rejected inline; restart_required list rendering; 4xx surfaces field errors; writeOnly renders as password input with placeholder; untouched writeOnly NOT sent; user-typed writeOnly IS sent.
+
+Gates:
+
+- hub: 1746 pass (1728 before, +18 new in `src/__tests__/api-modules-config.test.ts`).
+- web/ui: 160 pass (148 before, +12 new in `src/routes/ModuleConfig.test.tsx`).
+- typecheck + biome clean across root + web/ui.
+- SPA build clean (301 KB total — no library inflation).
+
+Smoke posture:
+
+Aaron is testing rc.3 in parallel against the live local hub + scribe, so this PR does not run a live smoke against the same hub (a side-by-side fresh-hub instance would diverge on issuer / JWKS and the running scribe would reject the minted JWT). Unit tests cover end-to-end JWT shape (decode + scope/audience/issuer assertions), proxy URL composition for both stripPrefix flavors, and the writeOnly safety property. Aaron tests the end-to-end SPA + live scribe write on rc.4 once this lands.
+
 ## [0.5.12-rc.3] - 2026-05-21
 
 **fix(hub): `parachute restart hub` detects orphan bun proc on bound port.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.12-rc.3",
+  "version": "0.5.12-rc.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-modules-config.test.ts
+++ b/src/__tests__/api-modules-config.test.ts
@@ -1,0 +1,492 @@
+/**
+ * Tests for `/api/modules/:short/config[/schema]` — admin-SPA module-config
+ * surface (hub#260).
+ *
+ * Coverage:
+ *   - path parser: shape + curated-only
+ *   - auth: 401 / 403 / 405 boundary
+ *   - module-not-installed → 404 with "module_not_installed" code
+ *   - module without config schema (upstream 404) → "no_config_schema"
+ *   - mint-and-forward (Option A): SPA bearer dropped, `<short>:admin`
+ *     proxy bearer carried upstream; verified by decoding the JWT the
+ *     fake upstream receives
+ *   - GET schema / GET values / PUT values pass through verbatim
+ *   - upstream unreachable → 502
+ *   - stripPrefix true (scribe-shape) vs false (notes-shape) → correct
+ *     upstream path
+ *   - 4xx upstream body forwarded verbatim so SPA can render module's
+ *     validation message inline
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { decodeJwt } from "jose";
+import {
+  API_MODULES_CONFIG_REQUIRED_SCOPE,
+  MODULE_CONFIG_PROXY_CLIENT_ID,
+  handleApiModulesConfig,
+  parseModulesConfigPath,
+} from "../api-modules-config.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { recordTokenMint, signAccessToken } from "../jwt-sign.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "http://127.0.0.1:1939";
+
+interface Harness {
+  dir: string;
+  manifestPath: string;
+  db: ReturnType<typeof openHubDb>;
+  userId: string;
+  cleanup: () => void;
+}
+
+async function makeHarness(): Promise<Harness> {
+  const dir = mkdtempSync(join(tmpdir(), "phub-api-modules-config-"));
+  const db = openHubDb(hubDbPath(dir));
+  rotateSigningKey(db);
+  const user = await createUser(db, "owner", "pw");
+  return {
+    dir,
+    manifestPath: join(dir, "services.json"),
+    db,
+    userId: user.id,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function mintBearer(h: Harness, scopes: string[]): Promise<string> {
+  const signed = await signAccessToken(h.db, {
+    sub: h.userId,
+    scopes,
+    audience: "parachute-hub",
+    clientId: "parachute-hub",
+    issuer: ISSUER,
+    ttlSeconds: 3600,
+  });
+  recordTokenMint(h.db, {
+    jti: signed.jti,
+    createdVia: "operator_mint",
+    subject: h.userId,
+    clientId: "parachute-hub",
+    scopes,
+    expiresAt: signed.expiresAt,
+  });
+  return signed.token;
+}
+
+function writeManifest(path: string, services: unknown[]): void {
+  writeFileSync(path, JSON.stringify({ services }));
+}
+
+function makeReq(
+  url: string,
+  init: { method?: string; headers?: Record<string, string>; body?: string } = {},
+): Request {
+  return new Request(`http://localhost${url}`, {
+    method: init.method ?? "GET",
+    headers: init.headers,
+    body: init.body,
+  });
+}
+
+/**
+ * Fake upstream fetch: records every call (so tests can assert on the
+ * URL, method, and Authorization header forwarded) and returns a
+ * canned Response.
+ */
+function makeFakeUpstream(responder: (url: string, init: RequestInit) => Response): {
+  fetchFn: (url: string, init: RequestInit) => Promise<Response>;
+  calls: Array<{ url: string; method: string; authorization: string | null; body: string | null }>;
+} {
+  const calls: Array<{
+    url: string;
+    method: string;
+    authorization: string | null;
+    body: string | null;
+  }> = [];
+  return {
+    fetchFn: async (url, init) => {
+      const headers = new Headers(init.headers);
+      let body: string | null = null;
+      if (init.body && typeof init.body === "string") body = init.body;
+      else if (init.body) {
+        try {
+          // ReadableStream from forwarded req.body — drain via Response
+          // for inspectability in tests.
+          body = await new Response(init.body as ReadableStream<Uint8Array> | null).text();
+        } catch {
+          body = null;
+        }
+      }
+      calls.push({
+        url,
+        method: init.method ?? "GET",
+        authorization: headers.get("authorization"),
+        body,
+      });
+      return responder(url, init);
+    },
+    calls,
+  };
+}
+
+describe("parseModulesConfigPath", () => {
+  test("matches /api/modules/<short>/config", () => {
+    expect(parseModulesConfigPath("/api/modules/scribe/config")).toEqual({
+      short: "scribe",
+      suffix: "",
+    });
+  });
+
+  test("matches /api/modules/<short>/config/schema", () => {
+    expect(parseModulesConfigPath("/api/modules/scribe/config/schema")).toEqual({
+      short: "scribe",
+      suffix: "schema",
+    });
+  });
+
+  test("matches vault and notes (curated modules)", () => {
+    expect(parseModulesConfigPath("/api/modules/vault/config")?.short).toBe("vault");
+    expect(parseModulesConfigPath("/api/modules/notes/config/schema")?.short).toBe("notes");
+  });
+
+  test("rejects unknown short (non-curated)", () => {
+    expect(parseModulesConfigPath("/api/modules/unknown/config")).toBeUndefined();
+    expect(parseModulesConfigPath("/api/modules/channel/config")).toBeUndefined();
+  });
+
+  test("rejects non-config suffix shapes", () => {
+    expect(parseModulesConfigPath("/api/modules/scribe/install")).toBeUndefined();
+    expect(parseModulesConfigPath("/api/modules/scribe/config/extra")).toBeUndefined();
+    expect(parseModulesConfigPath("/api/modules/scribe")).toBeUndefined();
+    expect(parseModulesConfigPath("/api/modules/scribe/")).toBeUndefined();
+  });
+
+  test("rejects non-/api/modules prefixes", () => {
+    expect(parseModulesConfigPath("/api/auth/tokens")).toBeUndefined();
+    expect(parseModulesConfigPath("/admin/modules/scribe/config")).toBeUndefined();
+  });
+});
+
+describe("handleApiModulesConfig — auth", () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+  });
+  afterEach(() => h.cleanup());
+
+  test("405 on POST", async () => {
+    const res = await handleApiModulesConfig(
+      makeReq("/api/modules/scribe/config", { method: "POST" }),
+      { short: "scribe", suffix: "" },
+      { db: h.db, issuer: ISSUER, manifestPath: h.manifestPath },
+    );
+    expect(res.status).toBe(405);
+  });
+
+  test("405 on PUT to /schema", async () => {
+    const res = await handleApiModulesConfig(
+      makeReq("/api/modules/scribe/config/schema", { method: "PUT" }),
+      { short: "scribe", suffix: "schema" },
+      { db: h.db, issuer: ISSUER, manifestPath: h.manifestPath },
+    );
+    expect(res.status).toBe(405);
+  });
+
+  test("401 with no Authorization header", async () => {
+    const res = await handleApiModulesConfig(
+      makeReq("/api/modules/scribe/config"),
+      { short: "scribe", suffix: "" },
+      { db: h.db, issuer: ISSUER, manifestPath: h.manifestPath },
+    );
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("unauthenticated");
+  });
+
+  test("403 when bearer lacks parachute:host:admin", async () => {
+    const bearer = await mintBearer(h, ["parachute:host:auth"]);
+    const res = await handleApiModulesConfig(
+      makeReq("/api/modules/scribe/config", { headers: { authorization: `Bearer ${bearer}` } }),
+      { short: "scribe", suffix: "" },
+      { db: h.db, issuer: ISSUER, manifestPath: h.manifestPath },
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("insufficient_scope");
+    expect(body.error_description).toContain(API_MODULES_CONFIG_REQUIRED_SCOPE);
+  });
+});
+
+describe("handleApiModulesConfig — module-not-installed", () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+    // No manifest file written → readManifest returns empty services list.
+  });
+  afterEach(() => h.cleanup());
+
+  test("404 module_not_installed when scribe absent from services.json", async () => {
+    const bearer = await mintBearer(h, [API_MODULES_CONFIG_REQUIRED_SCOPE]);
+    const res = await handleApiModulesConfig(
+      makeReq("/api/modules/scribe/config/schema", {
+        headers: { authorization: `Bearer ${bearer}` },
+      }),
+      { short: "scribe", suffix: "schema" },
+      { db: h.db, issuer: ISSUER, manifestPath: h.manifestPath },
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("module_not_installed");
+  });
+});
+
+describe("handleApiModulesConfig — proxy + mint", () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+    // Scribe at port 1943 with `/scribe` mount + stripPrefix true (matches
+    // FIRST_PARTY_FALLBACKS — verified upstream paths must be the bare
+    // `/.parachute/config/schema` shape).
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-scribe",
+        port: 1943,
+        paths: ["/scribe"],
+        health: "/health",
+        version: "0.4.0",
+      },
+    ]);
+  });
+  afterEach(() => h.cleanup());
+
+  test("GET /schema mints <short>:admin bearer, drops SPA bearer, hits bare path", async () => {
+    const bearer = await mintBearer(h, [API_MODULES_CONFIG_REQUIRED_SCOPE]);
+    const upstream = makeFakeUpstream(() =>
+      Response.json({ type: "object", properties: { transcribeProvider: { type: "string" } } }),
+    );
+    const res = await handleApiModulesConfig(
+      makeReq("/api/modules/scribe/config/schema", {
+        headers: { authorization: `Bearer ${bearer}` },
+      }),
+      { short: "scribe", suffix: "schema" },
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        upstreamFetch: upstream.fetchFn,
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { type: string };
+    expect(body.type).toBe("object");
+
+    // Exactly one upstream call.
+    expect(upstream.calls).toHaveLength(1);
+    const call = upstream.calls[0];
+    if (!call) throw new Error("upstream not called");
+
+    // Correct URL: scribe is stripPrefix-true, so the upstream sees the
+    // bare `/.parachute/config/schema` — no `/scribe` prefix.
+    expect(call.url).toBe("http://127.0.0.1:1943/.parachute/config/schema");
+    expect(call.method).toBe("GET");
+
+    // Authorization is the minted proxy token, NOT the SPA bearer.
+    expect(call.authorization).toBeString();
+    expect(call.authorization).not.toBe(`Bearer ${bearer}`);
+    const proxyJwt = call.authorization?.replace(/^Bearer /, "") ?? "";
+    const claims = decodeJwt(proxyJwt);
+    // Per-module scope (`scribe:admin`), per-module audience, correct issuer.
+    expect(claims.scope).toBe("scribe:admin");
+    expect(claims.aud).toBe("scribe");
+    expect(claims.iss).toBe(ISSUER);
+    expect(claims.client_id).toBe(MODULE_CONFIG_PROXY_CLIENT_ID);
+    expect(claims.sub).toBe(h.userId);
+    // Short TTL — exp should be ~60s out from iat. Tolerate small drift.
+    if (typeof claims.iat === "number" && typeof claims.exp === "number") {
+      expect(claims.exp - claims.iat).toBe(60);
+    } else {
+      throw new Error("proxy JWT missing iat/exp claims");
+    }
+  });
+
+  test("GET values returns upstream body verbatim", async () => {
+    const bearer = await mintBearer(h, [API_MODULES_CONFIG_REQUIRED_SCOPE]);
+    const upstream = makeFakeUpstream(() =>
+      Response.json({ transcribeProvider: "parakeet-mlx", cleanupProvider: "none" }),
+    );
+    const res = await handleApiModulesConfig(
+      makeReq("/api/modules/scribe/config", {
+        headers: { authorization: `Bearer ${bearer}` },
+      }),
+      { short: "scribe", suffix: "" },
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        upstreamFetch: upstream.fetchFn,
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { transcribeProvider: string };
+    expect(body.transcribeProvider).toBe("parakeet-mlx");
+    // Bare `/.parachute/config` (no /schema).
+    expect(upstream.calls[0]?.url).toBe("http://127.0.0.1:1943/.parachute/config");
+  });
+
+  test("PUT forwards body + uses PUT method", async () => {
+    const bearer = await mintBearer(h, [API_MODULES_CONFIG_REQUIRED_SCOPE]);
+    const upstream = makeFakeUpstream(() =>
+      Response.json({ restart_required: ["transcribeProvider"] }),
+    );
+    const res = await handleApiModulesConfig(
+      makeReq("/api/modules/scribe/config", {
+        method: "PUT",
+        headers: {
+          authorization: `Bearer ${bearer}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ transcribeProvider: "groq" }),
+      }),
+      { short: "scribe", suffix: "" },
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        upstreamFetch: upstream.fetchFn,
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { restart_required: string[] };
+    expect(body.restart_required).toEqual(["transcribeProvider"]);
+
+    const call = upstream.calls[0];
+    if (!call) throw new Error("upstream not called");
+    expect(call.method).toBe("PUT");
+    expect(call.body).toBe(JSON.stringify({ transcribeProvider: "groq" }));
+  });
+
+  test("4xx upstream body forwarded verbatim", async () => {
+    const bearer = await mintBearer(h, [API_MODULES_CONFIG_REQUIRED_SCOPE]);
+    const upstream = makeFakeUpstream(() =>
+      Response.json(
+        {
+          error: "validation_failed",
+          message: "transcribeProvider: must be one of [parakeet-mlx, ...]",
+          errors: [{ path: "transcribeProvider", message: "invalid enum" }],
+        },
+        { status: 400 },
+      ),
+    );
+    const res = await handleApiModulesConfig(
+      makeReq("/api/modules/scribe/config", {
+        method: "PUT",
+        headers: { authorization: `Bearer ${bearer}` },
+        body: JSON.stringify({ transcribeProvider: "bogus" }),
+      }),
+      { short: "scribe", suffix: "" },
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        upstreamFetch: upstream.fetchFn,
+      },
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; errors: unknown[] };
+    expect(body.error).toBe("validation_failed");
+    expect(body.errors).toBeArrayOfSize(1);
+  });
+
+  test("upstream 404 surfaces as no_config_schema (graceful empty-state hint)", async () => {
+    const bearer = await mintBearer(h, [API_MODULES_CONFIG_REQUIRED_SCOPE]);
+    const upstream = makeFakeUpstream(() => new Response("not found", { status: 404 }));
+    const res = await handleApiModulesConfig(
+      makeReq("/api/modules/scribe/config/schema", {
+        headers: { authorization: `Bearer ${bearer}` },
+      }),
+      { short: "scribe", suffix: "schema" },
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        upstreamFetch: upstream.fetchFn,
+      },
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("no_config_schema");
+  });
+
+  test("upstream unreachable → 502", async () => {
+    const bearer = await mintBearer(h, [API_MODULES_CONFIG_REQUIRED_SCOPE]);
+    const upstream = makeFakeUpstream(() => {
+      throw new Error("ECONNREFUSED");
+    });
+    const res = await handleApiModulesConfig(
+      makeReq("/api/modules/scribe/config/schema", {
+        headers: { authorization: `Bearer ${bearer}` },
+      }),
+      { short: "scribe", suffix: "schema" },
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        upstreamFetch: async () => {
+          // Wrapper to allow capturing the throw cleanly.
+          await upstream.fetchFn("http://127.0.0.1:1943/.parachute/config/schema", {});
+          throw new Error("unreachable");
+        },
+      },
+    );
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("upstream_unreachable");
+  });
+});
+
+describe("handleApiModulesConfig — stripPrefix=false (notes-shape)", () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+    // Notes is keep-prefix in FIRST_PARTY_FALLBACKS — the upstream URL
+    // should preserve the `/notes` mount. (Hub's notes-serve stub doesn't
+    // expose .parachute/config/schema today; this test only asserts the
+    // proxy URL shape, not the upstream's behavior.)
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-notes",
+        port: 1941,
+        paths: ["/notes"],
+        health: "/health",
+        version: "0.5.0",
+      },
+    ]);
+  });
+  afterEach(() => h.cleanup());
+
+  test("keep-prefix module → upstream path includes the mount", async () => {
+    const bearer = await mintBearer(h, [API_MODULES_CONFIG_REQUIRED_SCOPE]);
+    const upstream = makeFakeUpstream(() => Response.json({ type: "object", properties: {} }));
+    await handleApiModulesConfig(
+      makeReq("/api/modules/notes/config/schema", {
+        headers: { authorization: `Bearer ${bearer}` },
+      }),
+      { short: "notes", suffix: "schema" },
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        upstreamFetch: upstream.fetchFn,
+      },
+    );
+    expect(upstream.calls[0]?.url).toBe("http://127.0.0.1:1941/notes/.parachute/config/schema");
+  });
+});

--- a/src/api-modules-config.ts
+++ b/src/api-modules-config.ts
@@ -1,0 +1,329 @@
+/**
+ * `/api/modules/:short/config[/schema]` — admin SPA's module-config surface.
+ *
+ * The admin SPA renders a generic per-module config form at
+ * `/admin/modules/<short>/config`. It fetches three things off this hub-side
+ * endpoint:
+ *
+ *   - `GET /api/modules/:short/config/schema` → the module's draft-07 JSON
+ *     Schema (`{type:"object", properties:{...}, required:[...]}`).
+ *   - `GET /api/modules/:short/config`         → the module's current
+ *     resolved values (keys present in the schema; `writeOnly` keys omitted).
+ *   - `PUT /api/modules/:short/config`         → write new values; module
+ *     validates against its own schema and 4xx's on shape errors.
+ *
+ * Hub doesn't own the schema or the values — it just proxies to the module's
+ * own runtime endpoints (`/.parachute/config/schema`, `/.parachute/config`).
+ * Two reasons to wrap rather than expose the proxy directly:
+ *
+ *   1. **Scope translation (Option A).** Modules enforce per-module scopes
+ *      on `/.parachute/config*` (e.g. scribe requires `scribe:admin`). The
+ *      admin SPA's session-derived bearer carries `parachute:host:admin`,
+ *      not `<short>:admin`. We mint a fresh short-lived `<short>:admin`
+ *      JWT at proxy time so the upstream auth gate is satisfied without
+ *      handing the operator a permanent module-scoped bearer.
+ *   2. **Curated set + clean errors.** We restrict the surface to
+ *      `CURATED_MODULES` (vault / notes / scribe) and surface a clean
+ *      "module not installed" / "module has no config schema" empty state
+ *      rather than the upstream's raw 404. The admin UI gets a consistent
+ *      contract across modules even if individual modules drift on shape.
+ *
+ * Bearer-gated on `parachute:host:admin` (same scope as install / upgrade —
+ * config writes are destructive operator-only state changes). A read-only
+ * `parachute:host:auth` token gets 403 here. The SPA's host-admin mint at
+ * `/admin/host-admin-token` carries both scopes so the SPA path works.
+ *
+ * Option A vs B trade-off (Aaron's hub#260 brief): hub mints a one-shot
+ * `<short>:admin` JWT (audience = module short, ttl = 60s) and proxies
+ * the request with that bearer. The alternative (modules accept
+ * `parachute:host:admin` as a master scope) would centralize the override
+ * in the wrong place — each module would need to know hub's scope vocabulary
+ * and the master-scope concept would creep into module auth surfaces. The
+ * mint-and-forward shape keeps every module ignorant of hub's session model
+ * — they enforce their own scope as if a real `<short>:admin` token came
+ * over the wire, which is exactly what hub gave them.
+ */
+
+import type { Database } from "bun:sqlite";
+import { CURATED_MODULES, type CuratedModuleShort } from "./api-modules.ts";
+import { signAccessToken, validateAccessToken } from "./jwt-sign.ts";
+import { FIRST_PARTY_FALLBACKS } from "./service-spec.ts";
+import { readManifest } from "./services-manifest.ts";
+
+/** Scope required on the SPA's bearer to call any of these endpoints. */
+export const API_MODULES_CONFIG_REQUIRED_SCOPE = "parachute:host:admin";
+
+/** TTL on the minted module-scoped JWT we forward upstream. */
+export const MODULE_CONFIG_PROXY_TOKEN_TTL_SECONDS = 60;
+
+/** client_id stamped on the minted proxy token. Audit-friendly. */
+export const MODULE_CONFIG_PROXY_CLIENT_ID = "parachute-hub-module-config-proxy";
+
+export interface ApiModulesConfigDeps {
+  db: Database;
+  /** Hub origin — sets `iss` on the minted proxy token AND validates the SPA bearer. */
+  issuer: string;
+  /** services.json path. Module-mount + port come from here. */
+  manifestPath: string;
+  /**
+   * Loopback fetch — production calls `fetch()`; tests inject a fake that
+   * returns a canned Response without binding a port. Defaults to global
+   * `fetch`.
+   */
+  upstreamFetch?: (url: string, init: RequestInit) => Promise<Response>;
+  /** Test seam over wall-clock — passed through to `signAccessToken`. */
+  now?: () => Date;
+}
+
+interface PathMatch {
+  short: CuratedModuleShort;
+  /** `""` for `/api/modules/<short>/config`, `"schema"` for `.../schema`. */
+  suffix: "" | "schema";
+}
+
+/**
+ * Parse `/api/modules/<short>/config` or `/api/modules/<short>/config/schema`.
+ * Returns undefined for any other shape so the caller can fall through to
+ * other `/api/modules/...` handlers (install / upgrade / etc.).
+ */
+export function parseModulesConfigPath(pathname: string): PathMatch | undefined {
+  const prefix = "/api/modules/";
+  if (!pathname.startsWith(prefix)) return undefined;
+  const tail = pathname.slice(prefix.length);
+  // Accept exactly `<short>/config` or `<short>/config/schema`.
+  const m = tail.match(/^([a-z][a-z0-9-]*)\/config(\/schema)?$/);
+  if (!m) return undefined;
+  const short = m[1];
+  if (!CURATED_MODULES.includes(short as CuratedModuleShort)) return undefined;
+  return {
+    short: short as CuratedModuleShort,
+    suffix: m[2] ? "schema" : "",
+  };
+}
+
+/**
+ * Look up a module's upstream `http://127.0.0.1:<port>/<mount>` base URL.
+ * Returns `{installed: false}` when the module isn't in services.json —
+ * the SPA renders an empty state pointing the operator at /admin/modules
+ * to install it first.
+ */
+function resolveUpstream(
+  short: CuratedModuleShort,
+  manifestPath: string,
+): { installed: true; port: number; mount: string; stripPrefix: boolean } | { installed: false } {
+  const fb = FIRST_PARTY_FALLBACKS[short];
+  if (!fb) return { installed: false };
+  const manifest = readManifest(manifestPath);
+  const entry = manifest.services.find((s) => s.name === fb.manifest.manifestName);
+  if (!entry) return { installed: false };
+  // Mount = the first path the service registers (canonical convention
+  // matches `findServiceUpstream` in hub-server.ts). Strip prefix mirrors
+  // the proxy's `stripPrefixFor` — explicit on-entry wins, fallback supplies
+  // the default. We compute it here rather than threading the proxy helper
+  // because we're constructing the upstream URL ourselves, not piggy-backing
+  // on `proxyRequest`.
+  const mount = entry.paths[0] ?? fb.manifest.paths[0] ?? "/";
+  const stripPrefix =
+    entry.stripPrefix !== undefined ? entry.stripPrefix : (fb.manifest.stripPrefix ?? false);
+  return { installed: true, port: entry.port, mount, stripPrefix };
+}
+
+/**
+ * Build the upstream URL for `.parachute/config[/schema]`. When `stripPrefix`
+ * is true the module sees a bare `/.parachute/config/...`; otherwise the
+ * mount prefix is preserved (`/scribe/.parachute/config/...`).
+ *
+ * scribe ships `stripPrefix: true` (in FIRST_PARTY_FALLBACKS); notes and
+ * vault are keep-prefix. Honoring this here means the same proxy works
+ * across both shapes without per-module branches.
+ */
+function buildUpstreamPath(mount: string, stripPrefix: boolean, suffix: "" | "schema"): string {
+  const inner = suffix === "schema" ? "/.parachute/config/schema" : "/.parachute/config";
+  if (stripPrefix) return inner;
+  // Normalize trailing slash (mirrors `findServiceUpstream`'s normalization
+  // so a `paths: ["/scribe/"]` entry doesn't double-slash).
+  const norm = mount.replace(/\/+$/, "") || "";
+  return `${norm}${inner}`;
+}
+
+/**
+ * Validate the SPA's bearer + extract its scopes. Returns either an error
+ * response or the parsed sub.
+ */
+async function authorize(
+  req: Request,
+  deps: ApiModulesConfigDeps,
+): Promise<Response | { sub: string }> {
+  const auth = req.headers.get("authorization");
+  if (!auth || !auth.startsWith("Bearer ")) {
+    return jsonError(401, "unauthenticated", "Authorization: Bearer <token> required");
+  }
+  const bearer = auth.slice("Bearer ".length).trim();
+  if (!bearer) return jsonError(401, "unauthenticated", "empty bearer token");
+  try {
+    const validated = await validateAccessToken(deps.db, bearer, deps.issuer);
+    const sub = validated.payload.sub;
+    if (typeof sub !== "string" || sub.length === 0) {
+      return jsonError(401, "unauthenticated", "bearer token has no sub claim");
+    }
+    const scopes =
+      typeof validated.payload.scope === "string"
+        ? validated.payload.scope.split(/\s+/).filter((s) => s.length > 0)
+        : [];
+    if (!scopes.includes(API_MODULES_CONFIG_REQUIRED_SCOPE)) {
+      return jsonError(
+        403,
+        "insufficient_scope",
+        `bearer token lacks ${API_MODULES_CONFIG_REQUIRED_SCOPE}`,
+      );
+    }
+    return { sub };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return jsonError(401, "unauthenticated", `bearer token invalid — ${msg}`);
+  }
+}
+
+/**
+ * Mint a short-lived `<short>:admin` JWT to forward upstream. Re-uses the
+ * existing `signAccessToken` plumbing (active signing key from the DB,
+ * RS256, iss-stamped); audience = `short` so the module's audience check
+ * passes. The token is NOT recorded in the tokens registry — it's a
+ * one-shot proxy artifact, dies on its own in 60s, and we never hand it
+ * to a caller.
+ */
+async function mintProxyToken(
+  short: CuratedModuleShort,
+  sub: string,
+  deps: ApiModulesConfigDeps,
+): Promise<string> {
+  const opts: Parameters<typeof signAccessToken>[1] = {
+    sub,
+    scopes: [`${short}:admin`],
+    audience: short,
+    clientId: MODULE_CONFIG_PROXY_CLIENT_ID,
+    issuer: deps.issuer,
+    ttlSeconds: MODULE_CONFIG_PROXY_TOKEN_TTL_SECONDS,
+  };
+  if (deps.now) opts.now = deps.now;
+  const signed = await signAccessToken(deps.db, opts);
+  return signed.token;
+}
+
+/**
+ * Top-level dispatcher for `/api/modules/:short/config[/schema]`.
+ *
+ *   - `GET    /api/modules/:short/config/schema` → upstream `/.parachute/config/schema`
+ *   - `GET    /api/modules/:short/config`        → upstream `/.parachute/config`
+ *   - `PUT    /api/modules/:short/config`        → upstream `/.parachute/config` (PUT)
+ *
+ * Other verbs return 405.
+ */
+export async function handleApiModulesConfig(
+  req: Request,
+  match: PathMatch,
+  deps: ApiModulesConfigDeps,
+): Promise<Response> {
+  // Method gate per route. PUT only valid on the bare `config` path.
+  if (match.suffix === "schema") {
+    if (req.method !== "GET") return jsonError(405, "method_not_allowed", "use GET");
+  } else {
+    if (req.method !== "GET" && req.method !== "PUT") {
+      return jsonError(405, "method_not_allowed", "use GET or PUT");
+    }
+  }
+
+  // Auth.
+  const authOut = await authorize(req, deps);
+  if (authOut instanceof Response) return authOut;
+  const { sub } = authOut;
+
+  // Resolve upstream from services.json. Not-installed = clean empty state
+  // so the SPA can prompt the operator to install first.
+  const upstream = resolveUpstream(match.short, deps.manifestPath);
+  if (!upstream.installed) {
+    return jsonError(
+      404,
+      "module_not_installed",
+      `module "${match.short}" is not installed; visit /admin/modules to install it first`,
+    );
+  }
+
+  // Mint the per-request `<short>:admin` proxy token (Option A).
+  let proxyToken: string;
+  try {
+    proxyToken = await mintProxyToken(match.short, sub, deps);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return jsonError(500, "mint_failed", `failed to mint proxy token — ${msg}`);
+  }
+
+  // Build upstream URL.
+  const path = buildUpstreamPath(upstream.mount, upstream.stripPrefix, match.suffix);
+  const url = `http://127.0.0.1:${upstream.port}${path}`;
+
+  // Forward. We carry method + body through. The SPA's Authorization
+  // header is dropped (it's the host-admin scope, not what the module
+  // wants); we substitute the freshly-minted module-scoped JWT.
+  const init: RequestInit & { duplex?: "half" } = {
+    method: req.method,
+    headers: {
+      authorization: `Bearer ${proxyToken}`,
+      // Preserve content-type on PUT — modules parse JSON bodies based on
+      // it. Default to application/json so a SPA that forgot the header
+      // doesn't accidentally hit a text/plain body path upstream.
+      "content-type": req.headers.get("content-type") ?? "application/json",
+      accept: req.headers.get("accept") ?? "application/json",
+    },
+    redirect: "manual",
+  };
+  if (req.method === "PUT") {
+    init.body = req.body;
+    init.duplex = "half";
+  }
+
+  let upstreamRes: Response;
+  try {
+    const fetchFn = deps.upstreamFetch ?? fetch;
+    upstreamRes = await fetchFn(url, init);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return jsonError(
+      502,
+      "upstream_unreachable",
+      `module "${match.short}" upstream unreachable: ${msg}`,
+    );
+  }
+
+  // Special case: a module GET-schema that returns 404 means the module
+  // is up but doesn't expose `.parachute/config/schema`. Surface a
+  // distinguishable error so the SPA can render "this module has no
+  // operator-editable config" rather than a generic 404. Same for the
+  // bare `/.parachute/config` GET (some module versions may ship one
+  // without the other; we treat both upstream 404s as "no schema").
+  if (upstreamRes.status === 404 && req.method === "GET") {
+    return jsonError(
+      404,
+      "no_config_schema",
+      `module "${match.short}" does not expose a config schema at /.parachute/config/schema`,
+    );
+  }
+
+  // For all other responses, forward verbatim — body, status, and
+  // content-type. Modules already shape their own error bodies (scribe
+  // uses `{error, message, errors[]}` on a 400 validation fail); the
+  // SPA renders the module's message inline.
+  const body = await upstreamRes.text();
+  const headers = new Headers();
+  const ct = upstreamRes.headers.get("content-type");
+  if (ct) headers.set("content-type", ct);
+  else headers.set("content-type", "application/json");
+  return new Response(body, { status: upstreamRes.status, headers });
+}
+
+function jsonError(status: number, code: string, description: string): Response {
+  return new Response(JSON.stringify({ error: code, error_description: description }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -114,6 +114,7 @@ import { handleCreateVault } from "./admin-vaults.ts";
 import { handleAccountChangePasswordGet, handleAccountChangePasswordPost } from "./api-account.ts";
 import { handleApiMe } from "./api-me.ts";
 import { handleApiMintToken } from "./api-mint-token.ts";
+import { handleApiModulesConfig, parseModulesConfigPath } from "./api-modules-config.ts";
 import {
   getDefaultOperationsRegistry,
   handleInstall,
@@ -1540,6 +1541,29 @@ export function hubFetch(
         configDir: CONFIG_DIR,
         supervisor: deps.supervisor,
       });
+    }
+
+    // Per-module config surface (hub#260) — schema + values GET, values PUT.
+    // Sits ahead of the install/restart/upgrade/uninstall switch below so
+    // `/api/modules/<short>/config[/schema]` doesn't fall into the default-
+    // branch 404 (`parseModulesPath` only matches the action-suffix shape,
+    // not the `config` / `config/schema` shape).
+    //
+    // Diverges from the action endpoints in two ways: doesn't require a
+    // supervisor (we just proxy to the running module's HTTP surface, not
+    // spawn a child), and mints a `<short>:admin` token at proxy time so
+    // the upstream auth gate is satisfied without forcing the SPA bearer
+    // to carry per-module scopes.
+    {
+      const configMatch = parseModulesConfigPath(pathname);
+      if (configMatch) {
+        if (!getDb) return dbNotConfigured();
+        return handleApiModulesConfig(req, configMatch, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          manifestPath: deps?.manifestPath ?? SERVICES_MANIFEST_PATH,
+        });
+      }
     }
 
     // Per-module action endpoints: /api/modules/:short/{install,restart,upgrade,uninstall}.

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -25,6 +25,7 @@ import { type ReactNode, useEffect, useState } from "react";
 import { Link, Route, Routes, useLocation } from "react-router-dom";
 import { type MeResponse, getMe, signOut } from "./lib/api.ts";
 import { ApproveClient } from "./routes/ApproveClient.tsx";
+import { ModuleConfig } from "./routes/ModuleConfig.tsx";
 import { Modules } from "./routes/Modules.tsx";
 import { NewVault } from "./routes/NewVault.tsx";
 import { Permissions } from "./routes/Permissions.tsx";
@@ -46,6 +47,10 @@ function subtitleFor(pathname: string): string {
     return "tokens";
   }
   if (pathname === "/modules" || pathname.startsWith("/modules/")) {
+    // Sub-page disambiguation for the per-module config form so the nav
+    // breadcrumb tells the operator they're inside a module's settings,
+    // not on the module catalog.
+    if (/^\/modules\/[a-z][a-z0-9-]*\/config$/.test(pathname)) return "module config";
     return "modules";
   }
   if (pathname === "/users" || pathname.startsWith("/users/")) {
@@ -127,6 +132,7 @@ export function App() {
         <Route path="/vaults" element={<VaultsList />} />
         <Route path="/vaults/new" element={<NewVault />} />
         <Route path="/modules" element={<Modules />} />
+        <Route path="/modules/:short/config" element={<ModuleConfig />} />
         <Route path="/users" element={<Users />} />
         <Route path="/permissions" element={<Permissions />} />
         <Route path="/tokens" element={<Tokens />} />

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -799,6 +799,143 @@ export async function setHubOriginSetting(hubOrigin: string | null): Promise<str
 }
 
 /**
+ * Subset of JSON Schema fields the generic config form understands. Mirrors
+ * what scribe + future modules surface today (Draft-07 style). Unknown
+ * fields pass through unread — the renderer ignores them, which means a
+ * module can add `pattern`, `format`, etc. without breaking the form.
+ *
+ * `writeOnly` is the Draft-07 marker for "this is a secret, the GET
+ * response omits the current value." The renderer treats it as a
+ * password input with a "leave blank to keep current value" affordance
+ * — the form only sends the field when the user actually types into it,
+ * so an empty submit doesn't accidentally clear a stored secret.
+ */
+export interface ConfigSchemaProperty {
+  type?: "string" | "number" | "integer" | "boolean";
+  title?: string;
+  description?: string;
+  enum?: ReadonlyArray<string | number>;
+  default?: string | number | boolean | null;
+  minimum?: number;
+  maximum?: number;
+  writeOnly?: boolean;
+}
+
+export interface ModuleConfigSchema {
+  type?: "object";
+  properties?: Record<string, ConfigSchemaProperty>;
+  required?: readonly string[];
+  /** Modules pass arbitrary x-* extensions through — surfaced as-is. */
+  [key: string]: unknown;
+}
+
+/** Resolved config values for a module. Any JSON-serializable scalar / object. */
+export type ModuleConfigValues = Record<string, unknown>;
+
+/**
+ * GET /api/modules/:short/config/schema — fetch the module's JSON Schema.
+ *
+ * Returns null when the module is up but doesn't expose a config schema
+ * (upstream 404 → hub's "no_config_schema" error). Throws on auth /
+ * not-installed / unreachable so the page can render a distinct
+ * error state per case.
+ */
+export async function getModuleConfigSchema(short: string): Promise<ModuleConfigSchema | null> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch(`/api/modules/${encodeURIComponent(short)}/config/schema`, {
+    method: "GET",
+    headers: { accept: "application/json", authorization: `Bearer ${bearer}` },
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (res.status === 404) {
+    // Distinguish "module not installed" (operator path: go install first)
+    // from "module has no schema" (operator path: no UI for this module).
+    let code: string | undefined;
+    try {
+      const body = (await res.clone().json()) as { error?: string };
+      code = body.error;
+    } catch {
+      /* not JSON */
+    }
+    if (code === "no_config_schema") return null;
+    throw new HttpError(404, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as ModuleConfigSchema;
+}
+
+/**
+ * GET /api/modules/:short/config — fetch the module's current resolved
+ * config values. `writeOnly` keys are omitted by the module (the
+ * canonical Draft-07 secret-handling rule). 404 here means the module
+ * is installed but the operator hasn't loaded it through the form
+ * before — surface an empty object so the form pre-fills from
+ * schema defaults rather than 4xx'ing the whole page.
+ */
+export async function getModuleConfigValues(short: string): Promise<ModuleConfigValues> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch(`/api/modules/${encodeURIComponent(short)}/config`, {
+    method: "GET",
+    headers: { accept: "application/json", authorization: `Bearer ${bearer}` },
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (res.status === 404) {
+    // Module installed but no config endpoint, or no values yet. Treat as
+    // empty so the form pre-fills from schema defaults.
+    return {};
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as ModuleConfigValues;
+}
+
+/**
+ * Response from PUT /api/modules/:short/config. Forwards whatever the
+ * module returned in its own success body — scribe surfaces
+ * `restart_required` so the operator knows which fields need a process
+ * bounce. Treat as opaque metadata: the caller renders it as a list
+ * but doesn't branch on the contents.
+ */
+export interface ModuleConfigPutResult {
+  restart_required?: string[];
+  [key: string]: unknown;
+}
+
+/**
+ * PUT /api/modules/:short/config — write new config values. Only fields
+ * the user actually changed should be in `values` (per the
+ * writeOnly-leave-blank-to-preserve rule). Server-side validation runs
+ * against the module's own schema; on a 400 the response body carries
+ * a `{error, message, errors[]}` shape the caller surfaces inline.
+ */
+export async function putModuleConfigValues(
+  short: string,
+  values: ModuleConfigValues,
+): Promise<ModuleConfigPutResult> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch(`/api/modules/${encodeURIComponent(short)}/config`, {
+    method: "PUT",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json",
+      authorization: `Bearer ${bearer}`,
+    },
+    body: JSON.stringify(values),
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as ModuleConfigPutResult;
+}
+
+/**
  * GET /api/modules/operations/:id — poll for a long-running operation
  * kicked off by install or upgrade. Returns 404 (HttpError) when the
  * id is unknown / expired.

--- a/web/ui/src/routes/ModuleConfig.test.tsx
+++ b/web/ui/src/routes/ModuleConfig.test.tsx
@@ -1,0 +1,318 @@
+/**
+ * /admin/modules/<short>/config — smoke tests for the generic
+ * module-config form (hub#260).
+ *
+ * Covers:
+ *   - initial loading state
+ *   - schema + values fetched, scribe-shape form renders correctly
+ *   - empty-state when module exposes no schema (404 no_config_schema)
+ *   - empty-state when module not installed (raw 404)
+ *   - submit sends only dirty fields (writeOnly-safe)
+ *   - 4xx response surfaces field-level errors inline
+ *   - writeOnly field renders as password input with placeholder
+ *   - blank writeOnly + no dirty toggle = no PUT body inclusion
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import { ModuleConfig } from "./ModuleConfig.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    getModuleConfigSchema: vi.fn(),
+    getModuleConfigValues: vi.fn(),
+    putModuleConfigValues: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderRoute(short = "scribe") {
+  return render(
+    <MemoryRouter initialEntries={[`/modules/${short}/config`]}>
+      <Routes>
+        <Route path="/modules/:short/config" element={<ModuleConfig />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/**
+ * Fixture mirroring scribe's actual `/.parachute/config/schema` output —
+ * the golden test case the page must render correctly. Boolean + enum +
+ * string + integer all in one schema so the renderer's switch hits every
+ * branch.
+ */
+const SCRIBE_SCHEMA: api.ModuleConfigSchema = {
+  type: "object",
+  properties: {
+    transcribeProvider: {
+      type: "string",
+      enum: ["parakeet-mlx", "groq", "openai"],
+      title: "Transcription provider",
+      description: "Engine used to turn audio into text.",
+    },
+    cleanupProvider: {
+      type: "string",
+      enum: ["none", "claude", "ollama"],
+      title: "Cleanup provider",
+    },
+    cleanupDefault: {
+      type: "boolean",
+      title: "Run cleanup by default",
+      description: "Applied when a request omits an explicit cleanup flag.",
+    },
+    port: {
+      type: "integer",
+      minimum: 1,
+      maximum: 65535,
+      title: "Server port",
+    },
+  },
+  required: ["transcribeProvider"],
+};
+
+const SCRIBE_VALUES: api.ModuleConfigValues = {
+  transcribeProvider: "parakeet-mlx",
+  cleanupProvider: "none",
+  cleanupDefault: true,
+  port: 1943,
+};
+
+describe("ModuleConfig — load states", () => {
+  it("shows loading on first paint", () => {
+    vi.mocked(api.getModuleConfigSchema).mockImplementation(() => new Promise(() => {}));
+    vi.mocked(api.getModuleConfigValues).mockImplementation(() => new Promise(() => {}));
+    renderRoute();
+    expect(screen.getByText(/loading configuration/i)).toBeInTheDocument();
+  });
+
+  it("renders empty state when module exposes no config schema", async () => {
+    vi.mocked(api.getModuleConfigSchema).mockResolvedValue(null);
+    renderRoute();
+    await waitFor(() =>
+      expect(
+        screen.getByText(/does not expose an operator-editable configuration schema/i),
+      ).toBeInTheDocument(),
+    );
+    // No form rendered.
+    expect(screen.queryByTestId("config-form")).not.toBeInTheDocument();
+  });
+
+  it("renders empty state when module not installed (404 without no_config_schema code)", async () => {
+    vi.mocked(api.getModuleConfigSchema).mockRejectedValue(
+      new api.HttpError(
+        404,
+        JSON.stringify({ error: "module_not_installed", error_description: "absent" }),
+      ),
+    );
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByText(/is not installed on this hub/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("renders error + retry when schema fetch throws non-404", async () => {
+    vi.mocked(api.getModuleConfigSchema).mockRejectedValue(new Error("network down"));
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByText(/failed to load configuration/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+});
+
+describe("ModuleConfig — scribe golden fixture", () => {
+  beforeEach(() => {
+    vi.mocked(api.getModuleConfigSchema).mockResolvedValue(SCRIBE_SCHEMA);
+    vi.mocked(api.getModuleConfigValues).mockResolvedValue(SCRIBE_VALUES);
+  });
+
+  it("renders one field per schema property with pre-filled values", async () => {
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("config-form")).toBeInTheDocument());
+
+    // enum → select
+    const provider = screen.getByLabelText(/transcription provider/i) as HTMLSelectElement;
+    expect(provider.tagName).toBe("SELECT");
+    expect(provider.value).toBe("parakeet-mlx");
+
+    // boolean → checkbox, pre-checked
+    const cleanupDefault = screen.getByLabelText(/run cleanup by default/i) as HTMLInputElement;
+    expect(cleanupDefault.type).toBe("checkbox");
+    expect(cleanupDefault.checked).toBe(true);
+
+    // integer → number input
+    const port = screen.getByLabelText(/server port/i) as HTMLInputElement;
+    expect(port.type).toBe("number");
+    expect(port.value).toBe("1943");
+
+    // Required marker only on transcribeProvider.
+    expect(screen.getByLabelText(/transcription provider/i).parentElement?.textContent).toMatch(
+      /required/i,
+    );
+  });
+
+  it("submit sends only dirty fields (writeOnly-safe shape)", async () => {
+    vi.mocked(api.putModuleConfigValues).mockResolvedValue({ restart_required: [] });
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("config-form")).toBeInTheDocument());
+
+    // Change only the cleanup-default checkbox.
+    const cleanupDefault = screen.getByLabelText(/run cleanup by default/i) as HTMLInputElement;
+    fireEvent.click(cleanupDefault);
+
+    fireEvent.submit(screen.getByTestId("config-form"));
+
+    await waitFor(() => expect(api.putModuleConfigValues).toHaveBeenCalledTimes(1));
+    const [shortArg, payload] = vi.mocked(api.putModuleConfigValues).mock.calls[0] ?? [];
+    expect(shortArg).toBe("scribe");
+    // Exactly the one field we changed — provider / port / cleanupProvider
+    // must NOT be in the payload even though they're rendered.
+    expect(payload).toEqual({ cleanupDefault: false });
+  });
+
+  it("rejects empty submit (no changes) with an inline error banner", async () => {
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("config-form")).toBeInTheDocument());
+    fireEvent.submit(screen.getByTestId("config-form"));
+    await waitFor(() =>
+      expect(screen.getByTestId("save-error")).toHaveTextContent(/no changes to save/i),
+    );
+    // The PUT was never issued.
+    expect(api.putModuleConfigValues).not.toHaveBeenCalled();
+  });
+
+  it("renders restart_required list on successful save", async () => {
+    vi.mocked(api.putModuleConfigValues).mockResolvedValue({
+      restart_required: ["transcribeProvider"],
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("config-form")).toBeInTheDocument());
+
+    const provider = screen.getByLabelText(/transcription provider/i) as HTMLSelectElement;
+    fireEvent.change(provider, { target: { value: "groq" } });
+    fireEvent.submit(screen.getByTestId("config-form"));
+
+    await waitFor(() => expect(screen.getByTestId("save-success")).toBeInTheDocument());
+    expect(screen.getByTestId("save-success")).toHaveTextContent(/transcribeProvider/);
+  });
+
+  it("4xx response surfaces field-level errors inline", async () => {
+    vi.mocked(api.putModuleConfigValues).mockRejectedValue(
+      new api.HttpError(
+        400,
+        JSON.stringify({
+          error: "validation_failed",
+          message: "Validation failed; see field errors.",
+          errors: [
+            { path: "transcribeProvider", message: "Must be one of parakeet-mlx, groq, openai" },
+          ],
+        }),
+      ),
+    );
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("config-form")).toBeInTheDocument());
+
+    const provider = screen.getByLabelText(/transcription provider/i) as HTMLSelectElement;
+    // Inject a value the server will reject.
+    fireEvent.change(provider, { target: { value: "groq" } });
+    fireEvent.submit(screen.getByTestId("config-form"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("save-error")).toHaveTextContent(/validation failed/i),
+    );
+    // Per-field error rendered next to the input.
+    expect(screen.getByText(/must be one of parakeet-mlx/i)).toBeInTheDocument();
+  });
+});
+
+describe("ModuleConfig — writeOnly fields", () => {
+  /**
+   * Forward-looking test: the canonical writeOnly UX. scribe's actual
+   * schema doesn't ship a writeOnly field today, but the next module
+   * (e.g. agent with API keys) will. This fixture mirrors what a
+   * "groq API key" field would look like + asserts the rules:
+   *
+   *   - Renders as type=password
+   *   - Placeholder shows when stored value exists but blank locally
+   *   - Untouched (dirty=false) field is NOT sent on submit
+   *   - User-typed value IS sent on submit
+   */
+  const WRITE_ONLY_SCHEMA: api.ModuleConfigSchema = {
+    type: "object",
+    properties: {
+      apiKey: {
+        type: "string",
+        title: "API key",
+        writeOnly: true,
+        description: "Provider API key.",
+      },
+      name: {
+        type: "string",
+        title: "Display name",
+      },
+    },
+  };
+
+  it("renders writeOnly as password input with leave-blank placeholder when stored", async () => {
+    vi.mocked(api.getModuleConfigSchema).mockResolvedValue(WRITE_ONLY_SCHEMA);
+    // Server omits writeOnly fields from GET responses by convention.
+    // SPA infers "stored" from "writeOnly=true AND value absent."
+    vi.mocked(api.getModuleConfigValues).mockResolvedValue({ name: "scribe-1" });
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("config-form")).toBeInTheDocument());
+
+    const apiKey = screen.getByLabelText(/api key/i) as HTMLInputElement;
+    expect(apiKey.type).toBe("password");
+    expect(apiKey.value).toBe("");
+    expect(apiKey.placeholder).toContain("•");
+    // Hint copy points the operator at the leave-blank rule.
+    expect(screen.getByText(/leave blank to keep the current value/i)).toBeInTheDocument();
+  });
+
+  it("untouched writeOnly field is NOT included in PUT payload", async () => {
+    vi.mocked(api.getModuleConfigSchema).mockResolvedValue(WRITE_ONLY_SCHEMA);
+    vi.mocked(api.getModuleConfigValues).mockResolvedValue({ name: "scribe-1" });
+    vi.mocked(api.putModuleConfigValues).mockResolvedValue({});
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("config-form")).toBeInTheDocument());
+
+    // Change only the name field (keep API key untouched).
+    const name = screen.getByLabelText(/display name/i) as HTMLInputElement;
+    fireEvent.change(name, { target: { value: "scribe-renamed" } });
+    fireEvent.submit(screen.getByTestId("config-form"));
+
+    await waitFor(() => expect(api.putModuleConfigValues).toHaveBeenCalledTimes(1));
+    const [, payload] = vi.mocked(api.putModuleConfigValues).mock.calls[0] ?? [];
+    expect(payload).toEqual({ name: "scribe-renamed" });
+    // API key key must be absent — leave-blank-to-preserve semantics.
+    expect(payload).not.toHaveProperty("apiKey");
+  });
+
+  it("user-typed writeOnly value IS sent on submit", async () => {
+    vi.mocked(api.getModuleConfigSchema).mockResolvedValue(WRITE_ONLY_SCHEMA);
+    vi.mocked(api.getModuleConfigValues).mockResolvedValue({ name: "scribe-1" });
+    vi.mocked(api.putModuleConfigValues).mockResolvedValue({});
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("config-form")).toBeInTheDocument());
+
+    const apiKey = screen.getByLabelText(/api key/i) as HTMLInputElement;
+    fireEvent.change(apiKey, { target: { value: "sk-new-secret" } });
+    fireEvent.submit(screen.getByTestId("config-form"));
+
+    await waitFor(() => expect(api.putModuleConfigValues).toHaveBeenCalledTimes(1));
+    const [, payload] = vi.mocked(api.putModuleConfigValues).mock.calls[0] ?? [];
+    expect(payload).toEqual({ apiKey: "sk-new-secret" });
+  });
+});

--- a/web/ui/src/routes/ModuleConfig.test.tsx
+++ b/web/ui/src/routes/ModuleConfig.test.tsx
@@ -208,6 +208,31 @@ describe("ModuleConfig — scribe golden fixture", () => {
     expect(screen.getByTestId("save-success")).toHaveTextContent(/transcribeProvider/);
   });
 
+  it("typing a field back to its original value un-dirties it (revert)", async () => {
+    vi.mocked(api.putModuleConfigValues).mockResolvedValue({ restart_required: [] });
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("config-form")).toBeInTheDocument());
+
+    // Original transcribeProvider is "parakeet-mlx". Change to "groq",
+    // then back to "parakeet-mlx". The PUT must NOT include the field.
+    const provider = screen.getByLabelText(/transcription provider/i) as HTMLSelectElement;
+    fireEvent.change(provider, { target: { value: "groq" } });
+    fireEvent.change(provider, { target: { value: "parakeet-mlx" } });
+
+    // Also touch the cleanup-default checkbox so the submit has *something*
+    // dirty — otherwise the "no changes" early-exit short-circuits the PUT.
+    const cleanupDefault = screen.getByLabelText(/run cleanup by default/i) as HTMLInputElement;
+    fireEvent.click(cleanupDefault);
+
+    fireEvent.submit(screen.getByTestId("config-form"));
+
+    await waitFor(() => expect(api.putModuleConfigValues).toHaveBeenCalledTimes(1));
+    const [, payload] = vi.mocked(api.putModuleConfigValues).mock.calls[0] ?? [];
+    // Only the actually-changed field survives the revert.
+    expect(payload).toEqual({ cleanupDefault: false });
+    expect(payload).not.toHaveProperty("transcribeProvider");
+  });
+
   it("4xx response surfaces field-level errors inline", async () => {
     vi.mocked(api.putModuleConfigValues).mockRejectedValue(
       new api.HttpError(

--- a/web/ui/src/routes/ModuleConfig.tsx
+++ b/web/ui/src/routes/ModuleConfig.tsx
@@ -81,9 +81,13 @@ export function ModuleConfig() {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
   // `draft` mirrors the user's typed values per field. `dirty` is the
   // per-field "did the user touch this?" gate that drives the changed-
-  // fields-only PUT shape.
+  // fields-only PUT shape. `originalValues` is a frozen snapshot of the
+  // GET response so the dirty-tracker can un-dirty a field when the
+  // user types a value back to its original — without this, typing
+  // 'baz' then back to 'bar' would still include 'foo' in the PUT.
   const [draft, setDraft] = useState<ModuleConfigValues>({});
   const [dirty, setDirty] = useState<Record<string, boolean>>({});
+  const [originalValues, setOriginalValues] = useState<ModuleConfigValues>({});
   const [saving, setSaving] = useState(false);
   const [saveBanner, setSaveBanner] = useState<
     | { kind: "success"; message: string; restartRequired: readonly string[] }
@@ -96,6 +100,7 @@ export function ModuleConfig() {
     setState({ kind: "loading" });
     setDraft({});
     setDirty({});
+    setOriginalValues({});
     setSaveBanner(null);
     setFieldErrors({});
     try {
@@ -111,6 +116,9 @@ export function ModuleConfig() {
       // (the module omits them from GET responses) — the draft entry
       // stays undefined and the input renders empty with placeholder.
       setDraft({ ...values });
+      // Snapshot the same values for dirty-tracker comparison. Frozen
+      // here, refreshed only on next load / save-refresh.
+      setOriginalValues({ ...values });
     } catch (err) {
       if (err instanceof HttpError && err.status === 404) {
         // 404 with no `no_config_schema` code = module not installed.
@@ -129,7 +137,19 @@ export function ModuleConfig() {
 
   function onChangeField(name: string, value: unknown) {
     setDraft((prev) => ({ ...prev, [name]: value }));
-    setDirty((prev) => ({ ...prev, [name]: true }));
+    // Un-dirty on revert: if the user types a value back to what the
+    // server returned, drop it from the PUT payload. writeOnly fields
+    // are special — the server omits them from GET responses, so there's
+    // no "original" to compare against; any non-empty user input counts
+    // as dirty.
+    const schema = state.kind === "ok" ? state.schema.properties?.[name] : undefined;
+    const isWriteOnly = schema?.writeOnly === true;
+    if (isWriteOnly) {
+      const typed = value !== "" && value !== undefined && value !== null;
+      setDirty((prev) => ({ ...prev, [name]: typed }));
+    } else {
+      setDirty((prev) => ({ ...prev, [name]: value !== originalValues[name] }));
+    }
     // Clear any prior field error as the user edits — keeps the banner
     // honest about which fields are still in error.
     setFieldErrors((prev) => {
@@ -304,7 +324,10 @@ export function ModuleConfig() {
               property={prop}
               value={draft[name]}
               required={requiredSet.has(name)}
-              writeOnlyStored={prop.writeOnly === true && !state.values[name]}
+              // `name in values` distinguishes "GET omitted this key"
+              // (= stored writeOnly secret) from "GET included it with
+              // a falsy value." Falsy-coercion would conflate the two.
+              writeOnlyStored={prop.writeOnly === true && !(name in state.values)}
               error={fieldErrors[name]}
               dirty={Boolean(dirty[name])}
               onChange={(v) => onChangeField(name, v)}

--- a/web/ui/src/routes/ModuleConfig.tsx
+++ b/web/ui/src/routes/ModuleConfig.tsx
@@ -1,0 +1,550 @@
+/**
+ * /admin/modules/:short/config — generic per-module config form.
+ *
+ * Mounted off `/admin/modules` (the Modules page exposes a "Configure"
+ * link per installed module). The page fetches three things on load:
+ *
+ *   1. `GET /api/modules/<short>/config/schema` — Draft-07 JSON Schema
+ *   2. `GET /api/modules/<short>/config`        — current resolved values
+ *   3. (renders) form fields per schema property, pre-filled from values
+ *
+ * Save flow:
+ *
+ *   1. User edits fields (each tracks dirty/clean independently).
+ *   2. Submit → PUT `/api/modules/<short>/config` with ONLY changed fields.
+ *      The "changed fields only" rule is what makes writeOnly secrets
+ *      safe — a blank password input means "leave the stored value",
+ *      not "clear it." A user who wants to clear a stored value must
+ *      explicitly type "" or use the clear-CTA the field provides.
+ *   3. Module responds 200 + optional `restart_required` list → success
+ *      banner names the fields that need a process bounce.
+ *   4. Module responds 400 → inline field errors from `errors[]`.
+ *
+ * Schema shape supported:
+ *
+ *   - `type: "string" | "number" | "integer" | "boolean"`
+ *   - `enum: [...]` (renders a `<select>`)
+ *   - `default` (used as schema-default placeholder when value absent)
+ *   - `title`, `description`
+ *   - `minimum`, `maximum` (passed to numeric inputs)
+ *   - `writeOnly: true` (renders as `type=password` with leave-blank-
+ *     to-preserve UX)
+ *
+ * Unsupported (intentionally — scribe's schemas don't use these today):
+ *
+ *   - nested objects / arrays / oneOf / anyOf / allOf / $ref
+ *
+ * If/when a module ships one of those, we'll either lift in `@rjsf/core`
+ * (industry-standard library) or extend this renderer — neither hurries
+ * us today. Hand-rolling at v1 saves the SPA bundle ~250 KB of @rjsf
+ * + ajv + a plugin surface that doesn't match Parachute's narrow
+ * schema vocabulary.
+ *
+ * Design choice — Option A vs B for upstream auth: hub mints a short-
+ * lived `<short>:admin` JWT at proxy time and forwards it to the
+ * module. The SPA never sees per-module bearers; it only ever holds
+ * `parachute:host:admin`. See `src/api-modules-config.ts` for the
+ * server-side rationale.
+ */
+import { type FormEvent, useCallback, useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  type ConfigSchemaProperty,
+  HttpError,
+  type ModuleConfigSchema,
+  type ModuleConfigValues,
+  getModuleConfigSchema,
+  getModuleConfigValues,
+  putModuleConfigValues,
+} from "../lib/api.ts";
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "no_schema" } // upstream 404 — module exposes no config
+  | { kind: "not_installed" } // module absent from services.json
+  | { kind: "ok"; schema: ModuleConfigSchema; values: ModuleConfigValues }
+  | { kind: "error"; message: string };
+
+/**
+ * Per-field error from a 400 PUT response. Matches scribe's
+ * `{errors: [{path, message}]}` shape; other modules following the same
+ * convention slot in cleanly. Unrecognized shapes surface in the top-
+ * level banner instead.
+ */
+interface FieldError {
+  path: string;
+  message: string;
+}
+
+export function ModuleConfig() {
+  const { short = "" } = useParams<{ short: string }>();
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+  // `draft` mirrors the user's typed values per field. `dirty` is the
+  // per-field "did the user touch this?" gate that drives the changed-
+  // fields-only PUT shape.
+  const [draft, setDraft] = useState<ModuleConfigValues>({});
+  const [dirty, setDirty] = useState<Record<string, boolean>>({});
+  const [saving, setSaving] = useState(false);
+  const [saveBanner, setSaveBanner] = useState<
+    | { kind: "success"; message: string; restartRequired: readonly string[] }
+    | { kind: "error"; message: string }
+    | null
+  >(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  const refresh = useCallback(async () => {
+    setState({ kind: "loading" });
+    setDraft({});
+    setDirty({});
+    setSaveBanner(null);
+    setFieldErrors({});
+    try {
+      const schema = await getModuleConfigSchema(short);
+      if (schema === null) {
+        setState({ kind: "no_schema" });
+        return;
+      }
+      const values = await getModuleConfigValues(short);
+      setState({ kind: "ok", schema, values });
+      // Pre-fill the draft from current values so the form shows what's
+      // stored. writeOnly fields are absent from `values` by convention
+      // (the module omits them from GET responses) — the draft entry
+      // stays undefined and the input renders empty with placeholder.
+      setDraft({ ...values });
+    } catch (err) {
+      if (err instanceof HttpError && err.status === 404) {
+        // 404 with no `no_config_schema` code = module not installed.
+        // The schema fetch already pre-handles the no_schema case.
+        setState({ kind: "not_installed" });
+        return;
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      setState({ kind: "error", message: msg });
+    }
+  }, [short]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  function onChangeField(name: string, value: unknown) {
+    setDraft((prev) => ({ ...prev, [name]: value }));
+    setDirty((prev) => ({ ...prev, [name]: true }));
+    // Clear any prior field error as the user edits — keeps the banner
+    // honest about which fields are still in error.
+    setFieldErrors((prev) => {
+      if (!(name in prev)) return prev;
+      const next = { ...prev };
+      delete next[name];
+      return next;
+    });
+  }
+
+  async function onSave(e: FormEvent) {
+    e.preventDefault();
+    if (saving) return;
+    if (state.kind !== "ok") return;
+    setSaving(true);
+    setSaveBanner(null);
+    setFieldErrors({});
+
+    // Build the payload: only fields the user actually changed. This is
+    // the writeOnly-safe shape — a blank password input the user didn't
+    // touch is `dirty=false`, so we don't send the empty string and the
+    // module preserves its stored secret.
+    const payload: ModuleConfigValues = {};
+    for (const [name, isDirty] of Object.entries(dirty)) {
+      if (!isDirty) continue;
+      payload[name] = draft[name];
+    }
+    if (Object.keys(payload).length === 0) {
+      setSaving(false);
+      setSaveBanner({
+        kind: "error",
+        message: "No changes to save. Edit a field first.",
+      });
+      return;
+    }
+
+    try {
+      const result = await putModuleConfigValues(short, payload);
+      setSaveBanner({
+        kind: "success",
+        message: "Configuration saved.",
+        restartRequired: Array.isArray(result.restart_required) ? result.restart_required : [],
+      });
+      // Reset dirty flags so the next submit picks up only fields edited
+      // after this save. We do NOT re-fetch values automatically —
+      // some modules (like scribe) only apply provider changes on
+      // restart, and re-fetching would show the old value with no
+      // visual cue. The success banner's restart_required list is
+      // the operator's signal.
+      setDirty({});
+    } catch (err) {
+      if (err instanceof HttpError && err.status === 400) {
+        // Parse the 400 body for `errors[]` field-level details. Scribe
+        // and the canonical pattern surface `{error, message, errors[]}`.
+        try {
+          const body = JSON.parse(err.message) as {
+            error?: string;
+            message?: string;
+            errors?: readonly FieldError[];
+            error_description?: string;
+          };
+          const errs = Array.isArray(body.errors) ? body.errors : [];
+          if (errs.length > 0) {
+            const map: Record<string, string> = {};
+            for (const fe of errs) {
+              if (typeof fe?.path === "string" && typeof fe?.message === "string") {
+                map[fe.path] = fe.message;
+              }
+            }
+            setFieldErrors(map);
+            setSaveBanner({
+              kind: "error",
+              message: body.message ?? body.error_description ?? "Validation failed.",
+            });
+            return;
+          }
+          setSaveBanner({
+            kind: "error",
+            message: body.message ?? body.error_description ?? "Validation failed.",
+          });
+          return;
+        } catch {
+          // Fall through to generic display.
+        }
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      setSaveBanner({ kind: "error", message: `Save failed — ${msg}` });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (state.kind === "loading") {
+    return <div className="empty">Loading configuration…</div>;
+  }
+  if (state.kind === "not_installed") {
+    return (
+      <section className="module-config">
+        <h1>Configure {short}</h1>
+        <div className="empty">
+          <p>
+            <code>{short}</code> is not installed on this hub.
+          </p>
+          <p>
+            Visit <Link to="/modules">Modules</Link> to install it first.
+          </p>
+        </div>
+      </section>
+    );
+  }
+  if (state.kind === "no_schema") {
+    return (
+      <section className="module-config">
+        <h1>Configure {short}</h1>
+        <div className="empty">
+          <p>
+            <code>{short}</code> does not expose an operator-editable configuration schema.
+          </p>
+          <p>
+            Some modules are configured entirely through environment variables or files on disk —
+            check the module's documentation, or visit <Link to="/modules">Modules</Link>.
+          </p>
+        </div>
+      </section>
+    );
+  }
+  if (state.kind === "error") {
+    return (
+      <section className="module-config">
+        <h1>Configure {short}</h1>
+        <div className="empty">
+          Failed to load configuration: {state.message}.{" "}
+          <button type="button" onClick={() => void refresh()}>
+            Retry
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  const { schema } = state;
+  const properties = schema.properties ?? {};
+  const requiredSet = new Set(schema.required ?? []);
+  const propertyEntries = Object.entries(properties);
+
+  return (
+    <section className="module-config">
+      <header className="module-config-header">
+        <h1>Configure {short}</h1>
+        <p className="muted">
+          Edit values and save. Some changes apply immediately; others (provider, port) require
+          restarting the module to take effect. <Link to="/modules">Back to modules</Link>.
+        </p>
+      </header>
+
+      {propertyEntries.length === 0 && (
+        <div className="empty">
+          <p>This module's schema defines no editable properties.</p>
+        </div>
+      )}
+
+      <form
+        onSubmit={(e) => void onSave(e)}
+        className="module-config-form"
+        data-testid="config-form"
+      >
+        <fieldset>
+          {propertyEntries.map(([name, prop]) => (
+            <ConfigField
+              key={name}
+              name={name}
+              property={prop}
+              value={draft[name]}
+              required={requiredSet.has(name)}
+              writeOnlyStored={prop.writeOnly === true && !state.values[name]}
+              error={fieldErrors[name]}
+              dirty={Boolean(dirty[name])}
+              onChange={(v) => onChangeField(name, v)}
+            />
+          ))}
+        </fieldset>
+
+        <div className="actions">
+          <button type="submit" disabled={saving || propertyEntries.length === 0}>
+            {saving ? "Saving…" : "Save"}
+          </button>
+          <button
+            type="button"
+            className="destructive"
+            disabled={saving}
+            onClick={() => void refresh()}
+          >
+            Discard changes
+          </button>
+        </div>
+
+        {saveBanner?.kind === "success" && (
+          <div className="banner banner-success" data-testid="save-success">
+            <strong>{saveBanner.message}</strong>
+            {saveBanner.restartRequired.length > 0 && (
+              <>
+                <p className="muted">Restart {short} to apply these field changes:</p>
+                <ul>
+                  {saveBanner.restartRequired.map((f) => (
+                    <li key={f}>
+                      <code>{f}</code>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
+          </div>
+        )}
+        {saveBanner?.kind === "error" && (
+          <div className="banner banner-error error" data-testid="save-error">
+            {saveBanner.message}
+          </div>
+        )}
+      </form>
+    </section>
+  );
+}
+
+interface ConfigFieldProps {
+  name: string;
+  property: ConfigSchemaProperty;
+  value: unknown;
+  required: boolean;
+  /**
+   * True when the property is `writeOnly` AND the module's GET response
+   * omitted this key (= a stored value exists, just hidden). Drives
+   * the "leave blank to keep current" placeholder. When false +
+   * writeOnly, we're either: (a) the value was never set, or (b) the
+   * caller cleared `dirty` post-save and we're showing the new state.
+   * Either way, no need for the "leave blank" hint.
+   */
+  writeOnlyStored: boolean;
+  error: string | undefined;
+  /** True once the user has edited this field. Drives "leave blank" copy display. */
+  dirty: boolean;
+  onChange: (value: unknown) => void;
+}
+
+/**
+ * One rendered field. Switches on `property.type` + `property.enum` +
+ * `property.writeOnly` to pick the right input. All values land in the
+ * draft as their natural JS type (string / number / boolean) — the
+ * module's PUT handler re-validates against the schema, so the SPA
+ * doesn't need to coerce defensively.
+ */
+function ConfigField({
+  name,
+  property,
+  value,
+  required,
+  writeOnlyStored,
+  error,
+  dirty,
+  onChange,
+}: ConfigFieldProps) {
+  const id = `config-field-${name}`;
+  const label = property.title ?? name;
+  const description = property.description;
+  const hasEnum = Array.isArray(property.enum) && property.enum.length > 0;
+
+  // Boolean → checkbox.
+  if (property.type === "boolean") {
+    return (
+      <div className={`field field-inline ${error ? "field-invalid" : ""}`} data-field={name}>
+        <label htmlFor={id}>
+          <input
+            id={id}
+            type="checkbox"
+            checked={Boolean(value)}
+            onChange={(e) => onChange(e.target.checked)}
+          />
+          <span className="field-label-inline">{label}</span>
+        </label>
+        {description && <p className="muted field-hint">{description}</p>}
+        {error && <p className="error field-error">{error}</p>}
+      </div>
+    );
+  }
+
+  // Enum → select.
+  if (hasEnum) {
+    const options = property.enum as ReadonlyArray<string | number>;
+    return (
+      <div className={`field ${error ? "field-invalid" : ""}`} data-field={name}>
+        <label htmlFor={id}>
+          <span className="field-label">
+            {label}
+            {required && <span className="muted"> (required)</span>}
+          </span>
+          <select
+            id={id}
+            value={value == null ? "" : String(value)}
+            onChange={(e) => {
+              const raw = e.target.value;
+              // Re-coerce to number when the schema says so — selects are
+              // string-only DOM-side but the module wants the typed value
+              // back.
+              if (property.type === "number" || property.type === "integer") {
+                onChange(raw === "" ? undefined : Number(raw));
+              } else {
+                onChange(raw === "" ? undefined : raw);
+              }
+            }}
+          >
+            {!required && <option value="">(unset)</option>}
+            {options.map((opt) => (
+              <option key={String(opt)} value={String(opt)}>
+                {String(opt)}
+              </option>
+            ))}
+          </select>
+        </label>
+        {description && <p className="muted field-hint">{description}</p>}
+        {error && <p className="error field-error">{error}</p>}
+      </div>
+    );
+  }
+
+  // writeOnly string → password input with leave-blank affordance.
+  if (property.type === "string" && property.writeOnly === true) {
+    return (
+      <div className={`field ${error ? "field-invalid" : ""}`} data-field={name}>
+        <label htmlFor={id}>
+          <span className="field-label">
+            {label}
+            {required && <span className="muted"> (required)</span>}
+          </span>
+          <input
+            id={id}
+            type="password"
+            autoComplete="new-password"
+            placeholder={writeOnlyStored && !dirty ? "••••••••" : ""}
+            value={typeof value === "string" ? value : ""}
+            onChange={(e) => onChange(e.target.value)}
+          />
+        </label>
+        <p className="muted field-hint">
+          {description && <>{description} </>}
+          {writeOnlyStored ? (
+            <em>Leave blank to keep the current value.</em>
+          ) : (
+            <em>Secret — sent only when saved.</em>
+          )}
+        </p>
+        {error && <p className="error field-error">{error}</p>}
+      </div>
+    );
+  }
+
+  // String → text input.
+  if (property.type === "string") {
+    return (
+      <div className={`field ${error ? "field-invalid" : ""}`} data-field={name}>
+        <label htmlFor={id}>
+          <span className="field-label">
+            {label}
+            {required && <span className="muted"> (required)</span>}
+          </span>
+          <input
+            id={id}
+            type="text"
+            value={typeof value === "string" ? value : ""}
+            onChange={(e) => onChange(e.target.value)}
+          />
+        </label>
+        {description && <p className="muted field-hint">{description}</p>}
+        {error && <p className="error field-error">{error}</p>}
+      </div>
+    );
+  }
+
+  // Number / integer → number input.
+  if (property.type === "number" || property.type === "integer") {
+    return (
+      <div className={`field ${error ? "field-invalid" : ""}`} data-field={name}>
+        <label htmlFor={id}>
+          <span className="field-label">
+            {label}
+            {required && <span className="muted"> (required)</span>}
+          </span>
+          <input
+            id={id}
+            type="number"
+            step={property.type === "integer" ? 1 : "any"}
+            min={property.minimum}
+            max={property.maximum}
+            value={typeof value === "number" ? value : ""}
+            onChange={(e) => {
+              const raw = e.target.value;
+              if (raw === "") onChange(undefined);
+              else onChange(Number(raw));
+            }}
+          />
+        </label>
+        {description && <p className="muted field-hint">{description}</p>}
+        {error && <p className="error field-error">{error}</p>}
+      </div>
+    );
+  }
+
+  // Fallback for schema shapes the renderer doesn't understand. Surface
+  // a read-only debug view so the operator sees the field exists +
+  // can edit via the underlying module's own admin UI / CLI.
+  return (
+    <div className="field" data-field={name}>
+      <span className="field-label">
+        {label} <span className="muted">(unsupported type)</span>
+      </span>
+      <pre className="muted">{JSON.stringify(property, null, 2)}</pre>
+      {description && <p className="muted field-hint">{description}</p>}
+    </div>
+  );
+}

--- a/web/ui/src/routes/Modules.tsx
+++ b/web/ui/src/routes/Modules.tsx
@@ -389,6 +389,16 @@ function ModuleRow({
         )}
         {mod.installed && (
           <>
+            {/* Configure link routes to the generic per-module config
+                form (hub#260). Rendered as a Link rather than a button
+                because it's pure navigation — no async action attached,
+                no supervisor requirement. Stays clickable even when the
+                supervisor is offline so an operator on a hub-only CLI
+                install can still edit config (the config endpoints are
+                served by the module itself, not the supervisor). */}
+            <Link className="btn" to={`/modules/${encodeURIComponent(mod.short)}/config`}>
+              Configure
+            </Link>
             <button type="button" disabled={!canAct} onClick={onRestart}>
               Restart
             </button>

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -459,6 +459,119 @@ form .field-error {
 }
 
 /*
+ * /admin/modules/<short>/config — generic per-module config form
+ * (hub#260). Mirrors the form-row spacing used elsewhere in the SPA;
+ * banners reuse the `.banner-success` / `.banner-error` vocabulary
+ * from the rest of the admin shell.
+ */
+.module-config {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+.module-config-header h1 {
+  margin-bottom: 0.35rem;
+}
+.module-config-form fieldset {
+  border: 0;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.module-config-form .field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.module-config-form .field input,
+.module-config-form .field select,
+.module-config-form .field textarea {
+  width: 100%;
+}
+.module-config-form .field-inline {
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.module-config-form .field-inline label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.module-config-form .field-inline .field-hint {
+  flex-basis: 100%;
+  margin-left: 1.6rem;
+}
+.module-config-form .field-invalid input,
+.module-config-form .field-invalid select,
+.module-config-form .field-invalid textarea {
+  border-color: var(--error);
+}
+.module-config-form .actions {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  margin-top: 0.5rem;
+}
+.module-config-form .actions button.destructive {
+  background: white;
+  color: var(--fg);
+  border: 1px solid var(--border);
+}
+.module-config-form .actions button.destructive:hover {
+  background: var(--bg-soft);
+}
+.module-config-form .banner {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  font-size: 0.9rem;
+}
+.module-config-form .banner-success {
+  background: var(--success-soft);
+  border-color: var(--success);
+  color: var(--success);
+}
+.module-config-form .banner-success p,
+.module-config-form .banner-success ul {
+  margin: 0.4rem 0 0;
+}
+.module-config-form .banner-error {
+  background: var(--error-soft, rgba(163, 57, 43, 0.08));
+  border-color: var(--error);
+  color: var(--error);
+}
+
+/*
+ * "Configure" link styled to match sibling action buttons on
+ * `.module-row .actions`. React-router's <Link> renders an <a>, so
+ * default `a` styles take over without these overrides — we want it
+ * to look like a button next to Restart / Upgrade / Uninstall.
+ */
+.module-row .actions .btn,
+a.btn {
+  display: inline-block;
+  font: inherit;
+  background: var(--accent);
+  color: white;
+  border: 0;
+  border-radius: 6px;
+  padding: 0.55rem 1.1rem;
+  cursor: pointer;
+  transition: background 0.15s ease;
+  text-decoration: none;
+}
+.module-row .actions .btn:hover,
+a.btn:hover {
+  background: var(--accent-hover);
+  text-decoration: none;
+}
+
+/*
  * Visually-hidden utility for screen-reader-only text. Used by the
  * first-admin disabled-Delete button on /admin/users to wire
  * `aria-describedby` to an explanation that's invisible to sighted


### PR DESCRIPTION
Closes #260 — Phase 1 critical-path.

## What

`/admin/modules/<short>/config` — generic per-module configuration form in the admin SPA. Driven by each module's own `/.parachute/config/schema` declaration. Render-deployed friends can now configure scribe (transcription provider, cleanup provider, port, etc.) from the browser without dropping to a terminal — the last UI gap on the v0.6 single-container Phase 1 critical path.

## Design choices

### Option A vs B — chose A (hub mints `<short>:admin` at proxy time)

The SPA's session-derived bearer carries `parachute:host:admin`, but modules enforce per-module scopes on `/.parachute/config*` (scribe requires `scribe:admin`). Two bridges considered:

- **Option A (this PR).** Hub mints a short-lived (60s TTL) `<short>:admin` JWT on each proxied request, drops the SPA's bearer, and forwards. Minted token is NOT recorded in the tokens registry — one-shot proxy artifact. Audit-friendly (each proxy mint is one signed JWT), keeps modules ignorant of hub's session model, reuses existing `signAccessToken` pipeline.
- Option B (rejected). Modules accept `parachute:host:admin` as a master scope that overrides per-module scopes. Centralizes hub's vocabulary into every module's auth gate; couples module surfaces to hub's session model; harder to audit (no clear "who is acting" trail per request).

### Renderer — hand-rolled, NOT `@rjsf/core`

The task brief recommended `@rjsf/core`. The call here is hand-roll for v1:

- **Bundle savings.** @rjsf + ajv + plugins is ~250 KB; SPA today ships 301 KB total. The library would double the bundle.
- **Schema vocabulary.** scribe (the only module with a live schema) uses `string` / `number` / `integer` / `boolean` + `enum` + `default` + `title` + `description` + `minimum` / `maximum`. None of @rjsf's heavy-hitter features (oneOf / anyOf / dependencies / conditionals) appear. Hand-rolling matches the actual shape exactly.
- **Growth path.** When a module ships a schema feature this doesn't cover, lift in @rjsf at that point. Today's call is "no debt, no library."

### writeOnly UX (Draft-07 secret-handling, forward-looking)

scribe's schema has no `writeOnly` fields today, but the next module that needs a config-side secret (e.g. agent with API keys) will. The renderer implements the canonical pattern. The SPA form-state shape — `only-dirty-fields-on-submit` — is what makes the secret-preservation rule generalize without per-module branches:

```tsx
// web/ui/src/routes/ModuleConfig.tsx — relevant snippet

// writeOnly string → password input with leave-blank-to-preserve
if (property.type === "string" && property.writeOnly === true) {
  return (
    <input
      type="password"
      autoComplete="new-password"
      placeholder={writeOnlyStored && !dirty ? "••••••••" : ""}
      value={typeof value === "string" ? value : ""}
      onChange={(e) => onChange(e.target.value)}
    />
    // + hint: "Leave blank to keep the current value."
  );
}

// Submit handler — only dirty fields go in the PUT
const payload: ModuleConfigValues = {};
for (const [name, isDirty] of Object.entries(dirty)) {
  if (!isDirty) continue;
  payload[name] = draft[name];
}
```

A blank password input the user didn't touch has `dirty: false`, so it's NOT in the payload — the module preserves its stored secret. A user-typed value flips `dirty: true` and IS sent. Same rule applies to every field type, not just secrets: users editing two of ten fields don't accidentally re-send the other eight back to the module.

## Smoke posture

Aaron is testing rc.3 in parallel against the live local hub + scribe, so this PR does **not** run a live smoke against the same hub. A side-by-side fresh-hub instance would diverge on issuer / JWKS and the running scribe would reject the minted JWT (the JWT's `iss` claim must match what scribe's hub-JWT validator expects from `PARACHUTE_HUB_ORIGIN`).

The unit tests cover end-to-end JWT shape (decode + assert scope=`scribe:admin` / audience=`scribe` / iss=hub / ttl=60s), proxy URL composition for both stripPrefix flavors, the writeOnly safety property, and the changed-fields-only PUT body. End-to-end SPA + live scribe write happens when Aaron upgrades to rc.4.

## Surprises uncovered

- **scribe's actual runtime schema differs from the `configSchema` in module.json.** module.json's `configSchema` is install-time author-controlled (per the module manifest pattern); scribe's runtime `/.parachute/config/schema` is the live source-of-truth and includes `enum` values derived from the live provider registry. The proxy talks to the runtime endpoint, not module.json — which is the right call since the runtime endpoint is what scribe's own UI already uses.
- **`stripPrefix` matters here.** scribe ships `stripPrefix: true` in `FIRST_PARTY_FALLBACKS` (not in services.json directly). The proxy honors the fallback registry so scribe sees `/.parachute/config/schema` (bare) while notes-style modules would see `/notes/.parachute/config/schema` (with prefix). Test coverage on both shapes.

## Test plan

- [ ] Aaron upgrades local hub to rc.4 (rebuild + restart).
- [ ] Visit `/admin/modules` — every installed module row shows a "Configure" link.
- [ ] Click Configure on scribe → form renders with the four scribe fields pre-filled from current values.
- [ ] Change `transcribeProvider` (e.g. `parakeet-mlx` → `groq`), click Save.
- [ ] Verify success banner names `transcribeProvider` in restart-required list.
- [ ] Verify `~/.parachute/scribe/config.json` was updated.
- [ ] Restart scribe → new provider takes effect.
- [ ] Submit with no changes → "No changes to save" inline error.
- [ ] Submit with an invalid value (would need a non-enum value, hard to do via the select) → 400 surfaces the module's validation message.
- [ ] Visit `/admin/modules/notes/config` while notes is installed but exposes no runtime schema → empty state "does not expose an operator-editable configuration schema."
- [ ] Visit `/admin/modules/agent/config` while agent isn't installed → empty state "is not installed; visit Modules to install it first."

## Test gates

- hub: 1746 pass (1728 → 1746, +18 new in `src/__tests__/api-modules-config.test.ts`).
- web/ui: 160 pass (148 → 160, +12 new in `src/routes/ModuleConfig.test.tsx`).
- typecheck clean (root + web/ui).
- biome clean.
- SPA build clean (301 KB total).

## Patterns touched

- **service-to-service-auth** (hub mints + forwards module-scoped JWT). New surface within an existing pattern, no pattern change.
- **module-json-extensibility** — confirms the runtime `/.parachute/config*` vs install-time `module.json` configSchema split (config portal pattern). The runtime path is what the proxy uses; module.json's `configSchema` field stays an install-time concern.
- **oauth-scopes** (per-module `<short>:admin` continues to gate `/.parachute/config*`). Unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)