### PR TITLE
fix(hub): setup-flow UX — 404 after vault-create + wizard honors live expose-state

### DIFF
--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -23,6 +23,7 @@ import {
   getDefaultOperationsRegistry,
 } from "../api-modules-ops.ts";
 import { CSRF_COOKIE_NAME, CSRF_FIELD_NAME } from "../csrf.ts";
+import { type ExposeState, readExposeState, writeExposeState } from "../expose-state.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { hubFetch } from "../hub-server.ts";
 import { getSetting, setSetting } from "../hub-settings.ts";
@@ -44,6 +45,20 @@ import { createUser, getUserByUsername, userCount } from "../users.ts";
 interface Harness {
   dir: string;
   manifestPath: string;
+  /**
+   * Hermetic expose-state reader scoped to the harness's tmp dir. The
+   * production `readExposeState()` defaults to the operator's real
+   * `~/.parachute/expose-state.json` (a module-load constant), so a
+   * wizard test that omits an injected reader would auto-seed
+   * `setup_expose_mode` from the developer's LIVE exposure (hub#406) and
+   * flip expose-step assertions nondeterministically. Threading this
+   * harness reader keeps every wizard test isolated from the real
+   * filesystem — same isolation the harness already gives DB + manifest.
+   * Defaults to "no live exposure" (the tmp file doesn't exist) unless a
+   * test writes one via `writeExposeState(state, h.exposeStatePath)`.
+   */
+  exposeStatePath: string;
+  readExposeStateFn: () => ExposeState | undefined;
   cleanup: () => void;
 }
 
@@ -52,9 +67,12 @@ function makeHarness(): Harness {
   writeFileSync(join(dir, "hub.html"), "<html>discovery</html>");
   const manifestPath = join(dir, "services.json");
   writeManifest({ services: [] }, manifestPath);
+  const exposeStatePath = join(dir, "expose-state.json");
   return {
     dir,
     manifestPath,
+    exposeStatePath,
+    readExposeStateFn: () => readExposeState(exposeStatePath),
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
   };
 }
@@ -124,7 +142,11 @@ describe("deriveWizardState", () => {
   test("welcome step when no admin and no vault", () => {
     const db = openHubDb(hubDbPath(h.dir));
     try {
-      const s = deriveWizardState({ db, manifestPath: h.manifestPath });
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        readExposeStateFn: h.readExposeStateFn,
+      });
       expect(s.step).toBe("welcome");
       expect(s.hasAdmin).toBe(false);
       expect(s.hasVault).toBe(false);
@@ -137,7 +159,11 @@ describe("deriveWizardState", () => {
     const db = openHubDb(hubDbPath(h.dir));
     try {
       await createUser(db, "owner", "pw");
-      const s = deriveWizardState({ db, manifestPath: h.manifestPath });
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        readExposeStateFn: h.readExposeStateFn,
+      });
       expect(s.step).toBe("vault");
       expect(s.hasAdmin).toBe(true);
       expect(s.hasVault).toBe(false);
@@ -164,7 +190,11 @@ describe("deriveWizardState", () => {
         },
         h.manifestPath,
       );
-      const s = deriveWizardState({ db, manifestPath: h.manifestPath });
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        readExposeStateFn: h.readExposeStateFn,
+      });
       expect(s.step).toBe("expose");
       expect(s.hasAdmin).toBe(true);
       expect(s.hasVault).toBe(true);
@@ -201,7 +231,12 @@ describe("deriveWizardState", () => {
       );
       // Simulate Render env. detectAutoExposeMode reads RENDER_EXTERNAL_URL.
       const renderEnv = { RENDER_EXTERNAL_URL: "https://parachute-hub.onrender.com" };
-      const s = deriveWizardState({ db, manifestPath: h.manifestPath, env: renderEnv });
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        env: renderEnv,
+        readExposeStateFn: h.readExposeStateFn,
+      });
       expect(s.step).toBe("done");
       expect(s.hasExposeMode).toBe(true);
     } finally {
@@ -227,10 +262,197 @@ describe("deriveWizardState", () => {
         },
         h.manifestPath,
       );
-      const s = deriveWizardState({ db, manifestPath: h.manifestPath, env: {} });
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        env: {},
+        readExposeStateFn: h.readExposeStateFn,
+      });
       // Local install path — the operator still gets to choose
       expect(s.step).toBe("expose");
       expect(s.hasExposeMode).toBe(false);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("auto-seeds expose mode from a live `parachute expose tailnet` (hub#406 team-onboarding bug)", async () => {
+    // Team-onboarding bug: an operator ran `parachute expose tailnet`
+    // BEFORE opening the wizard. That writes expose-state.json
+    // (layer=tailnet) but never the `setup_expose_mode` hub_setting —
+    // the two are orthogonal axes. Pre-fix, the wizard consulted only
+    // the setting and re-rendered "How will this hub be reached?" though
+    // tailnet was already live. deriveWizardState now reads the live
+    // exposure layer and auto-seeds the setting, so the expose step is
+    // treated as satisfied and the wizard advances to done.
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      await createUser(db, "owner", "pw");
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              version: "0.1.0",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/health",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      // Simulate `parachute expose tailnet`: write a real expose-state
+      // file (round-trips through readExposeState's validator) into the
+      // harness tmp path. No env signal (not Render/Fly), no setting.
+      writeExposeState(
+        {
+          version: 1,
+          layer: "tailnet",
+          mode: "path",
+          canonicalFqdn: "my-mac.tailnet-name.ts.net",
+          port: 1939,
+          funnel: false,
+          entries: [],
+        },
+        h.exposeStatePath,
+      );
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        env: {},
+        readExposeStateFn: h.readExposeStateFn,
+      });
+      expect(s.step).toBe("done");
+      expect(s.hasExposeMode).toBe(true);
+      // The setting was auto-seeded from the live exposure layer.
+      expect(getSetting(db, "setup_expose_mode")).toBe("tailnet");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("auto-seeds expose mode = public from a live public exposure", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      await createUser(db, "owner", "pw");
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              version: "0.1.0",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/health",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      writeExposeState(
+        {
+          version: 1,
+          layer: "public",
+          mode: "path",
+          canonicalFqdn: "hub.example.com",
+          port: 1939,
+          funnel: true,
+          entries: [],
+        },
+        h.exposeStatePath,
+      );
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        env: {},
+        readExposeStateFn: h.readExposeStateFn,
+      });
+      expect(s.step).toBe("done");
+      expect(s.hasExposeMode).toBe(true);
+      expect(getSetting(db, "setup_expose_mode")).toBe("public");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("still asks the expose step when no live exposure + no setting (unchanged)", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      await createUser(db, "owner", "pw");
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              version: "0.1.0",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/health",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      // No env signal, no expose-state file written (reader returns
+      // undefined), no setting → the operator still gets the expose step.
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        env: {},
+        readExposeStateFn: h.readExposeStateFn,
+      });
+      expect(s.step).toBe("expose");
+      expect(s.hasExposeMode).toBe(false);
+      expect(getSetting(db, "setup_expose_mode")).toBeUndefined();
+    } finally {
+      db.close();
+    }
+  });
+
+  test("an explicit setup_expose_mode wins over a live exposure (no clobber)", async () => {
+    // If the operator already answered the expose step (or it was seeded
+    // by a prior call), a later live-exposure read must not overwrite the
+    // recorded answer. Guards the `=== undefined` gate.
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      await createUser(db, "owner", "pw");
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              version: "0.1.0",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/health",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      setSetting(db, "setup_expose_mode", "localhost");
+      writeExposeState(
+        {
+          version: 1,
+          layer: "public",
+          mode: "path",
+          canonicalFqdn: "hub.example.com",
+          port: 1939,
+          funnel: true,
+          entries: [],
+        },
+        h.exposeStatePath,
+      );
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        env: {},
+        readExposeStateFn: h.readExposeStateFn,
+      });
+      expect(s.step).toBe("done");
+      // Recorded answer is preserved, not overwritten by the live layer.
+      expect(getSetting(db, "setup_expose_mode")).toBe("localhost");
     } finally {
       db.close();
     }
@@ -255,7 +477,11 @@ describe("deriveWizardState", () => {
         h.manifestPath,
       );
       setSetting(db, "setup_expose_mode", "localhost");
-      const s = deriveWizardState({ db, manifestPath: h.manifestPath });
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        readExposeStateFn: h.readExposeStateFn,
+      });
       expect(s.step).toBe("done");
       expect(s.hasAdmin).toBe(true);
       expect(s.hasVault).toBe(true);
@@ -283,6 +509,7 @@ describe("handleSetupGet", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -304,6 +531,7 @@ describe("handleSetupGet", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -354,6 +582,7 @@ describe("handleSetupGet", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -386,6 +615,7 @@ describe("handleSetupGet", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -434,6 +664,7 @@ describe("handleSetupGet", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -483,6 +714,7 @@ describe("handleSetupGet", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -524,6 +756,7 @@ describe("handleSetupGet", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -548,6 +781,7 @@ describe("handleSetupGet", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: reg,
       });
@@ -577,6 +811,7 @@ describe("handleSetupGet", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: reg,
       });
@@ -608,6 +843,7 @@ describe("handleSetupAccountPost", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -632,6 +868,7 @@ describe("handleSetupAccountPost", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -660,6 +897,7 @@ describe("handleSetupAccountPost", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -680,6 +918,7 @@ describe("handleSetupAccountPost", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -712,6 +951,7 @@ describe("handleSetupAccountPost", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -731,6 +971,7 @@ describe("handleSetupAccountPost", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -751,6 +992,7 @@ describe("handleSetupAccountPost", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -794,6 +1036,7 @@ describe("handleSetupVaultPost", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -815,6 +1058,7 @@ describe("handleSetupVaultPost", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -834,6 +1078,7 @@ describe("handleSetupVaultPost", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           supervisor: makeSupervisor(),
           registry: getDefaultOperationsRegistry(),
@@ -863,6 +1108,7 @@ describe("handleSetupVaultPost", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -887,6 +1133,7 @@ describe("handleSetupVaultPost", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           supervisor: makeSupervisor(),
           registry: getDefaultOperationsRegistry(),
@@ -940,6 +1187,7 @@ describe("handleSetupVaultPost", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -966,6 +1214,7 @@ describe("handleSetupVaultPost", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           supervisor: makeSupervisor(),
           registry: getDefaultOperationsRegistry(),
@@ -1009,6 +1258,7 @@ describe("handleSetupVaultPost", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -1034,6 +1284,7 @@ describe("handleSetupVaultPost", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           supervisor: makeSupervisor(),
           registry: getDefaultOperationsRegistry(),
@@ -1070,6 +1321,7 @@ describe("handleSetupVaultPost", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -1099,6 +1351,7 @@ describe("handleSetupVaultPost", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           supervisor,
           registry: getDefaultOperationsRegistry(),
@@ -1153,6 +1406,7 @@ describe("handleSetupVaultPost", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -1178,6 +1432,7 @@ describe("handleSetupVaultPost", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           supervisor: makeSupervisor(),
           registry: getDefaultOperationsRegistry(),
@@ -1432,6 +1687,7 @@ describe("handleSetupExposePost", () => {
       db,
       manifestPath: h.manifestPath,
       configDir: h.dir,
+      readExposeStateFn: h.readExposeStateFn,
       issuer: "https://hub.example",
       registry: getDefaultOperationsRegistry(),
     });
@@ -1460,6 +1716,7 @@ describe("handleSetupExposePost", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -1495,6 +1752,7 @@ describe("handleSetupExposePost", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -1533,6 +1791,7 @@ describe("handleSetupExposePost", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -1567,6 +1826,7 @@ describe("handleSetupExposePost", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -1603,6 +1863,7 @@ describe("handleSetupExposePost", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -1653,6 +1914,7 @@ describe("done screen auto-minted token (hub#272 Item A)", () => {
       db,
       manifestPath: h.manifestPath,
       configDir: h.dir,
+      readExposeStateFn: h.readExposeStateFn,
       issuer: "https://hub.example",
       registry: getDefaultOperationsRegistry(),
     });
@@ -1681,6 +1943,7 @@ describe("done screen auto-minted token (hub#272 Item A)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -1727,6 +1990,7 @@ describe("done screen auto-minted token (hub#272 Item A)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -1792,6 +2056,7 @@ describe("done screen auto-minted token (hub#272 Item A)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -1836,6 +2101,7 @@ describe("done screen auto-minted token (hub#272 Item A)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       };
@@ -1892,6 +2158,7 @@ describe("done screen auto-minted token (hub#272 Item A)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -1957,6 +2224,7 @@ describe("done screen auto-minted token (hub#272 Item A)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -2015,6 +2283,7 @@ describe("done screen auto-minted token (hub#272 Item A)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -2076,6 +2345,7 @@ describe("done screen auto-minted token (hub#272 Item A)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -2139,6 +2409,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -2204,6 +2475,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -2255,6 +2527,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: reg,
         },
@@ -2294,6 +2567,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -2317,6 +2591,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           supervisor: makeSupervisor(),
           registry: getDefaultOperationsRegistry(),
@@ -2345,6 +2620,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -2363,6 +2639,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           supervisor: makeSupervisor(),
           registry: getDefaultOperationsRegistry(),
@@ -2390,6 +2667,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           supervisor: makeSupervisor(),
           registry: getDefaultOperationsRegistry(),
@@ -2411,6 +2689,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -2429,6 +2708,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           supervisor: makeSupervisor(),
           registry: getDefaultOperationsRegistry(),
@@ -2457,6 +2737,7 @@ describe("done screen install tiles (hub#272 Item B)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -2490,6 +2771,7 @@ describe("typed vault name (hub#267)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -2532,6 +2814,7 @@ describe("typed vault name (hub#267)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           supervisor,
           registry: getDefaultOperationsRegistry(),
@@ -2565,6 +2848,7 @@ describe("typed vault name (hub#267)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -2585,6 +2869,7 @@ describe("typed vault name (hub#267)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           supervisor: makeSupervisor(),
           registry: getDefaultOperationsRegistry(),
@@ -2610,6 +2895,7 @@ describe("typed vault name (hub#267)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -2650,6 +2936,7 @@ describe("typed vault name (hub#267)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           supervisor,
           registry: getDefaultOperationsRegistry(),
@@ -2712,6 +2999,7 @@ describe("typed vault name (hub#267)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -2763,6 +3051,7 @@ describe("typed vault name (hub#267)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -2814,6 +3103,7 @@ describe("typed vault name (hub#267)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -2884,6 +3174,7 @@ describe("bootstrap token gate (handleSetupAccountPost)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -2908,6 +3199,7 @@ describe("bootstrap token gate (handleSetupAccountPost)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -2933,6 +3225,7 @@ describe("bootstrap token gate (handleSetupAccountPost)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -2954,6 +3247,7 @@ describe("bootstrap token gate (handleSetupAccountPost)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -2976,6 +3270,7 @@ describe("bootstrap token gate (handleSetupAccountPost)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -2997,6 +3292,7 @@ describe("bootstrap token gate (handleSetupAccountPost)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -3026,6 +3322,7 @@ describe("bootstrap token gate (handleSetupAccountPost)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -3047,6 +3344,7 @@ describe("bootstrap token gate (handleSetupAccountPost)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -3074,6 +3372,7 @@ describe("bootstrap token gate (handleSetupAccountPost)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -3095,6 +3394,7 @@ describe("bootstrap token gate (handleSetupAccountPost)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -3120,6 +3420,7 @@ describe("bootstrap token gate (handleSetupAccountPost)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -3140,6 +3441,7 @@ describe("bootstrap token gate (handleSetupAccountPost)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -3186,6 +3488,7 @@ describe("bootstrap token gate (handleSetupAccountPost)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -3207,6 +3510,7 @@ describe("bootstrap token gate (handleSetupAccountPost)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       };
@@ -3290,6 +3594,7 @@ describe("done screen — 'Start using your vault' tile (hub#342)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -3353,6 +3658,7 @@ describe("done screen — 'Start using your vault' tile (hub#342)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -3411,6 +3717,7 @@ describe("done screen — 'Start using your vault' tile (hub#342)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: reg,
         },
@@ -3470,6 +3777,7 @@ describe("done screen — 'Start using your vault' tile (hub#342)", () => {
           db,
           manifestPath: h.manifestPath,
           configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
           issuer: "https://hub.example",
           registry: getDefaultOperationsRegistry(),
         },
@@ -3497,6 +3805,7 @@ describe("done screen — 'Start using your vault' tile (hub#342)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
@@ -3593,6 +3902,7 @@ describe("setup-wizard JSON surface (hub#168 Cuts 2/3)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "http://127.0.0.1:1939",
         registry: getDefaultOperationsRegistry(),
       };
@@ -3618,6 +3928,7 @@ describe("setup-wizard JSON surface (hub#168 Cuts 2/3)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "http://127.0.0.1:1939",
         registry: getDefaultOperationsRegistry(),
         supervisor,
@@ -3657,7 +3968,11 @@ describe("setup-wizard JSON surface (hub#168 Cuts 2/3)", () => {
       // The skip flag is persisted.
       expect(getSetting(db, "setup_vault_skipped")).toBe("true");
       // deriveWizardState advances past the vault step.
-      const s = deriveWizardState({ db, manifestPath: h.manifestPath });
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        readExposeStateFn: h.readExposeStateFn,
+      });
       expect(s.hasVault).toBe(true);
       expect(s.step).toBe("expose");
     } finally {
@@ -3674,6 +3989,7 @@ describe("setup-wizard JSON surface (hub#168 Cuts 2/3)", () => {
         db,
         manifestPath: h.manifestPath,
         configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
         issuer: "http://127.0.0.1:1939",
         registry: getDefaultOperationsRegistry(),
         supervisor,
@@ -3767,10 +4083,10 @@ describe("setup-wizard JSON surface (hub#168 Cuts 2/3)", () => {
     let capturedBody: unknown;
     const stubFetch = (async (_: string | URL | Request, init?: RequestInit) => {
       capturedBody = JSON.parse((init?.body as string) ?? "{}");
-      return new Response(
-        JSON.stringify({ notes_imported: 1 }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ notes_imported: 1 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
     }) as typeof fetch;
 
     await postVaultImportImpl({

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -55,6 +55,7 @@ import {
   renderCsrfHiddenInput,
   verifyCsrfToken,
 } from "./csrf.ts";
+import { type ExposeState, readExposeState } from "./expose-state.ts";
 import {
   SETUP_EXPOSE_MODES,
   type SetupExposeMode,
@@ -208,12 +209,40 @@ export interface DerivedWizardState {
 export const FIRST_VAULT_SHORT: CuratedModuleShort = "vault";
 
 /**
+ * Map a live exposure layer (`expose-state.json`) onto the wizard's
+ * `setup_expose_mode`. The two enums overlap exactly on the layers the
+ * exposure file can carry: `ExposeLayer` is `tailnet | public`, both of
+ * which are valid `SetupExposeMode` values. (There's no `localhost`
+ * exposure layer — running nothing is the absence of a state file, which
+ * `readExposeState` reports as `undefined`, so a missing/unexposed hub
+ * never seeds and the wizard still asks.)
+ *
+ * Returns `undefined` when no exposure is live (or the reader throws on
+ * a malformed file — we swallow that and fall through to "still ask"
+ * rather than crashing the wizard GET).
+ */
+function exposeModeFromLiveState(read: () => ExposeState | undefined): SetupExposeMode | undefined {
+  let state: ExposeState | undefined;
+  try {
+    state = read();
+  } catch {
+    // A corrupt expose-state.json shouldn't brick the wizard. Treat it
+    // as "no live exposure" and let the operator answer the step.
+    return undefined;
+  }
+  if (!state) return undefined;
+  // `ExposeLayer` ⊆ `SetupExposeMode` ("tailnet" | "public").
+  return state.layer;
+}
+
+/**
  * Read DB + services.json to decide which step the wizard should render.
  * Idempotent — re-running after partial setup picks up where it left
  * off. Mostly read-only, with one specific write: on Render (or any
- * platform `detectAutoExposeMode` recognizes), the first call auto-
- * seeds `setup_expose_mode = "public"` so the wizard skips the expose
- * step. Subsequent calls find the setting present and are read-only.
+ * platform `detectAutoExposeMode` recognizes), OR when a live tailscale
+ * exposure (`expose-state.json`) is already up, the first call auto-
+ * seeds `setup_expose_mode` so the wizard skips the expose step.
+ * Subsequent calls find the setting present and are read-only.
  */
 export function deriveWizardState(deps: {
   db: Database;
@@ -224,6 +253,15 @@ export function deriveWizardState(deps: {
    * SetupWizardDeps.env.
    */
   env?: Record<string, string | undefined>;
+  /**
+   * Optional injected reader for the live exposure state
+   * (`~/.parachute/expose-state.json`). Defaults to the real
+   * `readExposeState`. Mirrors the `init.ts` seam (`readExposeStateFn`)
+   * so tests can drive the "a tailnet layer is already live" branch
+   * without writing a real state file. When `setup_expose_mode` is
+   * unset, the live exposure layer auto-seeds the setting (see below).
+   */
+  readExposeStateFn?: () => ExposeState | undefined;
 }): DerivedWizardState {
   const hasAdmin = userCount(deps.db) > 0;
   // The wizard's first-vault provisioning uses the curated `vault` short,
@@ -251,6 +289,23 @@ export function deriveWizardState(deps: {
     detectAutoExposeMode(deps.env ?? process.env) === "public"
   ) {
     setSetting(deps.db, "setup_expose_mode", "public");
+  }
+  // hub#406 team-onboarding bug: `setup_expose_mode` (the wizard's
+  // answer) and `expose-state.json` (the live tailscale exposure) are
+  // orthogonal axes. An operator who ran `parachute expose tailnet`
+  // before opening the wizard has a live tailnet layer but no
+  // `setup_expose_mode` setting — so the wizard re-asked "how will this
+  // hub be reached?" even though tailnet was already up. Auto-seed the
+  // setting from the live exposure layer (tailnet→"tailnet",
+  // public→"public") so the answered-by-action case is treated as
+  // satisfied, mirroring the Render/Fly auto-seed above. Reading the
+  // live state is injected for testability (defaults to the real
+  // reader); a malformed/missing file falls through to "still ask."
+  if (getSetting(deps.db, "setup_expose_mode") === undefined) {
+    const seeded = exposeModeFromLiveState(deps.readExposeStateFn ?? readExposeState);
+    if (seeded !== undefined) {
+      setSetting(deps.db, "setup_expose_mode", seeded);
+    }
   }
   const hasExposeMode = getSetting(deps.db, "setup_expose_mode") !== undefined;
   let step: WizardStep;
@@ -314,6 +369,14 @@ export interface SetupWizardDeps {
    * without mutating the real process env.
    */
   env?: Record<string, string | undefined>;
+  /**
+   * Test seam: inject the live-exposure reader `deriveWizardState`
+   * consults to auto-seed `setup_expose_mode` from a live
+   * `parachute expose tailnet|public` (hub#406). Production omits this
+   * and the real `readExposeState` is used. Mirrors `init.ts`'s
+   * `readExposeStateFn` seam.
+   */
+  readExposeStateFn?: () => ExposeState | undefined;
 }
 
 /**

--- a/web/ui/src/routes/NewVault.test.tsx
+++ b/web/ui/src/routes/NewVault.test.tsx
@@ -31,11 +31,17 @@ afterEach(() => {
 });
 
 function renderForm() {
+  // Register the REAL post-create navigation target. The SPA has no
+  // per-vault detail route (App.tsx: /, /vaults, /vaults/new, …), so the
+  // "Done" / "Continue" affordances land on /vaults. The prior fixture
+  // registered a fabricated `/:name` route that doesn't exist in
+  // production — which masked the 404-after-create bug team onboarding
+  // hit. We mount /vaults here so the test exercises the real target.
   return render(
-    <MemoryRouter initialEntries={["/new"]}>
+    <MemoryRouter initialEntries={["/vaults/new"]}>
       <Routes>
-        <Route path="/new" element={<NewVault />} />
-        <Route path="/:name" element={<div>detail</div>} />
+        <Route path="/vaults/new" element={<NewVault />} />
+        <Route path="/vaults" element={<div>vaults list</div>} />
       </Routes>
     </MemoryRouter>,
   );
@@ -91,6 +97,11 @@ describe("NewVault", () => {
     expect(screen.getByText("pvt_abc123secret")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /done/i })).toBeInTheDocument();
     expect(screen.getByText(/vault\.db/)).toBeInTheDocument();
+
+    // "Done — I've saved the token" must land on the vaults list, NOT a
+    // non-existent `/${name}` detail route (which 404'd in production).
+    await user.click(screen.getByRole("button", { name: /done/i }));
+    await waitFor(() => expect(screen.getByText("vaults list")).toBeInTheDocument());
   });
 
   it("renders the no-token branch on idempotent re-POST (200)", async () => {
@@ -106,6 +117,11 @@ describe("NewVault", () => {
 
     await waitFor(() => expect(screen.getByText(/already existed/i)).toBeInTheDocument());
     expect(screen.queryByText(/shown once/i)).not.toBeInTheDocument();
+
+    // The idempotent-200 "Continue" link points at the real vaults list
+    // route too (same 404 bug, second site).
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+    await waitFor(() => expect(screen.getByText("vaults list")).toBeInTheDocument());
   });
 
   it("surfaces the API error_description on failure", async () => {

--- a/web/ui/src/routes/NewVault.tsx
+++ b/web/ui/src/routes/NewVault.tsx
@@ -70,12 +70,13 @@ export function NewVault() {
   };
 
   if (state.kind === "created") {
-    return (
-      <CreatedView
-        result={state.result}
-        onDone={() => navigate(`/${encodeURIComponent(state.result.name)}`)}
-      />
-    );
+    // Dismiss → vaults list. There is no per-vault detail route in the
+    // SPA (App.tsx routes are /, /vaults, /vaults/new, /modules, …); the
+    // old `/${name}` target resolved to e.g. `/work` and fell through to
+    // the catch-all "404 — back to vaults". `/vaults` is the real,
+    // existing post-create landing surface. Caught during team onboarding
+    // — "Done — I've saved the token" 404'd after every vault create.
+    return <CreatedView result={state.result} onDone={() => navigate("/vaults")} />;
   }
 
   return (
@@ -182,7 +183,9 @@ function CreatedView({
             <code>parachute-vault mint-token</code>.
           </p>
           <div className="actions">
-            <Link to={`/${encodeURIComponent(result.name)}`}>
+            {/* No per-vault detail route exists — land on the vaults list
+                (same fix as the 201 "Done" path above). */}
+            <Link to="/vaults">
               <button type="button">Continue</button>
             </Link>
           </div>


### PR DESCRIPTION
Two setup-flow UX bugs, both hit during real team onboarding.

## Bug 1 — Admin SPA "Done" after vault-create → 404

**Symptom:** after creating a vault, clicking "Done — I've saved the token" 404s.

**Root cause:** `web/ui/src/routes/NewVault.tsx` `onDone` navigated to `/${result.name}` (e.g. `/jon`). The admin SPA has **no per-vault detail route** — `App.tsx`'s route table is `/`, `/vaults`, `/vaults/new`, `/modules`, `/modules/:short/config`, `/users`, `/permissions`, `/tokens`, `/settings`, `/approve-client/:clientId`, and a catch-all `*` → "404 — back to vaults". So `/jon` fell through to the catch-all 404. Same bug on the idempotent-200 "Continue" `Link`.

The bug shipped green because `NewVault.test.tsx` **fabricated** a `/:name` route in its `MemoryRouter` fixture — a route that doesn't exist in production — so the test navigated successfully against a non-existent target.

**Fix:** both `onDone` and the idempotent-200 `Link` now target `/vaults` (the real, existing post-create landing surface, confirmed against `App.tsx`). The test fixture now registers the **real** `/vaults` route (no fabricated `/:name`), and the 201-token "Done" and 200-idempotent "Continue" tests click through and assert they land on the vaults list — exercising the real navigation target.

## Bug 2 — Setup wizard re-asks expose despite a live `parachute expose tailnet`

**Symptom:** after running `parachute expose tailnet`, the dashboard setup wizard still renders the expose step asking which mode to use.

**Root cause:** `deriveWizardState` (`src/setup-wizard.ts`) computed `hasExposeMode` solely from the `setup_expose_mode` hub_setting and never read the live `expose-state.json`. `parachute expose tailnet` writes `expose-state.json` (layer=tailnet) but never the setting — they're orthogonal axes — so the wizard re-rendered the expose step though tailnet was already live.

**Fix:** in `deriveWizardState`, when `setup_expose_mode` is undefined, read the live exposure layer via `readExposeState()` and auto-seed `setup_expose_mode` from it (tailnet→`"tailnet"`, public→`"public"`), mirroring the existing `detectAutoExposeMode` Render/Fly auto-seed path. The reader is threaded as an **optional injected dep** (defaults to the real `readExposeState`), matching the `init.ts` `readExposeStateFn` pattern. A malformed/missing file falls through to "still ask."

## Tests

- **Bug 1** (`web/ui` vitest): `NewVault.test.tsx` exercises the real `/vaults` target (no fabricated route); "Done" and "Continue" both assert landing on the vaults list.
- **Bug 2** (`src/__tests__/setup-wizard.test.ts`): live tailnet/public exposure auto-seeds the setting + advances to `done` (no expose re-render); no-exposure + no-setting still asks (unchanged); explicit setting not clobbered by a live layer. The test harness gained a hermetic expose-state reader scoped to its tmp dir so wizard tests don't read the developer's real `~/.parachute/expose-state.json` (same isolation the harness already gives DB + manifest).

### Gate counts
- `bun test ./src`: **2379 pass, 1 skip, 0 fail**
- `web/ui` vitest: **227 pass** (15 files)
- `bun run typecheck` (hub): clean
- `web/ui` typecheck: clean
- `web/ui` build + verify-base: ✓ (`dist/index.html` references `/admin/`-prefixed assets)

No rc bump (per instructions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)