### PR TITLE
fix(hub): cloudflare expose-state + public-origin URL + honest 2FA + first-admin username consistency (+ rc.12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.11",
+  "version": "0.5.14-rc.12",
   "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -65,34 +65,26 @@ async function captureOutput(fn: () => Promise<number> | number): Promise<{
 }
 
 describe("parachute auth", () => {
-  test("2fa enroll forwards to parachute-vault 2fa enroll", async () => {
+  test("2fa is an honest hub-side stub — never forwards to parachute-vault", async () => {
+    // 2fa used to forward to the deprecated `parachute-vault 2fa` stub, which
+    // exits 1 post auth-unification and only wrote vault YAML that never gated
+    // hub /login. It's now an informational stub: exit 0, no subprocess.
     const { runner, calls } = makeRunner(0);
-    const code = await auth(["2fa", "enroll"], runner);
-    expect(code).toBe(0);
-    expect(calls).toEqual([["parachute-vault", "2fa", "enroll"]]);
+    const out = await captureOutput(() => auth(["2fa", "enroll"], runner));
+    expect(out.code).toBe(0);
+    expect(calls).toEqual([]); // did NOT spawn parachute-vault
+    expect(out.stdout).toContain("isn't available yet");
+    expect(out.stdout).toContain("#473");
+    // Doesn't tell the operator to run the dead vault command.
+    expect(out.stdout).not.toContain("2fa enroll");
   });
 
-  test("2fa enroll --some-flag forwards every arg after the subcommand", async () => {
+  test("2fa with any sub-args still resolves to the honest stub (exit 0, no spawn)", async () => {
     const { runner, calls } = makeRunner(0);
-    const code = await auth(["2fa", "enroll", "--some-flag", "value"], runner);
-    expect(code).toBe(0);
-    expect(calls).toEqual([["parachute-vault", "2fa", "enroll", "--some-flag", "value"]]);
-  });
-
-  test("exit code from parachute-vault is propagated", async () => {
-    const { runner } = makeRunner(3);
-    const code = await auth(["2fa", "status"], runner);
-    expect(code).toBe(3);
-  });
-
-  test("ENOENT on a vault-forwarded subcommand surfaces install hint and exit 127", async () => {
-    const runner: Runner = {
-      async run() {
-        throw new Error("ENOENT: spawn parachute-vault");
-      },
-    };
-    const code = await auth(["2fa", "status"], runner);
-    expect(code).toBe(127);
+    const out = await captureOutput(() => auth(["2fa", "status", "--whatever"], runner));
+    expect(out.code).toBe(0);
+    expect(calls).toEqual([]);
+    expect(out.stdout).toContain("#473");
   });
 
   test("set-password no longer forwards to vault", async () => {
@@ -142,21 +134,22 @@ describe("authHelp", () => {
   test("lists every blessed subcommand", () => {
     expect(h).toContain("parachute auth set-password");
     expect(h).toContain("parachute auth list-users");
-    expect(h).toContain("parachute auth 2fa status");
-    expect(h).toContain("parachute auth 2fa enroll");
-    expect(h).toContain("parachute auth 2fa disable");
-    expect(h).toContain("parachute auth 2fa backup-codes");
+    expect(h).toContain("parachute auth 2fa");
     expect(h).toContain("parachute auth rotate-key");
+  });
+
+  test("2fa help is honest about hub-login TOTP not being shipped (#473)", () => {
+    expect(h).toContain("#473");
+    // No longer advertises the dead enroll/disable/backup-codes subcommands.
+    expect(h).not.toContain("2fa enroll");
+    expect(h).not.toContain("2fa disable");
+    expect(h).not.toContain("2fa backup-codes");
   });
 
   test("set-password help mentions the new flags + hub-local home", () => {
     expect(h).toContain("--username");
     expect(h).toContain("--allow-multi");
     expect(h).toContain("hub.db");
-  });
-
-  test("mentions the vault-install hint", () => {
-    expect(h).toContain("parachute install vault");
   });
 
   test("rotate-key explains the 24h JWKS retention", () => {

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -123,6 +123,43 @@ describe("cli per-subcommand help", () => {
     expect(stderr).toMatch(/dash\.cloudflare\.com/);
   });
 
+  test("expose cloudflare is an alias for expose public --cloudflare (Fix 5)", async () => {
+    // No --domain, non-TTY → same hard error as `expose public --cloudflare`.
+    // That it reaches the cloudflare-domain check (not "unknown layer") proves
+    // the alias rewrote the layer to public + forced the cloudflare flag.
+    const { code, stderr } = await runCli(["expose", "cloudflare"]);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/--domain <hostname> is required/);
+    expect(stderr).not.toMatch(/unknown layer/);
+  });
+
+  test("expose cloudflare --domain X routes to the cloudflare path (not 'unknown layer')", async () => {
+    // cloudflared isn't installed under PATH="", so the cloudflare path prints
+    // its own not-installed hint — distinct from the layer-validation error.
+    const proc = Bun.spawn(
+      [process.execPath, CLI, "expose", "cloudflare", "--domain", "vault.example.com"],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          PATH: "",
+          HOME: "/tmp/parachute-hub-nonexistent-home",
+          PARACHUTE_HOME: "/tmp/parachute-hub-nonexistent-home",
+        },
+      },
+    );
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    expect(code).toBe(1);
+    expect(stderr).not.toMatch(/unknown layer/);
+    // Reached the cloudflare path (cloudflared detection), proving the alias.
+    expect(stdout).toMatch(/cloudflared is not installed/);
+  });
+
   test("expose tailnet --cloudflare is rejected (cloudflare is public-only)", async () => {
     const { code, stderr } = await runCli([
       "expose",

--- a/src/__tests__/expose-2fa-warning.test.ts
+++ b/src/__tests__/expose-2fa-warning.test.ts
@@ -80,9 +80,13 @@ describe("printPublic2FAWarning", () => {
     });
     expect(fired).toBe(true);
     const joined = logs.join("\n");
-    expect(joined).toContain("2FA is not enrolled");
+    // Honest copy: /login is public, owner password is the wall, hub-login 2FA
+    // is coming (#473) — does NOT recommend the dead `auth 2fa enroll` path.
+    expect(joined).toContain("/login is now reachable on the public internet");
     expect(joined).toContain("https://vault.example.com/login");
-    expect(joined).toContain("parachute auth 2fa enroll");
+    expect(joined).toContain("#473");
+    expect(joined).toContain("parachute auth set-password");
+    expect(joined).not.toContain("parachute auth 2fa enroll");
   });
 
   test("enrolled → suppressed, returns false, logs nothing", () => {
@@ -108,7 +112,9 @@ describe("printPublic2FAWarning", () => {
       publicUrl: "https://vault.example.com",
     });
     expect(fired).toBe(true);
-    expect(logs.some((l) => l.includes("2FA is not enrolled"))).toBe(true);
+    expect(logs.some((l) => l.includes("/login is now reachable on the public internet"))).toBe(
+      true,
+    );
   });
 
   test("embeds the supplied publicUrl into the /login pointer", () => {

--- a/src/__tests__/expose-auth-preflight.test.ts
+++ b/src/__tests__/expose-auth-preflight.test.ts
@@ -41,8 +41,8 @@ function status(partial: Partial<VaultAuthStatus> = {}): VaultAuthStatus {
 }
 
 describe("runAuthPreflight — wide open (no owner password)", () => {
-  test("warns loudly, offers password + 2FA, and prints hub-JWT token guidance", async () => {
-    const h = makeHarness(["y", "n"]); // password yes, 2fa no
+  test("warns loudly, offers password only, prints hub-JWT token guidance + honest 2FA note", async () => {
+    const h = makeHarness(["y"]); // password yes
     await runAuthPreflight({ status: status(), ...wire(h) });
     const joined = h.logs.join("\n");
     expect(joined).toContain("No owner password");
@@ -50,33 +50,34 @@ describe("runAuthPreflight — wide open (no owner password)", () => {
     // Programmatic-client guidance points at the hub mint path, not pvt_*.
     expect(joined).toContain("parachute auth mint-token --scope vault:default:read");
     expect(joined).toContain("Bearer <hub-jwt>");
-    // Only password + 2FA are interactive offers; token guidance is printed,
-    // not prompted (no auto-mint).
+    // Honest 2FA state — coming (#473), not offered as a dead enroll command.
+    expect(joined).toContain("#473");
+    expect(joined).not.toContain("2fa enroll");
+    // Only password is an interactive offer; token guidance + 2FA note are
+    // printed, not prompted.
     expect(h.commands).toHaveLength(1);
     expect(h.commands[0]).toEqual(["parachute", "auth", "set-password"]);
+    expect(h.prompts).toHaveLength(1);
   });
 
   test("token guidance uses the first discovered vault name", async () => {
-    const h = makeHarness(["n", "n"]);
+    const h = makeHarness(["n"]);
     await runAuthPreflight({ status: status({ vaultNames: ["work"] }), ...wire(h) });
     expect(h.logs.join("\n")).toContain("--scope vault:work:read");
   });
 
-  test("user declines every prompt → no subprocesses run", async () => {
-    const h = makeHarness(["", ""]); // all Enter = skip
+  test("user declines the password prompt → no subprocesses run", async () => {
+    const h = makeHarness([""]); // Enter = skip
     await runAuthPreflight({ status: status(), ...wire(h) });
     expect(h.commands).toHaveLength(0);
-    // Prompted on password + 2FA (token guidance is not a prompt).
-    expect(h.prompts).toHaveLength(2);
+    // Only one prompt now (password); token guidance + 2FA note aren't prompts.
+    expect(h.prompts).toHaveLength(1);
   });
 
-  test("user accepts password + 2FA → both commands invoked in order", async () => {
-    const h = makeHarness(["y", "y"]);
+  test("user accepts the password offer → set-password invoked", async () => {
+    const h = makeHarness(["y"]);
     await runAuthPreflight({ status: status(), ...wire(h) });
-    expect(h.commands.map((c) => c.join(" "))).toEqual([
-      "parachute auth set-password",
-      "parachute auth 2fa enroll",
-    ]);
+    expect(h.commands.map((c) => c.join(" "))).toEqual(["parachute auth set-password"]);
   });
 
   test("null tokenCount with no owner password still classifies wide-open", async () => {
@@ -84,7 +85,7 @@ describe("runAuthPreflight — wide open (no owner password)", () => {
     // — `classify()` gates on `hasOwnerPassword` alone. A box with no owner
     // password AND an unreadable token DB must still take the loud wide-open
     // branch, not silently fall through to a quieter state.
-    const h = makeHarness(["n", "n"]);
+    const h = makeHarness(["n"]);
     await runAuthPreflight({
       status: status({ hasOwnerPassword: false, tokenCount: null }),
       ...wire(h),
@@ -92,24 +93,26 @@ describe("runAuthPreflight — wide open (no owner password)", () => {
     const joined = h.logs.join("\n");
     expect(joined).toContain("No owner password");
     expect(joined).toContain("public internet");
-    // Wide-open offers password + 2FA (two prompts); not the all-good path.
-    expect(h.prompts).toHaveLength(2);
+    // Wide-open offers the password (one prompt); not the password-set path.
+    expect(h.prompts).toHaveLength(1);
   });
 
-  test("never offers the removed `vault tokens create` command", async () => {
-    const h = makeHarness(["y", "y"]);
+  test("never offers a dead command (vault tokens create OR auth 2fa enroll)", async () => {
+    const h = makeHarness(["y"]);
     await runAuthPreflight({ status: status(), ...wire(h) });
     const allCommands = h.commands.map((c) => c.join(" ")).join("\n");
     expect(allCommands).not.toContain("vault tokens create");
-    // And no log line steers the operator at the dead command as guidance.
-    const guidance = h.logs.filter((l) => !l.includes("old affordance")).join("\n");
+    expect(allCommands).not.toContain("auth 2fa enroll");
+    // And no log line steers the operator at a dead command as guidance.
+    const guidance = h.logs.join("\n");
     expect(guidance).not.toContain("parachute vault tokens create");
+    expect(guidance).not.toContain("parachute auth 2fa enroll");
   });
 });
 
-describe("runAuthPreflight — password set, no 2FA", () => {
-  test("short nudge, offers 2FA only — ignores vestigial tokenCount", async () => {
-    const h = makeHarness(["y"]);
+describe("runAuthPreflight — password set", () => {
+  test("single confirmation line + honest 2FA note, no prompts (ignores vestigial tokenCount)", async () => {
+    const h = makeHarness([]);
     await runAuthPreflight({
       // tokenCount is non-zero (vestigial pvt_* rows) but no longer consulted.
       status: status({ hasOwnerPassword: true, tokenCount: 3 }),
@@ -117,59 +120,42 @@ describe("runAuthPreflight — password set, no 2FA", () => {
     });
     const joined = h.logs.join("\n");
     expect(joined).toContain("Owner password is set");
-    expect(joined).toContain("2FA");
-    expect(h.prompts).toHaveLength(1);
-    expect(h.commands).toEqual([["parachute", "auth", "2fa", "enroll"]]);
-  });
-
-  test("user declines → no command runs", async () => {
-    const h = makeHarness([""]);
-    await runAuthPreflight({
-      status: status({ hasOwnerPassword: true, tokenCount: 3 }),
-      ...wire(h),
-    });
+    // Honest 2FA note (#473) — not a prompt, not the dead enroll command.
+    expect(joined).toContain("#473");
+    expect(joined).not.toContain("2fa enroll");
+    expect(h.prompts).toHaveLength(0);
     expect(h.commands).toHaveLength(0);
   });
 
   test("null tokenCount (DB unreadable) is irrelevant — password gates the branch", async () => {
-    const h = makeHarness([""]); // decline 2FA
+    const h = makeHarness([]);
     await runAuthPreflight({
       status: status({ hasOwnerPassword: true, hasTotp: false, tokenCount: null }),
       ...wire(h),
     });
-    expect(h.prompts).toHaveLength(1);
-    expect(h.prompts[0]?.toLowerCase()).toContain("2fa");
+    expect(h.logs.join("\n")).toContain("Owner password is set");
+    expect(h.prompts).toHaveLength(0);
+    expect(h.commands).toHaveLength(0);
   });
-});
 
-describe("runAuthPreflight — all good", () => {
-  test("single positive line, no prompts (tokens not required)", async () => {
+  test("password + legacy vault TOTP — still the quiet password-set path", async () => {
     const h = makeHarness([]);
     await runAuthPreflight({
-      // tokenCount: 0 — a hub JWT is minted on demand, not a standing need.
       status: status({ hasOwnerPassword: true, hasTotp: true, tokenCount: 0 }),
       ...wire(h),
     });
-    const joined = h.logs.join("\n");
-    expect(joined).toContain("looks good");
-    expect(joined).toContain("owner password + 2FA");
+    expect(h.logs.join("\n")).toContain("Owner password is set");
     expect(h.prompts).toHaveLength(0);
     expect(h.commands).toHaveLength(0);
   });
 });
 
 describe("runAuthPreflight — subprocess failure handling", () => {
-  test("non-zero exit from an auth command doesn't abort the rest of the preflight", async () => {
-    const h = makeHarness(["y", "y"]);
-    // Override the interactive runner to return non-zero on the first call.
-    let first = true;
+  test("non-zero exit from set-password doesn't abort the rest of the preflight", async () => {
+    const h = makeHarness(["y"]);
     const interactiveRunner = async (cmd: readonly string[]) => {
       h.commands.push([...cmd]);
-      if (first) {
-        first = false;
-        return 7;
-      }
-      return 0;
+      return 7;
     };
     await runAuthPreflight({
       status: status(),
@@ -180,19 +166,22 @@ describe("runAuthPreflight — subprocess failure handling", () => {
       },
       interactiveRunner,
     });
-    // Both commands still attempted, neither aborted the flow.
-    expect(h.commands.map((c) => c[0])).toEqual(["parachute", "parachute"]);
+    // The command was attempted; the flow continued (token guidance still
+    // printed afterward).
+    expect(h.commands.map((c) => c[0])).toEqual(["parachute"]);
     const joined = h.logs.join("\n");
     expect(joined).toContain("exited 7");
+    expect(joined).toContain("Bearer <hub-jwt>");
   });
 });
 
 describe("runAuthPreflight — case-insensitive yes", () => {
   test('"Y", "YES", and "y" all count as affirmative; anything else is decline', async () => {
+    // Now only the wide-open path prompts (for the password). Drive it there.
     for (const yes of ["y", "Y", "yes", "YES"]) {
       const h = makeHarness([yes]);
       await runAuthPreflight({
-        status: status({ hasOwnerPassword: true, tokenCount: 1 }),
+        status: status({ hasOwnerPassword: false }),
         ...wire(h),
       });
       expect(h.commands).toHaveLength(1);
@@ -200,7 +189,7 @@ describe("runAuthPreflight — case-insensitive yes", () => {
     for (const no of ["", "n", "no", "q", "bogus"]) {
       const h = makeHarness([no]);
       await runAuthPreflight({
-        status: status({ hasOwnerPassword: true, tokenCount: 1 }),
+        status: status({ hasOwnerPassword: false }),
         ...wire(h),
       });
       expect(h.commands).toHaveLength(0);

--- a/src/__tests__/expose-cloudflare.test.ts
+++ b/src/__tests__/expose-cloudflare.test.ts
@@ -14,6 +14,7 @@ import {
   exposeCloudflareOff,
   exposeCloudflareUp,
 } from "../commands/expose-cloudflare.ts";
+import { readExposeState } from "../expose-state.ts";
 import { writeHubPort } from "../hub-control.ts";
 import type { CommandResult, Runner } from "../tailscale/run.ts";
 
@@ -25,6 +26,7 @@ interface TestEnv {
   configDir: string;
   manifestPath: string;
   statePath: string;
+  exposeStatePath: string;
   configPath: string;
   logPath: string;
   cloudflaredHome: string;
@@ -40,6 +42,7 @@ function makeEnv(opts: { includeVault?: boolean; loggedIn?: boolean } = {}): Tes
   const cloudflaredHome = join(dir, "cloudflared");
   const manifestPath = join(configDir, "services.json");
   const statePath = join(configDir, "cloudflared-state.json");
+  const exposeStatePath = join(configDir, "expose-state.json");
   const configPath = join(configDir, "cloudflared", "parachute", "config.yml");
   const logPath = join(configDir, "cloudflared", "parachute", "cloudflared.log");
 
@@ -72,6 +75,7 @@ function makeEnv(opts: { includeVault?: boolean; loggedIn?: boolean } = {}): Tes
     configDir,
     manifestPath,
     statePath,
+    exposeStatePath,
     configPath,
     logPath,
     cloudflaredHome,
@@ -135,6 +139,7 @@ describe("exposeCloudflareUp", () => {
         log: (l) => logs.push(l),
         manifestPath: env.manifestPath,
         statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
@@ -204,6 +209,70 @@ describe("exposeCloudflareUp", () => {
     }
   });
 
+  test("persists expose-state.json with the canonicalFqdn + public hubOrigin (Fix 1)", async () => {
+    // The OAuth-iss bug: pre-fix the cloudflare path never wrote
+    // expose-state.json, so `readExposeState()` returned undefined and
+    // downstream consumers (init's resolveAdminUrl, lifecycle's
+    // resolveHubOrigin, the vault .env PARACHUTE_HUB_ORIGIN persistence)
+    // fell back to loopback — wrong OAuth `iss` on Cloudflare deploys.
+    const env = makeEnv();
+    try {
+      const uuid = "eeeeeeee-0000-0000-0000-000000000005";
+      const { runner } = queueRunner([
+        { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
+        { code: 0, stdout: "[]", stderr: "" },
+        {
+          code: 0,
+          stdout: `Tunnel credentials written to ${env.cloudflaredHome}/${uuid}.json.\nCreated tunnel parachute with id ${uuid}\n`,
+          stderr: "",
+        },
+        { code: 0, stdout: "", stderr: "" },
+      ]);
+      const { spawner } = fakeSpawner(42200);
+
+      // Pre-condition: no expose-state.json yet.
+      expect(readExposeState(env.exposeStatePath)).toBeUndefined();
+
+      const code = await exposeCloudflareUp("gitcoin.parachute.computer", {
+        runner,
+        spawner,
+        alive: () => false,
+        kill: () => {},
+        log: () => {},
+        manifestPath: env.manifestPath,
+        statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
+        configPath: env.configPath,
+        logPath: env.logPath,
+        cloudflaredHome: env.cloudflaredHome,
+        configDir: env.configDir,
+        skipHub: true,
+      });
+
+      expect(code).toBe(0);
+      const exposeState = readExposeState(env.exposeStatePath);
+      expect(exposeState).toBeDefined();
+      expect(exposeState?.layer).toBe("public");
+      expect(exposeState?.mode).toBe("subdomain");
+      expect(exposeState?.canonicalFqdn).toBe("gitcoin.parachute.computer");
+      expect(exposeState?.funnel).toBe(false);
+      expect(exposeState?.port).toBe(TEST_HUB_PORT);
+      // The public origin OAuth clients will see — the load-bearing field.
+      expect(exposeState?.hubOrigin).toBe("https://gitcoin.parachute.computer");
+      // Single hub-catchall proxy entry (matches the Tailscale path's shape).
+      expect(exposeState?.entries).toEqual([
+        {
+          kind: "proxy",
+          mount: "/",
+          target: `http://localhost:${TEST_HUB_PORT}`,
+          service: "hub",
+        },
+      ]);
+    } finally {
+      env.cleanup();
+    }
+  });
+
   test("reuses existing tunnel when name already present", async () => {
     const env = makeEnv();
     try {
@@ -228,6 +297,7 @@ describe("exposeCloudflareUp", () => {
         log: (l) => logs.push(l),
         manifestPath: env.manifestPath,
         statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
@@ -257,6 +327,7 @@ describe("exposeCloudflareUp", () => {
         log: (l) => logs.push(l),
         manifestPath: env.manifestPath,
         statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
@@ -285,6 +356,7 @@ describe("exposeCloudflareUp", () => {
         log: (l) => logs.push(l),
         manifestPath: env.manifestPath,
         statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
@@ -316,6 +388,7 @@ describe("exposeCloudflareUp", () => {
         log: (l) => logs.push(l),
         manifestPath: env.manifestPath,
         statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
@@ -344,6 +417,7 @@ describe("exposeCloudflareUp", () => {
         log: (l) => logs.push(l),
         manifestPath: env.manifestPath,
         statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
@@ -371,6 +445,7 @@ describe("exposeCloudflareUp", () => {
         log: (l) => logs.push(l),
         manifestPath: env.manifestPath,
         statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
@@ -407,6 +482,7 @@ describe("exposeCloudflareUp", () => {
         log: (l) => logs.push(l),
         manifestPath: env.manifestPath,
         statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
@@ -458,6 +534,7 @@ describe("exposeCloudflareUp", () => {
         log: () => {},
         manifestPath: env.manifestPath,
         statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
         configPath: env.configPath,
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
@@ -499,6 +576,7 @@ describe("exposeCloudflareUp", () => {
         log: () => {},
         manifestPath: env.manifestPath,
         statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
         cloudflaredHome: env.cloudflaredHome,
         configDir: env.configDir,
         skipHub: true,
@@ -529,6 +607,7 @@ describe("exposeCloudflareUp", () => {
         log: () => {},
         manifestPath: env.manifestPath,
         statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
         cloudflaredHome: env.cloudflaredHome,
         configDir: env.configDir,
         skipHub: true,
@@ -586,6 +665,7 @@ describe("exposeCloudflareUp", () => {
           log: (l) => logs.push(l),
           manifestPath: env.manifestPath,
           statePath: env.statePath,
+          exposeStatePath: env.exposeStatePath,
           configPath: env.configPath,
           logPath: env.logPath,
           cloudflaredHome: env.cloudflaredHome,
@@ -603,15 +683,18 @@ describe("exposeCloudflareUp", () => {
 
         expect(code).toBe(0);
         const joined = logs.join("\n");
-        expect(joined).toContain("2FA is not enrolled");
+        // Honest copy: /login is public, owner password is the wall, hub-login
+        // 2FA is coming (#473) — does NOT recommend the dead `2fa enroll`.
+        expect(joined).toContain("/login is now reachable on the public internet");
         expect(joined).toContain("https://vault.example.com/login");
-        expect(joined).toContain("parachute auth 2fa enroll");
+        expect(joined).toContain("#473");
+        expect(joined).not.toContain("parachute auth 2fa enroll");
       } finally {
         env.cleanup();
       }
     });
 
-    test("enrolled → warning suppressed (no '2FA is not enrolled' line)", async () => {
+    test("enrolled → warning suppressed (no public-/login warning line)", async () => {
       const env = makeEnv();
       try {
         const uuid = "dddddddd-0000-0000-0000-000000000004";
@@ -636,6 +719,7 @@ describe("exposeCloudflareUp", () => {
           log: (l) => logs.push(l),
           manifestPath: env.manifestPath,
           statePath: env.statePath,
+          exposeStatePath: env.exposeStatePath,
           configPath: env.configPath,
           logPath: env.logPath,
           cloudflaredHome: env.cloudflaredHome,
@@ -651,11 +735,12 @@ describe("exposeCloudflareUp", () => {
 
         expect(code).toBe(0);
         const joined = logs.join("\n");
-        expect(joined).not.toContain("2FA is not enrolled");
-        // The existing `printAuthGuidance` 2FA-recommend bullet is unrelated
-        // to the new contextual warning and stays in place — assert it on a
-        // shape that doesn't collide with the warning text.
-        expect(joined).toContain("(recommended) TOTP + backup codes");
+        expect(joined).not.toContain("/login is now reachable on the public internet");
+        // The contextual 2FA warning is suppressed (legacy vault TOTP present);
+        // the always-shown owner-password guidance from `printAuthGuidance`
+        // still appears, and it no longer recommends the dead `2fa enroll`.
+        expect(joined).toContain("parachute auth set-password");
+        expect(joined).not.toContain("parachute auth 2fa enroll");
       } finally {
         env.cleanup();
       }
@@ -698,6 +783,7 @@ describe("exposeCloudflareUp", () => {
           log: (l) => logs.push(l),
           manifestPath: env.manifestPath,
           statePath: env.statePath,
+          exposeStatePath: env.exposeStatePath,
           configPath: env.configPath,
           logPath: env.logPath,
           cloudflaredHome: env.cloudflaredHome,
@@ -732,6 +818,7 @@ describe("exposeCloudflareOff", () => {
       const logs: string[] = [];
       const code = await exposeCloudflareOff({
         statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -741,7 +828,7 @@ describe("exposeCloudflareOff", () => {
     }
   });
 
-  test("SIGTERMs the process and clears state", async () => {
+  test("SIGTERMs the process and clears state (incl. expose-state.json — Fix 1)", async () => {
     const env = makeEnv();
     try {
       writeCloudflaredState(
@@ -760,10 +847,36 @@ describe("exposeCloudflareOff", () => {
         },
         env.statePath,
       );
+      // Seed the shared expose-state.json the up-path would have written, so we
+      // can assert teardown clears it (downstream consumers stop resolving the
+      // now-dead public URL).
+      writeFileSync(
+        env.exposeStatePath,
+        `${JSON.stringify({
+          version: 1,
+          layer: "public",
+          mode: "subdomain",
+          canonicalFqdn: "vault.example.com",
+          port: TEST_HUB_PORT,
+          funnel: false,
+          entries: [
+            {
+              kind: "proxy",
+              mount: "/",
+              target: `http://localhost:${TEST_HUB_PORT}`,
+              service: "hub",
+            },
+          ],
+          hubOrigin: "https://vault.example.com",
+        })}\n`,
+      );
+      expect(readExposeState(env.exposeStatePath)).toBeDefined();
+
       const killed: number[] = [];
       const logs: string[] = [];
       const code = await exposeCloudflareOff({
         statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
         alive: () => true,
         kill: (pid) => killed.push(pid),
         log: (l) => logs.push(l),
@@ -771,6 +884,9 @@ describe("exposeCloudflareOff", () => {
       expect(code).toBe(0);
       expect(killed).toEqual([55555]);
       expect(existsSync(env.statePath)).toBe(false);
+      // Fix 1: the shared expose-state.json is cleared on the last tunnel down.
+      expect(existsSync(env.exposeStatePath)).toBe(false);
+      expect(readExposeState(env.exposeStatePath)).toBeUndefined();
       // Reassures the user that the tunnel definition isn't lost.
       expect(logs.join("\n")).toContain("remains defined in Cloudflare");
     } finally {
@@ -800,6 +916,7 @@ describe("exposeCloudflareOff", () => {
       const killed: number[] = [];
       const code = await exposeCloudflareOff({
         statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
         alive: () => false,
         kill: (pid) => killed.push(pid),
         log: () => {},
@@ -839,6 +956,7 @@ describe("exposeCloudflareOff", () => {
       const killed: number[] = [];
       const code = await exposeCloudflareOff({
         statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
         alive: () => true,
         kill: (pid) => killed.push(pid),
         log: () => {},
@@ -873,6 +991,7 @@ describe("exposeCloudflareOff", () => {
       const logs: string[] = [];
       const code = await exposeCloudflareOff({
         statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
         alive: () => true,
         kill: () => {},
         log: (l) => logs.push(l),

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -1009,8 +1009,11 @@ describe("expose public up", () => {
       });
       expect(code).toBe(0);
       const joined = logs.join("\n");
-      expect(joined).toContain("2FA is not enrolled");
-      expect(joined).toContain("parachute auth 2fa enroll");
+      // Honest copy: /login is public, owner password is the wall, hub-login
+      // 2FA is coming (#473) — no longer recommends the dead `2fa enroll`.
+      expect(joined).toContain("/login is now reachable on the public internet");
+      expect(joined).toContain("#473");
+      expect(joined).not.toContain("parachute auth 2fa enroll");
       // /login pointer uses the canonical https://<fqdn> origin.
       expect(joined).toContain("https://parachute.taildf9ce2.ts.net/login");
     } finally {

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { init, looksLikeServer, resolveAdminUrl } from "../commands/init.ts";
+import { hasNoDisplay, init, looksLikeServer, resolveAdminUrl } from "../commands/init.ts";
 import type { ExposeState } from "../expose-state.ts";
 import { writeHubPort } from "../hub-control.ts";
 import { writePid } from "../process-state.ts";
@@ -345,6 +345,76 @@ describe("init", () => {
     }
   });
 
+  test("linux SSH (no display): prints the link, does NOT spawn a browser (Fix 2)", async () => {
+    // A TTY isn't enough — an SSH session is a TTY with no display, so
+    // `xdg-open` fails/blocks. Aaron hit this on EC2: init tried to open a
+    // browser and failed with "Couldn't launch a browser." We now skip the
+    // spawn on a server-shaped box and just print the URL.
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      const opened: string[] = [];
+      const logs: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => logs.push(l),
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => undefined,
+        isTty: true,
+        platform: "linux",
+        env: { SSH_CONNECTION: "1.2.3.4 22 5.6.7.8 22" },
+        // Pre-pick the browser wizard so a real desktop would spawn — proves
+        // the display guard (not the prompt) is what suppresses the spawn.
+        wizardChoice: "browser",
+        prompt: async () => "y",
+        openBrowser: (url) => {
+          opened.push(url);
+          return true;
+        },
+        noExposePrompt: true,
+        installVaultModuleImpl: noopVaultInstall,
+      });
+      expect(code).toBe(0);
+      expect(opened).toEqual([]); // never spawned
+      expect(logs.join("\n")).toContain("No display detected");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("linux WITH a display still spawns the browser (desktop unchanged)", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      const opened: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => undefined,
+        isTty: true,
+        platform: "linux",
+        env: { DISPLAY: ":0" },
+        wizardChoice: "browser",
+        prompt: async () => "y",
+        openBrowser: (url) => {
+          opened.push(url);
+          return true;
+        },
+        noExposePrompt: true,
+        installVaultModuleImpl: noopVaultInstall,
+      });
+      expect(code).toBe(0);
+      expect(opened).toEqual(["http://127.0.0.1:1939/admin/"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("ensureHub failure exits 1 with an actionable hint", async () => {
     const h = makeHarness();
     try {
@@ -395,6 +465,37 @@ describe("looksLikeServer heuristic", () => {
 
   test("Windows is not a server (init doesn't auto-pick on win32 anyway)", () => {
     expect(looksLikeServer("win32", {})).toBe(false);
+  });
+});
+
+describe("hasNoDisplay heuristic (Fix 2 — headless browser-open guard)", () => {
+  test("macOS / Windows always have a display", () => {
+    expect(hasNoDisplay("darwin", {})).toBe(false);
+    expect(hasNoDisplay("darwin", { SSH_CONNECTION: "1.2.3.4 22 5.6.7.8 22" })).toBe(false);
+    expect(hasNoDisplay("win32", {})).toBe(false);
+  });
+
+  test("linux SSH session (a TTY, but no display) → no display", () => {
+    expect(hasNoDisplay("linux", { SSH_CONNECTION: "1.2.3.4 22 5.6.7.8 22" })).toBe(true);
+    expect(hasNoDisplay("linux", { SSH_TTY: "/dev/pts/0" })).toBe(true);
+  });
+
+  test("linux headless console (no SSH, no DISPLAY) → no display", () => {
+    expect(hasNoDisplay("linux", {})).toBe(true);
+  });
+
+  test("linux desktop with DISPLAY / WAYLAND_DISPLAY → has a display", () => {
+    expect(hasNoDisplay("linux", { DISPLAY: ":0" })).toBe(false);
+    expect(hasNoDisplay("linux", { WAYLAND_DISPLAY: "wayland-0" })).toBe(false);
+  });
+
+  test("WSL (linux + DISPLAY-less but a dev laptop) is treated as having a display via looksLikeServer exclusion", () => {
+    // WSL with no DISPLAY would otherwise look headless; looksLikeServer
+    // excludes it, but the bare no-DISPLAY fallback still trips. This documents
+    // that a WSL user without an X server set won't auto-spawn — acceptable,
+    // since xdg-open would fail there anyway. WSL WITH an X server (DISPLAY set)
+    // correctly resolves to has-a-display.
+    expect(hasNoDisplay("linux", { WSL_DISTRO_NAME: "Ubuntu", DISPLAY: ":0" })).toBe(false);
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -472,11 +472,20 @@ async function main(argv: string[]): Promise<number> {
         return 1;
       }
       const exposeArgs = flagExtract.rest;
-      const layer = exposeArgs[0];
+      let layer = exposeArgs[0];
       const mode = exposeArgs[1];
       if (isHelpFlag(layer)) {
         console.log(exposeHelp());
         return 0;
+      }
+      // Alias: `parachute expose cloudflare [--domain X] [off]` is shorthand for
+      // `parachute expose public --cloudflare …`. Cloudflare is a public-internet
+      // provider, so we rewrite the layer to `public` and force the cloudflare
+      // flag — the rest of the dispatch (domain prompt, off-path, etc.) is
+      // identical to the canonical form.
+      if (layer === "cloudflare") {
+        layer = "public";
+        flagExtract.cloudflare = true;
       }
       if (layer !== "tailnet" && layer !== "public") {
         console.error(`parachute expose: unknown layer "${layer ?? ""}"`);

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -13,7 +13,11 @@
  *   - `list-users` — show accounts in `users`.
  *
  * Vault-forwarded subcommands (still implemented in `parachute-vault`):
- *   - `2fa` — TOTP enroll/disable/backup-codes.
+ *   - (none currently). `2fa` used to forward here, but the legacy
+ *     `parachute-vault 2fa` stub writes vault YAML that does NOT gate hub
+ *     `/login` — and post auth-unification it requires a vault owner password
+ *     that no longer exists, so it just exits 1. `parachute auth 2fa` is now an
+ *     honest informational stub on the hub side (real feature: #473).
  */
 
 import { join } from "node:path";
@@ -71,9 +75,10 @@ export const defaultRunner: Runner = {
   },
 };
 
-const VAULT_FORWARDED_SUBCOMMANDS = new Set(["2fa"]);
+const VAULT_FORWARDED_SUBCOMMANDS = new Set<string>([]);
 const HUB_LOCAL_SUBCOMMANDS = new Set([
   "rotate-key",
+  "2fa",
   "set-password",
   "list-users",
   "rotate-operator",
@@ -92,10 +97,8 @@ Usage:
   parachute auth set-password [--username <name>] [--password <pw>] [--allow-multi]
                                        Create or update the hub user's password
   parachute auth list-users            Show registered hub accounts
-  parachute auth 2fa status            Show 2FA state
-  parachute auth 2fa enroll            Enable TOTP 2FA (QR + backup codes)
-  parachute auth 2fa disable           Disable 2FA (requires password)
-  parachute auth 2fa backup-codes      Regenerate backup codes
+  parachute auth 2fa                   2FA status (hub-login TOTP not shipped
+                                       yet — tracked #473)
   parachute auth rotate-key            Rotate the hub's JWT signing key
   parachute auth rotate-operator [--scope-set <set>]
                                        Mint a fresh ~/.parachute/operator.token
@@ -128,10 +131,12 @@ The default username on first run is "owner" — override with --username.
 Single-user mode is the default; pass --allow-multi to add additional
 accounts beyond the first.
 
-2fa forwards to \`parachute-vault\` which still implements TOTP storage. If
-you see "not found on PATH", install vault first:
-
-  parachute install vault
+2fa is informational only for now: TOTP at the hub login layer isn't shipped
+yet (tracked #473). The legacy \`parachute-vault 2fa\` command writes vault YAML
+that does NOT gate hub \`/login\`, so it's intentionally no longer wired here —
+\`parachute auth 2fa\` prints the honest state and exits 0. Until hub-login TOTP
+ships, rely on a strong owner password (and don't expose \`/login\` if a
+guessable password is a concern).
 
 rotate-key generates a fresh RSA-2048 keypair and retires the previous
 one. The retired key keeps appearing in /.well-known/jwks.json for 24
@@ -1124,6 +1129,29 @@ async function runRevokeToken(args: readonly string[], deps: AuthDeps): Promise<
   }
 }
 
+/**
+ * Honest informational stub for `parachute auth 2fa [enroll|status|…]`.
+ *
+ * 2FA at the hub login layer isn't implemented yet (#473). The old path
+ * forwarded to the deprecated `parachute-vault 2fa` stub, which (a) post
+ * auth-unification requires a vault owner password that no longer exists, so it
+ * exits 1, and (b) even on success only writes vault YAML that does NOT gate
+ * hub `/login`. Telling operators to run it was actively misleading — enrolling
+ * did nothing for the exposed hub login. So we print the honest state and exit
+ * 0 (informational, not a crash).
+ */
+function run2faInfo(): number {
+  console.log("2FA for hub login isn't available yet (tracked: #473).");
+  console.log("");
+  console.log("The legacy `parachute-vault 2fa` command writes vault YAML but does NOT protect");
+  console.log("your hub login (`/login`), so enrolling there does nothing for the exposed hub.");
+  console.log("");
+  console.log("Until hub-login TOTP ships:");
+  console.log("  • Use a strong owner password (`parachute auth set-password`).");
+  console.log("  • If a guessable password is a concern, don't expose `/login` publicly.");
+  return 0;
+}
+
 function runListUsers(deps: AuthDeps): number {
   const db = deps.dbPath ? openHubDb(deps.dbPath) : openHubDb();
   try {
@@ -1181,6 +1209,9 @@ export async function auth(args: readonly string[], deps: AuthDeps | Runner = {}
         console.error(`parachute auth set-password: ${msg}`);
         return 1;
       }
+    }
+    if (sub === "2fa") {
+      return run2faInfo();
     }
     if (sub === "list-users") {
       return runListUsers(normalized);
@@ -1250,23 +1281,17 @@ export async function auth(args: readonly string[], deps: AuthDeps | Runner = {}
     }
   }
 
-  if (!VAULT_FORWARDED_SUBCOMMANDS.has(sub)) {
-    console.error(`parachute auth: unknown subcommand "${sub}"`);
-    console.error("run `parachute auth --help` for usage");
-    return 1;
-  }
-  try {
+  // No subcommands forward to parachute-vault anymore (VAULT_FORWARDED_SUBCOMMANDS
+  // is empty — `2fa` is now hub-local + honest, see #473). Anything that fell
+  // through every hub-local handler above is unknown.
+  if (VAULT_FORWARDED_SUBCOMMANDS.has(sub)) {
+    // Defensive: if a future subcommand is added back to the forward set, route
+    // it. Currently unreachable (the set is empty).
     return await runner.run(["parachute-vault", ...args]);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.toLowerCase().includes("enoent") || msg.toLowerCase().includes("not found")) {
-      console.error("parachute-vault not found on PATH.");
-      console.error("Install it with: parachute install vault");
-      return 127;
-    }
-    console.error(`failed to run parachute-vault: ${msg}`);
-    return 1;
   }
+  console.error(`parachute auth: unknown subcommand "${sub}"`);
+  console.error("run `parachute auth --help` for usage");
+  return 1;
 }
 
 // Re-exported so `users.ts` consumers can preserve the named-export.

--- a/src/commands/expose-2fa-warning.ts
+++ b/src/commands/expose-2fa-warning.ts
@@ -1,29 +1,27 @@
 /**
- * Public-exposure 2FA-enrollment warning (#186). Lands as the next layer of
- * defense after #188's `/login` rate-limit floor: once the operator brings
- * up cloudflare or Tailscale Funnel, `/login` is reachable from the public
- * internet on every layer admitting traffic. 2FA is the difference between
- * "password is the only wall" and "password + something-you-have."
+ * Public-exposure security warning (#186). Once the operator brings up
+ * cloudflare or Tailscale Funnel, `/login` is reachable from the public
+ * internet on every layer admitting traffic. After #188's `/login` rate-limit
+ * floor, the owner password is the wall.
+ *
+ * 2FA at the hub login layer is the planned next layer of defense — "password +
+ * something-you-have" — but it isn't shipped yet (#473). So this warning no
+ * longer recommends `parachute auth 2fa enroll` (that command writes vault YAML
+ * that does NOT gate hub `/login`, and post auth-unification it just exits 1).
+ * Instead it nudges toward a strong owner password and "don't expose /login if
+ * a guessable password is a concern."
  *
  * Why this is a warning, not a hard gate: hard-gating would surprise operators
  * mid-flow — they ran `parachute expose public` to expose, not to be told
- * "set up 2FA first." A loud, contextual warning + a clear one-line
- * remediation is the right shape; the operator decides whether to act now or
- * later. The tunnel is up regardless.
+ * "set up 2FA first." A loud, contextual warning + a clear remediation is the
+ * right shape; the operator decides whether to act now or later. The tunnel is
+ * up regardless.
  *
- * Why the source-of-truth is vault's `config.yaml`: 2FA enrollment lives in
- * `parachute-vault` (the hub forwards `parachute auth 2fa enroll` to vault —
- * see `commands/auth.ts` `VAULT_FORWARDED_SUBCOMMANDS`). The hub's `users`
- * table has no TOTP column today; it will gain one when hub-admin login
- * verifies TOTP against vault. Until then, "is 2FA enrolled?" maps cleanly
- * to "does vault's config.yaml carry a non-empty `totp_secret`?", which is
- * exactly what `readVaultAuthStatus().hasTotp` returns.
- *
- * If vault isn't installed at all (rare for the cloudflare path — it requires
- * a vault entry — but possible on the tailnet/funnel path): `hasTotp` comes
- * back `false` and the warning still fires. The remediation
- * `parachute auth 2fa enroll` then surfaces vault's "install vault first"
- * error, which is the right next step regardless.
+ * The probe still consults `readVaultAuthStatus().hasTotp` (true only when a
+ * legacy vault `config.yaml` carries a non-empty `totp_secret`) to suppress the
+ * warning for operators who DID set up the legacy vault TOTP — even though it
+ * doesn't gate hub login, suppressing avoids nagging them. Once hub-login TOTP
+ * (#473) lands with a hub-side column, this reads that instead.
  */
 
 import { type VaultAuthStatus, readVaultAuthStatus } from "../vault/auth-status.ts";
@@ -71,12 +69,14 @@ export function printPublic2FAWarning(opts: Public2FAWarningOpts): boolean {
     return false;
   }
   log("");
-  log("⚠ 2FA is not enrolled. /login is now reachable on the public internet");
-  log(`  (${opts.publicUrl}/login). Anyone who guesses your password`);
-  log("  is in. Strongly recommended:");
+  log("⚠ /login is now reachable on the public internet");
+  log(`  (${opts.publicUrl}/login). Anyone who guesses your password is in.`);
   log("");
-  log("    parachute auth 2fa enroll");
+  log("  2FA at the hub login layer is coming (#473) but isn't shipped yet —");
+  log("  for now your owner password is the wall. Make sure it's a strong one:");
   log("");
-  log("  Adds TOTP + backup codes. Takes 30 seconds.");
+  log("    parachute auth set-password");
+  log("");
+  log("  If a guessable password is a concern, don't expose /login publicly.");
   return true;
 }

--- a/src/commands/expose-auth-preflight.ts
+++ b/src/commands/expose-auth-preflight.ts
@@ -15,12 +15,17 @@
  * purely on password + 2FA; we no longer count vault-DB rows for the auth
  * decision.
  *
- * Three states we branch on, based on {@link VaultAuthStatus}:
+ * Two states we branch on, based on {@link VaultAuthStatus}:
  *
  *   - no owner password: loud warning — the exposure is wide open. Offer to
- *     set a password (+ 2FA), and point at the hub-JWT mint path for clients.
- *   - password, no 2FA: shorter "recommend 2FA" nudge.
- *   - password + 2FA: one-line "looks good" (the quiet path).
+ *     set a password, and point at the hub-JWT mint path for clients.
+ *   - password set: one-line "looks good" + an honest note that hub-login 2FA
+ *     isn't shipped yet (#473), so the owner password is the wall.
+ *
+ * We no longer offer "enable 2FA": `parachute auth 2fa enroll` forwarded to the
+ * deprecated vault stub, which post auth-unification exits 1 and (on the old
+ * happy path) only wrote vault YAML that never gated hub `/login`. Offering it
+ * was a dead path. Real hub-login TOTP is tracked at #473.
  *
  * Defaults are always "skip" — Enter declines every prompt. User can always
  * run `parachute auth set-password` / `parachute auth mint-token …` later.
@@ -108,10 +113,15 @@ async function offerOwnerPassword(r: Resolved): Promise<void> {
   }
 }
 
-async function offerTotp(r: Resolved): Promise<void> {
-  if (await yesNo(r, "Enable TOTP 2FA now?")) {
-    await runCmd(r, ["parachute", "auth", "2fa", "enroll"], "parachute auth 2fa enroll");
-  }
+/**
+ * Honest note that hub-login 2FA isn't shipped yet. Replaces the old
+ * `offerTotp` (which ran the dead `parachute auth 2fa enroll` path). No prompt —
+ * there's nothing actionable to offer until #473 lands.
+ */
+function note2faComing(r: Resolved): void {
+  r.log("");
+  r.log("Note: 2FA at the hub login layer is coming (#473) but isn't shipped yet —");
+  r.log("for now the owner password is the wall, so keep it strong.");
 }
 
 /**
@@ -155,34 +165,23 @@ async function handleWideOpen(r: Resolved): Promise<void> {
   r.log("sign-in (OAuth) and minting hub tokens for programmatic clients.");
   r.log("");
   await offerOwnerPassword(r);
-  // Offer 2FA regardless of the password step outcome: we can't observe it
-  // from outside the subprocess, and vault itself will reject a 2fa enroll
-  // if there's no password yet, surfacing the real error to the user.
-  await offerTotp(r);
   // Programmatic-client guidance is informational (no auto-mint) — print it
   // so the operator knows the headless path exists, not the dead pvt_* one.
   printTokenGuidance(r);
+  // Honest 2FA state — coming (#473), not yet shippable.
+  note2faComing(r);
   printDivider(r);
 }
 
 /**
- * `password set, no 2FA`: the common case where the user did the obvious
- * thing but hasn't opted into the stronger factor yet. Short nudge.
+ * `password set`: the operator did the obvious thing. One-line confirmation
+ * plus the honest 2FA note. (We don't assert on tokens — a hub JWT is minted
+ * on demand, not a standing prerequisite.)
  */
-async function handlePasswordNoTotp(r: Resolved): Promise<void> {
+function handlePasswordSet(r: Resolved): void {
   r.log("");
   r.log("✓  Owner password is set.");
-  r.log("   Consider also enabling 2FA for defense-in-depth.");
-  await offerTotp(r);
-}
-
-/**
- * `all set`: owner password + 2FA. Keep it tight. (We don't assert on
- * tokens — a hub JWT is minted on demand, not a standing prerequisite.)
- */
-function handleAllGood(r: Resolved): void {
-  r.log("");
-  r.log("✓  Auth config looks good (owner password + 2FA).");
+  note2faComing(r);
 }
 
 /**
@@ -190,12 +189,12 @@ function handleAllGood(r: Resolved): void {
  *
  * Owner-password-centric since the pvt_* DROP (hub#466): `tokenCount` is no
  * longer consulted — those rows are vestigial and minting access now flows
- * through the owner password, not a standing vault token. Three states.
+ * through the owner password, not a standing vault token. 2FA isn't a branch
+ * anymore (hub-login TOTP not shipped — #473): two states.
  */
-function classify(s: VaultAuthStatus): "wide-open" | "password-no-totp" | "all-good" {
+function classify(s: VaultAuthStatus): "wide-open" | "password-set" {
   if (!s.hasOwnerPassword) return "wide-open";
-  if (!s.hasTotp) return "password-no-totp";
-  return "all-good";
+  return "password-set";
 }
 
 export async function runAuthPreflight(opts: AuthPreflightOpts = {}): Promise<void> {
@@ -204,11 +203,8 @@ export async function runAuthPreflight(opts: AuthPreflightOpts = {}): Promise<vo
     case "wide-open":
       await handleWideOpen(r);
       return;
-    case "password-no-totp":
-      await handlePasswordNoTotp(r);
-      return;
-    case "all-good":
-      handleAllGood(r);
+    case "password-set":
+      handlePasswordSet(r);
       return;
   }
 }

--- a/src/commands/expose-cloudflare.ts
+++ b/src/commands/expose-cloudflare.ts
@@ -28,6 +28,12 @@ import {
 } from "../cloudflare/tunnel.ts";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import {
+  EXPOSE_STATE_PATH,
+  type ExposeState,
+  clearExposeState,
+  writeExposeState,
+} from "../expose-state.ts";
+import {
   type EnsureHubOpts,
   HUB_DEFAULT_PORT,
   ensureHubRunning,
@@ -103,6 +109,15 @@ export interface ExposeCloudflareOpts {
   manifestPath?: string;
   statePath?: string;
   /**
+   * Path to `expose-state.json` — the shared cross-provider expose record the
+   * Tailscale path also writes (`expose.ts`). Distinct from `statePath`
+   * (cloudflared-state.json, the per-tunnel process record). The cloudflare
+   * up-path writes this so downstream consumers (`resolveAdminUrl` in init,
+   * `resolveHubOrigin` in lifecycle / auth) see the public URL instead of
+   * loopback; the off-path clears it. Defaults to `EXPOSE_STATE_PATH`.
+   */
+  exposeStatePath?: string;
+  /**
    * Tunnel name targeted by this invocation. Defaults to `parachute` —
    * the canonical single-tunnel name. Override to run multiple tunnels on
    * one box (#32).
@@ -174,6 +189,7 @@ interface Resolved {
   log: (line: string) => void;
   manifestPath: string;
   statePath: string;
+  exposeStatePath: string;
   tunnelName: string;
   configPath: string;
   logPath: string;
@@ -204,6 +220,7 @@ function resolve(opts: ExposeCloudflareOpts): Resolved {
     log: opts.log ?? ((line) => console.log(line)),
     manifestPath: opts.manifestPath ?? SERVICES_MANIFEST_PATH,
     statePath: opts.statePath ?? CLOUDFLARED_STATE_PATH,
+    exposeStatePath: opts.exposeStatePath ?? EXPOSE_STATE_PATH,
     tunnelName,
     configPath: opts.configPath ?? paths.configPath,
     logPath: opts.logPath ?? paths.logPath,
@@ -228,8 +245,9 @@ function printAuthGuidance(log: (line: string) => void, vaultUrl: string): void 
   log("Pick the path that matches how you'll reach it:");
   log("");
   log("  Humans (claude.ai / ChatGPT connectors, browser):");
-  log("    parachute auth set-password         # set an owner password");
-  log("    parachute auth 2fa enroll           # (recommended) TOTP + backup codes");
+  log("    parachute auth set-password         # set a STRONG owner password");
+  log("    # (hub-login 2FA is coming — #473 — but not shipped yet; the owner");
+  log("    #  password is the wall for now, so make it a good one)");
   log("    then point your connector at:");
   log(`    ${vaultUrl}`);
   log("");
@@ -416,6 +434,38 @@ export async function exposeCloudflareUp(
   };
   writeCloudflaredState(withTunnelRecord(stateBefore, record), r.statePath);
 
+  // Persist the shared cross-provider expose record. Without this, the
+  // Tailscale path was the only one writing expose-state.json — so after a
+  // Cloudflare bring-up `readExposeState()` returned undefined and downstream
+  // consumers fell back to loopback:
+  //   - init's `resolveAdminUrl` printed http://127.0.0.1:1939/admin/ instead
+  //     of the public URL.
+  //   - lifecycle's `resolveHubOrigin` (and the hub#460 vault `.env`
+  //     PARACHUTE_HUB_ORIGIN persistence) kept the loopback origin, so vault's
+  //     OAuth `iss` claim didn't match the public host — the "rejected on
+  //     reconnect" P0 on Cloudflare deploys.
+  // Mode is "subdomain": cloudflared routes the whole FQDN at the hub catchall
+  // (one ingress → hub), unlike the Tailscale path's "path" routing. The single
+  // proxy entry mirrors the hub-catchall shape the Tailscale Funnel path plans.
+  const exposeState: ExposeState = {
+    version: 1,
+    layer: "public",
+    mode: "subdomain",
+    canonicalFqdn: hostname,
+    port: hubPort,
+    funnel: false,
+    entries: [
+      {
+        kind: "proxy",
+        mount: "/",
+        target: `http://localhost:${hubPort}`,
+        service: "hub",
+      },
+    ],
+    hubOrigin,
+  };
+  writeExposeState(exposeState, r.exposeStatePath);
+
   const baseUrl = `https://${hostname}`;
   // A well-formed vault manifest always lists at least one mount path. If
   // it's empty, something went sideways in `parachute install vault` — warn
@@ -485,6 +535,13 @@ export async function exposeCloudflareOff(opts: ExposeCloudflareOpts = {}): Prom
     writeCloudflaredState(stateAfter, r.statePath);
   } else {
     clearCloudflaredState(r.statePath);
+  }
+  // Clear the shared expose-state.json when no Cloudflare tunnels remain, so
+  // downstream consumers stop resolving the now-dead public URL (mirrors the
+  // up-path write above + the Tailscale off-path's expose-state teardown). When
+  // other tunnels survive we leave it — a later off for the last one clears it.
+  if (!stateAfter) {
+    clearExposeState(r.exposeStatePath);
   }
   r.log(`  ${record.hostname} is no longer reachable through this machine.`);
   r.log(

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -181,6 +181,26 @@ export function looksLikeServer(platform: NodeJS.Platform, env: NodeJS.ProcessEn
 }
 
 /**
+ * Heuristic: would a browser-spawn fail because there's no display?
+ *
+ * A TTY guard alone is insufficient — an SSH session is a TTY with no display,
+ * so `xdg-open` fails (or blocks). We treat a box as display-less when:
+ *   - it's a server per {@link looksLikeServer} (linux + SSH or no X/Wayland,
+ *     excluding WSL which is a dev laptop), OR
+ *   - it's linux with neither $DISPLAY nor $WAYLAND_DISPLAY (covers a local
+ *     headless linux console that isn't over SSH).
+ *
+ * macOS / Windows always have a window server, so they're never display-less
+ * here (someone SSH'd into a Mac is a rare enough edge that we keep the happy
+ * path — `open` no-ops gracefully there anyway).
+ */
+export function hasNoDisplay(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): boolean {
+  if (platform !== "linux") return false;
+  if (looksLikeServer(platform, env)) return true;
+  return !env.DISPLAY && !env.WAYLAND_DISPLAY;
+}
+
+/**
  * Default browser-opener. Tries `open` on macOS, `xdg-open` on Linux, and
  * returns false when neither is available (Windows / WSL fallthrough +
  * misc Unixes ship `xdg-open` so coverage is decent without bringing in
@@ -521,6 +541,17 @@ export async function init(opts: InitOpts = {}): Promise<number> {
   }
   if (platform !== "darwin" && platform !== "linux") {
     log("(Open the URL above in your browser to continue.)");
+    return 0;
+  }
+  // Headless guard: a TTY isn't enough — an SSH session is a TTY but has no
+  // display, so `xdg-open` either fails noisily or (worse) blocks. Skip the
+  // spawn entirely on a server-shaped box (linux + no $DISPLAY/$WAYLAND_DISPLAY,
+  // or SSH) and just print the link. Aaron hit this on EC2: init tried to open
+  // a browser, failed with "Couldn't launch a browser," and (pre-Fix-1) showed
+  // the loopback URL. With Fix 1 the printed link is now the public Cloudflare
+  // URL. Keep spawning on a real desktop (macOS, Linux-with-display).
+  if (hasNoDisplay(platform, env)) {
+    log("(No display detected — open the URL above in a browser to continue.)");
     return 0;
   }
   // `choice === "browser"` (either flag-driven or the operator picked

--- a/src/commands/wizard.ts
+++ b/src/commands/wizard.ts
@@ -76,8 +76,9 @@ export interface RunCliWizardOpts {
   sleep?: (ms: number) => Promise<void>;
   /**
    * Non-interactive escape hatch: pre-supply the account-step answers.
-   * Username defaults to `admin` when unset; password is required (no
-   * default, no prompt → exit-with-error). Mirrors the
+   * Username defaults to `owner` when unset (aligned with
+   * `parachute auth set-password` + the operator.token convention); password
+   * is required (no default, no prompt → exit-with-error). Mirrors the
    * `PARACHUTE_INITIAL_ADMIN_*` env-seed shape.
    */
   accountUsername?: string;
@@ -400,8 +401,11 @@ async function walkAccountStep(
   log("  Set up the operator account that owns this hub.");
   let username = opts.accountUsername;
   if (username === undefined) {
-    const raw = (await opts.prompt("  username [admin]: ")).trim();
-    username = raw === "" ? "admin" : raw;
+    // Default to "owner" — aligns with `parachute auth set-password` and the
+    // operator.token convention (the earliest-created user is the operator).
+    // The web wizard lets the operator name it freely; so does this prompt.
+    const raw = (await opts.prompt("  username [owner]: ")).trim();
+    username = raw === "" ? "owner" : raw;
   }
   let password = opts.accountPassword;
   if (password === undefined) {

--- a/src/help.ts
+++ b/src/help.ts
@@ -326,6 +326,7 @@ Usage:
   parachute expose public  --tailnet
   parachute expose public  --cloudflare --domain <hostname>
   parachute expose public  off --cloudflare
+  parachute expose cloudflare --domain <hostname>           # alias for the above
 
 Status:
   tailnet is the supported exposure shape. The hub's OAuth + per-module
@@ -381,6 +382,7 @@ Examples:
   parachute expose public off                              # stop the Funnel
   parachute expose public --cloudflare --domain vault.example.com
                                                            # stable URL via cloudflared
+  parachute expose cloudflare --domain vault.example.com   # alias for the line above
   parachute expose public off --cloudflare                 # stop the cloudflared tunnel
 
 Tailscale Funnel constraints:

--- a/src/help.ts
+++ b/src/help.ts
@@ -194,7 +194,7 @@ Flags:
                                  http://127.0.0.1:1939). \`parachute init\`
                                  passes this in when chaining; standalone
                                  callers supply it explicitly.
-  --account-username <name>      pre-supply the admin username (default: admin)
+  --account-username <name>      pre-supply the admin username (default: owner)
   --account-password <pw>        pre-supply the admin password (required when
                                  non-interactive)
   --bootstrap-token <token>      one-time bootstrap token when the hub is in

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -509,7 +509,11 @@ export interface RenderAccountStepProps {
 export function renderAccountStep(props: RenderAccountStepProps): string {
   const { csrfToken, errorMessage, username, requireBootstrapToken, bootstrapToken } = props;
   const error = errorMessage ? `<p class="error-banner">${escapeHtml(errorMessage)}</p>` : "";
-  const usernameAttr = username ? ` value="${escapeAttr(username)}"` : "";
+  // Pre-fill "owner" on a fresh render (no prior submission) so the web wizard's
+  // default matches the CLI paths (`set-password`, `setup-wizard`) + the
+  // operator.token convention. Operators can still type any name. On a
+  // validation-failure re-render we echo back what they typed instead.
+  const usernameAttr = ` value="${escapeAttr(username ?? "owner")}"`;
   const tokenAttr = bootstrapToken ? ` value="${escapeAttr(bootstrapToken)}"` : "";
   // Bootstrap-token field comes FIRST when required. An operator who
   // missed the log line is stopped here rather than after filling


### PR DESCRIPTION
Remote-deploy setup-correctness pass. Five fixes, all confirmed against a live EC2 + Cloudflare deploy. Bumps `0.5.14-rc.11` → `rc.12`.

## Fix 1 (highest value) — Cloudflare expose path now persists expose-state.json
The Cloudflare expose path never called `writeExposeState` — only the Tailscale path did. So after `parachute expose public --cloudflare --domain <host>`, `readExposeState()` returned `undefined` and every downstream consumer fell back to loopback:
- init's `resolveAdminUrl` printed `http://127.0.0.1:1939/admin/` instead of the public URL.
- lifecycle's `resolveHubOrigin` (and the hub#460 vault `.env` `PARACHUTE_HUB_ORIGIN` persistence) kept the loopback origin.

**OAuth-iss implication:** vault's OAuth `iss` claim stayed loopback while clients hit the public host → the "rejected on reconnect" P0 on Cloudflare deploys.

`exposeCloudflareUp` now writes expose-state.json (`layer: public`, `mode: subdomain`, `canonicalFqdn: <host>`, `hubOrigin: https://<host>`, single hub-catchall proxy entry) mirroring the Tailscale shape; `exposeCloudflareOff` clears it when the last tunnel goes down. New `exposeStatePath` seam keeps tests off the real `~/.parachute`. Verified end-to-end: after a cloudflare expose, `readExposeState()` carries the canonicalFqdn + public hubOrigin and `resolveAdminUrl` returns `https://<host>/admin/`.

## Fix 2 — headless browser-open prints the link instead of spawning
On EC2, init tried to launch a browser despite no display ("Couldn't launch a browser") AND (pre-Fix-1) showed the loopback URL. The TTY guard wasn't enough (SSH is a TTY). New `hasNoDisplay(platform, env)` gates the spawn on a real display: skip on linux + (SSH or no `$DISPLAY`/`$WAYLAND_DISPLAY`) and print the URL; keep spawning on a real desktop. With Fix 1, the printed URL is now the public Cloudflare https URL.

## Fix 3 — honest 2FA (real feature is #473)
`parachute auth 2fa` forwarded to the deprecated `parachute-vault 2fa` stub, which (a) post auth-unification requires a vault owner password that no longer exists → exits 1, and (b) even on success only writes vault YAML that does NOT gate hub `/login` (no TOTP step in `handleAdminLoginPost`; `auth-status` reports `hasTotp=false` on the hub-store path). Enrolling did nothing for the exposed hub login.
- Removed `2fa` from `VAULT_FORWARDED_SUBCOMMANDS`; `parachute auth 2fa` is now an honest hub-side stub (prints the real state, references #473, exits 0).
- Reworded the expose/init security nudges (`printPublic2FAWarning`, `printAuthGuidance`, `runAuthPreflight`): hub-login 2FA is coming (#473) but not shipped — rely on a strong owner password, don't expose `/login` if a guessable password is a concern. No code path recommends or invokes the dead `auth 2fa enroll` anymore.
- **Filed #473** for the real feature: TOTP at the hub login layer (totp_secret/backup_codes on hub.db users, SPA QR enroll, TOTP step in `handleAdminLoginPost`).

## Fix 4 — first-admin username consistency
The default diverged: web `/admin/setup` free-choice, CLI `set-password` → `owner`, `setup-wizard` → `admin`. Aligned all paths on `owner` (matches set-password + the operator.token convention) while still letting the operator name it freely: CLI setup-wizard account prompt default `admin`→`owner`; web `renderAccountStep` pre-fills `owner` (editable, echoes back typed value on re-render). The `--username` override and the `PARACHUTE_INITIAL_ADMIN_USERNAME` env-seed path are untouched.

## Fix 5 — `parachute expose cloudflare` alias
`parachute expose cloudflare [--domain X]` errored "unknown layer". Now accepted as shorthand for `parachute expose public --cloudflare …` (rewrite layer → public, force the cloudflare flag, reuse the identical downstream dispatch). Help + examples updated.

## Investigation — vault install channel (no code change)
Reported symptom: `init`/`install` left vault at `0.4.8` (npm @latest) despite `PARACHUTE_INSTALL_CHANNEL=rc`. **This is expected behavior, not a code gap:**
1. `resolveInstallChannel` and `install vault` DO honor `PARACHUTE_INSTALL_CHANNEL=rc` — verified it composes `bun add -g @openparachute/vault@rc` when vault isn't already present.
2. When vault is already linked / globally installed, `install` skips `bun add -g` entirely (install.ts ~590) → the channel never applies. Install is idempotent, not an in-place upgrader.
3. `init` only calls `install` for vault when no vault row exists (init.ts ~440) → on a box where vault is already present (at 0.4.8), init never re-invokes install, never re-resolves the channel.

So on the EC2 box vault was already present, so both init (skip-when-present) and install's bun-add gate (skip-when-linked) bypassed the channel resolver. The correct path to apply the rc channel to an already-present vault is `parachute upgrade vault` (or remove + `parachute install vault --channel rc`). No resolver bug; this is a docs/UX matter — left as-is per "fix only if it's a clear code gap."

## Verification
- `bun test ./src` — **2378 pass, 0 fail, 1 skip** (100 files).
- `bun run typecheck` — clean.
- `bunx biome check` on changed files — clean.
- Fix 1 downstream chain verified end-to-end in a sandboxed PARACHUTE_HOME (expose-state.json persists canonicalFqdn + public hubOrigin; resolveAdminUrl returns the public URL; off clears it).
- No `web/ui` SPA changes (the web wizard is server-rendered `src/setup-wizard.ts`), so no SPA build/vitest needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)