### PR TITLE
feat(scope-guard): surface permissions claim on HubJwtClaims (0.4.0-rc.2)

### DIFF
--- a/packages/scope-guard/CHANGELOG.md
+++ b/packages/scope-guard/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@openparachute/scope-guard` are documented here. The for
 
 The library's RC cadence is independent of `@openparachute/hub`'s — they ship from the same repo but aren't coupled in version.
 
+## 0.4.0-rc.2 — 2026-05-28
+
+Surfaces the raw `permissions` claim on `HubJwtClaims` (additive) so resource servers (e.g. vault reading `permissions.scoped_tags` for tag-scoping) can read it without re-decoding the token. scope-guard passes the object through verbatim — a non-null plain object surfaces; absent / null / non-object (string, number, array) leaves `permissions` `undefined`, distinct from an empty `{}`. Auth-unification arc C0.
+
 ## 0.4.0-rc.1 — 2026-05-22
 
 Adds the hub#218 jti-presence hardening: hub-signed JWTs that lack a `jti` claim are rejected by default. **Behaviour-breaking minor** — any adopter that bumps from `0.3.x` will start rejecting jti-less hub-signed tokens. The default is the security floor; an `allowMissingJti: true` opt-out is available for operators with pre-Phase-1 legacy tokens still in flight.

--- a/packages/scope-guard/package.json
+++ b/packages/scope-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scope-guard",
-  "version": "0.4.0-rc.1",
+  "version": "0.4.0-rc.2",
   "description": "Hub-issued JWT validation for Parachute resource servers (vault, scribe, parachute-agent, third-party modules).",
   "license": "AGPL-3.0",
   "type": "module",

--- a/packages/scope-guard/src/__tests__/validate.test.ts
+++ b/packages/scope-guard/src/__tests__/validate.test.ts
@@ -114,6 +114,13 @@ interface SignOpts {
    * JSON-null, plus mixed arrays with non-string entries.
    */
   vaultScopeRaw?: unknown;
+  /**
+   * Force a raw value into the `permissions` claim. Used to exercise the
+   * passthrough (a plain object surfaces verbatim) and the malformed-input
+   * paths the validate code leaves `undefined` (string / number / array /
+   * null). Omit to emit no `permissions` claim at all.
+   */
+  permissionsRaw?: unknown;
 }
 
 async function signJwt(kp: Keypair, opts: SignOpts): Promise<string> {
@@ -130,6 +137,9 @@ async function signJwt(kp: Keypair, opts: SignOpts): Promise<string> {
     // emit, even for admins). "OMIT_CLAIM" is the test seam for pre-PR-4
     // tokens that lack the claim entirely.
     payload.vault_scope = opts.vaultScope ?? [];
+  }
+  if (opts.permissionsRaw !== undefined) {
+    payload.permissions = opts.permissionsRaw;
   }
   const builder = new SignJWT(payload)
     .setProtectedHeader(opts.omitKid ? { alg: "RS256" } : { alg: "RS256", kid: opts.kid ?? kp.kid })
@@ -866,6 +876,66 @@ describe("createScopeGuard — vault_scope claim surfacing", () => {
     });
     const claims = await guard.validateHubJwt(token);
     expect(claims.vaultScope).toEqual(["aaron", "work", "personal"]);
+    guard.resetJwksCache();
+  });
+});
+
+describe("createScopeGuard — permissions claim surfacing", () => {
+  // The permissions claim is a raw passthrough: scope-guard surfaces the
+  // object verbatim (after full signature/issuer/expiry/revocation
+  // validation) without interpreting it. Consumers (e.g. vault reading
+  // `permissions.scoped_tags`) own the semantics. The validate-side contract:
+  // surface a non-null plain object, leave everything else `undefined`, never
+  // throw on malformed input. Mirrors the vault_scope tests above.
+
+  test("permissions object surfaces verbatim on claims", async () => {
+    const guard = makeGuard();
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      permissionsRaw: { scoped_tags: ["work", "personal"], extra: 1 },
+    });
+    const claims = await guard.validateHubJwt(token);
+    expect(claims.permissions).toEqual({ scoped_tags: ["work", "personal"], extra: 1 });
+    guard.resetJwksCache();
+  });
+
+  test("token without permissions claim → permissions === undefined", async () => {
+    const guard = makeGuard();
+    const token = await signJwt(kp, { iss: fixture.origin });
+    const claims = await guard.validateHubJwt(token);
+    expect(claims.permissions).toBeUndefined();
+    guard.resetJwksCache();
+  });
+
+  test("empty permissions object surfaces as {} (distinct from absent)", async () => {
+    // `{}` must stay distinguishable from "no claim" (undefined) — the lib
+    // does NOT default absent to `{}`.
+    const guard = makeGuard();
+    const token = await signJwt(kp, { iss: fixture.origin, permissionsRaw: {} });
+    const claims = await guard.validateHubJwt(token);
+    expect(claims.permissions).toEqual({});
+    expect(claims.permissions).not.toBeUndefined();
+    guard.resetJwksCache();
+  });
+
+  test("non-object permissions (string / number / array / null) → undefined, no throw", async () => {
+    // Malformed input is tolerated: the claim is dropped (undefined), the
+    // token still validates. An array is JSON-typeof "object" but is not a
+    // plain object, so it must also drop.
+    const guard = makeGuard();
+
+    const tokenStr = await signJwt(kp, { iss: fixture.origin, permissionsRaw: "scoped" });
+    expect((await guard.validateHubJwt(tokenStr)).permissions).toBeUndefined();
+
+    const tokenNum = await signJwt(kp, { iss: fixture.origin, permissionsRaw: 42 });
+    expect((await guard.validateHubJwt(tokenNum)).permissions).toBeUndefined();
+
+    const tokenArr = await signJwt(kp, { iss: fixture.origin, permissionsRaw: ["work"] });
+    expect((await guard.validateHubJwt(tokenArr)).permissions).toBeUndefined();
+
+    const tokenNull = await signJwt(kp, { iss: fixture.origin, permissionsRaw: null });
+    expect((await guard.validateHubJwt(tokenNull)).permissions).toBeUndefined();
+
     guard.resetJwksCache();
   });
 });

--- a/packages/scope-guard/src/validate.ts
+++ b/packages/scope-guard/src/validate.ts
@@ -61,6 +61,19 @@ export interface HubJwtClaims {
    * additive, not the sole gate.
    */
   vaultScope: string[];
+  /**
+   * Raw `permissions` claim from the validated JWT payload, surfaced
+   * verbatim. scope-guard does NOT interpret it — it parses-and-passes the
+   * object so resource servers can read their own permission shapes without
+   * re-decoding the token. e.g. vault reads `permissions.scoped_tags` for
+   * tag-scoping; scope-guard knows nothing of `scoped_tags` semantics.
+   *
+   * Present only when the validated payload carries a non-null plain object
+   * under `permissions`. Absent or non-object (string / number / array)
+   * surfaces as `undefined` — distinct from an empty object `{}` so consumers
+   * can tell "no permissions claim" from "permissions claim with no entries."
+   */
+  permissions?: Record<string, unknown>;
 }
 
 /** Reasons a hub JWT may fail validation. Each maps to a `HubJwtError.code`. */
@@ -347,6 +360,21 @@ export function createScopeGuard(opts: CreateScopeGuardOptions): ScopeGuard {
         ? vaultScopeRaw.filter((s): s is string => typeof s === "string")
         : [];
 
+      // permissions: raw passthrough of the consumer-interpreted permissions
+      // object (e.g. vault's `scoped_tags`). scope-guard surfaces it verbatim
+      // without knowing its shape. Only a non-null plain object is surfaced;
+      // absent / null / non-object (string, number, array) leaves it
+      // `undefined` so "no claim" stays distinguishable from `{}`. Mirrors
+      // the defensive style of vaultScope above — malformed input is tolerated
+      // (left undefined), never thrown on.
+      const permissionsRaw = (payload as { permissions?: unknown }).permissions;
+      const permissions: Record<string, unknown> | undefined =
+        typeof permissionsRaw === "object" &&
+        permissionsRaw !== null &&
+        !Array.isArray(permissionsRaw)
+          ? (permissionsRaw as Record<string, unknown>)
+          : undefined;
+
       // Revocation enforcement runs LAST — only consulted if the JWT is
       // otherwise valid. Cheaper checks (signature, iss, aud, expiry,
       // jti-presence) reject first, so a bad signature never costs a
@@ -376,7 +404,7 @@ export function createScopeGuard(opts: CreateScopeGuardOptions): ScopeGuard {
         }
       }
 
-      return { sub: payload.sub, scopes, aud, jti, clientId, vaultScope };
+      return { sub: payload.sub, scopes, aud, jti, clientId, vaultScope, permissions };
     },
 
     resetJwksCache() {


### PR DESCRIPTION
## What

`@openparachute/scope-guard`'s `validateHubJwt` returned a narrowed `HubJwtClaims` that dropped the JWT's `permissions` claim. Resource servers (vault) need it to read tag-scoping (`permissions.scoped_tags`) and were re-decoding the token themselves. This surfaces the `permissions` claim on `HubJwtClaims` so all RS consumers can read it natively.

This is the clean home for what vault **C0** needs (auth-unification arc): scope-guard surfaces `permissions` so vault can read tag-scoping without a side-decode workaround.

## The change (additive, minimal)

In `packages/scope-guard/src/validate.ts`:
- Add `HubJwtClaims.permissions?: Record<string, unknown>` — the raw `permissions` claim from the validated payload, surfaced **verbatim**. scope-guard does NOT interpret it (no `scoped_tags` knowledge — that's the consumer's domain); it parses-and-passes the object.
- After the existing claim extraction: if `payload.permissions` is a **non-null plain object**, set `claims.permissions`. Absent / null / non-object (string, number, array) → leave `undefined` (do NOT default to `{}` — absent must stay distinguishable from empty). Mirrors the defensive style of the existing `vaultScope` parsing.
- Surfaced only on the validated-payload path (after signature / issuer / expiry / revocation) — rides the existing claim-extraction, no separate decode.
- `HubJwtClaims` docstring documents `permissions` (raw passthrough, consumer interprets; e.g. vault reads `permissions.scoped_tags`).

## Version + tests

- `package.json`: `0.4.0-rc.1` → `0.4.0-rc.2`; CHANGELOG entry added.
- New tests (scope-guard suite, `src/__tests__/validate.test.ts`): permissions object surfaces verbatim; absent → `undefined`; empty `{}` surfaces distinct from absent; non-object (string / number / array / null) → `undefined`, no throw. Adds a `permissionsRaw` seam to the `signJwt` helper mirroring `vaultScopeRaw`.

## Gates

- `bun test ./packages/scope-guard/src` → **108 pass / 0 fail** (4 new)
- `bun test ./src` (hub, consumes scope-guard) → **2314 pass / 1 skip / 0 fail**
- `bun run typecheck` (repo root) → clean
- `bunx biome check` on changed files → clean

## Publishing

Publishing requires a **`scope-guard-v0.4.0-rc.2`** tag push after merge — CI handles the publish on tag.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)