### PR TITLE
fix(hub): expose-cloudflare test wrote fixtures to real ~/.parachute (sandbox leak)

### DIFF
--- a/src/__tests__/expose-cloudflare.test.ts
+++ b/src/__tests__/expose-cloudflare.test.ts
@@ -497,7 +497,10 @@ describe("exposeCloudflareUp", () => {
         cloudflaredHome: env.cloudflaredHome,
         configDir: env.configDir,
         skipHub: true,
-        // Use defaults for configPath/logPath so they're per-tunnel-derived.
+        // Omit configPath/logPath so they're per-tunnel-derived — but the
+        // derivation now resolves against the tmp `configDir` above, so the
+        // generated config.yml lands under tmp, not the operator's real
+        // ~/.parachute/cloudflared/parachute/.
       });
       expect(code1).toBe(0);
 
@@ -581,8 +584,8 @@ describe("exposeCloudflareUp", () => {
           configPath: env.configPath,
           logPath: env.logPath,
           cloudflaredHome: env.cloudflaredHome,
-        configDir: env.configDir,
-        skipHub: true,
+          configDir: env.configDir,
+          skipHub: true,
           // No password, no 2FA — fully wide open. The warning should still
           // fire; password-recovery copy already lives in `printAuthGuidance`.
           vaultAuthStatus: {
@@ -631,8 +634,8 @@ describe("exposeCloudflareUp", () => {
           configPath: env.configPath,
           logPath: env.logPath,
           cloudflaredHome: env.cloudflaredHome,
-        configDir: env.configDir,
-        skipHub: true,
+          configDir: env.configDir,
+          skipHub: true,
           vaultAuthStatus: {
             hasOwnerPassword: true,
             hasTotp: true,

--- a/src/cloudflare/config.ts
+++ b/src/cloudflare/config.ts
@@ -16,12 +16,21 @@ export const DEFAULT_TUNNEL_NAME = "parachute";
  * location change from pre-#32 (`~/.parachute/cloudflared/config.yml`).
  * Re-running `parachute expose public --cloudflare` regenerates the file
  * at the new path; the legacy file is left in place but unused.
+ *
+ * `configDir` overrides the base (`~/.parachute` by default). Tests pass a
+ * tmp dir so per-tunnel-derived paths never resolve against the operator's
+ * real `CONFIG_DIR` — otherwise running the suite scribbles fixture
+ * config.yml + log files into `~/.parachute/cloudflared/<name>/`.
  */
-export function cloudflaredPathsFor(tunnelName: string): {
+export function cloudflaredPathsFor(
+  tunnelName: string,
+  configDir: string = CONFIG_DIR,
+): {
   configPath: string;
   logPath: string;
 } {
-  const dir = join(CLOUDFLARED_DIR, tunnelName);
+  const base = configDir === CONFIG_DIR ? CLOUDFLARED_DIR : join(configDir, "cloudflared");
+  const dir = join(base, tunnelName);
   return {
     configPath: join(dir, "config.yml"),
     logPath: join(dir, "cloudflared.log"),

--- a/src/cloudflare/config.ts
+++ b/src/cloudflare/config.ts
@@ -2,8 +2,6 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { CONFIG_DIR } from "../config.ts";
 
-export const CLOUDFLARED_DIR = join(CONFIG_DIR, "cloudflared");
-
 export const DEFAULT_TUNNEL_NAME = "parachute";
 
 /**
@@ -29,8 +27,7 @@ export function cloudflaredPathsFor(
   configPath: string;
   logPath: string;
 } {
-  const base = configDir === CONFIG_DIR ? CLOUDFLARED_DIR : join(configDir, "cloudflared");
-  const dir = join(base, tunnelName);
+  const dir = join(configDir, "cloudflared", tunnelName);
   return {
     configPath: join(dir, "config.yml"),
     logPath: join(dir, "cloudflared.log"),

--- a/src/commands/expose-cloudflare.ts
+++ b/src/commands/expose-cloudflare.ts
@@ -190,7 +190,12 @@ interface Resolved {
 
 function resolve(opts: ExposeCloudflareOpts): Resolved {
   const tunnelName = opts.tunnelName ?? DEFAULT_TUNNEL_NAME;
-  const paths = cloudflaredPathsFor(tunnelName);
+  const configDir = opts.configDir ?? CONFIG_DIR;
+  // Derive per-tunnel config/log paths from the *resolved* configDir, not the
+  // real `CONFIG_DIR`. When a test threads a tmp `configDir` but omits explicit
+  // `configPath`/`logPath`, this keeps the derived files inside the tmp dir
+  // instead of writing fixtures into the operator's real ~/.parachute.
+  const paths = cloudflaredPathsFor(tunnelName, configDir);
   return {
     runner: opts.runner ?? defaultRunner,
     spawner: opts.spawner ?? defaultCloudflaredSpawner,
@@ -203,7 +208,7 @@ function resolve(opts: ExposeCloudflareOpts): Resolved {
     configPath: opts.configPath ?? paths.configPath,
     logPath: opts.logPath ?? paths.logPath,
     cloudflaredHome: opts.cloudflaredHome ?? DEFAULT_CLOUDFLARED_HOME,
-    configDir: opts.configDir ?? CONFIG_DIR,
+    configDir,
     hubOrigin: opts.hubOrigin,
     hubEnsureOpts: opts.hubEnsureOpts ?? {},
     wellKnownDir: opts.wellKnownDir ?? WELL_KNOWN_DIR,


### PR DESCRIPTION
## The leak

The `two tunnels with different --tunnel-name coexist in state` test in `src/__tests__/expose-cloudflare.test.ts` threaded a tmp `configDir` but **omitted** explicit `configPath`/`logPath`. Those fell through to `cloudflaredPathsFor(tunnelName)`, which resolved per-tunnel paths against the real `CONFIG_DIR` (`~/.parachute`).

Running the suite therefore scribbled fixture files into the operator's **real** home:

```
~/.parachute/cloudflared/parachute/{config.yml,cloudflared.log}
~/.parachute/cloudflared/second/{config.yml,cloudflared.log}
```

…with fake UUIDs (`aaaa1111-…`, `bbbb2222-…`) and `alpha.example.com` / `beta.example.com` hostnames. Aaron saw these stray dirs — they looked like a genuine Cloudflare tunnel attempt existed. This violates the sandbox-destructive-CLI discipline: tests must never write outside a tmp dir.

## The fix

- `cloudflaredPathsFor()` now takes an optional `configDir` base override (defaults to `CONFIG_DIR`, so production behavior is unchanged).
- `resolve()` in `expose-cloudflare.ts` derives the default per-tunnel `configPath`/`logPath` from the **resolved** `configDir` rather than the module-level `CONFIG_DIR`.

A test that threads a tmp `configDir` now keeps all derived cloudflared paths inside tmp, even when it omits explicit `configPath`/`logPath`. The "two tunnels" assertions only check path suffixes (`endsWith("/parachute/config.yml")`, `endsWith("/second/config.yml")`) and `existsSync`, so they still hold with tmp paths.

The other tests in this file already passed explicit tmp `configPath`/`logPath`, so they never leaked. Sibling expose tests (`expose-public-auto`, `expose-off-auto`, `expose-interactive`) inject a fake `exposeCloudflareUpImpl` and never reach the real path resolution.

## Verification — real home stays clean

```
# BEFORE (leaked dirs removed):
$ find ~/.parachute/cloudflared/ -mindepth 1
(empty)

# after `bun test ./src` (full suite, includes the cloudflare tests):
$ find ~/.parachute/cloudflared/ -mindepth 1
(empty)   ← no parachute/ or second/ dirs, no files
```

No writes to the real `~/.parachute/cloudflared/` after a full suite run.

## Gates

- `bun test ./src`: **2380 pass, 1 skip, 0 fail**
- `bun run typecheck`: clean
- `bunx biome check` on changed files: clean (also fixed pre-existing mis-indentation on two `configDir`/`skipHub` lines surfaced by the formatter)

No rc bump (test-hygiene fix; not a release-line change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)