### PR TITLE
fix(hub): typecheck on hub#366 regression test + bump to rc.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
-## [0.5.13-rc.36] - 2026-05-25
+## [0.5.13-rc.37] - 2026-05-25
 
 **fix(hub): home page Get Started + Services + Admin all broken by a SyntaxError in the inline `<script>`.**
+
+(rc.36 never published — `noUncheckedIndexedAccess` typecheck failure on the new regression test caught by release CI. rc.37 fixes the typecheck and is the published rollup.)
 
 After rc.35 landed and the iss-mismatch unstuck the wizard install, the home page at `/` rendered with the Services section stuck at "Loading…" and the Admin section empty. Root cause: a single regex literal inside the IIFE — `/\/+$/` — silently degenerated to `//+$/` in the served HTML, because `\/` inside `HTML_TEMPLATE`'s backtick template literal collapses to `/`. The browser parsed the leading `//` as a line comment, the rest of the regex bled into the comment, the IIFE never executed, and `renderAdmin()` + `renderServices()` + `renderGetStarted()` all silently failed.
 
@@ -25,7 +27,7 @@ After rc.35 landed and the iss-mismatch unstuck the wizard install, the home pag
 - `bun run typecheck` clean.
 - `bun test ./src`: 1945 pass / 0 fail (+1 from rc.35).
 - Container smoke CI: ✓ on `ac09e17`.
-- Live verify pending on Render redeploy after rc.36 publishes.
+- Live verify pending on Render redeploy after rc.37 publishes.
 
 ## [0.5.13-rc.35] - 2026-05-25
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.36",
+  "version": "0.5.13-rc.37",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub.test.ts
+++ b/src/__tests__/hub.test.ts
@@ -27,9 +27,9 @@ describe("renderHub", () => {
     // regex. Wrap in a try/catch so future template-escaping regressions
     // surface here with a clear message rather than as a runtime mystery.
     const m = html.match(/<script>([\s\S]*?)<\/script>/);
-    expect(m).not.toBeNull();
-    const scriptBody = m![1];
-    expect(() => new Function(scriptBody)).not.toThrow();
+    const scriptBody = m?.[1];
+    expect(scriptBody).toBeDefined();
+    expect(() => new Function(scriptBody as string)).not.toThrow();
   });
 
   test("fetches /.well-known/parachute.json for the Use section", () => {


### PR DESCRIPTION
## Summary

Two changes bundled because they ship together:
1. **Fix typecheck failure** on the hub#366 regression test (`m![1]` indexed access returns `string | undefined` under strict mode; need explicit guard before `new Function()`).
2. **Bump to rc.37** to publish the home-page IIFE fix. rc.36 never published — release CI caught the typecheck failure before publish-npm/publish-image ran.

## Why rc.36 was skipped

The rc.36 tag is dead but stays in history. CHANGELOG explicitly notes this so future archaeology doesn't confuse \"rc.36 missing from npm\" with a publish-side issue. rc.37 is the published rollup of the home-page fix.

## Test plan

- [x] `bun run typecheck` clean (the missing local step that caused this round-trip)
- [x] `bun test ./src`: 1945 pass / 0 fail
- [ ] Release CI: tag `v0.5.13-rc.37`, expect both publish jobs succeed
- [ ] Live verify on Render redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)