### PR TITLE
chore(release): 0.5.14-rc.9 — capability-attenuation auth arc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.8",
+  "version": "0.5.14-rc.9",
   "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Bumps `0.5.14-rc.8` → `0.5.14-rc.9`, bundling the non-breaking auth-unification arc (#449/#452/#454/#455 + README #456; scope-guard #453 published separately as 0.4.0-rc.2). Adversarially audited (0 P0/P1), live-smoked on the dev deploy. pvt_* validation untouched — DROP is the separate breaking 0.6.0 change (vault#282).

🤖 Generated with [Claude Code](https://claude.com/claude-code)