### PR TITLE
fix(hub): post-DROP connect-surface correctness + friend /account connect block + admin polish

### DIFF
--- a/src/__tests__/account-home-ui.test.ts
+++ b/src/__tests__/account-home-ui.test.ts
@@ -4,8 +4,9 @@
  * tests pin the load-bearing shape:
  *
  *   - Assigned-vault branch: Notes CTA href encodes the hub+vault URL,
- *     vault name shows in the body, hub origin appears as inline code
- *     in the custom-client disclosure.
+ *     vault name shows in the body, AND a per-tile MCP connect block
+ *     surfaces the endpoint + `claude mcp add` command (OAuth, no token)
+ *     with copy buttons — the multi-user friend-connect surface.
  *   - Admin (no assigned vault) branch: link to /admin/ visible.
  *   - Defensive third branch (non-admin + no vault): "ask the operator"
  *     copy renders.
@@ -13,7 +14,11 @@
  *     change-password link.
  */
 import { describe, expect, test } from "bun:test";
-import { renderAccountHome } from "../account-home-ui.ts";
+import {
+  accountClaudeMcpAddCommand,
+  accountMcpEndpoint,
+  renderAccountHome,
+} from "../account-home-ui.ts";
 
 const HUB_ORIGIN = "https://hub.example";
 const CSRF = "test-csrf-token";
@@ -38,9 +43,19 @@ describe("renderAccountHome", () => {
     expect(html).toContain(`https://notes.parachute.computer/add?url=${encodedVaultUrl}`);
     expect(html).toContain('target="_blank"');
     expect(html).toContain('rel="noopener"');
-    // Hub origin renders as inline <code> in the custom-client disclosure.
-    expect(html).toContain(`<code>${HUB_ORIGIN}</code>`);
-    expect(html).toContain("Use a custom client");
+    // The friend-connect surface: MCP endpoint + `claude mcp add` command,
+    // each with a copy button. OAuth path (no token in the command).
+    expect(html).toContain(`${HUB_ORIGIN}/vault/alice/mcp`);
+    expect(html).toContain(
+      `claude mcp add --transport http parachute-alice ${HUB_ORIGIN}/vault/alice/mcp`,
+    );
+    expect(html).toContain('data-testid="copy-mcp-endpoint"');
+    expect(html).toContain('data-testid="copy-mcp-add-command"');
+    // The connect command must NOT embed a token — the OAuth path needs none.
+    expect(html).not.toContain("--header");
+    expect(html).not.toContain("Authorization: Bearer");
+    // Copy-button progressive-enhancement script is present.
+    expect(html).toContain("navigator.clipboard");
   });
 
   test("assigned-vault branch — trailing slash on hubOrigin is normalized", () => {
@@ -57,9 +72,10 @@ describe("renderAccountHome", () => {
     });
     const cleanEncoded = encodeURIComponent(`${HUB_ORIGIN}/vault/alice`);
     expect(html).toContain(`https://notes.parachute.computer/add?url=${cleanEncoded}`);
-    // The inline-code display also drops the trailing slash.
-    expect(html).toContain(`<code>${HUB_ORIGIN}</code>`);
-    expect(html).not.toContain(`<code>${HUB_ORIGIN}/</code>`);
+    // The MCP endpoint + connect command also drop the trailing slash — no
+    // `//vault` double-slash sneaks in.
+    expect(html).toContain(`${HUB_ORIGIN}/vault/alice/mcp`);
+    expect(html).not.toContain(`${HUB_ORIGIN}//vault`);
   });
 
   test("admin branch — null assignedVault + isFirstAdmin renders an /admin/ link", () => {
@@ -139,8 +155,28 @@ describe("renderAccountHome", () => {
     const familyEncoded = encodeURIComponent(`${HUB_ORIGIN}/vault/family`);
     expect(html).toContain(`https://notes.parachute.computer/add?url=${personalEncoded}`);
     expect(html).toContain(`https://notes.parachute.computer/add?url=${familyEncoded}`);
-    // Hub origin block appears once at the section level, not per tile.
-    expect(html.split(`<code>${HUB_ORIGIN}</code>`).length - 1).toBe(1);
+    // One per-vault MCP connect block per tile (endpoint + command).
+    expect(html).toContain(`${HUB_ORIGIN}/vault/personal/mcp`);
+    expect(html).toContain(`${HUB_ORIGIN}/vault/family/mcp`);
+    expect(html).toContain(
+      `claude mcp add --transport http parachute-personal ${HUB_ORIGIN}/vault/personal/mcp`,
+    );
+    expect(html).toContain(
+      `claude mcp add --transport http parachute-family ${HUB_ORIGIN}/vault/family/mcp`,
+    );
+    // Two tiles → two copy-endpoint buttons.
+    expect(html.split('data-testid="copy-mcp-endpoint"').length - 1).toBe(2);
+    // The copy script is emitted once at the section level, not per-tile.
+    expect(html.split("<script>").length - 1).toBe(1);
+  });
+
+  test("accountMcpEndpoint / accountClaudeMcpAddCommand build the canonical shapes", () => {
+    expect(accountMcpEndpoint("https://hub.example", "work")).toBe(
+      "https://hub.example/vault/work/mcp",
+    );
+    expect(accountClaudeMcpAddCommand("https://hub.example", "work")).toBe(
+      "claude mcp add --transport http parachute-work https://hub.example/vault/work/mcp",
+    );
   });
 
   test("escapes hostile content in username and vault name", () => {
@@ -149,15 +185,21 @@ describe("renderAccountHome", () => {
     // the renderer is a pure function over arbitrary string input and the
     // escape is load-bearing if the validator ever loosens.
     const html = renderAccountHome({
-      username: "<script>",
+      username: "<script>alert(1)</script>",
       assignedVaults: ["<vault>"],
       passwordChanged: true,
       hubOrigin: HUB_ORIGIN,
       isFirstAdmin: false,
       csrfToken: CSRF,
     });
-    expect(html).not.toContain("<script>");
-    expect(html).toContain("&lt;script&gt;");
+    // The injected username/vault metacharacters are escaped — the only
+    // `<script>` tag in the output is the page's own copy-button helper, so
+    // we assert on the injected payload specifically rather than a blanket
+    // "no <script>" (the connect block legitimately emits one).
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
     expect(html).toContain("&lt;vault&gt;");
+    // The escaped vault name also flows into the connect command + endpoint.
+    expect(html).toContain("parachute-&lt;vault&gt;");
   });
 });

--- a/src/__tests__/admin-vaults.test.ts
+++ b/src/__tests__/admin-vaults.test.ts
@@ -8,11 +8,21 @@ import { signAccessToken } from "../jwt-sign.ts";
 import { upsertService, writeManifest } from "../services-manifest.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 
-/** Build the JSON shape parachute-vault create --json emits (PR #184). */
-function vaultCreateJson(name: string, token = `pvt_${name}_token`): string {
+/**
+ * Build the JSON shape `parachute-vault create --json` emits (PR #184).
+ * Post the pvt_* DROP the `token` is a hub-issued access JWT (scoped
+ * `vault:<name>:admin`), and may be the empty string when the vault
+ * couldn't mint — in which case `token_guidance` carries the reason.
+ */
+function vaultCreateJson(
+  name: string,
+  token = `hubjwt.${name}.access`,
+  tokenGuidance?: string,
+): string {
   return JSON.stringify({
     name,
     token,
+    ...(tokenGuidance ? { token_guidance: tokenGuidance } : {}),
     paths: {
       vault_dir: `/home/test/.parachute/vault/${name}`,
       vault_db: `/home/test/.parachute/vault/${name}/vault.db`,
@@ -404,7 +414,7 @@ describe("POST /vaults — orchestration", () => {
           );
           return {
             exitCode: 0,
-            stdout: vaultCreateJson("work", "pvt_supersecret"),
+            stdout: vaultCreateJson("work", "hubjwt.work.access"),
             stderr: "",
           };
         };
@@ -420,12 +430,68 @@ describe("POST /vaults — orchestration", () => {
           token?: string;
           paths?: { vault_dir: string; vault_db: string; vault_config: string };
         };
-        expect(body.token).toBe("pvt_supersecret");
+        expect(body.token).toBe("hubjwt.work.access");
         expect(body.paths).toEqual({
           vault_dir: "/home/test/.parachute/vault/work",
           vault_db: "/home/test/.parachute/vault/work/vault.db",
           vault_config: "/home/test/.parachute/vault/work/config.yaml",
         });
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("201 forwards an empty token + token_guidance when the vault couldn't mint (post-DROP)", async () => {
+    // The vault emits `token: ""` + a `token_guidance` reason when no hub
+    // origin was reachable to mint against (e.g. loopback create). The hub
+    // must forward both verbatim so the SPA can render the
+    // created-but-no-token state instead of confusing it with a re-POST.
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/default"],
+            health: "/health",
+            version: "0.3.5",
+          },
+          h.manifestPath,
+        );
+        const runCommand = async (_cmd: readonly string[]): Promise<RunResult> => {
+          upsertService(
+            {
+              name: "parachute-vault",
+              port: 1940,
+              paths: ["/vault/default", "/vault/work"],
+              health: "/health",
+              version: "0.3.5",
+            },
+            h.manifestPath,
+          );
+          return {
+            exitCode: 0,
+            stdout: vaultCreateJson("work", "", "no hub origin reachable to mint against"),
+            stderr: "",
+          };
+        };
+        const res = await call({
+          db,
+          manifestPath: h.manifestPath,
+          body: { name: "work" },
+          runCommand,
+        });
+        // Still a fresh create — HTTP 201, NOT 200.
+        expect(res.status).toBe(201);
+        const body = (await res.json()) as { token?: string; token_guidance?: string };
+        expect(body.token).toBe("");
+        expect(body.token_guidance).toBe("no hub origin reachable to mint against");
       } finally {
         db.close();
       }

--- a/src/__tests__/api-users.test.ts
+++ b/src/__tests__/api-users.test.ts
@@ -462,7 +462,7 @@ describe("handleDeleteUser", () => {
     expect(list.users.map((u) => u.id)).toContain(userId);
   });
 
-  test("204 deletes a non-first user and revokes their tokens", async () => {
+  test("200 + revocation_lag_seconds deletes a non-first user and revokes their tokens", async () => {
     const { bearer } = await makeAdminBearer();
     // Create a second user (non-first) + mint a token on their behalf.
     const second = await createUser(harness.db, "alice", "alice-strong-passphrase", {
@@ -497,7 +497,12 @@ describe("handleDeleteUser", () => {
       second.id,
       deps(),
     );
-    expect(res.status).toBe(204);
+    // 200 + body (was a bare 204) so the SPA can warn about revocation lag —
+    // consistency with the reset-password path.
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; revocation_lag_seconds: number };
+    expect(body.ok).toBe(true);
+    expect(body.revocation_lag_seconds).toBe(60);
 
     // User row is gone.
     const listRes = await handleListUsers(withBearer("/api/users", bearer), deps());

--- a/src/__tests__/expose-auth-preflight.test.ts
+++ b/src/__tests__/expose-auth-preflight.test.ts
@@ -79,6 +79,23 @@ describe("runAuthPreflight — wide open (no owner password)", () => {
     ]);
   });
 
+  test("null tokenCount with no owner password still classifies wide-open", async () => {
+    // The `tokenCount: null` (unreadable vault DB) path is vestigial post-DROP
+    // — `classify()` gates on `hasOwnerPassword` alone. A box with no owner
+    // password AND an unreadable token DB must still take the loud wide-open
+    // branch, not silently fall through to a quieter state.
+    const h = makeHarness(["n", "n"]);
+    await runAuthPreflight({
+      status: status({ hasOwnerPassword: false, tokenCount: null }),
+      ...wire(h),
+    });
+    const joined = h.logs.join("\n");
+    expect(joined).toContain("No owner password");
+    expect(joined).toContain("public internet");
+    // Wide-open offers password + 2FA (two prompts); not the all-good path.
+    expect(h.prompts).toHaveLength(2);
+  });
+
   test("never offers the removed `vault tokens create` command", async () => {
     const h = makeHarness(["y", "y"]);
     await runAuthPreflight({ status: status(), ...wire(h) });

--- a/src/account-home-ui.ts
+++ b/src/account-home-ui.ts
@@ -148,21 +148,54 @@ interface VaultCardOpts {
   isFirstAdmin: boolean;
 }
 
+/**
+ * Build `<hub-origin>/vault/<name>/mcp` — the MCP endpoint a client connects
+ * to. Mirrors the SPA's `mcpEndpointFor` (McpConnectCard.tsx) and the
+ * wizard's `renderMcpTile`. The friend's `/account/` tile is server-rendered
+ * (no SPA), so we compute it here from the hub origin + vault name rather
+ * than the vault's well-known `url`.
+ *
+ * Exported for direct unit testing.
+ */
+export function accountMcpEndpoint(trimmedOrigin: string, vaultName: string): string {
+  return `${trimmedOrigin}/vault/${vaultName}/mcp`;
+}
+
+/**
+ * The OAuth-path `claude mcp add` command — no token, triggers browser OAuth
+ * on first use. Same `parachute-<name>` server name as the SPA card and the
+ * wizard tile, so a friend and the operator end up with identically-named
+ * MCP servers. Exported for direct unit testing.
+ */
+export function accountClaudeMcpAddCommand(trimmedOrigin: string, vaultName: string): string {
+  return `claude mcp add --transport http parachute-${vaultName} ${accountMcpEndpoint(
+    trimmedOrigin,
+    vaultName,
+  )}`;
+}
+
 function renderVaultCard(opts: VaultCardOpts): string {
   const { assignedVaults, trimmedOrigin, isFirstAdmin } = opts;
 
   if (assignedVaults.length > 0) {
-    // One vault tile per assignment (multi-user Phase 2 PR 2). Each
-    // tile carries its own Notes "Open" CTA and the hub-origin code
-    // block. The disclosure ("Use a custom client") lives at the
-    // section level, not per-tile, because the hub origin is the same
-    // regardless of which vault the user picks.
-    const hubOriginDisplay = escapeHtml(trimmedOrigin);
+    // One vault tile per assignment (multi-user Phase 2 PR 2). Each tile
+    // carries the Notes "Open" CTA AND a server-rendered MCP connect block
+    // (endpoint + `claude mcp add` command, each with a copy button). The
+    // connect command is the OAuth path — no token, so a non-admin friend
+    // who can't run the SPA's host-admin mint still gets a working
+    // connect affordance (the first `claude mcp add` use opens a browser,
+    // signs them in, and approves the scope). This closes the multi-user
+    // gap where the friend tile only offered the external Notes link + a
+    // bare hub-origin string.
     const heading = assignedVaults.length === 1 ? "<h2>Your vault</h2>" : "<h2>Your vaults</h2>";
     const tiles = assignedVaults
       .map((vaultName) => {
         const safeVault = escapeHtml(vaultName);
         const vaultUrlForAdd = encodeURIComponent(`${trimmedOrigin}/vault/${vaultName}`);
+        const endpoint = accountMcpEndpoint(trimmedOrigin, vaultName);
+        const addCmd = accountClaudeMcpAddCommand(trimmedOrigin, vaultName);
+        const safeEndpoint = escapeHtml(endpoint);
+        const safeAddCmd = escapeHtml(addCmd);
         return `
         <div class="vault-tile" data-testid="vault-tile" data-vault-name="${safeVault}">
           <p class="vault-name"><strong>${safeVault}</strong></p>
@@ -170,6 +203,27 @@ function renderVaultCard(opts: VaultCardOpts): string {
             <a class="btn btn-primary" href="https://notes.parachute.computer/add?url=${vaultUrlForAdd}"
                target="_blank" rel="noopener" data-testid="open-notes-cta">Open Notes ↗</a>
           </p>
+          <div class="mcp-connect" data-testid="mcp-connect">
+            <p class="mcp-connect-label">Connect an MCP client (Claude Code, Claude.ai)</p>
+            <div class="mcp-field">
+              <span class="mcp-field-label">Endpoint</span>
+              <div class="copy-row">
+                <code data-testid="mcp-endpoint">${safeEndpoint}</code>
+                <button type="button" class="btn btn-copy" data-copy="${safeEndpoint}"
+                        data-testid="copy-mcp-endpoint">Copy</button>
+              </div>
+            </div>
+            <div class="mcp-field">
+              <span class="mcp-field-label">Claude Code</span>
+              <div class="copy-row">
+                <code data-testid="mcp-add-command">${safeAddCmd}</code>
+                <button type="button" class="btn btn-copy" data-copy="${safeAddCmd}"
+                        data-testid="copy-mcp-add-command">Copy</button>
+              </div>
+            </div>
+            <p class="mcp-connect-hint">No token needed — the command opens a browser to
+               sign you in to this hub and approve access on first use.</p>
+          </div>
         </div>`;
       })
       .join("");
@@ -178,18 +232,12 @@ function renderVaultCard(opts: VaultCardOpts): string {
         ${heading}
         <p>Open Notes — the canonical browser UI for your vault${
           assignedVaults.length === 1 ? "" : "s"
-        }. It connects to your hub
-          over HTTPS and remembers your URL after the first OAuth.</p>
+        } — or connect an MCP client
+          (Claude Code, Claude.ai) with the command below. Either way you sign in to your
+          hub over HTTPS and approve access on the first connection.</p>
         <div class="vault-tiles">${tiles}
         </div>
-        <details class="custom-client">
-          <summary>Use a custom client</summary>
-          <p>To connect a custom Surface or MCP client running on your own machine,
-             point it at the hub origin below and run through OAuth — the hub will
-             ask you to consent.</p>
-          <p class="hub-origin-line">Hub origin: <code>${hubOriginDisplay}</code></p>
-        </details>
-      </section>`;
+      </section>${COPY_SCRIPT}`;
   }
   if (isFirstAdmin) {
     return `
@@ -236,12 +284,39 @@ function renderAccountCard(opts: AccountCardOpts): string {
     </section>`;
 }
 
+// --- copy-button script ---------------------------------------------------
+//
+// Tiny inline progressive-enhancement script for the per-tile copy buttons.
+// Delegated click handler reads the command/endpoint from the button's
+// `data-copy` attribute and writes it to the clipboard, flashing "Copied ✓"
+// for 2s. No-ops gracefully when the Clipboard API is unavailable (insecure
+// context, older browser) — the command text stays selectable in the
+// codebox. Mirrors the SPA `CopyButton` posture (McpConnectCard.tsx) for a
+// surface that has no React. Only emitted on the assigned-vault branch
+// (where copy buttons exist).
+const COPY_SCRIPT = `
+  <script>
+    (function () {
+      document.addEventListener('click', function (e) {
+        var btn = e.target && e.target.closest ? e.target.closest('[data-copy]') : null;
+        if (!btn) return;
+        var value = btn.getAttribute('data-copy') || '';
+        if (typeof navigator === 'undefined' || !navigator.clipboard) return;
+        navigator.clipboard.writeText(value).then(function () {
+          var original = btn.textContent;
+          btn.textContent = 'Copied \\u2713';
+          setTimeout(function () { btn.textContent = original; }, 2000);
+        }).catch(function () { /* insecure context — leave selectable */ });
+      });
+    })();
+  </script>`;
+
 // --- styles ---------------------------------------------------------------
 //
 // Same brand palette + font stack as account-change-password-ui.ts so the
 // `/account/*` family is visually cohesive. Extra rules (.section, .kv,
-// .vault-name, .custom-client, .hub-origin-line) describe the new card +
-// disclosure shapes this page introduces.
+// .vault-name, .mcp-connect, .copy-row) describe the new card + MCP
+// connect-block shapes this page introduces.
 
 const STYLES = `
   *, *::before, *::after { box-sizing: border-box; }
@@ -338,22 +413,58 @@ const STYLES = `
   .vault-tile p { margin: 0.2rem 0; }
   .vault-tile p:last-child { margin-top: 0.5rem; }
 
-  .custom-client { margin-top: 0.8rem; }
-  .custom-client summary {
-    cursor: pointer;
+  .mcp-connect {
+    margin-top: 0.75rem;
+    padding-top: 0.6rem;
+    border-top: 1px solid ${PALETTE.borderLight};
+  }
+  .mcp-connect-label {
     font-size: 0.85rem;
+    font-weight: 500;
+    color: ${PALETTE.fg};
+    margin: 0 0 0.5rem;
+  }
+  .mcp-field { margin: 0.5rem 0; }
+  .mcp-field-label {
+    display: block;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
     color: ${PALETTE.fgMuted};
     font-family: ${FONT_MONO};
-    padding: 0.25rem 0;
-    user-select: none;
+    margin-bottom: 0.2rem;
   }
-  .custom-client[open] summary { color: ${PALETTE.fg}; }
-  .custom-client p {
-    font-size: 0.9rem;
+  .copy-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: ${PALETTE.cardBg};
+    border: 1px solid ${PALETTE.borderLight};
+    border-radius: 6px;
+    padding: 0.4rem 0.5rem;
+  }
+  .copy-row code {
+    flex: 1 1 auto;
+    overflow-x: auto;
+    white-space: nowrap;
+    background: transparent;
+    padding: 0;
+    font-size: 0.82rem;
+  }
+  .btn-copy {
+    flex: 0 0 auto;
+    font-size: 0.8rem;
+    padding: 0.3rem 0.7rem;
+    background: transparent;
+    color: ${PALETTE.fg};
+    border-color: ${PALETTE.border};
+  }
+  .btn-copy:hover { background: ${PALETTE.bgSoft}; border-color: ${PALETTE.accent}; }
+  .mcp-connect-hint {
+    font-size: 0.82rem;
     color: ${PALETTE.fgMuted};
-    margin: 0.4rem 0;
+    margin: 0.4rem 0 0;
   }
-  .hub-origin-line { font-family: ${FONT_MONO}; }
   code {
     font-family: ${FONT_MONO};
     background: ${PALETTE.bgSoft};
@@ -423,12 +534,14 @@ const STYLES = `
     body { background: #1a1815; color: #e8e4dc; }
     .card { background: #25221d; border-color: #3a362f; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3); }
     h1, h2 { color: #f0ece4; }
-    .subtitle, .kv dt, .custom-client summary { color: #a8a29a; }
-    .vault-name strong { color: #f0ece4; }
+    .subtitle, .kv dt, .mcp-field-label, .mcp-connect-hint { color: #a8a29a; }
+    .vault-name strong, .mcp-connect-label { color: #f0ece4; }
     code { background: #1f1c18; color: #e8e4dc; }
-    .section { border-top-color: #3a362f; }
+    .copy-row code { background: transparent; }
+    .section, .mcp-connect { border-top-color: #3a362f; }
     .brand-tag { border-color: #3a362f; color: #a8a29a; }
-    .btn-secondary { color: #e8e4dc; border-color: #3a362f; }
-    .btn-secondary:hover { background: #1f1c18; border-color: ${PALETTE.accent}; }
+    .copy-row { background: #1f1c18; border-color: #3a362f; }
+    .btn-secondary, .btn-copy { color: #e8e4dc; border-color: #3a362f; }
+    .btn-secondary:hover, .btn-copy:hover { background: #1f1c18; border-color: ${PALETTE.accent}; }
   }
 `;

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -12,16 +12,24 @@
  *   Content-Type: application/json
  *   { "name": "<vault-name>" }
  *
- *   201 → { name, url, version, token?, paths? }
- *           // vault freshly created. `token` (single-emit `pvt_*`) and
- *           // filesystem `paths` are present when the create path took the
- *           // `parachute-vault create --json` branch — that's the only time
- *           // the just-emitted token is captured. The first-vault-on-host
- *           // bootstrap (`parachute install vault`) doesn't emit JSON yet,
- *           // so a fresh-box response carries name/url/version only.
+ *   201 → { name, url, version, token?, token_guidance?, paths? }
+ *           // vault freshly created. `token` is a hub-issued ACCESS token
+ *           // (a JWT scoped `vault:<name>:admin`) captured from the
+ *           // `parachute-vault create --json` branch — NOT a `pvt_*` vault
+ *           // token (those were dropped). Post-DROP `token` may be the
+ *           // empty string `""` when the bootstrap mint was unavailable
+ *           // (e.g. a loopback origin the hub can't mint against); in that
+ *           // case `token_guidance` carries the vault's human-readable
+ *           // reason, forwarded verbatim so the SPA can explain the gap.
+ *           // `paths` is the new vault's filesystem layout. The
+ *           // first-vault-on-host bootstrap (`parachute install vault`)
+ *           // doesn't emit JSON yet, so a fresh-box response carries
+ *           // name/url/version only.
  *   200 → { name, url, version }
  *           // idempotent re-POST: existing vault. Never includes `token` —
- *           // tokens are single-emit at create time, not retrievable later.
+ *           // the create-time access token isn't retrievable later. The
+ *           // caller branches on HTTP status (201 vs 200), not on `token`
+ *           // truthiness, so an empty-token 201 isn't confused with a 200.
  *   400 → { error: "invalid_request", error_description: ... }
  *   401/403 → bearer-auth failure
  *   500 → orchestration failure
@@ -50,7 +58,7 @@
 import type { Database } from "bun:sqlite";
 import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
-import { findService, readManifest, readManifestLenient } from "./services-manifest.ts";
+import { findService, type readManifest, readManifestLenient } from "./services-manifest.ts";
 import { type WellKnownVaultEntry, isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
 
 /** Scope required to call POST /vaults. */
@@ -74,7 +82,20 @@ export interface CreateVaultRequest {
 /** Output shape of `parachute-vault create --json` (vault PR #184). */
 export interface VaultCreateJson {
   name: string;
+  /**
+   * Hub-issued access token (a JWT scoped `vault:<name>:admin`) the vault
+   * minted at create time. Post the pvt_* DROP this is the empty string
+   * `""` when no hub origin was reachable to mint against (e.g. a loopback
+   * create) — the field is always present but may be empty.
+   */
   token: string;
+  /**
+   * Vault-supplied human-readable reason no token was minted, present only
+   * when `token` is empty (e.g. "no hub origin reachable to mint against").
+   * Optional — older vaults that always minted don't emit it. Forwarded
+   * verbatim to the caller so the SPA can explain the empty-token state.
+   */
+  token_guidance?: string;
   paths: {
     vault_dir: string;
     vault_db: string;
@@ -239,8 +260,9 @@ interface OrchestrateError {
  * Run the orchestration step. Picks `parachute install` (bootstrap) vs
  * `parachute-vault create --json` (subsequent) based on whether vault is
  * already registered in services.json. The create branch parses stdout for
- * the just-emitted `pvt_*` token + filesystem paths so the caller can talk
- * to the new vault — those creds are single-emit.
+ * the just-minted hub access token (a `vault:<name>:admin` JWT, possibly
+ * empty post-DROP), the optional `token_guidance`, and filesystem paths so
+ * the caller can talk to the new vault — the access token is single-emit.
  */
 async function orchestrate(
   manifestPath: string,
@@ -348,14 +370,25 @@ export async function handleCreateVault(req: Request, deps: CreateVaultDeps): Pr
   }
 
   const entry = buildEntry(name, created.path, created.version, deps.issuer);
-  // Token + filesystem paths are single-emit at create time. We surface them
-  // here so the caller can immediately bootstrap a connection to the new
-  // vault. Idempotent re-POSTs intentionally never include them.
+  // Access token (a `vault:<name>:admin` JWT, possibly empty post-DROP) +
+  // filesystem paths are single-emit at create time. We surface them here so
+  // the caller can immediately bootstrap a connection to the new vault.
+  // `token_guidance` (when the vault couldn't mint) is forwarded verbatim so
+  // the SPA can explain the empty-token state rather than rendering a blank.
+  // Idempotent re-POSTs intentionally never include any of these.
   const body: WellKnownVaultEntry & {
     token?: string;
+    token_guidance?: string;
     paths?: VaultCreateJson["paths"];
   } = result.createJson
-    ? { ...entry, token: result.createJson.token, paths: result.createJson.paths }
+    ? {
+        ...entry,
+        token: result.createJson.token,
+        ...(result.createJson.token_guidance
+          ? { token_guidance: result.createJson.token_guidance }
+          : {}),
+        paths: result.createJson.paths,
+      }
     : entry;
 
   return new Response(JSON.stringify(body), {

--- a/src/api-users.ts
+++ b/src/api-users.ts
@@ -336,7 +336,16 @@ export async function handleCreateUser(req: Request, deps: ApiUsersDeps): Promis
   }
 }
 
-/** DELETE /api/users/:id — hard-delete + token revocation + session/grant cleanup. */
+/**
+ * DELETE /api/users/:id — hard-delete + token revocation + session/grant
+ * cleanup.
+ *
+ * Success returns `200 { ok: true, revocation_lag_seconds: 60 }` (was a bare
+ * 204 pre-consistency-fix) so the SPA can warn that the deleted user's
+ * tokens linger ~60s on resource-server revocation caches — same surface
+ * the reset-password path carries. The race-tolerant "row already gone"
+ * path stays a bodyless 204 (nothing was revoked here, no lag to report).
+ */
 export async function handleDeleteUser(
   req: Request,
   userId: string,
@@ -390,11 +399,28 @@ export async function handleDeleteUser(
   if (!removed) {
     // Race: row deleted by a concurrent request. Operator's intent
     // (no such user) is already satisfied — same shape as the grant-
-    // revoke race in `admin-grants.ts`.
+    // revoke race in `admin-grants.ts`. No tokens were revoked by THIS
+    // call, so there's no revocation lag to warn about; keep the bodyless
+    // 204 for the race path.
     return new Response(null, { status: 204 });
   }
   console.log(`user deleted: id=${userId} username=${target.username}`);
-  return new Response(null, { status: 204 });
+  // `revocation_lag_seconds`: same consistency fix the reset-password path
+  // got (smoke 2026-05-27 finding 3). Deleting a user revokes their tokens
+  // in hub's DB immediately, but resource servers (vault, scribe, …) cache
+  // the revocation list via scope-guard's `REVOCATION_CACHE_TTL_MS = 60_000`
+  // — a deleted user's tokens linger for up to ~60s on those caches. Surface
+  // that so the admin isn't surprised when a just-deleted user's client can
+  // still read for a minute (relevant in the stolen-device / compromise
+  // threat model). 200 + body instead of the old bare 204 so the SPA can
+  // render the warning banner.
+  return new Response(
+    JSON.stringify({ ok: true, revocation_lag_seconds: REVOCATION_LAG_SECONDS }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json", "cache-control": "no-store" },
+    },
+  );
 }
 
 /**

--- a/src/vault/auth-status.ts
+++ b/src/vault/auth-status.ts
@@ -54,9 +54,12 @@ export interface VaultAuthStatus {
   hasTotp: boolean;
   /**
    * `null` means we couldn't read the SQLite DB — distinct from "0 tokens
-   * exist." Callers branch the UI on this: `null` → "token status unknown,
-   * run `parachute vault tokens list` to check"; `0` → loud "no auth at
-   * all!" warning; `>0` → benign.
+   * exist." Post the pvt_* DROP (hub#466) the expose preflight no longer
+   * branches on this — `classify()` in expose-auth-preflight.ts gates on
+   * `hasOwnerPassword`, since access now flows through the owner password +
+   * on-demand hub JWT mint, not standing vault tokens. `tokenCount` is kept
+   * as a best-effort diagnostic only (these rows are vestigial); `null`
+   * still cleanly distinguishes "unreadable DB" from "0 rows."
    */
   tokenCount: number | null;
   /** Vault instance names discovered under data/. Empty when vault has
@@ -183,9 +186,11 @@ function defaultProbeHubDbHasUserPassword(dbPath: string): boolean | undefined {
     // simpler than a JOIN on earliest-created-at. A future env-seed
     // flow that creates friend accounts before the operator sets a
     // password would need to revisit this assumption.
-    const row = db?.prepare(
-      "SELECT COUNT(*) AS n FROM users WHERE password_hash IS NOT NULL AND length(password_hash) > 0",
-    ).get() as { n: number } | null;
+    const row = db
+      ?.prepare(
+        "SELECT COUNT(*) AS n FROM users WHERE password_hash IS NOT NULL AND length(password_hash) > 0",
+      )
+      .get() as { n: number } | null;
     return (row?.n ?? 0) > 0;
   } catch {
     return undefined;
@@ -205,8 +210,7 @@ function resolve(opts: AuthStatusOpts): Resolved {
     readText: opts.readText ?? defaultReadText,
     listVaultNames: opts.listVaultNames ?? defaultListVaultNames,
     countTokens: opts.countTokens ?? defaultCountTokens,
-    probeHubDbHasUserPassword:
-      opts.probeHubDbHasUserPassword ?? defaultProbeHubDbHasUserPassword,
+    probeHubDbHasUserPassword: opts.probeHubDbHasUserPassword ?? defaultProbeHubDbHasUserPassword,
   };
 }
 

--- a/web/ui/CLAUDE.md
+++ b/web/ui/CLAUDE.md
@@ -83,7 +83,7 @@ web/ui/
     │   └── api.ts          # listVaults + createVault
     ├── routes/
     │   ├── VaultsList.tsx  # / (under /vault basename)
-    │   ├── NewVault.tsx    # /new (single-emit pvt_* banner)
+    │   ├── NewVault.tsx    # /new (one-shot hub access-token banner)
     │   └── VaultDetail.tsx # /:name (Phase 2 placeholder)
     └── test/setup.ts
 ```

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -138,6 +138,53 @@ describe("App — nav structure", () => {
   });
 });
 
+describe("App — active nav indicator", () => {
+  it("marks the current section's NavLink active with aria-current + class", () => {
+    const { container } = renderAt("/tokens");
+    const tokens = within(screen.getByRole("navigation")).getByRole("link", {
+      name: /^tokens$/i,
+    });
+    expect(tokens).toHaveClass("nav-link-active");
+    expect(tokens).toHaveAttribute("aria-current", "page");
+    // Exactly one section is active at a time.
+    expect(container.querySelectorAll(".nav .nav-link-active")).toHaveLength(1);
+  });
+
+  it("lights up Vaults on the index route (/) via the alsoActiveAt alias", () => {
+    renderAt("/");
+    const vaults = within(screen.getByRole("navigation")).getByRole("link", {
+      name: /^vaults$/i,
+    });
+    expect(vaults).toHaveClass("nav-link-active");
+    expect(vaults).toHaveAttribute("aria-current", "page");
+  });
+
+  it("keeps Vaults active on the /vaults/new sub-route", () => {
+    renderAt("/vaults/new");
+    const vaults = within(screen.getByRole("navigation")).getByRole("link", {
+      name: /^vaults$/i,
+    });
+    expect(vaults).toHaveClass("nav-link-active");
+  });
+});
+
+describe("App — document title", () => {
+  it("sets a per-route document.title", async () => {
+    renderAt("/tokens");
+    await waitFor(() => expect(document.title).toBe("Tokens · Parachute"));
+  });
+
+  it("title-cases multi-word sections", async () => {
+    renderAt("/modules/scribe/config");
+    await waitFor(() => expect(document.title).toBe("Module Config · Parachute"));
+  });
+
+  it("falls back to Vaults on the index route", async () => {
+    renderAt("/");
+    await waitFor(() => expect(document.title).toBe("Vaults · Parachute"));
+  });
+});
+
 describe("App — auth indicator (rc.13)", () => {
   it("renders nothing on first paint, then 'Sign in' once /api/me resolves to signed-out", async () => {
     vi.mocked(api.getMe).mockResolvedValue({ hasSession: false });

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -67,10 +67,31 @@ function subtitleFor(pathname: string): string {
   return "vaults";
 }
 
+/**
+ * Title-case the route subtitle for the browser tab. `subtitleFor` returns
+ * lowercase section words ("vaults", "module config", "approve app"); the
+ * `<title>` reads better capitalized ("Vaults · Parachute Hub").
+ */
+function documentTitleFor(pathname: string): string {
+  const section = subtitleFor(pathname)
+    .split(" ")
+    .map((w) => (w.length > 0 ? w[0]!.toUpperCase() + w.slice(1) : w))
+    .join(" ");
+  return `${section} · ${WORDMARK_TEXT}`;
+}
+
 export function App() {
   const { pathname } = useLocation();
   const subtitle = subtitleFor(pathname);
   const [me, setMe] = useState<MeResponse | null>(null);
+
+  // Per-route document.title so a deep-link / multi-tab operator sees which
+  // admin section a tab holds without focusing it. The static index.html
+  // <title> only ever read "Parachute Hub"; this updates it on every
+  // client-side navigation.
+  useEffect(() => {
+    document.title = documentTitleFor(pathname);
+  }, [pathname]);
   const [signingOut, setSigningOut] = useState(false);
   // hub#342: surface a "Services" quick-access dropdown in the nav with
   // an entry per installed module that declares a `management_url`. One
@@ -147,13 +168,13 @@ export function App() {
           <span className="sub">{subtitle}</span>
         </Link>
         <AuthIndicator me={me} signingOut={signingOut} onSignOut={onSignOut} />
-        <Link to="/vaults">Vaults</Link>
-        <Link to="/modules">Modules</Link>
+        <NavSection to="/vaults" label="Vaults" alsoActiveAt="/" />
+        <NavSection to="/modules" label="Modules" />
         <InstalledServicesDropdown services={installedServices} />
-        <Link to="/users">Users</Link>
-        <Link to="/permissions">Permissions</Link>
-        <Link to="/tokens">Tokens</Link>
-        <Link to="/settings">Settings</Link>
+        <NavSection to="/users" label="Users" />
+        <NavSection to="/permissions" label="Permissions" />
+        <NavSection to="/tokens" label="Tokens" />
+        <NavSection to="/settings" label="Settings" />
         <span className="nav-divider" aria-hidden="true" />
         <a href="/" title="Hub discovery page (top-level)">
           Discovery
@@ -188,6 +209,45 @@ export function App() {
           ever see admin diagnostics, and /api/hub would 401 anyway. */}
       {me?.hasSession ? <HubVersionBadge /> : null}
     </div>
+  );
+}
+
+/**
+ * A top-level nav section link with an active-state class + `aria-current`.
+ *
+ * We compute the active state ourselves (prefix-match on the section path,
+ * plus an optional `alsoActiveAt` exact-match alias) rather than leaning on
+ * `NavLink`'s internal `aria-current`: NavLink only stamps `aria-current`
+ * when ITS OWN path matches, so the index-route alias (the SPA renders
+ * `<VaultsList>` at `/` as well as `/vaults`) wouldn't get the attribute.
+ * A plain `<Link>` + manual flags gives full control over both the class
+ * and `aria-current`, and still resolves against the router basename.
+ *
+ * `isPrefix` matches `/vaults` AND `/vaults/new`; the exact-segment check
+ * (`pathname === to`) guards against `/tokens` lighting up for an unrelated
+ * `/tokens-something` were such a route ever added.
+ */
+function NavSection({
+  to,
+  label,
+  alsoActiveAt,
+}: {
+  to: string;
+  label: string;
+  alsoActiveAt?: string;
+}) {
+  const { pathname } = useLocation();
+  const isPrefix = pathname === to || pathname.startsWith(`${to}/`);
+  const aliasActive = alsoActiveAt !== undefined && pathname === alsoActiveAt;
+  const active = isPrefix || aliasActive;
+  return (
+    <Link
+      to={to}
+      className={active ? "nav-link nav-link-active" : "nav-link"}
+      aria-current={active ? "page" : undefined}
+    >
+      {label}
+    </Link>
   );
 }
 

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -186,7 +186,7 @@ describe("createVault", () => {
         name: "work",
         url: "http://hub.local/vault/work/",
         version: "0.5.1",
-        token: "pvt_abc123",
+        token: "hubjwt.abc123",
         paths: {
           vault_dir: "/home/u/.parachute/vault/work",
           vault_db: "/home/u/.parachute/vault/work/vault.db",
@@ -199,7 +199,9 @@ describe("createVault", () => {
     const api = await import("./api.ts");
     const result = await api.createVault({ name: "work" });
 
-    expect(result.token).toBe("pvt_abc123");
+    // 201 → `created: true` is the authoritative create signal.
+    expect(result.created).toBe(true);
+    expect(result.token).toBe("hubjwt.abc123");
     expect(result.paths?.vault_dir).toContain("/vault/work");
     expect(fetchMock).toHaveBeenCalledWith(
       "/vaults",
@@ -214,11 +216,11 @@ describe("createVault", () => {
     );
   });
 
-  it("on 200 idempotent re-POST returns the existing entry without a token", async () => {
+  it("on 200 idempotent re-POST returns the existing entry without a token (created: false)", async () => {
     // Server short-circuits when the vault already exists: same name + url +
-    // version, but no fresh `token` (we only emit once, on first create).
-    // NewVault.tsx must handle the missing-token branch without claiming
-    // success-with-banner.
+    // version, but no fresh `token` (the create-time access token isn't
+    // retrievable later). `created: false` is the authoritative signal —
+    // NewVault.tsx renders the "already existed" branch off it.
     vi.stubGlobal(
       "fetch",
       vi.fn(async () =>
@@ -232,8 +234,34 @@ describe("createVault", () => {
     const api = await import("./api.ts");
     const result = await api.createVault({ name: "work" });
     expect(result.name).toBe("work");
+    expect(result.created).toBe(false);
     expect(result.token).toBeUndefined();
     expect(result.paths).toBeUndefined();
+  });
+
+  it("on 201 with an empty token reports created: true + forwards token_guidance", async () => {
+    // Post the pvt_* DROP, the vault emits `token: ""` when the bootstrap
+    // mint was unavailable (e.g. loopback origin). `created` must come from
+    // the HTTP status (201), NOT token truthiness — and the empty token must
+    // not survive as a falsy-but-present field. `token_guidance` is forwarded
+    // so the UI can explain the gap.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(201, {
+          name: "work",
+          url: "http://hub.local/vault/work/",
+          version: "0.5.1",
+          token: "",
+          token_guidance: "no hub origin reachable to mint against",
+        }),
+      ),
+    );
+    const api = await import("./api.ts");
+    const result = await api.createVault({ name: "work" });
+    expect(result.created).toBe(true);
+    expect(result.token).toBeUndefined();
+    expect(result.tokenGuidance).toBe("no hub origin reachable to mint against");
   });
 
   it("on 401 clears the cached token and throws HttpError(401)", async () => {

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -41,8 +41,32 @@ export interface CreateVaultResult {
   name: string;
   url: string;
   version: string;
-  /** Single-emit `pvt_*` token from `parachute-vault create --json`. Only on first creation. */
+  /**
+   * Whether THIS request freshly created the vault (HTTP 201) vs hit an
+   * already-existing one (idempotent re-POST, HTTP 200). Branch the UI on
+   * this, NOT on `token` truthiness — post the pvt_* DROP a freshly-created
+   * vault can come back with `token: ""` (the bootstrap mint was
+   * unavailable, e.g. on a loopback origin the hub can't mint against), and
+   * treating `""` as "already existed" wrongly tells the operator nothing
+   * was created. Status is the authoritative create signal.
+   */
+  created: boolean;
+  /**
+   * One-shot hub ACCESS token (a JWT scoped `vault:<name>:admin`) captured
+   * from `parachute-vault create --json`. Present and non-empty only when
+   * the hub could mint at create time. Empty string (or absent) on a 201
+   * means the vault was created but no token was minted — see
+   * `tokenGuidance`. This is NOT a `pvt_*` vault token (those were dropped);
+   * it's a hub-issued JWT the connect command can carry as a header.
+   */
   token?: string;
+  /**
+   * Vault-supplied human-readable reason no token was minted (e.g. "no hub
+   * origin reachable to mint against"), forwarded verbatim from the vault
+   * create JSON's `token_guidance` field. Surfaced on the empty-token-on-201
+   * state so the operator understands the gap rather than seeing a blank.
+   */
+  tokenGuidance?: string;
   paths?: {
     vault_dir: string;
     vault_db: string;
@@ -173,7 +197,30 @@ export async function createVault(input: CreateVaultInput): Promise<CreateVaultR
   if (!res.ok) {
     throw new HttpError(res.status, await readError(res));
   }
-  return (await res.json()) as CreateVaultResult;
+  // The hub returns 201 on a fresh create, 200 on an idempotent re-POST
+  // against an existing vault. Carry that distinction into `created` so the
+  // UI branches on status, not on `token` truthiness — a 201 can legitimately
+  // carry `token: ""` post-DROP (mint unavailable) and must NOT be treated as
+  // "already existed."
+  const created = res.status === 201;
+  const body = (await res.json()) as {
+    name: string;
+    url: string;
+    version: string;
+    token?: string;
+    token_guidance?: string;
+    paths?: CreateVaultResult["paths"];
+  };
+  const result: CreateVaultResult = {
+    name: body.name,
+    url: body.url,
+    version: body.version,
+    created,
+  };
+  if (body.token) result.token = body.token;
+  if (body.token_guidance) result.tokenGuidance = body.token_guidance;
+  if (body.paths) result.paths = body.paths;
+  return result;
 }
 
 /**
@@ -1125,8 +1172,15 @@ export async function createUser(input: CreateUserInput): Promise<UserListing> {
  * delete the first-created admin (403 `first_admin_undeletable`) so the
  * hub can't be self-locked. The SPA also disables the row-level button
  * for that user as a UX hint, but the server check is authoritative.
+ *
+ * Returns `{ revocationLagSeconds }` — same shape + rationale as
+ * `resetUserPassword`. A successful delete revokes the user's tokens, but
+ * resource servers cache the revocation list for ~60s; surface the lag so
+ * the SPA can warn the admin (consistency with the reset-password banner).
+ * The server's race-tolerant "row already gone" path returns a bodyless
+ * 204; we default to 60 when there's no body to parse.
  */
-export async function deleteUser(id: string): Promise<void> {
+export async function deleteUser(id: string): Promise<{ revocationLagSeconds: number }> {
   const bearer = await getHostAdminToken();
   const res = await fetch(`/api/users/${encodeURIComponent(id)}`, {
     method: "DELETE",
@@ -1141,6 +1195,12 @@ export async function deleteUser(id: string): Promise<void> {
     throw new HttpError(res.status, await readError(res));
   }
   if (!res.ok) throw new HttpError(res.status, await readError(res));
+  // 200 carries `{ ok, revocation_lag_seconds }`; the race-path 204 has no
+  // body. Default to 60 (the server constant) when missing — same posture
+  // as `resetUserPassword`.
+  const body = (await res.json().catch(() => ({}))) as { revocation_lag_seconds?: number };
+  const lag = typeof body.revocation_lag_seconds === "number" ? body.revocation_lag_seconds : 60;
+  return { revocationLagSeconds: lag };
 }
 
 /**

--- a/web/ui/src/routes/NewVault.test.tsx
+++ b/web/ui/src/routes/NewVault.test.tsx
@@ -1,10 +1,12 @@
 /**
- * NewVault smoke tests — validation, submit, single-emit token banner.
+ * NewVault smoke tests — validation, submit, and the three created-view
+ * branches (token present, created-but-no-token, already-existed).
  *
  * We mock `../lib/api.ts:createVault` so the form's submit path is
- * exercised without touching the wire. The token banner is the
- * single-emit surface — once it renders, the operator must dismiss
- * before the navigate fires.
+ * exercised without touching the wire. The created-view branches on the
+ * `created` flag (HTTP 201 vs 200), NOT on token truthiness — the
+ * empty-token-on-201 case (mint unavailable post-DROP) must render
+ * "created, no token minted", not "already existed".
  */
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -74,12 +76,13 @@ describe("NewVault", () => {
     expect(screen.getByRole("button", { name: /create vault/i })).toBeDisabled();
   });
 
-  it("renders the single-emit token banner on a 201 with token", async () => {
+  it("renders the one-shot access-token banner on a 201 with token", async () => {
     vi.mocked(api.createVault).mockResolvedValue({
       name: "work",
       url: "http://hub.local/vault/work/",
       version: "0.5.1",
-      token: "pvt_abc123secret",
+      created: true,
+      token: "hubjwt.abc123.secret",
       paths: {
         vault_dir: "/home/u/.parachute/vault/work",
         vault_db: "/home/u/.parachute/vault/work/vault.db",
@@ -92,9 +95,11 @@ describe("NewVault", () => {
     await user.click(screen.getByRole("button", { name: /create vault/i }));
 
     await waitFor(() =>
-      expect(screen.getByText(/your vault token \(shown once\)/i)).toBeInTheDocument(),
+      expect(screen.getByText(/your access token \(shown once\)/i)).toBeInTheDocument(),
     );
-    expect(screen.getByText("pvt_abc123secret")).toBeInTheDocument();
+    expect(screen.getByText("hubjwt.abc123.secret")).toBeInTheDocument();
+    // It's framed as a hub access token, not a vault password / pvt_* token.
+    expect(screen.getByText(/vault:work:admin/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /done/i })).toBeInTheDocument();
     expect(screen.getByText(/vault\.db/)).toBeInTheDocument();
 
@@ -112,11 +117,12 @@ describe("NewVault", () => {
     await waitFor(() => expect(screen.getByText("vaults list")).toBeInTheDocument());
   });
 
-  it("renders the no-token branch on idempotent re-POST (200)", async () => {
+  it("renders the already-existed branch on idempotent re-POST (200)", async () => {
     vi.mocked(api.createVault).mockResolvedValue({
       name: "work",
       url: "http://hub.local/vault/work/",
       version: "0.5.1",
+      created: false,
     });
     renderForm();
     const user = userEvent.setup();
@@ -129,6 +135,45 @@ describe("NewVault", () => {
     // The idempotent-200 "Continue" link points at the real vaults list
     // route too (same 404 bug, second site).
     await user.click(screen.getByRole("button", { name: /continue/i }));
+    await waitFor(() => expect(screen.getByText("vaults list")).toBeInTheDocument());
+  });
+
+  it("renders the created-but-no-token branch on a 201 with empty token (mint unavailable)", async () => {
+    // Post the pvt_* DROP, a freshly-created vault (HTTP 201) can come back
+    // with no token when the bootstrap mint was unavailable (e.g. loopback
+    // origin). `created: true` must win over the empty token — pre-fix this
+    // wrongly rendered "already existed" because `""` read as falsy.
+    vi.mocked(api.createVault).mockResolvedValue({
+      name: "work",
+      url: "http://hub.local/vault/work/",
+      version: "0.5.1",
+      created: true,
+      tokenGuidance: "no hub origin reachable to mint against",
+    });
+    renderForm();
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/vault name/i), "work");
+    await user.click(screen.getByRole("button", { name: /create vault/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/was created, but no access token was minted/i)).toBeInTheDocument(),
+    );
+    // The vault's guidance reason is surfaced verbatim.
+    expect(screen.getByText(/no hub origin reachable to mint against/i)).toBeInTheDocument();
+    // It must NOT claim the vault already existed.
+    expect(screen.queryByText(/already existed/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/shown once/i)).not.toBeInTheDocument();
+    // Still surfaces the real CLI mint path (not parachute-vault mint-token).
+    expect(
+      screen.getByText(/parachute auth mint-token --scope vault:work:read/i),
+    ).toBeInTheDocument();
+    // The connect card (OAuth, no token) is still mounted as the recovery path.
+    expect(screen.getByTestId("mcp-add-command")).toHaveTextContent(
+      "claude mcp add --transport http parachute-work http://hub.local/vault/work/mcp",
+    );
+
+    // "Done" lands on the vaults list.
+    await user.click(screen.getByRole("button", { name: /done/i }));
     await waitFor(() => expect(screen.getByText("vaults list")).toBeInTheDocument());
   });
 

--- a/web/ui/src/routes/NewVault.tsx
+++ b/web/ui/src/routes/NewVault.tsx
@@ -6,19 +6,30 @@
  *      "list" reserved) client-side so the operator gets immediate
  *      feedback, but the server is still authoritative — see admin-
  *      vaults.ts for the canonical list.
- *   2. Result: on 201 with `token`, render the single-emit token banner
- *      with copy + a "Done" dismiss. The token is shown ONCE, ever —
- *      refreshing the page or navigating away loses it; the hub can't
- *      re-emit it. We block navigation away while the banner is live so
- *      an accidental Back doesn't strand the operator. Below the token
- *      banner, the created-view renders the per-vault MCP connect card
- *      (the same `<McpConnectCard>` the Vaults list uses) so the bare
- *      token has a clear, in-context purpose — closing the team-onboarding
- *      gap where a freshly-minted token arrived with no stated use.
+ *   2. Result, branched on `created` (HTTP 201 vs 200), NOT on token
+ *      truthiness:
+ *        - created + token present → show the one-shot ACCESS-token banner
+ *          (a hub-issued JWT scoped `vault:<name>:admin`) with copy + a
+ *          "Done" dismiss. Shown ONCE — the hub captured it from the
+ *          create JSON and doesn't re-emit it. We block navigation away
+ *          while the banner is live so an accidental Back doesn't strand
+ *          the operator.
+ *        - created + NO token (HTTP 201, `token: ""`) → the vault exists
+ *          but the bootstrap mint was unavailable (e.g. a loopback origin
+ *          the hub can't mint against). Render a "created, but no token
+ *          minted" state with the vault's `token_guidance` reason and
+ *          point at the real mint path. Pre-fix this wrongly rendered
+ *          "already existed" because the empty string read as falsy.
+ *        - NOT created (HTTP 200, idempotent re-POST) → "already existed"
+ *          state. Nothing was minted.
  *
- * 200 (idempotent re-POST against an existing vault) is treated as
- * success but renders without a token banner — there's nothing to copy
- * because the original token was already emitted.
+ * Recovery story (all branches): the created-view mounts the per-vault
+ * `<McpConnectCard>` (same component the Vaults list uses). Its OAuth-first
+ * `claude mcp add` command needs NO token — that's the canonical connect
+ * path. For a header-auth token, mint a scope-narrow one via the card's
+ * "Use a token instead" disclosure, or from the CLI with
+ * `parachute auth mint-token --scope vault:<name>:read`. There is NO
+ * "mint from the vault directly" path — that mental model is gone post-DROP.
  */
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
@@ -39,11 +50,13 @@ export function NewVault() {
   const [name, setName] = useState("");
   const [state, setState] = useState<State>({ kind: "idle" });
 
-  // Block accidental navigation while a single-emit token is on-screen.
+  // Block accidental navigation while a one-shot access token is on-screen.
   // The browser's "leave this page?" dialog is the cheapest belt-and-
   // braces — react-router won't intercept window.close, but it covers
-  // refresh + tab-close, which are the realistic mistakes here.
-  const hasUnsavedToken = state.kind === "created" && state.result.token != null;
+  // refresh + tab-close, which are the realistic mistakes here. Guard on a
+  // non-empty token: a 201 with `token: ""` (mint unavailable) has nothing
+  // to lose, so don't nag the operator.
+  const hasUnsavedToken = state.kind === "created" && !!state.result.token;
   useEffect(() => {
     if (!hasUnsavedToken) return;
     const onBeforeUnload = (e: BeforeUnloadEvent) => {
@@ -161,11 +174,15 @@ function CreatedView({
 
       {result.token ? (
         <div className="mint-banner">
-          <h3>Your vault token (shown once)</h3>
+          <h3>Your access token (shown once)</h3>
           <p className="muted">
-            This is the only time the hub will show this token. Copy it and store it somewhere safe
-            — a password manager, the operator's notes, parachute-agent's secrets store. If you lose
-            it, you'll need to mint a new one from the vault directly.
+            This is a hub-issued access token (a JWT scoped <code>vault:{result.name}:admin</code>)
+            — not a vault password. It's the only time the hub will show it. Copy it and store it
+            somewhere safe — a password manager, the operator's notes. If you lose it, you don't
+            need it for the OAuth connect path below; for a header-auth token, mint a fresh
+            scope-narrow one with{" "}
+            <code>parachute auth mint-token --scope vault:{result.name}:read</code> (or the connect
+            card's "Use a token instead" option).
           </p>
           <div className="token-box">
             <code>{result.token}</code>
@@ -180,12 +197,45 @@ function CreatedView({
             </button>
           </div>
         </div>
-      ) : (
+      ) : result.created ? (
+        // HTTP 201, but no token came back (`token: ""`). The vault WAS
+        // created — the bootstrap mint just wasn't available (e.g. a
+        // loopback origin the hub can't mint a JWT against). Don't render
+        // "already existed" — that's the empty-token-wrong-branch bug.
+        // Steer the operator at the real connect path (the OAuth command in
+        // the card below needs no token) + the CLI mint path.
         <div className="section">
           <p>
-            Vault <code>{result.name}</code> already existed; nothing new was minted. Use the
-            existing token, or mint a fresh one from the vault directly with{" "}
-            <code>parachute-vault mint-token</code>.
+            Vault <code>{result.name}</code> was created, but no access token was minted
+            {result.tokenGuidance ? (
+              <>
+                {" "}
+                — <span className="muted">{result.tokenGuidance}</span>
+              </>
+            ) : (
+              <span className="muted">
+                {" "}
+                (the hub couldn't mint one at create time — common on a loopback origin)
+              </span>
+            )}
+            . You don't need a token for the OAuth connect command below. For a header-auth token,
+            mint a scope-narrow one with{" "}
+            <code>parachute auth mint-token --scope vault:{result.name}:read</code>.
+          </p>
+          <div className="actions">
+            <button type="button" onClick={onDone}>
+              Done
+            </button>
+          </div>
+        </div>
+      ) : (
+        // HTTP 200 — idempotent re-POST against an existing vault. Nothing
+        // was created or minted.
+        <div className="section">
+          <p>
+            Vault <code>{result.name}</code> already existed; nothing new was created. Connect to it
+            with the command below (OAuth, no token needed), or mint a scope-narrow header-auth
+            token with <code>parachute auth mint-token --scope vault:{result.name}:read</code>.
           </p>
           <div className="actions">
             {/* No per-vault detail route exists — land on the vaults list

--- a/web/ui/src/routes/Users.test.tsx
+++ b/web/ui/src/routes/Users.test.tsx
@@ -167,19 +167,25 @@ describe("Users — delete confirm flow", () => {
     expect(api.deleteUser).not.toHaveBeenCalled();
   });
 
-  it("confirm Delete calls deleteUser and refreshes the list", async () => {
+  it("confirm Delete calls deleteUser, refreshes the list, and shows the revocation-lag banner", async () => {
     const listMock = vi.mocked(api.listUsers);
     listMock.mockResolvedValueOnce([user("operator"), user("alice")]);
     listMock.mockResolvedValueOnce([user("operator")]);
     vi.mocked(api.listUserVaults).mockResolvedValue([]);
-    vi.mocked(api.deleteUser).mockResolvedValue();
+    vi.mocked(api.deleteUser).mockResolvedValue({ revocationLagSeconds: 60 });
     renderRoute();
     fireEvent.click(await screen.findByRole("button", { name: /delete alice/i }));
     const dialog = screen.getByRole("dialog", { name: /confirm delete alice/i });
     fireEvent.click(within(dialog).getByRole("button", { name: /^delete$/i }));
     await waitFor(() => expect(api.deleteUser).toHaveBeenCalledWith("id-alice"));
-    // alice gone after refresh.
-    await waitFor(() => expect(screen.queryByText("alice")).toBeNull());
+    // alice's row is gone after refresh (her Delete button no longer exists).
+    // We assert on the row affordance, not bare text — the success banner
+    // legitimately echoes the deleted username.
+    await waitFor(() => expect(screen.queryByRole("button", { name: /delete alice/i })).toBeNull());
+    // Revocation-lag warning banner appears (consistency with reset-password).
+    const banner = await screen.findByTestId("delete-done-banner");
+    expect(banner).toHaveTextContent(/tokens are revoked/i);
+    expect(banner).toHaveTextContent(/up to 60 seconds/i);
   });
 
   it("surfaces a per-row error banner when delete fails", async () => {

--- a/web/ui/src/routes/Users.tsx
+++ b/web/ui/src/routes/Users.tsx
@@ -104,6 +104,7 @@ type DeleteState =
   | { kind: "idle" }
   | { kind: "confirming"; user: UserListing }
   | { kind: "deleting"; userId: string }
+  | { kind: "done"; username: string; revocationLagSeconds: number }
   | { kind: "error"; userId: string; message: string };
 
 /**
@@ -253,8 +254,11 @@ export function Users() {
   async function onConfirmDelete(user: UserListing): Promise<void> {
     setDeleteSt({ kind: "deleting", userId: user.id });
     try {
-      await deleteUser(user.id);
-      setDeleteSt({ kind: "idle" });
+      const { revocationLagSeconds } = await deleteUser(user.id);
+      // Surface a done-banner with the revocation-lag warning (consistency
+      // with the reset-password flow) so the admin knows the deleted user's
+      // tokens linger ~60s on resource-server caches.
+      setDeleteSt({ kind: "done", username: user.username, revocationLagSeconds });
       setReload((n) => n + 1);
     } catch (err) {
       const message =
@@ -341,6 +345,31 @@ export function Users() {
         ) : null}
         .
       </p>
+
+      {deleteSt.kind === "done" && (
+        // Section-level (not per-row): the deleted user's row is gone after
+        // the reload, so the revocation-lag warning lives above the list.
+        // Mirrors the reset-password success banner's wording.
+        <output
+          className="success-banner"
+          style={{ display: "block", marginBottom: "0.75rem" }}
+          data-testid="delete-done-banner"
+        >
+          Deleted <code>{deleteSt.username}</code>. Their tokens are revoked. Resource servers
+          (vault, scribe, etc.) cache the revocation list for up to {deleteSt.revocationLagSeconds}{" "}
+          seconds — if you're deleting because of a suspected compromise, also restart the affected
+          services (e.g. <code>parachute restart vault</code>) to flush their cache immediately.
+          <div style={{ marginTop: "0.5rem" }}>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => setDeleteSt({ kind: "idle" })}
+            >
+              Dismiss
+            </button>
+          </div>
+        </output>
+      )}
 
       {renderListSection(
         state,

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -169,6 +169,16 @@ code {
   text-decoration: none;
   color: var(--fg);
 }
+/* Active section indicator (NavLink). The current section reads accent +
+   carries an underline so the operator sees where they are at a glance —
+   pairs with the aria-current="page" the NavLink sets for assistive tech. */
+.nav a.nav-link-active {
+  color: var(--accent);
+  font-weight: 500;
+  text-decoration: underline;
+  text-underline-offset: 0.3em;
+  text-decoration-thickness: 2px;
+}
 /* Visual grouping between nav sections — vault provisioning, host admin,
    top-level discovery. Subtle 1px vertical line; flex layout takes care
    of spacing via the parent `.nav { gap: 1rem }`. */
@@ -205,7 +215,7 @@ code {
   color: var(--fg);
 }
 .nav .nav-dropdown-summary::after {
-  content: ' \25BE'; /* ▾ */
+  content: " \25BE"; /* ▾ */
   font-size: 0.7em;
   color: var(--fg-dim);
 }
@@ -345,8 +355,13 @@ h2 {
  * Default cadence: 1.4s breath. Subtle enough to recede if the load
  * finishes within 100–200ms; recognizable on slow connections. */
 @keyframes pc-loading-pulse {
-  0%, 100% { opacity: 0.55; }
-  50% { opacity: 1; }
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
 }
 [data-loading="true"] {
   animation: pc-loading-pulse 1.4s ease-in-out infinite;
@@ -371,8 +386,14 @@ h2 {
  * area (opt-in — tests / specific routes can omit if they care about
  * deterministic paint timing). */
 @keyframes pc-route-fade-up {
-  from { opacity: 0; transform: translateY(6px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 [data-route-content] {
   animation: pc-route-fade-up 0.32s ease forwards;


### PR DESCRIPTION
Post the pvt_* DROP, the per-vault create `token` field is a hub-issued access
JWT (scoped `vault:<name>:admin`), can be empty when no hub origin is reachable
to mint against, and `parachute-vault mint-token` no longer exists. This PR fixes
the connect surfaces that still assumed the old `pvt_*` model, adds the
friend-facing connect path Aaron flagged, and polishes the admin dashboard.

## NewVault create-flow correctness (P1)
- **Branch on HTTP status, not token truthiness.** `createVault` now surfaces a
  `created` flag (201 vs 200). Pre-fix, a freshly-created vault (201) that came
  back with `token: ""` (mint unavailable) wrongly rendered "vault already
  existed; nothing minted". Now a 201-with-empty-token renders a distinct
  "created, but no token minted — <reason>" state.
- **Forward `token_guidance`.** The hub now forwards vault's `token_guidance`
  field (previously dropped) so the empty-token state explains the gap.
- **Reframe copy.** Heading "Your vault token" → "Your access token"; removed the
  dead `parachute-vault mint-token` recovery command; steer at the McpConnectCard
  OAuth path (no token) + `parachute auth mint-token --scope vault:<name>:read`.
  Dropped the "mint from the vault directly" mental model.
- New tests: NewVault empty-token-on-201 branch; lib/api created-flag +
  token_guidance parse; admin-vaults empty-token+guidance forwarding.

## Friend-facing connect surface (P1)
- Each assigned-vault tile on `/account/` now server-renders an MCP connect
  block: the endpoint `<hubOrigin>/vault/<name>/mcp` + the `claude mcp add`
  command, each with a copy button. This is the OAuth path (no token, no admin
  bearer) — the friend signs in + approves on first use. Notes CTA kept; it's no
  longer the only option. Replaces the redundant custom-client hub-origin
  disclosure.

## Admin dashboard polish (P2)
- **Per-route `document.title`** (e.g. "Tokens · Parachute") — the SPA never set
  it, so every route showed the static index.html title.
- **Active nav indicator** — `<Link>` → active-aware `NavSection` with a
  `nav-link-active` class + `aria-current="page"` (index-route `/` aliases to
  Vaults).
- **Comment/docstring de-stale** — admin-vaults.ts, lib/api.ts, web/ui/CLAUDE.md
  no longer call the create token a "single-emit `pvt_*`" token.

## #467 review nits + revocation-lag consistency (P2)
- auth-status.ts: refreshed the stale `tokenCount` JSDoc (pointed at the removed
  `vault tokens list`; classify() now gates on hasOwnerPassword post-DROP).
- expose-auth-preflight: added the missing `{ hasOwnerPassword:false,
  tokenCount:null }` → wide-open coverage.
- **mu-revocation-lag-on-delete:** DELETE /api/users/:id now returns 200
  `{ ok, revocation_lag_seconds }` (was a bare 204) on a real delete, and the SPA
  surfaces the 60s revocation-cache warning banner — consistency with the
  password-reset flow.

## Follow-ups filed (not done here)
- #468 — extract a shared loading/empty/error SPA component (workstream J;
  bigger, separate refactor).
- #469 — force-change-password is session-redirect-only, not per-request
  enforced (security-posture design call for Aaron; behavior unchanged here).

## Gates
- `bun test ./src`: **2369 pass, 1 skip, 0 fail**
- `cd web/ui && bunx vitest run`: **248 pass, 0 fail**
- `bun run typecheck` (hub + SPA): clean
- `bun run build:spa`: clean (verify-base ✓)
- biome: changed files formatted; the one remaining lint error is pre-existing
  on main (untouched `InstalledServicesDropdown` span) — confirmed via stash.

No rc bump: current version stays `0.5.14-rc.9`. Per the current governance rule
(RC versioning — bump+tag only when Aaron decides to ship, not per PR), a
code-touching PR does not bump rc on its own.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)