### PR TITLE
fix(hub): wizard installs app (not notes-daemon) — auto-bootstrap brings Notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.12] - 2026-05-22
+
+**fix(hub): wizard prompts to install app (not notes-daemon) — auto-bootstrap handles notes-ui (#323).**
+
+The setup wizard's done-step install tiles still telegraphed `notes` as the canonical first install — operators walking through saw an "Install Notes" tile, i.e., the notes-daemon. With the Notes-as-app migration in progress (notes-daemon deprecation tracked in parachute-notes#154; parachute-app §17 Phase 2.1 auto-bootstraps `@openparachute/notes-ui` as a sub-unit on first `parachute-app serve` boot) the wizard should prompt `app` instead. App's bootstrap-default-apps step then installs notes-ui under `/app/notes` automatically, so the operator gets Notes-the-UX without having to know about the daemon-vs-app split.
+
+**What landed.**
+
+- **`INSTALL_TILE_PROPS` in `src/setup-wizard.ts`** swaps the first tile from `notes` → `app`. Tagline telegraphs the auto-bootstrap so the architecture is legible from the wizard ("Host module for Parachute UIs — auto-installs Notes on first boot."). Order preserved: app → scribe.
+- **`CURATED_MODULES` in `src/api-modules.ts`** now lists `["vault", "app", "notes", "scribe", "runner"]`. App slots between vault and notes — `notes` stays curated as the back-compat install path for operators on pre-app architecture (`/api/modules/notes/install` + `parachute install notes` still work). The wizard tile is what changed; the install surface kept the broader compatibility lane.
+- **`KNOWN_MODULES["app"]` in `src/service-spec.ts`** carries the bootstrap data the install pathway needs pre-self-register: `package: "@openparachute/app"`, `manifestName: "parachute-app"`, `canonicalPort: 1946`, `kind: "frontend"`, `canonicalPaths: ["/app", "/.parachute"]`, `canonicalHealth: "/app/healthz"`, `extras.hasAuth: true` (app's `/app/admin` + per-UI surfaces gate behind hub-issued JWTs per design doc §6), `extras.startCmd: () => ["parachute-app", "serve"]` (backward-compat fallback for rows without `installDir`). Post-install, `<installDir>/.parachute/module.json` is authoritative — KNOWN_MODULES is just the pre-install bootstrap shape.
+- **`PORT_RESERVATIONS`** entry added: `{ port: 1946, name: "parachute-app", status: "assigned" }`. Status `assigned` keeps the `assignPort` fallback walker from handing 1946 to a colliding third-party module.
+- **`parachute setup` CLI BLURBS** in `src/commands/setup.ts` add `app` + `runner` entries the table had been missing. App's blurb telegraphs the "recommended over notes-daemon" framing; notes's blurb adds the "(notes-daemon; superseded by `app`)" suffix.
+
+**Out of scope (intentional).**
+
+- Removing `notes` from `CURATED_MODULES`. Notes-daemon stays installable for operators on pre-app architecture — only the wizard's recommendation surface changed. The full daemon retirement lands in parachute-notes#154's Phase 3 once `app` is fully shipped and the redirect window (hub#316) is no longer load-bearing.
+
+**Tests.** `bun run typecheck` clean. `bun test ./src` 1862 pass (was 1861; +1 net — added the `app row carries package + display props from KNOWN_MODULES` test; updated the wizard done-screen tile test (app+scribe, asserting Notes is no longer surfaced + app sits before scribe in render order), the wizard already-installed test (seeds `parachute-app` instead of `parachute-notes`), the wizard op-poll test (`?op_app=<id>` instead of `?op_notes=<id>`), the api-modules curated-list test (vault → app → notes → scribe → runner), the port-assign third-party-walks test (1947 instead of 1946 because 1946 is now assigned to parachute-app), and the setup CLI all-installed test (seeds `parachute-app` alongside the other shorts). `cd web/ui && bun run test` 188 pass (unchanged — no SPA copy mentions Notes-as-first-install). `bunx biome check src/` clean.
+
+**Cross-references.** Issue hub#323 (this PR). parachute-notes#154 — notes-daemon deprecation. parachute-app §17 Phase 2.1 — bootstrap-default-apps. hub#316 — `/notes/*` → `/app/notes/*` 301 redirect (Phase 2 of the migration arc). The wizard tile change is the last operator-facing surface that recommended notes-daemon as the canonical first install — every other surface (`/api/modules` install catalog, `/.well-known/parachute.json`, the discovery page) now ride on services.json + module.json, which app self-registers on boot.
+
 ## [0.5.13-rc.11] - 2026-05-22
 
 **fix(hub): consent surfaces stale `assigned_vault` cleanly with picker fallback (#284).**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.11",
+  "version": "0.5.13-rc.12",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -149,8 +149,10 @@ describe("GET /api/modules", () => {
 
   test("200 + curated list on fresh container (empty services.json)", async () => {
     // The v0.6 hot path: brand-new Render container, no services.json
-    // yet. UI must render "install vault / notes / scribe / runner"
-    // cards even though nothing's installed.
+    // yet. UI must render "install vault / app / notes / scribe / runner"
+    // cards even though nothing's installed. hub#323 inserted `app` between
+    // `vault` and `notes` — app auto-bootstraps notes-ui as a sub-unit;
+    // `notes` (notes-daemon) stays curated for back-compat install paths.
     const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
     const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
       db: h.db,
@@ -168,13 +170,44 @@ describe("GET /api/modules", () => {
       }>;
       supervisor_available: boolean;
     };
-    // Curated order is preserved: vault → notes → scribe → runner.
-    expect(body.modules.map((m) => m.short)).toEqual(["vault", "notes", "scribe", "runner"]);
+    // Curated order is preserved: vault → app → notes → scribe → runner.
+    expect(body.modules.map((m) => m.short)).toEqual(["vault", "app", "notes", "scribe", "runner"]);
     expect(body.modules.every((m) => m.available)).toBe(true);
     expect(body.modules.every((m) => !m.installed)).toBe(true);
     expect(body.modules.every((m) => m.latest_version === "0.9.9")).toBe(true);
     // Supervisor wasn't injected → flag reflects that.
     expect(body.supervisor_available).toBe(false);
+  });
+
+  test("app row carries package + display props from KNOWN_MODULES (#323)", async () => {
+    // hub#323 added app to CURATED_MODULES + KNOWN_MODULES so the admin SPA
+    // install catalog + setup-wizard install tile surface it. Spot-check the
+    // wire shape resolves app-specific fields (package, displayName, tagline)
+    // from KNOWN_MODULES rather than a stale default — same shape as the
+    // runner row test below.
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: async () => "0.2.0",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      modules: Array<{
+        short: string;
+        package: string;
+        display_name: string;
+        tagline: string;
+        available: boolean;
+      }>;
+    };
+    const app = body.modules.find((m) => m.short === "app");
+    expect(app).toBeDefined();
+    expect(app?.package).toBe("@openparachute/app");
+    expect(app?.display_name).toBe("App");
+    expect(app?.tagline).toContain("auto-installs Notes");
+    expect(app?.available).toBe(true);
   });
 
   test("runner row carries package + display props from FIRST_PARTY_FALLBACKS (#305)", async () => {

--- a/src/__tests__/port-assign.test.ts
+++ b/src/__tests__/port-assign.test.ts
@@ -68,8 +68,13 @@ describe("assignPort (pure)", () => {
   });
 
   test("third-party with reservations occupied walks further in the range", () => {
+    // PORT_RESERVATIONS post-hub#323: 1944 reserved, 1945 reserved, 1946
+    // assigned (parachute-app — KNOWN_MODULES carries the canonical slot
+    // so the fallback walker doesn't hand it to a third party), 1947
+    // reserved. With 1944 + 1945 occupied, the walker skips the assigned
+    // 1946 slot and lands on the next reserved-and-free port — 1947.
     const result = assignPort(undefined, [1944, 1945]);
-    expect(result.port).toBe(1946);
+    expect(result.port).toBe(1947);
     expect(result.source).toBe("fallback-in-range");
   });
 });

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -1712,7 +1712,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
   });
   afterEach(() => h.cleanup());
 
-  test("done screen renders Install Notes + Install Scribe tiles when neither is installed", async () => {
+  test("done screen renders Install App + Install Scribe tiles when neither is installed", async () => {
     const db = openHubDb(hubDbPath(h.dir));
     try {
       const user = await createUser(db, "owner", "pw");
@@ -1747,10 +1747,21 @@ describe("done screen install tiles (hub#272 Item B)", () => {
       );
       const html = await res.text();
       expect(html).toContain("What's next?");
-      expect(html).toContain("Install Notes");
+      // hub#323: App replaces Notes as the first install tile. App auto-bootstraps
+      // Notes (parachute-app §17 Phase 2.1) so operators don't need to install
+      // notes-daemon directly; the tagline telegraphs that Notes comes with App.
+      expect(html).toContain("Install App");
       expect(html).toContain("Install Scribe");
-      expect(html).toContain('action="/admin/setup/install/notes"');
+      expect(html).toContain('action="/admin/setup/install/app"');
       expect(html).toContain('action="/admin/setup/install/scribe"');
+      // App tile sits first in the render order — verified by both tiles
+      // appearing AND app's index in the rendered HTML preceding scribe's.
+      expect(html.indexOf("Install App")).toBeLessThan(html.indexOf("Install Scribe"));
+      // Notes is no longer a wizard tile; notes-daemon still installable
+      // via /api/modules/notes/install for back-compat, but the wizard
+      // doesn't surface it.
+      expect(html).not.toContain("Install Notes");
+      expect(html).not.toContain('action="/admin/setup/install/notes"');
     } finally {
       db.close();
     }
@@ -1770,12 +1781,15 @@ describe("done screen install tiles (hub#272 Item B)", () => {
               paths: ["/vault/default"],
               health: "/health",
             },
+            // hub#323: app replaces notes as the wizard's first install tile.
+            // Seeding services.json with `parachute-app` exercises the
+            // already-installed render path on the wizard's first tile.
             {
-              name: "parachute-notes",
-              version: "0.1.0",
-              port: 1942,
-              paths: ["/notes"],
-              health: "/notes/health",
+              name: "parachute-app",
+              version: "0.2.0",
+              port: 1946,
+              paths: ["/app", "/.parachute"],
+              health: "/app/healthz",
             },
           ],
         },
@@ -1804,7 +1818,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
     }
   });
 
-  test("done screen renders op-poll panel when ?op_notes=<id> matches a registry op", async () => {
+  test("done screen renders op-poll panel when ?op_app=<id> matches a registry op", async () => {
     const db = openHubDb(hubDbPath(h.dir));
     try {
       const user = await createUser(db, "owner", "pw");
@@ -1824,12 +1838,15 @@ describe("done screen install tiles (hub#272 Item B)", () => {
       );
       setSetting(db, "setup_expose_mode", "localhost");
       const reg = getDefaultOperationsRegistry();
-      const op = reg.create("install", "notes");
-      reg.update(op.id, { status: "running" }, "running bun add -g @openparachute/notes@latest");
+      // hub#323: op-poll panel rides on the `app` tile now (app is the wizard's
+      // first install tile post-Notes-as-app-migration). Same shape as the
+      // pre-#324 `op_notes=<id>` flow.
+      const op = reg.create("install", "app");
+      reg.update(op.id, { status: "running" }, "running bun add -g @openparachute/app@latest");
       const { createSession } = await import("../sessions.ts");
       const session = createSession(db, { userId: user.id });
       const res = handleSetupGet(
-        req(`/admin/setup?just_finished=1&op_notes=${op.id}`, {
+        req(`/admin/setup?just_finished=1&op_app=${op.id}`, {
           headers: { cookie: `${SESSION_COOKIE_NAME}=${session.id}` },
         }),
         {

--- a/src/__tests__/setup.test.ts
+++ b/src/__tests__/setup.test.ts
@@ -123,6 +123,7 @@ describe("setup", () => {
         { name: "parachute-scribe", port: 1943 },
         { name: "parachute-channel", port: 1941 },
         { name: "parachute-runner", port: 1945 },
+        { name: "parachute-app", port: 1946 },
       ];
       for (const s of seeds) {
         upsertService(

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -77,12 +77,14 @@ export const API_MODULES_REQUIRED_SCOPE = "parachute:host:auth";
 
 /**
  * Curated module short-names for v0.6 Render self-host. Marketplace is
- * Phase 2 — until then, the admin UI offers exactly these four. Order
- * is the recommended install order (vault → notes → scribe → runner;
- * runner comes last because it depends on a working vault + scribe to
- * be useful, and operators usually wire those up first).
+ * Phase 2 — until then, the admin UI offers exactly these. Order is the
+ * recommended install order (vault → app → notes → scribe → runner;
+ * app auto-bootstraps notes-ui on first boot — `notes` here is the
+ * notes-daemon back-compat install path retained for operators still on
+ * the pre-app architecture; scribe + runner come last because they
+ * depend on a working vault + app to be useful).
  */
-export const CURATED_MODULES = ["vault", "notes", "scribe", "runner"] as const;
+export const CURATED_MODULES = ["vault", "app", "notes", "scribe", "runner"] as const;
 export type CuratedModuleShort = (typeof CURATED_MODULES)[number];
 
 export interface ApiModulesDeps {

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -151,8 +151,10 @@ function surveyServices(manifestPath: string): ServiceChoice[] {
 
 const BLURBS: Record<string, string> = {
   vault: "knowledge graph (MCP) — your owner-authenticated note + tag store",
-  notes: "Notes PWA — web/mobile UI on top of vault",
+  app: "Parachute UI host — auto-installs Notes on first boot (recommended over notes-daemon)",
+  notes: "Notes PWA — web/mobile UI on top of vault (notes-daemon; superseded by `app`)",
   scribe: "audio transcription for dictation + recordings",
+  runner: "vault-as-job-substrate — scheduled claude -p against vault job notes",
   channel: "(exploratory — may retire) notification fan-out across modules",
 };
 

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -64,7 +64,11 @@ export const PORT_RESERVATIONS: readonly PortReservation[] = [
   { port: 1943, name: "parachute-scribe", status: "assigned" },
   { port: 1944, name: "unassigned", status: "reserved" },
   { port: 1945, name: "unassigned", status: "reserved" },
-  { port: 1946, name: "unassigned", status: "reserved" },
+  // hub#323: parachute-app's canonical slot. Status `assigned` keeps the
+  // fallback-port walker (`assignPort` in port-assign.ts) from handing this
+  // port out to a colliding third-party module. The matching KNOWN_MODULES
+  // row carries the canonicalPort + paths for status/expose surfaces.
+  { port: 1946, name: "parachute-app", status: "assigned" },
   { port: 1947, name: "unassigned", status: "reserved" },
   { port: 1948, name: "unassigned", status: "reserved" },
   { port: 1949, name: "unassigned", status: "reserved" },
@@ -481,6 +485,37 @@ export const KNOWN_MODULES: Record<string, KnownModule> = {
       // hub-issued JWT carrying `runner:admin` scope (see runner's
       // `src/auth.ts`). Surfaces in `parachute status` as auth-required by
       // default, same posture as vault.
+      hasAuth: true,
+    },
+  },
+  app: {
+    short: "app",
+    package: "@openparachute/app",
+    manifestName: "parachute-app",
+    canonicalPort: 1946,
+    displayName: "App",
+    // Tagline telegraphs the auto-bootstrap so wizard + admin-SPA copy explain
+    // the architecture: installing `app` brings Notes (and other UIs) along
+    // via the Phase 2.1 bootstrap-default-apps step. The notes-daemon path
+    // still exists as a back-compat install (CURATED_MODULES still lists
+    // `notes`) but `app` is the recommended first install post-vault.
+    tagline: "Host module for Parachute UIs — auto-installs Notes on first boot.",
+    // Frontend posture: app's primary surface is serving sub-app UIs under
+    // `/app/<name>/` mounted under one origin (design doc §12). Hub's
+    // exposure-default + supervisor-defaults follow the frontend lane.
+    kind: "frontend",
+    canonicalPaths: ["/app", "/.parachute"],
+    canonicalHealth: "/app/healthz",
+    canonicalStripPrefix: false,
+    extras: {
+      // Backward-compat startCmd — same rationale as scribe / vault / runner
+      // above. Post-self-register, lifecycle reads module.json's startCmd via
+      // `composeKnownModuleSpec` and that path wins.
+      startCmd: () => ["parachute-app", "serve"],
+      // App's admin + per-UI surfaces gate behind hub-issued JWTs (design
+      // doc §6 same-hub auto-trust + scope `app:admin`). Surfaces in
+      // `parachute status` as auth-required by default, same posture as vault
+      // + runner.
       hasAuth: true,
     },
   },

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -1522,7 +1522,11 @@ const INSTALL_TILE_PROPS: ReadonlyArray<{
   displayName: string;
   tagline: string;
 }> = [
-  { short: "notes", displayName: "Notes", tagline: "Notes PWA backed by your vault." },
+  {
+    short: "app",
+    displayName: "App",
+    tagline: "Host module for Parachute UIs — auto-installs Notes on first boot.",
+  },
   {
     short: "scribe",
     displayName: "Scribe",


### PR DESCRIPTION
Closes #323.

## Symptom

Aaron walked the setup wizard and saw an "Install Notes" tile on the done-step — the wizard was recommending the notes-daemon as the canonical first install. With the Notes-as-app migration in progress operators should be prompted to install `app` instead. App's bootstrap-default-apps step (parachute-app §17 Phase 2.1) then auto-installs `@openparachute/notes-ui` under `/app/notes`, so the operator gets Notes-the-UX without having to know about the daemon-vs-app split.

## Architecture shift

The wizard tile is the last operator-facing surface that still recommended notes-daemon as the canonical first install. Every other surface — `/api/modules` install catalog, `/.well-known/parachute.json`, the discovery page — already rides on services.json + module.json, which app self-registers on boot.

- **parachute-notes#154** — notes-daemon deprecation.
- **parachute-app §17 Phase 2.1** — bootstrap-default-apps auto-installs notes-ui on first boot.
- **hub#316** — `/notes/*` → `/app/notes/*` 301 redirect (Phase 2 of the migration arc).
- **This PR** — wizard tile + `app` curated entry + KNOWN_MODULES bootstrap.

## What changed

1. `INSTALL_TILE_PROPS` in `src/setup-wizard.ts` swaps first tile `notes` → `app`. New tagline telegraphs the auto-bootstrap so operators understand the architecture: _"Host module for Parachute UIs — auto-installs Notes on first boot."_ Order preserved: app → scribe.

2. `CURATED_MODULES` in `src/api-modules.ts` now lists `["vault", "app", "notes", "scribe", "runner"]`. `notes` stays curated as the back-compat install path for operators on pre-app architecture (`/api/modules/notes/install` + `parachute install notes` still work). The wizard tile is what changed; the install surface kept the broader compatibility lane.

3. `KNOWN_MODULES["app"]` in `src/service-spec.ts` carries the bootstrap data the install pathway needs pre-self-register: `package: "@openparachute/app"`, `manifestName: "parachute-app"`, `canonicalPort: 1946`, `kind: "frontend"`, `canonicalPaths: ["/app", "/.parachute"]`, `canonicalHealth: "/app/healthz"`, `extras.hasAuth: true`, `extras.startCmd: () => ["parachute-app", "serve"]`. Post-install, `<installDir>/.parachute/module.json` is authoritative — KNOWN_MODULES is just the pre-install bootstrap shape.

4. `PORT_RESERVATIONS` entry: `{ port: 1946, name: "parachute-app", status: "assigned" }`. Status `assigned` keeps the `assignPort` fallback walker from handing 1946 to a colliding third-party module.

5. `parachute setup` CLI BLURBS in `src/commands/setup.ts` add `app` + `runner` entries; `notes` blurb adds the "(notes-daemon; superseded by `app`)" suffix.

## Out of scope (intentional)

- Removing `notes` from `CURATED_MODULES`. Notes-daemon stays installable for operators on pre-app architecture — only the wizard's recommendation surface changed. The full daemon retirement lands in parachute-notes#154's Phase 3 once `app` is fully shipped and the redirect window (hub#316) is no longer load-bearing.

## Tile change (the load-bearing diff)

```ts
// before
const INSTALL_TILE_PROPS = [
  { short: "notes", displayName: "Notes", tagline: "Notes PWA backed by your vault." },
  { short: "scribe", displayName: "Scribe", tagline: "Local audio transcription for vault recordings." },
];

// after
const INSTALL_TILE_PROPS = [
  {
    short: "app",
    displayName: "App",
    tagline: "Host module for Parachute UIs — auto-installs Notes on first boot.",
  },
  {
    short: "scribe",
    displayName: "Scribe",
    tagline: "Local audio transcription for vault recordings.",
  },
];
```

## Version

`0.5.13-rc.11` → `0.5.13-rc.12`. RC chain at the same `0.5.13` target stable per governance rule 2.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test ./src` — 1862 pass (was 1861; +1 net)
  - Added: `app row carries package + display props from KNOWN_MODULES (#323)` in `api-modules.test.ts`
  - Updated: wizard done-screen tile test (asserts app+scribe + Notes is no longer surfaced + app sits before scribe), wizard already-installed test (seeds `parachute-app` instead of `parachute-notes`), wizard op-poll test (`?op_app=<id>`), api-modules curated-list test (vault → app → notes → scribe → runner), port-assign third-party-walks test (1947 instead of 1946 because 1946 is now assigned), setup CLI all-installed test (seeds `parachute-app` alongside the other shorts)
- [x] `cd web/ui && bun run test` — 188 pass (unchanged; no SPA copy mentions Notes-as-first-install)
- [x] `bunx biome check src/` clean
- [ ] Manual smoke: fresh PARACHUTE_HOME, walk wizard, confirm "Install App" tile appears (not "Install Notes"), click → `parachute-app` installs → app's bootstrap-default-apps installs notes-ui at `/app/notes` — deferred to reviewer / Aaron's pass; covered structurally by the tests asserting tile rendering + install POST routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)