### PR TITLE
feat(setup-wizard): auto-skip the expose step on Render (RENDER_EXTERNAL_URL detected)

### DIFF
--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -30,6 +30,7 @@ import { writeManifest } from "../services-manifest.ts";
 import { SESSION_COOKIE_NAME } from "../sessions.ts";
 import {
   deriveWizardState,
+  detectAutoExposeMode,
   handleSetupAccountPost,
   handleSetupExposePost,
   handleSetupGet,
@@ -2998,5 +2999,33 @@ describe("done screen — 'Start using your vault' tile (hub#342)", () => {
     } finally {
       db.close();
     }
+  });
+});
+
+describe("detectAutoExposeMode — Render env detection edge cases (hub#407 nit)", () => {
+  test("returns 'public' for a real https Render URL", () => {
+    expect(detectAutoExposeMode({ RENDER_EXTERNAL_URL: "https://parachute-hub.onrender.com" })).toBe("public");
+  });
+
+  test("returns 'public' for an http:// URL (defensive — if Render ever emits one)", () => {
+    expect(detectAutoExposeMode({ RENDER_EXTERNAL_URL: "http://local.test:1939" })).toBe("public");
+  });
+
+  test("returns undefined when RENDER_EXTERNAL_URL is absent", () => {
+    expect(detectAutoExposeMode({})).toBeUndefined();
+  });
+
+  test("returns undefined when RENDER_EXTERNAL_URL is empty", () => {
+    expect(detectAutoExposeMode({ RENDER_EXTERNAL_URL: "" })).toBeUndefined();
+  });
+
+  test("returns undefined for a non-http scheme (httpx://, ftp://, etc.)", () => {
+    expect(detectAutoExposeMode({ RENDER_EXTERNAL_URL: "httpx://foo.example" })).toBeUndefined();
+    expect(detectAutoExposeMode({ RENDER_EXTERNAL_URL: "ftp://foo.example" })).toBeUndefined();
+    expect(detectAutoExposeMode({ RENDER_EXTERNAL_URL: "javascript:alert(1)" })).toBeUndefined();
+  });
+
+  test("returns undefined when value is non-string (defensive)", () => {
+    expect(detectAutoExposeMode({ RENDER_EXTERNAL_URL: undefined })).toBeUndefined();
   });
 });

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -172,6 +172,62 @@ describe("deriveWizardState", () => {
     }
   });
 
+  test("auto-skips expose step when RENDER_EXTERNAL_URL is set (hub#406 follow-up)", async () => {
+    // Aaron's UX concern: on Render the "How will this hub be reached?"
+    // step asks the operator to pick between localhost / tailnet /
+    // public-with-custom-domain — none of which describe the actual
+    // setup. The platform owns the public URL via RENDER_EXTERNAL_URL.
+    // deriveWizardState now auto-seeds `setup_expose_mode = "public"`
+    // when that env var is present, so the wizard skips straight to
+    // the done screen instead of surfacing an irrelevant choice.
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      await createUser(db, "owner", "pw");
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              version: "0.1.0",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/health",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      // Simulate Render env. detectAutoExposeMode reads RENDER_EXTERNAL_URL.
+      const renderEnv = { RENDER_EXTERNAL_URL: "https://parachute-hub.onrender.com" };
+      const s = deriveWizardState({ db, manifestPath: h.manifestPath, env: renderEnv });
+      expect(s.step).toBe("done");
+      expect(s.hasExposeMode).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("does NOT auto-skip expose when RENDER_EXTERNAL_URL is unset (local install path)", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      await createUser(db, "owner", "pw");
+      writeManifest(
+        {
+          services: [
+            { name: "parachute-vault", version: "0.1.0", port: 1940, paths: ["/vault/default"], health: "/health" },
+          ],
+        },
+        h.manifestPath,
+      );
+      const s = deriveWizardState({ db, manifestPath: h.manifestPath, env: {} });
+      // Local install path — the operator still gets to choose
+      expect(s.step).toBe("expose");
+      expect(s.hasExposeMode).toBe(false);
+    } finally {
+      db.close();
+    }
+  });
+
   test("done step once admin + vault + expose mode all exist", async () => {
     const db = openHubDb(hubDbPath(h.dir));
     try {

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -141,8 +141,11 @@ export const FIRST_VAULT_SHORT: CuratedModuleShort = "vault";
 
 /**
  * Read DB + services.json to decide which step the wizard should render.
- * Pure, idempotent — re-running the wizard after partial setup picks up
- * where it left off.
+ * Idempotent — re-running after partial setup picks up where it left
+ * off. Mostly read-only, with one specific write: on Render (or any
+ * platform `detectAutoExposeMode` recognizes), the first call auto-
+ * seeds `setup_expose_mode = "public"` so the wizard skips the expose
+ * step. Subsequent calls find the setting present and are read-only.
  */
 export function deriveWizardState(deps: {
   db: Database;
@@ -245,7 +248,13 @@ export interface SetupWizardDeps {
  * detects when the platform clearly owns the public URL.
  */
 export function detectAutoExposeMode(env: Record<string, string | undefined>): "public" | undefined {
-  if (env.RENDER_EXTERNAL_URL && env.RENDER_EXTERNAL_URL.startsWith("http")) {
+  // Render always sets `RENDER_EXTERNAL_URL` to a real `https://` URL on
+  // any web service. `startsWith("https://")` is the precise shape; we
+  // also accept `http://` as a defensive fallback in case Render ever
+  // changes the scheme on some plan tier. Anything else (empty, weird,
+  // not a URL) → don't auto-skip; let the operator choose.
+  const url = env.RENDER_EXTERNAL_URL;
+  if (typeof url === "string" && (url.startsWith("https://") || url.startsWith("http://"))) {
     return "public";
   }
   return undefined;

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -147,6 +147,12 @@ export const FIRST_VAULT_SHORT: CuratedModuleShort = "vault";
 export function deriveWizardState(deps: {
   db: Database;
   manifestPath: string;
+  /**
+   * Optional env-override. When undefined, falls through to `process.env`.
+   * Used by tests + by handleSetupGet which threads through the full
+   * SetupWizardDeps.env.
+   */
+  env?: Record<string, string | undefined>;
 }): DerivedWizardState {
   const hasAdmin = userCount(deps.db) > 0;
   // The wizard's first-vault provisioning uses the curated `vault` short,
@@ -156,7 +162,19 @@ export function deriveWizardState(deps: {
   const hasVault = vaultEntry !== undefined;
   // Expose-mode is the operator's "how will this hub be reached?" answer
   // (hub#268 Item 2). Stored as a hub_setting; the wizard's expose step
-  // sets it; absence means we should still ask.
+  // sets it; absence means we should still ask. EXCEPT — if we're
+  // running on a platform where the answer is pre-determined (e.g.
+  // Render exposes the service at $RENDER_EXTERNAL_URL automatically),
+  // auto-seed `setup_expose_mode = "public"` so the wizard skips the
+  // expose step entirely. The operator landed here through a deploy
+  // path that already answered the question; asking again wastes a
+  // click and surfaces irrelevant options (localhost, tailnet).
+  if (
+    getSetting(deps.db, "setup_expose_mode") === undefined &&
+    detectAutoExposeMode(deps.env ?? process.env) === "public"
+  ) {
+    setSetting(deps.db, "setup_expose_mode", "public");
+  }
   const hasExposeMode = getSetting(deps.db, "setup_expose_mode") !== undefined;
   let step: WizardStep;
   // Note: `"account"` is a visual-only step in the progress header —
@@ -200,6 +218,37 @@ export interface SetupWizardDeps {
   registry?: OperationsRegistry;
   /** Test seam: stub `bun add` / `bun remove` runner. */
   run?: (cmd: readonly string[]) => Promise<number>;
+  /**
+   * Test seam: override the process env that `detectAutoExposeMode`
+   * consults. Production omits this and the helper reads `process.env`
+   * directly. Setting in tests lets the auto-skip branch be exercised
+   * without mutating the real process env.
+   */
+  env?: Record<string, string | undefined>;
+}
+
+/**
+ * Returns `"public"` when the runtime env indicates the hub is deployed
+ * on a platform where the "how will this hub be reached?" answer is
+ * pre-determined by the platform. Today: Render (sets RENDER_EXTERNAL_URL
+ * for any web service). Returns `undefined` otherwise — the wizard's
+ * expose step asks the operator.
+ *
+ * Why this matters: on Render, none of the three radio options
+ * (localhost, tailnet, public-with-custom-domain) match the actual
+ * setup. The hub is reached at `*.onrender.com` automatically. Asking
+ * the operator wastes a click and surfaces three options that don't
+ * speak to their situation. Auto-pinning `public` skips the step.
+ *
+ * Add more platforms here when we encounter them — e.g. Fly.io
+ * (FLY_APP_NAME), Railway (RAILWAY_ENVIRONMENT), etc. Each only auto-
+ * detects when the platform clearly owns the public URL.
+ */
+export function detectAutoExposeMode(env: Record<string, string | undefined>): "public" | undefined {
+  if (env.RENDER_EXTERNAL_URL && env.RENDER_EXTERNAL_URL.startsWith("http")) {
+    return "public";
+  }
+  return undefined;
 }
 
 // --- rendering -----------------------------------------------------------


### PR DESCRIPTION
## Why

Aaron flagged on hub#406: \"we're still showing the expose screen on here but i'm not sure how relevant that is for Render and I wonder how we want to handle this.\"

The three radio options on the expose step — **Just this machine (localhost)**, **My Tailscale network**, **Public URL (custom domain)** — all fail to describe a Render deploy. The platform owns the URL; the operator picks none of these and just wants to continue.

## What

\`detectAutoExposeMode(env)\` returns \`\"public\"\` when \`RENDER_EXTERNAL_URL\` is present + http-prefixed. \`deriveWizardState\` checks this **before** the expose-step branch — if detected and \`setup_expose_mode\` isn't already set, it auto-seeds \`\"public\"\` so the wizard skips straight to the done screen.

Operators see one fewer click + zero off-topic copy. The done screen still surfaces the canonical hub URL (the same \`hubOrigin\` it would've with manual \"public\" selection).

The seam supports more platforms later (Fly.io, Railway, etc.) — add detection branches as we encounter them.

## What it does NOT do

- Doesn't lock the choice. The operator can later override via admin UI / hub_setting if they want a different posture.
- Doesn't change non-Render behavior. Local installs still see the expose step.

## Test plan

- [x] 2 new tests: Render-skip + non-Render-still-asks
- [x] \`bun test ./src\` 2040/2040 pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)