### PR TITLE
fix(hub): route /.parachute/* to module's bare endpoint regardless of stripPrefix (#307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.3] - 2026-05-21
+
+**fix(hub): route /.parachute/* to module's bare endpoint regardless of stripPrefix (#307).**
+
+Closes the hub#305 follow-up the rc.2 changelog flagged. The admin SPA's `/admin/modules/runner/config` button 404'd against runner because the proxy at `/api/modules/:short/config[/schema]` only honored two upstream shapes: `stripPrefix: true` → bare `/.parachute/config`, `stripPrefix: false` → `<mount>/.parachute/config`. Runner ships `paths: ["/runner", "/.parachute"]` with `stripPrefix: false` (its `/runner/jobs` admin routes want the literal `/runner` prefix; only its universal-protocol endpoints sit at the bare URL), so the proxy built `http://127.0.0.1:1945/runner/.parachute/config` — which runner's HTTP server doesn't match.
+
+**Fix:** `resolveUpstream` + `buildUpstreamPath` in `src/api-modules-config.ts` now detect when a module declares `/.parachute` in its `paths[]` and route to the bare `/.parachute/config[/schema]` URL regardless of `stripPrefix`. The asymmetry rationale:
+
+- **Runner-shape** (new): `/.parachute` in `paths[]`, `stripPrefix: false`. The module is announcing "I serve the universal module-protocol endpoints at the bare URL." Bare-route.
+- **Scribe-shape** (unchanged): `paths: ["/scribe"]`, `stripPrefix: true`. The hub strips the mount on every request, so bare-route falls out naturally — same upstream URL as before this fix.
+- **Vault/notes-shape** (unchanged): no `/.parachute` in `paths[]`, `stripPrefix: false`. The module routes its `.parachute/config` per-mount (vault's `.parachute/config` is per-vault, scoped under `/vault/<name>` — routing it bare would lose the vault-name context). Mount-preserved as before.
+
+The detection looks at both the live services.json entry's `paths` (operator-authoritative) and the FIRST_PARTY_FALLBACKS vendored `paths` (so a `bun link` install without a written entry still routes correctly). A trailing slash and a `/.parachute/<subpath>` declaration both count as "hosts the bare URL."
+
+**Tests** (`bun test ./src`): 1762 pass (was 1755; +7 in `api-modules-config.test.ts` covering runner GET-schema / GET-values / PUT, runner-without-services.json-entry, vault unchanged, scribe unchanged, mixed-paths-order runner shape). The new tests live in a dedicated `hostsBareParachute (hub#307)` describe block so future drift here surfaces in one suite. No fix changes outside `api-modules-config.ts` — same surface contract for every other call site.
+
+**Smoke:** verify-via-tests only (live runner-supervised setup wasn't running locally during this PR).
+
+`bun run typecheck` clean. `bunx biome check src/` clean.
+
 ## [0.5.13-rc.2] - 2026-05-21
 
 **feat(hub): runner added to FIRST_PARTY_FALLBACKS + CURATED_MODULES — admin SPA can install runner (hub#305).**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.2",
+  "version": "0.5.13-rc.3",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-modules-config.test.ts
+++ b/src/__tests__/api-modules-config.test.ts
@@ -490,3 +490,252 @@ describe("handleApiModulesConfig — stripPrefix=false (notes-shape)", () => {
     expect(upstream.calls[0]?.url).toBe("http://127.0.0.1:1941/notes/.parachute/config/schema");
   });
 });
+
+/**
+ * hub#307: modules that declare `/.parachute` in their `paths[]` host the
+ * universal protocol endpoints at the bare URL — runner is the first
+ * example. Before this fix the proxy built `/runner/.parachute/config`
+ * (mount-prefixed because stripPrefix is false) and runner returned 404.
+ *
+ * The fix detects the `/.parachute` declaration in `paths[]` and routes
+ * to the bare URL regardless of `stripPrefix`. These tests pin that
+ * behavior + verify vault (mount-routed per-vault) keeps its prefixed
+ * path so the fix doesn't regress vault config.
+ */
+describe("handleApiModulesConfig — hostsBareParachute (hub#307)", () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+  });
+  afterEach(() => h.cleanup());
+
+  test("runner (stripPrefix:false + /.parachute in paths) → bare /.parachute/config", async () => {
+    // Runner's FIRST_PARTY_FALLBACKS shape: paths includes `/.parachute`
+    // explicitly because runner serves the universal protocol at the bare
+    // URL. The services.json entry can carry either path first; we put
+    // `/runner` first to mirror what `parachute install runner` writes
+    // (matches the FIRST_PARTY_FALLBACKS manifest paths order).
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-runner",
+        port: 1945,
+        paths: ["/runner", "/.parachute"],
+        health: "/runner/healthz",
+        version: "0.1.0",
+        stripPrefix: false,
+      },
+    ]);
+    const bearer = await mintBearer(h, [API_MODULES_CONFIG_REQUIRED_SCOPE]);
+    const upstream = makeFakeUpstream(() =>
+      Response.json({ type: "object", properties: { intervalSeconds: { type: "number" } } }),
+    );
+    const res = await handleApiModulesConfig(
+      makeReq("/api/modules/runner/config/schema", {
+        headers: { authorization: `Bearer ${bearer}` },
+      }),
+      { short: "runner", suffix: "schema" },
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        upstreamFetch: upstream.fetchFn,
+      },
+    );
+    expect(res.status).toBe(200);
+    // No /runner prefix — bare /.parachute/config/schema. This is the
+    // hub#307 fix: pre-fix the URL was http://127.0.0.1:1945/runner/.parachute/config/schema
+    // and runner returned 404.
+    expect(upstream.calls[0]?.url).toBe("http://127.0.0.1:1945/.parachute/config/schema");
+  });
+
+  test("runner GET /config (no schema) also routes bare", async () => {
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-runner",
+        port: 1945,
+        paths: ["/runner", "/.parachute"],
+        health: "/runner/healthz",
+        version: "0.1.0",
+        stripPrefix: false,
+      },
+    ]);
+    const bearer = await mintBearer(h, [API_MODULES_CONFIG_REQUIRED_SCOPE]);
+    const upstream = makeFakeUpstream(() => Response.json({ intervalSeconds: 60 }));
+    await handleApiModulesConfig(
+      makeReq("/api/modules/runner/config", {
+        headers: { authorization: `Bearer ${bearer}` },
+      }),
+      { short: "runner", suffix: "" },
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        upstreamFetch: upstream.fetchFn,
+      },
+    );
+    expect(upstream.calls[0]?.url).toBe("http://127.0.0.1:1945/.parachute/config");
+  });
+
+  test("runner PUT /config also routes bare with body", async () => {
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-runner",
+        port: 1945,
+        paths: ["/runner", "/.parachute"],
+        health: "/runner/healthz",
+        version: "0.1.0",
+        stripPrefix: false,
+      },
+    ]);
+    const bearer = await mintBearer(h, [API_MODULES_CONFIG_REQUIRED_SCOPE]);
+    const upstream = makeFakeUpstream(() => Response.json({ restart_required: [] }));
+    await handleApiModulesConfig(
+      makeReq("/api/modules/runner/config", {
+        method: "PUT",
+        headers: {
+          authorization: `Bearer ${bearer}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ intervalSeconds: 120 }),
+      }),
+      { short: "runner", suffix: "" },
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        upstreamFetch: upstream.fetchFn,
+      },
+    );
+    const call = upstream.calls[0];
+    if (!call) throw new Error("upstream not called");
+    expect(call.url).toBe("http://127.0.0.1:1945/.parachute/config");
+    expect(call.method).toBe("PUT");
+    expect(call.body).toBe(JSON.stringify({ intervalSeconds: 120 }));
+  });
+
+  test("runner fallback (no services.json entry) — picks up /.parachute from FIRST_PARTY_FALLBACKS paths", async () => {
+    // bun-link / fresh-install case: the runner row isn't in services.json
+    // yet but the fallback declares the shape. resolveUpstream returns
+    // not-installed when neither the row nor the fallback can prove the
+    // module is up — so this case actually 404s. Pinned as the expected
+    // shape: hub#307 only changes the upstream-URL math, not the
+    // installed-detection contract.
+    const bearer = await mintBearer(h, [API_MODULES_CONFIG_REQUIRED_SCOPE]);
+    const res = await handleApiModulesConfig(
+      makeReq("/api/modules/runner/config", {
+        headers: { authorization: `Bearer ${bearer}` },
+      }),
+      { short: "runner", suffix: "" },
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+      },
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("module_not_installed");
+  });
+
+  test("vault (stripPrefix:false, no /.parachute in paths) — keeps /vault/<name> prefix (unchanged)", async () => {
+    // Vault's `.parachute/config` is per-vault, scoped under the
+    // `/vault/<name>` mount. Routing it bare would lose the vault-name
+    // context. This test pins that hub#307 doesn't regress vault.
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/vault/default"],
+        health: "/vault/default/health",
+        version: "0.5.0",
+      },
+    ]);
+    const bearer = await mintBearer(h, [API_MODULES_CONFIG_REQUIRED_SCOPE]);
+    const upstream = makeFakeUpstream(() => Response.json({ type: "object", properties: {} }));
+    await handleApiModulesConfig(
+      makeReq("/api/modules/vault/config/schema", {
+        headers: { authorization: `Bearer ${bearer}` },
+      }),
+      { short: "vault", suffix: "schema" },
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        upstreamFetch: upstream.fetchFn,
+      },
+    );
+    // Preserved mount — same as pre-hub#307.
+    expect(upstream.calls[0]?.url).toBe(
+      "http://127.0.0.1:1940/vault/default/.parachute/config/schema",
+    );
+  });
+
+  test("scribe (stripPrefix:true) — bare URL preserved (unchanged)", async () => {
+    // Pre-hub#307: stripPrefix:true produced /.parachute/config (via the
+    // stripPrefix branch). Post-fix: same result via the hostsBareParachute
+    // branch when /.parachute is in paths, or via the stripPrefix branch
+    // when it isn't. Scribe ships `paths: ["/scribe"]` (no /.parachute),
+    // so it takes the stripPrefix branch. Either way, the upstream URL is
+    // identical to pre-fix behavior.
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-scribe",
+        port: 1943,
+        paths: ["/scribe"],
+        health: "/health",
+        version: "0.4.0",
+        stripPrefix: true,
+      },
+    ]);
+    const bearer = await mintBearer(h, [API_MODULES_CONFIG_REQUIRED_SCOPE]);
+    const upstream = makeFakeUpstream(() => Response.json({ type: "object", properties: {} }));
+    await handleApiModulesConfig(
+      makeReq("/api/modules/scribe/config/schema", {
+        headers: { authorization: `Bearer ${bearer}` },
+      }),
+      { short: "scribe", suffix: "schema" },
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        upstreamFetch: upstream.fetchFn,
+      },
+    );
+    // Unchanged from pre-hub#307.
+    expect(upstream.calls[0]?.url).toBe("http://127.0.0.1:1943/.parachute/config/schema");
+  });
+
+  test("mixed: stripPrefix:false module with both /custom and /.parachute → bare for protocol, prefix for others", async () => {
+    // The hostsBareParachute branch only governs the `/.parachute/config*`
+    // proxy here. Other proxy code-paths (the generic services-proxy in
+    // hub-server.ts) handle non-protocol requests; this surface only ever
+    // forwards to `/.parachute/config[/schema]`, so verifying just that
+    // route is the right scope.
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-runner",
+        port: 1945,
+        // Order doesn't matter for hostsBareParachute detection.
+        paths: ["/.parachute", "/runner"],
+        health: "/runner/healthz",
+        version: "0.1.0",
+        stripPrefix: false,
+      },
+    ]);
+    const bearer = await mintBearer(h, [API_MODULES_CONFIG_REQUIRED_SCOPE]);
+    const upstream = makeFakeUpstream(() => Response.json({ type: "object", properties: {} }));
+    await handleApiModulesConfig(
+      makeReq("/api/modules/runner/config/schema", {
+        headers: { authorization: `Bearer ${bearer}` },
+      }),
+      { short: "runner", suffix: "schema" },
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        upstreamFetch: upstream.fetchFn,
+      },
+    );
+    expect(upstream.calls[0]?.url).toBe("http://127.0.0.1:1945/.parachute/config/schema");
+  });
+});

--- a/src/api-modules-config.ts
+++ b/src/api-modules-config.ts
@@ -106,11 +106,27 @@ export function parseModulesConfigPath(pathname: string): PathMatch | undefined 
  * Returns `{installed: false}` when the module isn't in services.json —
  * the SPA renders an empty state pointing the operator at /admin/modules
  * to install it first.
+ *
+ * `hostsBareParachute` is true when the module declares `/.parachute` in
+ * its `paths[]`, meaning it serves the universal module-protocol endpoints
+ * at the bare URL (no module-name prefix) — runner is the first example.
+ * This is independent of `stripPrefix`: runner ships
+ * `paths: ["/runner", "/.parachute"]` with `stripPrefix: false` because its
+ * `/runner/jobs` admin endpoints want the literal `/runner` prefix, but
+ * `/.parachute/config` is hosted bare. See `buildUpstreamPath`.
  */
 function resolveUpstream(
   short: CuratedModuleShort,
   manifestPath: string,
-): { installed: true; port: number; mount: string; stripPrefix: boolean } | { installed: false } {
+):
+  | {
+      installed: true;
+      port: number;
+      mount: string;
+      stripPrefix: boolean;
+      hostsBareParachute: boolean;
+    }
+  | { installed: false } {
   const fb = FIRST_PARTY_FALLBACKS[short];
   if (!fb) return { installed: false };
   const manifest = readManifest(manifestPath);
@@ -125,20 +141,58 @@ function resolveUpstream(
   const mount = entry.paths[0] ?? fb.manifest.paths[0] ?? "/";
   const stripPrefix =
     entry.stripPrefix !== undefined ? entry.stripPrefix : (fb.manifest.stripPrefix ?? false);
-  return { installed: true, port: entry.port, mount, stripPrefix };
+  // Check both the live services.json entry (operator-authoritative) and the
+  // vendored fallback (so a `bun link` install without a written entry still
+  // routes correctly). Match a trailing slash too — `["/.parachute/"]` is the
+  // same intent as `["/.parachute"]`.
+  const isBareParachute = (p: string): boolean =>
+    p === "/.parachute" || p === "/.parachute/" || p.startsWith("/.parachute/");
+  const hostsBareParachute =
+    entry.paths.some(isBareParachute) || fb.manifest.paths.some(isBareParachute);
+  return { installed: true, port: entry.port, mount, stripPrefix, hostsBareParachute };
 }
 
 /**
- * Build the upstream URL for `.parachute/config[/schema]`. When `stripPrefix`
- * is true the module sees a bare `/.parachute/config/...`; otherwise the
- * mount prefix is preserved (`/scribe/.parachute/config/...`).
+ * Build the upstream URL for `.parachute/config[/schema]`.
  *
- * scribe ships `stripPrefix: true` (in FIRST_PARTY_FALLBACKS); notes and
- * vault are keep-prefix. Honoring this here means the same proxy works
- * across both shapes without per-module branches.
+ * The `/.parachute/*` endpoints (info, config, config/schema, clear-credential)
+ * are the **universal module protocol** — every module speaks them, and the
+ * shape they take depends on how the module exposes its mount(s):
+ *
+ *   1. **Module declares `/.parachute` in its `paths[]`** (runner-shape):
+ *      the module hosts the bare URL `/.parachute/config[/schema]` directly
+ *      and the proxy forwards there with no prefix, regardless of
+ *      `stripPrefix`. This is the explicit "I serve the universal endpoints
+ *      at the bare URL" declaration.
+ *   2. **`stripPrefix: true`** (scribe-shape): the proxy strips the module
+ *      mount on every request, so the bare `/.parachute/config[/schema]`
+ *      is what the module sees on the wire — same result as case 1.
+ *   3. **`stripPrefix: false` and no `/.parachute` in paths** (vault/notes-
+ *      shape): the proxy preserves the mount prefix
+ *      (`/vault/default/.parachute/config`). Vault routes its
+ *      `.parachute/config` per-vault, scoped under the `/vault/<name>` mount,
+ *      so it explicitly NEEDS the prefix to know which vault the request
+ *      targets.
+ *
+ * Case 1 was the gap that hub#307 fixed: runner ships
+ * `paths: ["/runner", "/.parachute"]` with `stripPrefix: false`. Before this
+ * fix, the proxy built `/runner/.parachute/config` because it only saw
+ * `paths[0]` and the stripPrefix flag — runner's HTTP server matches
+ * `/.parachute/config` literally and 404'd. Detecting the `/.parachute`
+ * declaration in `paths[]` lets runner (and any future module with the same
+ * shape) route correctly without affecting vault.
  */
-function buildUpstreamPath(mount: string, stripPrefix: boolean, suffix: "" | "schema"): string {
+function buildUpstreamPath(
+  mount: string,
+  stripPrefix: boolean,
+  hostsBareParachute: boolean,
+  suffix: "" | "schema",
+): string {
   const inner = suffix === "schema" ? "/.parachute/config/schema" : "/.parachute/config";
+  // Universal-protocol short-circuit: a module that declares `/.parachute`
+  // in its paths[] hosts the bare URL — same upstream path whether
+  // stripPrefix is true or false.
+  if (hostsBareParachute) return inner;
   if (stripPrefix) return inner;
   // Normalize trailing slash (mirrors `findServiceUpstream`'s normalization
   // so a `paths: ["/scribe/"]` entry doesn't double-slash).
@@ -259,7 +313,12 @@ export async function handleApiModulesConfig(
   }
 
   // Build upstream URL.
-  const path = buildUpstreamPath(upstream.mount, upstream.stripPrefix, match.suffix);
+  const path = buildUpstreamPath(
+    upstream.mount,
+    upstream.stripPrefix,
+    upstream.hostsBareParachute,
+    match.suffix,
+  );
   const url = `http://127.0.0.1:${upstream.port}${path}`;
 
   // Forward. We carry method + body through. The SPA's Authorization


### PR DESCRIPTION
## Summary

Closes the hub#305 follow-up the rc.2 changelog flagged: the admin SPA's `/admin/modules/runner/config` button 404'd because the proxy at `/api/modules/:short/config[/schema]` only knew two upstream shapes — `stripPrefix: true` → bare `/.parachute/config`, `stripPrefix: false` → `<mount>/.parachute/config`. Runner ships `paths: ["/runner", "/.parachute"]` with `stripPrefix: false` (its `/runner/jobs` admin routes want the literal `/runner` prefix; only its universal-protocol endpoints sit at the bare URL), so the proxy built `http://127.0.0.1:1945/runner/.parachute/config` and runner returned 404 (runner's HTTP server matches `/.parachute/config` literally).

## Fix shape

`resolveUpstream` + `buildUpstreamPath` in `src/api-modules-config.ts` now detect when a module declares `/.parachute` in its `paths[]` and route to the bare `/.parachute/config[/schema]` URL regardless of `stripPrefix`:

```ts
const isBareParachute = (p: string): boolean =>
  p === "/.parachute" || p === "/.parachute/" || p.startsWith("/.parachute/");
const hostsBareParachute =
  entry.paths.some(isBareParachute) || fb.manifest.paths.some(isBareParachute);
```

```ts
// In buildUpstreamPath, applied BEFORE the stripPrefix branch:
if (hostsBareParachute) return inner;
```

The detection looks at both the live `services.json` entry's paths (operator-authoritative) and the `FIRST_PARTY_FALLBACKS` vendored paths (so a `bun link` install without a written row still routes correctly).

## Asymmetry rationale

- **Runner-shape** (new): `/.parachute` in `paths[]`, `stripPrefix: false` → bare-route. The module is announcing "I serve the universal module-protocol endpoints at the bare URL."
- **Scribe-shape** (unchanged): `paths: ["/scribe"]`, `stripPrefix: true`. Hub strips the mount on every request, so bare-route falls out naturally — same upstream URL as before this fix.
- **Vault/notes-shape** (unchanged): no `/.parachute` in `paths[]`, `stripPrefix: false`. Vault's `.parachute/config` is per-vault, scoped under `/vault/<name>` — routing it bare would lose the vault-name context. Mount-preserved as before.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test ./src` — 1762 pass (was 1755; +7 in new `hostsBareParachute (hub#307)` describe block)
- [x] `bunx biome check src/` clean
- [x] `cd web/ui && bun run test` — 169 pass (unchanged)
- [x] New tests cover runner GET-schema, GET-values, PUT, runner-without-services-entry → `module_not_installed`, vault unchanged, scribe unchanged, mixed-paths-order
- [ ] Live smoke (deferred — no runner-supervised hub running locally; verified via test assertions)

## Patterns check

- Touches the **module protocol** (`/.parachute/config[/schema]`) — pinning bare-URL routing for the universal endpoints as the canonical shape when a module declares `/.parachute` in its paths. No pattern doc change needed today; this is a hub-internal proxy detail. Future ecosystem-wide doc work could call out the convention explicitly in `parachute-patterns`.
- Governance: rc bump from rc.2 → rc.3, continuing the 0.5.13 chain per the post-rc.2 / pre-stable practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)