### PR TITLE
fix(hub-server): proxyToService uses readManifestLenient — single bad services.json entry no longer cascades into 500s for every route (hub#406)

### DIFF
--- a/src/__tests__/services-manifest.test.ts
+++ b/src/__tests__/services-manifest.test.ts
@@ -8,6 +8,7 @@ import {
   type UiSubUnit,
   findService,
   readManifest,
+  readManifestLenient,
   removeService,
   upsertService,
   writeManifest,
@@ -1390,6 +1391,98 @@ describe("retired-module row de-dupe (hub#334)", () => {
       const m = readManifest(path);
       const names = m.services.map((s) => s.name).sort();
       expect(names).toEqual(["parachute-runner"]);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("readManifestLenient — skips bad entries instead of throwing (hub#406)", () => {
+  test("returns the healthy entries when one row has port=0 (the rc.4 app bug)", () => {
+    // Reproduces what hub saw 2026-05-26: a fresh deploy installed
+    // @openparachute/app@0.2.0-rc.4 which wrote a row with name="app"
+    // (wrong) + port=0 (wrong). Strict readManifest threw on the bad
+    // entry — every request to every service 500'd, not just app.
+    // Lenient reader skips the bad row + keeps routing healthy ones.
+    const { path, cleanup } = makeTempPath();
+    try {
+      writeFileSync(
+        path,
+        JSON.stringify({
+          services: [
+            { name: "parachute-vault", port: 1940, paths: ["/vault/default"], health: "/vault/default/health", version: "0.4.8-rc.10" },
+            { name: "parachute-app", port: 1946, paths: ["/app"], health: "/app/healthz", version: "0.2.0-rc.13" },
+            { name: "app", port: 0, paths: ["/app"], health: "/app/healthz", version: "0.2.0-rc.4" },
+          ],
+        }),
+      );
+      const warnings: string[] = [];
+      const log = { warn: (m: string) => warnings.push(m) };
+      const m = readManifestLenient(path, log);
+      const names = m.services.map((s) => s.name).sort();
+      expect(names).toEqual(["parachute-app", "parachute-vault"]);
+      expect(warnings.some((w) => w.includes("port") && w.includes("integer"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("returns empty services when the file is malformed JSON, logs the parse error", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writeFileSync(path, "{not valid json");
+      const warnings: string[] = [];
+      const m = readManifestLenient(path, { warn: (msg) => warnings.push(msg) });
+      expect(m.services).toEqual([]);
+      expect(warnings.some((w) => w.includes("failed to parse"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("returns empty services when the file is missing", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      // path not yet written
+      const m = readManifestLenient(path, { warn: () => {} });
+      expect(m.services).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("drops duplicate-port entries with a warning instead of throwing", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writeFileSync(
+        path,
+        JSON.stringify({
+          services: [
+            { name: "first", port: 1940, paths: ["/x"], health: "/x/health", version: "1.0.0" },
+            { name: "second", port: 1940, paths: ["/y"], health: "/y/health", version: "1.0.0" },
+          ],
+        }),
+      );
+      const warnings: string[] = [];
+      const m = readManifestLenient(path, { warn: (msg) => warnings.push(msg) });
+      expect(m.services).toHaveLength(1);
+      expect(m.services[0]?.name).toBe("first");
+      expect(warnings.some((w) => w.includes("duplicate-port"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("strict readManifest still throws on the same bad entry (contract preserved)", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writeFileSync(
+        path,
+        JSON.stringify({
+          services: [{ name: "app", port: 0, paths: ["/app"], health: "/app/healthz", version: "0.2.0-rc.4" }],
+        }),
+      );
+      expect(() => readManifest(path)).toThrow(ServicesManifestError);
     } finally {
       cleanup();
     }

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -177,7 +177,7 @@ import {
   effectivePublicExposure,
   shortNameForManifest,
 } from "./service-spec.ts";
-import { type ServiceEntry, readManifest } from "./services-manifest.ts";
+import { type ServiceEntry, readManifest, readManifestLenient } from "./services-manifest.ts";
 import { findActiveSession } from "./sessions.ts";
 import {
   type SetupWizardDeps,
@@ -582,16 +582,15 @@ export function findServiceUpstream(
  * Returns `undefined` when no service claims the pathname; caller 404s.
  */
 async function proxyToService(req: Request, manifestPath: string): Promise<Response | undefined> {
-  let services: readonly ServiceEntry[];
-  try {
-    services = readManifest(manifestPath).services;
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return new Response(JSON.stringify({ error: `service routing failed: ${msg}` }), {
-      status: 500,
-      headers: { "content-type": "application/json" },
-    });
-  }
+  // Lenient read on the hot-path — a single malformed services.json
+  // entry (e.g. a module installed at a buggy version that wrote
+  // `port: 0`) used to cascade into 500s for every route on this hub
+  // because the strict throw bailed BEFORE we could dispatch to the
+  // healthy entries. `readManifestLenient` skips + logs bad rows so
+  // unrelated services keep working. The strict `readManifest` is
+  // still used by write paths + admin surfaces that want errors
+  // surfaced immediately. See hub#406.
+  const services = readManifestLenient(manifestPath).services;
   const url = new URL(req.url);
   const match = findServiceUpstream(services, url.pathname);
   if (!match) return undefined;

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -590,6 +590,10 @@ async function proxyToService(req: Request, manifestPath: string): Promise<Respo
   // unrelated services keep working. The strict `readManifest` is
   // still used by write paths + admin surfaces that want errors
   // surfaced immediately. See hub#406.
+  //
+  // The default `log` is `console`, which under Render's container
+  // routing surfaces in the Logs panel — operators see the warning
+  // about the skipped entry.
   const services = readManifestLenient(manifestPath).services;
   const url = new URL(req.url);
   const match = findServiceUpstream(services, url.pathname);

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -431,6 +431,13 @@ function validateManifest(raw: unknown, where: string): ServicesManifest {
  * (instead of bound port). Hub's routing throw on services.json read
  * meant every request to every service 500'd — not just app — because
  * one row's bad shape took out the whole manifest read.
+ *
+ * One behavioral difference from strict `readManifest`: this function
+ * does NOT write cleanup mutations back to disk. The bad row persists
+ * on disk until a write-path call (upsertService, etc.) exercises the
+ * strict path. That's intentional — a hot-path read should not mutate
+ * state — but worth knowing: a fix upstream (e.g. app@rc.13 overwriting
+ * the bad row on its next selfRegister) is what finally clears it.
  */
 export function readManifestLenient(
   path: string = SERVICES_MANIFEST_PATH,
@@ -448,6 +455,8 @@ export function readManifestLenient(
   }
   const afterRetired = dropRetiredModuleRows(raw, path);
   const cleaned = dropLegacyShortNameRows(afterRetired.raw, path);
+  // `typeof null === "object"` in JS, so the `!cleaned.raw` part of this
+  // guard is load-bearing for the null case — not a typo or redundancy.
   if (!cleaned.raw || typeof cleaned.raw !== "object") return { services: [] };
   const services = (cleaned.raw as Record<string, unknown>).services;
   if (!Array.isArray(services)) return { services: [] };

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -405,6 +405,79 @@ function validateManifest(raw: unknown, where: string): ServicesManifest {
   return { services: entries };
 }
 
+/**
+ * Lenient counterpart to `readManifest` — used by hub's hot-path service
+ * routing (`proxyToService`). The strict `readManifest` throws when ANY
+ * entry fails validation; an entire bad row (e.g. an installed module
+ * that wrote `port: 0` to its services.json row before the module's
+ * own selfRegister gained validation) takes down ALL routing because
+ * the routing call site catches the throw and returns 500.
+ *
+ * This lenient reader:
+ *   - parses the file the same way (JSON parse + cleanup passes)
+ *   - validates each entry independently
+ *   - skips entries that fail validation, logging a warning per skip
+ *   - returns the validated remainder
+ *
+ * The trade-off: strict callers (admin SPA write paths, init flows,
+ * tests) keep the throw — they want bugs surfaced immediately. The
+ * routing path uses this so a single bad row doesn't cascade into
+ * "the whole hub appears broken to users." Operators see the rest
+ * of their services keep working + a warning in the logs pointing at
+ * the offending entry.
+ *
+ * Caught 2026-05-26 (hub#406) when @openparachute/app@0.2.0-rc.4 wrote
+ * a row with `name: "app"` (instead of `parachute-app`) + `port: 0`
+ * (instead of bound port). Hub's routing throw on services.json read
+ * meant every request to every service 500'd — not just app — because
+ * one row's bad shape took out the whole manifest read.
+ */
+export function readManifestLenient(
+  path: string = SERVICES_MANIFEST_PATH,
+  log: { warn?: (msg: string) => void } = console,
+): ServicesManifest {
+  if (!existsSync(path)) return { services: [] };
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    log.warn?.(
+      `[services-manifest] failed to parse ${path}: ${err instanceof Error ? err.message : String(err)} — treating as empty`,
+    );
+    return { services: [] };
+  }
+  const afterRetired = dropRetiredModuleRows(raw, path);
+  const cleaned = dropLegacyShortNameRows(afterRetired.raw, path);
+  if (!cleaned.raw || typeof cleaned.raw !== "object") return { services: [] };
+  const services = (cleaned.raw as Record<string, unknown>).services;
+  if (!Array.isArray(services)) return { services: [] };
+  const valid: ServiceEntry[] = [];
+  for (let i = 0; i < services.length; i++) {
+    try {
+      valid.push(validateEntry(services[i], `${path} services[${i}]`));
+    } catch (err) {
+      log.warn?.(
+        `[services-manifest] skipping bad entry: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+  // Best-effort duplicate-port detection — log + drop the duplicate
+  // rather than throw.
+  const seenPorts = new Set<number>();
+  const dedup: ServiceEntry[] = [];
+  for (const e of valid) {
+    if (seenPorts.has(e.port)) {
+      log.warn?.(
+        `[services-manifest] dropping duplicate-port entry: name=${JSON.stringify(e.name)} port=${e.port}`,
+      );
+      continue;
+    }
+    seenPorts.add(e.port);
+    dedup.push(e);
+  }
+  return { services: dedup };
+}
+
 export function readManifest(path: string = SERVICES_MANIFEST_PATH): ServicesManifest {
   if (!existsSync(path)) return { services: [] };
   let raw: unknown;


### PR DESCRIPTION
## Reproduction (Aaron caught)

Fresh wizard walk → Install App → click Notes → \`{\"error\":\"service routing failed: /parachute/services.json services[2]: \\\"port\\\" must be an integer 1..65535\"}\`

## Two bugs, one fix here

**Upstream bug (NOT fixed here):** \`@openparachute/app@0.2.0-rc.4\` selfRegister writes a row with \`name: \"app\"\` (should be \"parachute-app\") and \`port: 0\` (should be the bound port). Fixed in rc.13 already, but npm's \`latest\` dist-tag is stuck on rc.4 — so \`PARACHUTE_INSTALL_CHANNEL=latest\` (render.yaml default) pulls the broken version.

**Cascade bug (fixed here):** Hub's \`proxyToService\` called the strict \`readManifest\` which throws on ANY bad row. One bad row → entire manifest read throws → every service on the hub 500s. The user's "click Notes → 500" surfaced because of THIS, not just the upstream app bug.

## Fix

New \`readManifestLenient(path, log)\` that validates each row independently, skips bad rows with a logged warning, drops duplicate-port rows with a warning instead of throwing. \`proxyToService\` switches to it. The strict \`readManifest\` contract is preserved for write paths + admin SPA + tests that want bugs surfaced immediately.

## Operator-facing follow-ups (not in this PR)

- \`@openparachute/app\`: ship the rc.13 fix to npm's \`latest\` tag
- \`render.yaml\`: consider flipping default \`PARACHUTE_INSTALL_CHANNEL\` to \`rc\` until app stable lands, or add a callout
- Aaron's current deploy unblock: set \`PARACHUTE_INSTALL_CHANNEL=rc\` in the Render dashboard + redeploy

## Test plan

- [x] 4 new tests covering: rc.4 reproduction shape, malformed JSON, missing file, duplicate-port, + a regression-guarding that strict \`readManifest\` still throws
- [x] \`bun test ./src\` 2038/2038 pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)