### PR TITLE
chore(release): 0.5.14-rc.7 — parachute init exposure chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.6",
+  "version": "0.5.14-rc.7",
   "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Picks up #445 — parachute init optionally chains into expose flow. Laptop ≈ EC2 — same command both ways.

## Test plan

- [x] 2280 pass / 1 skip / 0 fail (from #445)
- [x] typecheck + biome clean
- [ ] After merge: tag v0.5.14-rc.7 + push → CI publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)