### PR TITLE
feat(hub): fresh-install UX — migrate redesign + init + expose-hub + cloudflared

### DIFF
--- a/src/__tests__/cloudflare-detect.test.ts
+++ b/src/__tests__/cloudflare-detect.test.ts
@@ -59,10 +59,65 @@ describe("cloudflare detect", () => {
     }
   });
 
-  test("install hint names brew on darwin and a URL elsewhere", () => {
-    expect(cloudflaredInstallHint("darwin")).toContain("brew install cloudflared");
-    expect(cloudflaredInstallHint("linux")).toContain(
-      "developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads",
-    );
+  describe("cloudflaredInstallHint", () => {
+    test("darwin: names brew + points at GitHub releases as fallback", () => {
+      const hint = cloudflaredInstallHint("darwin", "arm64");
+      expect(hint).toContain("brew install cloudflared");
+      expect(hint).toContain("https://github.com/cloudflare/cloudflared/releases/latest");
+    });
+
+    test("linux x64: writes the curl line with the amd64 artifact suffix", () => {
+      // Refresh of stale URLs (2026-05-27). Aaron hit this on a fresh
+      // Amazon Linux 2023 install — `sudo dnf install cloudflared`
+      // returned 'No match for argument: cloudflared', and the hub's
+      // hint pointed at developers.cloudflare.com paths that 404. The
+      // GitHub release is the reliable cross-distro path.
+      const hint = cloudflaredInstallHint("linux", "x64");
+      expect(hint).toContain("curl -L -o /usr/local/bin/cloudflared");
+      expect(hint).toContain(
+        "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64",
+      );
+      expect(hint).toContain("sudo chmod +x /usr/local/bin/cloudflared");
+    });
+
+    test("linux arm64: writes the arm64 artifact suffix", () => {
+      const hint = cloudflaredInstallHint("linux", "arm64");
+      expect(hint).toContain("cloudflared-linux-arm64");
+    });
+
+    test("linux arm (32-bit): writes the arm artifact suffix", () => {
+      const hint = cloudflaredInstallHint("linux", "arm");
+      expect(hint).toContain("cloudflared-linux-arm");
+    });
+
+    test("linux exotic arch: falls back to a generic GitHub releases pointer", () => {
+      // riscv64 / ppc64 / mips64 — no cloudflared artifact published, so
+      // we don't fabricate a 404-bound download URL; we point the user at
+      // the releases page and surface what their arch is so they can pick.
+      const hint = cloudflaredInstallHint("linux", "riscv64");
+      expect(hint).toContain("https://github.com/cloudflare/cloudflared/releases/latest");
+      expect(hint).toContain("riscv64");
+      expect(hint).not.toContain("curl -L -o /usr/local/bin/cloudflared");
+    });
+
+    test("no stale developers.cloudflare.com or pkg.cloudflare.com paths anywhere", () => {
+      // Aaron caught both URL shapes returning HTML/404 on 2026-05-27 —
+      // they had been the hub's installer instructions for months.
+      // Hard-assert they're gone so they don't regress.
+      for (const platform of ["darwin", "linux"] as const) {
+        for (const arch of ["x64", "arm64"] as const) {
+          const hint = cloudflaredInstallHint(platform, arch);
+          expect(hint).not.toContain("developers.cloudflare.com");
+          expect(hint).not.toContain("pkg.cloudflare.com");
+        }
+      }
+    });
+
+    test("non-Linux, non-darwin platform: GitHub releases pointer with no curl line", () => {
+      const hint = cloudflaredInstallHint("win32", "x64");
+      expect(hint).toContain("https://github.com/cloudflare/cloudflared/releases/latest");
+      expect(hint).not.toContain("brew install");
+      expect(hint).not.toContain("curl -L -o");
+    });
   });
 });

--- a/src/__tests__/expose-cloudflare.test.ts
+++ b/src/__tests__/expose-cloudflare.test.ts
@@ -14,7 +14,12 @@ import {
   exposeCloudflareOff,
   exposeCloudflareUp,
 } from "../commands/expose-cloudflare.ts";
+import { writeHubPort } from "../hub-control.ts";
 import type { CommandResult, Runner } from "../tailscale/run.ts";
+
+// Default seeded hub port used by tests with `skipHub: true`. The cloudflared
+// path reads `<configDir>/hub/run/hub.port` instead of spawning a real hub.
+const TEST_HUB_PORT = 1939;
 
 interface TestEnv {
   configDir: string;
@@ -40,6 +45,11 @@ function makeEnv(opts: { includeVault?: boolean; loggedIn?: boolean } = {}): Tes
 
   require("node:fs").mkdirSync(configDir, { recursive: true });
   require("node:fs").mkdirSync(cloudflaredHome, { recursive: true });
+
+  // Seed the hub port so `skipHub: true` invocations can resolve a port
+  // without spawning the actual hub process. Matches the seam pattern used
+  // by expose.test.ts (which threads `hubEnsureOpts` for the same purpose).
+  writeHubPort(TEST_HUB_PORT, configDir);
 
   if (loggedIn) {
     writeFileSync(join(cloudflaredHome, "cert.pem"), "---");
@@ -128,6 +138,8 @@ describe("exposeCloudflareUp", () => {
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
+        configDir: env.configDir,
+        skipHub: true,
         now: () => new Date("2026-04-22T12:00:00Z"),
       });
 
@@ -170,7 +182,12 @@ describe("exposeCloudflareUp", () => {
       const yaml = readFileSync(env.configPath, "utf8");
       expect(yaml).toContain(`tunnel: ${uuid}`);
       expect(yaml).toContain("- hostname: vault.example.com");
-      expect(yaml).toContain("service: http://localhost:1940");
+      // Routes through the hub (not directly at vault). The hub dispatches
+      // discovery / admin / OAuth / per-vault proxy / generic /<svc>/* —
+      // same shape Tailscale Funnel uses. Pre-2026-05-27 this was
+      // http://localhost:1940 (vault's port), which served vault's own 404
+      // page on every request that wasn't /vault/<name>/...
+      expect(yaml).toContain(`service: http://localhost:${TEST_HUB_PORT}`);
 
       // Security copy surfaces both paths plus a pointer to the auth doc.
       const joined = logs.join("\n");
@@ -209,6 +226,8 @@ describe("exposeCloudflareUp", () => {
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
+        configDir: env.configDir,
+        skipHub: true,
       });
       expect(code).toBe(0);
       // No `tunnel create` — only list + route.
@@ -236,6 +255,8 @@ describe("exposeCloudflareUp", () => {
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
+        configDir: env.configDir,
+        skipHub: true,
       });
 
       expect(code).toBe(1);
@@ -262,6 +283,8 @@ describe("exposeCloudflareUp", () => {
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
+        configDir: env.configDir,
+        skipHub: true,
         tunnelName: "bad name with spaces",
       });
 
@@ -291,6 +314,8 @@ describe("exposeCloudflareUp", () => {
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
+        configDir: env.configDir,
+        skipHub: true,
       });
 
       expect(code).toBe(1);
@@ -317,6 +342,8 @@ describe("exposeCloudflareUp", () => {
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
+        configDir: env.configDir,
+        skipHub: true,
       });
 
       expect(code).toBe(1);
@@ -342,6 +369,8 @@ describe("exposeCloudflareUp", () => {
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
+        configDir: env.configDir,
+        skipHub: true,
       });
 
       expect(code).toBe(1);
@@ -376,6 +405,8 @@ describe("exposeCloudflareUp", () => {
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
+        configDir: env.configDir,
+        skipHub: true,
       });
 
       expect(code).toBe(1);
@@ -425,6 +456,8 @@ describe("exposeCloudflareUp", () => {
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
+        configDir: env.configDir,
+        skipHub: true,
       });
 
       expect(code).toBe(0);
@@ -462,6 +495,8 @@ describe("exposeCloudflareUp", () => {
         manifestPath: env.manifestPath,
         statePath: env.statePath,
         cloudflaredHome: env.cloudflaredHome,
+        configDir: env.configDir,
+        skipHub: true,
         // Use defaults for configPath/logPath so they're per-tunnel-derived.
       });
       expect(code1).toBe(0);
@@ -487,6 +522,8 @@ describe("exposeCloudflareUp", () => {
         manifestPath: env.manifestPath,
         statePath: env.statePath,
         cloudflaredHome: env.cloudflaredHome,
+        configDir: env.configDir,
+        skipHub: true,
         tunnelName: "second",
       });
       expect(code2).toBe(0);
@@ -544,6 +581,8 @@ describe("exposeCloudflareUp", () => {
           configPath: env.configPath,
           logPath: env.logPath,
           cloudflaredHome: env.cloudflaredHome,
+        configDir: env.configDir,
+        skipHub: true,
           // No password, no 2FA — fully wide open. The warning should still
           // fire; password-recovery copy already lives in `printAuthGuidance`.
           vaultAuthStatus: {
@@ -592,6 +631,8 @@ describe("exposeCloudflareUp", () => {
           configPath: env.configPath,
           logPath: env.logPath,
           cloudflaredHome: env.cloudflaredHome,
+        configDir: env.configDir,
+        skipHub: true,
           vaultAuthStatus: {
             hasOwnerPassword: true,
             hasTotp: true,
@@ -607,6 +648,68 @@ describe("exposeCloudflareUp", () => {
         // to the new contextual warning and stays in place — assert it on a
         // shape that doesn't collide with the warning text.
         expect(joined).toContain("(recommended) TOTP + backup codes");
+      } finally {
+        env.cleanup();
+      }
+    });
+  });
+
+  describe("routes through hub, not vault", () => {
+    test("config.yml targets the hub port; success log mentions Admin + OAuth URLs", async () => {
+      // Regression guard for the 2026-05-27 cut. Aaron ran `parachute expose
+      // public` on a fresh EC2 box, configured Cloudflare with a custom
+      // domain, and hit it — and got vault's 404 page rather than the hub's
+      // discovery / admin. The pre-fix cloudflared config routed straight at
+      // vault's port; the fix routes at the hub, mirroring the Tailscale
+      // Funnel shape (single mount → hub catchall; hub dispatches per-request).
+      const env = makeEnv();
+      try {
+        // Re-seed hub port to a non-default value so the assertion is
+        // unambiguous about *which* port got into the yaml.
+        writeHubPort(1949, env.configDir);
+
+        const uuid = "ffff0000-0000-0000-0000-00000000beef";
+        const { runner } = queueRunner([
+          { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
+          { code: 0, stdout: "[]", stderr: "" },
+          {
+            code: 0,
+            stdout: `Created tunnel parachute with id ${uuid}\n`,
+            stderr: "",
+          },
+          { code: 0, stdout: "", stderr: "" },
+        ]);
+        const { spawner } = fakeSpawner(60001);
+        const logs: string[] = [];
+
+        const code = await exposeCloudflareUp("gitcoin.parachute.computer", {
+          runner,
+          spawner,
+          alive: () => false,
+          kill: () => {},
+          log: (l) => logs.push(l),
+          manifestPath: env.manifestPath,
+          statePath: env.statePath,
+          configPath: env.configPath,
+          logPath: env.logPath,
+          cloudflaredHome: env.cloudflaredHome,
+          configDir: env.configDir,
+          skipHub: true,
+        });
+
+        expect(code).toBe(0);
+        const yaml = readFileSync(env.configPath, "utf8");
+        // Routes through the hub on its loopback port.
+        expect(yaml).toContain("service: http://localhost:1949");
+        // Does NOT route directly at vault's port (1940 per makeEnv default).
+        expect(yaml).not.toContain("service: http://localhost:1940");
+
+        const joined = logs.join("\n");
+        // Discoverable surfaces: open / admin / vault / OAuth all surfaced.
+        expect(joined).toContain("https://gitcoin.parachute.computer/");
+        expect(joined).toContain("Admin:   https://gitcoin.parachute.computer/admin/");
+        expect(joined).toContain("Vault:   https://gitcoin.parachute.computer/vault/default");
+        expect(joined).toContain("OAuth:   https://gitcoin.parachute.computer");
       } finally {
         env.cleanup();
       }

--- a/src/__tests__/expose-interactive.test.ts
+++ b/src/__tests__/expose-interactive.test.ts
@@ -469,10 +469,16 @@ describe("exposePublicInteractive — neither ready", () => {
       expect(interactiveCalled).toBe(false);
       expect(cloudflareCalled).toBe(false);
       const joined = logs.join("\n");
-      expect(joined).toMatch(/apt-get|dnf/);
-      expect(joined).toContain(
-        "developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads",
-      );
+      // Post 2026-05-27 cloudflared-URL refresh: the install hint moved
+      // off apt-get / dnf / developers.cloudflare.com (all unreliable —
+      // Aaron hit `No match for argument: cloudflared` on AL2023 and
+      // 404s from the docs URL on the same box) onto the static binary
+      // from GitHub releases.
+      expect(joined).toContain("github.com/cloudflare/cloudflared/releases/latest");
+      expect(joined).toContain("curl -L -o /usr/local/bin/cloudflared");
+      expect(joined).not.toContain("developers.cloudflare.com");
+      expect(joined).not.toContain("pkg.cloudflare.com");
+      expect(joined).not.toContain("sudo dnf install cloudflared");
     } finally {
       env.cleanup();
     }

--- a/src/__tests__/expose-public-auto.test.ts
+++ b/src/__tests__/expose-public-auto.test.ts
@@ -126,7 +126,11 @@ describe("exposePublicAutoPick — neither ready", () => {
     expect(code).toBe(1);
     const joined = logs.join("\n");
     expect(joined).toContain("tailscale.com/download");
-    expect(joined).toContain("developers.cloudflare.com");
+    // Post 2026-05-27 cloudflared-URL refresh: the install hint now points
+    // at GitHub releases (developers.cloudflare.com / pkg.cloudflare.com
+    // both returned HTML/404 on Aaron's fresh AL2023 EC2 box).
+    expect(joined).toContain("github.com/cloudflare/cloudflared/releases/latest");
+    expect(joined).not.toContain("developers.cloudflare.com");
     expect(joined).toContain("--skip-provider-check");
   });
 

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { init, resolveAdminUrl } from "../commands/init.ts";
+import type { ExposeState } from "../expose-state.ts";
+import { writeHubPort } from "../hub-control.ts";
+import { writePid } from "../process-state.ts";
+
+interface Harness {
+  configDir: string;
+  manifestPath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-init-"));
+  const manifestPath = join(dir, "services.json");
+  writeFileSync(manifestPath, JSON.stringify({ services: [] }));
+  return {
+    configDir: dir,
+    manifestPath,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+function seedVault(manifestPath: string): void {
+  writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      services: [
+        {
+          name: "parachute-vault",
+          version: "0.5.0",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/health",
+          icon: "/icon.svg",
+          auth: { type: "none" },
+          mcp: {},
+        },
+      ],
+    }),
+  );
+}
+
+describe("resolveAdminUrl", () => {
+  test("prefers expose-state FQDN when present", () => {
+    const state: ExposeState = {
+      version: 1,
+      layer: "tailnet",
+      mode: "path",
+      canonicalFqdn: "box-1.tailnet.ts.net",
+      port: 443,
+      funnel: false,
+      entries: [],
+      hubOrigin: "https://box-1.tailnet.ts.net",
+    };
+    expect(resolveAdminUrl(state, 1939)).toBe("https://box-1.tailnet.ts.net/admin/");
+  });
+
+  test("falls back to loopback + hub port when no exposure", () => {
+    expect(resolveAdminUrl(undefined, 1939)).toBe("http://127.0.0.1:1939/admin/");
+  });
+
+  test("undefined when neither expose-state nor a hub port is known", () => {
+    expect(resolveAdminUrl(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe("init", () => {
+  test("starts the hub when not running and prints the loopback admin URL", async () => {
+    const h = makeHarness();
+    try {
+      const calls: string[] = [];
+      const logs: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => logs.push(l),
+        alive: () => false,
+        ensureHub: async () => {
+          calls.push("ensureHub");
+          // Seed the port file as a real ensureHubRunning would.
+          writeHubPort(1939, h.configDir);
+          return { pid: 5555, port: 1939, started: true };
+        },
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+      });
+      expect(code).toBe(0);
+      expect(calls).toEqual(["ensureHub"]);
+      const joined = logs.join("\n");
+      expect(joined).toContain("Hub not running — starting it now");
+      expect(joined).toContain("Hub started (pid 5555, port 1939)");
+      expect(joined).toContain("http://127.0.0.1:1939/admin/");
+      expect(joined).toContain("finish setup in the admin wizard");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("idempotent: skips ensureHub and confirms 'looks good' when hub up + vault configured", async () => {
+    const h = makeHarness();
+    try {
+      // Seed: hub running + vault row exists.
+      mkdirSync(join(h.configDir, "hub", "run"), { recursive: true });
+      writePid("hub", 1234, h.configDir);
+      writeHubPort(1939, h.configDir);
+      seedVault(h.manifestPath);
+
+      const calls: string[] = [];
+      const logs: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => logs.push(l),
+        alive: () => true,
+        ensureHub: async () => {
+          calls.push("ensureHub");
+          return { pid: 1234, port: 1939, started: false };
+        },
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+      });
+      expect(code).toBe(0);
+      // Hub was already running — ensureHub should not have been called.
+      expect(calls).toEqual([]);
+      const joined = logs.join("\n");
+      expect(joined).toContain("Hub already running (pid 1234, port 1939)");
+      expect(joined).toContain("Looks good");
+      expect(joined).toContain("http://127.0.0.1:1939/admin/");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("prefers the exposed FQDN over loopback", async () => {
+    const h = makeHarness();
+    try {
+      mkdirSync(join(h.configDir, "hub", "run"), { recursive: true });
+      writePid("hub", 4321, h.configDir);
+      writeHubPort(1939, h.configDir);
+
+      const state: ExposeState = {
+        version: 1,
+        layer: "public",
+        mode: "path",
+        canonicalFqdn: "gitcoin.parachute.computer",
+        port: 443,
+        funnel: false,
+        entries: [],
+        hubOrigin: "https://gitcoin.parachute.computer",
+      };
+
+      const logs: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => logs.push(l),
+        alive: () => true,
+        ensureHub: async () => ({ pid: 4321, port: 1939, started: false }),
+        readExposeStateFn: () => state,
+        isTty: false,
+        platform: "linux",
+      });
+      expect(code).toBe(0);
+      expect(logs.join("\n")).toContain("https://gitcoin.parachute.computer/admin/");
+      // Not the loopback fallback.
+      expect(logs.join("\n")).not.toContain("http://127.0.0.1");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("offers to open the browser in a TTY; 'y' invokes openBrowser", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      const opened: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => undefined,
+        isTty: true,
+        platform: "darwin",
+        prompt: async () => "y",
+        openBrowser: (url) => {
+          opened.push(url);
+          return true;
+        },
+      });
+      expect(code).toBe(0);
+      expect(opened).toEqual(["http://127.0.0.1:1939/admin/"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("offers to open the browser in a TTY; 'n' skips openBrowser", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      const opened: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => undefined,
+        isTty: true,
+        platform: "darwin",
+        prompt: async () => "n",
+        openBrowser: (url) => {
+          opened.push(url);
+          return true;
+        },
+      });
+      expect(code).toBe(0);
+      expect(opened).toEqual([]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("--no-browser skips the prompt and openBrowser entirely", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      const opened: string[] = [];
+      let prompted = false;
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => undefined,
+        isTty: true,
+        platform: "darwin",
+        prompt: async () => {
+          prompted = true;
+          return "y";
+        },
+        openBrowser: (url) => {
+          opened.push(url);
+          return true;
+        },
+        noBrowser: true,
+      });
+      expect(code).toBe(0);
+      expect(prompted).toBe(false);
+      expect(opened).toEqual([]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("non-TTY prints the URL and exits without prompting", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      let prompted = false;
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "darwin",
+        prompt: async () => {
+          prompted = true;
+          return "y";
+        },
+        openBrowser: () => true,
+      });
+      expect(code).toBe(0);
+      expect(prompted).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("Windows / unsupported platform: skip browser launch, just print", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      const opened: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => undefined,
+        isTty: true,
+        platform: "win32",
+        prompt: async () => "y",
+        openBrowser: (url) => {
+          opened.push(url);
+          return true;
+        },
+      });
+      expect(code).toBe(0);
+      // No prompt offered on Windows — just URL printed.
+      expect(opened).toEqual([]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("ensureHub failure exits 1 with an actionable hint", async () => {
+    const h = makeHarness();
+    try {
+      const logs: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => logs.push(l),
+        alive: () => false,
+        ensureHub: async () => {
+          throw new Error("port 1939 is in use");
+        },
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+      });
+      expect(code).toBe(1);
+      const joined = logs.join("\n");
+      expect(joined).toContain("Hub failed to start: port 1939 is in use");
+      expect(joined).toContain("parachute logs hub");
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/migrate.test.ts
+++ b/src/__tests__/migrate.test.ts
@@ -11,7 +11,15 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { migrate, migrateNotice, planArchive, safelistEntries } from "../commands/migrate.ts";
+import {
+  KNOWN_ARCHIVABLE_DIRS,
+  listRunningServices,
+  migrate,
+  migrateNotice,
+  planArchive,
+  safelistEntries,
+} from "../commands/migrate.ts";
+import { writePid } from "../process-state.ts";
 
 interface Harness {
   configDir: string;
@@ -42,27 +50,42 @@ function seedSafelist(configDir: string): void {
 }
 
 describe("safelistEntries", () => {
-  test("covers service dirs, hub, state files, and well-known", () => {
+  test("covers service dirs, hub, state files, hub.db family, well-known, cloudflared", () => {
     const s = safelistEntries();
     // Service dirs from SERVICE_SPECS
     expect(s.has("vault")).toBe(true);
     expect(s.has("notes")).toBe(true);
     expect(s.has("scribe")).toBe(true);
     expect(s.has("channel")).toBe(true);
-    // Legacy — kept across the Notes→Lens→Notes rename round-trip
-    // (Apr 19 → Apr 22) so existing ~/.parachute/lens/ dirs from the
-    // brief Lens window don't get archived on upgrade.
-    expect(s.has("lens")).toBe(true);
     // Internal
     expect(s.has("hub")).toBe(true);
     // CLI state
     expect(s.has("services.json")).toBe(true);
     expect(s.has("expose-state.json")).toBe(true);
+    expect(s.has("cloudflared-state.json")).toBe(true);
     expect(s.has("well-known")).toBe(true);
+    // hub.db family — the trigger for the 2026-05-27 redesign was hub.db
+    // not being recognized; the allowlist now defaults to "leave unknown
+    // alone," but hub.db is explicitly safelisted so it doesn't even show
+    // up as "unknown" in the plan.
+    expect(s.has("hub.db")).toBe(true);
+    expect(s.has("hub.db-wal")).toBe(true);
+    expect(s.has("hub.db-shm")).toBe(true);
+    // cloudflared per-tunnel config dir
+    expect(s.has("cloudflared")).toBe(true);
+  });
+
+  test("`lens` is in the archivable-dirs set (not safelist) — sweep, don't preserve", () => {
+    // The Notes→Lens→Notes rename round-trip (Apr 19 → Apr 22) left some
+    // installs with `~/.parachute/lens/`. Under the new allowlist model,
+    // lens/ is explicitly archivable rather than safelisted — we want
+    // operators upgrading to the post-rename world to actually clean it up.
+    expect(KNOWN_ARCHIVABLE_DIRS.has("lens")).toBe(true);
+    expect(safelistEntries().has("lens")).toBe(false);
   });
 });
 
-describe("planArchive", () => {
+describe("planArchive — allowlist behavior", () => {
   test("clean ecosystem root produces an empty plan", () => {
     const h = makeHarness();
     try {
@@ -71,31 +94,83 @@ describe("planArchive", () => {
       expect(plan.items).toEqual([]);
       expect(plan.totalBytes).toBe(0);
       expect(plan.archiveDirName).toBe(".archive-2026-04-19");
+      expect(plan.hasLiveDb).toBe(false);
     } finally {
       h.cleanup();
     }
   });
 
-  test("pre-restructure cruft is identified and sized", () => {
+  test("known-cruft is archived, unknowns are recorded but not archived", () => {
     const h = makeHarness();
     try {
       seedSafelist(h.configDir);
+      // Known cruft — archives.
       touch(join(h.configDir, "daily.db"), "X".repeat(100));
       touch(join(h.configDir, "daily.db-shm"), "S");
       touch(join(h.configDir, "server.yaml"), "port: 1940\n");
       mkdirSync(join(h.configDir, "logs"), { recursive: true });
       touch(join(h.configDir, "logs", "old.log"), "old-entry\n");
+      // Unknown — left alone (under old shape this would have been swept).
       touch(join(h.configDir, "random-note.txt"), "mystery content");
+      mkdirSync(join(h.configDir, "future-module"), { recursive: true });
+      touch(join(h.configDir, "future-module", "state.json"), "{}");
 
       const plan = planArchive(h.configDir, APRIL_19);
-      const names = plan.items.map((i) => i.name).sort();
-      expect(names).toEqual(["daily.db", "daily.db-shm", "logs", "random-note.txt", "server.yaml"]);
+      const archivable = plan.items.filter((i) => i.archive).map((i) => i.name);
+      const skipped = plan.items.filter((i) => !i.archive).map((i) => i.name);
+
+      expect(archivable.sort()).toEqual(["daily.db", "daily.db-shm", "logs", "server.yaml"]);
+      expect(skipped.sort()).toEqual(["future-module", "random-note.txt"]);
+
+      // Archivable totals reflect known-cruft only — unknowns contribute 0.
       expect(plan.totalBytes).toBeGreaterThan(100);
-      // known-cruft annotation is attached
+
+      // Known-cruft has a friendly annotation; unknowns have none.
       expect(plan.items.find((i) => i.name === "daily.db")?.annotation).toMatch(/daily/i);
       expect(plan.items.find((i) => i.name === "logs")?.annotation).toMatch(/logs/i);
-      // unknown files get no annotation
       expect(plan.items.find((i) => i.name === "random-note.txt")?.annotation).toBeUndefined();
+      expect(plan.items.find((i) => i.name === "future-module")?.annotation).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("`lens` directory is archivable per KNOWN_ARCHIVABLE_DIRS", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      mkdirSync(join(h.configDir, "lens"), { recursive: true });
+      touch(join(h.configDir, "lens", "config.json"), "{}");
+
+      const plan = planArchive(h.configDir, APRIL_19);
+      const lens = plan.items.find((i) => i.name === "lens");
+      expect(lens?.archive).toBe(true);
+      expect(lens?.risk).toBe("safe");
+      expect(lens?.annotation).toMatch(/legacy/i);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("SQLite-shape files carry the live-db risk label", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      touch(join(h.configDir, "daily.db"), "X".repeat(50));
+      touch(join(h.configDir, "daily.db-wal"), "W");
+      touch(join(h.configDir, "daily.db-shm"), "S");
+      touch(join(h.configDir, "server.yaml"), "p: 1\n");
+
+      const plan = planArchive(h.configDir, APRIL_19);
+      const db = plan.items.find((i) => i.name === "daily.db");
+      const wal = plan.items.find((i) => i.name === "daily.db-wal");
+      const shm = plan.items.find((i) => i.name === "daily.db-shm");
+      const yaml = plan.items.find((i) => i.name === "server.yaml");
+      expect(db?.risk).toBe("live-db");
+      expect(wal?.risk).toBe("live-db");
+      expect(shm?.risk).toBe("live-db");
+      expect(yaml?.risk).toBe("safe");
+      expect(plan.hasLiveDb).toBe(true);
     } finally {
       h.cleanup();
     }
@@ -117,20 +192,41 @@ describe("planArchive", () => {
     }
   });
 
-  test("directory sizes are summed recursively", () => {
+  test("directory sizes for archivable entries are summed recursively", () => {
     const h = makeHarness();
     try {
       seedSafelist(h.configDir);
-      const nested = join(h.configDir, "old-tree", "a", "b");
+      // `logs` is known cruft — its size should be summed.
+      const nested = join(h.configDir, "logs", "a", "b");
       mkdirSync(nested, { recursive: true });
       touch(join(nested, "inner.dat"), "Z".repeat(500));
-      touch(join(h.configDir, "old-tree", "top.dat"), "Q".repeat(300));
+      touch(join(h.configDir, "logs", "top.dat"), "Q".repeat(300));
 
       const plan = planArchive(h.configDir, APRIL_19);
-      const oldTree = plan.items.find((i) => i.name === "old-tree");
-      expect(oldTree).toBeDefined();
-      expect(oldTree?.kind).toBe("dir");
-      expect(oldTree?.bytes).toBe(800);
+      const logsItem = plan.items.find((i) => i.name === "logs");
+      expect(logsItem?.archive).toBe(true);
+      expect(logsItem?.kind).toBe("dir");
+      expect(logsItem?.bytes).toBe(800);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("unknown directories do not pay the recursive sizeOf cost", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      const deep = join(h.configDir, "future-module", "a", "b");
+      mkdirSync(deep, { recursive: true });
+      touch(join(deep, "inner.dat"), "Z".repeat(500));
+
+      const plan = planArchive(h.configDir, APRIL_19);
+      const item = plan.items.find((i) => i.name === "future-module");
+      expect(item?.archive).toBe(false);
+      // Unknowns get bytes=0 even when the directory tree is non-empty —
+      // we don't walk something we're not going to touch.
+      expect(item?.bytes).toBe(0);
+      expect(plan.totalBytes).toBe(0);
     } finally {
       h.cleanup();
     }
@@ -156,6 +252,8 @@ describe("planArchive", () => {
       const plan = planArchive(h.configDir, APRIL_19);
       const item = plan.items.find((i) => i.name === "external-backup");
       expect(item).toBeDefined();
+      // It's an unknown name — left alone.
+      expect(item?.archive).toBe(false);
       expect(item?.bytes).toBe(0);
       expect(item?.kind).toBe("file");
       expect(plan.totalBytes).toBe(0);
@@ -164,9 +262,27 @@ describe("planArchive", () => {
       targetHarness.cleanup();
     }
   });
+
+  test("plan sort order — archivable first, then skipped, alphabetical within each group", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      // Mix known-cruft and unknowns; assert ordering.
+      touch(join(h.configDir, "zzz-unknown"), "");
+      touch(join(h.configDir, "aaa-unknown"), "");
+      touch(join(h.configDir, "server.yaml"), "");
+      touch(join(h.configDir, "daily.db"), "");
+
+      const plan = planArchive(h.configDir, APRIL_19);
+      const names = plan.items.map((i) => i.name);
+      expect(names).toEqual(["daily.db", "server.yaml", "aaa-unknown", "zzz-unknown"]);
+    } finally {
+      h.cleanup();
+    }
+  });
 });
 
-describe("migrate", () => {
+describe("migrate — interactive + flag behavior", () => {
   test("no-op on a clean root with exit 0", async () => {
     const h = makeHarness();
     try {
@@ -179,6 +295,7 @@ describe("migrate", () => {
         prompt: async () => {
           throw new Error("prompt must not be called");
         },
+        isTty: true,
       });
       expect(code).toBe(0);
       expect(logs.join("\n")).toMatch(/nothing to archive/i);
@@ -188,12 +305,15 @@ describe("migrate", () => {
     }
   });
 
-  test("dry-run prints plan, makes no changes, no prompt", async () => {
+  test("--list prints plan, makes no changes, no prompt, no running-service check", async () => {
     const h = makeHarness();
     try {
       seedSafelist(h.configDir);
       touch(join(h.configDir, "daily.db"), "X");
       touch(join(h.configDir, "random"), "Y");
+      // A running vault should NOT block a read-only --list.
+      mkdirSync(join(h.configDir, "vault", "run"), { recursive: true });
+      writePid("vault", process.pid, h.configDir);
 
       const logs: string[] = [];
       const code = await migrate({
@@ -203,10 +323,11 @@ describe("migrate", () => {
         prompt: async () => {
           throw new Error("prompt must not be called");
         },
-        dryRun: true,
+        list: true,
+        isTty: true,
       });
       expect(code).toBe(0);
-      expect(logs.join("\n")).toMatch(/dry-run/i);
+      expect(logs.join("\n")).toMatch(/--list — no changes made/);
       expect(existsSync(join(h.configDir, "daily.db"))).toBe(true);
       expect(existsSync(join(h.configDir, "random"))).toBe(true);
       expect(existsSync(join(h.configDir, ".archive-2026-04-19"))).toBe(false);
@@ -215,14 +336,42 @@ describe("migrate", () => {
     }
   });
 
-  test("--yes archives without prompting, safelist untouched", async () => {
+  test("--dry-run is a synonym for --list (back-compat)", async () => {
     const h = makeHarness();
     try {
       seedSafelist(h.configDir);
+      touch(join(h.configDir, "daily.db"), "X");
+      const logs: string[] = [];
+      const code = await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: (l) => logs.push(l),
+        prompt: async () => {
+          throw new Error("prompt must not be called");
+        },
+        dryRun: true,
+        isTty: true,
+      });
+      expect(code).toBe(0);
+      expect(logs.join("\n")).toMatch(/dry-run/);
+      expect(existsSync(join(h.configDir, ".archive-2026-04-19"))).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("--yes archives known cruft; unknowns are preserved", async () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      // Known cruft (archives)
       touch(join(h.configDir, "daily.db"), "X".repeat(50));
       touch(join(h.configDir, "server.yaml"), "port: 1\n");
       mkdirSync(join(h.configDir, "logs"), { recursive: true });
       touch(join(h.configDir, "logs", "a.log"), "a");
+      // Unknown (must NOT move)
+      touch(join(h.configDir, "my-notes.txt"), "operator-owned content");
+      mkdirSync(join(h.configDir, "future-module"), { recursive: true });
 
       const logs: string[] = [];
       const code = await migrate({
@@ -233,6 +382,7 @@ describe("migrate", () => {
           throw new Error("prompt must not be called");
         },
         yes: true,
+        isTty: false,
       });
       expect(code).toBe(0);
       const archive = join(h.configDir, ".archive-2026-04-19");
@@ -245,22 +395,132 @@ describe("migrate", () => {
       expect(existsSync(join(h.configDir, "services.json"))).toBe(true);
       expect(existsSync(join(h.configDir, "well-known"))).toBe(true);
       expect(existsSync(join(h.configDir, "hub"))).toBe(true);
-      // originals gone
+      // archivable originals gone
       expect(existsSync(join(h.configDir, "daily.db"))).toBe(false);
       expect(existsSync(join(h.configDir, "server.yaml"))).toBe(false);
       expect(existsSync(join(h.configDir, "logs"))).toBe(false);
+      // unknowns preserved!
+      expect(existsSync(join(h.configDir, "my-notes.txt"))).toBe(true);
+      expect(existsSync(join(h.configDir, "future-module"))).toBe(true);
     } finally {
       h.cleanup();
     }
   });
 
-  test("--yes archives a symlink by moving the link, not the target", async () => {
+  test("refuses while a service is running", async () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      // Seed a running hub (use the current test process pid — guaranteed alive).
+      mkdirSync(join(h.configDir, "hub", "run"), { recursive: true });
+      writePid("hub", process.pid, h.configDir);
+      touch(join(h.configDir, "daily.db"), "X");
+
+      const logs: string[] = [];
+      const code = await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: (l) => logs.push(l),
+        prompt: async () => {
+          throw new Error("prompt must not be called");
+        },
+        yes: true,
+        isTty: true,
+      });
+      expect(code).toBe(1);
+      const joined = logs.join("\n");
+      expect(joined).toMatch(/services are currently running/i);
+      expect(joined).toMatch(/- hub/);
+      // No archive happened.
+      expect(existsSync(join(h.configDir, ".archive-2026-04-19"))).toBe(false);
+      expect(existsSync(join(h.configDir, "daily.db"))).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("refuses non-TTY without --yes (CI / pipe safety)", async () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      touch(join(h.configDir, "daily.db"), "X");
+
+      const logs: string[] = [];
+      const code = await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: (l) => logs.push(l),
+        prompt: async () => {
+          throw new Error("prompt must not be called");
+        },
+        isTty: false,
+      });
+      expect(code).toBe(1);
+      expect(logs.join("\n")).toMatch(/refusing to sweep without a TTY/i);
+      expect(existsSync(join(h.configDir, "daily.db"))).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("live-db items pull an extra confirmation; declining aborts", async () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      touch(join(h.configDir, "daily.db"), "X");
+      touch(join(h.configDir, "daily.db-wal"), "W");
+
+      const answers = ["y", "n"]; // first y to proceed, then n on the live-db gate.
+      const code = await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: () => {},
+        prompt: async () => answers.shift() ?? "n",
+        isTty: true,
+      });
+      expect(code).toBe(1);
+      // Aborted before any rename — daily.db still there.
+      expect(existsSync(join(h.configDir, "daily.db"))).toBe(true);
+      expect(existsSync(join(h.configDir, ".archive-2026-04-19"))).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("live-db items pull an extra confirmation; accepting both proceeds", async () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      touch(join(h.configDir, "daily.db"), "X");
+      touch(join(h.configDir, "daily.db-wal"), "W");
+
+      const answers = ["y", "y"];
+      const code = await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: () => {},
+        prompt: async () => answers.shift() ?? "y",
+        isTty: true,
+      });
+      expect(code).toBe(0);
+      const archive = join(h.configDir, ".archive-2026-04-19");
+      expect(existsSync(join(archive, "daily.db"))).toBe(true);
+      expect(existsSync(join(archive, "daily.db-wal"))).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("--yes archives a symlink (if known-archivable name) by moving the link, not the target", async () => {
+    // Reorient the symlink regression test against the new shape: only
+    // archivable names actually move. We synthesize a known-cruft symlink:
+    // `logs` (directory cruft) pointed at an external target.
     const targetHarness = makeHarness();
     const h = makeHarness();
     try {
       seedSafelist(h.configDir);
       touch(join(targetHarness.configDir, "huge.bin"), "X".repeat(10_000));
-      const linkPath = join(h.configDir, "external-backup");
+      const linkPath = join(h.configDir, "logs");
       symlinkSync(targetHarness.configDir, linkPath);
 
       const code = await migrate({
@@ -271,14 +531,48 @@ describe("migrate", () => {
           throw new Error("prompt must not be called");
         },
         yes: true,
+        isTty: false,
       });
       expect(code).toBe(0);
-      const archivedLink = join(h.configDir, ".archive-2026-04-19", "external-backup");
+      const archivedLink = join(h.configDir, ".archive-2026-04-19", "logs");
       expect(lstatSync(archivedLink).isSymbolicLink()).toBe(true);
       // Target tree untouched
       expect(existsSync(join(targetHarness.configDir, "huge.bin"))).toBe(true);
       // Original link site is empty
       expect(existsSync(linkPath)).toBe(false);
+    } finally {
+      h.cleanup();
+      targetHarness.cleanup();
+    }
+  });
+
+  test("unknown symlink is preserved (under new allowlist)", async () => {
+    const targetHarness = makeHarness();
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      touch(join(targetHarness.configDir, "huge.bin"), "X".repeat(10_000));
+      const linkPath = join(h.configDir, "external-backup");
+      symlinkSync(targetHarness.configDir, linkPath);
+
+      const logs: string[] = [];
+      const code = await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: (l) => logs.push(l),
+        prompt: async () => {
+          throw new Error("prompt must not be called");
+        },
+        yes: true,
+        isTty: false,
+      });
+      expect(code).toBe(0);
+      // The "nothing recognized" exit branch — no archive directory created.
+      expect(existsSync(join(h.configDir, ".archive-2026-04-19"))).toBe(false);
+      // The unknown symlink stays at the root.
+      expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+      // Plan was still printed.
+      expect(logs.join("\n")).toMatch(/Leaving alone/);
     } finally {
       h.cleanup();
       targetHarness.cleanup();
@@ -296,6 +590,7 @@ describe("migrate", () => {
         now: () => APRIL_19,
         log: (l) => logs.push(l),
         prompt: async () => "n",
+        isTty: true,
       });
       expect(code).toBe(1);
       expect(logs.join("\n")).toMatch(/aborted/i);
@@ -306,19 +601,20 @@ describe("migrate", () => {
     }
   });
 
-  test("prompt 'y' (and 'yes') proceeds", async () => {
+  test("prompt 'y' proceeds for non-live-db items", async () => {
     const h = makeHarness();
     try {
       seedSafelist(h.configDir);
-      touch(join(h.configDir, "cruft.txt"), "Z");
+      touch(join(h.configDir, "server.yaml"), "Z"); // known cruft, not live-db
       const code = await migrate({
         configDir: h.configDir,
         now: () => APRIL_19,
         log: () => {},
         prompt: async () => "y",
+        isTty: true,
       });
       expect(code).toBe(0);
-      expect(existsSync(join(h.configDir, ".archive-2026-04-19", "cruft.txt"))).toBe(true);
+      expect(existsSync(join(h.configDir, ".archive-2026-04-19", "server.yaml"))).toBe(true);
     } finally {
       h.cleanup();
     }
@@ -328,24 +624,26 @@ describe("migrate", () => {
     const h = makeHarness();
     try {
       seedSafelist(h.configDir);
-      touch(join(h.configDir, "first.txt"), "1");
+      touch(join(h.configDir, "server.yaml"), "1");
       await migrate({
         configDir: h.configDir,
         now: () => APRIL_19,
         log: () => {},
         yes: true,
+        isTty: false,
       });
       // Add more cruft and sweep again the same day
-      touch(join(h.configDir, "second.txt"), "2");
+      touch(join(h.configDir, "channel.log"), "2");
       await migrate({
         configDir: h.configDir,
         now: () => APRIL_19,
         log: () => {},
         yes: true,
+        isTty: false,
       });
       const archive = join(h.configDir, ".archive-2026-04-19");
-      expect(existsSync(join(archive, "first.txt"))).toBe(true);
-      expect(existsSync(join(archive, "second.txt"))).toBe(true);
+      expect(existsSync(join(archive, "server.yaml"))).toBe(true);
+      expect(existsSync(join(archive, "channel.log"))).toBe(true);
       // Only one archive dir at root
       const archiveDirs = readdirSync(h.configDir).filter((n) => n.startsWith(".archive-"));
       expect(archiveDirs).toEqual([".archive-2026-04-19"]);
@@ -358,12 +656,24 @@ describe("migrate", () => {
     const h = makeHarness();
     try {
       seedSafelist(h.configDir);
-      touch(join(h.configDir, "day1.txt"), "1");
-      await migrate({ configDir: h.configDir, now: () => APRIL_19, log: () => {}, yes: true });
-      touch(join(h.configDir, "day2.txt"), "2");
-      await migrate({ configDir: h.configDir, now: () => APRIL_20, log: () => {}, yes: true });
-      expect(existsSync(join(h.configDir, ".archive-2026-04-19", "day1.txt"))).toBe(true);
-      expect(existsSync(join(h.configDir, ".archive-2026-04-20", "day2.txt"))).toBe(true);
+      touch(join(h.configDir, "server.yaml"), "1");
+      await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: () => {},
+        yes: true,
+        isTty: false,
+      });
+      touch(join(h.configDir, "channel.log"), "2");
+      await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_20,
+        log: () => {},
+        yes: true,
+        isTty: false,
+      });
+      expect(existsSync(join(h.configDir, ".archive-2026-04-19", "server.yaml"))).toBe(true);
+      expect(existsSync(join(h.configDir, ".archive-2026-04-20", "channel.log"))).toBe(true);
     } finally {
       h.cleanup();
     }
@@ -373,21 +683,89 @@ describe("migrate", () => {
     const h = makeHarness();
     try {
       seedSafelist(h.configDir);
-      // Pre-existing archive with a same-name entry.
+      // Pre-existing archive with a same-name entry. server.yaml is known cruft.
       mkdirSync(join(h.configDir, ".archive-2026-04-19"), { recursive: true });
-      touch(join(h.configDir, ".archive-2026-04-19", "notes.md"), "old");
-      // New cruft with the same name.
-      touch(join(h.configDir, "notes.md"), "new");
+      touch(join(h.configDir, ".archive-2026-04-19", "server.yaml"), "old");
+      touch(join(h.configDir, "server.yaml"), "new");
       await migrate({
         configDir: h.configDir,
         now: () => APRIL_19,
         log: () => {},
         yes: true,
+        isTty: false,
       });
       const archive = join(h.configDir, ".archive-2026-04-19");
       const contents = readdirSync(archive);
-      expect(contents).toContain("notes.md");
-      expect(contents.some((n) => n.startsWith("notes.md.dup-"))).toBe(true);
+      expect(contents).toContain("server.yaml");
+      expect(contents.some((n) => n.startsWith("server.yaml.dup-"))).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("listRunningServices", () => {
+  test("empty when no pidfiles exist", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      const running = listRunningServices(
+        h.configDir,
+        join(h.configDir, "services.json"),
+        () => false,
+      );
+      expect(running).toEqual([]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("reports hub when its PID is live", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      mkdirSync(join(h.configDir, "hub", "run"), { recursive: true });
+      writePid("hub", 12345, h.configDir);
+      const running = listRunningServices(
+        h.configDir,
+        join(h.configDir, "services.json"),
+        () => true,
+      );
+      expect(running).toContain("hub");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("reports services from services.json when pidfiles are live", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      writeFileSync(
+        join(h.configDir, "services.json"),
+        JSON.stringify({
+          services: [
+            {
+              name: "parachute-vault",
+              version: "0.5.0",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/health",
+              icon: "/icon.svg",
+              auth: { type: "none" },
+              mcp: {},
+            },
+          ],
+        }),
+      );
+      mkdirSync(join(h.configDir, "vault", "run"), { recursive: true });
+      writePid("vault", 23456, h.configDir);
+      const running = listRunningServices(
+        h.configDir,
+        join(h.configDir, "services.json"),
+        () => true,
+      );
+      expect(running).toContain("vault");
     } finally {
       h.cleanup();
     }
@@ -395,26 +773,30 @@ describe("migrate", () => {
 });
 
 describe("migrateNotice", () => {
-  test("undefined when nothing to archive", () => {
+  test("undefined when nothing archivable", () => {
     const h = makeHarness();
     try {
       seedSafelist(h.configDir);
+      // Even with unknowns at the root, no notice — unknowns aren't candidates.
+      touch(join(h.configDir, "operator-owned.md"), "hi");
       expect(migrateNotice(h.configDir, APRIL_19)).toBeUndefined();
     } finally {
       h.cleanup();
     }
   });
 
-  test("returns a single line with the count when cruft exists", () => {
+  test("returns a single line with the count when archivable cruft exists", () => {
     const h = makeHarness();
     try {
       seedSafelist(h.configDir);
       touch(join(h.configDir, "daily.db"), "x");
-      touch(join(h.configDir, "stray"), "y");
+      touch(join(h.configDir, "server.yaml"), "y");
+      // An unknown — must NOT count.
+      touch(join(h.configDir, "stray"), "z");
       const notice = migrateNotice(h.configDir, APRIL_19);
       expect(notice).toBeDefined();
       expect(notice).toMatch(/parachute migrate/);
-      expect(notice).toMatch(/2 unrecognized/);
+      expect(notice).toMatch(/2 archivable/);
     } finally {
       h.cleanup();
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -627,14 +627,17 @@ async function main(argv: string[]): Promise<number> {
         return 0;
       }
       const dryRun = rest.includes("--dry-run");
+      const list = rest.includes("--list");
       const yes = rest.includes("--yes") || rest.includes("-y");
-      const unknown = rest.find((a) => a !== "--dry-run" && a !== "--yes" && a !== "-y");
+      const unknown = rest.find(
+        (a) => a !== "--dry-run" && a !== "--list" && a !== "--yes" && a !== "-y",
+      );
       if (unknown !== undefined) {
         console.error(`parachute migrate: unknown argument "${unknown}"`);
-        console.error("usage: parachute migrate [--dry-run] [--yes]");
+        console.error("usage: parachute migrate [--list] [--dry-run] [--yes]");
         return 1;
       }
-      return await migrate({ dryRun, yes });
+      return await migrate({ dryRun, list, yes });
     }
 
     case "serve": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import pkg from "../package.json" with { type: "json" };
 import { CloudflaredStateError } from "./cloudflare/state.ts";
 import { auth } from "./commands/auth.ts";
 import { exposePublic, exposeTailnet } from "./commands/expose.ts";
+import { init } from "./commands/init.ts";
 import { install } from "./commands/install.ts";
 import { logs, restart, start, stop } from "./commands/lifecycle.ts";
 import { migrate } from "./commands/migrate.ts";
@@ -21,6 +22,7 @@ import { dispatchVault } from "./commands/vault.ts";
 import { ExposeStateError } from "./expose-state.ts";
 import {
   exposeHelp,
+  initHelp,
   installHelp,
   logsHelp,
   migrateHelp,
@@ -303,6 +305,23 @@ async function main(argv: string[]): Promise<number> {
       if (tagExtract.tag) setupOpts.tag = tagExtract.tag;
       if (noStart) setupOpts.noStart = true;
       return await setup(setupOpts);
+    }
+
+    case "init": {
+      if (isHelpFlag(rest[0])) {
+        console.log(initHelp());
+        return 0;
+      }
+      const noBrowser = rest.includes("--no-browser");
+      const unknown = rest.find((a) => a !== "--no-browser");
+      if (unknown !== undefined) {
+        console.error(`parachute init: unknown argument "${unknown}"`);
+        console.error("usage: parachute init [--no-browser]");
+        return 1;
+      }
+      const initOpts: Parameters<typeof init>[0] = {};
+      if (noBrowser) initOpts.noBrowser = true;
+      return await init(initOpts);
     }
 
     case "install": {
@@ -700,7 +719,12 @@ async function main(argv: string[]): Promise<number> {
 
     default:
       console.error(`parachute: unknown command "${command}"`);
-      console.error("run `parachute --help` for usage");
+      console.error("");
+      console.error("If this is a fresh install, start here:");
+      console.error("  parachute init        # get the admin wizard going");
+      console.error("");
+      console.error("Or see all commands:");
+      console.error("  parachute --help");
       return 1;
   }
 }

--- a/src/cloudflare/detect.ts
+++ b/src/cloudflare/detect.ts
@@ -45,14 +45,81 @@ export function isCloudflaredLoggedIn(cloudflaredHome: string = DEFAULT_CLOUDFLA
   return existsSync(join(cloudflaredHome, "cert.pem"));
 }
 
-export function cloudflaredInstallHint(platform: NodeJS.Platform = process.platform): string {
-  const url =
-    "https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/";
+/**
+ * Cloudflare's "Downloads" page (developers.cloudflare.com/cloudflare-one/
+ * connections/connect-networks/downloads/) churns markdown anchors; pkg.cloudflare.com
+ * paths the older instructions referenced now serve HTML / 404. Aaron hit
+ * the failure mode on a fresh Amazon Linux 2023 EC2 install (2026-05-27):
+ * `sudo dnf install cloudflared` returned 'No match for argument:
+ * cloudflared'. The reliable cross-distro path is grabbing the static
+ * binary from Cloudflare's GitHub releases.
+ *
+ * Canonical install paths:
+ *
+ *   macOS  → `brew install cloudflared` (homebrew is the documented path)
+ *   Linux  → architecture-specific binary from GitHub releases
+ *   other  → the binary-download path is still the best generic answer
+ *
+ * The `arch` parameter is the architecture string in `process.arch`
+ * shape (`x64`, `arm64`, `arm`). Mapped to the suffix cloudflared uses
+ * in its release artifacts (`amd64`, `arm64`, `arm`). Unknown arches
+ * fall through to a generic pointer at the releases page.
+ */
+export function cloudflaredInstallHint(
+  platform: NodeJS.Platform = process.platform,
+  arch: NodeJS.Architecture = process.arch,
+): string {
   if (platform === "darwin") {
-    return `Install cloudflared:\n  brew install cloudflared\n(or see ${url})`;
+    return [
+      "Install cloudflared:",
+      "  brew install cloudflared",
+      "",
+      "(or download a static binary from",
+      "  https://github.com/cloudflare/cloudflared/releases/latest)",
+    ].join("\n");
   }
   if (platform === "linux") {
-    return `Install cloudflared: ${url}`;
+    const suffix = linuxArtifactSuffix(arch);
+    if (suffix) {
+      return [
+        "Install cloudflared (static binary — works across distros):",
+        `  curl -L -o /usr/local/bin/cloudflared \\`,
+        `    https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${suffix}`,
+        "  sudo chmod +x /usr/local/bin/cloudflared",
+        "  cloudflared --version",
+        "",
+        "(distro packages are unreliable across versions; the GitHub release is the canonical path.)",
+      ].join("\n");
+    }
+    return [
+      "Install cloudflared from the official binary release:",
+      "  https://github.com/cloudflare/cloudflared/releases/latest",
+      `(pick the linux-* artifact matching your architecture; your arch is "${arch}")`,
+    ].join("\n");
   }
-  return `Install cloudflared: ${url}`;
+  return [
+    "Install cloudflared from the official binary release:",
+    "  https://github.com/cloudflare/cloudflared/releases/latest",
+  ].join("\n");
+}
+
+/**
+ * Map a Node `process.arch` to the suffix Cloudflare uses for its
+ * cloudflared-linux-* release artifacts. Returns undefined for arches
+ * that don't have a published artifact (we surface a generic pointer
+ * in that case instead of fabricating a download URL that 404s).
+ */
+function linuxArtifactSuffix(arch: NodeJS.Architecture): string | undefined {
+  switch (arch) {
+    case "x64":
+      return "amd64";
+    case "arm64":
+      return "arm64";
+    case "arm":
+      return "arm";
+    case "ia32":
+      return "386";
+    default:
+      return undefined;
+  }
 }

--- a/src/commands/expose-cloudflare.ts
+++ b/src/commands/expose-cloudflare.ts
@@ -26,11 +26,19 @@ import {
   findTunnelByName,
   routeDns,
 } from "../cloudflare/tunnel.ts";
-import { SERVICES_MANIFEST_PATH } from "../config.ts";
+import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
+import {
+  type EnsureHubOpts,
+  HUB_DEFAULT_PORT,
+  ensureHubRunning,
+  readHubPort,
+} from "../hub-control.ts";
+import { deriveHubOrigin } from "../hub-origin.ts";
 import { type AliveFn, defaultAlive } from "../process-state.ts";
 import { readManifest } from "../services-manifest.ts";
 import { type Runner, defaultRunner } from "../tailscale/run.ts";
 import type { VaultAuthStatus } from "../vault/auth-status.ts";
+import { WELL_KNOWN_DIR } from "../well-known.ts";
 import { printPublic2FAWarning } from "./expose-2fa-warning.ts";
 
 const AUTH_DOC_URL =
@@ -112,6 +120,37 @@ export interface ExposeCloudflareOpts {
   logPath?: string;
   /** Override `~/.cloudflared` for tests and `$HOME`-free environments. */
   cloudflaredHome?: string;
+  /**
+   * Config root for hub PID / port / log files. Defaults to `~/.parachute`.
+   * Threaded into `ensureHubRunning` so cloudflared's ingress target stays
+   * in sync with where the hub actually bound.
+   */
+  configDir?: string;
+  /**
+   * Override the public hub origin (the `iss` claim baked into the OAuth
+   * issuer). Mirrors the Tailscale path — when set, this URL is what the
+   * hub advertises rather than the cloudflared hostname.
+   */
+  hubOrigin?: string;
+  /**
+   * Overrides for hub lifecycle — primarily for tests. Tests pass
+   * `skipHubLifecycle: true` (above) plus a seeded `hub.port` file so the
+   * cloudflare path can resolve a port without actually spawning a hub.
+   */
+  hubEnsureOpts?: Omit<EnsureHubOpts, "configDir" | "wellKnownDir" | "log">;
+  /**
+   * Directory holding hub.html (passed through to the hub server on first
+   * spawn). Defaults to the same `well-known/` resolution the Tailscale
+   * path uses.
+   */
+  wellKnownDir?: string;
+  /**
+   * Skip spawning the hub server. Tests flip this on and pre-seed
+   * `<configDir>/hub/run/hub.port` so `readHubPort` can resolve the
+   * cloudflared target without a live process. Production always leaves
+   * this off so the bringup self-heals a missing hub.
+   */
+  skipHub?: boolean;
   now?: () => Date;
   /**
    * Override `~/.parachute/vault` for the 2FA-enrollment probe. Tests
@@ -139,6 +178,11 @@ interface Resolved {
   configPath: string;
   logPath: string;
   cloudflaredHome: string;
+  configDir: string;
+  hubOrigin: string | undefined;
+  hubEnsureOpts: Omit<EnsureHubOpts, "configDir" | "wellKnownDir" | "log">;
+  wellKnownDir: string;
+  skipHub: boolean;
   now: () => Date;
   vaultHome: string | undefined;
   vaultAuthStatus: VaultAuthStatus | undefined;
@@ -159,6 +203,11 @@ function resolve(opts: ExposeCloudflareOpts): Resolved {
     configPath: opts.configPath ?? paths.configPath,
     logPath: opts.logPath ?? paths.logPath,
     cloudflaredHome: opts.cloudflaredHome ?? DEFAULT_CLOUDFLARED_HOME,
+    configDir: opts.configDir ?? CONFIG_DIR,
+    hubOrigin: opts.hubOrigin,
+    hubEnsureOpts: opts.hubEnsureOpts ?? {},
+    wellKnownDir: opts.wellKnownDir ?? WELL_KNOWN_DIR,
+    skipHub: opts.skipHub ?? false,
     now: opts.now ?? (() => new Date()),
     vaultHome: opts.vaultHome,
     vaultAuthStatus: opts.vaultAuthStatus,
@@ -239,6 +288,46 @@ export async function exposeCloudflareUp(
     return 1;
   }
 
+  // Resolve the public hub origin before spawning the hub server — it gets
+  // baked into the OAuth `iss` claim via the `--issuer` flag. For Cloudflare
+  // ingress the canonical origin is the user-supplied hostname (mirrors the
+  // Tailscale Funnel path which uses the tailnet FQDN). Falling back to the
+  // request origin would put `http://127.0.0.1:<port>` in tokens, which any
+  // client following RFC 8414 would reject.
+  const canonicalOrigin = `https://${hostname}`;
+  const hubOrigin =
+    deriveHubOrigin({ override: r.hubOrigin, exposeFqdn: hostname }) ?? canonicalOrigin;
+
+  // Ensure the hub is running and figure out the loopback port cloudflared
+  // should target. The hub does all internal routing (discovery, admin,
+  // OAuth, well-known, per-vault proxy, generic /<svc>/* dispatch) — same
+  // shape the Tailscale Funnel path uses (see `planEntries` in expose.ts).
+  // Pre-2026-05-27 the cloudflared config routed straight at vault's port,
+  // so a public URL like https://gitcoin.parachute.computer/ returned 404
+  // from vault itself instead of the hub's discovery page; admin / OAuth
+  // were unreachable. Aaron hit this on a fresh EC2 install.
+  let hubPort: number;
+  if (r.skipHub) {
+    const existing = readHubPort(r.configDir);
+    if (existing === undefined) {
+      throw new Error("skipHub set but no hub.port on disk — tests must seed one");
+    }
+    hubPort = existing;
+  } else {
+    const hub = await ensureHubRunning({
+      reservedPorts: manifest.services.map((s) => s.port),
+      ...r.hubEnsureOpts,
+      configDir: r.configDir,
+      wellKnownDir: r.wellKnownDir,
+      issuer: hubOrigin,
+      log: r.log,
+    });
+    hubPort = hub.port;
+    if (hub.started) r.log(`✓ hub started (pid ${hub.pid}, port ${hub.port}).`);
+    else r.log(`✓ hub already running (pid ${hub.pid}, port ${hub.port}).`);
+  }
+  if (hubPort === 0) hubPort = HUB_DEFAULT_PORT;
+
   let tunnel: Tunnel | undefined;
   try {
     tunnel = await findTunnelByName(r.runner, r.tunnelName);
@@ -282,7 +371,13 @@ export async function exposeCloudflareUp(
       tunnelUuid: tunnel.id,
       credentialsFile: credsFile,
       hostname,
-      servicePort: vaultEntry.port,
+      // Route into the hub, not vault directly. The hub dispatches
+      // discovery / admin / OAuth / per-vault proxy / generic /<svc>/*
+      // — same shape Tailscale Funnel uses (single mount → hub catchall).
+      // Pre-fix this was `vaultEntry.port`, which served vault's own 404
+      // page on every request that wasn't /vault/<name>/… — admin SPA and
+      // OAuth surfaces were unreachable from the public URL.
+      servicePort: hubPort,
     },
     r.configPath,
   );
@@ -329,9 +424,11 @@ export async function exposeCloudflareUp(
 
   r.log("");
   r.log(`✓ Cloudflare tunnel up (pid ${pid}).`);
-  r.log(`  URL:    ${baseUrl}`);
-  r.log(`  Vault:  ${vaultUrl}`);
-  r.log(`  Logs:   ${r.logPath}`);
+  r.log(`  Open:    ${baseUrl}/`);
+  r.log(`  Admin:   ${baseUrl}/admin/`);
+  r.log(`  Vault:   ${vaultUrl}`);
+  r.log(`  OAuth:   ${hubOrigin}`);
+  r.log(`  Logs:    ${r.logPath}`);
   r.log("");
   r.log("Point a claude.ai / ChatGPT connector at:");
   r.log(`  ${vaultUrl}`);

--- a/src/commands/expose-interactive.ts
+++ b/src/commands/expose-interactive.ts
@@ -13,6 +13,7 @@
 import { createInterface } from "node:readline/promises";
 import {
   DEFAULT_CLOUDFLARED_HOME,
+  cloudflaredInstallHint,
   isCloudflaredInstalled,
   isCloudflaredLoggedIn,
 } from "../cloudflare/detect.ts";
@@ -273,19 +274,17 @@ async function guideCloudflareSetup(
         return false;
       }
     } else {
+      // 2026-05-27 refresh: distro-package paths (`apt-get`, `dnf`) are
+      // unreliable across versions — Aaron hit `No match for argument:
+      // cloudflared` on Amazon Linux 2023 — and the
+      // pkg.cloudflare.com / developers.cloudflare.com paths the old hint
+      // pointed at now serve HTML/404. Defer to `cloudflaredInstallHint`,
+      // which writes the canonical GitHub-release static-binary path
+      // matching the host's architecture.
       r.log("");
       r.log("Cloudflare Tunnel uses the `cloudflared` binary, which isn't installed yet.");
-      r.log("Install one way:");
-      r.log("  Debian / Ubuntu:");
-      r.log(
-        "    curl -L https://pkg.cloudflare.com/install.sh | sudo bash && sudo apt-get install -y cloudflared",
-      );
-      r.log("  RHEL / Fedora:");
-      r.log("    sudo dnf install cloudflared");
-      r.log("  Tarball / other:");
-      r.log(
-        "    https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/",
-      );
+      r.log("");
+      for (const line of cloudflaredInstallHint(r.platform).split("\n")) r.log(line);
       r.log("");
       r.log("After install, re-run: parachute expose public");
       return false;

--- a/src/commands/expose-public-auto.ts
+++ b/src/commands/expose-public-auto.ts
@@ -28,7 +28,7 @@
  * tailscale/cloudflared.
  */
 
-import { DEFAULT_CLOUDFLARED_HOME } from "../cloudflare/detect.ts";
+import { DEFAULT_CLOUDFLARED_HOME, cloudflaredInstallHint } from "../cloudflare/detect.ts";
 import {
   type DetectProvidersOpts,
   type ProviderAvailability,
@@ -109,9 +109,11 @@ function reportNeitherReady(r: Resolved, p: ProviderAvailability): number {
   r.log("");
   r.log("  Option B — Cloudflare Tunnel (your own domain, Cloudflare DNS):");
   if (!p.cloudflare.available) {
-    r.log(
-      "    1. Install cloudflared: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/",
-    );
+    // 2026-05-27 refresh: defer to the shared install-hint helper so the
+    // canonical install path stays in one place. Pre-refresh this surface
+    // hard-coded a developers.cloudflare.com URL that now serves HTML/404.
+    r.log("    1. Install cloudflared:");
+    for (const line of cloudflaredInstallHint().split("\n")) r.log(`         ${line}`);
     r.log("    2. Log in:              cloudflared tunnel login");
     r.log("    3. Re-run with --domain: parachute expose public --cloudflare --domain <hostname>");
   } else {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,213 @@
+/**
+ * `parachute init` — fresh-install front door.
+ *
+ * Aaron's framing (2026-05-27): "On render I just install it and then the
+ * wizard walks me through all that including installing vault; I think
+ * that should be similar here. One quick thing to set it up then I can
+ * walk through in CLI (probably parachute init or something) or ideally
+ * I can visit the page and go through the wizard."
+ *
+ * The job: get the user from a fresh install to the admin SPA setup
+ * wizard with one command. The wizard already handles vault install +
+ * scribe install + first-boot bootstrap (`/admin/setup`). `init`'s
+ * responsibility is narrower:
+ *
+ *   1. The hub binary is already on PATH (you can't `parachute init`
+ *      without it). So "is hub installed" is always yes here.
+ *   2. Is the hub *running* on this box? If not, start it.
+ *   3. Print the canonical admin URL — local loopback if we're not
+ *      exposed, the tailnet / cloudflare FQDN if we are.
+ *   4. Offer to open the URL in a browser (macOS: `open`, Linux:
+ *      `xdg-open`). Skip in non-TTY shells.
+ *   5. If a vault is already configured, just confirm "looks good" and
+ *      point at the URL. The wizard surfaces install-state internally —
+ *      no need to duplicate that logic here.
+ *
+ * Idempotent: every re-run is safe. If hub is up and a vault row exists,
+ * we print the URL and exit 0 without touching anything.
+ */
+
+import { spawnSync } from "node:child_process";
+import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
+import { type ExposeState, readExposeState } from "../expose-state.ts";
+import {
+  type EnsureHubOpts,
+  HUB_DEFAULT_PORT,
+  HUB_SVC,
+  ensureHubRunning,
+  readHubPort,
+} from "../hub-control.ts";
+import { type AliveFn, defaultAlive, processState } from "../process-state.ts";
+import { readManifestLenient } from "../services-manifest.ts";
+
+export interface InitOpts {
+  configDir?: string;
+  manifestPath?: string;
+  log?: (line: string) => void;
+  /** Test seam: `processState` liveness check. */
+  alive?: AliveFn;
+  /**
+   * Test seam: `ensureHubRunning` shim. Production uses the real one;
+   * tests pass a stub that records calls without spawning.
+   */
+  ensureHub?: (opts: EnsureHubOpts) => Promise<{ pid: number; port: number; started: boolean }>;
+  /** Test seam: expose-state reader. */
+  readExposeStateFn?: () => ExposeState | undefined;
+  /** Test seam: TTY check (production reads `process.stdin.isTTY`). */
+  isTty?: boolean;
+  /** Test seam: prompt for "open in browser?". */
+  prompt?: (question: string) => Promise<string>;
+  /**
+   * Test seam: browser-open shim. Receives `url`; production shells out
+   * to `open` (darwin) / `xdg-open` (linux). Returns true on success.
+   */
+  openBrowser?: (url: string) => boolean;
+  /** Test seam: `process.platform`. */
+  platform?: NodeJS.Platform;
+  /**
+   * If true, don't even ask about opening the browser. Convenient flag for
+   * CI / scripts that just want the URL printed and exit 0.
+   */
+  noBrowser?: boolean;
+}
+
+/**
+ * Compute the canonical admin URL. Prefers the live expose state (so a
+ * user with an exposed hub sees the public URL, not the loopback) and
+ * falls back to localhost when nothing is exposed.
+ *
+ * Returns `undefined` only when the hub port can't be determined and no
+ * exposure is active — caller treats that as "hub didn't start" and
+ * surfaces an actionable error.
+ */
+export function resolveAdminUrl(
+  exposeState: ExposeState | undefined,
+  hubPort: number | undefined,
+): string | undefined {
+  if (exposeState && exposeState.canonicalFqdn) {
+    return `https://${exposeState.canonicalFqdn}/admin/`;
+  }
+  if (hubPort !== undefined) {
+    return `http://127.0.0.1:${hubPort}/admin/`;
+  }
+  return undefined;
+}
+
+/**
+ * Default browser-opener. Tries `open` on macOS, `xdg-open` on Linux, and
+ * returns false when neither is available (Windows / WSL fallthrough +
+ * misc Unixes ship `xdg-open` so coverage is decent without bringing in
+ * a dependency).
+ */
+function defaultOpenBrowser(url: string, platform: NodeJS.Platform): boolean {
+  const cmd = platform === "darwin" ? "open" : platform === "linux" ? "xdg-open" : undefined;
+  if (!cmd) return false;
+  // spawnSync's `stdio: "ignore"` keeps the launcher quiet; we'll log the
+  // outcome ourselves.
+  const result = spawnSync(cmd, [url], { stdio: "ignore" });
+  return result.status === 0;
+}
+
+async function defaultPrompt(question: string): Promise<string> {
+  const { createInterface } = await import("node:readline/promises");
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return await rl.question(question);
+  } finally {
+    rl.close();
+  }
+}
+
+export async function init(opts: InitOpts = {}): Promise<number> {
+  const configDir = opts.configDir ?? CONFIG_DIR;
+  const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const log = opts.log ?? ((line) => console.log(line));
+  const alive = opts.alive ?? defaultAlive;
+  const ensureHub = opts.ensureHub ?? ensureHubRunning;
+  const readExposeStateFn = opts.readExposeStateFn ?? (() => readExposeState());
+  const isTty = opts.isTty ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  const prompt = opts.prompt ?? defaultPrompt;
+  const platform = opts.platform ?? process.platform;
+  const openBrowser = opts.openBrowser ?? ((url: string) => defaultOpenBrowser(url, platform));
+
+  log("Parachute init — getting your hub set up.");
+  log("");
+
+  // Step 1: hub running?
+  const hubState = processState(HUB_SVC, configDir, alive);
+  let hubPort: number | undefined;
+  if (hubState.status === "running") {
+    hubPort = readHubPort(configDir);
+    log(`✓ Hub already running (pid ${hubState.pid}${hubPort ? `, port ${hubPort}` : ""}).`);
+  } else {
+    log("Hub not running — starting it now…");
+    try {
+      const result = await ensureHub({ configDir, log: () => {} });
+      hubPort = result.port;
+      log(`✓ Hub started (pid ${result.pid}, port ${result.port}).`);
+    } catch (err) {
+      log(`✗ Hub failed to start: ${err instanceof Error ? err.message : String(err)}`);
+      log("");
+      log("Try checking the logs:");
+      log("  parachute logs hub");
+      return 1;
+    }
+  }
+
+  // Fall back to the default canonical port if `readHubPort` returned
+  // undefined (which can happen if the hub was started by some prior tool
+  // that didn't write a port file). The hub binds 1939 unless explicitly
+  // overridden, so the fallback is almost always correct.
+  if (hubPort === undefined) hubPort = HUB_DEFAULT_PORT;
+
+  // Step 2: vault configured?
+  let hasVault = false;
+  try {
+    const manifest = readManifestLenient(manifestPath);
+    hasVault = manifest.services.some((s) => s.name.startsWith("parachute-vault"));
+  } catch {
+    // Lenient reader doesn't throw on most shapes, but be defensive — a
+    // malformed services.json shouldn't crash init. The wizard handles it.
+    hasVault = false;
+  }
+
+  // Step 3: resolve the admin URL.
+  const exposeState = readExposeStateFn();
+  const adminUrl = resolveAdminUrl(exposeState, hubPort);
+  if (!adminUrl) {
+    log("");
+    log("✗ Couldn't resolve an admin URL (no hub port, no exposure state).");
+    log("  This shouldn't happen if hub started successfully — file an issue.");
+    return 1;
+  }
+
+  log("");
+  if (hasVault) {
+    log("Looks good — your hub is up and a vault is configured.");
+  } else {
+    log("Next: finish setup in the admin wizard (installs vault, configures admin user).");
+  }
+  log("");
+  log(`  ${adminUrl}`);
+  log("");
+
+  // Step 4: offer to open the browser. Skip in non-TTY shells (CI),
+  // honor `--no-browser`.
+  if (opts.noBrowser) return 0;
+  if (!isTty) {
+    log("(Open the URL above in a browser to continue.)");
+    return 0;
+  }
+  if (platform !== "darwin" && platform !== "linux") {
+    log("(Open the URL above in your browser to continue.)");
+    return 0;
+  }
+  const answer = (await prompt("Open in your browser now? [Y/n] ")).trim().toLowerCase();
+  if (answer === "n" || answer === "no") return 0;
+  const ok = openBrowser(adminUrl);
+  if (!ok) {
+    log("");
+    log("(Couldn't launch a browser — open the URL above manually.)");
+  }
+  return 0;
+}

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,50 +1,108 @@
 import { existsSync, mkdirSync, readdirSync, renameSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { createInterface } from "node:readline/promises";
-import { CONFIG_DIR } from "../config.ts";
-import { knownServices } from "../service-spec.ts";
+import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
+import { HUB_SVC } from "../hub-control.ts";
+import { type AliveFn, defaultAlive, processState } from "../process-state.ts";
+import { knownServices, shortNameForManifest } from "../service-spec.ts";
+import { readManifestLenient } from "../services-manifest.ts";
 
 /**
- * `parachute migrate` — sweep unrecognized entries at the ecosystem root
+ * `parachute migrate` — sweep known-cruft entries at the ecosystem root
  * (`~/.parachute/`) into a dated archive directory so pre-restructure cruft
  * doesn't confuse beta installs.
  *
+ * Allowlist-of-what-to-archive (the original 2026-05-27 redesign closed
+ * the prior blocklist-with-safelist shape, hub#440). The risk with the
+ * older shape: anything new appearing at the ecosystem root (a future
+ * module's dir, `hub.db`, a user's own dotfile, etc.) would get swept by
+ * default unless someone remembered to add it to the safelist. Aaron
+ * caught a near-miss where `hub.db` was missing from the safelist; that
+ * was the trigger for flipping the model.
+ *
+ * The new model:
+ *
+ *   - `KNOWN_CRUFT` is the *actual archive criterion* — only entries that
+ *     match a rule there get archived.
+ *   - `KNOWN_ARCHIVABLE_DIRS` covers directories we explicitly sweep (the
+ *     `lens` legacy dir from the Notes→Lens→Notes rename round-trip).
+ *   - Everything else — including new modules' dirs, future state files,
+ *     and the user's own stray files — gets a `[unknown — skipping]`
+ *     annotation and is left in place. The user can remove unknowns
+ *     manually if they want.
+ *
  * Archive, never delete: moved under `.archive-<YYYY-MM-DD>/` so anything
- * swept is recoverable. Dotfiles and the recognized top-level entries
- * (service dirs, services.json, expose-state.json, well-known/) are left
- * alone. Content *inside* service dirs is owned by that service's own
- * migration.
+ * swept is recoverable. Dotfiles at root are still left alone (the user's
+ * own `.env`, `.DS_Store`, prior `.archive-*` dirs).
+ *
+ * Cut-2 safety procedures (also 2026-05-27):
+ *
+ *   - Refuses to sweep while any service in `services.json` (plus the hub)
+ *     is currently running — moving a path a daemon owns would corrupt
+ *     state.
+ *   - SQLite-shaped files (`*.db`, `*.db-wal`, `*.db-shm`) get a `[live-db]`
+ *     risk label and trigger an extra confirmation noting wal/shm
+ *     consistency.
+ *   - The printed plan annotates each item `[safe]` / `[live-db]` /
+ *     `[unknown — skipping]`, sorts skipped items last.
+ *   - Non-TTY invocations refuse without `--yes` so a pipe from CI can't
+ *     accidentally archive a real install.
+ *   - `--list` shows what would happen without prompting (friendlier
+ *     phrasing of `--dry-run`).
  */
 
 export const ARCHIVE_PREFIX = ".archive-";
 
 /**
- * Top-level names we keep in place. Service dirs derive from
- * `knownServices()` so adding a service doesn't require touching migrate;
- * `hub` is added explicitly since it's an internal-only lifecycle dir not
- * in SERVICE_SPECS.
+ * Top-level names we leave in place. Service dirs derive from
+ * `knownServices()`; `hub` is added explicitly since it's an internal-only
+ * lifecycle dir not in SERVICE_SPECS. Stays in step with the rest of the
+ * hub's view of what belongs at the root, so `migrateNotice` and
+ * `parachute install`'s post-install hint don't false-positive on the
+ * latest legitimate root entries.
  *
- * `lens` is kept across the Notes→Lens→Notes rename round-trip
- * (Apr 19 → Apr 22): users who installed during the brief Lens window
- * have `~/.parachute/lens/` dirs that shouldn't get swept into
- * `.archive-*` on upgrade. Safe to remove once launch users have all
- * had a chance to re-install under the restored name.
+ * Note: under the allowlist model the safelist is now informational —
+ * archiving only ever happens for entries that match an explicit rule
+ * (`KNOWN_CRUFT` / `KNOWN_ARCHIVABLE_DIRS`). The safelist is still
+ * retained so `migrateNotice`'s count of "things at the root that aren't
+ * recognized" stays meaningful, and so safelisted entries don't show up
+ * as `[unknown — skipping]` noise in the plan.
  */
 export function safelistEntries(): Set<string> {
   return new Set<string>([
     ...knownServices(),
-    "lens",
     "hub",
     "services.json",
     "expose-state.json",
+    "cloudflared-state.json",
+    "hub.db",
+    "hub.db-wal",
+    "hub.db-shm",
     "well-known",
+    "cloudflared",
   ]);
 }
 
 /**
- * Friendly labels for entries we've seen in the wild. Matched by exact name
- * or (for sqlite companion files) by prefix. Purely cosmetic — drives the
- * annotation column in the plan printout.
+ * Allowlist of known-archivable directories. Distinct from `KNOWN_CRUFT`
+ * (which matches by name/prefix predicate) — directories listed here are
+ * always treated as `safe` to archive.
+ *
+ * `lens` is the only entry: a legacy directory left over from the brief
+ * Notes→Lens→Notes rename round-trip (2026-04-19 → 2026-04-22). Users who
+ * installed during that window have `~/.parachute/lens/` dirs that should
+ * be archived now that the rename is finished. Safe to drop from this
+ * list once enough operator cycles have passed to be confident no
+ * install is still on the Lens-era code path.
+ */
+export const KNOWN_ARCHIVABLE_DIRS: ReadonlySet<string> = new Set<string>(["lens"]);
+
+/**
+ * Known-cruft rules. Each rule names a label (the friendly description in
+ * the plan) and a predicate that matches by name or prefix. Under the
+ * 2026-05-27 redesign this is the *primary* archive criterion: an entry
+ * at the ecosystem root that doesn't match here (or `KNOWN_ARCHIVABLE_DIRS`)
+ * is treated as unknown and left in place.
  */
 const KNOWN_CRUFT: Array<{ match: (name: string) => boolean; label: string }> = [
   {
@@ -61,24 +119,49 @@ const KNOWN_CRUFT: Array<{ match: (name: string) => boolean; label: string }> = 
   },
 ];
 
-function annotationFor(name: string): string | undefined {
+function cruftLabel(name: string): string | undefined {
   for (const rule of KNOWN_CRUFT) if (rule.match(name)) return rule.label;
   return undefined;
 }
 
-export interface ArchiveItem {
+/**
+ * SQLite shape — `.db` plus its WAL/SHM companions. Files with this shape
+ * carry the `live-db` risk label and pull a second confirmation in the
+ * interactive path because the three files are only consistent as a set.
+ */
+function isSqliteShape(name: string): boolean {
+  return /\.db(?:-wal|-shm)?$/.test(name);
+}
+
+export type RiskLabel = "safe" | "live-db" | "unknown";
+
+export interface PlanItem {
   name: string;
   absPath: string;
   kind: "file" | "dir";
   bytes: number;
+  /** Friendly description (e.g. "legacy parachute-daily state"). */
   annotation?: string;
+  risk: RiskLabel;
+  /** True iff this item will actually be moved into the archive. */
+  archive: boolean;
 }
+
+/**
+ * Kept as an alias for back-compat with callers / older tests that import
+ * `ArchiveItem`. Same shape as `PlanItem`.
+ */
+export type ArchiveItem = PlanItem;
 
 export interface ArchivePlan {
   archiveDirName: string;
   archiveDir: string;
-  items: ArchiveItem[];
+  /** Every entry encountered at the root (archivable + skipped). */
+  items: PlanItem[];
+  /** Total bytes across `archive: true` items only. */
   totalBytes: number;
+  /** True iff at least one `archive: true` item is a SQLite-shape file. */
+  hasLiveDb: boolean;
 }
 
 function sizeOf(path: string): number {
@@ -96,11 +179,35 @@ function archiveDirName(now: Date): string {
 }
 
 /**
+ * Classify a single root entry against the allowlist + known-cruft rules.
+ * `safelist` is the recognized-and-leave-alone set; nothing on it ever
+ * reaches the plan at all (filtered out upstream).
+ */
+function classify(name: string): { risk: RiskLabel; annotation?: string; archive: boolean } {
+  const cruft = cruftLabel(name);
+  if (cruft) {
+    const risk: RiskLabel = isSqliteShape(name) ? "live-db" : "safe";
+    return { risk, annotation: cruft, archive: true };
+  }
+  if (KNOWN_ARCHIVABLE_DIRS.has(name)) {
+    return { risk: "safe", annotation: "legacy directory", archive: true };
+  }
+  return { risk: "unknown", archive: false };
+}
+
+/**
  * Inspect the ecosystem root and build a plan. Pure-ish: reads filesystem
- * but never mutates. Returns zero-length items when nothing is archivable.
+ * but never mutates. Returns zero-length items when nothing is at the root
+ * beyond the safelist.
  *
  * Rule: skip anything starting with "." (dotfiles are the user's — `.env`,
  * `.DS_Store`, prior `.archive-*` dirs, etc.) and anything in the safelist.
+ * Everything else goes into the plan with a classification; only items
+ * with `archive: true` are actually swept.
+ *
+ * Sort order: archivable items first (alphabetical), then skipped items
+ * last — keeps the "what will happen" reading at the top of the plan
+ * printout.
  */
 export function planArchive(configDir: string, now: Date): ArchivePlan {
   const dirName = archiveDirName(now);
@@ -110,6 +217,7 @@ export function planArchive(configDir: string, now: Date): ArchivePlan {
     archiveDir,
     items: [],
     totalBytes: 0,
+    hasLiveDb: false,
   };
   if (!existsSync(configDir)) return plan;
 
@@ -117,35 +225,50 @@ export function planArchive(configDir: string, now: Date): ArchivePlan {
   const entries = readdirSync(configDir, { withFileTypes: true }).sort((a, b) =>
     a.name.localeCompare(b.name),
   );
+  const collected: PlanItem[] = [];
   for (const entry of entries) {
     if (entry.name.startsWith(".")) continue;
     if (safelist.has(entry.name)) continue;
     const abs = join(configDir, entry.name);
+    const cls = classify(entry.name);
     // Dirent.isDirectory() follows symlinks on macOS/Linux — so a link
     // pointing at an external tree would get sized via sizeOf() (bogus
     // byte count, and potentially a slow walk through /mnt/... or similar).
     // Classify the link itself as a zero-byte "file"; renameSync moves the
     // link, not the target, which is the behavior we want.
     if (entry.isSymbolicLink()) {
-      plan.items.push({
+      const item: PlanItem = {
         name: entry.name,
         absPath: abs,
         kind: "file",
         bytes: 0,
-        annotation: annotationFor(entry.name),
-      });
+        risk: cls.risk,
+        archive: cls.archive,
+      };
+      if (cls.annotation !== undefined) item.annotation = cls.annotation;
+      collected.push(item);
       continue;
     }
-    const bytes = sizeOf(abs);
-    plan.items.push({
+    const bytes = cls.archive ? sizeOf(abs) : 0;
+    const item: PlanItem = {
       name: entry.name,
       absPath: abs,
       kind: entry.isDirectory() ? "dir" : "file",
       bytes,
-      annotation: annotationFor(entry.name),
-    });
-    plan.totalBytes += bytes;
+      risk: cls.risk,
+      archive: cls.archive,
+    };
+    if (cls.annotation !== undefined) item.annotation = cls.annotation;
+    collected.push(item);
+    if (cls.archive) plan.totalBytes += bytes;
   }
+  // Sort: archivable first (alpha), then skipped (alpha). Stable across runs.
+  collected.sort((a, b) => {
+    if (a.archive !== b.archive) return a.archive ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+  plan.items = collected;
+  plan.hasLiveDb = collected.some((i) => i.archive && i.risk === "live-db");
   return plan;
 }
 
@@ -161,15 +284,35 @@ function formatBytes(bytes: number): string {
   return `${v.toFixed(1)} ${units[i]}`;
 }
 
+function riskTag(item: PlanItem): string {
+  if (!item.archive) return "[unknown — skipping]";
+  if (item.risk === "live-db") return "[live-db]";
+  return "[safe]";
+}
+
 function formatPlan(plan: ArchivePlan): string[] {
   const lines: string[] = [];
+  const archivable = plan.items.filter((i) => i.archive);
+  const skipped = plan.items.filter((i) => !i.archive);
   lines.push(
-    `Will archive: ${plan.items.length} item${plan.items.length === 1 ? "" : "s"} (${formatBytes(plan.totalBytes)}) → ${plan.archiveDirName}/`,
+    `Will archive: ${archivable.length} item${archivable.length === 1 ? "" : "s"} (${formatBytes(plan.totalBytes)}) → ${plan.archiveDirName}/`,
   );
-  for (const item of plan.items) {
+  for (const item of archivable) {
     const kindMark = item.kind === "dir" ? "/" : "";
     const note = item.annotation ? `  — ${item.annotation}` : "";
-    lines.push(`  ${item.name}${kindMark}  (${formatBytes(item.bytes)})${note}`);
+    lines.push(`  ${riskTag(item)} ${item.name}${kindMark}  (${formatBytes(item.bytes)})${note}`);
+  }
+  if (skipped.length > 0) {
+    lines.push("");
+    lines.push(
+      `Leaving alone: ${skipped.length} unknown entr${skipped.length === 1 ? "y" : "ies"} at the root.`,
+    );
+    lines.push("  (I don't recognize these — they may be from a module hub doesn't know about,");
+    lines.push("   or from your own setup. If they're safe to remove, you can do it manually.)");
+    for (const item of skipped) {
+      const kindMark = item.kind === "dir" ? "/" : "";
+      lines.push(`  ${riskTag(item)} ${item.name}${kindMark}`);
+    }
   }
   return lines;
 }
@@ -192,24 +335,91 @@ export async function defaultPrompt(question: string): Promise<string> {
   return answer;
 }
 
+/**
+ * Probe whether any managed service (or the hub) is currently running.
+ * Returns the list of short names that are live; an empty list means the
+ * sweep is safe to proceed.
+ *
+ * Reads services.json leniently so a malformed entry doesn't block the
+ * pre-flight (better to surface "running: vault" + a corrupt-entry warning
+ * elsewhere than to refuse migration on an unrelated parsing problem).
+ */
+export function listRunningServices(
+  configDir: string,
+  manifestPath: string,
+  alive: AliveFn,
+): string[] {
+  const running: string[] = [];
+  const hubState = processState(HUB_SVC, configDir, alive);
+  if (hubState.status === "running") running.push(HUB_SVC);
+  let manifest: ReturnType<typeof readManifestLenient>;
+  try {
+    manifest = readManifestLenient(manifestPath);
+  } catch {
+    return running;
+  }
+  for (const entry of manifest.services) {
+    const short = shortNameForManifest(entry.name) ?? entry.name;
+    if (running.includes(short)) continue;
+    const state = processState(short, configDir, alive);
+    if (state.status === "running") running.push(short);
+  }
+  return running;
+}
+
 export interface MigrateOpts {
   configDir?: string;
+  manifestPath?: string;
   now?: () => Date;
   log?: (line: string) => void;
   prompt?: (question: string) => Promise<string>;
   dryRun?: boolean;
   yes?: boolean;
+  /** `--list` — synonym for `--dry-run` with a more discoverable flag name. */
+  list?: boolean;
+  /** Test seam: process-liveness check used by `listRunningServices`. */
+  alive?: AliveFn;
+  /**
+   * Test seam: override the TTY check. Production reads
+   * `process.stdin.isTTY`; tests pass `true`/`false` to drive the
+   * non-interactive guard without manipulating real fds.
+   */
+  isTty?: boolean;
 }
 
 export async function migrate(opts: MigrateOpts = {}): Promise<number> {
   const configDir = opts.configDir ?? CONFIG_DIR;
+  const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
   const now = (opts.now ?? (() => new Date()))();
   const log = opts.log ?? ((line) => console.log(line));
   const prompt = opts.prompt ?? defaultPrompt;
-  const dryRun = opts.dryRun ?? false;
+  const dryRun = (opts.dryRun ?? false) || (opts.list ?? false);
   const yes = opts.yes ?? false;
+  const alive = opts.alive ?? defaultAlive;
+  const isTty = opts.isTty ?? Boolean(process.stdin.isTTY);
+
+  // Refuse-while-running: archiving a path a live daemon owns can corrupt
+  // its state. Print the runners and bail before we read the directory.
+  // `--list` and `--dry-run` are read-only and skip this guard; the
+  // operator may explicitly want to see what would move while things are
+  // up.
+  if (!dryRun) {
+    const running = listRunningServices(configDir, manifestPath, alive);
+    if (running.length > 0) {
+      log("parachute migrate: services are currently running — refusing to sweep:");
+      for (const short of running) log(`  - ${short}`);
+      log("");
+      log("Stop them first, then re-run:");
+      log("  parachute stop");
+      log("");
+      log("Or preview the plan without changing anything:");
+      log("  parachute migrate --list");
+      return 1;
+    }
+  }
 
   const plan = planArchive(configDir, now);
+  const archivable = plan.items.filter((i) => i.archive);
   if (plan.items.length === 0) {
     log(`Nothing to archive. ${configDir} is already clean.`);
     return 0;
@@ -217,9 +427,28 @@ export async function migrate(opts: MigrateOpts = {}): Promise<number> {
 
   for (const line of formatPlan(plan)) log(line);
 
-  if (dryRun) {
-    log("(dry-run — no changes made)");
+  if (archivable.length === 0) {
+    // Only unknowns at the root; nothing to do.
+    log("");
+    log("Nothing recognized to archive.");
     return 0;
+  }
+
+  if (dryRun) {
+    log("");
+    log(opts.list ? "(--list — no changes made)" : "(dry-run — no changes made)");
+    return 0;
+  }
+
+  // Non-TTY without `--yes` is a hard refuse. A pipe from CI or a launchd
+  // wrapper that lost its terminal shouldn't be able to silently archive
+  // user state — prefer an actionable error.
+  if (!isTty && !yes) {
+    log("");
+    log("parachute migrate: refusing to sweep without a TTY.");
+    log("Run interactively, or pass `--yes` if you're certain. To preview:");
+    log("  parachute migrate --list");
+    return 1;
   }
 
   if (!yes) {
@@ -228,15 +457,33 @@ export async function migrate(opts: MigrateOpts = {}): Promise<number> {
       log("Aborted.");
       return 1;
     }
+    // Extra confirmation when a SQLite-shape file is in the plan. The
+    // wal/shm companions are only consistent with their .db when the
+    // owning process is stopped (we already refused-while-running above,
+    // so they are), but operators sometimes have ad-hoc backup tooling
+    // that watches these — extra y/N is a cheap insurance against
+    // surprise.
+    if (plan.hasLiveDb) {
+      log("");
+      log("⚠ The plan includes SQLite-shape files (`*.db`, `*.db-wal`, `*.db-shm`).");
+      log("  These three are only consistent as a set — the archive moves them together,");
+      log("  but if anything outside Parachute is reading them (backup tooling, etc.),");
+      log("  that consumer will see a missing file after the sweep.");
+      const dbAnswer = (await prompt("Archive the live-db files too? [y/N] ")).trim().toLowerCase();
+      if (dbAnswer !== "y" && dbAnswer !== "yes") {
+        log("Aborted.");
+        return 1;
+      }
+    }
   }
 
   mkdirSync(plan.archiveDir, { recursive: true });
-  for (const item of plan.items) {
+  for (const item of archivable) {
     const dest = resolveDest(plan.archiveDir, item.name, now);
     renameSync(item.absPath, dest);
   }
   log(
-    `✓ Archived ${plan.items.length} item${plan.items.length === 1 ? "" : "s"} to ${plan.archiveDirName}/`,
+    `✓ Archived ${archivable.length} item${archivable.length === 1 ? "" : "s"} to ${plan.archiveDirName}/`,
   );
   return 0;
 }
@@ -245,9 +492,14 @@ export async function migrate(opts: MigrateOpts = {}): Promise<number> {
  * One-line notice for contexts where migrate is *not* what the user
  * asked for (e.g., after `parachute install`). Returns undefined when
  * there's nothing archivable so callers can branch on truthy/falsy.
+ *
+ * Counts only `archive: true` items — unknowns at the root don't trip
+ * the notice (they're not actually candidates for sweeping; the user
+ * sees them only when they explicitly run `parachute migrate`).
  */
 export function migrateNotice(configDir: string, now: Date): string | undefined {
   const plan = planArchive(configDir, now);
-  if (plan.items.length === 0) return undefined;
-  return `parachute migrate: ${plan.items.length} unrecognized entr${plan.items.length === 1 ? "y" : "ies"} at ecosystem root — run 'parachute migrate' to archive.`;
+  const archivable = plan.items.filter((i) => i.archive);
+  if (archivable.length === 0) return undefined;
+  return `parachute migrate: ${archivable.length} archivable entr${archivable.length === 1 ? "y" : "ies"} at ecosystem root — run 'parachute migrate' to archive.`;
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -466,29 +466,44 @@ Examples:
 }
 
 export function migrateHelp(): string {
-  return `parachute migrate — archive legacy files at the ecosystem root
+  return `parachute migrate — archive known-legacy files at the ecosystem root
 
 Usage:
-  parachute migrate [--dry-run] [--yes]
+  parachute migrate [--list] [--dry-run] [--yes]
 
 What it does:
-  Scans ~/.parachute/ for files and directories that don't belong to the
-  post-restructure layout. Recognized entries — per-service dirs
-  (vault/, notes/, scribe/, channel/, hub/; legacy lens/ also kept),
-  services.json,
-  expose-state.json, well-known/ — stay in place. Anything else (plus
-  known legacy cruft like daily.db, server.yaml) is moved under
-  ~/.parachute/.archive-<YYYY-MM-DD>/, never deleted.
+  Scans ~/.parachute/ for files and directories that match the
+  known-legacy allowlist (daily.db*, server.yaml, channel.log/err,
+  channel.start.sh, top-level logs/, tokens.db*, and the legacy lens/
+  directory). Matching entries are moved under
+  ~/.parachute/.archive-<YYYY-MM-DD>/ — never deleted.
 
-  Dotfiles at the root (.env, .DS_Store, prior .archive-* dirs) are left
-  alone.
+  Anything *not* on the allowlist is left in place with an "[unknown —
+  skipping]" note. The hub doesn't presume to know what every module
+  (or your own setup) puts at the root, so the default is conservative:
+  if it isn't a known-legacy pattern, migrate leaves it alone. Remove
+  unknowns manually if you're sure.
+
+  Dotfiles at the root (.env, .DS_Store, prior .archive-* dirs) are
+  never touched.
+
+Safety:
+  - Refuses to sweep while any service is running — stop them first
+    (\`parachute stop\`) or preview with \`--list\`.
+  - SQLite-shape files (\`*.db\`, \`*.db-wal\`, \`*.db-shm\`) get a
+    \`[live-db]\` label and pull an extra confirmation; wal/shm
+    consistency depends on all three moving together.
+  - Plan annotates each entry: \`[safe]\` / \`[live-db]\` /
+    \`[unknown — skipping]\`, with skipped items printed last.
+  - In a non-TTY shell (CI / piped), refuses without \`--yes\`.
 
 Flags:
-  --dry-run     print the plan; make no changes
-  --yes, -y     skip the confirmation prompt
+  --list        print the plan; make no changes (friendly preview)
+  --dry-run     synonym for --list (kept for back-compat)
+  --yes, -y     skip the confirmation prompt; required in non-TTY shells
 
 Examples:
-  parachute migrate --dry-run       see what would move, without touching anything
+  parachute migrate --list          see what would move, without touching anything
   parachute migrate                 interactive sweep (prompts before acting)
   parachute migrate --yes           sweep without prompting
 `;

--- a/src/help.ts
+++ b/src/help.ts
@@ -5,7 +5,11 @@ export function topLevelHelp(): string {
   const services = knownServices().join(" | ");
   return `parachute ${pkg.version} — top-level CLI for the Parachute ecosystem
 
+Fresh install? Start here:
+  parachute init                    one quick step → admin wizard in your browser
+
 Usage:
+  parachute init                    bring hub up + open admin wizard (idempotent)
   parachute setup                   interactive walk-through: install services + configure
   parachute install <service>       install and register a service
                                     services: ${services}
@@ -97,6 +101,38 @@ Aliases:
   lens → notes                      # accepted for one release cycle after
                                     # the brief Lens rebrand was reverted on
                                     # 2026-04-22; prints a rename notice.
+`;
+}
+
+export function initHelp(): string {
+  return `parachute init — get the admin wizard open in one step
+
+Usage:
+  parachute init [--no-browser]
+
+What it does:
+  Fresh-install front door. The admin SPA already walks operators through
+  the rest (install vault, set up the admin user, install scribe / runner
+  / app); this command's only job is to get you to that wizard with one
+  command.
+
+  Idempotent — every re-run is safe:
+    1. If the hub isn't running, start it.
+    2. Print the canonical admin URL (loopback when not exposed, the
+       tailnet / cloudflare FQDN when exposure is active).
+    3. In a terminal, offer to open the URL in your browser
+       (macOS \`open\`, Linux \`xdg-open\`). Skip with --no-browser or
+       run from a non-TTY shell.
+
+  If your hub is up and a vault is already configured, init just
+  confirms "looks good — here's your URL" and exits 0.
+
+Flags:
+  --no-browser     just print the URL; don't offer to launch a browser
+
+Examples:
+  parachute init                    bring up hub + open the wizard
+  parachute init --no-browser       same, but don't shell out to open / xdg-open
 `;
 }
 


### PR DESCRIPTION
## Summary

Five-cut fresh-install UX bundle, all triggered by Aaron's fresh EC2 walkthrough on 2026-05-27:

- **Cut 1 — `parachute migrate` allowlist redesign.** Flipped from blocklist-with-safelist to an explicit allowlist of known-archivable patterns (closes the hub#440 stopgap; Aaron caught a near-miss where `hub.db` was missing from the safelist). Unknown entries get `[unknown — skipping]` and are left in place. The `lens` legacy dir moves into `KNOWN_ARCHIVABLE_DIRS`. *Files: `src/commands/migrate.ts`, `src/__tests__/migrate.test.ts`, `src/help.ts`.*
- **Cut 2 — `parachute migrate` safety procedures.** Refuses to sweep while services are running; `[live-db]` risk label + extra confirmation for SQLite-shape files; risk-tag annotations in the printed plan (`[safe]` / `[live-db]` / `[unknown — skipping]`); non-TTY refuses without `--yes`; `--list` flag as a friendlier name for `--dry-run`. *Same files as Cut 1.*
- **Cut 3 — `parachute expose public --cloudflare` routes through hub, not vault.** Aaron pointed `gitcoin.parachute.computer` at his box and hit vault's 404 page because cloudflared was wired straight to vault's port. Now mirrors the Tailscale Funnel shape: single ingress → hub catchall, hub dispatches per request (admin / OAuth / well-known / per-vault / generic /<svc>/*). *Files: `src/commands/expose-cloudflare.ts`, `src/__tests__/expose-cloudflare.test.ts`.*
- **Cut 4 — `parachute init` wizard.** One command brings the hub up (if needed) and gets the operator to the admin SPA setup wizard in their browser. Idempotent — re-running on a healthy install just confirms "looks good" and prints the URL. Surfaced at the top of `parachute --help` and in the unrecognized-command error so a fresh-install operator's first guess (`parachute setup`, `parachute help`, anything) lands them on the right next step. *Files: `src/commands/init.ts` (new), `src/__tests__/init.test.ts` (new), `src/cli.ts`, `src/help.ts`.*
- **Cut 5 — Cloudflared install-URL refresh.** `sudo dnf install cloudflared` returned "No match for argument" on AL2023; `pkg.cloudflare.com` and `developers.cloudflare.com/.../downloads/` URLs returned HTML/404. Switched to the canonical GitHub-releases static-binary path, architecture-detected via `process.arch`. Centralized in `cloudflaredInstallHint`; `expose-interactive` + `expose-public-auto` both delegate now. Hard-asserted the stale URLs don't recur. *Files: `src/cloudflare/detect.ts`, `src/commands/expose-interactive.ts`, `src/commands/expose-public-auto.ts`, plus test updates.*

## Why now

Aaron just hit all five of these in one session on a fresh EC2 install. The migrate redesign supersedes the hub#440 stopgap. The cloudflared routing bug was a P1 (public URL → vault's 404 page; admin / OAuth invisible from the public surface). The init command is the missing on-ramp that the Render deploy shape has but the on-box shape didn't.

## Test plan

- [ ] `bun test ./src` — hub-only tests pass (current: 2217 pass, 1 skip, 0 fail across 95 files)
- [ ] `bun run typecheck` — clean
- [ ] On a real install: `parachute migrate --list` shows the new annotated plan; an unknown root entry stays put
- [ ] Refuse-while-running guard: start vault, run `parachute migrate`, verify it bails listing `vault`
- [ ] `*.db` confirmation: seed a stray `daily.db`, run interactive `parachute migrate`, verify the second y/N prompt
- [ ] `parachute init` on a clean box: hub starts, browser opens at `http://127.0.0.1:1939/admin/`
- [ ] `parachute init` after `parachute expose tailnet`: URL is the tailnet FQDN, not loopback
- [ ] `parachute expose public --cloudflare --domain <hostname>`: yaml lists `service: http://localhost:1939`; `https://<hostname>/admin/` shows the admin SPA
- [ ] On a fresh AL2023 box with no cloudflared: `parachute expose public --cloudflare` prints the new GitHub-release curl line, not the broken dnf hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)