### PR TITLE
feat(hub): capability attenuation in mint-token — vault:<name>:admin mints same-vault subtokens

### DIFF
--- a/src/__tests__/api-mint-token.test.ts
+++ b/src/__tests__/api-mint-token.test.ts
@@ -308,7 +308,7 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
         const body = (await resp.json()) as { error: string; error_description: string };
         expect(body.error).toBe("invalid_scope");
         expect(body.error_description).toContain("parachute:host:auth");
-        expect(body.error_description).toContain("not requestable");
+        expect(body.error_description).toContain("not grantable");
       } finally {
         db.close();
       }
@@ -440,6 +440,397 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
     } finally {
       h.cleanup();
     }
+  });
+
+  // ── Capability attenuation (hub PR — subsumes hub#449's PR-A carve-out) ──
+  //
+  // A `vault:<name>:admin` bearer may mint a token whose authority is a
+  // SUBSET of its own: same-vault read/write/admin. It can NEVER mint a
+  // cross-vault scope or any host-level authority. We hand-mint the bearer
+  // via signAccessToken (scope `vault:work:admin`, aud `vault.work`,
+  // vaultScope `["work"]`) — mirroring how the SPA / mcp-install obtain one.
+  async function mintVaultAdminBearer(
+    db: ReturnType<typeof openHubDb>,
+    userId: string,
+    vault: string,
+  ): Promise<string> {
+    const signed = await signAccessToken(db, {
+      sub: userId,
+      scopes: [`vault:${vault}:admin`],
+      audience: `vault.${vault}`,
+      clientId: "parachute-hub",
+      issuer: ISSUER,
+      ttlSeconds: 3600,
+      vaultScope: [vault],
+    });
+    return signed.token;
+  }
+
+  describe("capability attenuation — vault:<name>:admin bearer", () => {
+    test("mints vault:work:write → 200, aud=vault.work, vault_scope=[work]", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const bearer = await mintVaultAdminBearer(db, userId, "work");
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "vault:work:write" }, { authorization: `Bearer ${bearer}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.aud).toBe("vault.work");
+          expect(validated.payload.scope).toBe("vault:work:write");
+          expect(validated.payload.vault_scope).toEqual(["work"]);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("mints vault:work:read → 200", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const bearer = await mintVaultAdminBearer(db, userId, "work");
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "vault:work:read" }, { authorization: `Bearer ${bearer}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.vault_scope).toEqual(["work"]);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("mints vault:work:admin → 200 (same-level allowed)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const bearer = await mintVaultAdminBearer(db, userId, "work");
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "vault:work:admin" }, { authorization: `Bearer ${bearer}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.aud).toBe("vault.work");
+          expect(validated.payload.scope).toBe("vault:work:admin");
+          expect(validated.payload.vault_scope).toEqual(["work"]);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    // THE CRUX: cross-vault is the security boundary. A work-admin bearer
+    // MUST NOT be able to mint authority over any other vault.
+    test("mints vault:other:write → 400 (cross-vault BLOCKED)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const bearer = await mintVaultAdminBearer(db, userId, "work");
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "vault:other:write" }, { authorization: `Bearer ${bearer}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(400);
+          const body = (await resp.json()) as { error: string; error_description: string };
+          expect(body.error).toBe("invalid_scope");
+          expect(body.error_description).toContain("vault:other:write");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("mints vault:other:admin → 400 (cross-vault BLOCKED)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const bearer = await mintVaultAdminBearer(db, userId, "work");
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "vault:other:admin" }, { authorization: `Bearer ${bearer}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(400);
+          const body = (await resp.json()) as { error: string };
+          expect(body.error).toBe("invalid_scope");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("mints parachute:host:auth → 400 (no escalation to host authority)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const bearer = await mintVaultAdminBearer(db, userId, "work");
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "parachute:host:auth" }, { authorization: `Bearer ${bearer}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(400);
+          const body = (await resp.json()) as { error: string };
+          expect(body.error).toBe("invalid_scope");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("mints parachute:host:admin → 400 (no escalation to host authority)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const bearer = await mintVaultAdminBearer(db, userId, "work");
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "parachute:host:admin" }, { authorization: `Bearer ${bearer}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(400);
+          const body = (await resp.json()) as { error: string };
+          expect(body.error).toBe("invalid_scope");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    // No host:auth, and scribe:transcribe is not a vault:work scope → blocked.
+    test("mints scribe:transcribe → 400 (not a vault:work scope, no host:auth)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const bearer = await mintVaultAdminBearer(db, userId, "work");
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "scribe:transcribe" }, { authorization: `Bearer ${bearer}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(400);
+          const body = (await resp.json()) as { error: string };
+          expect(body.error).toBe("invalid_scope");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("multi-scope vault:work:read vault:work:write → 200, vault_scope=[work]", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const bearer = await mintVaultAdminBearer(db, userId, "work");
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:read vault:work:write" },
+              { authorization: `Bearer ${bearer}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.vault_scope).toEqual(["work"]);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    // One blocked scope rejects the whole request (no partial mint).
+    test("multi-scope vault:work:read vault:other:read → 400 (one blocked → all rejected)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const bearer = await mintVaultAdminBearer(db, userId, "work");
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:read vault:other:read" },
+              { authorization: `Bearer ${bearer}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(400);
+          const body = (await resp.json()) as { error: string; error_description: string };
+          expect(body.error).toBe("invalid_scope");
+          expect(body.error_description).toContain("vault:other:read");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+  });
+
+  describe("capability attenuation — entry gate + regression", () => {
+    test("host:auth-only bearer mints vault:work:read → 200 (rule 1, preserved)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER, scopeSet: "auth" });
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "vault:work:read" }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          // Pure host:auth requestable mint → no vault pin.
+          expect(validated.payload.vault_scope).toEqual([]);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("host:auth-only bearer mints vault:work:admin → 400 (rule 1 doesn't cover admin)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER, scopeSet: "auth" });
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "vault:work:admin" }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(400);
+          const body = (await resp.json()) as { error: string };
+          expect(body.error).toBe("invalid_scope");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("host:admin bearer mints vault:work:admin → 200 (rule 2, PR-A preserved)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "vault:work:admin" }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.aud).toBe("vault.work");
+          expect(validated.payload.vault_scope).toEqual(["work"]);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    // Entry gate: a bearer with no host:* and no vault-admin holds no minting
+    // authority → 403 before any per-scope check.
+    test("403 entry gate when bearer holds no minting authority", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const noAuthority = await signAccessToken(db, {
+            sub: userId,
+            scopes: ["hub:admin", "scribe:transcribe"],
+            audience: "hub",
+            clientId: "parachute-hub",
+            issuer: ISSUER,
+            ttlSeconds: 3600,
+          });
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:read" },
+              { authorization: `Bearer ${noAuthority.token}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(403);
+          const body = (await resp.json()) as { error: string };
+          expect(body.error).toBe("insufficient_scope");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    // A read-only token used AS A BEARER is not minting authority → 403.
+    test("403 entry gate when bearer is a vault:work:read token (read is not minting authority)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const readOnly = await signAccessToken(db, {
+            sub: userId,
+            scopes: ["vault:work:read"],
+            audience: "vault.work",
+            clientId: "parachute-hub",
+            issuer: ISSUER,
+            ttlSeconds: 3600,
+            vaultScope: ["work"],
+          });
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:read" },
+              { authorization: `Bearer ${readOnly.token}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(403);
+          const body = (await resp.json()) as { error: string };
+          expect(body.error).toBe("insufficient_scope");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
   });
 
   test("405 on non-POST", async () => {

--- a/src/__tests__/api-mint-token.test.ts
+++ b/src/__tests__/api-mint-token.test.ts
@@ -671,6 +671,49 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
       }
     });
 
+    // Realistic headless-runner shape: a bearer holding admin over MULTIPLE
+    // vaults composes rule 3 across them. Minting same-vault subsets of both
+    // succeeds; vault_scope collects every authorized vault name (order-
+    // insensitive). aud is first-wins (vault.work), which is fine — a
+    // multi-vault token only authenticates against its single aud, the pin is
+    // defense-in-depth.
+    test("multi-vault-admin bearer mints vault:work:read vault:other:read → 200, vault_scope=[work,other]", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const bearer = await signAccessToken(db, {
+            sub: userId,
+            scopes: ["vault:work:admin", "vault:other:admin"],
+            audience: "vault.work",
+            clientId: "parachute-hub",
+            issuer: ISSUER,
+            ttlSeconds: 3600,
+            vaultScope: ["work", "other"],
+          });
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:read vault:other:read" },
+              { authorization: `Bearer ${bearer.token}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.aud).toBe("vault.work");
+          const pin = validated.payload.vault_scope as string[];
+          expect(pin).toContain("work");
+          expect(pin).toContain("other");
+          expect(pin).toHaveLength(2);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
     // One blocked scope rejects the whole request (no partial mint).
     test("multi-scope vault:work:read vault:other:read → 400 (one blocked → all rejected)", async () => {
       const h = makeHarness();

--- a/src/api-mint-token.ts
+++ b/src/api-mint-token.ts
@@ -312,9 +312,13 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
     issuer: deps.issuer,
     ttlSeconds,
     // Operator-driven CLI/API mint — the bearer already cleared the
-    // attenuation guard. `vault_scope` is `[]` (no restriction) for pure
-    // host:auth verb mints, or the named vault(s) for vault-scoped mints
-    // authorized via rule 2 / rule 3 (see above).
+    // attenuation guard. `vault_scope` is `[]` (no restriction) for any
+    // verb scope granted by rule 1, or the named vault(s) for vault-scoped
+    // mints authorized via rule 2 / rule 3 (see above). The pin tracks the
+    // grant rule, not the bearer: a host:admin bearer minting
+    // `vault:work:write` goes through rule 1 (write is requestable), so it
+    // ALSO gets `vault_scope:[]` — only its `vault:work:admin` mints (rule 2)
+    // are pinned.
     vaultScope: vaultScopePin,
     ...(permissionsClaim !== undefined ? { extraClaims: { permissions: permissionsClaim } } : {}),
     ...(deps.now !== undefined ? { now: deps.now } : {}),

--- a/src/api-mint-token.ts
+++ b/src/api-mint-token.ts
@@ -8,19 +8,31 @@
  *   - the future admin SPA when the operator wants to mint a one-shot
  *     scope-narrow token without dropping to a terminal.
  *
- * Auth: `Authorization: Bearer <token>` where `token`'s `scope` claim
- * contains `parachute:host:auth`. The operator's local operator.token
- * (admin scope-set) covers this; a narrow `--scope-set=auth` operator
- * token also covers this.
+ * Auth — capability attenuation: any bearer may mint a token whose authority
+ * is a SUBSET of its own. A requested scope `s` is grantable (`canGrant`) iff:
  *
- * Mintable scopes: any requestable scope (vault/scribe/agent verbs, etc.).
- * Non-requestable scopes (`parachute:host:*`, `vault:<name>:admin`) are
- * refused — with ONE de-escalation exception: a bearer that carries
- * `parachute:host:admin` may mint `vault:<name>:admin`, because host:admin
- * already implies box-wide vault administration, so a vault-pinned admin is
- * strictly narrower. That's the canonical headless path to a per-vault admin
- * token (replacing deprecated `pvt_*` — vault#282) and the path the SPA
- * tokens page uses via session → /admin/host-admin-token → here.
+ *   1. `s` is requestable AND the bearer holds `parachute:host:auth`
+ *      — host:auth mints any requestable scope (vault/scribe verbs, etc.).
+ *   2. `s` is `vault:<N>:admin` AND the bearer holds `parachute:host:admin`
+ *      — box-wide admin attenuates to one named vault's admin.
+ *   3. `s` is `vault:<N>:<verb>` (verb ∈ read/write/admin) AND the bearer
+ *      holds `vault:<N>:admin` for the SAME `<N>` — a vault-admin attenuates
+ *      to any same-vault subset, including an equal-level admin.
+ *
+ * Otherwise `s` is refused (400 `invalid_scope`). This single rule subsumes
+ * the former two-part guard: the old hard `parachute:host:auth` gate is now
+ * rule 1, and PR-A's `host:admin → vault:<name>:admin` carve-out (hub#449) is
+ * now rule 2. Rule 3 is new — it lets a `vault:<name>:admin` bearer mint
+ * same-vault sub-tokens (the canonical headless path to per-vault admin,
+ * replacing deprecated `pvt_*` — vault#282 — and the path the SPA tokens
+ * page uses via session → /admin/host-admin-token → here). Cross-vault and
+ * host-authority escalation are always blocked: a `vault:work:admin` bearer
+ * can never mint `vault:other:*` or any `parachute:host:*`.
+ *
+ * Entry gate: the bearer must hold at least one minting authority —
+ * `parachute:host:auth`, `parachute:host:admin`, or some `vault:<*>:admin`.
+ * A bearer with none (e.g. a read-only token) gets 403 `insufficient_scope`
+ * before any per-scope check; it cannot mint anything.
  *
  * Why a separate endpoint instead of extending /admin/host-admin-token:
  * that endpoint is session-cookie-gated for the SPA's needs and only
@@ -35,28 +47,76 @@
 import type { Database } from "bun:sqlite";
 import { inferAudience } from "./jwt-audience.ts";
 import { recordTokenMint, signAccessToken, validateAccessToken } from "./jwt-sign.ts";
-import {
-  isNonRequestableScope,
-  isVaultAdminScope,
-  vaultAdminScopeName,
-} from "./scope-explanations.ts";
+import { isNonRequestableScope, isVaultAdminScope, vaultScopeName } from "./scope-explanations.ts";
 
 /** Default lifetime when --expires-in / `expires_in` is omitted. Matches the CLI. */
 export const API_MINT_TOKEN_DEFAULT_TTL_SECONDS = 90 * 24 * 60 * 60;
 /** Hard cap. Matches the CLI's --expires-in upper bound. */
 export const API_MINT_TOKEN_MAX_TTL_SECONDS = 365 * 24 * 60 * 60;
-/** Scope required on the bearer token to call this endpoint. */
-export const API_MINT_TOKEN_REQUIRED_SCOPE = "parachute:host:auth";
 /**
- * Bearer scope that admits an otherwise-non-requestable `vault:<name>:admin`
- * into a mint request. `parachute:host:admin` already implies box-wide
- * administration of every vault on the hub, so minting a vault-pinned admin
- * from it is a privilege *reduction* (de-escalation), not an escalation —
- * see the design doc `2026-05-28-operator-mintable-vault-admin.md`.
+ * Bearer scope that authorises minting any *requestable* scope (rule 1 of the
+ * attenuation model). The operator's admin scope-set carries this; a narrow
+ * `--scope-set=auth` operator token carries it too.
+ */
+export const API_MINT_TOKEN_HOST_AUTH_SCOPE = "parachute:host:auth";
+/**
+ * Bearer scope that authorises minting `vault:<name>:admin` (rule 2).
+ * `parachute:host:admin` already implies box-wide administration of every
+ * vault on the hub, so minting a vault-pinned admin from it is a privilege
+ * *reduction* (de-escalation), not an escalation — see the design doc
+ * `2026-05-28-operator-mintable-vault-admin.md`.
  */
 export const API_MINT_TOKEN_VAULT_ADMIN_BEARER_SCOPE = "parachute:host:admin";
 /** client_id stamped on minted tokens. Matches the CLI flow's value. */
 export const API_MINT_TOKEN_CLIENT_ID = "parachute-hub";
+
+/**
+ * Capability attenuation: can a bearer holding `bearerScopes` mint a token
+ * carrying `requestedScope`? True iff the requested scope is a subset of the
+ * bearer's own authority under one of three rules (see the file docstring):
+ *
+ *   1. requestable + bearer has `parachute:host:auth`;
+ *   2. `vault:<N>:admin` + bearer has `parachute:host:admin`;
+ *   3. `vault:<N>:<verb>` + bearer has `vault:<N>:admin` (same `<N>`).
+ *
+ * Pure function — no DB, no I/O — so it's trivially testable and the guard in
+ * the handler is a single `scopes.filter((s) => !canGrant(bearerScopes, s))`.
+ */
+export function canGrant(bearerScopes: string[], requestedScope: string): boolean {
+  // Rule 1 — host:auth mints any requestable scope.
+  if (
+    !isNonRequestableScope(requestedScope) &&
+    bearerScopes.includes(API_MINT_TOKEN_HOST_AUTH_SCOPE)
+  ) {
+    return true;
+  }
+  // Rule 2 — host:admin attenuates to a named vault's admin.
+  if (
+    isVaultAdminScope(requestedScope) &&
+    bearerScopes.includes(API_MINT_TOKEN_VAULT_ADMIN_BEARER_SCOPE)
+  ) {
+    return true;
+  }
+  // Rule 3 — vault:<N>:admin attenuates to any same-vault subset (incl. admin).
+  const requestedVault = vaultScopeName(requestedScope);
+  if (requestedVault !== null && bearerScopes.includes(`vault:${requestedVault}:admin`)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Does the bearer hold ANY minting authority? Entry gate before per-scope
+ * checks — a bearer with none (e.g. a read-only token) can mint nothing, so
+ * we 403 early rather than walking every requested scope to the same end.
+ */
+function hasMintingAuthority(bearerScopes: string[]): boolean {
+  return (
+    bearerScopes.includes(API_MINT_TOKEN_HOST_AUTH_SCOPE) ||
+    bearerScopes.includes(API_MINT_TOKEN_VAULT_ADMIN_BEARER_SCOPE) ||
+    bearerScopes.some((s) => isVaultAdminScope(s))
+  );
+}
 
 export interface ApiMintTokenDeps {
   db: Database;
@@ -108,12 +168,17 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
     return jsonError(401, "unauthenticated", `bearer token invalid — ${msg}`);
   }
 
-  // 3. Scope gate.
-  if (!bearerScopes.includes(API_MINT_TOKEN_REQUIRED_SCOPE)) {
+  // 3. Entry gate — the bearer must hold at least one minting authority
+  //    (`parachute:host:auth`, `parachute:host:admin`, or some
+  //    `vault:<*>:admin`). A bearer with none can mint nothing under the
+  //    attenuation model, so we 403 before per-scope checks. Per-scope
+  //    grantability (which authority covers which scope) is enforced below
+  //    via `canGrant`.
+  if (!hasMintingAuthority(bearerScopes)) {
     return jsonError(
       403,
       "insufficient_scope",
-      `bearer token lacks ${API_MINT_TOKEN_REQUIRED_SCOPE}`,
+      `bearer token holds no minting authority (need ${API_MINT_TOKEN_HOST_AUTH_SCOPE}, ${API_MINT_TOKEN_VAULT_ADMIN_BEARER_SCOPE}, or vault:<name>:admin)`,
     );
   }
 
@@ -138,33 +203,19 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
     return jsonError(400, "invalid_request", "scope must contain at least one scope");
   }
 
-  // Privilege-diffusion guard: mint paths cannot themselves mint tokens
-  // carrying non-requestable scopes (parachute:host:admin, the host:*
-  // narrow scopes, vault:<name>:admin). Holder of `parachute:host:auth`
-  // can mint vault/scribe/agent verb scopes for downstream services, but
-  // cannot mint another `:auth` (or any other non-requestable) without
-  // forced re-auth via the operator.token rotation path. Same set the
-  // public OAuth flow already rejects.
-  //
-  // Exception (de-escalation): a bearer that already carries
-  // `parachute:host:admin` may mint `vault:<name>:admin`. host:admin
-  // implies box-wide administration of every vault on the hub, so pinning
-  // it to a single named vault is a privilege *reduction*. This is the
-  // canonical headless path to a per-vault admin token (mcp-install via
-  // operator.token; SPA via session → host-admin-token → here) and the
-  // replacement for the deprecated `pvt_*` admin tokens (vault#282). The
-  // host:* narrow scopes and a bare `vault:admin` (no name) stay blocked.
-  const bearerHasHostAdmin = bearerScopes.includes(API_MINT_TOKEN_VAULT_ADMIN_BEARER_SCOPE);
-  const blocked = scopes.filter((s) => {
-    if (!isNonRequestableScope(s)) return false;
-    if (bearerHasHostAdmin && isVaultAdminScope(s)) return false;
-    return true;
-  });
+  // Capability-attenuation guard: every requested scope must be a subset of
+  // the bearer's own authority under `canGrant` (rules in the file docstring).
+  // A `parachute:host:auth` bearer mints any requestable scope; a
+  // `parachute:host:admin` bearer additionally mints `vault:<name>:admin`; a
+  // `vault:<name>:admin` bearer mints same-vault subsets only. Anything else
+  // — host:* escalation, cross-vault, a non-requestable with no covering
+  // authority — is blocked. One blocked scope rejects the whole request.
+  const blocked = scopes.filter((s) => !canGrant(bearerScopes, s));
   if (blocked.length > 0) {
     return jsonError(
       400,
       "invalid_scope",
-      `scope ${blocked.join(", ")} is not requestable via mint-token; use OAuth flow or operator rotation`,
+      `scope ${blocked.join(", ")} is not grantable by this bearer; use OAuth flow or operator rotation`,
     );
   }
 
@@ -218,22 +269,39 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
     permissionsCanonical = JSON.stringify(permissionsClaim);
   }
 
-  // Derive the `vault_scope` pin. For ordinary verb mints (read/write)
-  // this stays `[]` — the "no per-user restriction" sentinel; the scope
-  // string + audience are the authorization-bearing gate. For a
-  // `vault:<name>:admin` mint (admitted above for host:admin bearers) we
-  // pin the named vault(s) so the token can ONLY ever be used against
-  // that vault, matching the canonical session-path mint in
-  // `admin-vault-admin-token.ts` (defense-in-depth + least privilege).
+  // Derive the `vault_scope` pin. Collect the set of vault names `<N>` from
+  // every requested `vault:<N>:<verb>` scope that was authorized via a
+  // vault-scoped authority — rule 2 (host:admin → vault:<N>:admin) or rule 3
+  // (vault:<N>:admin → same-vault subset). These are the vault-scoped mints,
+  // so we pin the token to those vault(s): it can ONLY ever be used against
+  // them (defense-in-depth + least privilege), matching the canonical
+  // session-path mint in `admin-vault-admin-token.ts`.
   //
-  // Note: `audience` is single-valued and `inferAudience` is first-wins,
-  // so a multi-vault request (`vault:a:admin vault:b:admin`) gets
-  // `aud=vault.a` and the resulting token only authenticates against `a`.
-  // Mint one token per vault for the multi-vault case. The canonical
-  // consumers (mcp-install, SPA tokens page) request a single vault.
-  const vaultScopePin = scopes
-    .map((s) => vaultAdminScopeName(s))
-    .filter((n): n is string => n !== null);
+  // Pure `parachute:host:auth` requestable mints (a `vault:<N>:read/write`
+  // granted by rule 1 with no covering vault-admin authority) stay UNpinned
+  // (`[]`) — the "no per-user restriction" sentinel; the scope string +
+  // audience are the authorization-bearing gate there, as before. We
+  // distinguish by checking the bearer's own vault-scoped authority: a vault
+  // name is pinned only when the bearer held `vault:<N>:admin` (rule 3) or
+  // host:admin and the scope is admin (rule 2).
+  //
+  // Note: `audience` is single-valued and `inferAudience` is first-wins, so a
+  // multi-vault request gets `aud=vault.<first>` and only authenticates
+  // against that vault. Mint one token per vault for the multi-vault case.
+  // The canonical consumers (mcp-install, SPA tokens page) request a single
+  // vault.
+  const bearerHasHostAdmin = bearerScopes.includes(API_MINT_TOKEN_VAULT_ADMIN_BEARER_SCOPE);
+  const vaultScopePinSet = new Set<string>();
+  for (const s of scopes) {
+    const name = vaultScopeName(s);
+    if (name === null) continue;
+    const grantedByVaultAdminBearer = bearerScopes.includes(`vault:${name}:admin`); // rule 3
+    const grantedByHostAdminForAdmin = isVaultAdminScope(s) && bearerHasHostAdmin; // rule 2
+    if (grantedByVaultAdminBearer || grantedByHostAdminForAdmin) {
+      vaultScopePinSet.add(name);
+    }
+  }
+  const vaultScopePin = [...vaultScopePinSet];
 
   // 6. Mint + register.
   const minted = await signAccessToken(deps.db, {
@@ -244,8 +312,9 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
     issuer: deps.issuer,
     ttlSeconds,
     // Operator-driven CLI/API mint — the bearer already cleared the
-    // privilege gate. `vault_scope` is `[]` (no restriction) for verb
-    // mints, or the named vault(s) for an admin mint (see above).
+    // attenuation guard. `vault_scope` is `[]` (no restriction) for pure
+    // host:auth verb mints, or the named vault(s) for vault-scoped mints
+    // authorized via rule 2 / rule 3 (see above).
     vaultScope: vaultScopePin,
     ...(permissionsClaim !== undefined ? { extraClaims: { permissions: permissionsClaim } } : {}),
     ...(deps.now !== undefined ? { now: deps.now } : {}),

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -174,31 +174,15 @@ export function isVaultAdminScope(scope: string): boolean {
 }
 
 /**
- * Extract the vault name from a `vault:<name>:admin` scope, or null if the
- * scope isn't a per-vault admin scope. Used to derive the `vault_scope`
- * pin when minting an operator-requested vault-admin token.
- */
-export function vaultAdminScopeName(scope: string): string | null {
-  if (!VAULT_ADMIN_RE.test(scope)) return null;
-  return scope.split(":")[1] ?? null;
-}
-
-/**
  * Extract the vault name from ANY per-vault scope (`vault:<name>:<verb>` for
  * verb ∈ {read, write, admin}), or null if the scope isn't per-vault-scoped.
- * Broader than `vaultAdminScopeName` (which is admin-only) — used by the
- * mint-token attenuation model to (a) match a `vault:<name>:admin` bearer
- * against same-vault requested scopes, and (b) derive the `vault_scope` pin
- * for every vault-scoped mint regardless of verb.
+ * Used by the mint-token attenuation model to (a) match a `vault:<name>:admin`
+ * bearer against same-vault requested scopes, and (b) derive the `vault_scope`
+ * pin for every vault-scoped mint regardless of verb.
  */
 export function vaultScopeName(scope: string): string | null {
   const m = VAULT_SCOPED_RE.exec(scope);
   return m ? (m[1] ?? null) : null;
-}
-
-/** True when `scope` is any per-vault scope `vault:<name>:<read|write|admin>`. */
-export function isVaultScopedScope(scope: string): boolean {
-  return VAULT_SCOPED_RE.test(scope);
 }
 
 /** True when the scope is non-requestable via the public OAuth flow. */

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -142,20 +142,27 @@ export const NON_REQUESTABLE_SCOPES: ReadonlySet<string> = new Set([
  * public OAuth flow: they let the holder mint, revoke, and rotate tokens
  * for a specific vault instance, which is operator-only territory.
  *
- * They are mintable by two operator-proving local paths, both of which
- * require already-established hub-admin identity (never third-party consent):
+ * They are mintable by operator-proving local paths, all of which require
+ * already-established authority (never third-party consent):
  *   - the session-cookie-gated `/admin/vault-admin-token/:name` endpoint
  *     (the vault SPA's Manage link + setup wizard); and
- *   - `POST /api/auth/mint-token` when the calling bearer carries
- *     `parachute:host:admin` (operator-token / host-admin-token). Minting a
- *     vault-pinned admin from a box-wide `host:admin` is a privilege
- *     *reduction*, so the mint path admits it — see `isVaultAdminScope`
- *     and the guard in `api-mint-token.ts`.
+ *   - `POST /api/auth/mint-token` under the capability-attenuation model —
+ *     a `parachute:host:admin` bearer (box-wide → one-vault) or a
+ *     `vault:<name>:admin` bearer (same-vault subset). See `canGrant` and
+ *     the guard in `api-mint-token.ts`.
  *
  * Pattern-based because the set is open-ended — every vault instance the
  * operator creates implies a new scope, and we don't want to enumerate them.
  */
 const VAULT_ADMIN_RE = /^vault:[a-zA-Z0-9_-]+:admin$/;
+
+/**
+ * Any per-vault scope: `vault:<name>:<verb>` for verb ∈ {read, write, admin}.
+ * Captures the name in group 1 and the verb in group 2. Used by the
+ * mint-token capability-attenuation model to recognise the scopes a
+ * `vault:<name>:admin` bearer may attenuate to (same-vault subsets).
+ */
+const VAULT_SCOPED_RE = /^vault:([a-zA-Z0-9_-]+):(read|write|admin)$/;
 
 /**
  * True when `scope` is a per-vault admin scope (`vault:<name>:admin`).
@@ -174,6 +181,24 @@ export function isVaultAdminScope(scope: string): boolean {
 export function vaultAdminScopeName(scope: string): string | null {
   if (!VAULT_ADMIN_RE.test(scope)) return null;
   return scope.split(":")[1] ?? null;
+}
+
+/**
+ * Extract the vault name from ANY per-vault scope (`vault:<name>:<verb>` for
+ * verb ∈ {read, write, admin}), or null if the scope isn't per-vault-scoped.
+ * Broader than `vaultAdminScopeName` (which is admin-only) — used by the
+ * mint-token attenuation model to (a) match a `vault:<name>:admin` bearer
+ * against same-vault requested scopes, and (b) derive the `vault_scope` pin
+ * for every vault-scoped mint regardless of verb.
+ */
+export function vaultScopeName(scope: string): string | null {
+  const m = VAULT_SCOPED_RE.exec(scope);
+  return m ? (m[1] ?? null) : null;
+}
+
+/** True when `scope` is any per-vault scope `vault:<name>:<read|write|admin>`. */
+export function isVaultScopedScope(scope: string): boolean {
+  return VAULT_SCOPED_RE.test(scope);
 }
 
 /** True when the scope is non-requestable via the public OAuth flow. */


### PR DESCRIPTION
## What

Generalize `POST /api/auth/mint-token` to a single **capability-attenuation** model: *any bearer may mint a token whose authority is a subset of its own.* This subsumes PR-A (hub#449)'s `host:admin → vault:<name>:admin` carve-out into one uniform rule and adds the new level — a `vault:<name>:admin` bearer may mint same-vault sub-tokens.

## The rule

`canGrant(bearerScopes, requestedScope)` — a requested scope `s` is grantable iff ANY of:

1. `s` is requestable (`!isNonRequestableScope(s)`) AND bearer holds `parachute:host:auth`. *(Preserves today's behavior — host:auth mints any requestable scope.)*
2. `s` is `vault:<N>:admin` AND bearer holds `parachute:host:admin`. *(PR-A / hub#449, now expressed via the model — box-wide admin → one-vault admin.)*
3. `s` matches `vault:<N>:<verb>` (verb ∈ {read, write, admin}) AND bearer holds `vault:<N>:admin` for the **same** `<N>`. *(NEW — vault-admin attenuates to same-vault subsets, including equal-level admin.)*

Otherwise refused.

**Entry gate** (before per-scope checks): the bearer must hold at least one minting authority — `parachute:host:auth` OR `parachute:host:admin` OR at least one `vault:<*>:admin`. None → `403 insufficient_scope`. 401 paths (no/invalid bearer) unchanged. Per-scope: any `!canGrant` → `400 invalid_scope` (one blocked scope rejects the whole request).

**vault_scope pin** generalized: pinned to the set of vault names `<N>` from all requested `vault:<N>:<verb>` scopes authorized via rule 2 or 3; pure host:auth requestable mints stay `[]`. Audience unchanged (`inferAudience` → `vault.<N>`).

## Security matrix (the crux)

A `vault:work:admin` bearer:

| Requested scope | Result |
|---|---|
| `vault:work:write` | 200, aud=vault.work, vault_scope=["work"] |
| `vault:work:read` | 200 |
| `vault:work:admin` | 200 (same-level allowed) |
| `vault:other:write` | **400 — cross-vault BLOCKED** |
| `vault:other:admin` | **400** |
| `parachute:host:auth` | **400 — no escalation** |
| `parachute:host:admin` | **400** |
| `scribe:transcribe` | **400** (no host:auth; not a vault:work scope) |
| `vault:work:read vault:work:write` | 200, vault_scope ["work"] |
| `vault:work:read vault:other:read` | **400** (one blocked → whole request rejected) |

Regression (preserved):
- `host:auth`-only bearer mints `vault:work:read` → 200; `vault:work:admin` → 400.
- `host:admin` bearer mints `vault:work:admin` → 200 (PR-A).
- bearer with no host:* and no vault-admin → 403 entry gate.
- a `vault:work:read` token used as a bearer → 403 (read is not minting authority).

## Generalizes PR-A

The old guard was a hard `parachute:host:auth` gate plus an `if (bearerHasHostAdmin && isVaultAdminScope(s))` exemption. Both collapse into `canGrant`: the gate is rule 1, the exemption is rule 2. The PR-A tests still pass — they are now instances of the general rule.

## Helpers

`scope-explanations.ts`: add `vaultScopeName(scope)` (extract `<N>` from any `vault:<N>:<verb>`) + `isVaultScopedScope`. `isVaultAdminScope` / `vaultAdminScopeName` exports retained.

## Gates

- `bun test ./src`: **2313 pass, 1 skip, 0 fail** (33137 expect calls)
- `bun run typecheck`: clean
- `bunx biome check --write` on changed files: clean

No version/rc bump (per task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)