### PR TITLE
fix(services-manifest): sweep remaining server-side strict callers to lenient

### DIFF
--- a/src/__tests__/scope-registry.test.ts
+++ b/src/__tests__/scope-registry.test.ts
@@ -217,4 +217,49 @@ describe("loadDeclaredScopes", () => {
       cleanup();
     }
   });
+
+  test("one bad row in services.json — valid siblings' scopes still declared", () => {
+    // Regression for hub#411/#413/#415 lenient sweep: pre-sweep the reader
+    // threw on any bad row, the catch fired in loadDeclaredScopes, and we
+    // returned just FIRST_PARTY_SCOPES — dropping declared scopes from
+    // every VALID third-party module installed alongside the bad row.
+    // After the sweep we keep valid rows and skip the bad one with a warning.
+    const { manifestPath, cleanup } = tmp();
+    try {
+      writeFileSync(
+        manifestPath,
+        JSON.stringify({
+          services: [
+            // Bad row: port=0 violates the integer 1..65535 rule (the exact
+            // shape app@0.2.0-rc.4 wrote to operators' manifests).
+            {
+              name: "broken-module",
+              port: 0,
+              paths: ["/broken"],
+              health: "/healthz",
+              version: "0.0.1",
+            },
+            // Valid sibling.
+            {
+              name: "@acme/widget",
+              port: 1950,
+              paths: ["/widget"],
+              health: "/healthz",
+              version: "0.0.0-linked",
+            },
+          ],
+        }),
+      );
+      const declared = loadDeclaredScopes({
+        manifestPath,
+        readModuleScopes: (pkg) =>
+          pkg === "@acme/widget" ? ["widget:read", "widget:write"] : null,
+      });
+      expect(declared.has("vault:read")).toBe(true); // baseline
+      expect(declared.has("widget:read")).toBe(true); // valid sibling's scope survives
+      expect(declared.has("widget:write")).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
 });

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -50,7 +50,6 @@ import {
 } from "./service-spec.ts";
 import {
   findService,
-  readManifest,
   readManifestLenient,
   removeService,
 } from "./services-manifest.ts";

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -48,7 +48,12 @@ import {
   getSpec,
   synthesizeManifestForKnownModule,
 } from "./service-spec.ts";
-import { findService, readManifest, removeService } from "./services-manifest.ts";
+import {
+  findService,
+  readManifest,
+  readManifestLenient,
+  removeService,
+} from "./services-manifest.ts";
 import type { ModuleState, SpawnRequest, Supervisor } from "./supervisor.ts";
 import { WELL_KNOWN_PATH, type regenerateWellKnown } from "./well-known.ts";
 
@@ -396,7 +401,8 @@ async function spawnSupervised(
   spec: ServiceSpec,
   deps: ApiModulesOpsDeps,
 ): Promise<ModuleState | undefined> {
-  const manifest = readManifest(deps.manifestPath);
+  // Lenient: one bad row elsewhere shouldn't block spawning a valid one.
+  const manifest = readManifestLenient(deps.manifestPath);
   const entry = manifest.services.find((s) => s.name === spec.manifestName);
   if (!entry) return undefined;
   const cmd = spec.startCmd?.(entry);
@@ -785,8 +791,9 @@ export async function handleUninstall(
   const stopped = await deps.supervisor.stop(short);
   log.push(stopped ? `${short} supervisor stopped` : `${short} not supervised`);
 
-  // 2. Drop the services.json row (idempotent — readManifest is empty if missing).
-  const before = readManifest(deps.manifestPath);
+  // 2. Drop the services.json row (idempotent — readManifestLenient is empty if missing).
+  // Lenient so a malformed sibling row doesn't block uninstall of an unrelated module.
+  const before = readManifestLenient(deps.manifestPath);
   if (before.services.some((s) => s.name === spec.manifestName)) {
     removeService(spec.manifestName, deps.manifestPath);
     log.push(`removed ${spec.manifestName} from services.json`);

--- a/src/commands/serve-boot.ts
+++ b/src/commands/serve-boot.ts
@@ -26,7 +26,7 @@ import {
   getSpecFromInstallDir,
   shortNameForManifest,
 } from "../service-spec.ts";
-import { type ServiceEntry, readManifest } from "../services-manifest.ts";
+import { type ServiceEntry, readManifestLenient } from "../services-manifest.ts";
 import type { Supervisor } from "../supervisor.ts";
 
 export interface BootOpts {
@@ -57,7 +57,10 @@ export async function bootSupervisedModules(
   opts: BootOpts,
 ): Promise<BootedModule[]> {
   const log = opts.log ?? (() => {});
-  const manifest = readManifest(opts.manifestPath);
+  // Lenient: a single bad row shouldn't prevent the supervisor from booting
+  // the rest of the services. The container deploy hot path depends on this —
+  // we'd rather have N-1 modules up + one warning than zero modules up.
+  const manifest = readManifestLenient(opts.manifestPath);
   const results: BootedModule[] = [];
 
   for (const entry of manifest.services) {

--- a/src/scope-registry.ts
+++ b/src/scope-registry.ts
@@ -143,12 +143,10 @@ export interface LoadDeclaredScopesOpts {
 export function loadDeclaredScopes(opts: LoadDeclaredScopesOpts = {}): Set<string> {
   const declared = new Set<string>(FIRST_PARTY_SCOPES);
   const readModuleScopes = opts.readModuleScopes ?? defaultReadModuleScopes;
-  let services: { name: string; installDir?: string }[];
-  try {
-    services = readServicesManifest(opts.manifestPath).services;
-  } catch {
-    return declared;
-  }
+  // readServicesManifest is the lenient reader: it returns `{ services: [] }`
+  // on missing/unparseable files and skips individual bad rows with a warning.
+  // The for-loop below already degrades gracefully, so no try/catch needed.
+  const services = readServicesManifest(opts.manifestPath).services;
   for (const svc of services) {
     const defined = readModuleScopes(svc.name, svc.installDir);
     if (!defined) continue;

--- a/src/scope-registry.ts
+++ b/src/scope-registry.ts
@@ -24,7 +24,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { type ModuleManifest, validateModuleManifest } from "./module-manifest.ts";
 import { FIRST_PARTY_SCOPES } from "./scope-explanations.ts";
-import { readManifest as readServicesManifest } from "./services-manifest.ts";
+import { readManifestLenient as readServicesManifest } from "./services-manifest.ts";
 
 /**
  * RFC 6749 §3.3: scope strings are 1*( SP scope-token ). We accept any

--- a/src/vault-names.ts
+++ b/src/vault-names.ts
@@ -50,7 +50,7 @@ export function listVaultNames(manifest: ServicesManifest): string[] {
 /**
  * Read-from-disk convenience for callers that already have a manifest path
  * (e.g. `/api/users/vaults` reading the live `services.json`). Equivalent to
- * `listVaultNames(readManifest(manifestPath))`.
+ * `listVaultNames(readManifestLenient(manifestPath))`.
  */
 export function listVaultNamesFromPath(manifestPath: string): string[] {
   return listVaultNames(readManifestLenient(manifestPath));

--- a/src/vault-names.ts
+++ b/src/vault-names.ts
@@ -26,7 +26,7 @@
  * `vaultInstanceNameFor`. Entries with no paths still resolve to a name via
  * the helper's manifest-suffix fallback (hub#143).
  */
-import { type ServicesManifest, readManifest } from "./services-manifest.ts";
+import { type ServicesManifest, readManifestLenient } from "./services-manifest.ts";
 import { isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
 
 /**
@@ -53,5 +53,5 @@ export function listVaultNames(manifest: ServicesManifest): string[] {
  * `listVaultNames(readManifest(manifestPath))`.
  */
 export function listVaultNamesFromPath(manifestPath: string): string[] {
-  return listVaultNames(readManifest(manifestPath));
+  return listVaultNames(readManifestLenient(manifestPath));
 }

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -6,7 +6,7 @@ import {
   type ServiceEntry,
   type UiSubUnit,
   type UiSubUnitStatus,
-  readManifest,
+  readManifestLenient,
 } from "./services-manifest.ts";
 
 export interface WellKnownServiceEntry {
@@ -386,7 +386,11 @@ export async function regenerateWellKnown(
 ): Promise<{ path: string; doc: WellKnownDocument }> {
   const read = opts.readModuleManifest ?? readModuleManifest;
   const path = opts.wellKnownPath ?? WELL_KNOWN_PATH;
-  const services = readManifest(opts.manifestPath).services;
+  // Lenient: one malformed row shouldn't block well-known regen for everyone
+  // else (downstream consumers — Notes, Scribe, MCP — poll this; if it 500s
+  // they lose discovery). The function below already tolerates per-entry
+  // manifest errors via console.warn, so partial valid set is the right shape.
+  const services = readManifestLenient(opts.manifestPath).services;
   // Build the resolver maps the same way hub-server does — read each
   // module's `.parachute/module.json` from `installDir` and harvest
   // managementUrl (vault rows), uiUrl + displayName (all rows). Vaults


### PR DESCRIPTION
## Summary

Prophylactic follow-up to hub#411 + hub#413. After the deploy of rc.49 confirmed `/admin/setup` was fixed by the findService swap, audited every remaining strict `readManifest` caller on the server-side hot path and converted the ones where a single bad row shouldn't take down the surface.

## Converted (5 call sites)

- **well-known.ts:regenerateWellKnown** — downstream consumers (Notes, Scribe, MCP) poll `/.well-known/parachute.json`; a 500 here breaks discovery for everyone
- **api-modules-ops.ts:spawnSupervised + uninstall** — bad sibling row shouldn't block install/uninstall of an unrelated module
- **scope-registry.ts:loadDeclaredScopes** — already had try/catch fail-open (returns only FIRST_PARTY_SCOPES on throw); lenient lets it pick up scope contributions of every VALID row
- **vault-names.ts:listVaultNamesFromPath** — /api/users/vaults driver; one bad row shouldn't make the consent picker dropdown empty
- **commands/serve-boot.ts:bootSupervisedModules** — container-deploy boot path; N-1 modules + warning beats zero modules

## Deliberately NOT converted

CLI-side callers (`start/stop/status/upgrade/expose/install`) keep strict — operator runs them interactively, sees the error, fixes it. Different audience, different shape.

Also kept strict on `findService` callers in write-mode service-spec paths where the manifest *should* be coherent (those are pre-condition violations).

## Test plan

- [x] `bun test ./src` → 2058/2058
- [x] `bun run typecheck` → clean
- [ ] Post-merge: deploy, hit /.well-known/parachute.json on Render, expect 200 not 500
- [ ] Post-merge: hit /api/users/vaults after login, expect 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)