### PR TITLE
fix(hub): inject hub public origin into supervised vault env (fix OAuth iss mismatch → 401 on reconnect)

### DIFF
--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { exposePublic, exposeTailnet } from "../commands/expose.ts";
+import { readEnvFileValues } from "../env-file.ts";
 import { readExposeState, writeExposeState } from "../expose-state.ts";
 import type { EnsureHubOpts, HubSpawner, StopHubOpts } from "../hub-control.ts";
 import { writePid } from "../process-state.ts";
@@ -691,6 +692,53 @@ describe("expose tailnet off", () => {
       expect(existsSync(h.hubPath)).toBe(false);
       // Hub was running and got stopped.
       expect(signals).toContain("SIGTERM");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("clears the persisted PARACHUTE_HUB_ORIGIN from vault/.env on teardown", async () => {
+    // OAuth issuer-mismatch fix: `expose up` persisted the public origin into
+    // vault/.env so the daemon validates `iss` against it. With exposure gone,
+    // a local-only hub mints loopback-`iss` tokens, so a stale public origin
+    // left in `.env` would itself cause the mismatch on the next daemon boot.
+    // Tearing it down reverts vault to its loopback default.
+    const h = makeHarness();
+    try {
+      writeExposeState(
+        {
+          version: 1,
+          layer: "tailnet",
+          mode: "path",
+          canonicalFqdn: "parachute.taildf9ce2.ts.net",
+          port: 443,
+          funnel: false,
+          entries: [{ kind: "proxy", mount: "/", target: "http://127.0.0.1:1939", service: "hub" }],
+          hubOrigin: "https://parachute.taildf9ce2.ts.net",
+        },
+        h.statePath,
+      );
+      mkdirSync(join(h.configDir, "vault"), { recursive: true });
+      writeFileSync(
+        join(h.configDir, "vault", ".env"),
+        "SCRIBE_AUTH_TOKEN=secret\nPARACHUTE_HUB_ORIGIN=https://parachute.taildf9ce2.ts.net\n",
+      );
+      const { runner } = makeRunner();
+      const code = await exposeTailnet("off", {
+        runner,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        skipHub: true,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      const values = readEnvFileValues(join(h.configDir, "vault", ".env"));
+      expect(values.PARACHUTE_HUB_ORIGIN).toBeUndefined();
+      // Sibling keys preserved.
+      expect(values.SCRIBE_AUTH_TOKEN).toBe("secret");
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -11,6 +11,7 @@ import {
   start,
   stop,
 } from "../commands/lifecycle.ts";
+import { readEnvFileValues } from "../env-file.ts";
 import { writeHubPort } from "../hub-control.ts";
 import { ensureLogPath, logPath, readPid, writePid } from "../process-state.ts";
 import { upsertService } from "../services-manifest.ts";
@@ -348,6 +349,37 @@ describe("parachute start", () => {
         PORT: "1940",
         PARACHUTE_HUB_ORIGIN: "https://parachute.taildf9ce2.ts.net",
       });
+      // OAuth issuer-mismatch fix: the spawn-env injection above is ephemeral
+      // (lost on the next launchd / systemd boot). `start vault` ALSO persists
+      // the public origin into vault/.env so the out-of-band daemon validates
+      // hub-minted JWTs' `iss` against it. Without this, every reconnect after
+      // a reboot / crash-restart 401s.
+      expect(readEnvFileValues(join(h.configDir, "vault", ".env")).PARACHUTE_HUB_ORIGIN).toBe(
+        "https://parachute.taildf9ce2.ts.net",
+      );
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("does NOT persist a loopback origin into vault/.env (would shadow a later exposure)", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writeHubPort(1939, h.configDir);
+      const spawner = makeSpawner([4242]);
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      // Loopback is fine to inject into the ephemeral spawn env (local dev),
+      // but persisting it would brick the daemon path once exposure comes up:
+      // the baked loopback would shadow the real origin. So vault/.env stays
+      // absent of the key on a loopback-only start.
+      expect(existsSync(join(h.configDir, "vault", ".env"))).toBe(false);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/vault-hub-origin-env.test.ts
+++ b/src/__tests__/vault-hub-origin-env.test.ts
@@ -30,10 +30,12 @@ function vaultEnv(): string {
 }
 
 describe("isLoopbackOrigin", () => {
-  test("flags 127.0.0.1 / localhost / [::1]", () => {
+  test("flags 127.0.0.1 / localhost / [::1] / 0.0.0.0", () => {
     expect(isLoopbackOrigin("http://127.0.0.1:1939")).toBe(true);
     expect(isLoopbackOrigin("http://localhost:1939")).toBe(true);
     expect(isLoopbackOrigin("http://[::1]:1939")).toBe(true);
+    // 0.0.0.0 is a bind-all wildcard, not a reachable origin.
+    expect(isLoopbackOrigin("http://0.0.0.0:1939")).toBe(true);
   });
 
   test("does not flag a public FQDN", () => {
@@ -57,6 +59,15 @@ describe("persistVaultHubOrigin", () => {
 
   test("refuses to persist a loopback origin (would shadow a later exposure)", () => {
     const wrote = persistVaultHubOrigin(dir, "http://127.0.0.1:1939", () => {});
+    expect(wrote).toBe(false);
+    expect(existsSync(vaultEnv())).toBe(false);
+  });
+
+  test("refuses to persist a 0.0.0.0 origin (--hub-origin flows straight through)", () => {
+    // `--hub-origin http://0.0.0.0:1939` bypasses deriveHubOrigin and reaches
+    // here verbatim; baking a bind-all wildcard into vault/.env would advertise
+    // a non-functional issuer and recreate the iss-mismatch class.
+    const wrote = persistVaultHubOrigin(dir, "http://0.0.0.0:1939", () => {});
     expect(wrote).toBe(false);
     expect(existsSync(vaultEnv())).toBe(false);
   });

--- a/src/__tests__/vault-hub-origin-env.test.ts
+++ b/src/__tests__/vault-hub-origin-env.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the durable half of the OAuth issuer-mismatch fix: persisting the
+ * hub's PUBLIC origin into `<configDir>/vault/.env` so the launchd / systemd
+ * daemon — which boots vault out-of-band and never sees the `parachute start`
+ * spawn env — validates hub-minted JWTs' `iss` against the public origin
+ * instead of vault's loopback default. See `vault-hub-origin-env.ts`.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readEnvFileValues } from "../env-file.ts";
+import {
+  clearVaultHubOrigin,
+  isLoopbackOrigin,
+  persistVaultHubOrigin,
+} from "../vault-hub-origin-env.ts";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "pcli-vhoe-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function vaultEnv(): string {
+  return join(dir, "vault", ".env");
+}
+
+describe("isLoopbackOrigin", () => {
+  test("flags 127.0.0.1 / localhost / [::1]", () => {
+    expect(isLoopbackOrigin("http://127.0.0.1:1939")).toBe(true);
+    expect(isLoopbackOrigin("http://localhost:1939")).toBe(true);
+    expect(isLoopbackOrigin("http://[::1]:1939")).toBe(true);
+  });
+
+  test("does not flag a public FQDN", () => {
+    expect(isLoopbackOrigin("https://parachute-aaron.tailc75afc.ts.net")).toBe(false);
+    expect(isLoopbackOrigin("https://hub.example.com")).toBe(false);
+  });
+
+  test("non-URL strings are treated as non-loopback (don't block persistence)", () => {
+    expect(isLoopbackOrigin("not a url")).toBe(false);
+  });
+});
+
+describe("persistVaultHubOrigin", () => {
+  test("writes a non-loopback public origin into vault/.env", () => {
+    const wrote = persistVaultHubOrigin(dir, "https://parachute-aaron.tailc75afc.ts.net", () => {});
+    expect(wrote).toBe(true);
+    expect(readEnvFileValues(vaultEnv()).PARACHUTE_HUB_ORIGIN).toBe(
+      "https://parachute-aaron.tailc75afc.ts.net",
+    );
+  });
+
+  test("refuses to persist a loopback origin (would shadow a later exposure)", () => {
+    const wrote = persistVaultHubOrigin(dir, "http://127.0.0.1:1939", () => {});
+    expect(wrote).toBe(false);
+    expect(existsSync(vaultEnv())).toBe(false);
+  });
+
+  test("is idempotent — no rewrite when the value is already current", () => {
+    const log: string[] = [];
+    expect(persistVaultHubOrigin(dir, "https://hub.example.com", (l) => log.push(l))).toBe(true);
+    expect(persistVaultHubOrigin(dir, "https://hub.example.com", (l) => log.push(l))).toBe(false);
+    // Only the first call logged.
+    expect(log).toHaveLength(1);
+    expect(log[0]).toMatch(/persisted PARACHUTE_HUB_ORIGIN=https:\/\/hub\.example\.com/);
+  });
+
+  test("updates a stale origin in-place and preserves sibling keys", () => {
+    writeFileSync(
+      mkVaultDir(),
+      "SCRIBE_AUTH_TOKEN=secret\nPARACHUTE_HUB_ORIGIN=https://old.example.com\nSCRIBE_URL=http://127.0.0.1:1943\n",
+    );
+    const wrote = persistVaultHubOrigin(dir, "https://new.example.com", () => {});
+    expect(wrote).toBe(true);
+    const values = readEnvFileValues(vaultEnv());
+    expect(values.PARACHUTE_HUB_ORIGIN).toBe("https://new.example.com");
+    // Sibling keys untouched.
+    expect(values.SCRIBE_AUTH_TOKEN).toBe("secret");
+    expect(values.SCRIBE_URL).toBe("http://127.0.0.1:1943");
+  });
+});
+
+describe("clearVaultHubOrigin", () => {
+  test("removes a persisted origin and leaves sibling keys", () => {
+    writeFileSync(
+      mkVaultDir(),
+      "SCRIBE_AUTH_TOKEN=secret\nPARACHUTE_HUB_ORIGIN=https://hub.example.com\n",
+    );
+    const wrote = clearVaultHubOrigin(dir, () => {});
+    expect(wrote).toBe(true);
+    const values = readEnvFileValues(vaultEnv());
+    expect(values.PARACHUTE_HUB_ORIGIN).toBeUndefined();
+    expect(values.SCRIBE_AUTH_TOKEN).toBe("secret");
+  });
+
+  test("no-op when no origin is present", () => {
+    writeFileSync(mkVaultDir(), "SCRIBE_AUTH_TOKEN=secret\n");
+    expect(clearVaultHubOrigin(dir, () => {})).toBe(false);
+  });
+
+  test("no-op when vault/.env doesn't exist", () => {
+    expect(clearVaultHubOrigin(dir, () => {})).toBe(false);
+  });
+});
+
+/** Create `<dir>/vault/` and return the `.env` path so writeFileSync lands. */
+function mkVaultDir(): string {
+  mkdirSync(join(dir, "vault"), { recursive: true });
+  return vaultEnv();
+}

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -24,6 +24,7 @@ import { type ServiceEntry, readManifest } from "../services-manifest.ts";
 import { type ServeEntry, bringupCommand, teardownCommand } from "../tailscale/commands.ts";
 import { getFqdn, isTailscaleInstalled } from "../tailscale/detect.ts";
 import { type Runner, defaultRunner } from "../tailscale/run.ts";
+import { clearVaultHubOrigin } from "../vault-hub-origin-env.ts";
 import type { VaultAuthStatus } from "../vault/auth-status.ts";
 import {
   WELL_KNOWN_DIR,
@@ -438,6 +439,13 @@ export async function exposeOff(layer: ExposeLayer, opts: ExposeOpts = {}): Prom
   }
 
   clearExposeState(statePath);
+  // Drop the persisted PARACHUTE_HUB_ORIGIN from vault's `.env`. `expose up`
+  // (via the vault restart) persisted the public origin so the launchd /
+  // systemd daemon validates `iss` against it. With exposure gone, a
+  // local-only hub mints loopback-`iss` tokens, so a stale public origin left
+  // in `.env` would itself cause the mismatch on the next daemon restart.
+  // Reverting to vault's loopback default (`getHubOrigin`) keeps them aligned.
+  clearVaultHubOrigin(configDir, log);
   // Pair to the debug-only write at expose-up — clean up the inspection artifact
   // on teardown so it doesn't outlive the layer it described.
   if (existsSync(wellKnownFilePath)) {

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -33,6 +33,7 @@ import {
   shortNameForManifest,
 } from "../service-spec.ts";
 import { type ServiceEntry, readManifest } from "../services-manifest.ts";
+import { persistVaultHubOrigin } from "../vault-hub-origin-env.ts";
 
 /**
  * Tiny seam over `Bun.spawn` for lifecycle tests. The real spawner opens the
@@ -484,6 +485,17 @@ export async function start(svc: string | undefined, opts: LifecycleOpts = {}): 
 
     r.log(`✓ ${short} started (pid ${pid}); logs: ${logFile}`);
     if (r.hubOrigin) r.log(`  ${HUB_ORIGIN_ENV}=${r.hubOrigin}`);
+    // Persist the resolved public origin to vault's `.env` so the launchd /
+    // systemd daemon (which boots vault out-of-band on reboot / crash-restart
+    // and never sees this spawn env) validates hub-minted JWTs' `iss` against
+    // the public origin. The spawn-env injection above is ephemeral; this is
+    // the durable half of the OAuth issuer-mismatch fix. Vault is the only
+    // hub-origin-dependent service with an OS-supervised autostart daemon
+    // today — scribe/notes don't validate `iss`. See
+    // `vault-hub-origin-env.ts:persistVaultHubOrigin`.
+    if (short === "vault" && r.hubOrigin) {
+      persistVaultHubOrigin(r.configDir, r.hubOrigin, r.log);
+    }
   }
   return failures === 0 ? 0 : 1;
 }

--- a/src/env-file.ts
+++ b/src/env-file.ts
@@ -68,6 +68,16 @@ export function upsertEnvLine(lines: string[], key: string, value: string): stri
   return next;
 }
 
+/**
+ * Drop every `KEY=…` line for `key`, preserving the order of the rest.
+ * Returns a new array; the input is untouched. No-op (returns a copy) when
+ * the key isn't present.
+ */
+export function removeEnvLine(lines: string[], key: string): string[] {
+  const prefix = `${key}=`;
+  return lines.filter((line) => !line.startsWith(prefix));
+}
+
 export function writeEnvFile(path: string, lines: readonly string[]): void {
   mkdirSync(dirname(path), { recursive: true });
   const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;

--- a/src/vault-hub-origin-env.ts
+++ b/src/vault-hub-origin-env.ts
@@ -42,7 +42,17 @@ export function isLoopbackOrigin(origin: string): boolean {
     // URL.hostname keeps IPv6 in bracket form (`[::1]`); strip them so the
     // comparison is on the bare address.
     const hostname = new URL(origin).hostname.replace(/^\[|\]$/g, "");
-    return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1";
+    // `0.0.0.0` is a bind-all wildcard, not a reachable origin — `deriveHubOrigin`
+    // never emits it, but `--hub-origin http://0.0.0.0:1939` flows straight
+    // through `persistVaultHubOrigin`. Baking it into vault/.env would advertise
+    // a non-functional issuer and recreate the iss-mismatch class this guard
+    // exists to prevent. Refuse it like any other loopback.
+    return (
+      hostname === "127.0.0.1" ||
+      hostname === "localhost" ||
+      hostname === "::1" ||
+      hostname === "0.0.0.0"
+    );
   } catch {
     return false;
   }

--- a/src/vault-hub-origin-env.ts
+++ b/src/vault-hub-origin-env.ts
@@ -1,0 +1,90 @@
+/**
+ * Persist the resolved hub PUBLIC origin into `<configDir>/vault/.env` so the
+ * launchd / systemd daemon validates hub-minted JWTs against it.
+ *
+ * The OAuth issuer-mismatch P0 (this module's reason to exist): hub stamps the
+ * public origin (e.g. `https://parachute-x.ts.net`) on every JWT it mints.
+ * Vault, as the resource server, validates the `iss` claim against
+ * `getHubOrigin()` (`parachute-vault/src/hub-jwt.ts`), which reads ONLY
+ * `PARACHUTE_HUB_ORIGIN` from its process env and falls back to loopback
+ * `http://127.0.0.1:1939` when unset.
+ *
+ * `parachute start|restart vault` injects `PARACHUTE_HUB_ORIGIN` into the
+ * *spawn* env (see `commands/lifecycle.ts`). But the real-world boot path on an
+ * owner-operated box is the autostart daemon: `parachute-vault init` registers
+ * a launchd agent (macOS) / systemd unit (Linux) with `KeepAlive`/`Restart`,
+ * and that daemon boots vault out-of-band via `~/.parachute/vault/start.sh`.
+ * The wrapper sources `~/.parachute/vault/.env` and never reads expose-state,
+ * and the launchd plist carries no `EnvironmentVariables`. So on every reboot
+ * or crash-restart, launchd starts vault with NO `PARACHUTE_HUB_ORIGIN`, vault
+ * falls back to loopback, and every token stamped with the public FQDN fails
+ * the `iss` check → `HubJwtError('issuer')` → 401 on every OAuth/MCP reconnect.
+ * Bricks team onboarding on any exposed deploy.
+ *
+ * The durable fix: write `PARACHUTE_HUB_ORIGIN` into `vault/.env` so the daemon
+ * boot path picks it up too. Mirrors `auto-wire.ts`'s vault-.env writes
+ * (SCRIBE_AUTH_TOKEN / SCRIBE_URL) — hub owns these keys, vault's boot wrapper
+ * reads them.
+ */
+import { join } from "node:path";
+import { parseEnvFile, removeEnvLine, upsertEnvLine, writeEnvFile } from "./env-file.ts";
+import { HUB_ORIGIN_ENV } from "./hub-origin.ts";
+
+/**
+ * Loopback origins (`http://127.0.0.1:<port>`, `localhost`, `[::1]`) are the
+ * local-dev fallback `deriveHubOrigin` returns when no exposure is active. We
+ * never *persist* one — baking a loopback value into `.env` would SHADOW a
+ * later exposure on the daemon boot path (which has no other source of truth),
+ * recreating the exact `iss` mismatch this fix prevents. Worse than absent.
+ */
+export function isLoopbackOrigin(origin: string): boolean {
+  try {
+    // URL.hostname keeps IPv6 in bracket form (`[::1]`); strip them so the
+    // comparison is on the bare address.
+    const hostname = new URL(origin).hostname.replace(/^\[|\]$/g, "");
+    return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
+function vaultEnvPath(configDir: string): string {
+  return join(configDir, "vault", ".env");
+}
+
+/**
+ * Upsert `PARACHUTE_HUB_ORIGIN=<origin>` into `vault/.env` when `origin` is a
+ * non-loopback public origin. Idempotent — skips the write (and the log) when
+ * the value is already current so repeated `start`s don't churn the file.
+ * Returns true iff the file was written this call.
+ */
+export function persistVaultHubOrigin(
+  configDir: string,
+  origin: string,
+  log: (line: string) => void,
+): boolean {
+  if (isLoopbackOrigin(origin)) return false;
+  const path = vaultEnvPath(configDir);
+  const parsed = parseEnvFile(path);
+  if (parsed.values[HUB_ORIGIN_ENV] === origin) return false;
+  writeEnvFile(path, upsertEnvLine(parsed.lines, HUB_ORIGIN_ENV, origin));
+  log(`  persisted ${HUB_ORIGIN_ENV}=${origin} to ${path} (survives daemon restart)`);
+  return true;
+}
+
+/**
+ * Drop a previously-persisted `PARACHUTE_HUB_ORIGIN` from `vault/.env`. Called
+ * on `expose … off`: once exposure is torn down, a local-only hub mints tokens
+ * with a loopback `iss`, so a stale public origin left in `.env` would itself
+ * cause the mismatch. Removing the line reverts vault to its loopback default
+ * (`getHubOrigin`), which matches what the local hub now stamps. No-op (returns
+ * false) when the key isn't present. Returns true iff the file was rewritten.
+ */
+export function clearVaultHubOrigin(configDir: string, log: (line: string) => void): boolean {
+  const path = vaultEnvPath(configDir);
+  const parsed = parseEnvFile(path);
+  if (parsed.values[HUB_ORIGIN_ENV] === undefined) return false;
+  writeEnvFile(path, removeEnvLine(parsed.lines, HUB_ORIGIN_ENV));
+  log(`  cleared ${HUB_ORIGIN_ENV} from ${path} (exposure torn down)`);
+  return true;
+}


### PR DESCRIPTION
## Root cause (P0)

When a vault validates a hub-minted JWT, it checks the token's `iss` against `getHubOrigin()` (`parachute-vault/src/hub-jwt.ts`), which reads **only** `PARACHUTE_HUB_ORIGIN` from its process env and falls back to loopback `http://127.0.0.1:1939` when unset. The hub stamps the **public** origin (the exposed FQDN, e.g. `https://parachute-aaron.tailc75afc.ts.net`) on every token it mints. If the vault's environment doesn't carry the public origin, the jose `issuer` check fails → `HubJwtError('issuer')` → **401 on every OAuth/MCP reconnect**. Bricks team onboarding on any exposed deploy.

## Step-1 gap finding (why the team box's vault didn't get the right origin)

Hub **already** injects `PARACHUTE_HUB_ORIGIN` into the vault **spawn** env on `parachute start|restart vault` (`commands/lifecycle.ts:resolveHubOrigin` → `expose-state.hubOrigin` → loopback), and `expose` auto-restarts vault to refresh it (`expose.ts:HUB_DEPENDENT_SHORTS`). So why still 401?

**The injection is ephemeral and the real-world boot path bypasses it.** Vault's `init` registers a launchd agent (macOS) / systemd unit (Linux) by default, with `KeepAlive`/`Restart` (`parachute-vault/src/launchd.ts`). That daemon boots vault **out-of-band** via `~/.parachute/vault/start.sh` — *not* through `parachute start vault`. The wrapper sources `~/.parachute/vault/.env` (`daemon.ts`) and **never reads expose-state**, and the launchd plist carries **no `EnvironmentVariables`** key. So on every **reboot or KeepAlive crash-restart**, launchd starts vault with **no `PARACHUTE_HUB_ORIGIN`** → loopback fallback → mismatch.

Net: the `parachute start vault` spawn-env injection "worked" exactly once, until the next reboot/crash, after which the OS supervisor takes over with empty env. This is the **out-of-band-daemon gap** (case b in the brief). It also surfaces that vault's *mint*/URL path (`chooseHubOrigin`) reads expose-state, but the *validation* path (`getHubOrigin`) does not — the two diverge.

## The fix (hub-side, durable)

Persist `PARACHUTE_HUB_ORIGIN` into `~/.parachute/vault/.env` when the hub resolves a **non-loopback public** origin, so the launchd/systemd boot path (`start.sh` sources `.env`) validates against it too. Mirrors the existing `auto-wire.ts` vault-`.env` writes (`SCRIBE_AUTH_TOKEN` / `SCRIBE_URL`) — hub owns these keys, vault's boot wrapper reads them.

New module `src/vault-hub-origin-env.ts`:
- **`persistVaultHubOrigin`** — upsert on `start vault`. Guards: (1) **never persist a loopback origin** — baking it in would *shadow* a later exposure on the daemon boot path (which has no other source of truth), recreating the exact mismatch; (2) **idempotent** — skip rewrite + log when the value is already current.
- **`clearVaultHubOrigin`** — called on `expose … off`. Once exposure is torn down, a local-only hub mints loopback-`iss` tokens, so a stale public origin left in `.env` would itself cause the mismatch on the next daemon boot. Removing it reverts vault to its loopback default (`getHubOrigin`), which matches what the local hub now stamps.

Wired into `commands/lifecycle.ts` (`start`, vault only — the only hub-origin-dependent service with an OS-supervised autostart daemon today) and `commands/expose.ts` (`exposeOff`). The expose-up path is covered automatically: it already restarts vault via `restart` → `start`, by which point expose-state carries the public `hubOrigin`. Purely additive — no change to the existing ephemeral spawn-env injection.

## Vault-side fallback decision: SKIPPED (optional follow-up)

The brief's defense-in-depth idea — have vault's `getHubOrigin` accept a forwarded-host (`X-Forwarded-Host`/`-Proto`) for the `iss` check — is **security-sensitive**: the `iss` check is an auth boundary, and a spoofed forwarded-host must not be allowed to downgrade it. The hub-side persistence fully closes the P0 **without touching the auth boundary**, so the risky vault change is unnecessary here. If pursued later, it belongs in a separate vault PR with careful gating (accept forwarded-host only when it matches the hub's known origin set), not bundled into this fix.

## Tests

- `src/__tests__/vault-hub-origin-env.test.ts` (new) — persist writes the public origin / refuses loopback / idempotent / updates-in-place preserving sibling keys; clear removes + preserves siblings + no-ops on absent key/file; `isLoopbackOrigin` matrix (incl. `[::1]`).
- `lifecycle.test.ts` — `start vault` with active exposure persists the public origin to `vault/.env`; loopback-only start does **not** persist.
- `expose.test.ts` — `expose tailnet off` clears the persisted origin while preserving siblings.

Gate (`bun test ./src`): **2353 pass / 1 skip / 0 fail** (+12 from baseline 2341). `bun run typecheck` clean. `bunx biome check --write` on changed files clean.

No rc bump (orchestrator handles releases). Not merging — reviewer dispatch pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)