### PR TITLE
fix(oauth-ui): adopt canonical verbs in consent + approve-pending pages (workstream I)

### DIFF
--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -209,7 +209,9 @@ describe("handleAuthorizeGet", () => {
       const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
       expect(res.status).toBe(200);
       const html = await res.text();
-      expect(html).toContain("Authorize");
+      // Page h1: "Approve <client>?" per design-system.md §5 verb canon
+      // (Workstream I, 2026-05-25 — was "Authorize <client>?").
+      expect(html).toContain("Approve");
       expect(html).toContain("MyApp");
       expect(html).toContain("vault:read");
       expect(html).toContain('name="__action" value="consent"');
@@ -4498,8 +4500,9 @@ describe("inline approve button on pending /oauth/authorize (#208)", () => {
       expect(reentryRes.status).toBe(200);
       const consentHtml = await reentryRes.text();
       // Consent screen markers (renderConsent uses these).
+      // Page h1: "Approve <client>?" per design-system.md §5 (was "Authorize").
       expect(consentHtml).toContain('name="__action" value="consent"');
-      expect(consentHtml).toContain("Authorize");
+      expect(consentHtml).toContain("Approve");
       expect(consentHtml).toContain("RoundTrip");
     } finally {
       cleanup();

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -95,7 +95,9 @@ describe("renderConsent", () => {
       clientName: "MyApp",
       scopes: ["vault:read", "vault:admin"],
     });
-    expect(html).toContain("Authorize");
+    // Page h1: "Approve <client>?" per design-system.md §5 verb canon
+    // (Workstream I, 2026-05-25 — was "Authorize <client>?").
+    expect(html).toContain("Approve");
     expect(html).toContain("MyApp");
     expect(html).toContain("client-abc");
     expect(html).toContain("vault:read");
@@ -485,7 +487,10 @@ describe("renderApprovePending unauthenticated CTAs", () => {
       approveForm: { csrfToken: CSRF, returnTo: "/oauth/authorize?client_id=client-xyz" },
     });
     expect(html).toContain('action="/oauth/authorize/approve"');
-    expect(html).toContain("Approve and continue");
+    // Workstream I, 2026-05-25 — button label "Approve and continue"
+    // → "Approve" per design-system.md §5 (Approve is canon; the suffix
+    // was verbal noise implying optionality where there is none).
+    expect(html).toContain(">Approve</button>");
     expect(html).not.toContain("Sign in as admin to approve");
     expect(html).not.toContain("Or send this link to your hub admin");
     expect(html).not.toContain("parachute auth approve-client");

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -173,7 +173,7 @@ export interface ErrorViewProps {
  *          response to an `/oauth/authorize?...` request, `loginNextUrl`
  *          is that same authorize URL (pathname+search) so the operator
  *          lands BACK on the OAuth flow after sign-in — now authenticated,
- *          they see the inline "Approve and continue" form, click once,
+ *          they see the inline "Approve" form, click once,
  *          and the OAuth flow resumes through consent → redirect_uri.
  *          Without this, post-login the operator lands on the SPA approve
  *          page, which approves the client but discards the original
@@ -348,7 +348,7 @@ export function renderConsent(props: ConsentViewProps): string {
           <span class="brand-mark">⌬</span>
           <span class="brand-name">Parachute</span>
         </div>
-        <h1>Authorize <span class="client-name">${escapeHtml(clientName)}</span>?</h1>
+        <h1>Approve <span class="client-name">${escapeHtml(clientName)}</span>?</h1>
         <p class="subtitle">
           This app is requesting access to your Parachute account.
         </p>
@@ -373,7 +373,7 @@ export function renderConsent(props: ConsentViewProps): string {
         </div>
       </form>
     </div>`;
-  return baseDocument(`Authorize ${clientName}`, body);
+  return baseDocument(`Approve ${clientName}`, body);
 }
 
 function renderVaultPicker(picker: VaultPicker): string {
@@ -505,7 +505,7 @@ export function renderApprovePending(props: ApprovePendingViewProps): string {
         ${renderCsrfHiddenInput(approveForm.csrfToken)}
         <input type="hidden" name="client_id" value="${escapeHtml(clientId)}" />
         <input type="hidden" name="return_to" value="${escapeHtml(approveForm.returnTo)}" />
-        <button type="submit" class="btn btn-primary">Approve and continue</button>
+        <button type="submit" class="btn btn-primary">Approve</button>
       </form>`
     : renderUnauthenticatedApproveCtas(hubOrigin, clientId, loginNextUrl);
   const body = `


### PR DESCRIPTION
Workstream I sweep: 3 verb-vocab drift sites in hub's OAuth UI flagged by the just-extended audit-canonical-refs.sh (patterns#99). Replaces 'Authorize <client>?' → 'Approve <client>?' on the consent page h1+title, and 'Approve and continue' → 'Approve' on the inline approve-pending button. Updates 3 test assertions in lockstep.

2021 hub tests pass.