### PR TITLE
feat(hub): /admin/approve-client supports OAuth resume via return_to (workstream D)

### DIFF
--- a/src/__tests__/admin-clients.test.ts
+++ b/src/__tests__/admin-clients.test.ts
@@ -298,4 +298,165 @@ describe("handleApproveClient", () => {
     const res = await handleApproveClient(req, id, { db: harness.db, issuer: ISSUER });
     expect(res.status).toBe(405);
   });
+
+  // Workstream D — OAuth resume via `return_to`. The SPA approve page
+  // can pass a hub-relative authorize URL as JSON body; the response
+  // echoes it as `redirect_to` so the SPA can navigate the browser there
+  // and resume the parked OAuth flow. The pre-D no-body shape continues
+  // to work (no `redirect_to` field, share-link dead-end case).
+  describe("workstream D — return_to / redirect_to", () => {
+    function jsonApproveReq(clientId: string, bearer: string, body: unknown): Request {
+      return new Request(`${ISSUER}/api/oauth/clients/${encodeURIComponent(clientId)}/approve`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${bearer}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+    }
+
+    test("echoes a same-origin /oauth/authorize?... return_to as redirect_to", async () => {
+      const { bearer } = await makeOperatorBearer();
+      const id = regPending();
+      const returnTo =
+        "/oauth/authorize?client_id=" +
+        encodeURIComponent(id) +
+        "&response_type=code&scope=vault%3Awork%3Aread";
+      const res = await handleApproveClient(
+        jsonApproveReq(id, bearer, { return_to: returnTo }),
+        id,
+        { db: harness.db, issuer: ISSUER },
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.redirect_to).toBe(returnTo);
+      expect(body.status).toBe("approved");
+      expect(getClient(harness.db, id)?.status).toBe("approved");
+    });
+
+    test("omits redirect_to entirely when return_to is missing (share-link case preserved)", async () => {
+      const { bearer } = await makeOperatorBearer();
+      const id = regPending();
+      // No body — the pre-D shape. The endpoint must continue to work.
+      const res = await handleApproveClient(approveReq(id, bearer), id, {
+        db: harness.db,
+        issuer: ISSUER,
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body).not.toHaveProperty("redirect_to");
+      expect(body.status).toBe("approved");
+    });
+
+    test("drops an off-origin return_to (scheme-relative) silently, still approves", async () => {
+      const { bearer } = await makeOperatorBearer();
+      const id = regPending();
+      const res = await handleApproveClient(
+        jsonApproveReq(id, bearer, { return_to: "//evil.example/oauth/authorize?foo=1" }),
+        id,
+        { db: harness.db, issuer: ISSUER },
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      // No redirect_to — server refuses to echo a bad value. The client
+      // is still approved (we don't fail an otherwise-legitimate approve
+      // over a malformed return_to).
+      expect(body).not.toHaveProperty("redirect_to");
+      expect(getClient(harness.db, id)?.status).toBe("approved");
+    });
+
+    test("drops a non-authorize return_to (off-path) silently", async () => {
+      const { bearer } = await makeOperatorBearer();
+      const id = regPending();
+      const res = await handleApproveClient(
+        jsonApproveReq(id, bearer, { return_to: "/admin/vaults" }),
+        id,
+        { db: harness.db, issuer: ISSUER },
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      // `/admin/vaults` is same-origin but isn't a `/oauth/authorize?...`
+      // URL — the server-side gate is "authorize URL only" so the SPA
+      // can't be used as a redirect gadget for arbitrary in-SPA navigation.
+      expect(body).not.toHaveProperty("redirect_to");
+    });
+
+    test("drops absolute URL return_to silently", async () => {
+      const { bearer } = await makeOperatorBearer();
+      const id = regPending();
+      const res = await handleApproveClient(
+        jsonApproveReq(id, bearer, {
+          return_to: "https://evil.example/oauth/authorize?foo=1",
+        }),
+        id,
+        { db: harness.db, issuer: ISSUER },
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body).not.toHaveProperty("redirect_to");
+    });
+
+    test("non-JSON body is treated as 'no return_to' (no parser explosion)", async () => {
+      const { bearer } = await makeOperatorBearer();
+      const id = regPending();
+      // text/plain body — pre-D / unknown clients send anything. The
+      // endpoint must NOT throw on parse and must NOT echo a redirect_to.
+      const req = new Request(`${ISSUER}/api/oauth/clients/${id}/approve`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${bearer}`,
+          "content-type": "text/plain",
+        },
+        body: "garbage",
+      });
+      const res = await handleApproveClient(req, id, {
+        db: harness.db,
+        issuer: ISSUER,
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body).not.toHaveProperty("redirect_to");
+    });
+
+    test("malformed JSON body is treated as 'no return_to'", async () => {
+      const { bearer } = await makeOperatorBearer();
+      const id = regPending();
+      const req = new Request(`${ISSUER}/api/oauth/clients/${id}/approve`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${bearer}`,
+          "content-type": "application/json",
+        },
+        body: "{not json",
+      });
+      const res = await handleApproveClient(req, id, {
+        db: harness.db,
+        issuer: ISSUER,
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body).not.toHaveProperty("redirect_to");
+    });
+
+    test("re-approve with return_to echoes redirect_to (idempotent path)", async () => {
+      // The OAuth resume flow can legitimately race: operator opens the
+      // approve link, an automated path approves the same client, then
+      // operator clicks. We still want the redirect to fire so the
+      // operator's flow resumes — not dead-end on already_approved.
+      const { bearer } = await makeOperatorBearer();
+      const id = regPending();
+      approveClient(harness.db, id);
+      const returnTo = `/oauth/authorize?client_id=${encodeURIComponent(id)}&response_type=code&scope=vault%3Awork%3Aread`;
+      const res = await handleApproveClient(
+        jsonApproveReq(id, bearer, { return_to: returnTo }),
+        id,
+        { db: harness.db, issuer: ISSUER },
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.already_approved).toBe(true);
+      expect(body.redirect_to).toBe(returnTo);
+    });
+  });
 });

--- a/src/admin-clients.ts
+++ b/src/admin-clients.ts
@@ -18,6 +18,33 @@
  * the API path logs because cross-machine "who approved this" is the
  * audit-grade signal we'd want when the operator approves from a browser
  * rather than a terminal they own.
+ *
+ * ## OAuth resume via `return_to` (workstream D, AUDIT-UI-UX.md §5 row D)
+ *
+ * The SPA approve page (`web/ui/src/routes/ApproveClient.tsx`) was a
+ * documented dead-end pre-D: it flipped the client to approved, then told
+ * the operator to "return to the app and retry" — the parked OAuth flow
+ * had no way to resume.
+ *
+ * D adds the affordance, not a behaviour change for existing callers. If
+ * the POST body carries a `return_to` JSON field that's a hub-relative
+ * `/oauth/authorize?...` URL, the response echoes it back as `redirect_to`
+ * and the SPA navigates the browser there to resume the flow. Callers
+ * that don't pass `return_to` (the "share this link with another admin"
+ * case the unauth pending-client CTA renders) get the unchanged response
+ * shape; the SPA renders its dead-end success state and the deep-link
+ * UX is preserved.
+ *
+ * Two cases, one route — `return_to` is the discriminator. The pattern
+ * doc is `parachute-patterns/patterns/oauth-dcr-approval.md` §"SPA
+ * approve page (two cases, one route)".
+ *
+ * Validation reuses `isSafeAuthorizeReturnTo` from oauth-handlers.ts so
+ * the SPA endpoint and the inline `/oauth/authorize/approve` endpoint
+ * apply the same gate — single source of truth for "what's a valid OAuth
+ * resume target?" Off-origin or non-authorize values are silently dropped
+ * (the response omits `redirect_to`) rather than 4xx'ing — a bad
+ * `return_to` shouldn't block an otherwise-legitimate approve.
  */
 import type { Database } from "bun:sqlite";
 import {
@@ -28,6 +55,7 @@ import {
 } from "./admin-auth.ts";
 import { HOST_ADMIN_SCOPE } from "./admin-vaults.ts";
 import { approveClient, getClient } from "./clients.ts";
+import { isSafeAuthorizeReturnTo } from "./oauth-handlers.ts";
 
 export interface AdminClientsDeps {
   db: Database;
@@ -102,6 +130,11 @@ export async function handleApproveClient(
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }
+  // Parse the body OPTIONALLY — pre-D callers send no body at all, so a
+  // missing / empty / non-JSON body is fine. Only fish out `return_to` when
+  // the caller actually provided a parseable JSON object; everything else
+  // is treated as "no return_to specified," same as pre-D.
+  const returnTo = await readReturnTo(req);
   const before = getClient(deps.db, clientId);
   if (!before) {
     return jsonError(404, "not_found", `no client registered with id ${clientId}`);
@@ -123,20 +156,63 @@ export async function handleApproveClient(
       `client approved: client_id=${clientId} client_name=${before.clientName ?? ""} approver_sub=${ctx.sub}`,
     );
   }
-  return new Response(
-    JSON.stringify({
-      client_id: clientId,
-      status: "approved",
-      already_approved: !wasPending,
-    }),
-    {
-      status: 200,
-      headers: {
-        "content-type": "application/json",
-        "cache-control": "no-store",
-      },
+  // Only echo `redirect_to` when the caller's `return_to` passed the gate.
+  // Bad / missing values just drop off the response — the SPA falls back
+  // to its dead-end success state. We don't 4xx an otherwise-legitimate
+  // approve over a bad return_to (the client is now approved either way).
+  const body: ApproveClientResponse = {
+    client_id: clientId,
+    status: "approved",
+    already_approved: !wasPending,
+  };
+  if (returnTo !== null && isSafeAuthorizeReturnTo(returnTo)) {
+    body.redirect_to = returnTo;
+  }
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": "no-store",
     },
-  );
+  });
+}
+
+interface ApproveClientResponse {
+  client_id: string;
+  status: "approved";
+  already_approved: boolean;
+  /**
+   * Hub-relative `/oauth/authorize?...` URL the SPA should navigate to
+   * after approving, to resume a parked OAuth flow. Only present when the
+   * POST body's `return_to` passed `isSafeAuthorizeReturnTo`. Absent for
+   * the share-link case (no `return_to` provided) so the SPA's dead-end
+   * success state still renders.
+   */
+  redirect_to?: string;
+}
+
+/**
+ * Pull `return_to` out of the request body if present. Tolerant by design:
+ * pre-D callers (and tests, and curl probes) send no body or a non-JSON
+ * body, and the endpoint MUST continue to work in those shapes. Any parse
+ * failure or missing field returns null; the response omits `redirect_to`
+ * accordingly.
+ *
+ * Only `application/json` bodies are inspected — keeping the format
+ * restricted to JSON matches the existing API conventions (the SPA's
+ * other admin POSTs use JSON throughout) and avoids parser ambiguity
+ * over form-encoded variants on a deliberately optional field.
+ */
+async function readReturnTo(req: Request): Promise<string | null> {
+  const ct = req.headers.get("content-type") ?? "";
+  if (!ct.toLowerCase().includes("application/json")) return null;
+  try {
+    const body = (await req.json()) as { return_to?: unknown };
+    if (typeof body?.return_to !== "string") return null;
+    return body.return_to;
+  } catch {
+    return null;
+  }
 }
 
 function jsonError(status: number, error: string, description: string): Response {

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -1251,8 +1251,13 @@ export async function handleApproveClientPost(
  * (no scheme, no double-slash) targeting `/oauth/authorize` with a query
  * string — anything else is either an open-redirect attempt or a misuse of
  * the endpoint. Empty string is rejected (the form always supplies one).
+ *
+ * Exported so the SPA approve-client endpoint (`handleApproveClient` in
+ * admin-clients.ts) can apply the same gate when echoing a `return_to` back
+ * to the caller — workstream D. Single helper = single shape of "what's a
+ * valid OAuth-resume target?" for the whole hub.
  */
-function isSafeAuthorizeReturnTo(value: string): boolean {
+export function isSafeAuthorizeReturnTo(value: string): boolean {
   if (!value) return false;
   // Reject scheme-relative ("//evil.example/foo") and absolute URLs. Only
   // single-slash root-relative paths are allowed.

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -536,22 +536,55 @@ export interface ApproveClientResult {
   status: "approved";
   /** True when the row was already approved before this call. Idempotent re-approve. */
   already_approved: boolean;
+  /**
+   * Hub-relative `/oauth/authorize?...` URL the caller passed as
+   * `return_to`, echoed back when it passes the server's same-origin gate
+   * (`isSafeAuthorizeReturnTo` in oauth-handlers.ts). Workstream D — lets
+   * the SPA approve page resume a parked OAuth flow rather than dead-end
+   * on the "return to the app" success state. Absent for the share-link
+   * case (no `return_to` passed, or off-origin value dropped server-side).
+   */
+  redirect_to?: string;
 }
 
 /**
  * POST /api/oauth/clients/<client_id>/approve — flip a pending client to
  * approved. Idempotent: a second call after the row is already approved
  * returns `already_approved: true` with no audit-log line.
+ *
+ * Optional `returnTo` (workstream D): when present and same-origin-safe
+ * (a hub-relative `/oauth/authorize?...` URL), the server echoes it back
+ * as `redirect_to` and the SPA navigates the browser there to resume the
+ * parked OAuth flow. The SPA validates same-origin before passing the
+ * value through; the server runs the same gate again before echoing.
+ * Off-origin or non-authorize values silently drop off the response —
+ * the bad value doesn't fail the approve, the SPA falls back to its
+ * dead-end success state.
  */
-export async function approveOauthClient(clientId: string): Promise<ApproveClientResult> {
+export async function approveOauthClient(
+  clientId: string,
+  returnTo?: string,
+): Promise<ApproveClientResult> {
   const bearer = await getHostAdminToken();
-  const res = await fetch(`/api/oauth/clients/${encodeURIComponent(clientId)}/approve`, {
+  const init: RequestInit = {
     method: "POST",
     headers: {
       accept: "application/json",
       authorization: `Bearer ${bearer}`,
     },
-  });
+  };
+  // Send a JSON body iff the caller supplied `returnTo`. Pre-D callers
+  // (and the share-link case) pass no body; the server treats absent /
+  // empty bodies identically to "no return_to" and returns the dead-end-
+  // compatible shape.
+  if (returnTo !== undefined) {
+    init.headers = {
+      ...init.headers,
+      "content-type": "application/json",
+    };
+    init.body = JSON.stringify({ return_to: returnTo });
+  }
+  const res = await fetch(`/api/oauth/clients/${encodeURIComponent(clientId)}/approve`, init);
   if (res.status === 401 || res.status === 403) {
     clearCachedToken();
     throw new HttpError(res.status, await readError(res));

--- a/web/ui/src/routes/ApproveClient.test.tsx
+++ b/web/ui/src/routes/ApproveClient.test.tsx
@@ -275,5 +275,20 @@ describe("ApproveClient", () => {
       await waitFor(() => expect(screen.getByText(/already approved/i)).toBeInTheDocument());
       expect(assignSpy).not.toHaveBeenCalled();
     });
+
+    it("auto-redirects to non-authorize same-origin return_to (broader SPA gate is by design)", async () => {
+      // Pin the deliberately-broader SPA gate behaviour: the SPA's
+      // isSafeReturnTo accepts any same-origin path (starts with /, not //),
+      // not just /oauth/authorize?-prefixed targets. The server-side gate is
+      // stricter and only echoes redirect_to for /oauth/authorize? targets —
+      // but the SPA's on-load auto-redirect path doesn't round-trip through
+      // the server, so a future caller could wire ?return_to=/some/other/page.
+      // Today no caller does this; the test exists to document the contract
+      // (per patterns#97 "two cases, one route" + the deliberately-broader
+      // SPA gate notes).
+      vi.mocked(api.getOauthClient).mockResolvedValue(pendingClient({ status: "approved" }));
+      renderRoute("c1", "?return_to=/admin/vaults");
+      await waitFor(() => expect(assignSpy).toHaveBeenCalledWith("/admin/vaults"));
+    });
   });
 });

--- a/web/ui/src/routes/ApproveClient.test.tsx
+++ b/web/ui/src/routes/ApproveClient.test.tsx
@@ -26,9 +26,10 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-function renderRoute(clientId = "c1") {
+function renderRoute(clientId = "c1", search = "") {
+  const url = `/approve-client/${clientId}${search}`;
   return render(
-    <MemoryRouter initialEntries={[`/approve-client/${clientId}`]}>
+    <MemoryRouter initialEntries={[url]}>
       <Routes>
         <Route path="/approve-client/:clientId" element={<ApproveClient />} />
       </Routes>
@@ -66,7 +67,9 @@ describe("ApproveClient", () => {
     renderRoute();
     fireEvent.click(await screen.findByRole("button", { name: /approve notes/i }));
     await waitFor(() => expect(screen.getByText(/^approved\.$/i)).toBeInTheDocument());
-    expect(api.approveOauthClient).toHaveBeenCalledWith("c1");
+    // Workstream D added a second arg (returnTo); share-link case passes
+    // undefined.
+    expect(api.approveOauthClient).toHaveBeenCalledWith("c1", undefined);
     expect(screen.getByText(/can now run an OAuth flow/i)).toBeInTheDocument();
   });
 
@@ -132,5 +135,145 @@ describe("ApproveClient", () => {
     // Already-named scopes don't carry the wildcard, so the explanation
     // hint doesn't render.
     expect(screen.queryByText(/a specific vault is selected during sign-in/i)).toBeNull();
+  });
+
+  // Workstream D — the SPA approve page can resume a parked OAuth flow
+  // when given a `return_to` query parameter. The unauth share-link case
+  // (no return_to) still renders the dead-end success state. See
+  // AUDIT-UI-UX.md §5 row D and
+  // parachute-patterns/patterns/oauth-dcr-approval.md "SPA approve page
+  // (two cases, one route)".
+  describe("workstream D — OAuth resume via return_to", () => {
+    // `window.location.assign` doesn't work in jsdom by default; spy on
+    // it so we can assert the redirect was triggered without actually
+    // navigating the test runner away.
+    let originalLocation: Location;
+    let assignSpy: ReturnType<typeof vi.fn>;
+    beforeEach(() => {
+      originalLocation = window.location;
+      assignSpy = vi.fn();
+      // Override `window.location` with a minimal shim that captures
+      // `.assign(url)` calls. Restoring `originalLocation` after each
+      // test keeps suite isolation.
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: { ...originalLocation, assign: assignSpy },
+      });
+    });
+    afterEach(() => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+    });
+
+    const authorizeUrl =
+      "/oauth/authorize?client_id=c1&response_type=code&scope=vault%3Awork%3Aread";
+
+    it("approves with return_to and navigates to redirect_to on success", async () => {
+      vi.mocked(api.getOauthClient).mockResolvedValue(pendingClient());
+      vi.mocked(api.approveOauthClient).mockResolvedValue({
+        client_id: "c1",
+        status: "approved",
+        already_approved: false,
+        redirect_to: authorizeUrl,
+      });
+      renderRoute("c1", `?return_to=${encodeURIComponent(authorizeUrl)}`);
+      fireEvent.click(await screen.findByRole("button", { name: /approve notes/i }));
+      await waitFor(() => expect(assignSpy).toHaveBeenCalledWith(authorizeUrl));
+      // Approve API was called WITH the return_to argument — the SPA passes
+      // it through to the server's gate.
+      expect(api.approveOauthClient).toHaveBeenCalledWith("c1", authorizeUrl);
+    });
+
+    it("renders the dead-end success state when no return_to is in the URL", async () => {
+      vi.mocked(api.getOauthClient).mockResolvedValue(pendingClient());
+      vi.mocked(api.approveOauthClient).mockResolvedValue({
+        client_id: "c1",
+        status: "approved",
+        already_approved: false,
+      });
+      renderRoute(); // no search
+      fireEvent.click(await screen.findByRole("button", { name: /approve notes/i }));
+      await waitFor(() => expect(screen.getByText(/^approved\.$/i)).toBeInTheDocument());
+      // SPA called approve with `undefined` for return_to — the share-link
+      // case must not smuggle in a bogus value.
+      expect(api.approveOauthClient).toHaveBeenCalledWith("c1", undefined);
+      expect(assignSpy).not.toHaveBeenCalled();
+    });
+
+    it("rejects an off-origin return_to and falls back to the dead-end state", async () => {
+      vi.mocked(api.getOauthClient).mockResolvedValue(pendingClient());
+      vi.mocked(api.approveOauthClient).mockResolvedValue({
+        client_id: "c1",
+        status: "approved",
+        already_approved: false,
+      });
+      // Scheme-relative URL — points off-origin if the browser follows it.
+      // The SPA's same-origin gate must drop it before the API call.
+      renderRoute("c1", "?return_to=%2F%2Fevil.example%2Foauth%2Fauthorize");
+      fireEvent.click(await screen.findByRole("button", { name: /approve notes/i }));
+      await waitFor(() => expect(screen.getByText(/^approved\.$/i)).toBeInTheDocument());
+      // Critical: api call sees `undefined`, NOT the off-origin value.
+      expect(api.approveOauthClient).toHaveBeenCalledWith("c1", undefined);
+      expect(assignSpy).not.toHaveBeenCalled();
+    });
+
+    it("rejects an absolute URL return_to", async () => {
+      vi.mocked(api.getOauthClient).mockResolvedValue(pendingClient());
+      vi.mocked(api.approveOauthClient).mockResolvedValue({
+        client_id: "c1",
+        status: "approved",
+        already_approved: false,
+      });
+      renderRoute(
+        "c1",
+        `?return_to=${encodeURIComponent("https://evil.example/oauth/authorize")}`,
+      );
+      fireEvent.click(await screen.findByRole("button", { name: /approve notes/i }));
+      await waitFor(() => expect(screen.getByText(/^approved\.$/i)).toBeInTheDocument());
+      expect(api.approveOauthClient).toHaveBeenCalledWith("c1", undefined);
+      expect(assignSpy).not.toHaveBeenCalled();
+    });
+
+    it("re-validates redirect_to client-side as belt-and-suspenders", async () => {
+      // Defense-in-depth: even if the server (bug, or some future change)
+      // echoed back an off-origin value as `redirect_to`, the SPA's own
+      // gate must refuse to navigate there. This test pins that contract.
+      vi.mocked(api.getOauthClient).mockResolvedValue(pendingClient());
+      vi.mocked(api.approveOauthClient).mockResolvedValue({
+        client_id: "c1",
+        status: "approved",
+        already_approved: false,
+        redirect_to: "//evil.example/oauth/authorize",
+      });
+      renderRoute("c1", `?return_to=${encodeURIComponent(authorizeUrl)}`);
+      fireEvent.click(await screen.findByRole("button", { name: /approve notes/i }));
+      await waitFor(() => expect(screen.getByText(/^approved\.$/i)).toBeInTheDocument());
+      expect(assignSpy).not.toHaveBeenCalled();
+    });
+
+    it("auto-redirects on load when the client is already approved AND return_to is set", async () => {
+      // Race-tolerant resume: someone (parallel session, automation) approved
+      // the client between the original /oauth/authorize → /admin/approve-
+      // client navigation and the operator clicking the link. With
+      // return_to set we should resume immediately rather than make the
+      // operator click an Approve button against an already-approved row.
+      vi.mocked(api.getOauthClient).mockResolvedValue(pendingClient({ status: "approved" }));
+      renderRoute("c1", `?return_to=${encodeURIComponent(authorizeUrl)}`);
+      await waitFor(() => expect(assignSpy).toHaveBeenCalledWith(authorizeUrl));
+      // No Approve button rendered — we left the SPA before the success
+      // state could render.
+      expect(screen.queryByRole("button", { name: /approve/i })).toBeNull();
+    });
+
+    it("shows the dead-end already-approved state when no return_to is set", async () => {
+      // Pre-existing behaviour — pin it against the new code path so the
+      // share-link case still works.
+      vi.mocked(api.getOauthClient).mockResolvedValue(pendingClient({ status: "approved" }));
+      renderRoute(); // no return_to
+      await waitFor(() => expect(screen.getByText(/already approved/i)).toBeInTheDocument());
+      expect(assignSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/web/ui/src/routes/ApproveClient.tsx
+++ b/web/ui/src/routes/ApproveClient.tsx
@@ -119,7 +119,7 @@ export function ApproveClient() {
   async function onApprove(): Promise<void> {
     setAction({ kind: "approving" });
     try {
-      const result = await approveOauthClient(clientId, returnTo ?? undefined);
+      const result = await approveOauthClient(clientId, returnTo || undefined);
       // OAuth-resume case (workstream D): server echoed the same-origin-
       // validated `return_to` back as `redirect_to`. Leave the SPA to
       // resume the parked authorize flow rather than dead-ending on the

--- a/web/ui/src/routes/ApproveClient.tsx
+++ b/web/ui/src/routes/ApproveClient.tsx
@@ -1,27 +1,41 @@
 /**
- * /admin/approve-client/<client_id> — operator landing page for the
- * pending-approval deep link surfaced by `pendingClientJson()` on
- * /oauth/token. An app like Notes gets the JSON error with `approve_url`
- * pointing here; the operator opens the link, sees the client details,
- * and one-click approves without dropping to a terminal.
+ * /admin/approve-client/<client_id> — operator landing page for OAuth
+ * client approval. Two distinct cases land here, distinguished by the
+ * presence of the `return_to` query parameter (workstream D, see
+ * AUDIT-UI-UX.md §5 row D and the
+ * `parachute-patterns/patterns/oauth-dcr-approval.md` "SPA approve page
+ * (two cases, one route)" section).
  *
- * Three-state UI:
- *   - **pending** → render details + Approve button. Approve POSTs and
- *     transitions to "approved".
- *   - **approved** (on load or after click) → render success message
- *     telling the operator they can return to the requesting app and retry.
- *     Deliberately no auto-redirect: the operator opened this from another
- *     tab/app, so the goal is "close this and go back" rather than nav
- *     them around the SPA.
+ * **Case 1 — OAuth resume** (`?return_to=/oauth/authorize?...`). The
+ * caller has a parked OAuth flow and wants the operator to approve the
+ * client AND continue the flow in one click. On success the SPA leaves
+ * itself via `window.location.assign(redirect_to)` to hub-server's
+ * authorize handler, which finishes the OAuth dance against the
+ * now-approved client.
+ *
+ * **Case 2 — share link / direct nav** (no `return_to`). Original shape
+ * from before workstream D: the operator follows a deep-link surfaced by
+ * `pendingClientJson()` on /oauth/token (or browses to the URL directly),
+ * approves the client, then closes the tab and returns to the app that
+ * sent them. Deliberately no auto-redirect — the operator opened this
+ * from another tab / app, so "close this and go back" is the right goal.
+ *
+ * Validation: the `return_to` query param must be a hub-relative URL
+ * starting with `/` and NOT starting with `//` (open-redirect defense,
+ * mirroring `safeNext` in admin-handlers.ts). Off-origin values are
+ * dropped (treated as "no return_to") rather than 4xx'd — the operator
+ * shouldn't be locked out of a legitimate approve because of a malformed
+ * deep link.
+ *
+ * Three-state UI (unchanged from pre-D):
+ *   - **pending** → render details + Approve button.
+ *   - **approved** (on load or after click) → either redirect (case 1)
+ *     or render success message (case 2).
  *   - **unknown** (404 from the API) → render an error explaining the
  *     client_id wasn't found.
- *
- * Why one page instead of a modal in some other route: the OAuth client
- * sends the operator here from a different origin via `approve_url`, so
- * deep-linkable as a discrete route is the right shape.
  */
 import { useEffect, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams, useSearchParams } from "react-router-dom";
 import { type AdminClientView, HttpError, approveOauthClient, getOauthClient } from "../lib/api.ts";
 
 type LoadState =
@@ -39,6 +53,15 @@ type ActionState =
 export function ApproveClient() {
   const { clientId: rawClientId } = useParams<{ clientId: string }>();
   const clientId = rawClientId ?? "";
+  const [searchParams] = useSearchParams();
+  // Validate the `return_to` query param same-origin-style. Mirrors the
+  // server-side gate (`isSafeAuthorizeReturnTo` in oauth-handlers.ts) and
+  // `safeNext` in admin-handlers.ts — single shape across the codebase for
+  // "is this a hub-relative URL we're willing to navigate to?" Off-origin
+  // or malformed values are silently dropped (treated as "no return_to")
+  // so the page falls back to the share-link / dead-end success state
+  // rather than 4xx'ing.
+  const returnTo = sanitizeReturnTo(searchParams.get("return_to"));
   const [loadState, setLoadState] = useState<LoadState>({ kind: "loading" });
   const [action, setAction] = useState<ActionState>({ kind: "idle" });
   const [reload, setReload] = useState(0);
@@ -60,8 +83,23 @@ export function ApproveClient() {
         // If the row was already approved before the operator arrived,
         // surface the success message rather than the "Approve" button —
         // no point asking them to re-confirm an action that's done.
+        //
+        // Special case for the OAuth-resume flow: if `return_to` is set
+        // and the client is already approved, leave the SPA immediately
+        // — the parked authorize URL can finish the flow with no further
+        // operator action. Saves the operator a redundant manual click
+        // back to the calling app.
         if (client.status === "approved") {
+          // Set action state BEFORE triggering navigation so the
+          // intermediate render (between assign() being called and the
+          // browser actually navigating) doesn't show the pending Approve
+          // button. Real browsers finish the navigation almost instantly
+          // but the SPA must still be in a consistent state for the
+          // intermediate frame.
           setAction({ kind: "approved", alreadyApproved: true });
+          if (returnTo) {
+            window.location.assign(returnTo);
+          }
         }
       })
       .catch((err) => {
@@ -76,12 +114,22 @@ export function ApproveClient() {
     return () => {
       cancelled = true;
     };
-  }, [clientId, reload]);
+  }, [clientId, reload, returnTo]);
 
   async function onApprove(): Promise<void> {
     setAction({ kind: "approving" });
     try {
-      const result = await approveOauthClient(clientId);
+      const result = await approveOauthClient(clientId, returnTo ?? undefined);
+      // OAuth-resume case (workstream D): server echoed the same-origin-
+      // validated `return_to` back as `redirect_to`. Leave the SPA to
+      // resume the parked authorize flow rather than dead-ending on the
+      // success state. Re-validate same-origin client-side as belt-and-
+      // suspenders — the server already gated this, but the redirect is
+      // a sensitive surface and double-checking is cheap.
+      if (result.redirect_to && isSafeReturnTo(result.redirect_to)) {
+        window.location.assign(result.redirect_to);
+        return;
+      }
       setAction({ kind: "approved", alreadyApproved: result.already_approved });
     } catch (err) {
       const message =
@@ -102,6 +150,30 @@ export function ApproveClient() {
       {renderBody({ loadState, action, onApprove, onRetry: () => setReload((n) => n + 1) })}
     </div>
   );
+}
+
+/**
+ * Validate a `return_to` value as a hub-relative URL we're willing to
+ * navigate to. Must start with `/` and must NOT start with `//`
+ * (otherwise it's a scheme-relative URL pointing off-origin). Mirrors
+ * the server-side `isSafeAuthorizeReturnTo` shape (which additionally
+ * requires `/oauth/authorize?` prefix — the SPA could match that too,
+ * but keeping the SPA's gate slightly broader lets future flows wire
+ * different resume targets without touching the SPA. The server is the
+ * authoritative gate; the SPA's job is to refuse the obvious bad shapes
+ * before round-tripping a useless value).
+ */
+function isSafeReturnTo(value: string): boolean {
+  if (!value) return false;
+  if (!value.startsWith("/")) return false;
+  if (value.startsWith("//")) return false;
+  return true;
+}
+
+/** Sanitize once at the URL-parse boundary; downstream consumers see `string | null`. */
+function sanitizeReturnTo(raw: string | null): string | null {
+  if (raw === null) return null;
+  return isSafeReturnTo(raw) ? raw : null;
 }
 
 interface RenderBodyProps {


### PR DESCRIPTION
Workstream D from AUDIT-UI-UX.md (§2.2 + §5 row D + §6 Q "two surfaces to do the same thing"). The audit called out two unrelated approve surfaces:

- `/oauth/authorize` — inline approve-and-continue form, 302s back into the OAuth flow (rc.38).
- `/admin/approve-client/<id>` — SPA, flips client to approved, then dead-ends on "return to your app and retry."

D adds the affordance for the SPA route to resume a parked OAuth flow when given one. It does NOT change any existing caller — the unauth pending-client "share this link with another admin" case continues to render the dead-end success state. The presence of `return_to` is the discriminator.

## Server changes

**`src/admin-clients.ts`** — `handleApproveClient` learns an optional JSON body field `return_to`. Validated via `isSafeAuthorizeReturnTo` (the same gate used by the inline-button POST, exported from oauth-handlers.ts in this PR). Valid → response carries `redirect_to`. Invalid / missing → response omits the field. The approve always succeeds; a bad `return_to` doesn't fail the action.

`readReturnTo` is tolerant by design — pre-D callers send no body / non-JSON / malformed JSON, and the endpoint must continue to work. Any of those produce `null`, which means no `redirect_to` in the response.

**`src/oauth-handlers.ts`** — `isSafeAuthorizeReturnTo` exported (was file-local). Single source of truth for "is this a valid OAuth resume target?" — must start with `/`, not start with `//`, and target `/oauth/authorize?`.

## SPA changes

**`web/ui/src/routes/ApproveClient.tsx`** — reads `?return_to=<url>` via `useSearchParams`, validates same-origin (starts with `/`, doesn't start with `//`), passes through to the API call. On success with `redirect_to`, re-validates client-side as belt-and-suspenders and `window.location.assign(redirect_to)`.

Race-tolerance: if the client is already approved on page load AND `return_to` is set, the SPA auto-redirects immediately rather than dead-ending on "already approved" — saves the operator a redundant click.

**`web/ui/src/lib/api.ts`** — `approveOauthClient(clientId, returnTo?)`. The optional second argument is the SPA's only addition to the wire shape; the body is JSON `{ return_to }` when present, omitted otherwise.

## Pattern doc

`parachute-patterns/patterns/oauth-dcr-approval.md` updated (separate PR in the patterns repo) with a new "SPA approve page (two cases, one route)" section documenting:

- Case 1 — OAuth resume (`return_to` present): SPA POSTs with `return_to`, server echoes `redirect_to`, SPA navigates.
- Case 2 — Share link / direct nav (no `return_to`): unchanged pre-D shape.
- Why two cases on one route (not two routes).
- When to use which (table by caller).

The pattern doc also updates "four paths to approved" → "five paths" (added SPA approve page as a peer to inline button / CLI / cookie auto-approve / operator-bearer).

## Tests

- `src/__tests__/admin-clients.test.ts` — 7 new tests:
  - Valid same-origin `/oauth/authorize?...` return_to → response carries `redirect_to`.
  - Missing return_to (pre-D shape) → response omits `redirect_to` (share-link case preserved).
  - Scheme-relative (`//evil.example/...`) return_to → dropped silently, approve still succeeds.
  - Off-path same-origin (`/admin/vaults`) return_to → dropped (gate is "authorize URL only").
  - Absolute URL return_to → dropped.
  - `text/plain` body → no parser explosion, dropped.
  - Malformed JSON body → no parser explosion, dropped.
  - Re-approve with return_to (idempotent path) → still echoes `redirect_to`.

- `web/ui/src/routes/ApproveClient.test.tsx` — 7 new tests:
  - Approve with return_to in URL → API called with return_to arg, `window.location.assign(redirect_to)` triggered.
  - No return_to in URL → API called with `undefined`, dead-end success state renders.
  - Off-origin (`//evil.example/...`) return_to in URL → SPA's same-origin gate drops it BEFORE the API call (no off-origin value smuggled through).
  - Absolute URL return_to → dropped at SPA gate.
  - Server echoes off-origin redirect_to (defensive) → SPA's belt-and-suspenders gate refuses navigation.
  - Already-approved on load with return_to → auto-redirect, no Approve button.
  - Already-approved on load without return_to → unchanged dead-end "already approved" state.

## Gates

- `bun run typecheck` (hub + web/ui) — clean.
- `bun test ./src` — 1958/1958 pass.
- `bun run test` (web/ui) — 210/210 pass.

## Scope guardrails (audit's instructions)

- Inline-resume flow at `/oauth/authorize` is unchanged (working post-rc.38).
- Share-link affordance text + behaviour unchanged.
- No unauth CTA repointed at the SPA route — that's a separate design call. D adds the affordance; future work can choose to wire it.

## Test plan (reviewer)

- [ ] Read the new admin-clients tests; confirm the `return_to` gate matches the inline-button gate (same `isSafeAuthorizeReturnTo`).
- [ ] Read ApproveClient.tsx; confirm the client-side same-origin check matches the server's, and that off-origin values fall back cleanly to the share-link state.
- [ ] Confirm the share-link case is byte-identical pre/post-D for callers that don't pass `return_to` (no `redirect_to` in response, no `window.location.assign` call).
- [ ] Patterns check: workstream D adds a path to `oauth-dcr-approval.md`; verify the doc PR (separate, in `parachute-patterns`) accurately captures the two cases.
- [ ] Smoke: navigate to `/admin/approve-client/<id>` with no query string — should render the unchanged Approve button + dead-end success state.
- [ ] Smoke: navigate to `/admin/approve-client/<id>?return_to=/oauth/authorize?client_id=...&response_type=code&scope=vault%3Aread` — should redirect to the authorize URL after Approve.

Self-review pending fresh reviewer dispatch — see PR comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)