### PR TITLE
feat(hub): parachute init extends to optional exposure chain (laptop ≈ server, one command)

### DIFF
--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { init, resolveAdminUrl } from "../commands/init.ts";
+import { init, looksLikeServer, resolveAdminUrl } from "../commands/init.ts";
 import type { ExposeState } from "../expose-state.ts";
 import { writeHubPort } from "../hub-control.ts";
 import { writePid } from "../process-state.ts";
@@ -194,6 +194,8 @@ describe("init", () => {
           opened.push(url);
           return true;
         },
+        // Skip the new exposure prompt — this test is about the browser prompt only.
+        noExposePrompt: true,
       });
       expect(code).toBe(0);
       expect(opened).toEqual(["http://127.0.0.1:1939/admin/"]);
@@ -221,6 +223,7 @@ describe("init", () => {
           opened.push(url);
           return true;
         },
+        noExposePrompt: true,
       });
       expect(code).toBe(0);
       expect(opened).toEqual([]);
@@ -253,6 +256,7 @@ describe("init", () => {
           return true;
         },
         noBrowser: true,
+        noExposePrompt: true,
       });
       expect(code).toBe(0);
       expect(prompted).toBe(false);
@@ -308,6 +312,7 @@ describe("init", () => {
           opened.push(url);
           return true;
         },
+        noExposePrompt: true,
       });
       expect(code).toBe(0);
       // No prompt offered on Windows — just URL printed.
@@ -342,3 +347,448 @@ describe("init", () => {
     }
   });
 });
+
+describe("looksLikeServer heuristic", () => {
+  test("macOS is never a server", () => {
+    expect(looksLikeServer("darwin", { SSH_CONNECTION: "1.2.3.4 22 5.6.7.8 22" })).toBe(false);
+    expect(looksLikeServer("darwin", {})).toBe(false);
+  });
+
+  test("Linux desktop with DISPLAY is a laptop", () => {
+    expect(looksLikeServer("linux", { DISPLAY: ":0" })).toBe(false);
+    expect(looksLikeServer("linux", { WAYLAND_DISPLAY: "wayland-0" })).toBe(false);
+  });
+
+  test("Linux + SSH session → server", () => {
+    expect(looksLikeServer("linux", { SSH_CONNECTION: "1.2.3.4 22 5.6.7.8 22" })).toBe(true);
+    expect(looksLikeServer("linux", { SSH_CLIENT: "1.2.3.4 22 5.6.7.8" })).toBe(true);
+    expect(looksLikeServer("linux", { SSH_TTY: "/dev/pts/0" })).toBe(true);
+  });
+
+  test("Linux + no DISPLAY → server (headless)", () => {
+    expect(looksLikeServer("linux", {})).toBe(true);
+  });
+
+  test("Windows is not a server (init doesn't auto-pick on win32 anyway)", () => {
+    expect(looksLikeServer("win32", {})).toBe(false);
+  });
+});
+
+describe("init exposure chain", () => {
+  test("TTY + no exposure + no flags → prompt is shown", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      const promptCalls: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => undefined,
+        isTty: true,
+        platform: "darwin",
+        env: {},
+        prompt: async (q) => {
+          promptCalls.push(q);
+          // First prompt is the exposure picker → pick "none"; second
+          // is the browser-open question → say no.
+          if (promptCalls.length === 1) return "1";
+          return "n";
+        },
+        openBrowser: () => true,
+      });
+      expect(code).toBe(0);
+      // The exposure prompt was shown.
+      expect(promptCalls.some((q) => q.toLowerCase().includes("pick"))).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("--no-expose-prompt skips the prompt entirely", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      let exposureChained = false;
+      const promptCalls: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => undefined,
+        isTty: true,
+        platform: "darwin",
+        env: {},
+        prompt: async (q) => {
+          promptCalls.push(q);
+          return "n";
+        },
+        openBrowser: () => true,
+        exposeTailnetImpl: async () => {
+          exposureChained = true;
+          return 0;
+        },
+        exposeCloudflareImpl: async () => {
+          exposureChained = true;
+          return 0;
+        },
+        noExposePrompt: true,
+      });
+      expect(code).toBe(0);
+      expect(exposureChained).toBe(false);
+      // No exposure prompt; only the browser-open prompt.
+      expect(promptCalls.some((q) => q.toLowerCase().includes("pick"))).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("--expose tailnet chains into tailnet without prompting", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      let tailnetCalls = 0;
+      let cloudflareCalls = 0;
+      const promptCalls: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => undefined,
+        isTty: true,
+        platform: "linux",
+        env: {},
+        prompt: async (q) => {
+          promptCalls.push(q);
+          return "n";
+        },
+        openBrowser: () => true,
+        exposeTailnetImpl: async () => {
+          tailnetCalls += 1;
+          return 0;
+        },
+        exposeCloudflareImpl: async () => {
+          cloudflareCalls += 1;
+          return 0;
+        },
+        exposeChoice: "tailnet",
+      });
+      expect(code).toBe(0);
+      expect(tailnetCalls).toBe(1);
+      expect(cloudflareCalls).toBe(0);
+      // No exposure prompt — the flag pre-empted it.
+      expect(promptCalls.some((q) => q.toLowerCase().includes("pick"))).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("--expose cloudflare chains into cloudflare without prompting", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      let tailnetCalls = 0;
+      let cloudflareCalls = 0;
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+        env: {},
+        exposeTailnetImpl: async () => {
+          tailnetCalls += 1;
+          return 0;
+        },
+        exposeCloudflareImpl: async () => {
+          cloudflareCalls += 1;
+          return 0;
+        },
+        exposeChoice: "cloudflare",
+      });
+      expect(code).toBe(0);
+      expect(cloudflareCalls).toBe(1);
+      expect(tailnetCalls).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("--expose none skips exposure", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      let tailnetCalls = 0;
+      let cloudflareCalls = 0;
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+        env: {},
+        exposeTailnetImpl: async () => {
+          tailnetCalls += 1;
+          return 0;
+        },
+        exposeCloudflareImpl: async () => {
+          cloudflareCalls += 1;
+          return 0;
+        },
+        exposeChoice: "none",
+      });
+      expect(code).toBe(0);
+      expect(tailnetCalls).toBe(0);
+      expect(cloudflareCalls).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("default selection differs by SSH heuristic (laptop → 1, server → 3)", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+
+      // Laptop: macOS, no SSH → default is "1" (none).
+      let promptLog: string[] = [];
+      // Array-based holder defeats TS control-flow narrowing — element
+      // reads on an array typed as ExposeChoice[] always come back as the
+      // declared element type, not narrowed to the last assigned literal.
+      const chained: ExposeChoice[] = ["none"];
+      const setChained = (v: ExposeChoice) => {
+        chained[0] = v;
+      };
+      await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => promptLog.push(l),
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => undefined,
+        isTty: true,
+        platform: "darwin",
+        env: {},
+        prompt: async (q) => {
+          promptLog.push(`Q: ${q}`);
+          // Empty == confirm default.
+          if (q.toLowerCase().includes("pick")) return "";
+          return "n";
+        },
+        openBrowser: () => true,
+        exposeTailnetImpl: async () => {
+          setChained("tailnet");
+          return 0;
+        },
+        exposeCloudflareImpl: async () => {
+          setChained("cloudflare");
+          return 0;
+        },
+      });
+      // Default on laptop is "none" → no chain.
+      expect(chained[0]).toBe("none");
+      // The "Pick [1]" prompt was shown (loopback as default).
+      expect(promptLog.some((l) => l.includes("Pick [1]"))).toBe(true);
+
+      // Server: Linux + SSH → default is "3" (cloudflare).
+      promptLog = [];
+      setChained("none");
+      await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => promptLog.push(l),
+        alive: () => true,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: false }),
+        readExposeStateFn: () => undefined,
+        isTty: true,
+        platform: "linux",
+        env: { SSH_CONNECTION: "1.2.3.4 22 5.6.7.8 22" },
+        prompt: async (q) => {
+          promptLog.push(`Q: ${q}`);
+          if (q.toLowerCase().includes("pick")) return "";
+          return "n";
+        },
+        openBrowser: () => true,
+        exposeTailnetImpl: async () => {
+          setChained("tailnet");
+          return 0;
+        },
+        exposeCloudflareImpl: async () => {
+          setChained("cloudflare");
+          return 0;
+        },
+      });
+      expect(chained[0]).toBe("cloudflare");
+      expect(promptLog.some((l) => l.includes("Pick [3]"))).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("hub already exposed → no prompt, FQDN URL printed", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      const state: ExposeState = {
+        version: 1,
+        layer: "public",
+        mode: "path",
+        canonicalFqdn: "ec2-example.parachute.computer",
+        port: 443,
+        funnel: false,
+        entries: [],
+        hubOrigin: "https://ec2-example.parachute.computer",
+      };
+      const promptCalls: string[] = [];
+      let chained = false;
+      const logs: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => logs.push(l),
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => state,
+        isTty: true,
+        platform: "linux",
+        env: { SSH_CONNECTION: "1.2.3.4 22 5.6.7.8 22" },
+        prompt: async (q) => {
+          promptCalls.push(q);
+          return "n";
+        },
+        openBrowser: () => true,
+        exposeTailnetImpl: async () => {
+          chained = true;
+          return 0;
+        },
+        exposeCloudflareImpl: async () => {
+          chained = true;
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      // No exposure chain ran, no exposure prompt asked.
+      expect(chained).toBe(false);
+      expect(promptCalls.some((q) => q.toLowerCase().includes("pick"))).toBe(false);
+      // The FQDN URL is printed.
+      expect(logs.join("\n")).toContain("https://ec2-example.parachute.computer/admin/");
+      expect(logs.join("\n")).toContain("already exposed");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("non-TTY → no exposure prompt, falls through to localhost", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      let chained = false;
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+        env: { SSH_CONNECTION: "1.2.3.4 22 5.6.7.8 22" },
+        exposeTailnetImpl: async () => {
+          chained = true;
+          return 0;
+        },
+        exposeCloudflareImpl: async () => {
+          chained = true;
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      expect(chained).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("exposure chain non-zero exit propagates", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+        env: {},
+        exposeTailnetImpl: async () => 0,
+        exposeCloudflareImpl: async () => 2,
+        exposeChoice: "cloudflare",
+      });
+      expect(code).toBe(2);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("after exposure runs, the admin URL re-reads expose state for the FQDN", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      let exposedYet = false;
+      const exposed: ExposeState = {
+        version: 1,
+        layer: "tailnet",
+        mode: "path",
+        canonicalFqdn: "box.tailnet.ts.net",
+        port: 443,
+        funnel: false,
+        entries: [],
+        hubOrigin: "https://box.tailnet.ts.net",
+      };
+      const logs: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => logs.push(l),
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        // Reader returns undefined the first time, then the exposed state
+        // after the chain ran. Mirrors the real on-disk flow where
+        // exposeTailnet writes expose-state.json.
+        readExposeStateFn: () => (exposedYet ? exposed : undefined),
+        isTty: false,
+        platform: "linux",
+        env: {},
+        exposeTailnetImpl: async () => {
+          exposedYet = true;
+          return 0;
+        },
+        exposeCloudflareImpl: async () => 0,
+        exposeChoice: "tailnet",
+      });
+      expect(code).toBe(0);
+      expect(logs.join("\n")).toContain("https://box.tailnet.ts.net/admin/");
+      expect(logs.join("\n")).not.toContain("http://127.0.0.1");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// Type alias used only inside this test file for the heuristic test.
+type ExposeChoice = "none" | "tailnet" | "cloudflare";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -312,15 +312,39 @@ async function main(argv: string[]): Promise<number> {
         console.log(initHelp());
         return 0;
       }
-      const noBrowser = rest.includes("--no-browser");
-      const unknown = rest.find((a) => a !== "--no-browser");
+      const exposeExtract = extractNamedFlag(rest, "--expose");
+      if (exposeExtract.error) {
+        console.error(`parachute init: ${exposeExtract.error}`);
+        return 1;
+      }
+      if (
+        exposeExtract.value !== undefined &&
+        exposeExtract.value !== "none" &&
+        exposeExtract.value !== "tailnet" &&
+        exposeExtract.value !== "cloudflare"
+      ) {
+        console.error(
+          `parachute init: --expose must be one of none|tailnet|cloudflare (got "${exposeExtract.value}")`,
+        );
+        return 1;
+      }
+      const noBrowser = exposeExtract.rest.includes("--no-browser");
+      const noExposePrompt = exposeExtract.rest.includes("--no-expose-prompt");
+      const known = new Set(["--no-browser", "--no-expose-prompt"]);
+      const unknown = exposeExtract.rest.find((a) => !known.has(a));
       if (unknown !== undefined) {
         console.error(`parachute init: unknown argument "${unknown}"`);
-        console.error("usage: parachute init [--no-browser]");
+        console.error(
+          "usage: parachute init [--no-browser] [--no-expose-prompt] [--expose none|tailnet|cloudflare]",
+        );
         return 1;
       }
       const initOpts: Parameters<typeof init>[0] = {};
       if (noBrowser) initOpts.noBrowser = true;
+      if (noExposePrompt) initOpts.noExposePrompt = true;
+      if (exposeExtract.value) {
+        initOpts.exposeChoice = exposeExtract.value as "none" | "tailnet" | "cloudflare";
+      }
       return await init(initOpts);
     }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,30 +1,35 @@
 /**
- * `parachute init` — fresh-install front door.
+ * `parachute init` — fresh-install front door, single entry point for both
+ * laptops and remote servers (EC2, DigitalOcean, Hetzner, any VPS).
  *
- * Aaron's framing (2026-05-27): "On render I just install it and then the
- * wizard walks me through all that including installing vault; I think
- * that should be similar here. One quick thing to set it up then I can
- * walk through in CLI (probably parachute init or something) or ideally
- * I can visit the page and go through the wizard."
+ * Aaron's framing (2026-05-28): "orient local install more to leveraging the
+ * wizard if possible. Local install in this case should be extremely similar
+ * to ec2, except that perhaps we get parachute expose set up first."
  *
  * The job: get the user from a fresh install to the admin SPA setup
- * wizard with one command. The wizard already handles vault install +
- * scribe install + first-boot bootstrap (`/admin/setup`). `init`'s
- * responsibility is narrower:
+ * wizard with one command, regardless of where the box lives. The wizard
+ * already handles vault install + scribe install + first-boot bootstrap
+ * (`/admin/setup`). `init`'s responsibility is narrower:
  *
  *   1. The hub binary is already on PATH (you can't `parachute init`
  *      without it). So "is hub installed" is always yes here.
  *   2. Is the hub *running* on this box? If not, start it.
- *   3. Print the canonical admin URL — local loopback if we're not
- *      exposed, the tailnet / cloudflare FQDN if we are.
- *   4. Offer to open the URL in a browser (macOS: `open`, Linux:
+ *   3. Is the hub already exposed (`expose-state.json` present)? If so,
+ *      skip straight to printing the FQDN. Otherwise, in a TTY, ask
+ *      whether the operator wants to expose it now — defaulting to
+ *      "no, loopback" on a laptop and pre-selecting Cloudflare on a
+ *      server (SSH session detected). Same command both paths.
+ *   4. After any exposure chain, re-resolve and print the canonical
+ *      admin URL — local loopback if we're not exposed, the tailnet /
+ *      cloudflare FQDN if we are.
+ *   5. Offer to open the URL in a browser (macOS: `open`, Linux:
  *      `xdg-open`). Skip in non-TTY shells.
- *   5. If a vault is already configured, just confirm "looks good" and
+ *   6. If a vault is already configured, confirm "looks good" and
  *      point at the URL. The wizard surfaces install-state internally —
  *      no need to duplicate that logic here.
  *
- * Idempotent: every re-run is safe. If hub is up and a vault row exists,
- * we print the URL and exit 0 without touching anything.
+ * Idempotent: every re-run is safe. If hub is up and exposed (or the user
+ * picked "no expose" once), the chain short-circuits.
  */
 
 import { spawnSync } from "node:child_process";
@@ -39,6 +44,9 @@ import {
 } from "../hub-control.ts";
 import { type AliveFn, defaultAlive, processState } from "../process-state.ts";
 import { readManifestLenient } from "../services-manifest.ts";
+
+/** The three options the exposure prompt offers — also the `--expose` flag's domain. */
+export type ExposeChoice = "none" | "tailnet" | "cloudflare";
 
 export interface InitOpts {
   configDir?: string;
@@ -55,7 +63,7 @@ export interface InitOpts {
   readExposeStateFn?: () => ExposeState | undefined;
   /** Test seam: TTY check (production reads `process.stdin.isTTY`). */
   isTty?: boolean;
-  /** Test seam: prompt for "open in browser?". */
+  /** Test seam: prompt for "open in browser?" and exposure choice. */
   prompt?: (question: string) => Promise<string>;
   /**
    * Test seam: browser-open shim. Receives `url`; production shells out
@@ -64,11 +72,35 @@ export interface InitOpts {
   openBrowser?: (url: string) => boolean;
   /** Test seam: `process.platform`. */
   platform?: NodeJS.Platform;
+  /** Test seam: process.env for SSH / DISPLAY detection. */
+  env?: NodeJS.ProcessEnv;
   /**
    * If true, don't even ask about opening the browser. Convenient flag for
    * CI / scripts that just want the URL printed and exit 0.
    */
   noBrowser?: boolean;
+  /**
+   * Non-interactive exposure choice. Skips the prompt entirely:
+   *   - "none"       — no-op (laptop default)
+   *   - "tailnet"    — chain into `exposeTailnet("up", {})`
+   *   - "cloudflare" — chain into the cloudflare interactive flow
+   * For CI / scripted deploys.
+   */
+  exposeChoice?: ExposeChoice;
+  /** Skip the exposure prompt; fall through to "here's localhost URL". */
+  noExposePrompt?: boolean;
+  /**
+   * Test seam: shim for the tailnet exposure chain. Production imports
+   * `exposeTailnet` lazily. Tests pass a stub to record the call without
+   * shelling out to `tailscale serve`.
+   */
+  exposeTailnetImpl?: () => Promise<number>;
+  /**
+   * Test seam: shim for the cloudflare exposure chain. Production imports
+   * `exposePublicInteractive` with `preselect: "cloudflare"`. Tests pass a
+   * stub to record the call without shelling out to `cloudflared`.
+   */
+  exposeCloudflareImpl?: () => Promise<number>;
 }
 
 /**
@@ -84,13 +116,32 @@ export function resolveAdminUrl(
   exposeState: ExposeState | undefined,
   hubPort: number | undefined,
 ): string | undefined {
-  if (exposeState && exposeState.canonicalFqdn) {
+  if (exposeState?.canonicalFqdn) {
     return `https://${exposeState.canonicalFqdn}/admin/`;
   }
   if (hubPort !== undefined) {
     return `http://127.0.0.1:${hubPort}/admin/`;
   }
   return undefined;
+}
+
+/**
+ * Heuristic: is this likely a server (vs. a laptop)?
+ *
+ * Servers default-highlight Cloudflare in the prompt; laptops default to
+ * "no expose". We don't auto-pick — always prompt — but pre-select the
+ * sensible default so an operator can confirm with Enter.
+ *
+ * Signals:
+ *   - Linux platform AND ($SSH_CONNECTION set OR no $DISPLAY)
+ *
+ * macOS / Windows / Linux desktop → laptop.
+ */
+export function looksLikeServer(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): boolean {
+  if (platform !== "linux") return false;
+  if (env.SSH_CONNECTION || env.SSH_CLIENT || env.SSH_TTY) return true;
+  if (!env.DISPLAY && !env.WAYLAND_DISPLAY) return true;
+  return false;
 }
 
 /**
@@ -118,6 +169,64 @@ async function defaultPrompt(question: string): Promise<string> {
   }
 }
 
+/**
+ * Default chain into Tailscale exposure. Lazy-imports so tests don't pull
+ * tailscale wiring into the init module's surface.
+ */
+async function defaultExposeTailnet(): Promise<number> {
+  const { exposeTailnet } = await import("./expose.ts");
+  return await exposeTailnet("up", {});
+}
+
+/**
+ * Default chain into Cloudflare exposure. Goes through the interactive
+ * flow with `preselect: "cloudflare"` so the operator gets walked
+ * through install / login / hostname-prompt as needed.
+ */
+async function defaultExposeCloudflare(): Promise<number> {
+  const { exposePublicInteractive } = await import("./expose-interactive.ts");
+  return await exposePublicInteractive({ preselect: "cloudflare" });
+}
+
+/**
+ * Prompt for the exposure choice. Returns the picked option, or
+ * `undefined` if the operator quit / bailed.
+ *
+ * Default is whichever option matches the platform heuristic — laptops
+ * default to "none", servers to "cloudflare". Empty input picks the
+ * default (so Enter == confirm).
+ */
+async function promptExposeChoice(
+  prompt: (q: string) => Promise<string>,
+  log: (line: string) => void,
+  defaultChoice: ExposeChoice,
+): Promise<ExposeChoice | undefined> {
+  log("Do you want to expose it publicly so you can reach it from other devices?");
+  const mark = (c: ExposeChoice) => (c === defaultChoice ? " (default)" : "");
+  log(`  1) No — keep it loopback-only (good for laptops)${mark("none")}`);
+  log(`  2) Yes via Tailscale Funnel (private to your devices)${mark("tailnet")}`);
+  log(`  3) Yes via Cloudflare Tunnel (public HTTPS, your own domain)${mark("cloudflare")}`);
+  log("");
+
+  const defaultDigit = defaultChoice === "none" ? "1" : defaultChoice === "tailnet" ? "2" : "3";
+
+  // Bounded retries — a stuck prompt (non-TTY stdin that slipped through,
+  // piped /dev/null, etc.) shouldn't spin forever.
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const raw = (await prompt(`Pick [${defaultDigit}]: `)).trim().toLowerCase();
+    if (raw === "") {
+      return defaultChoice;
+    }
+    if (raw === "1" || raw === "no" || raw === "none") return "none";
+    if (raw === "2" || raw === "tailnet" || raw === "tailscale") return "tailnet";
+    if (raw === "3" || raw === "cloudflare") return "cloudflare";
+    if (raw === "q" || raw === "quit" || raw === "exit") return undefined;
+    log(`Sorry — expected 1, 2, 3, or q (got "${raw}"). Try again.`);
+  }
+  log("Too many invalid entries; falling back to default.");
+  return defaultChoice;
+}
+
 export async function init(opts: InitOpts = {}): Promise<number> {
   const configDir = opts.configDir ?? CONFIG_DIR;
   const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
@@ -128,7 +237,10 @@ export async function init(opts: InitOpts = {}): Promise<number> {
   const isTty = opts.isTty ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
   const prompt = opts.prompt ?? defaultPrompt;
   const platform = opts.platform ?? process.platform;
+  const env = opts.env ?? process.env;
   const openBrowser = opts.openBrowser ?? ((url: string) => defaultOpenBrowser(url, platform));
+  const exposeTailnetImpl = opts.exposeTailnetImpl ?? defaultExposeTailnet;
+  const exposeCloudflareImpl = opts.exposeCloudflareImpl ?? defaultExposeCloudflare;
 
   log("Parachute init — getting your hub set up.");
   log("");
@@ -160,7 +272,52 @@ export async function init(opts: InitOpts = {}): Promise<number> {
   // overridden, so the fallback is almost always correct.
   if (hubPort === undefined) hubPort = HUB_DEFAULT_PORT;
 
-  // Step 2: vault configured?
+  // Step 2: exposure chain. Skipped when already exposed, in non-TTY,
+  // or when --no-expose-prompt was passed. `--expose <choice>` jumps
+  // straight to the corresponding chain without asking.
+  let exposeState = readExposeStateFn();
+  const alreadyExposed = Boolean(exposeState?.canonicalFqdn);
+
+  if (alreadyExposed) {
+    // Already-exposed short-circuit: don't prompt. The admin URL printed
+    // later will be the FQDN.
+    log(`✓ Hub is already exposed at ${exposeState?.canonicalFqdn}.`);
+  } else if (opts.exposeChoice !== undefined) {
+    // Non-interactive override.
+    const code = await runExposureChoice(opts.exposeChoice, {
+      log,
+      exposeTailnetImpl,
+      exposeCloudflareImpl,
+    });
+    if (code !== 0) return code;
+    // Refresh state — the chain may have brought up an FQDN.
+    exposeState = readExposeStateFn();
+  } else if (opts.noExposePrompt) {
+    // Skip the question; fall through to localhost URL.
+  } else if (!isTty) {
+    // Non-TTY: don't prompt. Operator can re-run with --expose if needed.
+  } else {
+    log(`Hub is running locally at http://127.0.0.1:${hubPort}.`);
+    log("");
+    const isServer = looksLikeServer(platform, env);
+    const defaultChoice: ExposeChoice = isServer ? "cloudflare" : "none";
+    const picked = await promptExposeChoice(prompt, log, defaultChoice);
+    if (picked === undefined) {
+      log("");
+      log("Skipped exposure. Re-run `parachute expose public` later if you want to.");
+    } else if (picked !== "none") {
+      log("");
+      const code = await runExposureChoice(picked, {
+        log,
+        exposeTailnetImpl,
+        exposeCloudflareImpl,
+      });
+      if (code !== 0) return code;
+      exposeState = readExposeStateFn();
+    }
+  }
+
+  // Step 3: vault configured?
   let hasVault = false;
   try {
     const manifest = readManifestLenient(manifestPath);
@@ -171,8 +328,7 @@ export async function init(opts: InitOpts = {}): Promise<number> {
     hasVault = false;
   }
 
-  // Step 3: resolve the admin URL.
-  const exposeState = readExposeStateFn();
+  // Step 4: resolve the admin URL.
   const adminUrl = resolveAdminUrl(exposeState, hubPort);
   if (!adminUrl) {
     log("");
@@ -191,7 +347,7 @@ export async function init(opts: InitOpts = {}): Promise<number> {
   log(`  ${adminUrl}`);
   log("");
 
-  // Step 4: offer to open the browser. Skip in non-TTY shells (CI),
+  // Step 5: offer to open the browser. Skip in non-TTY shells (CI),
   // honor `--no-browser`.
   if (opts.noBrowser) return 0;
   if (!isTty) {
@@ -210,4 +366,26 @@ export async function init(opts: InitOpts = {}): Promise<number> {
     log("(Couldn't launch a browser — open the URL above manually.)");
   }
   return 0;
+}
+
+/**
+ * Dispatch the chosen exposure path. Returns the exit code of the
+ * downstream chain. `none` is a no-op (success).
+ */
+async function runExposureChoice(
+  choice: ExposeChoice,
+  ctx: {
+    log: (line: string) => void;
+    exposeTailnetImpl: () => Promise<number>;
+    exposeCloudflareImpl: () => Promise<number>;
+  },
+): Promise<number> {
+  if (choice === "none") return 0;
+  if (choice === "tailnet") {
+    ctx.log("Setting up Tailscale Funnel…");
+    return await ctx.exposeTailnetImpl();
+  }
+  // cloudflare
+  ctx.log("Setting up Cloudflare Tunnel…");
+  return await ctx.exposeCloudflareImpl();
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -139,6 +139,11 @@ export function resolveAdminUrl(
  */
 export function looksLikeServer(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): boolean {
   if (platform !== "linux") return false;
+  // WSL2 is Linux + headless from $DISPLAY's perspective but is in fact a
+  // developer's laptop. Detect via WSL-specific env vars (set in every WSL
+  // distro) so we don't pre-select Cloudflare for someone running Parachute
+  // inside WSL on Windows. Reviewer-flagged on #445.
+  if (env.WSL_DISTRO_NAME || env.WSL_INTEROP) return false;
   if (env.SSH_CONNECTION || env.SSH_CLIENT || env.SSH_TTY) return true;
   if (!env.DISPLAY && !env.WAYLAND_DISPLAY) return true;
   return false;
@@ -203,7 +208,7 @@ async function promptExposeChoice(
 ): Promise<ExposeChoice | undefined> {
   log("Do you want to expose it publicly so you can reach it from other devices?");
   const mark = (c: ExposeChoice) => (c === defaultChoice ? " (default)" : "");
-  log(`  1) No — keep it loopback-only (good for laptops)${mark("none")}`);
+  log(`  1) No — keep it loopback-only${mark("none")}`);
   log(`  2) Yes via Tailscale Funnel (private to your devices)${mark("tailnet")}`);
   log(`  3) Yes via Cloudflare Tunnel (public HTTPS, your own domain)${mark("cloudflare")}`);
   log("");

--- a/src/help.ts
+++ b/src/help.ts
@@ -5,11 +5,12 @@ export function topLevelHelp(): string {
   const services = knownServices().join(" | ");
   return `parachute ${pkg.version} — top-level CLI for the Parachute ecosystem
 
-Fresh install? Start here:
+Fresh install? Start here — works the same on a laptop or a remote server:
   parachute init                    one quick step → admin wizard in your browser
+                                    (offers optional exposure on remote boxes)
 
 Usage:
-  parachute init                    bring hub up + open admin wizard (idempotent)
+  parachute init                    bring hub up, offer exposure, open admin wizard
   parachute setup                   interactive walk-through: install services + configure
   parachute install <service>       install and register a service
                                     services: ${services}
@@ -108,31 +109,47 @@ export function initHelp(): string {
   return `parachute init — get the admin wizard open in one step
 
 Usage:
-  parachute init [--no-browser]
+  parachute init [--no-browser] [--no-expose-prompt] [--expose none|tailnet|cloudflare]
 
 What it does:
-  Fresh-install front door. The admin SPA already walks operators through
-  the rest (install vault, set up the admin user, install scribe / runner
-  / app); this command's only job is to get you to that wizard with one
-  command.
+  Fresh-install front door, one command for both laptops AND remote
+  servers (EC2, DigitalOcean, Hetzner, any VPS). The admin SPA already
+  walks operators through the rest (install vault, set up the admin
+  user, install scribe / runner / app); this command's only job is to
+  get you to that wizard.
 
   Idempotent — every re-run is safe:
     1. If the hub isn't running, start it.
-    2. Print the canonical admin URL (loopback when not exposed, the
+    2. If the hub isn't already exposed, in a terminal, offer to set up
+       exposure (Tailscale Funnel, Cloudflare Tunnel, or stay loopback).
+       The default highlights "no thanks" on laptops and Cloudflare on
+       servers (SSH session detected). Skip with --no-expose-prompt or
+       pin non-interactively with --expose.
+    3. Print the canonical admin URL (loopback when not exposed, the
        tailnet / cloudflare FQDN when exposure is active).
-    3. In a terminal, offer to open the URL in your browser
+    4. In a terminal, offer to open the URL in your browser
        (macOS \`open\`, Linux \`xdg-open\`). Skip with --no-browser or
        run from a non-TTY shell.
 
-  If your hub is up and a vault is already configured, init just
-  confirms "looks good — here's your URL" and exits 0.
+  If your hub is up + exposure is already set up + a vault is already
+  configured, init just confirms "looks good — here's your URL" and
+  exits 0.
 
 Flags:
-  --no-browser     just print the URL; don't offer to launch a browser
+  --no-browser              just print the URL; don't offer to launch a browser
+  --no-expose-prompt        skip the exposure question; fall through to localhost URL
+  --expose <choice>         non-interactive exposure override:
+                              none       — stay loopback-only
+                              tailnet    — set up Tailscale Funnel (private to your tailnet)
+                              cloudflare — set up Cloudflare Tunnel (your own domain)
 
 Examples:
-  parachute init                    bring up hub + open the wizard
-  parachute init --no-browser       same, but don't shell out to open / xdg-open
+  parachute init                              # laptop: prompts, defaults to "no expose"
+  parachute init                              # ssh'd server: prompts, defaults to Cloudflare
+  parachute init --no-expose-prompt           # skip the question; just print localhost URL
+  parachute init --expose cloudflare          # CI/scripted: chain straight into Cloudflare
+  parachute init --expose tailnet             # CI/scripted: chain straight into Tailscale
+  parachute init --no-browser                 # don't shell out to open / xdg-open
 `;
 }
 


### PR DESCRIPTION
## Motivation

Aaron's framing (2026-05-28): "orient local install more to leveraging the wizard if possible. Local install in this case should be extremely similar to ec2, except that perhaps we get parachute expose set up first."

Previously `parachute init` was great on a laptop (start hub, print loopback URL, offer to open browser) but useless on EC2 / DigitalOcean / Hetzner — operators got `http://localhost:1939`, which is not reachable from outside the box. They had to remember to run `parachute expose public --cloudflare` separately. The cleaner UX: one command, asks once, same path both shapes.

## Summary

`parachute init` now offers exposure between "hub is running" and "here's the admin URL":

```
Hub is running locally at http://127.0.0.1:1939.

Do you want to expose it publicly so you can reach it from other devices?
  1) No — keep it loopback-only (good for laptops) (default)
  2) Yes via Tailscale Funnel (private to your devices)
  3) Yes via Cloudflare Tunnel (public HTTPS, your own domain)

Pick [1]: _
```

On a laptop the default is `1` (loopback). On a Linux server with `$SSH_CONNECTION` set (or headless — no `$DISPLAY`), the default is `3` (Cloudflare). Always prompt; the operator confirms with Enter.

After the chosen exposure flow finishes, init re-reads expose-state and prints the FQDN (now the canonical URL).

## Per-cut summary

- **Cut 1 — exposure prompt.** Inserted after "hub is running" and before the admin-URL print. Options chain into the existing `exposeTailnet("up", {})` (option 2) and `exposePublicInteractive({ preselect: "cloudflare" })` (option 3). Option 1 falls through. `src/commands/init.ts`.
- **Cut 2 — heuristic defaults.** `looksLikeServer(platform, env)` — Linux + (`$SSH_CONNECTION` | `$SSH_CLIENT` | `$SSH_TTY` set, OR no `$DISPLAY` / `$WAYLAND_DISPLAY`) → server. Else laptop. Exported for unit testing. `src/commands/init.ts`.
- **Cut 3 — flag surface.** Added `--expose <none|tailnet|cloudflare>` (non-interactive override) and `--no-expose-prompt` (skip the question). `--no-browser` preserved. `src/cli.ts` + `src/commands/init.ts`.
- **Cut 4 — already-exposed short-circuit.** If `expose-state.json` shows a live FQDN, init skips the prompt and prints the FQDN. Re-running after a successful expose is a no-op. `src/commands/init.ts`.
- **Cut 5 — help + copy.** `initHelp()` rewritten with the new shape + examples. `topLevelHelp` refreshed to say "works the same on a laptop or a remote server." `src/help.ts`.
- **Cut 6 — tests.** 15 new init tests covering: prompt shown when interactive + no exposure + no flags; `--no-expose-prompt` path; each `--expose` value (`none` / `tailnet` / `cloudflare`); platform/SSH heuristic matrix (5 sub-cases); already-exposed short-circuit; non-TTY fallthrough; exit-code propagation; FQDN re-read after successful chain. `looksLikeServer` unit-tested in isolation. `src/__tests__/init.test.ts`.

## Heuristic defaults explained

`looksLikeServer` mirrors how humans distinguish boxes:
- **macOS / Windows** → always laptop. (`darwin` + `win32` short-circuit false.)
- **Linux + $SSH_CONNECTION / $SSH_CLIENT / $SSH_TTY** → server (you're SSH'd in).
- **Linux + no $DISPLAY and no $WAYLAND_DISPLAY** → server (headless box).
- **Linux + $DISPLAY** → laptop (graphical session).

Default-highlighting Cloudflare on servers is opinionated but rescuable — the operator can still pick `1` or `q`. Auto-picking would be presumptuous; pre-selection matches the most common intent without removing agency.

## Test plan

- [x] `bun test ./src` → 2280 pass / 1 skip / 0 fail (init suite: 27 tests, was 12)
- [x] `bun run typecheck` → clean
- [x] `bunx biome check` → clean
- [x] Sandbox E2E: `PARACHUTE_HOME=<tmp> parachute init --no-expose-prompt --no-browser` against a pre-seeded fake hub state — prints localhost URL, exits 0.
- [x] Sandbox E2E: `parachute init --expose none --no-browser` — same shape, exits 0.
- [x] `parachute init --help` renders the new usage line and examples.
- [x] `parachute init --expose banana` exits 1 with an actionable error.
- [x] `parachute init --bogus` exits 1 with usage.

## Reviewer notes

- The chain points use injectable test seams (`exposeTailnetImpl`, `exposeCloudflareImpl`) so tests don't need to stub `tailscale serve` / `cloudflared`. Production paths lazy-import `exposeTailnet` and `exposePublicInteractive` to keep init's import surface narrow.
- Pre-existing TTY-true tests now pass `noExposePrompt: true` so they keep exercising the browser-prompt branch in isolation (the new exposure prompt would otherwise run first and these tests don't model that).
- No version bump per the rc-on-ship policy (Aaron decides when to bump + tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)