### PR TITLE
chore(release): 0.5.14-rc.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.2",
+  "version": "0.5.14-rc.3",
   "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Bump to 0.5.14-rc.3. Picks up the launch-focus CURATED_MODULES trim (`hub#436`).

Code-touching PRs since v0.5.14-rc.2:
- #436 feat(hub): trim curated modules to [vault, scribe] for launch focus

The admin SPA's install catalog now shows only vault + scribe. Surface / notes / runner are still on npm and still work; they're just not the default install path.

## Test plan

- [x] #436 merged with green CI
- [ ] Tag push `v0.5.14-rc.3` → CI publishes to @rc

🤖 Generated with [Claude Code](https://claude.com/claude-code)