### PR TITLE
fix(hub): upgrade no longer crashes when git is absent (+ rc.11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.10",
+  "version": "0.5.14-rc.11",
   "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/upgrade.test.ts
+++ b/src/__tests__/upgrade.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { UpgradeRunner } from "../commands/upgrade.ts";
-import { compareVersions, detectChannel, upgrade } from "../commands/upgrade.ts";
+import { compareVersions, defaultRunner, detectChannel, upgrade } from "../commands/upgrade.ts";
 import { upsertService } from "../services-manifest.ts";
 
 interface RunCall {
@@ -400,6 +400,83 @@ describe("parachute upgrade", () => {
     } finally {
       h.cleanup();
     }
+  });
+
+  test("git absent (ENOENT): no crash, isGitCheckout → false, npm path taken", async () => {
+    // Real EC2 repro: a published-npm install on a minimal server with no
+    // `git` binary. The production runner's Bun.spawn(["git", ...]) throws
+    // synchronously with ENOENT; the upgrade flow must degrade to the npm
+    // path rather than crashing with an uncaught "Executable not found".
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.4.0");
+
+      const calls: RunCall[] = [];
+      // Simulate the git-absent host: any spawn of `git` ENOENTs, surfaced
+      // through the runner as a non-zero captured result (code 127). This is
+      // exactly what the patched defaultRunner produces — we assert the
+      // upgrade flow handles that result gracefully.
+      const runner: UpgradeRunner = {
+        async run(cmd, opts) {
+          calls.push({ cmd: [...cmd], cwd: opts?.cwd, kind: "run" });
+          if (cmd[0] === "git") return 127; // git-less host
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            writePackageJson(installDir, { name: "@openparachute/vault", version: "0.5.0" });
+          }
+          return 0;
+        },
+        async capture(cmd, opts) {
+          calls.push({ cmd: [...cmd], cwd: opts?.cwd, kind: "capture" });
+          if (cmd[0] === "git") return { code: 127, stdout: "git: not found on this host\n" };
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      let restartedShort: string | undefined;
+      const logs: string[] = [];
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async (svc) => {
+          restartedShort = svc;
+          return 0;
+        },
+        log: (l) => logs.push(l),
+      });
+
+      // No throw; the npm path ran end-to-end.
+      expect(code).toBe(0);
+      expect(restartedShort).toBe("vault");
+      const joined = logs.join("\n");
+      // isGitCheckout returned false → npm-installed branch, not bun-linked.
+      expect(joined).toMatch(/npm-installed/);
+      expect(joined).not.toMatch(/bun-linked/);
+      expect(joined).toMatch(/bun add -g @openparachute\/vault@latest/);
+      expect(joined).toMatch(/0\.4\.0 → 0\.5\.0/);
+      // We probed git (and degraded) but never reached the git-mutating
+      // commands (pull / status) that only run on the bun-linked branch.
+      const gitRun = calls.filter((c) => c.kind === "run" && c.cmd[0] === "git");
+      expect(gitRun).toHaveLength(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("defaultRunner.capture: git-absent ENOENT yields code 127, no throw", async () => {
+    // Drive the *production* runner against a binary that doesn't exist, to
+    // prove the synchronous-spawn-throw is caught (not just the injectable
+    // seam). Bun.spawn throws ENOENT synchronously for a missing binary.
+    const missing = `parachute-no-such-binary-${process.pid}`;
+    const captured = await defaultRunner.capture([missing, "--version"]);
+    expect(captured.code).toBe(127);
+    expect(captured.stdout).toContain("not found on this host");
+
+    const ran = await defaultRunner.run([missing, "--version"]);
+    expect(ran).toBe(127);
   });
 
   test("npm-installed: version unchanged → skip restart", async () => {

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -72,25 +72,69 @@ export interface UpgradeRunner {
   ): Promise<{ code: number; stdout: string }>;
 }
 
+/**
+ * Exit code we synthesize when a binary can't be spawned at all. 127 is the
+ * POSIX shell convention for "command not found" — it lets every git call
+ * degrade to a normal non-zero result instead of crashing the whole command.
+ */
+const SPAWN_NOT_FOUND_CODE = 127;
+
+/**
+ * True when an error thrown by `Bun.spawn` means "the executable doesn't
+ * exist on this host" (ENOENT). On a minimal server with no `git` installed —
+ * a legitimate, common shape for a published-npm install on the canonical
+ * install path — `Bun.spawn(["git", ...])` throws *synchronously* with this
+ * shape. We catch it so `parachute upgrade` degrades to the npm path rather
+ * than dying with an uncaught `Executable not found in $PATH: "git"`.
+ */
+function isSpawnNotFound(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const code = (err as { code?: unknown }).code;
+  const message = (err as { message?: unknown }).message;
+  return (
+    code === "ENOENT" ||
+    (typeof message === "string" && message.includes("Executable not found in $PATH"))
+  );
+}
+
 export const defaultRunner: UpgradeRunner = {
   async run(cmd, opts) {
     // Inherit env so `bun add -g` etc. see TMPDIR, BUN_INSTALL, PATH, HOME.
     // Bun.spawn defaults to empty env — see api-modules-ops.ts:defaultRun.
-    const proc = Bun.spawn([...cmd], {
-      cwd: opts?.cwd,
-      stdio: ["inherit", "inherit", "inherit"],
-      env: process.env,
-    });
+    let proc: Bun.Subprocess;
+    try {
+      proc = Bun.spawn([...cmd], {
+        cwd: opts?.cwd,
+        stdio: ["inherit", "inherit", "inherit"],
+        env: process.env,
+      });
+    } catch (err) {
+      // Binary not on this host (e.g. no `git` on a minimal server). Degrade
+      // to a non-zero exit rather than letting the throw crash the command.
+      if (isSpawnNotFound(err)) return SPAWN_NOT_FOUND_CODE;
+      throw err;
+    }
     return await proc.exited;
   },
   async capture(cmd, opts) {
     // Inherit env — same rationale as `run` above.
-    const proc = Bun.spawn([...cmd], {
-      cwd: opts?.cwd,
-      stdout: "pipe",
-      stderr: "pipe",
-      env: process.env,
-    });
+    let proc: Bun.Subprocess<"ignore", "pipe", "pipe">;
+    try {
+      proc = Bun.spawn([...cmd], {
+        cwd: opts?.cwd,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: process.env,
+      });
+    } catch (err) {
+      // See `run` above: ENOENT (binary-not-found) becomes a captured
+      // non-zero result so every git call degrades to "command failed".
+      if (isSpawnNotFound(err)) {
+        const bin = cmd[0] ?? "command";
+        return { code: SPAWN_NOT_FOUND_CODE, stdout: `${bin}: not found on this host\n` };
+      }
+      throw err;
+    }
     const [stdout, stderr] = await Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),


### PR DESCRIPTION
## The bug

`parachute upgrade <svc>` died with an **uncaught** `Executable not found in $PATH: "git"` (ENOENT) on a host without `git` — a legitimate, common shape for a published-npm install on the canonical install path (minimal server / npm-install, no git). Real stack trace from an EC2 box:

```
capture → Bun.spawn(["git", ...])   (upgrade.ts:88)
  → isGitCheckout            (~:436)
    → upgradeOne             (~:621)
      → upgrade              (~:643)
```

`Bun.spawn` throws **synchronously** when the binary is missing, and the `upgrade.ts` runner's `capture`/`run` didn't catch it, so the whole command died instead of degrading.

## The fix — spawn-ENOENT resilience at the shared seam

`defaultRunner.run` and `defaultRunner.capture` now catch a spawn ENOENT (binary-not-found) and return a non-zero result (`code: 127`, the POSIX "command not found" convention) instead of throwing. Every git call therefore degrades to "command failed" rather than crashing the command.

**Consequence (verified):** on a git-less host `isGitCheckout` returns `false` → `upgrade` proceeds via the npm/`bun add -g` path — the correct behavior for an npm-installed service. The git-*mutating* commands (`pull`/`status`/`rev-parse HEAD`/`diff`) only run on the bun-linked branch, which is never reached when git is absent → no follow-on crash.

`run`/`capture` are the **only** unprotected git seam in hub `src/`. The other git shell-out (`install-source.ts` `defaultReadGitHead`, via `execFileSync`) already wraps its call in `try/catch → undefined`. Git use in hub is upgrade-only (mirror/git-backup lives in vault). Confirmed by grep.

**Secondary (not-installed message):** already covered — `resolveTargets` returns `\`${svc} isn't installed. Run \`parachute install ${svc}\` first.\`` for first-party services, and `"No services installed yet…"` for an empty manifest. No change needed.

## Tests

Two added to `src/__tests__/upgrade.test.ts`:
1. **Injectable-seam test** — drives the `UpgradeRunner` with git returning ENOENT (code 127) and asserts: no throw, `isGitCheckout` → false (`npm-installed` log, never `bun-linked`), npm path runs end-to-end (`bun add -g …@latest`, restart), and **zero** git-mutating `run` calls.
2. **Production-runner test** — drives the real `defaultRunner.capture`/`run` against a missing binary and asserts `code 127` + no throw, proving the synchronous-spawn-throw is actually caught.

## Gates

- `bun test ./src` (canonical hub script): **2371 pass, 1 skip, 0 fail**
- upgrade suite alone: **26 pass, 0 fail**
- `bun run typecheck`: clean
- `bunx biome check` on changed code files: clean

## Version

Bumps `0.5.14-rc.10` → **`0.5.14-rc.11`** so the EC2 box can re-install a working hub (republishing immediately after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)