### PR TITLE
fix(hub): notes module tagline reflects deprecation (audit script catch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.13] - 2026-05-22
+
+**fix(hub): notes module tagline reflects deprecation (caught by audit script post-cleanup).**
+
+The `notes` entry in `NOTES_FALLBACK` (`src/service-spec.ts`) carried the pre-migration tagline `"Notes PWA backed by your vault."`, which made sense when notes-daemon was the canonical install path. Post-Notes-as-app migration (notes-daemon deprecation tracked in parachute-notes#154; wizard switched to `app` in #324), the tagline is stale — operators scanning the discovery surfaces shouldn't see notes-daemon framed as the canonical PWA. Audit script flagged it post-cleanup-wave as one of the last operator-visible stale refs.
+
+**What landed.**
+
+- **`NOTES_FALLBACK.manifest.tagline`** in `src/service-spec.ts:296` updated to `"Notes PWA — daemon deprecated 2026-05-22; install `app` for the current path."`. Telegraphs the deprecation + points operators at `parachute install app` (which auto-bootstraps notes-ui under `/app/notes` via parachute-app §17 Phase 2.1). Mirrors the tone the retired `parachute-agent` spec used before it was removed from the fallbacks.
+- **Assertion sites in `src/__tests__/well-known.test.ts:364, 371`** updated to match the new copy. The test exercises tagline-pass-through behavior; the literal string was incidental but had to track the spec.
+
+**Out of scope (intentional).**
+
+- The rest of the `NOTES_FALLBACK` entry (port `1942`, paths `["/notes"]`, health, startCmd, postInstallFooter). The daemon is still installable for back-compat — only the operator-facing tagline copy changed. Full daemon retirement lands in parachute-notes#154 Phase 3 once `app` is fully shipped and the redirect window (hub#316) is no longer load-bearing.
+
+**Tests.** `bun run typecheck` clean. `bun test ./src` — passing, count unchanged. `cd web/ui && bun run test` unchanged. `bunx biome check src/` clean.
+
+**Cross-references.** Audit script catch post-cleanup-wave. parachute-notes#154 — notes-daemon deprecation. #324 — wizard recommends `app` over notes-daemon (the previous rc in this chain). parachute-app §17 Phase 2.1 — bootstrap-default-apps auto-installs notes-ui.
+
 ## [0.5.13-rc.12] - 2026-05-22
 
 **fix(hub): wizard prompts to install app (not notes-daemon) — auto-bootstrap handles notes-ui (#323).**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.12",
+  "version": "0.5.13-rc.13",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/well-known.test.ts
+++ b/src/__tests__/well-known.test.ts
@@ -361,14 +361,16 @@ describe("buildWellKnown", () => {
   test("tagline rides through from services.json (no resolver needed)", () => {
     const notesWithTagline: ServiceEntry = {
       ...notes,
-      tagline: "Notes PWA backed by your vault.",
+      tagline: "Notes PWA — daemon deprecated 2026-05-22; install `app` for the current path.",
     };
     const doc = buildWellKnown({
       services: [notesWithTagline],
       canonicalOrigin: "https://x.example",
     });
     const svc = doc.services.find((s) => s.name === "parachute-notes");
-    expect(svc?.tagline).toBe("Notes PWA backed by your vault.");
+    expect(svc?.tagline).toBe(
+      "Notes PWA — daemon deprecated 2026-05-22; install `app` for the current path.",
+    );
   });
 
   test("falls back to / for empty paths", () => {

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -293,7 +293,7 @@ const NOTES_FALLBACK: FirstPartyFallback = {
     name: "notes",
     manifestName: "parachute-notes",
     displayName: "Notes",
-    tagline: "Notes PWA backed by your vault.",
+    tagline: "Notes PWA — daemon deprecated 2026-05-22; install `app` for the current path.",
     kind: "frontend",
     port: 1942,
     paths: ["/notes"],


### PR DESCRIPTION
## Summary

`NOTES_FALLBACK.manifest.tagline` in `src/service-spec.ts:296` carried the pre-migration string `"Notes PWA backed by your vault."`, framing notes-daemon as the canonical PWA install path. Post-Notes-as-app migration (notes-daemon deprecation in parachute-notes#154; wizard switched to `app` in #324), that's stale — operators reading `/.well-known/parachute.json` or the discovery page shouldn't see notes-daemon framed as canonical. Audit script flagged it post-cleanup-wave as one of the last operator-visible stale refs from the migration arc.

## What changed

- **`NOTES_FALLBACK.manifest.tagline`** (`src/service-spec.ts:296`) → `"Notes PWA — daemon deprecated 2026-05-22; install \`app\` for the current path."`. Telegraphs the deprecation + points operators at `parachute install app` (which auto-bootstraps notes-ui under `/app/notes` via parachute-app §17 Phase 2.1). Mirrors the tone the retired `parachute-agent` spec used before it was removed from the fallbacks.
- **Test assertion sites** (`src/__tests__/well-known.test.ts:364, 371`) updated to match. The test exercises tagline-pass-through behavior on `buildWellKnown`; the literal string was incidental but had to track the spec value.
- **Version bump**: `0.5.13-rc.12` → `0.5.13-rc.13` (rc chain at target stable per governance).
- **CHANGELOG**: entry added under `[0.5.13-rc.13]`.

## Out of scope (intentional)

- The rest of `NOTES_FALLBACK` is untouched — port `1942`, paths `["/notes"]`, health, startCmd, postInstallFooter all unchanged. The daemon is still installable for back-compat; only the operator-facing tagline copy changed. Full daemon retirement lands in parachute-notes#154 Phase 3 once `app` is fully shipped and the redirect window (hub#316) is no longer load-bearing.
- Other module entries (`vault`, `scribe`, `channel`, `app`, `runner`) untouched.

## Cross-references

- Audit script catch post-cleanup-wave (one of the last operator-visible stale Notes-as-app migration refs).
- parachute-notes#154 — notes-daemon deprecation.
- #324 — wizard recommends `app` over notes-daemon (the immediately preceding rc in this chain).
- parachute-app §17 Phase 2.1 — `bootstrap-default-apps` auto-installs notes-ui under `/app/notes` on first `parachute-app serve`.
- patterns/governance.md rule 2 — RC versioning chain at target stable.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test ./src` — 1862 pass (unchanged from rc.12)
- [x] `cd web/ui && bun run test` — 188 pass (unchanged)
- [x] `bunx biome check src/` clean
- [ ] Reviewer: confirm tagline reads correctly via `bun src/cli.ts` against a real install (well-known + discovery surfaces)