### PR TITLE
feat(hub): tag-triggered release workflow — npm + ghcr.io publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,144 @@
+# Release workflow — triggered by pushing a semver tag.
+#
+# Tag conventions (matches parachute-patterns governance rule 2):
+#   - rc:     v<X>.<Y>.<Z>-rc.<N>   (e.g. v0.5.13-rc.32)
+#   - stable: v<X>.<Y>.<Z>          (e.g. v0.5.13)
+#
+# Release flow:
+#   1. Code-touching PR merges to main, bumping `version` in package.json
+#      (rc.N → rc.N+1 for the rc chain; or drop -rc.N suffix for stable).
+#   2. After merge, push a matching tag:
+#        git tag v$(grep '"version"' package.json | cut -d'"' -f4) && git push --tags
+#   3. CI runs tests, then publishes in parallel to:
+#        - npm        (with provenance attestation, dist-tag = rc or latest)
+#        - ghcr.io    (multi-tagged: :rc / :stable / :vX.Y.Z[-rc.N])
+#
+# Operator setup (one-time):
+#   - npmjs.com → Access Tokens → New Token (Automation) → scope @openparachute/*
+#   - Add as `NPM_TOKEN` repo secret in GitHub settings
+#   - ghcr.io needs no secret (uses the runner's GITHUB_TOKEN)
+#
+# Why tag-triggered (not push-to-main):
+#   - tag = explicit release signal; main commits without a tag don't publish.
+#   - Preserves a deliberate gate (you push the tag when you mean to ship).
+#   - Tag-as-canonical means the tag itself is the audit trail of what was
+#     released and when.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+
+concurrency:
+  # Don't let two releases race on the same tag.
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+      - name: install deps
+        run: bun install --frozen-lockfile
+      - name: typecheck
+        run: bun run typecheck
+      - name: hub tests
+        run: bun test ./src
+
+  publish-npm:
+    name: publish to npm
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for npm provenance attestation.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+      - name: install deps
+        run: bun install --frozen-lockfile
+      - name: build SPA
+        # Builds web/ui/dist which is referenced in package.json "files"
+        # — the npm tarball needs it.
+        run: bun run build:spa
+      - name: verify package.json version matches tag
+        # Defense against tag-vs-package.json drift. If they don't match,
+        # we'd publish under the wrong version.
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::package.json version ($PKG_VERSION) doesn't match tag ($TAG_VERSION)"
+            exit 1
+          fi
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - name: publish
+        run: |
+          # Detect rc vs stable from tag name. Tag pattern in `on:` above
+          # enforces the shape, so this is just disambiguation.
+          if [[ "$GITHUB_REF_NAME" =~ -rc\. ]]; then
+            DIST_TAG=rc
+          else
+            DIST_TAG=latest
+          fi
+          echo "publishing with dist-tag=$DIST_TAG"
+          npm publish --tag "$DIST_TAG" --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-image:
+    name: publish to ghcr.io
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for ghcr.io push via GITHUB_TOKEN.
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: derive tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # Image name MUST be lowercase per OCI convention. The org slug
+          # ParachuteComputer is mixed-case on github, hence the explicit
+          # lowercase here.
+          images: ghcr.io/parachutecomputer/parachute-hub
+          tags: |
+            type=ref,event=tag
+            type=raw,value=rc,enable=${{ contains(github.ref_name, '-rc.') }}
+            type=raw,value=stable,enable=${{ !contains(github.ref_name, '-rc.') }}
+      - name: build + push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Single-arch is fine for now — Render runs linux/amd64. Add
+          # linux/arm64 later if cloud targets need it.
+          platforms: linux/amd64
+          # Layer cache via GitHub Actions cache so subsequent builds are
+          # fast (typically ~30s warm vs ~3min cold).
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # Release workflow — triggered by pushing a semver tag.
 #
 # Tag conventions (matches parachute-patterns governance rule 2):
-#   - rc:     v<X>.<Y>.<Z>-rc.<N>   (e.g. v0.5.13-rc.32)
+#   - rc:     v<X>.<Y>.<Z>-rc.<N>   (e.g. v0.5.13-rc.33)
 #   - stable: v<X>.<Y>.<Z>          (e.g. v0.5.13)
 #
 # Release flow:
@@ -66,12 +66,12 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
       - name: install deps
         run: bun install --frozen-lockfile
-      - name: build SPA
-        # Builds web/ui/dist which is referenced in package.json "files"
-        # — the npm tarball needs it.
-        run: bun run build:spa
       - name: verify package.json version matches tag
         # Defense against tag-vs-package.json drift. If they don't match,
         # we'd publish under the wrong version.
@@ -82,11 +82,10 @@ jobs:
             echo "::error::package.json version ($PKG_VERSION) doesn't match tag ($TAG_VERSION)"
             exit 1
           fi
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
       - name: publish
+        # `npm publish` runs the `prepack` script in package.json, which
+        # already does `bun run build:spa` — so web/ui/dist is built
+        # before the tarball is assembled. No explicit build step needed.
         run: |
           # Detect rc vs stable from tag name. Tag pattern in `on:` above
           # enforces the shape, so this is just disambiguation.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,82 @@
+# Releasing `@openparachute/hub`
+
+Releases are automated via [`.github/workflows/release.yml`](./.github/workflows/release.yml). Pushing a git tag triggers CI which:
+
+1. Runs `bun run typecheck` + `bun test ./src`
+2. Publishes to npm (with provenance attestation)
+3. Builds + pushes a container image to `ghcr.io/parachutecomputer/parachute-hub`
+
+## Tag conventions
+
+Per [parachute-patterns governance rule 2](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md):
+
+| Tag shape | Example | npm `dist-tag` | ghcr tags |
+|---|---|---|---|
+| `vX.Y.Z-rc.N` | `v0.5.13-rc.33` | `rc` | `:v0.5.13-rc.33`, `:rc` |
+| `vX.Y.Z` | `v0.5.13` | `latest` | `:v0.5.13`, `:stable` |
+
+The workflow auto-detects rc vs stable from the tag string (`-rc.` substring).
+
+## Release flow
+
+### For an rc bump (each code-touching PR merge)
+
+After your PR merges to `main` with a bumped `rc.N`:
+
+```sh
+git fetch && git checkout main && git pull --ff-only
+VERSION="v$(node -p "require('./package.json').version")"
+git tag "$VERSION"
+git push origin "$VERSION"
+```
+
+CI takes over from there — watch the run at [Actions](https://github.com/ParachuteComputer/parachute-hub/actions).
+
+### Promoting an rc chain to stable
+
+When the rc chain is ready to release:
+
+1. Open a PR that drops the `-rc.N` suffix from `package.json` (e.g. `0.5.13-rc.33` → `0.5.13`).
+2. Reviewer + merge as usual.
+3. Tag the merged commit with the bare version: `git tag v0.5.13 && git push origin v0.5.13`.
+4. CI publishes with `dist-tag=latest` and `ghcr` tag `:stable`.
+
+### Doc-only PRs
+
+Skip the rc chain per governance — bump straight to the next patch (e.g. `0.5.13` → `0.5.14`), tag, ship. No rc.N for docs.
+
+## One-time setup (operator)
+
+Before the workflow can publish, this repo needs:
+
+1. **`NPM_TOKEN` secret**: log into npmjs.com → Access Tokens → New Token (type: **Automation**) → scope to `@openparachute/*` packages. Add as `NPM_TOKEN` in [repo settings → Secrets and variables → Actions](https://github.com/ParachuteComputer/parachute-hub/settings/secrets/actions).
+
+2. **ghcr.io permissions**: no secret needed — the workflow uses the runner's auto-provisioned `GITHUB_TOKEN`. First push of the image will create the package; you may want to make it public under [package settings](https://github.com/orgs/ParachuteComputer/packages/container/parachute-hub/settings) once it lands.
+
+## Verifying a release
+
+```sh
+# npm
+npm view @openparachute/hub@<version> dist.tarball
+npm view @openparachute/hub dist-tags
+
+# ghcr
+docker pull ghcr.io/parachutecomputer/parachute-hub:<tag>
+docker inspect ghcr.io/parachutecomputer/parachute-hub:<tag> | jq '.[].Config.Labels'
+```
+
+The npm tarball page links to the GitHub Actions run that produced it (provenance attestation).
+
+## Rolling back
+
+There's no "unpublish" path for either npm (npm has a strict 72-hour unpublish policy that you should avoid for published packages anyway) or ghcr (containers are append-only). To roll back:
+
+- Cut a new patch from a known-good commit (e.g. `0.5.13` → `0.5.14` reverting the bad change).
+- Optionally republish the previous `:stable` ghcr tag onto the older image by pushing under the new tag locally and `docker push`-ing.
+
+## Troubleshooting
+
+- **Workflow doesn't trigger**: confirm the tag matches the workflow's `on.push.tags` pattern (`v[0-9]+.[0-9]+.[0-9]+` or `v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+`).
+- **`version mismatch` error in publish-npm**: package.json version differs from the tag. Re-tag the correct commit.
+- **`npm ERR! 403`**: `NPM_TOKEN` secret missing, expired, or has wrong scope. Regenerate.
+- **ghcr push fails with 403**: confirm `permissions.packages: write` is in the workflow (it is).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,7 +43,9 @@ When the rc chain is ready to release:
 
 ### Doc-only PRs
 
-Skip the rc chain per governance — bump straight to the next patch (e.g. `0.5.13` → `0.5.14`), tag, ship. No rc.N for docs.
+Per governance, doc-only PRs are EXEMPT from rc.N bumping — they merge without a version bump and get picked up by the next code-touching PR's rc bump (or by the stable promotion, whichever comes first). Don't fragment a release into many patch bumps mid-validation.
+
+If you DO need to ship a doc-only fix outside an active rc chain (i.e. main is on a stable version with no rc.N in flight), bump the next patch (`0.5.13` → `0.5.14`), tag, ship.
 
 ## One-time setup (operator)
 
@@ -51,7 +53,7 @@ Before the workflow can publish, this repo needs:
 
 1. **`NPM_TOKEN` secret**: log into npmjs.com → Access Tokens → New Token (type: **Automation**) → scope to `@openparachute/*` packages. Add as `NPM_TOKEN` in [repo settings → Secrets and variables → Actions](https://github.com/ParachuteComputer/parachute-hub/settings/secrets/actions).
 
-2. **ghcr.io permissions**: no secret needed — the workflow uses the runner's auto-provisioned `GITHUB_TOKEN`. First push of the image will create the package; you may want to make it public under [package settings](https://github.com/orgs/ParachuteComputer/packages/container/parachute-hub/settings) once it lands.
+2. **ghcr.io permissions**: no secret needed — the workflow uses the runner's auto-provisioned `GITHUB_TOKEN`. First push of the image will create the package as **private by default**. After that first push, go to [package settings](https://github.com/orgs/ParachuteComputer/packages/container/parachute-hub/settings) → "Change visibility" → **Public**. Until you do this, any deploy target that pulls the image (Render, etc.) will 403 on `docker pull` unless you supply a `GHCR_PAT` read token. Doing it once at first-push time is the simplest path.
 
 ## Verifying a release
 
@@ -72,7 +74,12 @@ The npm tarball page links to the GitHub Actions run that produced it (provenanc
 There's no "unpublish" path for either npm (npm has a strict 72-hour unpublish policy that you should avoid for published packages anyway) or ghcr (containers are append-only). To roll back:
 
 - Cut a new patch from a known-good commit (e.g. `0.5.13` → `0.5.14` reverting the bad change).
-- Optionally republish the previous `:stable` ghcr tag onto the older image by pushing under the new tag locally and `docker push`-ing.
+- Optionally re-point `:stable` ghcr tag to an older image so existing deploys pull the safe version. If you've already pruned the older image locally, pull it first:
+  ```sh
+  docker pull ghcr.io/parachutecomputer/parachute-hub:v0.5.10
+  docker tag ghcr.io/parachutecomputer/parachute-hub:v0.5.10 ghcr.io/parachutecomputer/parachute-hub:stable
+  docker push ghcr.io/parachutecomputer/parachute-hub:stable
+  ```
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.32",
+  "version": "0.5.13-rc.33",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Adds tag-triggered CI release for hub. Pushing `vX.Y.Z[-rc.N]` triggers:

1. **test job** — bun typecheck + 1932 hub tests
2. **publish-npm** — `bun run build:spa` then `npm publish` with provenance attestation. dist-tag auto-detected from tag string (`-rc.` → `rc`, else `latest`).
3. **publish-image** — builds the Dockerfile, pushes to `ghcr.io/parachutecomputer/parachute-hub` with tags `:rc` / `:stable` / `:vX.Y.Z[-rc.N]`.

## Why tag-triggered (not push-to-main)

- Tag = explicit release signal; main commits without a tag don't publish
- Tag itself becomes the audit trail of what was released and when
- Preserves a human gate (push the tag when you mean to ship) without the per-publish 2FA prompt that gates remote work — releases now ship from anywhere

## Why ghcr.io alongside npm

- Sets up infrastructure for image-based Render deploys later (image-pinned `:stable` and `:rc` tags exist automatically) without committing to that path now
- Provenance attestation gives auditable supply chain (npm tarball page links to the GitHub Actions run that produced it)
- Free for public images, integrated with the runner's auto-provisioned GITHUB_TOKEN — no secret to manage

## One-time setup needed before first tag push

1. **`NPM_TOKEN` secret**: npmjs.com → Access Tokens → New Token (type: **Automation**) → scope to `@openparachute/*`. Add as `NPM_TOKEN` in [repo Settings → Secrets and variables → Actions](https://github.com/ParachuteComputer/parachute-hub/settings/secrets/actions).
2. **ghcr permissions**: none — uses the runner's `GITHUB_TOKEN`. First image push auto-creates the package; you may want to set it public via [package settings](https://github.com/orgs/ParachuteComputer/packages/container/parachute-hub/settings) afterward.

## First release after merge

```sh
git fetch && git checkout main && git pull --ff-only
VERSION="v$(node -p "require('./package.json').version")"
git tag "$VERSION"   # v0.5.13-rc.33
git push origin "$VERSION"
```

Watch the run at [Actions](https://github.com/ParachuteComputer/parachute-hub/actions). On success, verify:

```sh
npm view @openparachute/hub@0.5.13-rc.33 dist.tarball   # provenance link in output
docker pull ghcr.io/parachutecomputer/parachute-hub:rc
```

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test ./src`: 1932 pass / 0 fail (unchanged from rc.32 — workflow is additive)
- [x] YAML parses; tag patterns match v0.5.13-rc.33, v0.5.13, v1.0.0; reject v1, v1.2.3-rc.foo, v0.5.13-beta.1
- [ ] After merge + NPM_TOKEN added: push test tag, verify npm + ghcr both publish

## Follow-up (separate PRs)

- patterns: add `patterns/release-ci.md` documenting the workflow shape; update `patterns/governance.md` rule 2 to reflect CI-driven publishing
- Roll same workflow out to vault / scribe / app / runner (each with its own NPM_TOKEN secret)

## Bumps 0.5.13-rc.32 → 0.5.13-rc.33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)