### PR TITLE
chore(release): 0.5.14-rc.1 — kick off rc chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.13",
-  "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
+  "version": "0.5.14-rc.1",
+  "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Bump to 0.5.14-rc.1 for the multi-user Phase 1+2 chain. Aaron-authorized 2026-05-27 ("push all things up to rc").

Code-touching PRs since v0.5.13:

- #422 rename(hub-side): app → surface
- #423 fix(status): treat HTTP 401 as healthy
- #424 feat(wizard): scribe-fold + notes.parachute.computer CTA + starter prompts
- #425 feat(hub): friend-facing /account/ home + first-admin gate
- #426 fix(account): change-password lands non-admin users at /account/ directly
- #427 feat(hub): admin password reset for users (Phase 2 PR 1)

Next patch from v0.5.13 stable per parachute-patterns governance rule 2.

## Test plan

- [x] All bundled PRs already merged with green CI
- [x] Local `bun test ./src` → 2125 pass / 1 skip on PR 427's branch (the most recent diff state)
- [ ] Tag push v0.5.14-rc.1 after merge → CI publishes to npm @rc

🤖 Generated with [Claude Code](https://claude.com/claude-code)