### PR TITLE
chore(notes-redirect): tighten outer guard to isLegacyNotesPath (closes hub#317)

### DIFF
--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -156,7 +156,7 @@ import {
   type ModuleManifest,
   readModuleManifest as defaultReadModuleManifest,
 } from "./module-manifest.ts";
-import { logNotesRedirect, maybeRedirectNotes } from "./notes-redirect.ts";
+import { isLegacyNotesPath, logNotesRedirect, maybeRedirectNotes } from "./notes-redirect.ts";
 import {
   authorizationServerMetadata,
   handleApproveClientPost,
@@ -1178,7 +1178,7 @@ export function hubFetch(
     // Lazy DB read: only consult `getDb` when the path actually matches a
     // legacy notes prefix — every non-notes request must NOT touch the DB
     // here (some tests + the /health route assert getDb is never called).
-    if (pathname === "/notes" || pathname.startsWith("/notes/")) {
+    if (isLegacyNotesPath(pathname)) {
       const notesRedirect = maybeRedirectNotes(pathname, url.search, getDb?.());
       if (notesRedirect !== undefined) {
         logNotesRedirect(pathname, notesRedirect);

--- a/src/notes-redirect.ts
+++ b/src/notes-redirect.ts
@@ -89,6 +89,8 @@ export function maybeRedirectNotes(
  * helper resets it between test runs.
  */
 const RATE_LIMIT_WINDOW_MS = 60_000;
+// Bounded by O(distinct legacy notes paths bookmarked by operators) —
+// operator-owned input set, not attacker-controlled. No eviction needed.
 const lastLogAt = new Map<string, number>();
 
 export interface LogNotesRedirectOpts {


### PR DESCRIPTION
Single-source-of-truth cleanup. Behaviorally identical.