### PR TITLE
feat(hub): admin SPA ModuleConfig dereferences $ref in schema definitions (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.4] - 2026-05-21
+
+**feat(hub): admin SPA ModuleConfig dereferences $ref in schema definitions (#303).**
+
+Closes the friction that hub#260's first-pass `ModuleConfig` form left: the renderer walked `schema.properties` directly with no awareness of `$ref` / `definitions` / `$defs`, so a module reusing a shared property block had to inline it per call-site. Scribe#47 took that workaround for `apiKeyAndModel` across openai/gemini/groq cleanup providers; after this PR scribe can revert to a clean `$ref` shape (tracked as a follow-up on the scribe side, not folded here).
+
+**What landed:** a new `web/ui/src/lib/json-schema.ts` with a `dereferenceSchema(schema, root?)` helper. The signature:
+
+```ts
+export function dereferenceSchema(schema: JsonSchema, root?: JsonSchema): JsonSchema
+```
+
+`ModuleConfig.tsx` calls it ONCE at fetch time — every downstream walk (property iteration, switch on `type`, future structural rendering) sees fully-expanded property objects. The renderer stays `$ref`-unaware; the resolve-once pass is the single seam.
+
+**Resolution rules** (Draft-07-compatible subset, all unit-tested):
+
+- `#/definitions/<name>` → `root.definitions[<name>]`
+- `#/$defs/<name>` → `root.$defs[<name>]` (newer keyword)
+- Nested refs (a → b → c) recurse to fully resolve
+- Sibling keywords on a `$ref`-bearing object (e.g. `{$ref, title}`) MERGE over the resolved value — matches what tools commonly support and what call-sites use to override `title` / `description` per-use
+- Circular refs (a → b → a) — visited-set detection, throws clearly
+- Unknown definition paths — throws clearly
+- External refs (URLs / file paths) — refused with a clear error
+- Path-based refs (`#/properties/foo`) — supported via the generic pointer walker
+- JSON Pointer escapes (`~0` / `~1`) handled per RFC 6901
+- A broken schema lifts to the page's `error` load state with a "Schema $ref resolution failed — <message>" prefix so the operator sees a clean failure mode rather than a render crash; the module-side schema needs the actual fix
+
+**Explicitly out of scope** (deferred to a follow-up): structured rendering of `oneOf` / `anyOf` / `allOf` arms. The resolver does recurse into those arms so a `$ref` inside resolves, but the SPA still shows them via the unsupported-type fallback (JSON debug view). Adding structural rendering for those is a separate concern.
+
+**Tests** (`cd web/ui && bun run test`): 183 pass (was 169; +14 across `json-schema.test.ts` and a new `$ref dereferencing` describe block in `ModuleConfig.test.tsx`). Highlights: definitions/`$defs`/nested/circular/unknown/external/no-refs/sibling-merge/`oneOf`-recursion/pointer-escapes plus the end-to-end "writeOnly password input renders from a `$ref`-using schema" + "broken `$ref` surfaces as the error load state" integrations. `bun run typecheck` clean (root + web/ui). `bun test ./src` (hub) 1762 pass — unchanged, since the SPA changes don't touch the server. `bun run build` for web/ui clean. `bunx biome check .` clean.
+
 ## [0.5.13-rc.3] - 2026-05-21
 
 **fix(hub): route /.parachute/* to module's bare endpoint regardless of stripPrefix (#307).**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.3",
+  "version": "0.5.13-rc.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/web/ui/src/lib/json-schema.test.ts
+++ b/web/ui/src/lib/json-schema.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for `dereferenceSchema` (hub#303).
+ *
+ * Covers the resolution rules + the integration shape:
+ *
+ *   - definitions / $defs / nested refs / sibling keywords / circular /
+ *     unknown / external / no-refs no-op
+ *   - end-to-end: a $ref-using schema renders through ModuleConfig as if
+ *     it were inline (writeOnly password input + correct field count)
+ */
+import { describe, expect, it } from "vitest";
+import { type JsonSchema, dereferenceSchema } from "./json-schema.ts";
+
+describe("dereferenceSchema", () => {
+  it("resolves a $ref pointing at #/definitions/<name>", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        cred: { $ref: "#/definitions/apiKeyAndModel" },
+      },
+      definitions: {
+        apiKeyAndModel: {
+          type: "object",
+          properties: {
+            apiKey: { type: "string", writeOnly: true },
+            model: { type: "string" },
+          },
+        },
+      },
+    };
+
+    const out = dereferenceSchema(schema);
+    const cred = (out.properties as Record<string, JsonSchema>).cred;
+    expect(cred.type).toBe("object");
+    const credProps = cred.properties as Record<string, JsonSchema>;
+    expect(credProps.apiKey).toMatchObject({ type: "string", writeOnly: true });
+    expect(credProps.model).toMatchObject({ type: "string" });
+  });
+
+  it("resolves a $ref pointing at #/$defs/<name> (newer keyword)", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        cred: { $ref: "#/$defs/apiKeyAndModel" },
+      },
+      $defs: {
+        apiKeyAndModel: {
+          type: "object",
+          properties: {
+            apiKey: { type: "string", writeOnly: true },
+          },
+        },
+      },
+    };
+    const out = dereferenceSchema(schema);
+    const cred = (out.properties as Record<string, JsonSchema>).cred;
+    const credProps = cred.properties as Record<string, JsonSchema>;
+    expect(credProps.apiKey).toMatchObject({ type: "string", writeOnly: true });
+  });
+
+  it("resolves nested refs (a → b → c)", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        outer: { $ref: "#/definitions/a" },
+      },
+      definitions: {
+        a: { $ref: "#/definitions/b" },
+        b: { $ref: "#/definitions/c" },
+        c: { type: "string", title: "deepest" },
+      },
+    };
+    const out = dereferenceSchema(schema);
+    const outer = (out.properties as Record<string, JsonSchema>).outer;
+    expect(outer).toMatchObject({ type: "string", title: "deepest" });
+  });
+
+  it("throws clearly on circular refs (a → b → a)", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        loop: { $ref: "#/definitions/a" },
+      },
+      definitions: {
+        a: { $ref: "#/definitions/b" },
+        b: { $ref: "#/definitions/a" },
+      },
+    };
+    expect(() => dereferenceSchema(schema)).toThrow(/circular/i);
+  });
+
+  it("throws clearly on a ref to an unknown definition path", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        broken: { $ref: "#/definitions/missing" },
+      },
+      definitions: {},
+    };
+    expect(() => dereferenceSchema(schema)).toThrow(/unknown \$ref/i);
+  });
+
+  it("throws clearly on external refs (URLs / file paths)", () => {
+    const schemaUrl: JsonSchema = {
+      type: "object",
+      properties: { remote: { $ref: "https://example.com/schema.json" } },
+    };
+    expect(() => dereferenceSchema(schemaUrl)).toThrow(/external refs/i);
+
+    const schemaFile: JsonSchema = {
+      type: "object",
+      properties: { local: { $ref: "./other.json" } },
+    };
+    expect(() => dereferenceSchema(schemaFile)).toThrow(/external refs/i);
+  });
+
+  it("merges sibling keywords over the resolved definition", () => {
+    // {$ref, title} — title at the call-site overrides the title in the
+    // definition. Matches what tools like ajv-non-strict + json-schema-
+    // ref-parser do in practice.
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        cred: {
+          $ref: "#/definitions/apiKeyAndModel",
+          title: "Per-call-site title override",
+        },
+      },
+      definitions: {
+        apiKeyAndModel: {
+          type: "object",
+          title: "Definition's own title",
+          properties: {
+            apiKey: { type: "string", writeOnly: true },
+          },
+        },
+      },
+    };
+    const out = dereferenceSchema(schema);
+    const cred = (out.properties as Record<string, JsonSchema>).cred;
+    expect(cred.title).toBe("Per-call-site title override");
+    expect(cred.type).toBe("object");
+    // Definition's own properties survive the merge.
+    const credProps = cred.properties as Record<string, JsonSchema>;
+    expect(credProps.apiKey).toMatchObject({ writeOnly: true });
+    // The `$ref` key itself is dropped from the output.
+    expect(cred).not.toHaveProperty("$ref");
+  });
+
+  it("leaves a schema with no refs structurally equivalent", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        port: { type: "integer", minimum: 1, maximum: 65535 },
+        flag: { type: "boolean", default: true },
+      },
+      required: ["port"],
+    };
+    const out = dereferenceSchema(schema);
+    expect(out).toEqual(schema);
+  });
+
+  it("does not mutate the input schema (returns a clone)", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        cred: { $ref: "#/definitions/x" },
+      },
+      definitions: {
+        x: { type: "string", writeOnly: true },
+      },
+    };
+    const before = JSON.stringify(schema);
+    dereferenceSchema(schema);
+    expect(JSON.stringify(schema)).toBe(before);
+  });
+
+  it("recurses into oneOf / anyOf / allOf arms so any $ref inside resolves", () => {
+    // Out of explicit-rendering scope per hub#303 (`Don't fold`), but the
+    // dereferenced output should still be internally consistent — a
+    // future PR adding structural rendering can rely on the arms being
+    // pre-resolved.
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        provider: {
+          oneOf: [{ $ref: "#/definitions/openai" }, { $ref: "#/definitions/gemini" }],
+        },
+      },
+      definitions: {
+        openai: { type: "object", properties: { apiKey: { type: "string", writeOnly: true } } },
+        gemini: { type: "object", properties: { apiKey: { type: "string", writeOnly: true } } },
+      },
+    };
+    const out = dereferenceSchema(schema);
+    const arms = ((out.properties as Record<string, JsonSchema>).provider.oneOf ??
+      []) as JsonSchema[];
+    expect(arms).toHaveLength(2);
+    const arm0Props = arms[0]?.properties as Record<string, JsonSchema>;
+    const arm1Props = arms[1]?.properties as Record<string, JsonSchema>;
+    expect(arm0Props.apiKey).toMatchObject({ writeOnly: true });
+    expect(arm1Props.apiKey).toMatchObject({ writeOnly: true });
+  });
+
+  it("resolves a $ref pointing at a non-definitions path (#/properties/foo)", () => {
+    // Path-based refs are the generic JSON Pointer shape. Not common in
+    // practice, but the resolver handles it for free since the lookup
+    // walks segments uniformly.
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        original: { type: "string", title: "Original field" },
+        clone: { $ref: "#/properties/original" },
+      },
+    };
+    const out = dereferenceSchema(schema);
+    const clone = (out.properties as Record<string, JsonSchema>).clone;
+    expect(clone).toMatchObject({ type: "string", title: "Original field" });
+  });
+
+  it("handles JSON Pointer escapes (~0 → ~, ~1 → /)", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        slashy: { $ref: "#/definitions/foo~1bar" },
+      },
+      definitions: {
+        "foo/bar": { type: "string", title: "with slash" },
+      },
+    };
+    const out = dereferenceSchema(schema);
+    const slashy = (out.properties as Record<string, JsonSchema>).slashy;
+    expect(slashy).toMatchObject({ type: "string", title: "with slash" });
+  });
+});

--- a/web/ui/src/lib/json-schema.ts
+++ b/web/ui/src/lib/json-schema.ts
@@ -1,0 +1,168 @@
+/**
+ * JSON Schema (Draft-07) `$ref` dereferencing for the admin SPA.
+ *
+ * Background — why this lives here, why now (hub#303).
+ *
+ * The admin SPA's `ModuleConfig` form walks `schema.properties` directly:
+ * it has no awareness of `$ref`, `definitions`, or `$defs`. Modules that
+ * want to reuse a shared property block (e.g. scribe's `apiKeyAndModel`
+ * across openai/gemini/groq cleanup providers) hit a wall — they either
+ * inline the block per provider (the workaround scribe#47 took) or watch
+ * the SPA render an "unsupported type" fallback for any `{$ref: ...}`
+ * property.
+ *
+ * This helper resolves `$ref` ONCE at schema-load time so every downstream
+ * walk (property iteration, oneOf arms, future structural rendering) sees
+ * a fully-expanded schema. The renderer stays `$ref`-unaware; the resolve-
+ * once pass is the single seam.
+ *
+ * Resolution rules (Draft-07-compatible subset):
+ *
+ *   - `$ref: "#/definitions/<name>"`  → `root.definitions[<name>]`
+ *   - `$ref: "#/$defs/<name>"`        → `root.$defs[<name>]` (newer keyword)
+ *   - Sibling keywords next to a `$ref` (e.g. `{$ref, title}`) — MERGE
+ *     them on top of the resolved object. JSON Schema Draft-07 says this
+ *     isn't compliant, but tools commonly support it and modules use it to
+ *     override the title / description of a shared shape per-call-site.
+ *   - Circular refs (a → b → a) — detected via a visited set, throws.
+ *   - External refs (URLs, file paths) — refused with a clear error so
+ *     they don't get silently swallowed.
+ *   - Unknown ref paths — refused.
+ *
+ * Out of scope for this PR (hub#303 explicitly defers these):
+ *
+ *   - `$ref` *inside* `oneOf` / `anyOf` / `allOf` arms — those arms aren't
+ *     structurally rendered today (the fallback path shows them as JSON).
+ *     We still recurse into them so a resolved schema is internally
+ *     consistent, but the SPA renderer doesn't act on them.
+ *   - Arbitrary path-based refs (`#/properties/foo`) — supported via the
+ *     generic resolver, but the only documented shape is the two
+ *     definition-table conventions.
+ */
+
+export type JsonSchema = Record<string, unknown>;
+
+/** Internal — the visited set carries the resolved-pointer strings so we
+ * can detect cycles without lugging the original object identities around
+ * (cheap structural-equality check on the pointer key). */
+type VisitedRefs = ReadonlySet<string>;
+
+/**
+ * Walk `schema` (and every nested object / array) replacing each `$ref`
+ * with the resolved value from `root`. Returns a new schema — never
+ * mutates the input. The output is structurally cloned along the way, so
+ * it's safe to read from concurrently if anything (including React's
+ * reconciliation) holds onto a reference.
+ *
+ * @param schema  The schema to resolve. Usually the same object as `root`
+ *   on the first call; recursive calls pass sub-objects.
+ * @param root    Optional override for the resolution root. Defaults to
+ *   `schema` so `dereferenceSchema(s)` is the common usage. Useful when
+ *   you've sliced off a sub-tree and still want refs to resolve against
+ *   the full document.
+ */
+export function dereferenceSchema(schema: JsonSchema, root?: JsonSchema): JsonSchema {
+  const rootSchema = root ?? schema;
+  return resolveValue(schema, rootSchema, new Set<string>()) as JsonSchema;
+}
+
+/**
+ * Recursive walker. Each call returns a structurally-cloned value with
+ * every `$ref` replaced. The `visited` set tracks pointer-strings on the
+ * resolution chain so a → b → a throws clearly instead of recursing
+ * forever.
+ */
+function resolveValue(value: unknown, root: JsonSchema, visited: VisitedRefs): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => resolveValue(item, root, visited));
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  const obj = value as JsonSchema;
+  if (typeof obj.$ref === "string") {
+    return resolveRef(obj, root, visited);
+  }
+  const out: JsonSchema = {};
+  for (const [k, v] of Object.entries(obj)) {
+    out[k] = resolveValue(v, root, visited);
+  }
+  return out;
+}
+
+/**
+ * Resolve a `{$ref: "..."}` object against `root`. Sibling keywords on
+ * the same object (e.g. `{$ref, title}`) override the resolved
+ * definition — convenient for "use the shared shape but rename the
+ * label per call-site." Same recurse-with-visited so a chain of refs
+ * (a → b → c) fully resolves and a cycle (a → b → a) throws.
+ */
+function resolveRef(refObj: JsonSchema, root: JsonSchema, visited: VisitedRefs): unknown {
+  const ref = refObj.$ref;
+  if (typeof ref !== "string") {
+    throw new Error(`Invalid $ref: expected string, got ${typeof ref}`);
+  }
+  if (!ref.startsWith("#")) {
+    throw new Error(
+      `Unsupported $ref "${ref}": external refs (URLs / file paths) are not supported`,
+    );
+  }
+  if (visited.has(ref)) {
+    throw new Error(`Circular $ref detected: "${ref}" already on resolution path`);
+  }
+  const target = lookupPointer(ref, root);
+  if (target === undefined) {
+    throw new Error(`Unknown $ref "${ref}": no definition at that path`);
+  }
+  if (target === null || typeof target !== "object" || Array.isArray(target)) {
+    throw new Error(`Invalid $ref target at "${ref}": expected object, got ${typeof target}`);
+  }
+  // Recurse into the resolved value with the visited set extended — handles
+  // nested refs (a → b → c) and surfaces cycles cleanly.
+  const nextVisited = new Set(visited);
+  nextVisited.add(ref);
+  const resolved = resolveValue(target, root, nextVisited) as JsonSchema;
+
+  // Merge sibling keywords on top of the resolved object. Draft-07 says
+  // a $ref-bearing object should ignore siblings; in practice tools merge
+  // them, and modules use the pattern to override title/description per
+  // call-site. We drop the $ref key itself so the merged output is fully
+  // dereferenced.
+  const siblings: JsonSchema = {};
+  for (const [k, v] of Object.entries(refObj)) {
+    if (k === "$ref") continue;
+    siblings[k] = resolveValue(v, root, nextVisited);
+  }
+  return { ...resolved, ...siblings };
+}
+
+/**
+ * Resolve a JSON Pointer fragment (`#/definitions/X`, `#/$defs/X`,
+ * `#/properties/foo/items`) against `root`. Returns the target value or
+ * `undefined` if any segment is missing.
+ *
+ * Segments are URI-decoded and `~0` / `~1` un-escaped per RFC 6901, so a
+ * definition literally named `apiKey/secret` (with the slash escaped) is
+ * looked up correctly. The common path — alphanumeric definition names —
+ * doesn't trigger any of that, but it's cheap to do right.
+ */
+function lookupPointer(ref: string, root: JsonSchema): unknown {
+  // Strip the leading `#`. An empty string ("" after the hash) is the
+  // root document itself per RFC 6901.
+  const fragment = ref.slice(1);
+  if (fragment === "") return root;
+  if (!fragment.startsWith("/")) {
+    throw new Error(`Unsupported $ref "${ref}": fragment must start with "/"`);
+  }
+  const segments = fragment
+    .slice(1)
+    .split("/")
+    .map((seg) => decodeURIComponent(seg).replace(/~1/g, "/").replace(/~0/g, "~"));
+  let cursor: unknown = root;
+  for (const seg of segments) {
+    if (cursor === null || typeof cursor !== "object") return undefined;
+    cursor = (cursor as Record<string, unknown>)[seg];
+    if (cursor === undefined) return undefined;
+  }
+  return cursor;
+}

--- a/web/ui/src/routes/ModuleConfig.test.tsx
+++ b/web/ui/src/routes/ModuleConfig.test.tsx
@@ -341,3 +341,65 @@ describe("ModuleConfig — writeOnly fields", () => {
     expect(payload).toEqual({ apiKey: "sk-new-secret" });
   });
 });
+
+describe("ModuleConfig — $ref dereferencing (hub#303)", () => {
+  /**
+   * Integration check: a schema that uses `$ref` against a `definitions`
+   * block must render the same as if the property were inlined. This is
+   * the canonical use case scribe#47 worked around by inlining — once
+   * scribe reverts to `$ref`, the SPA continues to render writeOnly /
+   * required / hint copy correctly because the dereferenceSchema pass
+   * runs first.
+   */
+  const REF_SCHEMA: api.ModuleConfigSchema = {
+    type: "object",
+    properties: {
+      // {$ref, title} — sibling title overrides the definition's title,
+      // exercising the merge path end-to-end.
+      cleanup: {
+        $ref: "#/definitions/apiKeyAndModel",
+        title: "Cleanup credentials",
+      } as unknown as api.ConfigSchemaProperty,
+    },
+    definitions: {
+      apiKeyAndModel: {
+        type: "string",
+        writeOnly: true,
+        title: "Generic API key",
+        description: "Provider API key.",
+      },
+    },
+  };
+
+  it("renders a $ref-using schema as if the definition were inlined", async () => {
+    vi.mocked(api.getModuleConfigSchema).mockResolvedValue(REF_SCHEMA);
+    vi.mocked(api.getModuleConfigValues).mockResolvedValue({});
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("config-form")).toBeInTheDocument());
+
+    // The sibling title wins — confirms the merge runs before render.
+    const cleanup = screen.getByLabelText(/cleanup credentials/i) as HTMLInputElement;
+    // writeOnly from the resolved definition propagates → password input.
+    expect(cleanup.type).toBe("password");
+    // Description from the definition survives the merge.
+    expect(screen.getByText(/provider api key/i)).toBeInTheDocument();
+  });
+
+  it("surfaces an error state when the schema contains a broken $ref", async () => {
+    const broken: api.ModuleConfigSchema = {
+      type: "object",
+      properties: {
+        // Pointer at a definition that doesn't exist — dereferenceSchema throws.
+        broken: { $ref: "#/definitions/missing" } as unknown as api.ConfigSchemaProperty,
+      },
+      definitions: {},
+    };
+    vi.mocked(api.getModuleConfigSchema).mockResolvedValue(broken);
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByText(/schema \$ref resolution failed/i)).toBeInTheDocument(),
+    );
+    // No form rendered when the schema is unresolvable.
+    expect(screen.queryByTestId("config-form")).not.toBeInTheDocument();
+  });
+});

--- a/web/ui/src/routes/ModuleConfig.tsx
+++ b/web/ui/src/routes/ModuleConfig.tsx
@@ -32,13 +32,20 @@
  *
  * Unsupported (intentionally — scribe's schemas don't use these today):
  *
- *   - nested objects / arrays / oneOf / anyOf / allOf / $ref
+ *   - nested objects / arrays / oneOf / anyOf / allOf
  *
- * If/when a module ships one of those, we'll either lift in `@rjsf/core`
- * (industry-standard library) or extend this renderer — neither hurries
- * us today. Hand-rolling at v1 saves the SPA bundle ~250 KB of @rjsf
- * + ajv + a plugin surface that doesn't match Parachute's narrow
- * schema vocabulary.
+ * `$ref` IS supported: the loaded schema is run through
+ * `dereferenceSchema` (see `../lib/json-schema.ts`) once at fetch time,
+ * so every downstream walk sees fully-expanded property objects. This
+ * lets modules reuse shared `definitions` / `$defs` shapes (scribe's
+ * `apiKeyAndModel` across openai/gemini/groq cleanup providers) without
+ * inlining. Added in hub#303 to retire scribe's inline workaround.
+ *
+ * If/when a module ships one of the other unsupported shapes, we'll
+ * either lift in `@rjsf/core` (industry-standard library) or extend
+ * this renderer — neither hurries us today. Hand-rolling at v1 saves
+ * the SPA bundle ~250 KB of @rjsf + ajv + a plugin surface that doesn't
+ * match Parachute's narrow schema vocabulary.
  *
  * Design choice — Option A vs B for upstream auth: hub mints a short-
  * lived `<short>:admin` JWT at proxy time and forwards it to the
@@ -57,6 +64,7 @@ import {
   getModuleConfigValues,
   putModuleConfigValues,
 } from "../lib/api.ts";
+import { dereferenceSchema } from "../lib/json-schema.ts";
 
 type LoadState =
   | { kind: "loading" }
@@ -104,9 +112,25 @@ export function ModuleConfig() {
     setSaveBanner(null);
     setFieldErrors({});
     try {
-      const schema = await getModuleConfigSchema(short);
-      if (schema === null) {
+      const rawSchema = await getModuleConfigSchema(short);
+      if (rawSchema === null) {
         setState({ kind: "no_schema" });
+        return;
+      }
+      // Resolve every `$ref` against `definitions` / `$defs` up front, so
+      // the downstream renderer walks fully-expanded property objects.
+      // Modules can use shared definition blocks without forcing the SPA
+      // to learn JSON Schema pointer-resolution at every walk site
+      // (hub#303). Errors here (circular, unknown, external) surface as
+      // the same "error" load state the network-failure path uses — the
+      // operator can retry, but the broken schema needs a module-side
+      // fix.
+      let schema: ModuleConfigSchema;
+      try {
+        schema = dereferenceSchema(rawSchema) as ModuleConfigSchema;
+      } catch (refErr) {
+        const refMsg = refErr instanceof Error ? refErr.message : String(refErr);
+        setState({ kind: "error", message: `Schema $ref resolution failed — ${refMsg}` });
         return;
       }
       const values = await getModuleConfigValues(short);


### PR DESCRIPTION
## Summary

- Adds `dereferenceSchema(schema, root?)` in `web/ui/src/lib/json-schema.ts` and applies it once at schema-load time in `ModuleConfig.tsx`. Modules can now reuse shared `definitions` / `$defs` blocks without inlining — retires the scribe#47 workaround for `apiKeyAndModel` across openai/gemini/groq cleanup providers (scribe-side `$ref` revert tracked separately).
- The renderer stays `$ref`-unaware; the resolve-once pass is the single seam. Future structural rendering (for `oneOf` / `anyOf` / `allOf`) can rely on a fully-expanded schema.

## Helper shape

```ts
export function dereferenceSchema(schema: JsonSchema, root?: JsonSchema): JsonSchema
```

**Resolution rules** (Draft-07-compatible subset):

- `#/definitions/<name>` → `root.definitions[<name>]`
- `#/$defs/<name>` → `root.$defs[<name>]` (newer keyword)
- Nested refs (a → b → c) recurse fully
- Sibling keywords on a `$ref`-bearing object (e.g. `{$ref, title}`) MERGE on top of the resolved value — matches what tools commonly support and what call-sites use to override `title` / `description` per-use
- Circular refs (a → b → a) detected via visited-set, throw clearly
- Unknown definition paths — throw clearly
- External refs (URLs / file paths) — refused with a clear error
- Path-based refs (`#/properties/foo`) — supported via the generic pointer walker (RFC 6901, including `~0` / `~1` escapes)
- A broken schema surfaces as the page's `error` load state with a "Schema $ref resolution failed — …" prefix; no render crash

**Out of scope per hub#303** (deferred): structural rendering of `oneOf` / `anyOf` / `allOf` arms. The resolver recurses into them so a `$ref` inside resolves, but the SPA still shows them via the unsupported-type JSON debug fallback. Separate follow-up.

## Versioning

`0.5.13-rc.3` → `0.5.13-rc.4` (rc chain at `0.5.13`).

## Patterns check

No pattern boundary crossed. The `parachute-patterns/patterns/module-protocol*` files describe the module-side schema contract; this PR is purely an SPA-side consumer change that makes the SPA more permissive about valid Draft-07 input. No pattern update needed.

## Test plan

- [x] `cd web/ui && bun run test` — 183 pass (was 169; +14)
  - +12 in new `web/ui/src/lib/json-schema.test.ts` (definitions / `$defs` / nested / circular / unknown / external / no-refs / sibling-merge / no-mutation / `oneOf`-recursion / path-refs / pointer-escapes)
  - +2 in a new `$ref dereferencing (hub#303)` describe block in `ModuleConfig.test.tsx` (end-to-end "writeOnly password input renders from a `$ref`-using schema" + "broken `$ref` surfaces as the error load state")
- [x] `bun test ./src` (hub) — 1762 pass (unchanged — no server-side change)
- [x] `bun run typecheck` — clean (root + web/ui)
- [x] `cd web/ui && bun run build` — clean (verify-base passes)
- [x] `bunx biome check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)