### PR TITLE
refactor(hub): factor shared installDir-stamp + well-known regen helper (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.12-rc.5] - 2026-05-21
+
+**refactor(hub): factor shared installDir-stamp + well-known regen between CLI and API install paths (#293).**
+
+Co-locates the two post-install responsibilities (stamp `installDir` on the services.json row, regenerate `/.well-known/parachute.json`) into a new `src/post-install.ts` so the CLI install path (`commands/install.ts`) and the API install path (`api-modules-ops.ts`) can't drift again. Background: hub#292 added both responsibilities inline in the API path after hub#298 caught that the API had diverged from the CLI on the installDir stamp — modules silently disappeared from the discovery page. The duplication is the failure mode.
+
+New surface:
+
+- `stampInstallDirOnRow({ manifestName, installDir, servicesJsonPath })` — idempotent stamp helper; returns true when a write happened.
+- `refreshWellKnown({ servicesJsonPath, canonicalOrigin, wellKnownPath, log, readModuleManifest? })` — regen-only wrapper around `regenerateWellKnown` with error-to-log semantics.
+- `finalizeModuleInstall(opts)` — paired entry point (stamp + regen) for callers that do both at one point.
+
+Call-site changes:
+
+- API `runInstall` / `runUpgrade` keep their pre-spawn `stampInstallDirOnRow` + post-spawn `refreshWellKnown` shape (the two ops happen at different timing points), now via the shared helpers.
+- API `handleUninstall` swaps its inline regen for `refreshWellKnown`.
+- CLI `install` calls `finalizeModuleInstall` at its terminal stamping point — adds well-known regen to interactive CLI installs (a small operator-visible enhancement; the live HTTP path already rebuilt per-request, this keeps the on-disk inspection artifact in sync). The mid-install intermediate stamp uses `stampInstallDirOnRow`. Test seam: `InstallOpts.wellKnownPath` defaults to `WELL_KNOWN_PATH` only when `manifestPath` is the production default, so the existing test suite (which uses tempdir `manifestPath`) never writes to `~/.parachute/well-known/`.
+
+Pure refactor on the API path — no behavior change. CLI install now regenerates the well-known doc (small enhancement, was a gap). New test asserts CLI- and API-path inputs through `finalizeModuleInstall` produce byte-identical well-known docs.
+
+`bun test ./src`: 1754 pass (was 1746; +8 from the new post-install suite). `bun run typecheck` + `bunx biome check src/` clean.
+
 ## [0.5.12-rc.4] - 2026-05-21
 
 **feat(hub): admin SPA module-config form (hub#260) — Phase 1 critical-path.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.12-rc.4",
+  "version": "0.5.12-rc.5",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/post-install.test.ts
+++ b/src/__tests__/post-install.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { finalizeModuleInstall, refreshWellKnown, stampInstallDirOnRow } from "../post-install.ts";
+import { findService, upsertService } from "../services-manifest.ts";
+
+/**
+ * Tail-end helpers shared between CLI install (`commands/install.ts`) and
+ * API install (`api-modules-ops.ts`). Cover the two responsibilities
+ * independently + the paired `finalizeModuleInstall` entry point so a
+ * future drift in either call site (the failure mode hub#292 / hub#298
+ * traced) surfaces here.
+ */
+
+function makeHarness(): {
+  dir: string;
+  servicesJsonPath: string;
+  wellKnownPath: string;
+  cleanup: () => void;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-post-install-"));
+  return {
+    dir,
+    servicesJsonPath: join(dir, "services.json"),
+    wellKnownPath: join(dir, "well-known.json"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("stampInstallDirOnRow", () => {
+  test("stamps installDir on an existing row + returns true", () => {
+    const h = makeHarness();
+    try {
+      upsertService(
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.2.4",
+        },
+        h.servicesJsonPath,
+      );
+      const wrote = stampInstallDirOnRow({
+        manifestName: "parachute-vault",
+        installDir: "/fake/install/vault",
+        servicesJsonPath: h.servicesJsonPath,
+      });
+      expect(wrote).toBe(true);
+      const row = findService("parachute-vault", h.servicesJsonPath);
+      expect(row?.installDir).toBe("/fake/install/vault");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("no-ops when the row already carries the same installDir", () => {
+    const h = makeHarness();
+    try {
+      upsertService(
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.2.4",
+          installDir: "/fake/install/vault",
+        },
+        h.servicesJsonPath,
+      );
+      const wrote = stampInstallDirOnRow({
+        manifestName: "parachute-vault",
+        installDir: "/fake/install/vault",
+        servicesJsonPath: h.servicesJsonPath,
+      });
+      expect(wrote).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("no-ops + returns false when the row doesn't exist", () => {
+    const h = makeHarness();
+    try {
+      const wrote = stampInstallDirOnRow({
+        manifestName: "parachute-vault",
+        installDir: "/fake/install/vault",
+        servicesJsonPath: h.servicesJsonPath,
+      });
+      expect(wrote).toBe(false);
+      expect(findService("parachute-vault", h.servicesJsonPath)).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("refreshWellKnown", () => {
+  test("writes the on-disk doc + logs the regenerated path", async () => {
+    const h = makeHarness();
+    try {
+      upsertService(
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.2.4",
+        },
+        h.servicesJsonPath,
+      );
+      const logs: string[] = [];
+      await refreshWellKnown({
+        servicesJsonPath: h.servicesJsonPath,
+        canonicalOrigin: "https://hub.example.com",
+        wellKnownPath: h.wellKnownPath,
+        log: (msg) => logs.push(msg),
+      });
+      expect(existsSync(h.wellKnownPath)).toBe(true);
+      expect(logs).toEqual([`regenerated ${h.wellKnownPath}`]);
+      const doc = JSON.parse(readFileSync(h.wellKnownPath, "utf8")) as {
+        services: Array<{ name: string }>;
+        vaults: Array<{ name: string }>;
+      };
+      expect(doc.services.some((s) => s.name === "parachute-vault")).toBe(true);
+      expect(doc.vaults.some((v) => v.name === "default")).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("logs failure + does not throw when the well-known write itself errors", async () => {
+    const h = makeHarness();
+    try {
+      // Point wellKnownPath at a directory rather than a file — writeFileSync
+      // → renameSync surfaces as EISDIR (or platform-equivalent), which the
+      // helper must catch and report rather than letting it propagate up
+      // and abort an otherwise-successful install op.
+      const logs: string[] = [];
+      await refreshWellKnown({
+        servicesJsonPath: h.servicesJsonPath,
+        canonicalOrigin: "https://hub.example.com",
+        wellKnownPath: h.dir, // tempdir itself, not a file inside it
+        log: (msg) => logs.push(msg),
+      });
+      expect(logs.some((l) => l.startsWith("well-known regen failed:"))).toBe(true);
+      expect(logs.some((l) => l.startsWith("regenerated"))).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("threads readModuleManifest through to the regen so uiUrl lands", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = "/fake/install/notes";
+      upsertService(
+        {
+          name: "parachute-notes",
+          port: 5173,
+          paths: ["/notes"],
+          health: "/notes/health",
+          version: "0.1.0",
+          installDir,
+        },
+        h.servicesJsonPath,
+      );
+      await refreshWellKnown({
+        servicesJsonPath: h.servicesJsonPath,
+        canonicalOrigin: "https://hub.example.com",
+        wellKnownPath: h.wellKnownPath,
+        log: () => {},
+        readModuleManifest: async (dir) =>
+          dir === installDir
+            ? {
+                name: "notes",
+                manifestName: "parachute-notes",
+                kind: "frontend",
+                port: 5173,
+                paths: ["/notes"],
+                health: "/notes/health",
+                uiUrl: "/notes",
+                displayName: "Notes",
+              }
+            : null,
+      });
+      const doc = JSON.parse(readFileSync(h.wellKnownPath, "utf8")) as {
+        services: Array<{ name: string; uiUrl?: string; displayName?: string }>;
+      };
+      const row = doc.services.find((s) => s.name === "parachute-notes");
+      expect(row?.uiUrl).toBe("https://hub.example.com/notes");
+      expect(row?.displayName).toBe("Notes");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("finalizeModuleInstall", () => {
+  test("stamps installDir AND regenerates well-known in one call", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = "/fake/install/vault";
+      upsertService(
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.2.4",
+        },
+        h.servicesJsonPath,
+      );
+      const logs: string[] = [];
+      await finalizeModuleInstall({
+        manifestName: "parachute-vault",
+        installDir,
+        servicesJsonPath: h.servicesJsonPath,
+        canonicalOrigin: "https://hub.example.com",
+        wellKnownPath: h.wellKnownPath,
+        log: (msg) => logs.push(msg),
+      });
+      // Stamp landed.
+      const row = findService("parachute-vault", h.servicesJsonPath);
+      expect(row?.installDir).toBe(installDir);
+      // Well-known reflects the stamped row.
+      expect(existsSync(h.wellKnownPath)).toBe(true);
+      const doc = JSON.parse(readFileSync(h.wellKnownPath, "utf8")) as {
+        services: Array<{ name: string; version: string }>;
+      };
+      expect(doc.services.some((s) => s.name === "parachute-vault")).toBe(true);
+      // The regen-success log fired exactly once — no double-regen from
+      // the helper.
+      expect(logs.filter((l) => l.startsWith("regenerated"))).toHaveLength(1);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("CLI- and API-path inputs produce byte-identical well-known docs", async () => {
+    // The PR's pure-refactor invariant (hub#293): both paths funnel
+    // through this helper, so given the same row state + same origin +
+    // same module manifest, the on-disk doc must be identical regardless
+    // of which call site drove it. Regression canary against the helper
+    // silently growing per-caller branching.
+    const cli = makeHarness();
+    const api = makeHarness();
+    try {
+      const installDir = "/fake/install/vault";
+      const row = {
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/vault/default"],
+        health: "/vault/default/health",
+        version: "0.2.4",
+      };
+      upsertService(row, cli.servicesJsonPath);
+      upsertService(row, api.servicesJsonPath);
+      const manifest = {
+        name: "vault",
+        manifestName: "parachute-vault",
+        kind: "api" as const,
+        port: 1940,
+        paths: ["/vault/default"],
+        health: "/vault/default/health",
+        managementUrl: "/vault/default/admin",
+      };
+      const opts = {
+        manifestName: "parachute-vault",
+        installDir,
+        canonicalOrigin: "https://hub.example.com",
+        log: () => {},
+        readModuleManifest: async (dir: string) => (dir === installDir ? manifest : null),
+      };
+      await finalizeModuleInstall({
+        ...opts,
+        servicesJsonPath: cli.servicesJsonPath,
+        wellKnownPath: cli.wellKnownPath,
+      });
+      await finalizeModuleInstall({
+        ...opts,
+        servicesJsonPath: api.servicesJsonPath,
+        wellKnownPath: api.wellKnownPath,
+      });
+      const cliDoc = readFileSync(cli.wellKnownPath, "utf8");
+      const apiDoc = readFileSync(api.wellKnownPath, "utf8");
+      expect(cliDoc).toEqual(apiDoc);
+    } finally {
+      cli.cleanup();
+      api.cleanup();
+    }
+  });
+});

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -38,10 +38,11 @@ import { dirname } from "node:path";
 import { CURATED_MODULES, type CuratedModuleShort } from "./api-modules.ts";
 import { getModuleInstallChannel } from "./hub-settings.ts";
 import { validateAccessToken } from "./jwt-sign.ts";
+import { refreshWellKnown, stampInstallDirOnRow } from "./post-install.ts";
 import { FIRST_PARTY_FALLBACKS, type ServiceSpec, composeServiceSpec } from "./service-spec.ts";
-import { findService, readManifest, removeService, upsertService } from "./services-manifest.ts";
+import { findService, readManifest, removeService } from "./services-manifest.ts";
 import type { ModuleState, SpawnRequest, Supervisor } from "./supervisor.ts";
-import { regenerateWellKnown } from "./well-known.ts";
+import { WELL_KNOWN_PATH, type regenerateWellKnown } from "./well-known.ts";
 
 /**
  * Scope required for every POST + operation-poll endpoint here.
@@ -283,58 +284,25 @@ function defaultRun(cmd: readonly string[]): Promise<number> {
 }
 
 /**
- * Stamp `installDir` on the services.json row for `spec.manifestName` when
- * the package's globally-installed path can be resolved. Idempotent —
- * no-ops when the row already carries the same `installDir`, when no row
- * exists, or when `findGlobalInstall` can't locate the package (e.g. in
- * tests with no global install).
- *
- * Mirrors the same stamp `parachute install <svc>` does in
- * `commands/install.ts`. Without it, the discovery page's
- * `loadServiceUiMetadata` resolver in `hub-server.ts` skips the entry (it
- * reads `module.json` from `installDir`), so `uiUrl` never lands on the
- * row + the new module's tile never renders on `/`.
+ * Resolve the `installDir` for `spec` from `findGlobalInstall`. Null when
+ * the dep isn't wired (tests without a stub) or the package can't be
+ * located on disk. Same fallback semantics the previous inline
+ * `stampInstallDir` had — callers fall through to a regen-only path.
  */
-function stampInstallDir(spec: ServiceSpec, deps: ApiModulesOpsDeps): void {
+function resolveInstallDirForSpec(spec: ServiceSpec, deps: ApiModulesOpsDeps): string | null {
   const findGlobalInstall = deps.findGlobalInstall;
-  if (!findGlobalInstall) return;
+  if (!findGlobalInstall) return null;
   const pkgJson = findGlobalInstall(spec.package);
-  if (!pkgJson) return;
-  const installDir = dirname(pkgJson);
-  const entry = findService(spec.manifestName, deps.manifestPath);
-  if (!entry || entry.installDir === installDir) return;
-  upsertService({ ...entry, installDir }, deps.manifestPath);
+  return pkgJson ? dirname(pkgJson) : null;
 }
 
 /**
- * Regenerate `/.well-known/parachute.json` on disk after a state-changing
- * module op (install / upgrade / uninstall). Wraps `regenerateWellKnown`
- * with the deps-aware defaults — issuer for canonicalOrigin, deps-overridable
- * paths + manifest reader. Errors land in the operation log rather than
- * throwing back to the caller; the on-disk doc is a debug / inspection
- * artifact, not the live discovery source, so a regen failure shouldn't
- * mask the op's actual outcome.
+ * Build the op-log sink for `opId`. Threaded into `finalizeModuleInstall` /
+ * `refreshWellKnown` so their `regenerated <path>` / `well-known regen
+ * failed: …` lines land on the operation the UI is polling.
  */
-async function regenAfterOp(
-  opId: string,
-  registry: OperationsRegistry,
-  deps: ApiModulesOpsDeps,
-): Promise<void> {
-  try {
-    const regenOpts: Parameters<typeof regenerateWellKnown>[0] = {
-      manifestPath: deps.manifestPath,
-      canonicalOrigin: deps.issuer,
-    };
-    if (deps.wellKnownPath !== undefined) regenOpts.wellKnownPath = deps.wellKnownPath;
-    if (deps.readModuleManifest !== undefined) {
-      regenOpts.readModuleManifest = deps.readModuleManifest;
-    }
-    const { path } = await regenerateWellKnown(regenOpts);
-    registry.update(opId, {}, `regenerated ${path}`);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    registry.update(opId, {}, `well-known regen failed: ${msg}`);
-  }
+function opLog(opId: string, registry: OperationsRegistry): (msg: string) => void {
+  return (msg) => registry.update(opId, {}, msg);
 }
 
 /**
@@ -463,13 +431,20 @@ export async function runInstall(
     }
   }
 
-  // Stamp installDir on the row so the discovery page's `uiUrl` /
-  // `displayName` resolver can find `<installDir>/.parachute/module.json`.
-  // Mirrors `parachute install <svc>` — without this, the new module's
-  // tile never renders on `/` because `loadServiceUiMetadata` skips
-  // installDir-less rows. (Doing this BEFORE the spawn so the supervisor
-  // also sees the updated row if it consults services.json post-spawn.)
-  stampInstallDir(spec, deps);
+  // Stamp `installDir` on the services.json row BEFORE the spawn so the
+  // supervisor sees the updated row if it consults services.json
+  // post-spawn. Mirrors `parachute install <svc>`. Without the stamp,
+  // the discovery page's `loadServiceUiMetadata` resolver skips the
+  // row (no installDir → no module.json → no uiUrl) and the new
+  // module's tile never renders on `/`.
+  const installDir = resolveInstallDirForSpec(spec, deps);
+  if (installDir) {
+    stampInstallDirOnRow({
+      manifestName: spec.manifestName,
+      installDir,
+      servicesJsonPath: deps.manifestPath,
+    });
+  }
 
   // Spawn the child via the supervisor. Boot-spawn semantics apply.
   const state = await spawnSupervised(short, spec, deps);
@@ -482,12 +457,20 @@ export async function runInstall(
     return;
   }
 
-  // Regenerate the on-disk well-known doc so the inspection artifact
-  // tracks the just-installed module's row. The HTTP path serves a
-  // per-request build, so the discovery page picks up the new module
-  // either way; this keeps `~/.parachute/well-known/parachute.json` in
-  // sync for tooling that reads it directly.
-  await regenAfterOp(opId, registry, deps);
+  // Regen the on-disk well-known doc. `~/.parachute/well-known/parachute.json`
+  // is an inspection artifact, not the live discovery source (hub-server.ts
+  // builds per-request from services.json), so it stays in lockstep with
+  // the live HTTP path only when we explicitly refresh it after a
+  // state-changing op. Paired with the pre-spawn stamp above so this op
+  // closes the "newly installed module doesn't appear on discovery"
+  // bug from hub#292 / hub#298.
+  await refreshWellKnown({
+    servicesJsonPath: deps.manifestPath,
+    canonicalOrigin: deps.issuer,
+    wellKnownPath: deps.wellKnownPath ?? WELL_KNOWN_PATH,
+    log: opLog(opId, registry),
+    ...(deps.readModuleManifest ? { readModuleManifest: deps.readModuleManifest } : {}),
+  });
 
   registry.update(opId, { status: "succeeded" }, `${short} installed + spawned (pid ${state.pid})`);
 }
@@ -575,7 +558,14 @@ async function runUpgrade(
   // Re-stamp installDir after upgrade — a major-version bump may relocate
   // the package on disk (e.g. node_modules layout change). Idempotent
   // when the path is stable.
-  stampInstallDir(spec, deps);
+  const installDir = resolveInstallDirForSpec(spec, deps);
+  if (installDir) {
+    stampInstallDirOnRow({
+      manifestName: spec.manifestName,
+      installDir,
+      servicesJsonPath: deps.manifestPath,
+    });
+  }
 
   const state = await deps.supervisor.restart(short);
   if (!state) {
@@ -591,7 +581,13 @@ async function runUpgrade(
   // module's row reflects the new install. The HTTP path rebuilds per
   // request, so the discovery page tracks the new version regardless;
   // this keeps the inspection artifact aligned.
-  await regenAfterOp(opId, registry, deps);
+  await refreshWellKnown({
+    servicesJsonPath: deps.manifestPath,
+    canonicalOrigin: deps.issuer,
+    wellKnownPath: deps.wellKnownPath ?? WELL_KNOWN_PATH,
+    log: opLog(opId, registry),
+    ...(deps.readModuleManifest ? { readModuleManifest: deps.readModuleManifest } : {}),
+  });
 
   registry.update(
     opId,
@@ -643,21 +639,13 @@ export async function handleUninstall(
   // longer appears in the inspection artifact. The HTTP path rebuilds
   // per request, so live discovery drops the entry immediately; this
   // is the disk-side equivalent.
-  try {
-    const regenOpts: Parameters<typeof regenerateWellKnown>[0] = {
-      manifestPath: deps.manifestPath,
-      canonicalOrigin: deps.issuer,
-    };
-    if (deps.wellKnownPath !== undefined) regenOpts.wellKnownPath = deps.wellKnownPath;
-    if (deps.readModuleManifest !== undefined) {
-      regenOpts.readModuleManifest = deps.readModuleManifest;
-    }
-    const { path } = await regenerateWellKnown(regenOpts);
-    log.push(`regenerated ${path}`);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log.push(`well-known regen failed: ${msg}`);
-  }
+  await refreshWellKnown({
+    servicesJsonPath: deps.manifestPath,
+    canonicalOrigin: deps.issuer,
+    wellKnownPath: deps.wellKnownPath ?? WELL_KNOWN_PATH,
+    log: (msg) => log.push(msg),
+    ...(deps.readModuleManifest ? { readModuleManifest: deps.readModuleManifest } : {}),
+  });
 
   return jsonOk({ short, log });
 }

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -11,6 +11,7 @@ import {
   validateModuleManifest,
 } from "../module-manifest.ts";
 import { assignServicePort } from "../port-assign.ts";
+import { finalizeModuleInstall, stampInstallDirOnRow } from "../post-install.ts";
 import {
   CANONICAL_PORT_MAX,
   CANONICAL_PORT_MIN,
@@ -21,6 +22,7 @@ import {
   isCanonicalPort,
 } from "../service-spec.ts";
 import { findService, readManifest, upsertService } from "../services-manifest.ts";
+import { WELL_KNOWN_PATH } from "../well-known.ts";
 import { start as lifecycleStart } from "./lifecycle.ts";
 import { migrateNotice } from "./migrate.ts";
 import {
@@ -142,6 +144,26 @@ export interface InstallOpts {
    * package's `name` (used to find the install dir post-bun-add).
    */
   readPackageName?: (absPath: string) => string | null;
+  /**
+   * Override the on-disk path for the regenerated `/.well-known/parachute.json`
+   * (test seam). When unset and `manifestPath` is the production default,
+   * defaults to `WELL_KNOWN_PATH` so an interactive `parachute install`
+   * refreshes the inspection artifact. When `manifestPath` is overridden
+   * (tests with tempdir services.json) AND this is unset, the regen is
+   * skipped — tests that want to assert on the well-known doc opt in by
+   * passing a tempdir path here.
+   */
+  wellKnownPath?: string;
+  /**
+   * Origin to embed in the regenerated well-known's `url` fields. When
+   * unset (the typical CLI case), the regen still runs but the
+   * canonicalOrigin defaults to `http://localhost:1939` — the live HTTP
+   * path at `/.well-known/parachute.json` rebuilds per request with the
+   * request's actual origin, so the on-disk doc's origin is best-effort
+   * for tooling that reads the file directly. Tests pass a synthetic
+   * origin for stable assertions.
+   */
+  wellKnownOrigin?: string;
 }
 
 async function defaultRunner(cmd: readonly string[]): Promise<number> {
@@ -612,9 +634,13 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
   // the service's own init may have written the row without installDir, and
   // the seed itself doesn't carry it (composeServiceSpec → seedEntry uses
   // the manifest, which doesn't know its own install location).
-  if (entry && installDir && entry.installDir !== installDir) {
-    upsertService({ ...entry, installDir }, manifestPath);
-    entry = findService(entryName, manifestPath);
+  if (entry && installDir) {
+    const stamped = stampInstallDirOnRow({
+      manifestName: entryName,
+      installDir,
+      servicesJsonPath: manifestPath,
+    });
+    if (stamped) entry = findService(entryName, manifestPath);
   }
 
   if (!entry) {
@@ -693,10 +719,39 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
   // missing entry into a visible failure rather than a silent one.
   let finalEntry = findService(entryName, manifestPath);
   // Re-stamp installDir if the service's first boot rewrote the row without
-  // it. Lifecycle commands beyond install (start/stop/restart/logs) need it
-  // present; we own this field, services don't have to know it exists.
-  if (finalEntry && installDir && finalEntry.installDir !== installDir) {
-    upsertService({ ...finalEntry, installDir }, manifestPath);
+  // it, AND refresh the on-disk well-known so the inspection artifact
+  // tracks the post-boot row. Lifecycle commands beyond install
+  // (start/stop/restart/logs) need installDir present; we own this field,
+  // services don't have to know it exists. The well-known regen mirrors
+  // what the API install path does (`runInstall` in api-modules-ops.ts) so
+  // CLI + API installs leave identical disk state — shared helper in
+  // `post-install.ts`, hub#293.
+  //
+  // Well-known regen is gated on `wellKnownPath` resolving to a non-null
+  // path. The production default (`manifestPath === SERVICES_MANIFEST_PATH`)
+  // falls back to `WELL_KNOWN_PATH`; tests with a tempdir manifestPath get
+  // `undefined` unless they opt in by passing `wellKnownPath` explicitly,
+  // so the test suite never writes to the operator's real
+  // `~/.parachute/well-known/`.
+  const wellKnownPath =
+    opts.wellKnownPath ?? (manifestPath === SERVICES_MANIFEST_PATH ? WELL_KNOWN_PATH : undefined);
+  if (finalEntry && installDir) {
+    if (wellKnownPath !== undefined) {
+      await finalizeModuleInstall({
+        manifestName: entryName,
+        installDir,
+        servicesJsonPath: manifestPath,
+        canonicalOrigin: opts.wellKnownOrigin ?? "http://localhost:1939",
+        wellKnownPath,
+        log,
+      });
+    } else {
+      stampInstallDirOnRow({
+        manifestName: entryName,
+        installDir,
+        servicesJsonPath: manifestPath,
+      });
+    }
     finalEntry = findService(entryName, manifestPath);
   }
   if (!finalEntry) {

--- a/src/post-install.ts
+++ b/src/post-install.ts
@@ -1,0 +1,130 @@
+/**
+ * Tail-end helpers shared between the CLI install path
+ * (`commands/install.ts`) and the API install path
+ * (`api-modules-ops.ts`). Both have to (a) stamp `installDir` on the
+ * services.json row so downstream resolvers (`uiUrl` / `displayName` /
+ * `managementUrl`) can find the module's `.parachute/module.json`, and
+ * (b) regenerate the on-disk `/.well-known/parachute.json` so the
+ * inspection artifact tracks the new state.
+ *
+ * Background: hub#292 added both responsibilities inline in the API
+ * path after reviewer (#298) caught that the API had diverged from the
+ * CLI on the installDir stamp. The duplication is fragile — if either
+ * path drifts again, modules silently stop appearing on the discovery
+ * page. Co-locating the pairing in one helper makes that drift visible:
+ * a new call site that imports `finalizeModuleInstall` gets both
+ * responsibilities for free.
+ *
+ * Two entry points:
+ *   - `finalizeModuleInstall` — stamp + regen, for install / upgrade.
+ *   - `refreshWellKnown` — regen only, for uninstall (no row to stamp)
+ *     and the API-path fallback when `installDir` can't be resolved.
+ *
+ * Both surface errors via `log` rather than throwing — the on-disk
+ * well-known is an inspection / debug artifact, not the live discovery
+ * source (hub-server.ts builds per-request), so a regen failure
+ * shouldn't mask the op's actual outcome.
+ */
+
+import type { ModuleManifest } from "./module-manifest.ts";
+import { findService, upsertService } from "./services-manifest.ts";
+import { regenerateWellKnown } from "./well-known.ts";
+
+export interface StampInstallDirOnRowOpts {
+  /** services.json row key — `manifestName` (e.g. `"parachute-vault"`). */
+  manifestName: string;
+  /** Absolute path to the installed package directory. */
+  installDir: string;
+  /** Path to services.json. */
+  servicesJsonPath: string;
+}
+
+/**
+ * Idempotent stamp of `installDir` on the services.json row for
+ * `manifestName`. Returns true when a write happened, false when the
+ * row was absent or already carried the same `installDir` (no-op).
+ *
+ * Exported so callers that need only the stamp step (e.g. the CLI's
+ * mid-install pre-startService stamp) can reuse the same logic without
+ * pulling in the well-known regen.
+ */
+export function stampInstallDirOnRow(opts: StampInstallDirOnRowOpts): boolean {
+  const entry = findService(opts.manifestName, opts.servicesJsonPath);
+  if (!entry || entry.installDir === opts.installDir) return false;
+  upsertService({ ...entry, installDir: opts.installDir }, opts.servicesJsonPath);
+  return true;
+}
+
+export interface RefreshWellKnownOpts {
+  /** Path to services.json. */
+  servicesJsonPath: string;
+  /**
+   * Origin to embed in the doc's `url` fields. Production passes the
+   * configured hub origin / issuer; tests pass a synthetic one.
+   */
+  canonicalOrigin: string;
+  /** Path to write the regenerated `/.well-known/parachute.json`. */
+  wellKnownPath: string;
+  /**
+   * Sink for progress / failure messages. CLI passes a `console.log`
+   * style sink; API passes an op-log appender so the operator can see
+   * "regenerated <path>" in the operation poll response.
+   */
+  log: (msg: string) => void;
+  /**
+   * Override the per-module `.parachute/module.json` reader used by
+   * the well-known regen. Production defaults to `readModuleManifest`;
+   * tests inject a stub. Mirrors the hub-server.ts seam so the disk
+   * regen and the per-request HTTP build stay aligned.
+   */
+  readModuleManifest?: (installDir: string) => Promise<ModuleManifest | null>;
+}
+
+/**
+ * Regenerate `/.well-known/parachute.json` on disk with errors logged
+ * rather than thrown. Use this directly for uninstall (no row to
+ * stamp) and for the API-path fallback when `installDir` can't be
+ * resolved post-bun-add. Install + upgrade should call
+ * `finalizeModuleInstall` instead, which pairs the regen with the
+ * installDir stamp.
+ */
+export async function refreshWellKnown(opts: RefreshWellKnownOpts): Promise<void> {
+  try {
+    const regenOpts: Parameters<typeof regenerateWellKnown>[0] = {
+      manifestPath: opts.servicesJsonPath,
+      canonicalOrigin: opts.canonicalOrigin,
+      wellKnownPath: opts.wellKnownPath,
+    };
+    if (opts.readModuleManifest !== undefined) {
+      regenOpts.readModuleManifest = opts.readModuleManifest;
+    }
+    const { path } = await regenerateWellKnown(regenOpts);
+    opts.log(`regenerated ${path}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    opts.log(`well-known regen failed: ${msg}`);
+  }
+}
+
+export interface FinalizeModuleInstallOpts
+  extends StampInstallDirOnRowOpts,
+    Omit<RefreshWellKnownOpts, "servicesJsonPath"> {
+  // servicesJsonPath comes from StampInstallDirOnRowOpts; Omit on the
+  // refresh side prevents the duplicate-key TS error.
+}
+
+/**
+ * Stamp `installDir` then regenerate the well-known doc. The canonical
+ * post-install / post-upgrade call. Single entry point so future call
+ * sites (cloud-install, restore-from-backup, …) can't accidentally
+ * ship one responsibility without the other.
+ *
+ * Errors from `refreshWellKnown` are logged, not thrown — see that
+ * function's docstring for the rationale. The stamp step is synchronous
+ * + cannot fail in any meaningful way (services-manifest writes are
+ * atomic via rename); it doesn't need its own error-handling.
+ */
+export async function finalizeModuleInstall(opts: FinalizeModuleInstallOpts): Promise<void> {
+  stampInstallDirOnRow(opts);
+  await refreshWellKnown(opts);
+}


### PR DESCRIPTION
## Summary

Closes hub#293. Factors the post-install pairing (stamp `installDir` + regenerate `/.well-known/parachute.json`) into a new `src/post-install.ts` so the CLI install path and the API install path can't drift again. Background: hub#292 added both responsibilities inline in the API path after hub#298 reviewer caught that the API had diverged from the CLI on the installDir stamp — modules silently disappeared from the discovery page. The duplication is the failure mode.

## What's in the helper

```ts
// src/post-install.ts

export function stampInstallDirOnRow(opts: {
  manifestName: string;
  installDir: string;
  servicesJsonPath: string;
}): boolean;

export async function refreshWellKnown(opts: {
  servicesJsonPath: string;
  canonicalOrigin: string;
  wellKnownPath: string;
  log: (msg: string) => void;
  readModuleManifest?: (installDir: string) => Promise<ModuleManifest | null>;
}): Promise<void>;

export async function finalizeModuleInstall(opts: FinalizeModuleInstallOpts): Promise<void>;
```

Three entry points instead of one because the API path needs the stamp + regen at different timing points (stamp pre-spawn so the supervisor sees the updated row; regen post-spawn), while the CLI path does both at its terminal stamping point.

## Before / after

API `runInstall` (api-modules-ops.ts):

```diff
-  stampInstallDir(spec, deps);
+  const installDir = resolveInstallDirForSpec(spec, deps);
+  if (installDir) {
+    stampInstallDirOnRow({ manifestName: spec.manifestName, installDir, servicesJsonPath: deps.manifestPath });
+  }
   const state = await spawnSupervised(short, spec, deps);
   ...
-  await regenAfterOp(opId, registry, deps);
+  await refreshWellKnown({
+    servicesJsonPath: deps.manifestPath,
+    canonicalOrigin: deps.issuer,
+    wellKnownPath: deps.wellKnownPath ?? WELL_KNOWN_PATH,
+    log: opLog(opId, registry),
+    ...(deps.readModuleManifest ? { readModuleManifest: deps.readModuleManifest } : {}),
+  });
```

API `handleUninstall` swaps its inline regen block (~17 lines) for one `refreshWellKnown` call (~6 lines).

CLI `install` (commands/install.ts):

```diff
-  if (finalEntry && installDir && finalEntry.installDir !== installDir) {
-    upsertService({ ...finalEntry, installDir }, manifestPath);
-    finalEntry = findService(entryName, manifestPath);
-  }
+  const wellKnownPath = opts.wellKnownPath ?? (manifestPath === SERVICES_MANIFEST_PATH ? WELL_KNOWN_PATH : undefined);
+  if (finalEntry && installDir) {
+    if (wellKnownPath !== undefined) {
+      await finalizeModuleInstall({ manifestName: entryName, installDir, servicesJsonPath: manifestPath, canonicalOrigin: opts.wellKnownOrigin ?? "http://localhost:1939", wellKnownPath, log });
+    } else {
+      stampInstallDirOnRow({ manifestName: entryName, installDir, servicesJsonPath: manifestPath });
+    }
+    finalEntry = findService(entryName, manifestPath);
+  }
```

The CLI's mid-install (pre-startService) stamp also moves to `stampInstallDirOnRow` for consistency.

## Behavior changes

- **API paths**: pure refactor. Same bytes to services.json, same bytes to well-known.
- **CLI install**: now regenerates the on-disk well-known at the end (was a gap). The live HTTP path at `/.well-known/parachute.json` already rebuilt per-request, so discovery itself was unaffected — this keeps the on-disk inspection artifact in sync. Test seam: `InstallOpts.wellKnownPath` defaults to `WELL_KNOWN_PATH` only when `manifestPath` is the production default, so the existing test suite (tempdir manifestPath) never writes to the operator's real `~/.parachute/well-known/`.

## Tests

- `bun test ./src`: 1754 pass / 0 fail / 31695 expect() calls (was 1746 / 0 / 31677 — +8 new post-install tests).
- `bun run typecheck` clean.
- `bunx biome check src/` clean.
- `cd web/ui && bun run test`: 161 pass (unchanged).

New `src/__tests__/post-install.test.ts` exercises:

- `stampInstallDirOnRow`: stamps a new row, no-ops on identical installDir, returns false on missing row.
- `refreshWellKnown`: writes the on-disk doc + logs the regenerated path; threads `readModuleManifest` so uiUrl / displayName / managementUrl land; logs (does not throw) when the write fails.
- `finalizeModuleInstall`: stamps + regens in one call; CLI- and API-path inputs through the helper produce byte-identical well-known docs (the PR's pure-refactor invariant as a regression canary).

## Test plan

- [ ] `bun run typecheck` clean
- [ ] `bun test ./src` shows 1754 pass / 0 fail
- [ ] `bunx biome check src/` clean
- [ ] `cd web/ui && bun run test` shows 161 pass
- [ ] Manual: `parachute install <svc>` regenerates `~/.parachute/well-known/parachute.json` and the discovery page shows the new tile
- [ ] Manual: install + upgrade via admin SPA still works end-to-end (the existing API-ops well-known regen tests cover this)