### PR TITLE
feat(hub): mint-token issues vault:<name>:admin to host-admin bearers

### DIFF
--- a/src/__tests__/api-mint-token.test.ts
+++ b/src/__tests__/api-mint-token.test.ts
@@ -342,19 +342,98 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
     }
   });
 
-  test("400 invalid_scope when minting vault:<name>:admin (regex non-requestable)", async () => {
+  // De-escalation (PR-A): a `parachute:host:admin` bearer MAY mint a
+  // vault-pinned admin token — host:admin already implies box-wide vault
+  // administration, so narrowing it to one vault is a privilege reduction.
+  // This is the canonical headless path replacing deprecated pvt_* (vault#282).
+  test("200 when host:admin bearer mints vault:<name>:admin (de-escalation)", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        // The default admin operator scope-set carries parachute:host:admin.
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiMintToken(
+          jsonRequest({ scope: "vault:work:admin" }, { authorization: `Bearer ${op.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as { jti: string; token: string; scope: string };
+        expect(body.scope).toBe("vault:work:admin");
+        const validated = await validateAccessToken(db, body.token, ISSUER);
+        // Audience must be the per-vault resource so vault's strict-equality
+        // audience check accepts it.
+        expect(validated.payload.aud).toBe("vault.work");
+        expect(validated.payload.scope).toBe("vault:work:admin");
+        // vault_scope is pinned to the named vault (defense-in-depth — the
+        // token can ONLY be used against `work`), matching the canonical
+        // session-path mint in admin-vault-admin-token.ts.
+        expect(validated.payload.vault_scope).toEqual(["work"]);
+        // Registry row written → revocable like any operator mint.
+        const row = db
+          .query<{ jti: string }, [string]>("SELECT jti FROM tokens WHERE jti = ?")
+          .get(body.jti);
+        expect(row).not.toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // The de-escalation exception is gated on host:admin specifically. A
+  // bearer that only holds `parachute:host:auth` (the narrow auth scope-set)
+  // can mint verb scopes but NOT vault-admin — that would be an escalation.
+  test("400 invalid_scope when auth-only bearer mints vault:<name>:admin", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, {
+          issuer: ISSUER,
+          scopeSet: "auth",
+        });
+        const resp = await handleApiMintToken(
+          jsonRequest({ scope: "vault:work:admin" }, { authorization: `Bearer ${op.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(400);
+        const body = (await resp.json()) as { error: string; error_description: string };
+        expect(body.error).toBe("invalid_scope");
+        expect(body.error_description).toContain("vault:work:admin");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // A bare `vault:admin` (no vault name) is NOT a per-vault admin scope —
+  // the de-escalation exception only covers `vault:<name>:admin`. It isn't
+  // in the non-requestable set either, so it's treated as an ordinary
+  // (unnamed) scope and mints — but with the `vault` fallback audience, not
+  // a per-vault one. Pinned so a future regex loosening can't silently let
+  // an unnamed admin through the named-vault exemption.
+  test("bare vault:admin (no name) is not caught by the de-escalation exemption", async () => {
     const h = makeHarness();
     try {
       const { db, userId } = await bootstrap(h.dir);
       try {
         const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
         const resp = await handleApiMintToken(
-          jsonRequest({ scope: "vault:work:admin" }, { authorization: `Bearer ${op.token}` }),
+          jsonRequest({ scope: "vault:admin" }, { authorization: `Bearer ${op.token}` }),
           { db, issuer: ISSUER },
         );
-        expect(resp.status).toBe(400);
-        const body = (await resp.json()) as { error: string };
-        expect(body.error).toBe("invalid_scope");
+        // `vault:admin` isn't a per-vault admin scope and isn't in the
+        // non-requestable set, so it mints as an ordinary scope. The point
+        // of this test is that it does NOT get a per-vault audience/pin.
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as { token: string };
+        const validated = await validateAccessToken(db, body.token, ISSUER);
+        expect(validated.payload.aud).toBe("vault");
+        expect(validated.payload.vault_scope).toEqual([]);
       } finally {
         db.close();
       }

--- a/src/api-mint-token.ts
+++ b/src/api-mint-token.ts
@@ -13,6 +13,15 @@
  * (admin scope-set) covers this; a narrow `--scope-set=auth` operator
  * token also covers this.
  *
+ * Mintable scopes: any requestable scope (vault/scribe/agent verbs, etc.).
+ * Non-requestable scopes (`parachute:host:*`, `vault:<name>:admin`) are
+ * refused — with ONE de-escalation exception: a bearer that carries
+ * `parachute:host:admin` may mint `vault:<name>:admin`, because host:admin
+ * already implies box-wide vault administration, so a vault-pinned admin is
+ * strictly narrower. That's the canonical headless path to a per-vault admin
+ * token (replacing deprecated `pvt_*` — vault#282) and the path the SPA
+ * tokens page uses via session → /admin/host-admin-token → here.
+ *
  * Why a separate endpoint instead of extending /admin/host-admin-token:
  * that endpoint is session-cookie-gated for the SPA's needs and only
  * mints `parachute:host:admin`. This endpoint is bearer-gated for
@@ -26,7 +35,11 @@
 import type { Database } from "bun:sqlite";
 import { inferAudience } from "./jwt-audience.ts";
 import { recordTokenMint, signAccessToken, validateAccessToken } from "./jwt-sign.ts";
-import { isNonRequestableScope } from "./scope-explanations.ts";
+import {
+  isNonRequestableScope,
+  isVaultAdminScope,
+  vaultAdminScopeName,
+} from "./scope-explanations.ts";
 
 /** Default lifetime when --expires-in / `expires_in` is omitted. Matches the CLI. */
 export const API_MINT_TOKEN_DEFAULT_TTL_SECONDS = 90 * 24 * 60 * 60;
@@ -34,6 +47,14 @@ export const API_MINT_TOKEN_DEFAULT_TTL_SECONDS = 90 * 24 * 60 * 60;
 export const API_MINT_TOKEN_MAX_TTL_SECONDS = 365 * 24 * 60 * 60;
 /** Scope required on the bearer token to call this endpoint. */
 export const API_MINT_TOKEN_REQUIRED_SCOPE = "parachute:host:auth";
+/**
+ * Bearer scope that admits an otherwise-non-requestable `vault:<name>:admin`
+ * into a mint request. `parachute:host:admin` already implies box-wide
+ * administration of every vault on the hub, so minting a vault-pinned admin
+ * from it is a privilege *reduction* (de-escalation), not an escalation —
+ * see the design doc `2026-05-28-operator-mintable-vault-admin.md`.
+ */
+export const API_MINT_TOKEN_VAULT_ADMIN_BEARER_SCOPE = "parachute:host:admin";
 /** client_id stamped on minted tokens. Matches the CLI flow's value. */
 export const API_MINT_TOKEN_CLIENT_ID = "parachute-hub";
 
@@ -124,7 +145,21 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
   // cannot mint another `:auth` (or any other non-requestable) without
   // forced re-auth via the operator.token rotation path. Same set the
   // public OAuth flow already rejects.
-  const blocked = scopes.filter((s) => isNonRequestableScope(s));
+  //
+  // Exception (de-escalation): a bearer that already carries
+  // `parachute:host:admin` may mint `vault:<name>:admin`. host:admin
+  // implies box-wide administration of every vault on the hub, so pinning
+  // it to a single named vault is a privilege *reduction*. This is the
+  // canonical headless path to a per-vault admin token (mcp-install via
+  // operator.token; SPA via session → host-admin-token → here) and the
+  // replacement for the deprecated `pvt_*` admin tokens (vault#282). The
+  // host:* narrow scopes and a bare `vault:admin` (no name) stay blocked.
+  const bearerHasHostAdmin = bearerScopes.includes(API_MINT_TOKEN_VAULT_ADMIN_BEARER_SCOPE);
+  const blocked = scopes.filter((s) => {
+    if (!isNonRequestableScope(s)) return false;
+    if (bearerHasHostAdmin && isVaultAdminScope(s)) return false;
+    return true;
+  });
   if (blocked.length > 0) {
     return jsonError(
       400,
@@ -183,6 +218,17 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
     permissionsCanonical = JSON.stringify(permissionsClaim);
   }
 
+  // Derive the `vault_scope` pin. For ordinary verb mints (read/write)
+  // this stays `[]` — the "no per-user restriction" sentinel; the scope
+  // string + audience are the authorization-bearing gate. For a
+  // `vault:<name>:admin` mint (admitted above for host:admin bearers) we
+  // pin the named vault(s) so the token can ONLY ever be used against
+  // that vault, matching the canonical session-path mint in
+  // `admin-vault-admin-token.ts` (defense-in-depth + least privilege).
+  const vaultScopePin = scopes
+    .map((s) => vaultAdminScopeName(s))
+    .filter((n): n is string => n !== null);
+
   // 6. Mint + register.
   const minted = await signAccessToken(deps.db, {
     sub: subject,
@@ -192,11 +238,9 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
     issuer: deps.issuer,
     ttlSeconds,
     // Operator-driven CLI/API mint — the bearer already cleared the
-    // `parachute:host:auth` privilege gate, so there's no per-user vault
-    // pin to enforce. Empty `vault_scope` is the "no restriction"
-    // sentinel; the `scopes` themselves remain authorization-bearing as
-    // before.
-    vaultScope: [],
+    // privilege gate. `vault_scope` is `[]` (no restriction) for verb
+    // mints, or the named vault(s) for an admin mint (see above).
+    vaultScope: vaultScopePin,
     ...(permissionsClaim !== undefined ? { extraClaims: { permissions: permissionsClaim } } : {}),
     ...(deps.now !== undefined ? { now: deps.now } : {}),
   });

--- a/src/api-mint-token.ts
+++ b/src/api-mint-token.ts
@@ -225,6 +225,12 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
   // pin the named vault(s) so the token can ONLY ever be used against
   // that vault, matching the canonical session-path mint in
   // `admin-vault-admin-token.ts` (defense-in-depth + least privilege).
+  //
+  // Note: `audience` is single-valued and `inferAudience` is first-wins,
+  // so a multi-vault request (`vault:a:admin vault:b:admin`) gets
+  // `aud=vault.a` and the resulting token only authenticates against `a`.
+  // Mint one token per vault for the multi-vault case. The canonical
+  // consumers (mcp-install, SPA tokens page) request a single vault.
   const vaultScopePin = scopes
     .map((s) => vaultAdminScopeName(s))
     .filter((n): n is string => n !== null);

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -138,16 +138,43 @@ export const NON_REQUESTABLE_SCOPES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Per-vault `vault:<name>:admin` scopes are also non-requestable: they let
- * the holder mint, revoke, and rotate tokens for a specific vault instance,
- * which is operator-only territory. Like `parachute:host:admin`, these are
- * minted by a session-cookie-gated hub endpoint (`/admin/vault-admin-token/:name`),
- * never by the public OAuth flow.
+ * Per-vault `vault:<name>:admin` scopes are also non-requestable via the
+ * public OAuth flow: they let the holder mint, revoke, and rotate tokens
+ * for a specific vault instance, which is operator-only territory.
+ *
+ * They are mintable by two operator-proving local paths, both of which
+ * require already-established hub-admin identity (never third-party consent):
+ *   - the session-cookie-gated `/admin/vault-admin-token/:name` endpoint
+ *     (the vault SPA's Manage link + setup wizard); and
+ *   - `POST /api/auth/mint-token` when the calling bearer carries
+ *     `parachute:host:admin` (operator-token / host-admin-token). Minting a
+ *     vault-pinned admin from a box-wide `host:admin` is a privilege
+ *     *reduction*, so the mint path admits it — see `isVaultAdminScope`
+ *     and the guard in `api-mint-token.ts`.
  *
  * Pattern-based because the set is open-ended — every vault instance the
  * operator creates implies a new scope, and we don't want to enumerate them.
  */
 const VAULT_ADMIN_RE = /^vault:[a-zA-Z0-9_-]+:admin$/;
+
+/**
+ * True when `scope` is a per-vault admin scope (`vault:<name>:admin`).
+ * Exported so the mint-token path can recognise the one non-requestable
+ * scope it conditionally admits for `parachute:host:admin` bearers.
+ */
+export function isVaultAdminScope(scope: string): boolean {
+  return VAULT_ADMIN_RE.test(scope);
+}
+
+/**
+ * Extract the vault name from a `vault:<name>:admin` scope, or null if the
+ * scope isn't a per-vault admin scope. Used to derive the `vault_scope`
+ * pin when minting an operator-requested vault-admin token.
+ */
+export function vaultAdminScopeName(scope: string): string | null {
+  if (!VAULT_ADMIN_RE.test(scope)) return null;
+  return scope.split(":")[1] ?? null;
+}
 
 /** True when the scope is non-requestable via the public OAuth flow. */
 export function isNonRequestableScope(scope: string): boolean {


### PR DESCRIPTION
## Motivation

Canonical headless path to a per-vault admin token — the missing precondition before `pvt_*` hard-removal (vault#282).

Today `POST /api/auth/mint-token` refuses `vault:<name>:admin` via the non-requestable-scope guard, so `parachute vault mcp-install` (and the vault admin SPA tokens page) fall back to minting deprecated `pvt_*` opaque tokens. Those break at vault 0.6.0 with no replacement.

## What changed

Relax the guard for exactly one caller class: a bearer that already carries **`parachute:host:admin`** may mint `vault:<name>:admin`. `host:admin` already implies box-wide administration of every vault on the hub, so pinning it to one named vault is a privilege **reduction** (de-escalation), not an escalation. A `parachute:host:auth`-only bearer still cannot mint vault-admin.

One hub change unlocks two consumers (no new endpoints):
- **mcp-install (CLI)**: `operator.token` → `mint-token` with `scope=vault:<name>:admin`.
- **SPA tokens page**: `session → /admin/host-admin-token → mint-token`.

## Correctness

- `audience` → `vault.<name>` via `inferAudience` (matches vault's strict audience check).
- `vault_scope` pinned to `[<name>]` for admin mints (defense-in-depth + least privilege, matching `admin-vault-admin-token.ts`), vs the `[]` sentinel for verb mints.
- Durable (90d default / 365d max), registry-recorded → revocable.

## Tests

- [x] host-admin bearer mints `vault:work:admin` → 200, `aud=vault.work`, `vault_scope=[work]`, registry row written
- [x] auth-only bearer mints `vault:work:admin` → 400 invalid_scope (still blocked)
- [x] bare `vault:admin` (no name) not caught by the exemption → `aud=vault`, pin `[]`
- [x] `bun test ./src` — 2298 pass, 1 skip, 0 fail; scope-guard 104 pass
- [x] `bun run typecheck` clean

## Docs

- Design: `parachute.computer/design/2026-05-28-operator-mintable-vault-admin.md`
- Migration: `parachute-patterns/migrations/2026-05-28-operator-mintable-vault-admin.md` (PR-A of A/B/C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)