### PR TITLE
fix(hub): honor RFC 8707 resource — narrow consent + named-scope mint for vault-bound MCP (fix scary scopes + broad-scope rejection)

### DIFF
--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -3,7 +3,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getClient, registerClient } from "../clients.ts";
+import { approveClient, getClient, registerClient } from "../clients.ts";
 import { CSRF_COOKIE_NAME } from "../csrf.ts";
 import { findGrant, recordGrant } from "../grants.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
@@ -7465,6 +7465,343 @@ describe("zero-vault non-admin privesc gate (hub#429 reviewer)", () => {
       expect(loc.origin + loc.pathname).toBe("https://app.example/cb");
       expect(loc.searchParams.get("code")?.length).toBeGreaterThan(20);
       expect(loc.searchParams.get("state")).toBe("first-admin-ok");
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// RFC 8707 resource binding (fix #461). A friend connecting an MCP client to
+// ONE vault (`<origin>/vault/<name>/mcp`) must see ONLY that vault's scopes on
+// consent, and the minted token must carry the narrow, NAMED scope +
+// `aud=vault.<name>` — otherwise (a) the consent screen is scary (whole-hub
+// catalog) and (b) a current-line vault REJECTS the token via
+// `findBroadVaultScopes` (unnamed `vault:read` → `aud=vault` → 401).
+//
+// The deps thread `hubBoundOrigins` so the resource's origin is recognized as
+// one the hub fronts — same set the same-origin CSRF gate consults.
+describe("RFC 8707 resource binding — vault-bound MCP (fix #461)", () => {
+  const RESOURCE_DEPS = {
+    issuer: ISSUER,
+    loadServicesManifest: () => MULTI_VAULT_MANIFEST,
+    hubBoundOrigins: () => [ISSUER],
+  };
+
+  // Two vaults on the hub so "narrow to ONE" is observable: a request bound to
+  // `jon` must NOT surface `boulder`'s scopes nor the rest of the catalog.
+  const MULTI_VAULT_MANIFEST: ServicesManifest = {
+    services: [
+      {
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/vault/jon", "/vault/boulder"],
+        health: "/health",
+        version: "0.6.0",
+      },
+      {
+        name: "parachute-scribe",
+        port: 1943,
+        paths: ["/scribe"],
+        health: "/health",
+        version: "0.6.0",
+      },
+    ],
+  };
+
+  /**
+   * Mirror of `parachute-vault/src/scopes.ts:findBroadVaultScopes` — the exact
+   * predicate `authenticateHubJwt` runs to REJECT hub tokens. A token a
+   * current-line vault accepts must (a) carry zero broad `vault:<verb>` scopes
+   * and (b) name the vault in the audience. Inlined (vault is a separate
+   * package, not a hub dep) so this hub test genuinely encodes vault's
+   * contract — the cross-cutting half of the E2E gate.
+   */
+  function findBroadVaultScopes(granted: string[]): string[] {
+    return granted.filter((s) => {
+      const parts = s.split(":");
+      return (
+        parts.length === 2 &&
+        parts[0] === "vault" &&
+        ["read", "write", "admin"].includes(parts[1] ?? "")
+      );
+    });
+  }
+
+  test("E2E GATE: DCR → /authorize?resource=…/vault/jon/mcp → consent → code → /token mints aud=vault.jon + NAMED narrow scopes that a current-line vault accepts", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      // --- the operator (first admin) signed into the hub ---
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const cookie = `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`;
+
+      // --- DCR: register the friend's MCP client (plain pending, then
+      //     operator-approve so consent renders rather than same-hub
+      //     auto-trust skipping it) ---
+      const regRes = await handleRegister(
+        db,
+        new Request(`${ISSUER}/oauth/register`, {
+          method: "POST",
+          body: JSON.stringify({
+            redirect_uris: ["https://claude.ai/mcp/callback"],
+            client_name: "claude-code",
+            scope: "vault:read vault:write",
+          }),
+          headers: { "content-type": "application/json" },
+        }),
+        RESOURCE_DEPS,
+      );
+      expect(regRes.status).toBe(201);
+      const reg = (await regRes.json()) as { client_id: string };
+      approveClient(db, reg.client_id);
+
+      // --- /authorize WITH the RFC 8707 resource indicator. The client asks
+      //     for UNNAMED vault:read/write but names the jon MCP resource. ---
+      const { verifier, challenge } = makePkce();
+      const authReq = new Request(
+        authorizeUrl({
+          client_id: reg.client_id,
+          redirect_uri: "https://claude.ai/mcp/callback",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:read vault:write",
+          resource: `${ISSUER}/vault/jon/mcp`,
+        }),
+        { headers: { cookie } },
+      );
+      const authRes = handleAuthorizeGet(db, authReq, RESOURCE_DEPS);
+      expect(authRes.status).toBe(200);
+      const consentHtml = await authRes.text();
+
+      // Consent shows ONLY jon's scopes — narrowed + locked, no whole-hub
+      // catalog, no dropdown to guess, no other vault.
+      expect(consentHtml).toContain("vault:jon:read");
+      expect(consentHtml).toContain("vault:jon:write");
+      // Scary-scope guard: the friend never sees the rest of the catalog or
+      // the other vault.
+      expect(consentHtml).not.toContain("vault:boulder");
+      expect(consentHtml).not.toContain("hub:admin");
+      expect(consentHtml).not.toContain("scribe:");
+      // No vault-picker dropdown — the vault is locked to jon by the resource.
+      expect(consentHtml).not.toContain('name="vault_pick"');
+
+      // --- consent submit (approve). The hidden inputs already carry the
+      //     narrowed named scopes; the POST path re-narrows defensively. ---
+      const consentForm = new URLSearchParams({
+        __action: "consent",
+        __csrf: TEST_CSRF,
+        approve: "yes",
+        client_id: reg.client_id,
+        redirect_uri: "https://claude.ai/mcp/callback",
+        response_type: "code",
+        scope: "vault:jon:read vault:jon:write",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        resource: `${ISSUER}/vault/jon/mcp`,
+      });
+      const consentRes = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: consentForm,
+          headers: { "content-type": "application/x-www-form-urlencoded", cookie },
+        }),
+        RESOURCE_DEPS,
+      );
+      expect(consentRes.status).toBe(302);
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      expect(code).toBeTruthy();
+
+      // --- /token exchange ---
+      const tokenRes = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: new URLSearchParams({
+            grant_type: "authorization_code",
+            code: code ?? "",
+            client_id: reg.client_id,
+            redirect_uri: "https://claude.ai/mcp/callback",
+            code_verifier: verifier,
+          }),
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        RESOURCE_DEPS,
+      );
+      expect(tokenRes.status).toBe(200);
+      const tok = (await tokenRes.json()) as { access_token: string; scope: string };
+
+      // Wire-level scope: NAMED + narrow — NOT the catalog, NOT unnamed.
+      expect(tok.scope).toBe("vault:jon:read vault:jon:write");
+
+      // --- minted access token claims ---
+      const { payload } = await validateAccessToken(db, tok.access_token, ISSUER);
+      expect(payload.aud).toBe("vault.jon"); // resource-bound audience (RFC 8707)
+      expect(payload.scope).toBe("vault:jon:read vault:jon:write");
+      expect(payload.iss).toBe(ISSUER);
+
+      // --- CROSS-CUTTING: the token shape a current-line vault REQUIRES.
+      //     vault's `authenticateHubJwt` runs `findBroadVaultScopes` (reject
+      //     any unnamed vault verb) + audience strict-check `vault.<name>`.
+      const grantedScopes = (payload.scope as string).split(" ");
+      expect(findBroadVaultScopes(grantedScopes)).toEqual([]); // no broad-scope rejection
+      expect(payload.aud).toBe("vault.jon"); // matches the URL-derived vault name at /vault/jon/mcp
+      // Every granted scope is the named form vault accepts.
+      for (const s of grantedScopes) {
+        expect(s).toMatch(/^vault:jon:(read|write)$/);
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("resource → consent narrows to the named vault (no whole-hub catalog, picker locked)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const res = handleAuthorizeGet(
+        db,
+        new Request(
+          authorizeUrl({
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+            scope: "vault:read",
+            resource: `${ISSUER}/vault/jon/.well-known/oauth-protected-resource`,
+          }),
+          {
+            headers: {
+              cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+            },
+          },
+        ),
+        RESOURCE_DEPS,
+      );
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      // PRM-URL form of the resource resolves to jon too.
+      expect(html).toContain("vault:jon:read");
+      expect(html).not.toContain('name="vault_pick"');
+      expect(html).not.toContain("vault:boulder");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("no resource param → behavior unchanged (unnamed scope still renders the picker)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const res = handleAuthorizeGet(
+        db,
+        new Request(
+          authorizeUrl({
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+            scope: "vault:read",
+            // no resource param
+          }),
+          {
+            headers: {
+              cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+            },
+          },
+        ),
+        RESOURCE_DEPS,
+      );
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      // Manual-pick path preserved: picker renders, vault not pre-narrowed.
+      expect(html).toContain("Pick a vault");
+      expect(html).toContain('name="vault_pick"');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("off-origin resource → ignored (no narrowing; manual-pick path)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const res = handleAuthorizeGet(
+        db,
+        new Request(
+          authorizeUrl({
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+            scope: "vault:read",
+            resource: "https://evil.example/vault/jon/mcp",
+          }),
+          {
+            headers: {
+              cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+            },
+          },
+        ),
+        RESOURCE_DEPS,
+      );
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      // An attacker-controlled resource origin can't drive narrowing — the
+      // flow falls back to the normal manual picker.
+      expect(html).toContain("Pick a vault");
+      expect(html).not.toContain("vault:jon:read");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("non-requestable scope still refused even with a resource (vault:admin → vault:jon:admin blocked)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const res = handleAuthorizeGet(
+        db,
+        new Request(
+          authorizeUrl({
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+            scope: "vault:admin",
+            resource: `${ISSUER}/vault/jon/mcp`,
+          }),
+          {
+            headers: {
+              cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+            },
+          },
+        ),
+        RESOURCE_DEPS,
+      );
+      // Narrowing turns vault:admin → vault:jon:admin which is NON-requestable;
+      // the gate rejects via redirect with invalid_scope.
+      expect(res.status).toBe(302);
+      const loc = res.headers.get("location") ?? "";
+      expect(loc).toContain("error=invalid_scope");
+      expect(loc).toContain("vault%3Ajon%3Aadmin");
     } finally {
       cleanup();
     }

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -20,6 +20,7 @@ const PARAMS: AuthorizeFormParams = {
   codeChallenge: "ch",
   codeChallengeMethod: "S256",
   state: "xyz",
+  resource: null,
 };
 
 const CSRF = "csrf-token-fixture";

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -51,9 +51,19 @@ describe("renderHiddenInputs", () => {
   });
 
   test("escapes hostile values into hidden inputs", () => {
-    const html = renderHiddenInputs({ ...PARAMS, state: `"><script>alert(1)</script>` });
+    const html = renderHiddenInputs({
+      ...PARAMS,
+      state: `"><script>alert(1)</script>`,
+      // RFC 8707 resource is round-tripped through a hidden input too, so a
+      // hostile value must be escaped the same way.
+      resource: `"><script>alert(2)</script>`,
+    });
     expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).not.toContain("<script>alert(2)</script>");
     expect(html).toContain("&lt;script&gt;");
+    // The resource value is emitted as a hidden input (escaped).
+    expect(html).toContain('name="resource"');
+    expect(html).toContain("alert(2)");
   });
 });
 

--- a/src/__tests__/resource-binding.test.ts
+++ b/src/__tests__/resource-binding.test.ts
@@ -48,6 +48,21 @@ describe("resolveResourceVault", () => {
     // `/vault/jon/mcp/extra` is not the canonical MCP endpoint.
     expect(resolveResourceVault(`${ORIGIN}/vault/jon/mcp/extra`, BOUND)).toBeNull();
   });
+
+  test("rejects a vault segment that isn't a well-formed vault name (no junk mint)", () => {
+    // A crafted `resource=…/vault/%2F..%2Fadmin/mcp` decodes to `/../admin`,
+    // which is not `[a-zA-Z0-9_-]+`. Returning null falls through to the
+    // unbound flow — no narrowing, no token stamped `aud=vault./../admin`.
+    expect(resolveResourceVault(`${ORIGIN}/vault/%2F..%2Fadmin/mcp`, BOUND)).toBeNull();
+    // Spaces / dots / slashes in the decoded name are all out of shape.
+    expect(resolveResourceVault(`${ORIGIN}/vault/a.b/mcp`, BOUND)).toBeNull();
+  });
+
+  test("returns null for a malformed percent-escape in the vault segment (safeDecode catch path)", () => {
+    // `%GG` is not a valid percent-escape — `decodeURIComponent` throws; the
+    // helper must degrade to null rather than 500 the authorize handler.
+    expect(resolveResourceVault(`${ORIGIN}/vault/%GG/mcp`, BOUND)).toBeNull();
+  });
 });
 
 describe("narrowResourceVaultScopes", () => {

--- a/src/__tests__/resource-binding.test.ts
+++ b/src/__tests__/resource-binding.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { narrowResourceVaultScopes, resolveResourceVault } from "../resource-binding.ts";
+
+const ORIGIN = "https://hub.example";
+const BOUND = [ORIGIN, "http://127.0.0.1:1939"];
+
+describe("resolveResourceVault", () => {
+  test("resolves a per-vault MCP resource to the vault name", () => {
+    expect(resolveResourceVault(`${ORIGIN}/vault/jon/mcp`, BOUND)).toBe("jon");
+  });
+
+  test("tolerates a trailing slash on the MCP path", () => {
+    expect(resolveResourceVault(`${ORIGIN}/vault/jon/mcp/`, BOUND)).toBe("jon");
+  });
+
+  test("ignores query string + fragment", () => {
+    expect(resolveResourceVault(`${ORIGIN}/vault/jon/mcp?x=1#y`, BOUND)).toBe("jon");
+  });
+
+  test("resolves the PRM document URL to the vault name", () => {
+    expect(
+      resolveResourceVault(`${ORIGIN}/vault/jon/.well-known/oauth-protected-resource`, BOUND),
+    ).toBe("jon");
+  });
+
+  test("resolves against a non-issuer bound origin (loopback)", () => {
+    expect(resolveResourceVault("http://127.0.0.1:1939/vault/work/mcp", BOUND)).toBe("work");
+  });
+
+  test("returns null for an off-origin resource (not one we front)", () => {
+    expect(resolveResourceVault("https://evil.example/vault/jon/mcp", BOUND)).toBeNull();
+  });
+
+  test("returns null for a non-vault path", () => {
+    expect(resolveResourceVault(`${ORIGIN}/scribe/mcp`, BOUND)).toBeNull();
+    expect(resolveResourceVault(`${ORIGIN}/vault/jon`, BOUND)).toBeNull();
+    expect(resolveResourceVault(`${ORIGIN}/vault/jon/notes`, BOUND)).toBeNull();
+  });
+
+  test("returns null for absent / empty / malformed resource", () => {
+    expect(resolveResourceVault(null, BOUND)).toBeNull();
+    expect(resolveResourceVault(undefined, BOUND)).toBeNull();
+    expect(resolveResourceVault("", BOUND)).toBeNull();
+    expect(resolveResourceVault("not a url", BOUND)).toBeNull();
+  });
+
+  test("does not collapse a deeper vault sub-path into the MCP shape", () => {
+    // `/vault/jon/mcp/extra` is not the canonical MCP endpoint.
+    expect(resolveResourceVault(`${ORIGIN}/vault/jon/mcp/extra`, BOUND)).toBeNull();
+  });
+});
+
+describe("narrowResourceVaultScopes", () => {
+  test("narrows unnamed vault verbs to the named form", () => {
+    expect(narrowResourceVaultScopes(["vault:read", "vault:write"], "jon")).toEqual([
+      "vault:jon:read",
+      "vault:jon:write",
+    ]);
+  });
+
+  test("leaves already-named scopes for other vaults untouched", () => {
+    expect(narrowResourceVaultScopes(["vault:other:read"], "jon")).toEqual(["vault:other:read"]);
+  });
+
+  test("passes non-vault scopes through unchanged", () => {
+    expect(narrowResourceVaultScopes(["scribe:transcribe", "vault:read"], "jon")).toEqual([
+      "scribe:transcribe",
+      "vault:jon:read",
+    ]);
+  });
+
+  test("narrows the admin verb too (gate happens downstream)", () => {
+    // narrowResourceVaultScopes only rewrites shape; the non-requestable gate
+    // (`vault:<name>:admin`) blocks it afterward.
+    expect(narrowResourceVaultScopes(["vault:admin"], "jon")).toEqual(["vault:jon:admin"]);
+  });
+
+  test("is idempotent over an already-narrowed list", () => {
+    const once = narrowResourceVaultScopes(["vault:read"], "jon");
+    expect(narrowResourceVaultScopes(once, "jon")).toEqual(once);
+  });
+});

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -66,6 +66,7 @@ import {
 } from "./oauth-ui.ts";
 import { isSameOriginRequest } from "./origin-check.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
+import { narrowResourceVaultScopes, resolveResourceVault } from "./resource-binding.ts";
 import { isNonRequestableScope, isRequestableScope, scopeIsAdmin } from "./scope-explanations.ts";
 import { findUnknownScopes, loadDeclaredScopes } from "./scope-registry.ts";
 import {
@@ -460,6 +461,9 @@ function parseAuthorizeFormParams(url: URL): AuthorizeFormParams | { error: stri
     codeChallenge,
     codeChallengeMethod,
     state: url.searchParams.get("state"),
+    // RFC 8707 resource indicator (optional). When present and resolvable to
+    // a per-vault MCP resource, drives the narrow-consent + named-scope path.
+    resource: url.searchParams.get("resource"),
   };
 }
 
@@ -844,6 +848,41 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
     );
   }
 
+  // RFC 8707 resource binding. When the client named a per-vault MCP
+  // resource (`<origin>/vault/<name>/mcp` or its PRM URL), narrow the
+  // requested vault verbs to the named `vault:<name>:<verb>` form BEFORE any
+  // downstream processing. Two effects:
+  //
+  //   1. The consent screen shows ONLY that vault's scopes (the picker locks
+  //      to <name>) instead of the whole-hub catalog — a friend connecting to
+  //      one vault no longer sees `hub:admin`, `scribe:admin`, or every other
+  //      vault's verbs.
+  //   2. The minted token carries the named scope, so `inferAudience` stamps
+  //      `aud=vault.<name>` and a current-line vault accepts it (an unnamed
+  //      `vault:read` token is rejected by `findBroadVaultScopes`).
+  //
+  // Narrowing happens before the non-requestable gate (below) on purpose: if
+  // a resource-bound client somehow asked for `vault:admin`, narrowing makes
+  // it `vault:<name>:admin`, which IS non-requestable — so the gate correctly
+  // blocks it. Read/write narrow to the requestable named form. Non-vault
+  // scopes and already-named scopes for other vaults pass through unchanged.
+  //
+  // No resource, or a resource that isn't one of our per-vault MCP resources
+  // (off-origin, malformed, non-vault path) → `boundVault` is null and the
+  // flow is byte-for-byte the pre-#461 behavior (manual picker, etc.).
+  const boundVault = resolveResourceVault(parsed.resource, resolveBoundOrigins(deps));
+  if (boundVault) {
+    const narrowed = narrowResourceVaultScopes(
+      parsed.scope.split(" ").filter((s) => s.length > 0),
+      boundVault,
+    );
+    // Rewrite `parsed.scope` so the narrowed named scopes flow through every
+    // downstream consumer: the login-redirect query round-trip, the consent
+    // props + hidden inputs, the skip-consent grant lookup, and the
+    // auth-code mint.
+    parsed.scope = narrowed.join(" ");
+  }
+
   // Operator-only scope gate (#96). Reject any request that names a scope
   // we'll never mint via this flow — `parachute:host:admin` and friends.
   // Per RFC 6749 §4.1.2.1, errors that aren't redirect-uri-related are
@@ -1121,6 +1160,21 @@ async function handleConsentSubmit(
   csrfToken: string,
 ): Promise<Response> {
   const params = paramsFromForm(form);
+  // RFC 8707 resource binding — defense-in-depth (mirror of the GET handler).
+  // The consent form's hidden inputs already carry the narrowed named scopes
+  // (the GET handler rewrote `parsed.scope` before rendering), but a hand-
+  // crafted POST could re-supply an unnamed `vault:read` alongside the
+  // `resource` field. Re-narrow here so the minted token is always named +
+  // correctly-audienced regardless of what the form body claims. Same
+  // semantics as the GET path: only when `resource` resolves to one of our
+  // per-vault MCP resources; no-op otherwise (manual-pick path unchanged).
+  const boundVault = resolveResourceVault(params.resource, resolveBoundOrigins(deps));
+  if (boundVault) {
+    params.scope = narrowResourceVaultScopes(
+      params.scope.split(" ").filter((s) => s.length > 0),
+      boundVault,
+    ).join(" ");
+  }
   const approve = String(form.get("approve") ?? "") === "yes";
   const sessionId = parseSessionCookie(req.headers.get("cookie"));
   const session = sessionId ? findSession(db, sessionId) : null;
@@ -1554,6 +1608,7 @@ function paramsFromForm(form: Awaited<ReturnType<Request["formData"]>>): Authori
     codeChallenge: String(form.get("code_challenge") ?? ""),
     codeChallengeMethod: String(form.get("code_challenge_method") ?? "S256"),
     state: (form.get("state") as string | null) ?? null,
+    resource: (form.get("resource") as string | null) ?? null,
   };
 }
 
@@ -1567,6 +1622,10 @@ function authorizeParamsToQuery(p: AuthorizeFormParams): Record<string, string> 
     code_challenge_method: p.codeChallengeMethod,
   };
   if (p.state) q.state = p.state;
+  // Round-trip the RFC 8707 resource indicator through the login redirect so
+  // the resource-bound narrowing survives a sign-in (it re-enters GET
+  // /oauth/authorize with the original params).
+  if (p.resource) q.resource = p.resource;
   return q;
 }
 

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -1255,6 +1255,11 @@ async function handleConsentSubmit(
   const sessionUser = getUserById(db, session.userId);
   const assignedVaults: string[] = userIsAdmin ? [] : (sessionUser?.assignedVaults ?? []);
   const isPinned = assignedVaults.length > 0;
+  // By design: the resource-bound re-narrow above does NOT check the bound
+  // vault exists in services.json for the admin path — admin (isPinned=false)
+  // can already consent to any vault via the manual picker, so the asymmetry
+  // (named-scope mint against a possibly-missing vault) is deliberate, not an
+  // oversight. Non-admins still hit the assignment + stale-vault defenses below.
 
   // Zero-vault non-admin gate (Phase 2 PR 2 reviewer fold). A non-admin
   // user with no `user_vaults` rows is a known-but-not-yet-assigned

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -20,7 +20,7 @@
  *     module scopes that the hub doesn't know about) render verbatim.
  *   - **No JavaScript.** Entirely form-based. Submit is the only interaction.
  */
-import { WORDMARK_TEXT, brandMarkSvg } from "./brand.ts";
+import { brandMarkSvg, WORDMARK_TEXT } from "./brand.ts";
 import { renderCsrfHiddenInput } from "./csrf.ts";
 import { type ScopeExplanation, explainScope } from "./scope-explanations.ts";
 

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -20,7 +20,7 @@
  *     module scopes that the hub doesn't know about) render verbatim.
  *   - **No JavaScript.** Entirely form-based. Submit is the only interaction.
  */
-import { brandMarkSvg, WORDMARK_TEXT } from "./brand.ts";
+import { WORDMARK_TEXT, brandMarkSvg } from "./brand.ts";
 import { renderCsrfHiddenInput } from "./csrf.ts";
 import { type ScopeExplanation, explainScope } from "./scope-explanations.ts";
 
@@ -62,6 +62,12 @@ export interface AuthorizeFormParams {
   codeChallenge: string;
   codeChallengeMethod: string;
   state: string | null;
+  /**
+   * RFC 8707 resource indicator. Carried through the login → consent →
+   * form-post round-trip so the resource-bound vault narrowing survives a
+   * sign-in redirect. Null when the client sent no `resource` param.
+   */
+  resource: string | null;
 }
 
 export interface LoginViewProps {
@@ -932,6 +938,10 @@ export function renderHiddenInputs(p: AuthorizeFormParams): string {
     ["code_challenge_method", p.codeChallengeMethod],
   ];
   if (p.state) fields.push(["state", p.state]);
+  // RFC 8707 resource indicator — round-tripped through the consent form so
+  // the resource-bound vault narrowing survives the POST (the consent submit
+  // path re-derives the bound vault from it).
+  if (p.resource) fields.push(["resource", p.resource]);
   return fields
     .map(([k, v]) => `<input type="hidden" name="${k}" value="${escapeHtml(v)}" />`)
     .join("\n        ");

--- a/src/resource-binding.ts
+++ b/src/resource-binding.ts
@@ -1,0 +1,120 @@
+/**
+ * RFC 8707 (Resource Indicators for OAuth 2.0) resource-binding helpers.
+ *
+ * An MCP client connecting to a single vault (`<origin>/vault/<name>/mcp`)
+ * discovers the hub as its authorization server via the RFC 9728 challenge
+ * (`WWW-Authenticate: Bearer resource_metadata=…`) → per-vault Protected
+ * Resource Metadata. A spec-following client then sends the `resource`
+ * parameter on `/oauth/authorize` naming that exact MCP endpoint.
+ *
+ * Before this module the hub dropped `resource` on the floor: the consent
+ * screen advertised the ENTIRE scope catalog (every vault + hub:admin +
+ * scribe:admin …) and the minted token's audience was derived purely from
+ * the operator's manual vault-picker choice. Two failures fell out:
+ *
+ *   1. Scary consent — a friend connecting to ONE vault saw the whole hub's
+ *      scope surface.
+ *   2. Broad-scope rejection — an unnamed `vault:read` token (the shape a
+ *      client gets when it never picks a specific vault) is REJECTED by a
+ *      current-line vault (`findBroadVaultScopes`), because hub-issued tokens
+ *      must carry resource-narrowed `vault:<name>:<verb>` scopes + a matching
+ *      `aud=vault.<name>`.
+ *
+ * This module consumes `resource` end-to-end: when it resolves to a per-vault
+ * MCP resource we derive `<name>`, narrow the consent scope list to that
+ * vault's named scopes, lock the picker to `<name>`, and mint named scopes so
+ * `inferAudience` stamps `aud=vault.<name>`.
+ *
+ * Source of truth for scope shape: `parachute-patterns/patterns/oauth-scopes.md`.
+ */
+
+import { VAULT_VERBS } from "./jwt-audience.ts";
+
+/**
+ * Two recognised per-vault resource shapes, both rooted at the hub origin:
+ *
+ *   - the MCP endpoint:  `<origin>/vault/<name>/mcp`  (the canonical RFC 8707
+ *     resource indicator the PRM `resource` field advertises and a spec-
+ *     following client echoes back);
+ *   - the PRM document:  `<origin>/vault/<name>/.well-known/oauth-protected-resource`
+ *     (some clients send the metadata URL itself as the resource).
+ *
+ * A trailing slash and any query/fragment are tolerated. Capture group 1 is
+ * the vault instance name (same `[^/]+` shape `vaultInstanceNameFor` derives
+ * from a `/vault/<name>` path).
+ */
+const VAULT_MCP_PATH_RE = /^\/vault\/([^/]+)\/mcp\/?$/;
+const VAULT_PRM_PATH_RE = /^\/vault\/([^/]+)\/\.well-known\/oauth-protected-resource\/?$/;
+
+/**
+ * Resolve the RFC 8707 `resource` parameter to a vault instance name, or null
+ * when it isn't a per-vault MCP resource (absent, malformed, off-origin, or a
+ * non-vault path). Off-origin resources return null deliberately: we only
+ * narrow consent for resources the hub itself fronts, so a `resource` naming
+ * some third party's URL can't drive the vault-narrowing path.
+ *
+ * `boundOrigins` is the hub's own origin set (issuer + loopback + tailnet +
+ * funnel — same set the same-origin CSRF gate uses). A resource whose origin
+ * isn't in that set is treated as not-ours.
+ *
+ * The vault name is NOT validated against the live services.json here — that
+ * check stays where it already lives (the consent picker / submit defenses).
+ * This helper's only job is shape recognition + name extraction.
+ */
+export function resolveResourceVault(
+  resource: string | null | undefined,
+  boundOrigins: readonly string[],
+): string | null {
+  if (!resource) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(resource);
+  } catch {
+    return null;
+  }
+  if (!boundOrigins.includes(parsed.origin)) return null;
+  const mcp = VAULT_MCP_PATH_RE.exec(parsed.pathname);
+  if (mcp?.[1]) return safeDecode(mcp[1]);
+  const prm = VAULT_PRM_PATH_RE.exec(parsed.pathname);
+  if (prm?.[1]) return safeDecode(prm[1]);
+  return null;
+}
+
+/**
+ * Decode a path segment, returning null on a malformed percent-escape rather
+ * than throwing (a malformed `resource` must degrade to the unbound flow, not
+ * 500 the authorize handler). Vault names are `[a-zA-Z0-9_-]` in practice so
+ * this is belt-and-suspenders.
+ */
+function safeDecode(segment: string): string | null {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Rewrite the requested scope list for a resource-bound vault flow.
+ *
+ *   - unnamed `vault:<verb>`        → `vault:<name>:<verb>` (the narrow,
+ *     audience-correct shape vault accepts);
+ *   - already-named `vault:<other>:<verb>` is LEFT UNTOUCHED — a client that
+ *     explicitly named a different vault is not silently re-pointed; the
+ *     downstream picker / assignment defenses decide whether that's allowed.
+ *   - non-vault scopes (`scribe:transcribe`, `hub:admin`, …) pass through
+ *     unchanged — resource-binding only narrows the vault verbs.
+ *
+ * Idempotent: a scope already shaped `vault:<name>:<verb>` for THIS name is
+ * returned as-is, so re-running over a narrowed list is a no-op.
+ */
+export function narrowResourceVaultScopes(scopes: readonly string[], vaultName: string): string[] {
+  return scopes.map((s) => {
+    const parts = s.split(":");
+    const verb = parts[1];
+    if (parts.length === 2 && parts[0] === "vault" && verb && VAULT_VERBS.has(verb)) {
+      return `vault:${vaultName}:${verb}`;
+    }
+    return s;
+  });
+}

--- a/src/resource-binding.ts
+++ b/src/resource-binding.ts
@@ -74,24 +74,38 @@ export function resolveResourceVault(
   }
   if (!boundOrigins.includes(parsed.origin)) return null;
   const mcp = VAULT_MCP_PATH_RE.exec(parsed.pathname);
-  if (mcp?.[1]) return safeDecode(mcp[1]);
+  if (mcp?.[1]) return decodeVaultName(mcp[1]);
   const prm = VAULT_PRM_PATH_RE.exec(parsed.pathname);
-  if (prm?.[1]) return safeDecode(prm[1]);
+  if (prm?.[1]) return decodeVaultName(prm[1]);
   return null;
 }
 
+/** Canonical vault-name shape — mirrors `VAULT_SCOPED_RE`'s name group. */
+const VAULT_NAME_RE = /^[a-zA-Z0-9_-]+$/;
+
 /**
- * Decode a path segment, returning null on a malformed percent-escape rather
- * than throwing (a malformed `resource` must degrade to the unbound flow, not
- * 500 the authorize handler). Vault names are `[a-zA-Z0-9_-]` in practice so
- * this is belt-and-suspenders.
+ * Decode a captured path segment into a vault name, returning null when it
+ * isn't a well-formed vault name. Two failure modes both fall through to the
+ * unbound flow (no narrowing, no junk mint):
+ *
+ *   - malformed percent-escape (`%GG`) → `decodeURIComponent` throws → null.
+ *     A bad `resource` must degrade gracefully, not 500 the authorize handler.
+ *   - decoded value isn't `[a-zA-Z0-9_-]+` → null. The `[^/]+` path capture
+ *     admits anything between slashes; a crafted `resource=…/vault/%2F..%2Fadmin/mcp`
+ *     decodes to `/../admin`, which would otherwise mint a token stamped
+ *     `aud=vault./../admin`. Harmless (the resource server rejects it) but it's
+ *     audit-log noise + a minting path for non-vault names. Anchoring the name
+ *     to the canonical shape closes it. Matches `VAULT_SCOPED_RE`'s name group
+ *     so what we accept here is exactly what a vault scope can name.
  */
-function safeDecode(segment: string): string | null {
+function decodeVaultName(segment: string): string | null {
+  let decoded: string;
   try {
-    return decodeURIComponent(segment);
+    decoded = decodeURIComponent(segment);
   } catch {
     return null;
   }
+  return VAULT_NAME_RE.test(decoded) ? decoded : null;
 }
 
 /**


### PR DESCRIPTION
## The two problems

1. **Scary consent scopes.** A friend connecting an MCP client to ONE vault (`/vault/jon/mcp`) saw a consent screen requesting the **entire** scope catalog — `hub:admin`, `scribe:admin`, every vault's verbs. They should see only `vault:jon:{read,write}`.
2. **Latent broad-scope rejection.** 0.6.x vaults (`parachute-vault/src/auth.ts` → `findBroadVaultScopes`) **reject** unnamed `vault:read`/`vault:write` — only the named `vault:<name>:<verb>` form works, with a matching `aud=vault.<name>`. The hub only narrowed unnamed → named when the operator manually picked a vault in the consent dropdown, so an MCP client that never picks a vault gets an unnamed-scope token a current-line vault 401s.

## Step-1 flow map (root cause)

- **RFC 9728 challenge → discovery.** Unauthenticated hit on `/vault/jon/mcp` → vault 401 with `WWW-Authenticate: Bearer resource_metadata="…/vault/jon/.well-known/oauth-protected-resource"` (`parachute-vault/src/routing.ts:99-118`). That per-vault PRM is **proxied through the hub to the vault backend** (`hub-server.ts:2097` → `proxyToVault`), which serves it via `handleProtectedResource` (`parachute-vault/src/oauth-discovery.ts:60-69`): `resource = <origin>/vault/jon/mcp`, names the hub as the AS.
- **(a) What the client sends to `/authorize`:** `resource=<origin>/vault/jon/mcp` (RFC 8707 / MCP 2025-06-18).
- **(b) Where it was dropped:** `parseAuthorizeFormParams` (`oauth-handlers.ts:439-464`) never read `resource`. `inferAudience` (`jwt-audience.ts:26-40`) derived `aud` purely from the picked scope.
- **(c) How the consent list was built:** hub-level discovery (`authorizationServerMetadata` / `protectedResourceMetadata`) published `Array.from(declared).filter(isRequestableScope)` = the full catalog; the consent screen rendered exactly the requested `scope` and, for an unnamed `vault:read`, a picker over **every** vault.
- **(d) How the token derived:** `/token` used the consent-stored scopes; `aud = inferAudience(scopes)`. Unnamed `vault:read` → `aud=vault` → rejected by `findBroadVaultScopes`.

## The resource-binding fix

New `src/resource-binding.ts`:
- `resolveResourceVault(resource, boundOrigins)` — recognizes a per-vault MCP resource (`.../vault/<name>/mcp` or its PRM URL) rooted at one of the hub's bound origins; returns `<name>`. Off-origin / malformed / non-vault → `null`.
- `narrowResourceVaultScopes(scopes, name)` — rewrites unnamed `vault:<verb>` → `vault:<name>:<verb>`; leaves other-vault named scopes + non-vault scopes untouched.

Wired into `oauth-handlers.ts`:
1. **`/oauth/authorize` (GET):** when `resource` resolves to a vault, narrow the requested vault verbs to the named form **before** the non-requestable gate. Consent shows **only** that vault's scopes (no picker dropdown, no whole-hub catalog); the vault is locked to `<name>`.
2. **Token mint:** the named scope flows through the grant + auth-code + `/token`, so `inferAudience` pins `aud=vault.<name>` (RFC 8707 resource-bound audience) and the minted scope is the narrow named form.
3. **`handleConsentSubmit` (POST):** re-narrows defensively so a hand-crafted POST can't re-supply an unnamed scope past the named-scope contract.
4. **Preserved behavior:** no `resource` → identical to prior behavior (manual picker / admin / hub OAuth all unchanged).
5. **`isRequestableScope` guard intact:** narrowing happens before the non-requestable gate, so a resource-bound `vault:admin` becomes `vault:<name>:admin` and is correctly **blocked** with `invalid_scope`.

`resource` threads through `AuthorizeFormParams` + hidden inputs + the login-redirect query so the binding survives a sign-in round-trip.

> Per-vault PRM note: the hub does **not** serve `/vault/<name>/.well-known/oauth-protected-resource` itself — it proxies to the vault backend, which already advertises `vault:read/write/admin` for that path (`oauth-discovery.ts`). No hub-side over-advertising on that path to fix; the hub-level `/.well-known/*` docs stay catalog-wide (correct for the hub-as-resource posture) but no longer drive per-vault consent.

## E2E gate (the test that would have caught the whole cluster)

`describe("RFC 8707 resource binding — vault-bound MCP")` in `oauth-handlers.test.ts`: full flow — DCR (register `claude-code`) → `/authorize` with `resource=<origin>/vault/jon/mcp` → consent → auth code → `/token`. Asserts:
- minted access token `aud=vault.jon`, `scope="vault:jon:read vault:jon:write"` (named, narrow — **not** the catalog, **not** unnamed), `iss=<origin>`;
- consent HTML shows `vault:jon:{read,write}` and **not** `vault:boulder`, `hub:admin`, `scribe:`, nor any `vault_pick` dropdown (two-vault fixture so "narrow to one" is observable);
- **cross-cutting:** the token shape a current-line vault requires — zero broad scopes via a mirror of `parachute-vault`'s `findBroadVaultScopes`, and `aud` matching the URL-derived vault name.

Plus unit tests: `resource-binding.test.ts` (14 cases — shape recognition, off-origin rejection, idempotent narrowing), and handler cases for resource→narrow-consent, resource→named+aud mint, no-resource→unchanged, off-origin→ignored, non-requestable refused even with a resource. Verified load-bearing: temporarily neutering the narrowing fails the gate + narrowing + non-requestable cases.

## Gates
- `bun test ./src`: **2373 pass / 1 skip / 0 fail**
- `bun run typecheck`: clean
- `bunx biome check` on touched files: clean (the two pre-existing `oauth-handlers.ts:1491` template-literal lint findings are unrelated and present on `main`)

No rc bump (per instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)