### PR TITLE
chore(hub): retire kind from types + parser + KNOWN_MODULES + upgrade branch (closes #330)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.19] - 2026-05-23
+
+**chore(hub): retire `kind` from types + manifest parser + `KNOWN_MODULES` + `upgrade.ts` build branch (closes [hub#330](https://github.com/ParachuteComputer/parachute-hub/issues/330)).**
+
+Completes hub#301 Phase C/D. Phase A ([hub#327](https://github.com/ParachuteComputer/parachute-hub/pull/327)) made `kind` optional in the manifest validator; Phase B retired `kind` from the per-module `.parachute/module.json` files in vault, scribe, runner, and app (vault#359, scribe#52, runner#7, app#29 — all merged); patterns#84 dropped the field from the canonical module-protocol pattern docs. This PR finishes the cleanup by deleting hub's remaining references.
+
+### Removed
+
+- `kind` field fully retired from hub. Removed the `ModuleKind` type alias, `ServiceKind` type alias, the `asKind` parser, and all `kind:` declarations in `KNOWN_MODULES` / `FIRST_PARTY_FALLBACKS`. The `upgrade.ts` `kind === "frontend"` branch (which ran `bun run build` post-install for notes-daemon on the bun-linked path) also retires — notes-daemon's `prepublishOnly` script builds `dist/` at publish time and its `files` array ships `dist/`, so consumers don't need a post-install rebuild. Module authors who still ship `kind` in `module.json` aren't broken: the validator silently ignores it.
+
+### What landed
+
+- **`src/module-manifest.ts`** — deleted `ModuleKind` export, the `kind?: ModuleKind` field from `ModuleManifest`, the `asKind` parser function, and the validator's `kind` write-through.
+- **`src/service-spec.ts`** — deleted the `ServiceKind` type alias, the `kind?: ServiceKind` field from `ServiceSpec`, the `kind: ModuleKind` field from `KnownModule`, the import-time `ModuleKind` alias, and the `kind:` value on every `KNOWN_MODULES` entry (vault, scribe, runner, app) + on both `FIRST_PARTY_FALLBACKS` (notes, channel). `composeServiceSpec`, `synthesizeManifestForKnownModule`, and `getSpec`'s synthesis path no longer set `kind`. `effectivePublicExposure` collapses to a single signal: `extras.hasAuth === false` ⇒ "auth-required", else "allowed" — same outcome for every module today (scribe is the canonical `hasAuth: false` case).
+- **`src/commands/upgrade.ts`** — dropped the `if (target.spec?.kind === "frontend") { bun run build }` branch and the now-unused `packageHasScript` helper. Updated the file's docstring to remove the "bun run build (frontend kind, if `build` script exists)" line.
+- **Tests** — collapsed `module-manifest.test.ts`'s five "kind is no longer validated" sub-tests into one "kind values in module.json are silently ignored" test that pins the new behavior (parsed manifest exposes no `kind` field). Refactored `upgrade.test.ts`'s "bun-linked frontend: runs bun run build" test into the inverse assertion: `bun run build` is NOT invoked even when a module declares a `build` script. Removed `kind:` from `readModuleManifest` fixtures in `hub-server.test.ts`, `post-install.test.ts`, `api-modules-ops.test.ts`, `install.test.ts`, and `lifecycle.test.ts` — those fixtures are typed against `ModuleManifest`, so the field deletion cascades into the test surface.
+
+### Verification
+
+- Notes-daemon's `prepublishOnly` runs `bun run build` (verified in `parachute-notes/packages/notes-daemon/package.json`); the `files` array publishes `dist/`. Post-install rebuild on the consumer side was never load-bearing — npm tarballs ship complete.
+- `bun run typecheck` clean; `bun test ./src` 1902 pass / 0 fail (delta from rc.18: −5 tests, all from the module-manifest kind sub-test collapse + the upgrade frontend-build test refactor); `bunx biome check src/` clean.
+
+### Back-compat
+
+- Third-party + first-party `module.json` files that still declare `kind` keep parsing fine — the validator silently ignores the field, no warnings, no errors.
+- Modules previously installed under any `kind` value continue to start, restart, upgrade, and expose normally. The `effectivePublicExposure` defaults preserve the previous behavior for every known module (vault / scribe / runner / app / notes / channel).
+- The bun-linked-checkout `parachute upgrade notes` path no longer runs `bun run build` post-pull. Operators running notes-daemon from a local checkout who relied on this can run `bun run build` themselves; the published npm tarball already includes `dist/`.
+
 ## [0.5.13-rc.18] - 2026-05-23
 
 **feat(hub): `parachute install` accepts `--channel rc|latest` + honors `PARACHUTE_INSTALL_CHANNEL` env; Render deploy cascades rc across modules.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.18",
+  "version": "0.5.13-rc.19",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-modules-ops.test.ts
+++ b/src/__tests__/api-modules-ops.test.ts
@@ -937,7 +937,6 @@ describe("well-known regen after module ops", () => {
     manifest: {
       name: string;
       manifestName: string;
-      kind: "api" | "frontend" | "tool";
       port: number;
       paths: string[];
       health: string;
@@ -965,7 +964,6 @@ describe("well-known regen after module ops", () => {
     const install = fakeInstall("@openparachute/vault", {
       name: "vault",
       manifestName: "parachute-vault",
-      kind: "api",
       port: 1940,
       paths: ["/vault/default"],
       health: "/vault/default/health",
@@ -1069,7 +1067,6 @@ describe("well-known regen after module ops", () => {
     const install = fakeInstall("@openparachute/vault", {
       name: "vault",
       manifestName: "parachute-vault",
-      kind: "api",
       port: 1940,
       paths: ["/vault/default"],
       health: "/vault/default/health",
@@ -1159,7 +1156,6 @@ describe("well-known regen after module ops", () => {
     const install = fakeInstall("@openparachute/vault", {
       name: "vault",
       manifestName: "parachute-vault",
-      kind: "api",
       port: 1940,
       paths: ["/vault/default"],
       health: "/vault/default/health",

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -243,7 +243,6 @@ describe("hubFetch routing", () => {
         readModuleManifest: async () => ({
           name: "vault",
           manifestName: "parachute-vault",
-          kind: "api",
           port: 1940,
           paths: ["/vault/default"],
           health: "/health",
@@ -298,7 +297,6 @@ describe("hubFetch routing", () => {
         readModuleManifest: async () => ({
           name: "notes",
           manifestName: "parachute-notes",
-          kind: "frontend",
           port: 5173,
           paths: ["/notes"],
           health: "/health",
@@ -335,7 +333,6 @@ describe("hubFetch routing", () => {
         readModuleManifest: async () => ({
           name: "notes",
           manifestName: "parachute-notes",
-          kind: "frontend",
           port: 5173,
           paths: ["/notes"],
           health: "/health",
@@ -362,7 +359,6 @@ describe("hubFetch routing", () => {
         readModuleManifest: async () => ({
           name: "vault",
           manifestName: "parachute-vault",
-          kind: "api",
           port: 1940,
           paths: ["/vault/default"],
           health: "/health",

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -779,7 +779,6 @@ describe("install", () => {
         readManifest: async () => ({
           name: "demo",
           manifestName: "@local/demo",
-          kind: "api",
           port: 1951,
           paths: ["/demo"],
           health: "/healthz",
@@ -1421,7 +1420,6 @@ describe("install", () => {
         readManifest: async () => ({
           name: "widget",
           manifestName: "@acme/widget",
-          kind: "api",
           port: 1950,
           paths: ["/widget"],
           health: "/healthz",
@@ -1479,7 +1477,6 @@ describe("install", () => {
         readManifest: async () => ({
           name: "vault",
           manifestName: "@evil/squatter",
-          kind: "api",
           port: 1950,
           paths: ["/vault"],
           health: "/healthz",
@@ -1512,7 +1509,6 @@ describe("install", () => {
         readManifest: async () => ({
           name: "demo",
           manifestName: "@local/demo",
-          kind: "api",
           port: 1951,
           paths: ["/demo"],
           health: "/healthz",
@@ -1564,7 +1560,6 @@ describe("install", () => {
         readManifest: async () => ({
           name: "demo",
           manifestName: "@local/demo",
-          kind: "api",
           port: 1951,
           paths: ["/demo"],
           health: "/healthz",
@@ -1608,7 +1603,6 @@ describe("install", () => {
         readManifest: async () => ({
           name: "demo",
           manifestName: "@local/demo",
-          kind: "api",
           port: 1951,
           paths: ["/demo"],
           health: "/healthz",
@@ -1641,7 +1635,6 @@ describe("install", () => {
         readManifest: async () => ({
           name: "widget",
           manifestName: "@vendor/widget",
-          kind: "api",
           port: 1952,
           paths: ["/widget"],
           health: "/widget/health",
@@ -1684,7 +1677,6 @@ describe("install", () => {
         readManifest: async () => ({
           name: "someapp",
           manifestName: "parachute-someapp",
-          kind: "api",
           port: 1945,
           paths: ["/someapp"],
           health: "/someapp/health",

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -80,7 +80,6 @@ function seedThirdParty(
   const manifest = {
     name,
     manifestName: opts.manifestName ?? name,
-    kind: "api" as const,
     port: opts.port ?? 1944,
     paths: [`/${name}`],
     health: `/${name}/health`,

--- a/src/__tests__/module-manifest.test.ts
+++ b/src/__tests__/module-manifest.test.ts
@@ -12,7 +12,6 @@ import {
 const VALID = {
   name: "demo",
   manifestName: "@example/demo",
-  kind: "api",
   port: 1950,
   paths: ["/demo"],
   health: "/healthz",
@@ -22,7 +21,6 @@ describe("validateModuleManifest", () => {
   test("accepts a minimal valid manifest", () => {
     const m = validateModuleManifest(VALID, "test");
     expect(m.name).toBe("demo");
-    expect(m.kind).toBe("api");
     expect(m.port).toBe(1950);
     expect(m.paths).toEqual(["/demo"]);
     expect(m.health).toBe("/healthz");
@@ -35,8 +33,6 @@ describe("validateModuleManifest", () => {
 
   test("rejects missing required fields", () => {
     expect(() => validateModuleManifest({ ...VALID, name: undefined }, "x")).toThrow(/name/);
-    // `kind` is NOT validated as of hub#327 — see the "kind is no longer
-    // validated" suite below for the full behavior surface.
     expect(() => validateModuleManifest({ ...VALID, port: -1 }, "x")).toThrow(/port/);
     expect(() => validateModuleManifest({ ...VALID, port: 99999 }, "x")).toThrow(/port/);
     expect(() => validateModuleManifest({ ...VALID, paths: "not-array" }, "x")).toThrow(/paths/);
@@ -45,59 +41,23 @@ describe("validateModuleManifest", () => {
     );
   });
 
-  // hub#327 (hub#301 Phase A fold): the validator no longer inspects `kind`.
-  // Any value — present, absent, valid string, typo, wrong type — is
-  // accepted. The single downstream read site
-  // (`commands/upgrade.ts: target.spec?.kind === "frontend"`) handles the
-  // absent / non-"frontend" case via falsy-fallthrough into the
-  // backend-proxy default.
-  describe("kind is no longer validated (hub#327)", () => {
-    test("missing kind is accepted and produces an undefined kind", () => {
-      const { kind: _ignored, ...withoutKind } = VALID;
-      const m = validateModuleManifest(withoutKind, "x");
-      expect(m.kind).toBeUndefined();
-    });
-
-    test("explicit kind: 'frontend' passes through unchanged", () => {
-      const m = validateModuleManifest({ ...VALID, kind: "frontend" }, "x");
-      expect(m.kind).toBe("frontend");
-    });
-
-    test("explicit kind: 'api' passes through unchanged", () => {
-      const m = validateModuleManifest({ ...VALID, kind: "api" }, "x");
-      expect(m.kind).toBe("api");
-    });
-
-    test("explicit kind: 'tool' passes through unchanged", () => {
-      const m = validateModuleManifest({ ...VALID, kind: "tool" }, "x");
-      expect(m.kind).toBe("tool");
-    });
-
-    test("invalid kind values are also accepted (validator no longer inspects)", () => {
-      // Per Aaron's direction on #327: stop validating kind. Typos,
-      // novel strings, wrong types — none of them error. The validator
-      // simply doesn't look at the field. Downstream routing branches on
-      // `kind === "frontend"` and falls through gracefully for anything
-      // else (including these), so accepting them is safe.
-      const m1 = validateModuleManifest({ ...VALID, kind: "static" }, "x");
-      expect(m1.kind).toBeUndefined();
-      const m2 = validateModuleManifest({ ...VALID, kind: "backend" }, "x");
-      expect(m2.kind).toBeUndefined();
-      const m3 = validateModuleManifest({ ...VALID, kind: null }, "x");
-      expect(m3.kind).toBeUndefined();
-      const m4 = validateModuleManifest({ ...VALID, kind: 42 }, "x");
-      expect(m4.kind).toBeUndefined();
-    });
-
-    test("routing-relevant kind: 'frontend' still survives the validator (upgrade.ts branch intact)", () => {
-      // Defensive sanity check: the one downstream branch that reads kind
-      // (commands/upgrade.ts checks `target.spec?.kind === "frontend"` to
-      // decide whether to run `bun run build`) keeps working — when a
-      // module DOES declare `kind: "frontend"`, the value reaches that
-      // branch untouched.
-      const m = validateModuleManifest({ ...VALID, kind: "frontend" }, "x");
-      expect(m.kind === "frontend").toBe(true);
-    });
+  // hub#301 Phase C/D (#330): the `kind` field is fully retired. Hub doesn't
+  // read it anymore; module.json values are silently ignored. Validation just
+  // doesn't inspect the field — present, absent, valid string, typo, wrong
+  // type — none of it errors and none of it surfaces on the parsed manifest.
+  test("kind values in module.json are silently ignored (hub#330)", () => {
+    // No matter what the author wrote, the validator passes through without
+    // throwing and the parsed manifest exposes no `kind` field.
+    expect(() => validateModuleManifest({ ...VALID, kind: "frontend" }, "x")).not.toThrow();
+    expect(() => validateModuleManifest({ ...VALID, kind: "api" }, "x")).not.toThrow();
+    expect(() => validateModuleManifest({ ...VALID, kind: "tool" }, "x")).not.toThrow();
+    expect(() => validateModuleManifest({ ...VALID, kind: "static" }, "x")).not.toThrow();
+    expect(() => validateModuleManifest({ ...VALID, kind: 42 }, "x")).not.toThrow();
+    expect(() => validateModuleManifest({ ...VALID, kind: null }, "x")).not.toThrow();
+    // The parsed manifest type has no `kind` field at all — confirm the
+    // validator doesn't smuggle it through as a hidden property.
+    const m = validateModuleManifest({ ...VALID, kind: "frontend" }, "x");
+    expect((m as { kind?: unknown }).kind).toBeUndefined();
   });
 
   test("rejects invalid name shape", () => {

--- a/src/__tests__/post-install.test.ts
+++ b/src/__tests__/post-install.test.ts
@@ -176,7 +176,6 @@ describe("refreshWellKnown", () => {
             ? {
                 name: "notes",
                 manifestName: "parachute-notes",
-                kind: "frontend",
                 port: 5173,
                 paths: ["/notes"],
                 health: "/notes/health",
@@ -260,7 +259,6 @@ describe("finalizeModuleInstall", () => {
       const manifest = {
         name: "vault",
         manifestName: "parachute-vault",
-        kind: "api" as const,
         port: 1940,
         paths: ["/vault/default"],
         health: "/vault/default/health",

--- a/src/__tests__/upgrade.test.ts
+++ b/src/__tests__/upgrade.test.ts
@@ -288,7 +288,13 @@ describe("parachute upgrade", () => {
     }
   });
 
-  test("bun-linked frontend: runs bun run build before restart", async () => {
+  // hub#301 Phase C/D (#330): `kind` retired and the bun-linked
+  // `kind === "frontend"` build branch retires with it. Notes-daemon's
+  // `prepublishOnly` builds dist at publish time so consumers don't need a
+  // post-install rebuild; this test pins the new behavior — even a
+  // historical frontend module (with a `build` script in package.json)
+  // does NOT trigger `bun run build` during an upgrade.
+  test("bun-linked: no bun run build invoked (kind branch retired in #330)", async () => {
     const h = makeHarness();
     try {
       const installDir = join(h.installRoot, "notes");
@@ -341,7 +347,7 @@ describe("parachute upgrade", () => {
         log: () => {},
       });
       expect(code).toBe(0);
-      expect(ranBuild.value).toBe(true);
+      expect(ranBuild.value).toBe(false);
     } finally {
       h.cleanup();
     }

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -7,7 +7,6 @@
  *
  *   bun-linked:   git -C <checkout> pull --ff-only;
  *                 bun install --frozen-lockfile (if package.json/bun.lock changed);
- *                 bun run build (frontend kind, if `build` script exists);
  *                 parachute restart <svc>.
  *
  *   npm-installed: bun add -g <pkg>@<tag>; parachute restart <svc>.
@@ -458,15 +457,6 @@ async function listChangedFiles(
   return stdout.trim().split("\n").filter(Boolean);
 }
 
-function packageHasScript(pkgJsonPath: string, name: string): boolean {
-  try {
-    const json = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
-    return Boolean(json?.scripts && typeof json.scripts[name] === "string");
-  } catch {
-    return false;
-  }
-}
-
 function readPackageVersion(pkgJsonPath: string): string | null {
   try {
     const json = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
@@ -530,18 +520,6 @@ async function upgradeLinked(
     if (inst !== 0) {
       r.log(`✗ ${target.short}: bun install failed (exit ${inst})`);
       return inst;
-    }
-  }
-
-  if (target.spec?.kind === "frontend") {
-    const pkgJsonPath = join(sourceDir, "package.json");
-    if (packageHasScript(pkgJsonPath, "build")) {
-      r.log(`${target.short}: bun run build`);
-      const build = await r.runner.run(["bun", "run", "build"], { cwd: sourceDir });
-      if (build !== 0) {
-        r.log(`✗ ${target.short}: bun run build failed (exit ${build})`);
-        return build;
-      }
     }
   }
 

--- a/src/module-manifest.ts
+++ b/src/module-manifest.ts
@@ -24,8 +24,6 @@
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 
-export type ModuleKind = "api" | "frontend" | "tool";
-
 export interface ModuleScopeBlock {
   /** OAuth scopes this module owns. Namespaced by `name` per oauth-scopes.md. */
   readonly defines?: readonly string[];
@@ -76,17 +74,6 @@ export interface ModuleManifest {
   readonly displayName?: string;
   /** One-line subtitle rendered under displayName. */
   readonly tagline?: string;
-  /**
-   * Historically drove card vs. iframe vs. launcher in the hub. As of
-   * hub#301 Phase A's fold (#327) the validator no longer inspects `kind` —
-   * any value, or no value at all, is accepted and passes through untouched.
-   * Routing branches downstream use `=== "frontend"` style checks which
-   * treat undefined/other values as the backend-proxy default (so the
-   * routing remains correct without validator enforcement). New modules
-   * may safely omit the field; existing values are preserved for the
-   * narrow `kind === "frontend"` branch in `commands/upgrade.ts`.
-   */
-  readonly kind?: ModuleKind;
   /** Default loopback port. CLI warns on conflict, doesn't block. */
   readonly port: number;
   /** URL paths the module serves under the hub origin. */
@@ -174,21 +161,6 @@ function asOptionalString(v: unknown, where: string, field: string): string | un
     throw new ModuleManifestError(`${where}: "${field}" must be a string if present`);
   }
   return v;
-}
-
-/**
- * Pass-through `kind` reader (hub#301 Phase A fold — #327).
- *
- * The validator no longer inspects `kind`. Any value, or no value, is
- * accepted. We narrow to the canonical `ModuleKind` only when the input is
- * one of the three known strings — otherwise we drop the field entirely so
- * downstream `kind === "frontend"` branches fall through to the
- * backend-proxy default. Author intent (typo, novel value, omission) is no
- * longer surfaced from this layer; it's not the validator's job anymore.
- */
-function asKind(v: unknown): ModuleKind | undefined {
-  if (v === "api" || v === "frontend" || v === "tool") return v;
-  return undefined;
 }
 
 function asPort(v: unknown, where: string): number {
@@ -358,10 +330,10 @@ function asDependencies(v: unknown, where: string): Record<string, ModuleDepende
 /**
  * Strict validator. Throws `ModuleManifestError` with the source path so
  * malformed third-party modules get a clear-enough error to fix. Required
- * fields are name, manifestName, port, paths, health. `kind` is no longer
- * inspected as of hub#301 Phase A's fold (#327) — any value (or none) is
- * accepted and passes through untouched. See `asKind` for the narrowing
- * behavior.
+ * fields are name, manifestName, port, paths, health. The historical `kind`
+ * field is fully retired as of hub#301 Phase C/D (#330) — any value (or none)
+ * is silently ignored; modules and third parties may continue to ship it in
+ * `module.json` without error but hub no longer reads it.
  *
  * The optional `logger` parameter is retained for forward-compatibility
  * with future validator soft-warnings, even though the kind soft-warning
@@ -384,7 +356,6 @@ export function validateModuleManifest(
     );
   }
   const manifestName = asString(m.manifestName, where, "manifestName");
-  const kind = asKind(m.kind);
   const port = asPort(m.port, where);
   const paths = asStringArray(m.paths, where, "paths");
   const health = asHealthPath(m.health, where);
@@ -433,7 +404,6 @@ export function validateModuleManifest(
   }
 
   const out: ModuleManifest = { name, manifestName, port, paths, health };
-  if (kind !== undefined) (out as { kind?: ModuleKind }).kind = kind;
   if (displayName !== undefined) (out as { displayName?: string }).displayName = displayName;
   if (tagline !== undefined) (out as { tagline?: string }).tagline = tagline;
   if (startCmd !== undefined) (out as { startCmd?: readonly string[] }).startCmd = startCmd;

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -79,16 +79,6 @@ export function isCanonicalPort(port: number): boolean {
 }
 
 /**
- * Broad shape of a service. Matches the hub's card-kind taxonomy.
- *   "frontend"  a user-facing UI (notes). Safe to expose by default.
- *   "api"       a programmatic surface (vault, channel, scribe). Whether
- *               it's safe to expose depends on `hasAuth`.
- *   "tool"      like "api" but specifically MCP-shaped / agent-callable.
- *               Treated the same as "api" for exposure defaults.
- */
-export type ServiceKind = "api" | "tool" | "frontend";
-
-/**
  * Imperative behaviors that don't fit the static `module.json` schema.
  *
  * First-party only. Each first-party fallback declares its own extras
@@ -174,14 +164,6 @@ export interface ServiceSpec {
    * First service boot overwrites the seed with its own authoritative version.
    */
   readonly seedEntry?: () => ServiceEntry;
-  /**
-   * Optional as of hub#327 (Phase A's fold): the validator no longer
-   * inspects `kind`, so synthesized + third-party-manifest specs may
-   * carry `undefined` here. The single read site
-   * (`commands/upgrade.ts: target.spec?.kind === "frontend"`) handles
-   * the absent case via the `=== "frontend"` falsy-fallthrough.
-   */
-  readonly kind?: ServiceKind;
   readonly hasAuth?: boolean;
   readonly urlForEntry?: (entry: ServiceEntry) => string | undefined;
   readonly postInstallFooter?: () => readonly string[];
@@ -239,7 +221,6 @@ export function composeServiceSpec(opts: {
     package: packageName,
     manifestName: manifest.manifestName,
     seedEntry: () => seedEntryFromManifest(manifest),
-    kind: manifest.kind,
   };
   if (extras?.init !== undefined) (spec as { init?: readonly string[] }).init = extras.init;
   if (startCmd !== undefined) {
@@ -301,7 +282,6 @@ const NOTES_FALLBACK: FirstPartyFallback = {
     manifestName: "parachute-notes",
     displayName: "Notes",
     tagline: "Notes PWA — daemon deprecated 2026-05-22; install `app` for the current path.",
-    kind: "frontend",
     port: 1942,
     paths: ["/notes"],
     health: "/notes/health",
@@ -331,7 +311,6 @@ const CHANNEL_FALLBACK: FirstPartyFallback = {
     manifestName: "parachute-channel",
     displayName: "Channel",
     tagline: "Notification fan-out across modules.",
-    kind: "api",
     port: 1941,
     paths: ["/channel"],
     health: "/channel/health",
@@ -397,9 +376,6 @@ export interface KnownModule {
   /** Pre-install catalog surfaces use these. After install, services.json wins. */
   readonly displayName: string;
   readonly tagline: string;
-  /** Module kind — needed for `synthesizeManifest` since KNOWN_MODULES doesn't
-   *  carry an embedded manifest. All three current entries are api/tool. */
-  readonly kind: ModuleKind;
   /** Canonical mount paths — used to synthesize a minimal manifest when
    *  module.json is unreadable (legacy install paths, test fixtures). The
    *  module's own `module.json` overrides these once it's installed. */
@@ -412,12 +388,6 @@ export interface KnownModule {
   readonly extras?: FirstPartyExtras;
 }
 
-// Local import-time alias for ModuleKind so the public KnownModule type can
-// reference it without forcing every consumer to import from
-// module-manifest. The same `ModuleKind` type is exported from there for
-// callers that want it directly.
-type ModuleKind = ModuleManifest["kind"];
-
 export const KNOWN_MODULES: Record<string, KnownModule> = {
   vault: {
     short: "vault",
@@ -426,7 +396,6 @@ export const KNOWN_MODULES: Record<string, KnownModule> = {
     canonicalPort: 1940,
     displayName: "Vault",
     tagline: "Your owner-authenticated MCP knowledge store.",
-    kind: "api",
     canonicalPaths: ["/vault/default"],
     canonicalHealth: "/vault/default/health",
     extras: {
@@ -446,7 +415,6 @@ export const KNOWN_MODULES: Record<string, KnownModule> = {
     canonicalPort: 1943,
     displayName: "Scribe",
     tagline: "Local audio transcription for vault recordings.",
-    kind: "api",
     canonicalPaths: ["/scribe"],
     canonicalHealth: "/scribe/health",
     canonicalStripPrefix: true,
@@ -481,7 +449,6 @@ export const KNOWN_MODULES: Record<string, KnownModule> = {
     displayName: "Runner",
     tagline:
       "Vault-as-job-substrate engine — spawns claude -p against vault job notes on schedule.",
-    kind: "tool",
     canonicalPaths: ["/runner", "/.parachute"],
     canonicalHealth: "/runner/healthz",
     canonicalStripPrefix: false,
@@ -507,10 +474,6 @@ export const KNOWN_MODULES: Record<string, KnownModule> = {
     // still exists as a back-compat install (CURATED_MODULES still lists
     // `notes`) but `app` is the recommended first install post-vault.
     tagline: "Host module for Parachute UIs — auto-installs Notes on first boot.",
-    // Frontend posture: app's primary surface is serving sub-app UIs under
-    // `/app/<name>/` mounted under one origin (design doc §12). Hub's
-    // exposure-default + supervisor-defaults follow the frontend lane.
-    kind: "frontend",
     canonicalPaths: ["/app", "/.parachute"],
     canonicalHealth: "/app/healthz",
     canonicalStripPrefix: false,
@@ -576,7 +539,6 @@ export function synthesizeManifestForKnownModule(km: KnownModule): ModuleManifes
     manifestName: km.manifestName,
     displayName: km.displayName,
     tagline: km.tagline,
-    kind: km.kind,
     port: km.canonicalPort,
     paths: km.canonicalPaths,
     health: km.canonicalHealth,
@@ -611,30 +573,17 @@ export function effectivePublicExposure(
   if (entry.publicExposure !== undefined) return entry.publicExposure;
   const short = shortNameForManifest(entry.name);
   if (short === undefined) return "allowed";
-  // FALLBACK path: notes / channel still vendor their kind + extras.
+  // Post hub#301 Phase C/D (`kind` field retired — hub#330), the
+  // exposure-default heuristic collapses to the imperative `extras.hasAuth`
+  // signal: an explicit `hasAuth: false` declaration ("no auth gate
+  // implemented yet") → require auth before exposing; anything else →
+  // allowed. Scribe is the canonical `hasAuth: false` case today.
   const fb = FIRST_PARTY_FALLBACKS[short];
   if (fb) {
-    if (
-      (fb.manifest.kind === "api" || fb.manifest.kind === "tool") &&
-      fb.extras?.hasAuth === false
-    ) {
-      return "auth-required";
-    }
-    return "allowed";
+    return fb.extras?.hasAuth === false ? "auth-required" : "allowed";
   }
-  // KNOWN_MODULES path: vault / scribe / runner. The `kind` lives on
-  // services.json (operator-authoritative after self-register) — if the row
-  // doesn't declare it, fall through to the imperative `extras.hasAuth`
-  // signal which says "no auth gate → require auth before exposing." This
-  // matches the pre-retirement FALLBACK behavior for scribe.
   const km = KNOWN_MODULES[short];
-  if (km && km.extras?.hasAuth === false) {
-    // Only api/tool services hit the "auth-required default" lane —
-    // services.json's `kind` is the authoritative source; absent it,
-    // KNOWN_MODULES doesn't carry `kind` so we assume an api/tool posture
-    // (the three KNOWN_MODULES entries are all api/tool today).
-    return "auth-required";
-  }
+  if (km && km.extras?.hasAuth === false) return "auth-required";
   return "allowed";
 }
 
@@ -699,14 +648,13 @@ export function getSpec(short: string): ServiceSpec | undefined {
   const km = KNOWN_MODULES[short];
   if (!km) return undefined;
   // Use the synthesized manifest from KNOWN_MODULES' canonical fields so
-  // downstream consumers (seedEntry, kind-aware exposure, port assignment)
-  // see a coherent spec. Module.json wins at lifecycle time
-  // (`composeKnownModuleSpec`); this synth is the bootstrap shape.
+  // downstream consumers (seedEntry, port assignment) see a coherent spec.
+  // Module.json wins at lifecycle time (`composeKnownModuleSpec`); this
+  // synth is the bootstrap shape.
   const synthManifest = synthesizeManifestForKnownModule(km);
   const spec: ServiceSpec = {
     package: km.package,
     manifestName: km.manifestName,
-    kind: synthManifest.kind,
     seedEntry: () => seedEntryFromManifest(synthManifest),
   };
   if (km.extras?.hasAuth !== undefined) {

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -551,10 +551,10 @@ export function synthesizeManifestForKnownModule(km: KnownModule): ModuleManifes
 
 /**
  * Effective publicExposure for a service, given what's on its services.json
- * entry. Explicit wins. If absent, derive from the spec: known api/tool
- * services without declared auth fall back to "auth-required"; everything
- * else defaults to "allowed" — so vault, notes, channel and unknown
- * third-party services continue to be exposed without needing to opt in.
+ * entry. Explicit wins. If absent, derive from the spec: services with
+ * declared auth (extras.hasAuth === true, or no hasAuth set) default to
+ * "allowed"; services with extras.hasAuth === false default to
+ * "auth-required". Unknown third-party services default to "allowed".
  *
  * Layer behavior (post-#187 layer-aware proxy):
  *   "allowed"        — reaches all layers (loopback / tailnet / public);
@@ -628,7 +628,7 @@ export function canonicalPortForManifest(manifestName: string): number | undefin
  *
  * KNOWN_MODULES shorts (vault / scribe / runner — post hub#310 FALLBACK
  * retirement) return a **minimal** spec carrying `package`, `manifestName`,
- * `kind` (best-effort api/tool), and the imperative `extras` fields
+ * and the imperative `extras` fields
  * (`init`, `hasAuth`, `urlForEntry`, `postInstallFooter`). They do NOT carry
  * `startCmd` or `seedEntry` — those come from `<installDir>/.parachute/module.json`
  * at lifecycle time via {@link getSpecFromInstallDir}, since the module

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -18,7 +18,7 @@ import { RETIRED_MODULES } from "./service-spec.ts";
  *                   auth state over `/.parachute/info`.
  *
  * Absent field: the CLI derives a safe default from the service's ServiceSpec
- * (known api/tool services without declared auth → "auth-required"; everything
+ * (services with extras.hasAuth === false → "auth-required"; everything
  * else → "allowed"). Unknown services default to "allowed" for back-compat.
  */
 export type PublicExposure = "allowed" | "loopback" | "auth-required";


### PR DESCRIPTION
## Summary

Completes hub#301 Phase C/D — `kind` field fully retired from hub. Drops the `ModuleKind` + `ServiceKind` type aliases, the `asKind` validator helper, every `kind:` declaration in `KNOWN_MODULES` (vault / scribe / runner / app) and `FIRST_PARTY_FALLBACKS` (notes / channel), and the `upgrade.ts` `kind === "frontend"` branch (which ran `bun run build` post-install for notes-daemon on the bun-linked path).

Closes [hub#330](https://github.com/ParachuteComputer/parachute-hub/issues/330).

## Phase context

- **Phase A** — [hub#327](https://github.com/ParachuteComputer/parachute-hub/pull/327): made `kind` optional in the manifest validator.
- **Phase B** — per-module drops: [vault#359](https://github.com/ParachuteComputer/parachute-vault/pull/359), [scribe#52](https://github.com/ParachuteComputer/parachute-scribe/pull/52), [runner#7](https://github.com/ParachuteComputer/parachute-runner/pull/7), [app#29](https://github.com/ParachuteComputer/parachute-app/pull/29) (all merged); [patterns#84](https://github.com/ParachuteComputer/parachute-patterns/pull/84) dropped `kind` as canonical from the module-protocol pattern docs.
- **Phase C/D (this PR)** — hub's TypeScript types + parser + registries + `upgrade.ts` branch.

## Notes-daemon build-step verification

Verified [`parachute-notes/packages/notes-daemon/package.json`](https://github.com/ParachuteComputer/parachute-notes/blob/main/packages/notes-daemon/package.json):

```json
"files": ["dist", ".parachute/module.json", "README.md", "LICENSE", "CHANGELOG.md", "DEPRECATED.md"],
"scripts": {
  "build": "node scripts/build.mjs",
  "test": "node scripts/build.test.mjs",
  "prepublishOnly": "bun run build"
}
```

`prepublishOnly` builds `dist/` at publish time and `files` ships the built artifact. Consumers of the published npm tarball get a complete bundle — no post-install rebuild needed. The `upgrade.ts` build branch was operator-only (bun-linked-checkout path) and notes-daemon is the only module that ever had `kind: "frontend"` anyway. The branch retires cleanly.

## What landed

- **`src/module-manifest.ts`** — deleted `ModuleKind` export, the `kind?` field from `ModuleManifest`, the `asKind` parser, and the validator's `kind` write-through.
- **`src/service-spec.ts`** — deleted `ServiceKind`, `ServiceSpec.kind`, `KnownModule.kind`, the import-time `ModuleKind` alias, and the `kind:` value on every `KNOWN_MODULES` + `FIRST_PARTY_FALLBACKS` entry. `composeServiceSpec`, `synthesizeManifestForKnownModule`, and `getSpec`'s synth path no longer set `kind`. `effectivePublicExposure` collapses to a single signal: `extras.hasAuth === false` ⇒ "auth-required", else "allowed". Same outcome for every known module today (scribe is the canonical `hasAuth: false` case).
- **`src/commands/upgrade.ts`** — dropped the `if (target.spec?.kind === "frontend") { bun run build }` branch and the now-unused `packageHasScript` helper. Updated the docstring.
- **Tests** — collapsed the five "kind is no longer validated" sub-tests in `module-manifest.test.ts` into one "kind values in module.json are silently ignored" assertion. Refactored `upgrade.test.ts`'s "bun-linked frontend: runs bun run build" test into the inverse assertion: even a module with a `build` script does NOT trigger `bun run build`. Removed `kind:` from `readModuleManifest` fixtures in `hub-server.test.ts`, `post-install.test.ts`, `api-modules-ops.test.ts`, `install.test.ts`, `lifecycle.test.ts`.

## Back-compat

- Third-party + first-party `module.json` files that still declare `kind` keep parsing fine — silently ignored.
- Modules previously installed under any `kind` value continue to install, start, restart, upgrade, and expose normally. `effectivePublicExposure` defaults preserve previous behavior for every known module (vault / scribe / runner / app / notes / channel).
- The bun-linked-checkout `parachute upgrade notes` path no longer runs `bun run build` post-pull. Operators running notes-daemon from a local checkout can run `bun run build` themselves; the published npm tarball already includes `dist/`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test ./src` — 1902 pass / 0 fail (delta from rc.18: −5 tests, from the module-manifest kind sub-test collapse + the upgrade frontend-build test refactor)
- [x] `bunx biome check src/` clean
- [x] Manually confirmed no `module.kind` / `spec.kind` / `manifest.kind` / `ModuleKind` / `ServiceKind` / `asKind` references remain in `src/`; the only remaining `kind` occurrences are unrelated discriminated-union tags (OperationKind, InstallSourceKind, ExposeEntry, etc.) and prose
- [x] Verified notes-daemon `prepublishOnly` builds dist at publish time
- [ ] Reviewer dispatch
- [ ] Aaron merge gate

## Patterns check

Touches the module-protocol surface (`module.json` shape). The canonical `parachute-patterns/patterns/module-json-extensibility.md` is the source of truth, and patterns#84 already retired `kind` there. This PR brings hub's implementation in line with the doc — no new pattern shift.

## Version

Bump rc.18 → rc.19. CHANGELOG entry under `Removed` documents the cleanup + the notes-daemon build-step retirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)