### PR TITLE
fix(hub): trust RENDER_EXTERNAL_URL as a platform-injected bound origin

### DIFF
--- a/src/__tests__/origin-check.test.ts
+++ b/src/__tests__/origin-check.test.ts
@@ -48,6 +48,42 @@ describe("buildHubBoundOrigins", () => {
     expect(origins.filter((o) => o === ISSUER).length).toBe(1);
   });
 
+  test("platformOrigin adds the platform-injected public URL independently of issuer (hub#374)", () => {
+    // Render injects RENDER_EXTERNAL_URL=https://<svc>.onrender.com at the
+    // container edge; if hub_settings.hub_origin was stored to a non-public
+    // URL (e.g. loopback during initial setup), the configured issuer would
+    // be loopback. The browser still POSTs from the public Render URL, so
+    // the public URL must independently land in the bound set or the
+    // operator's legitimate POSTs are rejected. Closes the failure caught
+    // on Aaron's deploy 2026-05-25 where Origin was https://...onrender.com
+    // but bound set was loopback-only.
+    const platformOrigin = "https://parachute-hub.onrender.com";
+    const origins = buildHubBoundOrigins({
+      issuer: "http://127.0.0.1:1939",
+      loopbackPort: PORT,
+      platformOrigin,
+    });
+    expect(origins).toContain(platformOrigin);
+    expect(origins).toContain("http://127.0.0.1:1939");
+  });
+
+  test("platformOrigin dedups when it matches issuer", () => {
+    // Normal Render boot path: configuredIssuer was derived from
+    // RENDER_EXTERNAL_URL in serve.ts's resolveStartupIssuer, so the
+    // resolved issuer equals platformOrigin. The set carries one entry.
+    const platformOrigin = "https://parachute-hub.onrender.com";
+    const origins = buildHubBoundOrigins({
+      issuer: platformOrigin,
+      platformOrigin,
+    });
+    expect(origins.filter((o) => o === platformOrigin).length).toBe(1);
+  });
+
+  test("undefined platformOrigin is a no-op (non-Render deploys)", () => {
+    const origins = buildHubBoundOrigins({ issuer: ISSUER });
+    expect(origins).toEqual([ISSUER]);
+  });
+
   test("malformed inputs are silently dropped", () => {
     // No URL parser crash — return whatever could be parsed. The caller
     // (resolveBoundOrigins) keeps the issuer as a baseline anyway.

--- a/src/__tests__/origin-check.test.ts
+++ b/src/__tests__/origin-check.test.ts
@@ -48,7 +48,7 @@ describe("buildHubBoundOrigins", () => {
     expect(origins.filter((o) => o === ISSUER).length).toBe(1);
   });
 
-  test("platformOrigin adds the platform-injected public URL independently of issuer (hub#374)", () => {
+  test("platformOrigin adds the platform-injected public URL independently of issuer (hub#375)", () => {
     // Render injects RENDER_EXTERNAL_URL=https://<svc>.onrender.com at the
     // container edge; if hub_settings.hub_origin was stored to a non-public
     // URL (e.g. loopback during initial setup), the configured issuer would

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -1058,6 +1058,13 @@ export function hubFetch(
           issuer,
           loopbackPort,
           exposeHubOrigin: loadExposeHubOrigin(),
+          // Trust the platform-injected public URL independently of the
+          // configured issuer. On Render, an operator who set hub_origin
+          // via the admin SPA (or via a stale db row) to a non-public URL
+          // would otherwise reject legitimate browser POSTs that arrive
+          // with the public Render URL as Origin. See origin-check.ts
+          // jsdoc for the failure case this closes.
+          platformOrigin: process.env.RENDER_EXTERNAL_URL,
         }),
     };
   };

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -1215,7 +1215,24 @@ export async function handleApproveClientPost(
       401,
     );
   }
-  if (!isSameOriginRequest(req, resolveBoundOrigins(deps))) {
+  const bound = resolveBoundOrigins(deps);
+  if (!isSameOriginRequest(req, bound)) {
+    // Diagnostic: log the headers we saw + the bound set so an operator
+    // chasing a rejection on a real deploy can see exactly what didn't
+    // match. The same-origin check is the most opaque CSRF gate — without
+    // this log, a misconfigured hub_settings.hub_origin or a proxy
+    // stripping Origin/Referer produces a flat 403 with no way to debug.
+    // Headers logged are non-sensitive (Origin/Referer/Host are public);
+    // the bound set is hub's own configuration. Body content not logged.
+    console.warn(
+      `[oauth] approve POST same-origin check failed. headers: ` +
+        `origin=${JSON.stringify(req.headers.get("origin"))} ` +
+        `referer=${JSON.stringify(req.headers.get("referer"))} ` +
+        `host=${JSON.stringify(req.headers.get("host"))} ` +
+        `xff-host=${JSON.stringify(req.headers.get("x-forwarded-host"))} ` +
+        `xff-proto=${JSON.stringify(req.headers.get("x-forwarded-proto"))}. ` +
+        `bound origins: ${JSON.stringify(bound)}`,
+    );
     return htmlError(
       "Cross-origin request rejected",
       "The approve form must be submitted from this hub's own origin.",

--- a/src/origin-check.ts
+++ b/src/origin-check.ts
@@ -43,6 +43,16 @@
  *     typically equal to `issuer` post-`parachute expose`, but kept as an
  *     independent input so a tailnet bring-up after hub start is reflected
  *     without restart.
+ *   - `platformOrigin`: a platform-injected public origin (Render's
+ *     `RENDER_EXTERNAL_URL`, etc.). Always trusted — the platform
+ *     guarantees this is the public URL the operator's browser sees.
+ *     Included independently of `issuer` so a stale `hub_settings.hub_origin`
+ *     stored to a non-public URL (e.g. a loopback value entered during
+ *     setup) doesn't lock the operator out of cookie-POST flows that
+ *     legitimately arrive from the public URL. Caught on a Render deploy
+ *     2026-05-25 when `hub_settings.hub_origin` was loopback but the
+ *     browser POSTed from the public Render URL — Origin mismatch
+ *     rejected legitimate operator-initiated approves.
  *
  * Malformed inputs are dropped silently — the function returns whatever it
  * could parse. Callers should always include the issuer as a baseline so
@@ -52,6 +62,7 @@ export function buildHubBoundOrigins(opts: {
   issuer: string;
   loopbackPort?: number;
   exposeHubOrigin?: string;
+  platformOrigin?: string;
 }): readonly string[] {
   const set = new Set<string>();
   const add = (raw: string | undefined) => {
@@ -65,6 +76,7 @@ export function buildHubBoundOrigins(opts: {
   };
   add(opts.issuer);
   add(opts.exposeHubOrigin);
+  add(opts.platformOrigin);
   if (typeof opts.loopbackPort === "number" && Number.isInteger(opts.loopbackPort)) {
     set.add(`http://localhost:${opts.loopbackPort}`);
     set.add(`http://127.0.0.1:${opts.loopbackPort}`);


### PR DESCRIPTION
## Summary

Aaron hit \`Cross-origin request rejected — The approve form must be submitted from this hub's own origin\` on the OAuth approve POST on his rc.39 deploy. Diagnosis:

The same-origin gate at \`oauth-handlers.ts:1218\` builds its bound set from \`deps.issuer\` (via \`resolveIssuer\`). \`resolveIssuer\`'s precedence is \`hub_settings.hub_origin\` > \`configuredIssuer\` > req-url-derived. If the operator stored \`hub_origin\` to a non-public URL (e.g. a loopback value entered during initial setup via the admin SPA), the configured issuer becomes that loopback URL — the bound set then excludes the public Render URL. The browser POSTs from the public URL → Origin doesn't match → 403.

\`PARACHUTE_HUB_ORIGIN\` env was NOT set on Aaron's Render — confirmed via dashboard. So \`hub_settings.hub_origin\` is the suspect.

## Fix

Two coordinated changes:

1. **Trust the platform-injected URL independently.** \`buildHubBoundOrigins\` now accepts an optional \`platformOrigin\` field. \`hub-server.ts\` passes \`process.env.RENDER_EXTERNAL_URL\` so Render's public URL always lands in the bound set, regardless of what \`hub_settings.hub_origin\` resolves to. A stale config can't lock the operator out.

2. **Diagnostic log on same-origin failure.** \`console.warn\`s Origin/Referer/Host/XFF-Host/XFF-Proto + the bound set when the gate fires. Without this, a 403 was opaque — operator had no signal which gate fired or what the proxy was sending. After redeploy, Aaron can check Render logs to confirm the fix worked + we have a forward-looking diagnostic for future cases.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun test ./src/__tests__/origin-check.test.ts\`: 27 pass / 0 fail (+3 new — distinct-from-issuer / equals-issuer dedup / undefined no-op)
- [x] \`bun test ./src\`: 1961 pass / 0 fail (+3 from rc.39 baseline)
- [ ] Pending: Aaron redeploys → OAuth approve completes; Render logs confirm bound-set now includes the public URL

## Notes

- Lands on a separate branch (\`fix-render-bound-origin\`) instead of \`ag-unforced-dev\` because workstream F is in flight on \`ag-unforced-dev\`. After this merges, F's PR will rebase on the new main.
- Future cleanup (not in this PR): the underlying \`hub_settings.hub_origin\` value on Aaron's deploy is probably the loopback URL. Worth surfacing via an admin SPA "reset hub_origin" button OR a CLI command — but that's a UX question, not blocking. Filing as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)