### PR TITLE
feat(hub): friend-facing /account/ home + first-admin gate on /admin/host-admin-token

### DIFF
--- a/src/__tests__/account-home-ui.test.ts
+++ b/src/__tests__/account-home-ui.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Renderer tests for the friend-facing `/account/` home (multi-user
+ * Phase 1 follow-up). The page is a pure function over its opts — these
+ * tests pin the load-bearing shape:
+ *
+ *   - Assigned-vault branch: Notes CTA href encodes the hub+vault URL,
+ *     vault name shows in the body, hub origin appears as inline code
+ *     in the custom-client disclosure.
+ *   - Admin (no assigned vault) branch: link to /admin/ visible.
+ *   - Defensive third branch (non-admin + no vault): "ask the operator"
+ *     copy renders.
+ *   - Common scaffolding: username in welcome, sign-out POST form,
+ *     change-password link.
+ */
+import { describe, expect, test } from "bun:test";
+import { renderAccountHome } from "../account-home-ui.ts";
+
+const HUB_ORIGIN = "https://hub.example";
+const CSRF = "test-csrf-token";
+
+describe("renderAccountHome", () => {
+  test("assigned-vault branch — Notes CTA carries the encoded hub+vault URL", () => {
+    const html = renderAccountHome({
+      username: "alice",
+      assignedVault: "alice",
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+    });
+    // Welcome header includes the username.
+    expect(html).toContain("Welcome, alice");
+    // Vault name renders as inline content in the vault card.
+    expect(html).toContain("<strong>alice</strong>");
+    // Notes "Open" CTA — same shape as setup-wizard's renderStartUsingTile.
+    // The href encodes `${hubOrigin}/vault/<name>` via encodeURIComponent.
+    const encodedVaultUrl = encodeURIComponent(`${HUB_ORIGIN}/vault/alice`);
+    expect(html).toContain(`https://notes.parachute.computer/add?url=${encodedVaultUrl}`);
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener"');
+    // Hub origin renders as inline <code> in the custom-client disclosure.
+    expect(html).toContain(`<code>${HUB_ORIGIN}</code>`);
+    expect(html).toContain("Use a custom client");
+  });
+
+  test("assigned-vault branch — trailing slash on hubOrigin is normalized", () => {
+    // The handler resolves origin per-request via `resolveIssuer`; some
+    // operators set a hub_origin setting with a trailing slash. The
+    // renderer must produce a clean `/vault/<name>` join either way.
+    const html = renderAccountHome({
+      username: "alice",
+      assignedVault: "alice",
+      passwordChanged: true,
+      hubOrigin: `${HUB_ORIGIN}/`,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+    });
+    const cleanEncoded = encodeURIComponent(`${HUB_ORIGIN}/vault/alice`);
+    expect(html).toContain(`https://notes.parachute.computer/add?url=${cleanEncoded}`);
+    // The inline-code display also drops the trailing slash.
+    expect(html).toContain(`<code>${HUB_ORIGIN}</code>`);
+    expect(html).not.toContain(`<code>${HUB_ORIGIN}/</code>`);
+  });
+
+  test("admin branch — null assignedVault + isFirstAdmin renders an /admin/ link", () => {
+    const html = renderAccountHome({
+      username: "admin",
+      assignedVault: null,
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: true,
+      csrfToken: CSRF,
+    });
+    expect(html).toContain("Welcome, admin");
+    expect(html).toContain("hub administrator");
+    expect(html).toContain('href="/admin/"');
+    // Should NOT carry the Notes CTA (no vault).
+    expect(html).not.toContain("notes.parachute.computer/add");
+  });
+
+  test("defensive branch — non-admin with null assignedVault renders an 'ask operator' message", () => {
+    // Shouldn't normally occur in Phase 1 (PR 2's /api/users always
+    // assigns a vault on create), but the renderer carries a clear
+    // explanation rather than a blank card if a row gets into that
+    // state via hand-edit or migration race.
+    const html = renderAccountHome({
+      username: "ghost",
+      assignedVault: null,
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+    });
+    expect(html).toContain("Welcome, ghost");
+    expect(html).toContain("Ask the hub operator");
+    // No /admin/ link in this branch — they have no admin role.
+    expect(html).not.toContain('href="/admin/"');
+    // No Notes CTA.
+    expect(html).not.toContain("notes.parachute.computer/add");
+  });
+
+  test("account card — change-password link and sign-out form are present", () => {
+    const html = renderAccountHome({
+      username: "alice",
+      assignedVault: "alice",
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+    });
+    // Change-password link points at the existing /account/change-password
+    // route (server-rendered HTML, separate handler).
+    expect(html).toContain('href="/account/change-password"');
+    // Sign-out form POSTs to /logout (existing handler), CSRF token
+    // round-trips via the renderCsrfHiddenInput helper.
+    expect(html).toContain('action="/logout"');
+    expect(html).toContain('method="POST"');
+    expect(html).toContain(CSRF);
+    // Username renders inside the account card too.
+    expect(html).toContain("<code>alice</code>");
+  });
+
+  test("escapes hostile content in username and vault name", () => {
+    // Defense-in-depth: usernames pass validateUsername (lowercase alnum
+    // + `_-`), so HTML metacharacters won't normally make it through. But
+    // the renderer is a pure function over arbitrary string input and the
+    // escape is load-bearing if the validator ever loosens.
+    const html = renderAccountHome({
+      username: "<script>",
+      assignedVault: "<vault>",
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+    });
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("&lt;vault&gt;");
+  });
+});

--- a/src/__tests__/admin-handlers.test.ts
+++ b/src/__tests__/admin-handlers.test.ts
@@ -426,6 +426,80 @@ describe("loginRedirectTarget — force-change-password (multi-user PR 3)", () =
     expect(res.headers.get("location")).toBe("/admin/tokens");
   });
 
+  test("non-admin (friend) targeting /admin/* gets rewritten to /account/", async () => {
+    // Multi-user follow-up: a signed-in friend account hitting an /admin/*
+    // URL via post-login `next=` would otherwise land on the admin SPA,
+    // which 403s on `/admin/host-admin-token` (first-admin gate) and
+    // bounces them back via the SPA-side 403 handler. Rewriting at the
+    // login boundary skips the bouncing-around UX. Friend has
+    // passwordChanged=true so the force-change path doesn't pre-empt.
+    await createUser(harness.db, "admin", "admin-pw", { passwordChanged: true });
+    await createUser(harness.db, "alice", "alice-pw", {
+      allowMulti: true,
+      passwordChanged: true,
+    });
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "alice",
+      password: "alice-pw",
+      next: "/admin/users",
+    });
+    const req = new Request("http://hub.test/login", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAdminLoginPost(harness.db, req);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/account/");
+  });
+
+  test("admin targeting /admin/* still lands at the original next= (rewrite doesn't fire for admin)", async () => {
+    // Belt-and-suspenders for the friend rewrite above: the same next=
+    // for the admin user must NOT redirect to /account/.
+    await createUser(harness.db, "admin", "admin-pw", { passwordChanged: true });
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "admin",
+      password: "admin-pw",
+      next: "/admin/users",
+    });
+    const req = new Request("http://hub.test/login", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAdminLoginPost(harness.db, req);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/admin/users");
+  });
+
+  test("non-admin (friend) keeps non-/admin next= intact (e.g. /oauth/authorize, /vault/...)", async () => {
+    // Legitimate user destinations — OAuth consent + per-vault routes —
+    // must pass through unchanged. Friends sign in through /login as part
+    // of the OAuth user-consent flow; rewriting their next= to /account/
+    // would break that.
+    await createUser(harness.db, "admin", "admin-pw", { passwordChanged: true });
+    await createUser(harness.db, "alice", "alice-pw", {
+      allowMulti: true,
+      passwordChanged: true,
+    });
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "alice",
+      password: "alice-pw",
+      next: "/oauth/authorize?client_id=abc",
+    });
+    const req = new Request("http://hub.test/login", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAdminLoginPost(harness.db, req);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/oauth/authorize?client_id=abc");
+  });
+
   test("password_changed=false defense-in-depth: unsafe next= is sanitized before encoding", async () => {
     // safeNext rewrites unsafe next values to /admin/vaults BEFORE the
     // redirect-target helper runs. The change-password URL should never

--- a/src/__tests__/admin-host-admin-token.test.ts
+++ b/src/__tests__/admin-host-admin-token.test.ts
@@ -56,6 +56,31 @@ async function withSession(): Promise<{ cookie: string; userId: string }> {
   return { cookie, userId: user.id };
 }
 
+/**
+ * Seed an admin (first-created user) + a second non-admin "friend"
+ * account, return cookies + ids for both. Used by the first-admin-gate
+ * tests.
+ */
+async function withAdminAndFriend(): Promise<{
+  adminCookie: string;
+  adminId: string;
+  friendCookie: string;
+  friendId: string;
+}> {
+  const admin = await createUser(harness.db, "admin", "admin-passphrase");
+  const friend = await createUser(harness.db, "alice", "alice-passphrase", {
+    allowMulti: true,
+  });
+  const adminSession = createSession(harness.db, { userId: admin.id });
+  const friendSession = createSession(harness.db, { userId: friend.id });
+  return {
+    adminCookie: buildSessionCookie(adminSession.id, Math.floor(SESSION_TTL_MS / 1000)),
+    adminId: admin.id,
+    friendCookie: buildSessionCookie(friendSession.id, Math.floor(SESSION_TTL_MS / 1000)),
+    friendId: friend.id,
+  };
+}
+
 describe("handleHostAdminToken", () => {
   test("401 when no session cookie is present", async () => {
     const req = new Request(`${ISSUER}/admin/host-admin-token`);
@@ -122,6 +147,43 @@ describe("handleHostAdminToken", () => {
     const scopes = scopeClaim.split(/\s+/);
     expect(scopes).toContain("parachute:host:admin");
     expect(scopes).toContain("parachute:host:auth");
+  });
+
+  test("403 not_admin when a signed-in non-first-admin (friend) hits the endpoint", async () => {
+    // Privesc closure: without the first-admin gate, any signed-in
+    // friend account could mint a JWT carrying parachute:host:admin +
+    // parachute:host:auth — the SPA bearer that gates vault provisioning,
+    // grants, and the token registry. The friend's session is valid;
+    // the endpoint must refuse because the session.userId doesn't match
+    // the first-admin row.
+    const { friendCookie } = await withAdminAndFriend();
+    rotateSigningKey(harness.db);
+    const req = new Request(`${ISSUER}/admin/host-admin-token`, {
+      headers: { cookie: friendCookie },
+    });
+    const res = await handleHostAdminToken(req, { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("not_admin");
+    // The wire description steers the SPA-side handler toward /account/.
+    expect(body.error_description).toContain("/account/");
+  });
+
+  test("first-admin path still succeeds when a friend exists alongside", async () => {
+    // Belt-and-suspenders for the gate above: adding a second user must
+    // not break the admin's own happy path. Same DB, same query — the
+    // admin's session.userId matches the earliest-created row, so the
+    // gate passes.
+    const { adminCookie, adminId } = await withAdminAndFriend();
+    rotateSigningKey(harness.db);
+    const req = new Request(`${ISSUER}/admin/host-admin-token`, {
+      headers: { cookie: adminCookie },
+    });
+    const res = await handleHostAdminToken(req, { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string };
+    const validated = await validateAccessToken(harness.db, body.token, ISSUER);
+    expect(validated.payload.sub).toBe(adminId);
   });
 
   // Regression for the end-to-end bug that motivated adding `:host:auth`

--- a/src/__tests__/admin-vault-admin-token.test.ts
+++ b/src/__tests__/admin-vault-admin-token.test.ts
@@ -152,6 +152,50 @@ describe("handleVaultAdminToken", () => {
     expect(scopeClaim.split(/\s+/)).toContain("vault:work:admin");
   });
 
+  test("403 not_admin when the session belongs to a non-first-admin user", async () => {
+    // Multi-user Phase 1 privesc gate (mirrors host-admin-token). The first-
+    // created user is the hub admin; subsequent users are friends pinned to
+    // a single vault and must NOT be able to mint vault:<name>:admin via
+    // this endpoint. The session check alone would let them — that's the
+    // whole reason this gate exists.
+    await createUser(harness.db, "operator", "hunter2-admin");
+    const friend = await createUser(harness.db, "friend", "hunter2-friend", {
+      assignedVault: "work",
+      allowMulti: true,
+    });
+    const session = createSession(harness.db, { userId: friend.id });
+    const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+    const req = new Request(`${ISSUER}/admin/vault-admin-token/work`, { headers: { cookie } });
+    const res = await handleVaultAdminToken(req, "work", {
+      db: harness.db,
+      issuer: ISSUER,
+      knownVaultNames: known("work", "default"),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("not_admin");
+    expect(body.error_description).toContain("/account/");
+  });
+
+  test("first admin still mints when other users exist", async () => {
+    // Regression: the first-admin gate must not regress the operator's
+    // happy path when there are friends in the DB.
+    const admin = await createUser(harness.db, "operator", "hunter2-admin");
+    await createUser(harness.db, "friend", "hunter2-friend", {
+      assignedVault: "work",
+      allowMulti: true,
+    });
+    const session = createSession(harness.db, { userId: admin.id });
+    const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+    const req = new Request(`${ISSUER}/admin/vault-admin-token/work`, { headers: { cookie } });
+    const res = await handleVaultAdminToken(req, "work", {
+      db: harness.db,
+      issuer: ISSUER,
+      knownVaultNames: known("work"),
+    });
+    expect(res.status).toBe(200);
+  });
+
   test("audience is per-vault — different vaults get different aud claims", async () => {
     // Regression for PR #173 follow-up: a single shared audience constant
     // meant a token minted for vault `boulder` carried `aud: "hub"` and

--- a/src/__tests__/api-account.test.ts
+++ b/src/__tests__/api-account.test.ts
@@ -25,6 +25,7 @@ import { join } from "node:path";
 import {
   handleAccountChangePasswordGet,
   handleAccountChangePasswordPost,
+  handleAccountHomeGet,
   markPasswordChanged,
 } from "../api-account.ts";
 import { CSRF_COOKIE_NAME, CSRF_FIELD_NAME } from "../csrf.ts";
@@ -626,5 +627,91 @@ describe("markPasswordChanged", () => {
     markPasswordChanged(harness.db, user.id);
     const after = getUserById(harness.db, user.id);
     expect(after?.passwordChanged).toBe(true);
+  });
+});
+
+describe("handleAccountHomeGet", () => {
+  // Integration smoke for `GET /account/` — verifies session gating
+  // (302 → /login when missing) and the happy path (200 + rendered HTML
+  // with the user's vault). The pure-renderer assertions live in
+  // `account-home-ui.test.ts`; this suite pins handler-level wiring.
+
+  const HUB_ORIGIN = "https://hub.test";
+
+  test("302 → /login when no session cookie is present", async () => {
+    const req = new Request(`${HUB_ORIGIN}/account/`);
+    const res = handleAccountHomeGet(req, { db: harness.db, hubOrigin: HUB_ORIGIN });
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    // Round-trip /account/ as the `next` param so post-login lands back.
+    expect(location).toBe(`/login?next=${encodeURIComponent("/account/")}`);
+  });
+
+  test("200 + HTML for a signed-in friend with an assigned vault", async () => {
+    // Create the admin first (so the friend is NOT the first admin),
+    // then a friend with an assigned vault.
+    await createUser(harness.db, "admin", "admin-passphrase", { passwordChanged: true });
+    const friend = await createUser(harness.db, "alice", "alice-passphrase", {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVault: "alice",
+    });
+    const session = createSession(harness.db, { userId: friend.id });
+    const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+    const req = new Request(`${HUB_ORIGIN}/account/`, { headers: { cookie } });
+    const res = handleAccountHomeGet(req, { db: harness.db, hubOrigin: HUB_ORIGIN });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const html = await res.text();
+    expect(html).toContain("Welcome, alice");
+    // Vault name visible.
+    expect(html).toContain("<strong>alice</strong>");
+    // Notes CTA carries the hub-origin-encoded vault URL.
+    const encoded = encodeURIComponent(`${HUB_ORIGIN}/vault/alice`);
+    expect(html).toContain(`https://notes.parachute.computer/add?url=${encoded}`);
+  });
+
+  test("200 + admin branch when the first-admin signs in (assignedVault=null)", async () => {
+    // The first-created user with no vault pin is the admin posture.
+    const admin = await createUser(harness.db, "admin", "admin-passphrase", {
+      passwordChanged: true,
+    });
+    const session = createSession(harness.db, { userId: admin.id });
+    const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+    const req = new Request(`${HUB_ORIGIN}/account/`, { headers: { cookie } });
+    const res = handleAccountHomeGet(req, { db: harness.db, hubOrigin: HUB_ORIGIN });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Welcome, admin");
+    expect(html).toContain("hub administrator");
+    expect(html).toContain('href="/admin/"');
+  });
+
+  test("302 → /login when the session points at a deleted user", async () => {
+    // Stale-session shape: a session row outlives its user. The handler
+    // hands back to /login rather than rendering against null.
+    //
+    // Construction note: `deleteUser` drops the session as part of its
+    // cleanup transaction, and the sessions.user_id FK is RESTRICT, so
+    // we briefly drop FK enforcement to fabricate the orphan-session
+    // shape. The handler's job is robustness against an externally-
+    // induced orphan (e.g. a race between session-read and user-delete
+    // on a different connection); the test exercises that defensive
+    // branch directly.
+    const user = await createUser(harness.db, "ghost", "ghost-passphrase", {
+      passwordChanged: true,
+    });
+    const session = createSession(harness.db, { userId: user.id });
+    const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+    harness.db.exec("PRAGMA foreign_keys = OFF");
+    try {
+      harness.db.prepare("DELETE FROM users WHERE id = ?").run(user.id);
+    } finally {
+      harness.db.exec("PRAGMA foreign_keys = ON");
+    }
+    const req = new Request(`${HUB_ORIGIN}/account/`, { headers: { cookie } });
+    const res = handleAccountHomeGet(req, { db: harness.db, hubOrigin: HUB_ORIGIN });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/login");
   });
 });

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -11,9 +11,11 @@ import {
   UsernameTakenError,
   createUser,
   deleteUser,
+  getFirstAdminId,
   getUserById,
   getUserByUsername,
   getUserByUsernameCI,
+  isFirstAdmin,
   listUsers,
   setPassword,
   userCount,
@@ -346,5 +348,68 @@ describe("validatePassword", () => {
     // toward passphrases we'll layer it as a separate signal, not a
     // hard gate.
     expect(validatePassword("aaaaaaaaaaaa").valid).toBe(true);
+  });
+});
+
+describe("getFirstAdminId / isFirstAdmin", () => {
+  test("getFirstAdminId returns null on an empty users table", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      expect(getFirstAdminId(db)).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("getFirstAdminId returns the earliest-created user id", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const admin = await createUser(db, "admin", "pw1", { now: () => new Date(1000) });
+      await createUser(db, "alice", "pw2", {
+        allowMulti: true,
+        now: () => new Date(2000),
+      });
+      await createUser(db, "bob", "pw3", {
+        allowMulti: true,
+        now: () => new Date(3000),
+      });
+      expect(getFirstAdminId(db)).toBe(admin.id);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("isFirstAdmin matches earliest user, false for everyone else", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const admin = await createUser(db, "admin", "pw1", { now: () => new Date(1000) });
+      const friend = await createUser(db, "alice", "pw2", {
+        allowMulti: true,
+        now: () => new Date(2000),
+      });
+      expect(isFirstAdmin(db, admin.id)).toBe(true);
+      expect(isFirstAdmin(db, friend.id)).toBe(false);
+      expect(isFirstAdmin(db, "no-such-id")).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("isFirstAdmin tracks the admin even after a later user is deleted", async () => {
+    // Deleting a non-first user doesn't promote anyone — the original
+    // admin still holds the "first" slot.
+    const { db, cleanup } = makeDb();
+    try {
+      const admin = await createUser(db, "admin", "pw1", { now: () => new Date(1000) });
+      const friend = await createUser(db, "alice", "pw2", {
+        allowMulti: true,
+        now: () => new Date(2000),
+      });
+      deleteUser(db, friend.id);
+      expect(getFirstAdminId(db)).toBe(admin.id);
+      expect(isFirstAdmin(db, admin.id)).toBe(true);
+    } finally {
+      cleanup();
+    }
   });
 });

--- a/src/account-home-ui.ts
+++ b/src/account-home-ui.ts
@@ -1,0 +1,414 @@
+/**
+ * Server-rendered HTML for `/account/` — the friend-facing user home.
+ *
+ * Multi-user Phase 1 follow-up. Companion to the first-admin gate on
+ * `/admin/host-admin-token` (see `admin-host-admin-token.ts`): without
+ * this landing surface, a non-admin friend signing in would either
+ * (a) hit a 403 wall when the SPA tries to mint a host-admin bearer,
+ * or (b) — pre-gate — silently escalate to full admin. The gate plus
+ * this page give the friend a coherent home: their assigned vault,
+ * password rotation link, sign-out.
+ *
+ * Pure renderer — no DB, no Bun.serve, no fs. The `/account/` route
+ * handler in `hub-server.ts` resolves the user + their vault + the
+ * is-first-admin flag, then calls in here. Same posture as
+ * `account-change-password-ui.ts` and `oauth-ui.ts`.
+ *
+ * Visual chrome: cloned from `account-change-password-ui.ts` so the
+ * `/account/*` surface family stays cohesive. If/when an
+ * `auth-ui-chrome.ts` lands, both should consolidate.
+ */
+import { WORDMARK_TEXT, brandMarkSvg } from "./brand.ts";
+import { renderCsrfHiddenInput } from "./csrf.ts";
+import { escapeHtml } from "./oauth-ui.ts";
+
+// --- shared chrome (mirrors account-change-password-ui.ts) ----------------
+
+const PALETTE = {
+  bg: "#faf8f4",
+  bgSoft: "#f3f0ea",
+  fg: "#2c2a26",
+  fgMuted: "#6b6860",
+  fgDim: "#9a9690",
+  accent: "#4a7c59",
+  accentHover: "#3d6849",
+  accentSoft: "rgba(74, 124, 89, 0.08)",
+  border: "#e4e0d8",
+  borderLight: "#ece9e2",
+  cardBg: "#ffffff",
+  danger: "#a3392b",
+  dangerSoft: "rgba(163, 57, 43, 0.08)",
+  success: "#3d6849",
+  successSoft: "rgba(61, 104, 73, 0.08)",
+} as const;
+
+const FONT_SERIF = `Georgia, "Times New Roman", serif`;
+const FONT_SANS = `-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`;
+const FONT_MONO = `ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", monospace`;
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}
+
+function baseDocument(title: string, body: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>${escapeHtml(title)}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="referrer" content="no-referrer" />
+  <style>${STYLES}</style>
+</head>
+<body>
+  <main>
+${body}
+  </main>
+</body>
+</html>`;
+}
+
+function header(): string {
+  return `
+        <div class="brand">
+          <span class="brand-mark" aria-hidden="true">${brandMarkSvg(20, "account-home")}</span>
+          <span class="brand-name">${WORDMARK_TEXT}</span>
+          <span class="brand-tag">account</span>
+        </div>`;
+}
+
+// --- /account/ ------------------------------------------------------------
+
+export interface RenderAccountHomeOpts {
+  username: string;
+  /**
+   * Assigned vault instance name, or `null` for users with no per-vault
+   * restriction. In Phase 1 a `null` assigned vault means "admin posture"
+   * (the OAuth issuer mints tokens for any requested vault) — combined
+   * with `isFirstAdmin: true` this is the hub administrator's account.
+   */
+  assignedVault: string | null;
+  /** Force-change-password completion flag. Currently informational only. */
+  passwordChanged: boolean;
+  /**
+   * Hub origin (no trailing slash) — the canonical URL operators connect
+   * their MCP / Surface clients to. Used both in the Notes "Open" CTA
+   * (encoded as `?url=...` on `notes.parachute.computer/add`) and as
+   * inline-code text for the "custom client" disclosure.
+   */
+  hubOrigin: string;
+  /**
+   * Whether the signed-in user is the hub administrator (the
+   * earliest-created users row). Drives the `assignedVault: null`
+   * branch — admins see an "open admin" affordance; non-admins (a
+   * Phase 1 shape that shouldn't normally occur — admins land with
+   * `assignedVault: null`, friends always have one set) see a
+   * defensive "ask the operator" message.
+   */
+  isFirstAdmin: boolean;
+  /**
+   * CSRF token for the sign-out form. Same pattern as
+   * `account-change-password-ui.ts` — POSTs to `/logout` are CSRF-gated
+   * to keep a cross-origin form from logging the user out.
+   */
+  csrfToken: string;
+}
+
+export function renderAccountHome(opts: RenderAccountHomeOpts): string {
+  const { username, assignedVault, hubOrigin, isFirstAdmin, csrfToken } = opts;
+  const safeUsername = escapeHtml(username);
+  // Origin is already canonicalized by the handler (trailing slash stripped),
+  // but defensively re-trim so a stray slash here doesn't break the CTA href.
+  const trimmedOrigin = hubOrigin.replace(/\/+$/, "");
+
+  const vaultCard = renderVaultCard({
+    assignedVault,
+    trimmedOrigin,
+    isFirstAdmin,
+  });
+
+  const accountCard = renderAccountCard({
+    username: safeUsername,
+    csrfToken,
+  });
+
+  const body = `
+    <div class="card">
+      <div class="card-header">
+        ${header()}
+        <h1>Welcome, ${safeUsername}</h1>
+        <p class="subtitle">Your Parachute account home.</p>
+      </div>
+      ${vaultCard}
+      ${accountCard}
+    </div>`;
+  return baseDocument(`${username} — Parachute`, body);
+}
+
+interface VaultCardOpts {
+  assignedVault: string | null;
+  trimmedOrigin: string;
+  isFirstAdmin: boolean;
+}
+
+function renderVaultCard(opts: VaultCardOpts): string {
+  const { assignedVault, trimmedOrigin, isFirstAdmin } = opts;
+
+  if (assignedVault !== null) {
+    const safeVault = escapeHtml(assignedVault);
+    // Mirror setup-wizard.ts:renderStartUsingTile — vault URLs are
+    // `${hubOrigin}/vault/<name>`. URL-encode defensively even though
+    // current vault-name validation rules mean it's a no-op.
+    const vaultUrlForAdd = encodeURIComponent(`${trimmedOrigin}/vault/${assignedVault}`);
+    const hubOriginDisplay = escapeHtml(trimmedOrigin);
+    return `
+      <section class="section" data-testid="vault-card">
+        <h2>Your vault</h2>
+        <p class="vault-name"><strong>${safeVault}</strong></p>
+        <p>Open Notes — the canonical browser UI for your vault. It connects to your
+          hub over HTTPS and remembers your URL after the first OAuth.</p>
+        <p>
+          <a class="btn btn-primary" href="https://notes.parachute.computer/add?url=${vaultUrlForAdd}"
+             target="_blank" rel="noopener" data-testid="open-notes-cta">Open Notes ↗</a>
+        </p>
+        <details class="custom-client">
+          <summary>Use a custom client</summary>
+          <p>To connect a custom Surface or MCP client running on your own machine,
+             point it at the hub origin below and run through OAuth — the hub will
+             ask you to consent.</p>
+          <p class="hub-origin-line">Hub origin: <code>${hubOriginDisplay}</code></p>
+        </details>
+      </section>`;
+  }
+  if (isFirstAdmin) {
+    return `
+      <section class="section" data-testid="admin-card">
+        <h2>Your vault</h2>
+        <p>You're the hub administrator. Visit
+          <a href="/admin/">the admin surface</a> to manage vaults, users, and clients.</p>
+      </section>`;
+  }
+  // Defensive third branch — non-admin with no assigned vault. PR 2's
+  // /api/users path always assigns a vault on create, so a friend reaching
+  // this state would have to come from a hand-edited row or a migration
+  // race. Surface a clear message instead of a blank card.
+  return `
+    <section class="section" data-testid="no-vault-card">
+      <h2>Your vault</h2>
+      <p>Your account isn't assigned to a vault yet. Ask the hub operator
+         to assign one.</p>
+    </section>`;
+}
+
+interface AccountCardOpts {
+  username: string;
+  csrfToken: string;
+}
+
+function renderAccountCard(opts: AccountCardOpts): string {
+  const { username, csrfToken } = opts;
+  return `
+    <section class="section" data-testid="account-card">
+      <h2>Account</h2>
+      <dl class="kv">
+        <dt>Username</dt>
+        <dd><code>${username}</code></dd>
+      </dl>
+      <p>
+        <a class="account-action" href="/account/change-password" data-testid="change-password-link">Change password →</a>
+      </p>
+      <form method="POST" action="/logout" class="signout-form" data-testid="signout-form">
+        ${renderCsrfHiddenInput(csrfToken)}
+        <button type="submit" class="btn btn-secondary">Sign out</button>
+      </form>
+    </section>`;
+}
+
+// --- styles ---------------------------------------------------------------
+//
+// Same brand palette + font stack as account-change-password-ui.ts so the
+// `/account/*` family is visually cohesive. Extra rules (.section, .kv,
+// .vault-name, .custom-client, .hub-origin-line) describe the new card +
+// disclosure shapes this page introduces.
+
+const STYLES = `
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: ${FONT_SANS};
+    background: ${PALETTE.bg};
+    color: ${PALETTE.fg};
+    line-height: 1.55;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  main {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 2rem 1.5rem;
+  }
+  .card {
+    width: 100%;
+    max-width: 34rem;
+    background: ${PALETTE.cardBg};
+    border: 1px solid ${PALETTE.border};
+    border-radius: 12px;
+    padding: 2rem 1.75rem;
+    box-shadow: 0 1px 2px rgba(44, 42, 38, 0.04), 0 8px 24px rgba(44, 42, 38, 0.06);
+  }
+  .card-header { margin-bottom: 1.5rem; }
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: ${PALETTE.accent};
+    font-weight: 500;
+    font-size: 0.95rem;
+    margin-bottom: 1.25rem;
+  }
+  .brand-mark { display: inline-flex; line-height: 0; }
+  .brand-mark svg { width: 20px; height: 20px; }
+  .brand-name { letter-spacing: 0.01em; }
+  .brand-tag {
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 0.7rem;
+    color: ${PALETTE.fgMuted};
+    border: 1px solid ${PALETTE.borderLight};
+    padding: 0.05rem 0.4rem;
+    border-radius: 999px;
+  }
+  h1 {
+    font-family: ${FONT_SERIF};
+    font-weight: 400;
+    font-size: 1.6rem;
+    line-height: 1.2;
+    margin: 0 0 0.4rem;
+    color: ${PALETTE.fg};
+  }
+  h2 {
+    font-family: ${FONT_SERIF};
+    font-weight: 400;
+    font-size: 1.15rem;
+    line-height: 1.25;
+    margin: 0 0 0.6rem;
+    color: ${PALETTE.fg};
+  }
+  .subtitle { margin: 0; color: ${PALETTE.fgMuted}; font-size: 0.95rem; }
+
+  .section {
+    border-top: 1px solid ${PALETTE.borderLight};
+    padding-top: 1.25rem;
+    margin-top: 1.25rem;
+  }
+  .section p { margin: 0.4rem 0; }
+  .vault-name {
+    font-family: ${FONT_MONO};
+    font-size: 1rem;
+    margin: 0 0 0.6rem;
+  }
+  .vault-name strong { color: ${PALETTE.fg}; font-weight: 600; }
+
+  .custom-client { margin-top: 0.8rem; }
+  .custom-client summary {
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: ${PALETTE.fgMuted};
+    font-family: ${FONT_MONO};
+    padding: 0.25rem 0;
+    user-select: none;
+  }
+  .custom-client[open] summary { color: ${PALETTE.fg}; }
+  .custom-client p {
+    font-size: 0.9rem;
+    color: ${PALETTE.fgMuted};
+    margin: 0.4rem 0;
+  }
+  .hub-origin-line { font-family: ${FONT_MONO}; }
+  code {
+    font-family: ${FONT_MONO};
+    background: ${PALETTE.bgSoft};
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.88em;
+  }
+
+  .kv { margin: 0 0 0.6rem; padding: 0; }
+  .kv dt {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: ${PALETTE.fgMuted};
+    font-family: ${FONT_MONO};
+    margin-top: 0.4rem;
+  }
+  .kv dd { margin: 0.15rem 0 0.4rem; }
+
+  .btn {
+    font: inherit;
+    font-weight: 500;
+    padding: 0.55rem 1rem;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    text-decoration: none;
+    display: inline-block;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  }
+  .btn-primary {
+    background: ${PALETTE.accent};
+    color: ${PALETTE.cardBg};
+  }
+  .btn-primary:hover { background: ${PALETTE.accentHover}; }
+  .btn-secondary {
+    background: transparent;
+    color: ${PALETTE.fg};
+    border-color: ${PALETTE.border};
+  }
+  .btn-secondary:hover {
+    background: ${PALETTE.bgSoft};
+    border-color: ${PALETTE.accent};
+  }
+
+  .signout-form { margin: 0.8rem 0 0; }
+
+  .account-action {
+    color: ${PALETTE.accent};
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 0.95rem;
+  }
+  .account-action:hover { color: ${PALETTE.accentHover}; text-decoration: underline; }
+
+  a { color: ${PALETTE.accent}; }
+  a:hover { color: ${PALETTE.accentHover}; }
+
+  @media (max-width: 480px) {
+    main { padding: 1rem 0.75rem; }
+    .card { padding: 1.5rem 1.25rem; border-radius: 10px; }
+    h1 { font-size: 1.4rem; }
+    h2 { font-size: 1.05rem; }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    body { background: #1a1815; color: #e8e4dc; }
+    .card { background: #25221d; border-color: #3a362f; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3); }
+    h1, h2 { color: #f0ece4; }
+    .subtitle, .kv dt, .custom-client summary { color: #a8a29a; }
+    .vault-name strong { color: #f0ece4; }
+    code { background: #1f1c18; color: #e8e4dc; }
+    .section { border-top-color: #3a362f; }
+    .brand-tag { border-color: #3a362f; color: #a8a29a; }
+    .btn-secondary { color: #e8e4dc; border-color: #3a362f; }
+    .btn-secondary:hover { background: #1f1c18; border-color: ${PALETTE.accent}; }
+  }
+`;
+
+// Silence "unused" warnings for tokens the renderer pulls in conditionally
+// — `escapeAttr` is reserved for a forthcoming "use a custom client"
+// payload that wants attribute-safe strings; keeping the helper resident
+// matches the pattern in account-change-password-ui.ts.
+export const __internal = { escapeAttr };

--- a/src/account-home-ui.ts
+++ b/src/account-home-ui.ts
@@ -46,10 +46,6 @@ const FONT_SERIF = `Georgia, "Times New Roman", serif`;
 const FONT_SANS = `-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`;
 const FONT_MONO = `ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", monospace`;
 
-function escapeAttr(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
-}
-
 function baseDocument(title: string, body: string): string {
   return `<!doctype html>
 <html lang="en">
@@ -406,9 +402,3 @@ const STYLES = `
     .btn-secondary:hover { background: #1f1c18; border-color: ${PALETTE.accent}; }
   }
 `;
-
-// Silence "unused" warnings for tokens the renderer pulls in conditionally
-// — `escapeAttr` is reserved for a forthcoming "use a custom client"
-// payload that wants attribute-safe strings; keeping the helper resident
-// matches the pattern in account-change-password-ui.ts.
-export const __internal = { escapeAttr };

--- a/src/admin-handlers.ts
+++ b/src/admin-handlers.ts
@@ -47,8 +47,12 @@ function redirect(location: string, extra: Record<string, string> = {}): Respons
  * `/admin/vaults` as its home (vault list, the default tab). Anywhere else
  * would either bounce the operator out of the SPA shell or land on a
  * legacy server-rendered page — `/admin/vaults` is the canonical entry.
+ *
+ * Exported because `api-account.ts` consumes the same constant for its
+ * change-password landing. Single source of truth so a future "default
+ * landing changed to /admin/dashboard" PR doesn't drift across two files.
  */
-const POST_LOGIN_DEFAULT = "/admin/vaults";
+export const POST_LOGIN_DEFAULT = "/admin/vaults";
 
 /**
  * Force-change-password landing. Multi-user Phase 1 PR 3: when a user

--- a/src/admin-handlers.ts
+++ b/src/admin-handlers.ts
@@ -23,7 +23,13 @@ import {
   deleteSession,
   parseSessionCookie,
 } from "./sessions.ts";
-import { PASSWORD_MAX_LEN, type User, getUserByUsername, verifyPassword } from "./users.ts";
+import {
+  PASSWORD_MAX_LEN,
+  type User,
+  getUserByUsername,
+  isFirstAdmin,
+  verifyPassword,
+} from "./users.ts";
 
 function htmlResponse(body: string, status = 200, extra: Record<string, string> = {}): Response {
   return new Response(body, {
@@ -75,22 +81,44 @@ function safeNext(raw: string | null): string {
  * boundary — once changed, no per-request scope check is needed and
  * no token claim carries the bit forward.
  *
- * When `password_changed === false`:
- *   - redirect to `/account/change-password`
- *   - preserve the user's intended `next` as a query param so the
- *     change-password POST can finish the trip
+ * Three precedence rules, in order:
  *
- * When `password_changed === true`: return `next` (today's behavior).
+ *   1. `password_changed === false` → `/account/change-password`
+ *      (preserves `next` as a query param so the change-password POST
+ *      finishes the trip).
+ *   2. Non-admin user (friend) whose `next` targets `/admin/*` → rewrite
+ *      to `/account/`. Friends have no business on admin SPA URLs —
+ *      `/admin/host-admin-token` would 403 (first-admin gate) and the
+ *      SPA would bounce them to `/account/` anyway. Doing the rewrite
+ *      at the login boundary avoids the bouncing-around UX. Other `next`
+ *      paths (`/`, `/oauth/authorize/...`, `/vault/...`) are legitimate
+ *      destinations for non-admin users and pass through unchanged.
+ *   3. Otherwise return `next` (the today's-default behavior).
+ *
+ * `db` is required for the non-admin check (it consults `getFirstAdminId`).
+ * Wizard-only test fixtures that pre-existed the `db` plumbing pass the
+ * harness DB through; the parameter is non-optional to make the
+ * "did you remember the gate?" review check explicit.
  */
-export function loginRedirectTarget(user: User, next: string): string {
-  if (user.passwordChanged) return next;
-  // Preserve the operator's intended destination; the change-password
-  // POST will read this and 302 there after the change lands.
-  // Only encode `next` if it isn't already the post-change default —
-  // keeps the URL clean for the common case (no `next` param specified
-  // at login time → no `?next=` on the change-password URL).
-  if (next === POST_LOGIN_DEFAULT) return FORCE_CHANGE_PASSWORD_PATH;
-  return `${FORCE_CHANGE_PASSWORD_PATH}?next=${encodeURIComponent(next)}`;
+export function loginRedirectTarget(db: Database, user: User, next: string): string {
+  if (!user.passwordChanged) {
+    // Preserve the operator's intended destination; the change-password
+    // POST will read this and 302 there after the change lands.
+    // Only encode `next` if it isn't already the post-change default —
+    // keeps the URL clean for the common case (no `next` param specified
+    // at login time → no `?next=` on the change-password URL).
+    if (next === POST_LOGIN_DEFAULT) return FORCE_CHANGE_PASSWORD_PATH;
+    return `${FORCE_CHANGE_PASSWORD_PATH}?next=${encodeURIComponent(next)}`;
+  }
+  // Non-admin friend aiming at admin SPA: rewrite to /account/. We check
+  // both the literal `/admin` and the `/admin/...` prefix; safeNext has
+  // already normalized to a leading-`/` same-origin path, so a plain
+  // string prefix check is sufficient (no `//admin.evil.com/` shape can
+  // reach here).
+  if (!isFirstAdmin(db, user.id) && (next === "/admin" || next.startsWith("/admin/"))) {
+    return "/account/";
+  }
+  return next;
 }
 
 // --- /login ---------------------------------------------------------------
@@ -193,7 +221,7 @@ export async function handleAdminLoginPost(
   // to change the admin-typed default before continuing. Their original
   // `next` rides along on the change-password URL so the post-change
   // POST can land them at their intended destination.
-  const target = loginRedirectTarget(user, next);
+  const target = loginRedirectTarget(db, user, next);
   return redirect(target, { "set-cookie": cookie });
 }
 

--- a/src/admin-host-admin-token.ts
+++ b/src/admin-host-admin-token.ts
@@ -25,6 +25,16 @@
  *   - this endpoint requires a valid `parachute_hub_session` cookie, which
  *     was set by `/login` after a password check.
  *
+ * **First-admin gate (multi-user Phase 1 follow-up).** A valid session is
+ * necessary but NOT sufficient. The session must belong to the hub admin
+ * (the earliest-created user row, per `getFirstAdminId` in users.ts).
+ * Without this gate, any signed-in friend account created via PR 2's
+ * `/api/users` could hit this endpoint and walk away with a JWT carrying
+ * `parachute:host:admin` + `parachute:host:auth` — a full-admin privesc,
+ * since both scopes are the SPA's gate-bypass into vault provisioning,
+ * grant management, and the token registry. The SPA-side mirror is in
+ * `web/ui/src/lib/auth.ts`: 403 → redirect to `/account/`.
+ *
  * Tokens minted here are deliberately NOT persisted in the `tokens` table
  * (no refresh, no revocation tracking). They expire on their own; the SPA
  * re-fetches when the JWT is about to lapse.
@@ -39,6 +49,7 @@
 import type { Database } from "bun:sqlite";
 import { signAccessToken } from "./jwt-sign.ts";
 import { findSession, parseSessionCookie } from "./sessions.ts";
+import { isFirstAdmin } from "./users.ts";
 
 /** Short TTL — page-snapshot threats can't carry the token forever. */
 export const HOST_ADMIN_TOKEN_TTL_SECONDS = 10 * 60;
@@ -63,6 +74,20 @@ export async function handleHostAdminToken(
   const session = sid ? findSession(deps.db, sid) : null;
   if (!session) {
     return jsonError(401, "unauthenticated", "no admin session — sign in at /login first");
+  }
+  // First-admin gate. A friend account (non-first-admin user created via
+  // `/api/users`) holds a valid session but must not be able to mint
+  // host-admin scopes. Without this check, any signed-in friend hitting
+  // `GET /admin/host-admin-token` would walk away with a JWT carrying
+  // `parachute:host:admin` + `parachute:host:auth` — full admin access.
+  // The 403 here is mirrored on the SPA side in `web/ui/src/lib/auth.ts`:
+  // 403 → redirect to `/account/` (the friend's home).
+  if (!isFirstAdmin(deps.db, session.userId)) {
+    return jsonError(
+      403,
+      "not_admin",
+      "host-admin token mint is restricted to the hub admin — your account home is at /account/",
+    );
   }
   const minted = await signAccessToken(deps.db, {
     sub: session.userId,

--- a/src/admin-vault-admin-token.ts
+++ b/src/admin-vault-admin-token.ts
@@ -18,10 +18,16 @@
  * masking a typo as a real (but unusable) credential. Resolved via the
  * already-built well-known doc — same source of truth the SPA's vault list
  * reads.
+ *
+ * Multi-user Phase 1 gate: the session must belong to the first admin (the
+ * single hub admin under the Phase 1 model — see `users.ts:isFirstAdmin`).
+ * Friends pinned to a vault use the OAuth flow to get vault:<name>:read/write
+ * for their assigned vault; they don't get vault admin via this endpoint.
  */
 import type { Database } from "bun:sqlite";
 import { signAccessToken } from "./jwt-sign.ts";
 import { findSession, parseSessionCookie } from "./sessions.ts";
+import { isFirstAdmin } from "./users.ts";
 
 /** Short TTL — matches host-admin-token. SPA re-fetches on near-expiry. */
 export const VAULT_ADMIN_TOKEN_TTL_SECONDS = 10 * 60;
@@ -56,6 +62,17 @@ export async function handleVaultAdminToken(
   const session = sid ? findSession(deps.db, sid) : null;
   if (!session) {
     return jsonError(401, "unauthenticated", "no admin session — sign in at /login first");
+  }
+  // Multi-user Phase 1 privesc gate (mirrors host-admin-token). vault:<name>:admin
+  // is the per-vault operator scope used by the vault admin SPA — friends pinned
+  // to a vault get vault:<name>:read/write via OAuth, never admin. Without this
+  // gate, any signed-in friend can mint a vault admin token for any vault.
+  if (!isFirstAdmin(deps.db, session.userId)) {
+    return jsonError(
+      403,
+      "not_admin",
+      "vault admin token mint is restricted to the hub admin — your account home is at /account/",
+    );
   }
   const scope = `vault:${vaultName}:admin`;
   // Per-vault audience: vault validates the JWT's `aud` claim against

--- a/src/api-account.ts
+++ b/src/api-account.ts
@@ -48,6 +48,7 @@
 import type { Database } from "bun:sqlite";
 import { hash as argonHash } from "@node-rs/argon2";
 import { type ChangePasswordMode, renderChangePassword } from "./account-change-password-ui.ts";
+import { renderAccountHome } from "./account-home-ui.ts";
 import { renderAdminError } from "./admin-login-ui.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
 import { changePasswordRateLimiter } from "./rate-limit.ts";
@@ -57,6 +58,7 @@ import {
   PASSWORD_MAX_LEN,
   UserNotFoundError,
   getUserById,
+  isFirstAdmin,
   validatePassword,
   verifyPassword,
 } from "./users.ts";
@@ -435,6 +437,58 @@ export async function handleAccountChangePasswordPost(
     "cache-control": "no-store",
     "x-secure-context": isHttpsRequest(req) ? "https" : "http",
   });
+}
+
+/**
+ * GET /account/ — friend-facing user home (multi-user Phase 1 follow-up).
+ *
+ * Companion surface to the first-admin gate on
+ * `/admin/host-admin-token`: friend users who can't reach the admin
+ * SPA need a coherent landing page that shows their assigned vault, a
+ * sign-out form, and a link to rotate their password. The admin lands
+ * here too (via the SPA's 403 redirect path) but mostly bounces back
+ * to `/admin/` immediately — for admins this is a "wait, what?" exit
+ * ramp.
+ *
+ * Auth: requires an active session. Session-less requests 302 to
+ * `/login?next=/account/` — same posture as `handleAccountChangePasswordGet`.
+ *
+ * `hubOrigin` is passed in by the route handler (resolved per-request
+ * via `resolveIssuer` in `hub-server.ts`). The page uses it to build
+ * the canonical Notes "Open" CTA URL and to show as inline code in
+ * the "use a custom client" disclosure.
+ */
+export interface AccountHomeDeps extends ApiAccountDeps {
+  /** Canonical hub origin for this request (e.g. `https://my-hub.example`). */
+  hubOrigin: string;
+}
+
+export function handleAccountHomeGet(req: Request, deps: AccountHomeDeps): Response {
+  const session = findActiveSession(deps.db, req);
+  if (!session) {
+    return redirect(`/login?next=${encodeURIComponent("/account/")}`);
+  }
+  const user = getUserById(deps.db, session.userId);
+  if (!user) {
+    // Stale session pointing at a deleted user — hand back to /login;
+    // the orphaned session row will time out on its own.
+    return redirect("/login");
+  }
+  const adminFlag = isFirstAdmin(deps.db, user.id);
+  const csrf = ensureCsrfToken(req);
+  const extra: Record<string, string> = csrf.setCookie ? { "set-cookie": csrf.setCookie } : {};
+  return htmlResponse(
+    renderAccountHome({
+      username: user.username,
+      assignedVault: user.assignedVault,
+      passwordChanged: user.passwordChanged,
+      hubOrigin: deps.hubOrigin,
+      isFirstAdmin: adminFlag,
+      csrfToken: csrf.token,
+    }),
+    200,
+    extra,
+  );
 }
 
 /**

--- a/src/api-account.ts
+++ b/src/api-account.ts
@@ -49,6 +49,7 @@ import type { Database } from "bun:sqlite";
 import { hash as argonHash } from "@node-rs/argon2";
 import { type ChangePasswordMode, renderChangePassword } from "./account-change-password-ui.ts";
 import { renderAccountHome } from "./account-home-ui.ts";
+import { POST_LOGIN_DEFAULT } from "./admin-handlers.ts";
 import { renderAdminError } from "./admin-login-ui.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
 import { changePasswordRateLimiter } from "./rate-limit.ts";
@@ -71,12 +72,10 @@ export interface ApiAccountDeps {
 
 /**
  * Where to land after a successful password change when no `next` param
- * is present. Matches `POST_LOGIN_DEFAULT` in `admin-handlers.ts` — the
- * admin SPA's vault list. Kept as a local const (not imported) so this
- * file doesn't accidentally couple to admin-handlers' internals; if the
- * default ever diverges the two should reconcile via a shared config.
+ * is present. Re-exported from `admin-handlers.ts` so login + change-
+ * password share a single source of truth (reviewer fold on hub#425).
  */
-const POST_CHANGE_DEFAULT = "/admin/vaults";
+const POST_CHANGE_DEFAULT = POST_LOGIN_DEFAULT;
 
 function safeNext(raw: string | null | undefined): string {
   if (!raw) return POST_CHANGE_DEFAULT;

--- a/src/api-users.ts
+++ b/src/api-users.ts
@@ -45,6 +45,7 @@ import {
   UsernameTakenError,
   createUser,
   deleteUser,
+  getFirstAdminId,
   getUserById,
   getUserByUsernameCI,
   listUsers,
@@ -324,10 +325,13 @@ export async function handleDeleteUser(
   // by a state conflict — RFC 7231 §6.5.3 fits cleaner than §6.5.8.
   // Either is defensible; the wire `error` string is the part the SPA
   // matches on for the "first admin can't be deleted" surface).
-  const firstAdminRow = deps.db
-    .query<{ id: string }, []>("SELECT id FROM users ORDER BY created_at ASC LIMIT 1")
-    .get();
-  if (firstAdminRow && firstAdminRow.id === userId) {
+  //
+  // The `getFirstAdminId` helper (users.ts) is the single source of
+  // truth for "who is the admin" — same SELECT also gates the SPA
+  // bearer-mint endpoint (admin-host-admin-token.ts) and drives the
+  // non-admin login-redirect default.
+  const firstAdminId = getFirstAdminId(deps.db);
+  if (firstAdminId && firstAdminId === userId) {
     return jsonError(
       403,
       "first_admin_undeletable",

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -117,7 +117,11 @@ import {
 import { handleHostAdminToken } from "./admin-host-admin-token.ts";
 import { handleVaultAdminToken } from "./admin-vault-admin-token.ts";
 import { handleCreateVault } from "./admin-vaults.ts";
-import { handleAccountChangePasswordGet, handleAccountChangePasswordPost } from "./api-account.ts";
+import {
+  handleAccountChangePasswordGet,
+  handleAccountChangePasswordPost,
+  handleAccountHomeGet,
+} from "./api-account.ts";
 import { handleApiHub } from "./api-hub.ts";
 import { handleApiMe } from "./api-me.ts";
 import { handleApiMintToken } from "./api-mint-token.ts";
@@ -266,10 +270,7 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
   if (hostname === undefined) hostname = env.PARACHUTE_BIND_HOST || "127.0.0.1";
   if (wellKnownDir === undefined) wellKnownDir = WELL_KNOWN_DIR;
   if (issuer === undefined) {
-    const fromEnv =
-      env.PARACHUTE_HUB_ORIGIN ??
-      env.RENDER_EXTERNAL_URL ??
-      flyDefaultOrigin(env);
+    const fromEnv = env.PARACHUTE_HUB_ORIGIN ?? env.RENDER_EXTERNAL_URL ?? flyDefaultOrigin(env);
     if (fromEnv) issuer = fromEnv.replace(/\/+$/, "") || undefined;
   }
   return { port, hostname, wellKnownDir, dbPath: dbPath ?? hubDbPath(), issuer };
@@ -1118,8 +1119,7 @@ export function hubFetch(
           // browser POSTs and must be trusted even when the operator's
           // configured issuer points elsewhere. See origin-check.ts
           // jsdoc for the failure case this closes.
-          platformOrigin:
-            process.env.RENDER_EXTERNAL_URL ?? flyDefaultOrigin(process.env),
+          platformOrigin: process.env.RENDER_EXTERNAL_URL ?? flyDefaultOrigin(process.env),
         }),
     };
   };
@@ -1959,6 +1959,24 @@ export function hubFetch(
       if (req.method === "GET") return handleAccountChangePasswordGet(req, accountDeps);
       if (req.method === "POST") return handleAccountChangePasswordPost(req, accountDeps);
       return new Response("method not allowed", { status: 405 });
+    }
+
+    // /account/ — friend-facing user home (multi-user Phase 1 follow-up).
+    // Companion to the first-admin gate on `/admin/host-admin-token`: a
+    // signed-in non-admin (friend) lands here instead of bouncing against
+    // a 403 wall on the admin SPA. Admin users also land here when they
+    // hit `/account/` directly, with a "you're the administrator → /admin/"
+    // exit ramp. Bare `/account` 301-redirects to `/account/` so links
+    // without the trailing slash work.
+    if (pathname === "/account" || pathname === "/account/") {
+      if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
+      if (pathname === "/account") {
+        return new Response(null, { status: 301, headers: { location: "/account/" } });
+      }
+      if (!getDb) return dbNotConfigured();
+      const db = getDb();
+      const hubOrigin = resolveIssuer(req, db, configuredIssuer);
+      return handleAccountHomeGet(req, { db, hubOrigin });
     }
 
     // Legacy `/admin/config` (server-rendered module-config portal, #46)

--- a/src/users.ts
+++ b/src/users.ts
@@ -188,6 +188,41 @@ export function userCount(db: Database): number {
   return (db.query<{ n: number }, []>("SELECT COUNT(*) AS n FROM users").get() ?? { n: 0 }).n;
 }
 
+/**
+ * Single source of truth for "who is *the* admin in Phase 1." The
+ * earliest-created user row is the wizard or env-seeded admin by
+ * construction — Phase 1 has no role model, so the first row is the
+ * hub administrator. Used by:
+ *
+ *   - `api-users.ts` for the first-admin-undeletable rail (the only
+ *     user who can't be deleted, since deleting them would self-lock
+ *     the hub).
+ *   - `admin-host-admin-token.ts` to gate the SPA-bearer mint endpoint
+ *     to the admin only — any signed-in non-admin friend hitting it
+ *     would otherwise get a JWT carrying `parachute:host:admin` +
+ *     `parachute:host:auth`, a full-admin privesc (multi-user Phase 1
+ *     friend-account follow-up).
+ *   - `admin-handlers.ts` for the login-redirect default — non-admin
+ *     users targeting `/admin/*` get redirected to `/account/` instead
+ *     of a 403 wall.
+ *
+ * Returns `null` only when the users table is empty (pre-wizard state).
+ */
+export function getFirstAdminId(db: Database): string | null {
+  const row = db
+    .query<{ id: string }, []>("SELECT id FROM users ORDER BY created_at ASC LIMIT 1")
+    .get();
+  return row?.id ?? null;
+}
+
+/**
+ * Convenience predicate over `getFirstAdminId`. Caller sites read
+ * cleaner as `isFirstAdmin(db, userId)` than `getFirstAdminId(db) === userId`.
+ */
+export function isFirstAdmin(db: Database, userId: string): boolean {
+  return getFirstAdminId(db) === userId;
+}
+
 export async function verifyPassword(user: User, password: string): Promise<boolean> {
   return argonVerify(user.passwordHash, password);
 }

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -69,6 +69,20 @@ export function redirectToLoginAndHang<T>(): Promise<T> {
 }
 
 /**
+ * Navigate to `/account/` (the friend-facing user home) and hang. Mirrors
+ * `redirectToLoginAndHang`'s tear-down posture: returning a never-resolving
+ * promise so SPA-route continuations don't render against a missing token.
+ *
+ * Fired on a 403 from `/admin/host-admin-token` — the hub's first-admin
+ * gate. A non-admin signed-in user landing on the admin SPA URL gets
+ * bounced to their own home rather than seeing a broken admin shell.
+ */
+export function redirectToAccountAndHang<T>(): Promise<T> {
+  window.location.replace("/account/");
+  return new Promise<T>(() => {});
+}
+
+/**
  * Returns the cached host-admin JWT, refreshing it if it's about to expire
  * (or if we don't have one yet). Concurrent callers share the in-flight
  * fetch — we don't want a burst of API calls to mint a token each.
@@ -98,6 +112,13 @@ async function fetchToken(): Promise<string> {
   if (res.status === 401) {
     cached = null;
     return redirectToLoginAndHang<string>();
+  }
+  if (res.status === 403) {
+    // First-admin gate: a signed-in non-admin (friend) is on an /admin/*
+    // URL they can't use. Send them to their account home rather than
+    // letting the SPA render an authenticated-but-broken shell.
+    cached = null;
+    return redirectToAccountAndHang<string>();
   }
   if (!res.ok) {
     throw new Error(`/admin/host-admin-token failed: ${res.status} ${await res.text()}`);


### PR DESCRIPTION
## Summary

Closes a privesc gap and ships a coherent friend-facing landing surface for multi-user Phase 1 — single PR because the gate and the UX surface together form the friend-account contract.

### The privesc

`GET /admin/host-admin-token` only checked for a session, not for *whose* session. Any signed-in friend account created via PR 2's `/api/users` could mint a JWT carrying `parachute:host:admin` + `parachute:host:auth` — the SPA bearer that gates vault provisioning, grant management, and the token registry. Both scopes are in `NON_REQUESTABLE_SCOPES`, so this endpoint was the *only* mint path — which made it the *only* privesc path too.

**Closure**: handler now calls `isFirstAdmin(db, session.userId)` and returns `403 {"error":"not_admin", ...}` to non-admin sessions. SPA side mirrors via `web/ui/src/lib/auth.ts:fetchToken` — 403 → `redirectToAccountAndHang()`, the same shape as the existing 401 → /login flow.

### The UX gap

With the gate closed, friends needed a landing surface. New `GET /account/`:

- Welcome + nav
- **Vault card** — assigned vault name, "Open Notes" CTA pointing at `notes.parachute.computer/add?url=<hub>/vault/<name>` (same shape the setup wizard uses), plus a "use a custom client" disclosure showing the hub origin as inline code
- **Account card** — change-password link, sign-out form (CSRF-gated POST /logout)

Admin users hitting `/account/` see an "open admin" exit ramp instead of a broken shell. Login redirect also rewrites `next=/admin/*` to `/account/` for friends, but leaves legitimate non-/admin destinations (`/`, `/oauth/authorize/...`, `/vault/...`) intact so OAuth user-consent still works.

### Single source of truth

Three call sites now need "who is the admin": the existing first-admin-undeletable rail in `/api/users`, the new host-admin-token gate, and the login-redirect rewrite. Lifted to `getFirstAdminId` / `isFirstAdmin` helpers in `users.ts`. Phase 2's multi-admin role model will grow more callers; centralizing now keeps the surface auditable.

## Why this is one PR, not two

The gate without the surface gives friends a 403 wall. The surface without the gate ships a privesc. The two together form the friend-account contract.

## Test gate counts

- `bun test ./src` → **2102 pass / 1 skip / 0 fail** (+18 net new tests across `users.test`, `admin-host-admin-token.test`, `account-home-ui.test`, `api-account.test`, `admin-handlers.test`)
- `bun run typecheck` → clean (per the rc.36 → rc.37 lesson — local bun test passes don't imply CI tsc-strict passes; ran both)
- `biome check --write` on touched files → clean

No version bump (RC bump + tag happen together when shipping).

## Patterns check

- **`patterns/governance.md`** — reviewer-gated, no auto-merge; PR doesn't bump rc.N (correct for current discipline)
- **`patterns/post-merge-hygiene.md`** — N/A, this PR is the change itself
- Touches the multi-user Phase 1 surface; doesn't change the design doc (the gap was a follow-up, not a redesign)

## Test plan

- [ ] Admin signs in via `/login` → lands on `/admin/vaults` (existing behavior unchanged)
- [ ] Friend (admin-created via /api/users, passwordChanged=true) signs in → lands on `/account/` if `next` was `/admin/*`, else honors `next`
- [ ] Friend hits `/admin/users` directly → SPA loads, calls `/admin/host-admin-token`, gets 403, SPA bounces to `/account/`
- [ ] Friend on `/account/` clicks "Open Notes" → `notes.parachute.computer/add?url=...` opens in new tab with the vault URL prefilled
- [ ] Friend on `/account/` clicks "Sign out" → POST /logout succeeds, lands on `/login`
- [ ] Friend on `/account/` clicks "Change password" → existing `/account/change-password` rotate flow renders
- [ ] Admin hits `/account/` directly → sees "you're the administrator → /admin/" with a working link

🤖 Generated with [Claude Code](https://claude.com/claude-code)