### PR TITLE
chore(release): 0.5.14-rc.8 — wizard parity (#447)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.7",
+  "version": "0.5.14-rc.8",
   "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
## What

Bumps `package.json` from `0.5.14-rc.7` → `0.5.14-rc.8`.

Picks up #447 (wizard parity: always-install-vault + CLI wizard + import-from-git first-vault) plus the in-PR critical auth fold (import POST now carries a vault-admin Bearer).

## Test plan

- [x] `bun test ./src` — 2295 pass, 1 skip, 0 fail
- [x] `bun run typecheck` — clean
- [ ] Smoke against a live Render rc.8 deploy after publish (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)