### PR TITLE
feat(hub): boot-readiness gating — transient vs persistent state, HTML + JSON, auto-retry, admin-link

### DIFF
--- a/src/__tests__/api-ready.test.ts
+++ b/src/__tests__/api-ready.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { handleApiReady } from "../api-ready.ts";
+import type { ModuleState, Supervisor } from "../supervisor.ts";
+
+function stubSupervisor(states: ModuleState[]): Supervisor {
+  return {
+    list: () => states,
+    get: (short: string) => states.find((s) => s.short === short),
+    start: async () => {
+      throw new Error("not implemented");
+    },
+    stop: async () => undefined,
+    restart: async () => undefined,
+  } as unknown as Supervisor;
+}
+
+function req(): Request {
+  return new Request("http://127.0.0.1/api/ready", {
+    headers: { accept: "application/json" },
+  });
+}
+
+function moduleState(partial: Partial<ModuleState> & { short: string }): ModuleState {
+  return {
+    status: "running",
+    restartsInWindow: 0,
+    ...partial,
+  };
+}
+
+describe("handleApiReady — no supervisor (CLI mode)", () => {
+  test("returns ready=true + empty arrays when supervisor absent", async () => {
+    const res = handleApiReady(req());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ready: boolean;
+      ready_modules: string[];
+      transient_modules: string[];
+      persistent_modules: string[];
+    };
+    expect(body.ready).toBe(true);
+    expect(body.ready_modules).toEqual([]);
+    expect(body.transient_modules).toEqual([]);
+    expect(body.persistent_modules).toEqual([]);
+  });
+});
+
+describe("handleApiReady — supervisor mode", () => {
+  test("all modules running past boot window → ready=true", async () => {
+    const now = 1_700_000_000_000;
+    const startedAt = new Date(now - 60_000).toISOString();
+    const sup = stubSupervisor([
+      moduleState({ short: "vault", status: "running", startedAt }),
+      moduleState({ short: "scribe", status: "running", startedAt }),
+    ]);
+    const res = handleApiReady(req(), { supervisor: sup, now: () => now });
+    const body = (await res.json()) as {
+      ready: boolean;
+      ready_modules: string[];
+      transient_modules: string[];
+      persistent_modules: string[];
+    };
+    expect(body.ready).toBe(true);
+    expect(body.ready_modules.sort()).toEqual(["scribe", "vault"]);
+    expect(body.transient_modules).toEqual([]);
+    expect(body.persistent_modules).toEqual([]);
+  });
+
+  test("module inside boot window → transient, ready=false", async () => {
+    const now = 1_700_000_000_000;
+    const sup = stubSupervisor([
+      moduleState({
+        short: "vault",
+        status: "running",
+        startedAt: new Date(now - 10_000).toISOString(),
+      }),
+    ]);
+    const res = handleApiReady(req(), { supervisor: sup, now: () => now });
+    const body = (await res.json()) as {
+      ready: boolean;
+      ready_modules: string[];
+      transient_modules: string[];
+    };
+    expect(body.ready).toBe(false);
+    expect(body.transient_modules).toEqual(["vault"]);
+    expect(body.ready_modules).toEqual([]);
+  });
+
+  test("starting + restarting + crashed all classified correctly", async () => {
+    const now = 1_700_000_000_000;
+    const sup = stubSupervisor([
+      moduleState({ short: "vault", status: "starting" }),
+      moduleState({ short: "scribe", status: "restarting" }),
+      moduleState({ short: "notes", status: "crashed" }),
+      moduleState({ short: "channel", status: "stopped" }),
+      moduleState({
+        short: "runner",
+        status: "running",
+        startedAt: new Date(now - 60_000).toISOString(),
+      }),
+    ]);
+    const res = handleApiReady(req(), { supervisor: sup, now: () => now });
+    const body = (await res.json()) as {
+      ready: boolean;
+      ready_modules: string[];
+      transient_modules: string[];
+      persistent_modules: string[];
+    };
+    expect(body.ready).toBe(false);
+    expect(body.ready_modules).toEqual(["runner"]);
+    expect(body.transient_modules.sort()).toEqual(["scribe", "vault"]);
+    expect(body.persistent_modules.sort()).toEqual(["channel", "notes"]);
+  });
+
+  test("only crashed/stopped + nothing transient → ready=false (still failing)", async () => {
+    const sup = stubSupervisor([moduleState({ short: "vault", status: "crashed" })]);
+    const res = handleApiReady(req(), { supervisor: sup });
+    const body = (await res.json()) as { ready: boolean };
+    expect(body.ready).toBe(false);
+  });
+});
+
+describe("handleApiReady — method check", () => {
+  test("rejects non-GET", () => {
+    const r = new Request("http://127.0.0.1/api/ready", { method: "POST" });
+    const res = handleApiReady(r);
+    expect(res.status).toBe(405);
+  });
+
+  test("accepts HEAD", () => {
+    const r = new Request("http://127.0.0.1/api/ready", { method: "HEAD" });
+    const res = handleApiReady(r);
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -17,6 +17,7 @@ import { clearNotesRedirectLogState } from "../notes-redirect.ts";
 import { pidPath } from "../process-state.ts";
 import { type ServiceEntry, writeManifest } from "../services-manifest.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
+import type { ModuleState, Supervisor } from "../supervisor.ts";
 import { createUser } from "../users.ts";
 
 interface Harness {
@@ -40,6 +41,33 @@ function req(path: string, init?: RequestInit): Request {
 
 function mkdirIfMissing(dir: string): void {
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+/**
+ * Minimal stub of the Supervisor surface that proxyRequest's classifier
+ * reads from. We don't drive real Bun.spawn — just hand back hand-crafted
+ * ModuleState values so the test can pin "vault is starting" / "vault has
+ * been running for a minute" exactly. See `supervisor.test.ts` for the
+ * real lifecycle tests.
+ */
+function stubSupervisor(states: ModuleState[]): Supervisor {
+  return {
+    list: () => states,
+    get: (short: string) => states.find((s) => s.short === short),
+    start: async () => {
+      throw new Error("not implemented");
+    },
+    stop: async () => undefined,
+    restart: async () => undefined,
+  } as unknown as Supervisor;
+}
+
+function moduleState(partial: Partial<ModuleState> & { short: string }): ModuleState {
+  return {
+    status: "running",
+    restartsInWindow: 0,
+    ...partial,
+  };
 }
 
 function vaultEntry(name: string): ServiceEntry {
@@ -1912,10 +1940,12 @@ describe("hubFetch /vault/<name>/* dynamic proxy (#144)", () => {
     }
   });
 
-  test("returns 502 when the matching vault upstream is unreachable", async () => {
+  test("returns 502 with persistent-state JSON when the matching vault upstream is unreachable", async () => {
     // Vault is in services.json but the port has nothing listening — vault
     // crashed, port shifted, or the user is mid-restart. We owe the caller a
-    // useful error instead of a hang or a silent 404.
+    // useful error instead of a hang or a silent 404. No supervisor +
+    // no pidfile → classifier returns "persistent" → 502 + admin_url
+    // (hub#444 boot-readiness gating).
     const h = makeHarness();
     try {
       writeManifest(
@@ -1934,10 +1964,261 @@ describe("hubFetch /vault/<name>/* dynamic proxy (#144)", () => {
         h.manifestPath,
       );
       const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
-      const res = await fetcher(req("/vault/default/health"));
+      const res = await fetcher(
+        req("/vault/default/health", { headers: { accept: "application/json" } }),
+      );
       expect(res.status).toBe(502);
-      const body = (await res.json()) as { error: string };
-      expect(body.error).toContain("vault upstream unreachable");
+      const body = (await res.json()) as {
+        error: string;
+        error_type: string;
+        admin_url?: string;
+        service: string;
+      };
+      expect(body.error_type).toBe("upstream_unreachable");
+      expect(body.error).toBe("upstream_unreachable");
+      expect(body.admin_url).toBe("/admin/modules");
+      expect(body.service).toBe("vault");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("transient state (supervisor reports starting) → 503 + Retry-After when fetch fails", async () => {
+    // Supervisor says vault is `starting` — the loopback port hasn't bound
+    // yet, fetch fails with ECONNREFUSED. Classifier returns "transient",
+    // proxy responds 503 with a Retry-After hint instead of 502.
+    const h = makeHarness();
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: await pickClosedPort(),
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const supervisor = stubSupervisor([moduleState({ short: "vault", status: "starting" })]);
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath, supervisor });
+      const res = await fetcher(
+        req("/vault/default/health", { headers: { accept: "application/json" } }),
+      );
+      expect(res.status).toBe(503);
+      expect(res.headers.get("retry-after")).toBe("2");
+      const body = (await res.json()) as {
+        error_type: string;
+        retry_after_ms: number;
+        attempts_remaining: number;
+        admin_url?: string;
+      };
+      expect(body.error_type).toBe("upstream_starting");
+      expect(body.retry_after_ms).toBe(2000);
+      expect(body.attempts_remaining).toBe(5);
+      // Transient JSON MUST NOT carry an admin link.
+      expect(body.admin_url).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("transient state + Accept: text/html → 503 HTML page with auto-refresh + poll, no admin link", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: await pickClosedPort(),
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const supervisor = stubSupervisor([moduleState({ short: "vault", status: "starting" })]);
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath, supervisor });
+      const res = await fetcher(req("/vault/default/health", { headers: { accept: "text/html" } }));
+      expect(res.status).toBe(503);
+      expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      const text = await res.text();
+      expect(text).toContain(`<meta http-equiv="refresh"`);
+      expect(text).toContain("/api/ready");
+      expect(text).toContain("Just a moment");
+      // Aaron design (d): transient page has no admin link.
+      expect(text).not.toContain("/admin/modules");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("persistent state + Accept: text/html → 502 HTML page with admin link, no auto-refresh", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: await pickClosedPort(),
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const supervisor = stubSupervisor([moduleState({ short: "vault", status: "crashed" })]);
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath, supervisor });
+      const res = await fetcher(req("/vault/default/health", { headers: { accept: "text/html" } }));
+      expect(res.status).toBe(502);
+      expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+      expect(res.headers.get("retry-after")).toBeNull();
+      const text = await res.text();
+      expect(text).toContain("Module unreachable");
+      expect(text).toContain("/admin/modules");
+      expect(text).not.toContain(`http-equiv="refresh"`);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("supervisor running-but-fresh-startedAt → transient classification", async () => {
+    // Supervisor says vault is running, but startedAt is recent enough that
+    // we trust the boot-window heuristic over the failed fetch.
+    const h = makeHarness();
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: await pickClosedPort(),
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const supervisor = stubSupervisor([
+        moduleState({
+          short: "vault",
+          status: "running",
+          startedAt: new Date(Date.now() - 5_000).toISOString(),
+        }),
+      ]);
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath, supervisor });
+      const res = await fetcher(
+        req("/vault/default/health", { headers: { accept: "application/json" } }),
+      );
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as { error_type: string };
+      expect(body.error_type).toBe("upstream_starting");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("supervisor running-but-old-startedAt → persistent (boot window expired)", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: await pickClosedPort(),
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const supervisor = stubSupervisor([
+        moduleState({
+          short: "vault",
+          status: "running",
+          startedAt: new Date(Date.now() - 120_000).toISOString(),
+        }),
+      ]);
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath, supervisor });
+      const res = await fetcher(
+        req("/vault/default/health", { headers: { accept: "application/json" } }),
+      );
+      expect(res.status).toBe(502);
+      const body = (await res.json()) as { error_type: string };
+      expect(body.error_type).toBe("upstream_unreachable");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("non-vault upstream (scribe) classified through supervisor when starting", async () => {
+    // Same logic as vault, but exercising the generic /<svc>/* dispatch path.
+    const h = makeHarness();
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "scribe",
+              port: await pickClosedPort(),
+              paths: ["/scribe"],
+              health: "/scribe/health",
+              version: "0.1.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const supervisor = stubSupervisor([moduleState({ short: "scribe", status: "starting" })]);
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath, supervisor });
+      const res = await fetcher(req("/scribe/health", { headers: { accept: "application/json" } }));
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as { error_type: string; service: string };
+      expect(body.error_type).toBe("upstream_starting");
+      expect(body.service).toBe("scribe");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/api/ready returns supervisor view + is reachable pre-admin", async () => {
+    // hub#444 endpoint is public + pre-admin (it has to be — the page that
+    // polls it is itself served pre-auth when modules are still booting).
+    const h = makeHarness();
+    try {
+      const supervisor = stubSupervisor([
+        moduleState({ short: "vault", status: "starting" }),
+        moduleState({
+          short: "scribe",
+          status: "running",
+          startedAt: new Date(Date.now() - 60_000).toISOString(),
+        }),
+      ]);
+      const fetcher = hubFetch(h.dir, { supervisor });
+      const res = await fetcher(req("/api/ready"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        ready: boolean;
+        ready_modules: string[];
+        transient_modules: string[];
+      };
+      expect(body.ready).toBe(false);
+      expect(body.transient_modules).toEqual(["vault"]);
+      expect(body.ready_modules).toEqual(["scribe"]);
     } finally {
       h.cleanup();
     }
@@ -2562,9 +2843,10 @@ describe("hubFetch /<svc>/* generic proxy dispatch (#182)", () => {
     }
   });
 
-  test("returns 502 when the matching upstream is unreachable", async () => {
+  test("returns 502 with persistent-state JSON when the matching upstream is unreachable", async () => {
     // Service is in services.json but the port has nothing listening — same
-    // shape as the vault-unreachable test, label is the entry's `name`.
+    // shape as the vault-unreachable test (hub#444 boot-readiness gating).
+    // No supervisor + no pidfile → persistent → 502 with admin_url.
     const h = makeHarness();
     try {
       writeManifest(
@@ -2582,10 +2864,17 @@ describe("hubFetch /<svc>/* generic proxy dispatch (#182)", () => {
         h.manifestPath,
       );
       const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
-      const res = await fetcher(req("/scribe/health"));
+      const res = await fetcher(req("/scribe/health", { headers: { accept: "application/json" } }));
       expect(res.status).toBe(502);
-      const body = (await res.json()) as { error: string };
-      expect(body.error).toContain("scribe upstream unreachable");
+      const body = (await res.json()) as {
+        error: string;
+        error_type: string;
+        admin_url?: string;
+        service: string;
+      };
+      expect(body.error_type).toBe("upstream_unreachable");
+      expect(body.admin_url).toBe("/admin/modules");
+      expect(body.service).toBe("scribe");
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -1945,7 +1945,7 @@ describe("hubFetch /vault/<name>/* dynamic proxy (#144)", () => {
     // crashed, port shifted, or the user is mid-restart. We owe the caller a
     // useful error instead of a hang or a silent 404. No supervisor +
     // no pidfile → classifier returns "persistent" → 502 + admin_url
-    // (hub#444 boot-readiness gating).
+    // (hub#443 boot-readiness gating).
     const h = makeHarness();
     try {
       writeManifest(
@@ -2013,12 +2013,12 @@ describe("hubFetch /vault/<name>/* dynamic proxy (#144)", () => {
       const body = (await res.json()) as {
         error_type: string;
         retry_after_ms: number;
-        attempts_remaining: number;
+        max_attempts: number;
         admin_url?: string;
       };
       expect(body.error_type).toBe("upstream_starting");
       expect(body.retry_after_ms).toBe(2000);
-      expect(body.attempts_remaining).toBe(5);
+      expect(body.max_attempts).toBe(5);
       // Transient JSON MUST NOT carry an admin link.
       expect(body.admin_url).toBeUndefined();
     } finally {
@@ -2196,7 +2196,7 @@ describe("hubFetch /vault/<name>/* dynamic proxy (#144)", () => {
   });
 
   test("/api/ready returns supervisor view + is reachable pre-admin", async () => {
-    // hub#444 endpoint is public + pre-admin (it has to be — the page that
+    // hub#443 endpoint is public + pre-admin (it has to be — the page that
     // polls it is itself served pre-auth when modules are still booting).
     const h = makeHarness();
     try {
@@ -2845,7 +2845,7 @@ describe("hubFetch /<svc>/* generic proxy dispatch (#182)", () => {
 
   test("returns 502 with persistent-state JSON when the matching upstream is unreachable", async () => {
     // Service is in services.json but the port has nothing listening — same
-    // shape as the vault-unreachable test (hub#444 boot-readiness gating).
+    // shape as the vault-unreachable test (hub#443 boot-readiness gating).
     // No supervisor + no pidfile → persistent → 502 with admin_url.
     const h = makeHarness();
     try {

--- a/src/__tests__/proxy-error-ui.test.ts
+++ b/src/__tests__/proxy-error-ui.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ADMIN_MODULES_URL,
+  ERROR_TYPE_PERSISTENT,
+  ERROR_TYPE_TRANSIENT,
+  TRANSIENT_MAX_ATTEMPTS,
+  TRANSIENT_RETRY_MS,
+  renderProxyError,
+  renderProxyErrorHtml,
+  renderProxyErrorJson,
+  statusForState,
+  toResponse,
+  wantsHtml,
+} from "../proxy-error-ui.ts";
+
+function req(accept?: string): Request {
+  const headers: Record<string, string> = {};
+  if (accept !== undefined) headers.accept = accept;
+  return new Request("http://127.0.0.1/vault/default/health", { headers });
+}
+
+describe("wantsHtml — Accept-header negotiation", () => {
+  test("text/html → HTML", () => {
+    expect(wantsHtml(req("text/html"))).toBe(true);
+  });
+  test("application/json → JSON", () => {
+    expect(wantsHtml(req("application/json"))).toBe(false);
+  });
+  test("missing Accept → HTML (browser-ish default)", () => {
+    expect(wantsHtml(req())).toBe(true);
+  });
+  test("*/* alone → HTML", () => {
+    expect(wantsHtml(req("*/*"))).toBe(true);
+  });
+  test("text/html,application/xhtml+xml,application/xml → HTML", () => {
+    expect(wantsHtml(req("text/html,application/xhtml+xml,application/xml"))).toBe(true);
+  });
+  test("application/json with text/html present → HTML", () => {
+    // If a client sends both, we lean HTML — matches the hub's existing
+    // one-line accept check at the 404 fallthrough.
+    expect(wantsHtml(req("application/json, text/html"))).toBe(true);
+  });
+});
+
+describe("statusForState", () => {
+  test("transient → 503", () => {
+    expect(statusForState("transient")).toBe(503);
+  });
+  test("persistent → 502", () => {
+    expect(statusForState("persistent")).toBe(502);
+  });
+});
+
+describe("renderProxyErrorJson", () => {
+  test("transient → 503 JSON with retry_after_ms + attempts_remaining + no admin_url", () => {
+    const out = renderProxyErrorJson({
+      short: "vault",
+      serviceLabel: "parachute-vault",
+      state: "transient",
+      upstreamError: "ECONNREFUSED",
+    });
+    expect(out.status).toBe(503);
+    expect(out.contentType).toBe("application/json");
+    expect(out.retryAfter).toBe("2");
+    const body = JSON.parse(out.body) as {
+      error: string;
+      error_type: string;
+      retry_after_ms: number;
+      attempts_remaining: number;
+      admin_url?: string;
+      service: string;
+    };
+    expect(body.error).toBe(ERROR_TYPE_TRANSIENT);
+    expect(body.error_type).toBe(ERROR_TYPE_TRANSIENT);
+    expect(body.retry_after_ms).toBe(TRANSIENT_RETRY_MS);
+    expect(body.attempts_remaining).toBe(TRANSIENT_MAX_ATTEMPTS);
+    expect(body.admin_url).toBeUndefined();
+    expect(body.service).toBe("vault");
+  });
+
+  test("persistent → 502 JSON with admin_url + no retry_after_ms", () => {
+    const out = renderProxyErrorJson({
+      short: "scribe",
+      serviceLabel: "scribe",
+      state: "persistent",
+      upstreamError: "ECONNREFUSED",
+    });
+    expect(out.status).toBe(502);
+    expect(out.contentType).toBe("application/json");
+    expect(out.retryAfter).toBeUndefined();
+    const body = JSON.parse(out.body) as {
+      error: string;
+      error_type: string;
+      retry_after_ms?: number;
+      admin_url?: string;
+    };
+    expect(body.error).toBe(ERROR_TYPE_PERSISTENT);
+    expect(body.error_type).toBe(ERROR_TYPE_PERSISTENT);
+    expect(body.admin_url).toBe(ADMIN_MODULES_URL);
+    expect(body.retry_after_ms).toBeUndefined();
+  });
+
+  test("persistent JSON folds upstreamError into error_description", () => {
+    const out = renderProxyErrorJson({
+      short: "vault",
+      serviceLabel: "parachute-vault",
+      state: "persistent",
+      upstreamError: "ECONNREFUSED 127.0.0.1:1940",
+    });
+    const body = JSON.parse(out.body) as { error_description: string };
+    expect(body.error_description).toContain("ECONNREFUSED");
+    expect(body.error_description).toContain("parachute-vault");
+  });
+});
+
+describe("renderProxyErrorHtml", () => {
+  test("transient HTML → 503 + meta-refresh + Retry-After + poll script", () => {
+    const out = renderProxyErrorHtml({
+      short: "vault",
+      serviceLabel: "parachute-vault",
+      state: "transient",
+      upstreamError: "ECONNREFUSED",
+    });
+    expect(out.status).toBe(503);
+    expect(out.contentType).toBe("text/html; charset=utf-8");
+    expect(out.retryAfter).toBe("2");
+    expect(out.body).toContain(`<meta http-equiv="refresh" content="2">`);
+    expect(out.body).toContain("Just a moment");
+    expect(out.body).toContain("/api/ready");
+    expect(out.body).toContain("ready_modules");
+    expect(out.body).toContain(`maxAttempts = ${TRANSIENT_MAX_ATTEMPTS}`);
+    // Transient page MUST NOT include an admin link (Aaron design (d)).
+    expect(out.body).not.toContain("/admin/modules");
+  });
+
+  test("persistent HTML → 502 + no meta-refresh + admin link + manual refresh", () => {
+    const out = renderProxyErrorHtml({
+      short: "vault",
+      serviceLabel: "parachute-vault",
+      state: "persistent",
+      upstreamError: "ECONNREFUSED",
+    });
+    expect(out.status).toBe(502);
+    expect(out.contentType).toBe("text/html; charset=utf-8");
+    expect(out.retryAfter).toBeUndefined();
+    expect(out.body).not.toContain(`http-equiv="refresh"`);
+    expect(out.body).toContain("Module unreachable");
+    expect(out.body).toContain("/admin/modules");
+    expect(out.body).toContain("View module status");
+    // No periodic poll on the persistent page — only the manual-refresh
+    // listener. Assert by checking that maxAttempts/intervalMs constants
+    // aren't emitted into the script.
+    expect(out.body).not.toContain("maxAttempts");
+  });
+
+  test("HTML escapes the service short name into the body", () => {
+    // Constructing a malicious short shouldn't break the page. ServiceEntry
+    // names are validated upstream but the renderer is defense-in-depth.
+    const out = renderProxyErrorHtml({
+      short: "<script>alert(1)</script>",
+      serviceLabel: "<malicious>",
+      state: "persistent",
+      upstreamError: "x",
+    });
+    expect(out.body).not.toContain("<script>alert(1)</script>");
+    expect(out.body).toContain("&lt;script&gt;");
+  });
+});
+
+describe("renderProxyError — Accept-driven dispatch", () => {
+  test("JSON-accepting request → JSON renderer", () => {
+    const out = renderProxyError(req("application/json"), {
+      short: "vault",
+      serviceLabel: "parachute-vault",
+      state: "transient",
+      upstreamError: "x",
+    });
+    expect(out.contentType).toBe("application/json");
+  });
+  test("HTML-accepting request → HTML renderer", () => {
+    const out = renderProxyError(req("text/html"), {
+      short: "vault",
+      serviceLabel: "parachute-vault",
+      state: "transient",
+      upstreamError: "x",
+    });
+    expect(out.contentType).toBe("text/html; charset=utf-8");
+  });
+});
+
+describe("toResponse", () => {
+  test("attaches Retry-After when present", () => {
+    const out = toResponse({
+      body: "{}",
+      status: 503,
+      contentType: "application/json",
+      retryAfter: "2",
+    });
+    expect(out.status).toBe(503);
+    expect(out.headers.get("retry-after")).toBe("2");
+    expect(out.headers.get("content-type")).toBe("application/json");
+    expect(out.headers.get("cache-control")).toBe("no-store");
+  });
+  test("omits Retry-After when absent", () => {
+    const out = toResponse({
+      body: "{}",
+      status: 502,
+      contentType: "application/json",
+    });
+    expect(out.headers.get("retry-after")).toBeNull();
+  });
+});

--- a/src/__tests__/proxy-error-ui.test.ts
+++ b/src/__tests__/proxy-error-ui.test.ts
@@ -52,7 +52,7 @@ describe("statusForState", () => {
 });
 
 describe("renderProxyErrorJson", () => {
-  test("transient → 503 JSON with retry_after_ms + attempts_remaining + no admin_url", () => {
+  test("transient → 503 JSON with retry_after_ms + max_attempts + no admin_url", () => {
     const out = renderProxyErrorJson({
       short: "vault",
       serviceLabel: "parachute-vault",
@@ -66,14 +66,14 @@ describe("renderProxyErrorJson", () => {
       error: string;
       error_type: string;
       retry_after_ms: number;
-      attempts_remaining: number;
+      max_attempts: number;
       admin_url?: string;
       service: string;
     };
     expect(body.error).toBe(ERROR_TYPE_TRANSIENT);
     expect(body.error_type).toBe(ERROR_TYPE_TRANSIENT);
     expect(body.retry_after_ms).toBe(TRANSIENT_RETRY_MS);
-    expect(body.attempts_remaining).toBe(TRANSIENT_MAX_ATTEMPTS);
+    expect(body.max_attempts).toBe(TRANSIENT_MAX_ATTEMPTS);
     expect(body.admin_url).toBeUndefined();
     expect(body.service).toBe("vault");
   });

--- a/src/__tests__/proxy-state.test.ts
+++ b/src/__tests__/proxy-state.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writePid } from "../process-state.ts";
+import { type ClassifyOpts, classifyUpstream } from "../proxy-state.ts";
+import type { ModuleState, Supervisor } from "../supervisor.ts";
+
+/**
+ * Stub supervisor — only `get(short)` is exercised by `classifyUpstream`.
+ * We construct it directly instead of standing up a real `Supervisor`
+ * + driving the spawn lifecycle, so test cases stay focused on the
+ * classifier's per-status branching.
+ */
+function stubSupervisor(states: Record<string, ModuleState>): Supervisor {
+  return {
+    get: (short: string) => states[short],
+    list: () => Object.values(states),
+    // Unused by classifyUpstream — present to satisfy the Supervisor type.
+    start: async () => {
+      throw new Error("not implemented");
+    },
+    stop: async () => undefined,
+    restart: async () => undefined,
+  } as unknown as Supervisor;
+}
+
+function moduleState(partial: Partial<ModuleState> & { short: string }): ModuleState {
+  return {
+    status: "running",
+    restartsInWindow: 0,
+    ...partial,
+  };
+}
+
+describe("classifyUpstream — supervisor mode", () => {
+  test("status=starting → transient", () => {
+    const sup = stubSupervisor({
+      vault: moduleState({ short: "vault", status: "starting" }),
+    });
+    expect(classifyUpstream("vault", { supervisor: sup })).toBe("transient");
+  });
+
+  test("status=restarting → transient", () => {
+    const sup = stubSupervisor({
+      vault: moduleState({ short: "vault", status: "restarting" }),
+    });
+    expect(classifyUpstream("vault", { supervisor: sup })).toBe("transient");
+  });
+
+  test("status=crashed → persistent", () => {
+    const sup = stubSupervisor({
+      vault: moduleState({ short: "vault", status: "crashed" }),
+    });
+    expect(classifyUpstream("vault", { supervisor: sup })).toBe("persistent");
+  });
+
+  test("status=stopped → persistent", () => {
+    const sup = stubSupervisor({
+      vault: moduleState({ short: "vault", status: "stopped" }),
+    });
+    expect(classifyUpstream("vault", { supervisor: sup })).toBe("persistent");
+  });
+
+  test("status=running, inside boot window → transient", () => {
+    const now = 1_700_000_000_000;
+    const startedAt = new Date(now - 10_000).toISOString(); // 10s ago
+    const sup = stubSupervisor({
+      vault: moduleState({ short: "vault", status: "running", startedAt }),
+    });
+    expect(classifyUpstream("vault", { supervisor: sup, now: () => now })).toBe("transient");
+  });
+
+  test("status=running, outside boot window → persistent", () => {
+    const now = 1_700_000_000_000;
+    const startedAt = new Date(now - 60_000).toISOString(); // 60s ago
+    const sup = stubSupervisor({
+      vault: moduleState({ short: "vault", status: "running", startedAt }),
+    });
+    expect(classifyUpstream("vault", { supervisor: sup, now: () => now })).toBe("persistent");
+  });
+
+  test("status=running, exactly at boot-window boundary → persistent", () => {
+    // The check is strict-less-than, so exactly 30s falls into persistent.
+    const now = 1_700_000_000_000;
+    const startedAt = new Date(now - 30_000).toISOString();
+    const sup = stubSupervisor({
+      vault: moduleState({ short: "vault", status: "running", startedAt }),
+    });
+    expect(classifyUpstream("vault", { supervisor: sup, now: () => now })).toBe("persistent");
+  });
+
+  test("status=running, missing startedAt → persistent", () => {
+    // Can't classify a running module without a start time; safer to call
+    // persistent and let the operator hit refresh than to lie that it's
+    // booting.
+    const sup = stubSupervisor({
+      vault: moduleState({ short: "vault", status: "running" }),
+    });
+    expect(classifyUpstream("vault", { supervisor: sup })).toBe("persistent");
+  });
+
+  test("custom boot window honored", () => {
+    const now = 1_700_000_000_000;
+    const startedAt = new Date(now - 5_000).toISOString(); // 5s ago
+    const sup = stubSupervisor({
+      vault: moduleState({ short: "vault", status: "running", startedAt }),
+    });
+    expect(
+      classifyUpstream("vault", { supervisor: sup, now: () => now, bootWindowMs: 2_000 }),
+    ).toBe("persistent");
+    expect(
+      classifyUpstream("vault", { supervisor: sup, now: () => now, bootWindowMs: 10_000 }),
+    ).toBe("transient");
+  });
+
+  test("module not tracked → falls back to pidfile path", () => {
+    // Empty supervisor map. Classifier must call through to processState;
+    // we inject a stub via readProcessState.
+    const sup = stubSupervisor({});
+    const opts: ClassifyOpts = {
+      supervisor: sup,
+      readProcessState: () => ({ status: "unknown" }),
+    };
+    expect(classifyUpstream("vault", opts)).toBe("persistent");
+  });
+});
+
+describe("classifyUpstream — on-box CLI mode (no supervisor)", () => {
+  test("running pidfile inside boot window → transient", () => {
+    const now = 1_700_000_000_000;
+    const opts: ClassifyOpts = {
+      now: () => now,
+      readProcessState: () => ({
+        status: "running",
+        pid: 12345,
+        startedAt: new Date(now - 5_000), // 5s old pidfile
+      }),
+    };
+    expect(classifyUpstream("vault", opts)).toBe("transient");
+  });
+
+  test("running pidfile outside boot window → persistent", () => {
+    const now = 1_700_000_000_000;
+    const opts: ClassifyOpts = {
+      now: () => now,
+      readProcessState: () => ({
+        status: "running",
+        pid: 12345,
+        startedAt: new Date(now - 60_000),
+      }),
+    };
+    expect(classifyUpstream("vault", opts)).toBe("persistent");
+  });
+
+  test("stopped pidfile (stale) → persistent", () => {
+    const opts: ClassifyOpts = {
+      readProcessState: () => ({ status: "stopped", pid: 12345 }),
+    };
+    expect(classifyUpstream("vault", opts)).toBe("persistent");
+  });
+
+  test("no pidfile (unknown) → persistent", () => {
+    const opts: ClassifyOpts = {
+      readProcessState: () => ({ status: "unknown" }),
+    };
+    expect(classifyUpstream("vault", opts)).toBe("persistent");
+  });
+
+  test("readProcessState throws → persistent (defensive)", () => {
+    // pidfile read can race with cleanup. Don't blow up the proxy.
+    const opts: ClassifyOpts = {
+      readProcessState: () => {
+        throw new Error("ENOENT");
+      },
+    };
+    expect(classifyUpstream("vault", opts)).toBe("persistent");
+  });
+
+  test("integration with real processState — running pid is alive + fresh mtime", () => {
+    // Write a real pidfile pointing at this test process (always alive),
+    // so `defaultAlive` returns true. Pidfile mtime will be ~now, so it
+    // falls inside the boot window.
+    const dir = mkdtempSync(join(tmpdir(), "proxy-state-"));
+    try {
+      writePid("vault", process.pid, dir);
+      expect(classifyUpstream("vault", { configDir: dir })).toBe("transient");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/api-ready.ts
+++ b/src/api-ready.ts
@@ -1,0 +1,102 @@
+/**
+ * `GET /api/ready` — hub-side boot-readiness probe (hub#444).
+ *
+ * Public (no bearer required) — used by:
+ *
+ *   1. The transient-state HTML page rendered by the upstream-error
+ *      flow (see `proxy-error-ui.ts`). Its inline poll script hits this
+ *      endpoint every 2s up to 5 times so a wizard mid-boot can refresh
+ *      itself without an HTML reload.
+ *   2. Any third-party tool (smoke test, dashboard) that wants to know
+ *      whether the hub's modules are all up.
+ *
+ * Shape:
+ *
+ *     {
+ *       "ready": boolean,
+ *       "ready_modules": string[],         // shorts that are up
+ *       "transient_modules": string[],     // shorts currently booting
+ *       "persistent_modules": string[]     // shorts crashed / stopped
+ *     }
+ *
+ * `ready: true` iff every supervised module is in the "running" state
+ * past its boot window AND no module is in transient/persistent
+ * failure. The hub itself is implicit — if you reached this endpoint,
+ * hub is up.
+ *
+ * Why public: the page that polls this is itself served pre-auth (a
+ * 503 from a proxied request before the operator has even reached
+ * /login). Bearer-gating would make the poll fail and the page sit
+ * forever on "still loading."
+ */
+
+import { DEFAULT_BOOT_WINDOW_MS } from "./proxy-state.ts";
+import type { Supervisor } from "./supervisor.ts";
+
+export interface ApiReadyDeps {
+  /** Container-mode supervisor handle. When absent the hub is in CLI
+   *  mode and we report ready=true (we have no visibility into other
+   *  processes' boot state). */
+  supervisor?: Supervisor;
+  /** Test seam over Date.now. */
+  now?: () => number;
+  /** Test seam over the boot window. */
+  bootWindowMs?: number;
+}
+
+export function handleApiReady(req: Request, deps: ApiReadyDeps = {}): Response {
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    return new Response("method not allowed", { status: 405 });
+  }
+  const now = (deps.now ?? Date.now)();
+  const bootWindow = deps.bootWindowMs ?? DEFAULT_BOOT_WINDOW_MS;
+
+  const ready: string[] = [];
+  const transient: string[] = [];
+  const persistent: string[] = [];
+
+  if (deps.supervisor) {
+    for (const m of deps.supervisor.list()) {
+      switch (m.status) {
+        case "starting":
+        case "restarting":
+          transient.push(m.short);
+          break;
+        case "crashed":
+        case "stopped":
+          persistent.push(m.short);
+          break;
+        case "running": {
+          // Inside the boot window we report transient even though the
+          // process is "running" — the listener may not have bound yet.
+          // After the window we report ready (process is up + presumed
+          // listening; if it's not, the proxy classifier still catches
+          // it via the same window check and surfaces persistent state).
+          let startedMs = 0;
+          if (m.startedAt) {
+            const parsed = Date.parse(m.startedAt);
+            if (Number.isFinite(parsed)) startedMs = parsed;
+          }
+          if (startedMs > 0 && now - startedMs < bootWindow) {
+            transient.push(m.short);
+          } else {
+            ready.push(m.short);
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  const isReady = transient.length === 0 && persistent.length === 0;
+  const body = JSON.stringify({
+    ready: isReady,
+    ready_modules: ready,
+    transient_modules: transient,
+    persistent_modules: persistent,
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}

--- a/src/api-ready.ts
+++ b/src/api-ready.ts
@@ -1,5 +1,5 @@
 /**
- * `GET /api/ready` — hub-side boot-readiness probe (hub#444).
+ * `GET /api/ready` — hub-side boot-readiness probe (hub#443).
  *
  * Public (no bearer required) — used by:
  *

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -456,7 +456,7 @@ export function layerOf(req: Request): RequestLayer {
  *
  *   - **transient** (still booting): 503 + Retry-After. HTML page polls
  *     /api/ready up to 5 attempts on a 2s cadence; JSON includes
- *     retry_after_ms + attempts_remaining.
+ *     retry_after_ms + max_attempts.
  *   - **persistent** (crashed / never started): 502, no auto-retry. HTML
  *     surfaces a /admin/modules link; JSON includes admin_url.
  *
@@ -538,7 +538,7 @@ async function proxyRequest(
     // Classify the failure (transient boot-window vs persistent crash) and
     // render either an HTML page or a JSON error per the request's Accept.
     // See `proxy-state.ts` for the classification logic + `proxy-error-ui.ts`
-    // for the two response shapes (closes hub#444).
+    // for the two response shapes (closes hub#443).
     const classifyOpts: Parameters<typeof classifyUpstream>[1] = {};
     if (supervisor !== undefined) classifyOpts.supervisor = supervisor;
     const state = classifyUpstream(short, classifyOpts);
@@ -1306,7 +1306,7 @@ export function hubFetch(
       );
     }
 
-    // Boot-readiness probe (hub#444). Used by the transient-state proxy
+    // Boot-readiness probe (hub#443). Used by the transient-state proxy
     // error page's inline poll script to detect when a still-booting
     // module has come up. Public + DB-free so it works during the pre-
     // admin lockout (the page that polls it is itself served pre-auth).

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -137,6 +137,7 @@ import {
   parseModulesPath,
 } from "./api-modules-ops.ts";
 import { handleApiModules, handleApiModulesChannel } from "./api-modules.ts";
+import { handleApiReady } from "./api-ready.ts";
 import { REVOCATION_LIST_MOUNT, handleRevocationList } from "./api-revocation-list.ts";
 import { handleApiRevokeToken } from "./api-revoke-token.ts";
 import { handleApiSettingsHubOrigin } from "./api-settings-hub-origin.ts";
@@ -177,6 +178,8 @@ import {
 import { renderNotFoundPage } from "./oauth-ui.ts";
 import { buildHubBoundOrigins } from "./origin-check.ts";
 import { clearPid, writePid } from "./process-state.ts";
+import { toResponse as proxyErrorToResponse, renderProxyError } from "./proxy-error-ui.ts";
+import { classifyUpstream } from "./proxy-state.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
 import {
   FIRST_PARTY_FALLBACKS,
@@ -446,10 +449,21 @@ export function layerOf(req: Request): RequestLayer {
  * / agent / vault want the prefix), so the decision lives one layer up in
  * `proxyToService` / `proxyToVault`.
  *
- * Returns 502 when the loopback fetch fails — port valid, target unreachable
- * (service crashed, port shifted, mid-restart). `serviceLabel` is folded into
- * the error message so 502 bodies say `vault upstream unreachable` /
- * `scribe upstream unreachable` etc.
+ * Returns a boot-readiness-classified response when the loopback fetch fails
+ * — port valid, target unreachable (service crashed, port shifted, mid-
+ * restart, OR module is still inside its boot window). The response is
+ * classified by `classifyUpstream` into:
+ *
+ *   - **transient** (still booting): 503 + Retry-After. HTML page polls
+ *     /api/ready up to 5 attempts on a 2s cadence; JSON includes
+ *     retry_after_ms + attempts_remaining.
+ *   - **persistent** (crashed / never started): 502, no auto-retry. HTML
+ *     surfaces a /admin/modules link; JSON includes admin_url.
+ *
+ * `serviceLabel` is the services.json entry name (`parachute-vault`,
+ * `scribe`, …) folded into the response body for operator clarity.
+ * `short` is the canonical short (`vault`/`scribe`/`notes`) — used as
+ * the supervisor map key + pidfile directory key for classification.
  *
  * Hop-by-hop notes: WebSocket upgrades and HTTP/2 trailers don't traverse
  * fetch-based proxies cleanly. No on-box service uses either today; if one
@@ -460,6 +474,8 @@ async function proxyRequest(
   req: Request,
   port: number,
   serviceLabel: string,
+  short: string,
+  supervisor: Supervisor | undefined,
   targetPath?: string,
 ): Promise<Response> {
   const url = new URL(req.url);
@@ -519,10 +535,20 @@ async function proxyRequest(
     return await fetch(upstream, init);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return new Response(JSON.stringify({ error: `${serviceLabel} upstream unreachable: ${msg}` }), {
-      status: 502,
-      headers: { "content-type": "application/json" },
+    // Classify the failure (transient boot-window vs persistent crash) and
+    // render either an HTML page or a JSON error per the request's Accept.
+    // See `proxy-state.ts` for the classification logic + `proxy-error-ui.ts`
+    // for the two response shapes (closes hub#444).
+    const classifyOpts: Parameters<typeof classifyUpstream>[1] = {};
+    if (supervisor !== undefined) classifyOpts.supervisor = supervisor;
+    const state = classifyUpstream(short, classifyOpts);
+    const rendered = renderProxyError(req, {
+      short,
+      serviceLabel,
+      state,
+      upstreamError: msg,
     });
+    return proxyErrorToResponse(rendered);
   }
 }
 
@@ -536,7 +562,11 @@ async function proxyRequest(
  * fall through to the SPA shell fallback for unknown vault names (the seam
  * #173 introduced).
  */
-async function proxyToVault(req: Request, manifestPath: string): Promise<Response | undefined> {
+async function proxyToVault(
+  req: Request,
+  manifestPath: string,
+  supervisor: Supervisor | undefined,
+): Promise<Response | undefined> {
   // Lenient — see hub#406. One bad services.json row no longer takes
   // down vault routing the way it used to take down /admin/setup and
   // /api/modules (the symptom Aaron hit 2026-05-26).
@@ -557,7 +587,11 @@ async function proxyToVault(req: Request, manifestPath: string): Promise<Respons
   // both proxies keeps the dispatch surface consistent for future readers.
   const stripPrefix = stripPrefixFor(match.entry);
   const targetPath = stripPrefix ? url.pathname.slice(match.mount.length) || "/" : undefined;
-  return proxyRequest(req, match.port, "vault", targetPath);
+  // Vault's short is the literal "vault" — fixed by KNOWN_MODULES. Multiple
+  // vault instances share the same supervisor key under hub's current
+  // single-vault-per-hub model; if multi-vault-per-hub ever ships, the
+  // classifier will need a per-instance key.
+  return proxyRequest(req, match.port, "vault", "vault", supervisor, targetPath);
 }
 
 /**
@@ -613,7 +647,11 @@ export function findServiceUpstream(
  *
  * Returns `undefined` when no service claims the pathname; caller 404s.
  */
-async function proxyToService(req: Request, manifestPath: string): Promise<Response | undefined> {
+async function proxyToService(
+  req: Request,
+  manifestPath: string,
+  supervisor: Supervisor | undefined,
+): Promise<Response | undefined> {
   // Lenient read on the hot-path — a single malformed services.json
   // entry (e.g. a module installed at a buggy version that wrote
   // `port: 0`) used to cascade into 500s for every route on this hub
@@ -649,7 +687,13 @@ async function proxyToService(req: Request, manifestPath: string): Promise<Respo
   // services).
   const stripPrefix = stripPrefixFor(match.entry);
   const targetPath = stripPrefix ? url.pathname.slice(match.mount.length) || "/" : undefined;
-  return proxyRequest(req, match.port, match.entry.name, targetPath);
+  // Resolve canonical short for classification — falls back to the
+  // services.json name when the entry isn't a KNOWN_MODULES / FALLBACK
+  // shape (third-party services have no canonical short; the classifier
+  // will land in "persistent" by default which is the safer choice for
+  // unknown lifecycle).
+  const short = shortNameForManifest(match.entry.name) ?? match.entry.name;
+  return proxyRequest(req, match.port, match.entry.name, short, supervisor, targetPath);
 }
 
 /**
@@ -1260,6 +1304,16 @@ export function hubFetch(
           },
         },
       );
+    }
+
+    // Boot-readiness probe (hub#444). Used by the transient-state proxy
+    // error page's inline poll script to detect when a still-booting
+    // module has come up. Public + DB-free so it works during the pre-
+    // admin lockout (the page that polls it is itself served pre-auth).
+    if (pathname === "/api/ready") {
+      const readyDeps: Parameters<typeof handleApiReady>[1] = {};
+      if (deps?.supervisor !== undefined) readyDeps.supervisor = deps.supervisor;
+      return handleApiReady(req, readyDeps);
     }
 
     // First-boot setup wizard (hub#259). Three steps server-rendered:
@@ -2041,7 +2095,7 @@ export function hubFetch(
     // here anymore (the SPA moved to /admin), so we can't accidentally
     // mask a backend 404 with HTML.
     if (pathname.startsWith("/vault/")) {
-      const proxied = await proxyToVault(req, manifestPath);
+      const proxied = await proxyToVault(req, manifestPath, deps?.supervisor);
       if (proxied) return decorateWithChrome(proxied, req, pathname, getDb);
       return new Response("not found", { status: 404 });
     }
@@ -2068,7 +2122,7 @@ export function hubFetch(
     // here only after every hub-owned prefix above has had its turn — so
     // `/`, `/admin/*`, `/oauth/*`, `/.well-known/*`, `/hub/*`, `/vault/*`,
     // `/api/*` are excluded by ordering, not by an explicit denylist (#182).
-    const proxied = await proxyToService(req, manifestPath);
+    const proxied = await proxyToService(req, manifestPath, deps?.supervisor);
     if (proxied) return decorateWithChrome(proxied, req, pathname, getDb);
 
     // Branded fall-through 404 (closes hub#392) — the operator who mistyped

--- a/src/proxy-error-ui.ts
+++ b/src/proxy-error-ui.ts
@@ -1,0 +1,492 @@
+/**
+ * HTML + JSON renderers for upstream-unreachable responses (hub#444).
+ *
+ * Two states, two presentations, two content types — four total responses.
+ *
+ *   transient + HTML  → 503, branded "Just a moment" page with
+ *                       meta-refresh + JS poll of `/api/ready` (max 5
+ *                       attempts on a 2s cadence ≈ 10s ceiling). After
+ *                       the budget, fall back to a manual Refresh button.
+ *
+ *   transient + JSON  → 503, `{ error: "upstream_starting", error_type,
+ *                       retry_after_ms: 2000, attempts_remaining: <N> }`
+ *                       so an API consumer can drive its own backoff.
+ *
+ *   persistent + HTML → 502, branded "Module unreachable" page with NO
+ *                       auto-retry (it won't help) and a prominent link
+ *                       to /admin/modules so the operator can inspect
+ *                       logs / restart / etc.
+ *
+ *   persistent + JSON → 502, `{ error: "upstream_unreachable", error_type,
+ *                       admin_url: "/admin/modules" }`.
+ *
+ * Status codes follow RFC 9110:
+ *   - 503 Service Unavailable = "temporary, try again" — pairs with a
+ *     `Retry-After` header on the response.
+ *   - 502 Bad Gateway         = "upstream broken, retry probably won't
+ *                                help" — no Retry-After.
+ *
+ * Design tokens (`--accent`, `--bg`, `--fg`, etc.) match the OAuth UI +
+ * SPA so a wizard interrupt blends visually with the surfaces operators
+ * just walked through. See `web/ui/src/styles.css` for the canonical
+ * source.
+ */
+
+import { WORDMARK_TEXT, brandMarkSvg } from "./brand.ts";
+import { escapeHtml } from "./oauth-ui.ts";
+import type { UpstreamState } from "./proxy-state.ts";
+
+/** Retry cadence for transient state, in ms. Mirrors meta-refresh content. */
+export const TRANSIENT_RETRY_MS = 2_000;
+
+/** Max polls a transient HTML page will run before showing a manual button. */
+export const TRANSIENT_MAX_ATTEMPTS = 5;
+
+/** Admin link surfaced on persistent responses. /admin/modules opens the
+ * modules pane with per-module status + restart controls. */
+export const ADMIN_MODULES_URL = "/admin/modules";
+
+/** JSON error vocabulary. Matches the snake_case shape used elsewhere
+ * in the hub's API (`api-modules-config.ts` etc.) for consistency. */
+export const ERROR_TYPE_TRANSIENT = "upstream_starting";
+export const ERROR_TYPE_PERSISTENT = "upstream_unreachable";
+
+/** Per-route HTTP status for each upstream state. */
+export function statusForState(state: UpstreamState): 502 | 503 {
+  return state === "transient" ? 503 : 502;
+}
+
+export interface BuildProxyErrorOpts {
+  /** Canonical short name (vault/scribe/notes/…). Folded into the response
+   *  for operator clarity. */
+  short: string;
+  /** services.json `name` field — what shipped on the entry. Falls back to
+   *  `short` when they coincide. Used in JSON error description. */
+  serviceLabel: string;
+  /** The classified failure mode. */
+  state: UpstreamState;
+  /** Raw error message from the failed `fetch()`. Surfaced in JSON so a
+   *  consumer can log it; not surfaced in HTML (operators don't read
+   *  ECONNREFUSED, the visual cue is enough). */
+  upstreamError: string;
+}
+
+export interface ProxyErrorResponse {
+  body: string;
+  status: 502 | 503;
+  contentType: string;
+  /** Optional Retry-After header value (seconds, per RFC 9110 §10.2.3). */
+  retryAfter?: string;
+}
+
+/**
+ * True iff the caller wants HTML. Mirrors the existing one-line check at
+ * `hub-server.ts:2079` rather than introducing a separate negotiation
+ * module — the hub's accept handling is uniformly "look for `text/html`"
+ * across surfaces.
+ */
+export function wantsHtml(req: Request): boolean {
+  const accept = req.headers.get("accept") ?? "";
+  if (accept === "") return true; // No Accept header → assume browser-ish.
+  if (accept.includes("application/json") && !accept.includes("text/html")) {
+    return false;
+  }
+  return accept.includes("text/html") || accept.includes("*/*");
+}
+
+/**
+ * Build the JSON response body for a proxy-error response.
+ *
+ *   - Transient: includes `retry_after_ms` + `attempts_remaining` so an
+ *     API consumer (CLI, MCP client) can implement its own bounded retry.
+ *   - Persistent: includes `admin_url` so a developer/operator tool can
+ *     surface a "go check the supervisor" affordance.
+ */
+export function renderProxyErrorJson(opts: BuildProxyErrorOpts): ProxyErrorResponse {
+  const status = statusForState(opts.state);
+  if (opts.state === "transient") {
+    const body = JSON.stringify({
+      error: ERROR_TYPE_TRANSIENT,
+      error_type: ERROR_TYPE_TRANSIENT,
+      error_description: `${opts.serviceLabel} is still starting; retry shortly.`,
+      service: opts.short,
+      retry_after_ms: TRANSIENT_RETRY_MS,
+      attempts_remaining: TRANSIENT_MAX_ATTEMPTS,
+    });
+    return {
+      body,
+      status,
+      contentType: "application/json",
+      retryAfter: String(Math.ceil(TRANSIENT_RETRY_MS / 1000)),
+    };
+  }
+  const body = JSON.stringify({
+    error: ERROR_TYPE_PERSISTENT,
+    error_type: ERROR_TYPE_PERSISTENT,
+    error_description: `${opts.serviceLabel} upstream unreachable: ${opts.upstreamError}`,
+    service: opts.short,
+    admin_url: ADMIN_MODULES_URL,
+  });
+  return {
+    body,
+    status,
+    contentType: "application/json",
+  };
+}
+
+/**
+ * Build the HTML response body for a proxy-error response. Two distinct
+ * layouts:
+ *
+ *   - **Transient**: title "Just a moment", subhead "Loading <module>",
+ *     a quiet spinner, a meta-refresh + JS poll that hits `/api/ready`
+ *     up to `TRANSIENT_MAX_ATTEMPTS` times at `TRANSIENT_RETRY_MS`
+ *     cadence, then a manual "Refresh" button. No admin link.
+ *
+ *   - **Persistent**: title "Module unreachable", subhead naming the
+ *     module, no auto-retry, prominent "View module status" link to
+ *     /admin/modules + a manual "Refresh" button. The visual treatment
+ *     leans on `--error` / `--error-soft` design tokens.
+ */
+export function renderProxyErrorHtml(opts: BuildProxyErrorOpts): ProxyErrorResponse {
+  const status = statusForState(opts.state);
+  const safeShort = escapeHtml(opts.short);
+  const safeLabel = escapeHtml(opts.serviceLabel);
+  const isTransient = opts.state === "transient";
+  const title = isTransient ? "Just a moment" : "Module unreachable";
+
+  const headerVariant = isTransient ? "transient" : "persistent";
+  const subheadCopy = isTransient
+    ? `<span class="muted">Loading</span> <code>${safeShort}</code><span class="muted">…</span>`
+    : `<code>${safeShort}</code> <span class="muted">is not responding right now.</span>`;
+
+  const explanation = isTransient
+    ? `<p class="explanation">The hub is still bringing up the <code>${safeLabel}</code> module. This usually resolves within a few seconds. We'll refresh automatically.</p>`
+    : `<p class="explanation">The hub couldn't reach the <code>${safeLabel}</code> module. It may have crashed, failed to start, or been stopped. Check the module's status for logs and a restart option.</p>`;
+
+  const metaRefresh = isTransient
+    ? `<meta http-equiv="refresh" content="${Math.ceil(TRANSIENT_RETRY_MS / 1000)}">`
+    : "";
+
+  const spinnerOrIcon = isTransient
+    ? `<div class="status-indicator status-transient" aria-hidden="true"><span class="spinner"></span></div>`
+    : `<div class="status-indicator status-persistent" aria-hidden="true"><span class="error-icon">!</span></div>`;
+
+  const actionsHtml = isTransient
+    ? `
+      <div class="actions" id="actions-transient">
+        <p class="poll-status" id="poll-status">Checking again in <span id="poll-countdown">${Math.ceil(
+          TRANSIENT_RETRY_MS / 1000,
+        )}</span>s… <span class="muted">(attempt <span id="poll-attempt">1</span> of ${TRANSIENT_MAX_ATTEMPTS})</span></p>
+      </div>
+      <div class="actions" id="actions-give-up" hidden>
+        <p class="give-up-copy">Still loading. <button type="button" class="btn btn-primary" id="manual-refresh">Refresh now</button></p>
+      </div>`
+    : `
+      <div class="actions">
+        <a href="${ADMIN_MODULES_URL}" class="btn btn-primary">View module status</a>
+        <button type="button" class="btn btn-secondary" id="manual-refresh">Refresh</button>
+      </div>`;
+
+  // The poll script only emits for transient state. It:
+  //   1. Polls /api/ready every TRANSIENT_RETRY_MS.
+  //   2. On `ready: true` for our module, reloads the page (which now
+  //      proxies through successfully).
+  //   3. After TRANSIENT_MAX_ATTEMPTS, swaps the "Checking…" UI for the
+  //      manual "Refresh now" button.
+  // Defensive: any fetch error counts as a missed attempt — we don't want
+  // a `/api/ready` outage to lock the page in a permanent "still loading"
+  // state.
+  const pollScript = isTransient
+    ? `
+      <script>
+        (function () {
+          var maxAttempts = ${TRANSIENT_MAX_ATTEMPTS};
+          var intervalMs = ${TRANSIENT_RETRY_MS};
+          var short = ${JSON.stringify(opts.short)};
+          var attempt = 1;
+          var elCountdown = document.getElementById('poll-countdown');
+          var elAttempt = document.getElementById('poll-attempt');
+          var elActive = document.getElementById('actions-transient');
+          var elGiveUp = document.getElementById('actions-give-up');
+          var elManualBtn = document.getElementById('manual-refresh');
+          var countdown = Math.ceil(intervalMs / 1000);
+          var countdownTimer = setInterval(function () {
+            countdown -= 1;
+            if (countdown <= 0) countdown = Math.ceil(intervalMs / 1000);
+            if (elCountdown) elCountdown.textContent = String(countdown);
+          }, 1000);
+          function giveUp() {
+            clearInterval(countdownTimer);
+            if (elActive) elActive.hidden = true;
+            if (elGiveUp) elGiveUp.hidden = false;
+          }
+          function poll() {
+            if (attempt > maxAttempts) {
+              giveUp();
+              return;
+            }
+            fetch('/api/ready', { headers: { accept: 'application/json' }, cache: 'no-store' })
+              .then(function (r) { return r.ok ? r.json() : null; })
+              .then(function (data) {
+                if (data && data.ready) {
+                  window.location.reload();
+                  return;
+                }
+                // Module-specific check: if /api/ready lists our short in
+                // ready_modules we can reload too.
+                if (data && Array.isArray(data.ready_modules) && data.ready_modules.indexOf(short) !== -1) {
+                  window.location.reload();
+                  return;
+                }
+                attempt += 1;
+                if (elAttempt) elAttempt.textContent = String(attempt);
+                if (attempt > maxAttempts) giveUp();
+              })
+              .catch(function () {
+                attempt += 1;
+                if (elAttempt) elAttempt.textContent = String(attempt);
+                if (attempt > maxAttempts) giveUp();
+              });
+          }
+          setTimeout(poll, intervalMs);
+          setInterval(function () {
+            if (attempt <= maxAttempts) poll();
+          }, intervalMs);
+          if (elManualBtn) {
+            elManualBtn.addEventListener('click', function () { window.location.reload(); });
+          }
+        }());
+      </script>`
+    : `
+      <script>
+        (function () {
+          var btn = document.getElementById('manual-refresh');
+          if (btn) btn.addEventListener('click', function () { window.location.reload(); });
+        }());
+      </script>`;
+
+  const body = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>${escapeHtml(title)}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="referrer" content="no-referrer" />
+  ${metaRefresh}
+  <style>${PROXY_ERROR_STYLES}</style>
+</head>
+<body>
+  <main>
+    <div class="card card-${headerVariant}">
+      <div class="card-header">
+        <div class="brand">
+          <span class="brand-mark" aria-hidden="true">${brandMarkSvg(20, `proxy-${headerVariant}`)}</span>
+          <span class="brand-name">${WORDMARK_TEXT}</span>
+        </div>
+        ${spinnerOrIcon}
+        <h1>${escapeHtml(title)}</h1>
+        <p class="subtitle">${subheadCopy}</p>
+      </div>
+      ${explanation}
+      ${actionsHtml}
+    </div>
+  </main>
+  ${pollScript}
+</body>
+</html>`;
+
+  const headers: ProxyErrorResponse = {
+    body,
+    status,
+    contentType: "text/html; charset=utf-8",
+  };
+  if (isTransient) {
+    headers.retryAfter = String(Math.ceil(TRANSIENT_RETRY_MS / 1000));
+  }
+  return headers;
+}
+
+/**
+ * Dispatch between HTML + JSON renderers based on the request's Accept
+ * header. Single entry point used by `proxyRequest`.
+ */
+export function renderProxyError(req: Request, opts: BuildProxyErrorOpts): ProxyErrorResponse {
+  return wantsHtml(req) ? renderProxyErrorHtml(opts) : renderProxyErrorJson(opts);
+}
+
+/**
+ * Construct the actual Response from a ProxyErrorResponse. Pulled out so
+ * tests can assert on the body shape without re-deriving the headers.
+ */
+export function toResponse(out: ProxyErrorResponse): Response {
+  const headers: Record<string, string> = {
+    "content-type": out.contentType,
+    "cache-control": "no-store",
+  };
+  if (out.retryAfter) headers["retry-after"] = out.retryAfter;
+  return new Response(out.body, { status: out.status, headers });
+}
+
+const PROXY_ERROR_STYLES = `
+  :root {
+    --bg: #faf8f4;
+    --bg-soft: #f3f0ea;
+    --fg: #2c2a26;
+    --fg-muted: #6b6860;
+    --fg-dim: #9a9690;
+    --accent: #4a7c59;
+    --accent-soft: rgba(74, 124, 89, 0.08);
+    --accent-hover: #3d6849;
+    --border: #e4e0d8;
+    --card-bg: #ffffff;
+    --error: #a3392b;
+    --error-soft: rgba(163, 57, 43, 0.08);
+    --warn: #b08023;
+    --warn-soft: rgba(176, 128, 35, 0.08);
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    background: var(--bg);
+    color: var(--fg);
+    line-height: 1.55;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+  }
+  main {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 1.5rem;
+  }
+  .card {
+    width: 100%;
+    max-width: 30rem;
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 2rem 1.75rem;
+    box-shadow: 0 1px 2px rgba(44, 42, 38, 0.04), 0 8px 24px rgba(44, 42, 38, 0.06);
+    text-align: center;
+  }
+  .card-header { margin-bottom: 1.25rem; }
+  .brand {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    color: var(--accent);
+    font-weight: 500;
+    font-size: 0.95rem;
+    margin-bottom: 1.5rem;
+  }
+  .brand-mark { display: inline-flex; line-height: 0; }
+  .brand-mark svg { width: 20px; height: 20px; }
+  .status-indicator {
+    width: 56px;
+    height: 56px;
+    margin: 0 auto 1.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+  }
+  .status-transient {
+    background: var(--accent-soft);
+  }
+  .status-persistent {
+    background: var(--error-soft);
+    color: var(--error);
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: 1.75rem;
+    font-weight: 600;
+  }
+  .spinner {
+    width: 24px;
+    height: 24px;
+    border: 2.5px solid var(--accent-soft);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: spin 0.9s linear infinite;
+  }
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+  h1 {
+    font-family: Georgia, "Times New Roman", serif;
+    font-weight: 400;
+    font-size: 1.6rem;
+    line-height: 1.2;
+    margin: 0 0 0.5rem;
+    color: var(--fg);
+  }
+  .subtitle {
+    margin: 0;
+    color: var(--fg-muted);
+    font-size: 0.95rem;
+  }
+  .subtitle code, .explanation code {
+    font-family: ui-monospace, "SF Mono", Menlo, Monaco, monospace;
+    background: var(--bg-soft);
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.85em;
+    color: var(--fg);
+  }
+  .muted { color: var(--fg-dim); }
+  .explanation {
+    color: var(--fg-muted);
+    font-size: 0.92rem;
+    margin: 0 0 1.5rem;
+    text-align: left;
+  }
+  .actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    align-items: stretch;
+  }
+  .poll-status {
+    margin: 0;
+    color: var(--fg-muted);
+    font-size: 0.88rem;
+    text-align: center;
+  }
+  .give-up-copy {
+    color: var(--fg-muted);
+    font-size: 0.92rem;
+    margin: 0;
+    text-align: center;
+  }
+  .btn {
+    display: inline-block;
+    font: inherit;
+    border-radius: 6px;
+    padding: 0.55rem 1.1rem;
+    cursor: pointer;
+    text-decoration: none;
+    text-align: center;
+    border: 1px solid transparent;
+    transition: background 0.15s ease, border-color 0.15s ease;
+  }
+  .btn-primary {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+  }
+  .btn-primary:hover {
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
+  }
+  .btn-secondary {
+    background: white;
+    color: var(--fg);
+    border-color: var(--border);
+  }
+  .btn-secondary:hover {
+    background: var(--bg-soft);
+  }
+`;

--- a/src/proxy-error-ui.ts
+++ b/src/proxy-error-ui.ts
@@ -1,5 +1,5 @@
 /**
- * HTML + JSON renderers for upstream-unreachable responses (hub#444).
+ * HTML + JSON renderers for upstream-unreachable responses (hub#443).
  *
  * Two states, two presentations, two content types — four total responses.
  *
@@ -9,7 +9,7 @@
  *                       the budget, fall back to a manual Refresh button.
  *
  *   transient + JSON  → 503, `{ error: "upstream_starting", error_type,
- *                       retry_after_ms: 2000, attempts_remaining: <N> }`
+ *                       retry_after_ms: 2000, max_attempts: <N> }`
  *                       so an API consumer can drive its own backoff.
  *
  *   persistent + HTML → 502, branded "Module unreachable" page with NO
@@ -97,8 +97,13 @@ export function wantsHtml(req: Request): boolean {
 /**
  * Build the JSON response body for a proxy-error response.
  *
- *   - Transient: includes `retry_after_ms` + `attempts_remaining` so an
- *     API consumer (CLI, MCP client) can implement its own bounded retry.
+ *   - Transient: includes `retry_after_ms` + `max_attempts` so an API
+ *     consumer (CLI, MCP client) can implement its own bounded retry.
+ *     `max_attempts` is the ceiling, not a per-request remaining count —
+ *     hub doesn't track per-consumer state, so it can't honestly emit a
+ *     decrementing counter. The HTML page tracks its own counter
+ *     client-side (5 polls then manual fallback); JSON consumers do
+ *     the same with this ceiling as the budget.
  *   - Persistent: includes `admin_url` so a developer/operator tool can
  *     surface a "go check the supervisor" affordance.
  */
@@ -111,7 +116,7 @@ export function renderProxyErrorJson(opts: BuildProxyErrorOpts): ProxyErrorRespo
       error_description: `${opts.serviceLabel} is still starting; retry shortly.`,
       service: opts.short,
       retry_after_ms: TRANSIENT_RETRY_MS,
-      attempts_remaining: TRANSIENT_MAX_ATTEMPTS,
+      max_attempts: TRANSIENT_MAX_ATTEMPTS,
     });
     return {
       body,
@@ -249,9 +254,18 @@ export function renderProxyErrorHtml(opts: BuildProxyErrorOpts): ProxyErrorRespo
                 if (attempt > maxAttempts) giveUp();
               });
           }
-          setTimeout(poll, intervalMs);
-          setInterval(function () {
-            if (attempt <= maxAttempts) poll();
+          // Single timer source: setInterval fires every intervalMs and
+          // self-stops at maxAttempts. The previous shape armed BOTH a
+          // setTimeout AND a setInterval at the same cadence — they
+          // double-fired at T+intervalMs, racing the attempt counter and
+          // reaching the giveUp ceiling in ~6s instead of the designed 10s.
+          // Reviewer-flagged on #443.
+          var pollTimer = setInterval(function () {
+            if (attempt > maxAttempts) {
+              clearInterval(pollTimer);
+              return;
+            }
+            poll();
           }, intervalMs);
           if (elManualBtn) {
             elManualBtn.addEventListener('click', function () { window.location.reload(); });

--- a/src/proxy-state.ts
+++ b/src/proxy-state.ts
@@ -1,5 +1,5 @@
 /**
- * Boot-readiness classifier for upstream proxy failures (hub#444).
+ * Boot-readiness classifier for upstream proxy failures (hub#443).
  *
  * When `proxyRequest` in `hub-server.ts` gets a fetch error talking to a
  * module's loopback port, we want to differentiate two operator

--- a/src/proxy-state.ts
+++ b/src/proxy-state.ts
@@ -1,0 +1,131 @@
+/**
+ * Boot-readiness classifier for upstream proxy failures (hub#444).
+ *
+ * When `proxyRequest` in `hub-server.ts` gets a fetch error talking to a
+ * module's loopback port, we want to differentiate two operator
+ * experiences:
+ *
+ *   - **transient** — the module is *currently* booting and the loopback
+ *     socket isn't bound yet (or is mid-restart). The right response is
+ *     "wait a moment, refresh." A `parachute start hub` triggers this
+ *     for the 5–15s window while modules are still coming up; without
+ *     classification the wizard renders a hard `Bad gateway` JSON 502
+ *     and operators panic.
+ *
+ *   - **persistent** — the module has been spawned long enough that it
+ *     should be reachable, OR the supervisor declared it crashed, OR
+ *     there's no live process at all. The right response is "something
+ *     went wrong, check logs." Auto-retry would just spin the SPA.
+ *
+ * The classification consults the cheapest signals we already have:
+ *
+ *   1. Container-mode (`parachute serve`): the `Supervisor` knows
+ *      lifecycle (`starting | running | stopped | crashed | restarting`)
+ *      and `startedAt`. Walks the four-state vocabulary; restarting +
+ *      starting are always transient, crashed/stopped are persistent,
+ *      running is transient inside the boot window and persistent after.
+ *
+ *   2. On-box CLI mode (`parachute start <svc>`): no supervisor. We
+ *      fall back to the pidfile state via `processState`. A live PID
+ *      whose pidfile mtime is recent → transient. Live PID with an old
+ *      pidfile → persistent (process is up but the listener went away).
+ *      No pidfile / stale pidfile → persistent.
+ *
+ * The default boot window is 30s — long enough that vault's SQLite
+ * pragma warmup + scribe's whisper-model load both finish inside it,
+ * short enough that an operator who's been staring at a `Loading…`
+ * spinner for 30+ seconds deserves the "something went wrong" page
+ * rather than another "still booting" tease.
+ */
+
+import { CONFIG_DIR } from "./config.ts";
+import { type ProcessState, processState } from "./process-state.ts";
+import type { Supervisor } from "./supervisor.ts";
+
+/** Classification result. */
+export type UpstreamState = "transient" | "persistent";
+
+/** Default boot window: a fetch failure within this many ms of the most
+ * recent spawn timestamp counts as transient (still warming up). 30s
+ * covers vault's SQLite pragma init + scribe's whisper model load with
+ * margin. */
+export const DEFAULT_BOOT_WINDOW_MS = 30_000;
+
+export interface ClassifyOpts {
+  /** Container-mode supervisor handle. Absent under on-box CLI mode. */
+  supervisor?: Supervisor;
+  /** Test seam over `Date.now()`. */
+  now?: () => number;
+  /** Test seam over `processState` (pidfile reader). */
+  readProcessState?: (svc: string, configDir?: string) => ProcessState;
+  /** Override config dir (test seam). Defaults to CONFIG_DIR. */
+  configDir?: string;
+  /** Override the boot window (test seam). Defaults to 30_000 ms. */
+  bootWindowMs?: number;
+}
+
+/**
+ * Classify why a loopback fetch to module `short` failed.
+ *
+ * `short` is the canonical short name (vault / scribe / notes / …) used as
+ * the supervisor map key AND the per-service `~/.parachute/<short>/` config
+ * directory key. Callers in `hub-server.ts` derive it from
+ * `shortNameForManifest(entry.name)` and fall back to the entry's raw name
+ * for unknown modules (third-party services with no canonical short — they
+ * land in "persistent" by default since we have no boot-window signal).
+ *
+ * Returns "persistent" by default — when in doubt, don't auto-retry. The
+ * worst outcome of a wrong "transient" classification is a JS poll that
+ * never sees the module come up; the worst outcome of a wrong "persistent"
+ * is an operator who has to refresh once. Persistent is the safer default.
+ */
+export function classifyUpstream(short: string, opts: ClassifyOpts = {}): UpstreamState {
+  const now = (opts.now ?? Date.now)();
+  const bootWindow = opts.bootWindowMs ?? DEFAULT_BOOT_WINDOW_MS;
+
+  // 1. Supervisor (container mode) — authoritative when present.
+  if (opts.supervisor) {
+    const state = opts.supervisor.get(short);
+    if (state) {
+      switch (state.status) {
+        case "starting":
+        case "restarting":
+          return "transient";
+        case "crashed":
+        case "stopped":
+          return "persistent";
+        case "running": {
+          // Running but socket isn't answering. Inside the boot window
+          // we assume the process hasn't bound its listener yet; after,
+          // we assume the listener died.
+          if (state.startedAt === undefined) return "persistent";
+          const startedAt = Date.parse(state.startedAt);
+          if (!Number.isFinite(startedAt)) return "persistent";
+          return now - startedAt < bootWindow ? "transient" : "persistent";
+        }
+      }
+    }
+    // Module not tracked by supervisor — could be a third-party row or a
+    // services.json entry that wasn't spawned at boot. Fall through to the
+    // pidfile check (still useful if the operator launched it via `parachute
+    // start` before this hub came up).
+  }
+
+  // 2. Pidfile (on-box CLI mode) — `~/.parachute/<short>/run/<short>.pid`.
+  const readState = opts.readProcessState ?? processState;
+  const configDir = opts.configDir ?? CONFIG_DIR;
+  let ps: ProcessState;
+  try {
+    ps = readState(short, configDir);
+  } catch {
+    // pidfile read can race with cleanup; treat read errors as no signal.
+    return "persistent";
+  }
+  if (ps.status === "running" && ps.startedAt) {
+    const ageMs = now - ps.startedAt.getTime();
+    return ageMs < bootWindow ? "transient" : "persistent";
+  }
+  // Stopped (stale pidfile), unknown (no pidfile) → persistent. No claim
+  // of "currently booting" can be made without a fresh-mtime pidfile.
+  return "persistent";
+}


### PR DESCRIPTION
## Summary

Hub's `proxyRequest` previously returned a flat JSON 502 (`{"error":"... upstream unreachable: ..."}`) whenever an upstream module's `fetch()` failed. Operators clicking the wizard during the 5–15s window after `parachute start hub` saw a hard error page even though modules were simply still booting. This PR ships boot-readiness gating per Aaron's 2026-05-27 design approval.

## The four design decisions (all approved 2026-05-27)

**(a) Transient vs persistent state — YES.** New `src/proxy-state.ts` classifier reads the supervisor (`status` + `startedAt` against a 30s boot window) AND pidfile state. Returns `"transient"` while a module is legitimately mid-boot; `"persistent"` once it's crashed / stopped / exceeded the window.

**(b) HTML vs JSON via Accept header — YES.** New `src/proxy-error-ui.ts` builds distinct responses for each content type. JSON consumers get structured error vocabulary (`upstream_starting` / `upstream_unreachable`); browsers get branded HTML pages matching the SPA's design tokens (`--accent`, `--bg`, `--fg`).

**(c) Auto-retry only in transient state, 2s cadence + max 5 attempts — YES.** HTML transient page carries `<meta http-equiv="refresh" content="2">` plus an inline JS poll against the new `/api/ready` endpoint (5 attempts × 2s ≈ 10s ceiling), then falls back to a manual Refresh button. JSON transient responses include `retry_after_ms: 2000` + `attempts_remaining: 5` + `Retry-After: 2` header. Persistent responses carry no retry hint — refresh won't help.

**(d) Admin-link only on persistent state — YES.** Persistent HTML page links to `/admin/modules` for log access + restart; persistent JSON carries `admin_url`. Transient surfaces stay clean (no admin noise while the wait is normal).

Status codes follow RFC 9110: **503 + Retry-After** for transient (Service Unavailable / try again), **502** for persistent (Bad Gateway / probably broken).

## Implementation cuts

- **`src/proxy-state.ts`** — `classifyUpstream(short, opts)` returns `"transient" | "persistent"`. Consults supervisor (container mode) → falls back to pidfile (`processState` in on-box CLI mode). Defensive: read errors / unknown lifecycle default to persistent.
- **`src/proxy-error-ui.ts`** — `renderProxyError(req, opts)` dispatches by Accept header. Includes inline CSS matching the OAuth UI palette. Two distinct HTML layouts (transient = spinner + "Just a moment" + poll script; persistent = error icon + "Module unreachable" + admin link).
- **`src/api-ready.ts`** — new `GET /api/ready` returns `{ ready, ready_modules, transient_modules, persistent_modules }`. Public + DB-free (the page polling it is itself pre-auth when modules are still booting).
- **`src/hub-server.ts`** — `proxyRequest` now takes `short` + `supervisor`, classifies on fetch failure, returns the appropriate response. Wires `/api/ready` route before the pre-admin setup gate. Threaded supervisor through `proxyToVault` + `proxyToService`.

## Test plan

`bun test ./src`: **2265 pass, 1 skip, 0 fail** (was 2215 before — +50 new tests). `bun run typecheck`: clean.

- [x] `src/__tests__/proxy-state.test.ts` — 16 cases covering supervisor mode (every status × boot-window boundary) + CLI mode (pidfile age, defensive throw handling, real `processState` integration).
- [x] `src/__tests__/proxy-error-ui.test.ts` — JSON + HTML shape, retry fields presence/absence per state, admin_url presence/absence per state, HTML-escapes injected fields, Accept-header negotiation edge cases.
- [x] `src/__tests__/api-ready.test.ts` — supervisor view assembly, per-status classification, method check (rejects POST, accepts HEAD).
- [x] `src/__tests__/hub-server.test.ts` — eight new end-to-end cases through `hubFetch`: each of the four lifecycle states × both Accept shapes (HTML / JSON), plus `/api/ready` reachable pre-admin. Updated two existing tests that asserted the old `body.error` shape.
- [ ] Manual smoke: `parachute start hub` with a known-slow module, observe the wizard auto-refreshes through transient phase + lands on the working module page (operator-driven, post-merge).

## Notes for reviewer

- Classifier defaults to `"persistent"` on every uncertainty (no supervisor + no pidfile, unknown short name, read errors). Safer to ask the operator to refresh once than to lie about boot state.
- The poll script is small enough to inline into the HTML (no separate JS bundle). Polls run via `setInterval` + a counter, with `giveUp()` after `TRANSIENT_MAX_ATTEMPTS`; any fetch error counts as a missed attempt so `/api/ready` outages can't lock the page in "still loading."
- `/api/ready` is intentionally public — the page that polls it is rendered pre-auth (modules failing means the operator may not even have a session yet). DB-free for the same reason.
- Existing tests in `hub-server.test.ts` that asserted the old plain-text `"upstream unreachable"` body were updated, not deleted — they still exercise the proxy fallback path, just with the new structured-JSON shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)