### PR TITLE
chore(release): 0.5.14-rc.6 — boot-readiness gating

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.5",
+  "version": "0.5.14-rc.6",
   "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Version bump only. Picks up #443 (boot-readiness gating):
- `proxy-state.ts` classifies upstream failures as transient (30s boot window) vs persistent
- Branded HTML pages for browser navigations (transient: spinner + 5x2s `/api/ready` poll + manual fallback; persistent: admin link)
- Structured JSON for API consumers (transient: `retry_after_ms` + `max_attempts`; persistent: `admin_url`)
- New public `/api/ready` endpoint for the polling page

## Test plan

- [x] `bun test ./src` — 2265 pass / 1 skip / 0 fail
- [x] `bun run typecheck` — clean
- [ ] After merge: tag `v0.5.14-rc.6` + push → CI publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)