### PR TITLE
feat(hub): surface friend sign-in URL + /account breadcrumb + audience-neutral login (onboarding discoverability)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,29 @@ parachute expose tailnet  # HTTPS, MagicDNS, only your devices (the supported sh
 
 Tear down with `parachute expose tailnet off`. The public layer (`expose public off`) tears down independently — `off` only affects the layer you name. Public-internet exposure is exploratory (see "Public exposure" below).
 
+### Onboarding a team member
+
+Want to give a friend or teammate their own account on your hub? The flow is
+self-service end to end:
+
+1. **Create the user.** In the admin UI, open **Users → Create User**: pick a
+   username, set a temporary password, and (optionally) assign one or more
+   vaults. The success banner echoes the exact sign-in URL.
+2. **Hand them three things:** your hub's sign-in URL (`<hub-origin>/login`),
+   their username, and the temporary password you set.
+3. **They sign in and set their own password.** On first sign-in they're
+   prompted to change it — they can't reach the rest of the hub until they do.
+4. **Later changes are self-service.** A signed-in user changes their password
+   anytime from their account home at `/account/` (reachable via the **Account**
+   link in the top-right once signed in).
+5. **You can reset it for them.** If they're locked out, the **Reset password**
+   button on the Users row sets a new temporary password and re-arms the
+   force-change-on-next-sign-in prompt.
+
+The first admin (the wizard / env-seeded account) is unrestricted and can't be
+deleted or reset from the Users page — it changes its own password at
+`/account/change-password` directly.
+
 ## Service lifecycle
 
 `parachute start`, `stop`, `restart`, and `logs` manage services as background processes — no launchd, no manual `bun serve`, no hunting for PIDs.

--- a/src/__tests__/hub.test.ts
+++ b/src/__tests__/hub.test.ts
@@ -189,6 +189,17 @@ describe("renderHub — signed-in indicator (rc.13)", () => {
     expect(html).not.toContain('href="/login?next=/"');
   });
 
+  test("signed-in indicator carries an Account breadcrumb to /account/", () => {
+    // Onboarding discoverability: a signed-in friend needs a single link
+    // to the self-service /account/ home (change password, their vault).
+    // Applies to admins too — harmless for them.
+    const html = renderHub({
+      session: { displayName: "aaron", csrfToken: "csrf-token-xyz" },
+    });
+    expect(html).toContain('href="/account/"');
+    expect(html).toContain("Account");
+  });
+
   test("displayName with HTML special chars is escaped", () => {
     // Username field allows alphanumerics historically, but the
     // displayName field on the wire is forward-compatible with profile

--- a/src/admin-login-ui.ts
+++ b/src/admin-login-ui.ts
@@ -67,7 +67,7 @@ function header(): string {
         <div class="brand">
           <span class="brand-mark" aria-hidden="true">${brandMarkSvg(20, "admin-login")}</span>
           <span class="brand-name">${WORDMARK_TEXT}</span>
-          <span class="brand-tag">admin</span>
+          <span class="brand-tag">sign in</span>
         </div>`;
 }
 
@@ -87,8 +87,8 @@ export function renderAdminLogin(props: AdminLoginProps): string {
     <div class="card">
       <div class="card-header">
         ${header()}
-        <h1>Sign in</h1>
-        <p class="subtitle">to administer this hub</p>
+        <h1>Sign in to your Parachute account</h1>
+        <p class="subtitle">Hub operators and invited members sign in here.</p>
       </div>
       ${error}
       <form method="POST" action="/login" class="auth-form">
@@ -105,7 +105,7 @@ export function renderAdminLogin(props: AdminLoginProps): string {
         <button type="submit" class="btn btn-primary">Sign in</button>
       </form>
     </div>`;
-  return baseDocument("Sign in to Parachute Hub admin", body);
+  return baseDocument("Sign in — Parachute", body);
 }
 
 // --- error page ------------------------------------------------------------

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -91,8 +91,15 @@ function renderSignedIn(displayName: string, csrfToken: string): string {
   // Inline POST form so sign-out works without JS. Submit button is
   // styled as a text link via `.auth-signout` so the visual weight
   // matches the surrounding "Signed in as <name>" text.
+  //
+  // The "Account" link is the single breadcrumb to `/account/` — the
+  // self-service home where any signed-in user (admin or invited
+  // member) can change their password, see their vault, and sign out.
+  // Without it, a friend who's been handed credentials has no way to
+  // discover the change-password surface after the first-login prompt.
   return `<div class="auth-indicator">
       <span class="muted">Signed in as <strong>${escapeHtml(displayName)}</strong></span>
+      <a href="/account/" class="auth-account">Account</a>
       <form method="POST" action="/logout" class="auth-signout-form">
         <input type="hidden" name="${CSRF_FIELD_NAME}" value="${escapeAttr(csrfToken)}" />
         <button type="submit" class="auth-signout">Sign out</button>
@@ -203,7 +210,7 @@ const HTML_TEMPLATE = `<!doctype html>
     margin: 0;
     display: inline;
   }
-  .auth-signout, .auth-signin {
+  .auth-signout, .auth-signin, .auth-account {
     background: none;
     border: none;
     padding: 0;
@@ -214,10 +221,10 @@ const HTML_TEMPLATE = `<!doctype html>
     text-decoration-thickness: 1px;
     text-underline-offset: 2px;
   }
-  .auth-signout:hover, .auth-signin:hover {
+  .auth-signout:hover, .auth-signin:hover, .auth-account:hover {
     color: var(--accent-hover);
   }
-  a.auth-signin {
+  a.auth-signin, a.auth-account {
     /* Anchor needs explicit reset since the a element has its own
        color/decoration. */
     border-bottom: none;

--- a/web/ui/src/routes/Users.test.tsx
+++ b/web/ui/src/routes/Users.test.tsx
@@ -22,11 +22,22 @@ vi.mock("../lib/api.ts", async (orig) => {
     deleteUser: vi.fn(),
     resetUserPassword: vi.fn(),
     updateUserVaults: vi.fn(),
+    getHubOriginSetting: vi.fn(),
   };
 });
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The Users load effect fetches the hub origin (for the sign-in
+  // handoff URL on the create / reset banners) alongside listUsers +
+  // listUserVaults. Default to a representative resolved issuer so every
+  // existing test loads cleanly; tests that assert the URL override the
+  // resolved_issuer value explicitly.
+  vi.mocked(api.getHubOriginSetting).mockResolvedValue({
+    hub_origin: "https://hub.example.com",
+    resolved_issuer: "https://hub.example.com",
+    source: "settings",
+  });
 });
 
 afterEach(() => {
@@ -480,5 +491,97 @@ describe("Users — multi-vault membership (Phase 2 PR 2)", () => {
     fireEvent.click(within(form).getByRole("button", { name: /cancel/i }));
     await waitFor(() => expect(screen.queryByLabelText(/vault assignments for alice/i)).toBeNull());
     expect(api.updateUserVaults).not.toHaveBeenCalled();
+  });
+});
+
+describe("Users — sign-in handoff URL (onboarding discoverability)", () => {
+  it("create-user success banner surfaces <hub-origin>/login with the username", async () => {
+    const listMock = vi.mocked(api.listUsers);
+    listMock.mockResolvedValueOnce([user("operator")]);
+    listMock.mockResolvedValueOnce([
+      user("operator"),
+      user("alice", { password_changed: false, assigned_vaults: ["home"] }),
+    ]);
+    vi.mocked(api.listUserVaults).mockResolvedValue(["home"]);
+    vi.mocked(api.getHubOriginSetting).mockResolvedValue({
+      hub_origin: "https://hub.example.com",
+      resolved_issuer: "https://hub.example.com",
+      source: "settings",
+    });
+    vi.mocked(api.createUser).mockResolvedValue(
+      user("alice", { password_changed: false, assigned_vaults: ["home"] }),
+    );
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /create user/i }));
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: "alice" } });
+    fireEvent.change(screen.getByLabelText(/^password/i), {
+      target: { value: "alice-strong-passphrase" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^create user$/i }));
+    // Scope to the success banner (<output>) so the assertion doesn't
+    // accidentally match the page-level intro prose, which also mentions
+    // the sign-in URL.
+    await waitFor(() =>
+      expect(screen.getByText(/prompted to change their password/i)).toBeInTheDocument(),
+    );
+    const banner = screen.getByText(/prompted to change their password/i).closest("output");
+    expect(banner).not.toBeNull();
+    // The concrete <hub-origin>/login URL + the username are both in the banner.
+    expect(within(banner!).getByText("https://hub.example.com/login")).toBeInTheDocument();
+    expect(banner?.textContent).toMatch(/send them to/i);
+    expect(banner?.textContent).toContain("alice");
+  });
+
+  it("reset-password success banner surfaces <hub-origin>/login with the username", async () => {
+    const listMock = vi.mocked(api.listUsers);
+    listMock.mockResolvedValueOnce([user("operator"), user("alice")]);
+    listMock.mockResolvedValueOnce([user("operator"), user("alice", { password_changed: false })]);
+    vi.mocked(api.listUserVaults).mockResolvedValue([]);
+    vi.mocked(api.getHubOriginSetting).mockResolvedValue({
+      hub_origin: null,
+      resolved_issuer: "https://my-hub.tailnet.ts.net",
+      source: "request",
+    });
+    vi.mocked(api.resetUserPassword).mockResolvedValue({ revocationLagSeconds: 60 });
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /reset password for alice/i }));
+    fireEvent.change(screen.getByLabelText(/new temporary password for alice/i), {
+      target: { value: "new-temp-passphrase" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /set new password/i }));
+    await waitFor(() => expect(screen.getByText(/password reset for/i)).toBeInTheDocument());
+    const banner = screen.getByText(/password reset for/i).closest("output");
+    expect(banner).not.toBeNull();
+    // resolved_issuer (request-origin precedence) drives the URL when no
+    // operator-set hub_origin is stored.
+    expect(within(banner!).getByText("https://my-hub.tailnet.ts.net/login")).toBeInTheDocument();
+    expect(banner?.textContent).toMatch(/send them to/i);
+    expect(banner?.textContent).toContain("alice");
+  });
+
+  it("trims a trailing slash from resolved_issuer before building the login URL", async () => {
+    const listMock = vi.mocked(api.listUsers);
+    listMock.mockResolvedValueOnce([user("operator")]);
+    listMock.mockResolvedValueOnce([user("operator"), user("alice", { password_changed: false })]);
+    vi.mocked(api.listUserVaults).mockResolvedValue([]);
+    vi.mocked(api.getHubOriginSetting).mockResolvedValue({
+      hub_origin: "https://hub.example.com/",
+      resolved_issuer: "https://hub.example.com/",
+      source: "settings",
+    });
+    vi.mocked(api.createUser).mockResolvedValue(user("alice", { password_changed: false }));
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /create user/i }));
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: "alice" } });
+    fireEvent.change(screen.getByLabelText(/^password/i), {
+      target: { value: "alice-strong-passphrase" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^create user$/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/prompted to change their password/i)).toBeInTheDocument(),
+    );
+    const banner = screen.getByText(/prompted to change their password/i).closest("output");
+    // No double slash — the loader trims the trailing slash.
+    expect(within(banner!).getByText("https://hub.example.com/login")).toBeInTheDocument();
   });
 });

--- a/web/ui/src/routes/Users.tsx
+++ b/web/ui/src/routes/Users.tsx
@@ -51,6 +51,7 @@ import {
   type UserListing,
   createUser,
   deleteUser,
+  getHubOriginSetting,
   listUserVaults,
   listUsers,
   resetUserPassword,
@@ -77,6 +78,15 @@ const USERNAME_MAX_LEN = 32;
 interface UsersData {
   users: UserListing[];
   vaults: string[];
+  /**
+   * Canonical hub origin (`resolved_issuer` from
+   * `GET /api/settings/hub-origin`) — the same value the OAuth issuer
+   * stamps into JWTs and the MCP-connect card / Settings page surface.
+   * Used to build the concrete `<hub-origin>/login` URL the operator
+   * hands a newly-created or password-reset user, so onboarding doesn't
+   * stall on "where does the friend sign in?". Trailing slash trimmed.
+   */
+  hubOrigin: string;
 }
 
 type ListState =
@@ -134,6 +144,34 @@ type EditVaultsState =
   | { kind: "done"; userId: string; username: string }
   | { kind: "error"; userId: string; selected: string[]; message: string };
 
+/**
+ * The "where do they sign in?" handoff line, shared by the create-user
+ * and reset-password success banners. Surfaces the concrete
+ * `<hub-origin>/login` URL + the username so the operator can hand a
+ * newly-created or reset user everything they need in one place — the
+ * onboarding-discoverability gap this addresses was that the banners
+ * said "they'll be prompted to change on first sign-in" but never showed
+ * *where* to sign in. `hubOrigin` is already trailing-slash-trimmed by
+ * the loader.
+ */
+function SignInHandoff({
+  username,
+  hubOrigin,
+}: {
+  username: string;
+  hubOrigin: string;
+}): React.ReactNode {
+  // Defensive: if the origin somehow didn't resolve (empty string), fall
+  // back to a relative `/login` so the line still tells them where to go.
+  const loginUrl = `${hubOrigin || ""}/login`;
+  return (
+    <div className="muted" style={{ marginTop: "0.5rem", fontSize: "0.9em" }}>
+      Send them to <code>{loginUrl}</code> with username <code>{username}</code> and this password —
+      they'll be prompted to set a new one on first sign-in.
+    </div>
+  );
+}
+
 export function Users() {
   const [state, setState] = useState<ListState>({ kind: "loading" });
   const [reload, setReload] = useState(0);
@@ -148,10 +186,14 @@ export function Users() {
     void reload;
     let cancelled = false;
     setState({ kind: "loading" });
-    Promise.all([listUsers(), listUserVaults()])
-      .then(([users, vaults]) => {
+    Promise.all([listUsers(), listUserVaults(), getHubOriginSetting()])
+      .then(([users, vaults, hubOriginSetting]) => {
         if (cancelled) return;
-        setState({ kind: "ok", data: { users, vaults } });
+        // `resolved_issuer` is the precedence-aware hub origin (settings
+        // → env → request). Trim any trailing slash so the banner builds
+        // a clean `<origin>/login` regardless of how it was configured.
+        const hubOrigin = hubOriginSetting.resolved_issuer.replace(/\/+$/, "");
+        setState({ kind: "ok", data: { users, vaults, hubOrigin } });
       })
       .catch((err) => {
         if (cancelled) return;
@@ -290,7 +332,14 @@ export function Users() {
         narrows their tokens to <code>vault:&lt;assigned&gt;:*</code> scopes for any vault in their
         list. Users with no assignments can't authorize any vault yet — assign at least one above.
         The first admin is unrestricted (admin posture). Admin-created users land with a default
-        password and are prompted to change it on first sign-in.
+        password and are prompted to change it on first sign-in
+        {state.kind === "ok" ? (
+          <>
+            {" "}
+            at <code>{state.data.hubOrigin}/login</code>
+          </>
+        ) : null}
+        .
       </p>
 
       {renderListSection(
@@ -305,6 +354,7 @@ export function Users() {
         setEditVaultsSt,
         onSubmitEditVaults,
         state.kind === "ok" ? state.data.vaults : [],
+        state.kind === "ok" ? state.data.hubOrigin : "",
         () => setReload((n) => n + 1),
       )}
 
@@ -315,6 +365,7 @@ export function Users() {
           form={form}
           setForm={setForm}
           vaults={state.data.vaults}
+          hubOrigin={state.data.hubOrigin}
           createState={createState}
           setCreateState={setCreateState}
           onSubmit={onSubmitCreate}
@@ -336,6 +387,7 @@ function renderListSection(
   setEditVaultsSt: (s: EditVaultsState) => void,
   onSubmitEditVaults: (user: UserListing, selected: string[]) => Promise<void>,
   availableVaults: string[],
+  hubOrigin: string,
   onRetry: () => void,
 ): React.ReactNode {
   if (state.kind === "loading") {
@@ -382,6 +434,7 @@ function renderListSection(
       setEditVaultsSt={setEditVaultsSt}
       onSubmitEditVaults={onSubmitEditVaults}
       availableVaults={availableVaults}
+      hubOrigin={hubOrigin}
     />
   );
 }
@@ -399,6 +452,8 @@ interface ListRenderedProps {
   setEditVaultsSt: (s: EditVaultsState) => void;
   onSubmitEditVaults: (user: UserListing, selected: string[]) => Promise<void>;
   availableVaults: string[];
+  /** Canonical hub origin for the reset-password sign-in handoff line. */
+  hubOrigin: string;
 }
 
 function ListRendered({
@@ -414,6 +469,7 @@ function ListRendered({
   setEditVaultsSt,
   onSubmitEditVaults,
   availableVaults,
+  hubOrigin,
 }: ListRenderedProps): React.ReactNode {
   return (
     <div className="user-list" style={{ marginTop: "1rem" }}>
@@ -668,13 +724,13 @@ function ListRendered({
                       >
                         Password reset for <code>{resetDone.username}</code>. Hand them the new
                         password and tell them they'll be prompted to change it on first sign-in.
+                        <SignInHandoff username={resetDone.username} hubOrigin={hubOrigin} />
                         <div className="muted" style={{ marginTop: "0.5rem", fontSize: "0.85em" }}>
                           Their existing tokens are revoked. Resource servers (vault, scribe, etc.)
                           cache the revocation list for up to {resetDone.revocationLagSeconds}{" "}
-                          seconds — if you're resetting
-                          because of a suspected compromise, also restart the affected services
-                          (e.g. <code>parachute restart vault</code>) to flush their cache
-                          immediately.
+                          seconds — if you're resetting because of a suspected compromise, also
+                          restart the affected services (e.g. <code>parachute restart vault</code>)
+                          to flush their cache immediately.
                         </div>
                         <div style={{ marginTop: "0.5rem" }}>
                           <button
@@ -908,6 +964,8 @@ interface CreateUserSectionProps {
   form: FormFields;
   setForm: (f: FormFields) => void;
   vaults: string[];
+  /** Canonical hub origin for the create-user sign-in handoff line. */
+  hubOrigin: string;
   createState: CreateState;
   setCreateState: (s: CreateState) => void;
   onSubmit: (e: FormEvent) => Promise<void>;
@@ -919,6 +977,7 @@ function CreateUserSection({
   form,
   setForm,
   vaults,
+  hubOrigin,
   createState,
   setCreateState,
   onSubmit,
@@ -1028,6 +1087,7 @@ function CreateUserSection({
             <output className="success-banner">
               User <code>{createState.username}</code> created. They'll be prompted to change their
               password on first sign-in.
+              <SignInHandoff username={createState.username} hubOrigin={hubOrigin} />
             </output>
           )}
 


### PR DESCRIPTION
## Why

The multi-user friend-flow **already works end to end** — an operator creates a user and sets a temp password, the friend is force-prompted to change it on first sign-in (`password_changed=false` → `/account/change-password`), `/account/` is the self-service home for later password changes, and the admin can reset via the Users-page button.

It was just **undiscoverable**. Aaron hit this during team onboarding: *"I was able to set up users and give them a password, but I don't quite know what the flow is to allow them to change their password."* The operator was never shown WHERE the friend signs in, and a signed-in friend had no breadcrumb to `/account/`.

This PR surfaces the existing flow. **No behavior changed** — it's copy, a link, and a doc.

## The 4 changes

1. **`src/admin-login-ui.ts`** — `/login` was framed admin-only ("to administer this hub", title "Sign in to Parachute Hub admin", brand tag "admin"). But it's the canonical entry for *all* users, including non-admin friends. Softened to audience-neutral: h1 "Sign in to your Parachute account", subtitle "Hub operators and invited members sign in here.", brand tag "sign in", title "Sign in — Parachute". Copy only.

2. **`web/ui/src/routes/Users.tsx`** — the create-user + reset-password success banners said "they'll be prompted to change on first sign-in" but never showed *where*. Both now append a shared `SignInHandoff` line: *"Send them to `<hub-origin>/login` with username `<username>` and this password — they'll be prompted to set a new one on first sign-in."* The intro prose also names the login URL. The hub origin is plumbed in via `getHubOriginSetting()`'s `resolved_issuer` — the same canonical source the Settings page and the JWT issuer use (no new round-trip type; trailing slash trimmed).

3. **`src/hub.ts` `renderSignedIn`** — the signed-in discovery-page indicator (previously just "Signed in as `<name>`" + Sign out) now carries an **"Account"** link to `/account/`. Any signed-in user (friend or admin) now has a single breadcrumb to the self-service surface. Harmless for admins.

4. **`README.md`** — a concise "Onboarding a team member" section: create the user → hand them `<hub-origin>/login` + username + temp password → force-change on first sign-in → `/account/` for later changes → admin reset via the Users page.

A parallel `parachute.computer/multi-user.njk` doc update is a separate follow-up (not in this PR).

## Tests

- `web/ui` vitest: **240 pass** (3 new in Users.test.tsx asserting the `<hub-origin>/login` text + username appear in the create + reset success banners, plus a trailing-slash-trim case). Typecheck clean. Build + verify-base pass.
- `bun test ./src`: **2380 pass, 1 skip, 0 fail** (1 new in hub.test.ts asserting the `/account/` breadcrumb in `renderSignedIn`). `bun run typecheck` clean.

No rc bump (copy + a link + a doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)