### PR TITLE
feat(hub): admin SPA install + upgrade UI — closes hub#260 v0.6 critical-path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.1] - 2026-05-21
+
+**feat(hub): admin SPA install + upgrade UI — closes Phase 1 critical-path (hub#260).**
+
+`/admin/modules` now lays out as two clearly-grouped sections: **Installed modules** on top + **Install a module** below. The install + upgrade actions have been wired since hub#262 (the catalog page rendered them inline per-row), but pre-this-PR there was no visual grouping — an operator scanning a fresh-deploy hub had to read past three tagline-plus-meta blocks to find the Install buttons. With the split, an empty hub lands on a near-empty Installed section + a clear "Install a module" catalog underneath; a populated hub lands on its modules up top + a smaller "available to add" list underneath.
+
+**Install card** (the new `InstallableCard` component) is visually lighter than the existing `ModuleRow`: a name+tagline+package+latest-version line with a single Install button. No status badge (nothing to be installed yet), no meta grid, no per-row Configure / Restart / Uninstall sub-actions. Distinct shape because the only affordance is one action — "get me this module."
+
+**In-flight install handling**: while an install op is pending, the corresponding card disappears from the catalog (replaced by a small "Install in progress — see In progress above" hint) so a fast-finger operator can't kick off a second op against the same module before the first lands. Belt-and-suspenders against the ~50ms gap before the new op settles into `pendingOps`; the per-button `disabled={installing}` was already there.
+
+**Upgrade affordance** stays where hub#262 put it — inline on each installed `ModuleRow` row. The button label reads "Upgrade to v{latest}" when `installed_version !== latest_version` and "Up to date" (disabled) otherwise. The available-version detection is driven entirely off `latest_version` in the `GET /api/modules` response (hub#262 added this field with a 5-minute in-memory cache); no SPA-side npm lookup, no second roundtrip.
+
+**Backend**: zero changes. Existing endpoints (`POST /api/modules/<short>/install` / `/upgrade` async, `POST /api/modules/<short>/restart` / `/uninstall` sync, `GET /api/modules/operations/<id>` poll) shipped via hub#262 already expose the right shape. The `latest_version` field on each module row was added the same PR.
+
+**Available-modules list source**: the entries in `FIRST_PARTY_FALLBACKS` that intersect `CURATED_MODULES` (`vault`, `notes`, `scribe`). The hardcoded list comes off the existing backend wire shape — `available: true` filters in, `installed: false` keeps it in the catalog after install. Third-party / `module.json`-shipping modules aren't part of v0.6 (per hub#260 scope); they retire when each module ships its own `.parachute/module.json`.
+
+CSS: new `.install-list`, `.install-card`, `.modules-installed > h2` / `.modules-installable > h2` rules in `web/ui/src/styles.css` for the section grouping + lighter install-card chrome. No new bundle dependencies; SPA bundle still ~303 KB.
+
+`bun run typecheck` clean (root + web/ui). `bun test ./src`: 1754 pass (no backend change). `cd web/ui && bun run test`: 169 pass (was 161, +8 covering the new section split, in-flight install hide, install + upgrade kick-off, supervisor-unavailable disabled-install path). `bunx biome check` clean.
+
 ## [0.5.12-rc.5] - 2026-05-21
 
 **refactor(hub): factor shared installDir-stamp + well-known regen between CLI and API install paths (#293).**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.12-rc.5",
+  "version": "0.5.13-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/web/ui/src/routes/Modules.test.tsx
+++ b/web/ui/src/routes/Modules.test.tsx
@@ -1,9 +1,11 @@
 /**
- * Modules route smoke tests — catalog rendering, status badges,
- * install kick-off + op polling → terminal, restart/uninstall sync
- * paths, supervisor-unavailable disabled state.
+ * Modules route smoke tests — catalog rendering (two-section layout
+ * for the hub#260 closeout: installed on top, available below), status
+ * badges, install kick-off + op polling, restart/uninstall sync paths,
+ * supervisor-unavailable disabled state, in-flight install hiding the
+ * row until catalog refresh, install-channel toggle.
  */
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -75,7 +77,37 @@ describe("Modules — catalog rendering", () => {
     expect(screen.getByText(/loading modules/i)).toBeInTheDocument();
   });
 
-  it("renders one row per module with display name + tagline", async () => {
+  it("renders all modules under their respective section", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [
+        moduleRow("vault", {
+          installed: true,
+          installed_version: "0.4.5",
+          latest_version: "0.4.5",
+          supervisor_status: "running",
+        }),
+        moduleRow("notes"),
+        moduleRow("scribe"),
+      ],
+      supervisor_available: true,
+      module_install_channel: "latest",
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+
+    const installed = screen.getByTestId("installed-section");
+    const installable = screen.getByTestId("installable-section");
+    // Vault sits under "Installed modules" because installed=true.
+    expect(within(installed).getByText("Vault")).toBeInTheDocument();
+    // Notes + Scribe sit under "Install a module" because installed=false.
+    expect(within(installable).getByText("Notes")).toBeInTheDocument();
+    expect(within(installable).getByText("Scribe")).toBeInTheDocument();
+    // Cross-pollination check — taglines from the installable section
+    // surface verbatim on the card.
+    expect(within(installable).getByText("the notes module")).toBeInTheDocument();
+  });
+
+  it("renders the 'no modules installed' empty state when nothing is installed", async () => {
     vi.mocked(api.listModules).mockResolvedValue({
       modules: [moduleRow("vault"), moduleRow("notes"), moduleRow("scribe")],
       supervisor_available: true,
@@ -83,21 +115,31 @@ describe("Modules — catalog rendering", () => {
     });
     renderRoute();
     await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
-    expect(screen.getByText("Notes")).toBeInTheDocument();
-    expect(screen.getByText("Scribe")).toBeInTheDocument();
-    // Tagline copy from the listing flows through to the row.
-    expect(screen.getByText("the vault module")).toBeInTheDocument();
+    // Empty hint copy under "Installed modules".
+    expect(screen.getByTestId("installed-empty")).toBeInTheDocument();
+    // Three install cards under "Install a module".
+    expect(within(screen.getByTestId("installable-section")).getAllByRole("button")).toHaveLength(
+      3,
+    );
   });
 
-  it("badges 'not installed' for available-but-uninstalled rows", async () => {
+  it("renders the 'all installed' empty state when no installables remain", async () => {
     vi.mocked(api.listModules).mockResolvedValue({
-      modules: [moduleRow("vault")],
+      modules: [
+        moduleRow("vault", {
+          installed: true,
+          installed_version: "0.4.5",
+          latest_version: "0.4.5",
+          supervisor_status: "running",
+        }),
+      ],
       supervisor_available: true,
       module_install_channel: "latest",
     });
     renderRoute();
     await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
-    expect(screen.getByText(/not installed/i)).toBeInTheDocument();
+    // Empty hint copy under "Install a module".
+    expect(screen.getByTestId("installable-empty")).toBeInTheDocument();
   });
 
   it("shows 'Running' badge + installed version for an installed+running row", async () => {
@@ -142,10 +184,26 @@ describe("Modules — supervisor unavailable", () => {
     const restartBtn = screen.getByRole("button", { name: /restart/i });
     expect(restartBtn).toBeDisabled();
   });
+
+  it("disables the Install button on installable cards under CLI mode", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [moduleRow("vault")],
+      supervisor_available: false,
+      module_install_channel: "latest",
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    // The install card's button is the only button rendered for an
+    // uninstalled module — disabled because supervisor_available is false.
+    const installBtn = within(screen.getByTestId("installable-section")).getByRole("button", {
+      name: /install/i,
+    });
+    expect(installBtn).toBeDisabled();
+  });
 });
 
 describe("Modules — install flow", () => {
-  it("kicks off install and starts polling the operation", async () => {
+  it("kicks off install from the Install a module section and starts polling", async () => {
     // Real timers — we just want to observe the kick-off and the poll
     // wiring. End-to-end poll → terminal → refresh is covered by the
     // server-side api-modules-ops tests; here we verify the SPA wires
@@ -168,13 +226,155 @@ describe("Modules — install flow", () => {
     renderRoute();
     await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole("button", { name: /install/i }));
+    // Click the Install button inside the install-card under the
+    // "Install a module" section — not the generic by-role click,
+    // which would also match buttons in other sections if they
+    // ever grow an /install/i label.
+    const installable = screen.getByTestId("installable-section");
+    fireEvent.click(within(installable).getByRole("button", { name: /install/i }));
 
     await waitFor(() => expect(api.installModule).toHaveBeenCalledWith("vault"));
     // Poll fires within ~1s — give waitFor 2s to be safe.
     await waitFor(() => expect(api.getModuleOperation).toHaveBeenCalledWith("op-abc"), {
       timeout: 2000,
     });
+  });
+
+  it("hides the install card while the install op is pending (avoids duplicate spawn)", async () => {
+    // Catalog still shows vault as not-installed (the install hasn't
+    // completed + the catalog hasn't been re-fetched yet). The pending
+    // op should suppress the install card to prevent a re-click that
+    // would spawn a second op.
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [moduleRow("vault")],
+      supervisor_available: true,
+      module_install_channel: "latest",
+    });
+    vi.mocked(api.installModule).mockResolvedValue("op-abc");
+    // Keep the poll pending — we want to observe the in-flight state.
+    vi.mocked(api.getModuleOperation).mockImplementation(() => new Promise(() => {}));
+
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    const installable = screen.getByTestId("installable-section");
+    fireEvent.click(within(installable).getByRole("button", { name: /install/i }));
+
+    // After the click, the install card disappears (replaced by the
+    // "Install in progress" empty hint) and the pending-ops banner
+    // shows the in-flight op.
+    await waitFor(() => expect(screen.getByTestId("installable-empty")).toBeInTheDocument());
+    expect(screen.getByText(/install in progress/i)).toBeInTheDocument();
+  });
+
+  it("surfaces an inline error on the install card when installModule rejects", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [moduleRow("vault")],
+      supervisor_available: true,
+      module_install_channel: "latest",
+    });
+    vi.mocked(api.installModule).mockRejectedValue(new api.HttpError(409, "module_busy"));
+
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    fireEvent.click(
+      within(screen.getByTestId("installable-section")).getByRole("button", { name: /install/i }),
+    );
+    await waitFor(() => expect(screen.getByText(/module_busy/)).toBeInTheDocument());
+  });
+});
+
+describe("Modules — upgrade affordance", () => {
+  it("shows 'Upgrade to vX' when installed_version < latest_version", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [
+        moduleRow("vault", {
+          installed: true,
+          installed_version: "0.4.5",
+          latest_version: "0.5.0",
+          supervisor_status: "running",
+        }),
+      ],
+      supervisor_available: true,
+      module_install_channel: "latest",
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    const upgradeBtn = screen.getByRole("button", { name: /upgrade to v0\.5\.0/i });
+    expect(upgradeBtn).toBeInTheDocument();
+    expect(upgradeBtn).not.toBeDisabled();
+  });
+
+  it("shows 'Up to date' (disabled) when installed_version == latest_version", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [
+        moduleRow("vault", {
+          installed: true,
+          installed_version: "0.5.0",
+          latest_version: "0.5.0",
+          supervisor_status: "running",
+        }),
+      ],
+      supervisor_available: true,
+      module_install_channel: "latest",
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    const upgradeBtn = screen.getByRole("button", { name: /up to date/i });
+    expect(upgradeBtn).toBeInTheDocument();
+    expect(upgradeBtn).toBeDisabled();
+  });
+
+  it("kicks off upgrade and starts polling the operation", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [
+        moduleRow("vault", {
+          installed: true,
+          installed_version: "0.4.5",
+          latest_version: "0.5.0",
+          supervisor_status: "running",
+        }),
+      ],
+      supervisor_available: true,
+      module_install_channel: "latest",
+    });
+    vi.mocked(api.upgradeModule).mockResolvedValue("op-up");
+    vi.mocked(api.getModuleOperation).mockResolvedValue({
+      id: "op-up",
+      kind: "upgrade",
+      short: "vault",
+      status: "running",
+      log: ["running bun add"],
+      startedAt: "2026-05-18T00:00:00Z",
+    });
+
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /upgrade to v0\.5\.0/i }));
+
+    await waitFor(() => expect(api.upgradeModule).toHaveBeenCalledWith("vault"));
+    await waitFor(() => expect(api.getModuleOperation).toHaveBeenCalledWith("op-up"), {
+      timeout: 2000,
+    });
+  });
+
+  it("surfaces an inline error on upgrade when upgradeModule rejects", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [
+        moduleRow("vault", {
+          installed: true,
+          installed_version: "0.4.5",
+          latest_version: "0.5.0",
+          supervisor_status: "running",
+        }),
+      ],
+      supervisor_available: true,
+      module_install_channel: "latest",
+    });
+    vi.mocked(api.upgradeModule).mockRejectedValue(new api.HttpError(503, "registry_unreachable"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /upgrade to v0\.5\.0/i }));
+    await waitFor(() => expect(screen.getByText(/registry_unreachable/)).toBeInTheDocument());
   });
 });
 

--- a/web/ui/src/routes/Modules.tsx
+++ b/web/ui/src/routes/Modules.tsx
@@ -12,6 +12,16 @@
  *     and we poll GET /api/modules/operations/:id every second until
  *     terminal. The op's `log` array drives a small progress banner.
  *
+ * Layout (hub#260 closeout): two clear sections, **Installed modules**
+ * on top + **Install a module** below. The split makes the "what's
+ * available to add?" affordance discoverable — pre-hub#260 the install
+ * + upgrade actions were wired but every module rendered as one row in
+ * a single list, so a fresh-deploy operator had to scan past three
+ * tagline+meta blocks to find the Install buttons. With the split, an
+ * empty hub lands on a near-empty Installed section + a clear "Install
+ * a module" catalog underneath; a populated hub lands on its modules
+ * up top + a smaller "available to add" list underneath.
+ *
  * `supervisor_available: false` is the on-box CLI path (no `parachute
  * serve`). Actions get disabled and a small banner tells the operator
  * to use `parachute install/upgrade/restart` from their shell instead.
@@ -125,6 +135,13 @@ export function Modules() {
   }, [pendingOps, refreshCatalog]);
 
   async function onInstall(short: string) {
+    // Clear any previous error on this module so a retry isn't shadowed
+    // by stale text — same shape as onRestart / onUninstall below.
+    setSyncError((prev) => {
+      const next = { ...prev };
+      delete next[short];
+      return next;
+    });
     try {
       const operationId = await installModule(short);
       setPendingOps((prev) => [
@@ -140,6 +157,11 @@ export function Modules() {
   }
 
   async function onUpgrade(short: string) {
+    setSyncError((prev) => {
+      const next = { ...prev };
+      delete next[short];
+      return next;
+    });
     try {
       const operationId = await upgradeModule(short);
       setPendingOps((prev) => [
@@ -230,6 +252,23 @@ export function Modules() {
   const okCatalog = catalog.catalog;
   const { modules, supervisor_available, module_install_channel } = okCatalog;
 
+  // Two visual buckets driven entirely off the wire shape — no client
+  // re-derivation of "is this available". Modules with `installed: true`
+  // go on top (operator's running set); modules with `available: true`
+  // and `!installed` go below as the install catalog.
+  const installedModules = modules.filter((m) => m.installed);
+  const installableModules = modules.filter((m) => !m.installed && m.available);
+
+  // While an install op is in flight for a given short, the catalog
+  // hasn't refreshed yet (we wait for the terminal poll) so the module
+  // still appears under "Install a module". Track shorts with an
+  // in-flight install op so we can suppress the duplicate render until
+  // the catalog refresh moves the row to the Installed section.
+  const installingShorts = new Set(
+    pendingOps.filter((p) => p.kind === "install").map((p) => p.short),
+  );
+  const visibleInstallable = installableModules.filter((m) => !installingShorts.has(m.short));
+
   async function onChangeChannel(next: ModuleInstallChannel) {
     if (next === module_install_channel) return;
     // Optimistic update so the radio reflects the click before the
@@ -278,7 +317,7 @@ export function Modules() {
       )}
 
       {pendingOps.length > 0 && (
-        <div className="banner">
+        <div className="banner" data-testid="pending-ops-banner">
           <strong>In progress:</strong>
           <ul>
             {pendingOps.map((p) => (
@@ -297,21 +336,54 @@ export function Modules() {
         </div>
       )}
 
-      <ul className="module-list">
-        {modules.map((mod) => (
-          <ModuleRow
-            key={mod.short}
-            module={mod}
-            supervisorAvailable={supervisor_available}
-            syncBusy={Boolean(syncBusy[mod.short])}
-            errorMessage={syncError[mod.short]}
-            onInstall={() => void onInstall(mod.short)}
-            onUpgrade={() => void onUpgrade(mod.short)}
-            onRestart={() => void onRestart(mod.short)}
-            onUninstall={() => void onUninstall(mod.short)}
-          />
-        ))}
-      </ul>
+      <section className="modules-installed" data-testid="installed-section">
+        <h2>Installed modules</h2>
+        {installedModules.length === 0 ? (
+          <p className="muted" data-testid="installed-empty">
+            No modules installed yet. Pick one from <strong>Install a module</strong> below to get
+            started.
+          </p>
+        ) : (
+          <ul className="module-list">
+            {installedModules.map((mod) => (
+              <ModuleRow
+                key={mod.short}
+                module={mod}
+                supervisorAvailable={supervisor_available}
+                syncBusy={Boolean(syncBusy[mod.short])}
+                errorMessage={syncError[mod.short]}
+                onUpgrade={() => void onUpgrade(mod.short)}
+                onRestart={() => void onRestart(mod.short)}
+                onUninstall={() => void onUninstall(mod.short)}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="modules-installable" data-testid="installable-section">
+        <h2>Install a module</h2>
+        {visibleInstallable.length === 0 ? (
+          <p className="muted" data-testid="installable-empty">
+            {installingShorts.size > 0
+              ? "Install in progress — see In progress above."
+              : "All available modules are installed."}
+          </p>
+        ) : (
+          <ul className="install-list">
+            {visibleInstallable.map((mod) => (
+              <InstallableCard
+                key={mod.short}
+                module={mod}
+                supervisorAvailable={supervisor_available}
+                installing={installingShorts.has(mod.short)}
+                errorMessage={syncError[mod.short]}
+                onInstall={() => void onInstall(mod.short)}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
     </section>
   );
 }
@@ -321,25 +393,29 @@ interface ModuleRowProps {
   supervisorAvailable: boolean;
   syncBusy: boolean;
   errorMessage: string | undefined;
-  onInstall: () => void;
   onUpgrade: () => void;
   onRestart: () => void;
   onUninstall: () => void;
 }
 
+/**
+ * Row for an installed module — shows version + supervisor status +
+ * Configure / Restart / Upgrade / Uninstall affordances. The "install"
+ * action lives on `InstallableCard` instead; this row is only rendered
+ * for `installed: true` modules.
+ */
 function ModuleRow({
   module: mod,
   supervisorAvailable,
   syncBusy,
   errorMessage,
-  onInstall,
   onUpgrade,
   onRestart,
   onUninstall,
 }: ModuleRowProps) {
   const canAct = supervisorAvailable && !syncBusy;
   const upgradeAvailable =
-    mod.installed && mod.installed_version !== mod.latest_version && mod.latest_version !== null;
+    mod.installed_version !== mod.latest_version && mod.latest_version !== null;
 
   return (
     <li className="module-row" data-short={mod.short}>
@@ -358,21 +434,11 @@ function ModuleRow({
         <dd>
           <code>{mod.package}</code>
         </dd>
-        {mod.installed && (
-          <>
-            <dt>Installed</dt>
-            <dd>
-              v{mod.installed_version ?? "unknown"}
-              {upgradeAvailable && <span className="badge">v{mod.latest_version} available</span>}
-            </dd>
-          </>
-        )}
-        {!mod.installed && mod.latest_version && (
-          <>
-            <dt>Latest on npm</dt>
-            <dd>v{mod.latest_version}</dd>
-          </>
-        )}
+        <dt>Installed</dt>
+        <dd>
+          v{mod.installed_version ?? "unknown"}
+          {upgradeAvailable && <span className="badge">v{mod.latest_version} available</span>}
+        </dd>
         {mod.pid && (
           <>
             <dt>PID</dt>
@@ -382,36 +448,82 @@ function ModuleRow({
       </dl>
 
       <div className="actions">
-        {!mod.installed && (
-          <button type="button" disabled={!canAct} onClick={onInstall}>
-            Install
-          </button>
-        )}
-        {mod.installed && (
-          <>
-            {/* Configure link routes to the generic per-module config
-                form (hub#260). Rendered as a Link rather than a button
-                because it's pure navigation — no async action attached,
-                no supervisor requirement. Stays clickable even when the
-                supervisor is offline so an operator on a hub-only CLI
-                install can still edit config (the config endpoints are
-                served by the module itself, not the supervisor). */}
-            <Link className="btn" to={`/modules/${encodeURIComponent(mod.short)}/config`}>
-              Configure
-            </Link>
-            <button type="button" disabled={!canAct} onClick={onRestart}>
-              Restart
-            </button>
-            <button type="button" disabled={!canAct || !upgradeAvailable} onClick={onUpgrade}>
-              {upgradeAvailable ? `Upgrade to v${mod.latest_version}` : "Up to date"}
-            </button>
-            <button type="button" className="destructive" disabled={!canAct} onClick={onUninstall}>
-              Uninstall
-            </button>
-          </>
-        )}
+        {/* Configure link routes to the generic per-module config form
+            (hub#260). Rendered as a Link rather than a button because
+            it's pure navigation — no async action attached, no
+            supervisor requirement. Stays clickable even when the
+            supervisor is offline so an operator on a hub-only CLI
+            install can still edit config (the config endpoints are
+            served by the module itself, not the supervisor). */}
+        <Link className="btn" to={`/modules/${encodeURIComponent(mod.short)}/config`}>
+          Configure
+        </Link>
+        <button type="button" disabled={!canAct} onClick={onRestart}>
+          Restart
+        </button>
+        <button type="button" disabled={!canAct || !upgradeAvailable} onClick={onUpgrade}>
+          {upgradeAvailable ? `Upgrade to v${mod.latest_version}` : "Up to date"}
+        </button>
+        <button type="button" className="destructive" disabled={!canAct} onClick={onUninstall}>
+          Uninstall
+        </button>
       </div>
 
+      {errorMessage && <div className="error">{errorMessage}</div>}
+    </li>
+  );
+}
+
+interface InstallableCardProps {
+  module: ModuleListing;
+  supervisorAvailable: boolean;
+  installing: boolean;
+  errorMessage: string | undefined;
+  onInstall: () => void;
+}
+
+/**
+ * Card for an available-but-not-installed module. Lives in the
+ * "Install a module" section and renders a name + tagline + npm
+ * version + a single Install button. Distinct from the installed
+ * ModuleRow because there's nothing to configure / restart / upgrade
+ * yet — the affordance is exactly one action ("get me this module").
+ *
+ * `installing` short-circuits to a spinner-ish label even before the
+ * row drops out of the visible list (which it does as soon as the
+ * pendingOps tracker picks up the kick-off). Belt-and-suspenders
+ * against a fast-finger double-click in the ~50ms gap before the op
+ * lands in `pendingOps`.
+ */
+function InstallableCard({
+  module: mod,
+  supervisorAvailable,
+  installing,
+  errorMessage,
+  onInstall,
+}: InstallableCardProps) {
+  const canInstall = supervisorAvailable && !installing;
+  return (
+    <li className="install-card" data-short={mod.short}>
+      <div className="install-card-body">
+        <h3>
+          {mod.display_name} <span className="muted">({mod.short})</span>
+        </h3>
+        {mod.tagline ? <p className="tagline">{mod.tagline}</p> : null}
+        <p className="muted install-card-meta">
+          <code>{mod.package}</code>
+          {mod.latest_version ? (
+            <>
+              {" · "}latest <code>v{mod.latest_version}</code>
+            </>
+          ) : null}
+        </p>
+      </div>
+      <div className="install-card-actions">
+        <button type="button" disabled={!canInstall} onClick={onInstall}>
+          {installing ? "Installing…" : "Install"}
+        </button>
+      </div>
       {errorMessage && <div className="error">{errorMessage}</div>}
     </li>
   );

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -547,6 +547,89 @@ form .field-error {
 }
 
 /*
+ * /admin/modules — two-section layout (hub#260 closeout).
+ *
+ * Installed modules sit on top in `.modules-installed`; the
+ * "Install a module" catalog sits below in `.modules-installable`.
+ * Each section gets a small top-margin and a sub-heading; the empty
+ * states are inline muted prose, not the page-level `.empty` block
+ * (that's the route-level error / loading affordance).
+ */
+.modules-installed,
+.modules-installable {
+  margin-top: 1.75rem;
+}
+.modules-installed > h2,
+.modules-installable > h2 {
+  font-size: 1.15rem;
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+  color: var(--fg);
+}
+.modules-installed > p.muted,
+.modules-installable > p.muted {
+  margin: 0 0 0.5rem;
+}
+
+/*
+ * "Install a module" catalog row — visually lighter than the heavier
+ * `.module-row` (no status badge, no meta grid, just name + tagline +
+ * package + Install). The card lays out as body+actions side by side
+ * on wide viewports and stacks on narrow ones.
+ */
+.install-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+.install-card {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding: 0.85rem 1rem;
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  transition: border-color 0.15s ease;
+}
+.install-card:hover {
+  border-color: var(--accent);
+}
+.install-card-body {
+  flex: 1 1 0;
+  min-width: 0;
+}
+.install-card-body h3 {
+  margin: 0 0 0.2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--fg);
+}
+.install-card-body .tagline {
+  margin: 0 0 0.35rem;
+  color: var(--fg-muted);
+  font-size: 0.92rem;
+}
+.install-card-meta {
+  margin: 0;
+  font-size: 0.82rem;
+}
+.install-card-actions {
+  flex: 0 0 auto;
+}
+.install-card .error {
+  flex-basis: 100%;
+  margin-top: 0.5rem;
+  color: var(--error);
+  font-size: 0.85rem;
+}
+
+/*
  * "Configure" link styled to match sibling action buttons on
  * `.module-row .actions`. React-router's <Link> renders an <a>, so
  * default `a` styles take over without these overrides — we want it


### PR DESCRIPTION
## Summary

Closes out [hub#260](https://github.com/ParachuteComputer/parachute-hub/issues/260) by restructuring the admin SPA's `/admin/modules` page into two clearly-grouped sections: **Installed modules** on top + **Install a module** below. The install + upgrade actions have been wired since hub#262 (the catalog rendered them inline per-row), but pre-this-PR there was no visual grouping — an operator on a fresh-deploy hub had to read past three tagline+meta blocks to find the Install buttons. With the split, an empty hub lands on a near-empty Installed section + a clear "Install a module" catalog underneath; a populated hub lands on its modules up top + a smaller "available to add" list underneath.

Companion to [hub#300](https://github.com/ParachuteComputer/parachute-hub/pull/300) which shipped the per-module Configure form. This PR is the last UI gap on the v0.6 Phase 1 critical path — friends deploying via Render can now install, upgrade, configure, restart, and uninstall modules entirely from the browser.

## Scope

- **Layout split** — new `<section>` wrappers `.modules-installed` + `.modules-installable` with H2 sub-headings, each rendering its own empty-state hint.
- **New `InstallableCard` component** — visually lighter than the existing `ModuleRow` (no status badge, no meta grid, no Restart/Uninstall buttons). Just name + tagline + package + latest-version + a single Install button. The shape matches the affordance: one action, "get me this module."
- **`ModuleRow` simplifies** — only rendered for `installed: true` modules now, so the Install button is removed from its actions; install exclusively goes through `InstallableCard`.
- **In-flight install hide** — while an install op is pending, the corresponding card disappears from the catalog (replaced by a "Install in progress — see In progress above" hint) so a fast-finger operator can't kick off a second op against the same module before the first lands.
- **Upgrade affordance** stays where hub#262 put it — inline on each installed `ModuleRow`. Detection uses the existing `latest_version` field on `GET /api/modules` (5-minute in-memory cache); no SPA-side npm lookup.
- **Backend**: zero changes. Existing endpoints (`POST /api/modules/<short>/install` / `/upgrade` async, restart/uninstall sync, `GET /api/modules/operations/<id>` poll) already expose the right shape.
- **Available-modules list source** — the entries in `FIRST_PARTY_FALLBACKS` that intersect `CURATED_MODULES` (`vault`, `notes`, `scribe`). Third-party / `module.json`-shipping modules aren't part of v0.6 per hub#260 scope; they retire when each module ships its own `.parachute/module.json`.
- **CSS** — new `.install-list`, `.install-card`, `.modules-installed > h2` / `.modules-installable > h2` rules. No new bundle deps; SPA bundle still ~303 KB.
- **Version bump** — `0.5.12-rc.5` → `0.5.13-rc.1`. New chain because this is a feature, not a continuation of the 0.5.12 refactor chain that just published rc.5.

## Smoke

Built the SPA bundle + bounced `parachute restart hub`. Confirmed the new bundle serves at `/admin/assets/index-…js` (302 KB) and that the new strings ("Install a module", "Installed modules", "install-card") all appear in the served JS + CSS. With three of three curated modules installed locally (vault + notes + scribe), `/api/modules` returns them all with `installed: true` — the live SPA shows the Installed section populated + the Install-a-module section in its all-installed empty state.

The full install kick-off → op poll → terminal → catalog refresh cycle is covered by the unit tests (mocked `installModule` + `getModuleOperation`), since this dev box doesn't have an uninstalled curated module to exercise the live install path (`supervisor_available: false` here — CLI-mode hub).

## Test plan

- [x] `bun run typecheck` clean (root + web/ui)
- [x] `bun test ./src` — 1754 pass (unchanged; no backend changes)
- [x] `cd web/ui && bun run test` — 169 pass (was 161, +8 new)
- [x] `cd web/ui && bun run build` — clean, verify-base.mjs passes
- [x] `bunx biome check` — clean

New test coverage:
- Modules render under the correct section (installed vs installable)
- "No modules installed" empty state
- "All installed" empty state on the installable section
- Install button disabled when `supervisor_available: false`
- Install kick-off scoped to the installable section
- In-flight install card hides until catalog refresh
- Install error surfaces inline on the card
- Upgrade button shows "Upgrade to vX" when versions differ
- Upgrade button shows "Up to date" (disabled) when versions match
- Upgrade kick-off + poll
- Upgrade error surfaces inline

## Patterns check

No new patterns touched. Reaffirms the existing patterns: snake_case wire shape on `/api/modules` (`installed`, `installed_version`, `latest_version`); session-cookie → minted-JWT → Bearer flow on the SPA; module supervisor + operation-poll registry from hub#262. The two-section layout convention is a UX/discoverability choice, not a pattern claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)