### PR TITLE
feat(hub): release.yml — add scope-guard publish path on `scope-guard-v*` tag prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,11 @@ jobs:
         run: bun run typecheck
       - name: hub tests
         run: bun test ./src
+      - name: scope-guard tests
+        # Run both suites regardless of tag prefix — small extra cost (~1s)
+        # for the safety of catching scope-guard regressions before
+        # publishing scope-guard.
+        run: bun test ./packages/scope-guard/src
 
   publish-hub-npm:
     name: publish hub to npm
@@ -132,7 +137,10 @@ jobs:
       id-token: write
     defaults:
       run:
-        # All shell steps run from the scope-guard package dir.
+        # All shell steps default to the scope-guard package dir. Steps
+        # that need to run from the repo root explicitly override
+        # `working-directory: ${{ github.workspace }}` (e.g. the workspace
+        # install below).
         working-directory: packages/scope-guard
     steps:
       - uses: actions/checkout@v4
@@ -145,9 +153,9 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - name: install deps
-        # Install at workspace root so hoisted deps resolve; scope-guard
-        # is a workspace package.
-        working-directory: .
+        # Install at workspace root so hoisted deps resolve. Override the
+        # job's default working-directory.
+        working-directory: ${{ github.workspace }}
         run: bun install --frozen-lockfile
       - name: verify package.json version matches tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,38 +1,49 @@
 # Release workflow — triggered by pushing a semver tag.
 #
+# This workflow publishes TWO packages on different tag namespaces:
+#
+#   - @openparachute/hub          ← tag prefix `v...`            (e.g. v0.5.13-rc.33)
+#   - @openparachute/scope-guard  ← tag prefix `scope-guard-v...` (e.g. scope-guard-v0.4.0-rc.2)
+#
+# Both packages have npm Trusted Publisher rules pointing at this workflow
+# file. The jobs below gate on the tag prefix so only one package publishes
+# per tag push. Independent release cadences; hub doesn't have to bump when
+# scope-guard ships and vice versa.
+#
 # Tag conventions (matches parachute-patterns governance rule 2):
 #   - rc:     v<X>.<Y>.<Z>-rc.<N>   (e.g. v0.5.13-rc.33)
+#                                    (scope-guard-v0.4.0-rc.2)
 #   - stable: v<X>.<Y>.<Z>          (e.g. v0.5.13)
+#                                    (scope-guard-v0.4.0)
 #
 # Release flow:
-#   1. Code-touching PR merges to main, bumping `version` in package.json
-#      (rc.N → rc.N+1 for the rc chain; or drop -rc.N suffix for stable).
-#   2. After merge, push a matching tag:
-#        git tag v$(grep '"version"' package.json | cut -d'"' -f4) && git push --tags
-#   3. CI runs tests, then publishes in parallel to:
-#        - npm        (with provenance attestation, dist-tag = rc or latest)
-#        - ghcr.io    (multi-tagged: :rc / :stable / :vX.Y.Z[-rc.N])
+#   1. When ready to ship: bump version in the relevant package.json on main
+#      (root for hub, packages/scope-guard/ for scope-guard).
+#   2. Push a matching tag:
+#        # for hub
+#        git tag v$(bun -e "console.log(require('./package.json').version)") && git push --tags
+#        # for scope-guard
+#        git tag scope-guard-v$(bun -e "console.log(require('./packages/scope-guard/package.json').version)") && git push --tags
+#   3. CI runs tests once (workspace-wide), then publishes the package matching
+#      the tag prefix. Hub also publishes a container image to ghcr.io.
 #
-# Operator setup (one-time) — see RELEASING.md for the full walkthrough:
-#   - npm Trusted Publisher: npmjs.com → @openparachute/hub → Settings →
-#     Trusted Publishers → add GitHub Actions rule (org=ParachuteComputer,
-#     repo=parachute-hub, workflow=release.yml, env blank). OIDC-based;
-#     no NPM_TOKEN secret needed.
+# Operator setup (one-time) — see RELEASING.md:
+#   - npm Trusted Publisher rules: one per package (hub, scope-guard).
+#     Both rules point at: org=ParachuteComputer, repo=parachute-hub,
+#     workflow=release.yml, env blank.
 #   - ghcr.io needs no secret (uses the runner's GITHUB_TOKEN).
-#
-# Why tag-triggered (not push-to-main):
-#   - tag = explicit release signal; main commits without a tag don't publish.
-#   - Preserves a deliberate gate (you push the tag when you mean to ship).
-#   - Tag-as-canonical means the tag itself is the audit trail of what was
-#     released and when.
 
 name: Release
 
 on:
   push:
     tags:
+      # Hub release tags
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+      # scope-guard release tags
+      - 'scope-guard-v[0-9]+.[0-9]+.[0-9]+'
+      - 'scope-guard-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
 
 concurrency:
   # Don't let two releases race on the same tag.
@@ -55,9 +66,11 @@ jobs:
       - name: hub tests
         run: bun test ./src
 
-  publish-npm:
-    name: publish to npm
+  publish-hub-npm:
+    name: publish hub to npm
     needs: test
+    # Hub-only: skip on scope-guard tags.
+    if: ${{ !startsWith(github.ref_name, 'scope-guard-') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -108,9 +121,58 @@ jobs:
           echo "publishing with dist-tag=$DIST_TAG"
           npm publish --tag "$DIST_TAG" --access public --provenance
 
+  publish-scope-guard-npm:
+    name: publish scope-guard to npm
+    needs: test
+    # scope-guard-only: skip on hub (`v*`) tags.
+    if: ${{ startsWith(github.ref_name, 'scope-guard-') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        # All shell steps run from the scope-guard package dir.
+        working-directory: packages/scope-guard
+    steps:
+      - uses: actions/checkout@v4
+        # checkout has no working-directory option; runs from repo root.
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      - name: install deps
+        # Install at workspace root so hoisted deps resolve; scope-guard
+        # is a workspace package.
+        working-directory: .
+        run: bun install --frozen-lockfile
+      - name: verify package.json version matches tag
+        run: |
+          PKG_VERSION=$(bun -e "console.log(require('./package.json').version)")
+          # Strip the `scope-guard-v` prefix from the tag.
+          TAG_VERSION="${GITHUB_REF_NAME#scope-guard-v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::packages/scope-guard/package.json version ($PKG_VERSION) doesn't match tag ($TAG_VERSION)"
+            exit 1
+          fi
+      - name: publish
+        run: |
+          if [[ "$GITHUB_REF_NAME" =~ -rc\. ]]; then
+            DIST_TAG=rc
+          else
+            DIST_TAG=latest
+          fi
+          echo "publishing @openparachute/scope-guard with dist-tag=$DIST_TAG"
+          npm publish --tag "$DIST_TAG" --access public --provenance
+
   publish-image:
     name: publish to ghcr.io
     needs: test
+    # Hub-only: scope-guard doesn't ship a container image.
+    if: ${{ !startsWith(github.ref_name, 'scope-guard-') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,65 +1,74 @@
-# Releasing `@openparachute/hub`
+# Releasing from `parachute-hub`
 
-Releases are automated via [`.github/workflows/release.yml`](./.github/workflows/release.yml). Pushing a git tag triggers CI which:
+This repo publishes TWO npm packages on independent release cadences via [`.github/workflows/release.yml`](./.github/workflows/release.yml):
 
-1. Runs `bun run typecheck` + `bun test ./src`
-2. Publishes to npm (with provenance attestation)
-3. Builds + pushes a container image to `ghcr.io/parachutecomputer/parachute-hub`
+| Package | Tag prefix | Container image |
+|---|---|---|
+| `@openparachute/hub` | `v...` (e.g. `v0.5.13-rc.33`) | yes — `ghcr.io/parachutecomputer/parachute-hub` |
+| `@openparachute/scope-guard` | `scope-guard-v...` (e.g. `scope-guard-v0.4.0`) | no |
+
+Pushing a tag triggers CI which runs `bun run typecheck` + `bun test ./src`, then publishes the package matching the tag prefix.
 
 ## Tag conventions
 
 Per [parachute-patterns governance rule 2](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md):
 
-| Tag shape | Example | npm `dist-tag` | ghcr tags |
+| Tag shape | Example | npm `dist-tag` | ghcr image tags (hub only) |
 |---|---|---|---|
 | `vX.Y.Z-rc.N` | `v0.5.13-rc.33` | `rc` | `:v0.5.13-rc.33`, `:rc` |
 | `vX.Y.Z` | `v0.5.13` | `latest` | `:v0.5.13`, `:stable` |
+| `scope-guard-vX.Y.Z-rc.N` | `scope-guard-v0.4.0-rc.2` | `rc` | — |
+| `scope-guard-vX.Y.Z` | `scope-guard-v0.4.0` | `latest` | — |
 
-The workflow auto-detects rc vs stable from the tag string (`-rc.` substring).
+The workflow auto-detects rc vs stable from the `-rc.` substring in the tag.
 
 ## Release flow
 
-### For an rc bump (each code-touching PR merge)
+Per [governance rule 2 (updated 2026-05-24)](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md), PRs do NOT bump version per-commit. Bump + tag together only when you intend to ship.
 
-After your PR merges to `main` with a bumped `rc.N`:
+### Releasing hub
 
 ```sh
 git fetch && git checkout main && git pull --ff-only
-VERSION="v$(node -p "require('./package.json').version")"
+# Bump the version in ./package.json (rc.N or drop -rc for stable), commit, push.
+VERSION="v$(bun -e "console.log(require('./package.json').version)")"
 git tag "$VERSION"
 git push origin "$VERSION"
 ```
 
-CI takes over from there — watch the run at [Actions](https://github.com/ParachuteComputer/parachute-hub/actions).
+CI takes over — watch the run at [Actions](https://github.com/ParachuteComputer/parachute-hub/actions). On success:
+- npm gets the new version with appropriate dist-tag
+- ghcr gets a new image at `:vX.Y.Z` plus `:rc` or `:stable`
+
+### Releasing scope-guard
+
+```sh
+git fetch && git checkout main && git pull --ff-only
+# Bump the version in ./packages/scope-guard/package.json, commit, push.
+VERSION="scope-guard-v$(bun -e "console.log(require('./packages/scope-guard/package.json').version)")"
+git tag "$VERSION"
+git push origin "$VERSION"
+```
+
+The hub package is NOT republished. scope-guard runs on its own cadence.
 
 ### Promoting an rc chain to stable
 
-When the rc chain is ready to release:
-
-1. Open a PR that drops the `-rc.N` suffix from `package.json` (e.g. `0.5.13-rc.33` → `0.5.13`).
-2. Reviewer + merge as usual.
-3. Tag the merged commit with the bare version: `git tag v0.5.13 && git push origin v0.5.13`.
-4. CI publishes with `dist-tag=latest` and `ghcr` tag `:stable`.
+Open a PR (or commit directly) that drops the `-rc.N` suffix from the relevant `package.json`, merge, then tag the bare version. CI publishes with `dist-tag=latest`.
 
 ### Doc-only PRs
 
-Per governance, doc-only PRs are EXEMPT from rc.N bumping — they merge without a version bump and get picked up by the next code-touching PR's rc bump (or by the stable promotion, whichever comes first). Don't fragment a release into many patch bumps mid-validation.
-
-If you DO need to ship a doc-only fix outside an active rc chain (i.e. main is on a stable version with no rc.N in flight), bump the next patch (`0.5.13` → `0.5.14`), tag, ship.
+Per governance, doc-only PRs DO NOT bump version. They merge straight to main; the changes get folded into whatever the next ship-driven version bump captures.
 
 ## One-time setup (operator)
 
 Before the workflow can publish, this repo needs:
 
-1. **npm Trusted Publisher**: log into npmjs.com → package `@openparachute/hub` → Settings → Trusted Publishers → "Add a new publisher" → choose **GitHub Actions**. Fill:
-   - Organization: `ParachuteComputer`
-   - Repository name: `parachute-hub`
-   - Workflow filename: `release.yml`
-   - Environment name: (leave blank)
+1. **npm Trusted Publishers — one per published package**:
+   - npmjs.com → `@openparachute/hub` → Settings → Trusted Publishers → add GitHub Actions: `ParachuteComputer` / `parachute-hub` / `release.yml` / env blank
+   - npmjs.com → `@openparachute/scope-guard` → same Trusted Publisher (same org/repo/workflow/env)
 
-   No `NPM_TOKEN` secret needed — the workflow uses OIDC.
-
-   `@openparachute/scope-guard` ships from this same repo but **this workflow does not publish it today** — scope-guard's CI publish path is a follow-up (independent release cadence, separate tag-prefix convention). A Trusted Publisher rule for scope-guard pointing at `release.yml` is harmless (it just won't ever fire under this workflow) but unnecessary until that follow-up lands.
+   Both rules point at the SAME workflow file. The jobs gate on tag prefix to decide which package to publish. No `NPM_TOKEN` secret needed — the workflow uses OIDC.
 
 2. **ghcr.io permissions**: no secret needed — the workflow uses the runner's auto-provisioned `GITHUB_TOKEN`. First push of the image will create the package as **private by default**. After that first push, go to [package settings](https://github.com/orgs/ParachuteComputer/packages/container/parachute-hub/settings) → "Change visibility" → **Public**. Until you do this, any deploy target that pulls the image (Render, etc.) will 403 on `docker pull` unless you supply a `GHCR_PAT` read token. Doing it once at first-push time is the simplest path.
 
@@ -69,8 +78,9 @@ Before the workflow can publish, this repo needs:
 # npm
 npm view @openparachute/hub@<version> dist.tarball
 npm view @openparachute/hub dist-tags
+npm view @openparachute/scope-guard dist-tags
 
-# ghcr
+# ghcr (hub only)
 docker pull ghcr.io/parachutecomputer/parachute-hub:<tag>
 docker inspect ghcr.io/parachutecomputer/parachute-hub:<tag> | jq '.[].Config.Labels'
 ```
@@ -91,8 +101,9 @@ There's no "unpublish" path for either npm (npm has a strict 72-hour unpublish p
 
 ## Troubleshooting
 
-- **Workflow doesn't trigger**: confirm the tag matches the workflow's `on.push.tags` pattern (`v[0-9]+.[0-9]+.[0-9]+` or `v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+`).
-- **`version mismatch` error in publish-npm**: package.json version differs from the tag. Re-tag the correct commit.
+- **Workflow doesn't trigger**: confirm the tag matches one of the patterns in `on.push.tags` (hub: `v[0-9]+...`; scope-guard: `scope-guard-v[0-9]+...`).
+- **`version mismatch` error in publish-npm**: the relevant `package.json` version differs from the tag. Re-tag the correct commit, or fix the version in `package.json`.
 - **`npm ERR! 403 You do not have permission to publish`**: Trusted Publisher rule on npm doesn't match this workflow. Verify org/repo/workflow filename are exactly `ParachuteComputer` / `parachute-hub` / `release.yml`. If the workflow file was renamed, the rule needs updating on npm.
 - **`npm ERR! 401 Unauthorized` with no OIDC token**: the workflow is missing `permissions: id-token: write` at the job level. Verify the YAML.
-- **ghcr push fails with 403**: confirm `permissions.packages: write` is in the workflow (it is).
+- **ghcr push fails with 403**: confirm `permissions.packages: write` is in the publish-image job (it is).
+- **Two publish jobs running for the same tag**: the `if:` gates filter by `startsWith(github.ref_name, 'scope-guard-')` — verify the tag matches exactly one prefix.


### PR DESCRIPTION
## Summary

Extends the existing release workflow to handle `@openparachute/scope-guard` releases via a separate tag namespace. Independent cadences — bumping scope-guard doesn't bump hub and vice versa.

## How it works

Single workflow, two tag namespaces:

| Tag | Publishes | Image? |
|---|---|---|
| `v0.5.13-rc.33` | `@openparachute/hub` | yes |
| `v0.5.13` | `@openparachute/hub` | yes (`:stable`) |
| `scope-guard-v0.4.0-rc.2` | `@openparachute/scope-guard` | no |
| `scope-guard-v0.4.0` | `@openparachute/scope-guard` | no |

Jobs gate via `if: startsWith(github.ref_name, 'scope-guard-')`. Both packages have npm Trusted Publishers pointing at this SAME workflow file (`release.yml`) — npm's OIDC verification checks `workflow_ref`, not the tag, so one workflow file can validly publish multiple packages with independent Trusted Publisher rules.

## RELEASING.md rewritten

- Table of supported tag patterns + what each publishes
- Per-package release-flow snippets (hub vs scope-guard)
- One-time setup note: both packages need Trusted Publisher rules (Aaron already configured both per earlier guidance)
- Troubleshooting expanded for the dual-package shape

## Test plan

- [x] YAML parses cleanly
- [x] Tag patterns match `v0.5.13-rc.33`, `v0.5.13`, `scope-guard-v0.4.0`, `scope-guard-v0.4.0-rc.2`
- [x] Tag patterns reject `scope-guard-v0.4.0-rc` (malformed), `badtag`
- [ ] After merge: tag `scope-guard-v0.4.0-rc.2` (or whatever's next) and verify only the scope-guard publish job fires (hub jobs skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)