### PR TITLE
fix(hub): bootSupervisedModules sets PORT (3rd spawn site, follow-up to #356)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.30",
+  "version": "0.5.13-rc.31",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/serve-boot.test.ts
+++ b/src/__tests__/serve-boot.test.ts
@@ -121,6 +121,27 @@ describe("bootSupervisedModules", () => {
     expect(recorder.calls[0]?.env?.PARACHUTE_HUB_ORIGIN).toBe("https://hub.example");
   });
 
+  test("sets PORT in child env from services.json entry (hub#357)", async () => {
+    // Container deploys (Render etc.) set PORT in hub's process.env via
+    // Dockerfile / platform injection. The supervisor's defaultSpawnFn
+    // passes `env: process.env` so children inherit hub's PORT and try
+    // to bind hub's own port → EADDRINUSE crashloop. This boot path
+    // (called on hub startup to re-spawn supervised modules from
+    // services.json) was missed by hub#356 which only fixed the
+    // install-time + lifecycle paths. Third spawn site, same fix shape.
+    writeManifest({ services: [VAULT_ENTRY] }, h.manifestPath);
+    const recorder = makeRecorder();
+    const sup = new Supervisor({ spawnFn: recorder.spawn });
+
+    await bootSupervisedModules(sup, {
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+    });
+
+    // VAULT_ENTRY's port = 1940 (vault's canonical).
+    expect(recorder.calls[0]?.env?.PORT).toBe("1940");
+  });
+
   test("merges per-module .env file into child env", async () => {
     writeManifest({ services: [VAULT_ENTRY] }, h.manifestPath);
     // Write a per-module .env at <configDir>/<short>/.env — what the

--- a/src/commands/serve-boot.ts
+++ b/src/commands/serve-boot.ts
@@ -89,11 +89,15 @@ export async function bootSupervisedModules(
       continue;
     }
 
-    // Per-module .env layers under HUB_ORIGIN (hub-origin wins on
-    // collision — it's the canonical issuer source, and a stale .env
-    // shouldn't override the live `parachute serve` env).
+    // PORT override (hub#357 — third spawn site missed by hub#356).
+    // Without this, modules that read process.env.PORT (vault, scribe)
+    // inherit hub's PORT from Bun.spawn's env: process.env default and
+    // crash EADDRINUSE on hub's port. Container deploy was still broken
+    // after #356 because this BOOT path runs on hub startup before the
+    // supervisor's other spawn paths see any traffic. fileEnv wins on
+    // collision so per-service .env can still override.
     const fileEnv = readEnvFileValues(join(opts.configDir, short, ".env"));
-    const env: Record<string, string> = { ...fileEnv };
+    const env: Record<string, string> = { PORT: String(entry.port), ...fileEnv };
     if (opts.hubOrigin) env[HUB_ORIGIN_ENV] = opts.hubOrigin;
 
     const req: {


### PR DESCRIPTION
## Summary

Verified live: after hub#356 deployed to Aaron's Render, vault **still** crashed EADDRINUSE on rc.30. Investigation found a third spawn site I missed.

Three spawn sites in hub. #356 fixed two; this PR fixes the third:

| Spawn site | Function | File | Status |
|---|---|---|---|
| Install-time spawn | `spawnSupervised` | `src/api-modules-ops.ts` | fixed in #356 |
| CLI lifecycle | `start` | `src/commands/lifecycle.ts` | fixed in #356 |
| Boot-time auto-spawn | `bootSupervisedModules` | `src/commands/serve-boot.ts` | **fixed here** |

The boot path is what runs FIRST when hub starts in a container — it walks services.json and auto-spawns each supervised module. Without PORT injection there, vault crashes immediately every container restart even though the wizard install path is fixed.

## Diagnosis trail

After hub#356 landed and Render deployed rc.30, I verified via SSH:
- Hub PID 7 running as bun (correct)
- App + scribe spawned (running)
- **Vault missing from process tree**

Hub logs showed vault crashed 3x in the first 60s after rc.30 came up with the same EADDRINUSE on hub's port. The boot-path spawn was inheriting hub's PORT.

## Fix

Same shape as #356:

```diff
- const env: Record<string, string> = { ...fileEnv };
+ const env: Record<string, string> = { PORT: String(entry.port), ...fileEnv };
```

`fileEnv` wins on collision (operator-set per-service `.env` still takes precedence).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test ./src` — 1928 pass / 0 fail (+1 new regression test)
- [x] New test: `bootSupervisedModules sets PORT in child env from services.json entry`
- [ ] After merge + Render auto-deploy: verify via SSH vault auto-starts on hub boot

## Bumps 0.5.13-rc.30 → 0.5.13-rc.31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)