### PR TITLE
fix(hub): parachute upgrade preserves channel + refuses silent downgrades (closes #332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Per [governance rule 2](https://github.com/ParachuteComputer/parachute-patterns/
 
 ### Install command — same bug?
 
-`parachute install <svc>` runs `bun add -g <pkg>` (no `@latest` literal but bun resolves an unsuffixed package to `@latest`). For install that's by design — there's no installed version to read a channel from. The fresh-install default-channel question is a separate concern; filing as a follow-up.
+`parachute install <svc>` runs `bun add -g <pkg>` (no `@latest` literal but bun resolves an unsuffixed package to `@latest`). For install that's by design — there's no installed version to read a channel from. The fresh-install default-channel question is a separate concern; tracked at [hub#337](https://github.com/ParachuteComputer/parachute-hub/issues/337).
 
 ### Cross-references
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.17] - 2026-05-23
+
+**fix(hub): `parachute upgrade` preserves the operator's channel + refuses silent downgrades.**
+
+`parachute upgrade <svc>` previously ran `bun add -g <pkg>@latest` unconditionally on the npm-installed path. When `@latest` pointed at a prior stable (the typical state mid-rc-chain), an operator on `@rc` got silently downgraded. Aaron's reproducer ([hub#332](https://github.com/ParachuteComputer/parachute-hub/issues/332)):
+
+```
+$ parachute upgrade hub
+hub: bun add -g @openparachute/hub@latest
+installed @openparachute/hub@0.5.10 with binaries:
+ - parachute
+hub: 0.5.13-rc.13 → 0.5.10; restarting…
+```
+
+Per [governance rule 2](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md), pre-1.0 operators on the dev chain stay on `@rc`; `@latest` is the explicit-stable channel. `parachute upgrade` now respects that.
+
+### What landed
+
+- **Channel auto-detection (`src/commands/upgrade.ts:detectChannel`)** — reads the installed `package.json` `version` and infers the channel: a trailing `-rc(\.\d+)?$` (e.g. `0.5.13-rc.13`, `0.5.13-rc`) → `@rc`; anything else → `@latest`. The npm branch composes `bun add -g <pkg>@<detected-channel>` instead of the old hardcoded `@latest`.
+- **Downgrade refusal (`src/commands/upgrade.ts:upgradeNpm`)** — before running `bun add -g`, resolves `npm view <pkg>@<channel> version` and compares to the installed version with an inline semver comparator (no new dependency). If the resolved target is lower, aborts with an actionable message that includes the exact `bun add -g <pkg>@<version>` command to force the downgrade, plus a `--channel rc` hint when the operator's on stable. Fail-open: a flaky `npm view` (network down, registry unreachable) skips the guard rather than blocking.
+- **`--channel rc|latest` flag (`src/cli.ts`, `src/help.ts`)** — operator override. Wins over auto-detection.
+- **`--allow-downgrade` flag (`src/cli.ts`)** — opt-in bypass of the refusal.
+- **`--tag <name>`** — still works, still ignored when bun-linked. Takes precedence over `--channel` for programmatic callers.
+- **Help text (`src/help.ts:upgradeHelp`)** — documents the new flags + the auto-detection rule.
+
+### Tests
+
+`bun test ./src` — 1889 pass / 0 fail (was 1880 in rc.16; +9 new cases in `src/__tests__/upgrade.test.ts` covering: `detectChannel` rc/latest discrimination including the `-rc` (no `.N`) edge case; `compareVersions` ordering (stable > matching rc, lower triple < higher rc); rc auto-detection from a rc.13-suffixed installed version; stable auto-detection from a clean version; `--channel rc` override against stable detection; downgrade refusal when `@rc` resolves to a lower version; `--allow-downgrade` bypass; Aaron's exact reproducer driven through the fix (rc.13 → rc.14 via `@rc`, not rc.13 → 0.5.10 via `@latest`); and `tag` precedence over both auto-detection and `--channel`). `bun run typecheck` clean. `bunx biome check src/` clean.
+
+### Install command — same bug?
+
+`parachute install <svc>` runs `bun add -g <pkg>` (no `@latest` literal but bun resolves an unsuffixed package to `@latest`). For install that's by design — there's no installed version to read a channel from. The fresh-install default-channel question is a separate concern; filing as a follow-up.
+
+### Cross-references
+
+- [hub#332](https://github.com/ParachuteComputer/parachute-hub/issues/332) — closes.
+- [governance rule 2](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md) — RC versioning convention.
+
 ## [0.5.13-rc.16] - 2026-05-23
 
 **fix(hub): update operator-facing help text post-Notes-as-app migration.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.16",
+  "version": "0.5.13-rc.17",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/upgrade.test.ts
+++ b/src/__tests__/upgrade.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { UpgradeRunner } from "../commands/upgrade.ts";
-import { upgrade } from "../commands/upgrade.ts";
+import { compareVersions, detectChannel, upgrade } from "../commands/upgrade.ts";
 import { upsertService } from "../services-manifest.ts";
 
 interface RunCall {
@@ -777,6 +777,359 @@ describe("parachute upgrade", () => {
       // Hub skipped restart (version unchanged), notes restarted after version bump.
       expect(restartCalls).toEqual(["notes"]);
       expect(logs.join("\n")).toMatch(/vault: bun add -g failed \(exit 7\)/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // hub#332 — channel preservation + downgrade refusal
+  // -------------------------------------------------------------------------
+
+  test("detectChannel: rc suffixes → 'rc', everything else → 'latest'", () => {
+    expect(detectChannel("0.5.13-rc.13")).toBe("rc");
+    expect(detectChannel("0.5.13-rc.1")).toBe("rc");
+    expect(detectChannel("0.5.13-rc")).toBe("rc"); // no .N suffix
+    expect(detectChannel("0.5.10")).toBe("latest");
+    expect(detectChannel("1.0.0")).toBe("latest");
+    expect(detectChannel("0.5.13-beta.1")).toBe("latest"); // not rc
+    expect(detectChannel("0.5.13-alpha")).toBe("latest");
+  });
+
+  test("compareVersions: stable > matching rc; later rc > earlier rc", () => {
+    // Stable beats prerelease at equal triple (semver §11.4.3)
+    expect(compareVersions("0.5.13", "0.5.13-rc.13")).toBeGreaterThan(0);
+    expect(compareVersions("0.5.13-rc.13", "0.5.13")).toBeLessThan(0);
+    // Aaron's reproducer: 0.5.10 < 0.5.13-rc.13 (lower triple beats prerelease tail)
+    expect(compareVersions("0.5.10", "0.5.13-rc.13")).toBeLessThan(0);
+    expect(compareVersions("0.5.13-rc.14", "0.5.13-rc.13")).toBeGreaterThan(0);
+    expect(compareVersions("0.5.13-rc.13", "0.5.13-rc.13")).toBe(0);
+    // Patch difference dominates prerelease tail
+    expect(compareVersions("0.5.14", "0.5.13-rc.99")).toBeGreaterThan(0);
+    // Garbage in → null
+    expect(compareVersions("not-a-version", "0.5.10")).toBeNull();
+  });
+
+  test("auto-detects rc channel: installed 0.5.13-rc.13 → bun add -g @openparachute/hub@rc", async () => {
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.13-rc.13" });
+
+      const seenCmd: string[][] = [];
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          seenCmd.push([...cmd]);
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            writePackageJson(hubInstallDir, {
+              name: "@openparachute/hub",
+              version: "0.5.13-rc.14",
+            });
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      const code = await upgrade("hub", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        restartFn: async () => 0,
+        // No resolveChannelVersion → npm view stub returns empty → guard skipped
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
+      expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@rc"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("auto-detects stable channel: installed 0.5.10 → bun add -g @openparachute/hub@latest", async () => {
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.10" });
+
+      const seenCmd: string[][] = [];
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          seenCmd.push([...cmd]);
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.11" });
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      await upgrade("hub", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        restartFn: async () => 0,
+        log: () => {},
+      });
+      const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
+      expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@latest"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("--channel rc overrides stable detection", async () => {
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.10" });
+
+      const seenCmd: string[][] = [];
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          seenCmd.push([...cmd]);
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            writePackageJson(hubInstallDir, {
+              name: "@openparachute/hub",
+              version: "0.5.13-rc.14",
+            });
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      await upgrade("hub", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        restartFn: async () => 0,
+        channel: "rc",
+        log: () => {},
+      });
+      const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
+      expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@rc"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("refuses downgrade: installed 0.5.13-rc.13, @rc resolves to 0.5.10 → abort", async () => {
+    // Aaron's exact reproducer modulo the channel fix — once channel detection
+    // lands, @rc is the right tag; if @rc itself somehow resolves backward we
+    // still refuse.
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.13-rc.13" });
+
+      const seenCmd: string[][] = [];
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          seenCmd.push([...cmd]);
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      const logs: string[] = [];
+      let restartCalled = false;
+      const code = await upgrade("hub", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        restartFn: async () => {
+          restartCalled = true;
+          return 0;
+        },
+        resolveChannelVersion: async (_pkg, _channel) => "0.5.10",
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(1);
+      expect(restartCalled).toBe(false);
+      // bun add was never run
+      const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
+      expect(addCall).toBeUndefined();
+      const joined = logs.join("\n");
+      expect(joined).toMatch(/refusing to downgrade/);
+      expect(joined).toMatch(/installed 0\.5\.13-rc\.13/);
+      expect(joined).toMatch(/0\.5\.10/);
+      expect(joined).toMatch(/--allow-downgrade/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("--allow-downgrade bypasses the refusal", async () => {
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.13-rc.13" });
+
+      const seenCmd: string[][] = [];
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          seenCmd.push([...cmd]);
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.10" });
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      const code = await upgrade("hub", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        restartFn: async () => 0,
+        resolveChannelVersion: async () => "0.5.10",
+        allowDowngrade: true,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
+      // Channel was auto-detected as `rc` from the rc-suffixed installed version
+      expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@rc"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("Aaron's reproducer: installed 0.5.13-rc.13 → upgrades via @rc, version goes UP not down", async () => {
+    // This is the exact bug from hub#332. Before the fix, `parachute upgrade
+    // hub` ran `bun add -g @openparachute/hub@latest` which (because @latest
+    // pointed at 0.5.10) silently downgraded an rc.13 install. With auto-
+    // channel detection: rc.13 → @rc → 0.5.13-rc.14, version increases.
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.13-rc.13" });
+
+      const seenCmd: string[][] = [];
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          seenCmd.push([...cmd]);
+          if (
+            cmd[0] === "bun" &&
+            cmd[1] === "add" &&
+            cmd[2] === "-g" &&
+            cmd[3] === "@openparachute/hub@rc"
+          ) {
+            writePackageJson(hubInstallDir, {
+              name: "@openparachute/hub",
+              version: "0.5.13-rc.14",
+            });
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      const logs: string[] = [];
+      let restartedShort: string | undefined;
+      const code = await upgrade("hub", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        restartFn: async (svc) => {
+          restartedShort = svc;
+          return 0;
+        },
+        // @rc resolves to a HIGHER version than installed — no downgrade.
+        resolveChannelVersion: async (_pkg, channel) =>
+          channel === "rc" ? "0.5.13-rc.14" : "0.5.10",
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(restartedShort).toBe("hub");
+      const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
+      expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@rc"]);
+      const joined = logs.join("\n");
+      // Version went UP (rc.13 → rc.14), not DOWN as in the original report
+      expect(joined).toMatch(/0\.5\.13-rc\.13 → 0\.5\.13-rc\.14/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("--tag still overrides everything (back-compat for programmatic pin)", async () => {
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.13-rc.13" });
+
+      const seenCmd: string[][] = [];
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          seenCmd.push([...cmd]);
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      await upgrade("hub", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        restartFn: async () => 0,
+        // Programmatic `tag` wins over auto-detection AND --channel.
+        tag: "next",
+        channel: "rc",
+        log: () => {},
+      });
+      const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
+      expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@next"]);
     } finally {
       h.cleanup();
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -549,14 +549,40 @@ async function main(argv: string[]): Promise<number> {
         console.error(`parachute upgrade: ${tagExtract.error}`);
         return 1;
       }
-      const remaining = tagExtract.rest;
+      const channelExtract = extractNamedFlag(tagExtract.rest, "--channel");
+      if (channelExtract.error) {
+        console.error(`parachute upgrade: ${channelExtract.error}`);
+        return 1;
+      }
+      if (
+        channelExtract.value !== undefined &&
+        channelExtract.value !== "rc" &&
+        channelExtract.value !== "latest"
+      ) {
+        console.error(
+          `parachute upgrade: --channel must be "rc" or "latest" (got "${channelExtract.value}")`,
+        );
+        return 1;
+      }
+      let remaining = channelExtract.rest;
+      const allowDowngradeIdx = remaining.indexOf("--allow-downgrade");
+      const allowDowngrade = allowDowngradeIdx !== -1;
+      if (allowDowngrade) {
+        remaining = remaining.filter((a) => a !== "--allow-downgrade");
+      }
       if (remaining.length > 1) {
         console.error(`parachute upgrade: unexpected argument "${remaining[1]}"`);
-        console.error("usage: parachute upgrade [<service>] [--tag <name>]");
+        console.error(
+          "usage: parachute upgrade [<service>] [--channel rc|latest] [--allow-downgrade] [--tag <name>]",
+        );
         return 1;
       }
       const upgradeOpts: Parameters<typeof upgrade>[1] = {};
       if (tagExtract.tag) upgradeOpts.tag = tagExtract.tag;
+      if (channelExtract.value === "rc" || channelExtract.value === "latest") {
+        upgradeOpts.channel = channelExtract.value;
+      }
+      if (allowDowngrade) upgradeOpts.allowDowngrade = true;
       return await upgrade(remaining[0], upgradeOpts);
     }
 

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -32,6 +32,19 @@
  * `bun add -g` to detect "already at latest" (the dist-tag didn't move).
  * Doing this avoids an unnecessary restart on a stable channel — a lot
  * cheaper than re-spawning a daemon that's already running the right code.
+ *
+ * Channel preservation (hub#332). The npm branch infers which dist-tag to
+ * use from the currently-installed version string: a `-rc(\.\d+)?$` suffix
+ * means the operator is on the rc chain → upgrade via `@rc`; otherwise
+ * `@latest`. This is load-bearing under pre-1.0 RC governance (parachute-
+ * patterns/patterns/governance.md rule 2): rc operators must stay on rc
+ * unless they explicitly promote. Before #332 the upgrade unconditionally
+ * pulled `@latest`, which silently downgraded an rc operator the moment
+ * `@latest` pointed at a prior stable. Operators can override the
+ * detection with `--channel rc|latest`. We also gate against silent
+ * downgrades: if `npm view <pkg>@<channel> version` resolves to something
+ * lower than what's installed, we abort with an actionable message
+ * (override with `--allow-downgrade`).
  */
 
 import { existsSync, readFileSync, realpathSync } from "node:fs";
@@ -101,8 +114,45 @@ export interface UpgradeOpts {
    * upgrade flow can be exercised without spawning real children.
    */
   restartFn?: (svc: string, opts: LifecycleOpts) => Promise<number>;
-  /** npm dist-tag for the npm-installed branch. Defaults to `latest`. Ignored when bun-linked. */
+  /**
+   * Explicit npm dist-tag for the npm-installed branch. When set, this
+   * overrides channel auto-detection AND the operator's `--channel` flag
+   * (it's a programmatic pin used by callers that already know what they
+   * want — e.g. tests). Operators don't pass `tag` directly; they pass
+   * `--channel rc|latest` which flows into `channel` below.
+   *
+   * Ignored when bun-linked.
+   */
   tag?: string;
+  /**
+   * Operator-facing channel override (`--channel rc|latest`). Bypasses the
+   * auto-detection that infers the channel from the currently-installed
+   * version string. When unset, `parachute upgrade` reads the installed
+   * package.json `version` and picks `@rc` if it matches `/-rc(\.\d+)?$/`,
+   * `@latest` otherwise.
+   *
+   * Per governance rule 2 (pre-1.0 RC versioning,
+   * `parachute-patterns/patterns/governance.md`), operators on the dev
+   * chain run `@rc`; `@latest` is the explicit-stable channel. The default
+   * `parachute upgrade` (pre hub#332) hard-coded `@latest`, which silently
+   * downgraded rc operators when `@latest` pointed at a prior stable.
+   */
+  channel?: "rc" | "latest";
+  /**
+   * Bypass the "refuses-to-downgrade" guard. The npm-install branch
+   * compares the target version (what `npm view <pkg>@<channel> version`
+   * resolves to) against the installed version and aborts if it would go
+   * backward. Set true to opt in to a real downgrade.
+   */
+  allowDowngrade?: boolean;
+  /**
+   * Test seam for resolving a dist-tag to a concrete version. Defaults to
+   * `npm view <pkg>@<channel> version` via the injected runner. Returning
+   * null is treated as "unknown — skip the downgrade guard" (network down,
+   * registry unreachable, package not yet published on that channel) so a
+   * flaky probe never blocks a legitimate upgrade.
+   */
+  resolveChannelVersion?: (pkg: string, channel: string) => Promise<string | null>;
 }
 
 interface ResolvedTarget {
@@ -119,7 +169,15 @@ interface Resolved {
   log: (line: string) => void;
   findGlobalInstall: (pkg: string) => string | null;
   restartFn: (svc: string, opts: LifecycleOpts) => Promise<number>;
-  tag: string;
+  /**
+   * Explicit pin (programmatic). When set, overrides both auto-detection
+   * and `channelOverride`. Undefined in the operator-facing default path.
+   */
+  tag: string | undefined;
+  /** Operator override (`--channel rc|latest`). Undefined → auto-detect. */
+  channelOverride: "rc" | "latest" | undefined;
+  allowDowngrade: boolean;
+  resolveChannelVersion: (pkg: string, channel: string) => Promise<string | null>;
 }
 
 function bunGlobalPrefixes(): string[] {
@@ -139,15 +197,117 @@ function defaultFindGlobalInstall(pkg: string): string | null {
 }
 
 function resolve(opts: UpgradeOpts): Resolved {
+  const runner = opts.runner ?? defaultRunner;
   return {
-    runner: opts.runner ?? defaultRunner,
+    runner,
     manifestPath: opts.manifestPath ?? SERVICES_MANIFEST_PATH,
     configDir: opts.configDir ?? CONFIG_DIR,
     log: opts.log ?? ((line) => console.log(line)),
     findGlobalInstall: opts.findGlobalInstall ?? defaultFindGlobalInstall,
     restartFn: opts.restartFn ?? ((svc, lifecycleOpts) => lifecycleRestart(svc, lifecycleOpts)),
-    tag: opts.tag ?? "latest",
+    tag: opts.tag,
+    channelOverride: opts.channel,
+    allowDowngrade: opts.allowDowngrade ?? false,
+    resolveChannelVersion:
+      opts.resolveChannelVersion ?? ((pkg, channel) => npmViewVersion(pkg, channel, runner)),
   };
+}
+
+/**
+ * Channel detection from a semver-ish version string. Pre-1.0 governance
+ * (parachute-patterns/patterns/governance.md rule 2) ships rc chains as
+ * `<x>.<y>.<z>-rc.<N>` (or sometimes `-rc` with no N). Anything matching that
+ * trailing suffix is the rc channel; everything else is the stable channel.
+ */
+export function detectChannel(installedVersion: string): "rc" | "latest" {
+  return /-rc(\.\d+)?$/.test(installedVersion) ? "rc" : "latest";
+}
+
+/**
+ * Inline semver-ish comparator. Returns < 0 / 0 / > 0 like `Array.prototype.sort`.
+ *
+ * Hub doesn't depend on `semver` and adding it for one call is overkill —
+ * npm dist-tags resolve to fully-qualified versions like `0.5.13-rc.13` or
+ * `0.5.10`, and we only need an ordering predicate ("would this be a
+ * downgrade?"). Spec compliance: split into [major, minor, patch] + an
+ * optional prerelease tail; numeric-compare the triple, then break ties by
+ * "no prerelease > has prerelease" (semver §11.4.3) and lex/numeric compare
+ * the prerelease dot-segments (§11.4.1–11.4.2). Returns null on malformed
+ * inputs so the caller can fail-open (skip the downgrade guard rather than
+ * block on a parser disagreement).
+ */
+export function compareVersions(a: string, b: string): number | null {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) return null;
+  for (let i = 0; i < 3; i++) {
+    const av = pa.parts[i] ?? 0;
+    const bv = pb.parts[i] ?? 0;
+    if (av !== bv) return av - bv;
+  }
+  // Equal triple: pre-release loses to no-pre-release.
+  if (pa.pre.length === 0 && pb.pre.length === 0) return 0;
+  if (pa.pre.length === 0) return 1;
+  if (pb.pre.length === 0) return -1;
+  // Both have pre-releases: dot-segment compare.
+  const len = Math.max(pa.pre.length, pb.pre.length);
+  for (let i = 0; i < len; i++) {
+    const av = pa.pre[i];
+    const bv = pb.pre[i];
+    if (av === undefined) return -1;
+    if (bv === undefined) return 1;
+    const an = /^\d+$/.test(av) ? Number(av) : null;
+    const bn = /^\d+$/.test(bv) ? Number(bv) : null;
+    if (an !== null && bn !== null) {
+      if (an !== bn) return an - bn;
+      continue;
+    }
+    if (an !== null) return -1; // numeric < non-numeric
+    if (bn !== null) return 1;
+    if (av < bv) return -1;
+    if (av > bv) return 1;
+  }
+  return 0;
+}
+
+function parseSemver(v: string): { parts: number[]; pre: string[] } | null {
+  // Tolerate a leading `v` and ignore build metadata after `+`.
+  const stripped = v.replace(/^v/, "").split("+")[0];
+  if (!stripped) return null;
+  const [core, ...preTail] = stripped.split("-");
+  if (!core) return null;
+  const partStrs = core.split(".");
+  if (partStrs.length < 1 || partStrs.length > 3) return null;
+  const parts: number[] = [];
+  for (const p of partStrs) {
+    if (!/^\d+$/.test(p)) return null;
+    parts.push(Number(p));
+  }
+  const pre = preTail.length === 0 ? [] : preTail.join("-").split(".").filter(Boolean);
+  return { parts, pre };
+}
+
+/**
+ * Resolve `<pkg>@<channel>` to a concrete version via `npm view`. Returns
+ * null when the probe fails (network down, registry unreachable, package
+ * not yet published on that channel) so callers can fail-open on the
+ * downgrade guard rather than block on a parser disagreement.
+ */
+async function npmViewVersion(
+  pkg: string,
+  channel: string,
+  runner: UpgradeRunner,
+): Promise<string | null> {
+  const { code, stdout } = await runner.capture(["npm", "view", `${pkg}@${channel}`, "version"]);
+  if (code !== 0) return null;
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+  // `npm view <pkg>@<tag> version` prints a single line ("0.5.10\n").
+  // Tag points to no version → empty stdout → return null above.
+  // Belt-and-braces: take the last non-empty line in case npm decided to be
+  // chatty.
+  const lines = trimmed.split("\n").filter(Boolean);
+  return lines[lines.length - 1] ?? null;
 }
 
 /**
@@ -389,10 +549,53 @@ async function upgradeLinked(
   return await r.restartFn(target.short, { manifestPath: r.manifestPath, configDir: r.configDir });
 }
 
+/**
+ * Pick which dist-tag we're going to ship at. Precedence:
+ *
+ *   1. explicit `tag` (programmatic — caller passed it directly)
+ *   2. operator `--channel rc|latest` flag
+ *   3. auto-detected from the installed version string (`-rc` suffix → rc)
+ *   4. `latest` fallback (no installed version to read — fresh-install case)
+ */
+function pickChannel(installedVersion: string | null, r: Resolved): string {
+  if (r.tag) return r.tag;
+  if (r.channelOverride) return r.channelOverride;
+  if (installedVersion) return detectChannel(installedVersion);
+  return "latest";
+}
+
 async function upgradeNpm(target: ResolvedTarget, sourceDir: string, r: Resolved): Promise<number> {
   r.log(`${target.short}: npm-installed (${sourceDir})`);
   const beforeVersion = readPackageVersion(join(sourceDir, "package.json"));
-  const spec = `${target.packageName}@${r.tag}`;
+  const channel = pickChannel(beforeVersion, r);
+
+  // Downgrade guard: refuse to silently move backward. Only applies when
+  // we can read both sides — beforeVersion from disk, targetVersion via
+  // `npm view`. A null on either side means we fail-open (legacy
+  // behavior: just run `bun add -g`). This is the load-bearing fix for
+  // hub#332 — Aaron got `0.5.13-rc.13` → `0.5.10` because the implicit
+  // `@latest` resolved to a prior stable while he was on the rc chain.
+  if (beforeVersion && !r.allowDowngrade) {
+    const targetVersion = await r.resolveChannelVersion(target.packageName, channel);
+    if (targetVersion) {
+      const cmp = compareVersions(targetVersion, beforeVersion);
+      if (cmp !== null && cmp < 0) {
+        const channelHint =
+          channel === "rc" ? "" : " or rerun with `--channel rc` to stay on the rc chain";
+        r.log(
+          `✗ ${target.short}: refusing to downgrade — installed ${beforeVersion}, ` +
+            `target @${channel} resolves to ${targetVersion}.`,
+        );
+        r.log(
+          `  To force this downgrade, run: bun add -g ${target.packageName}@${targetVersion}${channelHint}`,
+        );
+        r.log("  Or re-run with --allow-downgrade to bypass this check.");
+        return 1;
+      }
+    }
+  }
+
+  const spec = `${target.packageName}@${channel}`;
   r.log(`${target.short}: bun add -g ${spec}`);
   const code = await r.runner.run(["bun", "add", "-g", spec]);
   if (code !== 0) {

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -582,10 +582,15 @@ async function upgradeNpm(target: ResolvedTarget, sourceDir: string, r: Resolved
       if (cmp !== null && cmp < 0) {
         const channelHint =
           channel === "rc" ? "" : " or rerun with `--channel rc` to stay on the rc chain";
+        const rcNote =
+          channel === "rc"
+            ? "  (Unusual but possible: the @rc dist-tag may have been re-pointed at an older release.)"
+            : null;
         r.log(
           `✗ ${target.short}: refusing to downgrade — installed ${beforeVersion}, ` +
             `target @${channel} resolves to ${targetVersion}.`,
         );
+        if (rcNote) r.log(rcNote);
         r.log(
           `  To force this downgrade, run: bun add -g ${target.packageName}@${targetVersion}${channelHint}`,
         );

--- a/src/help.ts
+++ b/src/help.ts
@@ -330,9 +330,17 @@ export function upgradeHelp(): string {
 Usage:
   parachute upgrade                 upgrade every installed service
   parachute upgrade <service>       upgrade just that one
+  parachute upgrade [svc] --channel rc|latest
+                                    pin the dist-tag channel explicitly. Default:
+                                    auto-detect from the installed version (a
+                                    \`-rc\` suffix → rc; otherwise latest).
+  parachute upgrade [svc] --allow-downgrade
+                                    bypass the "refuses to downgrade" guard.
   parachute upgrade [svc] --tag <name>
-                                    npm-installed services only — pin a dist-tag
-                                    (default: latest). Ignored when bun-linked.
+                                    npm-installed services only — pin to an
+                                    explicit dist-tag or exact version. Overrides
+                                    --channel auto-detection. Ignored when
+                                    bun-linked.
 
 What it does:
   Detects whether the target service is bun-linked from a local checkout
@@ -343,18 +351,29 @@ What it does:
                 modules with a build script, then \`parachute restart\`.
                 Refuses on a dirty working tree — commit or stash first.
 
-    npm         bun add -g <pkg>@<tag>, then \`parachute restart\` if the
-                installed version actually moved.
+    npm         bun add -g <pkg>@<channel>, then \`parachute restart\` if the
+                installed version actually moved. Refuses silent downgrades:
+                if the resolved channel version is lower than what's installed,
+                aborts with an actionable message.
 
   Idempotent: if the source didn't change (HEAD unchanged after pull, or
   package.json version unchanged after bun add -g), the restart is skipped.
   Re-running on an up-to-date install is a fast no-op.
 
+Channel detection (hub#332):
+  Pre-1.0 governance ships two channels — \`@rc\` (the development chain) and
+  \`@latest\` (explicitly-promoted stable). \`parachute upgrade\` reads the
+  installed package.json \`version\` and keeps you on the same channel: a
+  \`-rc\` suffix (e.g. \`0.5.13-rc.13\`) means you're on rc and the upgrade
+  pulls \`@rc\`; otherwise it pulls \`@latest\`. Override with \`--channel\`.
+
 Examples:
   parachute upgrade                 sweep hub + every installed service
   parachute upgrade vault           just vault
   parachute upgrade hub             upgrade the dispatcher itself (closes #251)
-  parachute upgrade vault --tag rc  pin the rc dist-tag (npm path only)
+  parachute upgrade hub --channel rc        pin the rc channel
+  parachute upgrade hub --channel latest    pin the stable channel
+  parachute upgrade vault --tag 0.4.1       pin to an exact version
 `;
 }
 


### PR DESCRIPTION
Closes #332.

## The bug

Aaron's reproducer (live):

```
$ parachute upgrade hub
hub: bun add -g @openparachute/hub@latest
installed @openparachute/hub@0.5.10 with binaries:
 - parachute
hub: 0.5.13-rc.13 → 0.5.10; restarting…
```

`parachute upgrade <svc>` ran `bun add -g <pkg>@latest` unconditionally on the npm-installed path. When `@latest` pointed at a prior stable (the typical state mid-rc-chain), an operator on `@rc` got silently downgraded.

Per [governance rule 2](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md), pre-1.0 operators on the dev chain stay on `@rc`; `@latest` is the explicit-stable channel.

## What landed

- **Channel auto-detection (`src/commands/upgrade.ts:detectChannel`)** — reads the installed `package.json` `version` and infers the channel from a trailing `-rc(\.\d+)?$` suffix. The npm branch now composes `bun add -g <pkg>@<detected-channel>`.
- **Downgrade refusal (`src/commands/upgrade.ts:upgradeNpm`)** — before `bun add -g`, resolves `npm view <pkg>@<channel> version` and compares to the installed version with an inline semver comparator (no new dependency). If the resolved target is lower, aborts with an actionable message that includes the exact `bun add -g <pkg>@<exact-version>` command to force the downgrade. Fail-open: a flaky `npm view` skips the guard rather than blocking a legitimate upgrade.
- **`--channel rc|latest`** — operator override, wins over auto-detection.
- **`--allow-downgrade`** — opt-in bypass of the refusal.
- **`--tag <name>`** — unchanged behavior, still ignored when bun-linked. Takes precedence over `--channel` for programmatic callers.
- **Help text (`src/help.ts:upgradeHelp`)** — documents the new flags + the auto-detection rule.

## Install command — same bug?

Related but distinct shape: `parachute install <svc>` runs `bun add -g <pkg>` (no `@latest` literal but bun resolves an unsuffixed package to `@latest`). There's no installed version to detect a channel from, so the fresh-install default-channel question is a separate concern.

Filed as a follow-up: **[#337](https://github.com/ParachuteComputer/parachute-hub/issues/337)** — `parachute install` should accept `--channel rc|latest`.

## Version

`0.5.13-rc.16` → `0.5.13-rc.17`.

## Verify

- `bun run typecheck` → clean
- `bun test ./src` → 1889 pass / 0 fail (was 1880; +9 new cases in `upgrade.test.ts`)
- `bunx biome check src/` → clean

## Test plan

- [ ] Verify Aaron's reproducer no longer downgrades (`parachute upgrade hub` on 0.5.13-rc.13 pulls @rc, not @latest).
- [ ] Verify `parachute upgrade hub --channel latest` still allows promotion to a published stable when the operator opts in explicitly.
- [ ] Verify `parachute upgrade hub --allow-downgrade` bypasses the refusal.
- [ ] Verify a stable installed version (`0.5.10`) auto-detects to `@latest`.
- [ ] Verify the sweep path (`parachute upgrade` with no arg) preserves the channel for every service in services.json.

## Cross-references

- [governance rule 2](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md) — RC versioning convention.
- [#337](https://github.com/ParachuteComputer/parachute-hub/issues/337) — install-side follow-up.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>