### PR TITLE
chore(release): 0.5.14-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.1",
+  "version": "0.5.14-rc.2",
   "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Bump to 0.5.14-rc.2. Aaron-authorized 2026-05-27 ("push to rc").

Code-touching PRs since v0.5.14-rc.1: #425, #426, #427, #429, #430, #433.

Net of multi-user Phase 2 (admin pw reset + multi-vault), wizard scribe-cleanup sub-form, and smoke-driven hardening.

(Re-bump after the prior rc.2 commit got force-pushed away when ag-unforced-dev was reset post-#433-merge, auto-closing #434.)

## Test plan

- [x] All bundled PRs already merged with green CI
- [ ] Tag push `v0.5.14-rc.2` → CI publishes to @rc