### PR TITLE
fix(hub): drop admin env vars from default Render deploy + make bootstrap token banner prominent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.27] - 2026-05-23
+
+**fix(hub): drop admin env vars from default Render deploy + make bootstrap token banner prominent.**
+
+Aaron's framing: on first-time setup we don't want admin username/password as default config variables prompted in Render's dashboard — we just want to make sure the bootstrap token is easy to spot in the logs.
+
+### Changed
+
+- Render deploy default flow simplified: removed `PARACHUTE_INITIAL_ADMIN_USERNAME` / `PARACHUTE_INITIAL_ADMIN_PASSWORD` as prompted fields in `render.yaml`. New default: operators check Render Logs for the bootstrap token (now in a visually prominent banner with ═ delimiters), visit `/admin/setup`, paste the token, create admin. Operators who want env-var seeding can still set these env vars manually in the Render dashboard — hub honors them via `seedInitialAdminIfNeeded`. Cleaner secret hygiene: no admin passwords stored in Render's env-var dashboard.
+- The bootstrap-token banner in hub's startup logs now uses ═ delimiters + ALL-CAPS heading, making it easy to spot when scrolling through container logs. The `parachute-bootstrap-` prefix on the token line is preserved so operators can grep for that exact string.
+- README "Hosted (Render)" section updated to lead with the bootstrap-token-from-logs flow.
+
+### Patterns check
+
+- No pattern shifts. Surface polish on the Render deploy + first-boot operator experience; complements the rc.26 spawn-env fix that unblocked Render module installs. Cross-refs hub#337 / hub#347 (Render deploy infrastructure).
+
+### Verification
+
+- `bun run typecheck` clean.
+- `bun test ./src` — banner tests updated, all pass.
+
 ## [0.5.13-rc.26] - 2026-05-23
 
 **fix(hub): `Bun.spawn` subprocess calls now inherit `process.env` (closes the real-real root cause of [hub#349](https://github.com/ParachuteComputer/parachute-hub/issues/349)).**

--- a/README.md
+++ b/README.md
@@ -24,11 +24,14 @@ One-click Render deploy via the `render.yaml` Blueprint in this repo. Provisions
 
 **Want pre-release / rc modules?** Set `PARACHUTE_INSTALL_CHANNEL=rc` in your Render dashboard env vars (useful for dev/testing against the rc release line).
 
-After deploy:
+After deploy completes:
 
-1. Open your Render service URL → wizard runs at `/admin/setup`
-2. Set custom domain (optional) → set `PARACHUTE_HUB_ORIGIN` env to match
-3. Install modules via the admin SPA at `/admin/modules` (or via the wizard)
+1. Open Render Logs → search for `parachute-bootstrap-` to find your one-time admin setup token (printed in a prominent banner on first boot).
+2. Visit your Render service URL's `/admin/setup` → paste the token → create your admin account.
+3. Set custom domain (optional) → set `PARACHUTE_HUB_ORIGIN` env to match.
+4. Install modules via the admin SPA at `/admin/modules` (or via the wizard).
+
+Operators who want env-var-driven seeding (CI, scripted deploys) can still set `PARACHUTE_INITIAL_ADMIN_USERNAME` + `PARACHUTE_INITIAL_ADMIN_PASSWORD` manually in the Render dashboard — hub honors them when present.
 
 Render's docs on Blueprints: <https://render.com/docs/blueprint-spec>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.26",
+  "version": "0.5.13-rc.27",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/render.yaml
+++ b/render.yaml
@@ -7,9 +7,9 @@
 #
 # To use: connect a fresh Render account to a fork of this repo and click
 # "New Blueprint" → point at this file. Render will provision the
-# service + disk and start the build. Set the admin-seed env vars in the
-# Render dashboard (marked `sync: false`) or use the web wizard at
-# `/admin/setup` after the first deploy.
+# service + disk and start the build. After deploy, open Render Logs and
+# search for `parachute-bootstrap-` to find your one-time admin setup
+# token, then visit `/admin/setup` and paste it in.
 #
 # Custom domains: add the domain on the Render service page, then set
 # PARACHUTE_HUB_ORIGIN to `https://<your-domain>`. The OAuth issuer claim
@@ -90,17 +90,16 @@ services:
       - key: PARACHUTE_HUB_ORIGIN
         sync: false
 
-      # First-boot admin seed. Optional — if unset, the hub still comes
-      # up and routes non-/.well-known requests to /admin/setup so the
-      # operator can bootstrap via the web wizard.
+      # Admin setup: hub generates a one-time bootstrap token on first
+      # boot (printed prominently to logs). Visit /admin/setup, paste
+      # the token, create your admin account. No env-var passwords in
+      # the Render dashboard by default — cleaner secret hygiene.
       #
-      # `sync: false` so secrets never land in source control. Setting
-      # these is a one-time act; once an admin exists in hub.db, the
-      # seed code path is a no-op even if the env vars stay set.
-      - key: PARACHUTE_INITIAL_ADMIN_USERNAME
-        sync: false
-      - key: PARACHUTE_INITIAL_ADMIN_PASSWORD
-        sync: false
+      # Operators who need env-var-driven setup (CI, scripted deploys,
+      # etc.) can still add `PARACHUTE_INITIAL_ADMIN_USERNAME` +
+      # `PARACHUTE_INITIAL_ADMIN_PASSWORD` env vars manually in the
+      # Render dashboard. Hub honors them when present (per the
+      # `seedInitialAdminIfNeeded` code path in src/commands/serve.ts).
 
       # Run with a sensible Node-style production hint. Bun honors this
       # for any libraries that branch on NODE_ENV.

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -184,6 +184,15 @@ describe("formatBootstrapTokenBanner", () => {
       expect(line.startsWith("[wizard]")).toBe(true);
     }
   });
+
+  test("uses ═ delimiters and an ALL-CAPS heading so operators spot the block in log viewers", () => {
+    const banner = formatBootstrapTokenBanner("parachute-bootstrap-visual-token");
+    // The ═ box-drawing char is the visual cue an operator scrolling
+    // Render's log tab keys off; this assertion locks the new shape so
+    // a stylistic regression doesn't silently demote the banner.
+    expect(banner).toContain("═");
+    expect(banner).toContain("PARACHUTE BOOTSTRAP TOKEN");
+  });
 });
 
 // --- bootstrap-token generation under needs-setup (Issue 1 wiring) -------

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -150,15 +150,21 @@ export async function seedInitialAdminIfNeeded(
  * operator wins the race).
  */
 export function formatBootstrapTokenBanner(token: string): string {
+  const rule = "═".repeat(64);
   return [
-    "[wizard] No admin exists — wizard mode active. To claim ownership of this hub:",
-    "[wizard]   1. Visit http://localhost:1939/admin/setup (or your deployed URL)",
-    "[wizard]   2. Paste this bootstrap token into the form:",
+    "[wizard]",
+    `[wizard] ${rule}`,
+    "[wizard]   PARACHUTE BOOTSTRAP TOKEN",
+    `[wizard] ${rule}`,
     "[wizard]",
     `[wizard]   ${token}`,
     "[wizard]",
-    "[wizard] This token grants permission to create the first admin. It expires when",
-    "[wizard] admin is created OR when hub restarts.",
+    "[wizard]   → Visit <hub-url>/admin/setup and paste this token to create",
+    "[wizard]     your admin account.",
+    "[wizard]   → Expires when admin is created OR when hub restarts.",
+    "[wizard]",
+    `[wizard] ${rule}`,
+    "[wizard]",
   ].join("\n");
 }
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -149,8 +149,12 @@ export async function seedInitialAdminIfNeeded(
  * the token can't proceed; an attacker who reads it before the
  * operator wins the race).
  */
-export function formatBootstrapTokenBanner(token: string): string {
+export function formatBootstrapTokenBanner(token: string, hubUrl?: string): string {
   const rule = "═".repeat(64);
+  // Substitute the actual hub URL when known (PARACHUTE_HUB_ORIGIN). Operators
+  // staring at the banner in Render Logs shouldn't have to figure out their
+  // own URL — show the literal placeholder only when the issuer isn't set.
+  const url = hubUrl && hubUrl.length > 0 ? hubUrl.replace(/\/+$/, "") : "<hub-url>";
   return [
     "[wizard]",
     `[wizard] ${rule}`,
@@ -159,7 +163,7 @@ export function formatBootstrapTokenBanner(token: string): string {
     "[wizard]",
     `[wizard]   ${token}`,
     "[wizard]",
-    "[wizard]   → Visit <hub-url>/admin/setup and paste this token to create",
+    `[wizard]   → Visit ${url}/admin/setup and paste this token to create`,
     "[wizard]     your admin account.",
     "[wizard]   → Expires when admin is created OR when hub restarts.",
     "[wizard]",
@@ -205,14 +209,14 @@ export async function serve(opts: ServeOpts = {}): Promise<{
 
   if (adminBootstrap === "needs-setup") {
     log(
-      "parachute serve: no admin account configured. Set PARACHUTE_INITIAL_ADMIN_USERNAME + PARACHUTE_INITIAL_ADMIN_PASSWORD, or visit /admin/setup once the hub is reachable.",
+      "parachute serve: no admin account configured. Visit /admin/setup once the hub is reachable, or seed via PARACHUTE_INITIAL_ADMIN_USERNAME + PARACHUTE_INITIAL_ADMIN_PASSWORD env vars for scripted deploys.",
     );
     // Mint a bootstrap token + log it. The wizard's account POST will
     // require this token, so an attacker who beats the operator to the
     // freshly-provisioned URL still can't claim the admin row without
     // shell access to the platform's startup logs.
     const token = generateBootstrapToken();
-    log(formatBootstrapTokenBanner(token));
+    log(formatBootstrapTokenBanner(token, issuer));
   }
 
   const supervisor = opts.supervisor ?? new Supervisor();


### PR DESCRIPTION
## Framing

Aaron: "On set up I don't think we wanna have username and password as default config variables. We just wanna make sure it's quite easy for the bootstrap token to be revealed."

Default flow we want for operators: click Deploy to Render → service builds → open Render Logs → search for the bootstrap token (visually prominent in startup banner) → paste into `/admin/setup` wizard form. No env-var passwords. Cleaner secret hygiene, less leak surface, no rotation worries.

## The three coordinated changes

### 1. `render.yaml` — drop admin env vars from the prompted list

Removed `PARACHUTE_INITIAL_ADMIN_USERNAME` + `PARACHUTE_INITIAL_ADMIN_PASSWORD` from the `envVars` list so they no longer show up as `sync: false` prompted fields in Render's dashboard on Blueprint provisioning.

Replaced with a comment block explaining the new default and noting operators who want env-var-driven seeding (CI, scripted deploys) can still add them manually in the dashboard — hub's `seedInitialAdminIfNeeded` code path is unchanged and honors them when present.

Header comment updated to point at the new "Render Logs → bootstrap token → /admin/setup" flow.

### 2. `README.md` "Hosted (Render)" — lead with bootstrap-token reveal

Post-deploy steps now lead with: "Open Render Logs → search for `parachute-bootstrap-` to find your one-time admin setup token (printed in a prominent banner on first boot). Visit your Render service URL's `/admin/setup` → paste the token → create your admin account."

Kept the rc-cascade note + `PARACHUTE_HUB_ORIGIN` custom-domain note. Added a closing line noting the env-var escape hatch for CI / scripted deploys.

### 3. `src/commands/serve.ts:formatBootstrapTokenBanner` — visual emphasis

New banner format (each line carries the `[wizard]` log-grep prefix unchanged):

```
[wizard]
[wizard] ════════════════════════════════════════════════════════════════
[wizard]   PARACHUTE BOOTSTRAP TOKEN
[wizard] ════════════════════════════════════════════════════════════════
[wizard]
[wizard]   parachute-bootstrap-<token>
[wizard]
[wizard]   → Visit <hub-url>/admin/setup and paste this token to create
[wizard]     your admin account.
[wizard]   → Expires when admin is created OR when hub restarts.
[wizard]
[wizard] ════════════════════════════════════════════════════════════════
[wizard]
```

The ═ (box-drawing double-line) characters + ALL-CAPS heading let an operator scrolling Render's log viewer spot the block on the first scan. The `parachute-bootstrap-` prefix on the token line is preserved so operators can grep for that exact string.

### Test update

`src/__tests__/serve.test.ts` adds a banner-shape assertion: the output contains `═` + the literal `"PARACHUTE BOOTSTRAP TOKEN"` heading. Locks the new visual against silent stylistic regressions. The existing token / wizard URL / expiry / `[wizard]` prefix assertions all pass unchanged.

## Not changed

- Bootstrap-token logic (generation, validation, consumption) — only the LOG FORMAT
- `seedInitialAdminIfNeeded` — env-var seed path remains fully supported
- `/admin/setup` wizard UI

## Verification

- `bun run typecheck` clean
- `bun test ./src` — 1922 pass / 0 fail (+1 banner-visual test vs rc.26's 1921)
- `bunx biome check src/commands/serve.ts src/__tests__/serve.test.ts` clean
- Visual inspect via `bun -e 'console.log(formatBootstrapTokenBanner(...))'` — ═ chars render correctly in stdout

## Patterns check

No pattern shifts. Surface polish on the Render deploy + first-boot operator experience; complements the rc.26 spawn-env fix that unblocked Render module installs. Cross-refs hub#337 / hub#347 (Render deploy infrastructure).

## Version

`0.5.13-rc.26` → `0.5.13-rc.27`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)