### PR TITLE
fix(hub): PARACHUTE_INSTALL_CHANNEL env now authoritative over DB

### DIFF
--- a/src/__tests__/hub-settings.test.ts
+++ b/src/__tests__/hub-settings.test.ts
@@ -353,17 +353,22 @@ describe("hub-settings — module install channel bootstrap", () => {
     // at first boot before he set the env var).
     const db = openHubDb(hubDbPath(dir));
     try {
-      // First read with rc — DB seeds with rc.
-      getModuleInstallChannel(db, { env: { [PARACHUTE_INSTALL_CHANNEL_ENV]: "rc" } });
-      // Second read with a different env value returns the NEW env value
-      // (env wins over the previously-seeded DB row).
+      // First read with env=rc — env wins, returns "rc". DB stays empty
+      // (no auto-write to DB when env is set, per the design that
+      // preserves the SPA's last-write as the env-unset fallback).
+      expect(
+        getModuleInstallChannel(db, { env: { [PARACHUTE_INSTALL_CHANNEL_ENV]: "rc" } }),
+      ).toBe("rc");
+      // Second read with env=latest — env wins again (would have returned
+      // "rc" under the old DB-after-first-seed behavior).
       expect(
         getModuleInstallChannel(db, {
           env: { [PARACHUTE_INSTALL_CHANNEL_ENV]: "latest" },
         }),
       ).toBe("latest");
-      // With env unset, DB falls through and returns whatever was last
-      // written (latest from the previous call's idempotent sync).
+      // With env unset, DB takes over. DB is still empty (neither prior
+      // call wrote to it), so the "neither env nor DB" branch fires and
+      // seeds the default ("latest").
       expect(getModuleInstallChannel(db, { env: {} })).toBe("latest");
     } finally {
       db.close();

--- a/src/__tests__/hub-settings.test.ts
+++ b/src/__tests__/hub-settings.test.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_MODULE_INSTALL_CHANNEL,
   FIRST_CLIENT_AUTO_APPROVE_WINDOW_MS,
   MODULE_INSTALL_CHANNELS,
+  PARACHUTE_INSTALL_CHANNEL_ENV,
   PARACHUTE_MODULE_CHANNEL_ENV,
   SETUP_EXPOSE_MODES,
   consumeFirstClientAutoApproveWindow,
@@ -276,27 +277,31 @@ describe("hub-settings — module install channel bootstrap", () => {
     }
   });
 
-  test("first read with PARACHUTE_MODULE_CHANNEL=rc seeds with rc", () => {
+  test("env=rc returns rc (env shadows DB; no auto-write to DB per #137 redesign)", () => {
     const db = openHubDb(hubDbPath(dir));
     try {
       const channel = getModuleInstallChannel(db, {
         env: { [PARACHUTE_MODULE_CHANNEL_ENV]: "rc" },
       });
       expect(channel).toBe("rc");
-      expect(getSetting(db, "module_install_channel")).toBe("rc");
+      // DB stays empty — env wins on read without persisting (so a later
+      // SPA toggle can hold a different value as the "DB authoritative
+      // when env is unset" fallback). Pre-#137 the env value was written
+      // to DB; the new behavior preserves operator-write intent.
+      expect(getSetting(db, "module_install_channel")).toBeUndefined();
     } finally {
       db.close();
     }
   });
 
-  test("first read with PARACHUTE_MODULE_CHANNEL=latest seeds with latest", () => {
+  test("env=latest returns latest (env shadows DB; no auto-write)", () => {
     const db = openHubDb(hubDbPath(dir));
     try {
       const channel = getModuleInstallChannel(db, {
         env: { [PARACHUTE_MODULE_CHANNEL_ENV]: "latest" },
       });
       expect(channel).toBe("latest");
-      expect(getSetting(db, "module_install_channel")).toBe("latest");
+      expect(getSetting(db, "module_install_channel")).toBeUndefined();
     } finally {
       db.close();
     }
@@ -311,6 +316,9 @@ describe("hub-settings — module install channel bootstrap", () => {
         warn: (msg) => warns.push(msg),
       });
       expect(channel).toBe("latest");
+      // Invalid env value → warn fires, env contribution is discarded, falls
+      // through to DB (none) → default. DB seeded with default since neither
+      // env nor DB had a usable value.
       expect(getSetting(db, "module_install_channel")).toBe("latest");
       expect(warns.length).toBe(1);
       expect(warns[0]).toMatch(/PARACHUTE_MODULE_CHANNEL="stable"/);
@@ -335,34 +343,100 @@ describe("hub-settings — module install channel bootstrap", () => {
     }
   });
 
-  test("once seeded, env var is ignored on subsequent reads", () => {
+  test("env wins on every read — DB no longer authoritative when env is set (bug #137)", () => {
+    // Updated 2026-05-25: precedence flipped from "DB after first seed" to
+    // "env always wins when set." Operator on a container platform expects
+    // setting PARACHUTE_INSTALL_CHANNEL to take effect on the next request,
+    // not require an admin SPA toggle to "reset" the DB. Aaron caught the
+    // prior behavior on his Render deploy (set env=rc, container restarted,
+    // UI still showed `latest` because DB had been seeded with the default
+    // at first boot before he set the env var).
     const db = openHubDb(hubDbPath(dir));
     try {
-      // First read seeds with rc.
-      getModuleInstallChannel(db, { env: { [PARACHUTE_MODULE_CHANNEL_ENV]: "rc" } });
-      // Second read with a different env value still returns the seeded value.
-      const channel = getModuleInstallChannel(db, {
-        env: { [PARACHUTE_MODULE_CHANNEL_ENV]: "latest" },
-      });
-      expect(channel).toBe("rc");
-      // And with no env at all.
-      expect(getModuleInstallChannel(db, { env: {} })).toBe("rc");
+      // First read with rc — DB seeds with rc.
+      getModuleInstallChannel(db, { env: { [PARACHUTE_INSTALL_CHANNEL_ENV]: "rc" } });
+      // Second read with a different env value returns the NEW env value
+      // (env wins over the previously-seeded DB row).
+      expect(
+        getModuleInstallChannel(db, {
+          env: { [PARACHUTE_INSTALL_CHANNEL_ENV]: "latest" },
+        }),
+      ).toBe("latest");
+      // With env unset, DB falls through and returns whatever was last
+      // written (latest from the previous call's idempotent sync).
+      expect(getModuleInstallChannel(db, { env: {} })).toBe("latest");
     } finally {
       db.close();
     }
   });
 
-  test("setModuleInstallChannel persists the new value, subsequent reads return it", () => {
+  test("both env var names honored — PARACHUTE_INSTALL_CHANNEL preferred, PARACHUTE_MODULE_CHANNEL back-compat (bug #137)", () => {
     const db = openHubDb(hubDbPath(dir));
     try {
-      // Seed with rc via env.
-      getModuleInstallChannel(db, { env: { [PARACHUTE_MODULE_CHANNEL_ENV]: "rc" } });
-      // Admin toggles to latest.
-      setModuleInstallChannel(db, "latest");
-      expect(getModuleInstallChannel(db, { env: {} })).toBe("latest");
-      // And back to rc — no env needed.
+      // PARACHUTE_INSTALL_CHANNEL — canonical name (matches install.ts).
+      expect(
+        getModuleInstallChannel(db, { env: { [PARACHUTE_INSTALL_CHANNEL_ENV]: "rc" } }),
+      ).toBe("rc");
+      // PARACHUTE_MODULE_CHANNEL — legacy alias, still recognized.
+      const db2 = openHubDb(join(mkdtempSync(join(tmpdir(), "phub-hsalt-")), "hub.db"));
+      try {
+        expect(
+          getModuleInstallChannel(db2, { env: { [PARACHUTE_MODULE_CHANNEL_ENV]: "rc" } }),
+        ).toBe("rc");
+      } finally {
+        db2.close();
+      }
+      // When both are set, INSTALL_CHANNEL wins (operator-facing canonical).
+      const db3 = openHubDb(join(mkdtempSync(join(tmpdir(), "phub-hsalt-")), "hub.db"));
+      try {
+        expect(
+          getModuleInstallChannel(db3, {
+            env: {
+              [PARACHUTE_INSTALL_CHANNEL_ENV]: "rc",
+              [PARACHUTE_MODULE_CHANNEL_ENV]: "latest",
+            },
+          }),
+        ).toBe("rc");
+      } finally {
+        db3.close();
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  test("setModuleInstallChannel persists; reads return it when env unset", () => {
+    const db = openHubDb(hubDbPath(dir));
+    try {
+      // No env: write via setModuleInstallChannel, read returns it.
       setModuleInstallChannel(db, "rc");
       expect(getModuleInstallChannel(db, { env: {} })).toBe("rc");
+      setModuleInstallChannel(db, "latest");
+      expect(getModuleInstallChannel(db, { env: {} })).toBe("latest");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("SPA toggle is shadowed when env is set (env-wins trade-off)", () => {
+    // When the operator sets PARACHUTE_INSTALL_CHANNEL in their platform
+    // env, the admin SPA's channel-toggle effectively no-ops on the read
+    // path — writes still go through (so the DB stays in sync if env is
+    // later unset), but the env-set value wins on read. This trade-off is
+    // intentional: container env is the canonical source for operators on
+    // platforms like Render. Operators who want SPA-driven channel should
+    // unset the env.
+    const db = openHubDb(hubDbPath(dir));
+    try {
+      // Env says rc.
+      const env = { [PARACHUTE_INSTALL_CHANNEL_ENV]: "rc" };
+      expect(getModuleInstallChannel(db, { env })).toBe("rc");
+      // SPA "toggles" to latest. Write succeeds.
+      setModuleInstallChannel(db, "latest");
+      // Read still returns rc — env wins.
+      expect(getModuleInstallChannel(db, { env })).toBe("rc");
+      // If env is later unset, the DB value (latest) takes over.
+      expect(getModuleInstallChannel(db, { env: {} })).toBe("latest");
     } finally {
       db.close();
     }

--- a/src/hub-settings.ts
+++ b/src/hub-settings.ts
@@ -46,12 +46,14 @@ export type HubSettingKey =
   // (`bun add -g <pkg>@<channel>`). `"latest"` (default) tracks the
   // stable channel; `"rc"` follows the release-candidate chain so
   // operators on the rc cadence can pull pre-release builds without
-  // hand-editing the install command. Seeded from
-  // `PARACHUTE_MODULE_CHANNEL` on first read (operator can ship a fresh
-  // box with the env var set and have the row land with their preferred
-  // channel); after the first seed the row is source of truth and the
-  // env var is ignored — admin must use the SPA toggle (or
-  // `PUT /api/modules/channel`) to change channel.
+  // hand-editing the install command.
+  //
+  // Precedence (hub#381, 2026-05-25 — flipped from "DB after first
+  // seed"): env > DB > default. Env vars recognized:
+  // `PARACHUTE_INSTALL_CHANNEL` (canonical), `PARACHUTE_MODULE_CHANNEL`
+  // (legacy alias). When env is set it wins on every read; the SPA
+  // toggle still writes to this row as the fallback for when env is
+  // later unset.
   | "module_install_channel"
   // hub#298: operator-settable canonical hub URL. The value (when set)
   // is the OAuth issuer claim stamped into every JWT minted by hub.
@@ -248,9 +250,9 @@ export const DEFAULT_MODULE_INSTALL_CHANNEL: ModuleInstallChannel = "latest";
 
 /**
  * Resolve the env-set channel, if any. Returns the channel value or
- * `null` if no env var is set; throws via `warn()` if a value is set
- * but invalid (still returns null in that case, so caller falls
- * through to DB/default).
+ * `null` when no env var is set or only invalid values are present.
+ * Invalid values call `warn()` and are skipped (caller falls through
+ * to DB/default). Never throws.
  */
 function resolveChannelFromEnv(
   env: NodeJS.ProcessEnv,

--- a/src/hub-settings.ts
+++ b/src/hub-settings.ts
@@ -218,24 +218,65 @@ export function isModuleInstallChannel(s: unknown): s is ModuleInstallChannel {
 }
 
 /**
- * Env var that seeds `module_install_channel` on first read. Read only
- * when the hub_settings row is absent — once the row exists, the env
- * var is ignored on subsequent boots (admin must use the SPA toggle or
- * the API to change channel). Lets Aaron's fresh-machine deploys ship
- * with `PARACHUTE_MODULE_CHANNEL=rc` baked into the platform's env
- * config without baking the channel into the binary or first-boot.
+ * Env vars consulted by `getModuleInstallChannel`. Both names are
+ * recognized; `PARACHUTE_INSTALL_CHANNEL` (the operator-facing name
+ * documented in `parachute --help` and used by `src/commands/install.ts`
+ * + `src/api-modules-ops.ts`) is preferred. `PARACHUTE_MODULE_CHANNEL`
+ * is the legacy name kept for back-compat with deploys that already
+ * baked it into their env config; it's a back-compat alias and may
+ * be retired one rc-chain after this lands.
+ *
+ * **Precedence (changed 2026-05-25 — was DB-first):** env > DB > default.
+ * An operator who sets the env var in their platform dashboard expects
+ * that value to be authoritative on every boot — the prior "DB always
+ * wins after first seed" behavior produced the failure mode Aaron hit
+ * (set env=rc, container restarted, UI still showed `latest` because
+ * DB had been seeded with the default at first boot before the env was
+ * set). Bug #137 in the audit.
+ *
+ * When the env is set, the SPA's channel toggle is shadowed (writes go
+ * through to the DB but the env-set value still wins on read). That
+ * trade-off is acceptable for container deploys where env is the
+ * canonical source; operators who want SPA-driven control should unset
+ * the env var.
  */
-export const PARACHUTE_MODULE_CHANNEL_ENV = "PARACHUTE_MODULE_CHANNEL";
+export const PARACHUTE_INSTALL_CHANNEL_ENV = "PARACHUTE_INSTALL_CHANNEL";
+export const PARACHUTE_MODULE_CHANNEL_ENV = "PARACHUTE_MODULE_CHANNEL"; // legacy alias
 
 /** Fallback when nothing else is set — the stable channel. */
 export const DEFAULT_MODULE_INSTALL_CHANNEL: ModuleInstallChannel = "latest";
 
 /**
- * Read the configured module install channel. On first call (no row in
- * hub_settings), seeds from `process.env.PARACHUTE_MODULE_CHANNEL` if
- * valid, otherwise defaults to `"latest"` (an invalid env value warns
- * + still falls back to "latest"). After that first seed, the
- * hub_settings row is source of truth.
+ * Resolve the env-set channel, if any. Returns the channel value or
+ * `null` if no env var is set; throws via `warn()` if a value is set
+ * but invalid (still returns null in that case, so caller falls
+ * through to DB/default).
+ */
+function resolveChannelFromEnv(
+  env: NodeJS.ProcessEnv,
+  warn: (msg: string) => void,
+): ModuleInstallChannel | null {
+  for (const name of [PARACHUTE_INSTALL_CHANNEL_ENV, PARACHUTE_MODULE_CHANNEL_ENV]) {
+    const raw = env[name];
+    if (typeof raw !== "string" || raw.length === 0) continue;
+    if (isModuleInstallChannel(raw)) return raw;
+    warn(
+      `[hub-settings] ${name}="${raw}" is not a valid channel — expected one of ${MODULE_INSTALL_CHANNELS.join(", ")}. Falling back to "${DEFAULT_MODULE_INSTALL_CHANNEL}".`,
+    );
+  }
+  return null;
+}
+
+/**
+ * Read the configured module install channel.
+ *
+ * Precedence: env (PARACHUTE_INSTALL_CHANNEL > PARACHUTE_MODULE_CHANNEL)
+ * > DB (hub_settings) > default ("latest").
+ *
+ * The DB is still seeded with the resolved value on first read so the
+ * SPA shows a stable "current channel" even when env is set — but the
+ * env always wins on read, so a platform-level env change takes effect
+ * immediately without operator intervention.
  *
  * The `env` + `warn` knobs are test seams — production uses
  * `process.env` + `console.warn`. Tests inject a deterministic shape so
@@ -248,30 +289,34 @@ export function getModuleInstallChannel(
     warn?: (msg: string) => void;
   } = {},
 ): ModuleInstallChannel {
-  const existing = getSetting(db, "module_install_channel");
-  if (existing !== undefined) {
-    // Row already seeded — trust it. If somehow corrupted (manual sqlite
-    // edit, schema drift), fall back to "latest" silently rather than
-    // crashing the install path. Re-seeding the row is left to the
-    // admin's explicit setModuleInstallChannel call.
-    if (isModuleInstallChannel(existing)) return existing;
-    return DEFAULT_MODULE_INSTALL_CHANNEL;
-  }
   const env = opts.env ?? process.env;
   const warn = opts.warn ?? ((msg: string) => console.warn(msg));
-  const fromEnv = env[PARACHUTE_MODULE_CHANNEL_ENV];
-  let seed: ModuleInstallChannel = DEFAULT_MODULE_INSTALL_CHANNEL;
-  if (typeof fromEnv === "string" && fromEnv.length > 0) {
-    if (isModuleInstallChannel(fromEnv)) {
-      seed = fromEnv;
-    } else {
-      warn(
-        `[hub-settings] ${PARACHUTE_MODULE_CHANNEL_ENV}="${fromEnv}" is not a valid channel — expected one of ${MODULE_INSTALL_CHANNELS.join(", ")}. Falling back to "${DEFAULT_MODULE_INSTALL_CHANNEL}".`,
-      );
-    }
+
+  // Env wins.
+  const fromEnv = resolveChannelFromEnv(env, warn);
+  if (fromEnv !== null) {
+    // Do NOT write to DB — that would overwrite a separate operator-driven
+    // value (e.g. an SPA toggle while env was unset). The DB tracks the
+    // last operator-written value as a fallback for when env is later
+    // unset; env just shadows on read. Cost: the SPA's "current channel"
+    // indicator may show the DB value while env is shadowing it. Future
+    // work (#137 follow-up) can expose a `source` field so the SPA can
+    // surface "shadowed by env" UX.
+    return fromEnv;
   }
-  setSetting(db, "module_install_channel", seed);
-  return seed;
+
+  // Env unset → DB next.
+  const existing = getSetting(db, "module_install_channel");
+  if (existing !== undefined) {
+    if (isModuleInstallChannel(existing)) return existing;
+    // Corrupted value (manual sqlite edit, schema drift) — fall through
+    // to default silently rather than crashing the install path.
+    return DEFAULT_MODULE_INSTALL_CHANNEL;
+  }
+
+  // Neither env nor DB → seed default + return.
+  setSetting(db, "module_install_channel", DEFAULT_MODULE_INSTALL_CHANNEL);
+  return DEFAULT_MODULE_INSTALL_CHANNEL;
 }
 
 /**


### PR DESCRIPTION
Bug #137 (Aaron 2026-05-25): env=rc but UI showed latest. Two problems:

1. hub-settings read `PARACHUTE_MODULE_CHANNEL` (historical name), Aaron set `PARACHUTE_INSTALL_CHANNEL` (documented name).
2. DB-after-first-seed precedence ignored later env changes.

Fix: env > DB > default precedence. Both env var names honored (INSTALL preferred, MODULE back-compat). When env is set, SPA toggle shadows on read.

bun test ./src: 2018 pass / 0 fail (+3 new tests).

Self-review pending fresh reviewer dispatch from orchestrator.