### PR TITLE
fix(hub): auto-detect RENDER_EXTERNAL_URL + propagate PARACHUTE_HUB_ORIGIN to supervised modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [0.5.13-rc.35] - 2026-05-25
+
+**fix(hub): Render-injected `RENDER_EXTERNAL_URL` now auto-detected as OAuth issuer + propagates to supervised modules — fixes `unexpected "iss" claim value` after wizard install.**
+
+The next bug Aaron hit after rc.34's chain landed: wizard install completed, then the first authed call to vault returned `401: hub JWT verification failed: unexpected "iss" claim value`. Hub minted JWTs with the public Render URL as `iss`; vault's `validateHubJwt` compared against `process.env.PARACHUTE_HUB_ORIGIN` (unset on the spawned child) and fell back to `http://127.0.0.1:1939` — mismatch, reject.
+
+### Fixed
+
+- **Hub auto-detects `RENDER_EXTERNAL_URL` at boot when no explicit issuer is configured** (hub#365). New `resolveStartupIssuer` helper in `commands/serve.ts` formalizes the precedence: `--issuer` flag > `PARACHUTE_HUB_ORIGIN` env > `RENDER_EXTERNAL_URL` env > undefined. Trailing slashes stripped; empty / bare-slash values collapse to undefined. Same precedence mirrored into `hub-server.ts`'s standalone-entrypoint `parseArgs` (the alternate boot path advertised by the Dockerfile comment), so both entry points behave identically on Render.
+
+- **Supervised modules now inherit `PARACHUTE_HUB_ORIGIN` from `deps.issuer`** (hub#365). `spawnSupervised` in `api-modules-ops.ts` (the install/restart spawn path) was missing this env-var propagation — siblings at the boot path (`bootSupervisedModules`) and lifecycle path (`lifecycle.start`) already had it from prior hub#357. Now all three spawn sites are symmetric: child vault/scribe/app processes see the same issuer string the hub itself uses to mint JWTs, so the `iss` claim round-trips correctly.
+
+### Patterns check
+
+- Reinforces the `bun-container-deploy.md` pattern (rc.34): platform-injected env vars (`PORT`, `RENDER_EXTERNAL_URL`, `X-Forwarded-*`) all need explicit propagation/derivation discipline. This is the third such gotcha in the chain (PORT → X-Forwarded-Host → iss origin); each one slipped past the others.
+- No new patterns introduced.
+
+### Verification
+
+- `bun run typecheck` clean.
+- `bun test ./src`: 1944 pass / 0 fail (+12 from rc.34 — 6 `resolveStartupIssuer` precedence tests in serve.test.ts, 1 `runInstall` propagation regression in api-modules-ops.test.ts, 5 `parseArgs` precedence tests in hub-server.test.ts).
+- Container smoke CI: ✓ on `3ccddf8`.
+- Operator workaround for pre-rc.35 deploys: set `PARACHUTE_HUB_ORIGIN` to the public URL in Render's Environment tab. After rc.35 picks up automatically — no manual config needed for the default Render path.
+
 ## [0.5.13-rc.34] - 2026-05-24
 
 **fix(hub): Render container deploy now fully functional end-to-end + tag-triggered release CI.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.34",
+  "version": "0.5.13-rc.35",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-modules-ops.test.ts
+++ b/src/__tests__/api-modules-ops.test.ts
@@ -1043,6 +1043,50 @@ describe("well-known regen after module ops", () => {
     expect(spawns[0]?.env?.PORT).toBe("1940");
   });
 
+  test("runInstall sets PARACHUTE_HUB_ORIGIN in child env from deps.issuer (hub#365)", async () => {
+    // Supervised modules (vault, scribe, app) validate the `iss` claim
+    // on hub-minted JWTs against PARACHUTE_HUB_ORIGIN. Without it, they
+    // fall back to a loopback default and reject any token whose iss is
+    // the public Render URL — surfaces as "hub JWT verification failed:
+    // unexpected 'iss' claim value" on the first authed vault call.
+    // Regression guard: install-path spawn carries the hub's resolved
+    // issuer as PARACHUTE_HUB_ORIGIN.
+    const { supervisor, spawns } = makeIdleSupervisor();
+    const { run } = alwaysOkRun();
+    const wkPath = join(h.dir, "well-known.json");
+    const install = fakeInstall("@openparachute/vault", {
+      name: "vault",
+      manifestName: "parachute-vault",
+      port: 1940,
+      paths: ["/vault/default"],
+      health: "/vault/default/health",
+    });
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const deps = {
+      db: h.db,
+      // Use the test's canonical ISSUER (matches the bearer's iss claim
+      // so handleInstall doesn't 401 — mintBearer always uses ISSUER).
+      // The assertion below verifies whatever issuer is on `deps` lands
+      // in the child's PARACHUTE_HUB_ORIGIN env.
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+      supervisor,
+      run,
+      findGlobalInstall: install.findGlobalInstall,
+      readModuleManifest: install.readModuleManifest,
+      wellKnownPath: wkPath,
+    };
+    await handleInstall(
+      postReq("/api/modules/vault/install", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      deps,
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(spawns.length).toBe(1);
+    expect(spawns[0]?.env?.PARACHUTE_HUB_ORIGIN).toBe(ISSUER);
+  });
+
   test("runInstall failure: bun add fails -> no well-known regen (no partial state)", async () => {
     const { supervisor } = makeIdleSupervisor();
     const wkPath = join(h.dir, "well-known.json");

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -5,7 +5,13 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { HUB_SVC, hubPortPath } from "../hub-control.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
-import { findServiceUpstream, findVaultUpstream, hubFetch, layerOf } from "../hub-server.ts";
+import {
+  findServiceUpstream,
+  findVaultUpstream,
+  hubFetch,
+  layerOf,
+  parseArgs,
+} from "../hub-server.ts";
 import { setNotesRedirectDisabled } from "../hub-settings.ts";
 import { clearNotesRedirectLogState } from "../notes-redirect.ts";
 import { pidPath } from "../process-state.ts";
@@ -3211,4 +3217,45 @@ describe("hub-server.ts startup PID/port registration (#148)", () => {
       rmSync(configDir, { recursive: true, force: true });
     }
   }, 10_000);
+});
+
+describe("parseArgs — issuer env precedence (hub#365)", () => {
+  test("--issuer flag wins over both env vars", () => {
+    const got = parseArgs(["--issuer", "https://flag.example"], {
+      PARACHUTE_HUB_ORIGIN: "https://env.example",
+      RENDER_EXTERNAL_URL: "https://render.example",
+    });
+    expect(got.issuer).toBe("https://flag.example");
+  });
+
+  test("PARACHUTE_HUB_ORIGIN wins over RENDER_EXTERNAL_URL", () => {
+    const got = parseArgs([], {
+      PARACHUTE_HUB_ORIGIN: "https://hub.example",
+      RENDER_EXTERNAL_URL: "https://render.example",
+    });
+    expect(got.issuer).toBe("https://hub.example");
+  });
+
+  test("RENDER_EXTERNAL_URL is used when no override (standalone Render boot)", () => {
+    const got = parseArgs([], { RENDER_EXTERNAL_URL: "https://app.onrender.com" });
+    expect(got.issuer).toBe("https://app.onrender.com");
+  });
+
+  test("trailing slashes are stripped from all three sources", () => {
+    expect(parseArgs(["--issuer", "https://x.example/"], {}).issuer).toBe("https://x.example");
+    expect(parseArgs([], { PARACHUTE_HUB_ORIGIN: "https://x.example///" }).issuer).toBe(
+      "https://x.example",
+    );
+    expect(parseArgs([], { RENDER_EXTERNAL_URL: "https://x.example/" }).issuer).toBe(
+      "https://x.example",
+    );
+  });
+
+  test("issuer is undefined when no source is set", () => {
+    expect(parseArgs([], {}).issuer).toBeUndefined();
+    expect(parseArgs([], { PARACHUTE_HUB_ORIGIN: "" }).issuer).toBeUndefined();
+    expect(parseArgs([], { RENDER_EXTERNAL_URL: "" }).issuer).toBeUndefined();
+    // Bare slash collapses to empty after strip — must not become "" issuer.
+    expect(parseArgs([], { RENDER_EXTERNAL_URL: "/" }).issuer).toBeUndefined();
+  });
 });

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -6,6 +6,7 @@ import { _resetBootstrapTokenForTests, getBootstrapToken } from "../bootstrap-to
 import {
   formatBootstrapTokenBanner,
   formatListeningBanner,
+  resolveStartupIssuer,
   seedInitialAdminIfNeeded,
 } from "../commands/serve.ts";
 import { openHubDb } from "../hub-db.ts";
@@ -243,5 +244,68 @@ describe("bootstrap-token wiring under needs-setup", () => {
     );
     expect(result).toBe("seeded");
     expect(getBootstrapToken()).toBeUndefined();
+  });
+});
+
+describe("resolveStartupIssuer — precedence chain (hub#365)", () => {
+  test("explicit opts.issuer wins over everything", () => {
+    const got = resolveStartupIssuer(
+      { issuer: "https://override.example" },
+      {
+        PARACHUTE_HUB_ORIGIN: "https://env.example",
+        RENDER_EXTERNAL_URL: "https://render.example.onrender.com",
+      },
+    );
+    expect(got).toBe("https://override.example");
+  });
+
+  test("PARACHUTE_HUB_ORIGIN wins over RENDER_EXTERNAL_URL", () => {
+    const got = resolveStartupIssuer(
+      {},
+      {
+        PARACHUTE_HUB_ORIGIN: "https://custom-domain.example",
+        RENDER_EXTERNAL_URL: "https://parachute-hub.onrender.com",
+      },
+    );
+    expect(got).toBe("https://custom-domain.example");
+  });
+
+  test("RENDER_EXTERNAL_URL is used when PARACHUTE_HUB_ORIGIN unset", () => {
+    // The load-bearing case: operator clicks Deploy to Render, container
+    // boots without an explicit PARACHUTE_HUB_ORIGIN (it doesn't yet
+    // appear in render.yaml as a default), Render injects RENDER_EXTERNAL_URL
+    // → hub picks it up automatically → supervised modules get the right
+    // PARACHUTE_HUB_ORIGIN → vault's iss check passes on the first
+    // authenticated request.
+    const got = resolveStartupIssuer(
+      {},
+      { RENDER_EXTERNAL_URL: "https://parachute-hub.onrender.com" },
+    );
+    expect(got).toBe("https://parachute-hub.onrender.com");
+  });
+
+  test("strips trailing slashes from any source for canonical form", () => {
+    expect(resolveStartupIssuer({ issuer: "https://x.example/" }, {})).toBe("https://x.example");
+    expect(resolveStartupIssuer({ issuer: "https://x.example//" }, {})).toBe("https://x.example");
+    expect(
+      resolveStartupIssuer({}, { PARACHUTE_HUB_ORIGIN: "https://x.example/" }),
+    ).toBe("https://x.example");
+    expect(
+      resolveStartupIssuer({}, { RENDER_EXTERNAL_URL: "https://x.example/" }),
+    ).toBe("https://x.example");
+  });
+
+  test("returns undefined when no source has a value", () => {
+    expect(resolveStartupIssuer({}, {})).toBeUndefined();
+    expect(resolveStartupIssuer({}, { RENDER_EXTERNAL_URL: "" })).toBeUndefined();
+    expect(resolveStartupIssuer({}, { PARACHUTE_HUB_ORIGIN: "" })).toBeUndefined();
+  });
+
+  test("empty string after slash-strip collapses to undefined (defensive)", () => {
+    // `/` alone strips to empty string → `||` evaluates false → undefined.
+    // Guards against a misconfigured env where someone sets the var to "/"
+    // expecting it to mean "root" (it doesn't — leaves hub without a usable
+    // origin, which is the same as not setting it at all).
+    expect(resolveStartupIssuer({}, { PARACHUTE_HUB_ORIGIN: "/" })).toBeUndefined();
   });
 });

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -408,9 +408,21 @@ async function spawnSupervised(
   // server.ts:230) tries to bind hub's port and crashes EADDRINUSE.
   // Explicitly override with the child's services.json port so children
   // honor their canonical port assignment regardless of hub's PORT.
+  //
+  // PARACHUTE_HUB_ORIGIN propagation (hub#365): supervised modules
+  // (vault, scribe, app) need to know the canonical hub origin to
+  // validate the `iss` claim on hub-minted JWTs. Without it, they
+  // fall back to a loopback default and reject any token whose iss is
+  // the public Render URL — surfaces as "hub JWT verification failed:
+  // unexpected 'iss' claim value" on the first authed vault call.
+  // `deps.issuer` is per-request, derived via resolveIssuer (which
+  // honors X-Forwarded-Proto / Host). Passing it as PARACHUTE_HUB_ORIGIN
+  // anchors the child's iss expectation to the same value hub mints with.
+  //
   // `deps.spawnEnv` still wins (test seam + first-boot vault-name pass-through).
   const childEnv: Record<string, string> = {
     PORT: String(entry.port),
+    ...(deps.issuer ? { PARACHUTE_HUB_ORIGIN: deps.issuer } : {}),
     ...(deps.spawnEnv ?? {}),
   };
   const req: SpawnRequest = {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -111,6 +111,41 @@ function parsePort(raw: string | undefined): number | undefined {
 }
 
 /**
+ * Derive the canonical issuer URL hub uses for JWT iss claims + propagation
+ * to supervised modules' PARACHUTE_HUB_ORIGIN env.
+ *
+ * Precedence (highest first):
+ *   1. Explicit `--issuer` flag (test override too)
+ *   2. `PARACHUTE_HUB_ORIGIN` env (operator-set, typical custom-domain case)
+ *   3. Platform-injected public URL — currently Render's RENDER_EXTERNAL_URL.
+ *      This is the load-bearing tier for container deploys where the
+ *      operator can't know the URL at deploy time. Render generates the
+ *      *.onrender.com hostname after service creation and injects it for
+ *      web services; hub picks it up automatically.
+ *   4. None (returns undefined). Hub falls back to per-request derivation
+ *      via `resolveIssuer` in hub-server.ts — works for `/.well-known`
+ *      discovery but supervised modules with cached iss expectations
+ *      won't have a static value to validate against, so OAuth flows
+ *      through hub-mint → vault-validate will fail with iss-mismatch.
+ *      This is the "no canonical origin known" degraded mode.
+ *
+ * Future platforms (Fly's `FLY_APP_NAME` + region, Railway's
+ * `RAILWAY_PUBLIC_DOMAIN`, etc.) can extend tier 3 as needed.
+ *
+ * Trailing slashes are stripped for canonical-form comparison; empty
+ * strings collapse to undefined.
+ */
+export function resolveStartupIssuer(
+  opts: { issuer?: string },
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  return (
+    (opts.issuer ?? env.PARACHUTE_HUB_ORIGIN ?? env.RENDER_EXTERNAL_URL)?.replace(/\/+$/, "") ||
+    undefined
+  );
+}
+
+/**
  * Seed the initial admin from env vars when no admin exists. Returns the
  * bootstrap state so the caller can log it for operator visibility.
  *
@@ -189,7 +224,7 @@ export async function serve(opts: ServeOpts = {}): Promise<{
 
   const envPort = parsePort(env.PORT);
   const port = opts.port ?? envPort ?? DEFAULT_PORT;
-  const issuer = (opts.issuer ?? env.PARACHUTE_HUB_ORIGIN)?.replace(/\/+$/, "") || undefined;
+  const issuer = resolveStartupIssuer(opts, env);
   // Containers default to 0.0.0.0 so the platform's HTTP forwarder can
   // reach us; the `--hostname` flag / PARACHUTE_BIND_HOST is the escape
   // hatch for setups that want loopback-only inside a sidecar.

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -213,8 +213,14 @@ interface Args {
  *                                Containers should set 0.0.0.0.
  *   PARACHUTE_HUB_ORIGIN       — canonical https://… origin used as the
  *                                OAuth issuer claim.
+ *   RENDER_EXTERNAL_URL        — Render auto-injects the public https URL;
+ *                                used as fallback issuer so the standalone
+ *                                `bun src/hub-server.ts` boot path works
+ *                                without operator config. Mirrors the
+ *                                precedence in commands/serve.ts's
+ *                                resolveStartupIssuer.
  */
-function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): Args {
+export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): Args {
   let port: number | undefined;
   let hostname: string | undefined;
   let wellKnownDir: string | undefined;
@@ -250,8 +256,9 @@ function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): Args {
   if (port === undefined) port = HUB_DEFAULT_PORT;
   if (hostname === undefined) hostname = env.PARACHUTE_BIND_HOST || "127.0.0.1";
   if (wellKnownDir === undefined) wellKnownDir = WELL_KNOWN_DIR;
-  if (issuer === undefined && env.PARACHUTE_HUB_ORIGIN) {
-    issuer = env.PARACHUTE_HUB_ORIGIN.replace(/\/+$/, "");
+  if (issuer === undefined) {
+    const fromEnv = env.PARACHUTE_HUB_ORIGIN ?? env.RENDER_EXTERNAL_URL;
+    if (fromEnv) issuer = fromEnv.replace(/\/+$/, "") || undefined;
   }
   return { port, hostname, wellKnownDir, dbPath: dbPath ?? hubDbPath(), issuer };
 }


### PR DESCRIPTION
## Summary

Aaron's fresh Render install failed at first authed vault call with:
```
Vault rejected the token (401: hub JWT verification failed:
 unexpected 'iss' claim value)
```

## Root cause

Hub mints JWTs with `iss` derived per-request via `resolveIssuer` (X-Forwarded-* aware → public Render URL). Supervised modules cache `PARACHUTE_HUB_ORIGIN` at boot and validate `iss` against it. Yesterday's render.yaml change dropped `PARACHUTE_HUB_ORIGIN` as a prompted env var → vault fell back to a loopback default → token iss (public) ≠ vault expected (loopback) → 401.

## Fix (two contained changes)

### 1. Hub auto-detects `RENDER_EXTERNAL_URL` at boot

Render auto-injects `RENDER_EXTERNAL_URL` for web services (full URL). Adds a third tier to the issuer precedence chain in `serve.ts`:

```
1. explicit --issuer flag
2. PARACHUTE_HUB_ORIGIN env (operator-set, custom domains)
3. RENDER_EXTERNAL_URL (platform-injected, zero config) ← NEW
4. undefined (degraded mode, request-derived)
```

Extracted into `resolveStartupIssuer()` for testability.

### 2. `spawnSupervised` passes `PARACHUTE_HUB_ORIGIN` to children

From `deps.issuer` (which is the per-request resolveIssuer value). So vault spawned via `/api/modules/<short>/install` inherits the same iss hub mints with.

## Combined effect

Fresh Render deploy → zero env config required. Hub picks up `RENDER_EXTERNAL_URL` → threads to supervised modules → tokens validate correctly.

Custom-domain operators still set `PARACHUTE_HUB_ORIGIN` explicitly (tier 2 wins).

## Operator workaround for rc.34 and earlier

Set `PARACHUTE_HUB_ORIGIN` manually in Render dashboard env vars + redeploy. rc.35 makes this unnecessary.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test ./src`: 1939 pass / 0 fail (+7 new tests, 1932 → 1939)
- [x] 6 new tests for `resolveStartupIssuer` covering the precedence chain
- [x] 1 new regression test for spawn-site PARACHUTE_HUB_ORIGIN propagation
- [ ] After merge + tag + npm publish rc.35: Aaron redeploys (or wait for auto-deploy) → fresh wizard install → auth succeeds without manual env var

## Bumps 0.5.13-rc.34 → 0.5.13-rc.35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)