### PR TITLE
polish(oauth-ui): suppress underline on .btn applied to anchors

### DIFF
--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -1037,7 +1037,17 @@ const STYLES = `
     cursor: pointer;
     transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
     min-height: 2.5rem;
+    /* When the .btn class is applied to an anchor (e.g. the 404 page's
+     * "Go to hub home" link), suppress the default anchor underline +
+     * make it a layout block so padding behaves consistently with the
+     * <button> variant. Without this, anchor-buttons render with an
+     * underlined label which looks broken. */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
   }
+  a.btn:hover { text-decoration: none; }
   .btn-primary {
     background: ${PALETTE.accent};
     color: ${PALETTE.cardBg};


### PR DESCRIPTION
## Summary

Visual audit on the live deploy caught: the 404 page's "Go to hub home" CTA renders with the default anchor underline (because anchors get `text-decoration: underline` by default + the existing `.btn` rule doesn't override). Looks broken next to identical `.btn` applied to a `<button>`.

The same anchor-button pattern also appears in `renderUnauthenticatedApproveCtas` for the "Sign in as admin to approve" CTA — same affected surface.

## Fix

Lift the `.btn` rule to `display: inline-flex` + center alignment + `text-decoration: none`. `<button>` elements are unaffected (they default to no underline).

## Test plan

- [x] `bun test src/__tests__/oauth-ui.test.ts` 54/54 pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)