### PR TITLE
fix(hub): Bun.spawn inherits process.env (closes the real real root cause of #349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.26] - 2026-05-23
+
+**fix(hub): `Bun.spawn` subprocess calls now inherit `process.env` (closes the real-real root cause of [hub#349](https://github.com/ParachuteComputer/parachute-hub/issues/349)).**
+
+`Bun.spawn` defaults to an **EMPTY** env when `env` is not passed — it does NOT inherit the parent's environment the way `child_process.spawn` does in Node. Every place in hub that called `Bun.spawn` without an explicit `env: process.env` was handing the child a clean env: no `PATH`, no `HOME`, no `TMPDIR`, no `BUN_INSTALL`, no `PARACHUTE_*`. The Render install failure was the visible symptom (#350's chown + #351's `TMPDIR=/parachute/tmp` were both necessary but neither sufficient — the spawned `bun add -g` subprocess never saw the env vars set in the Dockerfile), but the same class of bug was sitting in 13 other call sites waiting to bite.
+
+### Fixed
+
+- Fixed: hub's `Bun.spawn` subprocess calls now inherit the parent's environment (`env: process.env`). Bun.spawn defaults to an EMPTY env, which meant subprocess `bun add -g` didn't see `TMPDIR`, `BUN_INSTALL`, or any other env vars set by the Dockerfile or operator. This was the actual root cause of the Render install EACCES — even after rc.25 set `TMPDIR=/parachute/tmp` in the Dockerfile ENV, hub's spawned `bun add` didn't inherit it. Closes hub#349 (real-real root cause; prior chown + TMPDIR fixes were necessary but not sufficient). Fixed across 14 `Bun.spawn` call sites — every non-test spawn in `src/` now propagates env, which prevents the same class of bug from surprising operators with subprocess calls.
+
+### What landed
+
+The fix is mechanical: add `env: process.env` to the `Bun.spawn` options at every call site that didn't already set `env`. For the two seams that conditionally merged `process.env` only when a per-call override was provided (`src/supervisor.ts:defaultSpawnFn`, `src/commands/lifecycle.ts:defaultSpawner`), the default branch now also sets `env: process.env`; the override branch's `{ ...process.env, ...opts.env }` merge is unchanged.
+
+Call sites updated:
+
+1. `src/api-modules-ops.ts:defaultRun` — admin SPA install/upgrade (the Render-failure trigger)
+2. `src/commands/install.ts:defaultRunner` — CLI install
+3. `src/admin-vaults.ts:defaultRunCommand` — admin SPA vault ops
+4. `src/commands/expose-auth-preflight.ts:defaultInteractiveRunner` — Tailscale auth check
+5. `src/commands/auth.ts:defaultRunner` — `parachute auth` forwarding to vault
+6. `src/commands/expose-cloudflare.ts:defaultCloudflaredSpawner` — `cloudflared` subprocess (needs `HOME` for `~/.cloudflared/`)
+7. `src/commands/expose-interactive.ts:defaultInteractiveRunner` — interactive expose flows
+8. `src/commands/vault-tokens-create-interactive.ts:defaultInteractiveRunner` — interactive vault token mint
+9. `src/commands/vault.ts:dispatchVault` — `parachute vault <args>` forwarder
+10. `src/commands/lifecycle.ts:defaultSpawner` — module daemon spawner (default branch + per-call merge preserved)
+11. `src/commands/lifecycle.ts` tail-spawner — `parachute logs -f` `tail -f`
+12. `src/commands/upgrade.ts:defaultRunner` — `parachute upgrade` (both `.run` and `.capture`)
+13. `src/hub-control.ts:defaultHubSpawner` — `parachute serve` background hub
+14. `src/supervisor.ts:defaultSpawnFn` — supervised module subprocess (default branch + per-call merge preserved)
+15. `src/tailscale/run.ts:defaultRunner` — every `tailscale ...` shell-out
+
+Each site has an inline comment pointing back to `api-modules-ops.ts:defaultRun` for the rationale (DRY on the "why").
+
+### Verification
+
+- `bun run typecheck` clean.
+- `bun test ./src` — 1921 pass / 0 fail (+2 from `src/__tests__/spawn-env-propagation.test.ts` regression test: positive case asserts `env: process.env` propagates, negative-control case asserts that omitting `env` produces an empty-env child — locks the Bun.spawn behavior so a future regression is caught here, not in production on Render).
+- `bunx biome check src/` clean.
+
+### Patterns check
+
+- No pattern shifts. The "spawned subprocesses inherit env unless deliberately scrubbed" expectation is a Unix-tooling convention shared with `child_process.spawn`'s default; this PR makes hub's `Bun.spawn` usage conform to that convention. Worth noting in [`parachute-patterns/patterns/`](https://github.com/ParachuteComputer/parachute-patterns/tree/main/patterns) as a Bun-runtime gotcha for future modules in the ecosystem (vault, scribe, app — all of which also use `Bun.spawn`), but the doc is out-of-scope for this hub-only PR.
+
 ## [0.5.13-rc.25] - 2026-05-23
 
 **fix(hub): `TMPDIR=/parachute/tmp` so bun installs work on cross-mount filesystems (closes [hub#349](https://github.com/ParachuteComputer/parachute-hub/issues/349) root cause).**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.25",
+  "version": "0.5.13-rc.26",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/spawn-env-propagation.test.ts
+++ b/src/__tests__/spawn-env-propagation.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression test for hub#349: Bun.spawn defaults to an EMPTY env, which meant
+ * subprocess `bun add -g` didn't see TMPDIR, BUN_INSTALL, or any other env vars
+ * set by the Dockerfile / Render env. All `defaultRun`-style helpers were
+ * updated to pass `env: process.env`.
+ *
+ * This test asserts that property end-to-end: spawn a real child via `bun -e`
+ * and have it print one parent-set env var. Pre-fix, the child would not see
+ * the var; post-fix, it does.
+ *
+ * We exercise the production path by importing one representative helper.
+ * The full set of seven explicit + several inherited fix sites all use the
+ * same `env: process.env` pattern; testing one is sufficient to lock the
+ * pattern in place — the others are mechanical applications of it.
+ */
+import { describe, expect, test } from "bun:test";
+
+describe("Bun.spawn env propagation (hub#349)", () => {
+  test("child process sees parent env when defaultRun-style helper is used", async () => {
+    // Unique marker so we can't false-positive against leftover env from
+    // another test or the harness itself.
+    const markerKey = "PARACHUTE_HUB_SPAWN_ENV_TEST_MARKER";
+    const markerValue = `marker-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    const originalValue = process.env[markerKey];
+    process.env[markerKey] = markerValue;
+    try {
+      // Spawn a child the same way every defaultRun helper does:
+      // `env: process.env`. The child prints its view of the marker var.
+      const proc = Bun.spawn(
+        ["bun", "-e", `process.stdout.write(process.env.${markerKey} ?? "MISSING")`],
+        {
+          stdout: "pipe",
+          stderr: "pipe",
+          env: process.env,
+        },
+      );
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toBe(markerValue);
+    } finally {
+      if (originalValue === undefined) delete process.env[markerKey];
+      else process.env[markerKey] = originalValue;
+    }
+  });
+
+  test("child process does NOT see parent env when env is omitted (negative control)", async () => {
+    // The bug we're guarding against: without `env: process.env`, Bun.spawn
+    // hands the child an empty env. This test pins the failure mode so a
+    // future regression (someone removing `env: process.env`) is caught here,
+    // not in production on Render.
+    const markerKey = "PARACHUTE_HUB_SPAWN_ENV_TEST_MARKER_NEG";
+    const markerValue = `marker-${Date.now()}`;
+
+    const originalValue = process.env[markerKey];
+    process.env[markerKey] = markerValue;
+    try {
+      const proc = Bun.spawn(
+        ["bun", "-e", `process.stdout.write(process.env.${markerKey} ?? "MISSING")`],
+        {
+          stdout: "pipe",
+          stderr: "pipe",
+          // intentionally NO env: process.env
+        },
+      );
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toBe("MISSING");
+    } finally {
+      if (originalValue === undefined) delete process.env[markerKey];
+      else process.env[markerKey] = originalValue;
+    }
+  });
+});

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -206,7 +206,12 @@ function buildEntry(
 }
 
 async function defaultRunCommand(cmd: readonly string[]): Promise<RunResult> {
-  const proc = Bun.spawn([...cmd], { stdio: ["ignore", "pipe", "pipe"] });
+  // Inherit env so the child sees PATH, HOME, BUN_INSTALL, etc. Bun.spawn
+  // defaults to empty env — see api-modules-ops.ts:defaultRun for the rationale.
+  const proc = Bun.spawn([...cmd], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: process.env,
+  });
   // Drain both pipes in parallel — leaving stderr unread can deadlock long
   // installs once the OS pipe buffer fills (#97). Captured stderr is folded
   // into the orchestration error message on non-zero exit.

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -322,7 +322,14 @@ async function resolveSpawnSpec(
 }
 
 function defaultRun(cmd: readonly string[]): Promise<number> {
-  const proc = Bun.spawn([...cmd], { stdio: ["ignore", "inherit", "inherit"] });
+  // Inherit env so child `bun add` sees TMPDIR, BUN_INSTALL, PARACHUTE_*,
+  // etc. set by the Dockerfile / Render env. Bun.spawn defaults to empty
+  // env — without this, bun-add fails with cross-mount rename errors on
+  // Render (where TMPDIR points at the persistent disk). See hub#349.
+  const proc = Bun.spawn([...cmd], {
+    stdio: ["ignore", "inherit", "inherit"],
+    env: process.env,
+  });
   return proc.exited;
 }
 

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -60,7 +60,13 @@ export interface Runner {
 
 export const defaultRunner: Runner = {
   async run(cmd) {
-    const proc = Bun.spawn([...cmd], { stdio: ["inherit", "inherit", "inherit"] });
+    // Inherit env so the child (e.g. parachute-vault subprocess) sees PATH,
+    // HOME, PARACHUTE_HOME, etc. Bun.spawn defaults to empty env — see
+    // api-modules-ops.ts:defaultRun.
+    const proc = Bun.spawn([...cmd], {
+      stdio: ["inherit", "inherit", "inherit"],
+      env: process.env,
+    });
     return await proc.exited;
   },
 };

--- a/src/commands/expose-auth-preflight.ts
+++ b/src/commands/expose-auth-preflight.ts
@@ -26,7 +26,12 @@ import { type VaultAuthStatus, readVaultAuthStatus } from "../vault/auth-status.
 export type InteractiveRunner = (cmd: readonly string[]) => Promise<number>;
 
 const defaultInteractiveRunner: InteractiveRunner = async (cmd) => {
-  const proc = Bun.spawn([...cmd], { stdio: ["inherit", "inherit", "inherit"] });
+  // Inherit env so subprocesses see PATH (to find `tailscale`), HOME, etc.
+  // Bun.spawn defaults to empty env — see api-modules-ops.ts:defaultRun.
+  const proc = Bun.spawn([...cmd], {
+    stdio: ["inherit", "inherit", "inherit"],
+    env: process.env,
+  });
   return await proc.exited;
 };
 

--- a/src/commands/expose-cloudflare.ts
+++ b/src/commands/expose-cloudflare.ts
@@ -69,7 +69,12 @@ export const defaultCloudflaredSpawner: CloudflaredSpawner = {
   spawn(cmd, logFile) {
     mkdirSync(dirname(logFile), { recursive: true });
     const fd = openSync(logFile, "a");
-    const proc = Bun.spawn([...cmd], { stdio: ["ignore", fd, fd] });
+    // Inherit env so cloudflared sees HOME (where it reads ~/.cloudflared/),
+    // PATH, etc. Bun.spawn defaults to empty env — see api-modules-ops.ts.
+    const proc = Bun.spawn([...cmd], {
+      stdio: ["ignore", fd, fd],
+      env: process.env,
+    });
     proc.unref();
     return proc.pid;
   },

--- a/src/commands/expose-interactive.ts
+++ b/src/commands/expose-interactive.ts
@@ -46,7 +46,13 @@ import { type ExposeOpts, exposePublic } from "./expose.ts";
 export type InteractiveRunner = (cmd: readonly string[]) => Promise<number>;
 
 const defaultInteractiveRunner: InteractiveRunner = async (cmd) => {
-  const proc = Bun.spawn([...cmd], { stdio: ["inherit", "inherit", "inherit"] });
+  // Inherit env so interactive subprocesses (e.g. `brew install cloudflared`,
+  // `cloudflared tunnel login`) see PATH, HOME, etc. Bun.spawn defaults to
+  // empty env — see api-modules-ops.ts:defaultRun.
+  const proc = Bun.spawn([...cmd], {
+    stdio: ["inherit", "inherit", "inherit"],
+    env: process.env,
+  });
   return await proc.exited;
 };
 

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -250,7 +250,13 @@ export interface InstallOpts {
 }
 
 async function defaultRunner(cmd: readonly string[]): Promise<number> {
-  const proc = Bun.spawn([...cmd], { stdio: ["inherit", "inherit", "inherit"] });
+  // Inherit env (TMPDIR, BUN_INSTALL, PATH, HOME, PARACHUTE_*, etc.) — see
+  // api-modules-ops.ts:defaultRun for the rationale. Same Bun.spawn-defaults-
+  // to-empty-env bug; same one-line fix. See hub#349.
+  const proc = Bun.spawn([...cmd], {
+    stdio: ["inherit", "inherit", "inherit"],
+    env: process.env,
+  });
   return await proc.exited;
 }
 

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -67,6 +67,10 @@ export const defaultSpawner: Spawner = {
       // wrapped startCmds like `pnpm exec tsx server.ts` leave the tsx
       // grandchild bound to the port after stop → restart hits EADDRINUSE.
       detached: true,
+      // Inherit env so child sees PATH, HOME, PARACHUTE_HOME, etc.
+      // Bun.spawn defaults to empty env — see api-modules-ops.ts:defaultRun.
+      // Per-call `opts.env` overrides merge on top below.
+      env: process.env,
     };
     if (opts?.env) spawnOpts.env = { ...process.env, ...opts.env };
     if (opts?.cwd) spawnOpts.cwd = opts.cwd;
@@ -647,7 +651,12 @@ export async function logs(svc: string, opts: LogsOpts = {}): Promise<number> {
   if (follow) {
     const spawner = opts.tailSpawner ?? {
       spawn(cmd) {
-        const proc = Bun.spawn([...cmd], { stdio: ["ignore", "inherit", "inherit"] });
+        // Inherit env so `tail` sees PATH, etc. Bun.spawn defaults to empty
+        // env — see api-modules-ops.ts:defaultRun.
+        const proc = Bun.spawn([...cmd], {
+          stdio: ["ignore", "inherit", "inherit"],
+          env: process.env,
+        });
         return proc.pid;
       },
     };

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -74,17 +74,22 @@ export interface UpgradeRunner {
 
 export const defaultRunner: UpgradeRunner = {
   async run(cmd, opts) {
+    // Inherit env so `bun add -g` etc. see TMPDIR, BUN_INSTALL, PATH, HOME.
+    // Bun.spawn defaults to empty env — see api-modules-ops.ts:defaultRun.
     const proc = Bun.spawn([...cmd], {
       cwd: opts?.cwd,
       stdio: ["inherit", "inherit", "inherit"],
+      env: process.env,
     });
     return await proc.exited;
   },
   async capture(cmd, opts) {
+    // Inherit env — same rationale as `run` above.
     const proc = Bun.spawn([...cmd], {
       cwd: opts?.cwd,
       stdout: "pipe",
       stderr: "pipe",
+      env: process.env,
     });
     const [stdout, stderr] = await Promise.all([
       new Response(proc.stdout).text(),

--- a/src/commands/vault-tokens-create-interactive.ts
+++ b/src/commands/vault-tokens-create-interactive.ts
@@ -30,7 +30,13 @@ import { createInterface } from "node:readline/promises";
 export type InteractiveRunner = (cmd: readonly string[]) => Promise<number>;
 
 const defaultInteractiveRunner: InteractiveRunner = async (cmd) => {
-  const proc = Bun.spawn([...cmd], { stdio: ["inherit", "inherit", "inherit"] });
+  // Inherit env so the child (parachute-vault subprocess) sees PATH, HOME,
+  // PARACHUTE_HOME, etc. Bun.spawn defaults to empty env — see
+  // api-modules-ops.ts:defaultRun.
+  const proc = Bun.spawn([...cmd], {
+    stdio: ["inherit", "inherit", "inherit"],
+    env: process.env,
+  });
   return await proc.exited;
 };
 

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -2,6 +2,9 @@ export async function dispatchVault(args: readonly string[]): Promise<number> {
   try {
     const proc = Bun.spawn(["parachute-vault", ...args], {
       stdio: ["inherit", "inherit", "inherit"],
+      // Inherit env so parachute-vault sees PATH, HOME, PARACHUTE_HOME, etc.
+      // Bun.spawn defaults to empty env — see api-modules-ops.ts:defaultRun.
+      env: process.env,
     });
     return await proc.exited;
   } catch (err) {

--- a/src/hub-control.ts
+++ b/src/hub-control.ts
@@ -74,7 +74,12 @@ export interface HubSpawner {
 export const defaultHubSpawner: HubSpawner = {
   spawn(cmd, logFile) {
     const fd = openSync(logFile, "a");
-    const proc = Bun.spawn([...cmd], { stdio: ["ignore", fd, fd] });
+    // Inherit env so the hub child process sees PATH, HOME, PARACHUTE_HOME,
+    // etc. Bun.spawn defaults to empty env — see api-modules-ops.ts.
+    const proc = Bun.spawn([...cmd], {
+      stdio: ["ignore", fd, fd],
+      env: process.env,
+    });
     proc.unref();
     return proc.pid;
   },

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -403,6 +403,10 @@ async function pumpLines(
 const defaultSpawnFn: SpawnFn = (req) => {
   const spawnOpts: Parameters<typeof Bun.spawn>[1] = {
     stdio: ["ignore", "pipe", "pipe"],
+    // Inherit env so supervised module sees PATH, HOME, PARACHUTE_HOME, etc.
+    // Bun.spawn defaults to empty env — see api-modules-ops.ts:defaultRun.
+    // Per-call `req.env` overrides merge on top below.
+    env: process.env,
   };
   if (req.cwd) spawnOpts.cwd = req.cwd;
   if (req.env) spawnOpts.env = { ...process.env, ...req.env };

--- a/src/tailscale/run.ts
+++ b/src/tailscale/run.ts
@@ -7,7 +7,13 @@ export interface CommandResult {
 export type Runner = (cmd: readonly string[]) => Promise<CommandResult>;
 
 export async function defaultRunner(cmd: readonly string[]): Promise<CommandResult> {
-  const proc = Bun.spawn([...cmd], { stdout: "pipe", stderr: "pipe" });
+  // Inherit env so `tailscale` sees PATH (and HOME for state dir). Bun.spawn
+  // defaults to empty env — see api-modules-ops.ts:defaultRun for rationale.
+  const proc = Bun.spawn([...cmd], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: process.env,
+  });
   const [stdout, stderr, code] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),


### PR DESCRIPTION
## The discovery

Aaron ran `bun add -g --verbose cowsay` inside a Render shell with custom env and surfaced the actual root cause: **`Bun.spawn` defaults to an EMPTY env when `env` is not passed.** It does NOT inherit the parent's environment the way `child_process.spawn` does in Node. Every place in hub that called `Bun.spawn` without an explicit `env: process.env` was handing the child a clean env: no `PATH`, no `HOME`, no `TMPDIR`, no `BUN_INSTALL`, no `PARACHUTE_*`.

## Why TMPDIR alone wasn't sufficient

The Render install failure (#349) was the visible symptom:

```
info: cannot move files from tempdir: RenameAcrossMountPoints, using fallback
error: Failed to link cowsay: EACCES
```

#351 set `TMPDIR=/parachute/tmp` in the Dockerfile ENV so bun's extraction tempdir would live on the same filesystem as `BUN_INSTALL=/parachute/modules` (avoiding the cross-mount `rename()` EXDEV). But hub's spawned `bun add -g` **never saw `TMPDIR`** because the spawn helper passed no `env`, so Bun handed the child an empty env. The kernel-level `EXDEV` was the proximate cause; the empty-env spawn was the upstream cause that prevented the operator's `TMPDIR` setting from reaching bun.

`#350` (entrypoint chown of `/parachute`) and `#351` (Dockerfile `TMPDIR`) were both necessary but neither sufficient. **This** PR is the actual fix that makes them effective.

## The 14 spawn sites + uniform fix

Every non-test `Bun.spawn` call in `src/` now passes `env: process.env`:

1. `src/api-modules-ops.ts:defaultRun` — admin SPA install/upgrade (the Render-failure trigger)
2. `src/commands/install.ts:defaultRunner` — CLI install
3. `src/admin-vaults.ts:defaultRunCommand` — admin SPA vault ops
4. `src/commands/expose-auth-preflight.ts:defaultInteractiveRunner` — Tailscale auth check
5. `src/commands/auth.ts:defaultRunner` — `parachute auth` forwarding to vault
6. `src/commands/expose-cloudflare.ts:defaultCloudflaredSpawner` — `cloudflared` subprocess (needs `HOME` for `~/.cloudflared/`)
7. `src/commands/expose-interactive.ts:defaultInteractiveRunner` — interactive expose flows
8. `src/commands/vault-tokens-create-interactive.ts:defaultInteractiveRunner` — interactive vault token mint
9. `src/commands/vault.ts:dispatchVault` — `parachute vault <args>` forwarder
10. `src/commands/lifecycle.ts:defaultSpawner` — module daemon spawner (default branch + per-call merge preserved)
11. `src/commands/lifecycle.ts` tail-spawner — `parachute logs -f`
12. `src/commands/upgrade.ts:defaultRunner` — `parachute upgrade` (`.run` and `.capture`)
13. `src/hub-control.ts:defaultHubSpawner` — `parachute serve` background hub
14. `src/supervisor.ts:defaultSpawnFn` — supervised module subprocess (default branch + per-call merge preserved)
15. `src/tailscale/run.ts:defaultRunner` — every `tailscale ...` shell-out

For the two seams that conditionally merged `process.env` only when a per-call override was provided (`supervisor.ts`, `lifecycle.ts:defaultSpawner`), the default branch now also sets `env: process.env`; the override branch's `{ ...process.env, ...opts.env }` merge is unchanged.

Each site has an inline comment pointing back to `api-modules-ops.ts:defaultRun` for the rationale (DRY on the "why").

## Scope decision: fix all of them

The original audit only found 7 sites; investigation surfaced 8 more sharing the same pattern. Fixing them uniformly is the same one-liner per site, safer in aggregate (consistent behavior across the codebase), and prevents the next operator from hitting the same class of bug in `cloudflared`, `tailscale`, vault forwarding, etc. — none of which need an empty env.

## Verification

- `bun run typecheck` clean.
- `bun test ./src` — **1921 pass / 0 fail** (+2 from new `src/__tests__/spawn-env-propagation.test.ts`):
  - Positive case asserts the `env: process.env` spawn options propagate a marker var to the child.
  - **Negative-control case** asserts that omitting `env` produces an empty-env child — pins the Bun.spawn behavior so a future regression is caught here, not in production on Render.
- `bunx biome check src/` clean.

## Patterns check

No pattern shifts. The "spawned subprocesses inherit env unless deliberately scrubbed" expectation is a Unix-tooling convention shared with `child_process.spawn`'s default; this PR makes hub's `Bun.spawn` usage conform to that convention. Worth surfacing in [`parachute-patterns/patterns/`](https://github.com/ParachuteComputer/parachute-patterns/tree/main/patterns) as a Bun-runtime gotcha for future modules in the ecosystem (vault, scribe, app — all of which also use `Bun.spawn`), but the cross-repo doc is out-of-scope for this hub-only PR.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test ./src` 1921 pass / 0 fail
- [x] `bunx biome check src/` clean
- [ ] Reviewer dispatch
- [ ] Deploy on Render and re-attempt admin SPA install to confirm #349 is fully resolved