### PR TITLE
fix(hub): upgrade-available version respects module_install_channel

### DIFF
--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -446,6 +446,68 @@ describe("GET /api/modules", () => {
     expect(calls).toBe(callsAfterFirst);
   });
 
+  test("fetchLatestVersion receives the configured install channel (hub#377 dist-tag fix)", async () => {
+    // The audit caught the bug 2026-05-25 on Aaron's deploy: operators
+    // on the `rc` channel saw the @latest dist-tag value as their upgrade
+    // target (e.g. app showed "rc.4 available" while the rc channel was
+    // actually at rc.13). The fix threads the configured channel into
+    // fetchLatestVersion so the probe targets the right dist-tag.
+    setModuleInstallChannel(h.db, "rc");
+    const callsByChannel: string[] = [];
+    const probe = async (_pkg: string, channel: "latest" | "rc"): Promise<string | null> => {
+      callsByChannel.push(channel);
+      return channel === "rc" ? "0.5.0-rc.13" : "0.5.0-rc.4";
+    };
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: probe,
+      cacheTtlMs: 0, // disable cache for this test
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      modules: Array<{ short: string; latest_version: string | null }>;
+    };
+    // Every probe call received the configured channel.
+    expect(callsByChannel.every((c) => c === "rc")).toBe(true);
+    expect(callsByChannel.length).toBeGreaterThan(0);
+    // The latest_version reflects the rc dist-tag.
+    for (const m of body.modules) {
+      expect(m.latest_version).toBe("0.5.0-rc.13");
+    }
+  });
+
+  test("cache key includes channel — toggling channel returns fresh value, not stale (hub#377)", async () => {
+    // The cache key includes channel so a runtime toggle between latest
+    // and rc surfaces the right version immediately, not after TTL expiry.
+    let callCount = 0;
+    const probe = async (_pkg: string, channel: "latest" | "rc"): Promise<string | null> => {
+      callCount++;
+      return channel === "rc" ? "1.0.0-rc.5" : "1.0.0";
+    };
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const deps = {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: probe,
+      cacheTtlMs: 60_000,
+    };
+    setModuleInstallChannel(h.db, "latest");
+    const r1 = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), deps);
+    const b1 = (await r1.json()) as { modules: Array<{ latest_version: string | null }> };
+    expect(b1.modules[0]?.latest_version).toBe("1.0.0");
+    const callsAfterLatest = callCount;
+    setModuleInstallChannel(h.db, "rc");
+    const r2 = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), deps);
+    const b2 = (await r2.json()) as { modules: Array<{ latest_version: string | null }> };
+    expect(b2.modules[0]?.latest_version).toBe("1.0.0-rc.5");
+    // Per-channel cache miss → fresh probe calls fired for the rc lookup.
+    expect(callCount).toBeGreaterThan(callsAfterLatest);
+  });
+
   test("surfaces module_install_channel in the response (hub#275)", async () => {
     // Default — first read seeds with `latest`.
     const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);

--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -427,7 +427,10 @@ describe("GET /api/modules", () => {
     // Second back-to-back request must not re-hit the registry. The
     // UI may poll this endpoint; we don't want it to slam npm.
     let calls = 0;
-    const probe = async (_pkg: string): Promise<string | null> => {
+    const probe = async (
+      _pkg: string,
+      _channel: "latest" | "rc",
+    ): Promise<string | null> => {
       calls++;
       return "0.5.0";
     };

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -97,11 +97,14 @@ export interface ApiModulesDeps {
   manifestPath: string;
   supervisor?: Supervisor;
   /**
-   * NPM @latest probe. Returns the version string or null on failure /
-   * timeout. Default is the real npm registry; tests inject a fake so
-   * they don't hit the network.
+   * NPM dist-tag probe. Returns the version string at the given dist-tag,
+   * or null on failure / timeout / unknown tag. Default is the real npm
+   * registry; tests inject a fake so they don't hit the network. Channel
+   * arg lets the probe respect the operator's configured install channel
+   * (`rc` operators see the rc version as the upgrade target, not the
+   * stable `latest`).
    */
-  fetchLatestVersion?: (pkg: string) => Promise<string | null>;
+  fetchLatestVersion?: (pkg: string, channel: ModuleInstallChannel) => Promise<string | null>;
   /**
    * Module-level cache TTL for `latest_version` probes, in ms. Default
    * 5 minutes — long enough that a tab refresh doesn't slam npm,
@@ -229,15 +232,30 @@ const latestVersionCache = new Map<string, CachedVersion>();
  * tolerates a missing latest_version, so we keep the response shape
  * stable even when the registry is flaky.
  */
-export async function defaultFetchLatestVersion(pkg: string): Promise<string | null> {
+export async function defaultFetchLatestVersion(
+  pkg: string,
+  channel: ModuleInstallChannel,
+): Promise<string | null> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 3_000);
   try {
-    const url = `https://registry.npmjs.org/${encodeURIComponent(pkg)}/latest`;
+    // npm exposes per-package dist-tags at /-/package/<pkg>/dist-tags as a
+    // simple map (e.g. `{"latest": "0.2.0-rc.4", "rc": "0.2.0-rc.13"}`).
+    // Look up the configured channel; fall back to `latest` if the channel
+    // is missing (e.g. a package that hasn't been published with @rc yet).
+    // Previously hit `/${pkg}/latest` directly — that endpoint always
+    // returns the `latest` dist-tag's package doc regardless of channel,
+    // so an operator on @rc saw the @latest version as the "available"
+    // upgrade target (audit caught on Aaron's deploy 2026-05-25: app
+    // showed "rc.4 available" while @rc was actually rc.13).
+    const url = `https://registry.npmjs.org/-/package/${encodeURIComponent(pkg)}/dist-tags`;
     const res = await fetch(url, { signal: controller.signal });
     if (!res.ok) return null;
-    const body = (await res.json()) as { version?: unknown };
-    return typeof body.version === "string" ? body.version : null;
+    const tags = (await res.json()) as Record<string, unknown>;
+    const fromChannel = tags[channel];
+    if (typeof fromChannel === "string") return fromChannel;
+    const fromLatest = tags.latest;
+    return typeof fromLatest === "string" ? fromLatest : null;
   } catch {
     return null;
   } finally {
@@ -378,11 +396,15 @@ export async function handleApiModules(req: Request, deps: ApiModulesDeps): Prom
     }
   }
 
-  // Resolve npm @latest in parallel — short timeout per request, cache
+  // Resolve npm dist-tag in parallel — short timeout per request, cache
   // shared across requests so a fast UI poll doesn't slam the registry.
+  // Channel-aware: an operator on @rc sees the rc-tagged version as the
+  // upgrade target (not the stable @latest which may be older). Cache key
+  // includes channel so a channel-toggle doesn't return a stale value.
   const fetchLatest = deps.fetchLatestVersion ?? defaultFetchLatestVersion;
   const cacheTtl = deps.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
   const now = deps.now ?? Date.now;
+  const channel = getModuleInstallChannel(deps.db);
 
   const latestByShort = new Map<string, string | null>();
   await Promise.all(
@@ -393,13 +415,14 @@ export async function handleApiModules(req: Request, deps: ApiModulesDeps): Prom
         return;
       }
       const pkg = m.package;
-      const cached = latestVersionCache.get(pkg);
+      const cacheKey = `${pkg}@${channel}`;
+      const cached = latestVersionCache.get(cacheKey);
       if (cached && cacheTtl > 0 && now() - cached.fetchedAt < cacheTtl) {
         latestByShort.set(short, cached.value);
         return;
       }
-      const value = await fetchLatest(pkg);
-      latestVersionCache.set(pkg, { value, fetchedAt: now() });
+      const value = await fetchLatest(pkg, channel);
+      latestVersionCache.set(cacheKey, { value, fetchedAt: now() });
       latestByShort.set(short, value);
     }),
   );

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -248,6 +248,8 @@ export async function defaultFetchLatestVersion(
     // so an operator on @rc saw the @latest version as the "available"
     // upgrade target (audit caught on Aaron's deploy 2026-05-25: app
     // showed "rc.4 available" while @rc was actually rc.13).
+    // encodeURIComponent handles scoped packages: @openparachute/vault →
+    // %40openparachute%2Fvault. npm resolves the encoded form correctly.
     const url = `https://registry.npmjs.org/-/package/${encodeURIComponent(pkg)}/dist-tags`;
     const res = await fetch(url, { signal: controller.signal });
     if (!res.ok) return null;


### PR DESCRIPTION
## Summary

Aaron's deploy showed \"v0.2.0-rc.4 available\" for app while the actually-published @rc was rc.13 — confirmed on the rc.40 deploy 2026-05-25. Cosmetic display drift: \`defaultFetchLatestVersion\` always hit npm's \`/latest\` endpoint regardless of the operator's configured \`module_install_channel\`. The install ACTION uses the channel correctly (\`bun add -g <pkg>@\${channel}\`), so clicking Upgrade still pulls the right version — but the displayed target is wrong, eroding trust.

## Fix

- \`defaultFetchLatestVersion(pkg, channel)\` now uses npm's \`/-/package/<pkg>/dist-tags\` endpoint (returns the full dist-tag map) and reads the configured channel's tag, falling back to \`@latest\` for packages that haven't published @rc yet.
- \`handleApiModules\` threads the channel from \`getModuleInstallChannel(db)\` into the probe.
- Cache key includes channel so a runtime toggle returns fresh values without TTL expiry.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun test ./src\`: 1967 pass / 0 fail (+5 from rc.40 baseline)
- [x] New test: fetchLatestVersion receives the configured channel; latest_version reflects the rc dist-tag
- [x] New test: cache key includes channel — toggling channel returns fresh value, not stale
- [ ] Pending: live verify after rc.41 ships + Aaron redeploys → admin SPA shows rc.X as available where X matches @rc

## Notes

- Separate branch (\`fix-upgrade-channel-display\`) so workstream G's in-flight PR (hub#377) on \`ag-unforced-dev\` doesn't conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)