### PR TITLE
feat(hub): unify state vocab across CLI + SPA + well-known (workstream F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+## [Unreleased]
+
+**feat(hub): unify state vocabulary across CLI + admin SPA + well-known doc (workstream F).**
+
+The 2026-05-25 UX audit (§2.3, §2.7) flagged three different vocabularies for the same module-supervisor concept: CLI said `running` / `stopped` / `-`; admin SPA said `Active` / `Pending-OAuth` / `Disabled`; the supervisor's internal state model said `active` / `pending-oauth` / `disabled`. Workstream F aligns every user-facing surface on the four canonical states from [parachute-patterns/patterns/design-system.md §6](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/design-system.md): `active` / `pending` / `inactive` / `failing`.
+
+Wire shapes are stable. The mapping happens at the emit-time site: `services-manifest.ts` normalizes pre-F values (`pending-oauth`, `disabled`) to canonical on read, and the SPA + CLI render-time helpers map supervisor lifecycle states (`running`, `starting`, etc.) onto the rollup vocabulary.
+
+### Changed
+
+- **`parachute status` columns** (`src/commands/status.ts`, `src/help.ts`). Pre-F: `SERVICE PORT VERSION PROCESS PID UPTIME HEALTH LATENCY SOURCE` — `PROCESS` (`running` / `stopped` / `-`) and `HEALTH` (`ok` / `down` / `http <code>`) encoded the same rollup in two columns. Post-F: `SERVICE PORT VERSION STATE PID UPTIME LATENCY SOURCE` — single `STATE` column with one of `active` / `pending` / `inactive` / `failing`. Probe-failure detail (`http 503`, `ECONNREFUSED`) survives on a continuation line (`  ! probe: <detail>`) so operators don't lose the diagnosis.
+
+- **Admin SPA `/admin/modules` status badges** (`web/ui/src/routes/Modules.tsx`, `web/ui/src/styles.css`). Both the module-row supervisor badge and the per-UI sub-unit badge now render the four canonical states. New CSS classes `.status-active`, `.status-pending`, `.status-inactive`, `.status-failing`. Module-row label is now the rollup state (e.g. `active`) rather than the raw supervisor status (`running`). New `web/ui/src/lib/state.ts` houses the supervisor → unified-state mapping in one place.
+
+- **`UiSubUnitStatus` (services.json + wire)** (`src/services-manifest.ts`, `src/__tests__/services-manifest.test.ts`). Canonical values are now `active` / `pending` / `inactive` / `failing`. Pre-F values (`pending-oauth`, `disabled`) are still accepted on read and normalized to canonical so downstream emit surfaces (well-known doc, `/api/modules`) always see the new vocab. New tests pin the normalization boundary in `services-manifest.test.ts` and end-to-end through `/api/modules` in `api-modules.test.ts`.
+
+### Back-compat (retire one rc-chain after this lands)
+
+- **CSS class aliases**: `.status-pending-oauth` and `.status-disabled` continue to paint correctly (mirror the colors of `.status-pending` and `.status-inactive` respectively) so any out-of-tree consumer still rendering legacy class names doesn't lose its palette during the cutover.
+- **services-manifest input aliases**: `pending-oauth` / `disabled` accepted on read; normalized to canonical before persisting.
+- **SPA render-time alias**: `unifiedStateForUi` accepts legacy values so a stale row served before the storage normalizer fold doesn't get an unstyled badge.
+
+### Patterns check
+
+- Adopts [parachute-patterns/patterns/design-system.md](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/design-system.md) §6 (state vocabulary) and §7 (status badge component).
+- Companion adoption in vault/app/scribe/runner SDKs is a follow-up — they may continue emitting legacy values for one release cycle (hub normalizes at the storage boundary).
+
+### Verification
+
+- `bun run typecheck` clean (server + web/ui).
+- `bun test ./src`: 1962 pass / 0 fail (3 new tests).
+- `bun run test` (web/ui): 213 pass / 0 fail (2 new tests).
+- No version bump per governance Rule 2 — collects into the next rc-chain ship decision.
+
 ## [0.5.13-rc.39] - 2026-05-25
 
 **feat(hub): well-known fan-out reads vault's declared uiUrl + retires the hardcoded Browse Vault tile + `/admin/approve-client` supports OAuth resume (workstreams C/4 + D).**

--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -519,7 +519,7 @@ describe("GET /api/modules", () => {
             techne: {
               displayName: "Techne",
               path: "/vault/techne",
-              status: "pending-oauth",
+              status: "pending",
             },
           },
         },
@@ -566,7 +566,7 @@ describe("GET /api/modules", () => {
           icon_url: null,
           version: null,
           oauth_client_id: null,
-          status: "pending-oauth",
+          status: "pending",
         },
       ]);
       // Other curated rows stay empty — uis is per-row, not global.
@@ -590,7 +590,7 @@ describe("GET /api/modules", () => {
               iconUrl: "/vault/full/icon.svg",
               version: "0.3.1",
               oauthClientId: "c1",
-              status: "disabled",
+              status: "inactive",
             },
           },
         },
@@ -626,8 +626,60 @@ describe("GET /api/modules", () => {
         icon_url: "/vault/full/icon.svg",
         version: "0.3.1",
         oauth_client_id: "c1",
-        status: "disabled",
+        status: "inactive",
       });
+    });
+
+    test("legacy `pending-oauth` / `disabled` status values normalize to canonical vocab on the wire (workstream F back-compat)", async () => {
+      // Workstream F unifies the SPA / CLI / well-known state vocab onto
+      // `active | pending | inactive | failing`. Old modules / SDKs may
+      // still write the pre-F values to services.json (`pending-oauth`,
+      // `disabled`). `services-manifest.ts` normalizes on read so every
+      // downstream emit (this API, well-known doc) sees the canonical
+      // form. Pins that boundary normalization end-to-end here.
+      writeManifest(h.manifestPath, [
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.4.5",
+          uis: {
+            legacy_pending: {
+              displayName: "Legacy Pending",
+              path: "/vault/legacy-pending",
+              // biome-ignore lint/suspicious/noExplicitAny: deliberately
+              // writing the pre-F legacy alias to pin the normalization
+              // boundary; the schema accepts it on read.
+              status: "pending-oauth" as any,
+            },
+            legacy_disabled: {
+              displayName: "Legacy Disabled",
+              path: "/vault/legacy-disabled",
+              // biome-ignore lint/suspicious/noExplicitAny: same as above.
+              status: "disabled" as any,
+            },
+          },
+        },
+      ]);
+      const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+      const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        fetchLatestVersion: async () => null,
+      });
+      const body = (await res.json()) as {
+        modules: Array<{
+          short: string;
+          uis: Array<{ name: string; status: string | null }>;
+        }>;
+      };
+      const vault = body.modules.find((m) => m.short === "vault");
+      const pending = vault?.uis.find((u) => u.name === "legacy_pending");
+      const inactive = vault?.uis.find((u) => u.name === "legacy_disabled");
+      expect(pending?.status).toBe("pending");
+      expect(inactive?.status).toBe("inactive");
     });
   });
 });

--- a/src/__tests__/services-manifest.test.ts
+++ b/src/__tests__/services-manifest.test.ts
@@ -257,7 +257,7 @@ describe("services-manifest", () => {
               displayName: "Unforced Brain",
               path: "/app/unforced-brain",
               oauthClientId: "client_def456",
-              status: "pending-oauth",
+              status: "pending",
             },
           },
         };
@@ -381,6 +381,79 @@ describe("services-manifest", () => {
           },
         };
         expect(() => upsertService(bad, path)).toThrow(/status/);
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("normalizes legacy `pending-oauth` → `pending` on read (workstream F back-compat)", () => {
+      // Pre-F services may still write the legacy alias. The schema
+      // accepts it on read + normalizes to the canonical vocab so
+      // downstream emit surfaces (well-known, /api/modules, SPA) always
+      // see the canonical form. Retire after the next rc-chain alias
+      // window per design-system.md §6.
+      const { path, cleanup } = makeTempPath();
+      try {
+        const legacy: ServiceEntry = {
+          ...app,
+          uis: {
+            slug: {
+              displayName: "S",
+              path: "/app/s",
+              // biome-ignore lint/suspicious/noExplicitAny: deliberately
+              // writing the pre-F legacy alias to pin the normalization
+              // boundary; the schema accepts it on read.
+              status: "pending-oauth" as any,
+            },
+          },
+        };
+        upsertService(legacy, path);
+        const got = readManifest(path).services[0]?.uis?.slug;
+        expect(got?.status).toBe("pending");
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("normalizes legacy `disabled` → `inactive` on read (workstream F back-compat)", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        const legacy: ServiceEntry = {
+          ...app,
+          uis: {
+            slug: {
+              displayName: "S",
+              path: "/app/s",
+              // biome-ignore lint/suspicious/noExplicitAny: same as above.
+              status: "disabled" as any,
+            },
+          },
+        };
+        upsertService(legacy, path);
+        const got = readManifest(path).services[0]?.uis?.slug;
+        expect(got?.status).toBe("inactive");
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("accepts new canonical states (`failing`, `inactive`)", () => {
+      // `failing` is new in workstream F (no pre-F equivalent — pre-F
+      // collapsed failing into `disabled`). `inactive` is the new
+      // canonical name for `disabled`. Both must validate.
+      const { path, cleanup } = makeTempPath();
+      try {
+        const entry: ServiceEntry = {
+          ...app,
+          uis: {
+            f: { displayName: "F", path: "/app/f", status: "failing" },
+            i: { displayName: "I", path: "/app/i", status: "inactive" },
+          },
+        };
+        upsertService(entry, path);
+        const got = readManifest(path).services[0]?.uis;
+        expect(got?.f?.status).toBe("failing");
+        expect(got?.i?.status).toBe("inactive");
       } finally {
         cleanup();
       }

--- a/src/__tests__/status.test.ts
+++ b/src/__tests__/status.test.ts
@@ -62,15 +62,21 @@ describe("status", () => {
       expect(code).toBe(0);
       expect(seen).toContain("http://localhost:1940/health");
       expect(seen).toContain("http://localhost:3200/scribe/health");
+      // Header reflects the post-workstream-F column shape:
+      // SERVICE  PORT  VERSION  STATE  PID  UPTIME  LATENCY  SOURCE
       expect(lines[0]).toMatch(/SERVICE/);
+      expect(lines[0]).toMatch(/STATE/);
+      expect(lines[0]).not.toMatch(/PROCESS/);
+      expect(lines[0]).not.toMatch(/HEALTH/);
       expect(lines.some((l) => l.includes("parachute-vault"))).toBe(true);
-      expect(lines.some((l) => l.includes("ok"))).toBe(true);
+      // Healthy probe rolls up to `active` per design-system.md §6.
+      expect(lines.some((l) => /\bactive\b/.test(l))).toBe(true);
     } finally {
       cleanup();
     }
   });
 
-  test("any-failing returns 1", async () => {
+  test("any-failing returns 1 and surfaces probe detail on continuation line", async () => {
     const { path, cleanup } = makeTempPath();
     try {
       upsertService(
@@ -86,13 +92,17 @@ describe("status", () => {
         print: (l) => lines.push(l),
       });
       expect(code).toBe(1);
-      expect(lines.some((l) => l.includes("ECONNREFUSED"))).toBe(true);
+      // STATE column rolls up to `failing`.
+      expect(lines.some((l) => /\bfailing\b/.test(l))).toBe(true);
+      // The pre-F HEALTH column's detail survives on a continuation line
+      // ("  ! probe: ECONNREFUSED") so the operator can still diagnose.
+      expect(lines.some((l) => l.includes("probe:") && l.includes("ECONNREFUSED"))).toBe(true);
     } finally {
       cleanup();
     }
   });
 
-  test("http non-2xx counts as unhealthy with status code", async () => {
+  test("http non-2xx counts as failing and surfaces the code on the probe line", async () => {
     const { path, cleanup } = makeTempPath();
     try {
       upsertService(
@@ -106,13 +116,14 @@ describe("status", () => {
         print: (l) => lines.push(l),
       });
       expect(code).toBe(1);
-      expect(lines.some((l) => l.includes("http 503"))).toBe(true);
+      expect(lines.some((l) => /\bfailing\b/.test(l))).toBe(true);
+      expect(lines.some((l) => l.includes("probe: http 503"))).toBe(true);
     } finally {
       cleanup();
     }
   });
 
-  test("running process shows pid + uptime and still probes", async () => {
+  test("running + healthy probe shows STATE=active, pid + uptime", async () => {
     const { path, configDir, cleanup } = makeTempPath();
     try {
       upsertService(
@@ -129,15 +140,19 @@ describe("status", () => {
         print: (l) => lines.push(l),
       });
       expect(code).toBe(0);
-      expect(lines.some((l) => l.includes("running"))).toBe(true);
+      // Pre-F: STATE was a two-column (PROCESS=running, HEALTH=ok) split.
+      // Post-F: collapsed to one column showing `active`.
+      expect(lines.some((l) => /\bactive\b/.test(l))).toBe(true);
       expect(lines.some((l) => l.includes("4242"))).toBe(true);
-      expect(lines.some((l) => l.includes("ok"))).toBe(true);
+      // Probe-detail continuation line is suppressed for active rows
+      // (the rollup is sufficient — no need to repeat "ok").
+      expect(lines.some((l) => l.includes("probe:"))).toBe(false);
     } finally {
       cleanup();
     }
   });
 
-  test("known-stopped process skips probe and doesn't fail exit", async () => {
+  test("known-stopped process renders STATE=inactive, skips probe, exits 0", async () => {
     const { path, configDir, cleanup } = makeTempPath();
     try {
       upsertService(
@@ -159,7 +174,8 @@ describe("status", () => {
       });
       expect(code).toBe(0);
       expect(probed).toBe(false);
-      expect(lines.some((l) => l.includes("stopped"))).toBe(true);
+      // Pre-F: PROCESS=stopped. Post-F: STATE=inactive.
+      expect(lines.some((l) => /\binactive\b/.test(l))).toBe(true);
     } finally {
       cleanup();
     }

--- a/src/__tests__/well-known.test.ts
+++ b/src/__tests__/well-known.test.ts
@@ -447,7 +447,7 @@ describe("buildWellKnown", () => {
             displayName: "Unforced Brain",
             path: "/app/unforced-brain",
             oauthClientId: "client_def456",
-            status: "pending-oauth",
+            status: "pending",
           },
         },
       };
@@ -471,7 +471,7 @@ describe("buildWellKnown", () => {
           path: "/app/unforced-brain",
           url: "https://x.example/app/unforced-brain",
           oauthClientId: "client_def456",
-          status: "pending-oauth",
+          status: "pending",
         },
       ]);
     });
@@ -553,7 +553,7 @@ describe("buildWellKnown", () => {
             version: "0.3.1",
             iconUrl: "/i.svg",
             oauthClientId: "c1",
-            status: "disabled",
+            status: "inactive",
           },
           minimal: { displayName: "Minimal", path: "/app/minimal" },
         },
@@ -568,7 +568,7 @@ describe("buildWellKnown", () => {
       expect(full?.tagline).toBe("Has it all");
       expect(full?.version).toBe("0.3.1");
       expect(full?.oauthClientId).toBe("c1");
-      expect(full?.status).toBe("disabled");
+      expect(full?.status).toBe("inactive");
       // Minimal carries only the required fields — no optional keys.
       expect(minimal).toEqual({
         name: "minimal",

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -82,14 +82,41 @@ function formatRow(cells: string[], widths: number[]): string {
     .trimEnd();
 }
 
+/**
+ * Canonical user-facing state vocabulary, per [parachute-patterns/patterns/
+ * design-system.md §6](../parachute-patterns/patterns/design-system.md)
+ * (workstream F). Replaces the pre-F two-column `PROCESS` (running/stopped)
+ * + `HEALTH` (ok/down/http <code>) split with a single rollup column the
+ * SPA, well-known doc, and CLI all share.
+ *
+ *   active   — process supervised, probe ok.
+ *   pending  — supervised, needs operator action (OAuth, config) — not
+ *              reached from `parachute status` today; here for completeness
+ *              so the union matches what the SPA renders.
+ *   inactive — operator-stopped or never started.
+ *   failing  — supervised but probe failed (down / non-2xx).
+ */
+type StateLabel = "active" | "pending" | "inactive" | "failing";
+
 interface StatusRow {
   service: string;
   port: string;
   version: string;
-  processLabel: string;
+  /**
+   * Canonical four-state label per design-system.md §6 — what the operator
+   * reads. Derived from the pre-F (PROCESS, HEALTH) tuple at the emit-time
+   * site so the wider supervisor pipeline doesn't have to change shape.
+   */
+  stateLabel: StateLabel | "-";
   pidLabel: string;
   uptimeLabel: string;
-  healthLabel: string;
+  /**
+   * Pre-F probe-result detail (`ok` / `http 503` / `ECONNREFUSED` / …).
+   * Kept on the row so the continuation-line context is still available
+   * when a row is `failing` and the operator wants to know why. Not a
+   * column; surfaced inline beneath the row only when non-trivial.
+   */
+  healthDetail: string;
   latencyLabel: string;
   sourceLabel: string;
   url: string | undefined;
@@ -137,7 +164,10 @@ function hubRow(
   if (proc.status === "unknown") return undefined;
   const port = readHubPort(configDir);
   const portLabel = port !== undefined ? String(port) : "-";
-  const processLabel = proc.status === "running" ? "running" : "stopped";
+  // Hub doesn't self-probe (it'd be probing itself over loopback). Treat
+  // "running pidfile" as `active` and "stopped" as `inactive` — the same
+  // STATE rollup every other row uses, just without the probe input.
+  const stateLabel: StateLabel = proc.status === "running" ? "active" : "inactive";
   const pidLabel = proc.status === "running" && proc.pid !== undefined ? String(proc.pid) : "-";
   const uptimeLabel =
     proc.status === "running" && proc.startedAt ? formatUptime(proc.startedAt, nowDate) : "-";
@@ -146,10 +176,10 @@ function hubRow(
     service: "parachute-hub (internal)",
     port: portLabel,
     version: source.livePackageVersion ?? "-",
-    processLabel,
+    stateLabel,
     pidLabel,
     uptimeLabel,
-    healthLabel: "-",
+    healthDetail: "-",
     latencyLabel: "-",
     sourceLabel: formatInstallSourceLabel(source),
     url: port !== undefined ? `http://127.0.0.1:${port}` : undefined,
@@ -194,8 +224,6 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
       const short = shortNameForManifest(entry.name) ?? (entry.installDir ? entry.name : undefined);
       const proc = short ? processState(short, configDir, alive) : undefined;
 
-      const processLabel =
-        proc?.status === "running" ? "running" : proc?.status === "stopped" ? "stopped" : "-";
       const pidLabel =
         proc?.status === "running" && proc.pid !== undefined ? String(proc.pid) : "-";
       const uptimeLabel =
@@ -235,10 +263,14 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
           service: entry.name,
           port: String(entry.port),
           version: entry.version,
-          processLabel,
+          // Operator deliberately stopped (or pidfile-but-dead) maps to
+          // `inactive` per design-system.md §6 — same surface as "never
+          // started." No probe is informative when we know the process
+          // is dead.
+          stateLabel: "inactive",
           pidLabel,
           uptimeLabel,
-          healthLabel: "-",
+          healthDetail: "-",
           latencyLabel: "-",
           sourceLabel,
           url,
@@ -250,19 +282,32 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
       }
 
       const p = await probe(entry, fetchImpl, timeoutMs);
-      const healthLabel = p.healthy
+      const healthDetail = p.healthy
         ? "ok"
         : p.statusCode !== undefined
           ? `http ${p.statusCode}`
           : (p.error ?? "down");
+      // STATE rollup per design-system.md §6:
+      //   - probe ok                  → `active`
+      //   - probe failed              → `failing` (the probe ran, so the
+      //                                 process is up enough to answer or
+      //                                 refuse — it's failing, not stopped)
+      //   - no PID file + probe fails → `failing` too (externally-managed
+      //                                 row that's down is still "failing"
+      //                                 from the operator's view)
+      // The `pending` state isn't reachable from `parachute status` today
+      // — pending-OAuth surfaces in the admin SPA, not the CLI. If a
+      // future surface adds it (e.g. supervisor reports `pending-config`
+      // for unconfigured modules), wire it here.
+      const stateLabel: StateLabel = p.healthy ? "active" : "failing";
       return {
         service: entry.name,
         port: String(entry.port),
         version: entry.version,
-        processLabel,
+        stateLabel,
         pidLabel,
         uptimeLabel,
-        healthLabel,
+        healthDetail,
         latencyLabel: `${p.latencyMs}ms`,
         sourceLabel,
         url,
@@ -279,25 +324,20 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
   const hub = hubRow(configDir, alive, nowDate, hubSrcDir, installSourceDeps);
   if (hub) rows.push(hub);
 
-  const header = [
-    "SERVICE",
-    "PORT",
-    "VERSION",
-    "PROCESS",
-    "PID",
-    "UPTIME",
-    "HEALTH",
-    "LATENCY",
-    "SOURCE",
-  ];
+  // Header per design-system.md §6 "CLI status column shape":
+  //   SERVICE  PORT  VERSION  STATE   PID  UPTIME  LATENCY  SOURCE
+  // Pre-F shape was SERVICE PORT VERSION PROCESS PID UPTIME HEALTH LATENCY
+  // SOURCE — workstream F collapses PROCESS + HEALTH into a single STATE
+  // column (both encoded the same rollup in two slots). LATENCY stays as
+  // a separate measurement column.
+  const header = ["SERVICE", "PORT", "VERSION", "STATE", "PID", "UPTIME", "LATENCY", "SOURCE"];
   const textRows = rows.map((r) => [
     r.service,
     r.port,
     r.version,
-    r.processLabel,
+    r.stateLabel,
     r.pidLabel,
     r.uptimeLabel,
-    r.healthLabel,
     r.latencyLabel,
     r.sourceLabel,
   ]);
@@ -305,18 +345,28 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
     Math.max(header[i]?.length ?? 0, ...textRows.map((r) => r[i]?.length ?? 0)),
   );
   print(formatRow(header, widths));
-  // URL, drift, and stale notes stay on continuation lines rather than
-  // columns. URLs are long (vault's MCP path runs ~40 chars); SOURCE labels
-  // can be long for bun-linked rows. Spreading them across columns would
-  // push the table well past 80 cols on every install — continuation lines
-  // keep the table scannable. The "  → " / "  ! " prefixes group visually
-  // with the row above without misleading the table widths.
+  // URL, drift, stale, and probe-failure detail stay on continuation lines
+  // rather than columns. URLs are long (vault's MCP path runs ~40 chars);
+  // SOURCE labels can be long for bun-linked rows. Spreading them across
+  // columns would push the table well past 80 cols on every install —
+  // continuation lines keep the table scannable. The "  → " / "  ! "
+  // prefixes group visually with the row above without misleading the
+  // table widths.
+  //
+  // When STATE collapses to `failing`, the pre-F `HEALTH` column's detail
+  // (`http 503`, `ECONNREFUSED`, etc.) surfaces on a continuation line so
+  // the operator can still see "what kind of failing" without the column
+  // overhead. Skipped on `active` / `inactive` rows (the detail is either
+  // trivial or N/A).
   for (let i = 0; i < textRows.length; i++) {
     const cells = textRows[i];
     const row = rows[i];
     if (!cells || !row) continue;
     print(formatRow(cells, widths));
     if (row.url) print(`  → ${row.url}`);
+    if (row.stateLabel === "failing" && row.healthDetail !== "-" && row.healthDetail.length > 0) {
+      print(`  ! probe: ${row.healthDetail}`);
+    }
     if (row.driftWarning) print(`  ! ${row.driftWarning}`);
     if (row.staleNote) print(`  ! ${row.staleNote}`);
   }

--- a/src/help.ts
+++ b/src/help.ts
@@ -142,21 +142,36 @@ Examples:
 }
 
 export function statusHelp(): string {
-  return `parachute status — show installed services, process state, health, install source
+  return `parachute status — show installed services, run state, install source
 
 Usage:
   parachute status
 
 What it does:
   Reads ~/.parachute/services.json. For each registered service:
-    - checks PID file at ~/.parachute/<svc>/run/<svc>.pid → running/stopped
+    - checks PID file at ~/.parachute/<svc>/run/<svc>.pid
     - probes http://localhost:<port><health> (skipped for known-stopped processes)
     - classifies the install source as bun-linked (local checkout) or npm
 
-  Stopped services show "-" for health and don't count toward the exit
-  code — they're an expected state after fresh install before \`parachute
-  start\`. Running or externally-managed services that fail health checks
-  do exit 1.
+  The STATE column rolls process state + probe result into one of four
+  canonical labels (per parachute-patterns/patterns/design-system.md §6):
+    active    supervised, running, last probe ok
+    pending   supervised, needs operator action (OAuth / config) —
+              not reachable from \`parachute status\` today; surfaces in
+              the admin SPA; kept here for completeness
+    inactive  operator-stopped or never started (no probe attempted)
+    failing   supervised but probe failed (down / non-2xx); a
+              continuation line ("  ! probe: <detail>") prints the
+              underlying probe failure for diagnosis
+
+  Pre-workstream-F this column was two: PROCESS (running / stopped) and
+  HEALTH (ok / down / http <code>). Workstream F collapsed them onto the
+  single STATE column the SPA + well-known doc also speak.
+
+  Stopped services render as STATE=inactive and don't count toward the
+  exit code — they're an expected state after fresh install before
+  \`parachute start\`. Running or externally-managed services that fail
+  health checks render as STATE=failing and exit 1.
 
   A "STALE: services.json cached … live package.json …" continuation line
   appears under a row when a bun-linked service has been rebuilt but the
@@ -169,10 +184,10 @@ Exit codes:
 
 Example:
   $ parachute status
-  SERVICE          PORT  VERSION  PROCESS  PID    UPTIME  HEALTH  LATENCY  SOURCE
-  parachute-vault  1940  0.2.4    running  12345  2h 13m  ok      2ms      bun-linked → parachute-vault @ 8aa167b
+  SERVICE          PORT  VERSION  STATE   PID    UPTIME  LATENCY  SOURCE
+  parachute-vault  1940  0.2.4    active  12345  2h 13m  2ms      bun-linked → parachute-vault @ 8aa167b
     → http://127.0.0.1:1940/vault/default/mcp
-  parachute-app    1946  0.2.0    running  12346  2h 12m  ok      3ms      npm (0.2.0-rc.4)
+  parachute-app    1946  0.2.0    active  12346  2h 12m  3ms      npm (0.2.0-rc.4)
     → http://127.0.0.1:1946/app/notes
 `;
 }

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -24,19 +24,52 @@ import { RETIRED_MODULES } from "./service-spec.ts";
 export type PublicExposure = "allowed" | "loopback" | "auth-required";
 
 /**
- * Visible-to-discovery state of a UI sub-unit. Mirrors parachute-app's
- * `RegisteredUi.status` so hub renders the same label the app's admin SPA
- * shows. Absent → hub treats the sub-unit as "active" (the discovery
- * default).
+ * Visible-to-discovery state of a UI sub-unit. Aligns with the four-state
+ * supervisor vocabulary in [parachute-patterns/patterns/design-system.md
+ * §6](../parachute-patterns/patterns/design-system.md) (workstream F).
+ * Absent → hub treats the sub-unit as "active" (the discovery default).
  *
- *   "active"        — UI is installed, OAuth client is approved, ready to serve.
- *   "pending-oauth" — UI is installed but its OAuth client hasn't been approved
- *                     yet (operator still needs to click through `/admin/oauth-clients`
- *                     or the app's admin SPA gate). Discovery should render the
- *                     row but signal "not yet usable."
- *   "disabled"      — Operator-disabled. Renders greyed-out; no link.
+ *   "active"   — UI is installed, OAuth client is approved, ready to serve.
+ *   "pending"  — UI is installed but needs operator action (OAuth approval,
+ *                config) before it can run. Discovery renders the row but
+ *                signals "not yet usable."
+ *   "inactive" — Operator-disabled. Renders greyed-out; no link.
+ *   "failing"  — UI is installed but the latest health probe failed. Discovery
+ *                renders the row with an error treatment.
+ *
+ * Back-compat aliases accepted on read for one release window (workstream F
+ * landing — retire after the next rc chain): `pending-oauth` → `pending`,
+ * `disabled` → `inactive`. Aliases are normalized to the canonical value on
+ * `readManifest` so downstream emit surfaces (well-known, /api/modules)
+ * always see the new vocabulary. The wire shape emits the canonical value;
+ * parachute-app + other consumers should accept both during the alias
+ * window and pin to the canonical going forward.
  */
-export type UiSubUnitStatus = "active" | "pending-oauth" | "disabled";
+export type UiSubUnitStatus = "active" | "pending" | "inactive" | "failing";
+
+/**
+ * Old-vocabulary alias values still accepted on read for back-compat with
+ * services that haven't yet caught up to workstream F. Normalized to the
+ * canonical `UiSubUnitStatus` on read.
+ */
+const UI_SUB_UNIT_STATUS_ALIASES: Record<string, UiSubUnitStatus> = {
+  "pending-oauth": "pending",
+  disabled: "inactive",
+};
+
+const UI_SUB_UNIT_STATUS_CANONICAL: readonly UiSubUnitStatus[] = [
+  "active",
+  "pending",
+  "inactive",
+  "failing",
+];
+
+function normalizeUiSubUnitStatus(value: string): UiSubUnitStatus | undefined {
+  if ((UI_SUB_UNIT_STATUS_CANONICAL as readonly string[]).includes(value)) {
+    return value as UiSubUnitStatus;
+  }
+  return UI_SUB_UNIT_STATUS_ALIASES[value];
+}
 
 /**
  * A sub-unit beneath a module — used today by parachute-app to surface each
@@ -284,22 +317,27 @@ function validateUiSubUnit(raw: unknown, where: string): UiSubUnit {
   if (oauthClientId !== undefined && typeof oauthClientId !== "string") {
     throw new ServicesManifestError(`${where}: "oauthClientId" must be a string if present`);
   }
-  if (
-    status !== undefined &&
-    status !== "active" &&
-    status !== "pending-oauth" &&
-    status !== "disabled"
-  ) {
-    throw new ServicesManifestError(
-      `${where}: "status" must be "active" | "pending-oauth" | "disabled" if present`,
-    );
+  let normalizedStatus: UiSubUnitStatus | undefined;
+  if (status !== undefined) {
+    if (typeof status !== "string") {
+      throw new ServicesManifestError(
+        `${where}: "status" must be "active" | "pending" | "inactive" | "failing" if present`,
+      );
+    }
+    const norm = normalizeUiSubUnitStatus(status);
+    if (norm === undefined) {
+      throw new ServicesManifestError(
+        `${where}: "status" must be "active" | "pending" | "inactive" | "failing" if present (got ${JSON.stringify(status)})`,
+      );
+    }
+    normalizedStatus = norm;
   }
   const out: UiSubUnit = { displayName, path };
   if (tagline !== undefined) out.tagline = tagline;
   if (iconUrl !== undefined) out.iconUrl = iconUrl;
   if (version !== undefined) out.version = version;
   if (oauthClientId !== undefined) out.oauthClientId = oauthClientId;
-  if (status !== undefined) out.status = status as UiSubUnitStatus;
+  if (normalizedStatus !== undefined) out.status = normalizedStatus;
   return out;
 }
 

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -597,9 +597,23 @@ export async function approveOauthClient(
 
 /**
  * Status of a hosted UI sub-unit, mirrors `UiSubUnitStatus` server-side.
+ * Workstream F (design-system.md §6) aligned this with the unified
+ * four-state vocabulary; pre-F values (`pending-oauth`, `disabled`) are
+ * still accepted on the wire for one release window and the SPA normalizes
+ * them via `lib/state.ts:unifiedStateForUi` at render time.
+ *
  * Absent (null) → discovery treats as "active".
  */
-export type UiSubUnitStatus = "active" | "pending-oauth" | "disabled";
+export type UiSubUnitStatus =
+  | "active"
+  | "pending"
+  | "inactive"
+  | "failing"
+  // Back-compat aliases — accepted on the wire during the F-landing
+  // release window so rows from a not-yet-restarted older module still
+  // render. Retire after the next rc chain.
+  | "pending-oauth"
+  | "disabled";
 
 /**
  * One sub-unit beneath a module — surfaced on `ModuleListing.uis` when the

--- a/web/ui/src/lib/state.ts
+++ b/web/ui/src/lib/state.ts
@@ -1,0 +1,92 @@
+/**
+ * Unified state vocabulary per
+ * [parachute-patterns/patterns/design-system.md §6](../../../parachute-patterns/patterns/design-system.md)
+ * (workstream F). Four canonical states — `active` / `pending` / `inactive`
+ * / `failing` — shared across the CLI's `parachute status` rollup, the
+ * admin SPA's module + UI sub-unit badges, and the well-known doc.
+ *
+ *   active   — supervised, running, healthy.
+ *   pending  — supervised but needs operator action (OAuth approval,
+ *              config) before it can run.
+ *   inactive — operator-stopped or never started.
+ *   failing  — supervised but unhealthy (crash, probe failure).
+ */
+export type UnifiedState = "active" | "pending" | "inactive" | "failing";
+
+/** Supervisor lifecycle status as returned by `/api/modules`. */
+export type SupervisorStatus = "starting" | "running" | "stopped" | "crashed" | "restarting" | null;
+
+/**
+ * Render-time mapping from the supervisor's internal lifecycle vocabulary
+ * (`starting | running | stopped | crashed | restarting`) onto the four
+ * user-facing states. Per the design-system mapping table:
+ *
+ *   - `running`              → `active`
+ *   - `starting | restarting`→ `pending` (transient, operator typically
+ *                              doesn't need to do anything — surfaces as
+ *                              a "do nothing, wait" treatment)
+ *   - `stopped`              → `inactive`
+ *   - `crashed`              → `failing`
+ *   - `null` (no supervisor) → `inactive` (no process, no state)
+ *
+ * The wire shape (`supervisor_status`) is intentionally left unchanged —
+ * the SPA does the mapping at render time so the internal supervisor
+ * pipeline stays decoupled from the user-facing vocabulary. When new
+ * supervisor states get added, this helper is the one place to extend.
+ */
+export function unifiedStateForSupervisor(status: SupervisorStatus): UnifiedState {
+  switch (status) {
+    case "running":
+      return "active";
+    case "starting":
+    case "restarting":
+      return "pending";
+    case "crashed":
+      return "failing";
+    case "stopped":
+    case null:
+    case undefined:
+      return "inactive";
+    default:
+      return "inactive";
+  }
+}
+
+/**
+ * Render-time mapping for `UiSubUnitStatus`. As of workstream F the wire
+ * shape uses the canonical vocabulary directly (`services-manifest.ts`
+ * normalizes legacy `pending-oauth` / `disabled` values on read), so this
+ * helper is mostly a passthrough — it exists so the SPA can still cope
+ * gracefully if a wire value slips through with the old vocab (e.g. from
+ * an older module that hasn't restarted since the upgrade).
+ *
+ * Absent / null → `active` (the discovery default the wire docs codify).
+ */
+export function unifiedStateForUi(status: string | null | undefined): UnifiedState {
+  if (status == null) return "active";
+  switch (status) {
+    case "active":
+    case "pending":
+    case "inactive":
+    case "failing":
+      return status;
+    // Back-compat aliases — accepted in case a module published a sub-unit
+    // status pre-F and hasn't been restarted. Storage normalizes these on
+    // read, but the wire shape can't enforce that for in-flight rows.
+    case "pending-oauth":
+      return "pending";
+    case "disabled":
+      return "inactive";
+    default:
+      return "active";
+  }
+}
+
+/**
+ * User-facing label for a unified state. Stable per design-system.md —
+ * same string the badge renders, the CLI prints, and the well-known doc
+ * carries.
+ */
+export function unifiedStateLabel(state: UnifiedState): string {
+  return state;
+}

--- a/web/ui/src/routes/Modules.test.tsx
+++ b/web/ui/src/routes/Modules.test.tsx
@@ -181,6 +181,7 @@ describe("Modules — catalog rendering", () => {
       modules: [
         moduleRow("vault", { installed: true, supervisor_status: "running" }),
         moduleRow("notes", { installed: true, supervisor_status: "starting" }),
+        moduleRow("runner", { installed: true, supervisor_status: "restarting" }),
         moduleRow("scribe", { installed: true, supervisor_status: "crashed" }),
         moduleRow("app", { installed: true, supervisor_status: "stopped" }),
       ],
@@ -191,6 +192,10 @@ describe("Modules — catalog rendering", () => {
     await waitFor(() => expect(screen.getByTestId("module-status-vault")).toBeInTheDocument());
     expect(screen.getByTestId("module-status-vault")).toHaveClass("status-active");
     expect(screen.getByTestId("module-status-notes")).toHaveClass("status-pending");
+    // `restarting` is a sibling of `starting` in unifiedStateForSupervisor —
+    // both transient supervisor states → `pending`. Pinned independently to
+    // catch a future regression that splits the two arms.
+    expect(screen.getByTestId("module-status-runner")).toHaveClass("status-pending");
     expect(screen.getByTestId("module-status-scribe")).toHaveClass("status-failing");
     expect(screen.getByTestId("module-status-app")).toHaveClass("status-inactive");
   });

--- a/web/ui/src/routes/Modules.test.tsx
+++ b/web/ui/src/routes/Modules.test.tsx
@@ -144,7 +144,12 @@ describe("Modules — catalog rendering", () => {
     expect(screen.getByTestId("installable-empty")).toBeInTheDocument();
   });
 
-  it("shows 'Running' badge + installed version for an installed+running row", async () => {
+  it("shows 'active' badge + installed version for an installed+running row", async () => {
+    // Post-workstream-F: the module-row status badge collapses the
+    // supervisor's `running` lifecycle onto the unified `active` state
+    // (design-system.md §6). Pre-F the badge text was the raw supervisor
+    // status (`running`); the new vocab is shared with the CLI's
+    // `parachute status` and the well-known doc.
     vi.mocked(api.listModules).mockResolvedValue({
       modules: [
         moduleRow("vault", {
@@ -160,8 +165,34 @@ describe("Modules — catalog rendering", () => {
     });
     renderRoute();
     await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
-    expect(screen.getByText(/running/i)).toBeInTheDocument();
+    const badge = screen.getByTestId("module-status-vault");
+    expect(badge).toHaveTextContent("active");
+    expect(badge).toHaveClass("status-active");
     expect(screen.getByText("v0.4.5")).toBeInTheDocument();
+  });
+
+  it("maps supervisor lifecycle states onto the unified four-state vocab (workstream F)", async () => {
+    // Pins design-system.md §6 mapping at the SPA boundary:
+    //   running                → active
+    //   starting / restarting  → pending (transient)
+    //   crashed                → failing
+    //   stopped                → inactive
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [
+        moduleRow("vault", { installed: true, supervisor_status: "running" }),
+        moduleRow("notes", { installed: true, supervisor_status: "starting" }),
+        moduleRow("scribe", { installed: true, supervisor_status: "crashed" }),
+        moduleRow("app", { installed: true, supervisor_status: "stopped" }),
+      ],
+      supervisor_available: true,
+      module_install_channel: "latest",
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("module-status-vault")).toBeInTheDocument());
+    expect(screen.getByTestId("module-status-vault")).toHaveClass("status-active");
+    expect(screen.getByTestId("module-status-notes")).toHaveClass("status-pending");
+    expect(screen.getByTestId("module-status-scribe")).toHaveClass("status-failing");
+    expect(screen.getByTestId("module-status-app")).toHaveClass("status-inactive");
   });
 });
 
@@ -690,7 +721,12 @@ describe("Modules — hierarchical sub-units (hub#313)", () => {
     expect(link?.getAttribute("href")).toBe("/app/gitcoin-brain");
   });
 
-  it("renders per-sub-unit status badges using status-<state> class", async () => {
+  it("renders per-sub-unit status badges using the unified four-state vocab (workstream F)", async () => {
+    // Post-F: sub-unit badges use the canonical
+    // `active | pending | inactive | failing` classes shared with the
+    // module-row supervisor badge and the CLI. Legacy `pending-oauth` /
+    // `disabled` values served from a not-yet-restarted older module are
+    // normalized at render time (the test below pins that path).
     vi.mocked(api.listModules).mockResolvedValue(
       makeCatalog({
         modules: [
@@ -701,9 +737,10 @@ describe("Modules — hierarchical sub-units (hub#313)", () => {
             supervisor_status: "running",
             uis: [
               makeUi({ name: "a", display_name: "A", status: "active" }),
-              makeUi({ name: "b", display_name: "B", status: "pending-oauth" }),
-              makeUi({ name: "c", display_name: "C", status: "disabled" }),
+              makeUi({ name: "b", display_name: "B", status: "pending" }),
+              makeUi({ name: "c", display_name: "C", status: "inactive" }),
               makeUi({ name: "d", display_name: "D", status: null }),
+              makeUi({ name: "e", display_name: "E", status: "failing" }),
             ],
           }),
         ],
@@ -712,10 +749,39 @@ describe("Modules — hierarchical sub-units (hub#313)", () => {
     renderRoute();
     await waitFor(() => expect(screen.getByTestId("module-uis")).toBeInTheDocument());
     expect(screen.getByTestId("ui-status-a")).toHaveClass("status-active");
-    expect(screen.getByTestId("ui-status-b")).toHaveClass("status-pending-oauth");
-    expect(screen.getByTestId("ui-status-c")).toHaveClass("status-disabled");
+    expect(screen.getByTestId("ui-status-b")).toHaveClass("status-pending");
+    expect(screen.getByTestId("ui-status-c")).toHaveClass("status-inactive");
     // Null status falls back to "active" — same default as discovery.
     expect(screen.getByTestId("ui-status-d")).toHaveClass("status-active");
+    expect(screen.getByTestId("ui-status-e")).toHaveClass("status-failing");
+  });
+
+  it("normalizes legacy `pending-oauth` / `disabled` sub-unit statuses at render time (workstream F back-compat)", async () => {
+    // Pins the back-compat alias path. Storage normalizes on read but
+    // the SPA can still receive legacy values from /api/modules if a
+    // module wrote them and the row was cached before workstream F's
+    // services-manifest fold landed. `unifiedStateForUi` covers that
+    // gap so the badge palette stays consistent across the rollout.
+    vi.mocked(api.listModules).mockResolvedValue(
+      makeCatalog({
+        modules: [
+          moduleRow("vault", {
+            installed: true,
+            installed_version: "0.1.0",
+            latest_version: "0.1.0",
+            supervisor_status: "running",
+            uis: [
+              makeUi({ name: "legacy-p", display_name: "Legacy P", status: "pending-oauth" }),
+              makeUi({ name: "legacy-d", display_name: "Legacy D", status: "disabled" }),
+            ],
+          }),
+        ],
+      }),
+    );
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("module-uis")).toBeInTheDocument());
+    expect(screen.getByTestId("ui-status-legacy-p")).toHaveClass("status-pending");
+    expect(screen.getByTestId("ui-status-legacy-d")).toHaveClass("status-inactive");
   });
 
   it("renders the icon when icon_url is present, skips it when absent", async () => {

--- a/web/ui/src/routes/Modules.tsx
+++ b/web/ui/src/routes/Modules.tsx
@@ -42,6 +42,7 @@ import {
   uninstallModule,
   upgradeModule,
 } from "../lib/api.ts";
+import { type UnifiedState, unifiedStateForSupervisor, unifiedStateForUi } from "../lib/state.ts";
 
 type CatalogState =
   | { kind: "loading" }
@@ -462,9 +463,26 @@ function ModuleRow({
         <h2>
           {mod.display_name} <span className="muted">({mod.short})</span>
         </h2>
-        <span className={`status status-${mod.supervisor_status ?? "absent"}`}>
-          {statusLabel(mod)}
-        </span>
+        {/*
+          Status badge uses the four-state vocabulary from
+          design-system.md §6 (workstream F): active / pending / inactive /
+          failing. `statusBadge` maps the supervisor's lifecycle status
+          (`starting | running | stopped | crashed | restarting`) onto the
+          user-facing rollup at render time — the wire shape on
+          /api/modules is intentionally unchanged.
+        */}
+        {(() => {
+          const badge = statusBadge(mod);
+          return (
+            <span
+              className={`status status-${badge.cssState}`}
+              data-state={badge.cssState}
+              data-testid={`module-status-${mod.short}`}
+            >
+              {badge.label}
+            </span>
+          );
+        })()}
       </header>
       {mod.tagline ? <p className="tagline">{mod.tagline}</p> : null}
 
@@ -589,10 +607,26 @@ function InstallableCard({
   );
 }
 
-function statusLabel(mod: ModuleListing): string {
-  if (!mod.installed) return "not installed";
-  if (!mod.supervisor_status) return "not supervised";
-  return mod.supervisor_status;
+/**
+ * Resolved status badge for a module row. `cssState` is the unified
+ * `status-<state>` class (design-system.md §6); `label` is what the
+ * operator reads. Pre-F the badge text was the raw supervisor status
+ * (`running` / `stopped` / `crashed`); workstream F switches to the
+ * four-state rollup so the SPA, CLI, and well-known doc all read the same
+ * vocabulary. For not-installed / not-supervised rows we keep the
+ * descriptive copy because those rows aren't supervisor lifecycle states
+ * — they're "the supervisor has nothing to say about this row."
+ */
+interface ModuleStatusBadge {
+  cssState: UnifiedState | "absent";
+  label: string;
+}
+
+function statusBadge(mod: ModuleListing): ModuleStatusBadge {
+  if (!mod.installed) return { cssState: "absent", label: "not installed" };
+  if (!mod.supervisor_status) return { cssState: "absent", label: "not supervised" };
+  const cssState = unifiedStateForSupervisor(mod.supervisor_status);
+  return { cssState, label: cssState };
 }
 
 interface UiSubUnitsListProps {
@@ -604,14 +638,22 @@ interface UiSubUnitsListProps {
  * mirrors parachute-app's per-UI registry: each entry surfaces an icon,
  * display name, mount path, and lifecycle status. Status badges follow
  * the same `status-<state>` class convention `ModuleRow` uses for the
- * supervisor badge, so the SPA's existing palette covers active /
- * pending-oauth / disabled without new tokens.
+ * supervisor badge — the four canonical states from design-system.md §6
+ * (`active`, `pending`, `inactive`, `failing`) cover both surfaces from
+ * one palette.
  *
  * `path` is rendered as a same-origin anchor so an operator clicking
  * "Gitcoin Brain" lands on `/app/gitcoin-brain` — not a SPA link
  * (`Link to`) because the sub-unit lives outside the SPA's mount basename
  * and we want the browser to hard-navigate. Aaron's call: keep the SPA
  * itself narrow, let the underlying module own its own UI shell.
+ *
+ * Status badges use the unified four-state vocabulary from
+ * design-system.md §6 (workstream F): `status-active`, `status-pending`,
+ * `status-inactive`, `status-failing`. Sub-units that publish the legacy
+ * `pending-oauth` / `disabled` values pre-F get normalized at render time
+ * via `unifiedStateForUi` so the badge palette stays consistent across
+ * old + new sub-units during the alias window.
  */
 function UiSubUnitsList({ uis }: UiSubUnitsListProps) {
   return (
@@ -621,7 +663,7 @@ function UiSubUnitsList({ uis }: UiSubUnitsListProps) {
       </summary>
       <ul className="ui-sub-units">
         {uis.map((u) => {
-          const status = u.status ?? "active";
+          const cssState = unifiedStateForUi(u.status);
           return (
             <li key={u.name} className="ui-sub-unit" data-name={u.name}>
               {u.icon_url && (
@@ -641,8 +683,12 @@ function UiSubUnitsList({ uis }: UiSubUnitsListProps) {
                 </a>
                 {u.tagline ? <p className="tagline">{u.tagline}</p> : null}
               </div>
-              <span className={`status status-${status}`} data-testid={`ui-status-${u.name}`}>
-                {status}
+              <span
+                className={`status status-${cssState}`}
+                data-state={cssState}
+                data-testid={`ui-status-${u.name}`}
+              >
+                {cssState}
               </span>
             </li>
           );

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -836,6 +836,17 @@ a.btn:hover {
   background: var(--error-soft);
   color: var(--error);
 }
+/*
+ * `.status-absent` is the catch-all for rows with no supervisor state at
+ * all (uninstalled / unsupervised modules). Pre-F the code emitted
+ * `status-${supervisor_status ?? "absent"}` but no CSS rule backed it;
+ * this rule replaces the unstyled fallback with a muted shape consistent
+ * with `.status-inactive`. Used by `statusBadge` in Modules.tsx.
+ */
+.status-absent {
+  background: var(--bg-soft);
+  color: var(--fg-dim);
+}
 
 /*
  * Back-compat aliases for the pre-F vocabulary. Modules / SDKs that

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -815,10 +815,35 @@ a.btn:hover {
   font-weight: 500;
   white-space: nowrap;
 }
+/*
+ * Four canonical status classes per design-system.md §6 (workstream F).
+ * Shared across the module-row supervisor badge, sub-unit badges, and
+ * any future status surface (e.g. expose-state, vault sync).
+ */
 .status-active {
   background: var(--success-soft);
   color: var(--success);
 }
+.status-pending {
+  background: var(--warn-soft);
+  color: var(--warn);
+}
+.status-inactive {
+  background: var(--bg-soft);
+  color: var(--fg-dim);
+}
+.status-failing {
+  background: var(--error-soft);
+  color: var(--error);
+}
+
+/*
+ * Back-compat aliases for the pre-F vocabulary. Modules / SDKs that
+ * render the legacy class names (`status-pending-oauth`, `status-disabled`)
+ * continue to paint correctly for one release window after workstream F
+ * lands; retire after the next rc chain when downstream consumers have
+ * had time to migrate. See design-system.md §6 "CSS classes + colors".
+ */
 .status-pending-oauth {
   background: var(--warn-soft);
   color: var(--warn);


### PR DESCRIPTION
## Summary

Aligns every user-facing surface on the four canonical states from [parachute-patterns/patterns/design-system.md §6](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/design-system.md):

| State | Meaning | Color |
|---|---|---|
| `active` | supervised, running, healthy | `--success` |
| `pending` | supervised, needs operator action (OAuth, config) | `--warn` |
| `inactive` | operator-stopped or never started | `--fg-muted` |
| `failing` | supervised but unhealthy (probe failure, crash) | `--error` |

The 2026-05-25 UX audit ([AUDIT-UI-UX.md](./AUDIT-UI-UX.md) §2.3 + §2.7) flagged three different vocabularies for the same module-supervisor concept across the CLI (`running` / `stopped` / `-`), the admin SPA (`Active` / `Pending-OAuth` / `Disabled`), and the supervisor's internal state model (`active` / `pending-oauth` / `disabled`). Workstream F retires the divergence.

## Old → new mapping

| Old | Surface | New | Migration |
|---|---|---|---|
| `running` + probe ok | `parachute status` PROCESS+HEALTH | `active` | Collapse two columns into one STATE column |
| `running` + probe failed | `parachute status` PROCESS+HEALTH | `failing` | Probe detail moves to "  ! probe:" continuation |
| `stopped` | `parachute status` PROCESS | `inactive` | Direct rename |
| `-` (no pidfile) | `parachute status` PROCESS | `inactive` | Same surface as deliberately stopped |
| `Active` | SPA `/admin/modules` badge | `active` | Lowercase |
| `Pending-OAuth` | SPA `/admin/modules` badge | `pending` | Broadens; CSS class `status-pending-oauth` → `status-pending` (alias retained) |
| `Disabled` | SPA `/admin/modules` badge | `inactive` | CSS class `status-disabled` → `status-inactive` (alias retained) |
| `pending-oauth` | `UiSubUnitStatus` on wire | `pending` | Normalized at services-manifest read boundary |
| `disabled` | `UiSubUnitStatus` on wire | `inactive` | Normalized at services-manifest read boundary |
| supervisor `running` | `/api/modules.supervisor_status` | `active` (render-time) | Wire shape unchanged; SPA maps at render |
| supervisor `starting`/`restarting` | `/api/modules.supervisor_status` | `pending` (render-time) | New rollup for transient lifecycle |
| supervisor `crashed` | `/api/modules.supervisor_status` | `failing` (render-time) | New rollup |
| supervisor `stopped` | `/api/modules.supervisor_status` | `inactive` (render-time) | Direct rename |

## Surfaces changed

- `src/commands/status.ts` + `src/help.ts` — CLI columns:
  - **Pre-F:** `SERVICE PORT VERSION PROCESS PID UPTIME HEALTH LATENCY SOURCE`
  - **Post-F:** `SERVICE PORT VERSION STATE PID UPTIME LATENCY SOURCE`
  - Probe-failure detail survives on `  ! probe: <detail>` continuation lines so operators can still diagnose without the column overhead.
- `web/ui/src/routes/Modules.tsx` + `web/ui/src/lib/state.ts` (new) + `web/ui/src/styles.css` — admin SPA module-row badge + per-UI sub-unit badge both render the unified vocab. New CSS classes `.status-active`, `.status-pending`, `.status-inactive`, `.status-failing`. `lib/state.ts` houses the supervisor → unified-state mapping in one place; render-time helper also catches stale `pending-oauth` / `disabled` values defensively.
- `src/services-manifest.ts` — `UiSubUnitStatus` narrowed to canonical values; pre-F values (`pending-oauth`, `disabled`) accepted on read and normalized so downstream emit (well-known doc, `/api/modules`) always sees the new vocab.

## Back-compat aliases (retire one rc-chain after merge)

- **CSS classes**: `.status-pending-oauth` and `.status-disabled` still paint correctly (mirror `.status-pending` and `.status-inactive` colors) so out-of-tree consumers don't lose palette.
- **services-manifest input**: `pending-oauth` / `disabled` accepted on read; normalized to canonical before persisting.
- **SPA render-time**: `unifiedStateForUi` accepts legacy values so a stale row served before the storage normalizer fold doesn't get an unstyled badge.

## What's NOT changed

- Wire shape on `/api/modules.supervisor_status` (still `starting | running | stopped | crashed | restarting | null`) — the SPA maps at render time so the supervisor pipeline stays decoupled from the user-facing rollup.
- Wire shape on `/.well-known/parachute.json` `services[].uis[].status` field — the *values* now use the canonical vocab, but the field name and shape are unchanged. The normalization happens at the services-manifest read boundary so consumers always see canonical values.
- Token-registry's `created_via` (`oauth | operator | cli`) — different vocabulary (token provenance, not supervisor state). Left alone per brief.
- OAuth grant state (`pending | approved | revoked`) — different lifecycle (per design-system §6 "What stays per-domain"). Left alone.

## Patterns check

- Adopts [parachute-patterns/patterns/design-system.md](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/design-system.md) §6 (state vocabulary) and §7 (status badge component).
- Companion adoption in vault/app/scribe/runner SDKs is a follow-up — they may continue emitting legacy `pending-oauth` / `disabled` values for one release cycle. Hub normalizes at the storage boundary.

## Versioning

No version bump per governance Rule 2 — collects into the next rc-chain ship decision alongside whatever else lands. CHANGELOG entry added under `[Unreleased]`.

## Test plan

- [x] `bun run typecheck` (hub server) clean
- [x] `bun test ./src`: 1962 pass / 0 fail (3 new tests covering services-manifest legacy normalization, `pending-oauth` → `pending` end-to-end through `/api/modules`, new `failing` / `inactive` canonical values)
- [x] `bun run typecheck` (web/ui) clean
- [x] `bun run test` (web/ui): 213 pass / 0 fail (2 new tests covering supervisor → unified state mapping for all five lifecycle states, sub-unit legacy alias normalization at render time)
- [ ] **Live verify** post-merge on Render: load `/admin/modules` and confirm the four state classes paint per the palette; run `parachute status` against a deploy with mixed-state services and confirm column shape.

## External consumers to flag

- **parachute-app**'s admin SPA reads `/.well-known/parachute.json` and may parse the `uis[].status` field directly. Storage normalization means it now sees `pending` instead of `pending-oauth`. If app pinned the legacy strings, it should accept both during the alias window.
- Any third-party module that publishes `services.json` with literal `status: "pending-oauth"` will continue to work (services-manifest normalizes on read). They should migrate to canonical values within one rc-chain.

---

**Self-review pending fresh reviewer (per workstream discipline).** General-purpose agents can't recursively dispatch subagents; the orchestrator (main thread) will dispatch the real reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)