### PR TITLE
fix(hub): readManifestLenient on every hot-path read — 500s on /admin/setup + /api/modules (hub#406 follow-up)

### DIFF
--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -510,17 +510,26 @@ describe("hubFetch routing", () => {
     }
   });
 
-  test("malformed services.json returns 500 + CORS, not a crash", async () => {
+  test("malformed services.json yields empty doc (lenient read) + CORS, not a crash (hub#406)", async () => {
+    // Pre-#406 behavior: strict readManifest threw → /.well-known/parachute.json
+    // returned 500. That cascaded into broken discovery for operators who
+    // had any kind of services.json corruption.
+    //
+    // Post-#406: readManifestLenient catches the parse error + logs +
+    // returns {services: []}. Well-known builds successfully with an empty
+    // services list, so discovery clients get a valid (empty) doc and the
+    // operator sees "no services here" rather than a generic 500.
     const h = makeHarness();
     try {
       writeFileSync(h.manifestPath, "{ not json");
       const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(
         req("/.well-known/parachute.json"),
       );
-      expect(res.status).toBe(500);
+      expect(res.status).toBe(200);
       expect(res.headers.get("access-control-allow-origin")).toBe("*");
-      const body = (await res.json()) as { error: string };
-      expect(body.error).toContain("well-known build failed");
+      const body = (await res.json()) as { vaults: unknown[]; services: unknown[] };
+      expect(body.vaults).toEqual([]);
+      expect(body.services).toEqual([]);
     } finally {
       h.cleanup();
     }

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -50,7 +50,7 @@
 import type { Database } from "bun:sqlite";
 import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
-import { findService, readManifest } from "./services-manifest.ts";
+import { findService, readManifest, readManifestLenient } from "./services-manifest.ts";
 import { type WellKnownVaultEntry, isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
 
 /** Scope required to call POST /vaults. */
@@ -172,7 +172,8 @@ function findExistingVault(
 ): { url: string; version: string; path: string } | null {
   let manifest: ReturnType<typeof readManifest>;
   try {
-    manifest = readManifest(manifestPath);
+    // Lenient read — see hub#406.
+    manifest = readManifestLenient(manifestPath);
   } catch {
     return null;
   }

--- a/src/api-modules-config.ts
+++ b/src/api-modules-config.ts
@@ -48,7 +48,7 @@ import type { Database } from "bun:sqlite";
 import { CURATED_MODULES, type CuratedModuleShort } from "./api-modules.ts";
 import { signAccessToken, validateAccessToken } from "./jwt-sign.ts";
 import { FIRST_PARTY_FALLBACKS, KNOWN_MODULES } from "./service-spec.ts";
-import { readManifest } from "./services-manifest.ts";
+import { readManifestLenient } from "./services-manifest.ts";
 
 /**
  * Resolve a curated short to its services.json `manifestName` key. Consults
@@ -154,7 +154,8 @@ function resolveUpstream(
   | { installed: false } {
   const manifestName = manifestNameForShort(short);
   if (!manifestName) return { installed: false };
-  const manifest = readManifest(manifestPath);
+  // Lenient — see hub#406.
+  const manifest = readManifestLenient(manifestPath);
   const entry = manifest.services.find((s) => s.name === manifestName);
   if (!entry) return { installed: false };
   // Mount = the first path the service registers (canonical convention

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -40,7 +40,7 @@ import { FIRST_PARTY_FALLBACKS, KNOWN_MODULES } from "./service-spec.ts";
 // still required) and the latter for vault/scribe/runner (post-FALLBACK
 // retirement, hub#310). The local helper hides the split from the rest of
 // this file.
-import { type UiSubUnit, type UiSubUnitStatus, readManifest } from "./services-manifest.ts";
+import { type UiSubUnit, type UiSubUnitStatus, readManifest, readManifestLenient } from "./services-manifest.ts";
 import type { ModuleState, Supervisor } from "./supervisor.ts";
 
 /**
@@ -303,7 +303,9 @@ export async function handleApiModules(req: Request, deps: ApiModulesDeps): Prom
   // Load installed state from services.json. Missing file = empty manifest
   // (fresh container), which is the v0.6 hot path — readManifest already
   // returns { services: [] } for a missing file, so no extra branching.
-  const manifest = readManifest(deps.manifestPath);
+  // Lenient read so a single bad row written by a buggy module install
+  // (e.g. app@0.2.0-rc.4) doesn't take down /api/modules — see hub#406.
+  const manifest = readManifestLenient(deps.manifestPath);
   const installedByShort = new Map<
     string,
     {

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -327,7 +327,8 @@ export function findVaultUpstream(
  */
 function hasVaultInstalled(manifestPath: string): boolean {
   try {
-    const services = readManifest(manifestPath).services;
+    // Lenient — see hub#406.
+    const services = readManifestLenient(manifestPath).services;
     return services.some((s) => isVaultEntry(s));
   } catch {
     return false;
@@ -499,16 +500,10 @@ async function proxyRequest(
  * #173 introduced).
  */
 async function proxyToVault(req: Request, manifestPath: string): Promise<Response | undefined> {
-  let services: readonly ServiceEntry[];
-  try {
-    services = readManifest(manifestPath).services;
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return new Response(JSON.stringify({ error: `vault routing failed: ${msg}` }), {
-      status: 500,
-      headers: { "content-type": "application/json" },
-    });
-  }
+  // Lenient — see hub#406. One bad services.json row no longer takes
+  // down vault routing the way it used to take down /admin/setup and
+  // /api/modules (the symptom Aaron hit 2026-05-26).
+  const services = readManifestLenient(manifestPath).services;
   const url = new URL(req.url);
   const match = findVaultUpstream(services, url.pathname);
   if (!match) return undefined;
@@ -1406,7 +1401,8 @@ export function hubFetch(
       // configured public origin (set by `--issuer https://<fqdn>`), else
       // the request's own origin (fine for direct loopback hits).
       try {
-        const manifest = readManifest(manifestPath);
+        // Lenient — see hub#406.
+        const manifest = readManifestLenient(manifestPath);
         // Same precedence as the OAuth issuer (hub#298): hub_settings →
         // env → request origin. The well-known doc embeds this origin
         // in service URLs + the issuer metadata link, so it must follow
@@ -1616,7 +1612,8 @@ export function hubFetch(
       // shape the well-known doc derives. Source from services.json so a
       // freshly-created vault is mintable on the next request without a
       // restart.
-      const manifest = readManifest(manifestPath);
+      // Lenient — see hub#406.
+      const manifest = readManifestLenient(manifestPath);
       const knownVaultNames = new Set<string>();
       for (const s of manifest.services) {
         if (!isVaultEntry(s)) continue;

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -70,7 +70,10 @@ import { isNonRequestableScope, isRequestableScope, scopeIsAdmin } from "./scope
 import { findUnknownScopes, loadDeclaredScopes } from "./scope-registry.ts";
 import {
   type ServicesManifest,
-  readManifest as readServicesManifest,
+  // Hot-path OAuth flows use the lenient reader so a single malformed
+  // services.json row (e.g. from a buggy module install) doesn't crash
+  // the entire OAuth dispatch. See hub#406.
+  readManifestLenient as readServicesManifest,
 } from "./services-manifest.ts";
 import {
   SESSION_TTL_MS,

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -471,17 +471,21 @@ export function readManifestLenient(
     }
   }
   // Best-effort duplicate-port detection — log + drop the duplicate
-  // rather than throw.
-  const seenPorts = new Set<number>();
+  // rather than throw. Mirrors the strict `assertNoDuplicatePorts`'s
+  // vault-on-vault exception: multiple parachute-vault-<name> rows
+  // legitimately share port 1940 because they're all served by the
+  // single vault module process.
+  const portsSeen = new Map<number, string>();
   const dedup: ServiceEntry[] = [];
   for (const e of valid) {
-    if (seenPorts.has(e.port)) {
+    const prev = portsSeen.get(e.port);
+    if (prev !== undefined && !(isVaultName(prev) && isVaultName(e.name))) {
       log.warn?.(
-        `[services-manifest] dropping duplicate-port entry: name=${JSON.stringify(e.name)} port=${e.port}`,
+        `[services-manifest] dropping duplicate-port entry: name=${JSON.stringify(e.name)} port=${e.port} (already claimed by ${JSON.stringify(prev)})`,
       );
       continue;
     }
-    seenPorts.add(e.port);
+    if (prev === undefined) portsSeen.set(e.port, e.name);
     dedup.push(e);
   }
   return { services: dedup };

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -65,7 +65,7 @@ import {
 import { escapeHtml } from "./oauth-ui.ts";
 import { mintOperatorToken } from "./operator-token.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
-import { findService, readManifest } from "./services-manifest.ts";
+import { findService, readManifestLenient } from "./services-manifest.ts";
 import {
   SESSION_TTL_MS,
   buildSessionCookie,
@@ -1716,7 +1716,7 @@ const INSTALL_TILE_PROPS: ReadonlyArray<{
  * (op status snapshot). Pure-ish — only the registry call is impure.
  */
 function buildInstallTiles(url: URL, deps: SetupWizardDeps): ModuleInstallTileState[] {
-  const manifest = readManifest(deps.manifestPath);
+  const manifest = readManifestLenient(deps.manifestPath);
   return INSTALL_TILE_PROPS.filter((p) =>
     (CURATED_MODULES as readonly string[]).includes(p.short),
   ).map((p) => {
@@ -1874,7 +1874,7 @@ function validateAccountFields(input: {
  * shared with `buildInstallTiles`.
  */
 function isModuleInstalled(short: CuratedModuleShort, manifestPath: string): boolean {
-  const manifest = readManifest(manifestPath);
+  const manifest = readManifestLenient(manifestPath);
   const spec = specFor(short);
   return manifest.services.some((s) => s.name === spec.manifestName);
 }
@@ -1885,7 +1885,7 @@ function isModuleInstalled(short: CuratedModuleShort, manifestPath: string): boo
  * entry's metadata isn't present.
  */
 function firstVaultName(manifestPath: string): string {
-  const manifest = readManifest(manifestPath);
+  const manifest = readManifestLenient(manifestPath);
   // Match on the canonical vault manifestName from the curated spec.
   // (`CURATED_MODULES.includes("vault")` was a dead guard — vault is a
   // tuple-literal member, so the conjunct is always true.)


### PR DESCRIPTION
## Why

Aaron just hit 500s all over the site. Stack trace:

\`\`\`
ServicesManifestError: /parachute/services.json services[2]: \"port\" must be an integer 1..65535
  at validateEntry (services-manifest.ts:214)
  at validateManifest (services-manifest.ts:403)
  at readManifest (services-manifest.ts:512)
  at handleApiModules (api-modules.ts:306)
\`\`\`

Same bug class as #406. An old install of \`@openparachute/app@0.2.0-rc.4\` wrote a malformed row (port=0, name=\"app\") to services.json. #406 patched the lenient reader in ONE place (\`proxyToService\`); every other hot-path read still threw 500.

## What

Swept all hot-path reads to \`readManifestLenient\`:
- \`/api/modules\` (admin SPA "Modules" page)
- \`/admin/setup\` (wizard GET — the 500 Aaron saw)
- \`/admin/vaults\` (admin SPA vault list)
- \`/vault/<name>/*\` proxy (proxyToVault)
- \`/.well-known/parachute.json\`
- OAuth flow (handleAuthorizeGet → loadServicesManifest)
- module config + various other read paths

Strict \`readManifest\` still used by write paths (admin SPA upsert) so genuine bugs at write time surface immediately.

## Bonus fix

`readManifestLenient`'s duplicate-port dedup now mirrors the strict path's vault-on-vault exception. Multiple `parachute-vault-<name>` rows on port 1940 are legitimate; they no longer get one silently dropped.

## Test plan

- [x] \`bun test ./src\` → 2058/2058
- [x] Typecheck clean
- [x] One pre-existing malformed-JSON test updated to assert new lenient-degrade behavior (empty services list + 200, not 500)
- [ ] Live: rebuild deploy → walk the wizard + click Modules — no 500s

🤖 Generated with [Claude Code](https://claude.com/claude-code)