### PR TITLE
feat(scope-guard): require jti claim on hub-signed JWTs (#218)

### DIFF
--- a/packages/scope-guard/CHANGELOG.md
+++ b/packages/scope-guard/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to `@openparachute/scope-guard` are documented here. The for
 
 The library's RC cadence is independent of `@openparachute/hub`'s — they ship from the same repo but aren't coupled in version.
 
+## 0.4.0-rc.1 — 2026-05-22
+
+Adds the hub#218 jti-presence hardening: hub-signed JWTs that lack a `jti` claim are rejected by default. **Behaviour-breaking minor** — any adopter that bumps from `0.3.x` will start rejecting jti-less hub-signed tokens. The default is the security floor; an `allowMissingJti: true` opt-out is available for operators with pre-Phase-1 legacy tokens still in flight.
+
+### Why this is hardening, not a bug fix
+
+Per hub#218 (and the conservative-today choice in hub#217 Phase 4), `validateHubJwt` previously *skipped* the revocation lookup for tokens without `jti` — they passed validation entirely. All legitimate hub-issued tokens carry `jti` per the token-registry contract introduced in hub#212 Phase 1 (the `tokens` table is keyed by jti; every mint path — `signAccessToken`, `recordTokenMint`, `signRefreshToken` — stamps one). A jti-less, hub-signed JWT is therefore an anomaly: either a pre-Phase-1 legacy issuance path that should have aged out, or a token forged by an attacker who got a signing key but skipped the registry path. Accepting it is the conservative-today choice; the stricter posture is to reject because revocation cannot be enforced on tokens we can't index.
+
+### Added
+
+- **`HubJwtError(code: "shape", "hub JWT missing required \`jti\` claim")`** for jti-less or empty-jti tokens. Surfaces alongside the existing `sub`-shape rejection so consumers can branch on `code: "shape"` and inspect the message for the specific missing-field detail.
+- **`CreateScopeGuardOptions.allowMissingJti?: boolean`** — operator opt-out for the strict default. When `true`, jti-less tokens validate successfully (with revocation-lookup skipped, since lists are keyed by jti). When `false` (the default), jti-less tokens are rejected as `code: "shape"`. The opt-out exists for the transition window where operators have legitimate pre-Phase-1 tokens in flight; it's NOT a steady-state configuration.
+- **`CreateScopeGuardOptions.missingJtiLogger?: (info) => void`** — observability seam for the opt-out path. When `allowMissingJti: true` and a jti-less token is accepted, the logger fires with `{ sub, aud, iat }` so operators can monitor the legacy-token decay curve before flipping strict-mode back on. Optional — omitting it gives silent accept.
+
+### Changed
+
+- **`validateHubJwt` rejects jti-less tokens by default.** The jti-presence check runs after signature + iss + sub + audience (so a forged or malformed token's signature failure surfaces first — no information leak about whether the forgery happened to carry a jti) but before the revocation lookup (which depends on jti existing). Tokens that DO carry jti still go through revocation enforcement unchanged.
+- **Empty-string `jti` ("")** is treated identically to a missing claim — the same `code: "shape"` rejection. Accepting it would let a forger bypass the registry contract by emitting `jti: ""`.
+
+### Migration notes for adopters (vault, scribe, parachute-agent)
+
+- **The behaviour change is automatic on dep bump.** Adopters that pick up `0.4.0` will start rejecting any hub-signed JWT without `jti`. Pre-Phase-1 hubs (older than `0.5.7`, before the token-registry contract) issued some tokens without `jti`; those tokens will be rejected once the consumer dep-bumps. Hub mints from `0.5.7` onwards all carry jti, so the practical exposure is "tokens minted before 2026-05 that haven't yet expired."
+- **Operators with legacy tokens in flight** set `allowMissingJti: true` in their `createScopeGuard({ ... })` call during a transition window. Once the legacy decay curve flattens (visible via `missingJtiLogger` traffic dropping to zero), flip back to the strict default.
+- **Adopting consumers should add a regression test** that exercises both paths: (a) a hand-built jti-less token is rejected with `code: "shape"` under the strict default, (b) the same token is accepted under `allowMissingJti: true`.
+
+### Compatibility
+
+- **bundler-resolution consumers (vault, scribe, hub workspace):** behavior change as above. The `vaultScope` claim surface from 0.3.0 carries forward unchanged.
+- **NodeNext-strict consumers (agent's tsc + vitest):** behavior change as above. The `.js`-extension convention from 0.2.1 carries forward.
+- **The new options (`allowMissingJti`, `missingJtiLogger`)** are both optional — the type signature change is additive at the construction site.
+
+### Hub-side audit
+
+Confirmed (via `git grep "SignJWT\\|setJti"` over hub's `src/`) that every JWT mint path in hub goes through `signAccessToken` (`src/jwt-sign.ts`), which always stamps jti via `randomBytes(16).toString("base64url")` when none is supplied. Callers: `oauth-handlers.ts` (auth-code + refresh grants), `api-mint-token.ts`, `operator-token.ts`, `admin-host-admin-token.ts`, `admin-vault-admin-token.ts`, `api-modules-config.ts`, `commands/auth.ts`. No raw `new SignJWT(...)` calls outside `signAccessToken`. The hub side is clean — no mint-path patches needed for this release.
+
 ## [0.3.0] - 2026-05-20
 
 Stable release. Multi-user Phase 1 vault scope enforcement.

--- a/packages/scope-guard/README.md
+++ b/packages/scope-guard/README.md
@@ -6,11 +6,11 @@ The Parachute hub mints OAuth access tokens as RS256 JWTs and publishes its publ
 
 ## What's in the box
 
-- **`createScopeGuard({ hubOrigin, jwks?, jwksGetter? })`** — factory bound to a hub origin. Holds the JWKS getter so the cache lives across requests. `hubOrigin` may be a string or a resolver function (for layered env-var precedence).
-- **`guard.validateHubJwt(token, { expectedAudience? })`** — JWKS-backed verify. Pins `iss` to the configured hub origin, strict-checks `aud` (RFC 7519 string-or-array) when supplied. Throws `HubJwtError` (with a `code`) on failure.
+- **`createScopeGuard({ hubOrigin, jwks?, jwksGetter?, allowMissingJti?, missingJtiLogger? })`** — factory bound to a hub origin. Holds the JWKS getter so the cache lives across requests. `hubOrigin` may be a string or a resolver function (for layered env-var precedence). `allowMissingJti` (default `false` — strict) controls whether hub-signed JWTs lacking a `jti` claim are accepted (see [Versioning](#versioning) for the 0.4.0 rationale).
+- **`guard.validateHubJwt(token, { expectedAudience? })`** — JWKS-backed verify. Pins `iss` to the configured hub origin, strict-checks `aud` (RFC 7519 string-or-array) when supplied. Rejects hub-signed tokens lacking `jti` by default (since 0.4.0; see CHANGELOG for the opt-out). Throws `HubJwtError` (with a `code`) on failure.
 - **`parseScopes(raw)` / `extractBearer(authHeader)` / `looksLikeJwt(token)`** — string helpers every consumer reaches for.
 - **`hasScope(granted, required)`** — generic `<resource>:<verb>` and `<resource>:<name>:<verb>` matcher with `admin ⊇ write ⊇ read` inheritance. The lib is the engine, not the dictionary; per-service vocabularies and cross-resource catch-alls stay in each service.
-- **`HubJwtError.code`** — single error class with a coarse code: `signature | issuer | expired | kid | jwks | audience | shape`. Branch on `code` rather than catching subclasses.
+- **`HubJwtError.code`** — single error class with a coarse code: `signature | issuer | expired | kid | jwks | audience | shape | revoked | revocation_unavailable`. Branch on `code` rather than catching subclasses.
 
 ## Quick start
 

--- a/packages/scope-guard/package.json
+++ b/packages/scope-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scope-guard",
-  "version": "0.3.0",
+  "version": "0.4.0-rc.1",
   "description": "Hub-issued JWT validation for Parachute resource servers (vault, scribe, parachute-agent, third-party modules).",
   "license": "AGPL-3.0",
   "type": "module",

--- a/packages/scope-guard/src/__tests__/validate.test.ts
+++ b/packages/scope-guard/src/__tests__/validate.test.ts
@@ -575,7 +575,13 @@ describe("createScopeGuard — revocation enforcement", () => {
     guard.resetRevocationCache();
   });
 
-  test("token without jti skips revocation lookup entirely", async () => {
+  test("token without jti (strict default) → code: shape, revocation not consulted", async () => {
+    // hub#218 hardening: a hub-signed JWT lacking `jti` is rejected by
+    // default. The hub token-registry contract (hub#212 Phase 1) stamps
+    // jti on every mint; a jti-less hub JWT is an anomaly we refuse to
+    // validate. Also pins ordering: jti-presence check runs before the
+    // revocation lookup (which depends on jti existing), so a jti-less
+    // token costs zero revocation calls.
     let revocationCalls = 0;
     const guard = createScopeGuard({
       hubOrigin: fixture.origin,
@@ -594,11 +600,157 @@ describe("createScopeGuard — revocation enforcement", () => {
       .setIssuedAt(iat)
       .setExpirationTime(iat + 60)
       .sign(kp.privateKey);
-    const claims = await guard.validateHubJwt(tokenNoJti);
-    expect(claims.jti).toBeUndefined();
+    let caught: HubJwtError | undefined;
+    try {
+      await guard.validateHubJwt(tokenNoJti);
+    } catch (e) {
+      caught = e as HubJwtError;
+    }
+    expect(caught).toBeInstanceOf(HubJwtError);
+    expect(caught?.code).toBe("shape");
+    expect(caught?.message).toMatch(/missing required `jti`/);
     expect(revocationCalls).toBe(0);
     guard.resetJwksCache();
     guard.resetRevocationCache();
+  });
+
+  test("token with empty-string jti → code: shape (strict default)", async () => {
+    // Empty-string jti is treated the same as missing — revocation lookup
+    // would be a no-op (no list entry can match the empty string in a way
+    // that maps back to a real token) and accepting it would let an
+    // attacker bypass the registry contract by emitting `jti: ""` on a
+    // forged token.
+    const guard = makeGuard();
+    const iat = Math.floor(Date.now() / 1000);
+    const tokenEmptyJti = await new SignJWT({ scope: "vault:read", client_id: "test-client" })
+      .setProtectedHeader({ alg: "RS256", kid: kp.kid })
+      .setIssuer(fixture.origin)
+      .setSubject("user-1")
+      .setAudience("operator")
+      .setIssuedAt(iat)
+      .setExpirationTime(iat + 60)
+      .setJti("")
+      .sign(kp.privateKey);
+    let caught: HubJwtError | undefined;
+    try {
+      await guard.validateHubJwt(tokenEmptyJti);
+    } catch (e) {
+      caught = e as HubJwtError;
+    }
+    expect(caught).toBeInstanceOf(HubJwtError);
+    expect(caught?.code).toBe("shape");
+    expect(caught?.message).toMatch(/missing required `jti`/);
+    guard.resetJwksCache();
+  });
+
+  test("allowMissingJti: true → jti-less token accepted, logger fires, revocation skipped", async () => {
+    // The opt-out path. Operators with pre-Phase-1 legacy tokens in flight
+    // set `allowMissingJti: true` during the transition window; jti-less
+    // tokens validate successfully but the missing claim is logged so
+    // operators can monitor the legacy-token decay curve before flipping
+    // strict-mode back on.
+    let revocationCalls = 0;
+    const logged: Array<{ sub: string; aud: string | undefined; iat?: number }> = [];
+    const guard = createScopeGuard({
+      hubOrigin: fixture.origin,
+      allowMissingJti: true,
+      missingJtiLogger: (info) => logged.push(info),
+      revocationFetcher: async () => {
+        revocationCalls += 1;
+        return { generated_at: new Date().toISOString(), jtis: [] };
+      },
+    });
+    const iat = Math.floor(Date.now() / 1000);
+    const tokenNoJti = await new SignJWT({ scope: "vault:read", client_id: "test-client" })
+      .setProtectedHeader({ alg: "RS256", kid: kp.kid })
+      .setIssuer(fixture.origin)
+      .setSubject("user-1")
+      .setAudience("operator")
+      .setIssuedAt(iat)
+      .setExpirationTime(iat + 60)
+      .sign(kp.privateKey);
+    const claims = await guard.validateHubJwt(tokenNoJti);
+    expect(claims.jti).toBeUndefined();
+    expect(claims.sub).toBe("user-1");
+    expect(revocationCalls).toBe(0);
+    expect(logged).toHaveLength(1);
+    expect(logged[0]?.sub).toBe("user-1");
+    expect(logged[0]?.aud).toBe("operator");
+    expect(logged[0]?.iat).toBe(iat);
+    guard.resetJwksCache();
+    guard.resetRevocationCache();
+  });
+
+  test("allowMissingJti: true + no logger supplied → no throw, no observability", async () => {
+    // The logger is optional — operators who opt in without wiring a
+    // logger get the back-compat behavior (silent accept). The logger
+    // is the observability seam, not a required dependency of the opt-out.
+    const guard = createScopeGuard({
+      hubOrigin: fixture.origin,
+      allowMissingJti: true,
+    });
+    const iat = Math.floor(Date.now() / 1000);
+    const tokenNoJti = await new SignJWT({ scope: "vault:read", client_id: "test-client" })
+      .setProtectedHeader({ alg: "RS256", kid: kp.kid })
+      .setIssuer(fixture.origin)
+      .setSubject("user-1")
+      .setAudience("operator")
+      .setIssuedAt(iat)
+      .setExpirationTime(iat + 60)
+      .sign(kp.privateKey);
+    const claims = await guard.validateHubJwt(tokenNoJti);
+    expect(claims.jti).toBeUndefined();
+    guard.resetJwksCache();
+  });
+
+  test("allowMissingJti: true does NOT relax revocation enforcement for tokens that DO carry jti", async () => {
+    // The opt-out narrows the jti-presence check, not the revocation
+    // lookup. A token with jti still goes through revocation; opt-out is
+    // a transition aid for legacy tokens, not a general-purpose
+    // security-relax.
+    const guard = createScopeGuard({
+      hubOrigin: fixture.origin,
+      allowMissingJti: true,
+    });
+    fixture.setRevokedJtis(["jti-doomed"]);
+    const token = await signJwt(kp, { iss: fixture.origin, jti: "jti-doomed" });
+    let caught: HubJwtError | undefined;
+    try {
+      await guard.validateHubJwt(token);
+    } catch (e) {
+      caught = e as HubJwtError;
+    }
+    expect(caught?.code).toBe("revoked");
+    guard.resetJwksCache();
+    guard.resetRevocationCache();
+  });
+
+  test("jti-presence check runs AFTER signature/iss/sub/aud (no info leak on malformed tokens)", async () => {
+    // Pin the ordering: a jti-less token whose signature is bad surfaces
+    // as `signature`, not `shape`. Without this ordering an attacker
+    // probing for forgeable shapes could distinguish "bad signature on a
+    // jti-having token" from "bad signature on a jti-less token" — the
+    // former is a single failure, the latter could be two stacked
+    // failures we'd surface unhelpfully.
+    const guard = makeGuard();
+    const otherKp = await makeKeypair("k1"); // same kid, different key
+    const iat = Math.floor(Date.now() / 1000);
+    const tokenBadSigNoJti = await new SignJWT({ scope: "vault:read" })
+      .setProtectedHeader({ alg: "RS256", kid: otherKp.kid })
+      .setIssuer(fixture.origin)
+      .setSubject("user-1")
+      .setAudience("operator")
+      .setIssuedAt(iat)
+      .setExpirationTime(iat + 60)
+      .sign(otherKp.privateKey);
+    let caught: HubJwtError | undefined;
+    try {
+      await guard.validateHubJwt(tokenBadSigNoJti);
+    } catch (e) {
+      caught = e as HubJwtError;
+    }
+    expect(caught?.code).toBe("signature");
+    guard.resetJwksCache();
   });
 });
 

--- a/packages/scope-guard/src/validate.ts
+++ b/packages/scope-guard/src/validate.ts
@@ -113,6 +113,33 @@ export interface CreateScopeGuardOptions {
    */
   hubOrigin: string | (() => string);
 
+  /**
+   * Accept hub-signed JWTs that lack the `jti` claim entirely. **Default
+   * `false` — strict rejection** (per hub#218 hardening). Operators with
+   * pre-Phase-1 legacy tokens (issued before the token-registry contract
+   * stamped `jti` on every mint) can set this to `true` during a
+   * transition window; the validate path logs a warning via
+   * `missingJtiLogger` (when supplied) but accepts the token.
+   *
+   * Trust framing: rejection is the right default because revocation
+   * cannot be enforced on tokens we can't index. A jti-less hub-signed
+   * JWT is an anomaly — either a pre-registry mint that should have
+   * aged out, or a forged token from an attacker who got a signing key
+   * but skipped the registry path. Operators who explicitly know they
+   * still have legacy tokens in flight can opt out; everyone else gets
+   * the security floor.
+   */
+  allowMissingJti?: boolean;
+
+  /**
+   * Logger called when a jti-less token is accepted under
+   * `allowMissingJti: true`. Lets operators monitor the legacy-token
+   * decay curve before flipping the opt-out back off. Defaults to a
+   * no-op when omitted — callers who want observability supply their
+   * service's structured logger here.
+   */
+  missingJtiLogger?: (info: { sub: string; aud: string | undefined; iat?: number }) => void;
+
   /** Optional JWKS cache tuning. Defaults: 5min cacheMaxAge, 30s cooldown. */
   jwks?: JwksOptions;
 
@@ -195,7 +222,13 @@ function resolveOrigin(input: string | (() => string)): string {
  * and reuse.
  */
 export function createScopeGuard(opts: CreateScopeGuardOptions): ScopeGuard {
-  const { hubOrigin, jwks: jwksOpts, jwksGetter: injected } = opts;
+  const {
+    hubOrigin,
+    jwks: jwksOpts,
+    jwksGetter: injected,
+    allowMissingJti = false,
+    missingJtiLogger,
+  } = opts;
 
   function pickGetter(origin: string): JwksGetter {
     if (injected) return injected;
@@ -266,7 +299,38 @@ export function createScopeGuard(opts: CreateScopeGuardOptions): ScopeGuard {
       const scopeRaw = (payload as { scope?: unknown }).scope;
       const scopes = typeof scopeRaw === "string" ? parseScopes(scopeRaw) : [];
 
-      const jti = typeof payload.jti === "string" ? payload.jti : undefined;
+      // jti presence is required by default (hub#218 hardening). The hub
+      // token-registry contract (introduced in hub#212 Phase 1) stamps `jti`
+      // on every issued JWT; a hub-signed token lacking the claim is an
+      // anomaly — either a pre-registry mint that should have aged out, or
+      // a forgery from an attacker who got a signing key but skipped the
+      // registry path. Revocation can't be enforced on tokens we can't
+      // index, so the strict default rejects them.
+      //
+      // Operators with legitimate pre-Phase-1 tokens still in flight can
+      // opt out via `allowMissingJti: true`, in which case the missing
+      // claim is logged (when `missingJtiLogger` is supplied) and the
+      // token is accepted. The opt-out is a transition aid, not a steady
+      // state.
+      //
+      // Placement: after signature + iss + sub + audience (so we don't
+      // surface a jti-shape error on a malformed/forged token whose
+      // signature already failed), but before the revocation lookup
+      // (which depends on jti existing).
+      const jtiRaw = payload.jti;
+      const jti = typeof jtiRaw === "string" && jtiRaw.length > 0 ? jtiRaw : undefined;
+      if (jti === undefined) {
+        if (!allowMissingJti) {
+          throw new HubJwtError("shape", "hub JWT missing required `jti` claim");
+        }
+        // Opt-out path: token is accepted but logged so operators can
+        // monitor the legacy-token decay curve.
+        missingJtiLogger?.({
+          sub: payload.sub,
+          aud,
+          iat: typeof payload.iat === "number" ? payload.iat : undefined,
+        });
+      }
       const clientIdRaw = (payload as { client_id?: unknown }).client_id;
       const clientId = typeof clientIdRaw === "string" ? clientIdRaw : undefined;
 
@@ -284,12 +348,14 @@ export function createScopeGuard(opts: CreateScopeGuardOptions): ScopeGuard {
         : [];
 
       // Revocation enforcement runs LAST — only consulted if the JWT is
-      // otherwise valid. Cheaper checks (signature, iss, aud, expiry) reject
-      // first, so a bad signature never costs a network roundtrip. A token
-      // with no jti claim can't appear on any revocation list (lists are
-      // keyed by jti); we let it through. The hub always stamps jti on
-      // OAuth-issued tokens — only ad-hoc/legacy tokens lack one, and those
-      // are out of scope for revocation.
+      // otherwise valid. Cheaper checks (signature, iss, aud, expiry,
+      // jti-presence) reject first, so a bad signature never costs a
+      // network roundtrip. A token with no jti claim can't appear on any
+      // revocation list (lists are keyed by jti); under the strict default
+      // the jti-presence check above already rejected, so we only reach
+      // here with a defined jti. Under the `allowMissingJti: true` opt-out
+      // we may have undefined jti — those tokens skip the lookup entirely
+      // since revocation can't be enforced without an index key.
       if (jti !== undefined) {
         const cache = pickRevocationCache(origin);
         const outcome = await cache.check(jti);


### PR DESCRIPTION
## Summary

- scope-guard rejects hub-signed JWTs that lack `jti` by default — revocation can't be enforced on tokens we can't index (closes #218)
- Opt-out via `createScopeGuard({ allowMissingJti: true, missingJtiLogger })` for operators with pre-Phase-1 legacy tokens still in flight
- Hub-side audit confirmed clean: every JWT mint goes through `signAccessToken` which always stamps jti
- Bump scope-guard `0.3.0` → `0.4.0-rc.1` (minor — security-relevant default-on behavior change)
- Downstream adopters (vault, scribe, runner, apps) pick up the strictness on next dep bump

## Test plan

- [x] `bun test packages/scope-guard/src` — 104 pass (was 99; +5 new tests + 1 rewritten)
- [x] `bun test ./src` — 1856 pass (unchanged; no hub src/ changes)
- [x] `bun run typecheck` clean
- [x] `bunx biome check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)