### PR TITLE
chore(release): 0.5.14-rc.5 — fresh-install UX bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.4",
+  "version": "0.5.14-rc.5",
   "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Version bump only. Picks up #441 (fresh-install UX bundle):
- Migrate allowlist redesign + safety procedures
- Expose-cloudflare routes through hub (was routing directly to vault)
- `parachute init` one-command front door
- Cloudflared install URL refresh (GitHub releases canonical)

## Test plan

- [x] `bun test ./src` — 2217 pass / 1 skip / 0 fail
- [x] `bun run typecheck` — clean
- [x] Live-verified migrate against a sandboxed PARACHUTE_HOME — known cruft archived, unknowns preserved, hub.db preserved
- [ ] After merge: tag `v0.5.14-rc.5` + push → CI publishes to npm rc dist-tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)