### PR TITLE
fix(hub): default Render PARACHUTE_INSTALL_CHANNEL to latest (rc is an opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.22] - 2026-05-23
+
+**fix(hub): Render Blueprint default channel `latest`, not `rc` (rc is now opt-in for dev/testing).**
+
+Per Aaron: "I don't want it all to be rc, just for that to be a choice. Most people installing via render want latest for hub and latest for other modules. But flexibility is key here. And for me, I want to be testing it with rc."
+
+Changes:
+
+- `render.yaml`: `PARACHUTE_INSTALL_CHANNEL` value `rc` → `latest`. Comment updated to reflect that rc is the opt-in choice (set in Render dashboard) rather than the default.
+- `README.md`: "Hosted (Render)" section now leads with "stable by default" and surfaces the rc-flip in a bold callout.
+- The rc.20 CHANGELOG entry for hub#337/#339 remains accurate as historical record (Aaron's testing did rely on rc-as-default during that rc chain); this rc reverses the default for the canonical operator path.
+
+Existing Render deploys with the env var manually set in the dashboard are unaffected — Render doesn't auto-overwrite operator-set env vars on Blueprint redeploys.
+
 ## [0.5.13-rc.21] - 2026-05-23
 
 **fix(hub): `parachute logs <svc>` no longer misreports a running daemon as not-started (closes [hub#335](https://github.com/ParachuteComputer/parachute-hub/issues/335)).**

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Prereqs: [Bun](https://bun.sh) 1.3.0 or later. `parachute expose` also requires 
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/ParachuteComputer/parachute-hub)
 
-One-click Render deploy via the `render.yaml` Blueprint in this repo. Provisions a $7/mo Starter service + 1 GiB persistent disk + auto-deploys from `main`. Comes pre-configured with `PARACHUTE_INSTALL_CHANNEL=rc` so any modules you add via the admin SPA (vault, app, scribe, runner) install at the rc channel — matching the hub's rc release line. Flip to `latest` in your Render dashboard if you prefer stable cluster-wide.
+One-click Render deploy via the `render.yaml` Blueprint in this repo. Provisions a $7/mo Starter service + 1 GiB persistent disk + auto-deploys from `main`. Comes pre-configured with `PARACHUTE_INSTALL_CHANNEL=latest` so modules you install via the admin SPA (vault, app, scribe, runner) pull stable releases by default.
+
+**Want pre-release / rc modules?** Set `PARACHUTE_INSTALL_CHANNEL=rc` in your Render dashboard env vars (useful for dev/testing against the rc release line).
 
 After deploy:
 

--- a/render.yaml
+++ b/render.yaml
@@ -70,12 +70,15 @@ services:
       # /admin/modules pull the same rc chain as hub itself (this image
       # is built from `main`, which tracks rc per governance rule 2). An
       # operator forking this repo gets the canonical "rc dev deploy"
-      # shape — hub on rc, every module on rc, no per-call --channel
-      # flags needed. Flip to `latest` (or remove the key) once 1.0
-      # lands and the cluster's settled on stable. Per-call --channel
-      # and --tag still override. (hub#337)
+      # shape — modules installed via admin SPA cascade to this channel
+      # by default. `latest` is the right default for most operators
+      # (stable releases of vault / app / scribe / runner). Flip to
+      # `rc` in your Render dashboard if you want the rc cascade
+      # (pre-release modules; useful for dev/testing). Per-call
+      # `--channel` and `--tag` still override on the install command.
+      # (hub#337)
       - key: PARACHUTE_INSTALL_CHANNEL
-        value: rc
+        value: latest
 
       # Canonical public origin baked into the OAuth issuer claim and
       # token aud claims. MUST match the custom domain you attach to

--- a/render.yaml
+++ b/render.yaml
@@ -66,17 +66,13 @@ services:
       - key: BUN_INSTALL
         value: /parachute/modules
 
-      # Cascade installs to @rc so vault/app/scribe/runner installed via
-      # /admin/modules pull the same rc chain as hub itself (this image
-      # is built from `main`, which tracks rc per governance rule 2). An
-      # operator forking this repo gets the canonical "rc dev deploy"
-      # shape — modules installed via admin SPA cascade to this channel
-      # by default. `latest` is the right default for most operators
+      # Modules installed via admin SPA cascade to this channel by
+      # default. `latest` is the right default for most operators
       # (stable releases of vault / app / scribe / runner). Flip to
       # `rc` in your Render dashboard if you want the rc cascade
       # (pre-release modules; useful for dev/testing). Per-call
       # `--channel` and `--tag` still override on the install command.
-      # (hub#337)
+      # (hub#337, hub#347)
       - key: PARACHUTE_INSTALL_CHANNEL
         value: latest
 


### PR DESCRIPTION
## What

Changes render.yaml's default \`PARACHUTE_INSTALL_CHANNEL\` from \`rc\` → \`latest\`. Updates README to reflect that rc is the opt-in choice for dev/testing.

## Why

Per Aaron: "I don't want it all to be rc, just for that to be a choice. Most people installing via render want latest for hub and latest for other modules. But flexibility is key here. And for me, I want to be testing it with rc."

The default-rc shape made sense pre-stable but is wrong for the common-case operator. Operators who want rc-cascade now set the env var in their Render dashboard.

## Test plan

- Existing Render deploys with the env var already set keep working (no auto-overwrite)
- New deploys via the Deploy-to-Render button get latest by default
- Operators wanting rc set the env var in dashboard → triggers a redeploy