### PR TITLE
polish(hub-ui): row hover + loading pulse + route fade-up + drift-test typecheck fix

### DIFF
--- a/web/ui/src/components/BrandMark.drift.test.ts
+++ b/web/ui/src/components/BrandMark.drift.test.ts
@@ -1,5 +1,7 @@
+/// <reference types="node" />
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 /**
@@ -18,7 +20,12 @@ import { describe, expect, it } from "vitest";
  * vendored copy if a build-time codegen lands).
  */
 describe("BrandMark drift guard", () => {
-  const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+  // ESM-friendly path resolution — `__dirname` doesn't exist under
+  // Vitest's ESM run; derive it from `import.meta.url`. The `/// reference`
+  // above wires node types into THIS file only without polluting the
+  // SPA's wider tsconfig (which intentionally limits types to vite/client).
+  const HERE = dirname(fileURLToPath(import.meta.url));
+  const REPO_ROOT = join(HERE, "..", "..", "..", "..");
 
   function extractPaths(filePath: string): string {
     const src = readFileSync(filePath, "utf8");

--- a/web/ui/src/routes/ApproveClient.tsx
+++ b/web/ui/src/routes/ApproveClient.tsx
@@ -185,7 +185,7 @@ interface RenderBodyProps {
 
 function renderBody({ loadState, action, onApprove, onRetry }: RenderBodyProps) {
   if (loadState.kind === "loading") {
-    return <p className="muted">Loading…</p>;
+    return <p className="muted" data-loading="true">Loading…</p>;
   }
   if (loadState.kind === "not_found") {
     return (

--- a/web/ui/src/routes/Permissions.tsx
+++ b/web/ui/src/routes/Permissions.tsx
@@ -147,7 +147,7 @@ interface RenderBodyProps {
 
 function renderBody({ state, revoke, setRevoke, onConfirm, onRetry }: RenderBodyProps) {
   if (state.kind === "loading") {
-    return <p className="muted">Loading…</p>;
+    return <p className="muted" data-loading="true">Loading…</p>;
   }
   if (state.kind === "error") {
     return (

--- a/web/ui/src/routes/Permissions.tsx
+++ b/web/ui/src/routes/Permissions.tsx
@@ -91,7 +91,7 @@ export function Permissions() {
   }
 
   return (
-    <div>
+    <div data-route-content="true">
       <div className="list-header">
         <h1>Permissions</h1>
       </div>

--- a/web/ui/src/routes/Tokens.tsx
+++ b/web/ui/src/routes/Tokens.tsx
@@ -482,7 +482,7 @@ function renderList({
   filtersActive,
 }: RenderListProps) {
   if (list.kind === "loading") {
-    return <p className="muted">Loading…</p>;
+    return <p className="muted" data-loading="true">Loading…</p>;
   }
   if (list.kind === "error") {
     return (

--- a/web/ui/src/routes/Tokens.tsx
+++ b/web/ui/src/routes/Tokens.tsx
@@ -520,7 +520,7 @@ function renderList({
   }
 
   return (
-    <div>
+    <div data-route-content="true">
       {list.tokens.map((t) => {
         const status = tokenStatus(t);
         const isRevoking = revoke.kind === "revoking" && revoke.jti === t.jti;

--- a/web/ui/src/routes/Users.tsx
+++ b/web/ui/src/routes/Users.tsx
@@ -191,7 +191,7 @@ export function Users() {
   }
 
   return (
-    <div>
+    <div data-route-content="true">
       <div className="list-header">
         <h1>Users</h1>
       </div>

--- a/web/ui/src/routes/VaultsList.tsx
+++ b/web/ui/src/routes/VaultsList.tsx
@@ -123,7 +123,7 @@ export function VaultsList() {
   const moduleMissing = state.vaults.length === 0 && !state.moduleInstalled;
 
   return (
-    <div>
+    <div data-route-content="true">
       <div className="list-header">
         <h1>Vaults ({state.vaults.length})</h1>
         {moduleMissing ? (

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -336,6 +336,55 @@ h2 {
   border-radius: 10px;
 }
 
+/* Loading state — subtle ellipsis pulse so "Loading…" feels alive
+ * without being noisy. Used everywhere `<p className="muted">Loading…</p>`
+ * appears today. Applied via the existing `.muted` class as a sibling
+ * condition would be intrusive; instead any element containing "Loading…"
+ * (we detect via [data-loading="true"] when authors want it) pulses.
+ *
+ * Default cadence: 1.4s breath. Subtle enough to recede if the load
+ * finishes within 100–200ms; recognizable on slow connections. */
+@keyframes pc-loading-pulse {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}
+[data-loading="true"] {
+  animation: pc-loading-pulse 1.4s ease-in-out infinite;
+}
+
+/* Table row hover — subtle warm-cream tint so admin tables feel
+ * navigable rather than static. Matches the .module-row hover affordance
+ * (lines ~799) so the visual language is consistent across SPA list
+ * shapes (rows of cards AND rows of cells). */
+.user-table tbody tr,
+.tokens-table tbody tr {
+  transition: background-color 0.12s ease;
+}
+.user-table tbody tr:hover,
+.tokens-table tbody tr:hover {
+  background: var(--bg-soft);
+}
+
+/* List content entrance — fade-up so freshly-loaded routes feel
+ * settled rather than slammed. Mirrors the hub home's `.card` fade.
+ * Apply via `[data-route-content]` on the root of any route's main
+ * area (opt-in — tests / specific routes can omit if they care about
+ * deterministic paint timing). */
+@keyframes pc-route-fade-up {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+[data-route-content] {
+  animation: pc-route-fade-up 0.32s ease forwards;
+}
+/* Respect users who prefer no motion. */
+@media (prefers-reduced-motion: reduce) {
+  [data-loading="true"],
+  [data-route-content] {
+    animation: none;
+  }
+}
+
 /* Mobile-safe table container — wraps a wide table so the document doesn't
  * overflow on narrow viewports. Tables with more columns than fit at 375 px
  * (e.g. /admin/users with 5 cols) would otherwise force horizontal scroll on


### PR DESCRIPTION
## Summary

Continued UI polish per Aaron's "look and feel really great" directive. Three small visual upgrades + a typecheck fix.

### Row hover
\`.user-table tr:hover\` gets a warm-cream tint so tables feel navigable. Matches the existing \`.module-row\` hover.

### Loading pulse
\`<p data-loading="true">Loading…</p>\` gets a 1.4s opacity breath. Subtle enough to disappear on fast loads; recognizable on slow ones. Applied to Permissions, ApproveClient, Tokens initial-load placeholders.

### Route fade-up
Opt-in \`[data-route-content]\` attribute fades content from \`translateY(6px)\` to rest over 320ms. Mirrors the hub home's card fade so routes feel settled, not slammed.

All three respect \`prefers-reduced-motion: reduce\`.

### Bonus: drift-test typecheck fix

\`BrandMark.drift.test.ts\` from #402 was passing under vitest but failing under \`tsc --noEmit\` because the SPA's tsconfig limits types to vite/client. Added \`/// reference types="node"\` (file-scoped, no wider tsconfig change) and moved off \`__dirname\` to ESM-friendly \`fileURLToPath(import.meta.url)\`. Typecheck now clean.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run test\` — 215/215 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)