### PR TITLE
fix(hub): /:home script SyntaxError broke Get Started, Services, Admin

### DIFF
--- a/src/__tests__/hub.test.ts
+++ b/src/__tests__/hub.test.ts
@@ -13,6 +13,25 @@ describe("renderHub", () => {
     expect(html).toContain("<script>");
   });
 
+  test("inline <script> body parses as valid JS (regression: hub#366)", () => {
+    // The script lives inside HTML_TEMPLATE — a backtick template literal.
+    // Backslash escapes inside the template silently mangle regex literals:
+    // `/\/+$/` written in the source becomes `//+$/` in the served HTML,
+    // which JS parses as the start of a line comment, killing the entire
+    // IIFE. Every section that renders inside that IIFE (Get started,
+    // Services, Admin) then never paints.
+    //
+    // Content assertions don't catch this — they pass on the broken
+    // string. A parse-check via `new Function(body)` does: it parses
+    // (no execution, no DOM needed) and throws SyntaxError on the bad
+    // regex. Wrap in a try/catch so future template-escaping regressions
+    // surface here with a clear message rather than as a runtime mystery.
+    const m = html.match(/<script>([\s\S]*?)<\/script>/);
+    expect(m).not.toBeNull();
+    const scriptBody = m![1];
+    expect(() => new Function(scriptBody)).not.toThrow();
+  });
+
   test("fetches /.well-known/parachute.json for the Use section", () => {
     expect(html).toContain("/.well-known/parachute.json");
     expect(html).toContain("doc.services");

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -496,7 +496,11 @@ const HTML_TEMPLATE = `<!doctype html>
       // firstVaultName() shape.
       let vaultName = 'default';
       if (typeof vault.path === 'string' && vault.path.startsWith('/vault/')) {
-        const tail = vault.path.slice('/vault/'.length).replace(/\/+$/, '');
+        // Character class for the slash so the template literal can't eat
+        // the backslash-escape — \/ collapses to / inside backticks, and
+        // /\/+$/ degenerates to a // line comment that breaks the whole
+        // IIFE. [/]+$ keeps the same semantics with no escape needed.
+        const tail = vault.path.slice('/vault/'.length).replace(/[/]+$/, '');
         if (tail.length > 0) vaultName = tail;
       }
       tiles.push({


### PR DESCRIPTION
## Summary

Aaron's freshly-deployed hub at https://parachute-hub.onrender.com/ — Services section stuck at \"Loading…\", Admin section empty, Get Started never paints. Root cause: a single regex literal inside the inline `<script>` parses as a line comment in the browser, killing the entire IIFE.

The bug: `HTML_TEMPLATE` in `src/hub.ts` is a backtick template literal. The line

```js
const tail = vault.path.slice('/vault/'.length).replace(/\/+$/, '');
```

inside that template renders into the served HTML as

```js
const tail = vault.path.slice('/vault/'.length).replace(//+$/, '');
```

because `\/` inside a template literal silently collapses to `/` (the backslash isn't a recognized escape sequence). The browser then parses `//` as the start of a line comment, the rest of the regex bleeds into the comment, the closing `}` of the function becomes orphan, and the IIFE that runs `renderAdmin()` + `renderServices()` + `renderGetStarted()` never executes.

## Fix

Switch to a character-class slash: `[/]+$`. Forward-slash inside a character class needs no escape, so the template literal preserves it intact. Semantically identical, no escaping surface.

## Regression test

`hub.test.ts` already had ~20 content assertions on the rendered HTML — none caught this because they only check substrings. Added a parse-check via `new Function(scriptBody)` that throws SyntaxError on the broken HTML and passes on the fixed one. Catches any future template-escaping bug at test time.

Verified the parse-check actually catches the bug (`new Function('replace(//+$/, \\'\\')')` throws as expected).

## Why hub#342 didn't catch it

Every other regex literal in this script is escape-free (`/^parachute-/`, `/&/g`, etc.). The vault-path slicing in hub#342 was the first regex in the IIFE to need a forward-slash escape. Latent bug, surfaced now on the first deploy that has a vault installed (`renderGetStarted` only runs the `replace` when `services.some(s => s.name === 'parachute-vault')`).

## Test plan

- [x] `bun test ./src` — 1945 pass / 0 fail (+1 from rc.35)
- [x] Verified served HTML has `replace(/[/]+$/, '')` (intact, not `//+$/`)
- [x] Verified `new Function()` catches the bug class via separate repro
- [ ] Live verify on Render redeploy after rc.36 publishes

Closes the Get Started + Services + Admin breakage Aaron reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)