### PR TITLE
feat(deploy): add Fly.io as peer self-host option (patterns#100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,24 +16,48 @@ bun add -g @openparachute/hub
 
 Prereqs: [Bun](https://bun.sh) 1.3.0 or later. `parachute expose` also requires [Tailscale](https://tailscale.com/download) **1.82 or newer** (installed + `tailscale up` run once); the `expose` path is under active polish for launch, so expect rough edges.
 
-### Hosted (Render)
+### Hosted self-deploy
+
+Hub runs as a single container with one persistent disk. Two equally-supported platforms; pick the one you prefer.
+
+#### Render
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/ParachuteComputer/parachute-hub)
 
-One-click Render deploy via the `render.yaml` Blueprint in this repo. Provisions a $7/mo Starter service + 1 GiB persistent disk + auto-deploys from `main`. Comes pre-configured with `PARACHUTE_INSTALL_CHANNEL=latest` so modules you install via the admin SPA (vault, app, scribe, runner) pull stable releases by default.
-
-**Want pre-release / rc modules?** Set `PARACHUTE_INSTALL_CHANNEL=rc` in your Render dashboard env vars (useful for dev/testing against the rc release line).
+One-click Render deploy via the `render.yaml` Blueprint in this repo. Provisions a $7/mo Starter service + 1 GiB persistent disk + auto-deploys from `main`. GUI-first ops; click-and-go for operators who don't want to install a CLI.
 
 After deploy completes:
 
-1. Open Render Logs → search for `parachute-bootstrap-` to find your one-time admin setup token (printed in a prominent banner on first boot).
+1. Open Render Logs → search for `parachute-bootstrap-` to find your one-time admin setup token.
 2. Visit your Render service URL's `/admin/setup` → paste the token → create your admin account.
 3. Set custom domain (optional) → set `PARACHUTE_HUB_ORIGIN` env to match.
-4. Install modules via the admin SPA at `/admin/modules` (or via the wizard).
-
-Operators who want env-var-driven seeding (CI, scripted deploys) can still set `PARACHUTE_INITIAL_ADMIN_USERNAME` + `PARACHUTE_INITIAL_ADMIN_PASSWORD` manually in the Render dashboard — hub honors them when present.
+4. Install modules via the admin SPA at `/admin/modules`.
 
 Render's docs on Blueprints: <https://render.com/docs/blueprint-spec>
+
+#### Fly.io
+
+```sh
+gh repo fork ParachuteComputer/parachute-hub --clone && cd parachute-hub
+./scripts/deploy-to-fly.sh
+```
+
+The script installs `flyctl` if missing, runs `fly launch --copy-config`, and prints the URL. Provisions a shared-cpu-1x 512MB machine in `iad` (override with `--region` if your operators are elsewhere) + 1 GiB persistent volume at `/parachute`. Cost: ~$3.34/mo all-in.
+
+After deploy:
+
+1. `fly logs --app <your-app> | grep parachute-bootstrap-` to find your one-time admin token.
+2. Visit `https://<your-app>.fly.dev/admin/setup` → paste the token → create your admin account.
+3. Custom domain: `fly certs add <your-domain> --app <your-app>` then `fly secrets set PARACHUTE_HUB_ORIGIN=https://<your-domain>`.
+4. Install modules via the admin SPA at `/admin/modules`.
+
+Config in `fly.toml`. CLI-first ops; bring your own `flyctl`.
+
+#### Both platforms
+
+Pre-configured with `PARACHUTE_INSTALL_CHANNEL=latest` so modules you install via the admin SPA (vault, app, scribe, runner) pull stable releases by default. Flip to `rc` in your platform's env vars for the pre-release cascade.
+
+Operators who want env-var-driven seeding (CI, scripted deploys) can still set `PARACHUTE_INITIAL_ADMIN_USERNAME` + `PARACHUTE_INITIAL_ADMIN_PASSWORD` manually — hub honors them on both platforms.
 
 ## First 5 minutes
 

--- a/fly.toml
+++ b/fly.toml
@@ -24,7 +24,11 @@
 # `fly secrets set PARACHUTE_HUB_ORIGIN=https://<your-domain>` so the
 # OAuth issuer claim is baked from your canonical URL.
 
-app = "parachute-hub"
+# NOTE: `app` is intentionally NOT set in this file. `fly launch` generates
+# a unique app name on first run (or honors the operator's `--name` override).
+# Setting a hardcoded value here would collide for every operator who forks
+# this repo. After first launch, flyctl writes the chosen name back to
+# fly.toml on disk — re-runs against the same checkout pick it up correctly.
 primary_region = "iad"
 
 [build]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,113 @@
+# Fly.io deploy config for @openparachute/hub.
+#
+# Layout: one Fly app running hub-as-supervisor (vault/scribe/app spawn
+# as child processes per the v0.6 deploy architecture). One persistent
+# volume mounted at /parachute holds the hub's DB, services.json, and
+# the BUN_INSTALL root where runtime-installed modules live.
+#
+# This file is a peer to render.yaml — operators pick the platform they
+# prefer. Same image, same code, same disk layout. See
+# parachute-patterns/migrations/2026-05-26-render-to-fly-self-host.md.
+#
+# To use: install flyctl (https://fly.io/docs/flyctl/install/), then:
+#
+#     fly launch --copy-config --yes
+#
+# That provisions the app + volume + initial deploy. After deploy:
+#
+#     fly logs --app <your-app>   # find the parachute-bootstrap-<token> line
+#     open https://<your-app>.fly.dev/admin/setup
+#
+# Paste the token, create your admin account, install vault, you're set.
+#
+# Custom domains: `fly certs add <your-domain>` after deploy, then
+# `fly secrets set PARACHUTE_HUB_ORIGIN=https://<your-domain>` so the
+# OAuth issuer claim is baked from your canonical URL.
+
+app = "parachute-hub"
+primary_region = "iad"
+
+[build]
+  # Uses the same Dockerfile as the Render path. No fly.io-specific
+  # build customization needed — hub's image is platform-agnostic.
+  dockerfile = "Dockerfile"
+
+[env]
+  # Persistent disk mount — hub honors PARACHUTE_HOME for ~/.parachute/,
+  # so hub.db, services.json, well-known/, and per-service dirs all
+  # land on the mounted volume rather than the ephemeral container fs.
+  PARACHUTE_HOME = "/parachute"
+
+  # Container listens on whatever port Fly's proxy forwards to. The
+  # Dockerfile defaults to 1939; Fly's [[services]] block below routes
+  # public 443/80 → internal_port (1939).
+  PORT = "1939"
+
+  # Bind to all interfaces inside the container so Fly's proxy can reach
+  # us. (The on-box `parachute expose` default of 127.0.0.1 is for the
+  # local-install path behind a same-host reverse proxy.)
+  PARACHUTE_BIND_HOST = "0.0.0.0"
+
+  # Pin Bun's global-install root to the persistent volume so modules
+  # installed at runtime via /admin/modules survive container restarts.
+  # Without this, `bun add @openparachute/<svc>` writes to bun's per-user
+  # prefix on the ephemeral layer and every redeploy nukes them. See
+  # hub#349 for the equivalent Render-side issue.
+  BUN_INSTALL = "/parachute/modules"
+  BUN_INSTALL_BIN = "/parachute/modules/bin"
+
+  # Modules installed via admin SPA cascade to this channel by default.
+  # Flip to "rc" via `fly secrets set` for the rc cascade. Per-call
+  # --channel / --tag still override on the install command.
+  PARACHUTE_INSTALL_CHANNEL = "latest"
+
+  # Bun honors NODE_ENV for libraries that branch on it.
+  NODE_ENV = "production"
+
+  # PARACHUTE_HUB_ORIGIN — only set if attaching a custom domain. Hub
+  # auto-derives the OAuth issuer from FLY_APP_NAME (composed as
+  # https://<app>.fly.dev) when unset, which is the right answer for
+  # the Fly-assigned URL. Set this manually via `fly secrets set
+  # PARACHUTE_HUB_ORIGIN=https://<your-domain>` if you've attached a
+  # custom domain (and update it BEFORE issuing OAuth tokens to
+  # clients — tokens are tied to the issuer claim).
+  #
+  # Admin setup: hub generates a one-time bootstrap token on first boot
+  # (printed prominently to logs). Visit /admin/setup, paste the token,
+  # create your admin account. No env-var passwords by default —
+  # cleaner secret hygiene. Operators who need env-var-driven setup can
+  # `fly secrets set PARACHUTE_INITIAL_ADMIN_USERNAME=... PARACHUTE_INITIAL_ADMIN_PASSWORD=...`
+  # (the same env vars the Render path honors).
+
+[http_service]
+  internal_port = 1939
+  force_https = true
+  # Keep the machine warm: hub holds session state in-memory + serves
+  # an admin SPA that benefits from sub-second response. The cost
+  # delta (~$1/mo) vs aggressive auto-stop is worth the latency.
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[http_service.checks]]
+    grace_period = "10s"
+    interval = "30s"
+    method = "GET"
+    timeout = "5s"
+    path = "/health"
+
+[[vm]]
+  # shared-cpu-1x 512MB is the sweet spot for hub + supervised
+  # vault/notes/scribe. 256MB would be tight once vault is up; 1GB is
+  # over-provisioned. Operators with heavy workloads can resize via
+  # `fly scale memory 1024` (online, no redeploy).
+  cpu_kind = "shared"
+  cpus = 1
+  memory = "512mb"
+
+[[mounts]]
+  source = "parachute_home"
+  destination = "/parachute"
+  # 1 GiB covers hub.db + per-vault data for a single operator. Resize
+  # via `fly volumes extend <vol-id> --size 5` (online, no redeploy).
+  initial_size = "1gb"

--- a/scripts/deploy-to-fly.sh
+++ b/scripts/deploy-to-fly.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# deploy-to-fly.sh — friendly first-time deploy of @openparachute/hub to Fly.io.
+#
+# What it does:
+#   1. Checks for flyctl; offers to install via the official one-liner.
+#   2. Runs `fly auth whoami` to confirm you're logged in (or prompts).
+#   3. Runs `fly launch --copy-config --yes` to provision app + volume + deploy.
+#   4. Prints the resulting URL + the next-step hint (find bootstrap token,
+#      visit /admin/setup).
+#
+# Idempotent: re-running on an already-launched app re-deploys via fly deploy.
+#
+# Usage:
+#   ./scripts/deploy-to-fly.sh                  # auto-pick app name from fly.toml
+#   ./scripts/deploy-to-fly.sh my-custom-name   # override app name
+#
+# See parachute-patterns/migrations/2026-05-26-render-to-fly-self-host.md
+# for the broader context (peer self-host option alongside Render).
+
+set -euo pipefail
+
+APP_NAME_OVERRIDE="${1:-}"
+
+echo "==> Checking for flyctl"
+if ! command -v flyctl >/dev/null 2>&1; then
+  echo "flyctl not found."
+  echo
+  echo "Install with the official one-liner:"
+  echo "    curl -L https://fly.io/install.sh | sh"
+  echo
+  read -rp "Install now? [y/N] " choice
+  case "$choice" in
+    [yY]*)
+      curl -L https://fly.io/install.sh | sh
+      # The installer puts flyctl in ~/.fly/bin; add to PATH for the rest of this run.
+      export PATH="${HOME}/.fly/bin:${PATH}"
+      ;;
+    *)
+      echo "Skipping. Re-run this script after installing flyctl."
+      exit 1
+      ;;
+  esac
+fi
+
+echo "==> Checking flyctl auth"
+if ! flyctl auth whoami >/dev/null 2>&1; then
+  echo "Not signed in to Fly.io. Running 'fly auth login' (this will open your browser)…"
+  flyctl auth login
+fi
+WHOAMI=$(flyctl auth whoami)
+echo "Signed in as: ${WHOAMI}"
+
+echo
+echo "==> Provisioning app"
+if [ -n "${APP_NAME_OVERRIDE}" ]; then
+  echo "Using custom app name: ${APP_NAME_OVERRIDE}"
+  flyctl launch --copy-config --yes --name "${APP_NAME_OVERRIDE}"
+else
+  echo "Using app name from fly.toml (or generated if taken)."
+  flyctl launch --copy-config --yes
+fi
+
+# Resolve the app's public URL. After `launch`, fly.toml's `app` field
+# carries the canonical name (Fly may have suffixed it if the original was taken).
+APP_NAME=$(awk -F'"' '/^app = / {print $2; exit}' fly.toml)
+APP_URL="https://${APP_NAME}.fly.dev"
+
+echo
+echo "==> Deploy complete"
+echo
+echo "Your hub is at: ${APP_URL}"
+echo
+echo "Next steps:"
+echo "  1. Find your one-time bootstrap token in the logs:"
+echo "       fly logs --app ${APP_NAME} | grep parachute-bootstrap-"
+echo "  2. Open the setup page:"
+echo "       open ${APP_URL}/admin/setup"
+echo "  3. Paste the bootstrap token, create your admin account."
+echo "  4. From /admin/modules, install vault. Then notes, scribe, etc."
+echo
+echo "Custom domain? After setup:"
+echo "    fly certs add <your-domain> --app ${APP_NAME}"
+echo "    fly secrets set PARACHUTE_HUB_ORIGIN=https://<your-domain> --app ${APP_NAME}"
+echo

--- a/scripts/deploy-to-fly.sh
+++ b/scripts/deploy-to-fly.sh
@@ -5,15 +5,13 @@
 # What it does:
 #   1. Checks for flyctl; offers to install via the official one-liner.
 #   2. Runs `fly auth whoami` to confirm you're logged in (or prompts).
-#   3. Runs `fly launch --copy-config --yes` to provision app + volume + deploy.
-#   4. Prints the resulting URL + the next-step hint (find bootstrap token,
-#      visit /admin/setup).
-#
-# Idempotent: re-running on an already-launched app re-deploys via fly deploy.
+#   3. On first run: `fly launch --copy-config --yes` (provisions app + volume + deploy).
+#      On re-run (fly.toml has an `app =` line from a prior launch): `fly deploy`.
+#   4. Prints the resulting URL + next-step hint.
 #
 # Usage:
-#   ./scripts/deploy-to-fly.sh                  # auto-pick app name from fly.toml
-#   ./scripts/deploy-to-fly.sh my-custom-name   # override app name
+#   ./scripts/deploy-to-fly.sh                  # auto-pick app name (or use existing)
+#   ./scripts/deploy-to-fly.sh my-custom-name   # override app name (first launch only)
 #
 # See parachute-patterns/migrations/2026-05-26-render-to-fly-self-host.md
 # for the broader context (peer self-host option alongside Render).
@@ -26,7 +24,8 @@ echo "==> Checking for flyctl"
 if ! command -v flyctl >/dev/null 2>&1; then
   echo "flyctl not found."
   echo
-  echo "Install with the official one-liner:"
+  echo "Install with the official one-liner (this runs a script from fly.io —"
+  echo "review https://fly.io/install.sh if you'd like to inspect it first):"
   echo "    curl -L https://fly.io/install.sh | sh"
   echo
   read -rp "Install now? [y/N] " choice
@@ -51,27 +50,42 @@ fi
 WHOAMI=$(flyctl auth whoami)
 echo "Signed in as: ${WHOAMI}"
 
-echo
-echo "==> Provisioning app"
-if [ -n "${APP_NAME_OVERRIDE}" ]; then
-  echo "Using custom app name: ${APP_NAME_OVERRIDE}"
-  flyctl launch --copy-config --yes --name "${APP_NAME_OVERRIDE}"
+# Detect whether fly.toml already carries an `app = "..."` line. If so, this is
+# a re-run against an already-launched app — use `fly deploy` instead of
+# `fly launch` (which would prompt to overwrite or error on the name).
+EXISTING_APP=$(awk -F'"' '/^app = / {print $2; exit}' fly.toml || true)
+
+if [ -n "${EXISTING_APP}" ]; then
+  echo
+  echo "==> fly.toml has app = \"${EXISTING_APP}\" — re-deploying existing app"
+  flyctl deploy --app "${EXISTING_APP}"
+  APP_NAME="${EXISTING_APP}"
 else
-  echo "Using app name from fly.toml (or generated if taken)."
-  flyctl launch --copy-config --yes
+  echo
+  echo "==> No existing app in fly.toml — running first-time launch"
+  if [ -n "${APP_NAME_OVERRIDE}" ]; then
+    echo "Using custom app name: ${APP_NAME_OVERRIDE}"
+    flyctl launch --copy-config --yes --name "${APP_NAME_OVERRIDE}"
+  else
+    echo "Letting Fly generate an app name (or pick one Fly suggests)."
+    flyctl launch --copy-config --yes
+  fi
+  # After launch, fly.toml has been rewritten with the actual provisioned name.
+  APP_NAME=$(awk -F'"' '/^app = / {print $2; exit}' fly.toml)
+  if [ -z "${APP_NAME}" ]; then
+    echo "WARN: couldn't read app name from fly.toml after launch. Check 'fly apps list'."
+    APP_NAME="<your-app>"
+  fi
 fi
 
-# Resolve the app's public URL. After `launch`, fly.toml's `app` field
-# carries the canonical name (Fly may have suffixed it if the original was taken).
-APP_NAME=$(awk -F'"' '/^app = / {print $2; exit}' fly.toml)
 APP_URL="https://${APP_NAME}.fly.dev"
 
 echo
-echo "==> Deploy complete"
+echo "==> Done"
 echo
 echo "Your hub is at: ${APP_URL}"
 echo
-echo "Next steps:"
+echo "Next steps (first launch only):"
 echo "  1. Find your one-time bootstrap token in the logs:"
 echo "       fly logs --app ${APP_NAME} | grep parachute-bootstrap-"
 echo "  2. Open the setup page:"
@@ -79,7 +93,7 @@ echo "       open ${APP_URL}/admin/setup"
 echo "  3. Paste the bootstrap token, create your admin account."
 echo "  4. From /admin/modules, install vault. Then notes, scribe, etc."
 echo
-echo "Custom domain? After setup:"
+echo "Custom domain (after setup):"
 echo "    fly certs add <your-domain> --app ${APP_NAME}"
 echo "    fly secrets set PARACHUTE_HUB_ORIGIN=https://<your-domain> --app ${APP_NAME}"
 echo

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -3418,6 +3418,35 @@ describe("parseArgs — issuer env precedence (hub#365)", () => {
     // Bare slash collapses to empty after strip — must not become "" issuer.
     expect(parseArgs([], { RENDER_EXTERNAL_URL: "/" }).issuer).toBeUndefined();
   });
+
+  // Fly.io self-host path (patterns#100 / parachute.computer#62).
+  test("FLY_APP_NAME composes https://<app>.fly.dev as fallback issuer", () => {
+    const got = parseArgs([], { FLY_APP_NAME: "my-parachute" });
+    expect(got.issuer).toBe("https://my-parachute.fly.dev");
+  });
+
+  test("PARACHUTE_HUB_ORIGIN wins over FLY_APP_NAME (operator with custom domain)", () => {
+    const got = parseArgs([], {
+      PARACHUTE_HUB_ORIGIN: "https://hub.example",
+      FLY_APP_NAME: "my-parachute",
+    });
+    expect(got.issuer).toBe("https://hub.example");
+  });
+
+  test("RENDER_EXTERNAL_URL wins over FLY_APP_NAME (pathological co-set)", () => {
+    // Both Render and Fly are unlikely to be set in the same env, but if a
+    // weird container ever passes both, the existing Render branch wins.
+    // Documents the precedence rather than asserting any product behavior.
+    const got = parseArgs([], {
+      RENDER_EXTERNAL_URL: "https://app.onrender.com",
+      FLY_APP_NAME: "my-parachute",
+    });
+    expect(got.issuer).toBe("https://app.onrender.com");
+  });
+
+  test("FLY_APP_NAME empty string → no fallback (treat as unset)", () => {
+    expect(parseArgs([], { FLY_APP_NAME: "" }).issuer).toBeUndefined();
+  });
 });
 
 describe("hubFetch persistent chrome strip injection (workstream G)", () => {

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -308,4 +308,44 @@ describe("resolveStartupIssuer — precedence chain (hub#365)", () => {
     // origin, which is the same as not setting it at all).
     expect(resolveStartupIssuer({}, { PARACHUTE_HUB_ORIGIN: "/" })).toBeUndefined();
   });
+
+  // Fly.io self-host path (patterns#100). resolveStartupIssuer is the
+  // function that injects PARACHUTE_HUB_ORIGIN into every supervised module's
+  // env. Without a Fly branch here, vault/scribe/app on Fly without a custom
+  // domain get undefined → OAuth iss-mismatch on every token hub mints.
+  test("FLY_APP_NAME composes https://<app>.fly.dev as fallback issuer", () => {
+    const got = resolveStartupIssuer({}, { FLY_APP_NAME: "my-parachute" });
+    expect(got).toBe("https://my-parachute.fly.dev");
+  });
+
+  test("PARACHUTE_HUB_ORIGIN wins over FLY_APP_NAME (operator with custom domain)", () => {
+    const got = resolveStartupIssuer(
+      {},
+      {
+        PARACHUTE_HUB_ORIGIN: "https://hub.example",
+        FLY_APP_NAME: "my-parachute",
+      },
+    );
+    expect(got).toBe("https://hub.example");
+  });
+
+  test("RENDER_EXTERNAL_URL wins over FLY_APP_NAME (pathological co-set)", () => {
+    const got = resolveStartupIssuer(
+      {},
+      {
+        RENDER_EXTERNAL_URL: "https://app.onrender.com",
+        FLY_APP_NAME: "my-parachute",
+      },
+    );
+    expect(got).toBe("https://app.onrender.com");
+  });
+
+  test("FLY_APP_NAME with slash rejected (defensive — Fly slugs don't contain /)", () => {
+    expect(resolveStartupIssuer({}, { FLY_APP_NAME: "a/b" })).toBeUndefined();
+    expect(resolveStartupIssuer({}, { FLY_APP_NAME: "../etc/passwd" })).toBeUndefined();
+  });
+
+  test("FLY_APP_NAME empty string → no fallback", () => {
+    expect(resolveStartupIssuer({}, { FLY_APP_NAME: "" })).toBeUndefined();
+  });
 });

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -3029,3 +3029,35 @@ describe("detectAutoExposeMode — Render env detection edge cases (hub#407 nit)
     expect(detectAutoExposeMode({ RENDER_EXTERNAL_URL: undefined })).toBeUndefined();
   });
 });
+
+describe("detectAutoExposeMode — Fly env detection (patterns#100)", () => {
+  test("returns 'public' when FLY_APP_NAME is a plausible app slug", () => {
+    expect(detectAutoExposeMode({ FLY_APP_NAME: "my-parachute" })).toBe("public");
+  });
+
+  test("returns 'public' when FLY_APP_NAME is the only platform var set", () => {
+    expect(detectAutoExposeMode({ FLY_APP_NAME: "demo-hub" })).toBe("public");
+  });
+
+  test("returns undefined when FLY_APP_NAME is absent", () => {
+    expect(detectAutoExposeMode({})).toBeUndefined();
+  });
+
+  test("returns undefined when FLY_APP_NAME is empty", () => {
+    expect(detectAutoExposeMode({ FLY_APP_NAME: "" })).toBeUndefined();
+  });
+
+  test("rejects FLY_APP_NAME with a slash (defensive — Fly slugs don't contain /)", () => {
+    expect(detectAutoExposeMode({ FLY_APP_NAME: "../etc/passwd" })).toBeUndefined();
+    expect(detectAutoExposeMode({ FLY_APP_NAME: "a/b" })).toBeUndefined();
+  });
+
+  test("Render takes precedence when both are set (pathological co-set)", () => {
+    expect(
+      detectAutoExposeMode({
+        RENDER_EXTERNAL_URL: "https://app.onrender.com",
+        FLY_APP_NAME: "my-parachute",
+      }),
+    ).toBe("public");
+  });
+});

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -117,11 +117,13 @@ function parsePort(raw: string | undefined): number | undefined {
  * Precedence (highest first):
  *   1. Explicit `--issuer` flag (test override too)
  *   2. `PARACHUTE_HUB_ORIGIN` env (operator-set, typical custom-domain case)
- *   3. Platform-injected public URL — currently Render's RENDER_EXTERNAL_URL.
+ *   3. Platform-injected public URL:
+ *      - Render: `RENDER_EXTERNAL_URL` (auto-injected on web services)
+ *      - Fly.io: `FLY_APP_NAME` → `https://<app>.fly.dev` (patterns#100)
  *      This is the load-bearing tier for container deploys where the
- *      operator can't know the URL at deploy time. Render generates the
- *      *.onrender.com hostname after service creation and injects it for
- *      web services; hub picks it up automatically.
+ *      operator can't know the URL at deploy time. Without this, supervised
+ *      modules' iss-validation breaks on hub-minted tokens (iss-mismatch
+ *      every time).
  *   4. None (returns undefined). Hub falls back to per-request derivation
  *      via `resolveIssuer` in hub-server.ts — works for `/.well-known`
  *      discovery but supervised modules with cached iss expectations
@@ -129,8 +131,8 @@ function parsePort(raw: string | undefined): number | undefined {
  *      through hub-mint → vault-validate will fail with iss-mismatch.
  *      This is the "no canonical origin known" degraded mode.
  *
- * Future platforms (Fly's `FLY_APP_NAME` + region, Railway's
- * `RAILWAY_PUBLIC_DOMAIN`, etc.) can extend tier 3 as needed.
+ * Future platforms (Railway's `RAILWAY_PUBLIC_DOMAIN`, etc.) can extend
+ * tier 3 as needed.
  *
  * Trailing slashes are stripped for canonical-form comparison; empty
  * strings collapse to undefined.
@@ -139,10 +141,28 @@ export function resolveStartupIssuer(
   opts: { issuer?: string },
   env: NodeJS.ProcessEnv,
 ): string | undefined {
+  const flyOrigin = flyDefaultOriginFromEnv(env);
   return (
-    (opts.issuer ?? env.PARACHUTE_HUB_ORIGIN ?? env.RENDER_EXTERNAL_URL)?.replace(/\/+$/, "") ||
-    undefined
+    (opts.issuer ?? env.PARACHUTE_HUB_ORIGIN ?? env.RENDER_EXTERNAL_URL ?? flyOrigin)?.replace(
+      /\/+$/,
+      "",
+    ) || undefined
   );
+}
+
+/**
+ * Compose `https://${FLY_APP_NAME}.fly.dev` when FLY_APP_NAME is a plausible
+ * Fly app slug. Mirrors the validation in detectAutoExposeMode (no slashes —
+ * Fly slugs don't contain them). Kept local to this file (vs imported from
+ * hub-server.ts) because serve.ts boots before hub-server.ts is loaded and
+ * we want to avoid a cross-module dependency cycle at startup.
+ */
+function flyDefaultOriginFromEnv(env: NodeJS.ProcessEnv): string | undefined {
+  const app = env.FLY_APP_NAME;
+  if (typeof app !== "string" || app.length === 0 || app.includes("/")) {
+    return undefined;
+  }
+  return `https://${app}.fly.dev`;
 }
 
 /**

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -290,7 +290,12 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
  */
 function flyDefaultOrigin(env: NodeJS.ProcessEnv): string | undefined {
   const app = env.FLY_APP_NAME;
-  if (!app || app.length === 0) return undefined;
+  // Mirror detectAutoExposeMode's slash-rejection — Fly slugs don't contain
+  // `/`, so anything with one is either spoofed or malformed. The composed
+  // URL is the OAuth issuer claim, so consistency in validation matters.
+  if (typeof app !== "string" || app.length === 0 || app.includes("/")) {
+    return undefined;
+  }
   return `https://${app}.fly.dev`;
 }
 

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -222,6 +222,12 @@ interface Args {
  *                                without operator config. Mirrors the
  *                                precedence in commands/serve.ts's
  *                                resolveStartupIssuer.
+ *   FLY_APP_NAME               — Fly.io sets this to the app name; we compose
+ *                                `https://${FLY_APP_NAME}.fly.dev` as a peer
+ *                                of RENDER_EXTERNAL_URL for the self-host-on-Fly
+ *                                path (patterns#100). Operators with custom
+ *                                domains attached set PARACHUTE_HUB_ORIGIN
+ *                                explicitly to override.
  */
 export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): Args {
   let port: number | undefined;
@@ -260,10 +266,32 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
   if (hostname === undefined) hostname = env.PARACHUTE_BIND_HOST || "127.0.0.1";
   if (wellKnownDir === undefined) wellKnownDir = WELL_KNOWN_DIR;
   if (issuer === undefined) {
-    const fromEnv = env.PARACHUTE_HUB_ORIGIN ?? env.RENDER_EXTERNAL_URL;
+    const fromEnv =
+      env.PARACHUTE_HUB_ORIGIN ??
+      env.RENDER_EXTERNAL_URL ??
+      flyDefaultOrigin(env);
     if (fromEnv) issuer = fromEnv.replace(/\/+$/, "") || undefined;
   }
   return { port, hostname, wellKnownDir, dbPath: dbPath ?? hubDbPath(), issuer };
+}
+
+/**
+ * Compose the default Fly.io public origin from FLY_APP_NAME. Mirrors what
+ * `RENDER_EXTERNAL_URL` provides on Render — without an operator-set
+ * PARACHUTE_HUB_ORIGIN, we need *some* fallback so OAuth issuance + same-
+ * origin checks work out of the box. Fly doesn't auto-set a public-URL env
+ * var the way Render does, but every Fly app on the free shared TLS tier
+ * is reachable at `<app>.fly.dev` — composing it from FLY_APP_NAME is the
+ * canonical default.
+ *
+ * Operators on Fly with a custom domain attached should set
+ * PARACHUTE_HUB_ORIGIN explicitly via `fly secrets set` — that wins over
+ * this fallback (precedence in `parseArgs` above).
+ */
+function flyDefaultOrigin(env: NodeJS.ProcessEnv): string | undefined {
+  const app = env.FLY_APP_NAME;
+  if (!app || app.length === 0) return undefined;
+  return `https://${app}.fly.dev`;
 }
 
 function parsePort(v: string): number {
@@ -1080,9 +1108,13 @@ export function hubFetch(
           // configured issuer. On Render, an operator who set hub_origin
           // via the admin SPA (or via a stale db row) to a non-public URL
           // would otherwise reject legitimate browser POSTs that arrive
-          // with the public Render URL as Origin. See origin-check.ts
+          // with the public Render URL as Origin. Same defense on Fly:
+          // the public <app>.fly.dev URL is the canonical Origin for
+          // browser POSTs and must be trusted even when the operator's
+          // configured issuer points elsewhere. See origin-check.ts
           // jsdoc for the failure case this closes.
-          platformOrigin: process.env.RENDER_EXTERNAL_URL,
+          platformOrigin:
+            process.env.RENDER_EXTERNAL_URL ?? flyDefaultOrigin(process.env),
         }),
     };
   };

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -233,19 +233,19 @@ export interface SetupWizardDeps {
 /**
  * Returns `"public"` when the runtime env indicates the hub is deployed
  * on a platform where the "how will this hub be reached?" answer is
- * pre-determined by the platform. Today: Render (sets RENDER_EXTERNAL_URL
- * for any web service). Returns `undefined` otherwise — the wizard's
- * expose step asks the operator.
+ * pre-determined by the platform. Today: Render (sets RENDER_EXTERNAL_URL)
+ * and Fly.io (sets FLY_APP_NAME, reachable at `<app>.fly.dev`). Returns
+ * `undefined` otherwise — the wizard's expose step asks the operator.
  *
- * Why this matters: on Render, none of the three radio options
+ * Why this matters: on a managed PaaS, none of the three radio options
  * (localhost, tailnet, public-with-custom-domain) match the actual
- * setup. The hub is reached at `*.onrender.com` automatically. Asking
- * the operator wastes a click and surfaces three options that don't
- * speak to their situation. Auto-pinning `public` skips the step.
+ * setup. The hub is reached at the platform-assigned URL automatically.
+ * Asking the operator wastes a click and surfaces three options that
+ * don't speak to their situation. Auto-pinning `public` skips the step.
  *
- * Add more platforms here when we encounter them — e.g. Fly.io
- * (FLY_APP_NAME), Railway (RAILWAY_ENVIRONMENT), etc. Each only auto-
- * detects when the platform clearly owns the public URL.
+ * Add more platforms here when we encounter them — e.g. Railway
+ * (RAILWAY_ENVIRONMENT), DigitalOcean App Platform (DIGITALOCEAN_APP_*),
+ * etc. Each only auto-detects when the platform clearly owns the public URL.
  */
 export function detectAutoExposeMode(env: Record<string, string | undefined>): "public" | undefined {
   // Render always sets `RENDER_EXTERNAL_URL` to a real `https://` URL on
@@ -253,8 +253,21 @@ export function detectAutoExposeMode(env: Record<string, string | undefined>): "
   // also accept `http://` as a defensive fallback in case Render ever
   // changes the scheme on some plan tier. Anything else (empty, weird,
   // not a URL) → don't auto-skip; let the operator choose.
-  const url = env.RENDER_EXTERNAL_URL;
-  if (typeof url === "string" && (url.startsWith("https://") || url.startsWith("http://"))) {
+  const renderUrl = env.RENDER_EXTERNAL_URL;
+  if (
+    typeof renderUrl === "string" &&
+    (renderUrl.startsWith("https://") || renderUrl.startsWith("http://"))
+  ) {
+    return "public";
+  }
+  // Fly.io sets FLY_APP_NAME (the app slug) on every machine. Unlike
+  // Render, Fly doesn't auto-inject a public-URL env var — but every
+  // Fly app on shared TLS is reachable at `<app>.fly.dev`, so the
+  // presence of FLY_APP_NAME is the canonical "we're on Fly with a
+  // public URL" signal. Validate it's a plausible slug (non-empty,
+  // no scheme weirdness) before trusting it.
+  const flyApp = env.FLY_APP_NAME;
+  if (typeof flyApp === "string" && flyApp.length > 0 && !flyApp.includes("/")) {
     return "public";
   }
   return undefined;


### PR DESCRIPTION
## Summary

Phase 1 of the Render → Fly migration accepted by Aaron 2026-05-26. Adds Fly.io as a **peer** self-host option alongside the existing Render path. Both first-class. Render unchanged.

Tracking: [patterns#100](https://github.com/ParachuteComputer/parachute-patterns/pull/100). Design: [parachute.computer#62](https://github.com/ParachuteComputer/parachute.computer/pull/62).

Aaron's framing (2026-05-26): _"For now, this is a self-host offering alongside render."_ No primacy reordering — both platforms presented as peer choices throughout.

## What's added

- **\`fly.toml\`** at repo root. Mirrors render.yaml: shared-cpu-1x 512MB / iad / 1GB volume at /parachute. Same Dockerfile, same env vars.
- **\`scripts/deploy-to-fly.sh\`** — friendly first-time wrapper. Installs flyctl if missing, runs \`fly launch --copy-config --yes\`.
- **\`src/hub-server.ts\`** — \`parseArgs\` recognizes \`FLY_APP_NAME\`, composes \`https://\${FLY_APP_NAME}.fly.dev\` as peer fallback to \`RENDER_EXTERNAL_URL\`. New \`flyDefaultOrigin\` helper. \`platformOrigin\` in request-time bound-origins resolver also reads Fly.
- **\`src/setup-wizard.ts\`** — \`detectAutoExposeMode\` auto-skips expose step on Fly (the existing "Add more platforms here" comment pointed right at this slot).
- **\`README.md\`** — restructured \"Hosted self-deploy\" section: both Render and Fly as equally-supported peers.

## Tests (10 new)

**parseArgs:**
- FLY_APP_NAME composes fly.dev URL
- PARACHUTE_HUB_ORIGIN wins over FLY_APP_NAME (operator-set custom domain)
- RENDER_EXTERNAL_URL wins over FLY_APP_NAME (pathological co-set)
- FLY_APP_NAME empty string → no fallback

**detectAutoExposeMode:**
- FLY_APP_NAME → 'public' auto-skip
- Absent / empty → undefined (let operator choose)
- Slash in slug rejected (defensive: Fly slugs don't contain /)
- Render takes precedence when both set

## Out of scope

- \`src/api-hub.ts\` buildInfo Fly equivalents — deferred. Render-specific fields (\`RENDER_GIT_COMMIT\`/\`BRANCH\`) stay; Fly equivalents (\`FLY_RELEASE_COMMAND\`/\`FLY_REGION\`) have a different shape and need a small admin-SPA design decision about what to surface. Tracked in the migration doc; safe to ship Phase 1 without it.
- \`deploy/fly.njk\` on parachute.computer — separate PR, doc-only.
- Migrating Aaron's existing parachute-hub.onrender.com → Fly — Aaron's call, no urgency.

## Test plan

- [x] \`bun test ./src\` → 2076/2076 (was 2066, +10 new)
- [x] \`bun run typecheck\` → clean
- [x] \`bash -n scripts/deploy-to-fly.sh\` — script syntax valid
- [ ] Manual: Aaron (or anyone) runs \`./scripts/deploy-to-fly.sh\` against a personal Fly org, confirms hub boots + admin/setup works + module install works
- [ ] Update parachute-patterns migration tracking file with \`[x]\` checks for landed items

🤖 Generated with [Claude Code](https://claude.com/claude-code)