### PR TITLE
feat(hub): comprehensive UI pass — wizard done-screen + Modules page Open + discovery quick-start (closes #342)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.20] - 2026-05-23
+
+**feat(hub): comprehensive UI pass — wizard done-screen + Modules page Open + discovery quick-start (closes [hub#342](https://github.com/ParachuteComputer/parachute-hub/issues/342)).**
+
+Closes the "I just installed it, where is it?" friction Aaron hit (two reports, 2026-05-22 → 23): (1) install-tile log lines overflowed the wizard card → text size jumped, page stretched; (2) "no clear way to go from setting up parachute to actually using parachute." Plus the architectural pivot Aaron named: Open and Configure aren't meaningfully different — each module ships its own UI handling both viewing and configuring. Hub becomes a dispatcher to that UI; the in-hub config form retires.
+
+### Architectural framing
+
+Per [`module-ui-declaration.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-ui-declaration.md) + [`module-surfaces.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-surfaces.md): each committed-core module exposes a canonical admin UI at `/<short>/admin` (or wherever its `managementUrl` declares). Hub's job is dispatch — point operators at the right module's UI; the module's own SPA handles view + configure via internal scope gates. The pre-#342 "Configure" link to a hub-side config form was an artifact of scribe being the only schema-backed module; with scribe + runner shipping their own SPAs (scribe#53, runner#8 — filed alongside), hub's generic config form becomes redundant.
+
+### Changed
+
+- **Install-log overflow CSS** — `.op-log` gains `overflow-x: auto`, `.log-lines li` gain `white-space: pre-wrap` + `overflow-wrap: anywhere`. `.install-tile` gains `min-width: 0` so the grid track can shrink below intrinsic content width. Aaron's reproducer: install long-package-name modules → page stretches off-screen. Fixed.
+- **Wizard done-screen leads with "Start using your vault"** — new lead tile above the MCP / install / admin tiles. When parachute-app is installed, links to `/app/notes/` (the canonical Notes-as-UI surface per parachute-app §17). When app isn't installed yet, falls back to the vault's own admin UI at `/vault/<name>/admin/`. Either way, the operator has one obvious "start using" target rather than three competing "next step" tiles.
+- **Wizard install-tile post-success: "Use it now" link** — terminal-state install tiles (succeeded + already-installed) now lead with "Use it now" pointing at the module's canonical UI (`/app/notes/` for App, `/scribe/admin/` for Scribe, etc. — per `USE_IT_NOW_URLS`). "Manage modules" stays as the secondary affordance. The link table mirrors `module-ui-declaration.md`'s `uiUrl` / `managementUrl` semantics.
+- **Admin SPA Modules page: Open + Configure collapse into a single Open button** — `ModuleRow` swaps the `<Link to="/modules/<short>/config">Configure</Link>` for an `<a href={management_url}>Open</a>` (full-page nav, since the module owns its surface). Modules without a declared `management_url` (scribe, runner today) render a disabled `<button>` with a tooltip pointing at the per-module follow-up issue — gentler than 404-on-click. `management_url` is a new wire field on the `/api/modules` shape: hub resolves each installed module's `managementUrl ?? uiUrl` from `.parachute/module.json` against its mount path. The pre-#342 in-hub config form code at `/admin/modules/:short/config` stays in place (back-compat for stale bookmarks) but no SPA surface links to it anymore; a future PR deletes it after the migration period.
+- **Discovery page (`/`) "Get started" section** — new section above the Services grid, hidden until at least one prereq is met. Two hardcoded tiles when applicable: "Open Notes" → `/app/notes/` (when parachute-app is installed); "Browse Vault" → `/vault/<first-vault>/admin/` (when vault is installed). Driven off the unauth `/.well-known/parachute.json` — no Bearer required, fresh installs still see a sensible empty state.
+- **Admin SPA nav: installed-services quick access** — new "Services ▾" dropdown between Modules and Users. One entry per installed module that declares a `management_url`; modules without one appear disabled with the same follow-up tooltip the Modules page surfaces. Native `<details>`/`<summary>` for the toggle, absolute-positioned panel, no JS framework dance. Fetches the same `/api/modules` catalog the Modules page reads; failure is silent (dropdown collapses).
+
+### Deprecated
+
+- `/admin/modules/:short/config` (the generic per-module config form) — file gets a deprecation docstring; SPA surface no longer links to it. Deletion follow-up tracked in this PR's body. Scribe + runner's own admin SPAs (scribe#53, runner#8) replace its purpose.
+
+### What landed
+
+- **`src/setup-wizard.ts`** — `.op-log` + `.log-lines li` overflow constraints; `.install-tile` gains `min-width: 0`; new `.start-using` block; new `renderStartUsingTile(vaultName, appInstalled)`; `RenderDoneStepProps` gains optional `appInstalled`; `handleSetupGet`'s done branch reads `isModuleInstalled("app", manifestPath)` and threads it through; new `USE_IT_NOW_URLS` table; install-tile renderer adds the "Use it now" primary CTA on succeeded + already-installed states.
+- **`src/api-modules.ts`** — `ModuleWireShape` gains `management_url: string | null`; new `readModuleManifest` dep on `ApiModulesDeps`; manifest read resolves `managementUrl ?? uiUrl` against the entry's mount path (first non-`.parachute` path); errors are quiet per-entry.
+- **`src/hub-server.ts`** — threads `readModuleManifest` through to `handleApiModules`.
+- **`src/hub.ts`** — new `<section id="get-started-section">` above Services; new `renderGetStarted(services)` JS that conditionally renders Notes / Vault tiles based on which modules are installed.
+- **`web/ui/src/lib/api.ts`** — `ModuleListing` gains `management_url`.
+- **`web/ui/src/routes/Modules.tsx`** — `ModuleRow` renders Open instead of Configure; disabled fallback with `NO_UI_FOLLOWUPS` tooltip.
+- **`web/ui/src/routes/ModuleConfig.tsx`** — deprecation docstring; route + handler stay for back-compat.
+- **`web/ui/src/App.tsx`** — new `InstalledServicesDropdown`; `useEffect` to fetch modules on signed-in transition.
+- **`web/ui/src/styles.css`** — `.nav-dropdown` + `.nav-dropdown-panel` + `.nav-dropdown-item` styles.
+
+### Verification
+
+- `bun run typecheck` clean.
+- `bun test ./src` 1909 pass / 0 fail (delta: +7 new tests — five in `setup-wizard.test.ts` covering the lead tile + Use it now + log-overflow CSS, two in `api-modules.test.ts` covering `management_url` resolution + the null-fallthrough case).
+- `cd web/ui && bunx vitest run` 193 pass / 0 fail (delta: +5 new tests — three in `Modules.test.tsx` covering Open active / disabled / no-Configure, two in `App.test.tsx` covering the nav dropdown empty + populated states).
+- `bunx biome check src/` clean.
+- `bun run build:spa` clean (the postinstall hook + prepack rebuild path).
+
+### Follow-ups
+
+- [parachute-scribe#53](https://github.com/ParachuteComputer/parachute-scribe/issues/53) — ship scribe admin SPA (currently config endpoints + schema only; Open button shows disabled-with-tooltip until this lands).
+- [parachute-runner#8](https://github.com/ParachuteComputer/parachute-runner/issues/8) — ship runner admin SPA (currently admin endpoints only; same gap).
+- Future PR: delete `web/ui/src/routes/ModuleConfig.tsx` + the `/api/modules/:short/config{,/schema}` endpoints once at least one rc cycle confirms no operator is bookmarking the legacy path.
+
+### Cross-references
+
+- [`module-ui-declaration.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-ui-declaration.md) — `uiUrl` vs `managementUrl` semantics.
+- [`module-surfaces.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-surfaces.md) — canonical surfaces per module.
+- [`runtime-tenancy-contract.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/runtime-tenancy-contract.md) — how the dispatched-to module reads its mount + hub origin from injected meta tags.
+
 ## [0.5.13-rc.19] - 2026-05-23
 
 **chore(hub): retire `kind` from types + manifest parser + `KNOWN_MODULES` + `upgrade.ts` build branch (closes [hub#330](https://github.com/ParachuteComputer/parachute-hub/issues/330)).**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.19",
+  "version": "0.5.13-rc.20",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -315,6 +315,96 @@ describe("GET /api/modules", () => {
     expect(body.supervisor_available).toBe(true);
   });
 
+  test("populates management_url from a relative managementUrl + module mount (hub#342)", async () => {
+    // Vault declares `managementUrl: "/admin"` in its module.json — hub
+    // resolves that against the entry's mount path (`/vault/default`)
+    // to produce the absolute admin URL the SPA's "Open" button targets.
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/vault/default"],
+        health: "/vault/default/health",
+        version: "0.4.5",
+        installDir: "/install/dir/vault",
+      },
+    ]);
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: async () => null,
+      readModuleManifest: async (installDir) => {
+        // Return a minimal module.json with managementUrl set. Cast the
+        // shape via `as unknown as ...` because the test only exercises
+        // the consumer-side resolver, not the validator (which lives in
+        // module-manifest.ts and has its own test suite).
+        if (installDir === "/install/dir/vault") {
+          return {
+            name: "parachute-vault",
+            manifestName: "parachute-vault",
+            displayName: "Vault",
+            tagline: "",
+            port: 1940,
+            paths: ["/vault/default"],
+            health: "/health",
+            managementUrl: "/admin",
+          } as unknown as Awaited<
+            ReturnType<typeof import("../module-manifest.ts").readModuleManifest>
+          >;
+        }
+        return null;
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      modules: Array<{ short: string; management_url: string | null }>;
+    };
+    const vault = body.modules.find((m) => m.short === "vault");
+    expect(vault?.management_url).toBe("/vault/default/admin");
+  });
+
+  test("management_url is null when the module declares neither managementUrl nor uiUrl (hub#342)", async () => {
+    // Scribe + runner today: no managementUrl declared yet. The SPA's
+    // "Open" button renders disabled with a follow-up tooltip in that
+    // case — null on the wire is the canonical signal.
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-scribe",
+        port: 1942,
+        paths: ["/scribe"],
+        health: "/scribe/health",
+        version: "0.1.0",
+        installDir: "/install/dir/scribe",
+      },
+    ]);
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: async () => null,
+      readModuleManifest: async () =>
+        ({
+          name: "parachute-scribe",
+          manifestName: "parachute-scribe",
+          displayName: "Scribe",
+          tagline: "",
+          port: 1942,
+          paths: ["/scribe"],
+          health: "/health",
+        }) as unknown as Awaited<
+          ReturnType<typeof import("../module-manifest.ts").readModuleManifest>
+        >,
+    });
+    const body = (await res.json()) as {
+      modules: Array<{ short: string; management_url: string | null }>;
+    };
+    const scribe = body.modules.find((m) => m.short === "scribe");
+    expect(scribe?.management_url).toBeNull();
+  });
+
   test("npm probe failure → latest_version is null but response still 200", async () => {
     // The whole point of the probe-is-opportunistic posture: a flaky
     // npm registry must not break the page render. The UI handles

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -2709,3 +2709,231 @@ describe("bootstrap token gate (handleSetupAccountPost)", () => {
     }
   });
 });
+
+// --- hub#342 UI pass: "Start using your vault" lead tile + Use it now ---
+
+describe("done screen — 'Start using your vault' tile (hub#342)", () => {
+  let h: Harness;
+  beforeEach(() => {
+    h = makeHarness();
+    _resetOperationsRegistryForTests();
+  });
+  afterEach(() => h.cleanup());
+
+  test("when only vault is installed, the lead tile links to vault admin", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const user = await createUser(db, "owner", "pw");
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              version: "0.1.0",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/health",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      setSetting(db, "setup_expose_mode", "localhost");
+      const { createSession } = await import("../sessions.ts");
+      const session = createSession(db, { userId: user.id });
+      const res = handleSetupGet(
+        req("/admin/setup?just_finished=1", {
+          headers: { cookie: `${SESSION_COOKIE_NAME}=${session.id}` },
+        }),
+        {
+          db,
+          manifestPath: h.manifestPath,
+          configDir: h.dir,
+          issuer: "https://hub.example",
+          registry: getDefaultOperationsRegistry(),
+        },
+      );
+      const html = await res.text();
+      // Section heading present + primary CTA points at the vault's own admin.
+      expect(html).toContain("Start using your vault");
+      expect(html).toContain('href="/vault/default/admin/"');
+      // Lead tile precedes the MCP / install tiles (it's the lead).
+      const startIdx = html.indexOf("Start using your vault");
+      const installIdx = html.indexOf("What's next?");
+      expect(startIdx).toBeLessThan(installIdx);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("when app is also installed, the lead tile links to /app/notes/", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const user = await createUser(db, "owner", "pw");
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              version: "0.1.0",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/health",
+            },
+            {
+              name: "parachute-app",
+              version: "0.2.0",
+              port: 1946,
+              paths: ["/app"],
+              health: "/app/healthz",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      setSetting(db, "setup_expose_mode", "localhost");
+      const { createSession } = await import("../sessions.ts");
+      const session = createSession(db, { userId: user.id });
+      const res = handleSetupGet(
+        req("/admin/setup?just_finished=1", {
+          headers: { cookie: `${SESSION_COOKIE_NAME}=${session.id}` },
+        }),
+        {
+          db,
+          manifestPath: h.manifestPath,
+          configDir: h.dir,
+          issuer: "https://hub.example",
+          registry: getDefaultOperationsRegistry(),
+        },
+      );
+      const html = await res.text();
+      expect(html).toContain("Start using your vault");
+      // App installed → primary CTA links to Notes-as-UI inside App.
+      expect(html).toContain('href="/app/notes/"');
+      expect(html).toContain("Open Notes");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("succeeded install op renders a 'Use it now' link pointing at the module's surface", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const user = await createUser(db, "owner", "pw");
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              version: "0.1.0",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/health",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      setSetting(db, "setup_expose_mode", "localhost");
+      const reg = getDefaultOperationsRegistry();
+      const op = reg.create("install", "app");
+      reg.update(op.id, { status: "succeeded" }, "installed @openparachute/app");
+      const { createSession } = await import("../sessions.ts");
+      const session = createSession(db, { userId: user.id });
+      const res = handleSetupGet(
+        req(`/admin/setup?just_finished=1&op_app=${op.id}`, {
+          headers: { cookie: `${SESSION_COOKIE_NAME}=${session.id}` },
+        }),
+        {
+          db,
+          manifestPath: h.manifestPath,
+          configDir: h.dir,
+          issuer: "https://hub.example",
+          registry: reg,
+        },
+      );
+      const html = await res.text();
+      expect(html).toContain("status: succeeded");
+      // Primary "Use it now" link goes to the app's surface; secondary
+      // "Manage modules" link still present.
+      expect(html).toContain(">Use it now<");
+      expect(html).toContain('href="/app/notes/"');
+      expect(html).toContain(">Manage modules<");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("'Already installed' tile gains a 'Use it now' link too", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const user = await createUser(db, "owner", "pw");
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              version: "0.1.0",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/health",
+            },
+            {
+              name: "parachute-app",
+              version: "0.2.0",
+              port: 1946,
+              paths: ["/app"],
+              health: "/app/healthz",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      setSetting(db, "setup_expose_mode", "localhost");
+      const { createSession } = await import("../sessions.ts");
+      const session = createSession(db, { userId: user.id });
+      const res = handleSetupGet(
+        req("/admin/setup?just_finished=1", {
+          headers: { cookie: `${SESSION_COOKIE_NAME}=${session.id}` },
+        }),
+        {
+          db,
+          manifestPath: h.manifestPath,
+          configDir: h.dir,
+          issuer: "https://hub.example",
+          registry: getDefaultOperationsRegistry(),
+        },
+      );
+      const html = await res.text();
+      expect(html).toContain("Already installed");
+      // App's already-installed tile carries the Use it now link.
+      expect(html).toContain('href="/app/notes/"');
+    } finally {
+      db.close();
+    }
+  });
+
+  test("install-log CSS includes overflow-wrap so long lines wrap in the card", async () => {
+    // Smoke test for the CSS fold (hub#342): the .op-log block sets
+    // overflow-x:auto and the .log-lines li set white-space:pre-wrap +
+    // overflow-wrap:anywhere. These are the three properties Aaron's
+    // bug report flagged — without them long install logs blow up the
+    // wizard layout.
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const res = handleSetupGet(req("/admin/setup"), {
+        db,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        issuer: "https://hub.example",
+        registry: getDefaultOperationsRegistry(),
+      });
+      const html = await res.text();
+      expect(html).toContain("overflow-x: auto");
+      expect(html).toContain("white-space: pre-wrap");
+      expect(html).toContain("overflow-wrap: anywhere");
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -30,6 +30,10 @@ import {
   setModuleInstallChannel,
 } from "./hub-settings.ts";
 import { validateAccessToken } from "./jwt-sign.ts";
+import {
+  type ModuleManifest,
+  readModuleManifest as defaultReadModuleManifest,
+} from "./module-manifest.ts";
 import { FIRST_PARTY_FALLBACKS, KNOWN_MODULES } from "./service-spec.ts";
 // `FIRST_PARTY_FALLBACKS` and `KNOWN_MODULES` are both consulted by
 // `lookupModule` below — the former for notes/channel (vendored manifests
@@ -107,6 +111,13 @@ export interface ApiModulesDeps {
   cacheTtlMs?: number;
   /** Test seam over wall-clock. */
   now?: () => number;
+  /**
+   * Override the per-module `.parachute/module.json` reader. Production
+   * reads from disk via `module-manifest.readModuleManifest`; tests
+   * inject a fake. Used to surface `managementUrl` on the wire shape
+   * (hub#342 — drives the admin SPA Modules page's "Open" button).
+   */
+  readModuleManifest?: (installDir: string) => Promise<ModuleManifest | null>;
 }
 
 /**
@@ -158,6 +169,30 @@ interface ModuleWireShape {
    * design doc §12.
    */
   uis: UiSubUnitWireShape[];
+  /**
+   * Canonical user-facing URL for this module's own UI (hub#342). Drives
+   * the admin SPA Modules page's "Open" button — clicking lands the
+   * operator on the module's own surface (combining view + configure
+   * per Aaron's framing: each module ships its own UI handling both).
+   *
+   * Resolution order:
+   *   1. Module's `managementUrl` from `<installDir>/.parachute/module.json`,
+   *      resolved against the module's mounted URL — matches the
+   *      well-known doc's resolution for vault rows.
+   *   2. Module's `uiUrl` from the same manifest, when it's the only
+   *      declared surface — for modules where the user-facing UI IS
+   *      the operator UI (App today).
+   *   3. Null when the module hasn't declared either field — the SPA
+   *      renders a disabled "Open" tooltip ("module hasn't shipped an
+   *      admin UI yet"). Tracked as follow-up issues per module
+   *      (scribe#53, runner#8 today).
+   *
+   * Always an absolute path on the hub origin (leading `/`) — the SPA
+   * navigates same-origin, no need to worry about cross-origin
+   * managementUrls (those are an escape hatch for off-origin admin
+   * surfaces, unused by first-party modules today).
+   */
+  management_url: string | null;
 }
 
 interface ModulesResponse {
@@ -251,7 +286,12 @@ export async function handleApiModules(req: Request, deps: ApiModulesDeps): Prom
   const manifest = readManifest(deps.manifestPath);
   const installedByShort = new Map<
     string,
-    { version: string; installDir?: string; uis?: Record<string, UiSubUnit> }
+    {
+      version: string;
+      installDir?: string;
+      uis?: Record<string, UiSubUnit>;
+      mountPath?: string;
+    }
   >();
   for (const entry of manifest.services) {
     // Join services.json rows to CURATED_MODULES by manifestName. The
@@ -266,13 +306,68 @@ export async function handleApiModules(req: Request, deps: ApiModulesDeps): Prom
           version: string;
           installDir?: string;
           uis?: Record<string, UiSubUnit>;
+          mountPath?: string;
         } = { version: entry.version };
         if (entry.installDir !== undefined) value.installDir = entry.installDir;
         if (entry.uis !== undefined) value.uis = entry.uis;
+        // First non-`.parachute` path is the module's user-facing mount
+        // (`/app`, `/scribe`, `/vault/<name>`). Used below to resolve
+        // a relative `managementUrl` to a full hub-origin path. Skips
+        // `.parachute` entries because those are protocol mounts, not
+        // user surfaces — every module declares one.
+        const userPath = (entry.paths ?? []).find(
+          (p) => p !== "/.parachute" && !p.startsWith("/.parachute/"),
+        );
+        if (userPath !== undefined) value.mountPath = userPath;
         installedByShort.set(short, value);
       }
     }
   }
+
+  // Read each installed module's `.parachute/module.json` so we can
+  // surface `managementUrl` on the wire shape (hub#342). Quiet on
+  // per-entry errors: a malformed manifest on one module shouldn't 500
+  // the whole catalog response — its row just renders with a null
+  // management_url and the SPA shows the disabled "Open" tooltip.
+  const readModuleManifestFn = deps.readModuleManifest ?? defaultReadModuleManifest;
+  const managementUrlByShort = new Map<string, string>();
+  await Promise.all(
+    Array.from(installedByShort.entries()).map(async ([short, value]) => {
+      if (!value.installDir) return;
+      try {
+        const m = await readModuleManifestFn(value.installDir);
+        if (!m) return;
+        // Resolution per the module-ui-declaration.md hierarchy:
+        // managementUrl > uiUrl. Both are EITHER an absolute
+        // http(s) URL OR a relative path. Relative paths are joined
+        // against the module's mount path (entry.paths[0]) since both
+        // surfaces conventionally live under it (vault's `/admin`,
+        // app's `/admin`). Absolute URLs pass through verbatim.
+        const candidate = m.managementUrl ?? m.uiUrl;
+        if (candidate === undefined) return;
+        if (/^https?:\/\//i.test(candidate)) {
+          managementUrlByShort.set(short, candidate);
+          return;
+        }
+        const mount = value.mountPath;
+        if (mount === undefined) {
+          // No user-facing mount declared — we can't resolve a relative
+          // path. Skip rather than guess. Vault rows hit this when
+          // services.json was hand-edited to remove the mount; the
+          // disabled-tooltip state in the SPA is the right surface.
+          return;
+        }
+        // Join mount + candidate path. Both pieces have leading slashes
+        // already (mount per services.json convention; candidate per
+        // managementUrl validation). Drop one to avoid `//`.
+        const tail = candidate.startsWith("/") ? candidate : `/${candidate}`;
+        managementUrlByShort.set(short, `${mount}${tail}`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`api-modules: skipping managementUrl for ${short}: ${msg}`);
+      }
+    }),
+  );
 
   // Supervisor state — per-module run status snapshot.
   const supervisor = deps.supervisor;
@@ -331,6 +426,7 @@ export async function handleApiModules(req: Request, deps: ApiModulesDeps): Prom
       pid: state?.pid ?? null,
       install_dir: installed?.installDir ?? null,
       uis: toUisWireShape(installed?.uis),
+      management_url: managementUrlByShort.get(short) ?? null,
     });
   }
 

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -1534,6 +1534,11 @@ export function hubFetch(
         manifestPath: deps?.manifestPath ?? SERVICES_MANIFEST_PATH,
       };
       if (deps?.supervisor !== undefined) modulesDeps.supervisor = deps.supervisor;
+      // hub#342: thread the test-injectable module-manifest reader
+      // through so `management_url` resolution can be exercised in
+      // unit tests without writing real install dirs.
+      if (deps?.readModuleManifest !== undefined)
+        modulesDeps.readModuleManifest = deps.readModuleManifest;
       return handleApiModules(req, modulesDeps);
     }
 

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -357,6 +357,12 @@ const HTML_TEMPLATE = `<!doctype html>
     <p class="tagline">Your personal-computing modules.</p>
   </header>
 
+  <section class="section" id="get-started-section" hidden>
+    <h2>Get started</h2>
+    <p class="section-sub">Jump straight into what you came here for.</p>
+    <div class="grid" id="get-started-grid"></div>
+  </section>
+
   <section class="section" id="services-section">
     <h2>Services</h2>
     <p class="section-sub">Surfaces provided by services running on this hub.</p>
@@ -379,6 +385,8 @@ const HTML_TEMPLATE = `<!doctype html>
 (async () => {
   const servicesGrid = document.getElementById('services-grid');
   const adminGrid = document.getElementById('admin-grid');
+  const getStartedSection = document.getElementById('get-started-section');
+  const getStartedGrid = document.getElementById('get-started-grid');
 
   // Services entries are now data-driven from /.well-known/parachute.json.
   // Each services[] row carries (since hub#... — Phase D consumer side):
@@ -444,6 +452,68 @@ const HTML_TEMPLATE = `<!doctype html>
     }
   }
 
+  /**
+   * Render the "Get started" section (hub#342) above the Services grid.
+   *
+   * Two hardcoded targets, each conditional on its prerequisite being
+   * installed:
+   *   - "Open Notes" → /app/notes/  (requires parachute-app installed;
+   *     App auto-bootstraps Notes-as-UI per parachute-app §17, so the
+   *     mere presence of App means /app/notes/ is live)
+   *   - "Browse Vault" → /vault/<first-vault-name>/admin/  (requires
+   *     parachute-vault installed; uses the first vault's name from
+   *     its services.json mount path tail)
+   *
+   * If neither prerequisite is met (fresh install pre-wizard) the
+   * section stays hidden. The hardcoded shape mirrors the wizard's
+   * own done-screen "Start using your vault" tile — same architectural
+   * shape (single obvious entry point) at a different surface.
+   *
+   * Not driven by /api/modules because discovery is unauth — the
+   * services list from /.well-known/parachute.json is sufficient
+   * (it carries the same install-detection signal we need, no
+   * Bearer required).
+   */
+  function renderGetStarted(services) {
+    if (!getStartedGrid || !getStartedSection) return;
+    const tiles = [];
+    const hasApp = services.some((s) => s && s.name === 'parachute-app');
+    // services[] is fanned out per-vault for parachute-vault rows (see
+    // well-known.ts emitVaultRows) — "path" is the per-instance mount
+    // "/vault/<name>". Pick the first vault entry; the order matches
+    // services.json's paths[] order, so this is deterministic.
+    const vault = services.find((s) => s && s.name === 'parachute-vault');
+    if (hasApp) {
+      tiles.push({
+        title: 'Open Notes',
+        desc: 'Browse + capture in the Notes app — reads from your vault.',
+        href: '/app/notes/',
+      });
+    }
+    if (vault) {
+      // vault.path is the per-instance mount "/vault/<name>". Extract
+      // the tail as the display name; mirror the wizard's own
+      // firstVaultName() shape.
+      let vaultName = 'default';
+      if (typeof vault.path === 'string' && vault.path.startsWith('/vault/')) {
+        const tail = vault.path.slice('/vault/'.length).replace(/\/+$/, '');
+        if (tail.length > 0) vaultName = tail;
+      }
+      tiles.push({
+        title: 'Browse Vault',
+        desc: "Open your vault's admin UI — content, settings, MCP.",
+        href: '/vault/' + encodeURIComponent(vaultName) + '/admin/',
+      });
+    }
+    if (tiles.length === 0) {
+      getStartedSection.setAttribute('hidden', '');
+      return;
+    }
+    getStartedSection.removeAttribute('hidden');
+    getStartedGrid.innerHTML = '';
+    for (const tile of tiles) getStartedGrid.appendChild(renderTile(tile));
+  }
+
   function renderServices(services) {
     // Render one tile per service that declares a uiUrl. Entries without
     // uiUrl are intentionally omitted — vault is the canonical example
@@ -503,6 +573,7 @@ const HTML_TEMPLATE = `<!doctype html>
       if (!wk.ok) throw new Error('well-known fetch failed: ' + wk.status);
       const doc = await wk.json();
       const services = Array.isArray(doc.services) ? doc.services : [];
+      renderGetStarted(services);
       renderServices(services);
     } catch (err) {
       servicesGrid.innerHTML = '<div class="error">Could not load services: ' +

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -646,22 +646,41 @@ export interface RenderDoneStepProps {
    * shape.
    */
   installTiles?: readonly ModuleInstallTileState[];
+  /**
+   * Whether parachute-app is installed alongside the vault. Drives the
+   * "Start using your vault" lead tile (hub#342): when true, the tile
+   * links to `/app/notes/` (the canonical user-facing surface — App
+   * auto-bootstraps Notes-as-UI per the 2026-05-21 migration). When
+   * false, it falls back to the vault's own admin UI at
+   * `/vault/<name>/admin/` so the operator still has a single obvious
+   * "start using parachute" target. Omitted = back-compat with tests
+   * that render the done step without dependency-checking; defaults to
+   * false (vault-admin fallback).
+   */
+  appInstalled?: boolean;
 }
 
 export function renderDoneStep(props: RenderDoneStepProps): string {
-  const { vaultName, hubOrigin, exposeMode, mintedToken, installTiles } = props;
+  const { vaultName, hubOrigin, exposeMode, mintedToken, installTiles, appInstalled } = props;
   const reachable = exposeMode ? renderReachableTile(exposeMode, hubOrigin) : "";
   const mcpTile = renderMcpTile(vaultName, hubOrigin, mintedToken);
   const tiles = installTiles && installTiles.length > 0 ? installTiles : [];
   const installSection = tiles.length > 0 ? renderInstallTiles(tiles) : "";
+  const startTile = renderStartUsingTile(vaultName, appInstalled === true);
   // The done-grid hosts the MCP-connect tile + the admin-UI fallback.
-  // The install tiles sit above it as a primary "what's next?" surface —
-  // they're the highest-friction next-step for most operators (operator
-  // just provisioned a vault, the obvious next action is installing the
-  // PWA / transcription module on top of it). Reachable tile leads
-  // everything because it answers "where's my hub?" before anything
-  // else — the question every operator hits before MCP / module
-  // installs even matter.
+  // The install tiles sit above it as a "what's next?" surface (curated
+  // catalog of modules an operator might want next). The "Start using
+  // your vault" tile leads everything user-facing because it answers
+  // Aaron's hub#342 friction directly: there was no clear way from the
+  // wizard's done screen to actually USE Parachute — the wizard
+  // surfaced "install more" + "go to admin" + an MCP command, none of
+  // which is "open the canonical user-facing UI" (Notes via App). With
+  // this tile in pole position, the operator's first click goes to a
+  // surface that says "hello, here's your vault" rather than a hub
+  // admin page. The reachable tile sits above even the start tile
+  // because "where's my hub?" answers the URL question every operator
+  // hits before they can click anything else (especially on tailnet /
+  // public expose where the loopback URL isn't the answer).
   const body = `
     <div class="card">
       <div class="card-header">
@@ -670,6 +689,7 @@ export function renderDoneStep(props: RenderDoneStepProps): string {
         <p class="subtitle">Your hub is ready. Here's what to do next.</p>
       </div>
       ${reachable}
+      ${startTile}
       ${installSection}
       <section class="done-grid">
         ${mcpTile}
@@ -840,6 +860,48 @@ function renderMcpTile(
 }
 
 /**
+ * The "Start using your vault" lead tile on the done step (hub#342).
+ *
+ * Closes Aaron's "no clear way to go from setting up parachute to
+ * actually using parachute" friction. Sits above the MCP / install
+ * tiles because it's the canonical user-facing entry point —
+ * everything else on the done screen is operator-flavored (MCP
+ * command, admin UI, additional module installs).
+ *
+ * Two shapes:
+ *   - **App installed** → primary tile targets `/app/notes/` (the
+ *     Notes app reading the just-created vault). This is the
+ *     canonical surface post-Notes-as-app migration (parachute-app §17).
+ *   - **App NOT installed** → primary tile targets the vault's own
+ *     admin UI at `/vault/<name>/admin/`. The copy explains that
+ *     installing App + Notes is the recommended next step for a
+ *     content-browsing surface, and points at the install tile below.
+ *
+ * Either way, the operator has ONE obvious click target that says
+ * "start using parachute" — not three competing tiles where the
+ * "real" entry point is buried under the MCP command pre-hub#342.
+ */
+function renderStartUsingTile(vaultName: string, appInstalled: boolean): string {
+  const safeVault = escapeHtml(vaultName);
+  if (appInstalled) {
+    return `<section class="start-using" data-testid="start-using-tile">
+      <h2>Start using your vault</h2>
+      <p>Notes is installed and ready. Capture your first note in the
+        Notes app — it reads from <code>${safeVault}</code> directly.</p>
+      <p><a class="btn btn-primary" href="/app/notes/">Open Notes</a></p>
+    </section>`;
+  }
+  return `<section class="start-using" data-testid="start-using-tile">
+    <h2>Start using your vault</h2>
+    <p>Your vault <code>${safeVault}</code> is provisioned. Install
+      <strong>App</strong> below (it bundles the Notes UI) to start
+      capturing — or open the vault's admin UI now to see what's
+      inside.</p>
+    <p><a class="btn btn-primary" href="/vault/${safeVault}/admin/">Open vault admin</a></p>
+  </section>`;
+}
+
+/**
  * The "What's next?" install-tiles row (hub#272 Item B). One tile per
  * curated module the operator might want next (Notes, Scribe). Each
  * tile is either an install form (POST → /admin/setup/install/<short>
@@ -859,6 +921,15 @@ function renderInstallTile(tile: ModuleInstallTileState): string {
   const safeShort = escapeHtml(tile.short);
   const safeName = escapeHtml(tile.displayName);
   const safeTagline = escapeHtml(tile.tagline);
+  const useItNowUrl = USE_IT_NOW_URLS[tile.short];
+  // "Use it now" → the canonical user-facing URL per
+  // module-ui-declaration.md, rendered as the PRIMARY action on a
+  // succeeded / already-installed install tile (hub#342). "Manage
+  // modules" stays as the secondary affordance so the admin SPA is
+  // one click away too. The URL table is keyed by the wizard's
+  // curated shorts (app, scribe today; vault excluded since the
+  // wizard owns its step); modules with no known surface fall
+  // through to a single "Manage modules" link, same as pre-#342.
   if (tile.operation) {
     const op = tile.operation;
     const logLines = op.log.map((l) => `<li>${escapeHtml(l)}</li>`).join("");
@@ -870,7 +941,13 @@ function renderInstallTile(tile: ModuleInstallTileState): string {
     // catches every in-flight op at once).
     let actions = "";
     if (op.status === "succeeded") {
-      actions = `<p><a class="btn btn-secondary" href="/admin/modules">Manage modules</a></p>`;
+      const useItNowLink = useItNowUrl
+        ? `<a class="btn btn-primary" href="${escapeAttr(useItNowUrl)}">Use it now</a>`
+        : "";
+      actions = `<p class="install-tile-actions">
+        ${useItNowLink}
+        <a class="btn btn-secondary" href="/admin/modules">Manage modules</a>
+      </p>`;
     } else if (op.status === "failed") {
       actions = `<form method="POST" action="/admin/setup/install/${safeShort}" class="install-retry">
         ${renderInstallTileCsrfPlaceholder()}
@@ -889,11 +966,17 @@ function renderInstallTile(tile: ModuleInstallTileState): string {
     </div>`;
   }
   if (tile.alreadyInstalled) {
+    const useItNowLink = useItNowUrl
+      ? `<a class="btn btn-primary" href="${escapeAttr(useItNowUrl)}">Use it now</a>`
+      : "";
     return `<div class="install-tile install-tile-installed">
       <h3>${safeName}</h3>
       <p class="install-tile-tagline">${safeTagline}</p>
       <p class="install-tile-status">Already installed.</p>
-      <p><a class="btn btn-secondary" href="/admin/modules">Manage in admin</a></p>
+      <p class="install-tile-actions">
+        ${useItNowLink}
+        <a class="btn btn-secondary" href="/admin/modules">Manage in admin</a>
+      </p>
     </div>`;
   }
   return `<div class="install-tile">
@@ -905,6 +988,27 @@ function renderInstallTile(tile: ModuleInstallTileState): string {
     </form>
   </div>`;
 }
+
+/**
+ * Canonical "Use it now" target per curated module short (hub#342).
+ * Each value is the canonical user-facing URL the module ships its UI
+ * at — per `module-ui-declaration.md` (`uiUrl` / `managementUrl` rules).
+ * App's surface is the bundled Notes-as-UI auto-bootstrap mount;
+ * Scribe is the operator-facing admin UI (per `module-surfaces.md`,
+ * scribe's admin surface is at `/scribe/admin` once an admin SPA ships
+ * — scribe#53 tracks). Missing entries here fall through to "Manage
+ * modules" only — i.e. modules without a declared first-party UI
+ * surface. Vault is intentionally omitted: the wizard's own vault
+ * step owns the post-vault-install flow and the lead "Start using
+ * your vault" tile (above the install row) handles the vault-side
+ * surface decision.
+ */
+const USE_IT_NOW_URLS: Partial<Record<CuratedModuleShort, string>> = {
+  app: "/app/notes/",
+  scribe: "/scribe/admin/",
+  notes: "/notes/",
+  runner: "/runner/admin/",
+};
 
 /**
  * CSRF token placeholder for install-tile forms. The token comes from
@@ -1045,10 +1149,16 @@ export function handleSetupGet(req: Request, deps: SetupWizardDeps): Response {
       // Module install tiles (hub#272 Item B). One per curated module
       // other than vault (which the wizard already provisioned).
       const installTiles = buildInstallTiles(url, deps);
+      // hub#342: drive the lead "Start using your vault" tile's target.
+      // When parachute-app is installed alongside vault, the tile links
+      // to `/app/notes/` (auto-bootstrapped Notes-as-UI per parachute-app
+      // §17). Otherwise it falls back to the vault's own admin UI.
+      const appInstalled = isModuleInstalled("app", deps.manifestPath);
       const doneProps: RenderDoneStepProps = {
         vaultName,
         hubOrigin: deps.issuer,
         installTiles,
+        appInstalled,
       };
       if (exposeMode !== undefined) doneProps.exposeMode = exposeMode;
       if (mintedToken) doneProps.mintedToken = mintedToken;
@@ -1691,6 +1801,20 @@ function validateAccountFields(input: {
 }
 
 /**
+ * Whether a given curated module is currently installed (has a row in
+ * services.json keyed by its canonical `manifestName`). Used by the
+ * done-step renderer (hub#342) to decide whether to point the "Start
+ * using your vault" tile at `/app/notes/` (App installed → Notes UI
+ * auto-bootstrapped) vs the vault's own admin UI. Cheap manifest read
+ * shared with `buildInstallTiles`.
+ */
+function isModuleInstalled(short: CuratedModuleShort, manifestPath: string): boolean {
+  const manifest = readManifest(manifestPath);
+  const spec = specFor(short);
+  return manifest.services.some((s) => s.name === spec.manifestName);
+}
+
+/**
  * Read the first vault's display name from services.json for the
  * step-4 success page. Falls back to "default" if for any reason the
  * entry's metadata isn't present.
@@ -2046,6 +2170,18 @@ const STYLES = `
     display: flex;
     flex-direction: column;
     gap: 0.4rem;
+    /* min-width: 0 lets the grid track shrink below the tile's intrinsic
+       content width — without it a long log line in .install-tile-log
+       forces the tile (and its parent grid track) wider than the card,
+       which is what stretched the wizard when Aaron clicked Install App. */
+    min-width: 0;
+  }
+  /* "Use it now" action row on a successful install-tile (hub#342 item 3). */
+  .install-tile-actions {
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
   }
   .install-tile h3 {
     margin: 0;
@@ -2131,6 +2267,23 @@ const STYLES = `
     margin: 1rem 0;
     font-family: ${FONT_MONO};
     font-size: 0.85rem;
+    /* Install logs spit long lines (npm package names with paths, JSON
+       dumps, stack traces). Without these constraints the <li> contents
+       overflow the card horizontally — caught Aaron mid-install (hub#342):
+       clicking Install App / Install Scribe blew up the entire wizard
+       layout, font size jumped, the page stretched off-screen. The
+       triple of overflow-x:auto + white-space:pre-wrap + min-width:0
+       keeps the log inside its container regardless of line length:
+       overflow-x:auto on .op-log gives a horizontal scrollbar as a
+       last-resort affordance; pre-wrap on .log-lines li wraps cleanly
+       at whitespace so the common case never even needs to scroll;
+       min-width:0 on the outer log-lines list is the magic-flex bit
+       that lets the list itself shrink below its content's intrinsic
+       width inside the card's flex/grid layout. break-word (rather
+       than break-all) keeps URLs / paths legible when they DO have to
+       break. */
+    overflow-x: auto;
+    max-width: 100%;
   }
   .op-status {
     margin: 0 0 0.5rem;
@@ -2139,8 +2292,18 @@ const STYLES = `
   }
   .op-succeeded { color: ${PALETTE.success}; }
   .op-failed { color: ${PALETTE.danger}; }
-  .log-lines { margin: 0; padding-left: 1.25rem; color: ${PALETTE.fgMuted}; }
-  .log-lines li { margin: 0.15rem 0; }
+  .log-lines {
+    margin: 0;
+    padding-left: 1.25rem;
+    color: ${PALETTE.fgMuted};
+    min-width: 0;
+  }
+  .log-lines li {
+    margin: 0.15rem 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+  }
 
   .done-grid {
     display: grid;
@@ -2257,6 +2420,30 @@ const STYLES = `
     margin: 0.4rem 0;
   }
   .reachable .fine { font-size: 0.85rem; color: ${PALETTE.fgMuted}; margin: 0.4rem 0 0; }
+
+  /* "Start using your vault" lead tile on the done step (hub#342).
+     Same visual weight as .reachable so the operator's eye lands here
+     as the primary user-facing entry — slightly more prominent
+     padding + a stronger heading to telegraph "this is the click
+     you're looking for." */
+  .start-using {
+    background: ${PALETTE.cardBg};
+    border: 1px solid ${PALETTE.accent};
+    border-radius: 8px;
+    padding: 1rem 1.1rem;
+    margin: 0 0 1rem;
+  }
+  .start-using h2 {
+    margin: 0 0 0.5rem;
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 1.1rem;
+    color: ${PALETTE.fg};
+    font-family: ${FONT_SERIF};
+    font-weight: 400;
+  }
+  .start-using p { margin: 0.4rem 0; }
+  .start-using p:last-child { margin-bottom: 0; }
 
   code {
     background: ${PALETTE.borderLight};

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -883,6 +883,9 @@ function renderMcpTile(
  */
 function renderStartUsingTile(vaultName: string, appInstalled: boolean): string {
   const safeVault = escapeHtml(vaultName);
+  // Vault names pass `/^[a-z0-9][a-z0-9-]*$/i` so URL-encoding is mostly
+  // a no-op today, but use encodeURIComponent defensively to match hub.ts:505.
+  const urlVault = encodeURIComponent(vaultName);
   if (appInstalled) {
     return `<section class="start-using" data-testid="start-using-tile">
       <h2>Start using your vault</h2>
@@ -897,7 +900,7 @@ function renderStartUsingTile(vaultName: string, appInstalled: boolean): string 
       <strong>App</strong> below (it bundles the Notes UI) to start
       capturing — or open the vault's admin UI now to see what's
       inside.</p>
-    <p><a class="btn btn-primary" href="/vault/${safeVault}/admin/">Open vault admin</a></p>
+    <p><a class="btn btn-primary" href="/vault/${urlVault}/admin/">Open vault admin</a></p>
   </section>`;
 }
 
@@ -1005,9 +1008,12 @@ function renderInstallTile(tile: ModuleInstallTileState): string {
  */
 const USE_IT_NOW_URLS: Partial<Record<CuratedModuleShort, string>> = {
   app: "/app/notes/",
-  scribe: "/scribe/admin/",
   notes: "/notes/",
-  runner: "/runner/admin/",
+  // Omitted: scribe + runner. They don't ship an admin SPA yet
+  // (scribe#53, runner#8 track). Pointing "Use it now" at /scribe/admin
+  // or /runner/admin today would 404 — better to fall through to the
+  // "Manage modules" link than to send the operator into a dead end.
+  // Add the entry here once those modules ship their admin UI.
 };
 
 /**

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -210,6 +210,78 @@ describe("App — auth indicator (rc.13)", () => {
   });
 });
 
+describe("App — installed-services dropdown (hub#342)", () => {
+  it("renders nothing in the nav when no modules are installed", async () => {
+    vi.mocked(api.getMe).mockResolvedValue({
+      hasSession: true,
+      user: { id: "u1", displayName: "aaron" },
+      csrf: "csrf",
+    });
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [],
+      supervisor_available: true,
+      module_install_channel: "latest",
+    });
+    renderAt("/vaults");
+    await waitFor(() => expect(screen.getByText(/signed in as/i)).toBeInTheDocument());
+    expect(screen.queryByTestId("installed-services-dropdown")).toBeNull();
+  });
+
+  it("renders an active <a> per installed module with a management_url", async () => {
+    vi.mocked(api.getMe).mockResolvedValue({
+      hasSession: true,
+      user: { id: "u1", displayName: "aaron" },
+      csrf: "csrf",
+    });
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [
+        {
+          short: "vault",
+          package: "@openparachute/vault",
+          display_name: "Vault",
+          tagline: "",
+          available: true,
+          installed: true,
+          installed_version: "0.4.5",
+          latest_version: "0.4.5",
+          supervisor_status: "running",
+          pid: 1,
+          install_dir: null,
+          uis: [],
+          management_url: "/vault/default/admin",
+        },
+        {
+          short: "scribe",
+          package: "@openparachute/scribe",
+          display_name: "Scribe",
+          tagline: "",
+          available: true,
+          installed: true,
+          installed_version: "0.1.0",
+          latest_version: "0.1.0",
+          supervisor_status: "running",
+          pid: 2,
+          install_dir: null,
+          uis: [],
+          management_url: null,
+        },
+      ],
+      supervisor_available: true,
+      module_install_channel: "latest",
+    });
+    renderAt("/vaults");
+    await waitFor(() =>
+      expect(screen.getByTestId("installed-services-dropdown")).toBeInTheDocument(),
+    );
+    const vaultItem = screen.getByTestId("nav-service-vault");
+    expect(vaultItem.tagName).toBe("A");
+    expect(vaultItem.getAttribute("href")).toBe("/vault/default/admin");
+    const scribeItem = screen.getByTestId("nav-service-scribe");
+    expect(scribeItem.tagName).toBe("SPAN");
+    expect(scribeItem.getAttribute("aria-disabled")).toBe("true");
+  });
+});
+
 describe("App — route rendering", () => {
   it("/vaults renders VaultsList (heading 'Vaults')", async () => {
     renderAt("/vaults");

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -23,7 +23,13 @@
  */
 import { type ReactNode, useEffect, useState } from "react";
 import { Link, Route, Routes, useLocation } from "react-router-dom";
-import { type MeResponse, getMe, signOut } from "./lib/api.ts";
+import {
+  type MeResponse,
+  type ModuleListing,
+  getMe,
+  listModules,
+  signOut,
+} from "./lib/api.ts";
 import { ApproveClient } from "./routes/ApproveClient.tsx";
 import { ModuleConfig } from "./routes/ModuleConfig.tsx";
 import { Modules } from "./routes/Modules.tsx";
@@ -70,6 +76,11 @@ export function App() {
   const subtitle = subtitleFor(pathname);
   const [me, setMe] = useState<MeResponse | null>(null);
   const [signingOut, setSigningOut] = useState(false);
+  // hub#342: surface a "Services" quick-access dropdown in the nav with
+  // an entry per installed module that declares a `management_url`. One
+  // round-trip per nav mount; failures collapse silently (the dropdown
+  // just doesn't render).
+  const [installedServices, setInstalledServices] = useState<ModuleListing[]>([]);
 
   useEffect(() => {
     let cancelled = false;
@@ -90,6 +101,29 @@ export function App() {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    // Don't fetch modules until we know we have a session — pre-auth
+    // the listModules() call would fail with 401 and pollute the
+    // console. The 401-clears-token shape in listModules cleans up
+    // after itself either way; this is just noise reduction.
+    if (!me || !me.hasSession) return;
+    let cancelled = false;
+    listModules()
+      .then((catalog) => {
+        if (cancelled) return;
+        setInstalledServices(catalog.modules.filter((m) => m.installed));
+      })
+      .catch(() => {
+        // Quiet failure — the dropdown just doesn't render. The Modules
+        // page itself surfaces the underlying error on its own.
+        if (cancelled) return;
+        setInstalledServices([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [me]);
 
   async function onSignOut(csrf: string): Promise<void> {
     setSigningOut(true);
@@ -117,6 +151,7 @@ export function App() {
         <AuthIndicator me={me} signingOut={signingOut} onSignOut={onSignOut} />
         <Link to="/vaults">Vaults</Link>
         <Link to="/modules">Modules</Link>
+        <InstalledServicesDropdown services={installedServices} />
         <Link to="/users">Users</Link>
         <Link to="/permissions">Permissions</Link>
         <Link to="/tokens">Tokens</Link>
@@ -148,6 +183,61 @@ export function App() {
         />
       </Routes>
     </div>
+  );
+}
+
+/**
+ * "Services" quick-access dropdown in the admin SPA nav (hub#342).
+ *
+ * Lists each installed module that declares a `management_url`, linking
+ * to that URL (full-page navigation — the module owns its surface).
+ * Modules without a `management_url` (scribe, runner today; tracked at
+ * scribe#53, runner#8) appear as disabled items with a follow-up
+ * tooltip so operators can see what's installed but-not-yet-open-able.
+ *
+ * Native `<details>` for the click-to-expand behavior — no client-side
+ * focus management, no portal, no z-index dance. Matches the existing
+ * `module-uis` `<details>` pattern in Modules.tsx.
+ *
+ * Renders nothing when no modules are installed yet (fresh hub) so the
+ * nav doesn't show an empty "Services ▾" affordance.
+ */
+function InstalledServicesDropdown({ services }: { services: ModuleListing[] }) {
+  if (services.length === 0) return null;
+  return (
+    <details className="nav-dropdown" data-testid="installed-services-dropdown">
+      <summary className="nav-dropdown-summary">Services</summary>
+      <div className="nav-dropdown-panel" role="menu">
+        {services.map((mod) => {
+          const url = mod.management_url;
+          if (url) {
+            return (
+              <a
+                key={mod.short}
+                className="nav-dropdown-item"
+                href={url}
+                role="menuitem"
+                data-testid={`nav-service-${mod.short}`}
+              >
+                {mod.display_name}
+              </a>
+            );
+          }
+          return (
+            <span
+              key={mod.short}
+              className="nav-dropdown-item nav-dropdown-item-disabled"
+              role="menuitem"
+              aria-disabled="true"
+              title="This module hasn't shipped an admin UI yet."
+              data-testid={`nav-service-${mod.short}`}
+            >
+              {mod.display_name}
+            </span>
+          );
+        })}
+      </div>
+    </details>
   );
 }
 

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -608,6 +608,19 @@ export interface ModuleListing {
    * consumer; the SPA renders each entry as an expandable sub-row.
    */
   uis: ModuleUiSubUnit[];
+  /**
+   * Canonical user-facing URL for this module's own UI (hub#342). Drives
+   * the Modules page's "Open" button. Resolved server-side from the
+   * module's `.parachute/module.json` (`managementUrl` ?? `uiUrl`)
+   * joined against its mount path. Null when the module hasn't declared
+   * either field — SPA renders a disabled-with-tooltip "Open" button
+   * pointing at the per-module follow-up issue.
+   *
+   * The collapse of Open + Configure into a single button is the
+   * architectural through-line: each module ships its own UI handling
+   * both viewing AND configuring; hub becomes a dispatcher to that UI.
+   */
+  management_url: string | null;
 }
 
 /** Module install channel — `latest` (stable) or `rc` (release candidates). */

--- a/web/ui/src/routes/ModuleConfig.tsx
+++ b/web/ui/src/routes/ModuleConfig.tsx
@@ -1,6 +1,22 @@
 /**
  * /admin/modules/:short/config — generic per-module config form.
  *
+ * **DEPRECATED (hub#342).** As of the 2026-05-23 UI pass, the admin SPA
+ * Modules page no longer links here — "Configure" collapsed into "Open"
+ * per Aaron's architectural framing (each module ships its OWN UI
+ * handling both viewing and configuring; hub becomes a dispatcher to
+ * that UI via `managementUrl`). The route + handler stay so existing
+ * bookmarks don't 404, but no SPA surface links to it anymore. A
+ * future PR deletes this route + the `/api/modules/:short/config{,
+ * /schema}` endpoints once the migration period has settled.
+ *
+ * Historical context (hub#260): the generic per-module config form was
+ * built because scribe was the only module shipping a schema-backed
+ * config endpoint, and we wanted one hub-side form rather than a
+ * per-module SPA. The Aaron-driven shift to "each module owns its UI"
+ * inverts that — scribe (scribe#53) and runner (runner#8) will ship
+ * their own admin SPAs per `module-surfaces.md`.
+ *
  * Mounted off `/admin/modules` (the Modules page exposes a "Configure"
  * link per installed module). The page fetches three things on load:
  *

--- a/web/ui/src/routes/Modules.test.tsx
+++ b/web/ui/src/routes/Modules.test.tsx
@@ -67,6 +67,7 @@ function moduleRow(short: string, overrides: Partial<api.ModuleListing> = {}): a
     pid: null,
     install_dir: null,
     uis: [],
+    management_url: null,
     ...overrides,
   };
 }
@@ -161,6 +162,72 @@ describe("Modules — catalog rendering", () => {
     await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
     expect(screen.getByText(/running/i)).toBeInTheDocument();
     expect(screen.getByText("v0.4.5")).toBeInTheDocument();
+  });
+});
+
+describe("Modules — Open button (hub#342)", () => {
+  it("renders an active <a> when management_url is set", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [
+        moduleRow("vault", {
+          installed: true,
+          installed_version: "0.4.5",
+          latest_version: "0.4.5",
+          supervisor_status: "running",
+          management_url: "/vault/default/admin",
+        }),
+      ],
+      supervisor_available: true,
+      module_install_channel: "latest",
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    const open = screen.getByTestId("open-vault");
+    expect(open.tagName).toBe("A");
+    expect(open.getAttribute("href")).toBe("/vault/default/admin");
+  });
+
+  it("renders a disabled button with a follow-up tooltip when management_url is null", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [
+        moduleRow("scribe", {
+          installed: true,
+          installed_version: "0.1.0",
+          latest_version: "0.1.0",
+          supervisor_status: "running",
+          management_url: null,
+        }),
+      ],
+      supervisor_available: true,
+      module_install_channel: "latest",
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Scribe")).toBeInTheDocument());
+    const open = screen.getByTestId("open-scribe");
+    expect(open.tagName).toBe("BUTTON");
+    expect(open).toBeDisabled();
+    expect(open.getAttribute("title")).toContain("scribe#53");
+  });
+
+  it("does not render the Configure link anymore (it was collapsed into Open)", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [
+        moduleRow("vault", {
+          installed: true,
+          installed_version: "0.4.5",
+          latest_version: "0.4.5",
+          supervisor_status: "running",
+          management_url: "/vault/default/admin",
+        }),
+      ],
+      supervisor_available: true,
+      module_install_channel: "latest",
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    // Pre-#342 had a "Configure" link under the actions row. Post-#342
+    // has only "Open" (and Restart / Upgrade / Uninstall).
+    expect(screen.queryByText(/^Configure$/)).toBeNull();
   });
 });
 

--- a/web/ui/src/routes/Modules.tsx
+++ b/web/ui/src/routes/Modules.tsx
@@ -400,10 +400,46 @@ interface ModuleRowProps {
 }
 
 /**
+ * Per-module follow-up issues filed alongside hub#342 (when a module
+ * hasn't yet shipped its own admin UI surface). Rendered as the
+ * `title` attribute on a disabled "Open" button so the operator knows
+ * the issue tracking the gap, not just that the button is greyed out.
+ *
+ * Vault declares `managementUrl: "/admin"` already, so it's not in this
+ * map — its row gets an active Open button pointing at its own UI.
+ * Notes is the deprecating notes-daemon path; its install surface
+ * still ships its own UI under `/notes/`, so it has a valid mount but
+ * doesn't actively need a follow-up. Scribe + runner are the
+ * outstanding gaps.
+ */
+const NO_UI_FOLLOWUPS: Record<string, string> = {
+  scribe: "Scribe admin SPA tracked at scribe#53",
+  runner: "Runner admin SPA tracked at runner#8",
+};
+
+/**
  * Row for an installed module — shows version + supervisor status +
- * Configure / Restart / Upgrade / Uninstall affordances. The "install"
- * action lives on `InstallableCard` instead; this row is only rendered
- * for `installed: true` modules.
+ * Open / Restart / Upgrade / Uninstall affordances.
+ *
+ * The "Open" button (hub#342) is the architectural-pivot affordance:
+ * Aaron's framing is that each module ships its OWN UI that handles
+ * both viewing and configuring; hub becomes a dispatcher. Pre-#342
+ * had both "Configure" (in-hub config form at `/admin/modules/<short>/config`)
+ * and an implicit "navigate to the module's own UI somewhere" — the
+ * two surfaces blurred. Post-#342 there's one click target: Open,
+ * which lands the operator on the module's `managementUrl`
+ * (resolved server-side from `.parachute/module.json`). The in-hub
+ * config form code at `/admin/modules/:short/config` is retained for
+ * the moment but no longer linked from this page; a future PR
+ * deletes it after the migration period.
+ *
+ * Modules without a declared `management_url` (today: scribe, runner —
+ * tracked at scribe#53, runner#8) get a disabled Open button with a
+ * tooltip pointing at the follow-up. Gentler than 404-on-click and
+ * makes the gap discoverable to operators.
+ *
+ * The "install" action lives on `InstallableCard` instead; this row is
+ * only rendered for `installed: true` modules.
  */
 function ModuleRow({
   module: mod,
@@ -417,6 +453,8 @@ function ModuleRow({
   const canAct = supervisorAvailable && !syncBusy;
   const upgradeAvailable =
     mod.installed_version !== mod.latest_version && mod.latest_version !== null;
+  const openUrl = mod.management_url;
+  const openFollowup = NO_UI_FOLLOWUPS[mod.short];
 
   return (
     <li className="module-row" data-short={mod.short}>
@@ -459,16 +497,27 @@ function ModuleRow({
       {mod.uis.length > 0 && <UiSubUnitsList uis={mod.uis} />}
 
       <div className="actions">
-        {/* Configure link routes to the generic per-module config form
-            (hub#260). Rendered as a Link rather than a button because
-            it's pure navigation — no async action attached, no
-            supervisor requirement. Stays clickable even when the
-            supervisor is offline so an operator on a hub-only CLI
-            install can still edit config (the config endpoints are
-            served by the module itself, not the supervisor). */}
-        <Link className="btn" to={`/modules/${encodeURIComponent(mod.short)}/config`}>
-          Configure
-        </Link>
+        {/* Open → the module's own UI (hub#342). Full-page navigation
+            via <a href> rather than react-router Link because we're
+            leaving the SPA — the module owns its surface. Disabled
+            state for modules without a declared management_url
+            telegraphs "this module hasn't shipped its UI yet" via
+            tooltip rather than 404-ing the operator. */}
+        {openUrl ? (
+          <a className="btn" href={openUrl} data-testid={`open-${mod.short}`}>
+            Open
+          </a>
+        ) : (
+          <button
+            type="button"
+            className="btn"
+            disabled
+            title={openFollowup ?? "This module hasn't shipped an admin UI yet."}
+            data-testid={`open-${mod.short}`}
+          >
+            Open
+          </button>
+        )}
         <button type="button" disabled={!canAct} onClick={onRestart}>
           Restart
         </button>

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -143,6 +143,69 @@ code {
   align-self: center;
 }
 
+/* Installed-services quick-access dropdown in the nav (hub#342).
+   Native <details>/<summary> for the toggle behavior, absolute-
+   positioned panel so the dropdown doesn't push siblings around when
+   open. summary triangle is suppressed for visual parity with the
+   other nav items. */
+.nav .nav-dropdown {
+  position: relative;
+}
+.nav .nav-dropdown-summary {
+  list-style: none;
+  cursor: pointer;
+  color: var(--fg-muted);
+  font-size: 0.95rem;
+  user-select: none;
+}
+.nav .nav-dropdown-summary::-webkit-details-marker {
+  display: none;
+}
+.nav .nav-dropdown-summary:hover {
+  color: var(--fg);
+}
+.nav .nav-dropdown[open] > .nav-dropdown-summary {
+  color: var(--fg);
+}
+.nav .nav-dropdown-summary::after {
+  content: ' \25BE'; /* ▾ */
+  font-size: 0.7em;
+  color: var(--fg-dim);
+}
+.nav .nav-dropdown-panel {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  left: 0;
+  z-index: 10;
+  min-width: 12rem;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  padding: 0.4rem 0;
+  display: flex;
+  flex-direction: column;
+}
+.nav .nav-dropdown-item {
+  padding: 0.4rem 0.85rem;
+  color: var(--fg);
+  font-size: 0.9rem;
+  text-decoration: none;
+}
+.nav .nav-dropdown-item:hover {
+  background: var(--bg-soft);
+  color: var(--fg);
+  text-decoration: none;
+}
+.nav .nav-dropdown-item-disabled {
+  color: var(--fg-dim);
+  cursor: not-allowed;
+}
+.nav .nav-dropdown-item-disabled:hover {
+  background: transparent;
+  color: var(--fg-dim);
+}
+
 /* SPA auth indicator — "Signed in as <name> · Sign out" or "Sign in".
    Sits in the nav, after brand's margin-right:auto pushes everything
    right. The brand keeps the layout balance; auth lands in the


### PR DESCRIPTION
## Aaron's two reports (2026-05-22 → 23)

**Bug** — "when I go to first install, I click things like install app and install scribe, then the text gets way bigger, and the whole screen gets stretched"

**UX direction** —
1. "no clear way to go from setting up parachute to actually using parachute"
2. "I'm not sure there's a huge difference between open and configure" — collapse them. Each module ships its own UI that handles both view + configure. Hub becomes a dispatcher.

Closes #342.

## Architectural through-line

Per [`module-ui-declaration.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-ui-declaration.md) + [`module-surfaces.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/module-surfaces.md): each committed-core module exposes a canonical admin UI at `/<short>/admin` (or wherever its `managementUrl` declares). Hub's job is dispatch — point operators at the right module's UI; the module's own SPA handles view + configure via internal scope gates. The pre-#342 hub-side "Configure" form was an artifact of scribe being the only schema-backed module; with scribe + runner shipping their own SPAs (scribe#53, runner#8), hub's generic form becomes redundant.

The dispatched-to module reads its mount + hub origin from injected meta tags per [`runtime-tenancy-contract.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/runtime-tenancy-contract.md). That contract is what makes a single Open click work uniformly across every module without hub needing per-module knowledge.

## The 6 changes

1. **Install-log overflow CSS** (`src/setup-wizard.ts`) — `.op-log` gains `overflow-x: auto`; `.log-lines li` gain `white-space: pre-wrap` + `overflow-wrap: anywhere`; `.install-tile` gains `min-width: 0` so the grid track can shrink. Aaron's reproducer fixed.
2. **Wizard done-screen lead tile** — new "Start using your vault" section above the existing tiles. App installed → `/app/notes/`; otherwise → `/vault/<name>/admin/`. One obvious click target instead of three competing ones.
3. **Install-tile "Use it now" link** — terminal-state install tiles (succeeded + already-installed) lead with the module's canonical UI URL; "Manage modules" demoted to secondary.
4. **Admin SPA Modules page: Open + Configure collapse → Open** — `/api/modules` wire shape gains `management_url` (resolved server-side from `.parachute/module.json` `managementUrl ?? uiUrl` against the entry's mount). Modules without one render a disabled button with a follow-up tooltip (scribe#53, runner#8). Pre-existing in-hub config form (`/admin/modules/:short/config`) stays for back-compat; SPA no longer links it; future PR deletes.
5. **Discovery page "Get started" section** — new section above Services grid in `src/hub.ts`; two conditional tiles ("Open Notes" / "Browse Vault") driven from `/.well-known/parachute.json`; hidden until at least one prereq is met.
6. **Admin SPA nav "Services ▾" dropdown** — quick access from any admin page; one entry per installed module that declares `management_url`; disabled fallback for the rest.

## Verification

- `bun run typecheck` clean
- `bun test ./src` 1909 pass / 0 fail (delta +7)
- `cd web/ui && bunx vitest run` 193 pass / 0 fail (delta +5)
- `bunx biome check src/` clean
- `bun run build:spa` clean

## Follow-up issues filed

- [parachute-scribe#53](https://github.com/ParachuteComputer/parachute-scribe/issues/53) — ship scribe admin SPA (currently config endpoints + schema only; Open shows disabled-with-tooltip until this lands)
- [parachute-runner#8](https://github.com/ParachuteComputer/parachute-runner/issues/8) — ship runner admin SPA (currently admin endpoints only; same gap)
- Future PR: delete `web/ui/src/routes/ModuleConfig.tsx` + the `/api/modules/:short/config{,/schema}` endpoints once at least one rc cycle confirms no operator is bookmarking the legacy path.

## Patterns check

- `module-ui-declaration.md` — change consumes `uiUrl` / `managementUrl` semantics; no change to the pattern itself.
- `module-surfaces.md` — change reinforces canonical surface convention; scribe + runner gaps now tracked at scribe#53 + runner#8.
- `runtime-tenancy-contract.md` — change is consumer-side of the contract; no change to the pattern.

No new pattern + no pattern revision needed.

## Don't

- Don't delete the in-hub config-form code in this PR (marked deprecated; follow-up filed).
- Don't merge — orchestrator handles.