### PR TITLE
release: hub 0.5.13 (stable)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13-rc.49",
+  "version": "0.5.13",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Aaron-authorized stable release per his 2026-05-26 directive. Drop rc.49 suffix; CI publishes to npm with `latest` dist-tag on tag push.