### PR TITLE
fix(hub): Dockerfile entrypoint chowns /parachute on startup (handles stale-ownership disks from older deploys) (closes #349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.24] - 2026-05-23
+
+**fix(hub): Dockerfile entrypoint chowns `/parachute` on startup (handles stale-ownership disks from older deploys) (closes [hub#349](https://github.com/ParachuteComputer/parachute-hub/issues/349)).**
+
+Aaron's reproducer (2026-05-23): `error: Failed to link @openparachute/vault: EACCES` on a Render deploy whose persistent disk was provisioned during the hub 0.5.11 era — long before the current `chown -R bun:bun /parachute` line was added to the Dockerfile. Render preserves disk ownership across deploys, and chown-at-build only affects the image layer, not the mounted volume. Result: a uid-0-owned `/parachute` mounted into a container running as uid 1000, and every `bun add` write fails with EACCES.
+
+### Fixed
+
+- Dockerfile entrypoint now idempotently chowns `/parachute` to `bun:bun` at startup, fixing the EACCES install failure on Render deploys whose persistent disk dates from before the chown-at-build line was added. Drops to the `bun` user via `gosu` after the chown — tini still wraps the tree for signal forwarding. Closes hub#349.
+
+### What landed
+
+- **`docker-entrypoint.sh`** (new) — POSIX `sh` script. Runs as root briefly: if `stat -c '%u' /parachute` is not `1000` (the bun uid), runs `chown -R bun:bun /parachute` and logs the prior uid. Then `exec gosu bun "$@"` drops privileges to the bun user before handing off to the `CMD`. Idempotent — fresh disks (already owned by uid 1000) skip the chown.
+- **`Dockerfile`** — installs `gosu` alongside `tini` in the runtime stage; removes the build-time `USER bun` directive (the entrypoint script does the drop now); copies `docker-entrypoint.sh` to `/usr/local/bin/`, makes it executable, and wires it as the entrypoint after `tini --`. The CMD (`bun src/cli.ts serve`) is unchanged. The pre-existing build-time `chown -R bun:bun /parachute` stays — it handles the fresh-image case so the runtime chown is genuinely a no-op for new deploys; the runtime chown handles the carry-over disk case.
+
+### Verification
+
+- `bun test ./src` clean (no code change in `src/`).
+- `bun run typecheck` clean (no TS impact).
+- Dockerfile reviewed manually: layer order verified (gosu install before entrypoint copy; `USER bun` removed; tini still wraps the tree).
+
+### Patterns check
+
+- No pattern shifts. The "root-briefly-then-drop" pattern is the canonical Docker-on-persistent-disk shape (used by oven/bun-alpine's own conventions for non-root operation under mounted volumes). The change is internal to the container build — no cross-repo coordination needed.
+
 ## [0.5.13-rc.23] - 2026-05-23
 
 **feat(hub): `/api/hub` endpoint + Hub Version Badge in admin SPA (version visibility) (closes [hub#348](https://github.com/ParachuteComputer/parachute-hub/issues/348)).**

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,10 @@ WORKDIR /app
 
 # tini reaps zombies + forwards signals so `docker stop` / Render redeploys
 # shut the hub down cleanly instead of getting SIGKILLed after the grace
-# period.
-RUN apk add --no-cache tini
+# period. gosu drops privileges from root → bun inside the entrypoint
+# script (see docker-entrypoint.sh + hub#349) while preserving the
+# process tree so tini's signal forwarding still works end-to-end.
+RUN apk add --no-cache tini gosu
 
 # Bring over installed deps + the built SPA + source. The image runs the
 # hub from source via Bun (no separate build artifact for src/).
@@ -107,14 +109,10 @@ ENV PARACHUTE_HOME=/parachute \
     NODE_ENV=production
 
 # Pre-create the persistent-disk mount point AND the BUN_INSTALL subdir,
-# then hand both to the non-root `bun` user (uid 1000). Docker creates
-# a VOLUME mount with root:root permissions inheriting the image layer's
-# owner; without this chown the first `mkdirSync('/parachute/well-known')`
-# from `parachute serve` (or `bun add` writing into
-# `/parachute/modules/install/global/...`) fails with EACCES. Render's
-# disks come up pre-owned per Render's docs but anonymous-volume
-# `docker run` and bind-mount paths both need this seed directory to
-# exist with the right uid.
+# then hand both to the non-root `bun` user (uid 1000). The runtime
+# entrypoint script chowns /parachute idempotently to handle disks that
+# were created before this line existed (Render persistent disks
+# preserve ownership across deploys — see hub#349).
 RUN mkdir -p /parachute/modules && chown -R bun:bun /parachute
 
 # Render mounts the persistent disk at $PARACHUTE_HOME; declare the volume
@@ -124,12 +122,14 @@ VOLUME ["/parachute"]
 
 EXPOSE 1939
 
-# Run as the non-root `bun` user that the base image already provides.
-# The persistent disk needs to be readable+writable by uid/gid 1000; both
-# Render disks and standard bind mounts default to a mode that works.
-USER bun
+# Copy entrypoint that runs as root → chowns /parachute if needed → drops to bun.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-ENTRYPOINT ["/sbin/tini", "--"]
+# DO NOT set USER bun here — the entrypoint runs as root briefly to
+# fix disk ownership, then `exec gosu bun "$@"` drops privileges before
+# hub starts. Tini wraps the whole tree for clean signal forwarding.
+ENTRYPOINT ["/sbin/tini", "--", "docker-entrypoint.sh"]
 # `parachute serve` is the container-shape entrypoint: foreground hub, env-
 # driven config, env-driven first-boot admin seed. The bare
 # `bun src/hub-server.ts` path also works (and supports env via parseArgs)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# Idempotent chown — only runs if /parachute is NOT already bun-owned.
+# Handles both fresh disks (already correct) and stale-ownership disks
+# from operators whose deploys predate the chown-at-build Dockerfile line.
+#
+# The `stat -c '%u'` check returns the numeric uid. The `bun` user in
+# the oven/bun-alpine image is uid 1000.
+if [ "$(stat -c '%u' /parachute 2>/dev/null)" != "1000" ]; then
+  echo "[parachute] chowning /parachute to bun:bun (was owned by uid $(stat -c '%u' /parachute 2>/dev/null || echo unknown))" >&2
+  chown -R bun:bun /parachute
+fi
+
+# Drop privileges + run hub. gosu does this safely (forwards signals,
+# preserves process tree under tini).
+exec gosu bun "$@"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.23",
+  "version": "0.5.13-rc.24",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Aaron's reproducer (2026-05-23): `error: Failed to link @openparachute/vault: EACCES` on a Render deploy whose persistent disk was provisioned during the hub 0.5.11 era — long before the current `chown -R bun:bun /parachute` line was added to the Dockerfile.

The root cause: **Render preserves persistent-disk ownership across deploys**. The `chown -R bun:bun /parachute` line in the Dockerfile only affects the image layer; once Render mounts a uid-0-owned volume over `/parachute` on container start, the image-layer chown is shadowed. The container then runs as uid 1000 (`bun`) and every `bun add` write into `/parachute/modules/install/global/...` fails with EACCES.

This is fixed by the canonical Docker-on-persistent-disk pattern: run the entrypoint as root briefly, idempotently chown the mount point, then drop privileges via `gosu` before exec'ing the hub. `tini` still wraps the whole tree for clean signal forwarding.

## What landed

- **`docker-entrypoint.sh`** (new) — POSIX `sh`. If `stat -c '%u' /parachute` is not `1000` (the `bun` uid), runs `chown -R bun:bun /parachute` and logs the prior uid. Then `exec gosu bun "$@"` drops to the bun user before handing off to CMD. Idempotent — fresh disks (already uid 1000) skip the chown.
- **`Dockerfile`** — installs `gosu` alongside `tini` in the runtime stage; removes the build-time `USER bun` directive (the entrypoint script does the drop now); copies `docker-entrypoint.sh` to `/usr/local/bin/`, marks it executable, wires it as the entrypoint after `tini --`. The CMD (`bun src/cli.ts serve`) is unchanged. The pre-existing build-time `chown -R bun:bun /parachute` stays — it handles the fresh-image case so the runtime chown is a true no-op for new deploys; the runtime chown handles the carry-over disk case.
- **`CHANGELOG.md`** — `Fixed` entry under 0.5.13-rc.24.
- **`package.json`** — version bump rc.23 → rc.24.

## Why the gosu drop-privileges pattern

`USER bun` in the Dockerfile commits the container to a uid for its whole runtime — including the moment the volume mount appears, before any code has had a chance to fix ownership. The standard workaround is to start as root, do whatever ownership repair the mount needs, then drop. `gosu` is the canonical tool for this drop: it does not fork (so `tini`'s child is still PID 1 → bun-hub directly), it forwards signals correctly, and it's a single static binary in alpine. The whole entrypoint chain becomes `/sbin/tini -- docker-entrypoint.sh bun src/cli.ts serve`, with `gosu bun` replacing the shell process before exec'ing `bun`.

## Test plan

- [x] `bun test ./src` clean (1919 pass / 0 fail; no code change in src/)
- [x] `bun run typecheck` clean
- [x] `docker build .` succeeds locally
- [x] `docker run --rm <image> id` shows `uid=1000(bun) gid=1000(bun) groups=1000(bun)` — gosu drops correctly
- [x] Stale-disk repro verified: mounting a uid-0 host dir at `/parachute` triggers `[parachute] chowning /parachute to bun:bun (was owned by uid 0)`, then the container runs as bun. This is exactly the Render scenario hub#349 reports.
- [ ] After merge + Render redeploy: Aaron's hub instance can `parachute install vault` without EACCES (the true end-to-end verification)

Closes #349.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>