### PR TITLE
feat(hub): trim curated modules to [vault, scribe] for launch focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.1",
+  "version": "0.5.14-rc.2",
   "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-modules-config.test.ts
+++ b/src/__tests__/api-modules-config.test.ts
@@ -23,6 +23,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { decodeJwt } from "jose";
+import type { CuratedModuleShort } from "../api-modules.ts";
 import {
   API_MODULES_CONFIG_REQUIRED_SCOPE,
   MODULE_CONFIG_PROXY_CLIENT_ID,
@@ -152,14 +153,19 @@ describe("parseModulesConfigPath", () => {
     });
   });
 
-  test("matches vault and notes (curated modules)", () => {
+  test("matches vault and scribe (curated modules)", () => {
     expect(parseModulesConfigPath("/api/modules/vault/config")?.short).toBe("vault");
-    expect(parseModulesConfigPath("/api/modules/notes/config/schema")?.short).toBe("notes");
+    expect(parseModulesConfigPath("/api/modules/scribe/config/schema")?.short).toBe("scribe");
   });
 
   test("rejects unknown short (non-curated)", () => {
     expect(parseModulesConfigPath("/api/modules/unknown/config")).toBeUndefined();
     expect(parseModulesConfigPath("/api/modules/channel/config")).toBeUndefined();
+    // Curated list trimmed 2026-05-27: notes / runner / surface are no
+    // longer curated and reject at the parse boundary.
+    expect(parseModulesConfigPath("/api/modules/notes/config")).toBeUndefined();
+    expect(parseModulesConfigPath("/api/modules/runner/config")).toBeUndefined();
+    expect(parseModulesConfigPath("/api/modules/surface/config")).toBeUndefined();
   });
 
   test("rejects non-config suffix shapes", () => {
@@ -302,7 +308,7 @@ describe("handleApiModulesConfig — FALLBACK retirement (hub#310)", () => {
       makeReq("/api/modules/runner/config/schema", {
         headers: { authorization: `Bearer ${bearer}` },
       }),
-      { short: "runner", suffix: "schema" },
+      { short: "runner" as CuratedModuleShort, suffix: "schema" },
       { db: h.db, issuer: ISSUER, manifestPath: h.manifestPath },
     );
     expect(res.status).toBe(404);
@@ -365,7 +371,7 @@ describe("handleApiModulesConfig — FALLBACK retirement (hub#310)", () => {
       makeReq("/api/modules/runner/config/schema", {
         headers: { authorization: `Bearer ${bearer}` },
       }),
-      { short: "runner", suffix: "schema" },
+      { short: "runner" as CuratedModuleShort, suffix: "schema" },
       {
         db: h.db,
         issuer: ISSUER,
@@ -614,7 +620,7 @@ describe("handleApiModulesConfig — stripPrefix=false (notes-shape)", () => {
       makeReq("/api/modules/notes/config/schema", {
         headers: { authorization: `Bearer ${bearer}` },
       }),
-      { short: "notes", suffix: "schema" },
+      { short: "notes" as CuratedModuleShort, suffix: "schema" },
       {
         db: h.db,
         issuer: ISSUER,
@@ -668,7 +674,7 @@ describe("handleApiModulesConfig — hostsBareParachute (hub#307)", () => {
       makeReq("/api/modules/runner/config/schema", {
         headers: { authorization: `Bearer ${bearer}` },
       }),
-      { short: "runner", suffix: "schema" },
+      { short: "runner" as CuratedModuleShort, suffix: "schema" },
       {
         db: h.db,
         issuer: ISSUER,
@@ -700,7 +706,7 @@ describe("handleApiModulesConfig — hostsBareParachute (hub#307)", () => {
       makeReq("/api/modules/runner/config", {
         headers: { authorization: `Bearer ${bearer}` },
       }),
-      { short: "runner", suffix: "" },
+      { short: "runner" as CuratedModuleShort, suffix: "" },
       {
         db: h.db,
         issuer: ISSUER,
@@ -733,7 +739,7 @@ describe("handleApiModulesConfig — hostsBareParachute (hub#307)", () => {
         },
         body: JSON.stringify({ intervalSeconds: 120 }),
       }),
-      { short: "runner", suffix: "" },
+      { short: "runner" as CuratedModuleShort, suffix: "" },
       {
         db: h.db,
         issuer: ISSUER,
@@ -760,7 +766,7 @@ describe("handleApiModulesConfig — hostsBareParachute (hub#307)", () => {
       makeReq("/api/modules/runner/config", {
         headers: { authorization: `Bearer ${bearer}` },
       }),
-      { short: "runner", suffix: "" },
+      { short: "runner" as CuratedModuleShort, suffix: "" },
       {
         db: h.db,
         issuer: ISSUER,
@@ -863,7 +869,7 @@ describe("handleApiModulesConfig — hostsBareParachute (hub#307)", () => {
       makeReq("/api/modules/runner/config/schema", {
         headers: { authorization: `Bearer ${bearer}` },
       }),
-      { short: "runner", suffix: "schema" },
+      { short: "runner" as CuratedModuleShort, suffix: "schema" },
       {
         db: h.db,
         issuer: ISSUER,

--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -149,10 +149,12 @@ describe("GET /api/modules", () => {
 
   test("200 + curated list on fresh container (empty services.json)", async () => {
     // The v0.6 hot path: brand-new Render container, no services.json
-    // yet. UI must render "install vault / app / notes / scribe / runner"
-    // cards even though nothing's installed. hub#323 inserted `app` between
-    // `vault` and `notes` — app auto-bootstraps notes-ui as a sub-unit;
-    // `notes` (notes-daemon) stays curated for back-compat install paths.
+    // yet. UI must render "install vault / scribe" cards even though
+    // nothing's installed. Trimmed 2026-05-27 (Aaron-directed launch
+    // focus): notes (notes-daemon), surface (host module), and runner
+    // (experimental) are no longer curated — notes.parachute.computer
+    // is the hosted PWA, surface-client is the library for custom UI
+    // builders, and runner isn't in the launch focus set.
     const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
     const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
       db: h.db,
@@ -170,8 +172,10 @@ describe("GET /api/modules", () => {
       }>;
       supervisor_available: boolean;
     };
-    // Curated order is preserved: vault → app → notes → scribe → runner.
-    expect(body.modules.map((m) => m.short)).toEqual(["vault", "surface", "notes", "scribe", "runner"]);
+    // Curated order is preserved: vault → scribe (vault first per the
+    // recommended install order — the wizard's vault step already runs
+    // before this catalog surfaces).
+    expect(body.modules.map((m) => m.short)).toEqual(["vault", "scribe"]);
     expect(body.modules.every((m) => m.available)).toBe(true);
     expect(body.modules.every((m) => !m.installed)).toBe(true);
     expect(body.modules.every((m) => m.latest_version === "0.9.9")).toBe(true);
@@ -179,18 +183,25 @@ describe("GET /api/modules", () => {
     expect(body.supervisor_available).toBe(false);
   });
 
-  test("app row carries package + display props from KNOWN_MODULES (#323)", async () => {
-    // hub#323 added app to CURATED_MODULES + KNOWN_MODULES so the admin SPA
-    // install catalog + setup-wizard install tile surface it. Spot-check the
-    // wire shape resolves app-specific fields (package, displayName, tagline)
-    // from KNOWN_MODULES rather than a stale default — same shape as the
-    // runner row test below.
+  test("scribe row carries package + display props from KNOWN_MODULES", async () => {
+    // Spot-check the wire shape resolves scribe-specific fields
+    // (package, displayName, tagline) from KNOWN_MODULES rather than a
+    // stale default. Vault is exercised via the install-state test below;
+    // this pins the other curated row's KNOWN_MODULES round-trip.
+    //
+    // Pre-2026-05-27 this test pinned the `surface` row (added by
+    // hub#323), and a sibling pinned the `runner` FIRST_PARTY_FALLBACKS
+    // row (hub#305). Both modules retired from CURATED_MODULES — the
+    // FIRST_PARTY_FALLBACKS / KNOWN_MODULES entries persist for the
+    // install-bootstrap path but `/api/modules` doesn't return them.
+    // The "uncurated modules don't surface here" test below pins that
+    // boundary.
     const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
     const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
       db: h.db,
       issuer: ISSUER,
       manifestPath: h.manifestPath,
-      fetchLatestVersion: async () => "0.2.0",
+      fetchLatestVersion: async () => "0.4.4",
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -202,42 +213,33 @@ describe("GET /api/modules", () => {
         available: boolean;
       }>;
     };
-    const surface = body.modules.find((m) => m.short === "surface");
-    expect(surface).toBeDefined();
-    expect(surface?.package).toBe("@openparachute/surface");
-    expect(surface?.display_name).toBe("Surface");
-    expect(surface?.tagline).toContain("auto-installs Notes");
-    expect(surface?.available).toBe(true);
+    const scribe = body.modules.find((m) => m.short === "scribe");
+    expect(scribe).toBeDefined();
+    expect(scribe?.package).toBe("@openparachute/scribe");
+    expect(scribe?.display_name).toBe("Scribe");
+    expect(scribe?.tagline).toContain("transcription");
+    expect(scribe?.available).toBe(true);
   });
 
-  test("runner row carries package + display props from FIRST_PARTY_FALLBACKS (#305)", async () => {
-    // hub#305 added runner to CURATED_MODULES + FIRST_PARTY_FALLBACKS so
-    // the admin SPA install catalog surfaces it. Spot-check the wire
-    // shape resolves the runner-specific fields (package, displayName,
-    // tagline) from the vendored fallback rather than a stale default.
+  test("uncurated modules (notes / runner / surface) are NOT returned by GET /api/modules", async () => {
+    // CURATED_MODULES was trimmed 2026-05-27 to [vault, scribe]. The
+    // KNOWN_MODULES + FIRST_PARTY_FALLBACKS registries still carry
+    // entries for notes / runner (install-bootstrap path), but
+    // /api/modules only returns CURATED rows. Pins the boundary so a
+    // future re-curation has to be intentional, not a stale registry
+    // leak.
     const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
     const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
       db: h.db,
       issuer: ISSUER,
       manifestPath: h.manifestPath,
-      fetchLatestVersion: async () => "0.1.0",
+      fetchLatestVersion: async () => null,
     });
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as {
-      modules: Array<{
-        short: string;
-        package: string;
-        display_name: string;
-        tagline: string;
-        available: boolean;
-      }>;
-    };
-    const runner = body.modules.find((m) => m.short === "runner");
-    expect(runner).toBeDefined();
-    expect(runner?.package).toBe("@openparachute/runner");
-    expect(runner?.display_name).toBe("Runner");
-    expect(runner?.tagline).toContain("Vault-as-job-substrate");
-    expect(runner?.available).toBe(true);
+    const body = (await res.json()) as { modules: Array<{ short: string }> };
+    const shorts = body.modules.map((m) => m.short);
+    expect(shorts).not.toContain("notes");
+    expect(shorts).not.toContain("runner");
+    expect(shorts).not.toContain("surface");
   });
 
   test("surfaces installed_version from services.json", async () => {
@@ -272,11 +274,11 @@ describe("GET /api/modules", () => {
     expect(vault?.installed_version).toBe("0.4.5");
     expect(vault?.latest_version).toBe("0.5.0");
     expect(vault?.install_dir).toBe("/parachute/modules/node_modules/@openparachute/vault");
-    // The other curated rows stay installed:false — the test installed
-    // only vault, so notes + scribe still render as available-but-not-installed.
-    const notes = body.modules.find((m) => m.short === "notes");
-    expect(notes?.installed).toBe(false);
-    expect(notes?.installed_version).toBeNull();
+    // The other curated row stays installed:false — the test installed
+    // only vault, so scribe still renders as available-but-not-installed.
+    const scribe = body.modules.find((m) => m.short === "scribe");
+    expect(scribe?.installed).toBe(false);
+    expect(scribe?.installed_version).toBeNull();
   });
 
   test("includes supervisor status + pid when a supervisor is injected", async () => {
@@ -309,9 +311,9 @@ describe("GET /api/modules", () => {
     expect(vault?.pid).toBe(12345);
     // Modules without a supervisor entry get null status — the UI
     // disables Restart/Stop for those since there's no live process.
-    const notes = body.modules.find((m) => m.short === "notes");
-    expect(notes?.supervisor_status).toBeNull();
-    expect(notes?.pid).toBeNull();
+    const scribe = body.modules.find((m) => m.short === "scribe");
+    expect(scribe?.supervisor_status).toBeNull();
+    expect(scribe?.pid).toBeNull();
     expect(body.supervisor_available).toBe(true);
   });
 
@@ -366,22 +368,28 @@ describe("GET /api/modules", () => {
   });
 
   test("management_url does not double-prepend mount when managementUrl is already mount-prefixed (hub#380)", async () => {
-    // Audit caught 2026-05-25: app declares `managementUrl: "/surface/admin/"`
+    // Audit caught 2026-05-25: surface declared `managementUrl: "/surface/admin/"`
     // (full hub-origin path) and `paths: ["/surface", "/.parachute"]`. The
-    // SPA's Services dropdown was navigating to `/app/surface/admin/` (404)
-    // because api-modules unconditionally prepended the mount onto the
-    // candidate. Fix: detect already-mount-prefixed paths and pass through.
+    // SPA's Services dropdown was navigating to `/surface/surface/admin/`
+    // (404) because api-modules unconditionally prepended the mount onto
+    // the candidate. Fix: detect already-mount-prefixed paths and pass
+    // through.
     //
     // Single-instance modules conventionally declare the full path; only
     // multi-instance modules (vault) use the per-instance relative form.
+    // Post 2026-05-27 CURATED trim the canonical single-instance example
+    // is scribe (when scribe ships a managementUrl — scribe#53). For now
+    // we exercise the same code path with vault declaring an
+    // already-mount-prefixed managementUrl: any module whose declared
+    // URL starts with its mount must pass through unchanged.
     writeManifest(h.manifestPath, [
       {
-        name: "parachute-surface",
-        port: 1946,
-        paths: ["/surface", "/.parachute"],
-        health: "/surface/healthz",
-        version: "0.2.0-rc.13",
-        installDir: "/install/dir/surface",
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/vault/default"],
+        health: "/vault/default/health",
+        version: "0.4.5",
+        installDir: "/install/dir/vault",
       },
     ]);
     const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
@@ -391,17 +399,18 @@ describe("GET /api/modules", () => {
       manifestPath: h.manifestPath,
       fetchLatestVersion: async () => null,
       readModuleManifest: async (installDir) => {
-        if (installDir === "/install/dir/surface") {
+        if (installDir === "/install/dir/vault") {
           return {
-            name: "surface",
-            manifestName: "parachute-surface",
-            displayName: "Surface",
+            name: "parachute-vault",
+            manifestName: "parachute-vault",
+            displayName: "Vault",
             tagline: "",
-            port: 1946,
-            paths: ["/surface", "/.parachute"],
-            health: "/surface/healthz",
-            uiUrl: "/surface/admin/",
-            managementUrl: "/surface/admin/",
+            port: 1940,
+            paths: ["/vault/default"],
+            health: "/vault/default/health",
+            // Already-mount-prefixed managementUrl — must NOT have the
+            // mount prepended again.
+            managementUrl: "/vault/default/admin/",
           } as unknown as Awaited<
             ReturnType<typeof import("../module-manifest.ts").readModuleManifest>
           >;
@@ -413,9 +422,9 @@ describe("GET /api/modules", () => {
     const body = (await res.json()) as {
       modules: Array<{ short: string; management_url: string | null }>;
     };
-    const surface = body.modules.find((m) => m.short === "surface");
-    // Single `/surface/`, not `/surface/surface/`.
-    expect(surface?.management_url).toBe("/surface/admin/");
+    const vault = body.modules.find((m) => m.short === "vault");
+    // Single `/vault/default/`, not `/vault/default/vault/default/`.
+    expect(vault?.management_url).toBe("/vault/default/admin/");
   });
 
   test("management_url prefix-ish names don't collide (hub#380 — /app vs /app-foo)", async () => {
@@ -786,8 +795,8 @@ describe("GET /api/modules", () => {
         },
       ]);
       // Other curated rows stay empty — uis is per-row, not global.
-      const notes = body.modules.find((m) => m.short === "notes");
-      expect(notes?.uis).toEqual([]);
+      const scribe = body.modules.find((m) => m.short === "scribe");
+      expect(scribe?.uis).toEqual([]);
     });
 
     test("optional fields ride through verbatim, missing fields become null on the wire", async () => {

--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -237,6 +237,14 @@ describe("GET /api/modules", () => {
     });
     const body = (await res.json()) as { modules: Array<{ short: string }> };
     const shorts = body.modules.map((m) => m.short);
+    // Positive shape assertion — stronger than `not.toContain` because
+    // it also catches "we accidentally added a new uncurated entry"
+    // and "we accidentally removed an existing curated entry." Update
+    // this assertion intentionally when CURATED_MODULES changes.
+    expect(shorts).toEqual(["vault", "scribe"]);
+    // Belt + suspenders: explicit negatives for the modules dropped
+    // 2026-05-27, so a developer regressing the curated list sees both
+    // the shape failure AND the named-module failure messages.
     expect(shorts).not.toContain("notes");
     expect(shorts).not.toContain("runner");
     expect(shorts).not.toContain("surface");

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -2162,6 +2162,9 @@ describe("done screen install tiles (hub#272 Item B)", () => {
     const db = openHubDb(hubDbPath(h.dir));
     try {
       const user = await createUser(db, "owner", "pw");
+      // Seed services.json with `parachute-scribe` so the wizard's scribe
+      // install tile renders the already-installed shape. Post-2026-05-27
+      // CURATED trim scribe is the only non-vault install tile.
       writeManifest(
         {
           services: [
@@ -2172,15 +2175,12 @@ describe("done screen install tiles (hub#272 Item B)", () => {
               paths: ["/vault/default"],
               health: "/health",
             },
-            // hub#323: app replaces notes as the wizard's first install tile.
-            // Seeding services.json with `parachute-app` exercises the
-            // already-installed render path on the wizard's first tile.
             {
-              name: "parachute-surface",
-              version: "0.2.0",
-              port: 1946,
-              paths: ["/app", "/.parachute"],
-              health: "/surface/healthz",
+              name: "parachute-scribe",
+              version: "0.4.4",
+              port: 1943,
+              paths: ["/scribe"],
+              health: "/scribe/health",
             },
           ],
         },
@@ -2203,13 +2203,16 @@ describe("done screen install tiles (hub#272 Item B)", () => {
       );
       const html = await res.text();
       expect(html).toContain("Already installed");
-      expect(html).toContain('action="/admin/setup/install/scribe"');
+      // The scribe tile rendered the installed shape, not the install form.
+      expect(html).not.toContain('action="/admin/setup/install/scribe"');
+      // "Manage in admin" is the secondary link on the already-installed tile.
+      expect(html).toContain("Manage in admin");
     } finally {
       db.close();
     }
   });
 
-  test("done screen renders op-poll panel when ?op_surface=<id> matches a registry op", async () => {
+  test("done screen renders op-poll panel when ?op_scribe=<id> matches a registry op", async () => {
     const db = openHubDb(hubDbPath(h.dir));
     try {
       const user = await createUser(db, "owner", "pw");
@@ -2229,15 +2232,16 @@ describe("done screen install tiles (hub#272 Item B)", () => {
       );
       setSetting(db, "setup_expose_mode", "localhost");
       const reg = getDefaultOperationsRegistry();
-      // hub#323: op-poll panel rides on the `app` tile now (app is the wizard's
-      // first install tile post-Notes-as-app-migration). Same shape as the
-      // pre-#324 `op_notes=<id>` flow.
-      const op = reg.create("install", "app");
-      reg.update(op.id, { status: "running" }, "running bun add -g @openparachute/app@latest");
+      // Post-2026-05-27 CURATED trim, scribe is the only non-vault wizard
+      // install tile, so it carries the op-poll panel. Same shape as the
+      // prior `op_app=<id>` / `op_notes=<id>` flows — the rendering code
+      // is per-`?op_<short>=<id>` query and tile-row agnostic.
+      const op = reg.create("install", "scribe");
+      reg.update(op.id, { status: "running" }, "running bun add -g @openparachute/scribe@latest");
       const { createSession } = await import("../sessions.ts");
       const session = createSession(db, { userId: user.id });
       const res = handleSetupGet(
-        req(`/admin/setup?just_finished=1&op_surface=${op.id}`, {
+        req(`/admin/setup?just_finished=1&op_scribe=${op.id}`, {
           headers: { cookie: `${SESSION_COOKIE_NAME}=${session.id}` },
         }),
         {
@@ -2293,7 +2297,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
         return 0;
       };
       const post = await handleSetupInstallPost(
-        req("/admin/setup/install/notes", {
+        req("/admin/setup/install/scribe", {
           method: "POST",
           body: new URLSearchParams({ [CSRF_FIELD_NAME]: csrf }).toString(),
           headers: {
@@ -2301,7 +2305,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
             cookie: `${CSRF_COOKIE_NAME}=${csrf}; ${SESSION_COOKIE_NAME}=${session.id}`,
           },
         }),
-        "notes",
+        "scribe",
         {
           db,
           manifestPath: h.manifestPath,
@@ -2315,10 +2319,10 @@ describe("done screen install tiles (hub#272 Item B)", () => {
       );
       expect(post.status).toBe(303);
       const location = post.headers.get("location") ?? "";
-      expect(location).toMatch(/^\/admin\/setup\?just_finished=1&op_notes=/);
+      expect(location).toMatch(/^\/admin\/setup\?just_finished=1&op_scribe=/);
       await new Promise((r) => setTimeout(r, 50));
       expect(runCalls.length).toBeGreaterThan(0);
-      expect(runCalls[0]?.join(" ")).toContain("bun add -g @openparachute/notes@latest");
+      expect(runCalls[0]?.join(" ")).toContain("bun add -g @openparachute/scribe@latest");
     } finally {
       db.close();
     }
@@ -2405,7 +2409,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
       });
       const csrf = setCookie(get, CSRF_COOKIE_NAME) ?? "";
       const post = await handleSetupInstallPost(
-        req("/admin/setup/install/notes", {
+        req("/admin/setup/install/scribe", {
           method: "POST",
           body: new URLSearchParams({ [CSRF_FIELD_NAME]: csrf }).toString(),
           headers: {
@@ -2413,7 +2417,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
             cookie: `${CSRF_COOKIE_NAME}=${csrf}`,
           },
         }),
-        "notes",
+        "scribe",
         {
           db,
           manifestPath: h.manifestPath,
@@ -3296,7 +3300,14 @@ describe("done screen — 'Start using your vault' tile (hub#342)", () => {
     }
   });
 
-  test("when app is also installed, the lead tile links to /surface/notes/", async () => {
+  test("lead tile always points at notes.parachute.computer (canonical hosted PWA) regardless of local module installs", async () => {
+    // Pre-2026-05-27 the lead tile flipped to `/surface/notes/` when the
+    // Surface module was installed locally. Aaron's launch-focus
+    // directive: notes.parachute.computer is the canonical user-facing
+    // UI, and the wizard should always point operators at it (rather
+    // than maybe-or-maybe-not-installed local Surface). This test pins
+    // that the lead tile is invariant under the install state of
+    // uncurated modules.
     const db = openHubDb(hubDbPath(h.dir));
     try {
       const user = await createUser(db, "owner", "pw");
@@ -3310,6 +3321,9 @@ describe("done screen — 'Start using your vault' tile (hub#342)", () => {
               paths: ["/vault/default"],
               health: "/health",
             },
+            // Even with parachute-surface installed locally (an uncurated
+            // module post-trim), the lead tile must NOT flip to a local
+            // path.
             {
               name: "parachute-surface",
               version: "0.2.0",
@@ -3338,15 +3352,27 @@ describe("done screen — 'Start using your vault' tile (hub#342)", () => {
       );
       const html = await res.text();
       expect(html).toContain("Start using your vault");
-      // App installed → primary CTA links to Notes-as-UI inside App.
-      expect(html).toContain('href="/surface/notes/"');
+      // Lead CTA always targets the hosted PWA.
+      expect(html).toContain("https://notes.parachute.computer/add?url=");
       expect(html).toContain("Open Notes");
+      // The pre-trim local-surface fallback is gone — the lead tile does
+      // NOT link to /surface/notes/ anymore.
+      expect(html).not.toContain('href="/surface/notes/"');
     } finally {
       db.close();
     }
   });
 
-  test("succeeded install op renders a 'Use it now' link pointing at the module's surface", async () => {
+  test("succeeded install op renders 'Manage modules' link (no 'Use it now' for modules without a hosted surface)", async () => {
+    // Pre-2026-05-27 the surface module had a USE_IT_NOW_URLS entry
+    // pointing at `/surface/notes/`, so a succeeded surface install tile
+    // rendered a primary "Use it now" link. Post-trim only scribe + vault
+    // are curated; vault has its own lead tile (above the install row);
+    // scribe doesn't ship a user-facing landing surface today
+    // (scribe#53 tracks the eventual admin SPA), so USE_IT_NOW_URLS is
+    // empty and a succeeded scribe install renders only the "Manage
+    // modules" secondary affordance. Future per-module surfaces can
+    // re-add an entry to that map.
     const db = openHubDb(hubDbPath(h.dir));
     try {
       const user = await createUser(db, "owner", "pw");
@@ -3366,12 +3392,12 @@ describe("done screen — 'Start using your vault' tile (hub#342)", () => {
       );
       setSetting(db, "setup_expose_mode", "localhost");
       const reg = getDefaultOperationsRegistry();
-      const op = reg.create("install", "app");
-      reg.update(op.id, { status: "succeeded" }, "installed @openparachute/app");
+      const op = reg.create("install", "scribe");
+      reg.update(op.id, { status: "succeeded" }, "installed @openparachute/scribe");
       const { createSession } = await import("../sessions.ts");
       const session = createSession(db, { userId: user.id });
       const res = handleSetupGet(
-        req(`/admin/setup?just_finished=1&op_surface=${op.id}`, {
+        req(`/admin/setup?just_finished=1&op_scribe=${op.id}`, {
           headers: { cookie: `${SESSION_COOKIE_NAME}=${session.id}` },
         }),
         {
@@ -3384,17 +3410,24 @@ describe("done screen — 'Start using your vault' tile (hub#342)", () => {
       );
       const html = await res.text();
       expect(html).toContain("status: succeeded");
-      // Primary "Use it now" link goes to the app's surface; secondary
-      // "Manage modules" link still present.
-      expect(html).toContain(">Use it now<");
-      expect(html).toContain('href="/surface/notes/"');
+      // No "Use it now" — scribe has no entry in USE_IT_NOW_URLS today.
+      expect(html).not.toContain(">Use it now<");
+      // "Manage modules" secondary link is always present on a terminal-
+      // succeeded install tile.
       expect(html).toContain(">Manage modules<");
     } finally {
       db.close();
     }
   });
 
-  test("'Already installed' tile gains a 'Use it now' link too", async () => {
+  test("'Already installed' tile renders without a 'Use it now' link when the module has no hosted surface", async () => {
+    // Post-2026-05-27 CURATED trim, USE_IT_NOW_URLS is empty (scribe has
+    // no first-class user-facing landing surface yet; vault gets its
+    // own lead tile, not an install tile). The already-installed tile
+    // therefore renders only the "Manage in admin" secondary link. Pre-
+    // trim the surface module had a USE_IT_NOW_URLS entry that drove
+    // this surface, so the test now pins the absence rather than the
+    // presence.
     const db = openHubDb(hubDbPath(h.dir));
     try {
       const user = await createUser(db, "owner", "pw");
@@ -3409,11 +3442,11 @@ describe("done screen — 'Start using your vault' tile (hub#342)", () => {
               health: "/health",
             },
             {
-              name: "parachute-surface",
-              version: "0.2.0",
-              port: 1946,
-              paths: ["/surface"],
-              health: "/surface/healthz",
+              name: "parachute-scribe",
+              version: "0.4.4",
+              port: 1943,
+              paths: ["/scribe"],
+              health: "/scribe/health",
             },
           ],
         },
@@ -3436,8 +3469,10 @@ describe("done screen — 'Start using your vault' tile (hub#342)", () => {
       );
       const html = await res.text();
       expect(html).toContain("Already installed");
-      // App's already-installed tile carries the Use it now link.
-      expect(html).toContain('href="/surface/notes/"');
+      // No "Use it now" on the scribe already-installed tile.
+      expect(html).not.toContain(">Use it now<");
+      // Secondary affordance still present.
+      expect(html).toContain("Manage in admin");
     } finally {
       db.close();
     }

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -80,15 +80,30 @@ function lookupModule(
 export const API_MODULES_REQUIRED_SCOPE = "parachute:host:auth";
 
 /**
- * Curated module short-names for v0.6 Render self-host. Marketplace is
- * Phase 2 — until then, the admin UI offers exactly these. Order is the
- * recommended install order (vault → app → notes → scribe → runner;
- * app auto-bootstraps notes-ui on first boot — `notes` here is the
- * notes-daemon back-compat install path retained for operators still on
- * the pre-app architecture; scribe + runner come last because they
- * depend on a working vault + app to be useful).
+ * Curated module short-names. The admin UI offers exactly these for install
+ * + management. Order is the recommended install order (vault first, scribe
+ * second).
+ *
+ * Trimmed 2026-05-27 (Aaron-directed launch focus) from the prior set of
+ * `["vault", "surface", "notes", "scribe", "runner"]`. The dropped modules
+ * are still published on npm and still work — they're just not the focus:
+ *
+ *   - `notes` (notes-daemon): retired. Notes-UI now lives at
+ *     `notes.parachute.computer` as a hosted SPA — operators don't install
+ *     a notes daemon anymore. The npm package `@openparachute/notes-ui`
+ *     is a library imported by `parachute-surface` and by custom-surface
+ *     builders.
+ *   - `surface` (host module): de-emphasized. `@openparachute/surface-client`
+ *     remains the canonical library for folks building their own UIs
+ *     against a Parachute hub; running the surface-host module on your
+ *     own box is no longer the headline path (use notes.parachute.computer
+ *     or build your own).
+ *   - `runner`: experimental, not in the focus set for launch.
+ *
+ * Re-adding any of these is one line — keep the list small until use
+ * cases demand otherwise.
  */
-export const CURATED_MODULES = ["vault", "surface", "notes", "scribe", "runner"] as const;
+export const CURATED_MODULES = ["vault", "scribe"] as const;
 export type CuratedModuleShort = (typeof CURATED_MODULES)[number];
 
 export interface ApiModulesDeps {

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -3,10 +3,12 @@
  *
  * Combines three sources into a single per-module row:
  *
- *   - **Curated availability** — vault, notes, scribe, runner (the v0.6
- *     release bar). The Phase-2 marketplace will broaden this; for now
- *     it's hardcoded so the admin UI has a stable "what can I install?"
- *     list even on a fresh container where services.json is empty.
+ *   - **Curated availability** — vault, scribe (the launch focus per
+ *     Aaron 2026-05-27). The list was previously broader; trimmed for
+ *     the launch arc. The Phase-2 marketplace will broaden this; for
+ *     now it's hardcoded so the admin UI has a stable "what can I
+ *     install?" list even on a fresh container where services.json is
+ *     empty.
  *   - **Installed state** — services.json reads (version, installDir).
  *   - **Supervisor state** — per-module run status (`running` / `stopped`
  *     / `crashed` / `starting` / `restarting`) + pid. Absent when the

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -1092,7 +1092,8 @@ function renderMcpTile(
 }
 
 /**
- * The "Start using your vault" lead tile on the done step (hub#342).
+ * The "Start using your vault" lead tile on the done step (hub#342,
+ * Aaron 2026-05-27 simplification).
  *
  * Closes Aaron's "no clear way to go from setting up parachute to
  * actually using parachute" friction. Sits above the MCP / install
@@ -1100,42 +1101,18 @@ function renderMcpTile(
  * everything else on the done screen is operator-flavored (MCP
  * command, admin UI, additional module installs).
  *
- * Two shapes:
- *   - **App installed** → primary tile targets `/surface/notes/` (the
- *     Notes app reading the just-created vault). This is the
- *     canonical surface post-Notes-as-app migration (parachute-app §17).
- *   - **App NOT installed** → primary tile targets the vault's own
- *     admin UI at `/vault/<name>/admin/`. The copy explains that
- *     installing App + Notes is the recommended next step for a
- *     content-browsing surface, and points at the install tile below.
- *
- * Either way, the operator has ONE obvious click target that says
- * "start using parachute" — not three competing tiles where the
- * "real" entry point is buried under the MCP command pre-hub#342.
- */
-/**
- * Lead "Start using your vault" tile. Points at the canonical
- * notes.parachute.computer hosted PWA as the primary CTA — with the
- * operator's own hub URL pre-filled via `?url=` so the connect screen
- * auto-populates + auto-focuses (notes-ui AddVault route, see
- * parachute-app/packages/notes-ui/src/app/routes/AddVault.tsx).
- *
- * Aaron 2026-05-27 directive: "skipping the local surface install for
- * most operators is good ... showing notes.parachute.computer more
- * prominently is a good idea." The notes.parachute.computer PWA is the
- * canonical user-facing UI; operators no longer need to install the
- * Surface module locally to use Notes. They still can (local install
- * works the same way), but the wizard doesn't push them toward it as
- * the default.
- *
+ * Points at the canonical notes.parachute.computer hosted PWA as the
+ * primary CTA — with the operator's own hub URL pre-filled via
+ * `?url=` so the connect screen auto-populates + auto-focuses
+ * (notes-ui AddVault route, see
+ * parachute-surface/packages/notes-ui/src/app/routes/AddVault.tsx).
  * Secondary CTA: "Open vault admin" (the vault's own admin UI on this
  * hub) for operators who want to look at raw vault state.
  *
- * `appInstalled` is no longer load-bearing for the primary path —
- * notes.parachute.computer works regardless of whether Surface is
- * installed locally. Kept in the signature so the older test fixtures
- * + the boolean flag stay coherent; only the secondary fallback message
- * differs based on it.
+ * Previously varied by whether `parachute-surface` was installed
+ * locally — pointing at `/surface/notes/` in that case. Dropped
+ * 2026-05-27: hub+vault+scribe is the focus; notes.parachute.computer
+ * is canonical regardless of local surface install state.
  */
 function renderStartUsingTile(vaultName: string, hubOrigin: string): string {
   const safeVault = escapeHtml(vaultName);
@@ -2294,11 +2271,10 @@ function validateAccountFields(input: {
 
 /**
  * Whether a given curated module is currently installed (has a row in
- * services.json keyed by its canonical `manifestName`). Used by the
- * done-step renderer (hub#342) to decide whether to point the "Start
- * using your vault" tile at `/surface/notes/` (App installed → Notes UI
- * auto-bootstrapped) vs the vault's own admin UI. Cheap manifest read
- * shared with `buildInstallTiles`.
+ * services.json keyed by its canonical `manifestName`). Used by
+ * `buildInstallTiles` to decide whether an install-tile row renders
+ * the "install" form or the "already installed" state. Cheap manifest
+ * read (no network).
  */
 function isModuleInstalled(short: CuratedModuleShort, manifestPath: string): boolean {
   const manifest = readManifestLenient(manifestPath);

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -889,27 +889,15 @@ export interface RenderDoneStepProps {
    * shape.
    */
   installTiles?: readonly ModuleInstallTileState[];
-  /**
-   * Whether parachute-app is installed alongside the vault. Drives the
-   * "Start using your vault" lead tile (hub#342): when true, the tile
-   * links to `/surface/notes/` (the canonical user-facing surface — App
-   * auto-bootstraps Notes-as-UI per the 2026-05-21 migration). When
-   * false, it falls back to the vault's own admin UI at
-   * `/vault/<name>/admin/` so the operator still has a single obvious
-   * "start using parachute" target. Omitted = back-compat with tests
-   * that render the done step without dependency-checking; defaults to
-   * false (vault-admin fallback).
-   */
-  appInstalled?: boolean;
 }
 
 export function renderDoneStep(props: RenderDoneStepProps): string {
-  const { vaultName, hubOrigin, exposeMode, mintedToken, installTiles, appInstalled } = props;
+  const { vaultName, hubOrigin, exposeMode, mintedToken, installTiles } = props;
   const reachable = exposeMode ? renderReachableTile(exposeMode, hubOrigin) : "";
   const mcpTile = renderMcpTile(vaultName, hubOrigin, mintedToken);
   const tiles = installTiles && installTiles.length > 0 ? installTiles : [];
   const installSection = tiles.length > 0 ? renderInstallTiles(tiles) : "";
-  const startTile = renderStartUsingTile(vaultName, appInstalled === true, hubOrigin);
+  const startTile = renderStartUsingTile(vaultName, hubOrigin);
   // The done-grid hosts the MCP-connect tile + the admin-UI fallback.
   // The install tiles sit above it as a "what's next?" surface (curated
   // catalog of modules an operator might want next). The "Start using
@@ -1149,11 +1137,7 @@ function renderMcpTile(
  * + the boolean flag stay coherent; only the secondary fallback message
  * differs based on it.
  */
-function renderStartUsingTile(
-  vaultName: string,
-  appInstalled: boolean,
-  hubOrigin: string,
-): string {
+function renderStartUsingTile(vaultName: string, hubOrigin: string): string {
   const safeVault = escapeHtml(vaultName);
   // Vault names pass `/^[a-z0-9][a-z0-9-]*$/i` so URL-encoding is mostly
   // a no-op today, but use encodeURIComponent defensively to match hub.ts:505.
@@ -1164,14 +1148,6 @@ function renderStartUsingTile(
   const vaultUrlForAdd = encodeURIComponent(
     `${hubOrigin.replace(/\/+$/, "")}/vault/${vaultName}`,
   );
-  // For appInstalled=false case (Surface NOT installed locally),
-  // notes.parachute.computer is the recommended path. For appInstalled=true,
-  // we mention the local option as a secondary affordance.
-  const localNotesFallback = appInstalled
-    ? `<p class="start-using-secondary">
-        <a href="/surface/notes/">Or use Notes installed locally on this hub →</a>
-      </p>`
-    : "";
   return `<section class="start-using" data-testid="start-using-tile">
     <h2>Start using your vault</h2>
     <p>Open Notes — the canonical browser UI for your vault <code>${safeVault}</code>.
@@ -1180,7 +1156,6 @@ function renderStartUsingTile(
     <p class="start-using-secondary">
       <a href="/vault/${urlVault}/admin/">Or browse the vault's admin UI →</a>
     </p>
-    ${localNotesFallback}
   </section>`;
 }
 
@@ -1323,13 +1298,12 @@ function renderInstallTile(tile: ModuleInstallTileState): string {
  * surface decision.
  */
 const USE_IT_NOW_URLS: Partial<Record<CuratedModuleShort, string>> = {
-  surface: "/surface/notes/",
-  notes: "/notes/",
-  // Omitted: scribe + runner. They don't ship an admin SPA yet
-  // (scribe#53, runner#8 track). Pointing "Use it now" at /scribe/admin
-  // or /runner/admin today would 404 — better to fall through to the
-  // "Manage modules" link than to send the operator into a dead end.
-  // Add the entry here once those modules ship their admin UI.
+  // Empty: vault has its own lead "Start using" tile (the
+  // notes.parachute.computer CTA), so it doesn't appear here. Scribe
+  // doesn't ship an admin SPA at /scribe/admin/ that's useful for
+  // first-time operators (the page exists but it's config-management;
+  // not "use it"). Re-add per-module entries here if/when a module
+  // ships a user-facing landing surface worth pointing at.
 };
 
 /**
@@ -1482,16 +1456,18 @@ export function handleSetupGet(req: Request, deps: SetupWizardDeps): Response {
       // Module install tiles (hub#272 Item B). One per curated module
       // other than vault (which the wizard already provisioned).
       const installTiles = buildInstallTiles(url, deps);
-      // hub#342: drive the lead "Start using your vault" tile's target.
-      // When parachute-app is installed alongside vault, the tile links
-      // to `/surface/notes/` (auto-bootstrapped Notes-as-UI per parachute-app
-      // §17). Otherwise it falls back to the vault's own admin UI.
-      const appInstalled = isModuleInstalled("surface", deps.manifestPath);
+      // The lead "Start using your vault" tile points at
+      // notes.parachute.computer/add — always, regardless of any
+      // local module install state. Prior versions of this code
+      // checked `isModuleInstalled("surface", ...)` to switch to a
+      // local `/surface/notes/` link, but the launch focus is
+      // hub+vault+scribe and notes.parachute.computer is the
+      // canonical Notes UI (Aaron-directed 2026-05-27). Dropped the
+      // local-fallback branch.
       const doneProps: RenderDoneStepProps = {
         vaultName,
         hubOrigin: deps.issuer,
         installTiles,
-        appInstalled,
       };
       if (exposeMode !== undefined) doneProps.exposeMode = exposeMode;
       if (mintedToken) doneProps.mintedToken = mintedToken;
@@ -2152,11 +2128,6 @@ const INSTALL_TILE_PROPS: ReadonlyArray<{
   displayName: string;
   tagline: string;
 }> = [
-  {
-    short: "surface",
-    displayName: "Surface",
-    tagline: "Host module for Parachute surfaces — auto-installs Notes on first boot.",
-  },
   {
     short: "scribe",
     displayName: "Scribe",


### PR DESCRIPTION
## Summary

Aaron-directed 2026-05-27: launch focus is hub + vault + scribe. Notes-UI lives at `notes.parachute.computer` (hosted SPA, no install needed). Surface stays useful as `@openparachute/surface-client` for custom-UI builders, but the host module isn't the headline path. Runner is experimental.

Trims `CURATED_MODULES` from `["vault", "surface", "notes", "scribe", "runner"]` → `["vault", "scribe"]`. Reach for the now-uncurated modules via `bun add -g` directly; they're still published.

## Changes

**Production code:**
- `src/api-modules.ts:91` — CURATED_MODULES trimmed. Docstring rewritten with per-module rationale for the drops.
- `src/setup-wizard.ts` — USE_IT_NOW_URLS emptied (no curated module ships a user-facing landing surface today). `renderStartUsingTile`'s `appInstalled` param + the local-Notes secondary CTA dropped (notes.parachute.computer is the canonical Notes path now, regardless of local install state). INSTALL_TILE_PROPS trimmed to just scribe.

**Tests (14 fixed, 0 removed):**
- `src/__tests__/api-modules-config.test.ts` — parser test asserts notes/runner/surface reject at the curated-list boundary; the deliberate-uncurated-handler-test calls cast to `CuratedModuleShort` to preserve test intent.
- `src/__tests__/api-modules.test.ts` — curated-list count assertions updated; surface-row test repurposed to scribe; runner-row test **repurposed as a negative test** ("uncurated modules are NOT returned by GET /api/modules") — pins the curated-list boundary going forward.
- `src/__tests__/setup-wizard.test.ts` — install-tile op-poll tests switched from `?op_surface` → `?op_scribe`. "Lead tile invariant under uncurated-module install state" test added (positive regression that seeding parachute-surface in services.json does NOT flip the lead tile). "Use it now" tests rewritten to assert ABSENCE of the link for scribe (which isn't in USE_IT_NOW_URLS today).

## Test plan

- [x] `bun test ./src` → 2174 pass / 1 skip / 0 fail (matches pre-trim baseline exactly)
- [x] `bun run typecheck` → clean
- [x] `biome check` → clean on touched files
- [ ] Reviewer to verify the repurposed tests still exercise their original intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)