### PR TITLE
polish(hub-ui): h1 page-title hierarchy + table-scroll utility

### DIFF
--- a/web/ui/src/routes/Permissions.tsx
+++ b/web/ui/src/routes/Permissions.tsx
@@ -93,7 +93,7 @@ export function Permissions() {
   return (
     <div>
       <div className="list-header">
-        <h2>Permissions</h2>
+        <h1>Permissions</h1>
       </div>
 
       <p className="muted">

--- a/web/ui/src/routes/Tokens.tsx
+++ b/web/ui/src/routes/Tokens.tsx
@@ -250,7 +250,7 @@ export function Tokens() {
   return (
     <div>
       <div className="list-header">
-        <h2>Tokens</h2>
+        <h1>Tokens</h1>
         <button type="button" onClick={() => setShowForm((s) => !s)}>
           {showForm ? "Hide form" : "Mint new token"}
         </button>

--- a/web/ui/src/routes/Users.tsx
+++ b/web/ui/src/routes/Users.tsx
@@ -193,7 +193,7 @@ export function Users() {
   return (
     <div>
       <div className="list-header">
-        <h2>Users</h2>
+        <h1>Users</h1>
       </div>
 
       <p className="muted">
@@ -287,7 +287,8 @@ function ListRendered({
 }: ListRenderedProps): React.ReactNode {
   return (
     <div className="user-list" style={{ marginTop: "1rem" }}>
-      <table className="user-table">
+      <div className="table-scroll">
+        <table className="user-table">
         <thead>
           <tr>
             <th scope="col">Username</th>
@@ -411,6 +412,7 @@ function ListRendered({
           })}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }

--- a/web/ui/src/routes/VaultsList.tsx
+++ b/web/ui/src/routes/VaultsList.tsx
@@ -90,7 +90,7 @@ export function VaultsList() {
     return (
       <div>
         <div className="list-header">
-          <h2>Vaults</h2>
+          <h1>Vaults</h1>
         </div>
         <p className="muted">Loading…</p>
       </div>
@@ -101,7 +101,7 @@ export function VaultsList() {
     return (
       <div>
         <div className="list-header">
-          <h2>Vaults</h2>
+          <h1>Vaults</h1>
           <Link to="/vaults/new">
             <button type="button">New vault</button>
           </Link>
@@ -125,7 +125,7 @@ export function VaultsList() {
   return (
     <div>
       <div className="list-header">
-        <h2>Vaults ({state.vaults.length})</h2>
+        <h1>Vaults ({state.vaults.length})</h1>
         {moduleMissing ? (
           // Cross-SPA-route navigation stays inside the SPA basename, so
           // react-router's <Link> resolves to /admin/modules. Plain

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -361,6 +361,7 @@ h2 {
   gap: 1rem;
   margin-bottom: 1rem;
 }
+.list-header h1,
 .list-header h2 {
   margin: 0;
 }

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -253,6 +253,24 @@ code {
   cursor: not-allowed;
 }
 
+/* Heading hierarchy.
+ *
+ *   h1 — page title. Serif (matches oauth-ui.ts's baseDocument), generous
+ *        line-height. Used once per route as the canonical "you are on the
+ *        X page" landmark. Screen readers + keyboard users (Tab + H
+ *        navigation) rely on it.
+ *   h2 — section / list title within a page. Sans, slightly smaller.
+ *   h3 — sub-section within a card.
+ */
+h1 {
+  margin: 0 0 0.5rem;
+  font-family: var(--font-serif);
+  font-size: 1.85rem;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  color: var(--fg);
+}
 h2 {
   margin: 0 0 1rem;
   font-size: 1.4rem;
@@ -293,6 +311,35 @@ h2 {
   color: var(--fg-muted);
   background: var(--bg-soft);
   border-radius: 10px;
+}
+
+/* Mobile-safe table container — wraps a wide table so the document doesn't
+ * overflow on narrow viewports. Tables with more columns than fit at 375 px
+ * (e.g. /admin/users with 5 cols) would otherwise force horizontal scroll on
+ * the entire document. With this wrapper, the table scrolls within its own
+ * bounded container; the rest of the page stays inside the viewport.
+ *
+ * Apply by wrapping any admin table: `<div className="table-scroll"><table>…`.
+ * Closes hub#398. */
+.table-scroll {
+  overflow-x: auto;
+  /* Smooth momentum scroll on iOS Safari. */
+  -webkit-overflow-scrolling: touch;
+  /* Render a subtle inner shadow at the right edge when content overflows
+   * so the user has a visual cue that there's more to see. Modern browsers
+   * support background-attachment: local; older fall back to no shadow.
+   * The cream gradient matches the page background. */
+  background:
+    linear-gradient(to right, var(--card-bg), var(--card-bg)) left center / 20px 100% no-repeat,
+    linear-gradient(to right, rgba(44, 42, 38, 0.08), rgba(44, 42, 38, 0)) left center / 8px 100% no-repeat,
+    linear-gradient(to left, var(--card-bg), var(--card-bg)) right center / 20px 100% no-repeat,
+    linear-gradient(to left, rgba(44, 42, 38, 0.08), rgba(44, 42, 38, 0)) right center / 8px 100% no-repeat;
+  background-attachment: local, scroll, local, scroll;
+}
+.table-scroll > table {
+  /* The table itself should take its intrinsic width — the container
+   * handles overflow. width: 100% would shrink columns and break layout. */
+  min-width: 100%;
 }
 .empty-rich {
   text-align: left;


### PR DESCRIPTION
## Summary

Two small UI polish wins.

### h1 page-title hierarchy (#394 partial)

Four admin routes (VaultsList, Permissions, Tokens, Users) rendered their page title as \`<h2>\` — same level as section headings within. Screen readers + keyboard users (Tab + H) lose the canonical "you are on the X page" landmark. Modules + Settings already had \`<h1>\`; this PR brings the other four to match.

Also adds a proper \`h1\` rule to \`styles.css\` (serif, 1.85rem, weight 400) that mirrors the OAuth/setup surfaces — SPA stays visually continuous with the server-rendered surfaces an operator just walked through.

### .table-scroll utility (closes #398)

Users.tsx 5-column table overflows the document at 375 px (~62 px). New \`.table-scroll\` wrapper gives the table its own horizontal-scroll container so the document stays bounded. Edge-shadow background gradients cue the operator that there's more to scroll to.

Only Users.tsx renders a \`<table>\` today — others use grids/lists. Utility is here for future tables.

## Note

The full #394 (empty-state cards across all routes) is mostly already met — every admin route renders \`.empty-rich\` with actionable copy when its list is empty. This PR doesn't expand those further; that's a separate polish pass.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] SPA \`bun run test\` 213/213
- [x] Hub \`bun test ./src\` 2033/2033
- [ ] Live verification (after merge + deploy): Users at 375 px no longer overflows; admin routes have proper h1

🤖 Generated with [Claude Code](https://claude.com/claude-code)