### PR TITLE
feat(hub): /notes/* → /app/notes/* redirect (Notes migration Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.9] - 2026-05-22
+
+**feat(hub): `/notes/*` → `/app/notes/*` redirect (Phase 2 of Notes migration arc).**
+
+Phase 2 of the Notes-as-app migration (parachute-app design doc §16). The notes-daemon retires over four phases; this PR adds the hub-side redirect window so operators with existing `/notes/*` bookmarks transparently land on the apps-hosted Notes (`parachute-app add @openparachute/notes-ui --name notes --path /app/notes`). Phase 3 (parachute-notes v0.5) retires the redirect entirely once the legacy daemon is fully decommissioned.
+
+**What landed.**
+
+- **`/notes`, `/notes/`, `/notes/*` → 301 → `/app/notes[/...]`.** Method-agnostic, matches the shape of the existing back-compat 301s in hub-server's dispatch. Query string is preserved verbatim. The new redirect block sits between the legacy `/admin/login`-style 301s and the CORS preflight handler — it fires before the generic services.json proxy (which is where `/notes/*` would otherwise route to notes-daemon).
+- **`hub_settings.notes_redirect_disabled` opt-out flag.** Default `false` (redirect on); set to `true` to skip the redirect and fall through to the legacy services.json proxy. The escape hatch covers the deprecation-window case where an operator runs notes-as-module without parachute-app installed yet — without the opt-out they'd hit redirect → 404. Stored as `"true"` / absent-row in the bare KV `hub_settings` table; `setNotesRedirectDisabled(false)` clears the row rather than writing `"false"` so the canonical "redirect on" default is an absent-row state. New helpers: `isNotesRedirectDisabled`, `setNotesRedirectDisabled`.
+- **Throttled migration log.** `[notes-migration] redirect /notes/foo → /app/notes/foo` fires on each hit, throttled per-path to one line per 60 seconds — operators see migration activity without flooding stdout if a misconfigured PWA loops.
+- **Boundary check on the match predicate.** `/notes`, `/notes/`, `/notes/*` match; `/notesy`, `/notes-archive`, `/vault/default/notes` do NOT (the prefix-with-no-boundary case that would otherwise capture unrelated paths).
+- **Lazy DB read.** The dispatch only consults `getDb` when the path actually matches a legacy notes prefix — every non-notes request still skips the DB entirely (the `/health` route + several CORS preflight tests assert this).
+
+**Tests.** `bun run typecheck` clean. `bun test ./src` 1836 pass (was 1805; +31 — 5 in hub-server's redirect-routing block, 22 in the new notes-redirect helper suite, 4 in hub-settings for the new flag). `cd web/ui && bun run test` 188 pass (unchanged — SPA not touched). `bunx biome check src/` clean.
+
+**Cross-references.** parachute-app design doc §16 names the four-phase Notes migration; this PR lands Phase 2. The opt-out flag retires when Phase 3 ships (parachute-notes v0.5 fully retires the module form + the redirect goes away).
+
 ## [0.5.13-rc.8] - 2026-05-22
 
 **feat(hub): ServiceEntry hierarchical `uis` schema extension (#313) — parachute-app sub-unit discovery.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.8",
+  "version": "0.5.13-rc.9",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -6,6 +6,8 @@ import { fileURLToPath } from "node:url";
 import { HUB_SVC, hubPortPath } from "../hub-control.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { findServiceUpstream, findVaultUpstream, hubFetch, layerOf } from "../hub-server.ts";
+import { setNotesRedirectDisabled } from "../hub-settings.ts";
+import { clearNotesRedirectLogState } from "../notes-redirect.ts";
 import { pidPath } from "../process-state.ts";
 import { type ServiceEntry, writeManifest } from "../services-manifest.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
@@ -858,6 +860,92 @@ describe("hubFetch routing", () => {
       const res = await hubFetch(h.dir)(req("/admin/logout"));
       expect(res.status).toBe(301);
       expect(res.headers.get("location")).toBe("/logout");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // Notes-as-app migration Phase 2 (parachute-app design doc §16).
+  // `/notes/*` 301-redirects to `/app/notes/*` so legacy bookmarks land
+  // on the apps-hosted Notes. Tested with no DB (the migration-default
+  // path — absent DB or absent row means redirect-on).
+  test("301: /notes/ → /app/notes/", async () => {
+    clearNotesRedirectLogState();
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir)(req("/notes/"));
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("/app/notes/");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("301: bare /notes → /app/notes", async () => {
+    // The bare-prefix form (no trailing slash) is the path browsers land
+    // on when an operator types `https://hub.example/notes` directly.
+    clearNotesRedirectLogState();
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir)(req("/notes"));
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("/app/notes");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("301: /notes/some/path?q=1 preserves query string", async () => {
+    clearNotesRedirectLogState();
+    const h = makeHarness();
+    try {
+      const res = await hubFetch(h.dir)(req("/notes/some/path?q=1&n=2"));
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe("/app/notes/some/path?q=1&n=2");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("301: /notes/* does NOT redirect when notes_redirect_disabled = true", async () => {
+    // Opt-out flag — the legacy operator running notes-as-module without
+    // parachute-app installed sets this so the dispatch falls through to
+    // the generic services.json proxy. Without an upstream registered
+    // here we expect a 404 (the proxy can't find a /notes route), which
+    // is exactly the pre-redirect behavior — proving the opt-out wires
+    // the dispatch back to the same shape it had before this PR.
+    clearNotesRedirectLogState();
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [] }, h.manifestPath);
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        setNotesRedirectDisabled(db, true);
+        const res = await hubFetch(h.dir, {
+          manifestPath: h.manifestPath,
+          getDb: () => db,
+        })(req("/notes/sw.js"));
+        expect(res.status).toBe(404);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/notesy (unrelated prefix) does NOT match the notes redirect", async () => {
+    // Boundary check — `/notes` matches `/notes`, `/notes/`, and
+    // `/notes/<rest>`, but a path that merely starts with the same five
+    // letters (`/notesy`, `/notes-archive`) is unrelated and falls
+    // through to the normal dispatch (which 404s here, no service
+    // registered).
+    clearNotesRedirectLogState();
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [] }, h.manifestPath);
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(req("/notesy"));
+      expect(res.status).toBe(404);
     } finally {
       h.cleanup();
     }
@@ -1805,10 +1893,15 @@ describe("hubFetch /<svc>/* generic proxy dispatch (#182)", () => {
     }
   });
 
-  test("routes /notes/sw.js to the matching upstream", async () => {
+  test("routes /notes/sw.js to the matching upstream (notes-redirect opt-out)", async () => {
     // Notes is the canonical path-mount case — the PWA shell has to see the
     // full `/notes/...` path so its service worker registers correctly (the
     // motivator for the `--mount` strip in notes-serve.ts).
+    //
+    // Post-parachute-app §16 Phase 2 the `/notes/*` path 301-redirects to
+    // `/app/notes/*` by default. This test pins the notes-as-module legacy
+    // path (notes-daemon still serving its own mount); set the opt-out
+    // flag so the dispatch falls through to the generic proxy.
     const h = makeHarness();
     const upstream = startUpstream("notes");
     try {
@@ -1826,12 +1919,21 @@ describe("hubFetch /<svc>/* generic proxy dispatch (#182)", () => {
         },
         h.manifestPath,
       );
-      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
-      const res = await fetcher(req("/notes/sw.js"));
-      expect(res.status).toBe(200);
-      const body = (await res.json()) as { tag: string; pathname: string };
-      expect(body.tag).toBe("notes");
-      expect(body.pathname).toBe("/notes/sw.js");
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        setNotesRedirectDisabled(db, true);
+        const fetcher = hubFetch(h.dir, {
+          manifestPath: h.manifestPath,
+          getDb: () => db,
+        });
+        const res = await fetcher(req("/notes/sw.js"));
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { tag: string; pathname: string };
+        expect(body.tag).toBe("notes");
+        expect(body.pathname).toBe("/notes/sw.js");
+      } finally {
+        db.close();
+      }
     } finally {
       upstream.stop();
       h.cleanup();
@@ -2002,6 +2104,10 @@ describe("hubFetch /<svc>/* generic proxy dispatch (#182)", () => {
     // forward the full path. The /notes/sw.js test above already exercises
     // this in the happy case; this test makes the absence-of-flag → keep-
     // prefix contract explicit.
+    //
+    // Notes-as-module legacy: the notes-redirect opt-out is set so the
+    // /notes/* request reaches proxyToService instead of 301-redirecting
+    // (parachute-app §16 Phase 2).
     const h = makeHarness();
     const upstream = startUpstream("notes");
     try {
@@ -2020,11 +2126,20 @@ describe("hubFetch /<svc>/* generic proxy dispatch (#182)", () => {
         },
         h.manifestPath,
       );
-      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
-      const res = await fetcher(req("/notes/health"));
-      expect(res.status).toBe(200);
-      const body = (await res.json()) as { pathname: string };
-      expect(body.pathname).toBe("/notes/health");
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        setNotesRedirectDisabled(db, true);
+        const fetcher = hubFetch(h.dir, {
+          manifestPath: h.manifestPath,
+          getDb: () => db,
+        });
+        const res = await fetcher(req("/notes/health"));
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { pathname: string };
+        expect(body.pathname).toBe("/notes/health");
+      } finally {
+        db.close();
+      }
     } finally {
       upstream.stop();
       h.cleanup();
@@ -2037,6 +2152,9 @@ describe("hubFetch /<svc>/* generic proxy dispatch (#182)", () => {
     // keep-prefix behavior as omitting the field. Confirms validator round-
     // tripping doesn't lose the explicit-false (separate from the absent
     // case which is checked above).
+    //
+    // Notes-as-module legacy: opt-out flag set so /notes/* reaches the
+    // proxy instead of 301-redirecting (parachute-app §16 Phase 2).
     const h = makeHarness();
     const upstream = startUpstream("notes");
     try {
@@ -2055,11 +2173,20 @@ describe("hubFetch /<svc>/* generic proxy dispatch (#182)", () => {
         },
         h.manifestPath,
       );
-      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
-      const res = await fetcher(req("/notes/sw.js"));
-      expect(res.status).toBe(200);
-      const body = (await res.json()) as { pathname: string };
-      expect(body.pathname).toBe("/notes/sw.js");
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        setNotesRedirectDisabled(db, true);
+        const fetcher = hubFetch(h.dir, {
+          manifestPath: h.manifestPath,
+          getDb: () => db,
+        });
+        const res = await fetcher(req("/notes/sw.js"));
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { pathname: string };
+        expect(body.pathname).toBe("/notes/sw.js");
+      } finally {
+        db.close();
+      }
     } finally {
       upstream.stop();
       h.cleanup();
@@ -2234,6 +2361,9 @@ describe("hubFetch /<svc>/* generic proxy dispatch (#182)", () => {
     // because `pathname.startsWith("/notes//")` is always false. Hub
     // returned 404 for `/notes/assets/*.js` even though the SPA shell
     // loaded fine, breaking the page silently.
+    //
+    // Notes-as-module legacy: opt-out flag set so /notes/* reaches the
+    // proxy instead of 301-redirecting (parachute-app §16 Phase 2).
     const h = makeHarness();
     const upstream = startUpstream("notes");
     try {
@@ -2251,14 +2381,23 @@ describe("hubFetch /<svc>/* generic proxy dispatch (#182)", () => {
         },
         h.manifestPath,
       );
-      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
-      const res = await fetcher(req("/notes/assets/index-XXX.js"));
-      expect(res.status).toBe(200);
-      const body = (await res.json()) as { tag: string; pathname: string };
-      expect(body.tag).toBe("notes");
-      // Path is forwarded verbatim — no stripPrefix on the notes entry, so
-      // backend sees the full mount-prefixed path.
-      expect(body.pathname).toBe("/notes/assets/index-XXX.js");
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        setNotesRedirectDisabled(db, true);
+        const fetcher = hubFetch(h.dir, {
+          manifestPath: h.manifestPath,
+          getDb: () => db,
+        });
+        const res = await fetcher(req("/notes/assets/index-XXX.js"));
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { tag: string; pathname: string };
+        expect(body.tag).toBe("notes");
+        // Path is forwarded verbatim — no stripPrefix on the notes entry,
+        // so backend sees the full mount-prefixed path.
+        expect(body.pathname).toBe("/notes/assets/index-XXX.js");
+      } finally {
+        db.close();
+      }
     } finally {
       upstream.stop();
       h.cleanup();

--- a/src/__tests__/hub-settings.test.ts
+++ b/src/__tests__/hub-settings.test.ts
@@ -23,10 +23,12 @@ import {
   getSetting,
   isFirstClientAutoApproveWindowOpen,
   isModuleInstallChannel,
+  isNotesRedirectDisabled,
   isSetupExposeMode,
   openFirstClientAutoApproveWindow,
   setHubOrigin,
   setModuleInstallChannel,
+  setNotesRedirectDisabled,
   setSetting,
 } from "../hub-settings.ts";
 
@@ -466,6 +468,69 @@ describe("hub-settings — hub_origin (hub#298)", () => {
       } else {
         process.env.PARACHUTE_HUB_ORIGIN = prior;
       }
+    }
+  });
+});
+
+describe("hub-settings — notes_redirect_disabled (parachute-app §16)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "hub-settings-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("isNotesRedirectDisabled defaults to false when no row is present", () => {
+    // Migration-default direction: absent row = redirect on.
+    const db = openHubDb(hubDbPath(dir));
+    try {
+      expect(isNotesRedirectDisabled(db)).toBe(false);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("setNotesRedirectDisabled(true) flips the flag to true", () => {
+    const db = openHubDb(hubDbPath(dir));
+    try {
+      setNotesRedirectDisabled(db, true);
+      expect(isNotesRedirectDisabled(db)).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("setNotesRedirectDisabled(false) clears the row → reads as false again", () => {
+    // Passing false clears the row rather than writing "false" — the
+    // absent-row state is the canonical redirect-on default.
+    const db = openHubDb(hubDbPath(dir));
+    try {
+      setNotesRedirectDisabled(db, true);
+      setNotesRedirectDisabled(db, false);
+      expect(isNotesRedirectDisabled(db)).toBe(false);
+      // The underlying row is actually gone, not stamped with "false".
+      expect(getSetting(db, "notes_redirect_disabled")).toBeUndefined();
+    } finally {
+      db.close();
+    }
+  });
+
+  test("any non-'true' value parses as redirect-on (corruption-resistant)", () => {
+    // The KV table is TEXT-typed, so a manual sqlite edit or a future
+    // schema drift could land an unexpected value. Read-side strictness
+    // means we only opt-out on the literal "true" — the migration-default
+    // direction is sticky.
+    const db = openHubDb(hubDbPath(dir));
+    try {
+      setSetting(db, "notes_redirect_disabled", "yes");
+      expect(isNotesRedirectDisabled(db)).toBe(false);
+      setSetting(db, "notes_redirect_disabled", "1");
+      expect(isNotesRedirectDisabled(db)).toBe(false);
+      setSetting(db, "notes_redirect_disabled", "false");
+      expect(isNotesRedirectDisabled(db)).toBe(false);
+      setSetting(db, "notes_redirect_disabled", "TRUE");
+      expect(isNotesRedirectDisabled(db)).toBe(false);
+    } finally {
+      db.close();
     }
   });
 });

--- a/src/__tests__/notes-redirect.test.ts
+++ b/src/__tests__/notes-redirect.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for the `/notes/*` → `/app/notes/*` redirect helper (Notes-as-app
+ * migration Phase 2, parachute-app design doc §16).
+ *
+ * Covers the path-match predicate, the target-URL builder, the DB-aware
+ * opt-out branching, and the throttled logger.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { setNotesRedirectDisabled } from "../hub-settings.ts";
+import {
+  buildNotesRedirectTarget,
+  clearNotesRedirectLogState,
+  isLegacyNotesPath,
+  logNotesRedirect,
+  maybeRedirectNotes,
+} from "../notes-redirect.ts";
+
+describe("notes-redirect — isLegacyNotesPath", () => {
+  test("matches the bare /notes path", () => {
+    expect(isLegacyNotesPath("/notes")).toBe(true);
+  });
+
+  test("matches the trailing-slash form /notes/", () => {
+    expect(isLegacyNotesPath("/notes/")).toBe(true);
+  });
+
+  test("matches a sub-path /notes/sw.js", () => {
+    expect(isLegacyNotesPath("/notes/sw.js")).toBe(true);
+  });
+
+  test("matches a deep sub-path /notes/foo/bar/baz", () => {
+    expect(isLegacyNotesPath("/notes/foo/bar/baz")).toBe(true);
+  });
+
+  test("does NOT match unrelated prefix /notesy (no boundary)", () => {
+    expect(isLegacyNotesPath("/notesy")).toBe(false);
+  });
+
+  test("does NOT match a same-letters-different-mount /notes-archive", () => {
+    expect(isLegacyNotesPath("/notes-archive")).toBe(false);
+  });
+
+  test("does NOT match an unrelated path like /vault/default/notes", () => {
+    // Per-vault content lives under /vault/<name>/* and shouldn't be
+    // captured by this matcher even though "notes" appears in the path.
+    expect(isLegacyNotesPath("/vault/default/notes")).toBe(false);
+  });
+});
+
+describe("notes-redirect — buildNotesRedirectTarget", () => {
+  test("rewrites the bare path /notes → /app/notes", () => {
+    expect(buildNotesRedirectTarget("/notes", "")).toBe("/app/notes");
+  });
+
+  test("rewrites the trailing-slash form /notes/ → /app/notes/", () => {
+    expect(buildNotesRedirectTarget("/notes/", "")).toBe("/app/notes/");
+  });
+
+  test("rewrites a sub-path /notes/sw.js → /app/notes/sw.js", () => {
+    expect(buildNotesRedirectTarget("/notes/sw.js", "")).toBe("/app/notes/sw.js");
+  });
+
+  test("preserves a single-param query string", () => {
+    expect(buildNotesRedirectTarget("/notes/foo", "?q=1")).toBe("/app/notes/foo?q=1");
+  });
+
+  test("preserves a multi-param query string verbatim (no re-encoding)", () => {
+    expect(buildNotesRedirectTarget("/notes/foo", "?a=1&b=hello%20world")).toBe(
+      "/app/notes/foo?a=1&b=hello%20world",
+    );
+  });
+
+  test("preserves the bare /notes + query (no trailing slash on rewrite)", () => {
+    expect(buildNotesRedirectTarget("/notes", "?next=foo")).toBe("/app/notes?next=foo");
+  });
+});
+
+describe("notes-redirect — maybeRedirectNotes", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "notes-redirect-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("returns the target URL when the path matches and no DB is configured", () => {
+    // Absent DB defaults to redirect-on — the migration-default direction.
+    // Operators flipping the opt-out flag have a hub-with-DB; the default
+    // doesn't depend on DB readiness.
+    expect(maybeRedirectNotes("/notes/foo", "?q=1", undefined)).toBe("/app/notes/foo?q=1");
+  });
+
+  test("returns the target URL when the path matches and the flag is absent (default)", () => {
+    const db = openHubDb(hubDbPath(dir));
+    try {
+      expect(maybeRedirectNotes("/notes/foo", "", db)).toBe("/app/notes/foo");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("returns the target URL when the flag is explicitly false (setNotesRedirectDisabled(false))", () => {
+    // Writing `false` clears the row, so the result should equal the
+    // absent-row case — redirect on.
+    const db = openHubDb(hubDbPath(dir));
+    try {
+      setNotesRedirectDisabled(db, true);
+      setNotesRedirectDisabled(db, false);
+      expect(maybeRedirectNotes("/notes/foo", "", db)).toBe("/app/notes/foo");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("returns undefined when the flag is true (operator opt-out)", () => {
+    const db = openHubDb(hubDbPath(dir));
+    try {
+      setNotesRedirectDisabled(db, true);
+      expect(maybeRedirectNotes("/notes/foo", "", db)).toBeUndefined();
+    } finally {
+      db.close();
+    }
+  });
+
+  test("returns undefined when the path does not match (unrelated prefix)", () => {
+    const db = openHubDb(hubDbPath(dir));
+    try {
+      expect(maybeRedirectNotes("/notesy", "", db)).toBeUndefined();
+      expect(maybeRedirectNotes("/admin/vaults", "", db)).toBeUndefined();
+      expect(maybeRedirectNotes("/vault/default", "", db)).toBeUndefined();
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe("notes-redirect — logNotesRedirect (throttled)", () => {
+  beforeEach(() => {
+    clearNotesRedirectLogState();
+  });
+
+  test("logs once on the first hit", () => {
+    const lines: string[] = [];
+    logNotesRedirect("/notes/foo", "/app/notes/foo", {
+      now: () => 1_000_000,
+      log: (m) => lines.push(m),
+    });
+    expect(lines).toEqual(["[notes-migration] redirect /notes/foo → /app/notes/foo"]);
+  });
+
+  test("throttles repeated hits to the same path within the window", () => {
+    const lines: string[] = [];
+    // Five hits within a 10-second span — well inside the 60-second window.
+    for (let i = 0; i < 5; i++) {
+      logNotesRedirect("/notes/foo", "/app/notes/foo", {
+        now: () => 1_000_000 + i * 2_000,
+        log: (m) => lines.push(m),
+      });
+    }
+    expect(lines).toHaveLength(1);
+  });
+
+  test("re-logs the same path after the window expires", () => {
+    const lines: string[] = [];
+    logNotesRedirect("/notes/foo", "/app/notes/foo", {
+      now: () => 1_000_000,
+      log: (m) => lines.push(m),
+    });
+    // 60_001 ms later → window has rolled, log fires again.
+    logNotesRedirect("/notes/foo", "/app/notes/foo", {
+      now: () => 1_000_000 + 60_001,
+      log: (m) => lines.push(m),
+    });
+    expect(lines).toHaveLength(2);
+  });
+
+  test("logs distinct paths independently (per-path bucket)", () => {
+    const lines: string[] = [];
+    logNotesRedirect("/notes/foo", "/app/notes/foo", {
+      now: () => 1_000_000,
+      log: (m) => lines.push(m),
+    });
+    logNotesRedirect("/notes/bar", "/app/notes/bar", {
+      now: () => 1_000_000,
+      log: (m) => lines.push(m),
+    });
+    // Two distinct paths → two log lines despite identical timestamps.
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain("/notes/foo");
+    expect(lines[1]).toContain("/notes/bar");
+  });
+});

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -22,6 +22,11 @@
  *   /hub, /hub/                                → 301 → /admin/vaults
  *   /admin/login, /admin/logout                → 301 → /login, /logout
  *
+ *   # Notes-as-app migration Phase 2 (parachute-app design doc §16).
+ *   /notes, /notes/, /notes/*                  → 301 → /app/notes[/...]
+ *                                                (opt-out via
+ *                                                 hub_settings.notes_redirect_disabled)
+ *
  *   # Discovery + well-known.
  *   /, /hub.html                               → hub.html (the discovery page)
  *   /.well-known/parachute.json                → built dynamically from services.json
@@ -148,6 +153,7 @@ import {
   type ModuleManifest,
   readModuleManifest as defaultReadModuleManifest,
 } from "./module-manifest.ts";
+import { logNotesRedirect, maybeRedirectNotes } from "./notes-redirect.ts";
 import {
   authorizationServerMetadata,
   handleApproveClientPost,
@@ -1067,6 +1073,34 @@ export function hubFetch(
         status: 301,
         headers: { location: `/logout${url.search}` },
       });
+    }
+
+    // Notes-as-app migration Phase 2 (parachute-app design doc §16).
+    // `/notes/*` 301-redirects to `/app/notes/*` so legacy bookmarks land on
+    // the apps-hosted Notes. Default-on; operators on notes-as-module-only
+    // installs can opt out via `hub_settings.notes_redirect_disabled = true`
+    // (see hub-settings.ts). The opt-out exists so a legacy operator
+    // doesn't hit redirect → 404 in the deprecation window. Phase 3
+    // (parachute-notes v0.5) retires this redirect entirely.
+    //
+    // Method-agnostic — same shape as the other back-compat 301s above.
+    // The browser re-issues GET on the new URL per RFC 7231 (a POST won't
+    // round-trip its body, but no /notes/* path hosts a POST endpoint
+    // worth preserving — the Notes PWA is read-write against vault, not
+    // against the hub mount itself).
+    //
+    // Lazy DB read: only consult `getDb` when the path actually matches a
+    // legacy notes prefix — every non-notes request must NOT touch the DB
+    // here (some tests + the /health route assert getDb is never called).
+    if (pathname === "/notes" || pathname.startsWith("/notes/")) {
+      const notesRedirect = maybeRedirectNotes(pathname, url.search, getDb?.());
+      if (notesRedirect !== undefined) {
+        logNotesRedirect(pathname, notesRedirect);
+        return new Response("", {
+          status: 301,
+          headers: { location: notesRedirect },
+        });
+      }
     }
 
     // CORS preflight for the public OAuth + discovery surface. Browsers

--- a/src/hub-settings.ts
+++ b/src/hub-settings.ts
@@ -66,7 +66,19 @@ export type HubSettingKey =
   // Operators must accept that flipping the canonical hub URL
   // invalidates any tokens already in circulation (issuer mismatch on
   // verification) — surfaced in the admin SPA's helper copy.
-  | "hub_origin";
+  | "hub_origin"
+  // Notes-as-app migration Phase 2 (parachute-app design doc §16).
+  // When unset (default) or "false", hub serves a 301 redirect from
+  // `/notes/*` → `/app/notes/*` so existing bookmarks transparently
+  // follow the operator to the apps-hosted Notes. When "true", the
+  // redirect is skipped and `/notes/*` falls through to the existing
+  // services.json-driven proxy — the escape hatch for operators
+  // running notes-as-a-module only (no parachute-app installed yet)
+  // who want the legacy daemon to keep serving its old mount during
+  // the deprecation window. Stored as the literal string "true" /
+  // "false"; any other value parses as "redirect on" (the migration
+  // default — operators must opt out, not opt in).
+  | "notes_redirect_disabled";
 
 export type SetupExposeMode = "localhost" | "tailnet" | "public";
 
@@ -308,4 +320,41 @@ export function setHubOrigin(db: Database, value: string | null): void {
     return;
   }
   setSetting(db, "hub_origin", value);
+}
+
+// --- domain helpers: notes-as-app redirect (parachute-app §16 Phase 2) ----
+
+/**
+ * Read whether the `/notes/*` → `/app/notes/*` redirect is disabled. Default
+ * is `false` (redirect on) — Phase 2 migrates operators to apps-hosted
+ * Notes, so the bookmark-friendly path is the default-on behavior. Only an
+ * operator running notes-as-a-module without parachute-app installed should
+ * flip this to `true`.
+ *
+ * Returns `true` only when the stored value is the literal string "true".
+ * Any other value (missing row, "false", typo, empty string) means
+ * redirect-enabled — the migration-default direction.
+ */
+export function isNotesRedirectDisabled(db: Database): boolean {
+  return getSetting(db, "notes_redirect_disabled") === "true";
+}
+
+/**
+ * Write the notes-redirect opt-out flag. The string form ("true"/"false")
+ * mirrors how other boolean-ish settings would land if we add them — the
+ * KV table is TEXT-typed, and centralizing the encoding here keeps any
+ * future caller from accidentally storing "1" / "0" / "on" / etc.
+ *
+ * Passing `false` deletes the row rather than writing the string "false"
+ * — the absent-row state is the canonical "redirect on" default, and
+ * leaving an explicit "false" in the row would be a footgun if a future
+ * default flip ever made absence mean something different. (Mirrors the
+ * `setHubOrigin(null)` semantics.)
+ */
+export function setNotesRedirectDisabled(db: Database, value: boolean): void {
+  if (value) {
+    setSetting(db, "notes_redirect_disabled", "true");
+  } else {
+    deleteSetting(db, "notes_redirect_disabled");
+  }
 }

--- a/src/notes-redirect.ts
+++ b/src/notes-redirect.ts
@@ -1,0 +1,121 @@
+/**
+ * Notes-as-app migration Phase 2 (parachute-app design doc §16).
+ *
+ * When parachute-app ships and Notes installs as `parachute-app add
+ * @openparachute/notes-ui --name notes --path /app/notes`, operators with
+ * existing `/notes/*` bookmarks need a transparent bridge. The hub serves a
+ * 301 redirect from `/notes/*` → `/app/notes/*` so:
+ *
+ *   - cached operator URLs (notes PWA install banners, browser history,
+ *     in-vault links) keep working
+ *   - the apps-hosted Notes inherits the traffic without per-operator
+ *     coordination
+ *   - Phase 3 retires the redirect entirely once parachute-notes (the
+ *     module form) is fully decommissioned
+ *
+ * The redirect is default-on. Operators still running notes-as-module
+ * without parachute-app installed can opt out via the `hub_settings`
+ * row `notes_redirect_disabled = "true"` (see hub-settings.ts) — without
+ * the escape hatch they'd hit a redirect → 404 loop the moment apps isn't
+ * present. The opt-out is the legacy-mode crutch, not the default.
+ *
+ * Placement in hub-server's dispatch matters: this fires BEFORE the
+ * generic services.json proxy (which is where `/notes/*` would otherwise
+ * route to the notes-daemon). When the opt-out flag is set, the redirect
+ * is skipped and dispatch falls through to the existing proxy path.
+ */
+
+import type { Database } from "bun:sqlite";
+import { isNotesRedirectDisabled } from "./hub-settings.ts";
+
+/**
+ * Matches the legacy notes mount: the bare `/notes`, the trailing-slash
+ * form `/notes/`, and any sub-path `/notes/<rest>`. Doesn't match unrelated
+ * prefixes like `/notesy` or `/notes-archive` — the boundary check rejects
+ * those.
+ */
+export function isLegacyNotesPath(pathname: string): boolean {
+  if (pathname === "/notes" || pathname === "/notes/") return true;
+  return pathname.startsWith("/notes/");
+}
+
+/**
+ * Compute the redirect target from a legacy `/notes/*` pathname + raw query
+ * string. The query is preserved verbatim; the fragment isn't visible
+ * server-side (clients reassemble it after following the redirect).
+ *
+ * The transform is purely path-rewrite — `/notes` → `/app/notes`, `/notes/`
+ * → `/app/notes/`, `/notes/foo/bar` → `/app/notes/foo/bar`.
+ */
+export function buildNotesRedirectTarget(pathname: string, search: string): string {
+  // Slice off the leading "/notes" — what remains is either "" (bare /notes),
+  // "/" (trailing slash), or "/<rest>" (sub-path).
+  const tail = pathname.slice("/notes".length);
+  return `/app/notes${tail}${search}`;
+}
+
+/**
+ * Decide whether a request should be redirected. Returns the new target URL
+ * when yes, `undefined` when no (path doesn't match, or opt-out flag is set,
+ * or no DB is configured so the flag can't be checked — in that last case
+ * we still redirect, since the migration default is on).
+ *
+ * `db` is optional: when absent (test seam or pre-DB-config hub startup),
+ * we redirect anyway — the absent-DB case mirrors absent-row, both meaning
+ * "no operator opt-out exists." The intent is that operators flipping the
+ * opt-out flag have a hub-with-DB; the redirect-on default doesn't depend
+ * on DB readiness.
+ */
+export function maybeRedirectNotes(
+  pathname: string,
+  search: string,
+  db: Database | undefined,
+): string | undefined {
+  if (!isLegacyNotesPath(pathname)) return undefined;
+  if (db !== undefined && isNotesRedirectDisabled(db)) return undefined;
+  return buildNotesRedirectTarget(pathname, search);
+}
+
+/**
+ * Throttled "we redirected an operator" log line, so a misbehaving client
+ * (a stuck PWA, a curl loop) doesn't flood stdout. Each distinct legacy
+ * pathname gets one log line per `RATE_LIMIT_WINDOW_MS` window; the
+ * window resets per-path so a healthy mix of bookmarks still surfaces
+ * operator-visible migration activity.
+ *
+ * Module-level state is fine here — the hub is a single process and the
+ * tracker is bounded in size by the number of distinct legacy paths
+ * operators have bookmarked (small). The `clearNotesRedirectLogState` test
+ * helper resets it between test runs.
+ */
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const lastLogAt = new Map<string, number>();
+
+export interface LogNotesRedirectOpts {
+  /** Test seam — production uses `Date.now()`. */
+  now?: () => number;
+  /** Test seam — production uses `console.log`. */
+  log?: (msg: string) => void;
+}
+
+export function logNotesRedirect(
+  pathname: string,
+  target: string,
+  opts: LogNotesRedirectOpts = {},
+): void {
+  const now = opts.now ?? Date.now;
+  const log = opts.log ?? ((msg: string) => console.log(msg));
+  const t = now();
+  const last = lastLogAt.get(pathname);
+  if (last !== undefined && t - last < RATE_LIMIT_WINDOW_MS) return;
+  lastLogAt.set(pathname, t);
+  log(`[notes-migration] redirect ${pathname} → ${target}`);
+}
+
+/**
+ * Test-only: clear the throttle bucket. Bun's module-level state survives
+ * across tests in the same process, so this gives tests a clean slate.
+ */
+export function clearNotesRedirectLogState(): void {
+  lastLogAt.clear();
+}


### PR DESCRIPTION
## Summary

Phase 2 of the Notes-as-app migration (parachute-app design doc §16). The notes-daemon retires over four phases; this PR adds the hub-side `/notes/*` → `/app/notes/*` redirect so operators with existing `/notes/*` bookmarks transparently follow Notes to its apps-hosted home. Phase 3 (parachute-notes v0.5) retires the redirect entirely.

- **Redirect routing.** `/notes`, `/notes/`, `/notes/*` 301 → `/app/notes[/...]`. Method-agnostic, query string preserved. Sits between the legacy `/admin/login`-style 301s and CORS preflight in hub-server's dispatch — fires before the generic services.json proxy.
- **Opt-out flag.** `hub_settings.notes_redirect_disabled` (default false). Set to `true` to skip the redirect and fall through to the legacy services.json proxy — for operators on notes-as-module-only installs without parachute-app, who'd otherwise hit redirect → 404 during the deprecation window.
- **Throttled migration log.** `[notes-migration] redirect /notes/foo → /app/notes/foo`, one line per distinct path per 60 seconds.
- **Lazy DB read.** Hub only consults `getDb` when the path matches a legacy notes prefix — every non-notes request skips the DB entirely.
- **Boundary check.** `/notes`, `/notes/`, `/notes/*` match; `/notesy`, `/notes-archive`, `/vault/default/notes` do not.

Bumps version to `0.5.13-rc.9` (0.5.13 still in rc chain; npm last published rc.4).

## Patterns check

Touches the back-compat-301 pattern in hub-server's dispatch — the new block mirrors the shape of the existing `/admin/login` → `/login` and `/hub/vaults` → `/admin/vaults` redirects. No new pattern; conforms to the established one.

## Cross-references

- parachute-app design doc §16 (`parachute.computer/design/2026-05-21-parachute-apps-design.md`) names the four-phase Notes migration; this PR lands Phase 2.
- `setNotesRedirectDisabled`'s clear-on-false shape mirrors `setHubOrigin(null)` (hub#298) — absent-row is the canonical default state.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test ./src` 1836 pass (was 1805; +31 — 5 in hub-server's redirect-routing block, 22 in the new notes-redirect helper suite, 4 in hub-settings for the new flag)
- [x] `cd web/ui && bun run test` 188 pass (unchanged — SPA not touched)
- [x] `bunx biome check src/` clean
- [ ] Reviewer subagent dispatch
- [ ] Operator smoke: curl `/notes/foo?q=1` against a running hub returns 301 → `/app/notes/foo?q=1`
- [ ] Operator smoke: `setNotesRedirectDisabled(db, true)` + curl `/notes/foo` reaches notes-daemon (if installed) or 404s (legacy operator path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)