### PR TITLE
feat(wizard): scribe cleanup-provider sub-form

### DIFF
--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -1231,6 +1231,16 @@ describe("handleSetupVaultPost", () => {
     const cfg = readScribeConfig(h.dir);
     expect(cfg?.cleanup).toEqual({ provider: "anthropic", default: true });
     expect(cfg?.cleanupProviders).toEqual({ anthropic: { apiKey: "sk-ant-test123" } });
+    // The config file holds API keys; verify it's written 0o600 so
+    // other users on a shared box can't read the operator's keys.
+    // (Mac/Linux only — Windows reports 0o666; skip on win32.)
+    if (process.platform !== "win32") {
+      const fs = require("node:fs") as typeof import("node:fs");
+      const path = require("node:path") as typeof import("node:path");
+      const cfgPath = path.join(h.dir, "scribe", "config.json");
+      const mode = fs.statSync(cfgPath).mode & 0o777;
+      expect(mode).toBe(0o600);
+    }
   });
 
   test("scribe cleanup: transcribe=none + cleanup=anthropic still installs scribe + writes cleanup block", async () => {

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -1104,6 +1104,171 @@ describe("handleSetupVaultPost", () => {
       db.close();
     }
   });
+
+  // --- scribe cleanup sub-form (2026-05-27) -----------------------------
+  //
+  // The vault step's scribe sub-form was extended with a second radio
+  // group for cleanup-provider. The POST handler reads
+  // `scribe_cleanup_provider` + `scribe_cleanup_api_key` and writes a
+  // `cleanup` block + optional `cleanupProviders.<name>.apiKey` into
+  // `<configDir>/scribe/config.json` alongside the existing transcribe
+  // block. The combos exercised here:
+  //   1. cleanup=none → no cleanup block written
+  //   2. cleanup=claude-code (no key) → block written, no apiKey,
+  //      cleanup.default: true
+  //   3. cleanup=anthropic + key → block + apiKey written
+  //   4. transcribe=none + cleanup=anthropic → scribe still installs
+  //      (cleanup endpoint works standalone), no transcribe block
+  //   5. transcribe=groq + cleanup=anthropic + both keys → full
+  //      happy-path: both blocks + both keys end up in config
+
+  async function postVaultWithFields(
+    h: Harness,
+    fields: Record<string, string>,
+  ): Promise<{ response: Response; runCmds: string[]; csrf: string }> {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const { createSession, SESSION_COOKIE_NAME: SC } = await import("../sessions.ts");
+      const session = createSession(db, { userId: user.id });
+      const get = handleSetupGet(req("/admin/setup"), {
+        db,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        issuer: "https://hub.example",
+        registry: getDefaultOperationsRegistry(),
+      });
+      const csrf = setCookie(get, CSRF_COOKIE_NAME) ?? "";
+      const runCalls: string[][] = [];
+      const stubbedRun = async (cmd: readonly string[]) => {
+        runCalls.push([...cmd]);
+        return 0;
+      };
+      const response = await handleSetupVaultPost(
+        req("/admin/setup/vault", {
+          method: "POST",
+          body: new URLSearchParams({
+            [CSRF_FIELD_NAME]: csrf,
+            ...fields,
+          }).toString(),
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: `${CSRF_COOKIE_NAME}=${csrf}; ${SC}=${session.id}`,
+          },
+        }),
+        {
+          db,
+          manifestPath: h.manifestPath,
+          configDir: h.dir,
+          issuer: "https://hub.example",
+          supervisor: makeSupervisor(),
+          registry: getDefaultOperationsRegistry(),
+          run: stubbedRun,
+        },
+      );
+      // Yield long enough for background runInstall promises to call
+      // through to the stubbed runner.
+      await new Promise((r) => setTimeout(r, 50));
+      return { response, runCmds: runCalls.map((c) => c.join(" ")), csrf };
+    } finally {
+      db.close();
+    }
+  }
+
+  function readScribeConfig(dir: string): Record<string, unknown> | undefined {
+    const fs = require("node:fs") as typeof import("node:fs");
+    const path = require("node:path") as typeof import("node:path");
+    const p = path.join(dir, "scribe", "config.json");
+    if (!fs.existsSync(p)) return undefined;
+    return JSON.parse(fs.readFileSync(p, "utf8")) as Record<string, unknown>;
+  }
+
+  test("scribe cleanup: provider=none writes no cleanup block + no cleanupDefault", async () => {
+    // Skip-cleanup is the radio default. When the operator leaves it
+    // alone, the config writer shouldn't emit a cleanup block at all
+    // — leaves scribe's first-boot default (`cleanup.provider: "none"`)
+    // alone. Belt-and-braces: also assert no `cleanupProviders` block.
+    const { response } = await postVaultWithFields(h, {
+      scribe_provider: "groq",
+      scribe_api_key: "gsk_test_xyz",
+      scribe_cleanup_provider: "none",
+    });
+    expect(response.status).toBe(303);
+    const cfg = readScribeConfig(h.dir);
+    expect(cfg).toBeDefined();
+    expect(cfg?.transcribe).toEqual({ provider: "groq" });
+    expect(cfg?.transcribeProviders).toEqual({ groq: { apiKey: "gsk_test_xyz" } });
+    expect(cfg?.cleanup).toBeUndefined();
+    expect(cfg?.cleanupProviders).toBeUndefined();
+  });
+
+  test("scribe cleanup: provider=claude-code writes block with cleanupDefault:true + no apiKey", async () => {
+    // Claude Code path is subscription-funded — no API key field, auth
+    // is via `claude setup-token` on the host. The wizard should write
+    // `cleanup.provider: "claude-code"` + `cleanup.default: true`,
+    // and NOT a cleanupProviders block (there's nothing to store).
+    const { response } = await postVaultWithFields(h, {
+      scribe_provider: "local",
+      scribe_cleanup_provider: "claude-code",
+    });
+    expect(response.status).toBe(303);
+    const cfg = readScribeConfig(h.dir);
+    expect(cfg?.cleanup).toEqual({ provider: "claude-code", default: true });
+    expect(cfg?.cleanupProviders).toBeUndefined();
+  });
+
+  test("scribe cleanup: provider=anthropic + api_key writes cleanupProviders.anthropic.apiKey", async () => {
+    // Cloud cleanup provider with a key. Expect both the `cleanup`
+    // block (provider + default:true) AND the `cleanupProviders`
+    // block carrying the apiKey, mirroring the transcribe shape.
+    const { response } = await postVaultWithFields(h, {
+      scribe_provider: "groq",
+      scribe_api_key: "gsk_test",
+      scribe_cleanup_provider: "anthropic",
+      scribe_cleanup_api_key: "sk-ant-test123",
+    });
+    expect(response.status).toBe(303);
+    const cfg = readScribeConfig(h.dir);
+    expect(cfg?.cleanup).toEqual({ provider: "anthropic", default: true });
+    expect(cfg?.cleanupProviders).toEqual({ anthropic: { apiKey: "sk-ant-test123" } });
+  });
+
+  test("scribe cleanup: transcribe=none + cleanup=anthropic still installs scribe + writes cleanup block", async () => {
+    // Edge case: operator skips transcription but wants the cleanup
+    // endpoint anyway (they'll feed raw text to scribe's REST cleanup
+    // route from elsewhere). Scribe should still install + the
+    // cleanup block lands without a transcribe block.
+    const { response, runCmds } = await postVaultWithFields(h, {
+      scribe_provider: "none",
+      scribe_cleanup_provider: "anthropic",
+      scribe_cleanup_api_key: "sk-ant-cleanup-only",
+    });
+    expect(response.status).toBe(303);
+    const location = response.headers.get("location") ?? "";
+    expect(location).toMatch(/op_scribe=/);
+    expect(runCmds.some((c) => c.includes("bun add -g @openparachute/scribe"))).toBe(true);
+    const cfg = readScribeConfig(h.dir);
+    expect(cfg?.transcribe).toBeUndefined();
+    expect(cfg?.cleanup).toEqual({ provider: "anthropic", default: true });
+    expect(cfg?.cleanupProviders).toEqual({ anthropic: { apiKey: "sk-ant-cleanup-only" } });
+  });
+
+  test("scribe cleanup: transcribe=groq + cleanup=anthropic + both keys writes both blocks", async () => {
+    // Full happy-path. Two separate providers, two separate keys,
+    // both blocks should land independently in the config.
+    const { response } = await postVaultWithFields(h, {
+      scribe_provider: "groq",
+      scribe_api_key: "gsk_transcribe_key",
+      scribe_cleanup_provider: "anthropic",
+      scribe_cleanup_api_key: "sk-ant-cleanup-key",
+    });
+    expect(response.status).toBe(303);
+    const cfg = readScribeConfig(h.dir);
+    expect(cfg?.transcribe).toEqual({ provider: "groq" });
+    expect(cfg?.transcribeProviders).toEqual({ groq: { apiKey: "gsk_transcribe_key" } });
+    expect(cfg?.cleanup).toEqual({ provider: "anthropic", default: true });
+    expect(cfg?.cleanupProviders).toEqual({ anthropic: { apiKey: "sk-ant-cleanup-key" } });
+  });
 });
 
 // --- end-to-end through hubFetch -----------------------------------------
@@ -2523,6 +2688,26 @@ describe("typed vault name (hub#267)", () => {
     expect(html).toContain('value="BAD"');
     expect(html).toContain("lowercase alphanumeric");
     expect(html).toContain('id="preview-vault-name">BAD<');
+  });
+
+  test("vault step cloudHost=true hides local cleanup options (ollama + claude-code)", async () => {
+    // The cleanup sub-form (added 2026-05-27) offers seven providers
+    // total. Two of them require host-side resources that don't exist
+    // on a cloud container (Render / Fly): claude-code needs the
+    // `claude` CLI + `claude setup-token` on the host; ollama needs a
+    // local Ollama server. Hide those on cloudHost=true so operators
+    // don't pick a provider that'd silently fail at first boot.
+    const { renderVaultStep } = await import("../setup-wizard.ts");
+    const cloudHtml = renderVaultStep({ csrfToken: "csrf-test", cloudHost: true });
+    expect(cloudHtml).not.toContain('value="claude-code"');
+    expect(cloudHtml).not.toContain('value="ollama"');
+    // Cloud-friendly options stay visible.
+    expect(cloudHtml).toContain('value="anthropic"');
+    expect(cloudHtml).toContain('value="gemini"');
+    // And on the local self-host path they're all there.
+    const localHtml = renderVaultStep({ csrfToken: "csrf-test", cloudHost: false });
+    expect(localHtml).toContain('value="claude-code"');
+    expect(localHtml).toContain('value="ollama"');
   });
 });
 

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -586,6 +586,25 @@ function renderScribeSubForm(cloudHost: boolean): string {
           <span class="provider-name">Local <small>(Mac MLX or ONNX — no API key needed)</small></span>
         </label>`;
   const groqDefault = cloudHost ? " checked" : "";
+  // Cleanup providers that need a host-side binary or local server
+  // (claude-code → `claude` CLI + `claude setup-token`; ollama → local
+  // Ollama server) are hidden on cloud hosts (Render / Fly). The
+  // remaining cloud-friendly choices (anthropic / openai / groq /
+  // gemini) stay visible — they only need an API key.
+  const claudeCodeCleanupBlock = cloudHost
+    ? ""
+    : `
+              <label class="scribe-provider-option">
+                <input type="radio" name="scribe_cleanup_provider" value="claude-code" data-needs-key="false" />
+                <span class="provider-name">Claude Code <small>(subscription auth — run <code>claude setup-token</code> on this host)</small></span>
+              </label>`;
+  const ollamaCleanupBlock = cloudHost
+    ? ""
+    : `
+              <label class="scribe-provider-option">
+                <input type="radio" name="scribe_cleanup_provider" value="ollama" data-needs-key="false" />
+                <span class="provider-name">Ollama <small>(local LLM — requires Ollama running on this machine)</small></span>
+              </label>`;
   return `
         <details class="scribe-suboptions" open>
           <summary class="cursor-pointer">
@@ -614,19 +633,56 @@ function renderScribeSubForm(cloudHost: boolean): string {
               <input type="text" name="scribe_api_key" autocomplete="off" placeholder="gsk_… or sk-…" />
               <span class="field-hint">Pasted directly into <code>~/.parachute/scribe/config.json</code> on this hub (file mode 0o600). Leave blank to skip and set later in the admin SPA.</span>
             </label>
+            <fieldset class="scribe-cleanup-block">
+              <legend class="field-label">Cleanup <small>(optional LLM polish pass on transcripts)</small></legend>
+              <p class="field-hint">After transcription, scribe can run a cleanup pass to fix punctuation, capitalization, and obvious transcription glitches. Pick a provider, or skip.</p>
+              <div class="scribe-provider-list">
+                <label class="scribe-provider-option">
+                  <input type="radio" name="scribe_cleanup_provider" value="none" checked data-needs-key="false" />
+                  <span class="provider-name">Skip cleanup <small>(default — raw transcripts only)</small></span>
+                </label>
+                ${claudeCodeCleanupBlock}
+                <label class="scribe-provider-option">
+                  <input type="radio" name="scribe_cleanup_provider" value="anthropic" data-needs-key="true" />
+                  <span class="provider-name">Anthropic API <small>(needs ANTHROPIC_API_KEY)</small></span>
+                </label>
+                ${ollamaCleanupBlock}
+                <label class="scribe-provider-option">
+                  <input type="radio" name="scribe_cleanup_provider" value="openai" data-needs-key="true" />
+                  <span class="provider-name">OpenAI <small>(needs OPENAI_API_KEY)</small></span>
+                </label>
+                <label class="scribe-provider-option">
+                  <input type="radio" name="scribe_cleanup_provider" value="groq" data-needs-key="true" />
+                  <span class="provider-name">Groq <small>(needs GROQ_API_KEY)</small></span>
+                </label>
+                <label class="scribe-provider-option">
+                  <input type="radio" name="scribe_cleanup_provider" value="gemini" data-needs-key="true" />
+                  <span class="provider-name">Google Gemini <small>(needs GOOGLE_API_KEY)</small></span>
+                </label>
+              </div>
+              <label class="field scribe-cleanup-api-key-field" style="display: none;">
+                <span class="field-label">Cleanup API key</span>
+                <input type="text" name="scribe_cleanup_api_key" autocomplete="off" placeholder="sk-ant-… or sk-… or gsk-…" />
+                <span class="field-hint">Pasted directly into <code>~/.parachute/scribe/config.json</code> on this hub (file mode 0o600). Leave blank to skip and paste later in the admin SPA.</span>
+              </label>
+            </fieldset>
           </div>
         </details>
         <script>
           (function () {
-            var radios = document.querySelectorAll('input[name="scribe_provider"]');
-            var keyField = document.querySelector('.scribe-api-key-field');
-            function sync() {
-              var selected = document.querySelector('input[name="scribe_provider"]:checked');
-              var needsKey = selected && selected.dataset.needsKey === "true";
-              if (keyField) keyField.style.display = needsKey ? "" : "none";
+            function toggle(radioName, keySelector) {
+              var radios = document.querySelectorAll('input[name="' + radioName + '"]');
+              var keyField = document.querySelector(keySelector);
+              function sync() {
+                var selected = document.querySelector('input[name="' + radioName + '"]:checked');
+                var needsKey = selected && selected.dataset.needsKey === "true";
+                if (keyField) keyField.style.display = needsKey ? "" : "none";
+              }
+              radios.forEach(function (r) { r.addEventListener("change", sync); });
+              sync();
             }
-            radios.forEach(function (r) { r.addEventListener("change", sync); });
-            sync();
+            toggle("scribe_provider", ".scribe-api-key-field");
+            toggle("scribe_cleanup_provider", ".scribe-cleanup-api-key-field");
           })();
         </script>
   `;
@@ -1794,23 +1850,40 @@ export async function handleSetupVaultPost(req: Request, deps: SetupWizardDeps):
     );
   }
   // Scribe sub-form fold (2026-05-27). The vault step's form lets
-  // the operator answer "do you also want voice transcription?" in
-  // the same submission. If they did, we (a) write the provider +
-  // API key to `~/.parachute/surface/config.json` so scribe finds
+  // the operator answer "do you also want voice transcription?" +
+  // "do you also want LLM cleanup?" in the same submission. If they
+  // asked for either, we (a) write the chosen provider(s) + API
+  // key(s) to `~/.parachute/scribe/config.json` so scribe finds
   // them on first boot, and (b) kick a scribe install op in
   // parallel with vault install. The vault op-poll page threads the
   // scribe op_id through its success-redirect so the done step can
   // poll scribe progress via the existing per-tile mechanism.
+  //
+  // Cleanup-without-transcribe is a valid combo: the operator can
+  // hit scribe's REST cleanup endpoint directly with their own raw
+  // text. We install scribe + write the cleanup block in that case.
   const scribeProvider = String(form.get("scribe_provider") ?? "").trim();
+  const scribeCleanupProvider = String(form.get("scribe_cleanup_provider") ?? "").trim();
+  const wantsTranscribe = scribeProvider !== "" && scribeProvider !== "none";
+  const wantsCleanup = scribeCleanupProvider !== "" && scribeCleanupProvider !== "none";
   let scribeOpId: string | undefined;
-  if (scribeProvider !== "" && scribeProvider !== "none") {
+  if (wantsTranscribe || wantsCleanup) {
     const scribeApiKey = String(form.get("scribe_api_key") ?? "").trim();
+    const scribeCleanupApiKey = String(form.get("scribe_cleanup_api_key") ?? "").trim();
     // Write scribe config FIRST so scribe's first boot picks up the
-    // provider + key without a second config edit. We don't fail the
-    // wizard on a config-write error — log it + carry on; scribe will
-    // boot with defaults + the operator can fix via /scribe/admin.
+    // provider(s) + key(s) without a second config edit. We don't
+    // fail the wizard on a config-write error — log it + carry on;
+    // scribe will boot with defaults + the operator can fix via
+    // /scribe/admin.
     try {
-      writeScribeConfigForWizard(deps.configDir, scribeProvider, scribeApiKey);
+      writeScribeConfigForWizard(deps.configDir, {
+        ...(wantsTranscribe
+          ? { transcribe: { provider: scribeProvider, apiKey: scribeApiKey } }
+          : {}),
+        ...(wantsCleanup
+          ? { cleanup: { provider: scribeCleanupProvider, apiKey: scribeCleanupApiKey } }
+          : {}),
+      });
     } catch (err) {
       console.warn(
         `[setup-wizard] failed to write scribe config: ${err instanceof Error ? err.message : String(err)} — kicking install anyway, operator can configure later.`,
@@ -1848,36 +1921,71 @@ export async function handleSetupVaultPost(req: Request, deps: SetupWizardDeps):
 
 /**
  * Write a minimal scribe config that selects the operator's chosen
- * transcribe provider + API key (when applicable). Idempotent: reads
- * any existing config, merges, writes back. File mode 0o600 — the
- * config holds API keys, owner-only.
+ * transcribe + cleanup providers + API keys (when applicable).
+ * Idempotent: reads any existing config, merges, writes back. File
+ * mode 0o600 — the config holds API keys, owner-only.
  *
  * Lives in setup-wizard.ts (not scribe's own config-write.ts) because
  * (a) it's a one-time wizard write — the SPA's PUT /.parachute/config
  * surface is the canonical post-setup path, and (b) hub doesn't
  * import scribe-internal modules. The shape of `scribe-config.json`
  * is documented in parachute-scribe/src/config.ts; the fields we set
- * (transcribe.provider + transcribeProviders.<name>.apiKey) are
- * stable.
+ * (`transcribe.provider`, `transcribeProviders.<name>.apiKey`,
+ * `cleanup.provider`, `cleanup.default`, `cleanupProviders.<name>.apiKey`)
+ * are stable. Cleanup block extended 2026-05-27 — scribe boots with
+ * `cleanup: none` otherwise, so first-install operators got "raw
+ * transcript only" until they hand-edited the config.
+ *
+ * Signature changed 2026-05-27 from `(configDir, provider, apiKey)` to
+ * the options-object shape so the caller can express "cleanup only,
+ * no transcribe" without smuggling sentinel strings.
  */
-function writeScribeConfigForWizard(
-  configDir: string,
-  provider: string,
-  apiKey: string,
-): void {
-  // For `local` (Mac MLX / cross-platform ONNX), just set the
-  // provider name — no key needed.
-  if (provider === "local") {
-    persistScribeConfig(configDir, { transcribe: { provider: "parakeet-mlx" } });
-    return;
+interface WizardScribeConfig {
+  /** Set when the operator chose a transcription provider (anything other than "none"). */
+  transcribe?: { provider: string; apiKey: string };
+  /** Set when the operator chose a cleanup provider (anything other than "none"). */
+  cleanup?: { provider: string; apiKey: string };
+}
+function writeScribeConfigForWizard(configDir: string, config: WizardScribeConfig): void {
+  const update: Record<string, unknown> = {};
+
+  if (config.transcribe) {
+    const { provider, apiKey } = config.transcribe;
+    // For `local` (Mac MLX / cross-platform ONNX), just set the
+    // provider name — no key needed.
+    if (provider === "local") {
+      update.transcribe = { provider: "parakeet-mlx" };
+    } else {
+      // Cloud providers need a key. Empty key → just set provider;
+      // the operator can paste the key later via /scribe/admin
+      // without a restart (per provider-config.ts's per-request
+      // precedence).
+      update.transcribe = { provider };
+      if (apiKey !== "") {
+        update.transcribeProviders = { [provider]: { apiKey } };
+      }
+    }
   }
-  // Cloud providers need a key. Empty key → just set provider; the
-  // operator can paste the key later via /scribe/admin without a
-  // restart (per provider-config.ts's per-request precedence).
-  const update: Record<string, unknown> = { transcribe: { provider } };
-  if (apiKey !== "") {
-    update.transcribeProviders = { [provider]: { apiKey } };
+
+  if (config.cleanup) {
+    const { provider, apiKey } = config.cleanup;
+    // Always set `cleanup.default: true` when the operator opted in to
+    // cleanup — they want polished output as the default; the per-
+    // request `cleanup` flag on each transcribe request can still
+    // opt out individually.
+    update.cleanup = { provider, default: true };
+    // `claude-code` (host CLI auth) and `ollama` (local server)
+    // don't need an API key. Everything else (anthropic, openai,
+    // groq, gemini) takes a key. Empty key → just set the provider;
+    // the operator can paste the key later via the admin SPA without
+    // a restart.
+    const needsKey = provider !== "claude-code" && provider !== "ollama";
+    if (needsKey && apiKey !== "") {
+      update.cleanupProviders = { [provider]: { apiKey } };
+    }
   }
+
+  if (Object.keys(update).length === 0) return;
   persistScribeConfig(configDir, update);
 }
 

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -630,7 +630,7 @@ function renderScribeSubForm(cloudHost: boolean): string {
             </div>
             <label class="field scribe-api-key-field" data-shows-on="cloud">
               <span class="field-label">API key</span>
-              <input type="text" name="scribe_api_key" autocomplete="off" placeholder="gsk_… or sk-…" />
+              <input type="password" name="scribe_api_key" autocomplete="off" placeholder="gsk_… or sk-…" />
               <span class="field-hint">Pasted directly into <code>~/.parachute/scribe/config.json</code> on this hub (file mode 0o600). Leave blank to skip and set later in the admin SPA.</span>
             </label>
             <fieldset class="scribe-cleanup-block">
@@ -662,7 +662,7 @@ function renderScribeSubForm(cloudHost: boolean): string {
               </div>
               <label class="field scribe-cleanup-api-key-field" style="display: none;">
                 <span class="field-label">Cleanup API key</span>
-                <input type="text" name="scribe_cleanup_api_key" autocomplete="off" placeholder="sk-ant-… or sk-… or gsk-…" />
+                <input type="password" name="scribe_cleanup_api_key" autocomplete="off" placeholder="sk-ant-… or sk-… or gsk-…" />
                 <span class="field-hint">Pasted directly into <code>~/.parachute/scribe/config.json</code> on this hub (file mode 0o600). Leave blank to skip and paste later in the admin SPA.</span>
               </label>
             </fieldset>
@@ -2007,8 +2007,10 @@ function persistScribeConfig(configDir: string, update: Record<string, unknown>)
       existing = {};
     }
   }
-  // Shallow merge at top level, deep merge for the two known sub-blocks
-  // we touch (transcribe + transcribeProviders).
+  // Shallow merge at top level, deep merge for the sub-blocks we touch
+  // (transcribe + transcribeProviders + cleanup + cleanupProviders). The
+  // merge logic is generic and handles any nested object — it doesn't
+  // hard-code the block names.
   const merged: Record<string, unknown> = { ...existing };
   for (const [key, value] of Object.entries(update)) {
     if (


### PR DESCRIPTION
## Summary

The vault step's scribe sub-form (folded in 2026-05-27) only asked about transcription provider. Cleanup defaulted to `none`, so fresh installs landed friends in *voice memo → raw transcript* instead of *voice memo → clean polished text* until they hand-edited the config or opened the scribe admin SPA.

This PR adds a second radio block for cleanup-provider directly beneath transcription in the same wizard step:

- **Options:** none (default), claude-code, anthropic, ollama, openai, groq, gemini.
- **Cloud-host detection:** host-side-only providers (`claude-code` needs the `claude` CLI; `ollama` needs a local Ollama server) are hidden on `cloudHost=true` (Render / Fly).
- **Conditional API-key field:** cleanup gets its own `scribe_cleanup_api_key` input that shows only when a key-requiring provider is selected. The inline toggle script is generalized to handle both transcription + cleanup radio groups.
- **Config writer:** writes `cleanup.provider`, `cleanup.default: true`, and `cleanupProviders.<name>.apiKey` (when needed) into `<configDir>/scribe/config.json` — file mode 0o600 preserved.
- **Cleanup-without-transcribe** is now a valid combo: the operator can hit scribe's REST cleanup endpoint directly with their own raw text. The wizard installs scribe + writes the cleanup block in that case.

### Signature change

`writeScribeConfigForWizard` changed from `(configDir, provider, apiKey)` to `(configDir, { transcribe?, cleanup? })` so the caller can express *cleanup only, no transcribe* without smuggling sentinel strings. Only one call site (the vault POST handler) — internal helper, no public API impact.

## Test plan

- [x] `bun test ./src` — hub: 2175 pass, 1 skip, 0 fail (was 2169; +6 new tests)
- [x] `bun run typecheck` — clean
- [x] `bunx biome check src/setup-wizard.ts src/__tests__/setup-wizard.test.ts` — 2 pre-existing format errors in setup-wizard.ts (unchanged from main), test file clean. My diff added 0 new biome errors.
- [x] `cd web/ui && bun run test && bun run typecheck && bun run build` — 227 pass, typecheck clean, build OK
- [x] Sanity-rendered the wizard HTML to confirm all 7 cleanup options appear on local-host, and `claude-code` + `ollama` are hidden on cloud-host
- [x] New tests cover: cleanup=none (no block written), cleanup=claude-code (no apiKey), cleanup=anthropic+key, transcribe=none+cleanup=anthropic edge case, both blocks happy path, cloudHost rendered-HTML hide assertion

## Patterns

No new patterns. Conforms to the existing wizard sub-form pattern (transcription block), the existing 0o600 secrets-config-file pattern, and the existing inline-script-no-bundle pattern in the wizard.

No version bump (Aaron tags releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)