### PR TITLE
fix(wizard,api): three smoke-2026-05-27 findings (isLinked, live vault name, revocation lag)

### DIFF
--- a/src/__tests__/api-modules-ops.test.ts
+++ b/src/__tests__/api-modules-ops.test.ts
@@ -126,6 +126,19 @@ function alwaysOkRun(): {
   };
 }
 
+/**
+ * Test default for `isLinked`: assume the package is NOT bun-linked so
+ * `runInstall` exercises the `bun add -g` path (which the stubbed runner
+ * captures into `calls`). The production default at
+ * `src/bun-link.ts` reads the contributor's real `~/.bun/install/global/`
+ * symlinks; on Aaron's machine vault/scribe/notes/hub are all linked
+ * (the canonical local-dev shape — smoke 2026-05-27 finding 1 caps the
+ * fix). Tests asserting "bun add WAS called" must opt out of that leakage
+ * by passing this stub. Tests specifically exercising the skip path use
+ * an inline `isLinked: () => true` or a per-pkg discriminator.
+ */
+const TEST_DEFAULT_NOT_LINKED = (_pkg: string): boolean => false;
+
 describe("parseModulesPath", () => {
   test("recognizes curated short + action", () => {
     expect(parseModulesPath("/api/modules/vault/install")).toEqual({
@@ -231,6 +244,7 @@ describe("POST /api/modules/:short/install", () => {
         configDir: h.dir,
         supervisor,
         run,
+        isLinked: TEST_DEFAULT_NOT_LINKED,
       },
     );
     expect(res.status).toBe(202);
@@ -280,6 +294,7 @@ describe("POST /api/modules/:short/install", () => {
         configDir: h.dir,
         supervisor,
         run,
+        isLinked: TEST_DEFAULT_NOT_LINKED,
       },
     );
     expect(res.status).toBe(202);
@@ -301,6 +316,7 @@ describe("POST /api/modules/:short/install", () => {
         configDir: h.dir,
         supervisor,
         run,
+        isLinked: TEST_DEFAULT_NOT_LINKED,
       },
     );
     const op = (await opRes.json()) as { status: string };
@@ -324,6 +340,7 @@ describe("POST /api/modules/:short/install", () => {
         configDir: h.dir,
         supervisor,
         run,
+        isLinked: TEST_DEFAULT_NOT_LINKED,
       },
     );
     expect(res.status).toBe(202);
@@ -348,6 +365,7 @@ describe("POST /api/modules/:short/install", () => {
         configDir: h.dir,
         supervisor,
         run,
+        isLinked: TEST_DEFAULT_NOT_LINKED,
       },
     );
     await new Promise((r) => setTimeout(r, 10));
@@ -379,6 +397,7 @@ describe("POST /api/modules/:short/install", () => {
         configDir: h.dir,
         supervisor,
         run,
+        isLinked: TEST_DEFAULT_NOT_LINKED,
       },
     );
     expect(res.status).toBe(202);
@@ -406,6 +425,7 @@ describe("POST /api/modules/:short/install", () => {
         configDir: h.dir,
         supervisor,
         run,
+        isLinked: TEST_DEFAULT_NOT_LINKED,
       },
     );
     await new Promise((r) => setTimeout(r, 10));
@@ -433,6 +453,7 @@ describe("POST /api/modules/:short/install", () => {
         configDir: h.dir,
         supervisor,
         run,
+        isLinked: TEST_DEFAULT_NOT_LINKED,
       },
     );
     expect(res.status).toBe(400);
@@ -458,6 +479,7 @@ describe("POST /api/modules/:short/install", () => {
         configDir: h.dir,
         supervisor,
         run,
+        isLinked: TEST_DEFAULT_NOT_LINKED,
       },
     );
     await new Promise((r) => setTimeout(r, 10));
@@ -487,6 +509,7 @@ describe("POST /api/modules/:short/install", () => {
           configDir: h.dir,
           supervisor,
           run,
+          isLinked: TEST_DEFAULT_NOT_LINKED,
         },
       );
       await new Promise((r) => setTimeout(r, 10));
@@ -524,6 +547,7 @@ describe("POST /api/modules/:short/install", () => {
           configDir: h.dir,
           supervisor,
           run,
+          isLinked: TEST_DEFAULT_NOT_LINKED,
         },
       );
       await new Promise((r) => setTimeout(r, 10));
@@ -557,6 +581,7 @@ describe("POST /api/modules/:short/install", () => {
           configDir: h.dir,
           supervisor,
           run,
+          isLinked: TEST_DEFAULT_NOT_LINKED,
         },
       );
       expect(res.status).toBe(202);
@@ -583,6 +608,7 @@ describe("POST /api/modules/:short/install", () => {
       supervisor,
       run: async () => 1,
       findGlobalInstall: () => null,
+      isLinked: TEST_DEFAULT_NOT_LINKED,
     };
     const res = await handleInstall(
       postReq("/api/modules/vault/install", { authorization: `Bearer ${bearer}` }),
@@ -601,6 +627,71 @@ describe("POST /api/modules/:short/install", () => {
     const op = (await opRes.json()) as { status: string; error?: string };
     expect(op.status).toBe("failed");
     expect(op.error).toMatch(/bun add -g exited 1/);
+  });
+
+  test("skips bun add -g when package is already bun-linked (smoke 2026-05-27 finding 1)", async () => {
+    // Smoke finding 1: the wizard's parallel install path was unconditionally
+    // invoking `bun add -g <pkg>` even when the package was already linked
+    // via `bun link <abspath>` (the standard local-dev shape). At best a
+    // wasted ~3s npm round-trip per install; at worst the global bun.lock
+    // had unrelated noise and the install failed outright, taking the
+    // wizard's vault step with it. Fix: mirror the CLI install path's
+    // `isLinked` short-circuit. Regression guard.
+    const { supervisor, spawns } = makeIdleSupervisor();
+    const { run, calls } = alwaysOkRun();
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleInstall(
+      postReq("/api/modules/vault/install", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run,
+        // The bug shape: package IS linked locally. Without the
+        // short-circuit, runInstall would still call bun add -g.
+        isLinked: (pkg) => pkg === "@openparachute/vault",
+      },
+    );
+    expect(res.status).toBe(202);
+    await new Promise((r) => setTimeout(r, 10));
+
+    // The fix: bun add -g was NOT invoked for the linked package.
+    expect(calls).not.toContainEqual(["bun", "add", "-g", "@openparachute/vault@latest"]);
+    // Downstream of the skip, the seed + spawn still happen — the install
+    // op completes successfully against the locally-linked checkout.
+    const manifest = JSON.parse(readFileSync(h.manifestPath, "utf8")) as {
+      services: Array<{ name: string }>;
+    };
+    expect(manifest.services.some((s) => s.name === "parachute-vault")).toBe(true);
+    expect(spawns.find((s) => s.short === "vault")?.cmd).toEqual(["parachute-vault", "serve"]);
+  });
+
+  test("still runs bun add -g when package is NOT bun-linked", async () => {
+    // Companion to the above — confirms the short-circuit doesn't
+    // unconditionally skip. On a friend's fresh machine (no bun link),
+    // bun add -g IS what installs the package from npm. `isLinked: () => false`
+    // is the production default behavior for a non-linked package.
+    const { supervisor } = makeIdleSupervisor();
+    const { run, calls } = alwaysOkRun();
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    await handleInstall(
+      postReq("/api/modules/vault/install", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run,
+        isLinked: () => false,
+      },
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(calls).toContainEqual(["bun", "add", "-g", "@openparachute/vault@latest"]);
   });
 });
 
@@ -682,6 +773,7 @@ describe("POST /api/modules/:short/upgrade", () => {
         configDir: h.dir,
         supervisor,
         run,
+        isLinked: TEST_DEFAULT_NOT_LINKED,
       },
     );
     expect(res.status).toBe(202);
@@ -706,6 +798,7 @@ describe("POST /api/modules/:short/upgrade", () => {
         configDir: h.dir,
         supervisor,
         run,
+        isLinked: TEST_DEFAULT_NOT_LINKED,
       },
     );
     expect(res.status).toBe(202);
@@ -736,6 +829,7 @@ describe("POST /api/modules/:short/upgrade", () => {
           configDir: h.dir,
           supervisor,
           run,
+          isLinked: TEST_DEFAULT_NOT_LINKED,
         },
       );
       await new Promise((r) => setTimeout(r, 10));
@@ -846,6 +940,7 @@ describe("POST /api/modules/:short/uninstall", () => {
         configDir: h.dir,
         supervisor,
         run,
+        isLinked: TEST_DEFAULT_NOT_LINKED,
       },
     );
     expect(res.status).toBe(200);
@@ -878,6 +973,7 @@ describe("POST /api/modules/:short/uninstall", () => {
         configDir: h.dir,
         supervisor,
         run,
+        isLinked: TEST_DEFAULT_NOT_LINKED,
       },
     );
     expect(res.status).toBe(200);
@@ -1099,6 +1195,7 @@ describe("well-known regen after module ops", () => {
       supervisor,
       run: async () => 1,
       findGlobalInstall: () => null,
+      isLinked: TEST_DEFAULT_NOT_LINKED,
       wellKnownPath: wkPath,
     };
     const res = await handleInstall(

--- a/src/__tests__/api-users.test.ts
+++ b/src/__tests__/api-users.test.ts
@@ -663,6 +663,30 @@ describe("handleResetUserPassword", () => {
     expect(await verifyPassword(fresh!, "alice-strong-passphrase")).toBe(false);
   });
 
+  test("response body includes revocation_lag_seconds = 60 so clients can surface the propagation lag (smoke 2026-05-27 finding 3)", async () => {
+    // Resource servers cache the revocation list via scope-guard's
+    // REVOCATION_CACHE_TTL_MS = 60_000 — so even though hub marks the
+    // user's tokens revoked immediately and publishes them on the
+    // revocation list, vault/scribe/etc. may keep accepting the
+    // revoked token for up to 60 seconds. For the stolen-device
+    // recovery threat model that's a meaningful exposure window
+    // the admin needs to know about. Surface the lag in the
+    // response body so the SPA's success banner can warn operators.
+    const { bearer } = await makeAdminBearer();
+    const friend = await createUser(harness.db, "alice", "alice-strong-passphrase", {
+      allowMulti: true,
+      passwordChanged: true,
+    });
+    const res = await post(bearer, friend.id, { new_password: "new-temp-passphrase" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      user: unknown;
+      revocation_lag_seconds: number;
+    };
+    expect(body.revocation_lag_seconds).toBe(60);
+  });
+
   test("revokes the friend's existing tokens (pre-reset token row has revoked_at after)", async () => {
     const { bearer } = await makeAdminBearer();
     const friend = await createUser(harness.db, "alice", "alice-strong-passphrase", {

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -884,6 +884,15 @@ describe("handleSetupVaultPost", () => {
           supervisor: makeSupervisor(),
           registry: getDefaultOperationsRegistry(),
           run: stubbedRun,
+          // Force the test to exercise the bun-add path; production
+          // `defaultIsLinked` reads the real ~/.bun globals which on
+          // a contributor's machine returns true (Aaron's vault is
+          // linked locally) and the runInstall short-circuit fires.
+          // For tests asserting "bun add WAS called," opt out of the
+          // skip explicitly. (Smoke 2026-05-27 finding 1 — the skip
+          // is the production behavior we want; tests assert both
+          // branches.)
+          isLinked: () => false,
         },
       );
       expect(post.status).toBe(303);
@@ -954,6 +963,7 @@ describe("handleSetupVaultPost", () => {
           supervisor: makeSupervisor(),
           registry: getDefaultOperationsRegistry(),
           run: stubbedRun,
+          isLinked: () => false,
         },
       );
       // 303 redirect with both op + op_scribe params.
@@ -1021,6 +1031,7 @@ describe("handleSetupVaultPost", () => {
           supervisor: makeSupervisor(),
           registry: getDefaultOperationsRegistry(),
           run: stubbedRun,
+          isLinked: () => false,
         },
       );
       expect(post.status).toBe(303);
@@ -1164,6 +1175,10 @@ describe("handleSetupVaultPost", () => {
           supervisor: makeSupervisor(),
           registry: getDefaultOperationsRegistry(),
           run: stubbedRun,
+          // Test default: assume nothing is bun-linked so `bun add -g`
+          // fires and runCmds reflects the real install commands.
+          // (Smoke 2026-05-27 finding 1.)
+          isLinked: () => false,
         },
       );
       // Yield long enough for background runInstall promises to call
@@ -2295,6 +2310,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
           supervisor: makeSupervisor(),
           registry: getDefaultOperationsRegistry(),
           run: stubbedRun,
+          isLinked: () => false,
         },
       );
       expect(post.status).toBe(303);
@@ -2647,6 +2663,15 @@ describe("typed vault name (hub#267)", () => {
   });
 
   test("done screen surfaces the typed name in the MCP command", async () => {
+    // Happy-path shape: operator typed `my-personal-vault`, vault
+    // first-boot wrote it through to services.json. Both sources
+    // agree, the done page renders the operator-typed name verbatim.
+    // (Pre-smoke-2026-05-27 this test used a mismatched fixture —
+    // services.json said `/vault/default` while the typed setting was
+    // `my-personal-vault`. The DB-priority shape that test was pinning
+    // is itself the smoke finding 2 bug; the fixture has been
+    // realigned to match the actual end-to-end flow where vault's
+    // first-boot honors PARACHUTE_VAULT_NAME.)
     const db = openHubDb(hubDbPath(h.dir));
     try {
       const user = await createUser(db, "owner", "pw");
@@ -2657,7 +2682,7 @@ describe("typed vault name (hub#267)", () => {
               name: "parachute-vault",
               version: "0.1.0",
               port: 1940,
-              paths: ["/vault/default"],
+              paths: ["/vault/my-personal-vault"],
               health: "/health",
             },
           ],
@@ -2683,6 +2708,108 @@ describe("typed vault name (hub#267)", () => {
       const html = await res.text();
       expect(html).toContain("parachute-my-personal-vault");
       expect(html).toContain("/vault/my-personal-vault/mcp");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("done screen renders LIVE vault name when services.json disagrees with the DB-cached value (smoke 2026-05-27 finding 2)", async () => {
+    // Scenario: operator typed `test` into the wizard, install failed
+    // (smoke finding 1), operator worked around it by installing vault
+    // via CLI which created it under the canonical `default` name. The
+    // DB's `setup_vault_name` is stale; services.json is the source of
+    // truth. Done page must render the LIVE name, not the stale typed
+    // one, or the operator's "Open Notes" CTA links to a 404 vault.
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const user = await createUser(db, "owner", "pw");
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              version: "0.1.0",
+              port: 1940,
+              paths: ["/vault/default"], // LIVE vault is "default"
+              health: "/health",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      setSetting(db, "setup_expose_mode", "localhost");
+      // DB cache says "test" — what the operator typed before the
+      // workaround. This is the bug shape: stale DB value vs live
+      // services.json.
+      setSetting(db, "setup_vault_name", "test");
+      const { createSession } = await import("../sessions.ts");
+      const session = createSession(db, { userId: user.id });
+      const res = handleSetupGet(
+        req("/admin/setup?just_finished=1", {
+          headers: { cookie: `${SESSION_COOKIE_NAME}=${session.id}` },
+        }),
+        {
+          db,
+          manifestPath: h.manifestPath,
+          configDir: h.dir,
+          issuer: "https://hub.example",
+          registry: getDefaultOperationsRegistry(),
+        },
+      );
+      const html = await res.text();
+      // The rendered name MUST be the live "default", not the
+      // operator-typed "test" cached in `setup_vault_name`.
+      expect(html).toContain("/vault/default");
+      expect(html).not.toContain("/vault/test");
+      // And the MCP service-namespace stamp should mirror it.
+      expect(html).toContain("parachute-default");
+      expect(html).not.toContain("parachute-test");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("done screen renders LIVE name even when it matches the DB value (happy path regression)", async () => {
+    // Sanity check: the priority swap (live > stored) must NOT
+    // break the happy path where both agree. The vault was installed
+    // under the typed name, services.json reflects that, both sources
+    // say the same thing.
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const user = await createUser(db, "owner", "pw");
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              version: "0.1.0",
+              port: 1940,
+              paths: ["/vault/my-vault"],
+              health: "/health",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      setSetting(db, "setup_expose_mode", "localhost");
+      setSetting(db, "setup_vault_name", "my-vault");
+      const { createSession } = await import("../sessions.ts");
+      const session = createSession(db, { userId: user.id });
+      const res = handleSetupGet(
+        req("/admin/setup?just_finished=1", {
+          headers: { cookie: `${SESSION_COOKIE_NAME}=${session.id}` },
+        }),
+        {
+          db,
+          manifestPath: h.manifestPath,
+          configDir: h.dir,
+          issuer: "https://hub.example",
+          registry: getDefaultOperationsRegistry(),
+        },
+      );
+      const html = await res.text();
+      expect(html).toContain("/vault/my-vault");
+      expect(html).toContain("parachute-my-vault");
     } finally {
       db.close();
     }

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -36,6 +36,7 @@ import type { Database } from "bun:sqlite";
 import { randomUUID } from "node:crypto";
 import { dirname } from "node:path";
 import { CURATED_MODULES, type CuratedModuleShort } from "./api-modules.ts";
+import { isLinked as defaultIsLinked } from "./bun-link.ts";
 import { PARACHUTE_INSTALL_CHANNEL_ENV } from "./commands/install.ts";
 import { getModuleInstallChannel } from "./hub-settings.ts";
 import { validateAccessToken } from "./jwt-sign.ts";
@@ -187,6 +188,21 @@ export interface ApiModulesOpsDeps {
    * null when not found.
    */
   findGlobalInstall?: (pkg: string) => string | null;
+  /**
+   * Override `isLinked` (test seam). Production probes bun's globals
+   * for a symlink-shaped entry under `<prefix>/node_modules/<pkg>` —
+   * true iff the package was installed via `bun link` from a local
+   * checkout. When true, `runInstall` skips `bun add -g <pkg>`
+   * entirely; the linked checkout already provides the binary on
+   * PATH and `bun add -g` would either be a wasted npm round-trip
+   * or fail outright on unrelated global-lockfile noise (smoke
+   * 2026-05-27 finding 1).
+   *
+   * Mirrors the CLI install path's `isLinked` short-circuit in
+   * `commands/install.ts`. Both paths use the same `src/bun-link.ts`
+   * helper so they can't drift again.
+   */
+  isLinked?: (pkg: string) => boolean;
   /**
    * Extra env vars merged onto the supervised child at spawn time (hub#267).
    *
@@ -543,23 +559,43 @@ export async function runInstall(
   // without a hub restart.
   const channel = resolveApiInstallChannel(channelOverride, deps);
   const spec_str = `${spec.package}@${channel}`;
-  registry.update(opId, { status: "running" }, `running bun add -g ${spec_str}`);
-  const code = await run(["bun", "add", "-g", spec_str]);
-  if (code !== 0) {
-    // Bun 1.2.x lockfile-recovery noise: probe the global prefix
-    // before treating non-zero as fatal. Mirrors the same defense in
-    // commands/install.ts.
-    const findGlobalInstall = deps.findGlobalInstall;
-    const probed = findGlobalInstall?.(spec.package) ?? null;
-    if (!probed) {
-      registry.update(
-        opId,
-        { status: "failed", error: `bun add -g exited ${code}` },
-        `bun add -g ${spec_str} failed (exit ${code})`,
-      );
-      return;
+  // bun-link short-circuit (smoke 2026-05-27, finding 1): mirror the
+  // CLI install path's `isLinked` check. When the package is already
+  // linked globally via `bun link <abspath>` (the standard local-dev
+  // shape — Aaron + every workspace contributor runs this way), the
+  // linked checkout already provides the binary on PATH. `bun add -g`
+  // is at best a wasted ~3s npm round-trip and at worst a hard failure
+  // on unrelated global-lockfile noise (one stale entry can crash the
+  // whole `bun add`, failing the wizard's vault step even though the
+  // linked vault is fine). The wizard's parallel install path diverged
+  // pre-this-fix; the shared `src/bun-link.ts` keeps both paths in
+  // lockstep going forward.
+  const isLinked = deps.isLinked ?? defaultIsLinked;
+  if (isLinked(spec.package)) {
+    registry.update(
+      opId,
+      { status: "running" },
+      `${spec.package} is already linked globally (bun link) — skipping bun add -g`,
+    );
+  } else {
+    registry.update(opId, { status: "running" }, `running bun add -g ${spec_str}`);
+    const code = await run(["bun", "add", "-g", spec_str]);
+    if (code !== 0) {
+      // Bun 1.2.x lockfile-recovery noise: probe the global prefix
+      // before treating non-zero as fatal. Mirrors the same defense in
+      // commands/install.ts.
+      const findGlobalInstall = deps.findGlobalInstall;
+      const probed = findGlobalInstall?.(spec.package) ?? null;
+      if (!probed) {
+        registry.update(
+          opId,
+          { status: "failed", error: `bun add -g exited ${code}` },
+          `bun add -g ${spec_str} failed (exit ${code})`,
+        );
+        return;
+      }
+      registry.update(opId, {}, `bun add reported exit ${code} but package landed at ${probed}`);
     }
-    registry.update(opId, {}, `bun add reported exit ${code} but package landed at ${probed}`);
   }
 
   // Seed services.json if absent (the install flow does this for the

--- a/src/api-users.ts
+++ b/src/api-users.ts
@@ -659,6 +659,21 @@ async function parseResetPasswordBody(
 }
 
 /**
+ * Resource-server revocation-cache TTL surfaced in the reset-password
+ * response (smoke 2026-05-27, finding 3). Mirrors
+ * `REVOCATION_CACHE_TTL_MS = 60_000` in
+ * `packages/scope-guard/src/revocation-cache.ts`. Duplicated as a
+ * constant here (not imported) because hub never imports scope-guard
+ * — hub is the issuer + revocation-list publisher; scope-guard runs
+ * at resource servers (vault, scribe, etc.) on the validation side.
+ * Crossing that dependency boundary just to share a constant would
+ * invert the architecture. If the TTL ever changes, update both
+ * places (the scope-guard CHANGELOG entry pins the wire contract;
+ * this constant is the operator-facing surface).
+ */
+export const REVOCATION_LAG_SECONDS = 60;
+
+/**
  * POST /api/users/:id/reset-password — admin sets a new temp password
  * for a non-admin user. The user is force-redirected through
  * `/account/change-password` on next sign-in (same rail as admin-created
@@ -679,10 +694,33 @@ async function parseResetPasswordBody(
  *   7. `resetUserPassword` — rotates hash, flips `password_changed=0`,
  *      revokes the user's still-active tokens, all in one tx.
  *
- * Response on success: `200 { ok: true, user: <wire shape> }`. We
- * deliberately don't echo the password — the admin already typed it
- * and will hand it to the friend out-of-band (Signal, in-person —
- * same as the create-user default-password flow).
+ * Response on success: `200 { ok: true, user: <wire shape>,
+ * revocation_lag_seconds: 60 }`. We deliberately don't echo the
+ * password — the admin already typed it and will hand it to the
+ * friend out-of-band (Signal, in-person — same as the create-user
+ * default-password flow).
+ *
+ * **Revocation propagation lag** (smoke 2026-05-27, finding 3):
+ * `resetUserPassword` marks tokens revoked in hub's DB immediately
+ * AND hub's `/.well-known/parachute-revocation.json` reflects the
+ * new revocation on the next fetch. BUT resource servers (vault,
+ * scribe, etc.) cache the revocation list via scope-guard's
+ * `REVOCATION_CACHE_TTL_MS = 60_000` — they may continue accepting
+ * the revoked token for up to 60 seconds after this call returns.
+ *
+ * - Friend-forgot-pw recovery path: fine. No adversary; the user
+ *   re-authenticates and the lag is invisible.
+ * - Stolen-device / "kill the friend's tokens NOW" path: a
+ *   meaningful exposure window. Operator should also restart the
+ *   affected resource servers (`parachute restart vault`, etc.) to
+ *   flush the cache immediately.
+ *
+ * The `revocation_lag_seconds` field in the response surfaces this
+ * to API clients (admin SPA's reset-password success banner) so
+ * the lag isn't a silent gotcha. The TTL is deliberate (network-
+ * cost tradeoff per the scope-guard CHANGELOG); changing it is a
+ * separate design question (cf. smoke 2026-05-27 Bug 3 mitigation
+ * option 2: inline cache-bust trigger).
  */
 export async function handleResetUserPassword(
   req: Request,
@@ -738,10 +776,22 @@ export async function handleResetUserPassword(
   // + bumped `updated_at`. Cheap (single SELECT). Saves the SPA a refetch
   // to see the row's "pending first login" badge come back.
   const fresh = getUserById(deps.db, userId);
-  return new Response(JSON.stringify({ ok: true, user: fresh ? toWire(fresh) : null }), {
-    status: 200,
-    headers: { "content-type": "application/json", "cache-control": "no-store" },
-  });
+  // `revocation_lag_seconds`: smoke 2026-05-27 finding 3. Resource
+  // servers cache the revocation list for up to 60s; surface that so
+  // the SPA's success banner can warn operators in the
+  // stolen-device-recovery threat model. See REVOCATION_LAG_SECONDS
+  // doc + handler docstring above.
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      user: fresh ? toWire(fresh) : null,
+      revocation_lag_seconds: REVOCATION_LAG_SECONDS,
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json", "cache-control": "no-store" },
+    },
+  );
 }
 
 function describeUsernameReason(reason: "format" | "length" | "reserved"): string {

--- a/src/bun-link.ts
+++ b/src/bun-link.ts
@@ -1,0 +1,55 @@
+/**
+ * bun-link detection — shared helper used by both the CLI install path
+ * (`commands/install.ts`) and the API/wizard install path (`api-modules-ops.ts`).
+ *
+ * "Linked" means a global symlink shape under `~/.bun/install/global/node_modules/<pkg>`
+ * created by `bun link` (from a local checkout). When the package is already linked,
+ * `bun add -g <pkg>` is at best a wasted npm round-trip (~3s) and at worst a hard
+ * failure when the global bun.lock has unrelated noise — neither outcome is desirable
+ * given the linked checkout already provides the binary on PATH.
+ *
+ * Both install paths gate the `bun add -g` call on `isLinked(pkg) === false`.
+ * Centralizing the detection here keeps the CLI and wizard in lockstep — diverging
+ * (as the wizard did pre-hub#XXX) is the bug class this module exists to prevent.
+ */
+
+import { lstatSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * The set of bun global-prefix locations to probe for a `<pkg>` symlink.
+ * Honors `BUN_INSTALL` (the canonical override) before falling back to the
+ * default `~/.bun` layout. Order matters — env-set prefix wins on a custom
+ * bun layout (containers, CI).
+ */
+export function bunGlobalPrefixes(): string[] {
+  const prefixes: string[] = [];
+  const fromEnv = process.env.BUN_INSTALL;
+  if (fromEnv) prefixes.push(join(fromEnv, "install", "global", "node_modules"));
+  prefixes.push(join(homedir(), ".bun", "install", "global", "node_modules"));
+  return prefixes;
+}
+
+/**
+ * True iff `<pkg>` resolves to a symlink under any bun global prefix —
+ * i.e. the package was installed via `bun link` from a local checkout
+ * rather than `bun add -g` from npm. Used to short-circuit `bun add -g`
+ * in both the CLI and the wizard install paths.
+ *
+ * Scoped packages (`@openparachute/vault`) are split on `/` so the probe
+ * lands at `<prefix>/@openparachute/vault`. Non-symlink resolutions
+ * (real dir from `bun add -g`) return false — we only want to skip the
+ * `bun add -g` when the symlink-shape is in place.
+ */
+export function isLinked(pkg: string): boolean {
+  for (const prefix of bunGlobalPrefixes()) {
+    const path = join(prefix, ...pkg.split("/"));
+    try {
+      if (lstatSync(path).isSymbolicLink()) return true;
+    } catch {
+      // Not present at this prefix; try the next.
+    }
+  }
+  return false;
+}

--- a/src/bun-link.ts
+++ b/src/bun-link.ts
@@ -10,7 +10,7 @@
  *
  * Both install paths gate the `bun add -g` call on `isLinked(pkg) === false`.
  * Centralizing the detection here keeps the CLI and wizard in lockstep — diverging
- * (as the wizard did pre-hub#XXX) is the bug class this module exists to prevent.
+ * (as the wizard did pre-hub#433) is the bug class this module exists to prevent.
  */
 
 import { lstatSync } from "node:fs";

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -262,7 +262,7 @@ async function defaultRunner(cmd: readonly string[]): Promise<number> {
 
 // `bunGlobalPrefixes` + `defaultIsLinked` were extracted to `src/bun-link.ts`
 // so the wizard's parallel install path (`api-modules-ops.ts:runInstall`) can
-// reuse the same detection — the two paths diverging is the bug class hub#XXX
+// reuse the same detection — the two paths diverging is the bug class hub#433
 // fixed (smoke 2026-05-27, finding 1). `defaultIsLinkedShared` is imported at
 // module scope; alias kept for the in-function local-shadow convention below.
 const defaultIsLinked = defaultIsLinkedShared;

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,8 +1,8 @@
-import { existsSync, lstatSync, readFileSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { createConnection } from "node:net";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { autoWireScribeAuth } from "../auto-wire.ts";
+import { bunGlobalPrefixes, isLinked as defaultIsLinkedShared } from "../bun-link.ts";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import {
   type ModuleManifest,
@@ -260,25 +260,12 @@ async function defaultRunner(cmd: readonly string[]): Promise<number> {
   return await proc.exited;
 }
 
-function bunGlobalPrefixes(): string[] {
-  const prefixes: string[] = [];
-  const fromEnv = process.env.BUN_INSTALL;
-  if (fromEnv) prefixes.push(join(fromEnv, "install", "global", "node_modules"));
-  prefixes.push(join(homedir(), ".bun", "install", "global", "node_modules"));
-  return prefixes;
-}
-
-function defaultIsLinked(pkg: string): boolean {
-  for (const prefix of bunGlobalPrefixes()) {
-    const path = join(prefix, ...pkg.split("/"));
-    try {
-      if (lstatSync(path).isSymbolicLink()) return true;
-    } catch {
-      // Not present at this prefix; try the next.
-    }
-  }
-  return false;
-}
+// `bunGlobalPrefixes` + `defaultIsLinked` were extracted to `src/bun-link.ts`
+// so the wizard's parallel install path (`api-modules-ops.ts:runInstall`) can
+// reuse the same detection — the two paths diverging is the bug class hub#XXX
+// fixed (smoke 2026-05-27, finding 1). `defaultIsLinkedShared` is imported at
+// module scope; alias kept for the in-function local-shadow convention below.
+const defaultIsLinked = defaultIsLinkedShared;
 
 function defaultLinkedPath(pkg: string): string | null {
   // bun has two install shapes for "linked-style" globals:

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -224,6 +224,18 @@ export interface SetupWizardDeps {
   /** Test seam: stub `bun add` / `bun remove` runner. */
   run?: (cmd: readonly string[]) => Promise<number>;
   /**
+   * Test seam: stub the bun-link detection used by `runInstall` to
+   * short-circuit `bun add -g` when a package is already linked
+   * locally (smoke 2026-05-27 finding 1). Production omits this and
+   * the production detection at `src/bun-link.ts` probes the real
+   * filesystem. Tests that need to assert "bun add -g WAS called"
+   * pass `() => false`; tests asserting the skip path pass `() => true`.
+   *
+   * Threaded through to `ApiModulesOpsDeps.isLinked` on every
+   * `runInstall` call from the wizard.
+   */
+  isLinked?: (pkg: string) => boolean;
+  /**
    * Test seam: override the process env that `detectAutoExposeMode`
    * consults. Production omits this and the helper reads `process.env`
    * directly. Setting in tests lets the auto-skip branch be exercised
@@ -1447,15 +1459,26 @@ export function handleSetupGet(req: Request, deps: SetupWizardDeps): Response {
       // /admin/tokens.
       const mintedToken = getSetting(deps.db, "setup_minted_token");
       if (mintedToken) deleteSetting(deps.db, "setup_minted_token");
-      // hub#267: the operator-typed vault name lives in hub_settings
-      // (persisted by handleSetupVaultPost). Fall back to scanning
-      // services.json — covers wizard runs from before this PR where
-      // setup_vault_name wasn't written. The services.json read
-      // returns the path-tail; vault's own first-boot write produces
-      // the canonical name so the two should agree once the vault
-      // boots authoritatively.
+      // Prefer the LIVE vault name from services.json over the
+      // operator-typed value cached in hub_settings (smoke
+      // 2026-05-27, finding 2). The cached value is what the
+      // operator typed into the wizard form — fine on the happy
+      // path, but stale if the vault install failed and the
+      // operator worked around it (e.g. installed vault under a
+      // different name via the CLI). The "static-write + stale-
+      // read" pattern Aaron's flagged repeatedly:
+      // `feedback_static_vs_dynamic_state.md`. Read state
+      // dynamically when it can change.
+      //
+      // Fall back to the DB setting only if services.json has no
+      // vault entry — covers a transient "wizard hit done but
+      // vault is still pending" race where the operator-typed
+      // value is the only signal we have. Final fallback is
+      // "default" so the rendered name is always something the
+      // operator can act on.
+      const liveName = firstVaultNameOrNull(deps.manifestPath);
       const storedName = getSetting(deps.db, "setup_vault_name");
-      const vaultName = storedName ?? firstVaultName(deps.manifestPath);
+      const vaultName = liveName ?? storedName ?? "default";
       // Module install tiles (hub#272 Item B). One per curated module
       // other than vault (which the wizard already provisioned).
       const installTiles = buildInstallTiles(url, deps);
@@ -1836,6 +1859,7 @@ export async function handleSetupVaultPost(req: Request, deps: SetupWizardDeps):
       supervisor: deps.supervisor,
       registry,
       ...(deps.run ? { run: deps.run } : {}),
+      ...(deps.isLinked ? { isLinked: deps.isLinked } : {}),
       ...(Object.keys(spawnEnv).length > 0 ? { spawnEnv } : {}),
     }).catch((err) => {
       const msg = err instanceof Error ? err.message : String(err);
@@ -1903,6 +1927,7 @@ export async function handleSetupVaultPost(req: Request, deps: SetupWizardDeps):
         supervisor: deps.supervisor,
         registry,
         ...(deps.run ? { run: deps.run } : {}),
+        ...(deps.isLinked ? { isLinked: deps.isLinked } : {}),
       }).catch((err) => {
         const msg = err instanceof Error ? err.message : String(err);
         registry.update(
@@ -2261,6 +2286,7 @@ export async function handleSetupInstallPost(
       supervisor: deps.supervisor,
       registry,
       ...(deps.run ? { run: deps.run } : {}),
+      ...(deps.isLinked ? { isLinked: deps.isLinked } : {}),
     }).catch((err) => {
       const msg = err instanceof Error ? err.message : String(err);
       registry.update(op.id, { status: "failed", error: msg }, `install failed: ${msg}`);
@@ -2310,17 +2336,21 @@ function isModuleInstalled(short: CuratedModuleShort, manifestPath: string): boo
 }
 
 /**
- * Read the first vault's display name from services.json for the
- * step-4 success page. Falls back to "default" if for any reason the
- * entry's metadata isn't present.
+ * Read the first vault's display name from services.json. Returns
+ * null when services.json has no vault entry or the entry has no
+ * `/vault/<name>` path — used by the done step to detect "no live
+ * vault, fall back to the operator-typed value." Distinguishing
+ * "no live vault" from "live vault named default" matters: the
+ * former should defer to the DB-cached name; the latter should
+ * win over a possibly-stale DB cache (smoke 2026-05-27 finding 2).
  */
-function firstVaultName(manifestPath: string): string {
+function firstVaultNameOrNull(manifestPath: string): string | null {
   const manifest = readManifestLenient(manifestPath);
   // Match on the canonical vault manifestName from the curated spec.
   // (`CURATED_MODULES.includes("vault")` was a dead guard — vault is a
   // tuple-literal member, so the conjunct is always true.)
   const entry = manifest.services.find((s) => s.name === specFor("vault").manifestName);
-  if (!entry) return "default";
+  if (!entry) return null;
   // services.json entries store the mount path (e.g. `/vault/default`).
   // Strip the canonical prefix to surface the display name.
   for (const p of entry.paths ?? []) {
@@ -2329,7 +2359,7 @@ function firstVaultName(manifestPath: string): string {
       if (tail.length > 0) return tail;
     }
   }
-  return "default";
+  return null;
 }
 
 function htmlResponse(body: string, status = 200, extra: Record<string, string> = {}): Response {

--- a/src/users.ts
+++ b/src/users.ts
@@ -423,6 +423,19 @@ export async function setPassword(
  * on bun:sqlite is sync; doing it inside silently breaks atomicity (same
  * constraint api-account.ts:399 documents for the change-password POST).
  *
+ * **Revocation propagation lag (smoke 2026-05-27, finding 3)**: this
+ * function marks tokens revoked in hub's DB immediately. Hub's
+ * `/.well-known/parachute-revocation.json` reflects the new revocation
+ * on the next fetch. BUT resource servers (vault, scribe, etc.) consult
+ * the revocation list via scope-guard's `REVOCATION_CACHE_TTL_MS = 60_000`
+ * cache — so they may continue accepting the revoked token for up to
+ * 60 seconds after this call returns. For the "friend forgot pw"
+ * recovery path this is fine (no adversary). For the "stolen device,
+ * kill the friend's tokens NOW" path it's a meaningful exposure
+ * window — operators in that scenario should also restart the
+ * affected resource servers to flush their cache. See
+ * `REVOCATION_LAG_SECONDS` for the value surfaced to API callers.
+ *
  * Caller responsibilities (not enforced here):
  *   - Validate `newPassword` first (`validatePassword`) — this helper
  *     trusts the input and runs argon2id over whatever it gets.

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1158,7 +1158,10 @@ export async function deleteUser(id: string): Promise<void> {
  * that case — same posture as `deleteUser` for the
  * first_admin_undeletable rail.
  */
-export async function resetUserPassword(userId: string, newPassword: string): Promise<void> {
+export async function resetUserPassword(
+  userId: string,
+  newPassword: string,
+): Promise<{ revocationLagSeconds: number }> {
   const bearer = await getHostAdminToken();
   const res = await fetch(`/api/users/${encodeURIComponent(userId)}/reset-password`, {
     method: "POST",
@@ -1174,6 +1177,15 @@ export async function resetUserPassword(userId: string, newPassword: string): Pr
     throw new HttpError(res.status, await readError(res));
   }
   if (!res.ok) throw new HttpError(res.status, await readError(res));
+  // The server returns `revocation_lag_seconds: 60` reflecting the
+  // scope-guard cache TTL on resource servers. Surface it to the caller
+  // so the UI banner stays in sync with the server's constant — one
+  // source of truth, not a third hardcoded copy in the SPA.
+  // Default to 60 if the field is missing (older server or unparseable
+  // response — better than failing the whole reset flow).
+  const body = (await res.json().catch(() => ({}))) as { revocation_lag_seconds?: number };
+  const lag = typeof body.revocation_lag_seconds === "number" ? body.revocation_lag_seconds : 60;
+  return { revocationLagSeconds: lag };
 }
 
 /**

--- a/web/ui/src/routes/Users.test.tsx
+++ b/web/ui/src/routes/Users.test.tsx
@@ -203,7 +203,7 @@ describe("Users — admin password reset (Phase 2 PR 1)", () => {
     // server flips it and the SPA re-reads). Round-trip through the mock.
     listMock.mockResolvedValueOnce([user("operator"), user("alice", { password_changed: false })]);
     vi.mocked(api.listUserVaults).mockResolvedValue([]);
-    vi.mocked(api.resetUserPassword).mockResolvedValue();
+    vi.mocked(api.resetUserPassword).mockResolvedValue({ revocationLagSeconds: 60 });
     renderRoute();
     fireEvent.click(await screen.findByRole("button", { name: /reset password for alice/i }));
     fireEvent.change(screen.getByLabelText(/new temporary password for alice/i), {

--- a/web/ui/src/routes/Users.tsx
+++ b/web/ui/src/routes/Users.tsx
@@ -106,7 +106,7 @@ type ResetState =
   | { kind: "idle" }
   | { kind: "open"; userId: string; password: string }
   | { kind: "submitting"; userId: string; password: string }
-  | { kind: "done"; userId: string; username: string }
+  | { kind: "done"; userId: string; username: string; revocationLagSeconds: number }
   | { kind: "error"; userId: string; password: string; message: string };
 
 interface FormFields {
@@ -257,8 +257,13 @@ export function Users() {
     }
     setResetSt({ kind: "submitting", userId: user.id, password });
     try {
-      await resetUserPassword(user.id, password);
-      setResetSt({ kind: "done", userId: user.id, username: user.username });
+      const { revocationLagSeconds } = await resetUserPassword(user.id, password);
+      setResetSt({
+        kind: "done",
+        userId: user.id,
+        username: user.username,
+        revocationLagSeconds,
+      });
       // Refresh so the row's "Password set" cell flips back to
       // "pending first login" — the server flipped password_changed
       // back to false, and the table needs to mirror that.
@@ -665,7 +670,8 @@ function ListRendered({
                         password and tell them they'll be prompted to change it on first sign-in.
                         <div className="muted" style={{ marginTop: "0.5rem", fontSize: "0.85em" }}>
                           Their existing tokens are revoked. Resource servers (vault, scribe, etc.)
-                          cache the revocation list for up to 60 seconds — if you're resetting
+                          cache the revocation list for up to {resetDone.revocationLagSeconds}{" "}
+                          seconds — if you're resetting
                           because of a suspected compromise, also restart the affected services
                           (e.g. <code>parachute restart vault</code>) to flush their cache
                           immediately.

--- a/web/ui/src/routes/Users.tsx
+++ b/web/ui/src/routes/Users.tsx
@@ -663,6 +663,13 @@ function ListRendered({
                       >
                         Password reset for <code>{resetDone.username}</code>. Hand them the new
                         password and tell them they'll be prompted to change it on first sign-in.
+                        <div className="muted" style={{ marginTop: "0.5rem", fontSize: "0.85em" }}>
+                          Their existing tokens are revoked. Resource servers (vault, scribe, etc.)
+                          cache the revocation list for up to 60 seconds — if you're resetting
+                          because of a suspected compromise, also restart the affected services
+                          (e.g. <code>parachute restart vault</code>) to flush their cache
+                          immediately.
+                        </div>
                         <div style={{ marginTop: "0.5rem" }}>
                           <button
                             type="button"


### PR DESCRIPTION
## Summary

Addresses the three majors from the 2026-05-27 multi-user smoke report (`/tmp/parachute-smoke-report-2026-05-27.md`):

- **Finding 1 (MAJOR — install path bypasses isLinked):** Wizard's `runInstall` in `src/api-modules-ops.ts` was unconditionally invoking `bun add -g` even when the package was already bun-linked locally. On a healthy machine this is a wasted ~3s npm round-trip per install; on a machine with stale global-lockfile noise (as the smoke agent had) the install can fail outright and take the wizard's vault step down with it. Extracted the canonical `isLinked` detection to `src/bun-link.ts`, refactored `src/commands/install.ts` to import it, added an `isLinked` test seam to `ApiModulesOpsDeps` + `SetupWizardDeps`, and threaded it through all three wizard `runInstall` call sites. Both install paths now share one source of truth and can't drift.

- **Finding 2 (MAJOR — Done page renders stale vault name):** Wizard's done step in `src/setup-wizard.ts:1457` was reading `setup_vault_name` from `hub_settings` first and only falling back to services.json on undefined. If vault install failed and the operator worked around it (e.g. installed under a different name via CLI), the done page rendered broken links forever. Swapped the priority — live services.json wins, DB cache is fallback. Standard "static-write + stale-read" fix per `feedback_static_vs_dynamic_state.md`.

- **Finding 3 (MAJOR (security UX) — 60s revocation lag):** Updated docstrings on `handleResetUserPassword` (api-users.ts) and `resetUserPassword` (users.ts) to explicitly note the scope-guard `REVOCATION_CACHE_TTL_MS = 60_000` propagation lag at resource servers. Added `revocation_lag_seconds: 60` to the response body. Updated SPA's reset-password success banner in `web/ui/src/routes/Users.tsx` with the "also restart the affected services" recommendation for the stolen-device threat model. Cache TTL itself unchanged (architectural — would increase hub load). Runbook update on parachute.computer is a separate follow-up.

## Test plan

- [x] `bun test ./src` — 2174 pass, 1 skip, 0 fail (was 2169; +5 new tests).
- [x] `bun run typecheck` — clean.
- [x] `bunx biome check` on touched files — clean (pre-existing biome issues in `api-modules-ops.ts` and `setup-wizard.ts` are unchanged from main; not introduced by this PR).
- [x] `cd web/ui && bun run test && bun run typecheck && bun run build` — 227 pass, build verifies base prefix.

New regression guards:
- `api-modules-ops.test.ts`: skip-when-bun-linked + still-runs-when-unlinked.
- `setup-wizard.test.ts`: done screen renders LIVE vault name when DB cache is stale (the exact smoke finding 2 scenario) + happy-path regression.
- `api-users.test.ts`: response body includes `revocation_lag_seconds = 60`.

Existing tests that asserted "bun add -g WAS called" gained `isLinked: TEST_DEFAULT_NOT_LINKED` (or `() => false`) — the production helper reads `~/.bun/install/global/` symlinks; on a contributor's machine (Aaron's vault/scribe/notes/hub are all linked) those tests would otherwise flip without explicit opt-out. The pre-existing "done screen surfaces typed name" test had a mismatched fixture (typed=my-personal-vault, services.json=/vault/default) that encoded the pre-fix bug — realigned to the actual happy-path shape.

No version bump (per current governance — RC bump happens at release time, not per PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)