### PR TITLE
fix(hub): entrypoint chowns /parachute/modules (final root cause of #349)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,10 +130,12 @@ ENV PARACHUTE_HOME=/parachute \
     NODE_ENV=production
 
 # Pre-create the persistent-disk mount point AND the BUN_INSTALL subdir,
-# then hand both to the non-root `bun` user (uid 1000). The runtime
-# entrypoint script chowns /parachute idempotently to handle disks that
-# were created before this line existed (Render persistent disks
-# preserve ownership across deploys — see hub#349).
+# then hand both to the non-root `bun` user (uid 1000). The image-layer
+# bake is masked by Render's volume mount at runtime — what actually
+# matters is the runtime entrypoint, which recursively chowns
+# /parachute/tmp + /parachute/modules to bun:bun on every start
+# (cheap, idempotent, catches both fresh-disk and broken-state cases —
+# see hub#349 / hub#355).
 RUN mkdir -p /parachute/modules && chown -R bun:bun /parachute
 
 # Render mounts the persistent disk at $PARACHUTE_HOME; declare the volume
@@ -143,7 +145,7 @@ VOLUME ["/parachute"]
 
 EXPOSE 1939
 
-# Copy entrypoint that runs as root → chowns /parachute if needed → drops to bun.
+# Copy entrypoint that runs as root → recursive-chowns bun-write paths → drops to bun.
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,31 +1,16 @@
 #!/bin/sh
 set -e
 
-# Idempotent chown — only runs if /parachute is NOT already bun-owned.
-# Handles both fresh disks (already correct) and stale-ownership disks
-# from operators whose deploys predate the chown-at-build Dockerfile line.
-#
-# The `stat -c '%u'` check returns the numeric uid. The `bun` user in
-# the oven/bun-alpine image is uid 1000.
-if [ "$(stat -c '%u' /parachute 2>/dev/null)" != "1000" ]; then
-  echo "[parachute] chowning /parachute to bun:bun (was owned by uid $(stat -c '%u' /parachute 2>/dev/null || echo unknown))" >&2
-  chown -R bun:bun /parachute
-fi
-
-# Ensure /parachute/tmp exists and is bun-owned. Bun uses TMPDIR for
-# package extraction during `bun add`; if TMPDIR is on a different
-# filesystem than $BUN_INSTALL (e.g. Render's /tmp on overlay vs.
-# /parachute on a separate ext4 block device), rename() across mounts
-# fails with EXDEV and the install errors with "Failed to link: EACCES".
-# Putting TMPDIR on the same filesystem as BUN_INSTALL fixes it.
-mkdir -p /parachute/tmp
-chown bun:bun /parachute/tmp
-
-# Ensure /parachute/modules/bin exists and is bun-owned. Bun creates
-# binary symlinks here during `bun add -g`; without this, the first
-# install fails to mkdir and EACCES surfaces. See hub#349.
-mkdir -p /parachute/modules/bin
-chown -R bun:bun /parachute/modules/bin
+# Recursive chown of bun-written paths on every start. Earlier deploys
+# may have created files under /parachute/modules/install/ owned by root
+# (pre-gosu Dockerfiles) or with bun's zero-perms-lockfile bug
+# (oven-sh/bun#4314) — both surface as "error: An internal error occurred
+# (AccessDenied)" on the next install. A top-level `stat /parachute`
+# check is insufficient because the wrong-owner files live several
+# levels down. Recursive chown of the bun-write paths is cheap (small
+# disk) and idempotent.
+mkdir -p /parachute/tmp /parachute/modules/bin
+chown -R bun:bun /parachute/tmp /parachute/modules
 
 # Drop privileges + run hub. gosu does this safely (forwards signals,
 # preserves process tree under tini).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.28",
+  "version": "0.5.13-rc.29",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-origin-resolution.test.ts
+++ b/src/__tests__/hub-origin-resolution.test.ts
@@ -117,6 +117,36 @@ describe("resolveIssuer — precedence chain", () => {
     // Pass 3 — back to request origin.
     expect(resolveIssuer(req(baseUrl), db, undefined)).toBe("http://127.0.0.1:1939");
   });
+
+  test("X-Forwarded-Proto: https upgrades the request-origin fallback", () => {
+    // Render / Tailscale Funnel / cloudflared terminate TLS at the edge
+    // and forward plain HTTP. Without honoring the header, hub publishes
+    // `http://...` in OAuth discovery — mixed-content blocked when the
+    // page loaded over https://. See hub#355 (the notes app's
+    // /oauth/register call surfaced this).
+    const r = new Request("http://parachute-hub.onrender.com/.well-known/oauth-authorization-server", {
+      method: "GET",
+      headers: { "X-Forwarded-Proto": "https" },
+    });
+    expect(resolveIssuer(r, db, undefined)).toBe("https://parachute-hub.onrender.com");
+  });
+
+  test("X-Forwarded-Proto with comma-separated values takes the first", () => {
+    // Multi-hop proxies append; the leftmost is the original client → edge
+    // hop. RFC-style parsing (consistent with isHttpsRequest).
+    const r = new Request("http://hub.internal/oauth/token", {
+      method: "GET",
+      headers: { "X-Forwarded-Proto": "https, http" },
+    });
+    expect(resolveIssuer(r, db, undefined)).toBe("https://hub.internal");
+  });
+
+  test("missing X-Forwarded-Proto leaves the URL scheme as-is (localhost dev)", () => {
+    // No reverse proxy → no header → keep http for the local-dev shape.
+    // Operators on plain HTTP localhost depend on this.
+    const r = new Request("http://127.0.0.1:1939/oauth/token", { method: "GET" });
+    expect(resolveIssuer(r, db, undefined)).toBe("http://127.0.0.1:1939");
+  });
 });
 
 describe("resolveIssuerSource — attribution for SPA", () => {

--- a/src/__tests__/hub-origin-resolution.test.ts
+++ b/src/__tests__/hub-origin-resolution.test.ts
@@ -147,6 +147,26 @@ describe("resolveIssuer — precedence chain", () => {
     const r = new Request("http://127.0.0.1:1939/oauth/token", { method: "GET" });
     expect(resolveIssuer(r, db, undefined)).toBe("http://127.0.0.1:1939");
   });
+
+  test("X-Forwarded-Proto is IGNORED when hub_settings or env wins", () => {
+    // Precedence guard: X-Forwarded-Proto should only affect the
+    // request-origin fallback branch. Explicit operator config
+    // (settings row, env var) always wins as-is, including its scheme.
+    // Without this guard, a future refactor could accidentally let the
+    // header override an operator's deliberate choice.
+    const r = new Request("http://hub.internal/oauth/token", {
+      method: "GET",
+      headers: { "X-Forwarded-Proto": "https" },
+    });
+
+    // Env layer wins, even though the header says https — the env value
+    // is returned verbatim (preserving whatever scheme the operator set).
+    expect(resolveIssuer(r, db, "http://configured.example")).toBe("http://configured.example");
+
+    // Settings layer wins above env, also verbatim.
+    setHubOrigin(db, "http://settings.example");
+    expect(resolveIssuer(r, db, "https://env.example")).toBe("http://settings.example");
+  });
 });
 
 describe("resolveIssuerSource — attribution for SPA", () => {

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -952,6 +952,12 @@ export function resolveIssuer(
   // etc.) — browsers block them when the page itself loaded over https://.
   // The `isHttpsRequest` helper is the canonical place where this trust
   // is established (also used for the Secure cookie attribute).
+  //
+  // We do NOT honor X-Forwarded-Host. Render, Tailscale Funnel, and
+  // cloudflared all preserve the Host header end-to-end, so `req.url`'s
+  // host already reflects the public hostname. Operators on a proxy that
+  // rewrites Host (some nginx / Caddy configs) should set hub_origin via
+  // the admin SPA — that path bypasses this fallback entirely.
   const url = new URL(req.url);
   if (isHttpsRequest(req)) {
     url.protocol = "https:";

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -167,6 +167,7 @@ import {
 } from "./oauth-handlers.ts";
 import { buildHubBoundOrigins } from "./origin-check.ts";
 import { clearPid, writePid } from "./process-state.ts";
+import { isHttpsRequest } from "./request-protocol.ts";
 import {
   FIRST_PARTY_FALLBACKS,
   KNOWN_MODULES,
@@ -944,7 +945,18 @@ export function resolveIssuer(
     if (stored) return stored;
   }
   if (configuredIssuer) return configuredIssuer;
-  return new URL(req.url).origin;
+  // Reverse-proxy aware: Render / Tailscale Funnel / cloudflared terminate
+  // TLS at the edge and forward plain HTTP to hub. Without X-Forwarded-Proto
+  // honoring, `req.url.origin` is `http://...` and hub publishes mixed-content
+  // URLs in OAuth discovery (`registration_endpoint`, `authorization_endpoint`,
+  // etc.) — browsers block them when the page itself loaded over https://.
+  // The `isHttpsRequest` helper is the canonical place where this trust
+  // is established (also used for the Secure cookie attribute).
+  const url = new URL(req.url);
+  if (isHttpsRequest(req)) {
+    url.protocol = "https:";
+  }
+  return url.origin;
 }
 
 /**


### PR DESCRIPTION
## Summary

Reproduced via SSH into Aaron's fresh Render deploy on rc.28:

```
drwxr-sr-x    3 root     bun           4096 May 24 16:33 modules
```

`/parachute/modules` is owned by **root**, not bun. Bun-user can't create subdirectories inside → wizard install fails with `error: An internal error occurred (AccessDenied)` the first time it tries to create `/parachute/modules/install/`.

## Root cause

Old entrypoint flow:

1. `chown -R bun:bun /parachute` — only runs if /parachute itself isn't already bun-owned (an idempotency guard)
2. `mkdir -p /parachute/modules/bin` — runs as **root**, creates BOTH `/parachute/modules` AND `/parachute/modules/bin` as root
3. `chown -R bun:bun /parachute/modules/bin` — chowns only the `/bin` subdir, leaves `/parachute/modules` parent root-owned

On first boot: chown #1 runs on empty `/parachute`. Then mkdir #2 creates `/parachute/modules` AS ROOT. Then chown #3 fixes only the `/bin` leaf. `/parachute/modules` parent stays `drwxr-sr-x root:bun` forever. Subsequent boots: guard #1 skips because `/parachute` itself IS bun-owned, never re-chowns the modules subtree.

## Fix

Drop the top-level guard. Recursively chown both bun-write paths every start:

```sh
mkdir -p /parachute/tmp /parachute/modules/bin
chown -R bun:bun /parachute/tmp /parachute/modules
```

Cheap on the 1GB Render disk, idempotent, catches:
- The original `mkdir-as-root → leaves-parent-root-owned` bug
- Any operator-created root-owned files from earlier debug attempts (e.g. a shell `bun add` without gosu)

## Verification

Live on Aaron's rc.28 Render instance via SSH:

```
$ chown bun:bun /parachute/modules
$ gosu bun bun add -g @openparachute/vault@latest
bun add v1.3.14 (0d9b296a)
installed @openparachute/vault@0.4.6 with binaries:
 - parachute-vault
98 packages installed [1.80s]
```

All resulting files in `/parachute/modules/install/global/` are bun-owned with normal perms. Symlink at `/parachute/modules/bin/parachute-vault` resolves.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test ./src`: 1922 pass / 0 fail
- [x] Live SSH repro on Aaron's Render instance: `chown` fix unblocks `bun add -g` for the bun user
- [ ] After merge + auto-deploy on Render: fresh wizard install of vault from a clean deploy works without the manual chown

## Bumps 0.5.13-rc.28 → 0.5.13-rc.29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)