### PR TITLE
feat(hub): runner added to FIRST_PARTY_FALLBACKS + CURATED_MODULES (#305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.2] - 2026-05-21
+
+**feat(hub): runner added to FIRST_PARTY_FALLBACKS + CURATED_MODULES — admin SPA can install runner (hub#305).**
+
+Closes the v0.6 friend-deploy gap that hub#304 left: the admin SPA install catalog renders from `FIRST_PARTY_FALLBACKS ∩ CURATED_MODULES`, and runner was in neither set, so operators landing on `/admin/modules` post-hub#304 had no UI affordance to install runner. After this PR the catalog renders four cards (vault → notes → scribe → runner), and clicking Install on runner kicks off the same `bun add @openparachute/runner` + supervised-spawn flow the other three modules use.
+
+**New entries:**
+
+- `service-spec.ts` — `RUNNER_FALLBACK` constant + `runner: RUNNER_FALLBACK` key on the `FIRST_PARTY_FALLBACKS` record. Mirror of `parachute-runner/.parachute/module.json` (rc.3 vintage, 2026-05-21). `kind: "tool"`, port `1945`, `paths: ["/runner", "/.parachute"]`, `health: "/runner/healthz"`, `startCmd: ["parachute-runner", "serve"]`, `stripPrefix: false` (runner's HTTP handler matches `/runner/jobs` + `/.parachute/config` literally — no internal mount strip). `extras.hasAuth: true` matches runner's posture (`runner:admin` scope gates everything past `/healthz`).
+- `api-modules.ts` — `CURATED_MODULES` grows from `["vault", "notes", "scribe"]` to `["vault", "notes", "scribe", "runner"]`. Order is recommended install order; runner is last because it depends on a working vault + scribe.
+
+**Tests** (`bun test ./src`): 1755 pass (was 1754; +1 — new `runner row carries package + display props` spot-check on the `GET /api/modules` wire shape). The existing `200 + curated list on fresh container` test updates its `expected` from three entries to four. No SPA-side test changes — `web/ui/src/routes/Modules.test.tsx` already drives module rendering off a per-test catalog fixture, not a hardcoded curated-list length.
+
+**Not in scope (follow-up):**
+
+- The `api-modules-config.ts` proxy for `/.parachute/config[/schema]` builds the upstream URL as `<paths[0]>/.parachute/config[/schema]`. For runner with `paths[0] === "/runner"` and `stripPrefix: false`, that produces `/runner/.parachute/config` — which runner's HTTP server does NOT match (it matches `/.parachute/config` literally, no `/runner/` prefix). The Configure button in the admin SPA will therefore 404 for runner until that proxy learns to use `/.parachute` from the module's `paths[]` when present. Tracked as a follow-up.
+- `PORT_RESERVATIONS` still labels slot 1945 as `"unassigned"`. The pattern doc says "first-party modules claim a slot the moment they ship"; runner ships rc.3 today, so a future doc-only PR can promote the entry to `"parachute-runner"`. Left out here to keep the PR a registry add.
+
+`bun run typecheck` clean. `cd web/ui && bun run test`: 169 pass (no SPA change). `bunx biome check src/` clean.
+
 ## [0.5.13-rc.1] - 2026-05-21
 
 **feat(hub): admin SPA install + upgrade UI — closes Phase 1 critical-path (hub#260).**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.1",
+  "version": "0.5.13-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -149,8 +149,8 @@ describe("GET /api/modules", () => {
 
   test("200 + curated list on fresh container (empty services.json)", async () => {
     // The v0.6 hot path: brand-new Render container, no services.json
-    // yet. UI must render "install vault / notes / scribe" cards even
-    // though nothing's installed.
+    // yet. UI must render "install vault / notes / scribe / runner"
+    // cards even though nothing's installed.
     const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
     const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
       db: h.db,
@@ -168,13 +168,43 @@ describe("GET /api/modules", () => {
       }>;
       supervisor_available: boolean;
     };
-    // Curated order is preserved: vault → notes → scribe.
-    expect(body.modules.map((m) => m.short)).toEqual(["vault", "notes", "scribe"]);
+    // Curated order is preserved: vault → notes → scribe → runner.
+    expect(body.modules.map((m) => m.short)).toEqual(["vault", "notes", "scribe", "runner"]);
     expect(body.modules.every((m) => m.available)).toBe(true);
     expect(body.modules.every((m) => !m.installed)).toBe(true);
     expect(body.modules.every((m) => m.latest_version === "0.9.9")).toBe(true);
     // Supervisor wasn't injected → flag reflects that.
     expect(body.supervisor_available).toBe(false);
+  });
+
+  test("runner row carries package + display props from FIRST_PARTY_FALLBACKS (#305)", async () => {
+    // hub#305 added runner to CURATED_MODULES + FIRST_PARTY_FALLBACKS so
+    // the admin SPA install catalog surfaces it. Spot-check the wire
+    // shape resolves the runner-specific fields (package, displayName,
+    // tagline) from the vendored fallback rather than a stale default.
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: async () => "0.1.0",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      modules: Array<{
+        short: string;
+        package: string;
+        display_name: string;
+        tagline: string;
+        available: boolean;
+      }>;
+    };
+    const runner = body.modules.find((m) => m.short === "runner");
+    expect(runner).toBeDefined();
+    expect(runner?.package).toBe("@openparachute/runner");
+    expect(runner?.display_name).toBe("Runner");
+    expect(runner?.tagline).toContain("Vault-as-job-substrate");
+    expect(runner?.available).toBe(true);
   });
 
   test("surfaces installed_version from services.json", async () => {

--- a/src/__tests__/setup.test.ts
+++ b/src/__tests__/setup.test.ts
@@ -122,6 +122,7 @@ describe("setup", () => {
         { name: "parachute-notes", port: 1942 },
         { name: "parachute-scribe", port: 1943 },
         { name: "parachute-channel", port: 1941 },
+        { name: "parachute-runner", port: 1945 },
       ];
       for (const s of seeds) {
         upsertService(

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -3,10 +3,10 @@
  *
  * Combines three sources into a single per-module row:
  *
- *   - **Curated availability** — vault, notes, scribe (the v0.6 release
- *     bar). The Phase-2 marketplace will broaden this; for now it's
- *     hardcoded so the admin UI has a stable "what can I install?" list
- *     even on a fresh container where services.json is empty.
+ *   - **Curated availability** — vault, notes, scribe, runner (the v0.6
+ *     release bar). The Phase-2 marketplace will broaden this; for now
+ *     it's hardcoded so the admin UI has a stable "what can I install?"
+ *     list even on a fresh container where services.json is empty.
  *   - **Installed state** — services.json reads (version, installDir).
  *   - **Supervisor state** — per-module run status (`running` / `stopped`
  *     / `crashed` / `starting` / `restarting`) + pid. Absent when the
@@ -39,10 +39,12 @@ export const API_MODULES_REQUIRED_SCOPE = "parachute:host:auth";
 
 /**
  * Curated module short-names for v0.6 Render self-host. Marketplace is
- * Phase 2 — until then, the admin UI offers exactly these three. Order
- * is the recommended install order (vault before notes, scribe last).
+ * Phase 2 — until then, the admin UI offers exactly these four. Order
+ * is the recommended install order (vault → notes → scribe → runner;
+ * runner comes last because it depends on a working vault + scribe to
+ * be useful, and operators usually wire those up first).
  */
-export const CURATED_MODULES = ["vault", "notes", "scribe"] as const;
+export const CURATED_MODULES = ["vault", "notes", "scribe", "runner"] as const;
 export type CuratedModuleShort = (typeof CURATED_MODULES)[number];
 
 export interface ApiModulesDeps {

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -377,6 +377,55 @@ const CHANNEL_FALLBACK: FirstPartyFallback = {
   },
 };
 
+// FALLBACK: Delete when @openparachute/runner ships .parachute/module.json
+// in its published artifact (parachute-runner repo already vendors it
+// alongside the source at `.parachute/module.json` — this fallback exists
+// so on a fresh hub the admin SPA install catalog can surface runner
+// before any `bun add @openparachute/runner` has placed a manifest on
+// disk to read from. Retires once hub#305's follow-up wires "load
+// FIRST_PARTY_FALLBACKS from each repo's shipped module.json"; for now
+// the manifest is mirrored here verbatim).
+//
+// Mirror of `parachute-runner/.parachute/module.json` (rc.3 vintage —
+// 2026-05-21). Keep these two files byte-equivalent for the fields they
+// share. Scope declarations (`runner:read`, `runner:admin`) intentionally
+// omitted from the fallback: the manifest's `scopes.defines` field flows
+// through to `composeServiceSpec` only via the install-time
+// `getSpecFromInstallDir` path; the fallback's role is upstream-catalog
+// rendering + post-install seed, where scopes aren't consumed today.
+const RUNNER_FALLBACK: FirstPartyFallback = {
+  package: "@openparachute/runner",
+  manifest: {
+    name: "runner",
+    manifestName: "parachute-runner",
+    displayName: "Runner",
+    tagline:
+      "Vault-as-job-substrate engine — spawns claude -p against vault job notes on schedule.",
+    kind: "tool",
+    port: 1945,
+    // Runner exposes two mount prefixes: `/runner/*` for its admin
+    // endpoints (jobs / runs / run-now) and `/.parachute/*` for the
+    // module-protocol endpoints (info / config / config/schema /
+    // clear-credential). Hub's longest-prefix router in
+    // `findServiceUpstream` picks the right one per request.
+    paths: ["/runner", "/.parachute"],
+    health: "/runner/healthz",
+    startCmd: ["parachute-runner", "serve"],
+    // Runner's HTTP server matches `/runner/jobs`, `/.parachute/config`
+    // etc. literally — no internal mount strip. Hub forwards the full
+    // path. Contrast with scribe (stripPrefix: true) whose internal
+    // routes are bare.
+    stripPrefix: false,
+  },
+  extras: {
+    // Runner's HTTP routes (everything past `/healthz`) gate on a
+    // hub-issued JWT carrying `runner:admin` scope (see runner's
+    // `src/auth.ts`). Surfaces in `parachute status` as auth-required by
+    // default, same posture as vault.
+    hasAuth: true,
+  },
+};
+
 /**
  * Vendored manifests + extras for first-party modules. Indexed by short name
  * (the `parachute install <X>` token). Each entry retires when its upstream
@@ -388,6 +437,7 @@ export const FIRST_PARTY_FALLBACKS: Record<string, FirstPartyFallback> = {
   notes: NOTES_FALLBACK,
   scribe: SCRIBE_FALLBACK,
   channel: CHANNEL_FALLBACK,
+  runner: RUNNER_FALLBACK,
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds `RUNNER_FALLBACK` to `FIRST_PARTY_FALLBACKS` in `service-spec.ts` — vendored mirror of `parachute-runner/.parachute/module.json` (rc.3, 2026-05-21). `kind: "tool"`, port `1945`, `paths: ["/runner", "/.parachute"]`, `health: "/runner/healthz"`, `startCmd: ["parachute-runner", "serve"]`, `stripPrefix: false`, `hasAuth: true`.
- Grows `CURATED_MODULES` from `["vault", "notes", "scribe"]` to `["vault", "notes", "scribe", "runner"]`. Order is recommended install order; runner is last because it depends on a working vault + scribe to be useful.

## Why

Closes the v0.6 friend-deploy gap that hub#304 left: the admin SPA install catalog (just shipped at `/admin/modules`) renders from `FIRST_PARTY_FALLBACKS ∩ CURATED_MODULES`. Runner was in neither set, so operators landing post-hub#304 had no UI affordance to install runner. After this PR the catalog renders four cards (vault → notes → scribe → runner), and Install on runner kicks off the same `bun add @openparachute/runner` + supervised-spawn flow the other three modules use.

Part of the runner Phase 1.2 close-out — runner ships rc.3 with its full HTTP admin surface + module-protocol config endpoints + encrypted vault-token-at-rest; this PR is the hub-side "make it discoverable through the SPA" half.

## `stripPrefix` verification

Runner's HTTP server matches `/runner/jobs`, `/.parachute/config`, `/healthz`, and `/runner/healthz` literally — see `parachute-runner/src/http-server.ts:108-167`. No internal mount strip. `stripPrefix: false` is correct: hub's `findServiceUpstream` longest-prefix-router routes both `/runner/*` and `/.parachute/*` to the runner backend, and `proxyToService` forwards the full path. The dual-prefix declaration in `module.json#paths` is so the longest-prefix router can pick `/.parachute` (length 11) over `/runner` (length 7) for module-protocol endpoints.

## Follow-up (not in this PR)

`api-modules-config.ts` builds the upstream URL for `/.parachute/config[/schema]` as `<paths[0]>/.parachute/config[/schema]`. For runner with `paths[0] === "/runner"` and `stripPrefix: false`, that yields `/runner/.parachute/config` — which runner's HTTP server does NOT match (it matches `/.parachute/config` literally, no `/runner/` prefix). The Configure button in the admin SPA will 404 for runner until that proxy learns to prefer `/.parachute` from the module's `paths[]` when present. Will file an issue after merge.

`PORT_RESERVATIONS` still labels slot 1945 as `"unassigned"`. Pattern doc says "first-party modules claim a slot the moment they ship"; runner ships rc.3 today, so a future doc-only PR can promote the entry to `"parachute-runner"`. Left out here to keep the PR a registry add.

## Test plan

- [x] `bun run typecheck`: clean
- [x] `bun test ./src`: 1755 pass / 0 fail / 31701 expect() calls (was 1754; +1 from the new `runner row carries package + display props` spot-check; existing curated-list test updated from `["vault", "notes", "scribe"]` → `["vault", "notes", "scribe", "runner"]`; `setup.test.ts`'s "all known services installed" test grows a fifth seed row for `parachute-runner` at port 1945)
- [x] `cd web/ui && bun run test`: 169 pass (no SPA-side change — `Modules.test.tsx` drives off a per-test catalog fixture, not a hardcoded curated-list length)
- [x] `bunx biome check src/`: clean
- [x] SPA bundle rebuilt: `web/ui/dist/` regenerated post-typecheck (302 KB)
- [ ] Reviewer: dispatch via blocking subagent before merge (governance rule 1).

## Patterns check

- **Module protocol** (`parachute-patterns/patterns/module-json-extensibility.md`): runner ships `.parachute/module.json` in its package; this PR's vendored fallback mirrors that manifest verbatim until the loader-driven retirement path lands.
- **Trust gradient + module taxonomy**: runner is committed-core (renamed from parachute-agent's retirement; see workspace CLAUDE.md). Curated module set now matches the committed-core line.
- **RC versioning** (governance rule 2): `0.5.13-rc.1` → `0.5.13-rc.2`. Same `0.X.Y`, bump `rc.N`. Stays on `@rc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)