### PR TITLE
feat(hub): multi-vault membership per user (multi-user Phase 2 PR 2)

### DIFF
--- a/src/__tests__/account-home-ui.test.ts
+++ b/src/__tests__/account-home-ui.test.ts
@@ -22,7 +22,7 @@ describe("renderAccountHome", () => {
   test("assigned-vault branch — Notes CTA carries the encoded hub+vault URL", () => {
     const html = renderAccountHome({
       username: "alice",
-      assignedVault: "alice",
+      assignedVaults: ["alice"],
       passwordChanged: true,
       hubOrigin: HUB_ORIGIN,
       isFirstAdmin: false,
@@ -49,7 +49,7 @@ describe("renderAccountHome", () => {
     // renderer must produce a clean `/vault/<name>` join either way.
     const html = renderAccountHome({
       username: "alice",
-      assignedVault: "alice",
+      assignedVaults: ["alice"],
       passwordChanged: true,
       hubOrigin: `${HUB_ORIGIN}/`,
       isFirstAdmin: false,
@@ -65,7 +65,7 @@ describe("renderAccountHome", () => {
   test("admin branch — null assignedVault + isFirstAdmin renders an /admin/ link", () => {
     const html = renderAccountHome({
       username: "admin",
-      assignedVault: null,
+      assignedVaults: [],
       passwordChanged: true,
       hubOrigin: HUB_ORIGIN,
       isFirstAdmin: true,
@@ -85,7 +85,7 @@ describe("renderAccountHome", () => {
     // state via hand-edit or migration race.
     const html = renderAccountHome({
       username: "ghost",
-      assignedVault: null,
+      assignedVaults: [],
       passwordChanged: true,
       hubOrigin: HUB_ORIGIN,
       isFirstAdmin: false,
@@ -102,7 +102,7 @@ describe("renderAccountHome", () => {
   test("account card — change-password link and sign-out form are present", () => {
     const html = renderAccountHome({
       username: "alice",
-      assignedVault: "alice",
+      assignedVaults: ["alice"],
       passwordChanged: true,
       hubOrigin: HUB_ORIGIN,
       isFirstAdmin: false,
@@ -120,6 +120,29 @@ describe("renderAccountHome", () => {
     expect(html).toContain("<code>alice</code>");
   });
 
+  test("multi-vault branch — renders one tile per assigned vault (Phase 2 PR 2)", () => {
+    const html = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["personal", "family"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+    });
+    // Plural heading.
+    expect(html).toContain("Your vaults");
+    // Each vault name appears.
+    expect(html).toContain("<strong>personal</strong>");
+    expect(html).toContain("<strong>family</strong>");
+    // One CTA per vault with the right encoded URL.
+    const personalEncoded = encodeURIComponent(`${HUB_ORIGIN}/vault/personal`);
+    const familyEncoded = encodeURIComponent(`${HUB_ORIGIN}/vault/family`);
+    expect(html).toContain(`https://notes.parachute.computer/add?url=${personalEncoded}`);
+    expect(html).toContain(`https://notes.parachute.computer/add?url=${familyEncoded}`);
+    // Hub origin block appears once at the section level, not per tile.
+    expect(html.split(`<code>${HUB_ORIGIN}</code>`).length - 1).toBe(1);
+  });
+
   test("escapes hostile content in username and vault name", () => {
     // Defense-in-depth: usernames pass validateUsername (lowercase alnum
     // + `_-`), so HTML metacharacters won't normally make it through. But
@@ -127,7 +150,7 @@ describe("renderAccountHome", () => {
     // escape is load-bearing if the validator ever loosens.
     const html = renderAccountHome({
       username: "<script>",
-      assignedVault: "<vault>",
+      assignedVaults: ["<vault>"],
       passwordChanged: true,
       hubOrigin: HUB_ORIGIN,
       isFirstAdmin: false,

--- a/src/__tests__/admin-vault-admin-token.test.ts
+++ b/src/__tests__/admin-vault-admin-token.test.ts
@@ -160,7 +160,7 @@ describe("handleVaultAdminToken", () => {
     // whole reason this gate exists.
     await createUser(harness.db, "operator", "hunter2-admin");
     const friend = await createUser(harness.db, "friend", "hunter2-friend", {
-      assignedVault: "work",
+      assignedVaults: ["work"],
       allowMulti: true,
     });
     const session = createSession(harness.db, { userId: friend.id });
@@ -182,7 +182,7 @@ describe("handleVaultAdminToken", () => {
     // happy path when there are friends in the DB.
     const admin = await createUser(harness.db, "operator", "hunter2-admin");
     await createUser(harness.db, "friend", "hunter2-friend", {
-      assignedVault: "work",
+      assignedVaults: ["work"],
       allowMulti: true,
     });
     const session = createSession(harness.db, { userId: admin.id });

--- a/src/__tests__/api-account.test.ts
+++ b/src/__tests__/api-account.test.ts
@@ -757,7 +757,7 @@ describe("handleAccountHomeGet", () => {
     const friend = await createUser(harness.db, "alice", "alice-passphrase", {
       allowMulti: true,
       passwordChanged: true,
-      assignedVault: "alice",
+      assignedVaults: ["alice"],
     });
     const session = createSession(harness.db, { userId: friend.id });
     const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
@@ -774,7 +774,7 @@ describe("handleAccountHomeGet", () => {
     expect(html).toContain(`https://notes.parachute.computer/add?url=${encoded}`);
   });
 
-  test("200 + admin branch when the first-admin signs in (assignedVault=null)", async () => {
+  test("200 + admin branch when the first-admin signs in (no vault assignments)", async () => {
     // The first-created user with no vault pin is the admin posture.
     const admin = await createUser(harness.db, "admin", "admin-passphrase", {
       passwordChanged: true,

--- a/src/__tests__/api-users.test.ts
+++ b/src/__tests__/api-users.test.ts
@@ -31,6 +31,7 @@ import {
   handleListUsers,
   handleListVaults,
   handleResetUserPassword,
+  handleUpdateUserVaults,
 } from "../api-users.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { findTokenRowByJti, recordTokenMint, signAccessToken } from "../jwt-sign.ts";
@@ -176,7 +177,7 @@ describe("handleListUsers", () => {
       expect(u).toHaveProperty("id");
       expect(u).toHaveProperty("username");
       expect(u).toHaveProperty("password_changed");
-      expect(u).toHaveProperty("assigned_vault");
+      expect(u).toHaveProperty("assigned_vaults");
       expect(u).toHaveProperty("created_at");
     }
   });
@@ -220,13 +221,13 @@ describe("handleCreateUser", () => {
     const res = await post(bearer, {
       username: "alice",
       password: "alice-strong-passphrase",
-      assignedVault: null,
+      assignedVaults: [],
     });
     expect(res.status).toBe(201);
     const body = (await res.json()) as { user: Record<string, unknown> };
     expect(body.user.username).toBe("alice");
     expect(body.user.password_changed).toBe(false);
-    expect(body.user.assigned_vault).toBeNull();
+    expect(body.user.assigned_vaults).toEqual([]);
     expect(body.user).not.toHaveProperty("password_hash");
   });
 
@@ -331,9 +332,9 @@ describe("handleCreateUser", () => {
     const stamp = "2026-05-20T00:00:00.000Z";
     harness.db
       .prepare(
-        "INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed, assigned_vault) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed) VALUES (?, ?, ?, ?, ?, ?)",
       )
-      .run("legacy-id", "Alice", "$argon2id$fake", stamp, stamp, 1, null);
+      .run("legacy-id", "Alice", "$argon2id$fake", stamp, stamp, 1);
     const { bearer } = await makeAdminBearer();
     const res = await post(bearer, {
       username: "alice",
@@ -349,25 +350,55 @@ describe("handleCreateUser", () => {
     const res = await post(bearer, {
       username: "alice",
       password: "alice-strong-passphrase",
-      assignedVault: "ghost-vault",
+      assignedVaults: ["ghost-vault"],
     });
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("assigned_vault_not_found");
   });
 
-  test("happy path with assigned_vault that exists in services.json", async () => {
+  test("happy path with single assigned_vaults that exists in services.json", async () => {
     harness.cleanup();
     harness = makeHarness(manifestWithVaults("home"));
     const { bearer } = await makeAdminBearer();
     const res = await post(bearer, {
       username: "alice",
       password: "alice-strong-passphrase",
-      assignedVault: "home",
+      assignedVaults: ["home"],
     });
     expect(res.status).toBe(201);
     const body = (await res.json()) as { user: Record<string, unknown> };
-    expect(body.user.assigned_vault).toBe("home");
+    expect(body.user.assigned_vaults).toEqual(["home"]);
+  });
+
+  test("happy path with multiple assigned_vaults (Phase 2 PR 2)", async () => {
+    harness.cleanup();
+    harness = makeHarness(manifestWithVaults("personal", "family"));
+    const { bearer } = await makeAdminBearer();
+    const res = await post(bearer, {
+      username: "alice",
+      password: "alice-strong-passphrase",
+      assignedVaults: ["personal", "family"],
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { user: Record<string, unknown> };
+    const list = body.user.assigned_vaults as string[];
+    expect(new Set(list)).toEqual(new Set(["personal", "family"]));
+  });
+
+  test("400 assigned_vault_not_found when ANY vault in the array is unknown", async () => {
+    harness.cleanup();
+    harness = makeHarness(manifestWithVaults("home"));
+    const { bearer } = await makeAdminBearer();
+    const res = await post(bearer, {
+      username: "alice",
+      password: "alice-strong-passphrase",
+      assignedVaults: ["home", "ghost"],
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("assigned_vault_not_found");
+    expect(body.error_description).toContain("ghost");
   });
 });
 
@@ -708,5 +739,132 @@ describe("handleListVaults", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { vaults: string[] };
     expect(body.vaults).toEqual(["home", "scratch", "work"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /api/users/:id/vaults — edit vault assignments (Phase 2 PR 2)
+// ---------------------------------------------------------------------------
+
+describe("handleUpdateUserVaults", () => {
+  async function patch(
+    bearer: string,
+    userId: string,
+    body: Record<string, unknown> | string,
+    headers: Record<string, string> = {},
+  ): Promise<Response> {
+    const init: RequestInit = {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${bearer}`,
+        ...headers,
+      },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    };
+    return await handleUpdateUserVaults(req(`/api/users/${userId}/vaults`, init), userId, deps());
+  }
+
+  test("401 with no Authorization header", async () => {
+    const res = await handleUpdateUserVaults(
+      req("/api/users/some-id/vaults", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ assigned_vaults: [] }),
+      }),
+      "some-id",
+      deps(),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("405 on non-PATCH", async () => {
+    const { bearer } = await makeAdminBearer();
+    const res = await handleUpdateUserVaults(
+      withBearer("/api/users/x/vaults", bearer, { method: "POST" }),
+      "x",
+      deps(),
+    );
+    expect(res.status).toBe(405);
+  });
+
+  test("404 when target user does not exist", async () => {
+    const { bearer } = await makeAdminBearer();
+    const res = await patch(bearer, "no-such-id", { assigned_vaults: [] });
+    expect(res.status).toBe(404);
+  });
+
+  test("403 cannot_edit_first_admin_vaults for the first admin", async () => {
+    // The bearer-minting helper creates the first admin already; mint
+    // again returns the same admin's id.
+    const { bearer, userId } = await makeAdminBearer();
+    const res = await patch(bearer, userId, { assigned_vaults: ["home"] });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("cannot_edit_first_admin_vaults");
+  });
+
+  test("400 when assigned_vaults is missing", async () => {
+    const { bearer } = await makeAdminBearer();
+    const friend = await createUser(harness.db, "alice", "alice-strong-passphrase", {
+      allowMulti: true,
+    });
+    const res = await patch(bearer, friend.id, {});
+    expect(res.status).toBe(400);
+  });
+
+  test("400 when assigned_vaults entry is not a string", async () => {
+    const { bearer } = await makeAdminBearer();
+    const friend = await createUser(harness.db, "alice", "alice-strong-passphrase", {
+      allowMulti: true,
+    });
+    const res = await patch(bearer, friend.id, { assigned_vaults: ["ok", 7] });
+    expect(res.status).toBe(400);
+  });
+
+  test("400 assigned_vault_not_found when a vault doesn't exist in services.json", async () => {
+    harness.cleanup();
+    harness = makeHarness(manifestWithVaults("home"));
+    const { bearer } = await makeAdminBearer();
+    const friend = await createUser(harness.db, "alice", "alice-strong-passphrase", {
+      allowMulti: true,
+    });
+    const res = await patch(bearer, friend.id, { assigned_vaults: ["home", "ghost"] });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("assigned_vault_not_found");
+  });
+
+  test("happy path — replaces the user's vault list and bumps updated_at", async () => {
+    harness.cleanup();
+    harness = makeHarness(manifestWithVaults("home", "work", "family"));
+    const { bearer } = await makeAdminBearer();
+    const friend = await createUser(harness.db, "alice", "alice-strong-passphrase", {
+      allowMulti: true,
+      assignedVaults: ["home"],
+    });
+    const res = await patch(bearer, friend.id, { assigned_vaults: ["work", "family"] });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      user: { id: string; assigned_vaults: string[]; updated_at: string };
+    };
+    expect(body.ok).toBe(true);
+    expect(new Set(body.user.assigned_vaults)).toEqual(new Set(["work", "family"]));
+    expect(body.user.assigned_vaults).not.toContain("home");
+  });
+
+  test("empty array clears every assignment", async () => {
+    harness.cleanup();
+    harness = makeHarness(manifestWithVaults("home", "work"));
+    const { bearer } = await makeAdminBearer();
+    const friend = await createUser(harness.db, "alice", "alice-strong-passphrase", {
+      allowMulti: true,
+      assignedVaults: ["home", "work"],
+    });
+    const res = await patch(bearer, friend.id, { assigned_vaults: [] });
+    expect(res.status).toBe(200);
+    const fresh = getUserById(harness.db, friend.id);
+    expect(fresh?.assignedVaults).toEqual([]);
   });
 });

--- a/src/__tests__/hub-db.test.ts
+++ b/src/__tests__/hub-db.test.ts
@@ -151,7 +151,7 @@ describe("openHubDb + migrate", () => {
     }
   });
 
-  test("v8 adds password_changed + assigned_vault columns on a fresh DB", () => {
+  test("v8 added password_changed column (still present at v10)", () => {
     const h = makeHarness();
     try {
       const db = openHubDb(h.dbPath);
@@ -160,8 +160,9 @@ describe("openHubDb + migrate", () => {
           db.query<{ version: number }, []>("SELECT version FROM schema_version").all() ?? []
         ).map((r) => r.version);
         expect(versions).toContain(8);
-        // PRAGMA table_info returns the column shape; we want both new
-        // columns present with the right defaults / nullability.
+        // PRAGMA table_info returns the column shape; password_changed
+        // should still be on users at v10 (only assigned_vault was
+        // dropped in v10's recreate).
         interface ColInfo {
           name: string;
           type: string;
@@ -180,10 +181,8 @@ describe("openHubDb + migrate", () => {
         expect(pc?.notnull).toBe(1);
         // Default literal — SQLite returns it as a string "0".
         expect(pc?.dflt_value).toBe("0");
-        const av = byName.get("assigned_vault");
-        expect(av).toBeDefined();
-        expect(av?.type).toBe("TEXT");
-        expect(av?.notnull).toBe(0);
+        // v10 dropped assigned_vault — verify the column is gone.
+        expect(byName.has("assigned_vault")).toBe(false);
       } finally {
         db.close();
       }
@@ -195,21 +194,13 @@ describe("openHubDb + migrate", () => {
   test("v8 backfills password_changed=1 for users that pre-date the migration", () => {
     const h = makeHarness();
     try {
-      // Stand up a DB at the v7 state by partially-applying migrations:
-      // open Database directly, call migrate after stripping the v8 entry
-      // would be invasive. Instead, drive the same migration shape by hand
-      // for v1-v7 then insert a row, then call migrate() to apply v8.
-      // Cleanest path: openHubDb runs everything, but we want a v7 snapshot.
-      // Approach: open with openHubDb (runs all migrations), drop the v8
-      // changes, mark v8 unapplied, insert a user with password_changed=0
-      // (simulating a row from before the backfill), then re-run migrate.
-      // SQLite doesn't have DROP COLUMN pre-3.35 universally, so we do the
-      // recreate-and-rename: drop v8's columns by recreating users without
-      // them, then delete the v8 schema_version row, then call migrate().
+      // Stand up a DB at the v7 state by recreating the users table
+      // without the v8/v10 columns and re-running migrate().
       const db = openHubDb(h.dbPath);
       try {
         // Build a v7-shape users table and copy the v8-shape rows.
         db.exec(`
+          DROP TABLE IF EXISTS user_vaults;
           CREATE TABLE users_v7 (
             id TEXT PRIMARY KEY,
             username TEXT UNIQUE NOT NULL,
@@ -222,26 +213,26 @@ describe("openHubDb + migrate", () => {
           DROP TABLE users;
           ALTER TABLE users_v7 RENAME TO users;
         `);
-        db.exec("DELETE FROM schema_version WHERE version = 8");
+        db.exec("DELETE FROM schema_version WHERE version IN (8, 10)");
         // Insert a row that pre-dates v8 (no password_changed column yet).
         db.prepare(
           `INSERT INTO users (id, username, password_hash, created_at, updated_at)
            VALUES (?, ?, ?, ?, ?)`,
         ).run("legacy-user", "owner", "h", "2026-01-01", "2026-01-01");
-        // Now re-run migrations — v8 should ALTER the table and backfill.
+        // Now re-run migrations — v8 + v10 apply.
         migrate(db);
         const row = db
-          .query<{ password_changed: number; assigned_vault: string | null }, [string]>(
-            "SELECT password_changed, assigned_vault FROM users WHERE id = ?",
+          .query<{ password_changed: number }, [string]>(
+            "SELECT password_changed FROM users WHERE id = ?",
           )
           .get("legacy-user");
         expect(row).not.toBeNull();
         expect(row?.password_changed).toBe(1);
-        expect(row?.assigned_vault).toBeNull();
         const versions = (
           db.query<{ version: number }, []>("SELECT version FROM schema_version").all() ?? []
         ).map((r) => r.version);
         expect(versions).toContain(8);
+        expect(versions).toContain(10);
       } finally {
         db.close();
       }
@@ -250,24 +241,198 @@ describe("openHubDb + migrate", () => {
     }
   });
 
-  test("v8 — fresh inserts default password_changed=0 and assigned_vault NULL", () => {
+  test("v8 — fresh inserts default password_changed=0 (v10 dropped assigned_vault)", () => {
     const h = makeHarness();
     try {
       const db = openHubDb(h.dbPath);
       try {
-        // Insert via the bare-columns SQL (mirrors what a pre-v8 caller
-        // would emit) to confirm the column DEFAULTs work.
+        // Insert via the bare-columns SQL to confirm the column DEFAULTs work.
         db.prepare(
           `INSERT INTO users (id, username, password_hash, created_at, updated_at)
            VALUES (?, ?, ?, ?, ?)`,
         ).run("u-default", "owner", "h", "2026-01-01", "2026-01-01");
         const row = db
-          .query<{ password_changed: number; assigned_vault: string | null }, [string]>(
-            "SELECT password_changed, assigned_vault FROM users WHERE id = ?",
+          .query<{ password_changed: number }, [string]>(
+            "SELECT password_changed FROM users WHERE id = ?",
           )
           .get("u-default");
         expect(row?.password_changed).toBe(0);
-        expect(row?.assigned_vault).toBeNull();
+        // user_vaults table is empty for a default insert.
+        const vaultCount = db
+          .query<{ n: number }, [string]>("SELECT COUNT(*) AS n FROM user_vaults WHERE user_id = ?")
+          .get("u-default");
+        expect(vaultCount?.n).toBe(0);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // v10 — user_vaults many-to-many membership (multi-user Phase 2 PR 2)
+  // ---------------------------------------------------------------------------
+
+  test("v10 creates user_vaults table with the expected shape", () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(h.dbPath);
+      try {
+        const versions = (
+          db.query<{ version: number }, []>("SELECT version FROM schema_version").all() ?? []
+        ).map((r) => r.version);
+        expect(versions).toContain(10);
+        const tables = (
+          db
+            .query<{ name: string }, []>(
+              "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
+            )
+            .all() ?? []
+        ).map((r) => r.name);
+        expect(tables).toContain("user_vaults");
+        interface ColInfo {
+          name: string;
+          type: string;
+          notnull: number;
+          dflt_value: string | null;
+        }
+        const cols = db
+          .query<ColInfo, []>(
+            "SELECT name, type, \"notnull\", dflt_value FROM pragma_table_info('user_vaults')",
+          )
+          .all();
+        const names = cols.map((c) => c.name);
+        expect(names).toContain("user_id");
+        expect(names).toContain("vault_name");
+        expect(names).toContain("role");
+        expect(names).toContain("created_at");
+        const role = cols.find((c) => c.name === "role");
+        expect(role?.notnull).toBe(1);
+        // SQLite represents the default literal verbatim — `'write'`.
+        expect(role?.dflt_value).toBe("'write'");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("v10 backfills user_vaults from v9 assigned_vault column", () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(h.dbPath);
+      try {
+        // Rebuild a v9-shape users table (with assigned_vault column),
+        // mark v10 unapplied, drop user_vaults, populate fixture rows,
+        // then re-run migrate to apply v10's backfill.
+        db.exec(`
+          DROP TABLE IF EXISTS user_vaults;
+          CREATE TABLE users_v9 (
+            id TEXT PRIMARY KEY,
+            username TEXT UNIQUE NOT NULL,
+            password_hash TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            password_changed INTEGER NOT NULL DEFAULT 0,
+            assigned_vault TEXT
+          );
+          INSERT INTO users_v9 (id, username, password_hash, created_at, updated_at, password_changed, assigned_vault)
+          VALUES
+            ('u-admin', 'admin', 'h', '2026-01-01', '2026-01-01', 1, NULL),
+            ('u-alice', 'alice', 'h', '2026-01-02', '2026-01-02', 1, 'personal'),
+            ('u-bob',   'bob',   'h', '2026-01-03', '2026-01-03', 1, 'family');
+          DROP TABLE users;
+          ALTER TABLE users_v9 RENAME TO users;
+        `);
+        db.exec("DELETE FROM schema_version WHERE version = 10");
+        migrate(db);
+        // Expect 2 rows in user_vaults (admin had NULL → no row).
+        const rows = db
+          .query<{ user_id: string; vault_name: string; role: string }, []>(
+            "SELECT user_id, vault_name, role FROM user_vaults ORDER BY user_id ASC",
+          )
+          .all();
+        expect(rows.length).toBe(2);
+        expect(rows[0]).toMatchObject({
+          user_id: "u-alice",
+          vault_name: "personal",
+          role: "write",
+        });
+        expect(rows[1]).toMatchObject({ user_id: "u-bob", vault_name: "family", role: "write" });
+        // No row for the admin.
+        const adminRows = db
+          .query<{ n: number }, [string]>("SELECT COUNT(*) AS n FROM user_vaults WHERE user_id = ?")
+          .get("u-admin");
+        expect(adminRows?.n).toBe(0);
+        // assigned_vault column should be gone.
+        interface ColInfo {
+          name: string;
+        }
+        const cols = db.query<ColInfo, []>("SELECT name FROM pragma_table_info('users')").all();
+        expect(cols.map((c) => c.name)).not.toContain("assigned_vault");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("v10 FK cascade: deleting a user drops their user_vaults rows", () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(h.dbPath);
+      try {
+        const stamp = "2026-05-27T00:00:00.000Z";
+        db.prepare(
+          "INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed) VALUES (?, ?, ?, ?, ?, ?)",
+        ).run("u1", "alice", "h", stamp, stamp, 1);
+        db.prepare(
+          "INSERT INTO user_vaults (user_id, vault_name, role, created_at) VALUES (?, ?, ?, ?)",
+        ).run("u1", "personal", "write", stamp);
+        db.prepare(
+          "INSERT INTO user_vaults (user_id, vault_name, role, created_at) VALUES (?, ?, ?, ?)",
+        ).run("u1", "family", "write", stamp);
+        // sanity
+        const before = db
+          .query<{ n: number }, [string]>("SELECT COUNT(*) AS n FROM user_vaults WHERE user_id = ?")
+          .get("u1");
+        expect(before?.n).toBe(2);
+        // Delete the user — ON DELETE CASCADE should drop the user_vaults rows.
+        db.prepare("DELETE FROM users WHERE id = ?").run("u1");
+        const after = db
+          .query<{ n: number }, [string]>("SELECT COUNT(*) AS n FROM user_vaults WHERE user_id = ?")
+          .get("u1");
+        expect(after?.n).toBe(0);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("v10 (user_id, vault_name) PRIMARY KEY blocks duplicate (user, vault) pairs", () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(h.dbPath);
+      try {
+        const stamp = "2026-05-27T00:00:00.000Z";
+        db.prepare(
+          "INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed) VALUES (?, ?, ?, ?, ?, ?)",
+        ).run("u1", "alice", "h", stamp, stamp, 1);
+        db.prepare(
+          "INSERT INTO user_vaults (user_id, vault_name, role, created_at) VALUES (?, ?, ?, ?)",
+        ).run("u1", "personal", "write", stamp);
+        expect(() =>
+          db
+            .prepare(
+              "INSERT INTO user_vaults (user_id, vault_name, role, created_at) VALUES (?, ?, ?, ?)",
+            )
+            .run("u1", "personal", "write", stamp),
+        ).toThrow();
       } finally {
         db.close();
       }

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -28,7 +28,7 @@ import {
 } from "../oauth-handlers.ts";
 import type { ServicesManifest } from "../services-manifest.ts";
 import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
-import { createUser } from "../users.ts";
+import { createUser, setUserVaults } from "../users.ts";
 
 const ISSUER = "https://hub.example";
 const TEST_CSRF = "csrf-test-token";
@@ -7274,6 +7274,148 @@ describe("zero-vault non-admin privesc gate (hub#429 reviewer)", () => {
       // token for non-admin users). Pin the helper's behavior so a
       // future change can't silently lift it to "include all vaults".
       expect(vaultScopeForUser(db, bob.id)).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("stale grant survives setUserVaults([]) → skip-consent gate fires consent screen, not silent code (path 5)", async () => {
+    // The 4th attack the prior fold didn't cover. Sequence:
+    //   1. bob has assignedVaults=["default"] (legitimate).
+    //   2. bob consents to a vault-scoped client → grants row recorded.
+    //   3. Admin clears bob's assignments via setUserVaults(_, []).
+    //   4. Grants table has no FK cascade from user_vaults, so the
+    //      grant row survives the assignment delete.
+    //   5. bob re-hits /oauth/authorize?scope=vault:default:read for
+    //      the same client. Pre-fix: skip-consent gate fires
+    //      (isCoveredByGrant=true), silent 302 with auth code and
+    //      vault_scope=[] (the admin "unrestricted" sentinel).
+    //   Post-fix: userHasVaultPosture=false → fall through to
+    //   consent render where the zero-vault gate also refuses.
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "admin-aaron", "pw");
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
+      expect(bob.assignedVaults).toEqual(["default"]);
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      // Record the grant while bob still has the assignment.
+      recordGrant(db, bob.id, reg.client.clientId, ["vault:default:read"]);
+      // Admin clears bob's assignments. Grant row is NOT cascaded.
+      expect(setUserVaults(db, bob.id, [])).toBe(true);
+      expect(findGrant(db, bob.id, reg.client.clientId)).not.toBeNull();
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          scope: "vault:default:read",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          state: "stale-grant",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      // Post-fix: 200 HTML consent screen, NOT 302 with code.
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
+      expect(res.headers.get("location")).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("trust-by-client_name auto-promote → recursive re-entry hits skip-consent gate (path 6)", async () => {
+    // The trust-by-client_name path (hub#409, ~line 554) recursively
+    // calls handleAuthorizeGet after approveClient + recordGrant on
+    // the fresh client_id. That recursive call now passes through
+    // the skip-consent gate with our new userHasVaultPosture check.
+    //
+    // Sequence:
+    //   1. bob has assignedVaults=["default"], consents to "claude-code"
+    //      (prior client_id) for vault:default:read.
+    //   2. Admin clears bob's assignments.
+    //   3. Claude re-DCRs a fresh "claude-code" with a new client_id
+    //      (status=pending).
+    //   4. bob hits /oauth/authorize on the fresh client_id.
+    //   5. Pre-fix: trust-by-client_name matches by name+scope,
+    //      approves the fresh client, records grant, recurses into
+    //      handleAuthorizeGet — which now finds a covering grant and
+    //      silently mints the auth code with vault_scope=[].
+    //   Post-fix: the recursive call's skip-consent gate sees
+    //   userHasVaultPosture=false and falls through to the consent
+    //   render. Same-hub gate also refuses (sameHub=false here, but
+    //   the posture check is the load-bearing constraint).
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "admin-aaron", "pw");
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
+      const session = createSession(db, { userId: bob.id });
+      // Prior approved client_name="claude-code" + grant.
+      const prior = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+        clientName: "claude-code",
+      });
+      recordGrant(db, bob.id, prior.client.clientId, ["vault:default:read"]);
+      // Admin clears bob's assignments. Prior grant survives.
+      expect(setUserVaults(db, bob.id, [])).toBe(true);
+      // Fresh DCR — same client_name, fresh client_id, status=pending.
+      const fresh = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "pending",
+        clientName: "claude-code",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: fresh.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:default:read",
+          state: "trust-by-name-zero",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+            origin: ISSUER,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      // Post-fix: 200 HTML consent screen, NOT 302 with code. The
+      // fresh client_id IS approved (the auto-promote ran), and a
+      // grant IS recorded — that's the design of hub#409. The
+      // load-bearing assertion is that the recursive re-entry into
+      // handleAuthorizeGet did NOT issue an auth code, because the
+      // zero-vault posture failed our gate.
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
+      expect(res.headers.get("location")).toBeNull();
+      expect(getClient(db, fresh.client.clientId)?.status).toBe("approved");
     } finally {
       cleanup();
     }

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getClient, registerClient } from "../clients.ts";
 import { CSRF_COOKIE_NAME } from "../csrf.ts";
+import { findGrant, recordGrant } from "../grants.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import {
   FIRST_CLIENT_AUTO_APPROVE_WINDOW_MS,
@@ -13,7 +14,6 @@ import {
   setSetting,
 } from "../hub-settings.ts";
 import { findTokenRowByJti, validateAccessToken } from "../jwt-sign.ts";
-import { findGrant, recordGrant } from "../grants.ts";
 import {
   authorizationServerMetadata,
   buildServicesCatalog,
@@ -24,6 +24,7 @@ import {
   handleRevoke,
   handleToken,
   protectedResourceMetadata,
+  vaultScopeForUser,
 } from "../oauth-handlers.ts";
 import type { ServicesManifest } from "../services-manifest.ts";
 import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
@@ -4880,6 +4881,66 @@ describe("DCR first-client auto-approve window (hub#268 Item 3)", () => {
 // non-admin users (with `assigned_vault` non-null) see the consent picker
 // locked, and the OAuth issuer mints tokens carrying `vault_scope: [<assigned>]`.
 // Server-side defense refuses any mint whose picked vault disagrees.
+describe("vaultScopeForUser (multi-user Phase 2 PR 2 — many-to-many)", () => {
+  test("first admin returns [] regardless of any user_vaults rows", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const admin = await createUser(db, "admin-aaron", "pw");
+      expect(vaultScopeForUser(db, admin.id)).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("non-admin with zero vault assignments returns []", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "admin-aaron", "pw");
+      const bob = await createUser(db, "bob", "pw", { allowMulti: true });
+      expect(vaultScopeForUser(db, bob.id)).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("non-admin with one assigned vault returns [name]", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "admin-aaron", "pw");
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
+      expect(vaultScopeForUser(db, bob.id)).toEqual(["default"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("non-admin with multiple assigned vaults returns each name", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "admin-aaron", "pw");
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["personal", "family"],
+      });
+      expect(new Set(vaultScopeForUser(db, bob.id))).toEqual(new Set(["personal", "family"]));
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("unknown user id returns [] defensively", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      expect(vaultScopeForUser(db, "no-such-id")).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
 describe("handleAuthorizeGet — multi-user assigned vault picker lock (PR 4)", () => {
   test("admin user (assigned_vault null) sees the free dropdown", async () => {
     const { db, cleanup } = await makeDb();
@@ -4918,13 +4979,131 @@ describe("handleAuthorizeGet — multi-user assigned vault picker lock (PR 4)", 
     }
   });
 
+  test("non-admin user with 2+ assigned vaults sees a free dropdown filtered to those (Phase 2 PR 2)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        // Only "default" is in the fixture manifest; non-admins with a
+        // mix of valid + invalid vaults effectively get the intersection.
+        assignedVaults: ["default", "personal"],
+      });
+      // Add a second vault to the manifest so the dropdown has two
+      // valid choices to filter to.
+      const multiVaultManifest: ServicesManifest = {
+        services: [
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/default", "/vault/personal", "/vault/family"],
+            health: "/health",
+            version: "0.3.0",
+          },
+        ],
+      };
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:read",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: () => multiVaultManifest,
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      // NOT the locked picker section — two vaults is a dropdown.
+      expect(html).not.toContain('class="vault-picker vault-picker-locked"');
+      // No locked-vault hidden input.
+      expect(html).not.toContain('<input type="hidden" name="vault_pick"');
+      // Two radios — for the two assigned vaults, in order.
+      expect(html).toContain('name="vault_pick" value="default"');
+      expect(html).toContain('name="vault_pick" value="personal"');
+      // NOT the third hub-wide vault (`family`) — filtered out.
+      expect(html).not.toContain('name="vault_pick" value="family"');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("non-admin requesting a named vault outside their list → 400 vault_scope_mismatch (Phase 2 PR 2)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["personal", "family"],
+      });
+      const multiVaultManifest: ServicesManifest = {
+        services: [
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/personal", "/vault/family", "/vault/work"],
+            health: "/health",
+            version: "0.3.0",
+          },
+        ],
+      };
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        __csrf: TEST_CSRF,
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        // Asking for "work" which exists on the hub but is NOT in
+        // bob's assigned list.
+        scope: "vault:work:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const consentRes = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+          },
+        }),
+        { issuer: ISSUER, loadServicesManifest: () => multiVaultManifest },
+      );
+      expect(consentRes.status).toBe(400);
+      const body = await consentRes.text();
+      expect(body).toContain("vault_scope_mismatch");
+    } finally {
+      cleanup();
+    }
+  });
+
   test("non-admin user (assigned_vault set) sees the locked picker with admin-managed note", async () => {
     const { db, cleanup } = await makeDb();
     try {
       const admin = await createUser(db, "admin-aaron", "pw");
       const bob = await createUser(db, "bob", "pw", {
         allowMulti: true,
-        assignedVault: "default",
+        assignedVaults: ["default"],
       });
       void admin;
       const session = createSession(db, { userId: bob.id });
@@ -4974,7 +5153,12 @@ describe("handleAuthorizeGet — resolved scope display (approval-UX rc.19)", ()
   test("non-admin user (assigned_vault set) sees vault:<assigned>:read on consent, not raw vault:read", async () => {
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
       const { challenge } = makePkce();
@@ -5050,7 +5234,12 @@ describe("handleAuthorizePost — multi-user assigned vault defense (PR 4)", () 
   test("non-admin happy path: token carries vault_scope=[assigned] and narrowed scope", async () => {
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
       const { verifier, challenge } = makePkce();
@@ -5164,7 +5353,12 @@ describe("handleAuthorizePost — multi-user assigned vault defense (PR 4)", () 
   test("non-admin with disagreeing vault_pick → 400 vault_scope_mismatch", async () => {
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
       const { challenge } = makePkce();
@@ -5223,7 +5417,12 @@ describe("handleAuthorizePost — multi-user assigned vault defense (PR 4)", () 
   test("non-admin requesting named scope for the wrong vault → 400 vault_scope_mismatch", async () => {
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
       const { challenge } = makePkce();
@@ -5263,7 +5462,12 @@ describe("handleAuthorizePost — multi-user assigned vault defense (PR 4)", () 
   test("non-admin requesting named scope for the assigned vault → happy path", async () => {
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
       const { verifier, challenge } = makePkce();
@@ -5320,7 +5524,12 @@ describe("handleAuthorizePost — multi-user assigned vault defense (PR 4)", () 
   test("refresh flow re-derives vault_scope from current assigned_vault", async () => {
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
       const { verifier, challenge } = makePkce();
@@ -5407,7 +5616,12 @@ describe("handleAuthorizePost — multi-user assigned vault defense (PR 4)", () 
   test("refresh flow picks up a mid-session assigned_vault change", async () => {
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "vault-a" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["vault-a"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
       const { verifier, challenge } = makePkce();
@@ -5477,12 +5691,15 @@ describe("handleAuthorizePost — multi-user assigned vault defense (PR 4)", () 
       expect(initial.payload.vault_scope).toEqual(["vault-a"]);
       expect(initial.payload.scope).toBe("vault:vault-a:read");
 
-      // Step 2: admin updates bob's assigned_vault to vault-b. Direct UPDATE
-      // because Phase 1 has no PATCH endpoint; same effect a future admin
-      // path would have. The refresh path reads the live row at mint time
-      // (`vaultScopeForUser`), so the next refresh should pick up the new
-      // value.
-      db.prepare("UPDATE users SET assigned_vault = ? WHERE id = ?").run("vault-b", bob.id);
+      // Step 2: admin updates bob's vault assignments to ["vault-b"].
+      // Direct DB writes against user_vaults — same effect as the PATCH
+      // /api/users/:id/vaults endpoint. The refresh path reads the live
+      // row at mint time (`vaultScopeForUser`), so the next refresh
+      // should pick up the new value.
+      db.prepare("DELETE FROM user_vaults WHERE user_id = ?").run(bob.id);
+      db.prepare(
+        "INSERT INTO user_vaults (user_id, vault_name, role, created_at) VALUES (?, ?, 'write', ?)",
+      ).run(bob.id, "vault-b", new Date().toISOString());
 
       // Step 3: refresh the token. vault_scope should be ["vault-b"] (the
       // new live value); the `scope` claim stays narrowed to the original
@@ -5982,7 +6199,12 @@ describe("handleAuthorizeGet — stale assigned_vault surfaces banner (hub#284)"
   test("unnamed vault scope + stale assignment → banner + no-vaults picker + disabled Approve", async () => {
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
       const { challenge } = makePkce();
@@ -6026,7 +6248,12 @@ describe("handleAuthorizeGet — stale assigned_vault surfaces banner (hub#284)"
   test("named vault scope targeting stale assignment → banner + disabled Approve", async () => {
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
       const { challenge } = makePkce();
@@ -6065,7 +6292,12 @@ describe("handleAuthorizeGet — stale assigned_vault surfaces banner (hub#284)"
   test("non-vault scope + stale assignment → informational banner + Approve stays enabled", async () => {
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
       const { challenge } = makePkce();
@@ -6143,7 +6375,12 @@ describe("handleAuthorizeGet — stale assigned_vault surfaces banner (hub#284)"
   test("user with intact assignment → no banner (pre-#284 happy path stays clean)", async () => {
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
       const { challenge } = makePkce();
@@ -6195,7 +6432,12 @@ describe("handleAuthorizePost — stale assigned_vault clean 400 (hub#284)", () 
   test("hand-crafted POST with stale vault_pick → 'Assigned vault was removed' 400 (not generic Unknown vault)", async () => {
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
       const { challenge } = makePkce();
@@ -6241,7 +6483,12 @@ describe("handleAuthorizePost — stale assigned_vault clean 400 (hub#284)", () 
   test("hand-crafted POST with vault_pick naming a never-existed vault → still hits generic Unknown vault 400", async () => {
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
       const { challenge } = makePkce();
@@ -6289,7 +6536,12 @@ describe("handleAuthorizePost — stale assigned_vault clean 400 (hub#284)", () 
   test("named scope vault:<stale>:read → POST refuses with 'Assigned vault was removed' 400", async () => {
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
       const { challenge } = makePkce();
@@ -6361,7 +6613,12 @@ describe("handleAuthorizeGet — stale assignment gates both fast-paths (hub#284
     // Post-fold the gate skips, the consent screen renders, banner shows.
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
       const { recordGrant } = await import("../grants.ts");
@@ -6409,7 +6666,12 @@ describe("handleAuthorizeGet — stale assignment gates both fast-paths (hub#284
     // consent screen renders.
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, {
         redirectUris: ["https://app.example/cb"],
@@ -6456,7 +6718,12 @@ describe("handleAuthorizeGet — stale assignment gates both fast-paths (hub#284
     // enabled — the user can still consent to scribe access.
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, {
         redirectUris: ["https://app.example/cb"],
@@ -6501,7 +6768,12 @@ describe("handleAuthorizeGet — stale assignment gates both fast-paths (hub#284
     // the fast-path so the fold doesn't break the existing UX.
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
       const { recordGrant } = await import("../grants.ts");
@@ -6543,7 +6815,12 @@ describe("handleAuthorizeGet — stale assignment gates both fast-paths (hub#284
     // non-admin vault scope, user's assignment is intact, gate fires.
     const { db, cleanup } = await makeDb();
     try {
-      const bob = await createUser(db, "bob", "pw", { assignedVault: "default" });
+      const admin = await createUser(db, "admin-aaron", "pw");
+      void admin;
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        assignedVaults: ["default"],
+      });
       const session = createSession(db, { userId: bob.id });
       const reg = registerClient(db, {
         redirectUris: ["https://app.example/cb"],

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -7053,3 +7053,278 @@ describe("handleAuthorizeGet — trust-by-client_name auto-approve (hub#409)", (
     }
   });
 });
+
+// Phase 2 PR 2 reviewer fold (hub#429 reviewer): a non-admin user with
+// ZERO `user_vaults` rows is a known-but-not-yet-assigned posture. They can
+// sign in to /account/, change their password, and see the home page, but
+// they have no vaults to authorize against. The original Phase 2 PR 2 left
+// three OAuth privilege-escalation paths open:
+//
+//   1. Named scope consent submit: handleConsentSubmit's vault-validation
+//      gates ran only when `isPinned = assignedVaults.length > 0`. Zero-
+//      vault non-admin slipped past every gate, minted a token with the
+//      admin "unrestricted" vault_scope sentinel ([]).
+//
+//   2. Same-hub auto-trust gate (hub#312): zero-vault non-admin satisfied
+//      every condition (no admin scope, no unnamed verb, no stale-
+//      assignment — length === 0 short-circuits the stale predicate).
+//      Silently minted a token, no consent screen.
+//
+//   3. Unnamed-scope picker: the empty-`assignedVaults` branch of
+//      `consentProps` rendered the FULL hub-wide vault list, letting a
+//      zero-vault non-admin pick any vault on the hub.
+//
+// The fix gates all three paths. These tests pin each one + verify the
+// first-admin happy path (`vaultScopeForUser` returns [] for first admin
+// too, and that posture must NOT regress to "no access").
+describe("zero-vault non-admin privesc gate (hub#429 reviewer)", () => {
+  test("named scope consent submit → blocked with vault_scope_mismatch (path 1)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      // First admin exists so `bob` is a non-admin.
+      await createUser(db, "admin-aaron", "pw");
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+        // No assigned vaults — the "known but not yet assigned" posture.
+      });
+      expect(bob.assignedVaults).toEqual([]);
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      // Hand-crafted POST naming a vault bob has no business consenting to.
+      const form = new URLSearchParams({
+        __action: "consent",
+        __csrf: TEST_CSRF,
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:default:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        state: "zv-1",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+        },
+      });
+      const res = await handleAuthorizePost(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      // NOT a 302 redirect (which would mean the auth code was issued).
+      expect(res.status).not.toBe(302);
+      expect(res.status).toBe(400);
+      const html = await res.text();
+      expect(html).toContain("vault_scope_mismatch");
+      expect(html).toContain("No vaults assigned");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("same-hub auto-trust GET with named vault scope → consent shown, not silent grant (path 2)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "admin-aaron", "pw");
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+      });
+      const session = createSession(db, { userId: bob.id });
+      // Same-hub client (DCR'd by the operator, sameHub=true).
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+        sameHub: true,
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          scope: "vault:default:read",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          state: "zv-2",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      // Pre-fix: 302 with auth code (silent mint). Post-fix: 200 HTML
+      // consent screen — falls through the same-hub gate to the consent
+      // render.
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("unnamed vault scope GET → empty-state picker with no-assignments copy, not hub-wide list (path 3)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "admin-aaron", "pw");
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+      });
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          // Unnamed `vault:read` — needs the picker to narrow.
+          scope: "vault:read",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        // Manifest with TWO vaults — pre-fix the picker would render BOTH
+        // as a free dropdown for bob (the "admin posture" empty-vaults
+        // branch).
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      // No-assignments empty-state picker. Approve disabled.
+      expect(html).toContain("you have no vaults assigned on this hub yet");
+      expect(html).toContain("/admin/users");
+      // NO hub-wide vault picker options rendered (the `default` and any
+      // other vault from the fixture must not appear as radio options).
+      expect(html).not.toMatch(/<input type="radio" name="vault_pick"/);
+      // Approve button disabled.
+      expect(html).toMatch(/<button[^>]*name="approve"[^>]*value="yes"[^>]*disabled/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("token endpoint cannot mint with empty vault_scope for zero-vault non-admin (defense in depth, path 4)", async () => {
+    // If the auth-code path is fully blocked above, the user can never
+    // get an auth code in the first place — this verifies the auth-code
+    // path stays blocked at the consent-submit boundary so no code is
+    // issued (the token endpoint never sees one for this user posture).
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "admin-aaron", "pw");
+      const bob = await createUser(db, "bob", "pw", {
+        allowMulti: true,
+      });
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      const form = new URLSearchParams({
+        __action: "consent",
+        __csrf: TEST_CSRF,
+        approve: "yes",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        scope: "vault:default:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+        },
+      });
+      const res = await handleAuthorizePost(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      // No 302 — no auth code redirect, no `code` param ever issued.
+      expect(res.status).toBe(400);
+      expect(res.headers.get("location")).toBeNull();
+      // Belt-and-suspenders: `vaultScopeForUser` would return [] for
+      // bob (the very sentinel the OAuth flow refuses to mint into a
+      // token for non-admin users). Pin the helper's behavior so a
+      // future change can't silently lift it to "include all vaults".
+      expect(vaultScopeForUser(db, bob.id)).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("first admin with no vault assignments still gets unrestricted access (regression guard)", async () => {
+    // First admin's `assignedVaults` is empty by design — that's the
+    // admin "unrestricted" sentinel. The zero-vault gate must NOT
+    // catch the first admin: they're not "non-admin with no
+    // assignments," they're "admin posture, empty list is the signal."
+    const { db, cleanup } = await makeDb();
+    try {
+      // Only one user — the first admin. No `user_vaults` rows.
+      const admin = await createUser(db, "admin-aaron", "pw");
+      expect(admin.assignedVaults).toEqual([]);
+      const session = createSession(db, { userId: admin.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+        sameHub: true,
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          scope: "vault:default:read",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          state: "first-admin-ok",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      // Silent grant — same-hub auto-trust fires for the first admin
+      // exactly as it did pre-fix.
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.get("location") ?? "");
+      expect(loc.origin + loc.pathname).toBe("https://app.example/cb");
+      expect(loc.searchParams.get("code")?.length).toBeGreaterThan(20);
+      expect(loc.searchParams.get("state")).toBe("first-admin-ok");
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -52,11 +52,11 @@ describe("seedInitialAdminIfNeeded", () => {
     expect(log.mock.calls[0]?.[0] ?? "").toContain("ops");
     // Multi-user Phase 1 (design 2026-05-20-multi-user-phase-1.md §wizard
     // interaction): env-seeded admin chose their password via env vars, so
-    // skip the force-change-password redirect. `assignedVault` stays null
-    // — admin posture.
+    // skip the force-change-password redirect. `assignedVaults` stays []
+    // — admin posture (multi-user Phase 2 PR 2 lifted single → array).
     const seeded = getUserByUsername(db, "ops");
     expect(seeded?.passwordChanged).toBe(true);
-    expect(seeded?.assignedVault).toBeNull();
+    expect(seeded?.assignedVaults).toEqual([]);
   });
 
   test("returns 'exists' when an admin already exists, even with env vars set", async () => {
@@ -287,12 +287,12 @@ describe("resolveStartupIssuer — precedence chain (hub#365)", () => {
   test("strips trailing slashes from any source for canonical form", () => {
     expect(resolveStartupIssuer({ issuer: "https://x.example/" }, {})).toBe("https://x.example");
     expect(resolveStartupIssuer({ issuer: "https://x.example//" }, {})).toBe("https://x.example");
-    expect(
-      resolveStartupIssuer({}, { PARACHUTE_HUB_ORIGIN: "https://x.example/" }),
-    ).toBe("https://x.example");
-    expect(
-      resolveStartupIssuer({}, { RENDER_EXTERNAL_URL: "https://x.example/" }),
-    ).toBe("https://x.example");
+    expect(resolveStartupIssuer({}, { PARACHUTE_HUB_ORIGIN: "https://x.example/" })).toBe(
+      "https://x.example",
+    );
+    expect(resolveStartupIssuer({}, { RENDER_EXTERNAL_URL: "https://x.example/" })).toBe(
+      "https://x.example",
+    );
   });
 
   test("returns undefined when no source has a value", () => {

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -215,7 +215,13 @@ describe("deriveWizardState", () => {
       writeManifest(
         {
           services: [
-            { name: "parachute-vault", version: "0.1.0", port: 1940, paths: ["/vault/default"], health: "/health" },
+            {
+              name: "parachute-vault",
+              version: "0.1.0",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/health",
+            },
           ],
         },
         h.manifestPath,
@@ -636,11 +642,11 @@ describe("handleSetupAccountPost", () => {
       expect(userCount(db)).toBe(1);
       // Multi-user Phase 1: the wizard's first admin chose their password
       // via this very form, so skip the force-change-password redirect on
-      // first sign-in (`password_changed=1`). `assigned_vault` stays NULL
-      // — admin posture (no per-vault restriction).
+      // first sign-in (`password_changed=1`). `assignedVaults` stays empty
+      // — admin posture (no per-vault restriction; Phase 2 PR 2 array shape).
       const created = getUserByUsername(db, "ops");
       expect(created?.passwordChanged).toBe(true);
-      expect(created?.assignedVault).toBeNull();
+      expect(created?.assignedVaults).toEqual([]);
     } finally {
       db.close();
     }
@@ -3142,7 +3148,9 @@ describe("done screen — 'Start using your vault' tile (hub#342)", () => {
 
 describe("detectAutoExposeMode — Render env detection edge cases (hub#407 nit)", () => {
   test("returns 'public' for a real https Render URL", () => {
-    expect(detectAutoExposeMode({ RENDER_EXTERNAL_URL: "https://parachute-hub.onrender.com" })).toBe("public");
+    expect(
+      detectAutoExposeMode({ RENDER_EXTERNAL_URL: "https://parachute-hub.onrender.com" }),
+    ).toBe("public");
   });
 
   test("returns 'public' for an http:// URL (defensive — if Render ever emits one)", () => {

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -20,6 +20,7 @@ import {
   listUsers,
   resetUserPassword,
   setPassword,
+  setUserVaults,
   userCount,
   validatePassword,
   validateUsername,
@@ -56,7 +57,7 @@ describe("createUser", () => {
       expect(userCount(db)).toBe(1);
       // Default multi-user-Phase-1 shape: unchanged password, no vault pin.
       expect(u.passwordChanged).toBe(false);
-      expect(u.assignedVault).toBeNull();
+      expect(u.assignedVaults).toEqual([]);
     } finally {
       cleanup();
     }
@@ -76,28 +77,63 @@ describe("createUser", () => {
     }
   });
 
-  test("assignedVault opt-in persists the column (admin-creates-user path)", async () => {
+  test("assignedVaults opt-in persists each vault (admin-creates-user path)", async () => {
     const { db, cleanup } = makeDb();
     try {
       const u = await createUser(db, "alice", "pw1", {
         allowMulti: true,
-        assignedVault: "alice",
+        assignedVaults: ["alice"],
       });
-      expect(u.assignedVault).toBe("alice");
+      expect(u.assignedVaults).toEqual(["alice"]);
       const fresh = getUserById(db, u.id);
-      expect(fresh?.assignedVault).toBe("alice");
+      expect(fresh?.assignedVaults).toEqual(["alice"]);
     } finally {
       cleanup();
     }
   });
 
-  test("assignedVault explicit null is treated the same as omitted", async () => {
+  test("assignedVaults with multiple entries — all persist (multi-vault Phase 2)", async () => {
     const { db, cleanup } = makeDb();
     try {
-      const u = await createUser(db, "admin1", "pw1", { assignedVault: null });
-      expect(u.assignedVault).toBeNull();
+      const u = await createUser(db, "alice", "pw1", {
+        allowMulti: true,
+        assignedVaults: ["personal", "family"],
+      });
+      expect(u.assignedVaults).toEqual(["personal", "family"]);
       const fresh = getUserById(db, u.id);
-      expect(fresh?.assignedVault).toBeNull();
+      // Loaded via the user_vaults JOIN — order matches insertion order
+      // because rows share the same `created_at` timestamp and tie-break
+      // on `vault_name` ASC. `family` precedes `personal` alphabetically.
+      expect(fresh?.assignedVaults.length).toBe(2);
+      expect(new Set(fresh?.assignedVaults)).toEqual(new Set(["personal", "family"]));
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("assignedVaults omitted defaults to empty array (admin posture)", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "admin1", "pw1");
+      expect(u.assignedVaults).toEqual([]);
+      const fresh = getUserById(db, u.id);
+      expect(fresh?.assignedVaults).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("assignedVaults de-duplicates repeated names", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "alice", "pw1", {
+        allowMulti: true,
+        assignedVaults: ["personal", "personal", "family"],
+      });
+      // De-dupe is silent; user gets one row per distinct name.
+      expect(u.assignedVaults).toEqual(["personal", "family"]);
+      const fresh = getUserById(db, u.id);
+      expect(fresh?.assignedVaults.length).toBe(2);
     } finally {
       cleanup();
     }
@@ -541,6 +577,96 @@ describe("resetUserPassword", () => {
         )
         .get(bobToken.jti);
       expect(bobRow?.revoked_at).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("setUserVaults (multi-user Phase 2 PR 2)", () => {
+  test("returns false when user does not exist", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      expect(setUserVaults(db, "no-such-id", ["a"])).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("replaces a user's vault list atomically", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "alice", "alice-strong-passphrase", {
+        assignedVaults: ["personal"],
+      });
+      expect(setUserVaults(db, u.id, ["family", "work"])).toBe(true);
+      const fresh = getUserById(db, u.id);
+      // Old vault dropped; new ones present.
+      expect(new Set(fresh?.assignedVaults)).toEqual(new Set(["family", "work"]));
+      expect(fresh?.assignedVaults).not.toContain("personal");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("empty array clears every existing assignment (non-admin = no access)", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "alice", "alice-strong-passphrase", {
+        assignedVaults: ["a", "b", "c"],
+      });
+      expect(setUserVaults(db, u.id, [])).toBe(true);
+      const fresh = getUserById(db, u.id);
+      expect(fresh?.assignedVaults).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("de-duplicates repeated names without throwing", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "alice", "alice-strong-passphrase");
+      expect(setUserVaults(db, u.id, ["a", "a", "b"])).toBe(true);
+      const fresh = getUserById(db, u.id);
+      expect(new Set(fresh?.assignedVaults)).toEqual(new Set(["a", "b"]));
+      expect(fresh?.assignedVaults.length).toBe(2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("bumps updated_at so the SPA row reflects the change", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "alice", "alice-strong-passphrase", {
+        now: () => new Date(1000),
+      });
+      const before = getUserById(db, u.id);
+      expect(setUserVaults(db, u.id, ["a"], () => new Date(2000))).toBe(true);
+      const after = getUserById(db, u.id);
+      expect(after?.updatedAt).not.toBe(before?.updatedAt);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("vault assignments cascade-delete with the user row", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "alice", "alice-strong-passphrase", {
+        assignedVaults: ["a", "b"],
+      });
+      // Sanity: rows exist in user_vaults.
+      const before = db
+        .query<{ n: number }, [string]>("SELECT COUNT(*) AS n FROM user_vaults WHERE user_id = ?")
+        .get(u.id);
+      expect(before?.n).toBe(2);
+      deleteUser(db, u.id);
+      const after = db
+        .query<{ n: number }, [string]>("SELECT COUNT(*) AS n FROM user_vaults WHERE user_id = ?")
+        .get(u.id);
+      expect(after?.n).toBe(0);
     } finally {
       cleanup();
     }

--- a/src/account-home-ui.ts
+++ b/src/account-home-ui.ts
@@ -78,12 +78,13 @@ function header(): string {
 export interface RenderAccountHomeOpts {
   username: string;
   /**
-   * Assigned vault instance name, or `null` for users with no per-vault
-   * restriction. In Phase 1 a `null` assigned vault means "admin posture"
-   * (the OAuth issuer mints tokens for any requested vault) — combined
-   * with `isFirstAdmin: true` this is the hub administrator's account.
+   * Vault instance names this user has access to (multi-user Phase 2
+   * PR 2). Empty `[]` for admin posture (combined with `isFirstAdmin:
+   * true` this is the hub administrator's account, whose vault access
+   * is unrestricted). One or more entries for non-admin users — the
+   * page renders one Notes-CTA tile per vault.
    */
-  assignedVault: string | null;
+  assignedVaults: string[];
   /** Force-change-password completion flag. Currently informational only. */
   passwordChanged: boolean;
   /**
@@ -111,14 +112,14 @@ export interface RenderAccountHomeOpts {
 }
 
 export function renderAccountHome(opts: RenderAccountHomeOpts): string {
-  const { username, assignedVault, hubOrigin, isFirstAdmin, csrfToken } = opts;
+  const { username, assignedVaults, hubOrigin, isFirstAdmin, csrfToken } = opts;
   const safeUsername = escapeHtml(username);
   // Origin is already canonicalized by the handler (trailing slash stripped),
   // but defensively re-trim so a stray slash here doesn't break the CTA href.
   const trimmedOrigin = hubOrigin.replace(/\/+$/, "");
 
   const vaultCard = renderVaultCard({
-    assignedVault,
+    assignedVaults,
     trimmedOrigin,
     isFirstAdmin,
   });
@@ -142,31 +143,45 @@ export function renderAccountHome(opts: RenderAccountHomeOpts): string {
 }
 
 interface VaultCardOpts {
-  assignedVault: string | null;
+  assignedVaults: string[];
   trimmedOrigin: string;
   isFirstAdmin: boolean;
 }
 
 function renderVaultCard(opts: VaultCardOpts): string {
-  const { assignedVault, trimmedOrigin, isFirstAdmin } = opts;
+  const { assignedVaults, trimmedOrigin, isFirstAdmin } = opts;
 
-  if (assignedVault !== null) {
-    const safeVault = escapeHtml(assignedVault);
-    // Mirror setup-wizard.ts:renderStartUsingTile — vault URLs are
-    // `${hubOrigin}/vault/<name>`. URL-encode defensively even though
-    // current vault-name validation rules mean it's a no-op.
-    const vaultUrlForAdd = encodeURIComponent(`${trimmedOrigin}/vault/${assignedVault}`);
+  if (assignedVaults.length > 0) {
+    // One vault tile per assignment (multi-user Phase 2 PR 2). Each
+    // tile carries its own Notes "Open" CTA and the hub-origin code
+    // block. The disclosure ("Use a custom client") lives at the
+    // section level, not per-tile, because the hub origin is the same
+    // regardless of which vault the user picks.
     const hubOriginDisplay = escapeHtml(trimmedOrigin);
+    const heading = assignedVaults.length === 1 ? "<h2>Your vault</h2>" : "<h2>Your vaults</h2>";
+    const tiles = assignedVaults
+      .map((vaultName) => {
+        const safeVault = escapeHtml(vaultName);
+        const vaultUrlForAdd = encodeURIComponent(`${trimmedOrigin}/vault/${vaultName}`);
+        return `
+        <div class="vault-tile" data-testid="vault-tile" data-vault-name="${safeVault}">
+          <p class="vault-name"><strong>${safeVault}</strong></p>
+          <p>
+            <a class="btn btn-primary" href="https://notes.parachute.computer/add?url=${vaultUrlForAdd}"
+               target="_blank" rel="noopener" data-testid="open-notes-cta">Open Notes ↗</a>
+          </p>
+        </div>`;
+      })
+      .join("");
     return `
       <section class="section" data-testid="vault-card">
-        <h2>Your vault</h2>
-        <p class="vault-name"><strong>${safeVault}</strong></p>
-        <p>Open Notes — the canonical browser UI for your vault. It connects to your
-          hub over HTTPS and remembers your URL after the first OAuth.</p>
-        <p>
-          <a class="btn btn-primary" href="https://notes.parachute.computer/add?url=${vaultUrlForAdd}"
-             target="_blank" rel="noopener" data-testid="open-notes-cta">Open Notes ↗</a>
-        </p>
+        ${heading}
+        <p>Open Notes — the canonical browser UI for your vault${
+          assignedVaults.length === 1 ? "" : "s"
+        }. It connects to your hub
+          over HTTPS and remembers your URL after the first OAuth.</p>
+        <div class="vault-tiles">${tiles}
+        </div>
         <details class="custom-client">
           <summary>Use a custom client</summary>
           <p>To connect a custom Surface or MCP client running on your own machine,
@@ -184,10 +199,11 @@ function renderVaultCard(opts: VaultCardOpts): string {
           <a href="/admin/">the admin surface</a> to manage vaults, users, and clients.</p>
       </section>`;
   }
-  // Defensive third branch — non-admin with no assigned vault. PR 2's
-  // /api/users path always assigns a vault on create, so a friend reaching
-  // this state would have to come from a hand-edited row or a migration
-  // race. Surface a clear message instead of a blank card.
+  // Defensive third branch — non-admin with no assigned vault. The
+  // /api/users path doesn't require a vault on create (admins can leave
+  // a new friend's vault list empty and fill it in later), so this
+  // state is reachable through normal flows — surface a clear "ask
+  // your admin" message.
   return `
     <section class="section" data-testid="no-vault-card">
       <h2>Your vault</h2>
@@ -307,6 +323,20 @@ const STYLES = `
     margin: 0 0 0.6rem;
   }
   .vault-name strong { color: ${PALETTE.fg}; font-weight: 600; }
+  .vault-tiles {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin: 0.75rem 0 0.4rem;
+  }
+  .vault-tile {
+    border: 1px solid ${PALETTE.borderLight};
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    background: ${PALETTE.bgSoft};
+  }
+  .vault-tile p { margin: 0.2rem 0; }
+  .vault-tile p:last-child { margin-top: 0.5rem; }
 
   .custom-client { margin-top: 0.8rem; }
   .custom-client summary {

--- a/src/api-account.ts
+++ b/src/api-account.ts
@@ -492,7 +492,7 @@ export function handleAccountHomeGet(req: Request, deps: AccountHomeDeps): Respo
   return htmlResponse(
     renderAccountHome({
       username: user.username,
-      assignedVault: user.assignedVault,
+      assignedVaults: user.assignedVaults,
       passwordChanged: user.passwordChanged,
       hubOrigin: deps.hubOrigin,
       isFirstAdmin: adminFlag,

--- a/src/api-users.ts
+++ b/src/api-users.ts
@@ -1,11 +1,13 @@
 /**
  * `/api/users*` — admin endpoints for managing hub user accounts.
  *
- * Multi-user Phase 1, PR 2 of 5. Design:
+ * Multi-user Phase 2 PR 2 (per-user multi-vault membership). Design:
  * [`parachute.computer/design/2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/).
- * Tracker: hub#252. Builds on PR 1 (hub#279) which shipped migration v8 +
- * the `validateUsername` / `validatePassword` validators this layer wires
- * through.
+ * Tracker: hub#252. Builds on PR 1 (hub#279) which shipped migration v8
+ * + the `validateUsername` / `validatePassword` validators, and Phase 2
+ * PR 1 (admin password reset). PR 2 lifts the single `assigned_vault`
+ * column into the `user_vaults` many-to-many table (migration v10) so a
+ * user can have access to multiple vaults.
  *
  * Surfaces:
  *
@@ -13,6 +15,7 @@
  *   POST   /api/users                       create user (host:admin)
  *   DELETE /api/users/:id                   hard-delete user (host:admin)
  *   POST   /api/users/:id/reset-password    admin password reset (host:admin)
+ *   PATCH  /api/users/:id/vaults            edit a user's vault list (host:admin)
  *   GET    /api/users/vaults                vault-name list for the
  *                                           assigned-vault dropdown
  *                                           (host:admin)
@@ -56,6 +59,7 @@ import {
   isFirstAdmin,
   listUsers,
   resetUserPassword,
+  setUserVaults,
   validatePassword,
   validateUsername,
 } from "./users.ts";
@@ -70,16 +74,21 @@ export interface ApiUsersDeps {
 }
 
 /**
- * Wire shape for a user row. Mirrors the DB columns but renames for
- * snake_case-on-the-wire camelCase-in-TS: `password_changed`,
- * `assigned_vault`, `created_at`. **`password_hash` is never present**
+ * Wire shape for a user row. Mirrors the schema but renames for snake_
+ * case-on-the-wire / camelCase-in-TS: `password_changed`,
+ * `assigned_vaults`, `created_at`. **`password_hash` is never present**
  * — it's the one column that must not leak.
+ *
+ * `assigned_vaults` replaces the Phase 1 `assigned_vault: string | null`
+ * shape (multi-user Phase 2 PR 2). Empty array = "no vault narrowing"
+ * for admin posture; a non-empty array lists every vault the user has
+ * access to.
  */
 export interface UserWireShape {
   id: string;
   username: string;
   password_changed: boolean;
-  assigned_vault: string | null;
+  assigned_vaults: string[];
   created_at: string;
 }
 
@@ -88,7 +97,7 @@ function toWire(u: User): UserWireShape {
     id: u.id,
     username: u.username,
     password_changed: u.passwordChanged,
-    assigned_vault: u.assignedVault,
+    assigned_vaults: [...u.assignedVaults],
     created_at: u.createdAt,
   };
 }
@@ -120,7 +129,7 @@ export async function handleListUsers(req: Request, deps: ApiUsersDeps): Promise
 interface CreateUserBody {
   username: string;
   password: string;
-  assignedVault: string | null;
+  assignedVaults: string[];
 }
 
 interface ParseOk {
@@ -198,27 +207,50 @@ async function parseCreateBody(req: Request): Promise<ParseOk | ParseErr> {
       description: `password length must be ≤ ${PASSWORD_MAX_LEN} characters`,
     };
   }
-  // `assigned_vault` is optional — omitted (undefined) or explicit null
-  // both mean "no restriction (admin-level access)." Empty string is
-  // rejected as a confused client send (would otherwise persist as ""
-  // and never resolve in services.json).
-  let assignedVault: string | null = null;
-  if (Object.hasOwn(obj, "assignedVault")) {
-    const v = obj.assignedVault;
-    if (v === null) {
-      assignedVault = null;
-    } else if (typeof v === "string" && v.length > 0) {
-      assignedVault = v;
-    } else if (typeof v !== "undefined") {
-      return {
-        ok: false,
-        status: 400,
-        error: "invalid_request",
-        description: '"assignedVault" must be a non-empty string or null',
-      };
+  // `assigned_vaults` is optional — omitted, explicit null, or empty
+  // array all mean "no vault narrowing." Multi-user Phase 2 PR 2: the
+  // wire shape moved from `assigned_vault: string | null` (single name)
+  // to `assigned_vaults: string[]` (array). We accept both camelCase
+  // `assignedVaults` (current SPA send) and snake_case `assigned_vaults`
+  // (defensive — matches the response wire shape). Empty strings in the
+  // array are rejected; the validation against services.json runs in
+  // the handler.
+  let assignedVaults: string[] = [];
+  const rawVaults =
+    Object.hasOwn(obj, "assignedVaults") && obj.assignedVaults !== undefined
+      ? obj.assignedVaults
+      : Object.hasOwn(obj, "assigned_vaults") && obj.assigned_vaults !== undefined
+        ? obj.assigned_vaults
+        : undefined;
+  if (rawVaults === null || rawVaults === undefined) {
+    assignedVaults = [];
+  } else if (Array.isArray(rawVaults)) {
+    const result: string[] = [];
+    const seen = new Set<string>();
+    for (const v of rawVaults) {
+      if (typeof v !== "string" || v.length === 0) {
+        return {
+          ok: false,
+          status: 400,
+          error: "invalid_request",
+          description: '"assigned_vaults" must be an array of non-empty strings',
+        };
+      }
+      if (!seen.has(v)) {
+        seen.add(v);
+        result.push(v);
+      }
     }
+    assignedVaults = result;
+  } else {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      description: '"assigned_vaults" must be an array of strings (or omitted / null for none)',
+    };
   }
-  return { ok: true, body: { username, password, assignedVault } };
+  return { ok: true, body: { username, password, assignedVaults } };
 }
 
 /** POST /api/users — create user. */
@@ -235,7 +267,7 @@ export async function handleCreateUser(req: Request, deps: ApiUsersDeps): Promis
   if (!parsed.ok) {
     return jsonError(parsed.status, parsed.error, parsed.description);
   }
-  const { username, password, assignedVault } = parsed.body;
+  const { username, password, assignedVaults } = parsed.body;
 
   // PR 1's username validator — charset + length + reserved-word check.
   const u = validateUsername(username);
@@ -260,34 +292,34 @@ export async function handleCreateUser(req: Request, deps: ApiUsersDeps): Promis
     return jsonError(409, "username_taken", `username "${username}" is already in use`);
   }
 
-  // Validate `assigned_vault` against the live services.json vault list.
-  // A stale name (vault since removed) is rejected at create time per
-  // design §security/`assigned_vault validation`. NULL means "no
-  // restriction" and skips the check.
-  if (assignedVault !== null) {
+  // Validate every `assigned_vaults` entry against the live services.json
+  // vault list. A stale name (vault since removed) is rejected at create
+  // time. Empty list = "no narrowing" and skips the manifest read.
+  if (assignedVaults.length > 0) {
     const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
     const known = new Set(listVaultNamesFromPath(manifestPath));
-    if (!known.has(assignedVault)) {
+    const unknown = assignedVaults.filter((v) => !known.has(v));
+    if (unknown.length > 0) {
       return jsonError(
         400,
         "assigned_vault_not_found",
-        `assigned_vault "${assignedVault}" is not registered in services.json`,
+        `assigned vault(s) ${unknown.map((n) => `"${n}"`).join(", ")} not registered in services.json`,
       );
     }
   }
 
   // Persist. The admin-created path lands `passwordChanged: false` so the
   // user gets force-redirected through `/account/change-password` on
-  // first sign-in (PR 3). The wizard's first-admin path and the env-
-  // seed path both set `passwordChanged: true` explicitly — neither of
-  // those touches this endpoint. `allowMulti: true` because Phase 1 is
-  // the whole point — `createUser`'s single-user guard would otherwise
-  // 500 here once the first admin exists.
+  // first sign-in. The wizard's first-admin path and the env-seed path
+  // both set `passwordChanged: true` explicitly — neither touches this
+  // endpoint. `allowMulti: true` because multi-user is the whole point —
+  // `createUser`'s single-user guard would otherwise 500 once the first
+  // admin exists.
   try {
     const created = await createUser(deps.db, username, password, {
       allowMulti: true,
       passwordChanged: false,
-      assignedVault,
+      assignedVaults,
     });
     return new Response(JSON.stringify({ user: toWire(created) }), {
       status: 201,
@@ -387,6 +419,176 @@ export async function handleListVaults(req: Request, deps: ApiUsersDeps): Promis
   const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
   const vaults = listVaultNamesFromPath(manifestPath);
   return new Response(JSON.stringify({ vaults }), {
+    status: 200,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /api/users/:id/vaults — replace a user's vault assignments
+// ---------------------------------------------------------------------------
+
+interface UpdateVaultsBody {
+  assigned_vaults: string[];
+}
+
+async function parseUpdateVaultsBody(
+  req: Request,
+): Promise<{ ok: true; body: UpdateVaultsBody } | ParseErr> {
+  const ctype = req.headers.get("content-type") ?? "";
+  if (!ctype.toLowerCase().includes("application/json")) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      description: "Content-Type must be application/json",
+    };
+  }
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      description: `invalid JSON body: ${msg}`,
+    };
+  }
+  if (!raw || typeof raw !== "object") {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      description: "request body must be a JSON object",
+    };
+  }
+  const obj = raw as Record<string, unknown>;
+  // Accept both `assigned_vaults` (snake_case, primary) and
+  // `assignedVaults` (camelCase, defensive) — same shape as parseCreateBody.
+  const rawVaults =
+    Object.hasOwn(obj, "assigned_vaults") && obj.assigned_vaults !== undefined
+      ? obj.assigned_vaults
+      : Object.hasOwn(obj, "assignedVaults") && obj.assignedVaults !== undefined
+        ? obj.assignedVaults
+        : undefined;
+  if (rawVaults === undefined) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      description: '"assigned_vaults" is required (array of strings; pass [] to clear)',
+    };
+  }
+  if (!Array.isArray(rawVaults)) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      description: '"assigned_vaults" must be an array of strings',
+    };
+  }
+  const seen = new Set<string>();
+  const list: string[] = [];
+  for (const v of rawVaults) {
+    if (typeof v !== "string" || v.length === 0) {
+      return {
+        ok: false,
+        status: 400,
+        error: "invalid_request",
+        description: '"assigned_vaults" entries must be non-empty strings',
+      };
+    }
+    if (!seen.has(v)) {
+      seen.add(v);
+      list.push(v);
+    }
+  }
+  return { ok: true, body: { assigned_vaults: list } };
+}
+
+/**
+ * PATCH /api/users/:id/vaults — replace the user's vault assignments
+ * atomically (multi-user Phase 2 PR 2).
+ *
+ * Body: `{ "assigned_vaults": ["maya", "family"] }`. Pass `[]` to clear
+ * every assignment (the user retains their account but loses every per-
+ * vault grant — no narrowing for admins; "no access" for non-admins).
+ *
+ * Order of checks (mirrors `handleResetUserPassword`):
+ *
+ *   1. Method gate (405 on non-PATCH).
+ *   2. Bearer carries `parachute:host:admin` (401 / 403 via `requireScope`).
+ *   3. Parse body (400 on shape).
+ *   4. Target user exists (404 `not_found`).
+ *   5. Target is NOT the first admin (403 `cannot_edit_first_admin_vaults`)
+ *      — admin posture is unrestricted by design (`isFirstAdmin`); the
+ *      first admin's "vault membership" is implicit and shouldn't be
+ *      mutated. Mirrors the first-admin-undeletable rail.
+ *   6. Every requested vault name is registered in services.json
+ *      (400 `assigned_vault_not_found`).
+ *   7. `setUserVaults` — atomic DELETE+INSERT inside one transaction.
+ *
+ * Response on success: `200 { ok: true, user: <wire shape> }` with the
+ * updated `assigned_vaults` reflected.
+ */
+export async function handleUpdateUserVaults(
+  req: Request,
+  userId: string,
+  deps: ApiUsersDeps,
+): Promise<Response> {
+  if (req.method !== "PATCH") {
+    return jsonError(405, "method_not_allowed", "use PATCH");
+  }
+  try {
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+  } catch (err) {
+    return adminAuthErrorResponse(err as AdminAuthError);
+  }
+  const parsed = await parseUpdateVaultsBody(req);
+  if (!parsed.ok) {
+    return jsonError(parsed.status, parsed.error, parsed.description);
+  }
+  const target = getUserById(deps.db, userId);
+  if (!target) {
+    return jsonError(404, "not_found", `no user with id "${userId}"`);
+  }
+  // First-admin protection — admin posture is "unrestricted" by design
+  // (`isFirstAdmin` short-circuits `vaultScopeForUser` to `[]`). Pinning
+  // the first admin to a vault list would muddy that semantic. The SPA
+  // disables this row's button as a UX hint; the server check is
+  // authoritative.
+  if (isFirstAdmin(deps.db, userId)) {
+    return jsonError(
+      403,
+      "cannot_edit_first_admin_vaults",
+      "the first admin's vault membership is unrestricted by design — no vault list to edit",
+    );
+  }
+  // Validate every vault name against the live services.json list.
+  const assignedVaults = parsed.body.assigned_vaults;
+  if (assignedVaults.length > 0) {
+    const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
+    const known = new Set(listVaultNamesFromPath(manifestPath));
+    const unknown = assignedVaults.filter((v) => !known.has(v));
+    if (unknown.length > 0) {
+      return jsonError(
+        400,
+        "assigned_vault_not_found",
+        `assigned vault(s) ${unknown.map((n) => `"${n}"`).join(", ")} not registered in services.json`,
+      );
+    }
+  }
+  const ok = setUserVaults(deps.db, userId, assignedVaults);
+  if (!ok) {
+    return jsonError(404, "not_found", `no user with id "${userId}"`);
+  }
+  console.log(
+    `user vaults updated: id=${userId} username=${target.username} vaults=${assignedVaults.join(",")}`,
+  );
+  const fresh = getUserById(deps.db, userId);
+  return new Response(JSON.stringify({ ok: true, user: fresh ? toWire(fresh) : null }), {
     status: 200,
     headers: { "content-type": "application/json", "cache-control": "no-store" },
   });

--- a/src/hub-db.ts
+++ b/src/hub-db.ts
@@ -278,6 +278,48 @@ const MIGRATIONS: readonly Migration[] = [
       UPDATE clients SET same_hub = 0;
     `,
   },
+  {
+    version: 10,
+    sql: `
+      -- Multi-user Phase 2 PR 2 (hub#252 follow-up, design
+      -- 2026-05-20-multi-user-phase-1.md §Phase 2). Lifts the single
+      -- \`users.assigned_vault TEXT\` column into a many-to-many
+      -- \`user_vaults\` table so one user can have access to multiple
+      -- vaults (e.g. a personal vault + a family-shared vault).
+      --
+      -- Schema:
+      --   * (user_id, vault_name) composite PK — one row per (user, vault).
+      --     ON DELETE CASCADE on user_id so user deletion drops the
+      --     assignments without us having to clean up manually.
+      --   * \`role\` TEXT DEFAULT 'write' — reserved for forward-compat per-
+      --     vault role granularity. Phase 1 had no role model; this column
+      --     gives later PRs a column to land scope-narrowing in without a
+      --     second migration. All backfilled rows default to 'write'.
+      --   * index on \`vault_name\` for the inverse lookup ("who has access
+      --     to vault X?") — useful when admin removes a vault and we want
+      --     to warn about pinned users.
+      --
+      -- Backfill: every existing row in \`users\` with a non-null
+      -- \`assigned_vault\` becomes a single (user_id, vault_name) row in
+      -- \`user_vaults\`. Rows with NULL \`assigned_vault\` (admin posture)
+      -- get no \`user_vaults\` entry — they remain "no narrowing" per
+      -- vaultScopeForUser semantics. After backfill the \`assigned_vault\`
+      -- column is dropped.
+      CREATE TABLE user_vaults (
+        user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        vault_name TEXT NOT NULL,
+        role TEXT NOT NULL DEFAULT 'write',
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (user_id, vault_name)
+      );
+      CREATE INDEX user_vaults_vault ON user_vaults (vault_name);
+      INSERT INTO user_vaults (user_id, vault_name, role, created_at)
+      SELECT id, assigned_vault, 'write', created_at
+      FROM users
+      WHERE assigned_vault IS NOT NULL;
+      ALTER TABLE users DROP COLUMN assigned_vault;
+    `,
+  },
 ];
 
 export function openHubDb(path: string = hubDbPath()): Database {

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -147,6 +147,7 @@ import {
   handleListUsers,
   handleListVaults,
   handleResetUserPassword,
+  handleUpdateUserVaults,
 } from "./api-users.ts";
 import { buildChromeForRequest, injectChromeIntoResponse } from "./chrome-strip.ts";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "./config.ts";
@@ -1924,6 +1925,24 @@ export function hubFetch(
           return new Response("not found", { status: 404 });
         }
         return handleResetUserPassword(req, id, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          manifestPath,
+        });
+      }
+    }
+    // Phase 2 PR 2 — `/api/users/:id/vaults` (replace a user's vault
+    // assignments). Routed before the per-id DELETE catch-all so the
+    // trailing `/vaults` segment isn't mistaken for part of a user id.
+    {
+      const vaultsMatch = pathname.match(/^\/api\/users\/([^/]+)\/vaults$/);
+      if (vaultsMatch) {
+        if (!getDb) return dbNotConfigured();
+        const id = decodeURIComponent(vaultsMatch[1] ?? "");
+        if (!id) {
+          return new Response("not found", { status: 404 });
+        }
+        return handleUpdateUserVaults(req, id, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
           manifestPath,

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -910,7 +910,7 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   const hasStaleAssignment = assignedVaults.length > 0 && remainingValidVaults.length === 0;
 
   // Skip-consent gate (#75). If the user has previously granted every
-  // requested scope to this client, mint the auth code immediately. Two
+  // requested scope to this client, mint the auth code immediately. Three
   // important constraints:
   //   - Unnamed vault verbs (`vault:read`) need the picker even if a prior
   //     grant exists, because the operator's vault choice isn't recorded
@@ -922,10 +922,25 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   //   - Stale-assignment (above) also forces the consent render so the
   //     banner explains the broken state rather than silently minting a
   //     token against the missing vault.
+  //   - The user is admin OR has at least one assigned vault (hub#429
+  //     reviewer fold, follow-up). A zero-vault non-admin whose prior
+  //     grants survived a `setUserVaults(_, [])` admin action would
+  //     otherwise silently re-mint a token against the now-revoked
+  //     vault assignment — the grants table has no FK cascade from
+  //     `user_vaults`, so deleting assignments doesn't revoke grants.
+  //     Same privesc shape as the same-hub auto-trust gate below;
+  //     identical guard (`userHasVaultPosture`). Force fall-through to
+  //     the consent render where the zero-vault gate in
+  //     `handleConsentSubmit` also refuses (defense in depth). This
+  //     also transitively defends the trust-by-client_name auto-
+  //     promote path (~line 554) which recursively re-enters
+  //     `handleAuthorizeGet` after promoting the pending client.
   const hasUnnamedVault = unnamedVaultVerbs(requestedScopes).length > 0;
+  const userHasVaultPosture = userIsAdmin || assignedVaults.length > 0;
   if (
     !hasStaleAssignment &&
     !hasUnnamedVault &&
+    userHasVaultPosture &&
     isCoveredByGrant(db, session.userId, client.clientId, requestedScopes)
   ) {
     console.log(
@@ -966,7 +981,6 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   // hit the standard skip-consent gate above. Logged so an operator
   // auditing "who did this" can trace it back to a same-hub DCR.
   const hasAdminScope = requestedScopes.some(scopeIsAdmin);
-  const userHasVaultPosture = userIsAdmin || assignedVaults.length > 0;
   if (
     client.sameHub &&
     !hasAdminScope &&

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -83,7 +83,7 @@ import {
   findSession,
   parseSessionCookie,
 } from "./sessions.ts";
-import { getUserById, getUserByUsername, verifyPassword } from "./users.ts";
+import { getUserById, getUserByUsername, isFirstAdmin, verifyPassword } from "./users.ts";
 import { listVaultNames } from "./vault-names.ts";
 import { isVaultEntry, shortName, vaultInstanceNameFor } from "./well-known.ts";
 
@@ -114,30 +114,35 @@ function narrowVaultScopes(scopes: string[], pickedVault: string): string[] {
 
 /**
  * Derive the `vault_scope` claim value for a given hub user. Multi-user
- * Phase 1 (design
- * [`2026-05-20-multi-user-phase-1.md`](https://parachute.computer/design/2026-05-20-multi-user-phase-1/),
- * §oauth-claim-shape).
+ * Phase 2 PR 2 (design 2026-05-20-multi-user-phase-1.md §Phase 2 —
+ * many-to-many membership via the `user_vaults` table).
  *
  *   - `userId` resolves to no row → `[]`. Defensive: the caller already
  *     validated the user existed (auth-code redemption / refresh row's
- *     user_id), but a delete-between-mint-and-now race shouldn't 500. Empty
- *     is the safe sentinel — the scope-bearing `scope` claim is still the
- *     gate.
- *   - User exists with `assignedVault === null` → `[]`. Admin / unpinned
- *     posture; the consent picker is the source of truth.
- *   - User exists with `assignedVault === "name"` → `["name"]`. The Phase 1
- *     single-vault pin; PR 5's scope-guard at vault/notes/scribe consumes
- *     this to enforce that an assigned user can't request scope against any
- *     vault other than their assigned one.
+ *     user_id), but a delete-between-mint-and-now race shouldn't 500.
+ *     Empty is the safe sentinel — the scope-bearing `scope` claim is
+ *     still the gate.
+ *   - First admin → `[]`. Admin posture is unrestricted by design (see
+ *     `isFirstAdmin`). The consent picker is the source of truth and
+ *     the scope-guard reads an empty `vault_scope` claim as "no
+ *     narrowing" — first admin can request scope against any vault.
+ *   - Non-admin user → the list of vault names from `user_vaults`. The
+ *     scope-guard at vault/notes/scribe enforces that the user can
+ *     only request scope against vaults in their list (Phase 1 pinned
+ *     to a single vault; Phase 2 lifts that to N). A non-admin with
+ *     zero assignments returns `[]` — distinct semantics from the
+ *     admin's `[]` because the consent picker plus the picked-must-
+ *     match-assignment defense in `handleConsentSubmit` enforces that
+ *     non-admin tokens carry a non-empty `vault_scope`.
  *
  * Always returns an array (never undefined) so the JWT carries the claim
  * unconditionally — readers don't have to distinguish "absent" from "empty."
  */
 export function vaultScopeForUser(db: Database, userId: string): string[] {
+  if (isFirstAdmin(db, userId)) return [];
   const user = getUserById(db, userId);
   if (!user) return [];
-  if (user.assignedVault === null) return [];
-  return [user.assignedVault];
+  return [...user.assignedVaults];
 }
 
 export interface OAuthDeps {
@@ -862,12 +867,20 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
     return htmlResponse(renderLogin({ params: parsed, csrfToken: csrf.token }), 200, extra);
   }
 
-  // Multi-user Phase 1: non-admin users (with `assigned_vault !== null`) see
-  // the picker locked to their assigned vault — they can't pick a different
-  // one. Admin users (assigned_vault === null) see the full dropdown.
-  // Defensive null-coalesce: the session points at a deleted user shouldn't
-  // 500; treat as admin posture (the broader scope-validation gate will
-  // catch any actual privilege issue).
+  // Multi-user Phase 2 PR 2: non-admin users see the picker narrowed to
+  // their assigned vault list — they can't pick a vault they don't own.
+  // First admin (admin posture) sees the full dropdown of every vault on
+  // the hub.
+  //
+  // Two shapes for non-admin users emerge:
+  //   - exactly one assigned vault → picker renders locked to that name
+  //     (same shape as Phase 1; smallest diff for the common case).
+  //   - two or more assigned vaults → picker renders a free dropdown
+  //     filtered to those names — user picks one per consent.
+  //
+  // Defensive null-coalesce: the session points at a deleted user
+  // shouldn't 500; treat as admin posture (the broader scope-validation
+  // gate will catch any actual privilege issue).
   //
   // Resolved here (before the fast-paths) because the stale-assignment
   // predicate below — which gates both skip-consent (#75) and same-hub
@@ -876,21 +889,25 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   // closing the silent-mint-on-stale-vault gap; the read is one JSON parse
   // off-disk per /authorize.
   const user = getUserById(db, session.userId);
-  const lockedVault = user?.assignedVault ?? null;
+  const userIsAdmin = isFirstAdmin(db, session.userId);
+  // Non-admin user's assigned vaults; admin posture (or no row) → empty.
+  const assignedVaults: string[] = userIsAdmin ? [] : (user?.assignedVaults ?? []);
   const manifest = (deps.loadServicesManifest ?? readServicesManifest)();
   const vaultNames = listVaultNames(manifest);
 
-  // Stale-assignment predicate (hub#284 reviewer fold). The user has an
-  // `assigned_vault` pinned on their row but the named vault is no longer
-  // in services.json. Both fast-paths below (#75 skip-consent, hub#312
-  // same-hub auto-trust) would otherwise silently mint a token for a vault
-  // that doesn't exist — the user thinks consent succeeded but the
-  // downstream API calls fail with no actionable signal. Fall through to
-  // the consent render in either case so the banner UX (and the disabled
-  // Approve when the requested scope depends on a vault) surfaces the
-  // condition + admin-remediation path. Admin users (`lockedVault === null`)
-  // are never stale.
-  const hasStaleAssignment = lockedVault !== null && !vaultNames.includes(lockedVault);
+  // Stale-assignment predicate (hub#284, generalized in Phase 2 PR 2 from
+  // single-vault to N-vault). For a non-admin user, "stale" means at
+  // least one of their assigned vaults no longer exists in services.json
+  // AND no vault in their list still exists — i.e. they have *zero*
+  // valid vaults to consent against. The banner surfaces this state with
+  // an admin-remediation hint instead of silently minting a token
+  // against a missing vault. If at least one of their vaults still
+  // exists, the consent flow proceeds normally — the missing ones drop
+  // out of the picker without ceremony.
+  //
+  // Admin users are never stale (they aren't pinned to any vault list).
+  const remainingValidVaults = assignedVaults.filter((v) => vaultNames.includes(v));
+  const hasStaleAssignment = assignedVaults.length > 0 && remainingValidVaults.length === 0;
 
   // Skip-consent gate (#75). If the user has previously granted every
   // requested scope to this client, mint the auth code immediately. Two
@@ -952,7 +969,7 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   }
 
   return htmlResponse(
-    renderConsent(consentProps(client, parsed, vaultNames, csrf.token, lockedVault)),
+    renderConsent(consentProps(client, parsed, vaultNames, csrf.token, assignedVaults)),
     200,
     extra,
   );
@@ -1140,18 +1157,18 @@ async function handleConsentSubmit(
       params.state,
     );
   }
-  // Multi-user Phase 1 (design 2026-05-20-multi-user-phase-1.md): non-admin
-  // users (`assigned_vault !== null`) are pinned to a single vault. The
-  // consent screen renders the picker locked to that vault and any named
-  // scopes (`vault:<name>:<verb>`) requested by the client must match. The
-  // server-side defense here refuses any mint where the user's submission
-  // disagrees — Aaron pinned this as "server-side defense refuses mints
-  // whose picked vault disagrees with assigned_vault" rather than silent
-  // overwrite, so a hand-crafted POST or a misbehaving SPA can't bypass the
-  // lock. Admin users (`assigned_vault === null`) keep the existing picker-
-  // as-source-of-truth behavior.
+  // Multi-user Phase 2 PR 2: non-admin users are pinned to a list of one
+  // or more vaults via `user_vaults`. The consent screen renders the
+  // picker narrowed to that list and any named scopes (`vault:<name>:
+  // <verb>`) requested by the client must target a vault in the list.
+  // The server-side defense here refuses any mint where the user's
+  // submission disagrees, so a hand-crafted POST or a misbehaving SPA
+  // can't bypass the narrowing. First admin (admin posture) keeps the
+  // existing picker-as-source-of-truth behavior (empty `assignedVaults`).
+  const userIsAdmin = isFirstAdmin(db, session.userId);
   const sessionUser = getUserById(db, session.userId);
-  const assignedVault = sessionUser?.assignedVault ?? null;
+  const assignedVaults: string[] = userIsAdmin ? [] : (sessionUser?.assignedVaults ?? []);
+  const isPinned = assignedVaults.length > 0;
 
   // Vault picker (Q1 of the vault-config-and-scopes design): an unnamed
   // `vault:<verb>` scope is ambiguous about which vault it grants access to.
@@ -1171,24 +1188,17 @@ async function handleConsentSubmit(
     const manifest = (deps.loadServicesManifest ?? readServicesManifest)();
     const validNames = listVaultNames(manifest);
     if (!validNames.includes(pickedVault)) {
-      // Stale-assignment branch (hub#284). Surfaced during hub#283
-      // reviewer pass — the pre-rc.11 path 400'd with the generic
-      // "Unknown vault" copy when a user whose assigned_vault was
-      // removed by the admin landed back on consent and submitted the
-      // stale name. The locked picker rendered the missing name, the
-      // form posted it, the user saw "vault X is not registered" and
-      // had no path forward. The new copy names the actual condition
-      // (assignment removed) and points at the admin remediation
-      // surface (/admin/users) instead of leaving the user wondering
-      // whether hub itself is broken.
+      // Stale-assignment branch (hub#284, generalized Phase 2 PR 2). The
+      // user is consenting via an assignment that points at a vault no
+      // longer in services.json. The new copy names the actual condition
+      // (assignment removed) and points at the admin remediation surface.
       //
-      // The check fires only when the user's `assigned_vault` claim
-      // matches the picked vault — narrows the special-case to the
-      // "user is consenting via their locked assignment that's now
-      // stale" shape rather than swallowing every Unknown-vault. A
-      // hand-crafted POST naming a never-existed vault still hits the
-      // generic branch.
-      if (assignedVault !== null && pickedVault === assignedVault) {
+      // The check fires when the picked vault is in the user's assigned
+      // list — narrows the special-case to the "user is consenting via
+      // a now-stale assignment" shape rather than swallowing every
+      // Unknown-vault. A hand-crafted POST naming a never-existed vault
+      // still hits the generic branch.
+      if (isPinned && assignedVaults.includes(pickedVault)) {
         return htmlError(
           "Assigned vault was removed",
           `Your assigned vault "${pickedVault}" is no longer registered on this hub. Ask the hub admin to reassign you to an existing vault via /admin/users, then try again.`,
@@ -1201,16 +1211,16 @@ async function handleConsentSubmit(
         400,
       );
     }
-    // Server-side defense: non-admin user submitted a vault that disagrees
-    // with their `assigned_vault`. The picker rendered as locked, so a UI-
-    // path user couldn't reach this — but a hand-crafted form bypassing the
-    // locked input lands here. Refuse the mint instead of silently
-    // overwriting; the explicit error tells the operator the assignment is
-    // load-bearing.
-    if (assignedVault !== null && pickedVault !== assignedVault) {
+    // Server-side defense: non-admin user submitted a vault that's not in
+    // their assigned list. The picker rendered as narrowed, so a UI-path
+    // user couldn't reach this — but a hand-crafted form bypassing the
+    // narrowed input lands here. Refuse the mint instead of silently
+    // overwriting; the explicit error tells the operator the assignment
+    // is load-bearing.
+    if (isPinned && !assignedVaults.includes(pickedVault)) {
       return htmlError(
         "Vault assignment mismatch",
-        `vault_scope_mismatch: the picked vault "${pickedVault}" does not match your vault assignment. Ask the hub admin to update your assignment, or pick the vault shown on the consent screen.`,
+        `vault_scope_mismatch: the picked vault "${pickedVault}" is not in your vault assignment. Ask the hub admin to update your assignment, or pick a vault shown on the consent screen.`,
         400,
       );
     }
@@ -1218,12 +1228,12 @@ async function handleConsentSubmit(
   }
 
   // Server-side defense for named-vault scopes (`vault:<name>:<verb>`) too.
-  // A non-admin user can't request scope against any vault other than their
-  // assigned one — same invariant as the picker check above, applied to
-  // scopes that arrived already-named (e.g. a client that knows the user's
-  // vault and asked for `vault:bob:read` directly). Admins (assigned_vault
-  // null) skip this check.
-  if (assignedVault !== null) {
+  // A non-admin user can't request scope against any vault outside their
+  // assignment list — same invariant as the picker check above, applied
+  // to scopes that arrived already-named (e.g. a client that knows the
+  // user's vault and asked for `vault:bob:read` directly). Admin posture
+  // (`isPinned === false`) skips this check.
+  if (isPinned) {
     const mismatched: string[] = [];
     for (const s of scopes) {
       const parts = s.split(":");
@@ -1233,7 +1243,7 @@ async function handleConsentSubmit(
         parts[1] &&
         parts[2] &&
         VAULT_VERBS.has(parts[2]) &&
-        parts[1] !== assignedVault
+        !assignedVaults.includes(parts[1])
       ) {
         mismatched.push(s);
       }
@@ -1241,29 +1251,29 @@ async function handleConsentSubmit(
     if (mismatched.length > 0) {
       return htmlError(
         "Vault assignment mismatch",
-        `vault_scope_mismatch: requested scopes ${mismatched.join(", ")} target a vault other than your vault assignment.`,
+        `vault_scope_mismatch: requested scopes ${mismatched.join(", ")} target a vault outside your assignment.`,
         400,
       );
     }
 
-    // Stale-assignment defense (hub#284) for named-vault scopes. A scope
-    // shaped `vault:<assigned>:<verb>` passes the mismatch check above but
-    // points at a vault that no longer exists in services.json. Minting a
-    // token here would silently issue scope against a vault the resource
-    // server can't find — the user thinks consent succeeded but the
-    // subsequent API calls fail with no actionable signal. Refuse the mint
-    // and surface the same admin-remediation hint the GET path's banner
-    // uses, so the picker-bypass POST and the natural form-render arrive at
-    // the same recovery story.
+    // Stale-assignment defense (hub#284, generalized Phase 2 PR 2). A
+    // named scope shaped `vault:<assigned>:<verb>` passes the mismatch
+    // check above but points at a vault that no longer exists in
+    // services.json. Minting a token here would silently issue scope
+    // against a vault the resource server can't find — the user thinks
+    // consent succeeded but the subsequent API calls fail with no
+    // actionable signal. Refuse the mint and surface the same admin-
+    // remediation hint the GET path's banner uses.
     const namedStaleScopes: string[] = [];
     for (const s of scopes) {
       const parts = s.split(":");
       if (
         parts.length === 3 &&
         parts[0] === "vault" &&
-        parts[1] === assignedVault &&
+        parts[1] !== undefined &&
         parts[2] &&
-        VAULT_VERBS.has(parts[2])
+        VAULT_VERBS.has(parts[2]) &&
+        assignedVaults.includes(parts[1])
       ) {
         namedStaleScopes.push(s);
       }
@@ -1273,10 +1283,19 @@ async function handleConsentSubmit(
       // the no-vault-scope hot path off-disk for the common admin flows.
       const manifest = (deps.loadServicesManifest ?? readServicesManifest)();
       const validNames = listVaultNames(manifest);
-      if (!validNames.includes(assignedVault)) {
+      // Collect the stale vault names embedded in the named scopes.
+      const staleNames = new Set<string>();
+      for (const s of namedStaleScopes) {
+        const parts = s.split(":");
+        if (parts[1] !== undefined && !validNames.includes(parts[1])) {
+          staleNames.add(parts[1]);
+        }
+      }
+      if (staleNames.size > 0) {
+        const exemplar = [...staleNames][0];
         return htmlError(
           "Assigned vault was removed",
-          `Your assigned vault "${assignedVault}" is no longer registered on this hub. Ask the hub admin to reassign you to an existing vault via /admin/users, then try again.`,
+          `Your assigned vault "${exemplar}" is no longer registered on this hub. Ask the hub admin to reassign you to an existing vault via /admin/users, then try again.`,
           400,
         );
       }
@@ -1421,10 +1440,7 @@ export async function handleApproveClientPost(
       );
     }
     target.searchParams.set("error", "access_denied");
-    target.searchParams.set(
-      "error_description",
-      "The user denied the authorization request.",
-    );
+    target.searchParams.set("error_description", "The user denied the authorization request.");
     if (denyState !== undefined) target.searchParams.set("state", denyState);
     return redirectResponse(target.toString());
   }
@@ -2156,95 +2172,101 @@ function consentProps(
   params: AuthorizeFormParams,
   vaultNames: string[],
   csrfToken: string,
-  lockedVault: string | null,
+  assignedVaults: readonly string[],
 ) {
   const scopes = params.scope.split(" ").filter((s) => s.length > 0);
   const unnamedVerbs = unnamedVaultVerbs(scopes);
-  // Multi-user Phase 1, stale-assignment branch (hub#284). The user has an
-  // `assigned_vault` pinned on their row but the named vault is no longer
-  // in services.json — admin removed / renamed it without reassigning the
-  // user. Pre-hub#284 this fell through to the locked picker, posted the
-  // stale name, and `handleConsentSubmit` rejected it with a generic
-  // "Unknown vault" 400. The user couldn't tell what happened or how to
-  // recover.
+  // Multi-user Phase 2 PR 2 stale-assignment branch (hub#284 generalized
+  // from one vault to N). A non-admin user whose entire vault list has
+  // been removed from services.json — admin removed / renamed the vaults
+  // without reassigning. The banner surfaces this state with an admin-
+  // remediation hint instead of silently minting against a missing vault.
   //
-  // Detect it here and surface the banner on the consent screen explaining
-  // the state and pointing at admin remediation. The banner is informational
-  // for non-vault-scoped flows (the user can still consent to e.g.
-  // `scribe:transcribe` without a working vault assignment), but the picker
-  // section + Approve button are gated when the requested scope actually
-  // depends on a vault — see the `vaultPicker` + `approveDisabled` logic
-  // below.
+  // The user-facing surface is "your assigned vault(s) were removed" —
+  // the banner names the first stale vault as the canonical example. The
+  // exact list is unimportant for the recovery path (operator goes to
+  // /admin/users either way), and pluralizing the banner copy doesn't
+  // change the action.
   //
-  // Security posture: we deliberately do NOT relax the picked-must-match-
-  // assigned check or let the user pick any other vault. Doing so would
-  // let assignment-binding be circumvented by getting an admin to remove
-  // the assigned vault. Stale-assignment is an admin-remediated state.
+  // Security posture: we deliberately do NOT relax the picked-must-be-in-
+  // assigned-list check. Stale-assignment is admin-remediated.
+  const remainingValidAssigned = assignedVaults.filter((v) => vaultNames.includes(v));
+  const hasStaleAssignment = assignedVaults.length > 0 && remainingValidAssigned.length === 0;
   const staleAssignedVault =
-    lockedVault !== null && !vaultNames.includes(lockedVault) ? lockedVault : undefined;
-  // A named scope like `vault:<old>:read` requested by the client where
-  // <old> is the user's stale assigned_vault. The server-side named-scope
-  // defense (`handleConsentSubmit`) allows this through because the scope
-  // matches `assignedVault`, but the token it mints would point at a vault
-  // that doesn't exist. Gate Approve on this case too so the user doesn't
-  // burn a consent into a token that fails at the resource server.
+    hasStaleAssignment && assignedVaults[0] !== undefined ? assignedVaults[0] : undefined;
+  // A named scope like `vault:<old>:<verb>` requested by the client where
+  // <old> is one of the user's stale vaults. The server-side named-scope
+  // defense allows this through because the scope matches an assigned
+  // vault, but the token it mints would point at a vault that no longer
+  // exists. Gate Approve on this case too so the user doesn't burn a
+  // consent into a token that fails at the resource server.
   const hasNamedStaleVaultScope =
-    staleAssignedVault !== undefined &&
+    hasStaleAssignment &&
     scopes.some((s) => {
       const parts = s.split(":");
-      return (
-        parts.length === 3 &&
-        parts[0] === "vault" &&
-        parts[1] === staleAssignedVault &&
-        parts[2] !== undefined &&
-        VAULT_VERBS.has(parts[2])
-      );
+      if (
+        parts.length !== 3 ||
+        parts[0] !== "vault" ||
+        parts[1] === undefined ||
+        parts[2] === undefined ||
+        !VAULT_VERBS.has(parts[2])
+      ) {
+        return false;
+      }
+      // Named for one of the user's vaults — and given hasStaleAssignment,
+      // none of the user's vaults exist on this hub, so this scope points
+      // at a stale name.
+      return assignedVaults.includes(parts[1]);
     });
 
-  // Multi-user Phase 1 (design 2026-05-20-multi-user-phase-1.md, decision-pin
-  // "consent picker for non-admin users"): non-admin users (assigned_vault
-  // non-null) see the picker locked to their `assigned_vault` rather than a
-  // free dropdown. Phase 2 will hide other vaults entirely; Phase 1 ships
-  // lock-the-picker (the smallest diff that satisfies "user can't pick a
-  // vault they don't own"). Server-side defense in `handleConsentSubmit`
-  // refuses mints whose POST disagrees regardless of how the picker is
-  // rendered.
+  // Multi-user Phase 2 PR 2: non-admin users see the picker narrowed to
+  // their assigned vault list. Three shapes emerge:
   //
-  // Stale-assignment shape (hub#284): when the user's assigned_vault no
-  // longer exists, the picker renders as no-vaults-available rather than
-  // locking onto a missing name — the banner above the scope list explains
-  // why and the disabled Approve prevents a form submit that would fail
-  // server-side anyway.
+  //   - Single assigned vault (still valid) → render locked to that name
+  //     (same shape as Phase 1).
+  //   - Two-or-more assigned vaults → render a dropdown filtered to the
+  //     user's list. Same control as the admin dropdown but narrowed.
+  //   - Stale-assigned (all vaults gone) → render no-vaults-available so
+  //     the form gracefully rejects an Approve click instead of silently
+  //     submitting a missing name.
+  //
+  // Admin users (empty `assignedVaults`) see the full hub-wide dropdown.
   let vaultPicker: VaultPickerProps | undefined;
   if (unnamedVerbs.length > 0) {
-    if (staleAssignedVault !== undefined) {
+    if (hasStaleAssignment) {
       vaultPicker = { unnamedVerbs, availableVaults: [] };
-    } else if (lockedVault !== null) {
-      vaultPicker = { unnamedVerbs, availableVaults: vaultNames, lockedVault };
+    } else if (remainingValidAssigned.length === 1) {
+      const only = remainingValidAssigned[0];
+      if (only !== undefined) {
+        vaultPicker = { unnamedVerbs, availableVaults: [only], lockedVault: only };
+      }
+    } else if (remainingValidAssigned.length > 1) {
+      vaultPicker = { unnamedVerbs, availableVaults: remainingValidAssigned };
     } else {
+      // Admin posture (no assignments) → full hub-wide list.
       vaultPicker = { unnamedVerbs, availableVaults: vaultNames };
     }
   }
   // Named-scope display: substitute unnamed `vault:<verb>` rows with the
   // resolved form the operator will actually consent to.
-  //   - Non-admin (lockedVault set, NOT stale) → render `vault:<lockedVault>:<verb>`.
-  //   - Stale-assigned (hub#284) → null; the scope row carries the
-  //     `<TBD>` placeholder. The banner explains why a name isn't bound.
-  //   - Admin with exactly one vault available → render that vault's name;
-  //     the picker pre-checks it and a default-Approve mints scope against
-  //     it, so the displayed scope matches the next state of the form.
-  //   - Admin with multiple vaults / no vaults → null sentinel; render with
-  //     a `<TBD>` placeholder + a hint pointing at the picker. Once the
-  //     operator clicks a radio the JS-free form still posts the chosen
-  //     name; the displayed scope only changes after the next page render.
+  //   - Non-admin with exactly one valid assigned vault → render that name.
+  //   - Stale-assigned → null; the row carries the `<TBD>` placeholder.
+  //     The banner explains why a name isn't bound.
+  //   - Non-admin with multiple assigned vaults → null sentinel (the user
+  //     hasn't picked yet).
+  //   - Admin with exactly one vault available → render that name.
+  //   - Admin with multiple / no vaults → null sentinel.
   let displayVault: string | null = null;
-  if (staleAssignedVault === undefined && lockedVault !== null) {
-    displayVault = lockedVault;
+  if (!hasStaleAssignment && remainingValidAssigned.length === 1) {
+    const only = remainingValidAssigned[0];
+    if (only !== undefined) displayVault = only;
   } else if (
-    staleAssignedVault === undefined &&
+    !hasStaleAssignment &&
+    assignedVaults.length === 0 &&
     unnamedVerbs.length > 0 &&
     vaultNames.length === 1
   ) {
+    // Admin with a single vault on the hub: pre-check pattern from Phase 1.
     const only = vaultNames[0];
     if (only) displayVault = only;
   }

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -948,16 +948,32 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   //      still want explicit consent as a sanity gate.
   //   3. No unnamed vault verbs are requested — those need the picker to
   //      narrow `vault:<verb>` → `vault:<name>:<verb>` before mint.
-  //   4. The user's assigned_vault is not stale (hub#284 reviewer fold) —
-  //      otherwise the same-hub gate would silently mint a token for a
-  //      removed vault before the consent-render path's stale detection
-  //      ever runs.
+  //   4. The user's assigned_vaults list is not stale (hub#284 reviewer
+  //      fold) — otherwise the same-hub gate would silently mint a token
+  //      for a removed vault before the consent-render path's stale
+  //      detection ever runs.
+  //   5. The user is admin OR has at least one assigned vault (Phase 2
+  //      PR 2 reviewer fold). A zero-vault non-admin has
+  //      `hasStaleAssignment=false` (length===0 short-circuits the stale
+  //      predicate above) and would otherwise sail through the auto-
+  //      trust gate. The resulting `vault_scope: []` claim is the admin
+  //      "unrestricted" sentinel — minting it for a non-admin grants
+  //      hub-wide vault access. Force fall-through to the consent
+  //      render where the zero-vault gate in `handleConsentSubmit` also
+  //      refuses (defense in depth).
   //
   // The grant is also recorded so subsequent flows with the same scopes
   // hit the standard skip-consent gate above. Logged so an operator
   // auditing "who did this" can trace it back to a same-hub DCR.
   const hasAdminScope = requestedScopes.some(scopeIsAdmin);
-  if (client.sameHub && !hasAdminScope && !hasUnnamedVault && !hasStaleAssignment) {
+  const userHasVaultPosture = userIsAdmin || assignedVaults.length > 0;
+  if (
+    client.sameHub &&
+    !hasAdminScope &&
+    !hasUnnamedVault &&
+    !hasStaleAssignment &&
+    userHasVaultPosture
+  ) {
     console.log(
       `[oauth] auto-approved same-hub client client_id=${client.clientId} user_id=${session.userId} scopes=${requestedScopes.join(" ")} (hub#312)`,
     );
@@ -969,7 +985,9 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   }
 
   return htmlResponse(
-    renderConsent(consentProps(client, parsed, vaultNames, csrf.token, assignedVaults)),
+    renderConsent(
+      consentProps(client, parsed, vaultNames, csrf.token, assignedVaults, userIsAdmin),
+    ),
     200,
     extra,
   );
@@ -1169,6 +1187,34 @@ async function handleConsentSubmit(
   const sessionUser = getUserById(db, session.userId);
   const assignedVaults: string[] = userIsAdmin ? [] : (sessionUser?.assignedVaults ?? []);
   const isPinned = assignedVaults.length > 0;
+
+  // Zero-vault non-admin gate (Phase 2 PR 2 reviewer fold). A non-admin
+  // user with no `user_vaults` rows is a known-but-not-yet-assigned
+  // posture — they can sign in to /account/, change their password, and
+  // see the home page, but they have no vaults to authorize against.
+  // Block any vault-scoped consent at the submit boundary so an OAuth
+  // client can't trick them into minting a token: an empty `vault_scope`
+  // claim is the admin "unrestricted" sentinel (see `vaultScopeForUser`),
+  // and we must keep that sentinel reserved for true admins. Non-vault
+  // scopes (`scribe:transcribe`, etc.) still consent normally — only
+  // `vault:...` scopes are gated here. The defense pairs with the GET-
+  // path same-hub-auto-trust gate below (which falls through to the
+  // consent render that would otherwise show the picker).
+  if (!userIsAdmin && assignedVaults.length === 0) {
+    const submittedScopes = params.scope.split(" ").filter((s) => s.length > 0);
+    const hasVaultScope = submittedScopes.some((s) => {
+      if (s === "vault:read" || s === "vault:write" || s === "vault:admin") return true;
+      const parts = s.split(":");
+      return parts.length === 3 && parts[0] === "vault" && parts[2] && VAULT_VERBS.has(parts[2]);
+    });
+    if (hasVaultScope) {
+      return htmlError(
+        "No vaults assigned",
+        "vault_scope_mismatch: you have no assigned vaults on this hub yet, so you can't authorize an app for vault access. Ask the hub admin to assign you at least one vault via /admin/users, then try again.",
+        400,
+      );
+    }
+  }
 
   // Vault picker (Q1 of the vault-config-and-scopes design): an unnamed
   // `vault:<verb>` scope is ambiguous about which vault it grants access to.
@@ -1676,11 +1722,17 @@ async function handleTokenAuthorizationCode(
     audience,
     clientId: redeemed.clientId,
     issuer: deps.issuer,
-    // vault_scope claim — Phase 1 per-user vault pin. Non-empty list for
-    // non-admin users with `assigned_vault` set; empty for admin / unpinned.
-    // The narrowing in `handleConsentSubmit` already rewrote `vault:<verb>` →
-    // `vault:<assigned_vault>:<verb>` for non-admin users, so the auth code's
-    // scopes are pre-aligned; this claim is the explicit "owned vault"
+    // vault_scope claim — Phase 2 per-user vault pin (Phase 1 had a single
+    // `assigned_vault` column; Phase 2 PR 2 generalized to `assigned_vaults`
+    // via `user_vaults`). Non-empty list for non-admin users with at least
+    // one assigned vault; empty for first-admin (unrestricted sentinel).
+    // Zero-vault non-admin is also empty by `vaultScopeForUser`, but the
+    // OAuth flow refuses to mint a vault-scoped token for them upstream
+    // (see the zero-vault gate in `handleConsentSubmit` + the same-hub
+    // auto-trust posture check), so we never reach here with that user
+    // posture. The narrowing in `handleConsentSubmit` already rewrote
+    // `vault:<verb>` → `vault:<assigned>:<verb>`, so the auth code's
+    // scopes are pre-aligned; this claim is the explicit "owned vaults"
     // signal PR 5 consumes downstream.
     vaultScope: vaultScopeForUser(db, redeemed.userId),
     now: deps.now,
@@ -1797,12 +1849,12 @@ async function handleTokenRefresh(
     clientId: row.clientId,
     issuer: deps.issuer,
     // vault_scope claim — re-derived from the user's *current*
-    // `assigned_vault` at refresh time (not snapshotted onto the refresh-
-    // token row). An admin who changes a user's `assigned_vault` between
+    // `assigned_vaults` at refresh time (not snapshotted onto the refresh-
+    // token row). An admin who changes a user's vault assignments between
     // mint and refresh sees the new value on the next refresh; existing
     // access tokens carry their original claim until their 15-minute TTL
     // elapses. Same posture as the design's "OAuth issuer reads
-    // `assigned_vault` at mint time, not at session-creation time" pin.
+    // `assigned_vaults` at mint time, not at session-creation time" pin.
     vaultScope: vaultScopeForUser(db, refreshUserId),
     now: deps.now,
   });
@@ -2173,6 +2225,7 @@ function consentProps(
   vaultNames: string[],
   csrfToken: string,
   assignedVaults: readonly string[],
+  userIsAdmin: boolean,
 ) {
   const scopes = params.scope.split(" ").filter((s) => s.length > 0);
   const unnamedVerbs = unnamedVaultVerbs(scopes);
@@ -2220,7 +2273,7 @@ function consentProps(
     });
 
   // Multi-user Phase 2 PR 2: non-admin users see the picker narrowed to
-  // their assigned vault list. Three shapes emerge:
+  // their assigned vault list. Four shapes emerge:
   //
   //   - Single assigned vault (still valid) → render locked to that name
   //     (same shape as Phase 1).
@@ -2229,8 +2282,15 @@ function consentProps(
   //   - Stale-assigned (all vaults gone) → render no-vaults-available so
   //     the form gracefully rejects an Approve click instead of silently
   //     submitting a missing name.
-  //
-  // Admin users (empty `assignedVaults`) see the full hub-wide dropdown.
+  //   - First admin (admin posture, empty `assignedVaults`) → full hub-
+  //     wide dropdown of every vault on the hub.
+  //   - Zero-vault non-admin (Phase 2 PR 2 reviewer fold) → no-vaults-
+  //     available so the form gracefully rejects an Approve click. The
+  //     prior shape rendered the full hub-wide list for non-admins with
+  //     zero assignments, which let them pick a vault they had no
+  //     business consenting to. The consent-submit gate refuses any
+  //     vault-scoped POST from a zero-vault non-admin (defense in depth);
+  //     this branch keeps the picker UI honest.
   let vaultPicker: VaultPickerProps | undefined;
   if (unnamedVerbs.length > 0) {
     if (hasStaleAssignment) {
@@ -2242,9 +2302,17 @@ function consentProps(
       }
     } else if (remainingValidAssigned.length > 1) {
       vaultPicker = { unnamedVerbs, availableVaults: remainingValidAssigned };
-    } else {
+    } else if (userIsAdmin) {
       // Admin posture (no assignments) → full hub-wide list.
       vaultPicker = { unnamedVerbs, availableVaults: vaultNames };
+    } else {
+      // Zero-vault non-admin → no-vaults-available picker with the
+      // "ask your admin to assign you" copy. The Approve button renders
+      // disabled (same shape as the empty-services-json case) so the
+      // form can't post a hand-picked name. The consent-submit gate
+      // refuses any vault-scoped POST from this user too (defense in
+      // depth — see `handleConsentSubmit`).
+      vaultPicker = { unnamedVerbs, availableVaults: [], emptyReason: "no-assignments" };
     }
   }
   // Named-scope display: substitute unnamed `vault:<verb>` rows with the
@@ -2293,4 +2361,5 @@ interface VaultPickerProps {
   unnamedVerbs: string[];
   availableVaults: string[];
   lockedVault?: string;
+  emptyReason?: "no-assignments" | "no-vaults-on-hub";
 }

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -153,6 +153,15 @@ export interface VaultPicker {
    * full dropdown — existing behavior.
    */
   lockedVault?: string;
+  /**
+   * Phase 2 PR 2 reviewer fold: set when the empty `availableVaults` is the
+   * "non-admin user has no vault assignments yet" shape (not "no vaults
+   * exist on the hub"). Swaps the picker empty-state copy from the admin-
+   * remediation hint (`parachute-vault create ...`) to a user-facing
+   * "ask your admin to assign you a vault" message. Only meaningful when
+   * `availableVaults.length === 0`.
+   */
+  emptyReason?: "no-assignments" | "no-vaults-on-hub";
 }
 
 export interface ErrorViewProps {
@@ -415,12 +424,19 @@ function renderVaultPicker(picker: VaultPicker): string {
   }
 
   if (picker.availableVaults.length === 0) {
+    // Phase 2 PR 2 reviewer fold: differentiate "no vaults on the hub"
+    // (admin-fixable) from "non-admin user has no vault assignments yet"
+    // (user has to wait for an admin to assign them). Default to the
+    // admin-remediation copy when unset — preserves Phase 1 behavior.
+    const noAssignments = picker.emptyReason === "no-assignments";
+    const helpHtml = noAssignments
+      ? `${verbList} need to be bound to a specific vault, but you have no vaults assigned on this hub yet. Ask the hub admin to assign you a vault via <code>/admin/users</code>, then try again.`
+      : `${verbList} need to be bound to a specific vault, but no vaults exist on this host yet. Create one with <code>parachute-vault create &lt;name&gt;</code> and try again.`;
     return `
         <section class="vault-picker vault-picker-empty">
           <h2 class="scopes-title">Pick a vault</h2>
           <p class="picker-help">
-            ${verbList} need to be bound to a specific vault, but no vaults exist on this host yet.
-            Create one with <code>parachute-vault create &lt;name&gt;</code> and try again.
+            ${helpHtml}
           </p>
         </section>`;
   }

--- a/src/users.ts
+++ b/src/users.ts
@@ -35,15 +35,20 @@ export interface User {
    */
   passwordChanged: boolean;
   /**
-   * The vault instance name this user is pinned to (Phase 1 multi-user is
-   * single-vault-per-user). `null` means "no per-vault restriction" — the
-   * default for admin accounts, where the OAuth issuer mints tokens for
-   * any requested vault. Non-null pins the issuer to narrow scopes to
-   * `vault:<assigned_vault>:<verb>`. No FK; vault names resolve through
-   * `services.json` at mint time. Stored as `users.assigned_vault TEXT`
-   * (added in migration v8).
+   * The vault instance names this user has access to (multi-user Phase 2
+   * PR 2 — many-to-many via the `user_vaults` table; design
+   * 2026-05-20-multi-user-phase-1.md §Phase 2). Empty `[]` means "no per-
+   * vault restriction" for admin accounts (where `isFirstAdmin` is true
+   * and the OAuth issuer mints tokens for any requested vault). Empty
+   * `[]` for a non-admin means "no access" — distinct semantics that the
+   * consent picker enforces. A non-empty array lists every vault the
+   * user is assigned to; the OAuth issuer narrows tokens to
+   * `vault:<name>:<verb>` for any name in the list. No FK; vault names
+   * resolve through `services.json` at mint time. Replaces the v8 single
+   * `assigned_vault` column (dropped in migration v10). Sorted in
+   * `created_at ASC` insert-order for deterministic iteration.
    */
-  assignedVault: string | null;
+  assignedVaults: string[];
 }
 
 export class SingleUserModeError extends Error {
@@ -76,10 +81,44 @@ interface Row {
   created_at: string;
   updated_at: string;
   password_changed: number;
-  assigned_vault: string | null;
 }
 
-function rowToUser(r: Row): User {
+/**
+ * Read every (user_id → vault_name list) tuple in one shot. Cheaper than
+ * issuing one SELECT per row when callers (listUsers, etc.) hydrate
+ * several rows. Returns a Map keyed by user_id with the vault names
+ * sorted by `created_at ASC` for stable iteration. Users with no
+ * `user_vaults` rows are absent from the map; rowToUser substitutes
+ * an empty array.
+ */
+function loadVaultMap(db: Database, userIds?: readonly string[]): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  let rows: { user_id: string; vault_name: string }[];
+  if (userIds && userIds.length > 0) {
+    const placeholders = userIds.map(() => "?").join(",");
+    rows = db
+      .query<{ user_id: string; vault_name: string }, string[]>(
+        `SELECT user_id, vault_name FROM user_vaults
+         WHERE user_id IN (${placeholders})
+         ORDER BY user_id ASC, created_at ASC, vault_name ASC`,
+      )
+      .all(...userIds);
+  } else {
+    rows = db
+      .query<{ user_id: string; vault_name: string }, []>(
+        "SELECT user_id, vault_name FROM user_vaults ORDER BY user_id ASC, created_at ASC, vault_name ASC",
+      )
+      .all();
+  }
+  for (const r of rows) {
+    const list = map.get(r.user_id);
+    if (list) list.push(r.vault_name);
+    else map.set(r.user_id, [r.vault_name]);
+  }
+  return map;
+}
+
+function rowToUser(r: Row, assignedVaults: string[]): User {
   return {
     id: r.id,
     username: r.username,
@@ -87,8 +126,22 @@ function rowToUser(r: Row): User {
     createdAt: r.created_at,
     updatedAt: r.updated_at,
     passwordChanged: r.password_changed === 1,
-    assignedVault: r.assigned_vault,
+    assignedVaults,
   };
+}
+
+/**
+ * Hydrate a single user's `assignedVaults` list directly. Single
+ * SELECT against `user_vaults` ordered by insertion time. Used by the
+ * single-row helpers (`getUserById`, `getUserByUsername`, etc.).
+ */
+function readVaultsForUser(db: Database, userId: string): string[] {
+  return db
+    .query<{ vault_name: string }, [string]>(
+      "SELECT vault_name FROM user_vaults WHERE user_id = ? ORDER BY created_at ASC, vault_name ASC",
+    )
+    .all(userId)
+    .map((r) => r.vault_name);
 }
 
 export interface CreateUserOpts {
@@ -105,13 +158,15 @@ export interface CreateUserOpts {
    */
   passwordChanged?: boolean;
   /**
-   * Vault instance name to pin the user to (Phase 1 single-vault). `null`
-   * (default) means "no restriction" — admin posture. The OAuth issuer
-   * (PR 4) reads this at mint time to narrow scopes. No validation here:
-   * the API endpoint (PR 2) is responsible for checking against
-   * `services.json` before passing through.
+   * Vault instance names this user should be granted access to (multi-
+   * user Phase 2 PR 2 — many-to-many via `user_vaults`). Default `[]`
+   * (no entries) means "no restriction" for admins / "no access" for
+   * non-admins. Each name is inserted into `user_vaults` within the same
+   * transaction as the `users` row so creation is atomic. No validation
+   * here: the API endpoint (`api-users.ts`) is responsible for checking
+   * each name against `services.json` before passing through.
    */
-  assignedVault?: string | null;
+  assignedVaults?: string[];
 }
 
 export async function createUser(
@@ -128,13 +183,35 @@ export async function createUser(
   const passwordHash = await argonHash(password);
   const stamp = (opts.now?.() ?? new Date()).toISOString();
   const passwordChanged = opts.passwordChanged === true ? 1 : 0;
-  const assignedVault = opts.assignedVault ?? null;
+  // De-dupe + preserve insert order so the returned array matches what
+  // `getUserById` would load right after (which sorts by created_at +
+  // vault_name). Empty array is "no vaults" — admin posture or a non-
+  // admin who'll have vaults added later via `setUserVaults`.
+  const assignedVaults: string[] = [];
+  const seen = new Set<string>();
+  for (const v of opts.assignedVaults ?? []) {
+    if (!seen.has(v)) {
+      seen.add(v);
+      assignedVaults.push(v);
+    }
+  }
   try {
-    db.prepare(
-      `INSERT INTO users
-         (id, username, password_hash, created_at, updated_at, password_changed, assigned_vault)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
-    ).run(id, username, passwordHash, stamp, stamp, passwordChanged, assignedVault);
+    db.transaction(() => {
+      db.prepare(
+        `INSERT INTO users
+           (id, username, password_hash, created_at, updated_at, password_changed)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(id, username, passwordHash, stamp, stamp, passwordChanged);
+      if (assignedVaults.length > 0) {
+        const insertVault = db.prepare(
+          `INSERT INTO user_vaults (user_id, vault_name, role, created_at)
+           VALUES (?, ?, 'write', ?)`,
+        );
+        for (const vaultName of assignedVaults) {
+          insertVault.run(id, vaultName, stamp);
+        }
+      }
+    })();
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes("UNIQUE") && msg.includes("users.username")) {
@@ -149,13 +226,13 @@ export async function createUser(
     createdAt: stamp,
     updatedAt: stamp,
     passwordChanged: passwordChanged === 1,
-    assignedVault,
+    assignedVaults,
   };
 }
 
 export function getUserByUsername(db: Database, username: string): User | null {
   const row = db.query<Row, [string]>("SELECT * FROM users WHERE username = ?").get(username);
-  return row ? rowToUser(row) : null;
+  return row ? rowToUser(row, readVaultsForUser(db, row.id)) : null;
 }
 
 /**
@@ -171,17 +248,24 @@ export function getUserByUsernameCI(db: Database, username: string): User | null
   const row = db
     .query<Row, [string]>("SELECT * FROM users WHERE username = ? COLLATE NOCASE")
     .get(username);
-  return row ? rowToUser(row) : null;
+  return row ? rowToUser(row, readVaultsForUser(db, row.id)) : null;
 }
 
 export function getUserById(db: Database, id: string): User | null {
   const row = db.query<Row, [string]>("SELECT * FROM users WHERE id = ?").get(id);
-  return row ? rowToUser(row) : null;
+  return row ? rowToUser(row, readVaultsForUser(db, row.id)) : null;
 }
 
 export function listUsers(db: Database): User[] {
   const rows = db.query<Row, []>("SELECT * FROM users ORDER BY created_at ASC").all();
-  return rows.map(rowToUser);
+  if (rows.length === 0) return [];
+  // One JOIN-ish read for everyone — single SELECT against user_vaults
+  // beats N+1 single-user reads.
+  const vaultMap = loadVaultMap(
+    db,
+    rows.map((r) => r.id),
+  );
+  return rows.map((r) => rowToUser(r, vaultMap.get(r.id) ?? []));
 }
 
 export function userCount(db: Database): number {
@@ -225,6 +309,72 @@ export function isFirstAdmin(db: Database, userId: string): boolean {
 
 export async function verifyPassword(user: User, password: string): Promise<boolean> {
   return argonVerify(user.passwordHash, password);
+}
+
+/**
+ * Replace a user's vault assignments atomically (multi-user Phase 2 PR 2).
+ *
+ * Two writes inside one transaction:
+ *   1. DELETE every existing `user_vaults` row for `userId`.
+ *   2. INSERT one row per name in `vaultNames`.
+ *
+ * Returns `false` when the user doesn't exist (idempotent — the API layer
+ * translates that to 404); `true` when the assignments were updated.
+ * Passing an empty array clears every existing assignment (non-admin
+ * non-empty array = "no vault access"). Duplicates are silently
+ * collapsed (de-duped at the array level before INSERT). No vault-name
+ * validation here — `api-users.ts` is responsible for checking each
+ * name against `services.json`. No FK on `vault_name` (matches the
+ * pre-existing schema contract — vault names resolve through
+ * `services.json`, not a DB row).
+ *
+ * Caller responsibilities:
+ *   - First-admin protection — admin "membership" is unrestricted by
+ *     design (see `isFirstAdmin`); `api-users.ts` refuses to call this
+ *     for the first admin's row.
+ *   - Vault-name validation against the live services manifest.
+ */
+export function setUserVaults(
+  db: Database,
+  userId: string,
+  vaultNames: readonly string[],
+  now: () => Date = () => new Date(),
+): boolean {
+  const exists = db
+    .query<{ id: string }, [string]>("SELECT id FROM users WHERE id = ?")
+    .get(userId);
+  if (!exists) return false;
+  // De-dupe before INSERT — duplicate names from a misbehaving client
+  // would trip the (user_id, vault_name) PRIMARY KEY constraint and
+  // abort the whole transaction. Silently collapse the dupes; the
+  // operator's intent is "this user has access to these vaults"
+  // regardless of how many times the same name appears.
+  const seen = new Set<string>();
+  const uniques: string[] = [];
+  for (const v of vaultNames) {
+    if (!seen.has(v)) {
+      seen.add(v);
+      uniques.push(v);
+    }
+  }
+  const stamp = now().toISOString();
+  db.transaction(() => {
+    db.prepare("DELETE FROM user_vaults WHERE user_id = ?").run(userId);
+    if (uniques.length > 0) {
+      const insertVault = db.prepare(
+        `INSERT INTO user_vaults (user_id, vault_name, role, created_at)
+         VALUES (?, ?, 'write', ?)`,
+      );
+      for (const vaultName of uniques) {
+        insertVault.run(userId, vaultName, stamp);
+      }
+    }
+    // Bump the user's updated_at so downstream observers (SPA row,
+    // /account/) reflect the change without us having to bake a
+    // separate "vault assignments changed" timestamp.
+    db.prepare("UPDATE users SET updated_at = ? WHERE id = ?").run(stamp, userId);
+  })();
+  return true;
 }
 
 /**
@@ -326,7 +476,7 @@ export async function resetUserPassword(
 /**
  * Hard-delete a user row and clean up FK-dependent rows.
  *
- * Schema reality at v8:
+ * Schema reality at v10:
  *   - `tokens.user_id` is nullable (made nullable in migration v6). The
  *     plan from the design doc is "tokens stay with `revoked_at` set so
  *     the audit trail of 'this user existed and held these tokens'
@@ -337,6 +487,9 @@ export async function resetUserPassword(
  *     `created_at`, `scopes`, `client_id`, `revoked_at` fields.
  *   - `sessions.user_id` and `grants.user_id` are NOT NULL with a
  *     non-cascading FK. Both are deleted before the users row drops.
+ *   - `user_vaults.user_id` has `ON DELETE CASCADE` (migration v10), so
+ *     vault assignments are dropped automatically when the parent row
+ *     goes. No explicit cleanup needed.
  *
  * Returns false when no user matches the id (idempotent — the API
  * layer translates that to 404). Returns true on a successful delete.

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1045,20 +1045,21 @@ export async function getModuleOperation(opId: string): Promise<ModuleOperation>
 }
 
 /**
- * Wire shape from `GET /api/users` — multi-user Phase 1.
+ * Wire shape from `GET /api/users` — multi-user Phase 2 PR 2.
  *
  * `password_hash` is intentionally absent — the hub never returns it
  * over the wire. `password_changed: false` means the user was created
  * via the admin path and hasn't yet completed the force-change-password
- * flow on first sign-in (PR 3 of the multi-user chain).
- * `assigned_vault: null` means "no per-vault restriction" — the admin
- * posture; non-null pins the user to that vault.
+ * flow on first sign-in. `assigned_vaults` lists every vault this user
+ * has access to (empty array = "no narrowing" for admin posture, or
+ * "no access" for non-admins). Replaces the Phase 1 single-vault
+ * `assigned_vault: string | null` shape.
  */
 export interface UserListing {
   id: string;
   username: string;
   password_changed: boolean;
-  assigned_vault: string | null;
+  assigned_vaults: string[];
   created_at: string;
 }
 
@@ -1066,8 +1067,8 @@ export interface UserListing {
 export interface CreateUserInput {
   username: string;
   password: string;
-  /** Vault to pin the user to. `null` = no restriction (admin-level). */
-  assignedVault: string | null;
+  /** Vault names to grant the user access to. Empty array = no narrowing. */
+  assignedVaults: string[];
 }
 
 /**
@@ -1167,6 +1168,31 @@ export async function resetUserPassword(userId: string, newPassword: string): Pr
       authorization: `Bearer ${bearer}`,
     },
     body: JSON.stringify({ new_password: newPassword }),
+  });
+  if (res.status === 401 || res.status === 403) {
+    if (res.status === 401) clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+}
+
+/**
+ * PATCH /api/users/:id/vaults — replace a user's vault assignments
+ * (multi-user Phase 2 PR 2). Empty array clears every grant. Server
+ * validates each name against services.json and refuses for the first
+ * admin (403 `cannot_edit_first_admin_vaults`). Same Bearer pattern as
+ * `resetUserPassword`.
+ */
+export async function updateUserVaults(userId: string, assignedVaults: string[]): Promise<void> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch(`/api/users/${encodeURIComponent(userId)}/vaults`, {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json",
+      authorization: `Bearer ${bearer}`,
+    },
+    body: JSON.stringify({ assigned_vaults: assignedVaults }),
   });
   if (res.status === 401 || res.status === 403) {
     if (res.status === 401) clearCachedToken();

--- a/web/ui/src/routes/Users.test.tsx
+++ b/web/ui/src/routes/Users.test.tsx
@@ -21,6 +21,7 @@ vi.mock("../lib/api.ts", async (orig) => {
     createUser: vi.fn(),
     deleteUser: vi.fn(),
     resetUserPassword: vi.fn(),
+    updateUserVaults: vi.fn(),
   };
 });
 
@@ -45,7 +46,7 @@ function user(username: string, overrides: Partial<api.UserListing> = {}): api.U
     id: `id-${username}`,
     username,
     password_changed: true,
-    assigned_vault: null,
+    assigned_vaults: [],
     created_at: "2026-05-01T12:00:00.000Z",
     ...overrides,
   };
@@ -68,8 +69,8 @@ describe("Users — list rendering", () => {
 
   it("renders one row per user with assigned vault + password status", async () => {
     vi.mocked(api.listUsers).mockResolvedValue([
-      user("operator", { password_changed: true, assigned_vault: null }),
-      user("alice", { password_changed: false, assigned_vault: "home" }),
+      user("operator", { password_changed: true, assigned_vaults: [] }),
+      user("alice", { password_changed: false, assigned_vaults: ["home"] }),
     ]);
     vi.mocked(api.listUserVaults).mockResolvedValue(["home"]);
     renderRoute();
@@ -283,27 +284,30 @@ describe("Users — create form", () => {
     expect(screen.queryByLabelText(/^password/i)).toBeNull();
   });
 
-  it("clicking Create User reveals the form with vault dropdown + No restriction option", async () => {
+  it("clicking Create User reveals the form with multi-select vault listing", async () => {
     vi.mocked(api.listUsers).mockResolvedValue([user("operator")]);
     vi.mocked(api.listUserVaults).mockResolvedValue(["home", "work"]);
     renderRoute();
     fireEvent.click(await screen.findByRole("button", { name: /create user/i }));
     expect(await screen.findByLabelText(/username/i)).toBeInTheDocument();
-    const select = screen.getByLabelText(/assigned vault/i) as HTMLSelectElement;
+    const select = screen.getByLabelText(/assigned vaults/i) as HTMLSelectElement;
+    expect(select.multiple).toBe(true);
     const optionTexts = Array.from(select.options).map((o) => o.text);
-    expect(optionTexts).toEqual(["No restriction (admin-level access)", "home", "work"]);
+    // Multi-select: no synthetic "No restriction" option — empty selection
+    // implicitly means no narrowing.
+    expect(optionTexts).toEqual(["home", "work"]);
   });
 
-  it("submits createUser with the assigned vault and refreshes the list on success", async () => {
+  it("submits createUser with the assigned vaults and refreshes the list on success", async () => {
     const listMock = vi.mocked(api.listUsers);
     listMock.mockResolvedValueOnce([user("operator")]);
     listMock.mockResolvedValueOnce([
       user("operator"),
-      user("alice", { password_changed: false, assigned_vault: "home" }),
+      user("alice", { password_changed: false, assigned_vaults: ["home"] }),
     ]);
     vi.mocked(api.listUserVaults).mockResolvedValue(["home"]);
     vi.mocked(api.createUser).mockResolvedValue(
-      user("alice", { password_changed: false, assigned_vault: "home" }),
+      user("alice", { password_changed: false, assigned_vaults: ["home"] }),
     );
     renderRoute();
     fireEvent.click(await screen.findByRole("button", { name: /create user/i }));
@@ -311,13 +315,17 @@ describe("Users — create form", () => {
     fireEvent.change(screen.getByLabelText(/^password/i), {
       target: { value: "alice-strong-passphrase" },
     });
-    fireEvent.change(screen.getByLabelText(/assigned vault/i), { target: { value: "home" } });
+    // Multi-select: pick "home" via selectedOptions handling.
+    const vaultsSelect = screen.getByLabelText(/assigned vaults/i) as HTMLSelectElement;
+    const homeOption = Array.from(vaultsSelect.options).find((o) => o.value === "home");
+    if (homeOption) homeOption.selected = true;
+    fireEvent.change(vaultsSelect);
     fireEvent.click(screen.getByRole("button", { name: /^create user$/i }));
     await waitFor(() =>
       expect(api.createUser).toHaveBeenCalledWith({
         username: "alice",
         password: "alice-strong-passphrase",
-        assignedVault: "home",
+        assignedVaults: ["home"],
       }),
     );
     // Success banner copy matches the design's "force-change on first login" wording.
@@ -362,5 +370,115 @@ describe("Users — create form", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /^create user$/i }));
     await waitFor(() => expect(screen.getByText(/create failed \(409\)/i)).toBeInTheDocument());
+  });
+});
+
+describe("Users — multi-vault membership (Phase 2 PR 2)", () => {
+  it("renders multiple assigned vaults as separate code chips in the row", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([
+      user("operator"),
+      user("alice", { assigned_vaults: ["personal", "family"] }),
+    ]);
+    vi.mocked(api.listUserVaults).mockResolvedValue(["personal", "family"]);
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+    // Both vault names appear as <code> chips in the alice row.
+    const aliceRow = screen.getByText("alice").closest("tr");
+    expect(aliceRow).not.toBeNull();
+    expect(within(aliceRow!).getByText("personal")).toBeInTheDocument();
+    expect(within(aliceRow!).getByText("family")).toBeInTheDocument();
+  });
+
+  it("disables Edit vaults for the first admin with a /design/ tooltip", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([user("operator"), user("alice")]);
+    vi.mocked(api.listUserVaults).mockResolvedValue(["home"]);
+    renderRoute();
+    const operatorBtn = await screen.findByRole("button", { name: /edit vaults for operator/i });
+    expect(operatorBtn).toBeDisabled();
+    expect(operatorBtn).toHaveAttribute("title", expect.stringMatching(/unrestricted by design/i));
+    const aliceBtn = screen.getByRole("button", { name: /edit vaults for alice/i });
+    expect(aliceBtn).not.toBeDisabled();
+  });
+
+  it("clicking Edit vaults reveals an inline multi-select pre-populated with current vaults", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([
+      user("operator"),
+      user("alice", { assigned_vaults: ["home"] }),
+    ]);
+    vi.mocked(api.listUserVaults).mockResolvedValue(["home", "work"]);
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /edit vaults for alice/i }));
+    const select = (await screen.findByLabelText(
+      /vault assignments for alice/i,
+    )) as HTMLSelectElement;
+    expect(select.multiple).toBe(true);
+    const selected = Array.from(select.selectedOptions).map((o) => o.value);
+    expect(selected).toEqual(["home"]);
+    // Available options match the listUserVaults set.
+    const optionTexts = Array.from(select.options).map((o) => o.value);
+    expect(optionTexts).toEqual(["home", "work"]);
+  });
+
+  it("happy path — PATCHes new vault list, shows success banner, refreshes the list", async () => {
+    const listMock = vi.mocked(api.listUsers);
+    listMock.mockResolvedValueOnce([
+      user("operator"),
+      user("alice", { assigned_vaults: ["home"] }),
+    ]);
+    listMock.mockResolvedValueOnce([
+      user("operator"),
+      user("alice", { assigned_vaults: ["home", "work"] }),
+    ]);
+    vi.mocked(api.listUserVaults).mockResolvedValue(["home", "work"]);
+    vi.mocked(api.updateUserVaults).mockResolvedValue();
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /edit vaults for alice/i }));
+    const select = (await screen.findByLabelText(
+      /vault assignments for alice/i,
+    )) as HTMLSelectElement;
+    // Add "work" — keep "home" selected.
+    const workOption = Array.from(select.options).find((o) => o.value === "work");
+    if (workOption) workOption.selected = true;
+    fireEvent.change(select);
+    fireEvent.click(screen.getByRole("button", { name: /save vault assignments/i }));
+    await waitFor(() =>
+      expect(api.updateUserVaults).toHaveBeenCalledWith(
+        "id-alice",
+        expect.arrayContaining(["home", "work"]),
+      ),
+    );
+    // Success banner copy.
+    await waitFor(() => expect(screen.getByText(/vault assignments updated/i)).toBeInTheDocument());
+    await waitFor(() => expect(api.listUsers).toHaveBeenCalledTimes(2));
+  });
+
+  it("surfaces server error_description from a 400 assigned_vault_not_found", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([
+      user("operator"),
+      user("alice", { assigned_vaults: ["home"] }),
+    ]);
+    vi.mocked(api.listUserVaults).mockResolvedValue(["home", "work"]);
+    vi.mocked(api.updateUserVaults).mockRejectedValue(
+      new api.HttpError(400, 'vault "ghost" not registered'),
+    );
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /edit vaults for alice/i }));
+    await screen.findByLabelText(/vault assignments for alice/i);
+    fireEvent.click(screen.getByRole("button", { name: /save vault assignments/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/edit vaults failed \(400\)/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("Cancel closes the inline edit form without posting", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([user("operator"), user("alice")]);
+    vi.mocked(api.listUserVaults).mockResolvedValue(["home"]);
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /edit vaults for alice/i }));
+    expect(await screen.findByLabelText(/vault assignments for alice/i)).toBeInTheDocument();
+    const form = screen.getByRole("form", { name: /edit vaults for alice/i });
+    fireEvent.click(within(form).getByRole("button", { name: /cancel/i }));
+    await waitFor(() => expect(screen.queryByLabelText(/vault assignments for alice/i)).toBeNull());
+    expect(api.updateUserVaults).not.toHaveBeenCalled();
   });
 });

--- a/web/ui/src/routes/Users.tsx
+++ b/web/ui/src/routes/Users.tsx
@@ -283,8 +283,9 @@ export function Users() {
       <p className="muted">
         Hub user accounts. Each user can be a member of one or more vaults — the OAuth issuer
         narrows their tokens to <code>vault:&lt;assigned&gt;:*</code> scopes for any vault in their
-        list. Users with no assignments have admin-level vault access. Admin-created users land with
-        a default password and are prompted to change it on first sign-in.
+        list. Users with no assignments can't authorize any vault yet — assign at least one above.
+        The first admin is unrestricted (admin posture). Admin-created users land with a default
+        password and are prompted to change it on first sign-in.
       </p>
 
       {renderListSection(
@@ -470,7 +471,14 @@ function ListRendered({
                         ))}
                       </span>
                     ) : (
-                      <span className="muted" title="No per-vault restriction (admin-level access)">
+                      <span
+                        className="muted"
+                        title={
+                          isFirstAdmin
+                            ? "First admin is unrestricted (admin posture)"
+                            : "No vaults assigned — user can't authorize any vault yet"
+                        }
+                      >
                         —
                       </span>
                     )}

--- a/web/ui/src/routes/Users.tsx
+++ b/web/ui/src/routes/Users.tsx
@@ -1,35 +1,31 @@
 /**
- * /admin/users — multi-user Phase 1 admin surface (Phase 2 PR 1
- * adds admin password reset).
+ * /admin/users — multi-user admin surface (Phase 1 list/create/delete,
+ * Phase 2 PR 1 admin password reset, Phase 2 PR 2 multi-vault membership).
  *
  * Design: `parachute.computer/design/2026-05-20-multi-user-phase-1.md`.
- * Tracker: hub#252. PR 2 of 5 in the original multi-user chain shipped
- * list + create + delete; Phase 2 PR 1 layers admin-initiated password
- * reset for non-admin users on top.
+ * Tracker: hub#252. Phase 2 PR 2 lifts the single-vault `assignedVault`
+ * shape to N-vault membership via the `user_vaults` join table — a user
+ * can have access to multiple vaults (e.g. personal + family).
  *
  * Surface:
  *
- *   1. **Users list table.** Username · Assigned vault · Password set ·
+ *   1. **Users list table.** Username · Assigned vaults · Password set ·
  *      Created · Actions. First admin (the wizard / env-seeded
- *      bootstrap row) has Delete + Reset Password disabled with a
- *      tooltip; the server enforces both rails
- *      (`first_admin_undeletable`, `cannot_reset_first_admin`).
+ *      bootstrap row) has every row action disabled with a tooltip; the
+ *      server enforces every rail (`first_admin_undeletable`,
+ *      `cannot_reset_first_admin`, `cannot_edit_first_admin_vaults`).
  *   2. **Create user form.** Collapsible section below the table.
- *      Username + password + assigned-vault dropdown (fetched on mount
- *      from `/api/users/vaults`). The dropdown's first option is the
- *      synthetic "No restriction (admin-level access)" → maps to
- *      `assignedVault: null`. Subsequent options are vault names from
- *      services.json.
- *   3. **Delete confirmation.** Inline confirm dialog mirroring the
- *      `Permissions.tsx` pattern — click → confirm dialog → DELETE →
- *      refresh.
- *   4. **Reset Password (Phase 2 PR 1).** Per-row inline form (mirrors
- *      Create User's collapse-then-form shape). Single password field;
- *      submit POSTs to `/api/users/:id/reset-password`; success collapses
- *      and surfaces a row-scoped banner with the "hand them the new
- *      password" copy. The server flips `password_changed=0` and revokes
- *      the friend's still-active tokens — leaked-password recovery
- *      shouldn't leave the attacker holding valid bearers.
+ *      Username + password + assigned-vaults multi-select (fetched on
+ *      mount from `/api/users/vaults`). `<select multiple>` with shift-
+ *      click semantics; selected names render as chips above the
+ *      control. Empty selection → no narrowing.
+ *   3. **Edit vaults (Phase 2 PR 2).** Per-row inline form mirroring the
+ *      reset-password inline shape. Multi-select pre-populated with the
+ *      user's current assignments; submit PATCHes /api/users/:id/vaults.
+ *   4. **Delete confirmation.** Inline confirm dialog mirroring the
+ *      `Permissions.tsx` pattern.
+ *   5. **Reset Password (Phase 2 PR 1).** Per-row inline form. Single
+ *      password field; success surfaces a row-scoped banner.
  *
  * Optimistic-update + rollback-on-error: the create + reset flows follow
  * the `Modules.tsx`-style "fire-and-recover" shape. On submit, the form
@@ -58,6 +54,7 @@ import {
   listUserVaults,
   listUsers,
   resetUserPassword,
+  updateUserVaults,
 } from "../lib/api.ts";
 
 /**
@@ -115,15 +112,27 @@ type ResetState =
 interface FormFields {
   username: string;
   password: string;
-  /** Empty string = the synthetic "No restriction" sentinel. */
-  assignedVault: string;
+  /** Selected vault names. Empty array = no narrowing (admin posture). */
+  assignedVaults: string[];
 }
 
 const EMPTY_FORM: FormFields = {
   username: "",
   password: "",
-  assignedVault: "",
+  assignedVaults: [],
 };
+
+/**
+ * Per-row Edit-vaults state. Same one-row-at-a-time pattern as the
+ * Delete + Reset password flows — only one row can have an open form
+ * at any time.
+ */
+type EditVaultsState =
+  | { kind: "idle" }
+  | { kind: "open"; userId: string; selected: string[] }
+  | { kind: "submitting"; userId: string; selected: string[] }
+  | { kind: "done"; userId: string; username: string }
+  | { kind: "error"; userId: string; selected: string[]; message: string };
 
 export function Users() {
   const [state, setState] = useState<ListState>({ kind: "loading" });
@@ -133,6 +142,7 @@ export function Users() {
   const [createState, setCreateState] = useState<CreateState>({ kind: "idle" });
   const [deleteSt, setDeleteSt] = useState<DeleteState>({ kind: "idle" });
   const [resetSt, setResetSt] = useState<ResetState>({ kind: "idle" });
+  const [editVaultsSt, setEditVaultsSt] = useState<EditVaultsState>({ kind: "idle" });
 
   useEffect(() => {
     void reload;
@@ -177,7 +187,7 @@ export function Users() {
     const input: CreateUserInput = {
       username: form.username,
       password: form.password,
-      assignedVault: form.assignedVault === "" ? null : form.assignedVault,
+      assignedVaults: form.assignedVaults,
     };
     try {
       const created = await createUser(input);
@@ -212,6 +222,23 @@ export function Users() {
             ? err.message
             : String(err);
       setDeleteSt({ kind: "error", userId: user.id, message });
+    }
+  }
+
+  async function onSubmitEditVaults(user: UserListing, selected: string[]): Promise<void> {
+    setEditVaultsSt({ kind: "submitting", userId: user.id, selected });
+    try {
+      await updateUserVaults(user.id, selected);
+      setEditVaultsSt({ kind: "done", userId: user.id, username: user.username });
+      setReload((n) => n + 1);
+    } catch (err) {
+      const message =
+        err instanceof HttpError
+          ? `Edit vaults failed (${err.status}): ${err.message}`
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      setEditVaultsSt({ kind: "error", userId: user.id, selected, message });
     }
   }
 
@@ -254,10 +281,10 @@ export function Users() {
       </div>
 
       <p className="muted">
-        Hub user accounts. Each user can be pinned to a single vault (Phase 1) — the OAuth issuer
-        narrows their tokens to <code>vault:&lt;assigned&gt;:*</code> scopes. Users with no
-        assignment have admin-level vault access. Admin-created users land with a default password
-        and are prompted to change it on first sign-in.
+        Hub user accounts. Each user can be a member of one or more vaults — the OAuth issuer
+        narrows their tokens to <code>vault:&lt;assigned&gt;:*</code> scopes for any vault in their
+        list. Users with no assignments have admin-level vault access. Admin-created users land with
+        a default password and are prompted to change it on first sign-in.
       </p>
 
       {renderListSection(
@@ -268,6 +295,10 @@ export function Users() {
         resetSt,
         setResetSt,
         onSubmitReset,
+        editVaultsSt,
+        setEditVaultsSt,
+        onSubmitEditVaults,
+        state.kind === "ok" ? state.data.vaults : [],
         () => setReload((n) => n + 1),
       )}
 
@@ -295,6 +326,10 @@ function renderListSection(
   resetSt: ResetState,
   setResetSt: (s: ResetState) => void,
   onSubmitReset: (user: UserListing, password: string) => Promise<void>,
+  editVaultsSt: EditVaultsState,
+  setEditVaultsSt: (s: EditVaultsState) => void,
+  onSubmitEditVaults: (user: UserListing, selected: string[]) => Promise<void>,
+  availableVaults: string[],
   onRetry: () => void,
 ): React.ReactNode {
   if (state.kind === "loading") {
@@ -337,6 +372,10 @@ function renderListSection(
       resetSt={resetSt}
       setResetSt={setResetSt}
       onSubmitReset={onSubmitReset}
+      editVaultsSt={editVaultsSt}
+      setEditVaultsSt={setEditVaultsSt}
+      onSubmitEditVaults={onSubmitEditVaults}
+      availableVaults={availableVaults}
     />
   );
 }
@@ -350,6 +389,10 @@ interface ListRenderedProps {
   resetSt: ResetState;
   setResetSt: (s: ResetState) => void;
   onSubmitReset: (user: UserListing, password: string) => Promise<void>;
+  editVaultsSt: EditVaultsState;
+  setEditVaultsSt: (s: EditVaultsState) => void;
+  onSubmitEditVaults: (user: UserListing, selected: string[]) => Promise<void>;
+  availableVaults: string[];
 }
 
 function ListRendered({
@@ -361,6 +404,10 @@ function ListRendered({
   resetSt,
   setResetSt,
   onSubmitReset,
+  editVaultsSt,
+  setEditVaultsSt,
+  onSubmitEditVaults,
+  availableVaults,
 }: ListRenderedProps): React.ReactNode {
   return (
     <div className="user-list" style={{ marginTop: "1rem" }}>
@@ -369,7 +416,7 @@ function ListRendered({
           <thead>
             <tr>
               <th scope="col">Username</th>
-              <th scope="col">Assigned vault</th>
+              <th scope="col">Assigned vaults</th>
               <th scope="col">Password set</th>
               <th scope="col">Created</th>
               <th scope="col">Actions</th>
@@ -390,6 +437,15 @@ function ListRendered({
                   ? resetSt
                   : null;
               const resetDone = resetSt.kind === "done" && resetSt.userId === u.id ? resetSt : null;
+              const editVaultsForRow =
+                (editVaultsSt.kind === "open" ||
+                  editVaultsSt.kind === "submitting" ||
+                  editVaultsSt.kind === "error") &&
+                editVaultsSt.userId === u.id
+                  ? editVaultsSt
+                  : null;
+              const editVaultsDone =
+                editVaultsSt.kind === "done" && editVaultsSt.userId === u.id ? editVaultsSt : null;
               return (
                 <tr key={u.id} data-user-id={u.id}>
                   <td>
@@ -401,8 +457,18 @@ function ListRendered({
                     )}
                   </td>
                   <td>
-                    {u.assigned_vault ? (
-                      <code>{u.assigned_vault}</code>
+                    {u.assigned_vaults.length > 0 ? (
+                      <span
+                        style={{
+                          display: "inline-flex",
+                          flexWrap: "wrap",
+                          gap: "0.25rem",
+                        }}
+                      >
+                        {u.assigned_vaults.map((v) => (
+                          <code key={v}>{v}</code>
+                        ))}
+                      </span>
                     ) : (
                       <span className="muted" title="No per-vault restriction (admin-level access)">
                         —
@@ -458,8 +524,38 @@ function ListRendered({
                             <span id={`first-admin-reset-tooltip-${u.id}`} className="sr-only">
                               First admin uses /account/change-password directly
                             </span>
+                            <span id={`first-admin-vaults-tooltip-${u.id}`} className="sr-only">
+                              First admin's vault membership is unrestricted by design
+                            </span>
                           </>
                         )}
+                        <button
+                          type="button"
+                          className="secondary"
+                          disabled={
+                            isFirstAdmin ||
+                            editVaultsForRow !== null ||
+                            (editVaultsSt.kind === "submitting" && editVaultsSt.userId === u.id)
+                          }
+                          title={
+                            isFirstAdmin
+                              ? "First admin's vault membership is unrestricted by design"
+                              : undefined
+                          }
+                          aria-describedby={
+                            isFirstAdmin ? `first-admin-vaults-tooltip-${u.id}` : undefined
+                          }
+                          onClick={() =>
+                            setEditVaultsSt({
+                              kind: "open",
+                              userId: u.id,
+                              selected: [...u.assigned_vaults],
+                            })
+                          }
+                          aria-label={`Edit vaults for ${u.username}`}
+                        >
+                          Edit vaults
+                        </button>
                         <button
                           type="button"
                           className="secondary"
@@ -570,6 +666,37 @@ function ListRendered({
                         </div>
                       </output>
                     )}
+                    {editVaultsForRow && (
+                      <EditVaultsRowForm
+                        user={u}
+                        state={editVaultsForRow}
+                        availableVaults={availableVaults}
+                        onCancel={() => setEditVaultsSt({ kind: "idle" })}
+                        onSelectedChange={(selected) =>
+                          setEditVaultsSt({ kind: "open", userId: u.id, selected })
+                        }
+                        onSubmit={(selected) => {
+                          void onSubmitEditVaults(u, selected);
+                        }}
+                      />
+                    )}
+                    {editVaultsDone && (
+                      <output
+                        className="success-banner"
+                        style={{ marginTop: "0.25rem", display: "block" }}
+                      >
+                        Vault assignments updated for <code>{editVaultsDone.username}</code>.
+                        <div style={{ marginTop: "0.5rem" }}>
+                          <button
+                            type="button"
+                            className="secondary"
+                            onClick={() => setEditVaultsSt({ kind: "idle" })}
+                          >
+                            Dismiss
+                          </button>
+                        </div>
+                      </output>
+                    )}
                   </td>
                 </tr>
               );
@@ -653,6 +780,107 @@ function ResetPasswordRowForm({
   );
 }
 
+interface EditVaultsRowFormProps {
+  user: UserListing;
+  state:
+    | { kind: "open"; userId: string; selected: string[] }
+    | { kind: "submitting"; userId: string; selected: string[] }
+    | { kind: "error"; userId: string; selected: string[]; message: string };
+  availableVaults: string[];
+  onCancel: () => void;
+  onSelectedChange: (selected: string[]) => void;
+  onSubmit: (selected: string[]) => void;
+}
+
+function EditVaultsRowForm({
+  user,
+  state,
+  availableVaults,
+  onCancel,
+  onSelectedChange,
+  onSubmit,
+}: EditVaultsRowFormProps): React.ReactNode {
+  const submitting = state.kind === "submitting";
+  const errorMsg = state.kind === "error" ? state.message : null;
+  const selectId = `edit-vaults-select-${user.id}`;
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>): void {
+    const next = Array.from(e.target.selectedOptions).map((o) => o.value);
+    onSelectedChange(next);
+  }
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit(state.selected);
+      }}
+      aria-label={`Edit vaults for ${user.username}`}
+      style={{
+        marginTop: "0.5rem",
+        padding: "0.5rem",
+        background: "var(--bg-soft, #f5f5f5)",
+        borderRadius: "4px",
+      }}
+    >
+      <p style={{ margin: 0 }}>
+        <label htmlFor={selectId}>
+          Vault assignments for <code>{user.username}</code>{" "}
+          <span className="muted">(empty = no narrowing; shift-click to multi-select)</span>
+        </label>
+      </p>
+      {state.selected.length > 0 && (
+        <div
+          data-testid={`edit-vaults-chips-${user.id}`}
+          style={{
+            marginTop: "0.4rem",
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "0.25rem",
+          }}
+        >
+          {state.selected.map((v) => (
+            <code key={v} style={{ padding: "0.1rem 0.4rem", borderRadius: "4px" }}>
+              {v}
+            </code>
+          ))}
+        </div>
+      )}
+      <select
+        id={selectId}
+        multiple
+        value={state.selected}
+        onChange={handleChange}
+        disabled={submitting}
+        size={Math.min(Math.max(availableVaults.length, 3), 8)}
+        style={{ marginTop: "0.4rem", minWidth: "12rem" }}
+      >
+        {availableVaults.map((v) => (
+          <option key={v} value={v}>
+            {v}
+          </option>
+        ))}
+      </select>
+      {availableVaults.length === 0 && (
+        <p className="muted" style={{ marginTop: "0.25rem" }}>
+          No vaults registered on this hub yet.
+        </p>
+      )}
+      {errorMsg && (
+        <div className="error-banner" style={{ marginTop: "0.25rem" }}>
+          <code>{errorMsg}</code>
+        </div>
+      )}
+      <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.5rem" }}>
+        <button type="submit" disabled={submitting}>
+          {submitting ? "Saving…" : "Save vault assignments"}
+        </button>
+        <button type="button" className="secondary" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
 interface CreateUserSectionProps {
   show: boolean;
   setShow: (s: boolean) => void;
@@ -721,20 +949,53 @@ function CreateUserSection({
             />
           </p>
           <p>
-            <label htmlFor="new-user-vault">Assigned vault</label>
+            <label htmlFor="new-user-vaults">
+              Assigned vaults{" "}
+              <span className="muted">
+                (empty = no restriction; shift-click to select multiple)
+              </span>
+            </label>
+            <br />
+            {form.assignedVaults.length > 0 && (
+              <span
+                data-testid="new-user-vault-chips"
+                style={{
+                  display: "inline-flex",
+                  flexWrap: "wrap",
+                  gap: "0.25rem",
+                  marginBottom: "0.25rem",
+                }}
+              >
+                {form.assignedVaults.map((v) => (
+                  <code key={v}>{v}</code>
+                ))}
+              </span>
+            )}
             <br />
             <select
-              id="new-user-vault"
-              value={form.assignedVault}
-              onChange={(e) => setForm({ ...form, assignedVault: e.target.value })}
+              id="new-user-vaults"
+              multiple
+              value={form.assignedVaults}
+              onChange={(e) =>
+                setForm({
+                  ...form,
+                  assignedVaults: Array.from(e.target.selectedOptions).map((o) => o.value),
+                })
+              }
+              size={Math.min(Math.max(vaults.length, 3), 8)}
+              style={{ minWidth: "12rem" }}
             >
-              <option value="">No restriction (admin-level access)</option>
               {vaults.map((v) => (
                 <option key={v} value={v}>
                   {v}
                 </option>
               ))}
             </select>
+            {vaults.length === 0 && (
+              <span className="muted" style={{ marginLeft: "0.5rem" }}>
+                No vaults registered on this hub yet.
+              </span>
+            )}
           </p>
 
           {createState.kind === "error" && (


### PR DESCRIPTION
## Summary

Each user is now a member of one or more vaults via a new `user_vaults` join table. The single `users.assigned_vault` column (Phase 1) is dropped — replaced by `user.assignedVaults: string[]` end-to-end. Closes the "friend wants both a personal vault and a family-shared vault" pain point called out in the Phase 2 design ([2026-05-20-multi-user-phase-1.md §Phase 2](../parachute.computer/design/2026-05-20-multi-user-phase-1.md)).

The JWT layer was already array-shaped (`vault_scope: string[]`), so Phase 1's forward-compat seams pay off here — the rest of the stack lifts to N-vault membership in one sweep without a wire-shape break on the token claim.

### What ships

- **Schema migration v10**: new `user_vaults (user_id FK CASCADE, vault_name, role DEFAULT 'write', created_at)` composite-PK table + index on `vault_name`. Backfill from v9 single-column → one row per non-null assignment. Drops `users.assigned_vault`.
- **`users.ts`**: `User.assignedVault: string | null` → `User.assignedVaults: string[]`. Atomic create transaction inserts vault rows alongside the users row. New `setUserVaults(db, userId, names, now)` helper for atomic DELETE+INSERT replace.
- **`oauth-handlers.ts`**: `vaultScopeForUser` returns `[]` for first admin (admin posture, unrestricted), the user's full vault list otherwise. Consent picker renders locked for single-vault users (Phase 1 shape), free dropdown filtered to the user's list for 2+. Mismatch + stale-assignment checks generalized from `===` to `.includes()`.
- **`api-users.ts`**: wire shape `assigned_vault: string \| null` → `assigned_vaults: string[]`. New `PATCH /api/users/:id/vaults` to replace a user's assignments (rejects first admin with `cannot_edit_first_admin_vaults`).
- **`account-home-ui.ts`**: one Notes-CTA tile per assigned vault; heading pluralizes; hub-origin disclosure stays section-level.
- **SPA (`Users.tsx`, `lib/api.ts`)**: create-form multi-select with chip preview; new per-row "Edit vaults" inline form; row display shows comma-separated `<code>` chips.

### Migration safety

rc.1 has not shipped stable. Pre-existing users have at most one `assigned_vault`, so the backfill is one row per affected user. No data loss on Render restart — the migration runs idempotently at boot.

Closes the architectural piece of multi-user Phase 2; references hub#252.

## Test plan

- [x] `bun test ./src` — hub 2156 pass / 1 skip / 0 fail
- [x] `bun run typecheck` — clean
- [x] `cd web/ui && bun run test` — 227 pass
- [x] `cd web/ui && bun run typecheck` + `bun run build` — clean
- [x] Migration test (`v10 backfills user_vaults from v9 assigned_vault column`) — passes; verifies a v9-shape table with mixed admin/single-vault rows lands the expected rows in `user_vaults`.
- [x] FK cascade test — deleting a user drops their `user_vaults` rows.
- [x] OAuth: non-admin with 2+ assigned vaults sees a free dropdown filtered to those vaults (not the hub-wide list); requesting a named vault outside the assignment → 400 `vault_scope_mismatch`.
- [ ] Manual: live exercise after merge — create a friend in `/admin/users` with two vaults, sign in as them, verify account home shows two tiles, run OAuth consent, verify the picker shows both vaults narrowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)