### PR TITLE
feat(hub): ServiceEntry hierarchical uis schema extension (#313) — parachute-app sub-units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.8] - 2026-05-22
+
+**feat(hub): ServiceEntry hierarchical `uis` schema extension (#313) — parachute-app sub-unit discovery.**
+
+Foundational schema work for parachute-app (per parachute-app design doc §12). apps wants hub's discovery surfaces — the well-known doc + admin SPA Modules view — to render the App module with each hosted UI (Gitcoin Brain, Unforced Brain, …) expanded as a sub-row, mirroring the per-instance shape vault already gives for `/vault/default`, `/vault/work`, etc. Today services.json entries are flat (`paths: ["/vault/default", "/vault/gitcoin"]`); this PR teaches the schema to carry display metadata per sub-unit so the discovery row can show a name + icon + status, not just a path.
+
+The extension is purely additive: existing flat entries (vault / scribe / notes / runner) continue to round-trip byte-identically — the `uis` field is optional throughout the read + write paths.
+
+**What landed.**
+
+- **`ServiceEntry.uis: Record<string, UiSubUnit>` on `src/services-manifest.ts`.** New `UiSubUnit` type carries `displayName` + `path` (required) plus optional `tagline`, `iconUrl`, `version`, `oauthClientId`, and `status` (`"active" | "pending-oauth" | "disabled"`). Validation runs in `validateEntry` → `validateUis` → `validateUiSubUnit`; the error messages name the offending sub-unit key so operators with N rows can jump straight to the offender.
+- **Well-known doc surfaces the sub-units.** `WellKnownServicesEntry.uis?: WellKnownUiSubUnit[]` mirrors the on-disk shape with the map key promoted to `name` and `path` joined onto the canonical origin into a deep-linkable `url`. `iconUrl` follows the same path-or-absolute-URL rule the services-level `uiUrl` uses. Empty map → field omitted (keeps the public contract tight); absent `uis` → field omitted (pre-#313 byte-identical for every existing module).
+- **`GET /api/modules` surfaces `uis: UiSubUnitWireShape[]` per row.** Snake-case wire keys (`display_name`, `oauth_client_id`, `icon_url`) to match the surrounding response. Empty array when the row doesn't declare `uis` — uniform shape across modules so the SPA can `.map` unconditionally.
+- **Admin SPA Modules view renders a `<details>`-wrapped "Hosted UIs" section per installed module with sub-units.** Each sub-row shows icon + displayName + path (same-origin anchor, not `<Link>` — the sub-unit lives outside the SPA's basename) + tagline + a status badge using the existing `status-<state>` class palette. Status falls back to `"active"` when absent. Empty / absent `uis` → section omitted entirely.
+
+**UiSubUnit shape (the canonical contract):**
+
+```ts
+export interface UiSubUnit {
+  displayName: string;
+  tagline?: string;
+  path: string;
+  iconUrl?: string;
+  version?: string;
+  oauthClientId?: string;
+  status?: "active" | "pending-oauth" | "disabled";
+}
+```
+
+`oauthClientId` is the load-bearing field for app's "install-once, multi-vault" pattern (design doc §6): each hosted UI gets its own OAuth client at install time, the operator sees the id verbatim on the approval surface, and revoking the client retires the UI's access in one shot without touching siblings.
+
+**Out of scope (deliberate).** Vault still uses flat `paths: ["/vault/default", "/vault/gitcoin"]`; a future PR can migrate vault to the hierarchical shape for per-instance display metadata. The flat shape continues to work through hub's existing path-prefix routing — the point of this PR is to make the hierarchical option available, not to retire the flat one.
+
+**Tests.** `bun run typecheck` clean (root + `web/ui`). `bun test ./src` 1805 pass (was 1781; +24 — 13 in services-manifest, 8 in well-known, 3 in api-modules). `cd web/ui && bun run test` 188 pass (was 183; +5 covering the SPA's Hosted UIs section across empty, populated, status-badge, icon, and sub-unit-count cases). `bunx biome check src/` clean.
+
 ## [0.5.13-rc.7] - 2026-05-22
 
 **feat(hub): mark same-hub DCR clients for auto-trust (#312) — parachute-app integration.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.7",
+  "version": "0.5.13-rc.8",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -349,6 +349,164 @@ describe("GET /api/modules", () => {
     const body = (await res.json()) as { module_install_channel: string };
     expect(body.module_install_channel).toBe("rc");
   });
+
+  // Hierarchical sub-units on the wire (hub#313). Each module row carries
+  // a `uis: []` array — empty for vault / scribe / notes / runner, populated
+  // for parachute-app once apps starts writing them. Snake-case keys
+  // throughout to match the rest of the response.
+  describe("uis hierarchical sub-units (hub#313)", () => {
+    test("uis defaults to empty array on every row when none declare it", async () => {
+      // The post-#313 wire shape must include `uis` unconditionally so
+      // the SPA can `.map` without a presence check. Modules with no
+      // `uis` declaration → empty array.
+      const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+      const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        fetchLatestVersion: async () => null,
+      });
+      const body = (await res.json()) as {
+        modules: Array<{ short: string; uis: unknown[] }>;
+      };
+      for (const m of body.modules) {
+        expect(Array.isArray(m.uis)).toBe(true);
+        expect(m.uis).toHaveLength(0);
+      }
+    });
+
+    test("vault row carries uis sub-units when services.json declares them", async () => {
+      // Synthetic: vault doesn't actually use `uis` yet, but the curated
+      // join is by manifestName so any short can carry a `uis` map.
+      // Once vault migrates (separate PR), this test pins the wire shape.
+      writeManifest(h.manifestPath, [
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.4.5",
+          uis: {
+            default: {
+              displayName: "Default Vault",
+              path: "/vault/default",
+              oauthClientId: "client_v1",
+              status: "active",
+            },
+            techne: {
+              displayName: "Techne",
+              path: "/vault/techne",
+              status: "pending-oauth",
+            },
+          },
+        },
+      ]);
+      const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+      const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        fetchLatestVersion: async () => null,
+      });
+      const body = (await res.json()) as {
+        modules: Array<{
+          short: string;
+          uis: Array<{
+            name: string;
+            display_name: string;
+            path: string;
+            tagline: string | null;
+            icon_url: string | null;
+            version: string | null;
+            oauth_client_id: string | null;
+            status: string | null;
+          }>;
+        }>;
+      };
+      const vault = body.modules.find((m) => m.short === "vault");
+      expect(vault?.uis).toEqual([
+        {
+          name: "default",
+          display_name: "Default Vault",
+          path: "/vault/default",
+          tagline: null,
+          icon_url: null,
+          version: null,
+          oauth_client_id: "client_v1",
+          status: "active",
+        },
+        {
+          name: "techne",
+          display_name: "Techne",
+          path: "/vault/techne",
+          tagline: null,
+          icon_url: null,
+          version: null,
+          oauth_client_id: null,
+          status: "pending-oauth",
+        },
+      ]);
+      // Other curated rows stay empty — uis is per-row, not global.
+      const notes = body.modules.find((m) => m.short === "notes");
+      expect(notes?.uis).toEqual([]);
+    });
+
+    test("optional fields ride through verbatim, missing fields become null on the wire", async () => {
+      writeManifest(h.manifestPath, [
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.4.5",
+          uis: {
+            "full-fields": {
+              displayName: "Full",
+              tagline: "All set",
+              path: "/vault/full",
+              iconUrl: "/vault/full/icon.svg",
+              version: "0.3.1",
+              oauthClientId: "c1",
+              status: "disabled",
+            },
+          },
+        },
+      ]);
+      const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+      const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        fetchLatestVersion: async () => null,
+      });
+      const body = (await res.json()) as {
+        modules: Array<{
+          short: string;
+          uis: Array<{
+            name: string;
+            display_name: string;
+            path: string;
+            tagline: string | null;
+            icon_url: string | null;
+            version: string | null;
+            oauth_client_id: string | null;
+            status: string | null;
+          }>;
+        }>;
+      };
+      const vault = body.modules.find((m) => m.short === "vault");
+      expect(vault?.uis[0]).toEqual({
+        name: "full-fields",
+        display_name: "Full",
+        path: "/vault/full",
+        tagline: "All set",
+        icon_url: "/vault/full/icon.svg",
+        version: "0.3.1",
+        oauth_client_id: "c1",
+        status: "disabled",
+      });
+    });
+  });
 });
 
 describe("PUT /api/modules/channel — hub#275 channel toggle", () => {

--- a/src/__tests__/services-manifest.test.ts
+++ b/src/__tests__/services-manifest.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   type ServiceEntry,
   ServicesManifestError,
+  type UiSubUnit,
   findService,
   readManifest,
   removeService,
@@ -221,6 +222,236 @@ describe("services-manifest", () => {
     } finally {
       cleanup();
     }
+  });
+
+  // Hierarchical sub-units (hub#313). parachute-app registers as a single
+  // module row with a `uis` map; each entry surfaces as a discoverable
+  // sub-row under the App module in hub's discovery surfaces. Schema is
+  // purely additive — pre-#313 flat entries (vault / scribe / notes /
+  // runner) round-trip byte-identically.
+  describe("ServiceEntry.uis hierarchical sub-units (hub#313)", () => {
+    const app: ServiceEntry = {
+      name: "parachute-app",
+      port: 1946,
+      paths: ["/app"],
+      health: "/app/healthz",
+      version: "0.1.0",
+    };
+
+    test("round-trips a fully-populated uis map", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        const full: ServiceEntry = {
+          ...app,
+          uis: {
+            "gitcoin-brain": {
+              displayName: "Gitcoin Brain",
+              tagline: "Reading room for the Gitcoin team's vault.",
+              path: "/app/gitcoin-brain",
+              iconUrl: "/app/gitcoin-brain/icon.svg",
+              version: "0.3.1",
+              oauthClientId: "client_abc123",
+              status: "active",
+            },
+            "unforced-brain": {
+              displayName: "Unforced Brain",
+              path: "/app/unforced-brain",
+              oauthClientId: "client_def456",
+              status: "pending-oauth",
+            },
+          },
+        };
+        upsertService(full, path);
+        expect(readManifest(path).services[0]).toEqual(full);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("absent uis round-trips as absent — backwards-compat for flat entries", () => {
+      // Vault / scribe / notes / runner all ship without `uis` today.
+      // The schema must round-trip them byte-identically so the post-#313
+      // services.json shape is a strict superset of the pre-#313 shape.
+      const { path, cleanup } = makeTempPath();
+      try {
+        upsertService(vault, path);
+        const got = readManifest(path).services[0];
+        expect(got).toEqual(vault);
+        expect(got).not.toHaveProperty("uis");
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("empty uis map round-trips as empty (not omitted)", () => {
+      // An app with no UIs yet is a distinct state from "doesn't support
+      // UIs" — preserve it so the SPA can render "no UIs installed yet"
+      // distinctly from "this isn't a UI-host module."
+      const { path, cleanup } = makeTempPath();
+      try {
+        const empty: ServiceEntry = { ...app, uis: {} };
+        upsertService(empty, path);
+        expect(readManifest(path).services[0]).toEqual(empty);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("minimal sub-unit — displayName + path only — accepted", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        const minimal: ServiceEntry = {
+          ...app,
+          uis: {
+            slug: { displayName: "Slug", path: "/app/slug" },
+          },
+        };
+        upsertService(minimal, path);
+        expect(readManifest(path).services[0]).toEqual(minimal);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("rejects uis that isn't an object", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        expect(() =>
+          upsertService({ ...app, uis: [] as unknown as Record<string, never> }, path),
+        ).toThrow(/"uis" must be an object map/);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("rejects sub-unit missing displayName", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        const bad: ServiceEntry = {
+          ...app,
+          uis: {
+            slug: { path: "/app/slug" } as unknown as UiSubUnit,
+          },
+        };
+        expect(() => upsertService(bad, path)).toThrow(/displayName/);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("rejects sub-unit missing path", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        const bad: ServiceEntry = {
+          ...app,
+          uis: {
+            slug: { displayName: "Slug" } as unknown as UiSubUnit,
+          },
+        };
+        expect(() => upsertService(bad, path)).toThrow(/"path"/);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("rejects sub-unit path not starting with /", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        const bad: ServiceEntry = {
+          ...app,
+          uis: { slug: { displayName: "S", path: "app/slug" } },
+        };
+        expect(() => upsertService(bad, path)).toThrow(/"path"/);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("rejects invalid status value", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        const bad: ServiceEntry = {
+          ...app,
+          uis: {
+            slug: {
+              displayName: "S",
+              path: "/app/s",
+              status: "weird" as unknown as "active",
+            },
+          },
+        };
+        expect(() => upsertService(bad, path)).toThrow(/status/);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("rejects non-string oauthClientId", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        const bad: ServiceEntry = {
+          ...app,
+          uis: {
+            slug: {
+              displayName: "S",
+              path: "/app/s",
+              oauthClientId: 42 as unknown as string,
+            },
+          },
+        };
+        expect(() => upsertService(bad, path)).toThrow(/oauthClientId/);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("rejects empty-string key in uis map", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        writeFileSync(
+          path,
+          JSON.stringify({
+            services: [
+              {
+                ...app,
+                uis: {
+                  "": { displayName: "S", path: "/app/s" },
+                },
+              },
+            ],
+          }),
+        );
+        expect(() => readManifest(path)).toThrow(/"uis" keys/);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("error message names the offending sub-unit key", () => {
+      // Multiple sub-units in the same entry — the error should pinpoint
+      // which slug carries the bad shape so an operator with N rows can
+      // jump straight to the offender.
+      const { path, cleanup } = makeTempPath();
+      try {
+        writeFileSync(
+          path,
+          JSON.stringify({
+            services: [
+              {
+                ...app,
+                uis: {
+                  good: { displayName: "Good", path: "/app/good" },
+                  "bad-one": { displayName: "Bad", path: "no-leading-slash" },
+                },
+              },
+            ],
+          }),
+        );
+        expect(() => readManifest(path)).toThrow(/bad-one/);
+      } finally {
+        cleanup();
+      }
+    });
   });
 
   // Duplicate-port detection (hub#195). The original collision had

--- a/src/__tests__/well-known.test.ts
+++ b/src/__tests__/well-known.test.ts
@@ -379,6 +379,186 @@ describe("buildWellKnown", () => {
     });
     expect(doc.vaults[0]?.url).toBe("https://x.example/");
   });
+
+  // Hierarchical sub-units (hub#313 — parachute-app design doc §12). Each
+  // entry in `s.uis` becomes one record in the well-known shape's
+  // `services[].uis` array, with map key promoted to `name` and `path`
+  // joined onto the canonical origin into a deep-linkable `url`.
+  describe("uis hierarchical sub-units (hub#313)", () => {
+    const app: ServiceEntry = {
+      name: "parachute-app",
+      port: 1946,
+      paths: ["/app"],
+      health: "/app/healthz",
+      version: "0.1.0",
+    };
+
+    test("uis map surfaces as services[].uis array with names promoted", () => {
+      const withUis: ServiceEntry = {
+        ...app,
+        uis: {
+          "gitcoin-brain": {
+            displayName: "Gitcoin Brain",
+            path: "/app/gitcoin-brain",
+            oauthClientId: "client_abc123",
+            status: "active",
+          },
+          "unforced-brain": {
+            displayName: "Unforced Brain",
+            path: "/app/unforced-brain",
+            oauthClientId: "client_def456",
+            status: "pending-oauth",
+          },
+        },
+      };
+      const doc = buildWellKnown({
+        services: [withUis],
+        canonicalOrigin: "https://x.example",
+      });
+      const appSvc = doc.services.find((s) => s.name === "parachute-app");
+      expect(appSvc?.uis).toEqual([
+        {
+          name: "gitcoin-brain",
+          displayName: "Gitcoin Brain",
+          path: "/app/gitcoin-brain",
+          url: "https://x.example/app/gitcoin-brain",
+          oauthClientId: "client_abc123",
+          status: "active",
+        },
+        {
+          name: "unforced-brain",
+          displayName: "Unforced Brain",
+          path: "/app/unforced-brain",
+          url: "https://x.example/app/unforced-brain",
+          oauthClientId: "client_def456",
+          status: "pending-oauth",
+        },
+      ]);
+    });
+
+    test("absent uis → services entry has no uis field (backwards-compat)", () => {
+      // The pre-#313 byte-identical shape for every existing module.
+      // Adding the `uis` field to the well-known doc when the parent
+      // didn't declare one would break consumers (and force a schema
+      // bump on every existing module).
+      const doc = buildWellKnown({
+        services: [notes, scribe, vault],
+        canonicalOrigin: "https://x.example",
+      });
+      for (const svc of doc.services) {
+        expect(svc).not.toHaveProperty("uis");
+      }
+    });
+
+    test("empty uis map → services entry has no uis field (avoid empty noise)", () => {
+      // Per buildWellKnown: an empty map omits the field. The SPA's
+      // `mod.uis.length > 0` predicate on the wire side already handles
+      // this, but the well-known doc is a public contract so we keep
+      // the shape tight.
+      const empty: ServiceEntry = { ...app, uis: {} };
+      const doc = buildWellKnown({
+        services: [empty],
+        canonicalOrigin: "https://x.example",
+      });
+      const svc = doc.services.find((s) => s.name === "parachute-app");
+      expect(svc).not.toHaveProperty("uis");
+    });
+
+    test("iconUrl resolves relative path to absolute against canonical origin", () => {
+      const withIcon: ServiceEntry = {
+        ...app,
+        uis: {
+          slug: {
+            displayName: "Slug",
+            path: "/app/slug",
+            iconUrl: "/app/slug/icon.svg",
+          },
+        },
+      };
+      const doc = buildWellKnown({
+        services: [withIcon],
+        canonicalOrigin: "https://x.example",
+      });
+      const svc = doc.services.find((s) => s.name === "parachute-app");
+      expect(svc?.uis?.[0]?.iconUrl).toBe("https://x.example/app/slug/icon.svg");
+    });
+
+    test("iconUrl absolute URL passes through verbatim", () => {
+      const withIcon: ServiceEntry = {
+        ...app,
+        uis: {
+          slug: {
+            displayName: "Slug",
+            path: "/app/slug",
+            iconUrl: "https://cdn.example.com/icon.svg",
+          },
+        },
+      };
+      const doc = buildWellKnown({
+        services: [withIcon],
+        canonicalOrigin: "https://x.example",
+      });
+      const svc = doc.services.find((s) => s.name === "parachute-app");
+      expect(svc?.uis?.[0]?.iconUrl).toBe("https://cdn.example.com/icon.svg");
+    });
+
+    test("optional fields ride through when present, absent when not", () => {
+      const mixed: ServiceEntry = {
+        ...app,
+        uis: {
+          full: {
+            displayName: "Full",
+            path: "/app/full",
+            tagline: "Has it all",
+            version: "0.3.1",
+            iconUrl: "/i.svg",
+            oauthClientId: "c1",
+            status: "disabled",
+          },
+          minimal: { displayName: "Minimal", path: "/app/minimal" },
+        },
+      };
+      const doc = buildWellKnown({
+        services: [mixed],
+        canonicalOrigin: "https://x.example",
+      });
+      const svc = doc.services.find((s) => s.name === "parachute-app");
+      const full = svc?.uis?.find((u) => u.name === "full");
+      const minimal = svc?.uis?.find((u) => u.name === "minimal");
+      expect(full?.tagline).toBe("Has it all");
+      expect(full?.version).toBe("0.3.1");
+      expect(full?.oauthClientId).toBe("c1");
+      expect(full?.status).toBe("disabled");
+      // Minimal carries only the required fields — no optional keys.
+      expect(minimal).toEqual({
+        name: "minimal",
+        displayName: "Minimal",
+        path: "/app/minimal",
+        url: "https://x.example/app/minimal",
+      });
+    });
+
+    test("multiple modules each carry their own uis", () => {
+      const app1: ServiceEntry = {
+        ...app,
+        uis: { a: { displayName: "A", path: "/app/a" } },
+      };
+      const app2: ServiceEntry = {
+        ...app,
+        name: "parachute-app-2",
+        port: 1947,
+        uis: { b: { displayName: "B", path: "/app-2/b" } },
+      };
+      const doc = buildWellKnown({
+        services: [app1, app2],
+        canonicalOrigin: "https://x.example",
+      });
+      const svc1 = doc.services.find((s) => s.name === "parachute-app");
+      const svc2 = doc.services.find((s) => s.name === "parachute-app-2");
+      expect(svc1?.uis?.map((u) => u.name)).toEqual(["a"]);
+      expect(svc2?.uis?.map((u) => u.name)).toEqual(["b"]);
+    });
+  });
 });
 
 describe("writeWellKnownFile", () => {

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -36,7 +36,7 @@ import { FIRST_PARTY_FALLBACKS, KNOWN_MODULES } from "./service-spec.ts";
 // still required) and the latter for vault/scribe/runner (post-FALLBACK
 // retirement, hub#310). The local helper hides the split from the rest of
 // this file.
-import { readManifest } from "./services-manifest.ts";
+import { type UiSubUnit, type UiSubUnitStatus, readManifest } from "./services-manifest.ts";
 import type { ModuleState, Supervisor } from "./supervisor.ts";
 
 /**
@@ -107,6 +107,29 @@ export interface ApiModulesDeps {
   now?: () => number;
 }
 
+/**
+ * Wire shape for a sub-unit surfaced under a module row. Mirrors the
+ * services.json `UiSubUnit` map value, with the map key promoted to `name`
+ * — same shape `WellKnownUiSubUnit` uses. Snake-case keys to match the
+ * surrounding response (`display_name`, `oauth_client_id`).
+ *
+ * Discovery + admin SPA both consume this without reaching back into
+ * services.json — `display_name` / `path` / `icon_url` are sufficient to
+ * render the sub-row; `oauth_client_id` lets future SPA work cross-link
+ * to `/api/oauth/clients/<id>` for approval status without an extra
+ * resolver. Per parachute-app design doc §12.
+ */
+interface UiSubUnitWireShape {
+  name: string;
+  display_name: string;
+  path: string;
+  tagline: string | null;
+  icon_url: string | null;
+  version: string | null;
+  oauth_client_id: string | null;
+  status: UiSubUnitStatus | null;
+}
+
 interface ModuleWireShape {
   short: string;
   package: string;
@@ -125,6 +148,14 @@ interface ModuleWireShape {
    * so a vanished disk is obvious.
    */
   install_dir: string | null;
+  /**
+   * Hierarchical sub-units beneath this module (hub#313). Empty when the
+   * module's services.json row doesn't declare `uis` (vault, scribe, notes,
+   * runner today). Used by parachute-app to surface each hosted UI as its
+   * own discoverable sub-row under the App module. Per parachute-app
+   * design doc §12.
+   */
+  uis: UiSubUnitWireShape[];
 }
 
 interface ModulesResponse {
@@ -216,7 +247,10 @@ export async function handleApiModules(req: Request, deps: ApiModulesDeps): Prom
   // (fresh container), which is the v0.6 hot path — readManifest already
   // returns { services: [] } for a missing file, so no extra branching.
   const manifest = readManifest(deps.manifestPath);
-  const installedByShort = new Map<string, { version: string; installDir?: string }>();
+  const installedByShort = new Map<
+    string,
+    { version: string; installDir?: string; uis?: Record<string, UiSubUnit> }
+  >();
   for (const entry of manifest.services) {
     // Join services.json rows to CURATED_MODULES by manifestName. The
     // mapping table lives in lookupModule (which consults both
@@ -226,8 +260,13 @@ export async function handleApiModules(req: Request, deps: ApiModulesDeps): Prom
     for (const short of CURATED_MODULES) {
       const m = lookupModule(short);
       if (m?.manifestName === entry.name) {
-        const value: { version: string; installDir?: string } = { version: entry.version };
+        const value: {
+          version: string;
+          installDir?: string;
+          uis?: Record<string, UiSubUnit>;
+        } = { version: entry.version };
         if (entry.installDir !== undefined) value.installDir = entry.installDir;
+        if (entry.uis !== undefined) value.uis = entry.uis;
         installedByShort.set(short, value);
       }
     }
@@ -289,6 +328,7 @@ export async function handleApiModules(req: Request, deps: ApiModulesDeps): Prom
       supervisor_status: state?.status ?? null,
       pid: state?.pid ?? null,
       install_dir: installed?.installDir ?? null,
+      uis: toUisWireShape(installed?.uis),
     });
   }
 
@@ -395,6 +435,29 @@ function jsonError(status: number, code: string, description: string): Response 
     status,
     headers: { "content-type": "application/json" },
   });
+}
+
+/**
+ * Map a services.json `uis` record to the snake-case wire shape the SPA
+ * consumes. Each missing optional field on the source becomes an explicit
+ * `null` on the wire so the consumer's shape is uniform — same convention
+ * `install_dir` / `latest_version` follow on `ModuleWireShape`.
+ *
+ * Returns `[]` when the source is absent, so the response shape is uniform
+ * across modules with and without `uis` (the SPA can `.map` unconditionally).
+ */
+function toUisWireShape(uis: Record<string, UiSubUnit> | undefined): UiSubUnitWireShape[] {
+  if (!uis) return [];
+  return Object.entries(uis).map(([name, u]) => ({
+    name,
+    display_name: u.displayName,
+    path: u.path,
+    tagline: u.tagline ?? null,
+    icon_url: u.iconUrl ?? null,
+    version: u.version ?? null,
+    oauth_client_id: u.oauthClientId ?? null,
+    status: u.status ?? null,
+  }));
 }
 
 /**

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -22,6 +22,81 @@ import { SERVICES_MANIFEST_PATH } from "./config.ts";
  */
 export type PublicExposure = "allowed" | "loopback" | "auth-required";
 
+/**
+ * Visible-to-discovery state of a UI sub-unit. Mirrors parachute-app's
+ * `RegisteredUi.status` so hub renders the same label the app's admin SPA
+ * shows. Absent → hub treats the sub-unit as "active" (the discovery
+ * default).
+ *
+ *   "active"        — UI is installed, OAuth client is approved, ready to serve.
+ *   "pending-oauth" — UI is installed but its OAuth client hasn't been approved
+ *                     yet (operator still needs to click through `/admin/oauth-clients`
+ *                     or the app's admin SPA gate). Discovery should render the
+ *                     row but signal "not yet usable."
+ *   "disabled"      — Operator-disabled. Renders greyed-out; no link.
+ */
+export type UiSubUnitStatus = "active" | "pending-oauth" | "disabled";
+
+/**
+ * A sub-unit beneath a module — used today by parachute-app to surface each
+ * hosted UI as its own discoverable row under the App module, and the shape
+ * vault is expected to adopt in a follow-up so per-vault display metadata
+ * (icon, tagline) can ride alongside the mount path.
+ *
+ * Per parachute-app design doc §12, the canonical shape for parachute-app's
+ * services.json row mirrors vault's multi-instance pattern but carries
+ * display metadata per instance. Today vault encodes instances as flat
+ * `paths: ["/vault/default", "/vault/work"]`; the discovery surface only
+ * sees the path. With `uis`, each sub-unit can ride its own displayName,
+ * tagline, iconUrl, and OAuth client id without the parent module forging
+ * a fake services.json row per UI.
+ *
+ * `oauthClientId` is the load-bearing field for app's "install-once,
+ * multi-vault" pattern (design doc §6 ¶219): each UI gets its own OAuth
+ * client at install time, the operator sees that id verbatim on the
+ * approval surface, and revoking the client retires the UI's access in
+ * one shot without touching its siblings.
+ *
+ * Backwards-compat: this is purely additive. Modules that don't use `uis`
+ * (vault, scribe, notes, runner today) continue to render as flat rows;
+ * the field is optional throughout the read + write paths.
+ */
+export interface UiSubUnit {
+  /** Human-readable name for the discovery row (e.g. "Gitcoin Brain"). */
+  displayName: string;
+  /** One-line subtitle, same shape as `ServiceEntry.tagline`. */
+  tagline?: string;
+  /**
+   * Path under the hub origin where this sub-unit is mounted (e.g.
+   * `/app/gitcoin-brain`). Must start with `/` — same shape rule as
+   * `ServiceEntry.paths[]`.
+   */
+  path: string;
+  /**
+   * Absolute URL or path to an icon (svg / png). Discovery renders this as
+   * the sub-unit's tile glyph; absent → hub falls back to a generic
+   * placeholder. Path-relative URLs are resolved against the hub origin
+   * the same way `uiUrl` is in `well-known.ts`.
+   */
+  iconUrl?: string;
+  /**
+   * Optional version stamp. Each UI iterates independently of its parent
+   * module — Gitcoin Brain at 0.3.1 + Unforced Brain at 0.2.0 ride on the
+   * same parachute-app process. Surfaced on the admin SPA row so operators
+   * can spot a drift.
+   */
+  version?: string;
+  /**
+   * OAuth client id minted at UI install time. Hub doesn't validate this
+   * shape (the OAuth server already does); it round-trips verbatim so the
+   * admin SPA can render the per-UI approval status without re-resolving
+   * from `/api/oauth/clients/<id>`.
+   */
+  oauthClientId?: string;
+  /** UI sub-unit lifecycle state. Absent → discovery treats as "active". */
+  status?: UiSubUnitStatus;
+}
+
 export interface ServiceEntry {
   name: string;
   port: number;
@@ -61,6 +136,21 @@ export interface ServiceEntry {
    *     bridges the gap. Tracked in parachute-scribe (separate issue).
    */
   stripPrefix?: boolean;
+  /**
+   * Sub-units hosted under this module — parachute-app's bag of UIs, and
+   * the shape vault is expected to adopt for per-instance metadata in a
+   * follow-up. Empty or absent → flat row, the legacy shape. See
+   * `UiSubUnit` above + parachute-app design doc §12 for the canonical
+   * usage. Keys are short slugs (`gitcoin-brain`, `default`); the slug
+   * carries no semantic meaning beyond being a stable identity for the
+   * row across renders.
+   *
+   * Discovery surfaces (`/.well-known/parachute.json`, admin SPA Modules
+   * view) render each entry as a discoverable sub-row under the parent
+   * module — same UX shape as vault's per-instance paths today, only
+   * with display metadata attached.
+   */
+  uis?: Record<string, UiSubUnit>;
 }
 
 export interface ServicesManifest {
@@ -125,13 +215,91 @@ function validateEntry(raw: unknown, where: string): ServiceEntry {
   if (stripPrefix !== undefined && typeof stripPrefix !== "boolean") {
     throw new ServicesManifestError(`${where}: "stripPrefix" must be a boolean if present`);
   }
+  const uis = e.uis;
+  const validatedUis = validateUis(uis, where);
   const entry: ServiceEntry = { name, port, paths: paths as string[], health, version };
   if (displayName !== undefined) entry.displayName = displayName;
   if (tagline !== undefined) entry.tagline = tagline;
   if (publicExposure !== undefined) entry.publicExposure = publicExposure as PublicExposure;
   if (installDir !== undefined) entry.installDir = installDir;
   if (stripPrefix !== undefined) entry.stripPrefix = stripPrefix;
+  if (validatedUis !== undefined) entry.uis = validatedUis;
   return entry;
+}
+
+/**
+ * Validate the optional `uis` map on a ServiceEntry. `undefined` round-trips
+ * unchanged (the field is optional); a present map must be a plain object
+ * keyed by string with each value satisfying `UiSubUnit`.
+ *
+ * Each sub-unit is validated against the same shape `UiSubUnit` declares:
+ * `displayName` + `path` required, everything else optional with type-narrow
+ * checks. Errors carry the parent entry's `where` context plus the offending
+ * sub-unit key so an operator scanning logs knows exactly which row to
+ * reconcile.
+ */
+function validateUis(raw: unknown, where: string): Record<string, UiSubUnit> | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ServicesManifestError(`${where}: "uis" must be an object map if present`);
+  }
+  const out: Record<string, UiSubUnit> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof key !== "string" || key.length === 0) {
+      throw new ServicesManifestError(`${where}: "uis" keys must be non-empty strings`);
+    }
+    out[key] = validateUiSubUnit(value, `${where} uis[${JSON.stringify(key)}]`);
+  }
+  return out;
+}
+
+function validateUiSubUnit(raw: unknown, where: string): UiSubUnit {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ServicesManifestError(`${where}: expected object, got ${typeof raw}`);
+  }
+  const u = raw as Record<string, unknown>;
+  const displayName = u.displayName;
+  const path = u.path;
+  if (typeof displayName !== "string" || displayName.length === 0) {
+    throw new ServicesManifestError(`${where}: "displayName" must be a non-empty string`);
+  }
+  if (typeof path !== "string" || !path.startsWith("/")) {
+    throw new ServicesManifestError(`${where}: "path" must be a path starting with "/"`);
+  }
+  const tagline = u.tagline;
+  const iconUrl = u.iconUrl;
+  const version = u.version;
+  const oauthClientId = u.oauthClientId;
+  const status = u.status;
+  if (tagline !== undefined && typeof tagline !== "string") {
+    throw new ServicesManifestError(`${where}: "tagline" must be a string if present`);
+  }
+  if (iconUrl !== undefined && typeof iconUrl !== "string") {
+    throw new ServicesManifestError(`${where}: "iconUrl" must be a string if present`);
+  }
+  if (version !== undefined && typeof version !== "string") {
+    throw new ServicesManifestError(`${where}: "version" must be a string if present`);
+  }
+  if (oauthClientId !== undefined && typeof oauthClientId !== "string") {
+    throw new ServicesManifestError(`${where}: "oauthClientId" must be a string if present`);
+  }
+  if (
+    status !== undefined &&
+    status !== "active" &&
+    status !== "pending-oauth" &&
+    status !== "disabled"
+  ) {
+    throw new ServicesManifestError(
+      `${where}: "status" must be "active" | "pending-oauth" | "disabled" if present`,
+    );
+  }
+  const out: UiSubUnit = { displayName, path };
+  if (tagline !== undefined) out.tagline = tagline;
+  if (iconUrl !== undefined) out.iconUrl = iconUrl;
+  if (version !== undefined) out.version = version;
+  if (oauthClientId !== undefined) out.oauthClientId = oauthClientId;
+  if (status !== undefined) out.status = status as UiSubUnitStatus;
+  return out;
 }
 
 /**

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -2,11 +2,42 @@ import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { CONFIG_DIR } from "./config.ts";
 import { type ModuleManifest, readModuleManifest } from "./module-manifest.ts";
-import { type ServiceEntry, readManifest } from "./services-manifest.ts";
+import {
+  type ServiceEntry,
+  type UiSubUnit,
+  type UiSubUnitStatus,
+  readManifest,
+} from "./services-manifest.ts";
 
 export interface WellKnownServiceEntry {
   url: string;
   version: string;
+}
+
+/**
+ * Sub-unit entry surfaced in `/.well-known/parachute.json` under a parent
+ * module. Mirrors the shape `UiSubUnit` carries on disk, plus:
+ *
+ *   - `name` — the map key promoted to a field so consumers iterating an
+ *     array don't have to round-trip through the parent map. Same shape
+ *     `WellKnownVaultEntry` uses.
+ *   - `url` — `path` joined onto `canonicalOrigin`, so a consumer can deep
+ *     link to the sub-unit without re-resolving the hub origin.
+ *
+ * `iconUrl` is resolved through the same path-or-absolute-URL rule the
+ * services-level `uiUrl` uses (absolute http(s) → verbatim; path → joined
+ * onto `canonicalOrigin`).
+ */
+export interface WellKnownUiSubUnit {
+  name: string;
+  displayName: string;
+  path: string;
+  url: string;
+  tagline?: string;
+  iconUrl?: string;
+  version?: string;
+  oauthClientId?: string;
+  status?: UiSubUnitStatus;
 }
 
 export interface WellKnownVaultEntry {
@@ -52,6 +83,14 @@ export interface WellKnownServicesEntry {
   uiUrl?: string;
   /** One-line subtitle for the discovery tile, sourced from `services.json:tagline`. */
   tagline?: string;
+  /**
+   * Sub-units hosted under this module, surfaced as an array (the on-disk
+   * shape is a map; the well-known shape is an array so consumers iterate
+   * cleanly). Each entry promotes the map key into `name`. Absent on
+   * modules that don't declare `uis` (vault, scribe, notes, runner today).
+   * See `UiSubUnit` in services-manifest.ts + parachute-app design doc §12.
+   */
+  uis?: WellKnownUiSubUnit[];
 }
 
 /**
@@ -147,6 +186,42 @@ function joinInfoPath(path: string): string {
   return `${trimmed}/.parachute/info`;
 }
 
+/**
+ * Resolve a UI sub-unit map to the well-known array shape. Per hub#313 /
+ * parachute-app design doc §12: each map entry expands into a
+ * `WellKnownUiSubUnit` record with the map key promoted to `name` and
+ * `path` joined onto `canonicalOrigin` for a deep-linkable `url`. Empty
+ * map → empty array (the caller decides whether to omit the field).
+ *
+ * `iconUrl` follows the same shape `uiUrl` does on the services row:
+ * absolute http(s) → verbatim; relative path → joined onto `base`.
+ *
+ * Pulled out of `buildWellKnown` so the per-sub-unit shape stays a pure
+ * transform — tests can call it directly; consumers can re-use it for
+ * their own well-known builders (rare, but the surface stays small).
+ */
+function buildUisArray(uis: Record<string, UiSubUnit>, base: string): WellKnownUiSubUnit[] {
+  return Object.entries(uis).map(([name, u]) => {
+    const url = new URL(u.path, `${base}/`).toString();
+    const out: WellKnownUiSubUnit = {
+      name,
+      displayName: u.displayName,
+      path: u.path,
+      url,
+    };
+    if (u.tagline !== undefined) out.tagline = u.tagline;
+    if (u.iconUrl !== undefined) {
+      out.iconUrl = /^https?:\/\//i.test(u.iconUrl)
+        ? u.iconUrl
+        : new URL(u.iconUrl, `${base}/`).toString();
+    }
+    if (u.version !== undefined) out.version = u.version;
+    if (u.oauthClientId !== undefined) out.oauthClientId = u.oauthClientId;
+    if (u.status !== undefined) out.status = u.status;
+    return out;
+  });
+}
+
 export function buildWellKnown(opts: BuildWellKnownOpts): WellKnownDocument {
   const base = opts.canonicalOrigin.replace(/\/$/, "");
   const doc: WellKnownDocument = { vaults: [], services: [] };
@@ -184,6 +259,24 @@ export function buildWellKnown(opts: BuildWellKnownOpts): WellKnownDocument {
         entry.uiUrl = /^https?:\/\//i.test(uiUrlRaw)
           ? uiUrlRaw
           : new URL(uiUrlRaw, `${base}/`).toString();
+      }
+      // Hierarchical sub-units (hub#313 / parachute-app design doc §12). The
+      // on-disk shape is a map keyed by short slug; the well-known shape is
+      // an array of records so JS consumers iterate cleanly without a second
+      // Object.entries round-trip. `name` promotes the map key into a field
+      // — same convention as `WellKnownVaultEntry`. Absent on the parent
+      // when the entry doesn't declare `uis`, so vault / notes / scribe /
+      // runner rows stay byte-identical to their pre-#313 shape.
+      //
+      // Emitted on every path of a multi-path entry — today only vault has
+      // multi-path entries, and vault doesn't declare `uis` yet, so the
+      // duplication is theoretical. Once vault adopts the hierarchical
+      // shape (separate migration), each path-loop iteration will still see
+      // the same `uis` map and emit the same array; consumers de-duplicate
+      // by parent `services[].name` if they care.
+      if (s.uis) {
+        const arr = buildUisArray(s.uis, base);
+        if (arr.length > 0) entry.uis = arr;
       }
       doc.services.push(entry);
       if (isVault) {

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -563,6 +563,30 @@ export async function approveOauthClient(clientId: string): Promise<ApproveClien
 }
 
 /**
+ * Status of a hosted UI sub-unit, mirrors `UiSubUnitStatus` server-side.
+ * Absent (null) → discovery treats as "active".
+ */
+export type UiSubUnitStatus = "active" | "pending-oauth" | "disabled";
+
+/**
+ * One sub-unit beneath a module — surfaced on `ModuleListing.uis` when the
+ * underlying services.json row declares a `uis` map. Snake-case to mirror
+ * the wire shape from `src/api-modules.ts:UiSubUnitWireShape`. See
+ * parachute-app design doc §12 for the canonical use case (per-UI rows
+ * under the App module).
+ */
+export interface ModuleUiSubUnit {
+  name: string;
+  display_name: string;
+  path: string;
+  tagline: string | null;
+  icon_url: string | null;
+  version: string | null;
+  oauth_client_id: string | null;
+  status: UiSubUnitStatus | null;
+}
+
+/**
  * One row from `GET /api/modules`. Mirrors the snake_case wire shape
  * from `src/api-modules.ts`.
  */
@@ -578,6 +602,12 @@ export interface ModuleListing {
   supervisor_status: "starting" | "running" | "stopped" | "crashed" | "restarting" | null;
   pid: number | null;
   install_dir: string | null;
+  /**
+   * Hierarchical sub-units (hub#313). Empty when the row doesn't declare
+   * `uis` — most modules today. parachute-app's App module is the first
+   * consumer; the SPA renders each entry as an expandable sub-row.
+   */
+  uis: ModuleUiSubUnit[];
 }
 
 /** Module install channel — `latest` (stable) or `rc` (release candidates). */

--- a/web/ui/src/routes/Modules.test.tsx
+++ b/web/ui/src/routes/Modules.test.tsx
@@ -66,6 +66,7 @@ function moduleRow(short: string, overrides: Partial<api.ModuleListing> = {}): a
     supervisor_status: null,
     pid: null,
     install_dir: null,
+    uis: [],
     ...overrides,
   };
 }
@@ -539,5 +540,169 @@ describe("Modules — install channel toggle (hub#275)", () => {
     fireEvent.click(screen.getByRole("radio", { name: /stable/i }));
     await Promise.resolve();
     expect(api.setModuleChannel).not.toHaveBeenCalled();
+  });
+});
+
+// Hierarchical sub-units (hub#313). Installed module rows render an
+// expandable "Hosted UIs" section per sub-unit when `uis` is non-empty.
+// Empty (the default for vault / notes / scribe / runner) suppresses the
+// section entirely.
+describe("Modules — hierarchical sub-units (hub#313)", () => {
+  function makeUi(overrides: Partial<api.ModuleUiSubUnit>): api.ModuleUiSubUnit {
+    return {
+      name: "gitcoin-brain",
+      display_name: "Gitcoin Brain",
+      path: "/app/gitcoin-brain",
+      tagline: null,
+      icon_url: null,
+      version: null,
+      oauth_client_id: null,
+      status: null,
+      ...overrides,
+    };
+  }
+
+  it("does not render the Hosted UIs section when uis is empty", async () => {
+    vi.mocked(api.listModules).mockResolvedValue(
+      makeCatalog({
+        modules: [
+          moduleRow("vault", {
+            installed: true,
+            installed_version: "0.4.5",
+            latest_version: "0.4.5",
+            supervisor_status: "running",
+            uis: [],
+          }),
+        ],
+      }),
+    );
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    expect(screen.queryByTestId("module-uis")).not.toBeInTheDocument();
+  });
+
+  it("renders the Hosted UIs section with one row per sub-unit", async () => {
+    vi.mocked(api.listModules).mockResolvedValue(
+      makeCatalog({
+        modules: [
+          moduleRow("vault", {
+            display_name: "App",
+            installed: true,
+            installed_version: "0.1.0",
+            latest_version: "0.1.0",
+            supervisor_status: "running",
+            uis: [
+              makeUi({
+                name: "gitcoin-brain",
+                display_name: "Gitcoin Brain",
+                path: "/app/gitcoin-brain",
+                tagline: "Reading room for the Gitcoin team",
+                status: "active",
+              }),
+              makeUi({
+                name: "unforced-brain",
+                display_name: "Unforced Brain",
+                path: "/app/unforced-brain",
+                status: "pending-oauth",
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("App")).toBeInTheDocument());
+    const section = screen.getByTestId("module-uis");
+    expect(within(section).getByText("Gitcoin Brain")).toBeInTheDocument();
+    expect(within(section).getByText("Unforced Brain")).toBeInTheDocument();
+    // Tagline rides through verbatim.
+    expect(within(section).getByText("Reading room for the Gitcoin team")).toBeInTheDocument();
+    // Path is rendered as a same-origin anchor (the sub-unit lives outside
+    // the SPA's basename — see UiSubUnitsList comment for the rationale).
+    const link = within(section).getByText("Gitcoin Brain").closest("a");
+    expect(link?.getAttribute("href")).toBe("/app/gitcoin-brain");
+  });
+
+  it("renders per-sub-unit status badges using status-<state> class", async () => {
+    vi.mocked(api.listModules).mockResolvedValue(
+      makeCatalog({
+        modules: [
+          moduleRow("vault", {
+            installed: true,
+            installed_version: "0.1.0",
+            latest_version: "0.1.0",
+            supervisor_status: "running",
+            uis: [
+              makeUi({ name: "a", display_name: "A", status: "active" }),
+              makeUi({ name: "b", display_name: "B", status: "pending-oauth" }),
+              makeUi({ name: "c", display_name: "C", status: "disabled" }),
+              makeUi({ name: "d", display_name: "D", status: null }),
+            ],
+          }),
+        ],
+      }),
+    );
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("module-uis")).toBeInTheDocument());
+    expect(screen.getByTestId("ui-status-a")).toHaveClass("status-active");
+    expect(screen.getByTestId("ui-status-b")).toHaveClass("status-pending-oauth");
+    expect(screen.getByTestId("ui-status-c")).toHaveClass("status-disabled");
+    // Null status falls back to "active" — same default as discovery.
+    expect(screen.getByTestId("ui-status-d")).toHaveClass("status-active");
+  });
+
+  it("renders the icon when icon_url is present, skips it when absent", async () => {
+    vi.mocked(api.listModules).mockResolvedValue(
+      makeCatalog({
+        modules: [
+          moduleRow("vault", {
+            installed: true,
+            installed_version: "0.1.0",
+            latest_version: "0.1.0",
+            supervisor_status: "running",
+            uis: [
+              makeUi({
+                name: "with-icon",
+                display_name: "With Icon",
+                icon_url: "/app/with-icon/icon.svg",
+              }),
+              makeUi({ name: "no-icon", display_name: "No Icon", icon_url: null }),
+            ],
+          }),
+        ],
+      }),
+    );
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("module-uis")).toBeInTheDocument());
+    const section = screen.getByTestId("module-uis");
+    // The icon <img alt=""> is presentational (per a11y conventions for
+    // decorative images), so getByRole("img") wouldn't match. Query via
+    // the .ui-icon class instead — same class the component renders.
+    const imgs = section.querySelectorAll("img.ui-icon");
+    expect(imgs).toHaveLength(1);
+    expect(imgs[0]?.getAttribute("src")).toBe("/app/with-icon/icon.svg");
+  });
+
+  it("shows the sub-unit count in the section summary", async () => {
+    vi.mocked(api.listModules).mockResolvedValue(
+      makeCatalog({
+        modules: [
+          moduleRow("vault", {
+            installed: true,
+            installed_version: "0.1.0",
+            latest_version: "0.1.0",
+            supervisor_status: "running",
+            uis: [
+              makeUi({ name: "a", display_name: "A" }),
+              makeUi({ name: "b", display_name: "B" }),
+              makeUi({ name: "c", display_name: "C" }),
+            ],
+          }),
+        ],
+      }),
+    );
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("module-uis")).toBeInTheDocument());
+    expect(screen.getByText(/\(3\)/)).toBeInTheDocument();
   });
 });

--- a/web/ui/src/routes/Modules.tsx
+++ b/web/ui/src/routes/Modules.tsx
@@ -32,6 +32,7 @@ import {
   type ModuleInstallChannel,
   type ModuleListing,
   type ModuleOperation,
+  type ModuleUiSubUnit,
   type ModulesCatalog,
   getModuleOperation,
   installModule,
@@ -447,6 +448,16 @@ function ModuleRow({
         )}
       </dl>
 
+      {/*
+        Hierarchical sub-units (hub#313). Rendered only when the module's
+        services.json row declares a non-empty `uis` map — most modules
+        today have none and this block is omitted entirely. parachute-app
+        is the first consumer: the App module surfaces each hosted UI
+        (Gitcoin Brain, Unforced Brain, ...) as its own discoverable
+        sub-row. See parachute-app design doc §12.
+      */}
+      {mod.uis.length > 0 && <UiSubUnitsList uis={mod.uis} />}
+
       <div className="actions">
         {/* Configure link routes to the generic per-module config form
             (hub#260). Rendered as a Link rather than a button because
@@ -533,6 +544,63 @@ function statusLabel(mod: ModuleListing): string {
   if (!mod.installed) return "not installed";
   if (!mod.supervisor_status) return "not supervised";
   return mod.supervisor_status;
+}
+
+interface UiSubUnitsListProps {
+  uis: ModuleUiSubUnit[];
+}
+
+/**
+ * Hierarchical sub-units rendered under a module row (hub#313). The shape
+ * mirrors parachute-app's per-UI registry: each entry surfaces an icon,
+ * display name, mount path, and lifecycle status. Status badges follow
+ * the same `status-<state>` class convention `ModuleRow` uses for the
+ * supervisor badge, so the SPA's existing palette covers active /
+ * pending-oauth / disabled without new tokens.
+ *
+ * `path` is rendered as a same-origin anchor so an operator clicking
+ * "Gitcoin Brain" lands on `/app/gitcoin-brain` — not a SPA link
+ * (`Link to`) because the sub-unit lives outside the SPA's mount basename
+ * and we want the browser to hard-navigate. Aaron's call: keep the SPA
+ * itself narrow, let the underlying module own its own UI shell.
+ */
+function UiSubUnitsList({ uis }: UiSubUnitsListProps) {
+  return (
+    <details className="module-uis" data-testid="module-uis" open>
+      <summary>
+        Hosted UIs <span className="muted">({uis.length})</span>
+      </summary>
+      <ul className="ui-sub-units">
+        {uis.map((u) => {
+          const status = u.status ?? "active";
+          return (
+            <li key={u.name} className="ui-sub-unit" data-name={u.name}>
+              {u.icon_url && (
+                <img
+                  src={u.icon_url}
+                  alt=""
+                  className="ui-icon"
+                  width={20}
+                  height={20}
+                  loading="lazy"
+                />
+              )}
+              <div className="ui-sub-unit-body">
+                <a href={u.path} className="ui-sub-unit-link">
+                  <strong>{u.display_name}</strong>
+                  <span className="muted"> · {u.path}</span>
+                </a>
+                {u.tagline ? <p className="tagline">{u.tagline}</p> : null}
+              </div>
+              <span className={`status status-${status}`} data-testid={`ui-status-${u.name}`}>
+                {status}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </details>
+  );
 }
 
 interface ChannelToggleProps {

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -655,6 +655,117 @@ a.btn:hover {
 }
 
 /*
+ * Hosted-UI sub-units rendered under a `.module-row` (hub#313 / #315).
+ *
+ * `<details className="module-uis">` is the operator-collapsible
+ * wrapper; the `<ul className="ui-sub-units">` inside it lays each
+ * sub-unit out as a single icon + body + status row. Indented from the
+ * parent module row so the operator reads it as "stuff this module
+ * hosts" rather than as a peer module. Status badges reuse the same
+ * `.status status-<state>` shape as the supervisor badge on
+ * `.module-row` — colors are sourced from the existing accent / warn /
+ * fg-muted tokens so the palette stays continuous.
+ */
+.module-uis {
+  margin: 0.5rem 0 0;
+  padding: 0.5rem 0 0;
+  border-top: 1px solid var(--border-light);
+}
+.module-uis > summary {
+  cursor: pointer;
+  font-size: 0.88rem;
+  color: var(--fg-muted);
+  font-weight: 500;
+  padding: 0.15rem 0;
+  list-style: revert; /* keep native disclosure triangle */
+}
+.module-uis > summary:hover {
+  color: var(--fg);
+}
+.ui-sub-units {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.ui-sub-unit {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--bg-soft);
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.ui-sub-unit:hover {
+  border-color: var(--accent);
+  background: white;
+}
+.ui-icon {
+  flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  object-fit: contain;
+}
+.ui-sub-unit-body {
+  flex: 1 1 0;
+  min-width: 0;
+}
+.ui-sub-unit-link {
+  color: var(--fg);
+  font-size: 0.95rem;
+  text-decoration: none;
+}
+.ui-sub-unit-link:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+.ui-sub-unit-link strong {
+  font-weight: 600;
+}
+.ui-sub-unit .tagline {
+  margin: 0.2rem 0 0;
+  font-size: 0.82rem;
+  color: var(--fg-muted);
+}
+
+/*
+ * Generic `.status` badge + per-state colors. Used by both the
+ * `.module-row` supervisor badge and by `.ui-sub-unit` (hub#313).
+ * Shape mirrors `.tag` — small inline-block pill, palette-aligned.
+ * Defaults to muted gray; per-state classes override only color +
+ * background so adding a new state is a one-rule extension.
+ */
+.status {
+  flex: 0 0 auto;
+  display: inline-block;
+  padding: 0.1em 0.55em;
+  background: var(--bg-soft);
+  color: var(--fg-muted);
+  border-radius: 4px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.status-active {
+  background: var(--success-soft);
+  color: var(--success);
+}
+.status-pending-oauth {
+  background: var(--warn-soft);
+  color: var(--warn);
+}
+.status-disabled {
+  background: var(--bg-soft);
+  color: var(--fg-dim);
+}
+
+/*
  * Visually-hidden utility for screen-reader-only text. Used by the
  * first-admin disabled-Delete button on /admin/users to wire
  * `aria-describedby` to an explanation that's invisible to sighted


### PR DESCRIPTION
## Summary

- Adds optional `uis: Record<string, UiSubUnit>` to `ServiceEntry` so parachute-app (and a future vault migration) can register hosted UIs as discoverable sub-rows under their parent module. Per [parachute-app design doc §12](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-05-21-parachute-apps-design.md#12-servicesjson-shape--hierarchical-mirror-vault).
- Wires the new shape through three discovery surfaces: `/.well-known/parachute.json` (well-known doc), `GET /api/modules` (admin SPA's catalog endpoint), and the admin SPA Modules view.
- Purely additive — every pre-#313 flat row (vault / scribe / notes / runner) round-trips byte-identically; the field is optional throughout the read + write paths.

## What landed

- **Schema (`src/services-manifest.ts`).** New `UiSubUnit` interface + `UiSubUnitStatus` union. `validateEntry` → `validateUis` → `validateUiSubUnit` validates the shape and pinpoints the offending sub-unit key in the error message.
- **Well-known doc.** `WellKnownServicesEntry.uis?: WellKnownUiSubUnit[]` — map-keys promoted to `name`, `path` joined onto `canonicalOrigin` into a deep-linkable `url`, `iconUrl` resolved through the same path-or-absolute-URL rule the services-level `uiUrl` uses. Empty / absent maps omit the field (preserves the public contract).
- **`GET /api/modules`.** Adds `uis: UiSubUnitWireShape[]` per row — snake-case (`display_name`, `oauth_client_id`, `icon_url`), empty array when the row doesn't declare `uis` so the SPA can `.map` unconditionally.
- **Admin SPA Modules view (`web/ui/src/routes/Modules.tsx`).** Installed-module rows render a `<details>`-wrapped "Hosted UIs" section per sub-unit when `uis` is non-empty. Icon + displayName + path (same-origin anchor — the sub-unit lives outside the SPA basename, so hard nav) + tagline + status badge via the existing `status-<state>` palette.

## UiSubUnit shape (canonical)

```ts
export interface UiSubUnit {
  displayName: string;
  tagline?: string;
  path: string;
  iconUrl?: string;
  version?: string;
  oauthClientId?: string;
  status?: "active" | "pending-oauth" | "disabled";
}
```

`oauthClientId` is the load-bearing field for app's "install-once, multi-vault" pattern (design doc §6): each hosted UI gets its own OAuth client at install time, the operator sees that id verbatim on the approval surface, and revoking the client retires the UI's access in one shot without touching its siblings.

## Out of scope

- **Vault doesn't migrate yet.** Vault still uses flat `paths: ["/vault/default", "/vault/gitcoin"]`. A future PR can adopt the hierarchical shape so per-instance display metadata (tagline, icon) can ride alongside the path. The flat shape continues to work through hub's existing path-prefix routing.
- **Phase 2 `required_schema` declaration on `UiSubUnit`** — not needed for app's first integration; can land alongside vault's migration if useful.

## Tests

- `bun run typecheck` clean (root + `web/ui`).
- `bun test ./src` 1805 pass (was 1781; +24 — 13 in services-manifest, 8 in well-known, 3 in api-modules).
- `cd web/ui && bun run test` 188 pass (was 183; +5 in Modules.test.tsx).
- `bunx biome check src/` clean.

## Test plan

- [ ] Reviewer dispatch confirms schema + wire shape + SPA rendering all align with parachute-app design doc §12.
- [ ] Backwards-compat sanity: an existing services.json without any `uis` fields renders unchanged in `/.well-known/parachute.json` (no new `uis: []` noise on flat rows in the well-known shape — the field is omitted).
- [ ] Smoke (when hub + parachute-app both running): apps writes a `uis` map → hub admin SPA Modules page shows the App module with expandable sub-units → `/.well-known/parachute.json` includes the UIs in the hierarchical shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)