### PR TITLE
fix(hub): /api/modules management_url no longer double-prepends mount

### DIFF
--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -365,7 +365,7 @@ describe("GET /api/modules", () => {
     expect(vault?.management_url).toBe("/vault/default/admin");
   });
 
-  test("management_url does not double-prepend mount when managementUrl is already mount-prefixed (hub#XXX)", async () => {
+  test("management_url does not double-prepend mount when managementUrl is already mount-prefixed (hub#380)", async () => {
     // Audit caught 2026-05-25: app declares `managementUrl: "/app/admin/"`
     // (full hub-origin path) and `paths: ["/app", "/.parachute"]`. The
     // SPA's Services dropdown was navigating to `/app/app/admin/` (404)
@@ -416,6 +416,104 @@ describe("GET /api/modules", () => {
     const app = body.modules.find((m) => m.short === "app");
     // Single `/app/`, not `/app/app/`.
     expect(app?.management_url).toBe("/app/admin/");
+  });
+
+  test("management_url prefix-ish names don't collide (hub#380 — /app vs /app-foo)", async () => {
+    // The detection uses `tail.startsWith(\`${mount}/\`)` with the trailing
+    // slash specifically to avoid a false positive when a candidate
+    // path looks like a sibling name (e.g. `/app-foo/admin` shouldn't be
+    // treated as "already prefixed by /app"). Without the slash gate,
+    // a future module named `app-foo` would silently inherit the
+    // pass-through behavior and `/app` mount would skip its prepend.
+    // Tests the trailing-slash discriminator stays load-bearing.
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/app"], // mount is /app (using vault as a stand-in installable)
+        health: "/app/health",
+        version: "0.4.5",
+        installDir: "/install/dir/contrived",
+      },
+    ]);
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: async () => null,
+      readModuleManifest: async (installDir) => {
+        if (installDir === "/install/dir/contrived") {
+          return {
+            name: "parachute-vault",
+            manifestName: "parachute-vault",
+            displayName: "Vault",
+            tagline: "",
+            port: 1940,
+            paths: ["/app"],
+            health: "/app/health",
+            // candidate looks like a sibling-name prefix but is NOT a
+            // mount-prefix of /app — should still get prepended.
+            managementUrl: "/app-foo/admin",
+          } as unknown as Awaited<
+            ReturnType<typeof import("../module-manifest.ts").readModuleManifest>
+          >;
+        }
+        return null;
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      modules: Array<{ short: string; management_url: string | null }>;
+    };
+    const vault = body.modules.find((m) => m.short === "vault");
+    // /app + /app-foo/admin → /app/app-foo/admin (prepend fires; not treated
+    // as already-mount-prefixed because /app-foo/ doesn't start with /app/).
+    expect(vault?.management_url).toBe("/app/app-foo/admin");
+  });
+
+  test("management_url equality edge: tail equals mount exactly (hub#380)", async () => {
+    // mount=/foo, candidate=/foo → tail === mount → pass through unchanged.
+    // Not a "real" config but pins the equality branch of the detection.
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/foo"],
+        health: "/foo/health",
+        version: "0.4.5",
+        installDir: "/install/dir/equality",
+      },
+    ]);
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: async () => null,
+      readModuleManifest: async (installDir) => {
+        if (installDir === "/install/dir/equality") {
+          return {
+            name: "parachute-vault",
+            manifestName: "parachute-vault",
+            displayName: "Vault",
+            tagline: "",
+            port: 1940,
+            paths: ["/foo"],
+            health: "/foo/health",
+            managementUrl: "/foo",
+          } as unknown as Awaited<
+            ReturnType<typeof import("../module-manifest.ts").readModuleManifest>
+          >;
+        }
+        return null;
+      },
+    });
+    const body = (await res.json()) as {
+      modules: Array<{ short: string; management_url: string | null }>;
+    };
+    const vault = body.modules.find((m) => m.short === "vault");
+    expect(vault?.management_url).toBe("/foo");
   });
 
   test("management_url is null when the module declares neither managementUrl nor uiUrl (hub#342)", async () => {

--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -365,6 +365,59 @@ describe("GET /api/modules", () => {
     expect(vault?.management_url).toBe("/vault/default/admin");
   });
 
+  test("management_url does not double-prepend mount when managementUrl is already mount-prefixed (hub#XXX)", async () => {
+    // Audit caught 2026-05-25: app declares `managementUrl: "/app/admin/"`
+    // (full hub-origin path) and `paths: ["/app", "/.parachute"]`. The
+    // SPA's Services dropdown was navigating to `/app/app/admin/` (404)
+    // because api-modules unconditionally prepended the mount onto the
+    // candidate. Fix: detect already-mount-prefixed paths and pass through.
+    //
+    // Single-instance modules conventionally declare the full path; only
+    // multi-instance modules (vault) use the per-instance relative form.
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-app",
+        port: 1946,
+        paths: ["/app", "/.parachute"],
+        health: "/app/healthz",
+        version: "0.2.0-rc.13",
+        installDir: "/install/dir/app",
+      },
+    ]);
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: async () => null,
+      readModuleManifest: async (installDir) => {
+        if (installDir === "/install/dir/app") {
+          return {
+            name: "app",
+            manifestName: "parachute-app",
+            displayName: "App",
+            tagline: "",
+            port: 1946,
+            paths: ["/app", "/.parachute"],
+            health: "/app/healthz",
+            uiUrl: "/app/admin/",
+            managementUrl: "/app/admin/",
+          } as unknown as Awaited<
+            ReturnType<typeof import("../module-manifest.ts").readModuleManifest>
+          >;
+        }
+        return null;
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      modules: Array<{ short: string; management_url: string | null }>;
+    };
+    const app = body.modules.find((m) => m.short === "app");
+    // Single `/app/`, not `/app/app/`.
+    expect(app?.management_url).toBe("/app/admin/");
+  });
+
   test("management_url is null when the module declares neither managementUrl nor uiUrl (hub#342)", async () => {
     // Scribe + runner today: no managementUrl declared yet. The SPA's
     // "Open" button renders disabled with a follow-up tooltip in that

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -377,11 +377,20 @@ export async function handleApiModules(req: Request, deps: ApiModulesDeps): Prom
           // disabled-tooltip state in the SPA is the right surface.
           return;
         }
-        // Join mount + candidate path. Both pieces have leading slashes
-        // already (mount per services.json convention; candidate per
-        // managementUrl validation). Drop one to avoid `//`.
+        // Resolution rule (per module-ui-declaration.md):
+        //   - Multi-instance modules (vault) declare a per-instance
+        //     relative path (e.g. `/admin/`); hub prepends the mount
+        //     (e.g. `/vault/default` + `/admin/` → `/vault/default/admin/`).
+        //   - Single-instance modules (app, scribe, runner) declare a
+        //     full hub-origin path that ALREADY includes the mount
+        //     (e.g. `/app/admin/`, `/scribe/admin`); the mount must NOT
+        //     be prepended again or the result is `/app/app/admin/`
+        //     (the audit bug caught 2026-05-25 on the SPA's Services
+        //     dropdown).
+        // Detect by checking if candidate is already mount-prefixed.
         const tail = candidate.startsWith("/") ? candidate : `/${candidate}`;
-        managementUrlByShort.set(short, `${mount}${tail}`);
+        const alreadyMountPrefixed = tail === mount || tail.startsWith(`${mount}/`);
+        managementUrlByShort.set(short, alreadyMountPrefixed ? tail : `${mount}${tail}`);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.warn(`api-modules: skipping managementUrl for ${short}: ${msg}`);


### PR DESCRIPTION
Audit bug #140: SPA's Services dropdown navigated to `/app/app/admin/` when clicking the App tile. `api-modules.ts` unconditionally prepended the mount path to the managementUrl candidate. Worked for vault (multi-instance, relative path) but broke for single-instance modules declaring full hub-origin paths.

Fix: detect already-mount-prefixed paths and pass through. New test pins the contract.

Per workstream discipline: self-review pending fresh reviewer dispatch from orchestrator.