### PR TITLE
feat(oauth): explicit Deny button on approve-pending page (closes hub#390)

### DIFF
--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -4545,6 +4545,194 @@ describe("inline approve button on pending /oauth/authorize (#208)", () => {
       cleanup();
     }
   });
+
+  // Deny path tests (hub#390). The shared describe block above pins the
+  // approve path's security model; these tests pin that the deny path
+  // honors the same guards AND constructs a spec-shaped error redirect.
+
+  test("deny POST happy path: valid redirect_uri + state → 302 to client with access_denied", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "pending",
+      });
+      const form = new URLSearchParams({
+        __csrf: TEST_CSRF,
+        client_id: reg.client.clientId,
+        return_to: `/oauth/authorize?client_id=${reg.client.clientId}`,
+        decision: "deny",
+        redirect_uri: "https://app.example/cb",
+        state: "deny-state-abc",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize/approve`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, SESSION_COOKIE_TTL_S)}`,
+          origin: ISSUER,
+        },
+      });
+      const res = await handleApproveClientPost(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(302);
+      const loc = res.headers.get("location") ?? "";
+      const target = new URL(loc);
+      expect(target.origin).toBe("https://app.example");
+      expect(target.pathname).toBe("/cb");
+      expect(target.searchParams.get("error")).toBe("access_denied");
+      expect(target.searchParams.get("state")).toBe("deny-state-abc");
+      // Client row stays pending — deny does not mutate.
+      expect(getClient(db, reg.client.clientId)?.status).toBe("pending");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("deny POST: no state in form → redirect omits state param (spec-compliant)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "pending",
+      });
+      const form = new URLSearchParams({
+        __csrf: TEST_CSRF,
+        client_id: reg.client.clientId,
+        return_to: `/oauth/authorize?client_id=${reg.client.clientId}`,
+        decision: "deny",
+        redirect_uri: "https://app.example/cb",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize/approve`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, SESSION_COOKIE_TTL_S)}`,
+          origin: ISSUER,
+        },
+      });
+      const res = await handleApproveClientPost(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(302);
+      const target = new URL(res.headers.get("location") ?? "");
+      expect(target.searchParams.get("error")).toBe("access_denied");
+      expect(target.searchParams.has("state")).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("deny POST: redirect_uri not in client's registered URIs → 400 (open-redirect defense)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "pending",
+      });
+      const form = new URLSearchParams({
+        __csrf: TEST_CSRF,
+        client_id: reg.client.clientId,
+        return_to: `/oauth/authorize?client_id=${reg.client.clientId}`,
+        decision: "deny",
+        // attacker-controlled redirect_uri
+        redirect_uri: "https://attacker.example/grab",
+        state: "x",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize/approve`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, SESSION_COOKIE_TTL_S)}`,
+          origin: ISSUER,
+        },
+      });
+      const res = await handleApproveClientPost(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(400);
+      // No mutation, no redirect to attacker.
+      expect(res.headers.get("location")).toBeNull();
+      expect(getClient(db, reg.client.clientId)?.status).toBe("pending");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("deny POST: CSRF + session + same-origin guards apply to deny path too", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "pending",
+      });
+      const form = new URLSearchParams({
+        __csrf: TEST_CSRF,
+        client_id: reg.client.clientId,
+        return_to: `/oauth/authorize?client_id=${reg.client.clientId}`,
+        decision: "deny",
+        redirect_uri: "https://app.example/cb",
+        state: "x",
+      });
+      // Cross-origin Origin header — same defense as approve path.
+      const req = new Request(`${ISSUER}/oauth/authorize/approve`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, SESSION_COOKIE_TTL_S)}`,
+          origin: "https://attacker.example",
+        },
+      });
+      const res = await handleApproveClientPost(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(403);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("approve POST: explicit decision=approve still works (no regression)", async () => {
+    // Back-compat: forms that explicitly carry decision=approve should
+    // continue to flip the client to approved + redirect to return_to.
+    // Pre-deny PR the field didn't exist; the new form sends it explicitly.
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "pending",
+      });
+      const returnTo = `/oauth/authorize?client_id=${reg.client.clientId}&state=rt-208`;
+      const form = new URLSearchParams({
+        __csrf: TEST_CSRF,
+        client_id: reg.client.clientId,
+        return_to: returnTo,
+        decision: "approve",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize/approve`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, SESSION_COOKIE_TTL_S)}`,
+          origin: ISSUER,
+        },
+      });
+      const res = await handleApproveClientPost(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe(returnTo);
+      expect(getClient(db, reg.client.clientId)?.status).toBe("approved");
+    } finally {
+      cleanup();
+    }
+  });
 });
 
 // DCR first-client auto-approve window (hub#268 Item 3). The wizard's

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -511,7 +511,11 @@ describe("renderApprovePending unauthenticated CTAs", () => {
   test("admin-authenticated branch hides the unauth CTAs and renders the inline approve form", () => {
     const html = renderApprovePending({
       ...COMMON,
-      approveForm: { csrfToken: CSRF, returnTo: "/oauth/authorize?client_id=client-xyz" },
+      approveForm: {
+        csrfToken: CSRF,
+        returnTo: "/oauth/authorize?client_id=client-xyz",
+        redirectUri: "https://client.example/cb",
+      },
     });
     expect(html).toContain('action="/oauth/authorize/approve"');
     // Workstream I, 2026-05-25 — button label "Approve and continue"
@@ -521,6 +525,39 @@ describe("renderApprovePending unauthenticated CTAs", () => {
     expect(html).not.toContain("Sign in as admin to approve");
     expect(html).not.toContain("Or send this link to your hub admin");
     expect(html).not.toContain("parachute auth approve-client");
+  });
+
+  test("authed branch renders Deny button + hidden inputs for redirect_uri / state (hub#390)", () => {
+    const html = renderApprovePending({
+      ...COMMON,
+      approveForm: {
+        csrfToken: CSRF,
+        returnTo: "/oauth/authorize?client_id=client-xyz",
+        redirectUri: "https://client.example/cb",
+        state: "abc-state",
+      },
+    });
+    // Both buttons present, distinguished by decision value.
+    expect(html).toContain('name="decision" value="approve"');
+    expect(html).toContain('name="decision" value="deny"');
+    expect(html).toContain(">Deny</button>");
+    // Hidden inputs carry redirect_uri + state for the deny handler.
+    expect(html).toContain('name="redirect_uri" value="https://client.example/cb"');
+    expect(html).toContain('name="state" value="abc-state"');
+  });
+
+  test("authed branch omits state hidden input when state is undefined (spec-allowed)", () => {
+    const html = renderApprovePending({
+      ...COMMON,
+      approveForm: {
+        csrfToken: CSRF,
+        returnTo: "/oauth/authorize?client_id=client-xyz",
+        redirectUri: "https://client.example/cb",
+        // state intentionally absent
+      },
+    });
+    expect(html).toContain('name="redirect_uri" value="https://client.example/cb"');
+    expect(html).not.toContain('name="state"');
   });
 });
 
@@ -612,7 +649,11 @@ describe("renderApprovePending scope display (wildcard substitution)", () => {
     const html = renderApprovePending({
       ...COMMON,
       requestedScopes: ["vault:read", "vault:write"],
-      approveForm: { csrfToken: CSRF, returnTo: "/oauth/authorize?client_id=client-xyz" },
+      approveForm: {
+        csrfToken: CSRF,
+        returnTo: "/oauth/authorize?client_id=client-xyz",
+        redirectUri: "https://client.example/cb",
+      },
     });
     expect(html).toContain('action="/oauth/authorize/approve"');
     expect(html).toMatch(/<code class="scope-name">vault:\*:read<\/code>/);

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -590,6 +590,13 @@ function pendingClientResponse(
   // the authed branch's inline approve form, and the flow resumes.
   const returnTo = `${authorizeUrl.pathname}${authorizeUrl.search}`;
   if (session && sameOrigin) {
+    // Plumb redirect_uri + state for the Deny path (hub#390): an operator
+    // who clicks Deny gets routed back to the client's redirect_uri with
+    // an RFC 6749 §4.1.2.1 error response. redirect_uri is required by
+    // the spec on /oauth/authorize so it's reliably present; state is
+    // optional per the spec, so undefined-passes-through.
+    const requestRedirectUri = authorizeUrl.searchParams.get("redirect_uri") ?? "";
+    const requestState = authorizeUrl.searchParams.get("state") ?? undefined;
     return htmlResponse(
       renderApprovePending({
         clientName: client.clientName ?? client.clientId,
@@ -598,7 +605,12 @@ function pendingClientResponse(
         requestedScopes,
         ...(requestedVault !== undefined && { requestedVault }),
         hubOrigin: deps.issuer,
-        approveForm: { csrfToken: csrf.token, returnTo },
+        approveForm: {
+          csrfToken: csrf.token,
+          returnTo,
+          redirectUri: requestRedirectUri,
+          ...(requestState !== undefined && { state: requestState }),
+        },
         loginNextUrl: returnTo,
       }),
       403,
@@ -1359,10 +1371,43 @@ export async function handleApproveClientPost(
   if (!client) {
     return htmlError("Unknown application", "This client_id is not registered with this hub.", 404);
   }
-  // Validate return_to BEFORE the DB mutation: if an authenticated operator
-  // submits a hand-crafted form with a bad return_to, we refuse without
-  // committing the client to `approved`. Practical risk is low (all three
-  // belts already passed), but ordering matters — validate, then mutate.
+
+  // Deny branch (hub#390): RFC 6749 §4.1.2.1 — when the resource owner
+  // denies an access request, the AS bounces back to the client's
+  // redirect_uri with `error=access_denied` (+ original state). Validate
+  // redirect_uri against the client's registered URIs to prevent open
+  // redirect via a hand-crafted form; refuse with 400 if it doesn't match.
+  // Deny does NOT mutate the client row — the client stays `pending` and
+  // the operator can revisit later from /admin/permissions or re-trigger
+  // OAuth from the calling app.
+  const decision = String(form.get("decision") ?? "approve");
+  if (decision === "deny") {
+    const denyRedirectUri = String(form.get("redirect_uri") ?? "");
+    if (!denyRedirectUri || !client.redirectUris.includes(denyRedirectUri)) {
+      return htmlError(
+        "Invalid form submission",
+        "The redirect_uri does not match any URI registered for this app.",
+        400,
+      );
+    }
+    const stateRaw = form.get("state");
+    const denyState = typeof stateRaw === "string" && stateRaw.length > 0 ? stateRaw : undefined;
+    const target = new URL(denyRedirectUri);
+    target.searchParams.set("error", "access_denied");
+    target.searchParams.set(
+      "error_description",
+      "The user denied the authorization request.",
+    );
+    if (denyState !== undefined) target.searchParams.set("state", denyState);
+    return redirectResponse(target.toString());
+  }
+
+  // Approve branch (default — also the back-compat path for any form that
+  // doesn't carry an explicit `decision` field). Validate return_to BEFORE
+  // the DB mutation: if an authenticated operator submits a hand-crafted
+  // form with a bad return_to, we refuse without committing the client to
+  // `approved`. Practical risk is low (all three belts already passed),
+  // but ordering matters — validate, then mutate.
   const returnTo = String(form.get("return_to") ?? "");
   if (!isSafeAuthorizeReturnTo(returnTo)) {
     return htmlError(

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -595,6 +595,12 @@ function pendingClientResponse(
     // an RFC 6749 §4.1.2.1 error response. redirect_uri is required by
     // the spec on /oauth/authorize so it's reliably present; state is
     // optional per the spec, so undefined-passes-through.
+    //
+    // We round-trip both values through hidden form inputs rather than
+    // re-parsing them from `return_to` in the handler. Reason: keeps the
+    // handler stateless about authorize-URL shape — it just reads the
+    // form. State is also not stored server-side (it never was; OAuth
+    // state lives in the query string by design).
     const requestRedirectUri = authorizeUrl.searchParams.get("redirect_uri") ?? "";
     const requestState = authorizeUrl.searchParams.get("state") ?? undefined;
     return htmlResponse(
@@ -1380,6 +1386,14 @@ export async function handleApproveClientPost(
   // Deny does NOT mutate the client row — the client stays `pending` and
   // the operator can revisit later from /admin/permissions or re-trigger
   // OAuth from the calling app.
+  //
+  // The decision default is `"approve"` — that covers both back-compat
+  // (older forms that don't carry the field at all) AND any unexpected
+  // value (e.g. `decision="garbage"`). The reasoning: only the literal
+  // string `"deny"` triggers the destructive-from-the-client's-perspective
+  // path; everything else is treated as the safe, prior behavior. A user
+  // can't accidentally land on the error redirect by clicking a malformed
+  // button.
   const decision = String(form.get("decision") ?? "approve");
   if (decision === "deny") {
     const denyRedirectUri = String(form.get("redirect_uri") ?? "");
@@ -1392,7 +1406,20 @@ export async function handleApproveClientPost(
     }
     const stateRaw = form.get("state");
     const denyState = typeof stateRaw === "string" && stateRaw.length > 0 ? stateRaw : undefined;
-    const target = new URL(denyRedirectUri);
+    // `new URL()` could in principle throw if a legacy code path bypassed
+    // `isValidRedirectUri` at registration and wrote a non-http(s) URI.
+    // Current DCR enforces validity at write time, so this catch is
+    // belt-and-suspenders, but cost is near-zero.
+    let target: URL;
+    try {
+      target = new URL(denyRedirectUri);
+    } catch {
+      return htmlError(
+        "Invalid form submission",
+        "The registered redirect_uri for this app is not a valid URL.",
+        400,
+      );
+    }
     target.searchParams.set("error", "access_denied");
     target.searchParams.set(
       "error_description",

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -226,10 +226,19 @@ export interface ApprovePendingViewProps {
    * server will redirect to after the approve commits — the original
    * `/oauth/authorize?...` URL so the OAuth flow re-enters with the now-
    * approved client and lands on the consent screen.
+   *
+   * Deny path (closes hub#390): the same form also surfaces a Deny button.
+   * `redirectUri` + `state` are plumbed through as hidden inputs so the deny
+   * handler can construct an RFC 6749 §4.1.2.1 error redirect back to the
+   * calling client (`<redirect_uri>?error=access_denied&state=<state>`).
+   * `redirectUri` is required because deny must signal back to the client;
+   * `state` may be undefined (OAuth clients sometimes omit it).
    */
   approveForm?: {
     csrfToken: string;
     returnTo: string;
+    redirectUri: string;
+    state?: string;
   };
   /**
    * Same-origin hub-relative URL (path + search) to send the operator to
@@ -506,7 +515,12 @@ export function renderApprovePending(props: ApprovePendingViewProps): string {
         ${renderCsrfHiddenInput(approveForm.csrfToken)}
         <input type="hidden" name="client_id" value="${escapeHtml(clientId)}" />
         <input type="hidden" name="return_to" value="${escapeHtml(approveForm.returnTo)}" />
-        <button type="submit" class="btn btn-primary">Approve</button>
+        <input type="hidden" name="redirect_uri" value="${escapeHtml(approveForm.redirectUri)}" />
+        ${approveForm.state !== undefined ? `<input type="hidden" name="state" value="${escapeHtml(approveForm.state)}" />` : ""}
+        <div class="approve-actions">
+          <button type="submit" name="decision" value="approve" class="btn btn-primary">Approve</button>
+          <button type="submit" name="decision" value="deny" class="btn btn-secondary">Deny</button>
+        </div>
       </form>`
     : renderUnauthenticatedApproveCtas(hubOrigin, clientId, loginNextUrl);
   const body = `


### PR DESCRIPTION
## Summary

Adds an explicit Deny button alongside Approve on the \`/oauth/authorize\` approve-pending page. On Deny, the server redirects to the client's \`redirect_uri\` with \`?error=access_denied&state=<state>\` per RFC 6749 §4.1.2.1 — the spec-shaped signal the calling OAuth client expects.

Closes hub#390. Implements the issue's recommended Option 3.

## Why

Previously the page offered only Approve. An operator who saw a DCR they didn't want had no way to signal "no" to the calling client — they could only close the tab, leaving the OAuth flow hanging until timeout. Caught in the 2026-05-26 Playwright audit.

## Implementation

- \`oauth-ui.ts\` — \`ApprovePendingViewProps.approveForm\` gains required \`redirectUri\` + optional \`state\`. Form renders both as hidden inputs. Two buttons (Approve / Deny) distinguished by \`name=\"decision\"\` values.
- \`oauth-handlers.ts\` — \`pendingClientResponse\` threads redirect_uri + state from the authorize URL into the form props. \`handleApproveClientPost\` branches on \`decision\`. Deny path validates redirect_uri against \`client.redirectUris\` (exact match per RFC 6749 — open-redirect defense), then 302s to the error URL. Deny does NOT mutate the client row.
- Same CSRF + session + same-origin gates apply to both decisions (branch happens AFTER security checks).
- Back-compat: missing \`decision\` field defaults to approve.

## Tests added

- approve POST: explicit \`decision=approve\` still works (regression guard)
- deny POST happy path: 302 to client with \`access_denied\` + \`state\`
- deny POST: no state in form → redirect omits state param (spec-compliant)
- deny POST: redirect_uri not in client's registered URIs → 400 (open-redirect defense)
- deny POST: cross-origin Origin → 403 (same defense as approve)
- view: Deny button + redirect_uri/state hidden inputs render
- view: state hidden input omitted when undefined

## Test plan

- [x] \`bun test ./src\` → 2066/2066 pass (was 2059, +7 new)
- [x] \`bun run typecheck\` → clean
- [ ] Post-deploy manual: click Deny on a real DCR flow, observe redirect to \`redirect_uri?error=access_denied\`
- [ ] Post-deploy manual: confirm Claude.ai shows a clean \"denied\" state vs a hung flow

## Out of scope

The issue also mentioned an inline link \"or remove this app permanently\" pointing at \`/admin/permissions/<client_id>\` for the option-2 (delete-client) semantic. Skipped here to keep this PR tight; that's an additive UI change that can land separately if Aaron wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)