### PR TITLE
polish(hub): wrap Tokens.tsx filter rows on mobile

### DIFF
--- a/web/ui/src/routes/Tokens.tsx
+++ b/web/ui/src/routes/Tokens.tsx
@@ -382,7 +382,16 @@ export function Tokens() {
         </div>
       ) : null}
 
-      <div style={{ marginTop: "1rem", marginBottom: "0.5rem", display: "flex", gap: "0.5rem" }}>
+      <div
+        style={{
+          marginTop: "1rem",
+          marginBottom: "0.5rem",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "0.5rem",
+          alignItems: "center",
+        }}
+      >
         <span className="muted" style={{ marginRight: "0.5rem", minWidth: "4rem" }}>
           Status:
         </span>
@@ -404,7 +413,15 @@ export function Tokens() {
           </button>
         ))}
       </div>
-      <div style={{ marginBottom: "1rem", display: "flex", gap: "0.5rem" }}>
+      <div
+        style={{
+          marginBottom: "1rem",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "0.5rem",
+          alignItems: "center",
+        }}
+      >
         <span className="muted" style={{ marginRight: "0.5rem", minWidth: "4rem" }}>
           Source:
         </span>


### PR DESCRIPTION
## Summary

End-to-end walk on the freshly-rebuilt Render instance caught a residual mobile-overflow regression on \`/admin/tokens\` after #396 fixed the nav. At 375 px the page measures 474 px wide (~100 px overflow); the source is the Status + Source filter rows on \`Tokens.tsx\` — both inline-styled \`display: flex; gap: 0.5rem\` with no \`flex-wrap\`.

The four buttons in the Source filter ("All sources / OAuth / Operator / CLI mint") chain in a single row and force horizontal scroll on mobile.

## Fix

Add \`flexWrap: "wrap"\` + \`alignItems: "center"\` to both filter row containers. Same shape as #396's nav fix.

## Test plan

- [x] Identified via Playwright at 375 px on the live deploy (after #396 landed)
- [x] \`bun run typecheck\` clean
- [x] SPA \`bun run test\` — 213/213 pass
- [ ] Live deploy after merge: re-measure /admin/tokens at 375 px

🤖 Generated with [Claude Code](https://claude.com/claude-code)