### PR TITLE
fix(hub): reject malformed vault-shaped scopes at mint-token (defensive hygiene)

### DIFF
--- a/src/__tests__/api-mint-token.test.ts
+++ b/src/__tests__/api-mint-token.test.ts
@@ -876,6 +876,172 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
     });
   });
 
+  // ── Malformed vault-shaped scope guard (defensive hygiene, audit 2026-05-28) ──
+  //
+  // A `parachute:host:auth` bearer can craft scope strings that LOOK like a
+  // named per-vault scope but slip past `isNonRequestableScope`'s strict
+  // regexes, so `canGrant` rule 1 would admit them as "requestable" and mint a
+  // junk registry row. They grant zero access today (the vault consumer rejects
+  // them), so this isn't exploitable now — the mint-time shape check is a
+  // backstop against a future consumer-normalization regression + registry
+  // hygiene. It's an input-shape check, orthogonal to authority.
+  describe("malformed vault-shaped scope rejection", () => {
+    const MALFORMED = [
+      "vault:work:ADMIN", // uppercase verb
+      "vault::admin", // empty name
+      "vault:work:read:admin", // extra segment
+      "VAULT:work:admin", // uppercase resource
+    ];
+
+    for (const scope of MALFORMED) {
+      test(`host:auth bearer minting ${scope} → 400 invalid_scope (malformed)`, async () => {
+        const h = makeHarness();
+        try {
+          const { db, userId } = await bootstrap(h.dir);
+          try {
+            const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+            const resp = await handleApiMintToken(
+              jsonRequest({ scope }, { authorization: `Bearer ${op.token}` }),
+              { db, issuer: ISSUER },
+            );
+            expect(resp.status).toBe(400);
+            const body = (await resp.json()) as { error: string; error_description: string };
+            expect(body.error).toBe("invalid_scope");
+            expect(body.error_description).toContain("malformed vault scope");
+            expect(body.error_description).toContain(scope);
+            // No junk registry row written — the request was rejected before
+            // mint. The only `cli_mint` provenance comes from this endpoint;
+            // the operator bearer's own row is `operator` provenance, so a
+            // count of zero proves the malformed mint never landed.
+            const row = db
+              .query<{ n: number }, []>(
+                "SELECT COUNT(*) AS n FROM tokens WHERE created_via = 'cli_mint'",
+              )
+              .get();
+            expect(row?.n ?? 0).toBe(0);
+          } finally {
+            db.close();
+          }
+        } finally {
+          h.cleanup();
+        }
+      });
+    }
+
+    // Regression: well-formed named scopes still mint (host:auth → read/write
+    // via rule 1; host:admin → admin via rule 2). The guard is shape-only.
+    test("host:auth bearer minting vault:work:read → 200 (well-formed, regression)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER, scopeSet: "auth" });
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "vault:work:read" }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { scope: string };
+          expect(body.scope).toBe("vault:work:read");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("host:auth bearer minting vault:work:write → 200 (well-formed, regression)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER, scopeSet: "auth" });
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "vault:work:write" }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { scope: string };
+          expect(body.scope).toBe("vault:work:write");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("host:admin bearer minting vault:work:admin → 200 (well-formed, attenuation path)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "vault:work:admin" }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { scope: string };
+          expect(body.scope).toBe("vault:work:admin");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    // The existing non-requestable behaviour is unchanged: a host:auth-only
+    // bearer minting the well-formed `vault:work:admin` is still 400 (rule 1
+    // doesn't cover admin) — this path is reached AFTER the shape guard passes.
+    test("host:auth-only bearer minting vault:work:admin → 400 (non-requestable, unchanged)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER, scopeSet: "auth" });
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "vault:work:admin" }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(400);
+          const body = (await resp.json()) as { error: string; error_description: string };
+          expect(body.error).toBe("invalid_scope");
+          // Not the malformed-shape message — it cleared the shape guard.
+          expect(body.error_description).toContain("not grantable");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    // Non-vault scopes are entirely unaffected by the shape guard.
+    test("host:auth bearer minting scribe:transcribe → 200 (non-vault, unaffected)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER, scopeSet: "auth" });
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "scribe:transcribe" }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { scope: string };
+          expect(body.scope).toBe("scribe:transcribe");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+  });
+
   test("405 on non-POST", async () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/scope-explanations.test.ts
+++ b/src/__tests__/scope-explanations.test.ts
@@ -5,6 +5,7 @@ import {
   SCOPE_EXPLANATIONS,
   explainScope,
   isRequestableScope,
+  isWellFormedOrNonVaultScope,
   scopeIsAdmin,
 } from "../scope-explanations.ts";
 
@@ -131,5 +132,40 @@ describe("isRequestableScope", () => {
   test("vault:<name>:read|write stays requestable (only :admin is locked down)", () => {
     expect(isRequestableScope("vault:default:read")).toBe(true);
     expect(isRequestableScope("vault:work:write")).toBe(true);
+  });
+});
+
+// Mint-time shape guard (defensive hygiene, audit 2026-05-28). Rejects only the
+// *named* three-segment vault shape when malformed; leaves the unnamed two-
+// segment forms and all non-vault scopes alone.
+describe("isWellFormedOrNonVaultScope", () => {
+  test("rejects the four audited malformed named-vault forms", () => {
+    expect(isWellFormedOrNonVaultScope("vault:work:ADMIN")).toBe(false); // uppercase verb
+    expect(isWellFormedOrNonVaultScope("vault::admin")).toBe(false); // empty name
+    expect(isWellFormedOrNonVaultScope("vault:work:read:admin")).toBe(false); // extra segment
+    expect(isWellFormedOrNonVaultScope("VAULT:work:admin")).toBe(false); // uppercase resource
+  });
+
+  test("admits well-formed named-vault scopes (all three verbs)", () => {
+    expect(isWellFormedOrNonVaultScope("vault:work:read")).toBe(true);
+    expect(isWellFormedOrNonVaultScope("vault:work:write")).toBe(true);
+    expect(isWellFormedOrNonVaultScope("vault:work:admin")).toBe(true);
+    expect(isWellFormedOrNonVaultScope("vault:my-techne_2:admin")).toBe(true);
+  });
+
+  test("admits the unnamed two-segment vault forms (out of remit)", () => {
+    expect(isWellFormedOrNonVaultScope("vault:read")).toBe(true);
+    expect(isWellFormedOrNonVaultScope("vault:write")).toBe(true);
+    expect(isWellFormedOrNonVaultScope("vault:admin")).toBe(true);
+    expect(isWellFormedOrNonVaultScope("vault")).toBe(true); // bare, no colon
+  });
+
+  test("admits all non-vault scopes unconditionally", () => {
+    expect(isWellFormedOrNonVaultScope("scribe:transcribe")).toBe(true);
+    expect(isWellFormedOrNonVaultScope("parachute:host:auth")).toBe(true);
+    expect(isWellFormedOrNonVaultScope("parachute:host:admin")).toBe(true);
+    expect(isWellFormedOrNonVaultScope("hub:admin")).toBe(true);
+    // A three-segment non-vault scope is not constrained even if malformed-looking.
+    expect(isWellFormedOrNonVaultScope("scribe:work:ADMIN")).toBe(true);
   });
 });

--- a/src/api-mint-token.ts
+++ b/src/api-mint-token.ts
@@ -53,7 +53,11 @@ import {
   canGrant,
   hasMintingAuthority,
 } from "./scope-attenuation.ts";
-import { isVaultAdminScope, vaultScopeName } from "./scope-explanations.ts";
+import {
+  isVaultAdminScope,
+  isWellFormedOrNonVaultScope,
+  vaultScopeName,
+} from "./scope-explanations.ts";
 
 // Re-export `canGrant` so existing importers (and the symmetric revoke path)
 // have a single name to reach for; the implementation lives in the shared
@@ -161,6 +165,27 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
   const scopes = body.scope.split(/\s+/).filter((s) => s.length > 0);
   if (scopes.length === 0) {
     return jsonError(400, "invalid_request", "scope must contain at least one scope");
+  }
+
+  // Shape guard (defensive hygiene — adversarial audit 2026-05-28): reject any
+  // scope that is shaped like a *named* per-vault scope but malformed —
+  // `vault:work:ADMIN` (uppercase verb), `vault::admin` (empty name),
+  // `vault:work:read:admin` (extra segment), `VAULT:work:admin` (uppercase
+  // resource). These slip past `isNonRequestableScope`'s strict regexes, so
+  // `canGrant` rule 1 would admit them as "requestable" and mint a junk
+  // registry row. They grant zero access today (the vault consumer's
+  // `decomposeVaultScope` rejects all four), so this is NOT exploitable now —
+  // the check is a backstop against a future consumer-normalization regression
+  // plus registry hygiene. It's an input-shape check, orthogonal to authority,
+  // so it runs for ALL callers before any `canGrant` attenuation. Non-vault
+  // scopes and the unnamed `vault:<verb>` forms are unaffected.
+  const malformed = scopes.filter((s) => !isWellFormedOrNonVaultScope(s));
+  if (malformed.length > 0) {
+    return jsonError(
+      400,
+      "invalid_scope",
+      `malformed vault scope ${malformed.join(", ")}; expected vault:<name>:<read|write|admin>`,
+    );
   }
 
   // Capability-attenuation guard: every requested scope must be a subset of

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -187,6 +187,57 @@ export function vaultScopeName(scope: string): string | null {
   return m ? (m[1] ?? null) : null;
 }
 
+/**
+ * Mint-time shape guard: reject scopes that LOOK like a *named* per-vault scope
+ * (`vault:<name>:<verb>`, three+ colon-segments, first segment `vault`
+ * case-insensitively to catch `VAULT:…`) but are malformed — i.e. they don't
+ * match the strict `vault:<name>:<read|write|admin>` shape (`VAULT_SCOPED_RE`).
+ *
+ * Returns true for (i.e. ADMITS):
+ *   - well-formed named scopes `vault:<name>:<read|write|admin>`;
+ *   - the canonical *unnamed* two-segment scopes `vault:read|write|admin`
+ *     (legitimate OAuth/consent forms — keys in `SCOPE_EXPLANATIONS`, narrowed
+ *     to a named vault at consent time) and any other non-three-segment
+ *     `vault`-prefixed string — those aren't attempting the named shape, so
+ *     they're out of this guard's remit and keep their existing behaviour;
+ *   - every non-vault scope (`scribe:transcribe`, `parachute:host:*`, …).
+ *
+ * Returns false for (i.e. REJECTS) only a `vault`-prefixed string with three
+ * or more colon-segments that fails `VAULT_SCOPED_RE`:
+ *   `vault:work:ADMIN` (uppercase verb), `vault::admin` (empty name),
+ *   `vault:work:read:admin` (extra segment), `VAULT:work:admin` (uppercase
+ *   resource).
+ *
+ * Why this exists (defensive hygiene — adversarial audit, 2026-05-28): a
+ * `parachute:host:auth` bearer can today mint those four malformed strings.
+ * `isNonRequestableScope`'s strict regexes don't match them, so `canGrant`
+ * rule 1 admits them as "requestable" — the mint succeeds (200) carrying the
+ * literal junk string and writes a registry row. They grant ZERO access today
+ * (the vault consumer's `decomposeVaultScope` is case-sensitive + anchored and
+ * rejects all four), so this is NOT exploitable now. The value is (a) registry
+ * hygiene (no junk rows) and (b) a backstop against a FUTURE consumer-
+ * normalization regression — if vault ever started case-folding scope verbs,
+ * those junk tokens could silently become live admin. A strict mint-time shape
+ * check closes that door now.
+ *
+ * Orthogonal to authority: this is an input-shape check applied to ALL mint
+ * callers (host:auth, host:admin, vault:<name>:admin) before any `canGrant`
+ * attenuation. It does not affect non-vault scopes or the unnamed `vault:<verb>`
+ * forms.
+ */
+export function isWellFormedOrNonVaultScope(scope: string): boolean {
+  const segments = scope.split(":");
+  // Only constrain the *named* per-vault shape: first segment names the vault
+  // resource (case-insensitive, to catch `VAULT:`) AND there are three or more
+  // segments (an attempt at `vault:<name>:<verb>`). The unnamed two-segment
+  // forms (`vault:read|write|admin`) and a bare `vault` are out of remit.
+  const firstSegment = segments[0] ?? "";
+  if (firstSegment.toLowerCase() !== "vault" || segments.length < 3) {
+    return true;
+  }
+  return VAULT_SCOPED_RE.test(scope);
+}
+
 /** True when the scope is non-requestable via the public OAuth flow. */
 export function isNonRequestableScope(scope: string): boolean {
   return NON_REQUESTABLE_SCOPES.has(scope) || VAULT_ADMIN_RE.test(scope);


### PR DESCRIPTION
## The issue (nit — defensive hardening, confirmed by adversarial audit)

At `POST /api/auth/mint-token`, a `parachute:host:auth` bearer can mint scope strings that LOOK like a named vault admin scope but evade the non-requestable guard:

- `vault:work:ADMIN` — uppercase verb
- `vault::admin` — empty name
- `vault:work:read:admin` — extra segment
- `VAULT:work:admin` — uppercase resource

`canGrant` rule 1 (`src/scope-attenuation.ts`) admits them because `isNonRequestableScope` returns `false` — the strict `VAULT_ADMIN_RE` / `VAULT_SCOPED_RE` regexes don't match these malformed forms. The mint succeeds (200) carrying the literal junk string and writes a registry row.

## Why it's non-exploitable today — but worth the backstop

These grant **zero access** right now: the vault consumer's `decomposeVaultScope` rejects all four (case-sensitive, anchored, no empty names / extra segments), so a token carrying them authorizes nothing. This is **not exploitable today**.

The value of fixing it:
1. **Registry hygiene** — no junk rows in the `tokens` table.
2. **Backstop against a future consumer-normalization regression** — if vault ever started case-normalizing scope verbs, these junk tokens could silently become live admin tokens. A strict mint-time shape check is the defensive backstop that closes that door now.

## The fix

New helper `isWellFormedOrNonVaultScope(scope)` in `src/scope-explanations.ts` (alongside the existing vault-scope regexes). It constrains only the **named** per-vault shape: a `vault`-prefixed string (case-insensitive, to catch `VAULT:`) with **three or more** colon-segments MUST match the strict `vault:<name>:<read|write|admin>` shape (`VAULT_SCOPED_RE`); otherwise it's malformed and rejected. Everything else returns `true` (admits):

- the unnamed two-segment forms `vault:read` / `vault:write` / `vault:admin` (legitimate OAuth/consent scopes) — out of remit;
- all non-vault scopes (`scribe:transcribe`, `parachute:host:*`, `hub:admin`, …) — unaffected.

Applied in `src/api-mint-token.ts` in the scope-validation loop **before** the `canGrant`/`blocked` filter. Malformed scopes get `400 invalid_scope` (`malformed vault scope <s>; expected vault:<name>:<read|write|admin>`). It's an input-shape check, **orthogonal to authority**, so it runs for ALL callers (host:auth, host:admin, vault:<name>:admin). Well-formed `vault:<name>:<verb>` continues to work exactly as before, subject to the existing attenuation rules.

## `subject` intentionally NOT touched

The audit also flagged caller-controlled `subject`. That is **intentionally left alone** — the vault admin SPA legitimately uses `subject` as a human label for minted tokens. This PR is ONLY the malformed-vault-scope rejection.

## Tests

`src/__tests__/api-mint-token.test.ts` (new `malformed vault-shaped scope rejection` describe block):
- 4 malformed variants (host:auth bearer) → **400 invalid_scope** + no `cli_mint` registry row written
- well-formed `vault:work:read` / `vault:work:write` (host:auth) → **200** (regression)
- `vault:work:admin` (host:admin bearer) → **200** (regression — attenuation path)
- `vault:work:admin` (host:auth-only bearer) → **400** (existing non-requestable behaviour, unchanged — cleared the shape guard, still blocked by `canGrant`)
- `scribe:transcribe` (host:auth) → **200** (non-vault, unaffected)

`src/__tests__/scope-explanations.test.ts` — unit coverage for the helper (4 malformed → false, named/unnamed well-formed → true, non-vault → true).

Gates: hub tests **2341 pass / 1 skip / 0 fail**; `bun run typecheck` clean; `bunx biome check` clean on changed files.

No version / rc bump (defensive hardening; rc bump + tag happen when shipping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)