### PR TITLE
fix(account): change-password lands non-admin users at /account/ directly

### DIFF
--- a/src/__tests__/api-account.test.ts
+++ b/src/__tests__/api-account.test.ts
@@ -306,6 +306,58 @@ describe("POST /account/change-password", () => {
     expect(res.headers.get("location")).toBe("/account/");
   });
 
+  test("non-admin user with non-admin next= passes through unchanged", async () => {
+    // Friends with a legitimate non-admin destination (e.g. /oauth/authorize
+    // mid-flow) should land where they intended — the rewrite only catches
+    // /admin/* targets.
+    await createUser(harness.db, "operator", "operator-strong-passphrase");
+    const { cookie } = await sessionCookieFor(harness.db, "friend", "old-default-pw", {
+      passwordChanged: false,
+      allowMulti: true,
+    });
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      current_password: "old-default-pw",
+      new_password: "user-chosen-strong-passphrase",
+      new_password_confirm: "user-chosen-strong-passphrase",
+      next: "/oauth/authorize?client_id=abc",
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/oauth/authorize?client_id=abc");
+  });
+
+  test("non-admin with exact next=/admin (no trailing slash) rewrites to /account/", async () => {
+    // Pins the exact-match arm of the prefix gate. Tests in #426 cover
+    // /admin/users (prefix match) and the no-next case (POST_CHANGE_DEFAULT
+    // → rewrite). This is the third arm.
+    await createUser(harness.db, "operator", "operator-strong-passphrase");
+    const { cookie } = await sessionCookieFor(harness.db, "friend", "old-default-pw", {
+      passwordChanged: false,
+      allowMulti: true,
+    });
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      current_password: "old-default-pw",
+      new_password: "user-chosen-strong-passphrase",
+      new_password_confirm: "user-chosen-strong-passphrase",
+      next: "/admin",
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/account/");
+  });
+
   test("first admin with no next still defaults to /admin/vaults", async () => {
     // Existing behavior — preserved by the non-admin gate. The first user
     // is the admin under Phase 1; admin SPA is the intended landing.

--- a/src/__tests__/api-account.test.ts
+++ b/src/__tests__/api-account.test.ts
@@ -257,7 +257,58 @@ describe("POST /account/change-password", () => {
     }
   });
 
-  test("missing next defaults to /admin/vaults", async () => {
+  test("non-admin user with no next defaults to /account/ (no admin-shell flash)", async () => {
+    // Without this rewrite, a friend's change-password POST would 302 to
+    // /admin/vaults, the SPA would load, the 403 from
+    // /admin/host-admin-token would bounce them to /account/ — a visible
+    // two-hop flash. Mirror the login-redirect rewrite in admin-handlers.ts.
+    await createUser(harness.db, "operator", "operator-strong-passphrase");
+    const { cookie } = await sessionCookieFor(harness.db, "friend", "old-default-pw", {
+      passwordChanged: false,
+      allowMulti: true,
+    });
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      current_password: "old-default-pw",
+      new_password: "user-chosen-strong-passphrase",
+      new_password_confirm: "user-chosen-strong-passphrase",
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/account/");
+  });
+
+  test("non-admin user with next=/admin/users gets rewritten to /account/", async () => {
+    await createUser(harness.db, "operator", "operator-strong-passphrase");
+    const { cookie } = await sessionCookieFor(harness.db, "friend", "old-default-pw", {
+      passwordChanged: false,
+      allowMulti: true,
+    });
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      current_password: "old-default-pw",
+      new_password: "user-chosen-strong-passphrase",
+      new_password_confirm: "user-chosen-strong-passphrase",
+      next: "/admin/users",
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/account/");
+  });
+
+  test("first admin with no next still defaults to /admin/vaults", async () => {
+    // Existing behavior — preserved by the non-admin gate. The first user
+    // is the admin under Phase 1; admin SPA is the intended landing.
     const { cookie } = await sessionCookieFor(harness.db, "newbie", "old-default-pw", {
       passwordChanged: false,
     });

--- a/src/api-account.ts
+++ b/src/api-account.ts
@@ -235,7 +235,20 @@ export async function handleAccountChangePasswordPost(
   const currentPassword = String(form.get("current_password") ?? "");
   const newPassword = String(form.get("new_password") ?? "");
   const confirmPassword = String(form.get("new_password_confirm") ?? "");
-  const next = safeNext(String(form.get("next") ?? ""));
+  // Friend-facing redirect: non-admin users who would otherwise land in the
+  // admin SPA (because POST_CHANGE_DEFAULT = /admin/vaults) get bounced to
+  // /account/ directly. Without this, the SPA loads, hits 403 on its host-
+  // admin-token mint, then redirects to /account/ via the SPA's auth.ts —
+  // a visible two-hop flash for the friend. The login-redirect path
+  // (admin-handlers.ts:118) does the same rewrite at sign-in time; this
+  // mirrors it for the change-password POST. (hub#425 reviewer fold —
+  // operator runbook accuracy: the doc said "lands at /account/", but
+  // without this fix the user briefly sees the admin shell.)
+  const rawNext = safeNext(String(form.get("next") ?? ""));
+  const next =
+    !isFirstAdmin(deps.db, user.id) && (rawNext === "/admin" || rawNext.startsWith("/admin/"))
+      ? "/account/"
+      : rawNext;
   const mode = modeFor(user.passwordChanged);
 
   // Rate-limit gate (hub#282). Fires *after* CSRF (so a junk cross-site


### PR DESCRIPTION
## Summary

Follow-up to hub#425 caught by the reviewer on parachute.computer#67 (the multi-user operator runbook).

The operator runbook claims a friend "lands at /account/ after changing their password." Functionally true, but the actual chain was a visible two-hop:

```
POST /account/change-password (friend, no `next`)
  → 302 to POST_CHANGE_DEFAULT = /admin/vaults
  → SPA loads, calls GET /admin/host-admin-token
  → 403 (first-admin gate from #425)
  → SPA's auth.ts: redirectToAccountAndHang() → /account/
```

A brief flash of the admin shell, more visible on slow connections.

The fix mirrors the login-redirect rewrite from `admin-handlers.ts:118` (also landed in #425): if the session is a non-first-admin AND the resolved `next` would land in `/admin/*`, substitute `/account/` at the 302 boundary in `api-account.ts:238`.

Now: `POST /account/change-password → 302 /account/` — one hop.

First admin's path is unchanged (`next` → /admin/vaults).

## Test plan

- [x] `bun test ./src` → 2106 pass / 1 skip (+2 net new tests for the friend rewrite)
- [x] `bun run typecheck` → clean
- [x] `biome check` → clean
- [x] Renamed existing "missing next defaults to /admin/vaults" test → "first admin with no next still defaults to /admin/vaults" to keep the existing assertion + clarify the now-conditional behavior
- [ ] Reviewer to confirm the rewrite is path-prefix correct (no `/administrator` false-match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)