### PR TITLE
fix(hub): same-origin check falls through on Origin: null (Aaron's OAuth blocker)

### DIFF
--- a/src/__tests__/origin-check.test.ts
+++ b/src/__tests__/origin-check.test.ts
@@ -159,6 +159,45 @@ describe("isSameOriginRequest", () => {
       const req = reqWithHeaders({ origin: "not a valid url" });
       expect(isSameOriginRequest(req, BOUND)).toBe(false);
     });
+
+    test('Origin "null" falls through to Host fallback (hub#386 — no-referrer pages)', () => {
+      // Browsers send the literal string "null" as Origin when the form
+      // POST comes from a page with a restrictive referrer policy
+      // (`<meta name="referrer" content="no-referrer">` on hub's OAuth
+      // pages), from a sandboxed iframe, or from certain cross-origin
+      // redirect chains. The "null" signal means "I'm intentionally not
+      // telling you where this came from" — not "the origin is the literal
+      // string null." Previously the code returned false at tier 1 for
+      // this case, blocking legitimate operator POSTs. Caught 2026-05-26
+      // on Aaron's Render deploy via the rc.40 diagnostic warn.
+      //
+      // Fix: skip tier 1 when Origin is literal "null", fall through to
+      // Referer/Host. Host with the public Render URL is in the bound set
+      // → tier 3 accepts.
+      const req = reqWithHeaders({
+        origin: "null",
+        host: new URL(ISSUER).host,
+      });
+      expect(isSameOriginRequest(req, BOUND)).toBe(true);
+    });
+
+    test('Origin "null" + Host mismatch still rejects (no security regression)', () => {
+      // The Origin: null fall-through doesn't weaken the defense — if the
+      // Host header also doesn't match a bound origin, the request is
+      // still rejected at tier 3.
+      const req = reqWithHeaders({
+        origin: "null",
+        host: "attacker.example",
+      });
+      expect(isSameOriginRequest(req, BOUND)).toBe(false);
+    });
+
+    test('Origin "null" + no Host header rejects (defense-fails-closed)', () => {
+      // If Origin is null AND no Referer AND no Host, the request has no
+      // useful provenance signal at all — fail closed.
+      const req = reqWithHeaders({ origin: "null" });
+      expect(isSameOriginRequest(req, BOUND)).toBe(false);
+    });
   });
 
   describe("Referer header (fallback when Origin is absent)", () => {

--- a/src/origin-check.ts
+++ b/src/origin-check.ts
@@ -104,7 +104,21 @@ export function isSameOriginRequest(req: Request, boundOrigins: readonly string[
   const boundOriginSet = new Set(boundOrigins);
 
   const origin = req.headers.get("origin");
-  if (origin) {
+  // "null" is the browser's opaque-origin signal — sent on form POSTs from
+  // pages with restrictive referrer policies (`<meta name="referrer"
+  // content="no-referrer">`), sandboxed iframes, or certain cross-origin
+  // redirect chains. The browser is saying "I'm intentionally not telling
+  // you where this came from" rather than "this is from origin null".
+  // Treat as "Origin not informative" and fall through to Referer/Host —
+  // the CSRF token check upstream is still the real authentication;
+  // same-origin is belt-and-suspenders, not the only defense.
+  //
+  // Caught 2026-05-26 on Aaron's Render deploy: hub's OAuth pages set
+  // `referrer-policy: no-referrer` for privacy, which made browsers
+  // send `Origin: null` on the approve POST. The strict-reject behavior
+  // here blocked the legitimate operator action; the Host fallback (tier
+  // 3 below) would have correctly accepted the request.
+  if (origin && origin !== "null") {
     try {
       return boundOriginSet.has(new URL(origin).origin);
     } catch {


### PR DESCRIPTION
**Smoking gun for the cross-origin OAuth approve failure.** rc.40's diagnostic warn fired on Aaron's Render deploy with:

```
Origin: "null"
Referer: null
Host: parachute-hub.onrender.com
bound: ["https://parachute-hub.onrender.com", "http://localhost:1939", ...]
```

Browser sent literal string `"null"` because hub's OAuth pages have `<meta name="referrer" content="no-referrer">` for privacy. The pre-fix tier 1 threw on `new URL("null")` → returned false without falling through to Host (which would have matched).

Fix: skip tier 1 when Origin is literal "null", let Referer/Host tiers run. CSRF token remains the authoritative defense.

3 new tests pin the fall-through + the security non-regression (null Origin + bad Host still rejects).

bun test ./src: 2024 pass / 0 fail (+3 new). Typecheck clean.

Self-review pending fresh reviewer dispatch from orchestrator.