### PR TITLE
feat(hub): per-vault "MCP connection" card in admin UI (connect snippet for every vault; closes create-token confusion + starter-prompt dead-end)

### DIFF
--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -2063,10 +2063,14 @@ describe("done screen auto-minted token (hub#272 Item A)", () => {
       );
       const html = await res.text();
       expect(html).toContain("claude mcp add --transport http parachute-default");
-      // The fallback explanatory text mentions `pvt_...` as a placeholder
-      // but the actual `--header` flag must NOT be appended to the
-      // command line itself.
-      expect(html).toContain("Bearer pvt_");
+      // The fallback explanatory text leads with the OAuth path (no token
+      // needed) and, for headless clients, references a hub JWT placeholder
+      // — NOT the retired `pvt_*` format (gap #4). The `--header` flag must
+      // also NOT be appended to the command line itself.
+      expect(html).toContain("browser OAuth");
+      expect(html).toContain("Bearer &lt;token&gt;");
+      expect(html).not.toContain("pvt_");
+      expect(html).toContain("parachute auth mint-token");
       expect(html).toContain("/admin/tokens");
       // Specifically no Copy button — that's a token-present surface.
       expect(html).not.toContain('id="mcp-cmd"');

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -1295,9 +1295,12 @@ function renderMcpTile(
     <h2>Connect Claude Code (MCP)</h2>
     <p>Wire <code>vault:${safeVault}</code> into Claude Code as an MCP server:</p>
     <pre>${escapeHtml(bareCmd)}</pre>
-    <p class="fine">Mint an operator token at
-      <a href="/admin/tokens"><code>/admin/tokens</code></a> and append
-      <code>--header "Authorization: Bearer pvt_..."</code> on first use.</p>
+    <p class="fine">No token needed — the command triggers browser OAuth on
+      first use (you sign in to this hub and approve access). For headless
+      clients that can't do the browser flow, mint a hub token at
+      <a href="/admin/tokens"><code>/admin/tokens</code></a> (or with
+      <code>parachute auth mint-token</code>) and append
+      <code>--header "Authorization: Bearer &lt;token&gt;"</code>.</p>
   </div>`;
 }
 

--- a/web/ui/src/components/McpConnectCard.test.tsx
+++ b/web/ui/src/components/McpConnectCard.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * McpConnectCard tests — the per-vault "MCP connection" surface.
+ *
+ * Covers:
+ *   - the pure command/endpoint builders (the load-bearing strings the
+ *     operator pastes into a terminal);
+ *   - the rendered card showing the correct `/vault/<name>/mcp` endpoint +
+ *     the `claude mcp add` OAuth command for a given vault name + hub origin;
+ *   - the Copy affordance writing the real command to the clipboard;
+ *   - the optional header-auth mint path going through the hub-JWT chain
+ *     (`mintToken` with a `vault:<name>:read vault:<name>:write` scope) and
+ *     rendering the `--header "Authorization: Bearer <jwt>"` variant once.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import {
+  McpConnectCard,
+  claudeMcpAddCommand,
+  claudeMcpAddCommandWithToken,
+  mcpEndpointFor,
+} from "./McpConnectCard.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    mintToken: vi.fn(),
+  };
+});
+
+let writeText: ReturnType<typeof vi.fn<(text: string) => Promise<void>>>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("command builders", () => {
+  it("derives the MCP endpoint from the vault URL, stripping a trailing slash", () => {
+    expect(mcpEndpointFor("https://hub.example.ts.net/vault/work")).toBe(
+      "https://hub.example.ts.net/vault/work/mcp",
+    );
+    expect(mcpEndpointFor("https://hub.example.ts.net/vault/work/")).toBe(
+      "https://hub.example.ts.net/vault/work/mcp",
+    );
+  });
+
+  it("builds the OAuth `claude mcp add` command with no token", () => {
+    expect(claudeMcpAddCommand("work", "https://hub.example.ts.net/vault/work")).toBe(
+      "claude mcp add --transport http parachute-work https://hub.example.ts.net/vault/work/mcp",
+    );
+  });
+
+  it("builds the header-auth variant with the Bearer token appended", () => {
+    expect(
+      claudeMcpAddCommandWithToken("work", "https://hub.example.ts.net/vault/work", "jwt-abc"),
+    ).toBe(
+      'claude mcp add --transport http parachute-work https://hub.example.ts.net/vault/work/mcp --header "Authorization: Bearer jwt-abc"',
+    );
+  });
+});
+
+describe("McpConnectCard", () => {
+  const VAULT_URL = "https://hub.example.ts.net/vault/work";
+
+  it("renders the correct /vault/<name>/mcp endpoint for the given vault + hub origin", () => {
+    render(<McpConnectCard vaultName="work" vaultUrl={VAULT_URL} />);
+    expect(screen.getByTestId("mcp-endpoint")).toHaveTextContent(
+      "https://hub.example.ts.net/vault/work/mcp",
+    );
+  });
+
+  it("renders the `claude mcp add` OAuth command (no token in the command)", () => {
+    render(<McpConnectCard vaultName="work" vaultUrl={VAULT_URL} />);
+    const cmd = screen.getByTestId("mcp-add-command");
+    expect(cmd).toHaveTextContent(
+      "claude mcp add --transport http parachute-work https://hub.example.ts.net/vault/work/mcp",
+    );
+    // The default command carries NO bearer header — OAuth is the path.
+    expect(cmd.textContent).not.toContain("Authorization");
+  });
+
+  it("copies the real command to the clipboard via the Copy button", async () => {
+    render(<McpConnectCard vaultName="work" vaultUrl={VAULT_URL} />);
+    // The command's own Copy button (second copy button — endpoint is first).
+    const copyButtons = screen.getAllByRole("button", { name: /^copy$/i });
+    fireEvent.click(copyButtons[1]);
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        "claude mcp add --transport http parachute-work https://hub.example.ts.net/vault/work/mcp",
+      ),
+    );
+  });
+
+  it("mints a read+write hub JWT via the tokens chain and shows the header-auth command once", async () => {
+    vi.mocked(api.mintToken).mockResolvedValue({
+      jti: "jti-1",
+      token: "jwt-headerauth",
+      expires_at: "2026-09-01T00:00:00.000Z",
+      scope: "vault:work:read vault:work:write",
+    });
+    render(<McpConnectCard vaultName="work" vaultUrl={VAULT_URL} />);
+
+    // Open the optional token path + mint.
+    fireEvent.click(screen.getByText(/use a token instead/i));
+    fireEvent.click(screen.getByRole("button", { name: /mint a token/i }));
+
+    // Mint goes through the hub-JWT chain with a vault:read+write scope —
+    // NOT admin.
+    await waitFor(() =>
+      expect(api.mintToken).toHaveBeenCalledWith({
+        scope: "vault:work:read vault:work:write",
+      }),
+    );
+
+    // The header-auth command renders once with the minted JWT in the header.
+    const headerCmd = await screen.findByTestId("mcp-header-command");
+    expect(headerCmd).toHaveTextContent(
+      'claude mcp add --transport http parachute-work https://hub.example.ts.net/vault/work/mcp --header "Authorization: Bearer jwt-headerauth"',
+    );
+  });
+
+  it("surfaces a mint error inline without showing the header command", async () => {
+    vi.mocked(api.mintToken).mockRejectedValue(new api.HttpError(403, "scope not permitted"));
+    render(<McpConnectCard vaultName="work" vaultUrl={VAULT_URL} />);
+
+    fireEvent.click(screen.getByText(/use a token instead/i));
+    fireEvent.click(screen.getByRole("button", { name: /mint a token/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/mint failed \(403\): scope not permitted/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("mcp-header-command")).toBeNull();
+  });
+
+  it("links to the full connect docs", () => {
+    render(<McpConnectCard vaultName="work" vaultUrl={VAULT_URL} />);
+    expect(screen.getByRole("link", { name: /full connect docs/i })).toHaveAttribute(
+      "href",
+      "https://parachute.computer/install#connect-mcp-clients",
+    );
+  });
+});

--- a/web/ui/src/components/McpConnectCard.tsx
+++ b/web/ui/src/components/McpConnectCard.tsx
@@ -1,0 +1,249 @@
+/**
+ * Per-vault "MCP connection" card.
+ *
+ * The canonical in-product affordance for "how do I connect an MCP client
+ * (Claude Code, Claude.ai, …) to THIS vault?" — surfaced on every vault,
+ * any time, not just on the first-boot wizard's done screen.
+ *
+ * It's the SPA twin of the server-rendered `renderMcpTile` in
+ * `src/setup-wizard.ts` — same command shape, same OAuth-first framing,
+ * same one-time-reveal posture for the optional header-auth token. Two
+ * mount points consume it:
+ *
+ *   1. The Vaults list — a per-row "Connect" toggle (VaultsList.tsx).
+ *   2. The NewVault created-view — replaces the bare "here's your token"
+ *      display so the freshly-minted token has a clear, in-context purpose
+ *      (NewVault.tsx CreatedView).
+ *
+ * Why two auth paths, OAuth-first:
+ *   - **OAuth (default).** `claude mcp add --transport http …` with NO
+ *     token in the command. On first use the client opens a browser, the
+ *     operator signs in to the hub + approves the scope, and the client
+ *     caches its own OAuth tokens. This is the path we lead with — nothing
+ *     secret ends up pasted into a shell history.
+ *   - **Header auth (secondary, optional).** For clients that can't do the
+ *     browser OAuth dance (headless / CI / some hosted clients), mint a
+ *     scope-narrow hub JWT (`vault:<name>:read vault:<name>:write`, NOT
+ *     admin) via the existing tokens-page mint chain and append
+ *     `--header "Authorization: Bearer <jwt>"`. Shown once, copy-only,
+ *     never persisted — same posture as the Tokens page mint banner.
+ *
+ * Origin source: the MCP endpoint is derived from the vault's own
+ * well-known `url` (which the hub publishes as `<canonical-origin>/vault/
+ * <name>` — see src/well-known.ts), so the card never has to re-resolve
+ * the hub origin and never hardcodes the :1940 vault loopback. We just
+ * append `/mcp` to the vault URL.
+ */
+import { useState } from "react";
+import { HttpError, type MintedToken, mintToken } from "../lib/api.ts";
+
+const CONNECT_DOCS_URL = "https://parachute.computer/install#connect-mcp-clients";
+
+/**
+ * Build `<hub-origin>/vault/<name>/mcp` from the vault's published URL.
+ * `vaultUrl` is the well-known `url` field — already origin-absolute and
+ * pointing at the vault's mount (`<origin>/vault/<name>`, possibly with a
+ * trailing slash). Strip any trailing slash before appending `/mcp` so we
+ * never emit `…/vault/work//mcp`.
+ *
+ * Exported for direct unit testing.
+ */
+export function mcpEndpointFor(vaultUrl: string): string {
+  return `${vaultUrl.replace(/\/+$/, "")}/mcp`;
+}
+
+/**
+ * The OAuth-path `claude mcp add` command — no token, triggers browser
+ * OAuth on first use. The server name is `parachute-<vault>` to match the
+ * wizard's `renderMcpTile`. Exported for direct unit testing.
+ */
+export function claudeMcpAddCommand(vaultName: string, vaultUrl: string): string {
+  return `claude mcp add --transport http parachute-${vaultName} ${mcpEndpointFor(vaultUrl)}`;
+}
+
+/**
+ * Header-auth variant of the command, for clients that can't do browser
+ * OAuth. Appends the Bearer header carrying a freshly-minted hub JWT.
+ * Exported for direct unit testing.
+ */
+export function claudeMcpAddCommandWithToken(
+  vaultName: string,
+  vaultUrl: string,
+  token: string,
+): string {
+  return `${claudeMcpAddCommand(vaultName, vaultUrl)} --header "Authorization: Bearer ${token}"`;
+}
+
+type MintState =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "minted"; token: MintedToken }
+  | { kind: "error"; message: string };
+
+interface McpConnectCardProps {
+  /** Vault short name — drives the server name + scope. */
+  vaultName: string;
+  /**
+   * Vault's published URL (`<hub-origin>/vault/<name>`), from the
+   * well-known doc / create response. The MCP endpoint is this + `/mcp`.
+   */
+  vaultUrl: string;
+  /**
+   * Render without the outer `.mcp-connect-card` chrome — used inside the
+   * NewVault created-view where the card already sits in a surrounding
+   * banner. Defaults to false (standalone card with its own border).
+   */
+  embedded?: boolean;
+}
+
+/**
+ * Copy-to-clipboard button that flips its label to "Copied ✓" for 2s.
+ * Mirrors the Tokens page / wizard copy affordance. Clipboard can be
+ * unavailable in insecure contexts; we no-op gracefully (the command is
+ * still selectable in the codebox).
+ */
+function CopyButton({ value, label = "Copy" }: { value: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      className="secondary"
+      onClick={() => {
+        if (typeof navigator === "undefined" || !navigator.clipboard) return;
+        void navigator.clipboard.writeText(value).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        });
+      }}
+    >
+      {copied ? "Copied ✓" : label}
+    </button>
+  );
+}
+
+export function McpConnectCard({ vaultName, vaultUrl, embedded = false }: McpConnectCardProps) {
+  const endpoint = mcpEndpointFor(vaultUrl);
+  const oauthCmd = claudeMcpAddCommand(vaultName, vaultUrl);
+
+  const [showTokenPath, setShowTokenPath] = useState(false);
+  const [mint, setMint] = useState<MintState>({ kind: "idle" });
+
+  async function onMintHeaderToken(): Promise<void> {
+    if (mint.kind === "submitting") return;
+    setMint({ kind: "submitting" });
+    try {
+      // Read+write, NOT admin — the header-auth path is for MCP clients
+      // reading and writing vault data, not for vault administration.
+      // Goes through the same operator-mint chain the Tokens page uses
+      // (host-admin Bearer → POST /api/auth/mint-token), so it lands in
+      // the registry and is revocable like any other token.
+      const minted = await mintToken({
+        scope: `vault:${vaultName}:read vault:${vaultName}:write`,
+      });
+      setMint({ kind: "minted", token: minted });
+    } catch (err) {
+      const message =
+        err instanceof HttpError
+          ? `mint failed (${err.status}): ${err.message}`
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      setMint({ kind: "error", message });
+    }
+  }
+
+  const headerCmd =
+    mint.kind === "minted"
+      ? claudeMcpAddCommandWithToken(vaultName, vaultUrl, mint.token.token)
+      : null;
+
+  const inner = (
+    <>
+      <h3>Connect an MCP client</h3>
+      <p className="muted">
+        Connect an MCP client — Claude Code, Claude.ai, etc. — to the <code>{vaultName}</code>{" "}
+        vault. The client signs in to this hub and reads/writes vault data over MCP.
+      </p>
+
+      <div className="mcp-field">
+        <span className="mcp-field-label">Endpoint</span>
+        <div className="token-box">
+          <code data-testid="mcp-endpoint">{endpoint}</code>
+          <CopyButton value={endpoint} />
+        </div>
+      </div>
+
+      <div className="mcp-field">
+        <span className="mcp-field-label">Claude Code</span>
+        <div className="token-box">
+          <code data-testid="mcp-add-command">{oauthCmd}</code>
+          <CopyButton value={oauthCmd} />
+        </div>
+        <p className="dim">
+          No token needed — the command triggers browser OAuth on first use (you sign in to this hub
+          and approve access). For other clients, point them at the endpoint above.
+        </p>
+      </div>
+
+      <details
+        className="mcp-token-path"
+        open={showTokenPath}
+        onToggle={(e) => setShowTokenPath((e.currentTarget as HTMLDetailsElement).open)}
+      >
+        <summary>Use a token instead (headless / CI clients)</summary>
+        <p className="dim">
+          For clients that can't do browser OAuth, mint a scope-narrow hub token (
+          <code>
+            vault:{vaultName}:read vault:{vaultName}:write
+          </code>{" "}
+          — not admin) and pass it as a header. Revealed once; copy it now.
+        </p>
+
+        {mint.kind === "minted" && headerCmd ? (
+          <div className="mint-banner" data-testid="mcp-header-banner">
+            <h3>Token minted</h3>
+            <p className="muted">
+              This is the only time the hub shows this token. Copy the command below — it embeds the
+              live token in the <code>Authorization</code> header.
+            </p>
+            <div className="token-box">
+              <code data-testid="mcp-header-command">{headerCmd}</code>
+              <CopyButton value={headerCmd} />
+            </div>
+            <p className="warn">
+              ⚠ Manage and revoke this token at <code>/admin/tokens</code>.
+            </p>
+          </div>
+        ) : (
+          <div className="actions">
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => {
+                void onMintHeaderToken();
+              }}
+              disabled={mint.kind === "submitting"}
+            >
+              {mint.kind === "submitting" ? "Minting…" : "Mint a token"}
+            </button>
+          </div>
+        )}
+
+        {mint.kind === "error" ? (
+          <div className="error-banner" style={{ marginTop: "0.5rem" }}>
+            <code>{mint.message}</code>
+          </div>
+        ) : null}
+      </details>
+
+      <p className="dim mcp-docs-link">
+        <a href={CONNECT_DOCS_URL} target="_blank" rel="noreferrer">
+          Full connect docs →
+        </a>
+      </p>
+    </>
+  );
+
+  if (embedded) return <div className="mcp-connect-card mcp-connect-card-embedded">{inner}</div>;
+  return <div className="mcp-connect-card">{inner}</div>;
+}

--- a/web/ui/src/routes/NewVault.test.tsx
+++ b/web/ui/src/routes/NewVault.test.tsx
@@ -98,6 +98,14 @@ describe("NewVault", () => {
     expect(screen.getByRole("button", { name: /done/i })).toBeInTheDocument();
     expect(screen.getByText(/vault\.db/)).toBeInTheDocument();
 
+    // The created-view also surfaces the per-vault MCP connect card so the
+    // freshly-minted token has a clear purpose (team-onboarding gap #1).
+    // The card derives its endpoint from the created vault's URL.
+    expect(screen.getByTestId("mcp-endpoint")).toHaveTextContent("http://hub.local/vault/work/mcp");
+    expect(screen.getByTestId("mcp-add-command")).toHaveTextContent(
+      "claude mcp add --transport http parachute-work http://hub.local/vault/work/mcp",
+    );
+
     // "Done — I've saved the token" must land on the vaults list, NOT a
     // non-existent `/${name}` detail route (which 404'd in production).
     await user.click(screen.getByRole("button", { name: /done/i }));

--- a/web/ui/src/routes/NewVault.tsx
+++ b/web/ui/src/routes/NewVault.tsx
@@ -6,11 +6,15 @@
  *      "list" reserved) client-side so the operator gets immediate
  *      feedback, but the server is still authoritative — see admin-
  *      vaults.ts for the canonical list.
- *   2. Result: on 201 with `token`, render the single-emit `pvt_*`
- *      banner with copy + a "Done" dismiss. The token is shown ONCE,
- *      ever — refreshing the page or navigating away loses it; the hub
- *      can't re-emit it. We block navigation away while the banner is
- *      live so an accidental Back doesn't strand the operator.
+ *   2. Result: on 201 with `token`, render the single-emit token banner
+ *      with copy + a "Done" dismiss. The token is shown ONCE, ever —
+ *      refreshing the page or navigating away loses it; the hub can't
+ *      re-emit it. We block navigation away while the banner is live so
+ *      an accidental Back doesn't strand the operator. Below the token
+ *      banner, the created-view renders the per-vault MCP connect card
+ *      (the same `<McpConnectCard>` the Vaults list uses) so the bare
+ *      token has a clear, in-context purpose — closing the team-onboarding
+ *      gap where a freshly-minted token arrived with no stated use.
  *
  * 200 (idempotent re-POST against an existing vault) is treated as
  * success but renders without a token banner — there's nothing to copy
@@ -18,6 +22,7 @@
  */
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { McpConnectCard } from "../components/McpConnectCard.tsx";
 import { type CreateVaultResult, HttpError, createVault } from "../lib/api.ts";
 
 const VAULT_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
@@ -191,6 +196,14 @@ function CreatedView({
           </div>
         </div>
       )}
+
+      {/* The per-vault MCP connect card — same component the Vaults list
+          renders. Gives the freshly-minted token a clear purpose and
+          surfaces the OAuth-first connect snippet right where the operator
+          lands after creating a vault (team-onboarding gap #1). */}
+      <div className="section">
+        <McpConnectCard vaultName={result.name} vaultUrl={result.url} />
+      </div>
 
       <div className="kv section">
         <div>Name</div>

--- a/web/ui/src/routes/VaultsList.test.tsx
+++ b/web/ui/src/routes/VaultsList.test.tsx
@@ -186,6 +186,39 @@ describe("VaultsList", () => {
     );
   });
 
+  it("toggles a per-row MCP connect card showing the /vault/<name>/mcp endpoint + command", async () => {
+    vi.mocked(api.listVaults).mockResolvedValue({
+      moduleInstalled: true,
+      vaults: [
+        {
+          name: "work",
+          url: "https://hub.example.ts.net/vault/work",
+          version: "0.5.1",
+          path: "/vault/work",
+          managementUrl: "/admin",
+        },
+      ],
+    });
+    renderList();
+    const connectBtn = await screen.findByRole("button", {
+      name: /connect an mcp client to vault work/i,
+    });
+    // Card is collapsed until the operator clicks Connect.
+    expect(screen.queryByTestId("mcp-endpoint")).toBeNull();
+    fireEvent.click(connectBtn);
+
+    expect(screen.getByTestId("mcp-endpoint")).toHaveTextContent(
+      "https://hub.example.ts.net/vault/work/mcp",
+    );
+    expect(screen.getByTestId("mcp-add-command")).toHaveTextContent(
+      "claude mcp add --transport http parachute-work https://hub.example.ts.net/vault/work/mcp",
+    );
+
+    // Clicking again collapses it.
+    fireEvent.click(screen.getByRole("button", { name: /connect an mcp client to vault work/i }));
+    expect(screen.queryByTestId("mcp-endpoint")).toBeNull();
+  });
+
   it("surfaces a per-row error banner when the mint fails (no redirect)", async () => {
     vi.mocked(api.listVaults).mockResolvedValue({
       moduleInstalled: true,

--- a/web/ui/src/routes/VaultsList.tsx
+++ b/web/ui/src/routes/VaultsList.tsx
@@ -10,6 +10,7 @@
  */
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { McpConnectCard } from "../components/McpConnectCard.tsx";
 import {
   HttpError,
   type VaultListing,
@@ -37,6 +38,9 @@ export function VaultsList() {
   const [state, setState] = useState<State>({ kind: "loading" });
   const [reload, setReload] = useState(0);
   const [manage, setManage] = useState<ManageState>({ kind: "idle" });
+  // Which row's MCP-connect card is expanded. Single-open: clicking
+  // Connect on another row swaps the open card rather than stacking them.
+  const [connectFor, setConnectFor] = useState<string | null>(null);
 
   async function onManage(vault: VaultListing): Promise<void> {
     if (!vault.managementUrl) return;
@@ -174,43 +178,58 @@ export function VaultsList() {
           {state.vaults.map((v) => {
             const isMinting = manage.kind === "minting" && manage.name === v.name;
             const rowError = manage.kind === "error" && manage.name === v.name ? manage : null;
+            const isConnectOpen = connectFor === v.name;
             return (
-              <div key={v.name} className="vault-row">
-                <div className="body">
-                  <div className="name">
-                    <code>{v.name}</code>
-                    <span className="tag muted" title="Vault version">
-                      v{v.version}
-                    </span>
-                  </div>
-                  <div className="dim url">
-                    <code>{v.url}</code>
-                  </div>
-                  {rowError ? (
-                    <div className="error-banner" style={{ marginTop: "0.5rem" }}>
-                      <code>{rowError.message}</code>
+              <div key={v.name} className="vault-row-group">
+                <div className="vault-row">
+                  <div className="body">
+                    <div className="name">
+                      <code>{v.name}</code>
+                      <span className="tag muted" title="Vault version">
+                        v{v.version}
+                      </span>
                     </div>
-                  ) : null}
+                    <div className="dim url">
+                      <code>{v.url}</code>
+                    </div>
+                    {rowError ? (
+                      <div className="error-banner" style={{ marginTop: "0.5rem" }}>
+                        <code>{rowError.message}</code>
+                      </div>
+                    ) : null}
+                  </div>
+                  <div className="vault-row-actions">
+                    <button
+                      type="button"
+                      className={isConnectOpen ? undefined : "secondary"}
+                      aria-expanded={isConnectOpen}
+                      aria-label={`Connect an MCP client to vault ${v.name}`}
+                      onClick={() => setConnectFor((cur) => (cur === v.name ? null : v.name))}
+                    >
+                      {isConnectOpen ? "Hide connect" : "Connect"}
+                    </button>
+                    {v.managementUrl ? (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void onManage(v);
+                        }}
+                        disabled={isMinting}
+                        aria-label={`Manage vault ${v.name}`}
+                      >
+                        {isMinting ? "Opening…" : "Manage"}
+                      </button>
+                    ) : (
+                      <span
+                        className="muted"
+                        title="This vault has no admin SPA — manage with parachute-vault on the host."
+                      >
+                        CLI only
+                      </span>
+                    )}
+                  </div>
                 </div>
-                {v.managementUrl ? (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      void onManage(v);
-                    }}
-                    disabled={isMinting}
-                    aria-label={`Manage vault ${v.name}`}
-                  >
-                    {isMinting ? "Opening…" : "Manage"}
-                  </button>
-                ) : (
-                  <span
-                    className="muted"
-                    title="This vault has no admin SPA — manage with parachute-vault on the host."
-                  >
-                    CLI only
-                  </span>
-                )}
+                {isConnectOpen ? <McpConnectCard vaultName={v.name} vaultUrl={v.url} /> : null}
               </div>
             );
           })}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -532,6 +532,94 @@ h2 {
   color: var(--fg-dim);
   font-size: 1.2rem;
 }
+/* Groups a vault row with its (optionally expanded) MCP-connect card so
+ * the card reads as belonging to the row above it. */
+.vault-row-group {
+  margin-bottom: 0.5rem;
+}
+.vault-row-group .vault-row {
+  margin-bottom: 0;
+}
+.vault-row-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+/*
+ * Per-vault "MCP connection" card (the SPA twin of setup-wizard.ts
+ * renderMcpTile). Surfaced inline under a vault row (Vaults list) and
+ * inside the NewVault created-view. The endpoint + command codeboxes
+ * reuse the `.token-box` shape from the mint banner so copy affordances
+ * read consistently across the SPA.
+ */
+.mcp-connect-card {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1.1rem 1.25rem;
+  margin: 0 0 0.5rem;
+}
+.mcp-connect-card-embedded {
+  background: white;
+  margin-bottom: 0;
+}
+.mcp-connect-card h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1rem;
+}
+.mcp-connect-card > p {
+  margin-top: 0;
+}
+.mcp-connect-card .token-box {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.35rem 0 0.25rem;
+}
+.mcp-connect-card .token-box code {
+  flex: 1;
+  font-size: 0.85rem;
+  padding: 0.55rem 0.7rem;
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  word-break: break-all;
+  user-select: all;
+}
+.mcp-field {
+  margin-top: 0.9rem;
+}
+.mcp-field-label {
+  display: block;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--fg-muted);
+}
+.mcp-field .dim {
+  margin: 0.3rem 0 0;
+}
+.mcp-token-path {
+  margin-top: 1rem;
+  border-top: 1px solid var(--border);
+  padding-top: 0.75rem;
+}
+.mcp-token-path > summary {
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: var(--fg-muted);
+}
+.mcp-token-path > summary:hover {
+  color: var(--accent);
+}
+.mcp-token-path .mint-banner {
+  margin-top: 0.75rem;
+  margin-bottom: 0;
+}
+.mcp-docs-link {
+  margin: 0.9rem 0 0;
+}
 
 form .row {
   margin-bottom: 1rem;


### PR DESCRIPTION
## Why — closes 3 team-onboarding gaps + a renderMcpTile fix

Aaron hit these during team onboarding:

1. **Token with no purpose.** After creating a vault, the operator got a raw token with no stated purpose and no connect instructions ("I don't know what the token is for").
2. **No connect affordance for later-created vaults.** Only the first-boot setup wizard ever showed a connect snippet (`renderMcpTile`). Vaults created later (e.g. per-user team vaults) had no in-product "how do I connect a client to this vault" affordance.
3. **Starter-prompt dead-end.** The onboarding starter prompt pointed users at "/admin/users → click username → MCP connection" — a surface that did **not** exist. This card is now that surface.

Plus **gap #4** (in `renderMcpTile` itself): the no-token-minted fallback still told operators to append `--header "Authorization: Bearer pvt_..."`. `pvt_*` is being retired — the SPA + mint paths issue hub JWTs now. The fallback now leads with the OAuth path (no token needed) and references a hub JWT placeholder (`<token>`, minted from `/admin/tokens` or `parachute auth mint-token`).

## Placement decision

A reusable `McpConnectCard` component, mounted in **two** places:

- **(a) canonical — Vaults list:** a per-row **"Connect"** toggle that expands the card. Every vault, anytime. This is the surface the starter prompt should point at (closes gap #2 + #3).
- **(b) reuse — NewVault created-view:** the same card is rendered beneath the (still one-time-reveal) token banner, so the freshly-minted token has a clear in-context purpose (closes gap #1).

## The card

- **Endpoint:** `<hub-origin>/vault/<name>/mcp` — derived from the vault's well-known `url` (`<canonical-origin>/vault/<name>`, see `src/well-known.ts`), **never** the `:1940` vault loopback. No extra round-trip; anonymous-safe on the Vaults list.
- **Claude Code command (default):** `claude mcp add --transport http parachute-<name> <hub-origin>/vault/<name>/mcp` with a Copy button. Notes that it triggers browser OAuth on first use — no token in the command.
- **Optional secondary "mint a token" path:** for headless / CI clients that can't do browser OAuth. Mints a scope-narrow hub JWT (`vault:<name>:read vault:<name>:write` — **not** admin) via the existing tokens-page mint chain, shows the `--header "Authorization: Bearer <jwt>"` variant once (copy-only, never persisted).
- A one-liner explaining what it's for, and a link to the parachute.computer `/install#connect-mcp-clients` connect docs.

## What's reused

- `renderMcpTile`'s command shape (`claude mcp add --transport http parachute-<name> …`).
- The tokens-page mint chain: `mintToken` → host-admin Bearer → `POST /api/auth/mint-token`. The minted token lands in the registry and is revocable like any other.
- The vault's well-known `url` as the origin source (same source `resolveManagementUrl` trusts for the Manage button).
- Existing `.token-box` / `.mint-banner` design-system styles.

## renderMcpTile pvt_ fix

`src/setup-wizard.ts` — the no-token-minted fallback text now leads with browser OAuth and references a hub JWT placeholder instead of `pvt_*`. Updated the corresponding assertion in `setup-wizard.test.ts`.

## Tests / gates

- **web/ui vitest:** 237 pass (16 files). 9 new `McpConnectCard` tests (endpoint/command builders, rendered `/vault/<name>/mcp` URL + `claude mcp add` command, Copy affordance, the hub-JWT mint path with `vault:<name>:read/write` scope, the docs link) + a Vaults-list Connect-toggle test + a NewVault created-view card assertion.
- **web/ui:** `bun run typecheck` clean, `bun run build` + `verify-base` pass.
- **hub:** `bun test ./src` → 2379 pass / 1 skip / 0 fail. `bun run typecheck` clean.
- No rc bump (stays `0.5.14-rc.9`).

## Follow-up (not in this PR)

A separate parachute.computer change should repoint the onboarding starter prompt at this Vaults-list Connect card (the prompt currently names the nonexistent `/admin/users → MCP connection` surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)