### PR TITLE
feat(hub): capability attenuation in revoke-token (revoke what you could mint)

### DIFF
--- a/src/__tests__/api-revoke-token.test.ts
+++ b/src/__tests__/api-revoke-token.test.ts
@@ -581,4 +581,124 @@ describe("POST /api/auth/revoke-token — capability attenuation (symmetric to h
       h.cleanup();
     }
   });
+
+  test("HOST-ESCALATION BLOCKED: host:admin bearer revokes parachute:host:auth jti → 403, NOT revoked", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        // host:admin is NOT host:auth, so it goes through the per-jti
+        // attenuation check. `parachute:host:auth` is non-requestable and not
+        // a vault-admin scope, so canGrant returns false for it → 403.
+        const hostAdmin = await signAccessToken(db, {
+          sub: userId,
+          scopes: ["parachute:host:admin"],
+          audience: "hub",
+          clientId: "parachute-hub",
+          issuer: ISSUER,
+          ttlSeconds: 3600,
+        });
+        const jti = await seedToken(db, userId, ["parachute:host:auth"]);
+        const resp = await handleApiRevokeToken(
+          jsonRequest({ jti }, { authorization: `Bearer ${hostAdmin.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(403);
+        expect(((await resp.json()) as { error: string }).error).toBe("insufficient_scope");
+        expect(findTokenRowByJti(db, jti)?.revokedAt).toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("EMPTY-SCOPES GUARD: non-host:auth bearer cannot revoke a scopeless target → 403, NOT revoked", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const bearer = await mintVaultAdminBearer(db, userId, "work");
+        // Seed a registry row with ZERO recorded scopes directly — the CLI/SPA
+        // never mint these, but a vacuous `[].filter(canGrant)` would
+        // otherwise pass the authority check for any entry-gate-clearing
+        // bearer. The explicit empty-scopes guard must 403 instead.
+        const jti = "scopeless-target-jti";
+        recordTokenMint(db, {
+          jti,
+          createdVia: "cli_mint",
+          subject: userId,
+          clientId: "parachute-hub",
+          scopes: [],
+          expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+        });
+        expect(findTokenRowByJti(db, jti)?.scopes).toEqual([]);
+
+        const resp = await handleApiRevokeToken(
+          jsonRequest({ jti }, { authorization: `Bearer ${bearer}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(403);
+        expect(((await resp.json()) as { error: string }).error).toBe("insufficient_scope");
+        // SECURITY: the scopeless token must NOT have been revoked.
+        expect(findTokenRowByJti(db, jti)?.revokedAt).toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("EMPTY-SCOPES: host:auth bearer CAN revoke a scopeless target → 200 (guard is non-host:auth-only)", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const jti = "scopeless-target-host-auth";
+        recordTokenMint(db, {
+          jti,
+          createdVia: "cli_mint",
+          subject: userId,
+          clientId: "parachute-hub",
+          scopes: [],
+          expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+        });
+        const resp = await handleApiRevokeToken(
+          jsonRequest({ jti }, { authorization: `Bearer ${op.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(200);
+        expect(findTokenRowByJti(db, jti)?.revokedAt).not.toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("JTI LENGTH GUARD: jti longer than the cap → 400 invalid_request", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiRevokeToken(
+          jsonRequest({ jti: "x".repeat(257) }, { authorization: `Bearer ${op.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(400);
+        const body = (await resp.json()) as { error: string; error_description: string };
+        expect(body.error).toBe("invalid_request");
+        expect(body.error_description).toContain("256");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
 });

--- a/src/__tests__/api-revoke-token.test.ts
+++ b/src/__tests__/api-revoke-token.test.ts
@@ -318,3 +318,267 @@ describe("POST /api/auth/revoke-token (closes hub#220)", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Capability attenuation — symmetric to mint-token (hub#452). A bearer that
+// is NOT host:auth may revoke a jti iff every one of the jti's recorded scopes
+// is one the bearer could have minted (`canGrant`): you may revoke what you
+// could mint. This is the security-critical half of the auth arc.
+// ---------------------------------------------------------------------------
+describe("POST /api/auth/revoke-token — capability attenuation (symmetric to hub#452)", () => {
+  /**
+   * Hand-mint a `vault:<vault>:admin` bearer the way the SPA / mcp-install
+   * path obtains one (scope `vault:<vault>:admin`, aud `vault.<vault>`,
+   * vaultScope `[vault]`). Mirrors `mintVaultAdminBearer` in
+   * api-mint-token.test.ts.
+   */
+  async function mintVaultAdminBearer(
+    db: ReturnType<typeof openHubDb>,
+    userId: string,
+    vault: string,
+  ): Promise<string> {
+    const signed = await signAccessToken(db, {
+      sub: userId,
+      scopes: [`vault:${vault}:admin`],
+      audience: `vault.${vault}`,
+      clientId: "parachute-hub",
+      issuer: ISSUER,
+      ttlSeconds: 3600,
+      vaultScope: [vault],
+    });
+    return signed.token;
+  }
+
+  test("host:auth bearer revokes ANY jti (preserved) — incl. a host-scoped target", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        // Seed a target whose own scopes a vault-admin could never mint.
+        const jti = await seedToken(db, userId, ["parachute:host:auth"]);
+        const resp = await handleApiRevokeToken(
+          jsonRequest({ jti }, { authorization: `Bearer ${op.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(200);
+        expect(findTokenRowByJti(db, jti)?.revokedAt).not.toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("vault:work:admin revokes a vault:work:write jti → 200 (could have minted it)", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const bearer = await mintVaultAdminBearer(db, userId, "work");
+        const jti = await seedToken(db, userId, ["vault:work:write"]);
+        const resp = await handleApiRevokeToken(
+          jsonRequest({ jti }, { authorization: `Bearer ${bearer}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(200);
+        expect(findTokenRowByJti(db, jti)?.revokedAt).not.toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("vault:work:admin revokes a vault:work:admin jti → 200", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const bearer = await mintVaultAdminBearer(db, userId, "work");
+        const jti = await seedToken(db, userId, ["vault:work:admin"]);
+        const resp = await handleApiRevokeToken(
+          jsonRequest({ jti }, { authorization: `Bearer ${bearer}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(200);
+        expect(findTokenRowByJti(db, jti)?.revokedAt).not.toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("CROSS-VAULT BLOCKED: vault:work:admin revokes vault:other:write jti → 403, NOT revoked", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const bearer = await mintVaultAdminBearer(db, userId, "work");
+        const jti = await seedToken(db, userId, ["vault:other:write"]);
+        const resp = await handleApiRevokeToken(
+          jsonRequest({ jti }, { authorization: `Bearer ${bearer}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(403);
+        expect(((await resp.json()) as { error: string }).error).toBe("insufficient_scope");
+        // SECURITY: the cross-vault token must NOT have been revoked.
+        expect(findTokenRowByJti(db, jti)?.revokedAt).toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("HOST-ESCALATION BLOCKED: vault:work:admin revokes parachute:host:auth jti → 403, NOT revoked", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const bearer = await mintVaultAdminBearer(db, userId, "work");
+        const jti = await seedToken(db, userId, ["parachute:host:auth"]);
+        const resp = await handleApiRevokeToken(
+          jsonRequest({ jti }, { authorization: `Bearer ${bearer}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(403);
+        expect(findTokenRowByJti(db, jti)?.revokedAt).toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("NO LEAK: vault:work:admin revokes an UNKNOWN jti → 404 (same as host:auth, no leak)", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const bearer = await mintVaultAdminBearer(db, userId, "work");
+        const resp = await handleApiRevokeToken(
+          jsonRequest({ jti: "no-such-jti-ever-minted" }, { authorization: `Bearer ${bearer}` }),
+          { db, issuer: ISSUER },
+        );
+        // Identical to today's unknown-jti behavior for a host:auth bearer:
+        // the attenuated caller cannot distinguish "doesn't exist" here.
+        expect(resp.status).toBe(404);
+        expect(((await resp.json()) as { error: string }).error).toBe("not_found");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("ENTRY GATE: vault:work:read bearer (no admin, no host) → 403, NOT revoked", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const readOnly = await signAccessToken(db, {
+          sub: userId,
+          scopes: ["vault:work:read"],
+          audience: "vault.work",
+          clientId: "parachute-hub",
+          issuer: ISSUER,
+          ttlSeconds: 3600,
+          vaultScope: ["work"],
+        });
+        // Seed a target the read bearer could never mint anyway.
+        const jti = await seedToken(db, userId, ["vault:work:write"]);
+        const resp = await handleApiRevokeToken(
+          jsonRequest({ jti }, { authorization: `Bearer ${readOnly.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(403);
+        expect(((await resp.json()) as { error: string }).error).toBe("insufficient_scope");
+        // Entry-gated before any lookup — the target stays intact.
+        expect(findTokenRowByJti(db, jti)?.revokedAt).toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("MULTI-SCOPE: vault:work:admin revokes vault:work:read+write jti → 200 (all in authority)", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const bearer = await mintVaultAdminBearer(db, userId, "work");
+        const jti = await seedToken(db, userId, ["vault:work:read", "vault:work:write"]);
+        const resp = await handleApiRevokeToken(
+          jsonRequest({ jti }, { authorization: `Bearer ${bearer}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(200);
+        expect(findTokenRowByJti(db, jti)?.revokedAt).not.toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("MULTI-SCOPE BLOCKED: one out-of-authority scope blocks the whole revoke → 403, NOT revoked", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const bearer = await mintVaultAdminBearer(db, userId, "work");
+        // In-authority scope + one cross-vault scope: must block entirely.
+        const jti = await seedToken(db, userId, ["vault:work:write", "vault:other:read"]);
+        const resp = await handleApiRevokeToken(
+          jsonRequest({ jti }, { authorization: `Bearer ${bearer}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(403);
+        expect(findTokenRowByJti(db, jti)?.revokedAt).toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("host:admin bearer revokes a vault:<name>:admin jti → 200 (rule 2 symmetry)", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const hostAdmin = await signAccessToken(db, {
+          sub: userId,
+          scopes: ["parachute:host:admin"],
+          audience: "hub",
+          clientId: "parachute-hub",
+          issuer: ISSUER,
+          ttlSeconds: 3600,
+        });
+        const jti = await seedToken(db, userId, ["vault:work:admin"]);
+        const resp = await handleApiRevokeToken(
+          jsonRequest({ jti }, { authorization: `Bearer ${hostAdmin.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(200);
+        expect(findTokenRowByJti(db, jti)?.revokedAt).not.toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/api-mint-token.ts
+++ b/src/api-mint-token.ts
@@ -47,7 +47,18 @@
 import type { Database } from "bun:sqlite";
 import { inferAudience } from "./jwt-audience.ts";
 import { recordTokenMint, signAccessToken, validateAccessToken } from "./jwt-sign.ts";
-import { isNonRequestableScope, isVaultAdminScope, vaultScopeName } from "./scope-explanations.ts";
+import {
+  MINT_HOST_ADMIN_SCOPE,
+  MINT_HOST_AUTH_SCOPE,
+  canGrant,
+  hasMintingAuthority,
+} from "./scope-attenuation.ts";
+import { isVaultAdminScope, vaultScopeName } from "./scope-explanations.ts";
+
+// Re-export `canGrant` so existing importers (and the symmetric revoke path)
+// have a single name to reach for; the implementation lives in the shared
+// `scope-attenuation.ts` module alongside `hasMintingAuthority`.
+export { canGrant } from "./scope-attenuation.ts";
 
 /** Default lifetime when --expires-in / `expires_in` is omitted. Matches the CLI. */
 export const API_MINT_TOKEN_DEFAULT_TTL_SECONDS = 90 * 24 * 60 * 60;
@@ -55,68 +66,17 @@ export const API_MINT_TOKEN_DEFAULT_TTL_SECONDS = 90 * 24 * 60 * 60;
 export const API_MINT_TOKEN_MAX_TTL_SECONDS = 365 * 24 * 60 * 60;
 /**
  * Bearer scope that authorises minting any *requestable* scope (rule 1 of the
- * attenuation model). The operator's admin scope-set carries this; a narrow
- * `--scope-set=auth` operator token carries it too.
+ * attenuation model). Re-exported alias of the shared `MINT_HOST_AUTH_SCOPE`
+ * for back-compat with existing importers.
  */
-export const API_MINT_TOKEN_HOST_AUTH_SCOPE = "parachute:host:auth";
+export const API_MINT_TOKEN_HOST_AUTH_SCOPE = MINT_HOST_AUTH_SCOPE;
 /**
  * Bearer scope that authorises minting `vault:<name>:admin` (rule 2).
- * `parachute:host:admin` already implies box-wide administration of every
- * vault on the hub, so minting a vault-pinned admin from it is a privilege
- * *reduction* (de-escalation), not an escalation — see the design doc
- * `2026-05-28-operator-mintable-vault-admin.md`.
+ * Re-exported alias of the shared `MINT_HOST_ADMIN_SCOPE`.
  */
-export const API_MINT_TOKEN_VAULT_ADMIN_BEARER_SCOPE = "parachute:host:admin";
+export const API_MINT_TOKEN_VAULT_ADMIN_BEARER_SCOPE = MINT_HOST_ADMIN_SCOPE;
 /** client_id stamped on minted tokens. Matches the CLI flow's value. */
 export const API_MINT_TOKEN_CLIENT_ID = "parachute-hub";
-
-/**
- * Capability attenuation: can a bearer holding `bearerScopes` mint a token
- * carrying `requestedScope`? True iff the requested scope is a subset of the
- * bearer's own authority under one of three rules (see the file docstring):
- *
- *   1. requestable + bearer has `parachute:host:auth`;
- *   2. `vault:<N>:admin` + bearer has `parachute:host:admin`;
- *   3. `vault:<N>:<verb>` + bearer has `vault:<N>:admin` (same `<N>`).
- *
- * Pure function — no DB, no I/O — so it's trivially testable and the guard in
- * the handler is a single `scopes.filter((s) => !canGrant(bearerScopes, s))`.
- */
-export function canGrant(bearerScopes: string[], requestedScope: string): boolean {
-  // Rule 1 — host:auth mints any requestable scope.
-  if (
-    !isNonRequestableScope(requestedScope) &&
-    bearerScopes.includes(API_MINT_TOKEN_HOST_AUTH_SCOPE)
-  ) {
-    return true;
-  }
-  // Rule 2 — host:admin attenuates to a named vault's admin.
-  if (
-    isVaultAdminScope(requestedScope) &&
-    bearerScopes.includes(API_MINT_TOKEN_VAULT_ADMIN_BEARER_SCOPE)
-  ) {
-    return true;
-  }
-  // Rule 3 — vault:<N>:admin attenuates to any same-vault subset (incl. admin).
-  const requestedVault = vaultScopeName(requestedScope);
-  if (requestedVault !== null && bearerScopes.includes(`vault:${requestedVault}:admin`)) {
-    return true;
-  }
-  return false;
-}
-
-/**
- * Does the bearer hold ANY minting authority? Entry gate before per-scope
- * checks — a bearer with none (e.g. a read-only token) can mint nothing, so
- * we 403 early rather than walking every requested scope to the same end.
- */
-function hasMintingAuthority(bearerScopes: string[]): boolean {
-  return (
-    bearerScopes.includes(API_MINT_TOKEN_HOST_AUTH_SCOPE) ||
-    bearerScopes.includes(API_MINT_TOKEN_VAULT_ADMIN_BEARER_SCOPE) ||
-    bearerScopes.some((s) => isVaultAdminScope(s))
-  );
-}
 
 export interface ApiMintTokenDeps {
   db: Database;

--- a/src/api-revoke-token.ts
+++ b/src/api-revoke-token.ts
@@ -1,38 +1,66 @@
 /**
  * `POST /api/auth/revoke-token` — HTTP companion to `parachute auth
- * revoke-token <jti>` (hub#221) and the missing piece behind the future
- * admin UI's revoke action.
+ * revoke-token <jti>` (hub#221) and the backing endpoint for the admin
+ * UI's revoke action. Closes hub#220.
  *
- * Same auth shape as `POST /api/auth/mint-token`: bearer-gated on
- * `parachute:host:auth` (admin scope-set tokens carry it as a superset;
- * narrow `--scope-set auth` operator tokens carry it directly). Closes
- * hub#220.
+ * Auth — capability attenuation, SYMMETRIC to mint-token (hub#452): you may
+ * revoke exactly what you could have minted. After validating the bearer
+ * (signature / issuer / expiry — same as today):
+ *
+ *   1. If the bearer holds `parachute:host:auth` → it may revoke ANY jti
+ *      (the original, broadest behavior — preserved unchanged).
+ *   2. Otherwise the bearer must clear the entry gate — it must hold at least
+ *      one minting authority (`parachute:host:auth`, `parachute:host:admin`,
+ *      or some `vault:<*>:admin`, via `hasMintingAuthority`). A bearer with
+ *      none (e.g. a read-only token) gets 403 up front — it can revoke
+ *      nothing, just as it can mint nothing.
+ *   3. The per-jti authority check then governs what such a bearer may
+ *      actually revoke: the target jti is revocable iff EVERY one of its
+ *      recorded scopes satisfies `canGrant(bearerScopes, scope)` — i.e. the
+ *      bearer could have minted that exact token. A `vault:work:admin` bearer
+ *      can revoke a `vault:work:write` or `vault:work:admin` jti, but NOT a
+ *      `vault:other:*` jti and NOT a `parachute:host:*` jti — the same
+ *      cross-vault / host-escalation walls mint enforces.
+ *
+ * Idempotency / no-info-leak: an UNKNOWN jti (no `tokens` row — never minted
+ * or already purged) returns the SAME 404 `not_found` the endpoint has always
+ * returned, for every caller including host:auth. The per-jti authority check
+ * only runs when the row is FOUND. So an attenuated bearer probing a jti it
+ * doesn't own cannot distinguish "exists but not yours" from "doesn't exist"
+ * by the unknown-jti path — it gets the identical 404 a host:auth bearer
+ * would. A jti that EXISTS but is out of the bearer's authority returns 403
+ * (and is NOT revoked): the caller already knows the jti string, so "exists
+ * but not yours" leaks nothing beyond what it already holds — and returning
+ * idempotent-ok there would be a lie (it revoked nothing).
  *
  * Body: `{ jti: string }`.
  *
- * Responses (matching the OAuth 2.0 error-shape vocabulary used by
- * mint-token and the rest of the hub's bearer-protected admin API):
+ * Responses (OAuth 2.0 error-shape vocabulary, matching mint-token):
  *
  *   - 200 `{ jti, revoked_at }` — success. Idempotent: re-revoking an
- *     already-revoked jti returns the existing `revoked_at` and 200,
- *     same as the CLI's exit-0-with-existing-timestamp behavior.
+ *     already-revoked jti returns the existing `revoked_at` and 200.
  *   - 400 `invalid_request` — missing/malformed body, missing jti.
  *   - 401 `unauthenticated` — missing or invalid bearer.
- *   - 403 `insufficient_scope` — bearer lacks `parachute:host:auth`.
+ *   - 403 `insufficient_scope` — bearer holds no minting authority (entry
+ *     gate), or the target jti carries a scope the bearer couldn't have
+ *     minted (per-jti authority check).
  *   - 404 `not_found` — no `tokens` row matches the jti.
  *   - 405 `method_not_allowed` — non-POST.
  *
  * Identity field in audit-friendly success: not echoed in the response
  * body (the JSON shape is intentionally minimal — `jti` + `revoked_at`
  * is all a UI consumer needs); operator-side audit lives in hub logs.
- * Mirrors the CLI's design where `identity=` was added for stdout but
- * the wire response stays narrow.
  */
 import type { Database } from "bun:sqlite";
 import { findTokenRowByJti, revokeTokenByJti, validateAccessToken } from "./jwt-sign.ts";
+import { MINT_HOST_AUTH_SCOPE, canGrant, hasMintingAuthority } from "./scope-attenuation.ts";
 
-/** Scope required on the bearer token to call this endpoint. */
-export const API_REVOKE_TOKEN_REQUIRED_SCOPE = "parachute:host:auth";
+/**
+ * Scope that authorises revoking ANY jti unconditionally (rule 1). A bearer
+ * without it may still revoke via attenuation (rule 3) if it clears the
+ * `hasMintingAuthority` entry gate.
+ */
+export const API_REVOKE_TOKEN_REQUIRED_SCOPE = MINT_HOST_AUTH_SCOPE;
 
 export interface ApiRevokeTokenDeps {
   db: Database;
@@ -80,12 +108,19 @@ export async function handleApiRevokeToken(
     return jsonError(401, "unauthenticated", `bearer token invalid — ${msg}`);
   }
 
-  // 3. Scope gate.
-  if (!bearerScopes.includes(API_REVOKE_TOKEN_REQUIRED_SCOPE)) {
+  // 3. Entry gate. A `parachute:host:auth` bearer may revoke anything
+  //    (rule 1) and skips the per-jti authority check below. Any other
+  //    bearer must hold SOME minting authority (host:admin or a
+  //    `vault:<*>:admin`) to attempt a revoke at all — a bearer with none
+  //    can revoke nothing under attenuation, so we 403 it here rather than
+  //    looking up the jti. Whether such a bearer may revoke a SPECIFIC jti
+  //    is decided per-jti in step 5 via `canGrant`.
+  const bearerHasHostAuth = bearerScopes.includes(API_REVOKE_TOKEN_REQUIRED_SCOPE);
+  if (!bearerHasHostAuth && !hasMintingAuthority(bearerScopes)) {
     return jsonError(
       403,
       "insufficient_scope",
-      `bearer token lacks ${API_REVOKE_TOKEN_REQUIRED_SCOPE}`,
+      `bearer token holds no revoke authority (need ${API_REVOKE_TOKEN_REQUIRED_SCOPE}, parachute:host:admin, or vault:<name>:admin)`,
     );
   }
 
@@ -105,13 +140,35 @@ export async function handleApiRevokeToken(
   }
   const jti = body.jti;
 
-  // 5. Lookup + revoke. Order: row-existence first (404 if missing), then
-  // attempt revoke. Idempotent: if already revoked, surface the existing
-  // revoked_at — same CLI semantics from hub#221.
+  // 5. Lookup + per-jti authority + revoke. Order: row-existence first
+  // (404 if missing — same response for every caller, no leak), then the
+  // attenuation authority check (for non-host:auth bearers), then attempt
+  // revoke. Idempotent: if already revoked, surface the existing revoked_at
+  // — same CLI semantics from hub#221.
   const existing = findTokenRowByJti(deps.db, jti);
   if (!existing) {
     return jsonError(404, "not_found", `no token with jti ${jti} found in registry`);
   }
+
+  // Per-jti authority (rule 3 / symmetric to mint attenuation). A host:auth
+  // bearer skips this — it may revoke anything. Any other bearer may revoke
+  // this jti only if EVERY one of its recorded scopes is one the bearer could
+  // have minted (`canGrant`). One out-of-authority scope (cross-vault, a
+  // host:* scope, etc.) blocks the whole revoke with 403 — and the token is
+  // left intact. The caller already knows the jti, so "exists but not yours"
+  // leaks nothing beyond what it holds; idempotent-ok would falsely imply a
+  // revoke happened.
+  if (!bearerHasHostAuth) {
+    const ungrantable = existing.scopes.filter((s) => !canGrant(bearerScopes, s));
+    if (ungrantable.length > 0) {
+      return jsonError(
+        403,
+        "insufficient_scope",
+        `bearer token cannot revoke jti ${jti}: its scope(s) ${ungrantable.join(", ")} are outside the bearer's authority`,
+      );
+    }
+  }
+
   if (existing.revokedAt) {
     return ok({ jti, revoked_at: existing.revokedAt });
   }

--- a/src/api-revoke-token.ts
+++ b/src/api-revoke-token.ts
@@ -62,6 +62,13 @@ import { MINT_HOST_AUTH_SCOPE, canGrant, hasMintingAuthority } from "./scope-att
  */
 export const API_REVOKE_TOKEN_REQUIRED_SCOPE = MINT_HOST_AUTH_SCOPE;
 
+/**
+ * Maximum accepted length of a caller-supplied `jti`. A real jti is a UUID or
+ * short opaque token; anything materially longer is malformed input. Capping
+ * it keeps the verbatim-echoed value out of structured logs from bloating.
+ */
+export const MAX_JTI_LENGTH = 256;
+
 export interface ApiRevokeTokenDeps {
   db: Database;
   /** Hub origin — used to validate the bearer's `iss`. */
@@ -138,6 +145,14 @@ export async function handleApiRevokeToken(
   if (typeof body.jti !== "string" || body.jti.length === 0) {
     return jsonError(400, "invalid_request", "jti is required and must be a non-empty string");
   }
+  // Cap the jti length. It's echoed verbatim into `error_description` and
+  // structured log lines; a real jti is a UUID/short token (well under 256
+  // chars), so a longer value is malformed input — reject it before it can
+  // bloat log lines. JSON-encoded responses already neutralize injection;
+  // this is a size guard, not an escaping one.
+  if (body.jti.length > MAX_JTI_LENGTH) {
+    return jsonError(400, "invalid_request", `jti exceeds ${MAX_JTI_LENGTH}-character maximum`);
+  }
   const jti = body.jti;
 
   // 5. Lookup + per-jti authority + revoke. Order: row-existence first
@@ -159,6 +174,20 @@ export async function handleApiRevokeToken(
   // leaks nothing beyond what it holds; idempotent-ok would falsely imply a
   // revoke happened.
   if (!bearerHasHostAuth) {
+    // A scopeless target (recorded `scopes: []`) would otherwise pass the
+    // `canGrant` filter vacuously — `[].filter(...)` is empty, so
+    // `ungrantable.length === 0`. That's silently permissive: any bearer
+    // clearing the entry gate could revoke a zero-scope token. Such tokens
+    // shouldn't exist (the CLI/SPA never mint them), but if one does, only a
+    // host:auth bearer may revoke it — a non-host:auth bearer has no
+    // attenuation authority that "covers" the empty scope set.
+    if (existing.scopes.length === 0) {
+      return jsonError(
+        403,
+        "insufficient_scope",
+        `bearer token cannot revoke jti ${jti}: target has no recorded scopes (only ${API_REVOKE_TOKEN_REQUIRED_SCOPE} may revoke a scopeless token)`,
+      );
+    }
     const ungrantable = existing.scopes.filter((s) => !canGrant(bearerScopes, s));
     if (ungrantable.length > 0) {
       return jsonError(

--- a/src/scope-attenuation.ts
+++ b/src/scope-attenuation.ts
@@ -1,0 +1,85 @@
+/**
+ * Capability attenuation — the shared authority model behind both the
+ * mint side (`/api/auth/mint-token`, hub#452) and the revoke side
+ * (`/api/auth/revoke-token`). The two endpoints are symmetric: you may
+ * revoke exactly what you could have minted.
+ *
+ * `canGrant(bearerScopes, scope)` answers: could a bearer holding
+ * `bearerScopes` mint a token carrying `scope`? It is the single source of
+ * truth for "is `scope` within this bearer's authority" — mint uses it to
+ * gate what a request may issue; revoke uses it to gate what a request may
+ * tear down (every recorded scope on the target jti must be `canGrant`-able).
+ *
+ * `hasMintingAuthority(bearerScopes)` is the cheap entry gate: does the
+ * bearer hold ANY authority at all (host:auth, host:admin, or some
+ * `vault:<*>:admin`)? A bearer with none can neither mint nor revoke via
+ * attenuation, so both endpoints 403 it before any per-scope work.
+ *
+ * Pure functions — no DB, no I/O — so they're trivially testable and both
+ * handlers stay thin.
+ */
+import { isNonRequestableScope, isVaultAdminScope, vaultScopeName } from "./scope-explanations.ts";
+
+/**
+ * Bearer scope that authorises minting any *requestable* scope (rule 1 of the
+ * attenuation model). The operator's admin scope-set carries this; a narrow
+ * `--scope-set=auth` operator token carries it too.
+ */
+export const MINT_HOST_AUTH_SCOPE = "parachute:host:auth";
+/**
+ * Bearer scope that authorises minting `vault:<name>:admin` (rule 2).
+ * `parachute:host:admin` already implies box-wide administration of every
+ * vault on the hub, so minting a vault-pinned admin from it is a privilege
+ * *reduction* (de-escalation), not an escalation — see the design doc
+ * `2026-05-28-operator-mintable-vault-admin.md`.
+ */
+export const MINT_HOST_ADMIN_SCOPE = "parachute:host:admin";
+
+/**
+ * Capability attenuation: can a bearer holding `bearerScopes` mint a token
+ * carrying `requestedScope`? True iff the requested scope is a subset of the
+ * bearer's own authority under one of three rules:
+ *
+ *   1. requestable + bearer has `parachute:host:auth`;
+ *   2. `vault:<N>:admin` + bearer has `parachute:host:admin`;
+ *   3. `vault:<N>:<verb>` + bearer has `vault:<N>:admin` (same `<N>`).
+ *
+ * Pure function — no DB, no I/O — so it's trivially testable and the guard in
+ * each handler is a single `scopes.filter((s) => !canGrant(bearerScopes, s))`.
+ *
+ * On the revoke side this is the symmetric rule: a target jti is revocable by
+ * a non-host:auth bearer iff EVERY one of its recorded scopes is `canGrant`-able
+ * — i.e. the bearer could have minted that token, so it may also tear it down.
+ * Cross-vault and host-authority targets are never `canGrant`-able by a mere
+ * `vault:<N>:admin` bearer, so it can neither mint nor revoke them.
+ */
+export function canGrant(bearerScopes: string[], requestedScope: string): boolean {
+  // Rule 1 — host:auth mints any requestable scope.
+  if (!isNonRequestableScope(requestedScope) && bearerScopes.includes(MINT_HOST_AUTH_SCOPE)) {
+    return true;
+  }
+  // Rule 2 — host:admin attenuates to a named vault's admin.
+  if (isVaultAdminScope(requestedScope) && bearerScopes.includes(MINT_HOST_ADMIN_SCOPE)) {
+    return true;
+  }
+  // Rule 3 — vault:<N>:admin attenuates to any same-vault subset (incl. admin).
+  const requestedVault = vaultScopeName(requestedScope);
+  if (requestedVault !== null && bearerScopes.includes(`vault:${requestedVault}:admin`)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Does the bearer hold ANY minting authority? Entry gate before per-scope
+ * checks — a bearer with none (e.g. a read-only token) can mint (or revoke
+ * via attenuation) nothing, so both endpoints 403 it early rather than
+ * walking every scope to the same end.
+ */
+export function hasMintingAuthority(bearerScopes: string[]): boolean {
+  return (
+    bearerScopes.includes(MINT_HOST_AUTH_SCOPE) ||
+    bearerScopes.includes(MINT_HOST_ADMIN_SCOPE) ||
+    bearerScopes.some((s) => isVaultAdminScope(s))
+  );
+}

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -148,8 +148,10 @@ export const NON_REQUESTABLE_SCOPES: ReadonlySet<string> = new Set([
  *     (the vault SPA's Manage link + setup wizard); and
  *   - `POST /api/auth/mint-token` under the capability-attenuation model —
  *     a `parachute:host:admin` bearer (box-wide → one-vault) or a
- *     `vault:<name>:admin` bearer (same-vault subset). See `canGrant` and
- *     the guard in `api-mint-token.ts`.
+ *     `vault:<name>:admin` bearer (same-vault subset). The same model governs
+ *     `POST /api/auth/revoke-token` (revoke what you could mint). See
+ *     `canGrant` in `scope-attenuation.ts` and the guards in
+ *     `api-mint-token.ts` / `api-revoke-token.ts`.
  *
  * Pattern-based because the set is open-ended — every vault instance the
  * operator creates implies a new scope, and we don't want to enumerate them.


### PR DESCRIPTION
## What

Make `POST /api/auth/revoke-token` symmetric to `mint-token` (hub#452): **a bearer may revoke a token whose recorded scopes are all within its own minting authority** — you may revoke exactly what you could have minted.

## Why

hub#452 let a `vault:<N>:admin` bearer MINT `vault:<N>:{read,write,admin}` subtokens (capability attenuation). The revoke side was never updated — it hard-gated on `parachute:host:auth`. So a `vault:<N>:admin` bearer (e.g. the manage-token MCP tool forwarding its caller's bearer, the canonical headless path from hub#452) got **403** trying to revoke a token it had just minted. This closes that asymmetry.

## The rule

After validating the bearer (signature / issuer / expiry — unchanged):

1. **host:auth bearer → may revoke ANY jti** (the original, broadest behavior — preserved).
2. **Entry gate:** any other bearer must hold some minting authority (`parachute:host:admin` or a `vault:<*>:admin`, via `hasMintingAuthority`). A bearer with none (e.g. read-only) → 403 up front, before any lookup.
3. **Per-jti authority:** for a non-host:auth bearer, the target jti is revocable iff EVERY one of its recorded scopes satisfies `canGrant(bearerScopes, scope)` — the exact symmetric check to mint. One out-of-authority scope blocks the whole revoke.

## Security matrix (all covered by tests)

| bearer | target jti scopes | result |
|---|---|---|
| `parachute:host:auth` | anything (incl. host-scoped) | **200** (preserved) |
| `vault:work:admin` | `vault:work:write` | **200** (could have minted) |
| `vault:work:admin` | `vault:work:admin` | **200** |
| `vault:work:admin` | `vault:other:write` | **403**, not revoked |
| `vault:work:admin` | `parachute:host:auth` | **403**, not revoked |
| `vault:work:admin` | UNKNOWN jti | **404** (no leak) |
| `vault:work:read` (no minting authority) | — | **403** entry gate |
| `vault:work:admin` | `vault:work:read vault:work:write` | **200** |
| `vault:work:admin` | `vault:work:write vault:other:read` | **403**, not revoked |
| `parachute:host:admin` | `vault:work:admin` | **200** (rule 2 symmetry) |

## Idempotency / no-info-leak decision

An **unknown** jti returns the **same 404** every caller (including host:auth) has always received — the per-jti authority check runs only when the row is FOUND. So an attenuated bearer probing a jti it doesn't own cannot distinguish "exists but not yours" from "doesn't exist" via the unknown path.

A jti that **exists but is out of authority** returns **403 and is NOT revoked**. The caller already knows the jti string, so "exists but not yours" leaks nothing beyond what it already holds — and returning idempotent-ok there would be a lie (it revoked nothing). This is the consistent, correct choice.

## Symmetry with hub#452

`canGrant` + `hasMintingAuthority` moved from `api-mint-token.ts` into a shared `src/scope-attenuation.ts`, so the mint and revoke paths import one source of truth. The former `api-mint-token.ts` constants are kept as re-export aliases for back-compat. Mint gates *what a request may issue*; revoke gates *what a request may tear down* — both via the same `canGrant`.

## Tests / gates

- hub: **2324 pass / 0 fail** (revoke suite 21, mint suite 32 — refactor intact)
- `bun run typecheck` clean, `bunx biome check` clean on changed files
- The cross-vault-blocked + host-escalation + multi-scope-blocked tests were confirmed load-bearing by temporarily removing the authority filter (exactly those 3 failed, all others passed).
- **No version bump** (orchestrator handles release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)