### PR TITLE
feat(hub): /api/hub endpoint + Hub Version Badge in admin SPA (version visibility)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.23] - 2026-05-23
+
+**feat(hub): `/api/hub` endpoint + Hub Version Badge in admin SPA (version visibility) (closes [hub#348](https://github.com/ParachuteComputer/parachute-hub/issues/348)).**
+
+Aaron's framing (2026-05-23, mid-install): "I can't really tell with mine if it's updated or not. And I'm not sure how I would queue it to update or if it just already did." Render auto-deploys on every push to source; the operator doesn't actively trigger updates and needs to see the result land somewhere visible. The CLI surface `parachute status` already shows version + uptime + install-source; this PR mirrors it for the admin SPA.
+
+### Added
+
+- `/api/hub` endpoint + Hub Version Badge in admin SPA. Operators can now see at a glance what version of hub they're running, when it last started, and how it's installed (npm tag, bun-linked checkout, or container). Especially useful for Render deployers tracking auto-deploys from main. Click the badge for a detail panel + manual refresh button.
+
+### What landed
+
+- **`src/api-hub.ts`** — new `GET /api/hub` handler. Bearer-gated on `parachute:host:admin` (same as `/vaults` and `/api/grants`). Returns `{ version, started_at, uptime_ms, source, bun_linked_path?, git_head?, container_build_time? }`. `source` reuses `detectHubInstallSource` from install-source.ts with one container override: when `PARACHUTE_HOME === "/parachute"` (the Render Blueprint pin) we surface `"container"` instead of `"bun-linked from /app"` — operator-friendly. `started_at` is captured once at module load (`HUB_PROCESS_STARTED_AT`); `uptime_ms` is computed server-side so the client doesn't deal with clock skew. `PARACHUTE_BUILD_TIME` env var passes through opportunistically as `container_build_time` (not surfaced when unset).
+- **`src/hub-server.ts`** — wires the new `/api/hub` route alongside `/api/me`; adds it to the route-table docstring.
+- **`web/ui/src/lib/api.ts`** — `getHubStatus()` + `HubStatus` / `HubStatusSource` types. Same `getHostAdminToken()` bearer pattern as the other admin endpoints; 401/403 clears the cached token.
+- **`web/ui/src/components/HubVersionBadge.tsx`** — persistent footer affordance. Renders `Hub <version> · running <uptime> · <source>` on one muted line. Click expands an inline detail panel with the full source label (bun-linked path + git head when applicable), formatted UTC timestamps for started + built, plus a Refresh button. Auto-refreshes every 30s while mounted and on tab focus. 401/403 collapses to render-null (no redirect loop — the SPA's other surfaces handle auth flow).
+- **`web/ui/src/App.tsx`** — mounts `<HubVersionBadge />` at the bottom of the page, gated on `me?.hasSession` so it never renders for signed-out visitors (the badge would 401 anyway).
+- **`web/ui/src/styles.css`** — `.hub-version-badge` + panel styling. Muted single line above a `1px` top-border, expandable `<dl>` grid for the detail rows.
+
+### Verification
+
+- `bun test ./src` 1919 pass / 0 fail (delta: +7 new tests in `src/__tests__/api-hub.test.ts` — 405 / 401 / 403 gate; happy path shape; uptime increments between calls; `PARACHUTE_HOME=/parachute` overrides to `container`; `PARACHUTE_BUILD_TIME` passes through).
+- `cd web/ui && bunx vitest run` 203 pass / 0 fail (delta: +10 new tests in `HubVersionBadge.test.tsx` — `formatUptime` boundaries; null-on-pending render; happy-path render; null-on-401; click-expand panel; refresh button refetches; container_build_time surfaces).
+- `bun run typecheck` clean.
+- `cd web/ui && bun run build` clean (`verify-base.mjs` passes; `/admin/`-prefixed asset URLs intact).
+
+### Patterns check
+
+- No pattern shifts. New `/api/*` endpoint follows the canonical bearer-gated read shape established by `/api/grants`, `/api/tokens`, `/api/modules` — `requireScope(parachute:host:admin)`, snake-case wire fields, `cache-control: no-store`. SPA-side, the badge follows the existing `getHostAdminToken()` cached-bearer pattern; auto-refresh + focus-refresh mirror what the Modules page already does for the supervisor status poll.
+
 ## [0.5.13-rc.22] - 2026-05-23
 
 **fix(hub): Render Blueprint default channel `latest`, not `rc` (rc is now opt-in for dev/testing).**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.21",
+  "version": "0.5.13-rc.23",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-hub.test.ts
+++ b/src/__tests__/api-hub.test.ts
@@ -1,0 +1,251 @@
+/**
+ * `GET /api/hub` — hub version + uptime + install-source surface for the
+ * admin SPA's version badge.
+ *
+ * Tests assert the contract:
+ *   - 405 on non-GET (matches the shape of other /api/* read endpoints).
+ *   - 401/403 on missing or under-scoped bearer (host:admin required).
+ *   - Happy path returns the expected shape + uptime increments between
+ *     calls.
+ *   - PARACHUTE_HOME=/parachute (the Render Blueprint pin) overrides
+ *     `source` to "container".
+ *   - PARACHUTE_BUILD_TIME passes through as `container_build_time`.
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { type HubStatusResponse, handleApiHub } from "../api-hub.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { signAccessToken } from "../jwt-sign.ts";
+import { mintOperatorToken } from "../operator-token.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+
+interface Harness {
+  dir: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-api-hub-"));
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+const ISSUER = "http://127.0.0.1:1939";
+
+// `hubSrcDir` defaults to `dirname(import.meta.url)` of api-hub.ts — but in
+// tests we drive it explicitly so test-side test-double dirs don't accidentally
+// pick up the real package.json. Point it at this file's dir (under __tests__/)
+// so the climb-to-package.json loop walks up to the repo root and finds the
+// real hub package.json.
+const HUB_SRC_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+async function bootstrap(
+  dir: string,
+): Promise<{ db: ReturnType<typeof openHubDb>; userId: string }> {
+  const db = openHubDb(hubDbPath(dir));
+  rotateSigningKey(db);
+  const u = await createUser(db, "owner", "pw");
+  return { db, userId: u.id };
+}
+
+function getRequest(headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/api/hub", {
+    method: "GET",
+    headers,
+  });
+}
+
+describe("GET /api/hub (hub version + uptime badge surface)", () => {
+  test("405 on non-GET", async () => {
+    const h = makeHarness();
+    try {
+      const { db } = await bootstrap(h.dir);
+      try {
+        const req = new Request("http://localhost/api/hub", { method: "POST" });
+        const resp = await handleApiHub(req, { db, issuer: ISSUER });
+        expect(resp.status).toBe(405);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("401 when no Authorization header", async () => {
+    const h = makeHarness();
+    try {
+      const { db } = await bootstrap(h.dir);
+      try {
+        const resp = await handleApiHub(getRequest(), { db, issuer: ISSUER });
+        expect(resp.status).toBe(401);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("403 when bearer scope lacks parachute:host:admin", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const narrow = await signAccessToken(db, {
+          sub: userId,
+          // Adjacent host scope but NOT host:admin — host:auth is the
+          // tokens-registry scope, not the admin one. Confirms the gate
+          // checks the exact scope, not any host:* membership.
+          scopes: ["parachute:host:auth"],
+          audience: "hub",
+          clientId: "parachute-hub",
+          issuer: ISSUER,
+          ttlSeconds: 3600,
+        });
+        const resp = await handleApiHub(getRequest({ authorization: `Bearer ${narrow.token}` }), {
+          db,
+          issuer: ISSUER,
+        });
+        expect(resp.status).toBe(403);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("happy path: returns version + started_at + uptime_ms + source", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const startedAt = new Date(Date.now() - 5000); // started 5s ago
+        const resp = await handleApiHub(getRequest({ authorization: `Bearer ${op.token}` }), {
+          db,
+          issuer: ISSUER,
+          hubSrcDir: HUB_SRC_DIR,
+          startedAt,
+          // Override env so we're not at the mercy of the host's
+          // PARACHUTE_HOME (or PARACHUTE_BUILD_TIME) when the test runs.
+          env: {},
+        });
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as HubStatusResponse;
+        // Version pulled from the real hub package.json — assert SemVer
+        // shape rather than pinning a specific number (otherwise this test
+        // breaks on every rc bump).
+        expect(body.version).toMatch(/^\d+\.\d+\.\d+/);
+        expect(body.started_at).toBe(startedAt.toISOString());
+        expect(body.uptime_ms).toBeGreaterThanOrEqual(5000);
+        // hubSrcDir points at the real repo's src/, so install-source
+        // classification will report bun-linked OR npm OR unknown — never
+        // "container" because we cleared PARACHUTE_HOME.
+        expect(body.source).not.toBe("container");
+        expect(body.container_build_time).toBeUndefined();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("uptime_ms increments between calls", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const startedAt = new Date("2026-05-23T14:00:00.000Z");
+        // Drive "now" so the assertion isn't a flaky timing test.
+        const first = await handleApiHub(getRequest({ authorization: `Bearer ${op.token}` }), {
+          db,
+          issuer: ISSUER,
+          hubSrcDir: HUB_SRC_DIR,
+          startedAt,
+          now: () => new Date("2026-05-23T14:00:05.000Z"),
+          env: {},
+        });
+        const second = await handleApiHub(getRequest({ authorization: `Bearer ${op.token}` }), {
+          db,
+          issuer: ISSUER,
+          hubSrcDir: HUB_SRC_DIR,
+          startedAt,
+          now: () => new Date("2026-05-23T14:00:08.000Z"),
+          env: {},
+        });
+        const firstBody = (await first.json()) as HubStatusResponse;
+        const secondBody = (await second.json()) as HubStatusResponse;
+        expect(firstBody.uptime_ms).toBe(5000);
+        expect(secondBody.uptime_ms).toBe(8000);
+        expect(secondBody.uptime_ms).toBeGreaterThan(firstBody.uptime_ms);
+        // started_at stays stable across calls (captured once at process
+        // start, not per-request).
+        expect(secondBody.started_at).toBe(firstBody.started_at);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("PARACHUTE_HOME=/parachute overrides source to 'container'", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiHub(getRequest({ authorization: `Bearer ${op.token}` }), {
+          db,
+          issuer: ISSUER,
+          hubSrcDir: HUB_SRC_DIR,
+          env: { PARACHUTE_HOME: "/parachute" },
+        });
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as HubStatusResponse;
+        expect(body.source).toBe("container");
+        // bun_linked_path is suppressed under container source — operators
+        // on Render don't have a meaningful "checkout path" to surface.
+        expect(body.bun_linked_path).toBeUndefined();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("PARACHUTE_BUILD_TIME passes through as container_build_time", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiHub(getRequest({ authorization: `Bearer ${op.token}` }), {
+          db,
+          issuer: ISSUER,
+          hubSrcDir: HUB_SRC_DIR,
+          env: {
+            PARACHUTE_HOME: "/parachute",
+            PARACHUTE_BUILD_TIME: "2026-05-23T14:21:00.000Z",
+          },
+        });
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as HubStatusResponse;
+        expect(body.container_build_time).toBe("2026-05-23T14:21:00.000Z");
+        expect(body.source).toBe("container");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/api-hub.ts
+++ b/src/api-hub.ts
@@ -1,0 +1,181 @@
+import type { Database } from "bun:sqlite";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
+import { HOST_ADMIN_SCOPE } from "./admin-vaults.ts";
+import { detectHubInstallSource } from "./install-source.ts";
+
+/**
+ * `GET /api/hub` — hub runtime info for the admin SPA's version badge.
+ *
+ * Operators (especially Render deployers tracking auto-deploys from `main`)
+ * need to tell at a glance: what version is this hub running, when did it
+ * last restart, is this the version I expect? The CLI surface `parachute
+ * status` already shows the same data; this endpoint mirrors it for the
+ * browser SPA.
+ *
+ * Bearer-gated on `parachute:host:admin` (same as `/vaults` and `/api/grants`).
+ * Operators-only: the version + uptime + install-source fingerprint isn't
+ * sensitive per se, but it's adjacent to operator-only diagnostics so it
+ * lives behind the same gate as the rest of the admin surface.
+ *
+ * Response shape (snake_case to match other `/api/*` endpoints):
+ *
+ *   {
+ *     "version":              "0.5.13-rc.23",
+ *     "started_at":           "2026-05-23T14:23:45.000Z",
+ *     "uptime_ms":            8025000,
+ *     "source":               "bun-linked" | "npm" | "container" | "unknown",
+ *     "bun_linked_path":      "/Users/.../parachute-hub"        // optional
+ *     "git_head":             "a53af21"                          // optional
+ *     "container_build_time": "2026-05-23T14:21:00Z"             // optional
+ *   }
+ *
+ * - `source` reuses `detectHubInstallSource` from install-source.ts (the
+ *   same logic `parachute status` uses for the SOURCE column). The fourth
+ *   value `"container"` is hub-specific: when `process.env.PARACHUTE_HOME
+ *   === "/parachute"` (the Render Blueprint pin) we override `bun-linked`
+ *   → `container` so the badge tells operators "you're on Render", not
+ *   the misleading "bun-linked from /app".
+ * - `started_at` is captured once at module load (see `HUB_PROCESS_STARTED_AT`).
+ *   `uptime_ms` is computed server-side at request time so the client
+ *   doesn't have to deal with clock skew.
+ * - `container_build_time` reads `process.env.PARACHUTE_BUILD_TIME` —
+ *   passed through by the Dockerfile when set as a build arg (operators
+ *   can set this themselves in render.yaml or via `--build-arg` to surface
+ *   the image build time). Not surfaced when unset.
+ */
+
+export interface ApiHubDeps {
+  db: Database;
+  /** Hub origin — used to validate the bearer's `iss`. */
+  issuer: string;
+  /**
+   * Override the directory used to locate the hub's package.json and to
+   * classify install source. Defaults to `dirname(import.meta.url)` —
+   * which is `<repo>/src/` for normal layouts. Test seam.
+   */
+  hubSrcDir?: string;
+  /** Override `process.env` lookups. Test seam. */
+  env?: Record<string, string | undefined>;
+  /** Override the started-at timestamp. Test seam — defaults to the module-level capture. */
+  startedAt?: Date;
+  /** Override "now" for uptime computation. Test seam. */
+  now?: () => Date;
+}
+
+/**
+ * The hub process's start time. Captured exactly once at module load and
+ * re-exported so the request handler returns a stable value across calls
+ * (and so the `parachute status` CLI surface in the same process can pull
+ * it from one source).
+ */
+export const HUB_PROCESS_STARTED_AT: Date = new Date();
+
+/** Wire shape returned by `GET /api/hub`. Snake-case to match other `/api/*` endpoints. */
+export interface HubStatusResponse {
+  version: string;
+  started_at: string;
+  uptime_ms: number;
+  source: "bun-linked" | "npm" | "container" | "unknown";
+  bun_linked_path?: string;
+  git_head?: string;
+  container_build_time?: string;
+}
+
+export async function handleApiHub(req: Request, deps: ApiHubDeps): Promise<Response> {
+  if (req.method !== "GET") {
+    return jsonError(405, "method_not_allowed", "use GET");
+  }
+
+  // Bearer-gate on `parachute:host:admin`. Same shape as the other admin
+  // endpoints — SPA mints via /admin/host-admin-token.
+  try {
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+  } catch (err) {
+    return adminAuthErrorResponse(err);
+  }
+
+  const env = deps.env ?? process.env;
+  const startedAt = deps.startedAt ?? HUB_PROCESS_STARTED_AT;
+  const now = (deps.now ?? (() => new Date()))();
+  const hubSrcDir = deps.hubSrcDir ?? dirname(fileURLToPath(import.meta.url));
+
+  // detectHubInstallSource climbs from src/ to the nearest package.json,
+  // reads its version, classifies as bun-linked vs npm vs unknown.
+  const source = detectHubInstallSource(hubSrcDir);
+
+  // Read version from the nearest package.json (same logic the install-source
+  // detector ran). We don't reuse `source.livePackageVersion` because the
+  // unknown-source branch leaves it undefined — but the version field on the
+  // response must always be present.
+  const version = readHubVersion(hubSrcDir) ?? "unknown";
+
+  // Container override: the Render Blueprint pins PARACHUTE_HOME=/parachute,
+  // which is a reliable container-mode signal. The install-source detector
+  // would label this `bun-linked` (the image runs from /app/src, not bun
+  // globals), which is technically true but misleading for the operator —
+  // "container" is what they actually want to see.
+  const isContainer = env.PARACHUTE_HOME === "/parachute";
+
+  const body: HubStatusResponse = {
+    version,
+    started_at: startedAt.toISOString(),
+    uptime_ms: Math.max(0, now.getTime() - startedAt.getTime()),
+    source: isContainer ? "container" : source.kind,
+  };
+
+  if (!isContainer && source.kind === "bun-linked" && source.path) {
+    body.bun_linked_path = source.path;
+  }
+  if (source.gitHead) {
+    body.git_head = source.gitHead;
+  }
+  const buildTime = env.PARACHUTE_BUILD_TIME;
+  if (typeof buildTime === "string" && buildTime.length > 0) {
+    body.container_build_time = buildTime;
+  }
+
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": "no-store",
+    },
+  });
+}
+
+/**
+ * Read the hub's package.json `version` field. Climbs from `srcDir` to the
+ * nearest package.json (same pattern as `findNearestPackageDir` in
+ * install-source.ts). Returns undefined if the file's missing or malformed.
+ */
+function readHubVersion(srcDir: string): string | undefined {
+  let current = resolve(srcDir);
+  for (let i = 0; i < 16; i++) {
+    try {
+      const parsed = JSON.parse(readFileSync(join(current, "package.json"), "utf8")) as unknown;
+      if (parsed && typeof parsed === "object") {
+        const v = (parsed as Record<string, unknown>).version;
+        if (typeof v === "string" && v.length > 0) return v;
+      }
+    } catch {
+      // No package.json here — climb.
+    }
+    const parent = dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+  return undefined;
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/src/api-hub.ts
+++ b/src/api-hub.ts
@@ -82,6 +82,9 @@ export interface HubStatusResponse {
   bun_linked_path?: string;
   git_head?: string;
   container_build_time?: string;
+  /** Render-set runtime env vars surfaced when running on Render. Sourced from RENDER_GIT_COMMIT + RENDER_GIT_BRANCH. */
+  render_commit?: string;
+  render_branch?: string;
 }
 
 export async function handleApiHub(req: Request, deps: ApiHubDeps): Promise<Response> {
@@ -129,12 +132,29 @@ export async function handleApiHub(req: Request, deps: ApiHubDeps): Promise<Resp
   if (!isContainer && source.kind === "bun-linked" && source.path) {
     body.bun_linked_path = source.path;
   }
-  if (source.gitHead) {
+  // `git_head` is meaningful only for bun-linked dev installs — the container
+  // image strips `.git` at build time so source.gitHead is always undefined
+  // there. Explicit !isContainer guard for symmetry with bun_linked_path.
+  if (!isContainer && source.gitHead) {
     body.git_head = source.gitHead;
   }
   const buildTime = env.PARACHUTE_BUILD_TIME;
   if (typeof buildTime === "string" && buildTime.length > 0) {
     body.container_build_time = buildTime;
+  }
+  // Render exposes RENDER_GIT_COMMIT + RENDER_GIT_BRANCH at runtime when
+  // the container is running on Render. Surface for operator diagnostics
+  // (the commit SHA is a more rigorous identity than build-time wall-clock).
+  // Container-mode only — local dev never has these set.
+  if (isContainer) {
+    const renderCommit = env.RENDER_GIT_COMMIT;
+    if (typeof renderCommit === "string" && renderCommit.length > 0) {
+      body.render_commit = renderCommit;
+    }
+    const renderBranch = env.RENDER_GIT_BRANCH;
+    if (typeof renderBranch === "string" && renderBranch.length > 0) {
+      body.render_branch = renderBranch;
+    }
   }
 
   return new Response(JSON.stringify(body), {

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -46,6 +46,7 @@
  *   /admin/host-admin-token       (GET)        → SPA bearer mint (cookie-gated)
  *   /admin/vault-admin-token/<n>  (GET)        → per-vault bearer mint (cookie-gated)
  *   /api/me                       (GET)        → who-am-I (session+CSRF or hasSession:false)
+ *   /api/hub                      (GET)        → hub version + uptime + install-source (host:admin)
  *   /api/modules                  (GET)        → curated + installed module catalog (host:auth)
  *   /api/modules/channel          (PUT)        → operator channel toggle (host:admin)
  *   /api/modules/:short/install   (POST)       → bun add + spawn (async op)
@@ -117,6 +118,7 @@ import { handleHostAdminToken } from "./admin-host-admin-token.ts";
 import { handleVaultAdminToken } from "./admin-vault-admin-token.ts";
 import { handleCreateVault } from "./admin-vaults.ts";
 import { handleAccountChangePasswordGet, handleAccountChangePasswordPost } from "./api-account.ts";
+import { handleApiHub } from "./api-hub.ts";
 import { handleApiMe } from "./api-me.ts";
 import { handleApiMintToken } from "./api-mint-token.ts";
 import { handleApiModulesConfig, parseModulesConfigPath } from "./api-modules-config.ts";
@@ -1524,6 +1526,17 @@ export function hubFetch(
     if (pathname === "/api/me") {
       if (!getDb) return dbNotConfigured();
       return handleApiMe(req, { db: getDb() });
+    }
+
+    // Hub version + uptime + install-source — drives the admin SPA's
+    // version badge (hub#348). Bearer-gated on `parachute:host:admin`
+    // (same as the rest of the operator-only admin surface).
+    if (pathname === "/api/hub") {
+      if (!getDb) return dbNotConfigured();
+      return handleApiHub(req, {
+        db: getDb(),
+        issuer: oauthDeps(req).issuer,
+      });
     }
 
     if (pathname === "/api/modules") {

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -23,13 +23,8 @@
  */
 import { type ReactNode, useEffect, useState } from "react";
 import { Link, Route, Routes, useLocation } from "react-router-dom";
-import {
-  type MeResponse,
-  type ModuleListing,
-  getMe,
-  listModules,
-  signOut,
-} from "./lib/api.ts";
+import { HubVersionBadge } from "./components/HubVersionBadge.tsx";
+import { type MeResponse, type ModuleListing, getMe, listModules, signOut } from "./lib/api.ts";
 import { ApproveClient } from "./routes/ApproveClient.tsx";
 import { ModuleConfig } from "./routes/ModuleConfig.tsx";
 import { Modules } from "./routes/Modules.tsx";
@@ -182,6 +177,13 @@ export function App() {
           }
         />
       </Routes>
+
+      {/* Hub version + uptime badge (hub#348). Persistent footer affordance
+          so operators (especially Render auto-deployers) can confirm at a
+          glance which hub version is running and when it last restarted.
+          Hidden when /api/me reports no session — only signed-in operators
+          ever see admin diagnostics, and /api/hub would 401 anyway. */}
+      {me?.hasSession ? <HubVersionBadge /> : null}
     </div>
   );
 }

--- a/web/ui/src/components/HubVersionBadge.test.tsx
+++ b/web/ui/src/components/HubVersionBadge.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * HubVersionBadge smoke tests — renders version + uptime + source on
+ * mount; click expands the detail panel; refresh button refetches.
+ *
+ * Auth failure shapes: 401/403 from getHubStatus surface as thrown
+ * HttpErrors; the badge swallows and renders null (or the prior
+ * status). We assert the null-on-initial-failure shape rather than the
+ * recovery shape — that one's exercised through the live SPA, not
+ * worth the extra mock juggle here.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HttpError, type HubStatus } from "../lib/api.ts";
+import * as api from "../lib/api.ts";
+import { HubVersionBadge, formatUptime } from "./HubVersionBadge.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    getHubStatus: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const mkStatus = (overrides: Partial<HubStatus> = {}): HubStatus => ({
+  version: "0.5.13-rc.23",
+  started_at: "2026-05-23T14:23:45.000Z",
+  uptime_ms: 8025000, // 2h 13m
+  source: "container",
+  ...overrides,
+});
+
+describe("formatUptime", () => {
+  it("seconds for <1m", () => {
+    expect(formatUptime(45_000)).toBe("45s");
+  });
+  it("minutes for <1h", () => {
+    expect(formatUptime(45 * 60 * 1000)).toBe("45m");
+  });
+  it("hours+minutes for <1d", () => {
+    expect(formatUptime((2 * 60 + 13) * 60 * 1000)).toBe("2h 13m");
+  });
+  it("days+hours for >=1d", () => {
+    expect(formatUptime((30 * 60 + 0) * 60 * 1000)).toBe("1d 6h");
+  });
+});
+
+describe("HubVersionBadge — initial render", () => {
+  it("renders nothing until the first fetch resolves", () => {
+    vi.mocked(api.getHubStatus).mockReturnValue(new Promise(() => {})); // never resolves
+    const { container } = render(<HubVersionBadge />);
+    expect(container.querySelector("[data-testid=hub-version-badge]")).toBeNull();
+  });
+
+  it("renders version + uptime + source after fetch", async () => {
+    vi.mocked(api.getHubStatus).mockResolvedValue(mkStatus());
+    render(<HubVersionBadge />);
+    await waitFor(() =>
+      expect(screen.getByTestId("hub-version-badge-summary")).toBeInTheDocument(),
+    );
+    const summary = screen.getByTestId("hub-version-badge-summary");
+    expect(summary.textContent).toContain("0.5.13-rc.23");
+    expect(summary.textContent).toContain("2h 13m");
+    expect(screen.getByTestId("hub-version-badge-source").textContent).toBe("container");
+  });
+
+  it("collapses (renders null) when first fetch fails with 401", async () => {
+    vi.mocked(api.getHubStatus).mockRejectedValue(new HttpError(401, "no session"));
+    const { container } = render(<HubVersionBadge />);
+    // Let the rejection settle.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(container.querySelector("[data-testid=hub-version-badge]")).toBeNull();
+  });
+});
+
+describe("HubVersionBadge — expand + refresh", () => {
+  it("clicking the summary expands the detail panel", async () => {
+    vi.mocked(api.getHubStatus).mockResolvedValue(
+      mkStatus({
+        source: "bun-linked",
+        bun_linked_path: "/Users/p/ParachuteComputer/parachute-hub",
+        git_head: "a53af21",
+      }),
+    );
+    render(<HubVersionBadge />);
+    const summary = await waitFor(() => screen.getByTestId("hub-version-badge-summary"));
+
+    // Panel hidden initially.
+    expect(screen.queryByTestId("hub-version-badge-panel")).toBeNull();
+
+    fireEvent.click(summary);
+
+    const panel = await waitFor(() => screen.getByTestId("hub-version-badge-panel"));
+    expect(panel.textContent).toContain("@openparachute/hub 0.5.13-rc.23");
+    expect(panel.textContent).toContain("bun-linked");
+    // Source detail surfaces basename + git head when bun-linked.
+    expect(panel.textContent).toContain("parachute-hub");
+    expect(panel.textContent).toContain("a53af21");
+    // "Started" line carries the formatted UTC timestamp + (uptime ago).
+    expect(panel.textContent).toMatch(/Started/);
+    expect(panel.textContent).toMatch(/2026-05-23 14:23:45 UTC/);
+  });
+
+  it("clicking refresh refetches /api/hub", async () => {
+    const first = mkStatus({ uptime_ms: 8025000 });
+    const second = mkStatus({ uptime_ms: 8055000 }); // 30s later
+    vi.mocked(api.getHubStatus).mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+
+    render(<HubVersionBadge />);
+    const summary = await waitFor(() => screen.getByTestId("hub-version-badge-summary"));
+    fireEvent.click(summary);
+
+    const refresh = await waitFor(() => screen.getByTestId("hub-version-badge-refresh"));
+    fireEvent.click(refresh);
+
+    await waitFor(() =>
+      expect(vi.mocked(api.getHubStatus).mock.calls.length).toBeGreaterThanOrEqual(2),
+    );
+    // After the refetch, the summary uptime should reflect the new value
+    // (8055s = still 2h 14m — assert the call count instead, which is
+    // deterministic regardless of formatting boundaries).
+    expect(vi.mocked(api.getHubStatus)).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows container_build_time when surfaced", async () => {
+    vi.mocked(api.getHubStatus).mockResolvedValue(
+      mkStatus({
+        source: "container",
+        container_build_time: "2026-05-23T14:21:00.000Z",
+      }),
+    );
+    render(<HubVersionBadge />);
+    const summary = await waitFor(() => screen.getByTestId("hub-version-badge-summary"));
+    fireEvent.click(summary);
+
+    const panel = await waitFor(() => screen.getByTestId("hub-version-badge-panel"));
+    expect(panel.textContent).toContain("Built");
+    expect(panel.textContent).toContain("2026-05-23 14:21:00 UTC");
+  });
+});

--- a/web/ui/src/components/HubVersionBadge.tsx
+++ b/web/ui/src/components/HubVersionBadge.tsx
@@ -1,0 +1,173 @@
+/**
+ * Persistent footer affordance showing hub version + uptime (hub#348).
+ *
+ * Aaron's motivating framing: "I can't really tell with mine if it's
+ * updated or not. And I'm not sure how I would queue it to update or if
+ * it just already did." Render auto-deploys on every push to source —
+ * the operator doesn't actively trigger updates and needs to see the
+ * result land somewhere visible.
+ *
+ * Renders a single muted line in the page footer:
+ *
+ *   Hub 0.5.13-rc.23 · running 2h 13m · container
+ *
+ * Click expands to a detail panel:
+ *
+ *   Hub:        @openparachute/hub 0.5.13-rc.23
+ *   Source:     container
+ *   Started:    2026-05-23 14:23:45 UTC (2h 13m ago)
+ *   Built:      2026-05-23 14:21:00 UTC                     (if applicable)
+ *
+ * Plus a Refresh button — useful for "I just pushed; did the new version
+ * land yet?" Refresh triggers an immediate refetch.
+ *
+ * Auto-refresh shapes:
+ *   - Polls every 30s while mounted (so a quiet operator-tab still picks up
+ *     a redeploy without manual click).
+ *   - Refetches on focus (when the operator returns to the tab after a
+ *     deploy).
+ *
+ * 401/403 from /api/hub silently collapses the badge (renders null). The
+ * SPA's other surfaces handle the redirect-to-login on their own auth
+ * failures; the badge is decorative-enough not to drive its own flow.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { type HubStatus, getHubStatus } from "../lib/api.ts";
+
+/** Auto-refresh interval. 30s feels often enough to confirm a deploy without thrashing. */
+const POLL_INTERVAL_MS = 30_000;
+
+/** Human-friendly uptime — mirrors `formatUptime` in src/process-state.ts. */
+export function formatUptime(uptimeMs: number): string {
+  const ms = Math.max(0, uptimeMs);
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ${m % 60}m`;
+  const d = Math.floor(h / 24);
+  return `${d}d ${h % 24}h`;
+}
+
+/**
+ * Format an ISO timestamp as `YYYY-MM-DD HH:MM:SS UTC`. Plain UTC string
+ * (not the operator's local timezone) so it lines up with `parachute
+ * status` and the CHANGELOG dates the operator is cross-referencing.
+ */
+export function formatTimestampUtc(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())} UTC`;
+}
+
+/** Human-friendly source label. Mirrors the SOURCE column in `parachute status`. */
+function sourceLabel(status: HubStatus): string {
+  if (status.source === "container") return "container";
+  if (status.source === "npm") return "npm";
+  if (status.source === "bun-linked") {
+    const basename = status.bun_linked_path?.split("/").filter(Boolean).pop();
+    if (basename && status.git_head) return `bun-linked → ${basename} @ ${status.git_head}`;
+    if (basename) return `bun-linked → ${basename}`;
+    return "bun-linked";
+  }
+  return "unknown";
+}
+
+export function HubVersionBadge() {
+  const [status, setStatus] = useState<HubStatus | null>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [lastCheckedAt, setLastCheckedAt] = useState<Date | null>(null);
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      const next = await getHubStatus();
+      setStatus(next);
+      setLastCheckedAt(new Date());
+    } catch {
+      // 401 / 403 / network blip — leave the previously-rendered status
+      // in place (or null if first-load). Silent: the rest of the SPA
+      // will surface auth failures via its own routes.
+    } finally {
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    const onFocus = () => {
+      void refresh();
+    };
+    window.addEventListener("focus", onFocus);
+    const interval = window.setInterval(() => {
+      void refresh();
+    }, POLL_INTERVAL_MS);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      window.clearInterval(interval);
+    };
+  }, [refresh]);
+
+  if (!status) return null;
+
+  return (
+    <footer className="hub-version-badge" data-testid="hub-version-badge">
+      <button
+        type="button"
+        className="hub-version-badge-summary"
+        onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
+        data-testid="hub-version-badge-summary"
+      >
+        Hub <strong>{status.version}</strong> · running{" "}
+        <span data-testid="hub-version-badge-uptime">{formatUptime(status.uptime_ms)}</span> ·{" "}
+        <span className="hub-version-badge-source" data-testid="hub-version-badge-source">
+          {status.source}
+        </span>
+      </button>
+      {expanded ? (
+        <div className="hub-version-badge-panel" data-testid="hub-version-badge-panel">
+          <dl>
+            <dt>Hub</dt>
+            <dd>
+              <code>@openparachute/hub {status.version}</code>
+            </dd>
+            <dt>Source</dt>
+            <dd>{sourceLabel(status)}</dd>
+            <dt>Started</dt>
+            <dd>
+              {formatTimestampUtc(status.started_at)} ({formatUptime(status.uptime_ms)} ago)
+            </dd>
+            {status.container_build_time ? (
+              <>
+                <dt>Built</dt>
+                <dd>{formatTimestampUtc(status.container_build_time)}</dd>
+              </>
+            ) : null}
+            {lastCheckedAt ? (
+              <>
+                <dt>Last checked</dt>
+                <dd>{formatTimestampUtc(lastCheckedAt.toISOString())}</dd>
+              </>
+            ) : null}
+          </dl>
+          <button
+            type="button"
+            className="hub-version-badge-refresh secondary"
+            onClick={() => void refresh()}
+            disabled={refreshing}
+            data-testid="hub-version-badge-refresh"
+          >
+            {refreshing ? "Refreshing…" : "Refresh"}
+          </button>
+        </div>
+      ) : null}
+    </footer>
+  );
+}

--- a/web/ui/src/components/HubVersionBadge.tsx
+++ b/web/ui/src/components/HubVersionBadge.tsx
@@ -150,6 +150,15 @@ export function HubVersionBadge() {
                 <dd>{formatTimestampUtc(status.container_build_time)}</dd>
               </>
             ) : null}
+            {status.render_commit ? (
+              <>
+                <dt>Commit</dt>
+                <dd>
+                  <code>{status.render_commit.slice(0, 8)}</code>
+                  {status.render_branch ? <> on <code>{status.render_branch}</code></> : null}
+                </dd>
+              </>
+            ) : null}
             {lastCheckedAt ? (
               <>
                 <dt>Last checked</dt>

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1130,6 +1130,9 @@ export interface HubStatus {
   bun_linked_path?: string;
   git_head?: string;
   container_build_time?: string;
+  /** Render-set runtime env vars surfaced when running on Render. */
+  render_commit?: string;
+  render_branch?: string;
 }
 
 /**

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1115,6 +1115,45 @@ export async function listUserVaults(): Promise<string[]> {
   return body.vaults ?? [];
 }
 
+/**
+ * Wire shape returned by `GET /api/hub`. Mirrors the snake_case payload
+ * defined in `src/api-hub.ts:HubStatusResponse`. Drives the admin SPA's
+ * version badge.
+ */
+export type HubStatusSource = "bun-linked" | "npm" | "container" | "unknown";
+
+export interface HubStatus {
+  version: string;
+  started_at: string;
+  uptime_ms: number;
+  source: HubStatusSource;
+  bun_linked_path?: string;
+  git_head?: string;
+  container_build_time?: string;
+}
+
+/**
+ * GET /api/hub — read hub runtime info for the admin SPA's version badge.
+ * Same `parachute:host:admin` Bearer pattern as the other read endpoints.
+ *
+ * On 401/403 the badge collapses to a non-rendered state — see
+ * `HubVersionBadge` for the swallow-and-render-empty contract. We surface
+ * a typed null here so callers don't have to catch.
+ */
+export async function getHubStatus(): Promise<HubStatus> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch("/api/hub", {
+    method: "GET",
+    headers: { accept: "application/json", authorization: `Bearer ${bearer}` },
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as HubStatus;
+}
+
 async function readError(res: Response): Promise<string> {
   try {
     const text = await res.text();

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -847,3 +847,75 @@ a.btn:hover {
   white-space: nowrap;
   border: 0;
 }
+
+/* Hub version + uptime footer badge (hub#348). Persistent, low-noise:
+   muted single line at the bottom of the SPA page, click expands a
+   detail panel inline (no portal, no overlay). Sits in `.page`'s
+   bottom padding (`6rem`) so longer detail panels don't overlap the
+   primary content. */
+.hub-version-badge {
+  margin-top: 3rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-light);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+  color: var(--fg-muted);
+  font-size: 0.8rem;
+}
+.hub-version-badge-summary {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  color: var(--fg-muted);
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  border-radius: 4px;
+}
+.hub-version-badge-summary:hover {
+  color: var(--fg);
+  background: transparent;
+}
+.hub-version-badge-summary strong {
+  color: var(--fg);
+  font-weight: 600;
+}
+.hub-version-badge-source {
+  font-variant: small-caps;
+  letter-spacing: 0.04em;
+}
+.hub-version-badge-panel {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.85rem 1rem;
+  font-size: 0.85rem;
+  color: var(--fg);
+  width: 100%;
+  max-width: 28rem;
+}
+.hub-version-badge-panel dl {
+  margin: 0 0 0.75rem;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.3rem 0.85rem;
+}
+.hub-version-badge-panel dt {
+  color: var(--fg-muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding-top: 0.1rem;
+}
+.hub-version-badge-panel dd {
+  margin: 0;
+  color: var(--fg);
+  word-break: break-all;
+}
+.hub-version-badge-refresh {
+  font-size: 0.8rem;
+  padding: 0.35rem 0.85rem;
+}


### PR DESCRIPTION
## Summary

Closes [hub#348](https://github.com/ParachuteComputer/parachute-hub/issues/348). Aaron's framing (2026-05-23, mid-install):

> I can't really tell with mine if it's updated or not. And I'm not sure how I would queue it to update or if it just already did.

Render auto-deploys on every push to source — the operator doesn't actively trigger updates and needs to see the result land somewhere visible. The CLI surface `parachute status` already shows version + uptime + install-source; this PR mirrors it for the admin SPA.

- **Backend (`src/api-hub.ts`)** — `GET /api/hub` bearer-gated on `parachute:host:admin`. Returns `{ version, started_at, uptime_ms, source, bun_linked_path?, git_head?, container_build_time? }`. `source` reuses `detectHubInstallSource` with a container override: `PARACHUTE_HOME=/parachute` (the Render Blueprint pin) surfaces `"container"` so Render deployers see a friendly label instead of "bun-linked from /app". `HUB_PROCESS_STARTED_AT` captured once at module load; uptime computed server-side. `PARACHUTE_BUILD_TIME` env var passes through as `container_build_time` (opportunistic — not surfaced when unset).
- **Frontend (`web/ui/src/components/HubVersionBadge.tsx` + `App.tsx`)** — persistent footer affordance: muted single line `Hub <version> · running <uptime> · <source>`. Click expands an inline detail panel with full source label (basename + git head when bun-linked), formatted UTC timestamps for started + built, plus a Refresh button. Auto-refreshes every 30s + on tab focus — confirms a Render auto-deploy landed without manual click. Gated on `me?.hasSession` so signed-out visitors don't see admin diagnostics.

### Rendered badge shape

Collapsed (footer line):
```
Hub 0.5.13-rc.23 · running 2h 13m · container
```

Expanded panel (click summary):
```
HUB         @openparachute/hub 0.5.13-rc.23
SOURCE      container
STARTED     2026-05-23 14:23:45 UTC (2h 13m ago)
BUILT       2026-05-23 14:21:00 UTC          (if PARACHUTE_BUILD_TIME set)
LAST CHECKED 2026-05-23 16:36:50 UTC
                                              [Refresh]
```

### Placement

Footer (option A from the task brief) — sits below the routed content, separated by a muted `1px` top-border. Always visible, low-noise, doesn't compete with primary nav.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test ./src` 1919 pass / 0 fail (+7 new in `api-hub.test.ts` — 405 / 401 / 403 gate, happy path shape, uptime increments, container override, PARACHUTE_BUILD_TIME pass-through)
- [x] `cd web/ui && bunx vitest run` 203 pass / 0 fail (+10 new in `HubVersionBadge.test.tsx` — formatUptime boundaries, render states, expand panel, refresh refetches, container_build_time surfaces)
- [x] `cd web/ui && bun run build` clean (`verify-base.mjs` passes)
- [ ] Manually: spin up hub locally, sign in to `/admin`, see the badge update; click to expand; verify refresh refetches; verify it disappears on sign-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)