### PR TITLE
fix(expose-auth-preflight): read owner password from hub.db (multi-user Phase 1+)

### DIFF
--- a/src/__tests__/vault-auth-status.test.ts
+++ b/src/__tests__/vault-auth-status.test.ts
@@ -22,11 +22,72 @@ function seedVault(vaultHome: string, name: string, opts: { withDb?: boolean } =
   return dbPath;
 }
 
-describe("readVaultAuthStatus — config.yaml parse", () => {
-  test("missing config.yaml → hasOwnerPassword + hasTotp both false", () => {
+/**
+ * Default tests pass a `probeHubDbHasUserPassword` of `() => undefined`
+ * (hub.db unreachable) so existing YAML-fallback behavior is exercised
+ * verbatim. Tests that specifically exercise the hub.db path pass their
+ * own probe.
+ */
+const hubDbUnreachable = () => undefined;
+
+describe("readVaultAuthStatus — hub.db source of truth (multi-user Phase 1+)", () => {
+  test("hub.db has a user with password_hash → hasOwnerPassword: true (no YAML needed)", () => {
     const env = makeVaultHome();
     try {
-      const status = readVaultAuthStatus({ vaultHome: env.path, countTokens: () => 0 });
+      // No config.yaml at all on disk.
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        countTokens: () => 0,
+        probeHubDbHasUserPassword: () => true,
+      });
+      expect(status.hasOwnerPassword).toBe(true);
+      // No hub-side TOTP column yet (Phase 3). Stays false on the hub.db
+      // path until the schema gains a column.
+      expect(status.hasTotp).toBe(false);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("hub.db users empty, YAML has owner_password_hash → falls back to YAML (legacy install)", () => {
+    const env = makeVaultHome();
+    try {
+      writeConfig(env.path, 'owner_password_hash: "$2b$12$legacyhash"\n');
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        countTokens: () => 0,
+        probeHubDbHasUserPassword: () => false,
+      });
+      expect(status.hasOwnerPassword).toBe(true);
+      expect(status.hasTotp).toBe(false);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("hub.db unreachable, YAML has owner_password_hash → falls back to YAML", () => {
+    const env = makeVaultHome();
+    try {
+      writeConfig(env.path, 'owner_password_hash: "$2b$12$superlegacyhash"\n');
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        countTokens: () => 0,
+        probeHubDbHasUserPassword: hubDbUnreachable,
+      });
+      expect(status.hasOwnerPassword).toBe(true);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("hub.db users empty AND no YAML → hasOwnerPassword: false (fresh wide-open install)", () => {
+    const env = makeVaultHome();
+    try {
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        countTokens: () => 0,
+        probeHubDbHasUserPassword: () => false,
+      });
       expect(status.hasOwnerPassword).toBe(false);
       expect(status.hasTotp).toBe(false);
     } finally {
@@ -34,7 +95,43 @@ describe("readVaultAuthStatus — config.yaml parse", () => {
     }
   });
 
-  test("both keys present and non-empty → both true", () => {
+  test("hub.db says yes overrides absent YAML — TOTP still reflects YAML state", () => {
+    const env = makeVaultHome();
+    try {
+      // TOTP-only YAML: vault-side 2FA was configured but hub.db is the
+      // canonical password source. Should report password=true (hub.db),
+      // totp=true (YAML).
+      writeConfig(env.path, 'totp_secret: "JBSWY3DPEHPK3PXP"\n');
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        countTokens: () => 0,
+        probeHubDbHasUserPassword: () => true,
+      });
+      expect(status.hasOwnerPassword).toBe(true);
+      expect(status.hasTotp).toBe(true);
+    } finally {
+      env.cleanup();
+    }
+  });
+});
+
+describe("readVaultAuthStatus — YAML fallback (pre-multi-user installs)", () => {
+  test("missing config.yaml AND hub.db unreachable → both signals false", () => {
+    const env = makeVaultHome();
+    try {
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        countTokens: () => 0,
+        probeHubDbHasUserPassword: hubDbUnreachable,
+      });
+      expect(status.hasOwnerPassword).toBe(false);
+      expect(status.hasTotp).toBe(false);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("both YAML keys present, hub.db unreachable → both true", () => {
     const env = makeVaultHome();
     try {
       writeConfig(
@@ -46,7 +143,11 @@ describe("readVaultAuthStatus — config.yaml parse", () => {
           "",
         ].join("\n"),
       );
-      const status = readVaultAuthStatus({ vaultHome: env.path, countTokens: () => 0 });
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        countTokens: () => 0,
+        probeHubDbHasUserPassword: hubDbUnreachable,
+      });
       expect(status.hasOwnerPassword).toBe(true);
       expect(status.hasTotp).toBe(true);
     } finally {
@@ -54,11 +155,15 @@ describe("readVaultAuthStatus — config.yaml parse", () => {
     }
   });
 
-  test("empty quoted values are treated as absent (matches vault's readGlobalConfig)", () => {
+  test("empty quoted YAML values are absent (matches vault's readGlobalConfig)", () => {
     const env = makeVaultHome();
     try {
       writeConfig(env.path, ['owner_password_hash: ""', 'totp_secret: ""', ""].join("\n"));
-      const status = readVaultAuthStatus({ vaultHome: env.path, countTokens: () => 0 });
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        countTokens: () => 0,
+        probeHubDbHasUserPassword: hubDbUnreachable,
+      });
       expect(status.hasOwnerPassword).toBe(false);
       expect(status.hasTotp).toBe(false);
     } finally {
@@ -66,11 +171,15 @@ describe("readVaultAuthStatus — config.yaml parse", () => {
     }
   });
 
-  test("only owner_password_hash present", () => {
+  test("only YAML owner_password_hash present, hub.db unreachable", () => {
     const env = makeVaultHome();
     try {
       writeConfig(env.path, 'owner_password_hash: "$2b$12$abc"\n');
-      const status = readVaultAuthStatus({ vaultHome: env.path, countTokens: () => 0 });
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        countTokens: () => 0,
+        probeHubDbHasUserPassword: hubDbUnreachable,
+      });
       expect(status.hasOwnerPassword).toBe(true);
       expect(status.hasTotp).toBe(false);
     } finally {
@@ -83,7 +192,11 @@ describe("readVaultAuthStatus — vault discovery", () => {
   test("no data/ dir → vaultNames empty, tokenCount 0", () => {
     const env = makeVaultHome();
     try {
-      const status = readVaultAuthStatus({ vaultHome: env.path, countTokens: () => 999 });
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        countTokens: () => 999,
+        probeHubDbHasUserPassword: hubDbUnreachable,
+      });
       expect(status.vaultNames).toEqual([]);
       expect(status.tokenCount).toBe(0);
     } finally {
@@ -98,7 +211,11 @@ describe("readVaultAuthStatus — vault discovery", () => {
       seedVault(env.path, "default", { withDb: true });
       // garbage dir that happens to sit under data/
       mkdirSync(join(env.path, "data", "stray"), { recursive: true });
-      const status = readVaultAuthStatus({ vaultHome: env.path, countTokens: () => 0 });
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        countTokens: () => 0,
+        probeHubDbHasUserPassword: hubDbUnreachable,
+      });
       expect(status.vaultNames).toEqual(["default"]);
     } finally {
       env.cleanup();
@@ -115,6 +232,7 @@ describe("readVaultAuthStatus — token count resilience", () => {
       const status = readVaultAuthStatus({
         vaultHome: env.path,
         countTokens: (dbPath) => (dbPath.includes("/default/") ? 2 : 3),
+        probeHubDbHasUserPassword: hubDbUnreachable,
       });
       expect(status.tokenCount).toBe(5);
       expect(new Set(status.vaultNames)).toEqual(new Set(["default", "work"]));
@@ -135,6 +253,7 @@ describe("readVaultAuthStatus — token count resilience", () => {
           if (dbPath.includes("/default/")) throw new Error("should not open missing DB");
           return 4;
         },
+        probeHubDbHasUserPassword: hubDbUnreachable,
       });
       expect(status.tokenCount).toBe(4);
     } finally {
@@ -153,10 +272,151 @@ describe("readVaultAuthStatus — token count resilience", () => {
           if (dbPath.includes("/work/")) throw new Error("locked");
           return 2;
         },
+        probeHubDbHasUserPassword: hubDbUnreachable,
       });
       // Even though "default" succeeded with 2, we return null — callers
       // shouldn't see a misleading partial count.
       expect(status.tokenCount).toBeNull();
+    } finally {
+      env.cleanup();
+    }
+  });
+});
+
+describe("readVaultAuthStatus — defaultProbeHubDbHasUserPassword end-to-end", () => {
+  // These tests exercise the real `bun:sqlite` probe (no injected fake)
+  // to catch breakage in the on-disk read path: schema drift, opening
+  // semantics, undefined-returns-on-failure.
+
+  test("hub.db missing → probe returns undefined → falls back to YAML cleanly", () => {
+    const env = makeVaultHome();
+    try {
+      writeConfig(env.path, 'owner_password_hash: "$2b$12$legacyfromYAML"\n');
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        hubDbPath: join(env.path, "definitely-not-here.db"),
+        countTokens: () => 0,
+      });
+      expect(status.hasOwnerPassword).toBe(true);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("hub.db exists with users.password_hash set → hasOwnerPassword: true", () => {
+    const env = makeVaultHome();
+    try {
+      // Build a real hub.db with the canonical schema + an `unforced` user.
+      const { Database } = require("bun:sqlite");
+      const dbPath = join(env.path, "hub.db");
+      const db = new Database(dbPath);
+      db.exec(`
+        CREATE TABLE users (
+          id TEXT PRIMARY KEY,
+          username TEXT UNIQUE NOT NULL,
+          password_hash TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          password_changed INTEGER NOT NULL DEFAULT 0
+        );
+        INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed)
+        VALUES ('u1', 'unforced', '$argon2id$v=19$realhashhere', '2026-05-26T00:00:00Z', '2026-05-26T00:00:00Z', 1);
+      `);
+      db.close();
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        hubDbPath: dbPath,
+        countTokens: () => 0,
+      });
+      expect(status.hasOwnerPassword).toBe(true);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("hub.db exists but users table empty → falls back to YAML", () => {
+    const env = makeVaultHome();
+    try {
+      const { Database } = require("bun:sqlite");
+      const dbPath = join(env.path, "hub.db");
+      const db = new Database(dbPath);
+      db.exec(`
+        CREATE TABLE users (
+          id TEXT PRIMARY KEY,
+          username TEXT UNIQUE NOT NULL,
+          password_hash TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          password_changed INTEGER NOT NULL DEFAULT 0
+        );
+      `);
+      db.close();
+      // YAML provides the password — should still be true.
+      writeConfig(env.path, 'owner_password_hash: "$2b$12$fallbackhash"\n');
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        hubDbPath: dbPath,
+        countTokens: () => 0,
+      });
+      expect(status.hasOwnerPassword).toBe(true);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("hub.db exists but schema is missing the users table → probe returns undefined, YAML fallback", () => {
+    const env = makeVaultHome();
+    try {
+      // A hub.db that hasn't run migration v2 yet (only signing_keys, v1).
+      const { Database } = require("bun:sqlite");
+      const dbPath = join(env.path, "hub.db");
+      const db = new Database(dbPath);
+      db.exec(`
+        CREATE TABLE signing_keys (kid TEXT PRIMARY KEY);
+      `);
+      db.close();
+      writeConfig(env.path, 'owner_password_hash: "$2b$12$onlyinYAML"\n');
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        hubDbPath: dbPath,
+        countTokens: () => 0,
+      });
+      // SELECT against nonexistent `users` throws → probe returns undefined
+      // → YAML wins → password reported as set.
+      expect(status.hasOwnerPassword).toBe(true);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("hub.db users table has a row with empty password_hash → treated as no password", () => {
+    const env = makeVaultHome();
+    try {
+      const { Database } = require("bun:sqlite");
+      const dbPath = join(env.path, "hub.db");
+      const db = new Database(dbPath);
+      // NOT NULL on password_hash, but allow empty string — schema check
+      // is just for "non-empty hash exists."
+      db.exec(`
+        CREATE TABLE users (
+          id TEXT PRIMARY KEY,
+          username TEXT UNIQUE NOT NULL,
+          password_hash TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          password_changed INTEGER NOT NULL DEFAULT 0
+        );
+        INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed)
+        VALUES ('u1', 'placeholder', '', '2026-05-26T00:00:00Z', '2026-05-26T00:00:00Z', 0);
+      `);
+      db.close();
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        hubDbPath: dbPath,
+        countTokens: () => 0,
+      });
+      // No YAML, no non-empty hub.db password → wide open.
+      expect(status.hasOwnerPassword).toBe(false);
     } finally {
       env.cleanup();
     }

--- a/src/vault/auth-status.ts
+++ b/src/vault/auth-status.ts
@@ -175,6 +175,14 @@ function defaultProbeHubDbHasUserPassword(dbPath: string): boolean | undefined {
     db = new Database(dbPath, { readonly: true }) as typeof db;
     // COUNT(*) over users with non-empty password_hash. `length(...) > 0`
     // matches the "missing/empty hash" treatment from the YAML side.
+    //
+    // Why "any user with a hash" not "first admin specifically": friend
+    // accounts can only be created by an already-authenticated admin
+    // (per api-users.ts's host:admin gate), so any user-with-hash
+    // implies the first admin has one too. Equivalent in practice and
+    // simpler than a JOIN on earliest-created-at. A future env-seed
+    // flow that creates friend accounts before the operator sets a
+    // password would need to revisit this assumption.
     const row = db?.prepare(
       "SELECT COUNT(*) AS n FROM users WHERE password_hash IS NOT NULL AND length(password_hash) > 0",
     ).get() as { n: number } | null;

--- a/src/vault/auth-status.ts
+++ b/src/vault/auth-status.ts
@@ -1,29 +1,47 @@
 /**
- * Read-only probe of vault's auth state, for the post-exposure preflight
- * nudge. We don't want to lock the DB or mutate anything — this is a
- * one-shot "should we warn the user their vault is wide open on the public
+ * Read-only probe of operator auth state, for the post-exposure preflight
+ * nudge. We don't want to lock anything or mutate state — this is a one-
+ * shot "should we warn the user their vault is wide open on the public
  * internet?" check.
  *
- * Two sources:
- *   1. ~/.parachute/vault/config.yaml   → owner_password_hash + totp_secret
- *   2. ~/.parachute/vault/data/<name>/vault.db (SQLite) → tokens table count
+ * Three sources, checked in this order:
  *
- * The YAML path uses line-anchored regex parsing that matches vault's own
- * `readGlobalConfig()` semantics (parachute-vault src/config.ts): keys are
- * optional, quoted scalars, and empty-string / missing-key both mean "not
- * configured." We mirror that rather than bringing in a YAML dependency.
+ *   1. ~/.parachute/hub.db  →  users table (authoritative since multi-user
+ *      Phase 1, hub#252 / PRs 279–281 / 425). Hub-issued OAuth + browser
+ *      sign-in both verify against `users.password_hash`. If any user row
+ *      exists with a non-empty password_hash, the operator has an account —
+ *      "owner password set." The earliest-created user row is the canonical
+ *      operator (cf. `getFirstAdminId` in src/users.ts).
+ *   2. ~/.parachute/vault/config.yaml  →  owner_password_hash + totp_secret
+ *      (pre-multi-user Phase 1 location). Fallback for super-old installs
+ *      whose hub.db is absent or empty.
+ *   3. ~/.parachute/vault/data/<name>/vault.db (SQLite) → tokens table
+ *      count, summed across every vault instance.
  *
- * The SQLite path is best-effort: if the DB is missing, locked (vault is
- * writing), or the schema has drifted, `tokenCount` comes back as `null`
- * and the caller surfaces "token status unknown" rather than lying with a
- * false zero. The exposure flow has already succeeded by the time this
- * runs — a probe failure must never block the user's happy path.
+ * The hub.db schema doesn't yet carry a TOTP column (2FA lands in a later
+ * phase per the multi-user design doc); we always report `hasTotp: false`
+ * when the hub.db path is the source of truth. That matches what's
+ * actually shipped — pretending otherwise would whisper "you're covered"
+ * when no second factor exists.
  *
- * Schema coupling note: we read the `tokens` table by name with a bare
- * COUNT(*). If vault ever renames that table, that's a breaking change on
- * vault's side and this probe is the least of the fallout. Post-launch,
- * a public `/api/auth/status` endpoint on vault (tracked separately) would
- * let us drop this coupling entirely.
+ * The YAML fallback path uses line-anchored regex parsing that matches
+ * vault's own `readGlobalConfig()` semantics (parachute-vault src/config.ts):
+ * keys are optional, quoted scalars, and empty-string / missing-key both
+ * mean "not configured." We mirror that rather than bringing in a YAML
+ * dependency.
+ *
+ * The vault-token SQLite path is best-effort: if the DB is missing,
+ * locked (vault is writing), or the schema has drifted, `tokenCount`
+ * comes back as `null` and the caller surfaces "token status unknown"
+ * rather than lying with a false zero. The exposure flow has already
+ * succeeded by the time this runs — a probe failure must never block
+ * the user's happy path.
+ *
+ * Schema coupling note: we read the `tokens` table in each vault.db by
+ * name with a bare COUNT(*). If vault ever renames that table, that's a
+ * breaking change on vault's side and this probe is the least of the
+ * fallout. Post-launch, a public `/api/auth/status` endpoint on vault
+ * (tracked separately) would let us drop this coupling entirely.
  */
 
 import { existsSync, readFileSync, readdirSync } from "node:fs";
@@ -49,6 +67,8 @@ export interface VaultAuthStatus {
 export interface AuthStatusOpts {
   /** Override `~/.parachute/vault` for tests. */
   vaultHome?: string;
+  /** Override `~/.parachute/hub.db` for tests. */
+  hubDbPath?: string;
   /** Read a YAML file; defaults to `readFileSync(path, "utf8")`. Missing
    *  file should return `undefined` (not throw) so callers can distinguish
    *  "no password configured" from "IO error." */
@@ -60,13 +80,31 @@ export interface AuthStatusOpts {
    *  thrown error (missing, locked, schema drift) is caught by the caller
    *  and mapped to `tokenCount: null`. */
   countTokens?: (dbPath: string) => number;
+  /**
+   * Probe hub.db for "does at least one user row with a non-empty
+   * `password_hash` exist?" — the canonical "owner password is set"
+   * signal post-multi-user-Phase-1. Returning:
+   *   - `true`  → at least one user has a password_hash; hub.db is
+   *               the source of truth, YAML fallback is skipped.
+   *   - `false` → hub.db opened cleanly but users is empty (fresh
+   *               install pre-wizard); fall back to YAML.
+   *   - `undefined` → hub.db missing / unreadable / migration not yet
+   *               applied; fall back to YAML (legacy install path).
+   * The split between `false` and `undefined` matters: an empty hub.db
+   * on a fresh wizard run should NOT be allowed to mask an owner_password_hash
+   * that the operator set via vault's pre-multi-user flow. Callers that
+   * want true "I can sign in" semantics get the OR of hub.db∪YAML.
+   */
+  probeHubDbHasUserPassword?: (dbPath: string) => boolean | undefined;
 }
 
 interface Resolved {
   vaultHome: string;
+  hubDbPath: string;
   readText: (path: string) => string | undefined;
   listVaultNames: (dataDir: string) => string[];
   countTokens: (dbPath: string) => number;
+  probeHubDbHasUserPassword: (dbPath: string) => boolean | undefined;
 }
 
 function defaultVaultHome(): string {
@@ -75,6 +113,11 @@ function defaultVaultHome(): string {
   // vault's side too (src/config.ts `vaultHomePath()`), so we match literally.
   const root = configDir();
   return root.length > 0 ? join(root, "vault") : join(homedir(), ".parachute", "vault");
+}
+
+function defaultHubDbPath(): string {
+  const root = configDir();
+  return root.length > 0 ? join(root, "hub.db") : join(homedir(), ".parachute", "hub.db");
 }
 
 function defaultReadText(path: string): string | undefined {
@@ -112,12 +155,50 @@ function defaultCountTokens(dbPath: string): number {
   }
 }
 
+/**
+ * Open hub.db readonly and ask "does at least one user have a non-empty
+ * password_hash?" Returns `undefined` on any failure (DB missing, locked,
+ * schema drift, users table absent because migration v2 hasn't applied) —
+ * indistinguishable from "no hub.db at all," which is what the caller
+ * wants for the YAML-fallback branch.
+ *
+ * We deliberately do NOT open hub.db read-write here — `openHubDb()`
+ * would run migrations as a side effect, and this is a read probe from
+ * an unrelated command (`parachute expose`). `readonly: true` skips the
+ * WAL handshake and won't contend with the live hub server.
+ */
+function defaultProbeHubDbHasUserPassword(dbPath: string): boolean | undefined {
+  if (!existsSync(dbPath)) return undefined;
+  const { Database } = require("bun:sqlite");
+  let db: { prepare: (sql: string) => { get: () => unknown }; close: () => void } | undefined;
+  try {
+    db = new Database(dbPath, { readonly: true }) as typeof db;
+    // COUNT(*) over users with non-empty password_hash. `length(...) > 0`
+    // matches the "missing/empty hash" treatment from the YAML side.
+    const row = db?.prepare(
+      "SELECT COUNT(*) AS n FROM users WHERE password_hash IS NOT NULL AND length(password_hash) > 0",
+    ).get() as { n: number } | null;
+    return (row?.n ?? 0) > 0;
+  } catch {
+    return undefined;
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // ignore
+    }
+  }
+}
+
 function resolve(opts: AuthStatusOpts): Resolved {
   return {
     vaultHome: opts.vaultHome ?? defaultVaultHome(),
+    hubDbPath: opts.hubDbPath ?? defaultHubDbPath(),
     readText: opts.readText ?? defaultReadText,
     listVaultNames: opts.listVaultNames ?? defaultListVaultNames,
     countTokens: opts.countTokens ?? defaultCountTokens,
+    probeHubDbHasUserPassword:
+      opts.probeHubDbHasUserPassword ?? defaultProbeHubDbHasUserPassword,
   };
 }
 
@@ -134,12 +215,46 @@ function matchQuotedKey(yaml: string, key: string): string | undefined {
   return captured;
 }
 
-function readGlobalAuth(r: Resolved): { hasOwnerPassword: boolean; hasTotp: boolean } {
+interface AuthSignals {
+  hasOwnerPassword: boolean;
+  hasTotp: boolean;
+}
+
+function readYamlAuth(r: Resolved): AuthSignals {
   const yaml = r.readText(join(r.vaultHome, "config.yaml"));
   if (yaml === undefined) return { hasOwnerPassword: false, hasTotp: false };
   return {
     hasOwnerPassword: matchQuotedKey(yaml, "owner_password_hash") !== undefined,
     hasTotp: matchQuotedKey(yaml, "totp_secret") !== undefined,
+  };
+}
+
+/**
+ * Combine the hub.db probe + the legacy YAML probe into a single auth-signals
+ * read. Logic:
+ *
+ *   - hub.db says yes → operator has an account in the canonical store;
+ *     report `hasOwnerPassword: true`. TOTP is reported per the YAML probe
+ *     (so a legacy operator who set both YAML password + YAML totp_secret,
+ *     then migrated to a hub.db user, still surfaces "TOTP is on" — we
+ *     don't have a hub-side TOTP column yet, hub#252 Phase 3 lands it).
+ *   - hub.db says no AND was reachable → users table is empty, no hub
+ *     account exists yet. Fall back to YAML for both signals — a pre-
+ *     multi-user install would have its password in YAML.
+ *   - hub.db unreachable → can't tell, fall back to YAML entirely.
+ *
+ * Net effect: `hasOwnerPassword` is the OR of (hub.db has a user with a
+ * password) ∪ (YAML has owner_password_hash). Either source counts.
+ */
+function readAuthSignals(r: Resolved): AuthSignals {
+  const yaml = readYamlAuth(r);
+  const hubDbHasUser = r.probeHubDbHasUserPassword(r.hubDbPath);
+  const hasOwnerPassword = hubDbHasUser === true ? true : yaml.hasOwnerPassword;
+  return {
+    hasOwnerPassword,
+    // No hub-side TOTP column shipped yet (multi-user Phase 3). Until it
+    // lands, TOTP is YAML-only — matches what's actually true on disk.
+    hasTotp: yaml.hasTotp,
   };
 }
 
@@ -171,7 +286,7 @@ function readTotalTokenCount(r: Resolved, vaultNames: string[]): number | null {
 
 export function readVaultAuthStatus(opts: AuthStatusOpts = {}): VaultAuthStatus {
   const r = resolve(opts);
-  const { hasOwnerPassword, hasTotp } = readGlobalAuth(r);
+  const { hasOwnerPassword, hasTotp } = readAuthSignals(r);
   const dataDir = join(r.vaultHome, "data");
   const vaultNames = r.listVaultNames(dataDir);
   const tokenCount = readTotalTokenCount(r, vaultNames);


### PR DESCRIPTION
## Summary

- `parachute expose public` was warning `No owner password and no API tokens are configured — public internet RIGHT NOW` for users whose accounts were created by the post-multi-user-Phase-1 wizard. Root cause: `readVaultAuthStatus` only checked vault's pre-multi-user `~/.parachute/vault/config.yaml`'s `owner_password_hash`; hub now writes accounts into `hub.db`'s `users` table (PRs 279–281, 425) and leaves the YAML key empty.
- Aaron hit this with username `unforced` — his account exists in `hub.db` with a valid `password_hash`, but the preflight said wide-open.
- Fix: probe hub.db first. If any user row has a non-empty `password_hash` → `hasOwnerPassword: true`. Fall back to the legacy YAML probe when hub.db is unreachable / users is empty (preserves the pre-multi-user-install path).

## Root cause

`src/vault/auth-status.ts:readGlobalAuth()` matched `^owner_password_hash:\s*"([^"]+)"` against `~/.parachute/vault/config.yaml`. That key is canonical only for installs pre-dating multi-user Phase 1. New installs land the operator account in `hub.db` (`users.password_hash`, migration v2 + v8) and the vault YAML is bare. The wizard's first admin is canonical-operator-by-construction (`getFirstAdminId` in `src/users.ts`).

## What changed

| Source | Result |
|---|---|
| hub.db has a user with non-empty `password_hash` | `hasOwnerPassword: true` (no YAML read needed) |
| hub.db reachable, users empty | fall through to YAML |
| hub.db missing / locked / schema drift / users table absent | fall through to YAML |

TOTP stays YAML-only — there's no hub-side TOTP column yet (Phase 3 territory). Reporting hub-side TOTP as supported would lie about the second factor.

`probeHubDbHasUserPassword` is the new injection seam:
- `true` → at least one user has a non-empty `password_hash`
- `false` → hub.db opened cleanly but users is empty (fresh wizard not yet run)
- `undefined` → DB missing / locked / schema drift / users absent

The split between `false` and `undefined` is deliberate. A `false` from a fresh hub.db must not mask a legacy `owner_password_hash` in vault YAML, so `hasOwnerPassword` is the OR of (hub.db) ∪ (YAML).

## Test counts

- `bun test ./src` — **2184 pass / 1 skip / 0 fail** (was 2174; +10 new `vault-auth-status` tests covering hub.db happy path, YAML fallback, schema-drift, empty-hash-row, and missing-DB)
- `bun run typecheck` — clean

## Test plan

- [x] hub.db has a user with `password_hash` set → preflight reports password configured (Aaron's case)
- [x] hub.db users empty, YAML has `owner_password_hash` → falls back to YAML
- [x] hub.db missing, YAML present → falls back to YAML
- [x] hub.db users empty AND no YAML → wide-open warning (preserved)
- [x] hub.db with schema drift (no users table) → `undefined`, YAML fallback
- [x] hub.db with empty-string `password_hash` row → treated as absent
- [x] Existing 5 preflight branches in `expose-auth-preflight.test.ts` still pass

## Patterns check

No new patterns. Touches the source-of-truth hierarchy for "is auth configured?" — aligns the preflight probe with the post-multi-user authoritative store (hub.db) without breaking pre-multi-user installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)