### PR TITLE
fix(hub-server): Bun.serve idleTimeout=255s — close Render edge keep-alive 502 race (#399)

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -287,6 +287,12 @@ export async function serve(opts: ServeOpts = {}): Promise<{
   const server = Bun.serve({
     port,
     hostname,
+    // Hold idle keep-alive connections for Bun's maximum 255s so reverse-
+    // proxy edges (Render, Cloudflare, fly.io) don't race us when reusing
+    // pooled connections. See `src/hub-server.ts` for the full rationale —
+    // this is the active code path for `bun src/cli.ts serve` (the Docker
+    // CMD), so the fix has to land here too. Closes hub#399.
+    idleTimeout: 255,
     fetch: hubFetch(WELL_KNOWN_DIR, {
       getDb: () => db,
       issuer,

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -2052,6 +2052,18 @@ if (import.meta.main) {
   Bun.serve({
     port,
     hostname,
+    // Hold idle connections open for 255 seconds (Bun's max) instead of
+    // the 10-second default. When the hub sits behind a reverse-proxy edge
+    // that pools keep-alive connections (Render, Cloudflare, fly proxy,
+    // etc.), the edge's idle timeout is longer than our default — so the
+    // proxy reaches into the pool, sends a request on a connection we
+    // just closed, and returns 502 (Bad Gateway) to the client. The bug
+    // is invisible to us (no log, no restart, deployStatus=live) and
+    // manifests as a 5–15% "random" 502 rate under steady probing.
+    // Canonical fix on Node is `keepAliveTimeout > edge.idle_timeout`;
+    // Bun's equivalent is this. 255s comfortably exceeds Render's edge
+    // pool TTL (community-observed ~120s). Closes hub#399.
+    idleTimeout: 255,
     fetch: hubFetch(wellKnownDir, { getDb, issuer, loopbackPort: port }),
   });
   // Register PID + port from the running hub itself so any startup path


### PR DESCRIPTION
## Root cause (after slowing down and researching)

\`Bun.serve\`'s default \`idleTimeout\` is **10 seconds**. Render's edge proxy pools keep-alive connections to the upstream with a longer idle timeout (community-observed ~120s). The race:

1. Edge receives a request, picks a pooled connection.
2. Hub's 10s timeout already closed that connection (FIN sent).
3. Edge writes the request before the FIN reaches it.
4. Connection drops mid-write; edge returns **502 Bad Gateway**.
5. The next request gets a fresh connection and succeeds.

**The bug is invisible to the app** — no log entry, no restart, \`deployStatus: live\` throughout. Manifests as a 5–15% "random" 502 rate under steady probing. We hit it consistently during no-delay Playwright walks (a burst of requests is exactly the workload that exercises the connection pool).

## How we found it

Aaron asked for a no-delay rebuild-and-walk to surface timing bugs. The walk reproduced the flap. SSH'd into the container — hub responded fine **locally** in <100ms; **externally** probes flapped between 200 and 502. That differential pinned the issue to the edge proxy, not the upstream. Search of Render community + Bun docs (after Aaron pushed back on shooting in the dark) found this is the canonical "alive but 502s" pattern.

## Fix

\`Bun.serve({ idleTimeout: 255 })\` — Bun's max value. Comfortably exceeds Render's edge pool TTL. Standard pattern; the Node.js equivalent is \`server.keepAliveTimeout > edge.idle_timeout\`.

## References

- [Bun docs — idleTimeout](https://bun.com/docs/runtime/http/server) (default 10s, max 255)
- [TCP mechanics writeup](https://iximiuz.com/en/posts/reverse-proxy-http-keep-alive-and-502s/)
- Multiple Render community reports of this exact pattern:
  - [502 randomly on established service](https://render.discourse.group/t/502-error-randomly-occurs-on-established-service/6200)
  - [502 on healthy deployments](https://render.discourse.group/t/getting-502-on-healthy-deployments/3628)

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun test ./src\` — 2033/2033 pass (no behavior tested directly; this is a runtime cloud-edge interaction)
- [ ] Live verification: rebuild Render with this code; run 20 rapid probes; expect 0 flaps where the prior config saw 3–5/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)