### PR TITLE
fix(hub): proxyRequest forwards X-Forwarded-* headers to upstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.31",
+  "version": "0.5.13-rc.32",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -1390,7 +1390,8 @@ describe("hubFetch /vault/<name>/* dynamic proxy (#144)", () => {
       fetch: async (req) => {
         const u = new URL(req.url);
         // Echo enough metadata for tests to verify path + method + body
-        // arrive intact end-to-end.
+        // arrive intact end-to-end. Also echo X-Forwarded-* headers so
+        // tests can assert hub forwards proxy hints (hub#358).
         const body = req.body ? await req.text() : "";
         return new Response(
           JSON.stringify({
@@ -1399,6 +1400,8 @@ describe("hubFetch /vault/<name>/* dynamic proxy (#144)", () => {
             pathname: u.pathname,
             search: u.search,
             body,
+            forwardedHost: req.headers.get("x-forwarded-host"),
+            forwardedProto: req.headers.get("x-forwarded-proto"),
           }),
           { status: 200, headers: { "content-type": "application/json" } },
         );
@@ -1408,6 +1411,87 @@ describe("hubFetch /vault/<name>/* dynamic proxy (#144)", () => {
     // returns synchronously with the bound port — non-null assertion is safe.
     return { port: server.port as number, stop: () => server.stop(true) };
   }
+
+  test("forwards X-Forwarded-Host + X-Forwarded-Proto to upstream (hub#358)", async () => {
+    // Container deploys: supervised modules (vault, scribe, app) reverse-
+    // proxy through hub. They need the public origin to construct OAuth
+    // discovery metadata and redirect URIs. Without forwarded headers,
+    // they fall back to their internal loopback URL — breaking OAuth
+    // flows for clients that landed on a hub-proxied URL.
+    const h = makeHarness();
+    const upstream = startUpstream("hdr-test");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: upstream.port,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      // Simulate Render-shape: page came in over HTTPS at parachute-hub.onrender.com
+      // Render terminates TLS and sets X-Forwarded-Proto: https; the Host
+      // header is preserved as the public hostname.
+      const incoming = new Request("http://parachute-hub.onrender.com/vault/default/.well-known/oauth-authorization-server", {
+        headers: {
+          host: "parachute-hub.onrender.com",
+          "x-forwarded-proto": "https",
+        },
+      });
+      const res = await fetcher(incoming);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { forwardedHost: string; forwardedProto: string };
+      // Hub captured the public Host and forwarded it as X-Forwarded-Host.
+      expect(body.forwardedHost).toBe("parachute-hub.onrender.com");
+      // X-Forwarded-Proto preserved (edge already set it).
+      expect(body.forwardedProto).toBe("https");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("synthesizes X-Forwarded-Proto when edge didn't set it (direct HTTPS to hub)", async () => {
+    // Non-Render shape: hub bound directly to https (e.g. local TLS or a
+    // proxy that doesn't set X-Forwarded-Proto). isHttpsRequest sees the
+    // URL's https scheme; proxyRequest synthesizes X-Forwarded-Proto.
+    const h = makeHarness();
+    const upstream = startUpstream("hdr-test");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: upstream.port,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const incoming = new Request("https://hub.example.com/vault/default/health", {
+        headers: { host: "hub.example.com" },
+      });
+      const res = await fetcher(incoming);
+      const body = (await res.json()) as { forwardedHost: string; forwardedProto: string };
+      expect(body.forwardedHost).toBe("hub.example.com");
+      expect(body.forwardedProto).toBe("https");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
 
   test("proxies a /vault/<name>/* request to the matching upstream", async () => {
     const h = makeHarness();

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -1493,6 +1493,83 @@ describe("hubFetch /vault/<name>/* dynamic proxy (#144)", () => {
     }
   });
 
+  test("synthesizes X-Forwarded-Proto=http when neither edge nor URL signal HTTPS", async () => {
+    // Plain-HTTP path: no edge, no https URL scheme. isHttpsRequest returns
+    // false; proxyRequest synthesizes "http". This is local-dev shape.
+    const h = makeHarness();
+    const upstream = startUpstream("hdr-test");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: upstream.port,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const incoming = new Request("http://127.0.0.1:1939/vault/default/health", {
+        headers: { host: "127.0.0.1:1939" },
+      });
+      const res = await fetcher(incoming);
+      const body = (await res.json()) as { forwardedProto: string };
+      expect(body.forwardedProto).toBe("http");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("preserves X-Forwarded-Host when edge already set it (nested-proxy chain)", async () => {
+    // Multi-hop chain: client → edge proxy → hub → upstream. Edge captures
+    // the original host as X-Forwarded-Host before its own host-rewrite;
+    // hub MUST preserve that, not overwrite with its own incoming Host
+    // (which may be the edge's hostname). "Don't clobber" semantics.
+    const h = makeHarness();
+    const upstream = startUpstream("hdr-test");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: upstream.port,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      // Edge already labeled the canonical hop: original-client.example
+      // (this is what an HTTPS termination proxy in front of hub would set).
+      const incoming = new Request("http://edge.local/vault/default/health", {
+        headers: {
+          host: "edge.local",
+          "x-forwarded-host": "original-client.example",
+          "x-forwarded-proto": "https",
+        },
+      });
+      const res = await fetcher(incoming);
+      const body = (await res.json()) as { forwardedHost: string; forwardedProto: string };
+      // Edge's X-Forwarded-Host preserved verbatim, NOT clobbered by the
+      // edge.local Host that hub itself saw.
+      expect(body.forwardedHost).toBe("original-client.example");
+      expect(body.forwardedProto).toBe("https");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
   test("proxies a /vault/<name>/* request to the matching upstream", async () => {
     const h = makeHarness();
     const upstream = startUpstream("default-vault");

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -972,11 +972,16 @@ export function resolveIssuer(
   // The `isHttpsRequest` helper is the canonical place where this trust
   // is established (also used for the Secure cookie attribute).
   //
-  // We do NOT honor X-Forwarded-Host. Render, Tailscale Funnel, and
-  // cloudflared all preserve the Host header end-to-end, so `req.url`'s
-  // host already reflects the public hostname. Operators on a proxy that
-  // rewrites Host (some nginx / Caddy configs) should set hub_origin via
-  // the admin SPA — that path bypasses this fallback entirely.
+  // We do NOT honor X-Forwarded-Host *for hub's own issuer derivation*.
+  // (Note: hub DOES forward X-Forwarded-Host to upstream supervised
+  // modules in `proxyRequest` — that's a separate concern, see #358.
+  // Here we're deriving hub's own canonical origin from the incoming
+  // request, not what to tell downstream services.) Render, Tailscale
+  // Funnel, and cloudflared all preserve the Host header end-to-end,
+  // so `req.url`'s host already reflects the public hostname.
+  // Operators on a proxy that rewrites Host (some nginx / Caddy
+  // configs) should set hub_origin via the admin SPA — that path
+  // bypasses this fallback entirely.
   const url = new URL(req.url);
   if (isHttpsRequest(req)) {
     url.protocol = "https:";

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -418,9 +418,28 @@ async function proxyRequest(
   const path = targetPath ?? url.pathname;
   const upstream = `http://127.0.0.1:${port}${path}${url.search}`;
   const headers = new Headers(req.headers);
+  // Capture the public hostname BEFORE deleting Host so we can forward it
+  // as X-Forwarded-Host (hub#358). Without this, supervised modules like
+  // vault see no X-Forwarded-Host header and fall back to their internal
+  // loopback URL when constructing OAuth metadata — publishing
+  // `http://127.0.0.1:1940/...` as the issuer instead of the public origin.
+  const publicHost = req.headers.get("host");
   // Host comes from the requester (tailnet FQDN); the loopback target wants
   // its own. Bun's fetch fills it in when omitted.
   headers.delete("host");
+  // Forward the public origin so downstream services build their public-
+  // facing URLs (OAuth metadata, redirect URIs) against the same host the
+  // client used. We DON'T overwrite X-Forwarded-Host if already set —
+  // some platforms (Render) set it at the edge.
+  if (publicHost && !headers.has("x-forwarded-host")) {
+    headers.set("x-forwarded-host", publicHost);
+  }
+  // Same for protocol — if the edge set X-Forwarded-Proto we preserve it,
+  // otherwise we set it from isHttpsRequest's signal (direct HTTPS to hub
+  // is unusual on Render, but covers local TLS-terminating proxies too).
+  if (!headers.has("x-forwarded-proto")) {
+    headers.set("x-forwarded-proto", isHttpsRequest(req) ? "https" : "http");
+  }
 
   const init: RequestInit & { duplex?: "half" } = {
     method: req.method,


### PR DESCRIPTION
## Summary

After the PORT chain (#356, #357) got vault running cleanly on Aaron's Render deploy, I probed vault's OAuth metadata through hub:

```
$ curl https://parachute-hub.onrender.com/vault/default/.well-known/oauth-authorization-server
{
  "issuer": "http://127.0.0.1:1940/vault/default",
  "authorization_endpoint": "http://127.0.0.1:1940/vault/default/oauth/authorize",
  ...
}
```

Vault publishes loopback URLs as the issuer. Any OAuth flow that touches the metadata (notes app fetching `/oauth/authorize` for vault) would redirect to an internal address.

## Root cause

Hub's `proxyRequest`:

```typescript
const headers = new Headers(req.headers);
headers.delete("host");  // ✓ correct: upstream wants its own
// ❌ never sets X-Forwarded-Host or X-Forwarded-Proto
```

Vault's `getBaseUrl` (in oauth.ts) DOES honor X-Forwarded-Host + X-Forwarded-Proto correctly — but hub never forwards them, so vault falls back to `new URL(req.url).origin` which is the internal loopback URL.

## Fix

`proxyRequest` now captures `req.headers.get("host")` BEFORE deleting it, then sets `X-Forwarded-Host` (only if upstream chain hasn't already set it). Also synthesizes `X-Forwarded-Proto` from `isHttpsRequest` when the edge didn't already set it.

```typescript
const publicHost = req.headers.get("host");
headers.delete("host");
if (publicHost && !headers.has("x-forwarded-host")) {
  headers.set("x-forwarded-host", publicHost);
}
if (!headers.has("x-forwarded-proto")) {
  headers.set("x-forwarded-proto", isHttpsRequest(req) ? "https" : "http");
}
```

The "don't overwrite if already set" semantics matter — Render's edge already sets X-Forwarded-Proto: https; we preserve that.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test ./src` — 1930 pass / 0 fail (+2 new tests, 1928 → 1930)
- [x] Two new tests:
  - Render shape: preserves edge's X-Forwarded-Proto, adds X-Forwarded-Host from Host
  - Direct HTTPS shape: synthesizes X-Forwarded-Proto from request URL
- [ ] After merge + Render auto-deploy: re-probe vault's OAuth metadata via the hub-proxied URL — issuer should be `https://parachute-hub.onrender.com/vault/default`

## Bumps 0.5.13-rc.31 → 0.5.13-rc.32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)