### PR TITLE
chore(release): hub 0.5.14-rc.10 (publish #467 + #470 to rc channel)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.9",
+  "version": "0.5.14-rc.10",
   "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Advances hub to `0.5.14-rc.10` so the rc channel carries the post-DROP work that landed on main after rc.9 was published:
- **#467** — expose-flow auth guidance repointed off the removed `vault tokens create` (pvt_* DROP propagation; `classify()` simplified)
- **#470** — NewVault create-flow correctness (201-vs-200, dead command removed), friend `/account/` MCP connect block, admin polish (per-route titles, active-nav, revocation-lag)

Version-only change vs main @ `42bdaac`. After merge: tag `v0.5.14-rc.10` → CI publishes to the npm `rc` channel so a second machine can install the current hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)