### PR TITLE
polish(hub): fix mobile overflow + branded 404 + RFC 9728 endpoint

### DIFF
--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -639,6 +639,68 @@ describe("hubFetch routing", () => {
     }
   });
 
+  test("/.well-known/oauth-protected-resource returns RFC 9728 metadata + CORS (closes hub#393)", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, {
+          getDb: () => db,
+          issuer: "https://hub.example",
+        })(req("/.well-known/oauth-protected-resource"));
+        expect(res.status).toBe(200);
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+        const body = (await res.json()) as Record<string, unknown>;
+        expect(body.resource).toBe("https://hub.example");
+        expect(body.authorization_servers).toEqual(["https://hub.example"]);
+        expect(body.bearer_methods_supported).toEqual(["header"]);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("unknown path returns branded HTML 404 when Accept includes text/html (closes hub#392)", async () => {
+    const h = makeHarness();
+    try {
+      const r = new Request("https://hub.example/this-page-does-not-exist", {
+        headers: { accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8" },
+      });
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(r);
+      expect(res.status).toBe(404);
+      expect(res.headers.get("content-type")).toMatch(/text\/html/);
+      const body = await res.text();
+      expect(body).toContain("Not found");
+      expect(body).toContain("/this-page-does-not-exist");
+      expect(body).toContain("Go to hub home");
+      // Brand mark present so it's clearly a Parachute page
+      expect(body).toContain("pc-brand-mark-clip-not-found");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("unknown path returns plain-text 404 when client doesn't accept HTML (curl-style)", async () => {
+    const h = makeHarness();
+    try {
+      // curl default Accept is "*/*" — no explicit text/html.
+      const r = new Request("https://hub.example/this-page-does-not-exist", {
+        headers: { accept: "*/*" },
+      });
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(r);
+      expect(res.status).toBe(404);
+      // Plain-text fallback has no explicit content-type header — that's
+      // fine, it's the absence of `text/html` we care about.
+      const ct = res.headers.get("content-type") ?? "";
+      expect(ct).not.toContain("text/html");
+      expect(await res.text()).toBe("not found");
+    } finally {
+      h.cleanup();
+    }
+  });
+
   // SPA mount after hub#231: single `/admin/*` mount serves vault
   // provisioning + permissions + tokens. Pre-rename `/vault` and `/hub/*`
   // SPA URLs are 301-redirected; the per-vault content proxy at

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -22,6 +22,7 @@ import {
   handleRegister,
   handleRevoke,
   handleToken,
+  protectedResourceMetadata,
 } from "../oauth-handlers.ts";
 import type { ServicesManifest } from "../services-manifest.ts";
 import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
@@ -148,6 +149,41 @@ describe("authorizationServerMetadata", () => {
     expect(scopesSupported).toContain("hub:admin");
     // NON_REQUESTABLE filter still applies even when the scope is declared
     expect(scopesSupported).not.toContain("parachute:host:admin");
+  });
+});
+
+describe("protectedResourceMetadata (RFC 9728, closes hub#393)", () => {
+  test("emits the required RFC 9728 fields rooted at the issuer", async () => {
+    const res = protectedResourceMetadata({ issuer: ISSUER });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/application\/json/);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.resource).toBe(ISSUER);
+    expect(body.authorization_servers).toEqual([ISSUER]);
+    expect(body.bearer_methods_supported).toEqual(["header"]);
+    expect(Array.isArray(body.scopes_supported)).toBe(true);
+    expect(body.resource_documentation).toMatch(/parachute\.computer/);
+  });
+
+  test("scopes_supported mirrors authorizationServerMetadata after the same operator-only filter", async () => {
+    // Same declared-scope set as the authorizationServerMetadata test; the
+    // resource-server view should advertise the same shape.
+    const declared = new Set<string>([
+      "vault:read",
+      "vault:admin",
+      "hub:admin",
+      "parachute:host:admin",
+      "agent:read",
+    ]);
+    const res = protectedResourceMetadata({
+      issuer: ISSUER,
+      loadDeclaredScopes: () => declared,
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    const scopes = body.scopes_supported as string[];
+    expect(scopes).toContain("vault:read");
+    expect(scopes).toContain("agent:read");
+    expect(scopes).not.toContain("parachute:host:admin");
   });
 });
 

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -7,6 +7,7 @@ import {
   renderError,
   renderHiddenInputs,
   renderLogin,
+  renderNotFoundPage,
   renderUnknownClient,
   substituteVaultDisplay,
 } from "../oauth-ui.ts";
@@ -233,6 +234,32 @@ describe("renderError", () => {
     });
     expect(html).not.toContain("<script>1</script>");
     expect(html).not.toContain('"><img>');
+    expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+describe("renderNotFoundPage (closes hub#392)", () => {
+  test("renders a branded full-page HTML doc with a path back to /", () => {
+    const html = renderNotFoundPage("/some-missing-route");
+    expect(html).toStartWith("<!doctype html>");
+    expect(html).toContain("<title>Not found");
+    expect(html).toContain("Not found");
+    // Brand mark — the operator sees this is a Parachute page, not just a generic 404
+    expect(html).toContain("pc-brand-mark-clip-not-found");
+    expect(html).toContain("Parachute");
+    // The CTA back to hub home
+    expect(html).toContain('href="/"');
+    expect(html).toContain("Go to hub home");
+  });
+
+  test("echoes + escapes the requested pathname in the message", () => {
+    const html = renderNotFoundPage("/this-page-does-not-exist");
+    expect(html).toContain("/this-page-does-not-exist");
+  });
+
+  test("escapes hostile pathnames", () => {
+    const html = renderNotFoundPage('/"><script>alert(1)</script>');
+    expect(html).not.toContain('"><script>alert(1)</script>');
     expect(html).toContain("&lt;script&gt;");
   });
 });

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -165,7 +165,9 @@ import {
   handleRegister,
   handleRevoke,
   handleToken,
+  protectedResourceMetadata,
 } from "./oauth-handlers.ts";
+import { renderNotFoundPage } from "./oauth-ui.ts";
 import { buildHubBoundOrigins } from "./origin-check.ts";
 import { clearPid, writePid } from "./process-state.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
@@ -1512,6 +1514,23 @@ export function hubFetch(
       return new Response(res.body, { status: res.status, headers: merged });
     }
 
+    if (pathname === "/.well-known/oauth-protected-resource") {
+      // RFC 9728 — companion to oauth-authorization-server. MCP clients
+      // (since 2025-06-18 spec) probe this to discover scopes + the
+      // authorization server. Same wildcard CORS shape. Closes hub#393.
+      const corsHeaders = {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "GET, OPTIONS",
+      };
+      if (req.method === "OPTIONS") {
+        return new Response(null, { status: 204, headers: corsHeaders });
+      }
+      const res = protectedResourceMetadata(oauthDeps(req));
+      const merged = new Headers(res.headers);
+      for (const [k, v] of Object.entries(corsHeaders)) merged.set(k, v);
+      return new Response(res.body, { status: res.status, headers: merged });
+    }
+
     // OAuth surface — every handler return is wrapped in `applyCorsHeaders`
     // so third-party SPAs can fetch these endpoints cross-origin (the entire
     // point of OAuth DCR: arbitrary SPAs register → authorize → exchange
@@ -1953,6 +1972,18 @@ export function hubFetch(
     const proxied = await proxyToService(req, manifestPath);
     if (proxied) return decorateWithChrome(proxied, req, pathname, getDb);
 
+    // Branded fall-through 404 (closes hub#392) — the operator who mistyped
+    // a URL sees a clear "not found" page with a path back home, not the
+    // browser's default empty-body chrome. Only HTML clients get the
+    // rendered page; non-HTML callers (curl, API probes) still see the
+    // shorter "not found" text so log noise stays low.
+    const wantsHtml = (req.headers.get("accept") ?? "").includes("text/html");
+    if (wantsHtml) {
+      return new Response(renderNotFoundPage(pathname), {
+        status: 404,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
     return new Response("not found", { status: 404 });
   };
 }

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -348,6 +348,40 @@ function oauthErrorRedirect(
   return redirectResponse(u.toString());
 }
 
+// --- /.well-known/oauth-protected-resource ---------------------------------
+
+/**
+ * RFC 9728 (April 2025) — OAuth 2.0 Protected Resource Metadata. The
+ * resource-server-side companion to `authorizationServerMetadata`. MCP
+ * clients (since the 2025-06-18 spec draft) probe this endpoint to
+ * discover which authorization server signs tokens for the resource,
+ * which scopes the resource accepts, and how tokens are presented.
+ *
+ * Hub-as-resource posture: hub itself is the protected resource. The
+ * authorization server is also hub (the issuer). The advertised scopes
+ * mirror `authorizationServerMetadata.scopes_supported` — same set, same
+ * filtering (operator-only scopes hidden per RFC 8414 §2 framing).
+ *
+ * Per-vault metadata could also live at
+ * `/vault/<name>/.well-known/oauth-protected-resource` to scope the
+ * advertised resource indicator and scope subset to one vault. Deferred
+ * until an MCP client actually probes that path — today the spec
+ * accepts the hub-level form for the resource indicator.
+ *
+ * Closes hub#393.
+ */
+export function protectedResourceMetadata(deps: OAuthDeps): Response {
+  const iss = deps.issuer;
+  const declared = (deps.loadDeclaredScopes ?? loadDeclaredScopes)();
+  return jsonResponse({
+    resource: iss,
+    authorization_servers: [iss],
+    scopes_supported: Array.from(declared).filter(isRequestableScope),
+    bearer_methods_supported: ["header"],
+    resource_documentation: "https://parachute.computer",
+  });
+}
+
 // --- /.well-known/oauth-authorization-server -------------------------------
 
 export function authorizationServerMetadata(deps: OAuthDeps): Response {

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -379,6 +379,14 @@ export function protectedResourceMetadata(deps: OAuthDeps): Response {
     scopes_supported: Array.from(declared).filter(isRequestableScope),
     bearer_methods_supported: ["header"],
     resource_documentation: "https://parachute.computer",
+    // Intentional omission: `resource_signing_alg_values_supported` +
+    // `signed_metadata`. Hub serves the resource metadata document
+    // unsigned today — MCP clients that probe for a signed metadata
+    // JWT will fall back to verifying the resource via the
+    // authorization-server's JWKS-signed access tokens. When the signed
+    // metadata path lands here (likely once a downstream MCP client
+    // requires it for offline verification), add the alg list + the
+    // `signed_metadata` JWT alongside.
   });
 }
 

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -698,6 +698,40 @@ export function renderError(props: ErrorViewProps): string {
   return baseDocument(props.title, body);
 }
 
+/**
+ * Generic "Not found" page rendered when no other route matches. Replaces
+ * the `new Response("not found", { status: 404 })` plaintext fallback
+ * (closes hub#392) with a branded HTML page that:
+ *
+ *   1. Tells the operator they took a wrong turn (vs. "the hub is broken").
+ *   2. Offers one clear CTA back to the hub home.
+ *
+ * Status code stays 404 — no soft-redirect to `/`. The Response is built
+ * by the caller in `hub-server.ts`; this function returns only the HTML
+ * body so a future caller can use it from other 404 surfaces (per-vault
+ * 404, per-module 404) without going through Response construction here.
+ */
+export function renderNotFoundPage(pathname: string): string {
+  const body = `
+    <div class="card">
+      <div class="card-header">
+        <div class="brand">
+          <span class="brand-mark" aria-hidden="true">${brandMarkSvg(20, "not-found")}</span>
+          <span class="brand-name">${WORDMARK_TEXT}</span>
+        </div>
+        <h1 class="error-title">Not found</h1>
+        <p class="subtitle">
+          We don't have anything at <code>${escapeHtml(pathname)}</code>. The link
+          may have changed, or the page never existed.
+        </p>
+      </div>
+      <p class="error-help">
+        <a href="/" class="btn btn-primary">Go to hub home</a>
+      </p>
+    </div>`;
+  return baseDocument("Not found", body);
+}
+
 export interface UnknownClientViewProps {
   /** The unknown client_id the request carried. Surfaced verbatim for debugging. */
   clientId: string;

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -108,10 +108,13 @@ code {
   /* Wrap on narrow viewports so the nav reflows instead of forcing
      horizontal overflow on the document. At 375 px the document was
      measuring 787 px — every nav child (10 links + brand + auth) lined
-     up in a single flex row that stretched past the viewport. Without
-     `flex-wrap`, the row's intrinsic width sets the document width
-     even though `.page`'s `max-width: 880px` constraint should bound
-     it. Closes hub#391. */
+     up in a single flex row whose intrinsic min-content width exceeded
+     the viewport. `.page`'s `max-width: 880px` doesn't help here:
+     max-width caps the box's layout size but does not prevent overflow
+     from a flex row's intrinsic content width. Only `flex-wrap`,
+     `overflow: hidden`, or `min-width: 0` on flex children can. We pick
+     `flex-wrap: wrap` because the nav reflowing naturally on narrow
+     viewports is the desired UX. Closes hub#391. */
   flex-wrap: wrap;
   /* Tighter vertical gap (row-gap 0.6rem) than horizontal (column-gap
      1rem) so a wrapped second/third row reads as continuation, not a

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -105,7 +105,18 @@ code {
 
 .nav {
   display: flex;
-  gap: 1rem;
+  /* Wrap on narrow viewports so the nav reflows instead of forcing
+     horizontal overflow on the document. At 375 px the document was
+     measuring 787 px — every nav child (10 links + brand + auth) lined
+     up in a single flex row that stretched past the viewport. Without
+     `flex-wrap`, the row's intrinsic width sets the document width
+     even though `.page`'s `max-width: 880px` constraint should bound
+     it. Closes hub#391. */
+  flex-wrap: wrap;
+  /* Tighter vertical gap (row-gap 0.6rem) than horizontal (column-gap
+     1rem) so a wrapped second/third row reads as continuation, not a
+     new section. */
+  gap: 0.6rem 1rem;
   align-items: center;
   padding-bottom: 1rem;
   border-bottom: 1px solid var(--border);


### PR DESCRIPTION
## Summary

Three round-3 audit findings folded into one polish PR. Each one small in code, all operator-facing. **Stacked on #389** (uses `src/brand.ts` from that PR for the 404 page's brand mark). Retarget base to \`main\` once #389 merges.

## Changes

### #391 — Mobile overflow on /admin/* (375 px → 787 px doc width)

The admin SPA nav renders 10 nav links + brand + auth indicator in a single non-wrapping flex row. On mobile the row's intrinsic width sets document width past the viewport → 2.1× horizontal scroll.

\`web/ui/src/styles.css:106\` — adds \`flex-wrap: wrap\` + asymmetric \`gap: 0.6rem 1rem\`. Pure CSS, no HTML change.

### #392 — Branded 404 replaces empty-body fallback

Hub's fall-through 404 returned \`new Response("not found")\` with no body. New \`renderNotFoundPage(pathname)\` in \`src/oauth-ui.ts\` produces a branded HTML page; the catch-all sniffs \`Accept\` so HTML clients get the rendered page while curl + API probes still see plain text (low log noise).

### #393 — \`/.well-known/oauth-protected-resource\` (RFC 9728)

The companion to oauth-authorization-server, probed by MCP clients (2025-06-18 spec draft). New \`protectedResourceMetadata()\` in \`oauth-handlers.ts\` mirrors the AS-metadata shape + scope filter. Wired with the same wildcard CORS as AS-metadata.

## Deferred

- **#390 (Deny button on approve-pending)** — needs design decision on semantic (cancel vs delete vs OAuth \`access_denied\` redirect); separate PR.
- **#394 (admin SPA empty states + consistent h1s)** — substantial, larger surface area; separate PR.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun test ./src\` — 2033/2033 pass (+5 new tests)
- [x] SPA \`bun run test\` — 213/213 pass
- [ ] Reviewer dispatch (mandatory)
- [ ] After merge + Render deploy: verify the live deploy at 375 px no longer overflows; verify \`/this-page-does-not-exist\` renders the branded 404; verify \`curl /.well-known/oauth-protected-resource\` returns RFC 9728 JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)