### PR TITLE
feat(hub): real TOTP 2FA at hub login + backup codes (#473) (+ rc.13)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,10 +7,13 @@
       "dependencies": {
         "@node-rs/argon2": "^2.0.2",
         "jose": "^6.2.2",
+        "otpauth": "^9.5.0",
+        "qrcode": "^1.5.4",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@types/bun": "latest",
+        "@types/qrcode": "^1.5.6",
       },
       "peerDependencies": {
         "typescript": "^5",
@@ -18,7 +21,7 @@
     },
     "packages/scope-guard": {
       "name": "@openparachute/scope-guard",
-      "version": "0.1.0-rc.1",
+      "version": "0.4.0-rc.2",
       "dependencies": {
         "jose": "^6.2.2",
       },
@@ -53,6 +56,8 @@
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
+
+    "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
     "@node-rs/argon2": ["@node-rs/argon2@2.0.2", "", { "optionalDependencies": { "@node-rs/argon2-android-arm-eabi": "2.0.2", "@node-rs/argon2-android-arm64": "2.0.2", "@node-rs/argon2-darwin-arm64": "2.0.2", "@node-rs/argon2-darwin-x64": "2.0.2", "@node-rs/argon2-freebsd-x64": "2.0.2", "@node-rs/argon2-linux-arm-gnueabihf": "2.0.2", "@node-rs/argon2-linux-arm64-gnu": "2.0.2", "@node-rs/argon2-linux-arm64-musl": "2.0.2", "@node-rs/argon2-linux-x64-gnu": "2.0.2", "@node-rs/argon2-linux-x64-musl": "2.0.2", "@node-rs/argon2-wasm32-wasi": "2.0.2", "@node-rs/argon2-win32-arm64-msvc": "2.0.2", "@node-rs/argon2-win32-ia32-msvc": "2.0.2", "@node-rs/argon2-win32-x64-msvc": "2.0.2" } }, "sha512-t64wIsPEtNd4aUPuTAyeL2ubxATCBGmeluaKXEMAFk/8w6AJIVVkeLKMBpgLW6LU2t5cQxT+env/c6jxbtTQBg=="],
 
@@ -92,14 +97,76 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@types/qrcode": ["@types/qrcode@1.5.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
+    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
+    "cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
+
+    "dijkstrajs": ["dijkstrajs@1.0.3", "", {}, "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "otpauth": ["otpauth@9.5.1", "", { "dependencies": { "@noble/hashes": "2.2.0" } }, "sha512-fJmDAHc8wImfqqqOXIlBvT1dEKrZK0Cmb2VEgScpNTolCz0PHh6ExUZGv4sLtOsWNaHCQlD+rRqaPgnoxFoZjQ=="],
+
+    "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
+
+    "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
+
+    "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
+
+    "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
+
+    "yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
+
+    "yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.12",
-  "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
+  "version": "0.5.14-rc.13",
+  "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {
     "access": "public"
@@ -37,13 +37,16 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "@types/qrcode": "^1.5.6"
   },
   "peerDependencies": {
     "typescript": "^5"
   },
   "dependencies": {
     "@node-rs/argon2": "^2.0.2",
-    "jose": "^6.2.2"
+    "jose": "^6.2.2",
+    "otpauth": "^9.5.0",
+    "qrcode": "^1.5.4"
   }
 }

--- a/src/__tests__/account-home-ui.test.ts
+++ b/src/__tests__/account-home-ui.test.ts
@@ -32,6 +32,7 @@ describe("renderAccountHome", () => {
       hubOrigin: HUB_ORIGIN,
       isFirstAdmin: false,
       csrfToken: CSRF,
+      twoFactorEnabled: false,
     });
     // Welcome header includes the username.
     expect(html).toContain("Welcome, alice");
@@ -69,6 +70,7 @@ describe("renderAccountHome", () => {
       hubOrigin: `${HUB_ORIGIN}/`,
       isFirstAdmin: false,
       csrfToken: CSRF,
+      twoFactorEnabled: false,
     });
     const cleanEncoded = encodeURIComponent(`${HUB_ORIGIN}/vault/alice`);
     expect(html).toContain(`https://notes.parachute.computer/add?url=${cleanEncoded}`);
@@ -86,6 +88,7 @@ describe("renderAccountHome", () => {
       hubOrigin: HUB_ORIGIN,
       isFirstAdmin: true,
       csrfToken: CSRF,
+      twoFactorEnabled: false,
     });
     expect(html).toContain("Welcome, admin");
     expect(html).toContain("hub administrator");
@@ -106,6 +109,7 @@ describe("renderAccountHome", () => {
       hubOrigin: HUB_ORIGIN,
       isFirstAdmin: false,
       csrfToken: CSRF,
+      twoFactorEnabled: false,
     });
     expect(html).toContain("Welcome, ghost");
     expect(html).toContain("Ask the hub operator");
@@ -123,6 +127,7 @@ describe("renderAccountHome", () => {
       hubOrigin: HUB_ORIGIN,
       isFirstAdmin: false,
       csrfToken: CSRF,
+      twoFactorEnabled: false,
     });
     // Change-password link points at the existing /account/change-password
     // route (server-rendered HTML, separate handler).
@@ -136,6 +141,37 @@ describe("renderAccountHome", () => {
     expect(html).toContain("<code>alice</code>");
   });
 
+  test("account card — 2FA status reflects twoFactorEnabled (hub#473)", () => {
+    const off = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["alice"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+    });
+    expect(off).toContain('data-testid="2fa-status"');
+    expect(off).toContain(">Off<");
+    // Off → "Set up two-factor" affordance.
+    expect(off).toContain('data-testid="setup-2fa-link"');
+    expect(off).toContain('href="/account/2fa"');
+
+    const on = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["alice"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: true,
+    });
+    expect(on).toContain(">On<");
+    // On → "Manage two-factor" affordance.
+    expect(on).toContain('data-testid="manage-2fa-link"');
+    expect(on).toContain('href="/account/2fa"');
+  });
+
   test("multi-vault branch — renders one tile per assigned vault (Phase 2 PR 2)", () => {
     const html = renderAccountHome({
       username: "alice",
@@ -144,6 +180,7 @@ describe("renderAccountHome", () => {
       hubOrigin: HUB_ORIGIN,
       isFirstAdmin: false,
       csrfToken: CSRF,
+      twoFactorEnabled: false,
     });
     // Plural heading.
     expect(html).toContain("Your vaults");
@@ -191,6 +228,7 @@ describe("renderAccountHome", () => {
       hubOrigin: HUB_ORIGIN,
       isFirstAdmin: false,
       csrfToken: CSRF,
+      twoFactorEnabled: false,
     });
     // The injected username/vault metacharacters are escaped — the only
     // `<script>` tag in the output is the page's own copy-button helper, so

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -65,26 +65,159 @@ async function captureOutput(fn: () => Promise<number> | number): Promise<{
 }
 
 describe("parachute auth", () => {
-  test("2fa is an honest hub-side stub — never forwards to parachute-vault", async () => {
-    // 2fa used to forward to the deprecated `parachute-vault 2fa` stub, which
-    // exits 1 post auth-unification and only wrote vault YAML that never gated
-    // hub /login. It's now an informational stub: exit 0, no subprocess.
-    const { runner, calls } = makeRunner(0);
-    const out = await captureOutput(() => auth(["2fa", "enroll"], runner));
-    expect(out.code).toBe(0);
-    expect(calls).toEqual([]); // did NOT spawn parachute-vault
-    expect(out.stdout).toContain("isn't available yet");
-    expect(out.stdout).toContain("#473");
-    // Doesn't tell the operator to run the dead vault command.
-    expect(out.stdout).not.toContain("2fa enroll");
+  test("2fa is hub-local — never forwards to parachute-vault", async () => {
+    // 2fa used to forward to the deprecated `parachute-vault 2fa` stub. As of
+    // hub#473 it's real hub-login TOTP, fully hub-local (hub.db). No subprocess.
+    const tmp = makeTmp();
+    try {
+      const db = openHubDb(tmp.dbPath);
+      await createUser(db, "owner", "owner-password-123");
+      db.close();
+      const { runner, calls } = makeRunner(0);
+      const out = await captureOutput(() =>
+        auth(["2fa", "status"], { runner, dbPath: tmp.dbPath }),
+      );
+      expect(out.code).toBe(0);
+      expect(calls).toEqual([]); // did NOT spawn parachute-vault
+      expect(out.stdout).toContain("Two-factor authentication: OFF");
+    } finally {
+      tmp.cleanup();
+    }
   });
 
-  test("2fa with any sub-args still resolves to the honest stub (exit 0, no spawn)", async () => {
-    const { runner, calls } = makeRunner(0);
-    const out = await captureOutput(() => auth(["2fa", "status", "--whatever"], runner));
-    expect(out.code).toBe(0);
-    expect(calls).toEqual([]);
-    expect(out.stdout).toContain("#473");
+  test("2fa status reports OFF for a fresh user, then ON after a CLI enroll round-trip", async () => {
+    const tmp = makeTmp();
+    try {
+      const db = openHubDb(tmp.dbPath);
+      await createUser(db, "owner", "owner-password-123");
+      db.close();
+
+      // status → OFF
+      const off = await captureOutput(() =>
+        auth(["2fa", "status"], { dbPath: tmp.dbPath, isInteractive: () => false }),
+      );
+      expect(off.code).toBe(0);
+      expect(off.stdout).toContain("OFF");
+
+      // enroll requires a confirm code — drive the readLine seam with the
+      // live TOTP code generated from the secret the command prints.
+      const { generateTotpSecret } = await import("../totp.ts");
+      // We can't intercept the random secret the command mints, so instead
+      // exercise the store directly to assert the ON path is reachable, then
+      // assert the CLI status reflects it. (The handler-level enroll round
+      // trip is covered in two-factor.test.ts against the real secret.)
+      const db2 = openHubDb(tmp.dbPath);
+      const { persistEnrollment } = await import("../two-factor-store.ts");
+      const u = listUsers(db2)[0]!;
+      const { secret } = generateTotpSecret(u.username);
+      await persistEnrollment(db2, u.id, secret);
+      db2.close();
+
+      const on = await captureOutput(() =>
+        auth(["2fa", "status"], { dbPath: tmp.dbPath, isInteractive: () => false }),
+      );
+      expect(on.code).toBe(0);
+      expect(on.stdout).toContain("ON");
+      expect(on.stdout).toContain("backup_codes");
+
+      // disenroll clears it.
+      const dis = await captureOutput(() =>
+        auth(["2fa", "disenroll"], { dbPath: tmp.dbPath, isInteractive: () => false }),
+      );
+      expect(dis.code).toBe(0);
+      expect(dis.stdout).toContain("Turned off");
+
+      const off2 = await captureOutput(() =>
+        auth(["2fa", "status"], { dbPath: tmp.dbPath, isInteractive: () => false }),
+      );
+      expect(off2.stdout).toContain("OFF");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("2fa enroll confirms the printed secret against a live code, prints backup codes", async () => {
+    const tmp = makeTmp();
+    try {
+      const db = openHubDb(tmp.dbPath);
+      await createUser(db, "owner", "owner-password-123");
+      db.close();
+
+      // Single console.log interception that BOTH accumulates stdout and lets
+      // the readLine seam read the secret the command just printed. (Avoids
+      // nesting two console.log replacements.)
+      const OTPAuth = await import("otpauth");
+      const origLog = console.log;
+      let stdout = "";
+      let capturedSecret = "";
+      console.log = (...a: unknown[]) => {
+        const line = a.map(String).join(" ");
+        stdout += `${line}\n`;
+        const m = line.match(/secret key:\s+([A-Z2-7]+)/);
+        if (m) capturedSecret = m[1]!;
+      };
+      let code = "";
+      let exitCode = 0;
+      try {
+        exitCode = await auth(["2fa", "enroll"], {
+          dbPath: tmp.dbPath,
+          isInteractive: () => true,
+          readLine: async () => {
+            // The secret has been printed by the time the prompt fires.
+            const totp = new OTPAuth.TOTP({
+              issuer: "Parachute Hub",
+              label: "owner",
+              algorithm: "SHA1",
+              digits: 6,
+              period: 30,
+              secret: OTPAuth.Secret.fromBase32(capturedSecret),
+            });
+            code = totp.generate();
+            return code;
+          },
+        });
+      } finally {
+        console.log = origLog;
+      }
+      expect(exitCode).toBe(0);
+      expect(capturedSecret.length).toBeGreaterThan(0);
+      expect(stdout).toContain("now ON");
+      // 10 backup codes printed (hyphenated form).
+      const backupLines = stdout.split("\n").filter((l) => /^ {2}[a-z2-9]{5}-[a-z2-9]{5}$/.test(l));
+      expect(backupLines.length).toBe(10);
+      expect(code.length).toBe(6);
+      // The persisted state reflects the enrollment: the captured secret is
+      // now stored on the user row. (We don't re-verify `code` — the enroll
+      // confirm consumed it via the replay cache, by design.)
+      const db2 = openHubDb(tmp.dbPath);
+      const { getTotpState } = await import("../two-factor-store.ts");
+      const uid = listUsers(db2)[0]!.id;
+      const persisted = getTotpState(db2, uid);
+      expect(persisted.secret).toBe(capturedSecret);
+      expect(persisted.backupCodes.length).toBe(10);
+      db2.close();
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("2fa enroll refuses to re-enroll when already on", async () => {
+    const tmp = makeTmp();
+    try {
+      const db = openHubDb(tmp.dbPath);
+      const u = await createUser(db, "owner", "owner-password-123");
+      const { generateTotpSecret } = await import("../totp.ts");
+      const { persistEnrollment } = await import("../two-factor-store.ts");
+      await persistEnrollment(db, u.id, generateTotpSecret("owner").secret);
+      db.close();
+      const out = await captureOutput(() =>
+        auth(["2fa", "enroll"], { dbPath: tmp.dbPath, isInteractive: () => true }),
+      );
+      expect(out.code).toBe(1);
+      expect(out.stderr).toContain("already enabled");
+    } finally {
+      tmp.cleanup();
+    }
   });
 
   test("set-password no longer forwards to vault", async () => {
@@ -138,12 +271,13 @@ describe("authHelp", () => {
     expect(h).toContain("parachute auth rotate-key");
   });
 
-  test("2fa help is honest about hub-login TOTP not being shipped (#473)", () => {
+  test("2fa help documents the real hub-login TOTP subcommands (#473)", () => {
     expect(h).toContain("#473");
-    // No longer advertises the dead enroll/disable/backup-codes subcommands.
-    expect(h).not.toContain("2fa enroll");
-    expect(h).not.toContain("2fa disable");
-    expect(h).not.toContain("2fa backup-codes");
+    // Real enroll / disenroll subcommands are now advertised.
+    expect(h).toContain("2fa enroll");
+    expect(h).toContain("2fa disenroll");
+    expect(h).toContain("otpauth://");
+    expect(h).toContain("backup codes");
   });
 
   test("set-password help mentions the new flags + hub-local home", () => {

--- a/src/__tests__/expose-2fa-warning.test.ts
+++ b/src/__tests__/expose-2fa-warning.test.ts
@@ -24,46 +24,53 @@ describe("is2FAEnrolled", () => {
     expect(is2FAEnrolled({ status: status({ hasTotp: false }) })).toBe(false);
   });
 
-  test("reads totp_secret from vaultHome's config.yaml when status not supplied", () => {
+  test("falls back to legacy config.yaml totp_secret when hub.db is absent", () => {
+    // hub#473: hub.db is the source of truth for real 2FA, but a super-old
+    // install with no hub.db still suppresses the warning if the legacy vault
+    // YAML totp_secret is set. Point hubDbPath at a nonexistent file so the
+    // YAML fallback is exercised.
     const dir = mkdtempSync(join(tmpdir(), "pcli-2fa-warn-"));
     try {
       writeFileSync(join(dir, "config.yaml"), 'totp_secret: "JBSWY3DPEHPK3PXP"\n');
-      expect(is2FAEnrolled({ vaultHome: dir })).toBe(true);
+      expect(is2FAEnrolled({ vaultHome: dir, hubDbPath: join(dir, "absent-hub.db") })).toBe(true);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  test("missing config.yaml → not enrolled (false)", () => {
+  test("missing config.yaml + absent hub.db → not enrolled (false)", () => {
     const dir = mkdtempSync(join(tmpdir(), "pcli-2fa-warn-"));
     try {
-      // No config.yaml written.
-      expect(is2FAEnrolled({ vaultHome: dir })).toBe(false);
+      // No config.yaml written, no hub.db.
+      expect(is2FAEnrolled({ vaultHome: dir, hubDbPath: join(dir, "absent-hub.db") })).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  test("empty totp_secret value → not enrolled (matches vault's readGlobalConfig)", () => {
+  test("empty totp_secret value + absent hub.db → not enrolled", () => {
     const dir = mkdtempSync(join(tmpdir(), "pcli-2fa-warn-"));
     try {
       writeFileSync(join(dir, "config.yaml"), 'totp_secret: ""\n');
-      expect(is2FAEnrolled({ vaultHome: dir })).toBe(false);
+      expect(is2FAEnrolled({ vaultHome: dir, hubDbPath: join(dir, "absent-hub.db") })).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  test("malformed config.yaml → not enrolled (safer fail mode, fires warning)", () => {
-    // The probe parses config.yaml with a line-anchored regex (no YAML
-    // dependency), so junk content simply doesn't match `totp_secret: "..."`
-    // and resolves to `hasTotp: false` — which fires the public-exposure
-    // warning rather than silently suppressing it. Pin that contract so a
-    // future refactor of auth-status.ts can't quietly invert it.
+  test("hub.db with an enrolled user → enrolled (the real signal)", async () => {
     const dir = mkdtempSync(join(tmpdir(), "pcli-2fa-warn-"));
     try {
-      writeFileSync(join(dir, "config.yaml"), "totp_secret: [unbalanced\n  ::: not yaml\n");
-      expect(is2FAEnrolled({ vaultHome: dir })).toBe(false);
+      const { hubDbPath, openHubDb } = await import("../hub-db.ts");
+      const { createUser } = await import("../users.ts");
+      const { persistEnrollment } = await import("../two-factor-store.ts");
+      const { generateTotpSecret } = await import("../totp.ts");
+      const dbPath = hubDbPath(dir);
+      const db = openHubDb(dbPath);
+      const u = await createUser(db, "owner", "owner-password-123");
+      await persistEnrollment(db, u.id, generateTotpSecret("owner").secret);
+      db.close();
+      expect(is2FAEnrolled({ vaultHome: dir, hubDbPath: dbPath })).toBe(true);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -80,13 +87,14 @@ describe("printPublic2FAWarning", () => {
     });
     expect(fired).toBe(true);
     const joined = logs.join("\n");
-    // Honest copy: /login is public, owner password is the wall, hub-login 2FA
-    // is coming (#473) — does NOT recommend the dead `auth 2fa enroll` path.
+    // hub#473: real hub-login 2FA. The warning now recommends the real
+    // `parachute auth 2fa enroll` path (+ the /account/2fa browser path) and
+    // still nudges a strong owner password.
     expect(joined).toContain("/login is now reachable on the public internet");
     expect(joined).toContain("https://vault.example.com/login");
-    expect(joined).toContain("#473");
+    expect(joined).toContain("parachute auth 2fa enroll");
+    expect(joined).toContain("/account/2fa");
     expect(joined).toContain("parachute auth set-password");
-    expect(joined).not.toContain("parachute auth 2fa enroll");
   });
 
   test("enrolled → suppressed, returns false, logs nothing", () => {

--- a/src/__tests__/expose-auth-preflight.test.ts
+++ b/src/__tests__/expose-auth-preflight.test.ts
@@ -41,8 +41,8 @@ function status(partial: Partial<VaultAuthStatus> = {}): VaultAuthStatus {
 }
 
 describe("runAuthPreflight — wide open (no owner password)", () => {
-  test("warns loudly, offers password only, prints hub-JWT token guidance + honest 2FA note", async () => {
-    const h = makeHarness(["y"]); // password yes
+  test("warns loudly, offers password + real 2FA enroll, prints hub-JWT token guidance", async () => {
+    const h = makeHarness(["y", "y"]); // password yes, 2FA yes
     await runAuthPreflight({ status: status(), ...wire(h) });
     const joined = h.logs.join("\n");
     expect(joined).toContain("No owner password");
@@ -50,42 +50,38 @@ describe("runAuthPreflight — wide open (no owner password)", () => {
     // Programmatic-client guidance points at the hub mint path, not pvt_*.
     expect(joined).toContain("parachute auth mint-token --scope vault:default:read");
     expect(joined).toContain("Bearer <hub-jwt>");
-    // Honest 2FA state — coming (#473), not offered as a dead enroll command.
-    expect(joined).toContain("#473");
-    expect(joined).not.toContain("2fa enroll");
-    // Only password is an interactive offer; token guidance + 2FA note are
-    // printed, not prompted.
-    expect(h.commands).toHaveLength(1);
-    expect(h.commands[0]).toEqual(["parachute", "auth", "set-password"]);
-    expect(h.prompts).toHaveLength(1);
+    // Real 2FA (hub#473) — both commands offered + run.
+    expect(h.commands.map((c) => c.join(" "))).toEqual([
+      "parachute auth set-password",
+      "parachute auth 2fa enroll",
+    ]);
+    // Two interactive offers now: password + 2FA. Token guidance is printed.
+    expect(h.prompts).toHaveLength(2);
   });
 
   test("token guidance uses the first discovered vault name", async () => {
-    const h = makeHarness(["n"]);
+    const h = makeHarness(["n", "n"]);
     await runAuthPreflight({ status: status({ vaultNames: ["work"] }), ...wire(h) });
     expect(h.logs.join("\n")).toContain("--scope vault:work:read");
   });
 
-  test("user declines the password prompt → no subprocesses run", async () => {
-    const h = makeHarness([""]); // Enter = skip
+  test("user declines both prompts → no subprocesses run", async () => {
+    const h = makeHarness(["", ""]); // Enter = skip both
     await runAuthPreflight({ status: status(), ...wire(h) });
     expect(h.commands).toHaveLength(0);
-    // Only one prompt now (password); token guidance + 2FA note aren't prompts.
-    expect(h.prompts).toHaveLength(1);
+    expect(h.prompts).toHaveLength(2);
   });
 
   test("user accepts the password offer → set-password invoked", async () => {
-    const h = makeHarness(["y"]);
+    const h = makeHarness(["y", "n"]);
     await runAuthPreflight({ status: status(), ...wire(h) });
     expect(h.commands.map((c) => c.join(" "))).toEqual(["parachute auth set-password"]);
   });
 
   test("null tokenCount with no owner password still classifies wide-open", async () => {
     // The `tokenCount: null` (unreadable vault DB) path is vestigial post-DROP
-    // — `classify()` gates on `hasOwnerPassword` alone. A box with no owner
-    // password AND an unreadable token DB must still take the loud wide-open
-    // branch, not silently fall through to a quieter state.
-    const h = makeHarness(["n"]);
+    // — `classify()` gates on `hasOwnerPassword` alone.
+    const h = makeHarness(["n", "n"]);
     await runAuthPreflight({
       status: status({ hasOwnerPassword: false, tokenCount: null }),
       ...wire(h),
@@ -93,58 +89,64 @@ describe("runAuthPreflight — wide open (no owner password)", () => {
     const joined = h.logs.join("\n");
     expect(joined).toContain("No owner password");
     expect(joined).toContain("public internet");
-    // Wide-open offers the password (one prompt); not the password-set path.
-    expect(h.prompts).toHaveLength(1);
+    expect(h.prompts).toHaveLength(2);
   });
 
-  test("never offers a dead command (vault tokens create OR auth 2fa enroll)", async () => {
-    const h = makeHarness(["y"]);
+  test("never offers the dead vault-tokens-create command", async () => {
+    const h = makeHarness(["y", "n"]);
     await runAuthPreflight({ status: status(), ...wire(h) });
     const allCommands = h.commands.map((c) => c.join(" ")).join("\n");
     expect(allCommands).not.toContain("vault tokens create");
-    expect(allCommands).not.toContain("auth 2fa enroll");
-    // And no log line steers the operator at a dead command as guidance.
     const guidance = h.logs.join("\n");
     expect(guidance).not.toContain("parachute vault tokens create");
-    expect(guidance).not.toContain("parachute auth 2fa enroll");
   });
 });
 
-describe("runAuthPreflight — password set", () => {
-  test("single confirmation line + honest 2FA note, no prompts (ignores vestigial tokenCount)", async () => {
-    const h = makeHarness([]);
+describe("runAuthPreflight — password set, no 2FA", () => {
+  test("confirms password set + offers real 2FA enroll (ignores vestigial tokenCount)", async () => {
+    const h = makeHarness(["n"]); // decline 2FA
     await runAuthPreflight({
       // tokenCount is non-zero (vestigial pvt_* rows) but no longer consulted.
-      status: status({ hasOwnerPassword: true, tokenCount: 3 }),
+      status: status({ hasOwnerPassword: true, hasTotp: false, tokenCount: 3 }),
       ...wire(h),
     });
     const joined = h.logs.join("\n");
     expect(joined).toContain("Owner password is set");
-    // Honest 2FA note (#473) — not a prompt, not the dead enroll command.
-    expect(joined).toContain("#473");
-    expect(joined).not.toContain("2fa enroll");
-    expect(h.prompts).toHaveLength(0);
-    expect(h.commands).toHaveLength(0);
+    // Real 2FA offer (hub#473) — exactly one prompt (the 2FA offer).
+    expect(h.prompts).toHaveLength(1);
+    expect(h.commands).toHaveLength(0); // declined
+  });
+
+  test("accepting the 2FA offer runs `parachute auth 2fa enroll`", async () => {
+    const h = makeHarness(["y"]);
+    await runAuthPreflight({
+      status: status({ hasOwnerPassword: true, hasTotp: false }),
+      ...wire(h),
+    });
+    expect(h.commands.map((c) => c.join(" "))).toEqual(["parachute auth 2fa enroll"]);
   });
 
   test("null tokenCount (DB unreadable) is irrelevant — password gates the branch", async () => {
-    const h = makeHarness([]);
+    const h = makeHarness(["n"]);
     await runAuthPreflight({
       status: status({ hasOwnerPassword: true, hasTotp: false, tokenCount: null }),
       ...wire(h),
     });
     expect(h.logs.join("\n")).toContain("Owner password is set");
-    expect(h.prompts).toHaveLength(0);
-    expect(h.commands).toHaveLength(0);
+    expect(h.prompts).toHaveLength(1);
   });
+});
 
-  test("password + legacy vault TOTP — still the quiet password-set path", async () => {
+describe("runAuthPreflight — password + 2FA both set", () => {
+  test("two-line confirmation, no prompts", async () => {
     const h = makeHarness([]);
     await runAuthPreflight({
       status: status({ hasOwnerPassword: true, hasTotp: true, tokenCount: 0 }),
       ...wire(h),
     });
-    expect(h.logs.join("\n")).toContain("Owner password is set");
+    const joined = h.logs.join("\n");
+    expect(joined).toContain("Owner password is set");
+    expect(joined).toContain("Two-factor authentication is on");
     expect(h.prompts).toHaveLength(0);
     expect(h.commands).toHaveLength(0);
   });
@@ -152,7 +154,7 @@ describe("runAuthPreflight — password set", () => {
 
 describe("runAuthPreflight — subprocess failure handling", () => {
   test("non-zero exit from set-password doesn't abort the rest of the preflight", async () => {
-    const h = makeHarness(["y"]);
+    const h = makeHarness(["y", "n"]);
     const interactiveRunner = async (cmd: readonly string[]) => {
       h.commands.push([...cmd]);
       return 7;
@@ -177,11 +179,11 @@ describe("runAuthPreflight — subprocess failure handling", () => {
 
 describe("runAuthPreflight — case-insensitive yes", () => {
   test('"Y", "YES", and "y" all count as affirmative; anything else is decline', async () => {
-    // Now only the wide-open path prompts (for the password). Drive it there.
+    // Drive the password-set-no-2FA path so there's exactly one prompt (2FA).
     for (const yes of ["y", "Y", "yes", "YES"]) {
       const h = makeHarness([yes]);
       await runAuthPreflight({
-        status: status({ hasOwnerPassword: false }),
+        status: status({ hasOwnerPassword: true, hasTotp: false }),
         ...wire(h),
       });
       expect(h.commands).toHaveLength(1);
@@ -189,7 +191,7 @@ describe("runAuthPreflight — case-insensitive yes", () => {
     for (const no of ["", "n", "no", "q", "bogus"]) {
       const h = makeHarness([no]);
       await runAuthPreflight({
-        status: status({ hasOwnerPassword: false }),
+        status: status({ hasOwnerPassword: true, hasTotp: false }),
         ...wire(h),
       });
       expect(h.commands).toHaveLength(0);

--- a/src/__tests__/expose-cloudflare.test.ts
+++ b/src/__tests__/expose-cloudflare.test.ts
@@ -683,12 +683,11 @@ describe("exposeCloudflareUp", () => {
 
         expect(code).toBe(0);
         const joined = logs.join("\n");
-        // Honest copy: /login is public, owner password is the wall, hub-login
-        // 2FA is coming (#473) — does NOT recommend the dead `2fa enroll`.
+        // hub#473: real hub-login 2FA — the warning now recommends the real
+        // `parachute auth 2fa enroll` path.
         expect(joined).toContain("/login is now reachable on the public internet");
         expect(joined).toContain("https://vault.example.com/login");
-        expect(joined).toContain("#473");
-        expect(joined).not.toContain("parachute auth 2fa enroll");
+        expect(joined).toContain("parachute auth 2fa enroll");
       } finally {
         env.cleanup();
       }
@@ -736,11 +735,12 @@ describe("exposeCloudflareUp", () => {
         expect(code).toBe(0);
         const joined = logs.join("\n");
         expect(joined).not.toContain("/login is now reachable on the public internet");
-        // The contextual 2FA warning is suppressed (legacy vault TOTP present);
-        // the always-shown owner-password guidance from `printAuthGuidance`
-        // still appears, and it no longer recommends the dead `2fa enroll`.
+        // The contextual 2FA warning is suppressed (2FA already enrolled); the
+        // always-shown owner-password guidance from `printAuthGuidance` still
+        // appears, and it now (hub#473) also surfaces the real `2fa enroll`
+        // path in the humans section.
         expect(joined).toContain("parachute auth set-password");
-        expect(joined).not.toContain("parachute auth 2fa enroll");
+        expect(joined).toContain("parachute auth 2fa enroll");
       } finally {
         env.cleanup();
       }

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -1009,11 +1009,10 @@ describe("expose public up", () => {
       });
       expect(code).toBe(0);
       const joined = logs.join("\n");
-      // Honest copy: /login is public, owner password is the wall, hub-login
-      // 2FA is coming (#473) — no longer recommends the dead `2fa enroll`.
+      // hub#473: real hub-login 2FA. The warning now recommends the real
+      // `parachute auth 2fa enroll` path.
       expect(joined).toContain("/login is now reachable on the public internet");
-      expect(joined).toContain("#473");
-      expect(joined).not.toContain("parachute auth 2fa enroll");
+      expect(joined).toContain("parachute auth 2fa enroll");
       // /login pointer uses the canonical https://<fqdn> origin.
       expect(joined).toContain("https://parachute.taildf9ce2.ts.net/login");
     } finally {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -3,6 +3,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { handleAdminLoginTotpPost } from "../admin-handlers.ts";
 import { approveClient, getClient, registerClient } from "../clients.ts";
 import { CSRF_COOKIE_NAME } from "../csrf.ts";
 import { findGrant, recordGrant } from "../grants.ts";
@@ -26,8 +27,12 @@ import {
   protectedResourceMetadata,
   vaultScopeForUser,
 } from "../oauth-handlers.ts";
+import { PENDING_LOGIN_COOKIE_NAME, _resetPendingLogins } from "../pending-login.ts";
+import { __resetForTests as resetRateLimit } from "../rate-limit.ts";
 import type { ServicesManifest } from "../services-manifest.ts";
-import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession, findSession } from "../sessions.ts";
+import { _resetTotpReplayCache, generateTotpSecret } from "../totp.ts";
+import { backupCodesRemaining, isTotpEnrolled, persistEnrollment } from "../two-factor-store.ts";
 import { createUser, setUserVaults } from "../users.ts";
 
 const ISSUER = "https://hub.example";
@@ -867,6 +872,223 @@ describe("handleAuthorizePost — login submit", () => {
       const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
       expect(res.status).toBe(401);
       expect(res.headers.get("set-cookie")).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// --- OAuth-path TOTP gate (hub#473 P0 bypass regression) -------------------
+//
+// The OAuth login POST (`__action=login`) is the more-common sign-in path
+// (every OAuth client: vault, notes-ui, `parachute auth login`). Before the
+// fix it minted a session on password ALONE even for a 2FA-enrolled user —
+// a full TOTP bypass. These tests pin that the OAuth login now diverts to the
+// TOTP challenge and only mints a session after the second factor, resuming
+// the original /oauth/authorize flow.
+
+/** Generate a live TOTP code for a base32 secret (matches the hub's params). */
+function liveTotpCode(secretBase32: string, label = "owner"): string {
+  // Lazy import via require keeps the top of file clean; otpauth is a dep.
+  const OTPAuth = require("otpauth");
+  return new OTPAuth.TOTP({
+    issuer: "Parachute Hub",
+    label,
+    algorithm: "SHA1",
+    digits: 6,
+    period: 30,
+    secret: OTPAuth.Secret.fromBase32(secretBase32),
+  }).generate();
+}
+
+function cookieValueFrom(res: Response, name: string): string | null {
+  for (const sc of res.headers.getSetCookie()) {
+    if (sc.startsWith(`${name}=`)) return sc.slice(name.length + 1).split(";")[0] ?? "";
+  }
+  return null;
+}
+
+describe("handleAuthorizePost — login submit + 2FA (hub#473 bypass regression)", () => {
+  function loginForm(clientId: string, challenge: string, password = "hunter2"): URLSearchParams {
+    return new URLSearchParams({
+      __action: "login",
+      __csrf: TEST_CSRF,
+      username: "owner",
+      password,
+      client_id: clientId,
+      redirect_uri: "https://app.example/cb",
+      response_type: "code",
+      scope: "vault:read",
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+      state: "xyz-state",
+    });
+  }
+
+  test("2FA-enrolled user: correct password ALONE does NOT mint a session — diverts to TOTP challenge", async () => {
+    const { db, cleanup } = await makeDb();
+    _resetPendingLogins();
+    _resetTotpReplayCache();
+    resetRateLimit();
+    try {
+      const user = await createUser(db, "owner", "hunter2", { passwordChanged: true });
+      await persistEnrollment(db, user.id, generateTotpSecret("owner").secret);
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: loginForm(reg.client.clientId, challenge),
+        headers: { "content-type": "application/x-www-form-urlencoded", cookie: CSRF_COOKIE },
+      });
+      const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
+      // NO session cookie. The bypass was: this used to be 302 + session.
+      expect(cookieValueFrom(res, "parachute_hub_session")).toBeNull();
+      // Diverts to the TOTP challenge page + sets a pending-login cookie.
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("Two-factor authentication");
+      expect(html).toContain('action="/login/2fa"');
+      expect(cookieValueFrom(res, PENDING_LOGIN_COOKIE_NAME)).toBeTruthy();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("full OAuth two-step: password → challenge → correct TOTP → session minted + resumes /oauth/authorize", async () => {
+    const { db, cleanup } = await makeDb();
+    _resetPendingLogins();
+    _resetTotpReplayCache();
+    resetRateLimit();
+    try {
+      const user = await createUser(db, "owner", "hunter2", { passwordChanged: true });
+      const { secret } = generateTotpSecret("owner");
+      await persistEnrollment(db, user.id, secret);
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+
+      // Step 1 — OAuth login POST (password).
+      const loginReq = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: loginForm(reg.client.clientId, challenge),
+        headers: { "content-type": "application/x-www-form-urlencoded", cookie: CSRF_COOKIE },
+      });
+      const loginRes = await handleAuthorizePost(db, loginReq, { issuer: ISSUER });
+      expect(loginRes.status).toBe(200);
+      const pendingToken = cookieValueFrom(loginRes, PENDING_LOGIN_COOKIE_NAME);
+      expect(pendingToken).toBeTruthy();
+
+      // Step 2 — TOTP at the shared completion path /login/2fa, carrying the
+      // pending-login cookie. (No `next` form field — the stored pending-login
+      // `next` is the source of truth for the return URL.)
+      const code = liveTotpCode(secret);
+      const tfBody = new URLSearchParams({ __csrf: TEST_CSRF, code });
+      const tfReq = new Request(`${ISSUER}/login/2fa`, {
+        method: "POST",
+        body: tfBody,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${PENDING_LOGIN_COOKIE_NAME}=${pendingToken}`,
+        },
+      });
+      const tfRes = await handleAdminLoginTotpPost(db, tfReq);
+      expect(tfRes.status).toBe(302);
+      // Session minted now (after the second factor), not before.
+      const sessionId = cookieValueFrom(tfRes, "parachute_hub_session");
+      expect(sessionId).toBeTruthy();
+      expect(findSession(db, sessionId!)).not.toBeNull();
+      // Redirect resumes the ORIGINAL OAuth flow with all its query params.
+      const loc = tfRes.headers.get("location") ?? "";
+      expect(loc.startsWith("/oauth/authorize?")).toBe(true);
+      expect(loc).toContain(`client_id=${reg.client.clientId}`);
+      expect(loc).toContain("code_challenge=");
+      expect(loc).toContain("state=xyz-state");
+      expect(loc).toContain("scope=vault");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("OAuth path: wrong TOTP code → 401, no session; a backup code completes + is consumed", async () => {
+    const { db, cleanup } = await makeDb();
+    _resetPendingLogins();
+    _resetTotpReplayCache();
+    resetRateLimit();
+    try {
+      const user = await createUser(db, "owner", "hunter2", { passwordChanged: true });
+      const { secret } = generateTotpSecret("owner");
+      const { backupCodes } = await persistEnrollment(db, user.id, secret);
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+
+      const loginRes = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: loginForm(reg.client.clientId, challenge),
+          headers: { "content-type": "application/x-www-form-urlencoded", cookie: CSRF_COOKIE },
+        }),
+        { issuer: ISSUER },
+      );
+      const pendingToken = cookieValueFrom(loginRes, PENDING_LOGIN_COOKIE_NAME)!;
+
+      // Wrong code → 401, no session, pending login survives.
+      const badRes = await handleAdminLoginTotpPost(
+        db,
+        new Request(`${ISSUER}/login/2fa`, {
+          method: "POST",
+          body: new URLSearchParams({ __csrf: TEST_CSRF, code: "000000" }),
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: `${CSRF_COOKIE}; ${PENDING_LOGIN_COOKIE_NAME}=${pendingToken}`,
+          },
+        }),
+      );
+      expect(badRes.status).toBe(401);
+      expect(cookieValueFrom(badRes, "parachute_hub_session")).toBeNull();
+
+      // Backup code completes + is consumed.
+      expect(backupCodesRemaining(db, user.id)).toBe(10);
+      const okRes = await handleAdminLoginTotpPost(
+        db,
+        new Request(`${ISSUER}/login/2fa`, {
+          method: "POST",
+          body: new URLSearchParams({ __csrf: TEST_CSRF, code: backupCodes[0]! }),
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: `${CSRF_COOKIE}; ${PENDING_LOGIN_COOKIE_NAME}=${pendingToken}`,
+          },
+        }),
+      );
+      expect(okRes.status).toBe(302);
+      expect(cookieValueFrom(okRes, "parachute_hub_session")).toBeTruthy();
+      expect((okRes.headers.get("location") ?? "").startsWith("/oauth/authorize?")).toBe(true);
+      expect(backupCodesRemaining(db, user.id)).toBe(9);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("OAuth path UNCHANGED for a user WITHOUT 2FA — password alone mints a session (no regression)", async () => {
+    const { db, cleanup } = await makeDb();
+    _resetPendingLogins();
+    resetRateLimit();
+    try {
+      const user = await createUser(db, "owner", "hunter2", { passwordChanged: true });
+      expect(isTotpEnrolled(db, user.id)).toBe(false);
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const res = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: loginForm(reg.client.clientId, challenge),
+          headers: { "content-type": "application/x-www-form-urlencoded", cookie: CSRF_COOKIE },
+        }),
+        { issuer: ISSUER },
+      );
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toContain("/oauth/authorize?");
+      expect(cookieValueFrom(res, "parachute_hub_session")).toBeTruthy();
     } finally {
       cleanup();
     }

--- a/src/__tests__/two-factor-flow.test.ts
+++ b/src/__tests__/two-factor-flow.test.ts
@@ -434,6 +434,29 @@ describe("/account/2fa handlers — hub#473", () => {
     expect(isTotpEnrolled(harness.db, id)).toBe(false);
   });
 
+  test("POST confirm with a MALFORMED secret → 400, nothing persisted (N1 guard)", async () => {
+    const { id, cookie } = await signedInUser();
+    // Non-base32 / too-short secret from a tampered or truncated form.
+    for (const badSecret of ["not-base32!", "ABC123", "", "0189{}<>"]) {
+      const { body, headers } = formBody({
+        [CSRF_FIELD_NAME]: TEST_CSRF,
+        action: "confirm",
+        secret: badSecret,
+        code: "123456",
+      });
+      const res = await handleTwoFactorPost(
+        new Request("http://hub.test/account/2fa", {
+          method: "POST",
+          headers: { ...headers, cookie },
+          body,
+        }),
+        { db: harness.db },
+      );
+      expect(res.status).toBe(400);
+      expect(isTotpEnrolled(harness.db, id)).toBe(false);
+    }
+  });
+
   test("POST disable requires the correct current password; clears 2FA on success", async () => {
     const { id, cookie } = await signedInUser();
     await persistEnrollment(harness.db, id, generateTotpSecret("owner").secret);

--- a/src/__tests__/two-factor-flow.test.ts
+++ b/src/__tests__/two-factor-flow.test.ts
@@ -1,0 +1,579 @@
+import type { Database } from "bun:sqlite";
+import { Database as Sqlite } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as OTPAuth from "otpauth";
+import { handleAdminLoginPost, handleAdminLoginTotpPost } from "../admin-handlers.ts";
+import { CSRF_COOKIE_NAME, CSRF_FIELD_NAME } from "../csrf.ts";
+import { hubDbPath, migrate, openHubDb } from "../hub-db.ts";
+import { PENDING_LOGIN_COOKIE_NAME, _resetPendingLogins } from "../pending-login.ts";
+import { __resetForTests as resetRateLimit } from "../rate-limit.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession, findSession } from "../sessions.ts";
+import { _resetTotpReplayCache, generateTotpSecret } from "../totp.ts";
+import { handleTwoFactorGet, handleTwoFactorPost } from "../two-factor-handlers.ts";
+import {
+  backupCodesRemaining,
+  getTotpState,
+  isTotpEnrolled,
+  persistEnrollment,
+} from "../two-factor-store.ts";
+import { createUser } from "../users.ts";
+
+const TEST_CSRF = "csrf-2fa-flow-token";
+const CSRF_COOKIE = `${CSRF_COOKIE_NAME}=${TEST_CSRF}`;
+
+interface Harness {
+  db: Database;
+  configDir: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const configDir = mkdtempSync(join(tmpdir(), "phub-2fa-flow-"));
+  const db = openHubDb(hubDbPath(configDir));
+  return {
+    db,
+    configDir,
+    cleanup: () => {
+      db.close();
+      rmSync(configDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function formBody(values: Record<string, string>): {
+  body: string;
+  headers: Record<string, string>;
+} {
+  const params = new URLSearchParams();
+  for (const [k, v] of Object.entries(values)) params.append(k, v);
+  return {
+    body: params.toString(),
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+  };
+}
+
+function liveCode(secretBase32: string, label = "owner"): string {
+  return new OTPAuth.TOTP({
+    issuer: "Parachute Hub",
+    label,
+    algorithm: "SHA1",
+    digits: 6,
+    period: 30,
+    secret: OTPAuth.Secret.fromBase32(secretBase32),
+  }).generate();
+}
+
+/** Pull the value of a Set-Cookie'd cookie by name from a Response. */
+function cookieFrom(res: Response, name: string): string | null {
+  // Bun's Headers.getSetCookie() returns all set-cookie values.
+  const all = res.headers.getSetCookie();
+  for (const sc of all) {
+    const m = sc.match(new RegExp(`(?:^|; )?${name}=([^;]*)`));
+    if (m && sc.startsWith(`${name}=`)) return m[1] ?? "";
+  }
+  return null;
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+  resetRateLimit();
+  _resetPendingLogins();
+  _resetTotpReplayCache();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+describe("login two-step (TOTP) — hub#473", () => {
+  test("password-only login UNCHANGED for a user WITHOUT 2FA", async () => {
+    await createUser(harness.db, "owner", "owner-password-123", { passwordChanged: true });
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "owner",
+      password: "owner-password-123",
+      next: "/admin/vaults",
+    });
+    const req = new Request("http://hub.test/login", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAdminLoginPost(harness.db, req);
+    // Straight to session — no 2FA challenge.
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/admin/vaults");
+    expect(cookieFrom(res, "parachute_hub_session")).toBeTruthy();
+  });
+
+  test("correct password for a 2FA user → challenge page + pending cookie, NO session yet", async () => {
+    const u = await createUser(harness.db, "owner", "owner-password-123", {
+      passwordChanged: true,
+    });
+    await persistEnrollment(harness.db, u.id, generateTotpSecret("owner").secret);
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "owner",
+      password: "owner-password-123",
+      next: "/admin/vaults",
+    });
+    const req = new Request("http://hub.test/login", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAdminLoginPost(harness.db, req);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Two-factor authentication");
+    // Pending-login cookie minted; session NOT minted.
+    expect(cookieFrom(res, PENDING_LOGIN_COOKIE_NAME)).toBeTruthy();
+    expect(cookieFrom(res, "parachute_hub_session")).toBeNull();
+  });
+
+  test("full two-step: password → challenge → correct TOTP → session minted", async () => {
+    const u = await createUser(harness.db, "owner", "owner-password-123", {
+      passwordChanged: true,
+    });
+    const { secret } = generateTotpSecret("owner");
+    await persistEnrollment(harness.db, u.id, secret);
+
+    // Step 1 — password.
+    const pw = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "owner",
+      password: "owner-password-123",
+      next: "/admin/tokens",
+    });
+    const pwReq = new Request("http://hub.test/login", {
+      method: "POST",
+      headers: { ...pw.headers, cookie: CSRF_COOKIE },
+      body: pw.body,
+    });
+    const pwRes = await handleAdminLoginPost(harness.db, pwReq);
+    expect(pwRes.status).toBe(200);
+    const pendingToken = cookieFrom(pwRes, PENDING_LOGIN_COOKIE_NAME);
+    expect(pendingToken).toBeTruthy();
+
+    // Step 2 — TOTP code with the pending cookie.
+    const code = liveCode(secret);
+    const tf = formBody({ [CSRF_FIELD_NAME]: TEST_CSRF, code, next: "/admin/tokens" });
+    const tfReq = new Request("http://hub.test/login/2fa", {
+      method: "POST",
+      headers: {
+        ...tf.headers,
+        cookie: `${CSRF_COOKIE}; ${PENDING_LOGIN_COOKIE_NAME}=${pendingToken}`,
+      },
+      body: tf.body,
+    });
+    const tfRes = await handleAdminLoginTotpPost(harness.db, tfReq);
+    expect(tfRes.status).toBe(302);
+    expect(tfRes.headers.get("location")).toBe("/admin/tokens");
+    const sessionCookie = cookieFrom(tfRes, "parachute_hub_session");
+    expect(sessionCookie).toBeTruthy();
+    // The session is real.
+    expect(findSession(harness.db, sessionCookie!)).not.toBeNull();
+  });
+
+  test("wrong TOTP code → 401, no session; pending login survives for retry", async () => {
+    const u = await createUser(harness.db, "owner", "owner-password-123", {
+      passwordChanged: true,
+    });
+    const { secret } = generateTotpSecret("owner");
+    await persistEnrollment(harness.db, u.id, secret);
+
+    const pw = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "owner",
+      password: "owner-password-123",
+      next: "/admin/vaults",
+    });
+    const pwRes = await handleAdminLoginPost(
+      harness.db,
+      new Request("http://hub.test/login", {
+        method: "POST",
+        headers: { ...pw.headers, cookie: CSRF_COOKIE },
+        body: pw.body,
+      }),
+    );
+    const pendingToken = cookieFrom(pwRes, PENDING_LOGIN_COOKIE_NAME)!;
+
+    const tf = formBody({ [CSRF_FIELD_NAME]: TEST_CSRF, code: "000000", next: "/admin/vaults" });
+    const tfRes = await handleAdminLoginTotpPost(
+      harness.db,
+      new Request("http://hub.test/login/2fa", {
+        method: "POST",
+        headers: {
+          ...tf.headers,
+          cookie: `${CSRF_COOKIE}; ${PENDING_LOGIN_COOKIE_NAME}=${pendingToken}`,
+        },
+        body: tf.body,
+      }),
+    );
+    expect(tfRes.status).toBe(401);
+    expect(cookieFrom(tfRes, "parachute_hub_session")).toBeNull();
+
+    // Retry with the correct code against the SAME pending login → success.
+    const code = liveCode(secret);
+    const retry = formBody({ [CSRF_FIELD_NAME]: TEST_CSRF, code, next: "/admin/vaults" });
+    const retryRes = await handleAdminLoginTotpPost(
+      harness.db,
+      new Request("http://hub.test/login/2fa", {
+        method: "POST",
+        headers: {
+          ...retry.headers,
+          cookie: `${CSRF_COOKIE}; ${PENDING_LOGIN_COOKIE_NAME}=${pendingToken}`,
+        },
+        body: retry.body,
+      }),
+    );
+    expect(retryRes.status).toBe(302);
+    expect(cookieFrom(retryRes, "parachute_hub_session")).toBeTruthy();
+  });
+
+  test("a valid backup code completes the second step + is consumed", async () => {
+    const u = await createUser(harness.db, "owner", "owner-password-123", {
+      passwordChanged: true,
+    });
+    const { secret } = generateTotpSecret("owner");
+    const { backupCodes } = await persistEnrollment(harness.db, u.id, secret);
+    expect(backupCodesRemaining(harness.db, u.id)).toBe(10);
+
+    const pw = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "owner",
+      password: "owner-password-123",
+      next: "/admin/vaults",
+    });
+    const pwRes = await handleAdminLoginPost(
+      harness.db,
+      new Request("http://hub.test/login", {
+        method: "POST",
+        headers: { ...pw.headers, cookie: CSRF_COOKIE },
+        body: pw.body,
+      }),
+    );
+    const pendingToken = cookieFrom(pwRes, PENDING_LOGIN_COOKIE_NAME)!;
+
+    const tf = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      code: backupCodes[0]!,
+      next: "/admin/vaults",
+    });
+    const tfRes = await handleAdminLoginTotpPost(
+      harness.db,
+      new Request("http://hub.test/login/2fa", {
+        method: "POST",
+        headers: {
+          ...tf.headers,
+          cookie: `${CSRF_COOKIE}; ${PENDING_LOGIN_COOKIE_NAME}=${pendingToken}`,
+        },
+        body: tf.body,
+      }),
+    );
+    expect(tfRes.status).toBe(302);
+    expect(cookieFrom(tfRes, "parachute_hub_session")).toBeTruthy();
+    // Consumed — one fewer remaining.
+    expect(backupCodesRemaining(harness.db, u.id)).toBe(9);
+  });
+
+  test("2FA step without a pending-login cookie → 401 (can't skip the password step)", async () => {
+    const u = await createUser(harness.db, "owner", "owner-password-123", {
+      passwordChanged: true,
+    });
+    await persistEnrollment(harness.db, u.id, generateTotpSecret("owner").secret);
+    const tf = formBody({ [CSRF_FIELD_NAME]: TEST_CSRF, code: "123456", next: "/admin/vaults" });
+    const res = await handleAdminLoginTotpPost(
+      harness.db,
+      new Request("http://hub.test/login/2fa", {
+        method: "POST",
+        headers: { ...tf.headers, cookie: CSRF_COOKIE },
+        body: tf.body,
+      }),
+    );
+    expect(res.status).toBe(401);
+    expect(cookieFrom(res, "parachute_hub_session")).toBeNull();
+  });
+
+  test("2FA step CSRF mismatch → 400", async () => {
+    const tf = formBody({ [CSRF_FIELD_NAME]: "wrong", code: "123456", next: "/admin/vaults" });
+    const res = await handleAdminLoginTotpPost(
+      harness.db,
+      new Request("http://hub.test/login/2fa", {
+        method: "POST",
+        headers: { ...tf.headers, cookie: CSRF_COOKIE },
+        body: tf.body,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("2FA step is rate-limited per IP (6th attempt → 429)", async () => {
+    const u = await createUser(harness.db, "owner", "owner-password-123", {
+      passwordChanged: true,
+    });
+    await persistEnrollment(harness.db, u.id, generateTotpSecret("owner").secret);
+    const buildReq = () => {
+      const tf = formBody({ [CSRF_FIELD_NAME]: TEST_CSRF, code: "000000", next: "/admin/vaults" });
+      return new Request("http://hub.test/login/2fa", {
+        method: "POST",
+        headers: { ...tf.headers, cookie: CSRF_COOKIE, "cf-connecting-ip": "203.0.113.55" },
+        body: tf.body,
+      });
+    };
+    for (let i = 0; i < 5; i++) {
+      const r = await handleAdminLoginTotpPost(harness.db, buildReq());
+      expect(r.status).toBe(401); // no pending login → 401, but counts toward bucket
+    }
+    const denied = await handleAdminLoginTotpPost(harness.db, buildReq());
+    expect(denied.status).toBe(429);
+    expect(denied.headers.get("retry-after")).not.toBeNull();
+  });
+});
+
+describe("/account/2fa handlers — hub#473", () => {
+  async function signedInUser(username = "owner"): Promise<{ id: string; cookie: string }> {
+    const u = await createUser(harness.db, username, "owner-password-123", {
+      passwordChanged: true,
+    });
+    const session = createSession(harness.db, { userId: u.id });
+    return {
+      id: u.id,
+      cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+    };
+  }
+
+  test("GET requires a session — redirects to /login when absent", () => {
+    const res = handleTwoFactorGet(new Request("http://hub.test/account/2fa"), { db: harness.db });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("/login");
+  });
+
+  test("GET (not enrolled) renders the set-up CTA", async () => {
+    const { cookie } = await signedInUser();
+    const res = handleTwoFactorGet(
+      new Request("http://hub.test/account/2fa", { headers: { cookie } }),
+      { db: harness.db },
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Set up two-factor authentication");
+  });
+
+  test("POST start → enrolling page with a QR svg + manual secret; nothing persisted yet", async () => {
+    const { id, cookie } = await signedInUser();
+    const { body, headers } = formBody({ [CSRF_FIELD_NAME]: TEST_CSRF, action: "start" });
+    const res = await handleTwoFactorPost(
+      new Request("http://hub.test/account/2fa", {
+        method: "POST",
+        headers: { ...headers, cookie },
+        body,
+      }),
+      { db: harness.db },
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("<svg");
+    expect(html).toContain('data-testid="totp-secret"');
+    // Not persisted until confirm.
+    expect(isTotpEnrolled(harness.db, id)).toBe(false);
+  });
+
+  test("POST confirm with a live code persists enrollment + shows backup codes once", async () => {
+    const { id, cookie } = await signedInUser();
+    const { secret } = generateTotpSecret("owner");
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      action: "confirm",
+      secret,
+      code: liveCode(secret),
+    });
+    const res = await handleTwoFactorPost(
+      new Request("http://hub.test/account/2fa", {
+        method: "POST",
+        headers: { ...headers, cookie },
+        body,
+      }),
+      { db: harness.db },
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('data-testid="backup-codes"');
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    // Persisted.
+    expect(isTotpEnrolled(harness.db, id)).toBe(true);
+    expect(getTotpState(harness.db, id).secret).toBe(secret);
+    expect(backupCodesRemaining(harness.db, id)).toBe(10);
+  });
+
+  test("POST confirm with a WRONG code re-renders the enrolling page; nothing persisted", async () => {
+    const { id, cookie } = await signedInUser();
+    const { secret } = generateTotpSecret("owner");
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      action: "confirm",
+      secret,
+      code: "000000",
+    });
+    const res = await handleTwoFactorPost(
+      new Request("http://hub.test/account/2fa", {
+        method: "POST",
+        headers: { ...headers, cookie },
+        body,
+      }),
+      { db: harness.db },
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Apostrophe is HTML-escaped in the rendered banner.
+    expect(html).toContain("match");
+    expect(html).toContain("error-banner");
+    expect(isTotpEnrolled(harness.db, id)).toBe(false);
+  });
+
+  test("POST disable requires the correct current password; clears 2FA on success", async () => {
+    const { id, cookie } = await signedInUser();
+    await persistEnrollment(harness.db, id, generateTotpSecret("owner").secret);
+    expect(isTotpEnrolled(harness.db, id)).toBe(true);
+
+    // Wrong password → 401, still enrolled.
+    const bad = formBody({ [CSRF_FIELD_NAME]: TEST_CSRF, action: "disable", password: "nope" });
+    const badRes = await handleTwoFactorPost(
+      new Request("http://hub.test/account/2fa", {
+        method: "POST",
+        headers: { ...bad.headers, cookie },
+        body: bad.body,
+      }),
+      { db: harness.db },
+    );
+    expect(badRes.status).toBe(401);
+    expect(isTotpEnrolled(harness.db, id)).toBe(true);
+
+    // Correct password → 302, cleared.
+    const ok = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      action: "disable",
+      password: "owner-password-123",
+    });
+    const okRes = await handleTwoFactorPost(
+      new Request("http://hub.test/account/2fa", {
+        method: "POST",
+        headers: { ...ok.headers, cookie },
+        body: ok.body,
+      }),
+      { db: harness.db },
+    );
+    expect(okRes.status).toBe(302);
+    expect(okRes.headers.get("location")).toContain("/account/2fa");
+    expect(isTotpEnrolled(harness.db, id)).toBe(false);
+  });
+
+  test("POST start refuses when already enrolled (409)", async () => {
+    const { id, cookie } = await signedInUser();
+    await persistEnrollment(harness.db, id, generateTotpSecret("owner").secret);
+    const { body, headers } = formBody({ [CSRF_FIELD_NAME]: TEST_CSRF, action: "start" });
+    const res = await handleTwoFactorPost(
+      new Request("http://hub.test/account/2fa", {
+        method: "POST",
+        headers: { ...headers, cookie },
+        body,
+      }),
+      { db: harness.db },
+    );
+    expect(res.status).toBe(409);
+  });
+
+  test("POST CSRF mismatch → 400", async () => {
+    const { cookie } = await signedInUser();
+    const { body, headers } = formBody({ [CSRF_FIELD_NAME]: "wrong", action: "start" });
+    const res = await handleTwoFactorPost(
+      new Request("http://hub.test/account/2fa", {
+        method: "POST",
+        headers: { ...headers, cookie },
+        body,
+      }),
+      { db: harness.db },
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("migration v11 — existing-DB safety", () => {
+  test("applies cleanly on a hub.db built at v10; pre-existing users keep NULL totp + password-only login", async () => {
+    const configDir = mkdtempSync(join(tmpdir(), "phub-2fa-mig-"));
+    try {
+      const dbPath = hubDbPath(configDir);
+      // Build a DB at the OLD schema (only migrations <= 10 applied), with a
+      // pre-existing user, simulating an install from before hub#473.
+      {
+        const old = new Sqlite(dbPath);
+        old.exec("PRAGMA journal_mode = WAL");
+        old.exec("PRAGMA foreign_keys = ON");
+        // Run the real migrator but stop it from seeing v11 by faking the
+        // schema_version table: apply through v10 only via a manual replay is
+        // brittle. Instead, run the full migrator (which includes v11) but
+        // assert the column is nullable + existing rows are NULL. To exercise
+        // the "user predates v11" path we insert via the v2-shaped INSERT and
+        // confirm the totp columns default NULL.
+        migrate(old);
+        // Insert a user the way createUser would, but WITHOUT touching totp.
+        const now = new Date().toISOString();
+        old
+          .prepare(
+            "INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed) VALUES (?, ?, ?, ?, ?, 1)",
+          )
+          .run("legacy-1", "legacy", "$argon2id$fakehash", now, now);
+        old.close();
+      }
+
+      // Re-open (runs migrate() again — idempotent) and verify the legacy row
+      // has NULL totp state → not enrolled.
+      const db = openHubDb(dbPath);
+      try {
+        const state = getTotpState(db, "legacy-1");
+        expect(state.secret).toBeNull();
+        expect(state.backupCodes).toEqual([]);
+        expect(isTotpEnrolled(db, "legacy-1")).toBe(false);
+
+        // Password-only login still works (no 2FA challenge) — verified by the
+        // login handler taking the password-only branch for a NULL-totp user.
+        // (Covered end-to-end above; here we just assert the not-enrolled
+        // predicate the login handler branches on.)
+        expect(isTotpEnrolled(db, "legacy-1")).toBe(false);
+      } finally {
+        db.close();
+      }
+    } finally {
+      rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+
+  test("schema_version records v11", () => {
+    const configDir = mkdtempSync(join(tmpdir(), "phub-2fa-mig2-"));
+    try {
+      const db = openHubDb(hubDbPath(configDir));
+      try {
+        const versions = (
+          db.query("SELECT version FROM schema_version ORDER BY version").all() as {
+            version: number;
+          }[]
+        ).map((r) => r.version);
+        expect(versions).toContain(11);
+        // The totp columns exist on `users`.
+        const cols = (db.query("PRAGMA table_info(users)").all() as { name: string }[]).map(
+          (c) => c.name,
+        );
+        expect(cols).toContain("totp_secret");
+        expect(cols).toContain("totp_backup_codes");
+        expect(cols).toContain("totp_enrolled_at");
+      } finally {
+        db.close();
+      }
+    } finally {
+      rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/two-factor.test.ts
+++ b/src/__tests__/two-factor.test.ts
@@ -1,0 +1,183 @@
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as OTPAuth from "otpauth";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import {
+  _resetTotpReplayCache,
+  findBackupCodeIndex,
+  generateBackupCodes,
+  generateTotpSecret,
+  normalizeBackupCode,
+  verifyTotpCode,
+} from "../totp.ts";
+import {
+  backupCodesRemaining,
+  clearEnrollment,
+  getTotpState,
+  isTotpEnrolled,
+  persistEnrollment,
+  verifySecondFactor,
+} from "../two-factor-store.ts";
+import { createUser } from "../users.ts";
+
+/** Generate the current live TOTP code for a base32 secret. */
+function liveCode(secretBase32: string, label = "owner"): string {
+  return new OTPAuth.TOTP({
+    issuer: "Parachute Hub",
+    label,
+    algorithm: "SHA1",
+    digits: 6,
+    period: 30,
+    secret: OTPAuth.Secret.fromBase32(secretBase32),
+  }).generate();
+}
+
+describe("totp — secret + code", () => {
+  beforeEach(() => _resetTotpReplayCache());
+
+  test("generateTotpSecret returns a base32 secret + an otpauth:// URI", () => {
+    const { secret, otpauthUrl } = generateTotpSecret("alice");
+    expect(secret.length).toBeGreaterThan(0);
+    expect(/^[A-Z2-7]+$/.test(secret)).toBe(true);
+    expect(otpauthUrl.startsWith("otpauth://totp/")).toBe(true);
+    expect(otpauthUrl).toContain("Parachute%20Hub");
+  });
+
+  test("a live code verifies; a wrong code does not", () => {
+    const { secret } = generateTotpSecret("alice");
+    expect(verifyTotpCode(secret, liveCode(secret))).toBe(true);
+    _resetTotpReplayCache();
+    expect(verifyTotpCode(secret, "000000")).toBe(false);
+  });
+
+  test("non-6-digit input is rejected without throwing", () => {
+    const { secret } = generateTotpSecret("alice");
+    expect(verifyTotpCode(secret, "12345")).toBe(false);
+    expect(verifyTotpCode(secret, "1234567")).toBe(false);
+    expect(verifyTotpCode(secret, "abcdef")).toBe(false);
+    expect(verifyTotpCode(secret, "")).toBe(false);
+  });
+
+  test("replay: a code accepted once is rejected on the second try (markUsed default)", () => {
+    const { secret } = generateTotpSecret("alice");
+    const code = liveCode(secret);
+    expect(verifyTotpCode(secret, code)).toBe(true);
+    expect(verifyTotpCode(secret, code)).toBe(false); // replay rejected
+  });
+});
+
+describe("totp — backup codes", () => {
+  test("generates 10 hyphenated codes + matching argon2id hashes", async () => {
+    const { codes, hashes } = await generateBackupCodes();
+    expect(codes.length).toBe(10);
+    expect(hashes.length).toBe(10);
+    for (const c of codes) {
+      expect(/^[a-z2-9]{5}-[a-z2-9]{5}$/.test(c)).toBe(true);
+    }
+    for (const h of hashes) {
+      expect(h.startsWith("$argon2")).toBe(true);
+    }
+  });
+
+  test("findBackupCodeIndex matches a code (hyphen-insensitive) and rejects unknowns", async () => {
+    const { codes, hashes } = await generateBackupCodes();
+    // Match by normalized form (strip hyphen) and by raw hyphenated form.
+    const idx0 = await findBackupCodeIndex(codes[0]!, hashes);
+    expect(idx0).toBe(0);
+    const idxNorm = await findBackupCodeIndex(normalizeBackupCode(codes[3]!), hashes);
+    expect(idxNorm).toBe(3);
+    const miss = await findBackupCodeIndex("zzzzz-zzzzz", hashes);
+    expect(miss).toBe(-1);
+  });
+});
+
+describe("two-factor-store", () => {
+  let db: Database;
+  let configDir: string;
+  let userId: string;
+
+  beforeEach(async () => {
+    _resetTotpReplayCache();
+    configDir = mkdtempSync(join(tmpdir(), "phub-2fa-store-"));
+    db = openHubDb(hubDbPath(configDir));
+    const u = await createUser(db, "owner", "owner-password-123");
+    userId = u.id;
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
+  test("fresh user: not enrolled, no backup codes", () => {
+    expect(isTotpEnrolled(db, userId)).toBe(false);
+    expect(getTotpState(db, userId).secret).toBeNull();
+    expect(backupCodesRemaining(db, userId)).toBe(0);
+  });
+
+  test("persistEnrollment stores the secret + 10 backup codes (hashed) + a timestamp", async () => {
+    const { secret } = generateTotpSecret("owner");
+    const result = await persistEnrollment(db, userId, secret);
+    expect(result.backupCodes.length).toBe(10);
+    expect(isTotpEnrolled(db, userId)).toBe(true);
+    const state = getTotpState(db, userId);
+    expect(state.secret).toBe(secret);
+    expect(state.backupCodes.length).toBe(10);
+    expect(state.enrolledAt).toBeTruthy();
+    // Stored codes are hashes, NOT the plaintext returned to the user.
+    for (const stored of state.backupCodes) {
+      expect(stored.startsWith("$argon2")).toBe(true);
+      expect(result.backupCodes).not.toContain(stored);
+    }
+  });
+
+  test("verifySecondFactor accepts a live TOTP code", async () => {
+    const { secret } = generateTotpSecret("owner");
+    await persistEnrollment(db, userId, secret);
+    const res = await verifySecondFactor(db, userId, liveCode(secret), false);
+    expect(res).toEqual({ ok: true, via: "totp" });
+  });
+
+  test("verifySecondFactor accepts a backup code ONCE, then rejects its reuse (single-use)", async () => {
+    const { secret } = generateTotpSecret("owner");
+    const { backupCodes } = await persistEnrollment(db, userId, secret);
+    const code = backupCodes[0]!;
+    expect(backupCodesRemaining(db, userId)).toBe(10);
+
+    const first = await verifySecondFactor(db, userId, code, false);
+    expect(first).toEqual({ ok: true, via: "backup_code" });
+    // Consumed: one fewer remaining.
+    expect(backupCodesRemaining(db, userId)).toBe(9);
+
+    // Reuse of the same code is rejected.
+    const second = await verifySecondFactor(db, userId, code, false);
+    expect(second).toEqual({ ok: false });
+    expect(backupCodesRemaining(db, userId)).toBe(9);
+  });
+
+  test("verifySecondFactor rejects a wrong code without consuming anything", async () => {
+    const { secret } = generateTotpSecret("owner");
+    await persistEnrollment(db, userId, secret);
+    const res = await verifySecondFactor(db, userId, "999999", false);
+    expect(res).toEqual({ ok: false });
+    expect(backupCodesRemaining(db, userId)).toBe(10);
+  });
+
+  test("clearEnrollment removes secret + backup codes (idempotent)", async () => {
+    const { secret } = generateTotpSecret("owner");
+    await persistEnrollment(db, userId, secret);
+    expect(isTotpEnrolled(db, userId)).toBe(true);
+    clearEnrollment(db, userId);
+    expect(isTotpEnrolled(db, userId)).toBe(false);
+    expect(backupCodesRemaining(db, userId)).toBe(0);
+    // Idempotent — clearing again is a no-op.
+    clearEnrollment(db, userId);
+    expect(isTotpEnrolled(db, userId)).toBe(false);
+  });
+
+  test("verifySecondFactor on a not-enrolled user returns ok:false", async () => {
+    expect(await verifySecondFactor(db, userId, "123456", false)).toEqual({ ok: false });
+  });
+});

--- a/src/__tests__/vault-auth-status.test.ts
+++ b/src/__tests__/vault-auth-status.test.ts
@@ -39,10 +39,10 @@ describe("readVaultAuthStatus — hub.db source of truth (multi-user Phase 1+)",
         vaultHome: env.path,
         countTokens: () => 0,
         probeHubDbHasUserPassword: () => true,
+        probeHubDbHasTotp: () => false,
       });
       expect(status.hasOwnerPassword).toBe(true);
-      // No hub-side TOTP column yet (Phase 3). Stays false on the hub.db
-      // path until the schema gains a column.
+      // No TOTP enrolled in hub.db (and no legacy YAML) → false.
       expect(status.hasTotp).toBe(false);
     } finally {
       env.cleanup();
@@ -57,6 +57,7 @@ describe("readVaultAuthStatus — hub.db source of truth (multi-user Phase 1+)",
         vaultHome: env.path,
         countTokens: () => 0,
         probeHubDbHasUserPassword: () => false,
+        probeHubDbHasTotp: () => false,
       });
       expect(status.hasOwnerPassword).toBe(true);
       expect(status.hasTotp).toBe(false);
@@ -87,6 +88,7 @@ describe("readVaultAuthStatus — hub.db source of truth (multi-user Phase 1+)",
         vaultHome: env.path,
         countTokens: () => 0,
         probeHubDbHasUserPassword: () => false,
+        probeHubDbHasTotp: () => false,
       });
       expect(status.hasOwnerPassword).toBe(false);
       expect(status.hasTotp).toBe(false);
@@ -95,20 +97,55 @@ describe("readVaultAuthStatus — hub.db source of truth (multi-user Phase 1+)",
     }
   });
 
-  test("hub.db says yes overrides absent YAML — TOTP still reflects YAML state", () => {
+  test("hub.db password=true, hub.db TOTP unreachable → TOTP falls back to YAML state", () => {
     const env = makeVaultHome();
     try {
-      // TOTP-only YAML: vault-side 2FA was configured but hub.db is the
-      // canonical password source. Should report password=true (hub.db),
-      // totp=true (YAML).
+      // hub#473: hub.db is the canonical TOTP source, but when the TOTP probe
+      // is unreachable (pre-v11 column absent) it falls back to the legacy
+      // vault YAML totp_secret. password=true (hub.db), totp=true (YAML fallback).
       writeConfig(env.path, 'totp_secret: "JBSWY3DPEHPK3PXP"\n');
       const status = readVaultAuthStatus({
         vaultHome: env.path,
         countTokens: () => 0,
         probeHubDbHasUserPassword: () => true,
+        probeHubDbHasTotp: () => undefined,
       });
       expect(status.hasOwnerPassword).toBe(true);
       expect(status.hasTotp).toBe(true);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("hub.db TOTP=true is the real signal — overrides absent YAML", () => {
+    const env = makeVaultHome();
+    try {
+      // No YAML totp_secret, but a hub.db user has enrolled real 2FA (hub#473).
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        countTokens: () => 0,
+        probeHubDbHasUserPassword: () => true,
+        probeHubDbHasTotp: () => true,
+      });
+      expect(status.hasTotp).toBe(true);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("hub.db TOTP=false (column present, none enrolled) overrides a stale YAML true", () => {
+    const env = makeVaultHome();
+    try {
+      // Legacy YAML totp_secret present, but hub.db definitively says no user
+      // has enrolled real hub-login 2FA → report false (the real signal wins).
+      writeConfig(env.path, 'totp_secret: "JBSWY3DPEHPK3PXP"\n');
+      const status = readVaultAuthStatus({
+        vaultHome: env.path,
+        countTokens: () => 0,
+        probeHubDbHasUserPassword: () => true,
+        probeHubDbHasTotp: () => false,
+      });
+      expect(status.hasTotp).toBe(false);
     } finally {
       env.cleanup();
     }
@@ -123,6 +160,7 @@ describe("readVaultAuthStatus — YAML fallback (pre-multi-user installs)", () =
         vaultHome: env.path,
         countTokens: () => 0,
         probeHubDbHasUserPassword: hubDbUnreachable,
+        probeHubDbHasTotp: hubDbUnreachable,
       });
       expect(status.hasOwnerPassword).toBe(false);
       expect(status.hasTotp).toBe(false);
@@ -147,6 +185,7 @@ describe("readVaultAuthStatus — YAML fallback (pre-multi-user installs)", () =
         vaultHome: env.path,
         countTokens: () => 0,
         probeHubDbHasUserPassword: hubDbUnreachable,
+        probeHubDbHasTotp: hubDbUnreachable,
       });
       expect(status.hasOwnerPassword).toBe(true);
       expect(status.hasTotp).toBe(true);
@@ -163,6 +202,7 @@ describe("readVaultAuthStatus — YAML fallback (pre-multi-user installs)", () =
         vaultHome: env.path,
         countTokens: () => 0,
         probeHubDbHasUserPassword: hubDbUnreachable,
+        probeHubDbHasTotp: hubDbUnreachable,
       });
       expect(status.hasOwnerPassword).toBe(false);
       expect(status.hasTotp).toBe(false);
@@ -179,6 +219,7 @@ describe("readVaultAuthStatus — YAML fallback (pre-multi-user installs)", () =
         vaultHome: env.path,
         countTokens: () => 0,
         probeHubDbHasUserPassword: hubDbUnreachable,
+        probeHubDbHasTotp: hubDbUnreachable,
       });
       expect(status.hasOwnerPassword).toBe(true);
       expect(status.hasTotp).toBe(false);

--- a/src/account-home-ui.ts
+++ b/src/account-home-ui.ts
@@ -109,6 +109,12 @@ export interface RenderAccountHomeOpts {
    * to keep a cross-origin form from logging the user out.
    */
   csrfToken: string;
+  /**
+   * Whether the signed-in user has TOTP 2FA enrolled (hub#473). Drives the
+   * Account card's 2FA status line + enroll/manage link. The link points at
+   * `/account/2fa` either way — "Set up" when off, "Manage" when on.
+   */
+  twoFactorEnabled: boolean;
 }
 
 export function renderAccountHome(opts: RenderAccountHomeOpts): string {
@@ -127,6 +133,7 @@ export function renderAccountHome(opts: RenderAccountHomeOpts): string {
   const accountCard = renderAccountCard({
     username: safeUsername,
     csrfToken,
+    twoFactorEnabled: opts.twoFactorEnabled,
   });
 
   const body = `
@@ -263,19 +270,31 @@ function renderVaultCard(opts: VaultCardOpts): string {
 interface AccountCardOpts {
   username: string;
   csrfToken: string;
+  twoFactorEnabled: boolean;
 }
 
 function renderAccountCard(opts: AccountCardOpts): string {
-  const { username, csrfToken } = opts;
+  const { username, csrfToken, twoFactorEnabled } = opts;
+  const twoFactorStatus = twoFactorEnabled
+    ? `<dd><span class="badge badge-on" data-testid="2fa-status">On</span></dd>`
+    : `<dd><span class="badge badge-off" data-testid="2fa-status">Off</span></dd>`;
+  const twoFactorLink = twoFactorEnabled
+    ? `<a class="account-action" href="/account/2fa" data-testid="manage-2fa-link">Manage two-factor →</a>`
+    : `<a class="account-action" href="/account/2fa" data-testid="setup-2fa-link">Set up two-factor →</a>`;
   return `
     <section class="section" data-testid="account-card">
       <h2>Account</h2>
       <dl class="kv">
         <dt>Username</dt>
         <dd><code>${username}</code></dd>
+        <dt>Two-factor authentication</dt>
+        ${twoFactorStatus}
       </dl>
       <p>
         <a class="account-action" href="/account/change-password" data-testid="change-password-link">Change password →</a>
+      </p>
+      <p>
+        ${twoFactorLink}
       </p>
       <form method="POST" action="/logout" class="signout-form" data-testid="signout-form">
         ${renderCsrfHiddenInput(csrfToken)}
@@ -483,6 +502,17 @@ const STYLES = `
     margin-top: 0.4rem;
   }
   .kv dd { margin: 0.15rem 0 0.4rem; }
+
+  .badge {
+    display: inline-block;
+    font-size: 0.78rem;
+    font-weight: 500;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+  }
+  .badge-on { background: ${PALETTE.successSoft}; color: ${PALETTE.success}; border-color: ${PALETTE.success}; }
+  .badge-off { background: ${PALETTE.bgSoft}; color: ${PALETTE.fgMuted}; border-color: ${PALETTE.border}; }
 
   .btn {
     font: inherit;

--- a/src/admin-handlers.ts
+++ b/src/admin-handlers.ts
@@ -11,9 +11,17 @@
  * (`parachute_hub_csrf` cookie + `__csrf` form field, constant-time compare).
  */
 import type { Database } from "bun:sqlite";
-import { renderAdminError, renderAdminLogin } from "./admin-login-ui.ts";
+import { renderAdminError, renderAdminLogin, renderTotpChallenge } from "./admin-login-ui.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
-import { checkAndRecord, clientIpFromRequest } from "./rate-limit.ts";
+import {
+  buildPendingLoginClearCookie,
+  buildPendingLoginCookie,
+  consumePendingLogin,
+  createPendingLogin,
+  getPendingLogin,
+  parsePendingLoginCookie,
+} from "./pending-login.ts";
+import { checkAndRecord, clientIpFromRequest, totpRateLimiter } from "./rate-limit.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
 import {
   SESSION_TTL_MS,
@@ -23,9 +31,11 @@ import {
   deleteSession,
   parseSessionCookie,
 } from "./sessions.ts";
+import { isTotpEnrolled, verifySecondFactor } from "./two-factor-store.ts";
 import {
   PASSWORD_MAX_LEN,
   type User,
+  getUserById,
   getUserByUsername,
   isFirstAdmin,
   verifyPassword,
@@ -214,8 +224,42 @@ export async function handleAdminLoginPost(
       401,
     );
   }
+
+  // 2FA gate (hub#473). If the user has TOTP enrolled, the password is only
+  // the *first* factor — do NOT mint a session yet. Stash a short-lived
+  // pending-login (server-side, keyed by an opaque cookie token) and render
+  // the "enter your code" page. The session is minted in
+  // `handleAdminLoginTotpPost` only after the second factor verifies.
+  // Users WITHOUT 2FA fall through to the existing password-only path
+  // unchanged — existing operators keep signing in exactly as before.
+  if (isTotpEnrolled(db, user.id)) {
+    const pendingToken = createPendingLogin(user.id, next);
+    // Reuse the same CSRF token (cookie unchanged) for the challenge form.
+    return htmlResponse(renderTotpChallenge({ next, csrfToken }), 200, {
+      "set-cookie": buildPendingLoginCookie(pendingToken, req),
+    });
+  }
+
+  return mintSessionAndRedirect(db, req, user, next);
+}
+
+/**
+ * Mint a session for an authenticated user and 302 to the resolved target.
+ * Shared by the password-only login path and the post-2FA path so both apply
+ * the identical force-change-password / friend-rewrite redirect logic.
+ *
+ * `extraCookies` lets the 2FA path also clear the pending-login cookie in the
+ * same response.
+ */
+function mintSessionAndRedirect(
+  db: Database,
+  req: Request,
+  user: User,
+  next: string,
+  extraCookies: string[] = [],
+): Response {
   const session = createSession(db, { userId: user.id });
-  const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000), {
+  const sessionCookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000), {
     secure: isHttpsRequest(req),
   });
   // Multi-user Phase 1 PR 3 — `password_changed === false` (admin-created
@@ -226,7 +270,118 @@ export async function handleAdminLoginPost(
   // `next` rides along on the change-password URL so the post-change
   // POST can land them at their intended destination.
   const target = loginRedirectTarget(db, user, next);
-  return redirect(target, { "set-cookie": cookie });
+  const headers = new Headers({ location: target });
+  headers.append("set-cookie", sessionCookie);
+  for (const c of extraCookies) headers.append("set-cookie", c);
+  return new Response(null, { status: 302, headers });
+}
+
+/**
+ * POST `/login/2fa` — the second-factor step (hub#473).
+ *
+ * Reached only after a correct password POST for a 2FA-enrolled user handed
+ * back a pending-login cookie. Order of checks:
+ *   1. CSRF (else 400 — same shape as `/login`).
+ *   2. Per-IP rate-limit (5 / 15 min) BEFORE the factor check, so backup-code
+ *      / TOTP grinding by a password-holder is bounded.
+ *   3. Pending-login cookie resolves to a live half-login (else 401 — the
+ *      pending login expired or was never created; restart the password step).
+ *   4. The user row still exists + still has 2FA enrolled (defensive).
+ *   5. Verify the submitted code as TOTP (±1 window) OR a backup code (single-
+ *      use, consumed on match). On success: consume the pending login, mint
+ *      the session, 302 to the resolved target + clear the pending cookie.
+ *      On failure: re-render the challenge with an error (the pending login
+ *      stays valid so the user can retry without re-entering the password).
+ */
+export async function handleAdminLoginTotpPost(
+  db: Database,
+  req: Request,
+  deps: AdminLoginDeps = {},
+): Promise<Response> {
+  const form = await req.formData();
+  const formCsrf = form.get(CSRF_FIELD_NAME);
+  const csrfToken = typeof formCsrf === "string" ? formCsrf : "";
+  if (!verifyCsrfToken(req, csrfToken || null)) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Invalid form submission",
+        message: "The form's CSRF token did not match. Reload the page and try again.",
+      }),
+      400,
+    );
+  }
+
+  const next = safeNext(String(form.get("next") ?? ""));
+  const code = String(form.get("code") ?? "");
+
+  // Rate-limit BEFORE resolving the pending login or verifying the factor.
+  const clientIp = clientIpFromRequest(req);
+  const now = deps.now ? deps.now() : new Date();
+  const gate = totpRateLimiter.checkAndRecord(clientIp, now);
+  if (!gate.allowed) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Too many attempts",
+        message: `Too many verification attempts from this IP. Try again in ${gate.retryAfterSeconds ?? 1} seconds.`,
+      }),
+      429,
+      { "retry-after": String(gate.retryAfterSeconds ?? 1) },
+    );
+  }
+
+  const pendingToken = parsePendingLoginCookie(req.headers.get("cookie"));
+  const pending = getPendingLogin(pendingToken, () => now);
+  if (!pending) {
+    // No live pending login — expired, missing, or tampered. Send the user
+    // back to the start; clear any stale pending cookie.
+    return htmlResponse(
+      renderAdminError({
+        title: "Session expired",
+        message: "Your sign-in attempt expired. Please sign in again.",
+      }),
+      401,
+      { "set-cookie": buildPendingLoginClearCookie(req) },
+    );
+  }
+
+  const user = getUserById(db, pending.userId);
+  if (!user || !isTotpEnrolled(db, user.id)) {
+    consumePendingLogin(pendingToken);
+    return htmlResponse(
+      renderAdminError({
+        title: "Sign-in unavailable",
+        message: "Please sign in again.",
+      }),
+      401,
+      { "set-cookie": buildPendingLoginClearCookie(req) },
+    );
+  }
+
+  if (!code) {
+    return htmlResponse(
+      renderTotpChallenge({ next, csrfToken, errorMessage: "Enter your authentication code." }),
+      400,
+    );
+  }
+
+  const result = await verifySecondFactor(db, user.id, code);
+  if (!result.ok) {
+    return htmlResponse(
+      renderTotpChallenge({
+        next,
+        csrfToken,
+        errorMessage: "That code is incorrect or expired. Try again.",
+      }),
+      401,
+    );
+  }
+
+  // Second factor good. Consume the pending login (single use), mint the
+  // session, and clear the pending cookie in the same response. Use the
+  // pending login's stored `next` if the form's was tampered to the default.
+  consumePendingLogin(pendingToken);
+  const target = pending.next && pending.next !== POST_LOGIN_DEFAULT ? pending.next : next;
+  return mintSessionAndRedirect(db, req, user, target, [buildPendingLoginClearCookie(req)]);
 }
 
 /**

--- a/src/admin-login-ui.ts
+++ b/src/admin-login-ui.ts
@@ -12,7 +12,7 @@
  *
  * Pure functions — DB, sessions live in `admin-handlers.ts`.
  */
-import { brandMarkSvg, WORDMARK_TEXT } from "./brand.ts";
+import { WORDMARK_TEXT, brandMarkSvg } from "./brand.ts";
 import { renderCsrfHiddenInput } from "./csrf.ts";
 import { escapeHtml } from "./oauth-ui.ts";
 
@@ -106,6 +106,50 @@ export function renderAdminLogin(props: AdminLoginProps): string {
       </form>
     </div>`;
   return baseDocument("Sign in — Parachute", body);
+}
+
+// --- /login/2fa (second-factor step) --------------------------------------
+
+export interface TotpChallengeProps {
+  /** Continuation path after a successful second factor — hidden field. */
+  next: string;
+  csrfToken: string;
+  errorMessage?: string;
+}
+
+/**
+ * Server-rendered "enter your code" page shown after a correct password when
+ * the user has 2FA enrolled (hub#473). Posts to `/login/2fa` along with the
+ * pending-login cookie minted by the password step. Accepts either a 6-digit
+ * TOTP code or a backup code in the same field — the handler tries TOTP first,
+ * then backup codes.
+ *
+ * No JS, stands alone like `/login`. `inputmode`/`autocomplete` hint mobile
+ * keyboards toward a numeric pad + the platform's one-time-code autofill.
+ */
+export function renderTotpChallenge(props: TotpChallengeProps): string {
+  const { next, csrfToken, errorMessage } = props;
+  const error = errorMessage ? `<p class="error-banner">${escapeHtml(errorMessage)}</p>` : "";
+  const body = `
+    <div class="card">
+      <div class="card-header">
+        ${header()}
+        <h1>Two-factor authentication</h1>
+        <p class="subtitle">Enter the 6-digit code from your authenticator app, or a backup code.</p>
+      </div>
+      ${error}
+      <form method="POST" action="/login/2fa" class="auth-form">
+        ${renderCsrfHiddenInput(csrfToken)}
+        <input type="hidden" name="next" value="${escapeAttr(next)}" />
+        <label class="field">
+          <span class="field-label">Authentication code</span>
+          <input type="text" name="code" inputmode="numeric" autocomplete="one-time-code"
+                 autofocus required placeholder="123456" />
+        </label>
+        <button type="submit" class="btn btn-primary">Verify</button>
+      </form>
+    </div>`;
+  return baseDocument("Two-factor authentication — Parachute", body);
 }
 
 // --- error page ------------------------------------------------------------

--- a/src/api-account.ts
+++ b/src/api-account.ts
@@ -55,6 +55,7 @@ import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
 import { changePasswordRateLimiter } from "./rate-limit.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
 import { findActiveSession } from "./sessions.ts";
+import { isTotpEnrolled } from "./two-factor-store.ts";
 import {
   PASSWORD_MAX_LEN,
   UserNotFoundError,
@@ -497,6 +498,7 @@ export function handleAccountHomeGet(req: Request, deps: AccountHomeDeps): Respo
       hubOrigin: deps.hubOrigin,
       isFirstAdmin: adminFlag,
       csrfToken: csrf.token,
+      twoFactorEnabled: isTotpEnrolled(deps.db, user.id),
     }),
     200,
     extra,

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -15,9 +15,12 @@
  * Vault-forwarded subcommands (still implemented in `parachute-vault`):
  *   - (none currently). `2fa` used to forward here, but the legacy
  *     `parachute-vault 2fa` stub writes vault YAML that does NOT gate hub
- *     `/login` — and post auth-unification it requires a vault owner password
- *     that no longer exists, so it just exits 1. `parachute auth 2fa` is now an
- *     honest informational stub on the hub side (real feature: #473).
+ *     `/login`. As of hub#473 `parachute auth 2fa` is the REAL hub-login TOTP
+ *     surface: it reads/writes the hub.db `users` TOTP columns and gates
+ *     `/login`. Subcommands: `status`, `enroll` (CLI text enroll — prints the
+ *     otpauth:// URI + base32 secret for manual authenticator entry, then
+ *     prompts for the confirm code), `disenroll`. The browser path lives at
+ *     `<hub-origin>/account/2fa` (QR + backup codes).
  */
 
 import { join } from "node:path";
@@ -48,6 +51,13 @@ import {
 } from "../operator-token.ts";
 import { isNonRequestableScope } from "../scope-explanations.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
+import { generateTotpSecret, otpauthUrlFor, verifyTotpCode } from "../totp.ts";
+import {
+  clearEnrollment,
+  getTotpState,
+  isTotpEnrolled,
+  persistEnrollment,
+} from "../two-factor-store.ts";
 import {
   SingleUserModeError,
   UsernameTakenError,
@@ -97,8 +107,14 @@ Usage:
   parachute auth set-password [--username <name>] [--password <pw>] [--allow-multi]
                                        Create or update the hub user's password
   parachute auth list-users            Show registered hub accounts
-  parachute auth 2fa                   2FA status (hub-login TOTP not shipped
-                                       yet — tracked #473)
+  parachute auth 2fa [status]          Show hub-login 2FA (TOTP) status
+  parachute auth 2fa enroll [--username <name>]
+                                       Enroll TOTP for hub login (prints the
+                                       otpauth:// URI + base32 secret for manual
+                                       authenticator entry, then prompts for a
+                                       confirm code; prints backup codes once)
+  parachute auth 2fa disenroll [--username <name>]
+                                       Turn off hub-login 2FA for the account
   parachute auth rotate-key            Rotate the hub's JWT signing key
   parachute auth rotate-operator [--scope-set <set>]
                                        Mint a fresh ~/.parachute/operator.token
@@ -131,12 +147,20 @@ The default username on first run is "owner" — override with --username.
 Single-user mode is the default; pass --allow-multi to add additional
 accounts beyond the first.
 
-2fa is informational only for now: TOTP at the hub login layer isn't shipped
-yet (tracked #473). The legacy \`parachute-vault 2fa\` command writes vault YAML
-that does NOT gate hub \`/login\`, so it's intentionally no longer wired here —
-\`parachute auth 2fa\` prints the honest state and exits 0. Until hub-login TOTP
-ships, rely on a strong owner password (and don't expose \`/login\` if a
-guessable password is a concern).
+2fa is real hub-login TOTP (hub#473). It reads/writes the hub.db \`users\` TOTP
+columns and gates \`/login\`: once enrolled, signing in requires a 6-digit code
+from your authenticator app (or a single-use backup code) after your password.
+
+\`parachute auth 2fa enroll\` is headless-friendly — it prints the \`otpauth://\`
+URI and the base32 secret as text so you can type them into an authenticator
+manually (no QR scan needed on a server), then prompts for the current 6-digit
+code to confirm. On success it prints 10 single-use backup codes ONCE — save
+them. The browser path (\`<hub-origin>/account/2fa\`) shows a scannable QR code.
+
+\`parachute auth 2fa disenroll\` clears the TOTP secret + backup codes.
+
+In single-user mode both default to the only hub account; pass --username to
+target a specific account when more than one exists.
 
 rotate-key generates a fresh RSA-2048 keypair and retires the previous
 one. The retired key keeps appearing in /.well-known/jwks.json for 24
@@ -1130,26 +1154,112 @@ async function runRevokeToken(args: readonly string[], deps: AuthDeps): Promise<
 }
 
 /**
- * Honest informational stub for `parachute auth 2fa [enroll|status|…]`.
+ * Real hub-login TOTP 2FA CLI (hub#473). `parachute auth 2fa [status|enroll|
+ * disenroll]`. Reads/writes the hub.db `users` TOTP columns — the same store
+ * the `/login` flow and `/account/2fa` browser surface use, so a CLI enroll
+ * gates the exposed hub login exactly like the browser one.
  *
- * 2FA at the hub login layer isn't implemented yet (#473). The old path
- * forwarded to the deprecated `parachute-vault 2fa` stub, which (a) post
- * auth-unification requires a vault owner password that no longer exists, so it
- * exits 1, and (b) even on success only writes vault YAML that does NOT gate
- * hub `/login`. Telling operators to run it was actively misleading — enrolling
- * did nothing for the exposed hub login. So we print the honest state and exit
- * 0 (informational, not a crash).
+ * Headless-first by design: `enroll` prints the `otpauth://` URI + base32
+ * secret as text so the operator can type them into an authenticator app
+ * manually (no QR scan on a server), then prompts for the current code to
+ * confirm before persisting. Browser enroll (QR) lives at
+ * `<hub-origin>/account/2fa`.
  */
-function run2faInfo(): number {
-  console.log("2FA for hub login isn't available yet (tracked: #473).");
-  console.log("");
-  console.log("The legacy `parachute-vault 2fa` command writes vault YAML but does NOT protect");
-  console.log("your hub login (`/login`), so enrolling there does nothing for the exposed hub.");
-  console.log("");
-  console.log("Until hub-login TOTP ships:");
-  console.log("  • Use a strong owner password (`parachute auth set-password`).");
-  console.log("  • If a guessable password is a concern, don't expose `/login` publicly.");
-  return 0;
+async function run2fa(args: readonly string[], deps: AuthDeps): Promise<number> {
+  const flag = extractUsernameFlag(args);
+  if (flag.error) {
+    console.error(`parachute auth 2fa: ${flag.error}`);
+    return 1;
+  }
+  const sub = flag.rest[0] ?? "status";
+  if (flag.rest.length > 1) {
+    console.error(`parachute auth 2fa: unexpected argument "${flag.rest[1]}"`);
+    console.error("usage: parachute auth 2fa [status|enroll|disenroll] [--username <name>]");
+    return 1;
+  }
+  if (sub !== "status" && sub !== "enroll" && sub !== "disenroll") {
+    console.error(`parachute auth 2fa: unknown subcommand "${sub}"`);
+    console.error("usage: parachute auth 2fa [status|enroll|disenroll] [--username <name>]");
+    return 1;
+  }
+
+  const db = deps.dbPath ? openHubDb(deps.dbPath) : openHubDb();
+  try {
+    const target = resolveTargetUser(db, flag.username, sub);
+    if ("error" in target) {
+      console.error(`parachute auth 2fa: ${target.error}`);
+      return 1;
+    }
+
+    if (sub === "status") {
+      const state = getTotpState(db, target.id);
+      if (state.secret) {
+        console.log(`Two-factor authentication: ON for "${target.username}".`);
+        if (state.enrolledAt) console.log(`  enrolled_at:   ${state.enrolledAt}`);
+        console.log(`  backup_codes:  ${state.backupCodes.length} remaining`);
+      } else {
+        console.log(`Two-factor authentication: OFF for "${target.username}".`);
+        console.log("Run `parachute auth 2fa enroll` to turn it on.");
+      }
+      return 0;
+    }
+
+    if (sub === "disenroll") {
+      if (!isTotpEnrolled(db, target.id)) {
+        console.log(`Two-factor authentication is already off for "${target.username}".`);
+        return 0;
+      }
+      clearEnrollment(db, target.id);
+      console.log(`Turned off two-factor authentication for "${target.username}".`);
+      return 0;
+    }
+
+    // sub === "enroll"
+    if (isTotpEnrolled(db, target.id)) {
+      console.error(
+        `parachute auth 2fa: two-factor is already enabled for "${target.username}". Run \`parachute auth 2fa disenroll\` first to re-enroll.`,
+      );
+      return 1;
+    }
+    const isInteractive = (deps.isInteractive ?? defaultIsInteractive)();
+    if (!isInteractive) {
+      console.error(
+        "parachute auth 2fa enroll: a TTY is required to confirm the enrollment code (run it interactively)",
+      );
+      return 1;
+    }
+    const readLine = deps.readLine ?? defaultReadLine;
+
+    const { secret } = generateTotpSecret(target.username);
+    const otpauthUrl = otpauthUrlFor(secret, target.username);
+    console.log(`Enrolling two-factor authentication for "${target.username}".`);
+    console.log("");
+    console.log("Add this account to your authenticator app. Either scan the otpauth URL");
+    console.log("(paste it into a QR generator), or enter the secret key manually:");
+    console.log("");
+    console.log(`  otpauth URL:  ${otpauthUrl}`);
+    console.log(`  secret key:   ${secret}`);
+    console.log("");
+    const code = (await readLine("Enter the 6-digit code from your app to confirm: ")).trim();
+    if (!verifyTotpCode(secret, code)) {
+      console.error(
+        "parachute auth 2fa enroll: that code didn't match — nothing was saved. Check your device clock and try again.",
+      );
+      return 1;
+    }
+    const result = await persistEnrollment(db, target.id, secret);
+    console.log("");
+    console.log("✓ Two-factor authentication is now ON for hub login.");
+    console.log("");
+    console.log("Save these backup codes — each works once if you lose your authenticator:");
+    console.log("");
+    for (const c of result.backupCodes) console.log(`  ${c}`);
+    console.log("");
+    console.log("They are shown only once. Store them somewhere safe.");
+    return 0;
+  } finally {
+    db.close();
+  }
 }
 
 function runListUsers(deps: AuthDeps): number {
@@ -1211,7 +1321,13 @@ export async function auth(args: readonly string[], deps: AuthDeps | Runner = {}
       }
     }
     if (sub === "2fa") {
-      return run2faInfo();
+      try {
+        return await run2fa(args.slice(1), normalized);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`parachute auth 2fa: ${msg}`);
+        return 1;
+      }
     }
     if (sub === "list-users") {
       return runListUsers(normalized);

--- a/src/commands/expose-2fa-warning.ts
+++ b/src/commands/expose-2fa-warning.ts
@@ -2,14 +2,12 @@
  * Public-exposure security warning (#186). Once the operator brings up
  * cloudflare or Tailscale Funnel, `/login` is reachable from the public
  * internet on every layer admitting traffic. After #188's `/login` rate-limit
- * floor, the owner password is the wall.
+ * floor, the owner password is the wall — and now (hub#473) hub-login TOTP 2FA
+ * is the second wall.
  *
- * 2FA at the hub login layer is the planned next layer of defense — "password +
- * something-you-have" — but it isn't shipped yet (#473). So this warning no
- * longer recommends `parachute auth 2fa enroll` (that command writes vault YAML
- * that does NOT gate hub `/login`, and post auth-unification it just exits 1).
- * Instead it nudges toward a strong owner password and "don't expose /login if
- * a guessable password is a concern."
+ * 2FA at the hub login layer is real as of hub#473: "password +
+ * something-you-have." This warning recommends `parachute auth 2fa enroll`
+ * (which now gates hub `/login` for real) when the operator hasn't enrolled.
  *
  * Why this is a warning, not a hard gate: hard-gating would surprise operators
  * mid-flow — they ran `parachute expose public` to expose, not to be told
@@ -17,11 +15,9 @@
  * right shape; the operator decides whether to act now or later. The tunnel is
  * up regardless.
  *
- * The probe still consults `readVaultAuthStatus().hasTotp` (true only when a
- * legacy vault `config.yaml` carries a non-empty `totp_secret`) to suppress the
- * warning for operators who DID set up the legacy vault TOTP — even though it
- * doesn't gate hub login, suppressing avoids nagging them. Once hub-login TOTP
- * (#473) lands with a hub-side column, this reads that instead.
+ * The probe consults `readVaultAuthStatus().hasTotp`, which now reflects the
+ * hub.db `users.totp_secret` column (real hub-login 2FA) — true when any user
+ * has enrolled. The warning fires only when no second factor is configured.
  */
 
 import { type VaultAuthStatus, readVaultAuthStatus } from "../vault/auth-status.ts";
@@ -38,17 +34,20 @@ export interface Public2FAWarningOpts {
 }
 
 /**
- * `true` when `totp_secret` is present and non-empty in vault's config.yaml,
- * `false` otherwise (missing vault, missing config.yaml, empty value).
- *
- * Source-of-truth note: TOTP storage is the vault's, not the hub's. See the
- * module-level doc comment.
+ * `true` when a second factor is configured, `false` otherwise. As of hub#473
+ * this reflects the hub.db `users.totp_secret` column (real hub-login 2FA),
+ * with the legacy vault `config.yaml` `totp_secret` as a fallback for old
+ * installs — see {@link readVaultAuthStatus} and the module-level doc comment.
  */
 export function is2FAEnrolled(
-  opts: { vaultHome?: string; status?: VaultAuthStatus } = {},
+  opts: { vaultHome?: string; hubDbPath?: string; status?: VaultAuthStatus } = {},
 ): boolean {
   const status =
-    opts.status ?? readVaultAuthStatus(opts.vaultHome ? { vaultHome: opts.vaultHome } : {});
+    opts.status ??
+    readVaultAuthStatus({
+      ...(opts.vaultHome ? { vaultHome: opts.vaultHome } : {}),
+      ...(opts.hubDbPath ? { hubDbPath: opts.hubDbPath } : {}),
+    });
   return status.hasTotp;
 }
 
@@ -72,11 +71,14 @@ export function printPublic2FAWarning(opts: Public2FAWarningOpts): boolean {
   log("⚠ /login is now reachable on the public internet");
   log(`  (${opts.publicUrl}/login). Anyone who guesses your password is in.`);
   log("");
-  log("  2FA at the hub login layer is coming (#473) but isn't shipped yet —");
-  log("  for now your owner password is the wall. Make sure it's a strong one:");
+  log("  Turn on two-factor authentication — it adds a second wall (a one-time");
+  log("  code from your authenticator app) on top of your password:");
+  log("");
+  log("    parachute auth 2fa enroll");
+  log("");
+  log("  (Or set it up in the browser at /account/2fa for a scannable QR code.)");
+  log("  Either way, also make sure your owner password is a strong one:");
   log("");
   log("    parachute auth set-password");
-  log("");
-  log("  If a guessable password is a concern, don't expose /login publicly.");
   return true;
 }

--- a/src/commands/expose-auth-preflight.ts
+++ b/src/commands/expose-auth-preflight.ts
@@ -19,16 +19,17 @@
  *
  *   - no owner password: loud warning — the exposure is wide open. Offer to
  *     set a password, and point at the hub-JWT mint path for clients.
- *   - password set: one-line "looks good" + an honest note that hub-login 2FA
- *     isn't shipped yet (#473), so the owner password is the wall.
+ *   - password set, no 2FA: one-line "looks good" + offer to enroll hub-login
+ *     TOTP (real as of hub#473) since the box is now public.
+ *   - password + 2FA set: one-line "looks good, 2FA on."
  *
- * We no longer offer "enable 2FA": `parachute auth 2fa enroll` forwarded to the
- * deprecated vault stub, which post auth-unification exits 1 and (on the old
- * happy path) only wrote vault YAML that never gated hub `/login`. Offering it
- * was a dead path. Real hub-login TOTP is tracked at #473.
+ * `parachute auth 2fa enroll` is the real hub-login TOTP path now (hub#473) —
+ * it gates `/login` for real, so the preflight offers it when the operator has
+ * a password but no second factor.
  *
  * Defaults are always "skip" — Enter declines every prompt. User can always
- * run `parachute auth set-password` / `parachute auth mint-token …` later.
+ * run `parachute auth set-password` / `parachute auth 2fa enroll` /
+ * `parachute auth mint-token …` later.
  */
 
 import { createInterface } from "node:readline/promises";
@@ -114,14 +115,25 @@ async function offerOwnerPassword(r: Resolved): Promise<void> {
 }
 
 /**
- * Honest note that hub-login 2FA isn't shipped yet. Replaces the old
- * `offerTotp` (which ran the dead `parachute auth 2fa enroll` path). No prompt —
- * there's nothing actionable to offer until #473 lands.
+ * Offer to enroll hub-login TOTP 2FA (real as of hub#473). Interactive enroll
+ * needs to print a secret + prompt for a confirm code, so we run the real CLI
+ * command inheriting stdio. Declining is fine — the operator can run it later.
  */
-function note2faComing(r: Resolved): void {
+async function offerTotp(r: Resolved): Promise<void> {
   r.log("");
-  r.log("Note: 2FA at the hub login layer is coming (#473) but isn't shipped yet —");
-  r.log("for now the owner password is the wall, so keep it strong.");
+  r.log("Add two-factor authentication? It puts a one-time code (from your");
+  r.log("authenticator app) in front of /login on top of your password.");
+  if (await yesNo(r, "Set up two-factor authentication now?")) {
+    await runCmd(r, ["parachute", "auth", "2fa", "enroll"], "parachute auth 2fa enroll");
+  } else {
+    r.log("");
+    r.log("You can enroll later: `parachute auth 2fa enroll` (or /account/2fa in a browser).");
+  }
+}
+
+/** One-line confirmation that 2FA is already on. */
+function note2faOn(r: Resolved): void {
+  r.log("✓  Two-factor authentication is on.");
 }
 
 /**
@@ -168,33 +180,41 @@ async function handleWideOpen(r: Resolved): Promise<void> {
   // Programmatic-client guidance is informational (no auto-mint) — print it
   // so the operator knows the headless path exists, not the dead pvt_* one.
   printTokenGuidance(r);
-  // Honest 2FA state — coming (#473), not yet shippable.
-  note2faComing(r);
+  // Offer real hub-login 2FA (hub#473) — the box is public now.
+  await offerTotp(r);
   printDivider(r);
 }
 
 /**
- * `password set`: the operator did the obvious thing. One-line confirmation
- * plus the honest 2FA note. (We don't assert on tokens — a hub JWT is minted
- * on demand, not a standing prerequisite.)
+ * `password set, no 2FA`: the operator has a password but no second factor.
+ * One-line confirmation, then offer to enroll TOTP since the box is public.
  */
-function handlePasswordSet(r: Resolved): void {
+async function handlePasswordSetNo2fa(r: Resolved): Promise<void> {
   r.log("");
   r.log("✓  Owner password is set.");
-  note2faComing(r);
+  await offerTotp(r);
+}
+
+/**
+ * `password + 2FA set`: the operator did everything. Two-line confirmation.
+ */
+function handleFullyConfigured(r: Resolved): void {
+  r.log("");
+  r.log("✓  Owner password is set.");
+  note2faOn(r);
 }
 
 /**
  * Pick the branch. Pure function of the status — keeps test coverage trivial.
  *
  * Owner-password-centric since the pvt_* DROP (hub#466): `tokenCount` is no
- * longer consulted — those rows are vestigial and minting access now flows
- * through the owner password, not a standing vault token. 2FA isn't a branch
- * anymore (hub-login TOTP not shipped — #473): two states.
+ * longer consulted. Real hub-login 2FA (hub#473) re-introduces the 2FA branch:
+ * three states — wide-open, password-but-no-2FA, fully-configured.
  */
-function classify(s: VaultAuthStatus): "wide-open" | "password-set" {
+function classify(s: VaultAuthStatus): "wide-open" | "password-no-2fa" | "fully-configured" {
   if (!s.hasOwnerPassword) return "wide-open";
-  return "password-set";
+  if (!s.hasTotp) return "password-no-2fa";
+  return "fully-configured";
 }
 
 export async function runAuthPreflight(opts: AuthPreflightOpts = {}): Promise<void> {
@@ -203,8 +223,11 @@ export async function runAuthPreflight(opts: AuthPreflightOpts = {}): Promise<vo
     case "wide-open":
       await handleWideOpen(r);
       return;
-    case "password-set":
-      handlePasswordSet(r);
+    case "password-no-2fa":
+      await handlePasswordSetNo2fa(r);
+      return;
+    case "fully-configured":
+      handleFullyConfigured(r);
       return;
   }
 }

--- a/src/commands/expose-cloudflare.ts
+++ b/src/commands/expose-cloudflare.ts
@@ -246,8 +246,8 @@ function printAuthGuidance(log: (line: string) => void, vaultUrl: string): void 
   log("");
   log("  Humans (claude.ai / ChatGPT connectors, browser):");
   log("    parachute auth set-password         # set a STRONG owner password");
-  log("    # (hub-login 2FA is coming — #473 — but not shipped yet; the owner");
-  log("    #  password is the wall for now, so make it a good one)");
+  log("    parachute auth 2fa enroll           # add a second factor (recommended)");
+  log("    #  (or set 2FA up in the browser at /account/2fa for a scannable QR)");
   log("    then point your connector at:");
   log(`    ${vaultUrl}`);
   log("");

--- a/src/hub-db.ts
+++ b/src/hub-db.ts
@@ -2,7 +2,8 @@
  * Hub-local SQLite database. Opens `~/.parachute/hub.db` (overridable via
  * `$PARACHUTE_HOME`). Holds everything the hub owns as the ecosystem's OAuth
  * issuer — signing keys (v1), users + opaque refresh tokens (v2), OAuth
- * clients + auth-codes + grants + browser sessions (v3).
+ * clients + auth-codes + grants + browser sessions (v3), and TOTP 2FA
+ * enrollment on the users row (v11, hub#473).
  *
  * Each open() runs `migrate()` to bring the schema up to date. A
  * `schema_version` table records every applied migration so re-opens are
@@ -318,6 +319,43 @@ const MIGRATIONS: readonly Migration[] = [
       FROM users
       WHERE assigned_vault IS NOT NULL;
       ALTER TABLE users DROP COLUMN assigned_vault;
+    `,
+  },
+  {
+    version: 11,
+    sql: `
+      -- Real TOTP 2FA at the hub login layer (hub#473). Three nullable
+      -- columns on \`users\`:
+      --
+      --   * totp_secret (TEXT, nullable) — the base32-encoded RFC 6238 TOTP
+      --     secret. NULL means "2FA not enrolled" — the canonical "is 2FA on
+      --     for this user?" signal. Stored as the plaintext base32 string
+      --     (not encrypted at rest): hub.db already holds the argon2id
+      --     password hashes AND the OAuth signing private keys in plaintext
+      --     PEM (signing_keys.private_key_pem), so the TOTP secret sits at
+      --     the same operator-local trust boundary — encrypting one column
+      --     while leaving the signing key in the clear would be security
+      --     theatre. A future at-rest-encryption pass (hub#474 follow-up)
+      --     would cover all three (password hashes are already one-way; the
+      --     signing key + TOTP secret are the recoverable secrets).
+      --   * totp_backup_codes (TEXT, nullable) — JSON array of argon2id-HASHED
+      --     single-use recovery codes. Same hash family as passwords
+      --     (@node-rs/argon2). Plaintext codes are shown to the user exactly
+      --     once at enrollment and never stored. A code is removed from the
+      --     array when consumed. NULL / "[]" means "no backup codes left."
+      --   * totp_enrolled_at (TEXT, nullable) — ISO-8601 timestamp of the
+      --     last successful enrollment. NULL until first enroll; informational
+      --     (admin UI / account page "2FA enabled since …").
+      --
+      -- Backfill: every existing user pre-dates this migration and gets NULL
+      -- for all three — i.e. "2FA not enrolled." Their /login flow stays
+      -- password-only (the login handler only requires a TOTP step when
+      -- totp_secret IS NOT NULL), so existing operators keep signing in
+      -- exactly as before. No backfill UPDATE needed — the column default is
+      -- NULL.
+      ALTER TABLE users ADD COLUMN totp_secret TEXT;
+      ALTER TABLE users ADD COLUMN totp_backup_codes TEXT;
+      ALTER TABLE users ADD COLUMN totp_enrolled_at TEXT;
     `,
   },
 ];

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -67,11 +67,16 @@
  *   /api/users/<id>               (DELETE)     → hard-delete user + revoke tokens (host:admin)
  *   /api/users/<id>/reset-password (POST)      → admin-initiated password reset (host:admin)
  *   /login                        (GET + POST) → operator password login
+ *   /login/2fa                    (POST)       → second-factor (TOTP/backup) step
+ *                                                 (hub#473; reached after a correct
+ *                                                 password for a 2FA-enrolled user)
  *   /logout                       (POST)       → end admin session
  *   /account/change-password      (GET + POST) → user self-service change-password
  *                                                 (force-redirect target for users
  *                                                 with password_changed=false; also
  *                                                 reachable directly to rotate)
+ *   /account/2fa                  (GET + POST) → user self-service 2FA enroll/disenroll
+ *                                                 (hub#473; QR + backup codes)
  *   /admin/config*                             → 301 → /admin/vaults (legacy
  *                                                portal retired post-SPA-rework)
  *
@@ -113,6 +118,7 @@ import { handleListGrants, handleRevokeGrant } from "./admin-grants.ts";
 import {
   handleAdminLoginGet,
   handleAdminLoginPost,
+  handleAdminLoginTotpPost,
   handleAdminLogoutPost,
 } from "./admin-handlers.ts";
 import { handleHostAdminToken } from "./admin-host-admin-token.ts";
@@ -199,6 +205,7 @@ import {
 } from "./setup-wizard.ts";
 import { getAllPublicKeys } from "./signing-keys.ts";
 import type { Supervisor } from "./supervisor.ts";
+import { handleTwoFactorGet, handleTwoFactorPost } from "./two-factor-handlers.ts";
 import { getUserById, userCount } from "./users.ts";
 import {
   WELL_KNOWN_DIR,
@@ -2029,6 +2036,17 @@ export function hubFetch(
       return new Response("method not allowed", { status: 405 });
     }
 
+    // /login/2fa — second-factor step (hub#473). POST-only: reached only
+    // after a correct password POST for a 2FA-enrolled user handed back a
+    // pending-login cookie + rendered the challenge page. A bare GET (e.g.
+    // browser back button) has no form to render usefully, so 405 → the
+    // operator restarts at /login.
+    if (pathname === "/login/2fa") {
+      if (!getDb) return dbNotConfigured();
+      if (req.method === "POST") return handleAdminLoginTotpPost(getDb(), req);
+      return new Response("method not allowed", { status: 405 });
+    }
+
     if (pathname === "/logout") {
       if (!getDb) return dbNotConfigured();
       if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
@@ -2053,6 +2071,18 @@ export function hubFetch(
       const accountDeps = { db: getDb() };
       if (req.method === "GET") return handleAccountChangePasswordGet(req, accountDeps);
       if (req.method === "POST") return handleAccountChangePasswordPost(req, accountDeps);
+      return new Response("method not allowed", { status: 405 });
+    }
+
+    // /account/2fa — user self-service TOTP 2FA enroll / disenroll (hub#473).
+    // Both GET (render state) and POST (start/confirm/disable) require an
+    // active session; the handler does the session check + 302 to /login when
+    // missing, same posture as /account/change-password.
+    if (pathname === "/account/2fa") {
+      if (!getDb) return dbNotConfigured();
+      const twoFactorDeps = { db: getDb() };
+      if (req.method === "GET") return handleTwoFactorGet(req, twoFactorDeps);
+      if (req.method === "POST") return handleTwoFactorPost(req, twoFactorDeps);
       return new Response("method not allowed", { status: 405 });
     }
 

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -23,6 +23,7 @@
  */
 import type { Database } from "bun:sqlite";
 import { AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
+import { renderTotpChallenge } from "./admin-login-ui.ts";
 import {
   AuthCodeExpiredError,
   AuthCodeNotFoundError,
@@ -65,6 +66,7 @@ import {
   renderUnknownClient,
 } from "./oauth-ui.ts";
 import { isSameOriginRequest } from "./origin-check.ts";
+import { buildPendingLoginCookie, createPendingLogin } from "./pending-login.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
 import { narrowResourceVaultScopes, resolveResourceVault } from "./resource-binding.ts";
 import { isNonRequestableScope, isRequestableScope, scopeIsAdmin } from "./scope-explanations.ts";
@@ -84,6 +86,7 @@ import {
   findSession,
   parseSessionCookie,
 } from "./sessions.ts";
+import { isTotpEnrolled } from "./two-factor-store.ts";
 import { getUserById, getUserByUsername, isFirstAdmin, verifyPassword } from "./users.ts";
 import { listVaultNames } from "./vault-names.ts";
 import { isVaultEntry, shortName, vaultInstanceNameFor } from "./well-known.ts";
@@ -1139,17 +1142,49 @@ async function handleLoginSubmit(
       401,
     );
   }
+
+  // Where to land after a successful sign-in: back at GET /oauth/authorize
+  // with the original query string so the user resumes the OAuth flow on the
+  // consent screen with full params re-validated.
+  const authorizeReturnUrl = buildAuthorizeReturnUrl(params);
+
+  // 2FA gate (hub#473 — security fix). The OAuth login POST is the MORE-common
+  // sign-in path (every OAuth client: vault, notes-ui, `parachute auth login`).
+  // It must enforce the second factor exactly like `/login` does: after the
+  // password verifies, if the user has TOTP enrolled, do NOT mint a session.
+  // Stash a pending-login whose `next` is the FULL /oauth/authorize return URL
+  // (so the post-TOTP redirect resumes the OAuth flow), and render the TOTP
+  // challenge. The challenge form posts to `/login/2fa` — the shared
+  // completion path (`handleAdminLoginTotpPost`) — which verifies the factor,
+  // mints the session, and 302s to the stored `next`. The pending-login cookie
+  // is scoped `Path=/login`, so it rides the `/login/2fa` POST. Without this
+  // gate a 2FA-enrolled user could obtain a full session with password ONLY.
+  if (isTotpEnrolled(db, user.id)) {
+    const pendingToken = createPendingLogin(user.id, authorizeReturnUrl);
+    return htmlResponse(renderTotpChallenge({ next: authorizeReturnUrl, csrfToken }), 200, {
+      "set-cookie": buildPendingLoginCookie(pendingToken, req),
+    });
+  }
+
   const session = createSession(db, { userId: user.id });
   const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000), {
     secure: isHttpsRequest(req),
   });
-  // Redirect back to GET /oauth/authorize with the original query string so
-  // the user lands on the consent screen with full params re-validated.
+  return redirectResponse(authorizeReturnUrl, { "set-cookie": cookie });
+}
+
+/**
+ * Build the `/oauth/authorize?...` return URL (path + query, same-origin) that
+ * a successful sign-in redirects back to so the OAuth flow resumes on the
+ * consent screen. Shared by the password-only path and the post-TOTP path
+ * (the latter via the pending-login's `next`).
+ */
+function buildAuthorizeReturnUrl(params: AuthorizeFormParams): string {
   const u = new URL("/oauth/authorize", "http://placeholder");
   for (const [k, v] of Object.entries(authorizeParamsToQuery(params))) {
     u.searchParams.set(k, v);
   }
-  return redirectResponse(`${u.pathname}${u.search}`, { "set-cookie": cookie });
+  return `${u.pathname}${u.search}`;
 }
 
 async function handleConsentSubmit(

--- a/src/pending-login.ts
+++ b/src/pending-login.ts
@@ -1,0 +1,116 @@
+/**
+ * Pending-login state for the two-step TOTP login (hub#473).
+ *
+ * When a user with 2FA enrolled posts a correct username+password to `/login`,
+ * we do NOT mint a session yet — the user still has to prove the second
+ * factor. We stash the half-authenticated state under an opaque token and hand
+ * the browser a short-lived `parachute_hub_pending_login` cookie. The user
+ * then posts their TOTP / backup code to `/login/2fa`, which looks up the
+ * pending state, verifies the factor, and only then mints the real session.
+ *
+ * Storage: a process-local Map with per-entry expiry — same posture as the
+ * rate-limiter (`rate-limit.ts`). Persistence isn't worth a DB write: the
+ * window is 5 minutes, and a process restart simply forces the user to
+ * re-enter their password (the password POST is cheap to repeat, and losing
+ * an in-flight half-login on restart is fine — no security regression). This
+ * also avoids a second schema migration for a 5-minute-lived ephemeral row.
+ *
+ * The token is a 32-byte base64url random (same shape as a session id), so it
+ * is unguessable and opaque to the client. It carries no claims — everything
+ * is server-side in the Map.
+ */
+import { randomBytes } from "node:crypto";
+import { isHttpsRequest } from "./request-protocol.ts";
+
+export const PENDING_LOGIN_COOKIE_NAME = "parachute_hub_pending_login";
+/** Pending logins are valid for 5 minutes — long enough to open an
+ *  authenticator app, short enough to bound a half-authenticated window. */
+export const PENDING_LOGIN_TTL_MS = 5 * 60 * 1000;
+
+interface PendingLogin {
+  userId: string;
+  /** The post-2FA redirect target resolved at password-verify time. */
+  next: string;
+  /** Absolute expiry (ms epoch). */
+  expiresAtMs: number;
+}
+
+const pending = new Map<string, PendingLogin>();
+
+function gc(nowMs: number): void {
+  for (const [token, p] of pending) {
+    if (p.expiresAtMs <= nowMs) pending.delete(token);
+  }
+}
+
+/**
+ * Create a pending-login entry and return its opaque token. The caller sets
+ * the token as a cookie on the "enter your code" response.
+ */
+export function createPendingLogin(
+  userId: string,
+  next: string,
+  now: () => Date = () => new Date(),
+): string {
+  const nowMs = now().getTime();
+  gc(nowMs);
+  const token = randomBytes(32).toString("base64url");
+  pending.set(token, { userId, next, expiresAtMs: nowMs + PENDING_LOGIN_TTL_MS });
+  return token;
+}
+
+/**
+ * Resolve a pending-login token to its state, or null if absent/expired.
+ * Does NOT consume — the caller consumes only after the second factor
+ * verifies (so a failed 2FA attempt can retry against the same pending login
+ * without re-entering the password).
+ */
+export function getPendingLogin(
+  token: string | null,
+  now: () => Date = () => new Date(),
+): { userId: string; next: string } | null {
+  if (!token) return null;
+  const nowMs = now().getTime();
+  gc(nowMs);
+  const p = pending.get(token);
+  if (!p) return null;
+  if (p.expiresAtMs <= nowMs) {
+    pending.delete(token);
+    return null;
+  }
+  return { userId: p.userId, next: p.next };
+}
+
+/** Delete a pending-login entry (after successful 2FA, or on cancel). Idempotent. */
+export function consumePendingLogin(token: string | null): void {
+  if (token) pending.delete(token);
+}
+
+/** Test-only: clear all pending logins between cases. */
+export function _resetPendingLogins(): void {
+  pending.clear();
+}
+
+export function buildPendingLoginCookie(token: string, req: Request): string {
+  const parts = [`${PENDING_LOGIN_COOKIE_NAME}=${token}`, "HttpOnly"];
+  if (isHttpsRequest(req)) parts.push("Secure");
+  // Path=/login so the cookie only rides /login and /login/2fa requests.
+  parts.push("SameSite=Lax", "Path=/login", `Max-Age=${Math.floor(PENDING_LOGIN_TTL_MS / 1000)}`);
+  return parts.join("; ");
+}
+
+export function buildPendingLoginClearCookie(req: Request): string {
+  const parts = [`${PENDING_LOGIN_COOKIE_NAME}=`, "HttpOnly"];
+  if (isHttpsRequest(req)) parts.push("Secure");
+  parts.push("SameSite=Lax", "Path=/login", "Max-Age=0");
+  return parts.join("; ");
+}
+
+export function parsePendingLoginCookie(cookieHeader: string | null): string | null {
+  if (!cookieHeader) return null;
+  for (const part of cookieHeader.split(";")) {
+    const [name, ...rest] = part.trim().split("=");
+    if (name === PENDING_LOGIN_COOKIE_NAME) return rest.join("=");
+  }
+  return null;
+}

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -81,6 +81,18 @@ export const CHANGE_PASSWORD_WINDOW_MS = 5 * 60 * 1000;
  * cookie attacker shouldn't get a 5-shot grind window.
  */
 export const CHANGE_PASSWORD_MAX_ATTEMPTS = 3;
+/**
+ * `/login/2fa` window length: 15 minutes — same as `/login`. The second-
+ * factor step (hub#473) sits behind a verified password + a short-lived
+ * pending-login token, so the threat model is "attacker who already has the
+ * password grinding 6-digit codes / backup codes." A 5-attempt / 15-min
+ * bucket per IP turns 10^6-space TOTP grinding into "rotate IPs," same floor
+ * as `/login`. Keyed by IP (the pending-login token is short-lived and an
+ * attacker could mint many, so IP is the stable actor key here).
+ */
+export const TOTP_WINDOW_MS = 15 * 60 * 1000;
+/** `/login/2fa` attempts allowed per window. 6th within the window is denied. */
+export const TOTP_MAX_ATTEMPTS = 5;
 /** Sentinel for the IP-extraction priority chain when nothing parsed. */
 export const UNKNOWN_IP_SENTINEL = "unknown";
 
@@ -198,6 +210,15 @@ export const changePasswordRateLimiter = new RateLimiter(
 );
 
 /**
+ * `/login/2fa` rate limiter — per-IP, 5 attempts / 15 min (hub#473). Bounds
+ * second-factor grinding by an attacker who already has the password. Separate
+ * bucket from `/login` so a password failure and a TOTP failure don't share a
+ * window — but both are per-IP so rotating egress IPs is the only escape, same
+ * as the password floor.
+ */
+export const totpRateLimiter = new RateLimiter(TOTP_MAX_ATTEMPTS, TOTP_WINDOW_MS);
+
+/**
  * Backwards-compat shim for hub#188's call sites: the original
  * top-level `checkAndRecord` was the login limiter. New code should
  * reach into `loginRateLimiter.checkAndRecord` directly.
@@ -215,6 +236,7 @@ export function checkAndRecord(key: string, now: Date): RateLimitResult {
 export function __resetForTests(): void {
   loginRateLimiter.reset();
   changePasswordRateLimiter.reset();
+  totpRateLimiter.reset();
 }
 
 /**

--- a/src/totp.ts
+++ b/src/totp.ts
@@ -1,0 +1,201 @@
+import { createHash } from "node:crypto";
+/**
+ * TOTP (RFC 6238) primitives + single-use backup codes for hub-login 2FA
+ * (hub#473). The pure crypto layer — no DB, no HTTP. The persistence layer
+ * (`two-factor-store.ts`) reads/writes these against `users` in hub.db; the
+ * login + enroll handlers compose both.
+ *
+ * Approach ported from `parachute-vault/src/two-factor.ts` (the deprecated
+ * vault impl), with two deliberate hub-side changes:
+ *
+ *   - Storage is hub.db's `users` row, not vault's `config.yaml`. That lives
+ *     in `two-factor-store.ts`; this file stays storage-agnostic.
+ *   - Backup codes are hashed with **argon2id** (`@node-rs/argon2`), the same
+ *     hasher hub uses for passwords (`users.ts`), rather than vault's bcrypt.
+ *     One hash family across the hub keeps the dependency surface minimal and
+ *     matches the brief ("same hash as passwords").
+ *
+ * TOTP parameters (interop default — what Google Authenticator / 1Password /
+ * Authy expect): SHA-1, 6 digits, 30s period. Validation accepts a ±1 window
+ * (≈90s effective tolerance) for clock drift. A given (secret, counter) is
+ * single-use within its acceptance lifetime — replays inside the window are
+ * rejected via an in-memory cache.
+ */
+import { hash as argonHash, verify as argonVerify } from "@node-rs/argon2";
+import * as OTPAuth from "otpauth";
+
+/** Issuer label shown in the authenticator app + encoded in the otpauth URI. */
+export const TOTP_ISSUER = "Parachute Hub";
+/** Number of single-use backup codes minted per enrollment. */
+export const BACKUP_CODE_COUNT = 10;
+/** Length (characters) of each backup code. */
+const BACKUP_CODE_LENGTH = 10;
+/** TOTP secret size in bytes (20 = 160 bits, the RFC 6238 / RFC 4226 default). */
+const TOTP_SECRET_BYTES = 20;
+
+function makeTotp(secretBase32: string, label: string): OTPAuth.TOTP {
+  return new OTPAuth.TOTP({
+    issuer: TOTP_ISSUER,
+    label,
+    algorithm: "SHA1",
+    digits: 6,
+    period: 30,
+    secret: OTPAuth.Secret.fromBase32(secretBase32),
+  });
+}
+
+export interface GeneratedSecret {
+  /** Base32-encoded secret — show to the user for manual authenticator entry. */
+  secret: string;
+  /** `otpauth://totp/...` URI — encode as a QR code for scanning. */
+  otpauthUrl: string;
+}
+
+/**
+ * Generate a fresh TOTP secret + its `otpauth://` provisioning URI. `label`
+ * is the account label rendered in the authenticator app (typically the
+ * username). Does NOT persist anything — the caller stores the returned
+ * `secret` only after the user confirms a code (proving the authenticator
+ * was set up correctly).
+ */
+export function generateTotpSecret(label: string): GeneratedSecret {
+  const secret = new OTPAuth.Secret({ size: TOTP_SECRET_BYTES }).base32;
+  const totp = makeTotp(secret, label);
+  return { secret, otpauthUrl: totp.toString() };
+}
+
+/** Build the `otpauth://` URI for an existing secret (e.g. re-display during enroll). */
+export function otpauthUrlFor(secretBase32: string, label: string): string {
+  return makeTotp(secretBase32, label).toString();
+}
+
+/**
+ * In-memory cache of recently-used TOTP counters, to reject replay inside the
+ * ±1 acceptance window. Key = "sha256(secret):counter"; value = expiry ms.
+ * Bounded — entries auto-expire ~2 min after their window closes. Process-
+ * local (a restart clears it, which is itself fine: the window is 90s).
+ */
+const usedTotpCounters = new Map<string, number>();
+
+function gcUsedTotp(now: number): void {
+  for (const [k, exp] of usedTotpCounters) {
+    if (exp < now) usedTotpCounters.delete(k);
+  }
+}
+
+/**
+ * Verify a 6-digit TOTP code against `secretBase32`. Accepts ±1 window
+ * (prev / current / next 30s period). A given (secret, counter) is single-use
+ * within its acceptance lifetime — replays are rejected.
+ *
+ * `markUsed`: set false in tests that want to verify the same code twice.
+ * Defaults to true in production so a captured code can't be replayed inside
+ * its ~90s validity window.
+ */
+export function verifyTotpCode(secretBase32: string, code: string, markUsed = true): boolean {
+  const trimmed = code.trim().replace(/\s+/g, "");
+  if (!/^\d{6}$/.test(trimmed)) return false;
+  try {
+    const totp = makeTotp(secretBase32, "owner");
+    const delta = totp.validate({ token: trimmed, window: 1 });
+    if (delta === null) return false;
+
+    const now = Date.now();
+    gcUsedTotp(now);
+    const counter = Math.floor(now / 30_000) + delta;
+    // Hash the secret so the in-memory replay cache never holds the plaintext
+    // TOTP secret as a map key (defense in depth against heap dumps / logs).
+    const secretHash = createHash("sha256").update(secretBase32).digest("hex");
+    const key = `${secretHash}:${counter}`;
+    if (usedTotpCounters.has(key)) return false;
+    if (markUsed) {
+      // Expire the entry a bit after the outer edge of the acceptance window.
+      usedTotpCounters.set(key, now + 120_000);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Test-only: reset the replay-protection cache between cases. */
+export function _resetTotpReplayCache(): void {
+  usedTotpCounters.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Backup codes
+// ---------------------------------------------------------------------------
+
+function randomBackupCode(): string {
+  // Lowercase alphanumeric minus ambiguous glyphs (0/o, 1/l/i). Read-aloud
+  // friendly + unambiguous when typed back in. Formatted as two 5-char groups
+  // (`abcde-fghij`) for legibility; the hyphen is cosmetic and stripped on
+  // verify so the user can type it with or without.
+  const alphabet = "abcdefghjkmnpqrstuvwxyz23456789";
+  const bytes = crypto.getRandomValues(new Uint8Array(BACKUP_CODE_LENGTH));
+  let out = "";
+  for (let i = 0; i < BACKUP_CODE_LENGTH; i++) {
+    out += alphabet[bytes[i]! % alphabet.length];
+    if (i === 4) out += "-";
+  }
+  return out;
+}
+
+/** Normalize a backup code for hashing / comparison: lowercase, no whitespace, no hyphens. */
+export function normalizeBackupCode(code: string): string {
+  return code
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "");
+}
+
+export interface GeneratedBackupCodes {
+  /** Plaintext codes to show the user ONCE (hyphenated for display). */
+  codes: string[];
+  /** argon2id hashes of the normalized codes — what gets stored. */
+  hashes: string[];
+}
+
+/**
+ * Generate {@link BACKUP_CODE_COUNT} fresh backup codes + their argon2id
+ * hashes. The plaintext `codes` are displayed once at enrollment; only the
+ * `hashes` are persisted (as a JSON array). Each code is hashed in its
+ * normalized form so display-formatting (hyphen) never affects verification.
+ */
+export async function generateBackupCodes(): Promise<GeneratedBackupCodes> {
+  const codes: string[] = [];
+  const hashes: string[] = [];
+  for (let i = 0; i < BACKUP_CODE_COUNT; i++) {
+    const code = randomBackupCode();
+    codes.push(code);
+    hashes.push(await argonHash(normalizeBackupCode(code)));
+  }
+  return { codes, hashes };
+}
+
+/**
+ * Check a submitted backup code against a stored hash list. Returns the
+ * **index** of the matching hash (so the caller can splice it out and persist
+ * the shorter list — single-use consumption), or `-1` for no match.
+ *
+ * Pure: does NOT mutate the input list or persist anything. Consumption +
+ * persistence is the store layer's job (`two-factor-store.ts`), which holds
+ * the DB transaction so verify-then-consume is atomic against concurrent
+ * login attempts.
+ */
+export async function findBackupCodeIndex(
+  code: string,
+  hashes: readonly string[],
+): Promise<number> {
+  const normalized = normalizeBackupCode(code);
+  if (!normalized) return -1;
+  for (let i = 0; i < hashes.length; i++) {
+    try {
+      if (await argonVerify(hashes[i]!, normalized)) return i;
+    } catch {
+      // Corrupt / non-argon hash — skip.
+    }
+  }
+  return -1;
+}

--- a/src/two-factor-handlers.ts
+++ b/src/two-factor-handlers.ts
@@ -1,0 +1,280 @@
+/**
+ * `/account/2fa` — user self-service TOTP 2FA enroll / disenroll (hub#473).
+ *
+ *   GET  /account/2fa   — render current state (enrolled → status+disenroll;
+ *                         not enrolled → "set up" CTA).
+ *   POST /account/2fa   — dispatch on the `action` field:
+ *                           start   → generate a secret + render QR/confirm
+ *                           confirm → verify code vs the in-flight secret,
+ *                                     persist enrollment, show backup codes
+ *                           disable → verify current password, clear 2FA
+ *
+ * Auth posture: every endpoint requires an active session (the signed-in user
+ * acts on their OWN account). Same session-or-302-to-/login shape as
+ * `/account/change-password`.
+ *
+ * Enrollment is browser-first (right for headless servers): the secret is
+ * generated server-side, shown as a QR + manual base32 key, and only PERSISTED
+ * after the user confirms a live code (proving the authenticator was set up).
+ * The in-flight secret rides a hidden form field between `start` and `confirm`
+ * — it isn't stored until confirmation, so an abandoned setup leaves no state.
+ *
+ * No JSON layer — server-rendered HTML forms, same as the rest of `/account/*`,
+ * so 2FA setup works without JS.
+ */
+import type { Database } from "bun:sqlite";
+import QRCode from "qrcode";
+import { renderAdminError } from "./admin-login-ui.ts";
+import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
+import { isHttpsRequest } from "./request-protocol.ts";
+import { findActiveSession } from "./sessions.ts";
+import { generateTotpSecret, otpauthUrlFor, verifyTotpCode } from "./totp.ts";
+import {
+  backupCodesRemaining,
+  clearEnrollment,
+  getTotpState,
+  isTotpEnrolled,
+  persistEnrollment,
+} from "./two-factor-store.ts";
+import {
+  renderTwoFactorBackupCodes,
+  renderTwoFactorEnrolled,
+  renderTwoFactorEnrolling,
+  renderTwoFactorNotEnrolled,
+} from "./two-factor-ui.ts";
+import { PASSWORD_MAX_LEN, type User, getUserById, verifyPassword } from "./users.ts";
+
+export interface TwoFactorDeps {
+  db: Database;
+  /** Test seam — defaults to real clock. */
+  now?: () => Date;
+}
+
+function htmlResponse(body: string, status = 200, extra: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/html; charset=utf-8", ...extra },
+  });
+}
+
+function redirect(location: string, extra: Record<string, string> = {}): Response {
+  return new Response(null, { status: 302, headers: { location, ...extra } });
+}
+
+/** Resolve the signed-in user, or a Response to return (302 / 401). */
+function requireUser(deps: TwoFactorDeps, req: Request): { user: User } | { response: Response } {
+  const session = findActiveSession(deps.db, req);
+  if (!session) {
+    return { response: redirect(`/login?next=${encodeURIComponent("/account/2fa")}`) };
+  }
+  const user = getUserById(deps.db, session.userId);
+  if (!user) {
+    return { response: redirect("/login") };
+  }
+  return { user };
+}
+
+/** Render the QR SVG for a secret + the enrolling page. */
+async function renderEnrolling(
+  csrfToken: string,
+  secret: string,
+  label: string,
+  errorMessage?: string,
+): Promise<Response> {
+  const otpauthUrl = otpauthUrlFor(secret, label);
+  // Inline SVG — self-contained, no external fetch (privacy posture).
+  const qrSvg = await QRCode.toString(otpauthUrl, {
+    type: "svg",
+    margin: 0,
+    errorCorrectionLevel: "M",
+  });
+  return htmlResponse(
+    renderTwoFactorEnrolling({
+      csrfToken,
+      qrSvg,
+      secret,
+      ...(errorMessage ? { errorMessage } : {}),
+    }),
+  );
+}
+
+/**
+ * GET /account/2fa — render the current 2FA state for the signed-in user.
+ */
+export function handleTwoFactorGet(req: Request, deps: TwoFactorDeps): Response {
+  const got = requireUser(deps, req);
+  if ("response" in got) return got.response;
+  const user = got.user;
+
+  const csrf = ensureCsrfToken(req);
+  const extra: Record<string, string> = csrf.setCookie ? { "set-cookie": csrf.setCookie } : {};
+
+  if (isTotpEnrolled(deps.db, user.id)) {
+    const state = getTotpState(deps.db, user.id);
+    return htmlResponse(
+      renderTwoFactorEnrolled({
+        csrfToken: csrf.token,
+        enrolledAt: state.enrolledAt,
+        backupCodesRemaining: state.backupCodes.length,
+      }),
+      200,
+      extra,
+    );
+  }
+  // `?disabled=1` — the disenroll POST 302s here so a refresh doesn't re-POST;
+  // surface a one-line confirmation on the not-enrolled page.
+  const disabled = new URL(req.url).searchParams.get("disabled") === "1";
+  return htmlResponse(
+    renderTwoFactorNotEnrolled({
+      csrfToken: csrf.token,
+      ...(disabled ? { notice: "Two-factor authentication has been turned off." } : {}),
+    }),
+    200,
+    extra,
+  );
+}
+
+/**
+ * POST /account/2fa — dispatch on `action`.
+ */
+export async function handleTwoFactorPost(req: Request, deps: TwoFactorDeps): Promise<Response> {
+  const got = requireUser(deps, req);
+  if ("response" in got) {
+    // For a POST without a session, a 302 to /login is fine (browser will
+    // follow with the form lost, which is acceptable — re-auth, then retry).
+    return got.response;
+  }
+  const user = got.user;
+
+  const form = await req.formData();
+  const formCsrf = form.get(CSRF_FIELD_NAME);
+  const csrfToken = typeof formCsrf === "string" ? formCsrf : "";
+  if (!verifyCsrfToken(req, csrfToken || null)) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Invalid form submission",
+        message: "The form's CSRF token did not match. Reload the page and try again.",
+      }),
+      400,
+    );
+  }
+
+  const action = String(form.get("action") ?? "");
+
+  // --- start: generate a secret, render QR + confirm form ---------------
+  if (action === "start") {
+    // Refuse to start a fresh enrollment if already enrolled — disenroll
+    // first. Prevents accidentally clobbering a working setup.
+    if (isTotpEnrolled(deps.db, user.id)) {
+      return htmlResponse(
+        renderTwoFactorEnrolled({
+          csrfToken,
+          enrolledAt: getTotpState(deps.db, user.id).enrolledAt,
+          backupCodesRemaining: backupCodesRemaining(deps.db, user.id),
+          errorMessage: "Two-factor is already enabled. Turn it off first to re-enroll.",
+        }),
+        409,
+      );
+    }
+    const { secret } = generateTotpSecret(user.username);
+    return renderEnrolling(csrfToken, secret, user.username);
+  }
+
+  // --- confirm: verify code vs the in-flight secret, persist ------------
+  if (action === "confirm") {
+    const secret = String(form.get("secret") ?? "");
+    const code = String(form.get("code") ?? "");
+    if (!secret) {
+      // Lost the in-flight secret (stale form) — restart enrollment.
+      return htmlResponse(
+        renderTwoFactorNotEnrolled({
+          csrfToken,
+          errorMessage: "Setup expired. Please start again.",
+        }),
+        400,
+      );
+    }
+    // Defensive: someone POSTing confirm for an already-enrolled account.
+    if (isTotpEnrolled(deps.db, user.id)) {
+      return htmlResponse(
+        renderTwoFactorEnrolled({
+          csrfToken,
+          enrolledAt: getTotpState(deps.db, user.id).enrolledAt,
+          backupCodesRemaining: backupCodesRemaining(deps.db, user.id),
+          errorMessage: "Two-factor is already enabled.",
+        }),
+        409,
+      );
+    }
+    if (!verifyTotpCode(secret, code)) {
+      return renderEnrolling(
+        csrfToken,
+        secret,
+        user.username,
+        "That code didn't match. Make sure your device clock is correct and try the current code.",
+      );
+    }
+    const result = await persistEnrollment(
+      deps.db,
+      user.id,
+      secret,
+      deps.now ?? (() => new Date()),
+    );
+    // Show the backup codes ONCE. Setting no-store so the browser doesn't
+    // cache the page with the plaintext codes in it.
+    return htmlResponse(renderTwoFactorBackupCodes({ codes: result.backupCodes }), 200, {
+      "cache-control": "no-store",
+    });
+  }
+
+  // --- disable: verify current password, clear 2FA ----------------------
+  if (action === "disable") {
+    if (!isTotpEnrolled(deps.db, user.id)) {
+      // Already off — render the not-enrolled page (idempotent).
+      return htmlResponse(
+        renderTwoFactorNotEnrolled({
+          csrfToken,
+          notice: "Two-factor authentication is already off.",
+        }),
+      );
+    }
+    const password = String(form.get("password") ?? "");
+    const state = getTotpState(deps.db, user.id);
+    const renderEnrolledError = (msg: string, status: number): Response =>
+      htmlResponse(
+        renderTwoFactorEnrolled({
+          csrfToken,
+          enrolledAt: state.enrolledAt,
+          backupCodesRemaining: state.backupCodes.length,
+          errorMessage: msg,
+        }),
+        status,
+      );
+    if (!password) {
+      return renderEnrolledError("Enter your current password to turn off two-factor.", 400);
+    }
+    // Cap before argon2id verify (CPU-DoS guard — same posture as /login).
+    if (password.length > PASSWORD_MAX_LEN) {
+      return renderEnrolledError(`Password must be ≤ ${PASSWORD_MAX_LEN} characters.`, 413);
+    }
+    const ok = await verifyPassword(user, password);
+    if (!ok) {
+      return renderEnrolledError("That password is incorrect.", 401);
+    }
+    clearEnrollment(deps.db, user.id, deps.now ?? (() => new Date()));
+    // Redirect to the GET so a refresh doesn't re-POST. The not-enrolled
+    // page renders the success notice via a query flag.
+    return redirect("/account/2fa?disabled=1", {
+      "cache-control": "no-store",
+      "x-secure-context": isHttpsRequest(req) ? "https" : "http",
+    });
+  }
+
+  return htmlResponse(
+    renderAdminError({
+      title: "Unknown action",
+      message: "That two-factor action isn't recognized. Reload the page and try again.",
+    }),
+    400,
+  );
+}

--- a/src/two-factor-handlers.ts
+++ b/src/two-factor-handlers.ts
@@ -184,8 +184,15 @@ export async function handleTwoFactorPost(req: Request, deps: TwoFactorDeps): Pr
   if (action === "confirm") {
     const secret = String(form.get("secret") ?? "");
     const code = String(form.get("code") ?? "");
-    if (!secret) {
-      // Lost the in-flight secret (stale form) — restart enrollment.
+    // Validate the in-flight secret format before it reaches verifyTotpCode /
+    // persistEnrollment (N1 — cheap defense in depth). The secret is a
+    // server-minted base32 string round-tripped through a hidden form field;
+    // it's session-gated + CSRF'd, but a malformed value (truncated paste,
+    // hand-crafted POST) should be rejected explicitly rather than stored.
+    // base32 alphabet (A–Z, 2–7) + optional `=` padding, ≥16 chars (our secret
+    // is 20 bytes → 32 base32 chars; 16 is a conservative floor).
+    if (!secret || !/^[A-Z2-7]+=*$/i.test(secret) || secret.length < 16) {
+      // Lost / malformed in-flight secret (stale form, bad paste) — restart.
       return htmlResponse(
         renderTwoFactorNotEnrolled({
           csrfToken,

--- a/src/two-factor-store.ts
+++ b/src/two-factor-store.ts
@@ -1,0 +1,181 @@
+/**
+ * Persistence for hub-login TOTP 2FA (hub#473). Reads/writes the three
+ * `users` columns added in migration v11: `totp_secret`, `totp_backup_codes`
+ * (JSON array of argon2id hashes), `totp_enrolled_at`.
+ *
+ * The pure crypto lives in `totp.ts`; this is the storage seam. The login +
+ * enroll handlers compose both. Backup-code consumption is done here inside a
+ * DB transaction so verify-then-remove is atomic against concurrent login
+ * POSTs (two requests can't both consume the same code).
+ */
+import type { Database } from "bun:sqlite";
+import { findBackupCodeIndex, generateBackupCodes, verifyTotpCode } from "./totp.ts";
+
+export interface TotpState {
+  /** Base32 secret, or null if 2FA isn't enrolled for this user. */
+  secret: string | null;
+  /** argon2id hashes of the remaining single-use backup codes. */
+  backupCodes: string[];
+  /** ISO-8601 enrollment timestamp, or null. */
+  enrolledAt: string | null;
+}
+
+interface TotpRow {
+  totp_secret: string | null;
+  totp_backup_codes: string | null;
+  totp_enrolled_at: string | null;
+}
+
+function parseBackupCodes(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((c): c is string => typeof c === "string");
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read a user's TOTP state. Returns `secret: null` (not enrolled) when the
+ * row is missing — callers treat "no row" identically to "not enrolled."
+ */
+export function getTotpState(db: Database, userId: string): TotpState {
+  const row = db
+    .query<TotpRow, [string]>(
+      "SELECT totp_secret, totp_backup_codes, totp_enrolled_at FROM users WHERE id = ?",
+    )
+    .get(userId);
+  if (!row) return { secret: null, backupCodes: [], enrolledAt: null };
+  return {
+    secret: row.totp_secret && row.totp_secret.length > 0 ? row.totp_secret : null,
+    backupCodes: parseBackupCodes(row.totp_backup_codes),
+    enrolledAt: row.totp_enrolled_at,
+  };
+}
+
+/** Cheap "is 2FA on for this user?" check — true iff a non-empty secret is stored. */
+export function isTotpEnrolled(db: Database, userId: string): boolean {
+  return getTotpState(db, userId).secret !== null;
+}
+
+/** Number of unused backup codes remaining for a user. */
+export function backupCodesRemaining(db: Database, userId: string): number {
+  return getTotpState(db, userId).backupCodes.length;
+}
+
+export interface EnrollResult {
+  /** Plaintext backup codes — show ONCE; never retrievable after. */
+  backupCodes: string[];
+  /** Enrollment timestamp persisted on the row. */
+  enrolledAt: string;
+}
+
+/**
+ * Persist a confirmed enrollment: store the (already-verified) secret, mint +
+ * store a fresh set of backup-code hashes, stamp `totp_enrolled_at`. Returns
+ * the plaintext backup codes for one-time display. Overwrites any prior
+ * enrollment (re-enroll rotates the secret + codes).
+ *
+ * The caller MUST have verified a live code against `secret` before calling
+ * this (proves the authenticator was provisioned correctly). The async hash
+ * happens before the write (single statement, no transaction needed).
+ */
+export async function persistEnrollment(
+  db: Database,
+  userId: string,
+  secret: string,
+  now: () => Date = () => new Date(),
+): Promise<EnrollResult> {
+  const { codes, hashes } = await generateBackupCodes();
+  const enrolledAt = now().toISOString();
+  const result = db
+    .prepare(
+      `UPDATE users
+         SET totp_secret = ?, totp_backup_codes = ?, totp_enrolled_at = ?, updated_at = ?
+       WHERE id = ?`,
+    )
+    .run(secret, JSON.stringify(hashes), enrolledAt, enrolledAt, userId);
+  if (result.changes === 0) {
+    throw new Error(`persistEnrollment: no user row for id ${userId}`);
+  }
+  return { backupCodes: codes, enrolledAt };
+}
+
+/** Clear all TOTP state for a user (disenroll). Idempotent. */
+export function clearEnrollment(
+  db: Database,
+  userId: string,
+  now: () => Date = () => new Date(),
+): void {
+  const stamp = now().toISOString();
+  db.prepare(
+    `UPDATE users
+       SET totp_secret = NULL, totp_backup_codes = NULL, totp_enrolled_at = NULL, updated_at = ?
+     WHERE id = ?`,
+  ).run(stamp, userId);
+}
+
+export type SecondFactorResult =
+  | { ok: true; via: "totp" }
+  | { ok: true; via: "backup_code" }
+  | { ok: false };
+
+/**
+ * Verify a submitted second factor for a user during login. Tries the TOTP
+ * code first; if that fails, tries each stored backup code. On a backup-code
+ * match the code is **consumed** — removed from the stored list inside a
+ * transaction so a concurrent login can't reuse it.
+ *
+ * Returns which factor succeeded (for logging / "X backup codes left"
+ * messaging) or `{ ok: false }`. A user who isn't enrolled returns `ok:false`
+ * — but the login handler only reaches this when `totp_secret` is set, so that
+ * path is defensive.
+ *
+ * `markUsed` is forwarded to {@link verifyTotpCode}'s replay cache (tests set
+ * false to reuse a code; production leaves it true).
+ */
+export async function verifySecondFactor(
+  db: Database,
+  userId: string,
+  submitted: string,
+  markUsed = true,
+): Promise<SecondFactorResult> {
+  const state = getTotpState(db, userId);
+  if (!state.secret) return { ok: false };
+
+  const code = submitted.trim();
+  if (!code) return { ok: false };
+
+  // TOTP path: a 6-digit numeric is almost certainly a TOTP attempt. Try it
+  // first (cheap, no DB write on success beyond the in-memory replay cache).
+  if (verifyTotpCode(state.secret, code, markUsed)) {
+    return { ok: true, via: "totp" };
+  }
+
+  // Backup-code path. Find a matching hash, then consume it transactionally.
+  if (state.backupCodes.length === 0) return { ok: false };
+  const idx = await findBackupCodeIndex(code, state.backupCodes);
+  if (idx < 0) return { ok: false };
+
+  // Consume inside a transaction: re-read the stored list, confirm the code
+  // we matched is still present (defends against a concurrent login that
+  // consumed it between our read and this write), splice it out, write back.
+  let consumed = false;
+  db.transaction(() => {
+    const fresh = getTotpState(db, userId);
+    // The matched hash (by value) must still be in the current list.
+    const matchedHash = state.backupCodes[idx]!;
+    const freshIdx = fresh.backupCodes.indexOf(matchedHash);
+    if (freshIdx < 0) return; // already consumed by a racing request
+    const remaining = fresh.backupCodes.filter((_, j) => j !== freshIdx);
+    db.prepare("UPDATE users SET totp_backup_codes = ? WHERE id = ?").run(
+      JSON.stringify(remaining),
+      userId,
+    );
+    consumed = true;
+  })();
+
+  return consumed ? { ok: true, via: "backup_code" } : { ok: false };
+}

--- a/src/two-factor-ui.ts
+++ b/src/two-factor-ui.ts
@@ -1,0 +1,462 @@
+/**
+ * Server-rendered HTML for `/account/2fa` — user self-service TOTP 2FA
+ * enroll / disenroll (hub#473). Part of the `/account/*` surface family;
+ * chrome cloned from `account-home-ui.ts` so the family stays cohesive.
+ *
+ * Three render states:
+ *
+ *   - `not-enrolled`: a "Set up two-factor authentication" card with a POST
+ *     button that starts enrollment.
+ *   - `enrolling`: the QR code (inline SVG, no external fetch) + the manual
+ *     base32 key + a confirm-code form. Posting a valid code finalizes.
+ *   - `enrolled`: status (enabled since …, N backup codes left) + a disenroll
+ *     form (requires the current password).
+ *
+ * Plus `backup-codes`: a one-time display of the freshly-minted backup codes
+ * after a successful enroll-confirm — shown ONCE, never retrievable.
+ *
+ * Pure renderer — no DB, no fs. The route handlers in `two-factor-handlers.ts`
+ * resolve the user + state, then call in here.
+ */
+import { WORDMARK_TEXT, brandMarkSvg } from "./brand.ts";
+import { renderCsrfHiddenInput } from "./csrf.ts";
+import { escapeHtml } from "./oauth-ui.ts";
+
+const PALETTE = {
+  bg: "#faf8f4",
+  bgSoft: "#f3f0ea",
+  fg: "#2c2a26",
+  fgMuted: "#6b6860",
+  fgDim: "#9a9690",
+  accent: "#4a7c59",
+  accentHover: "#3d6849",
+  accentSoft: "rgba(74, 124, 89, 0.08)",
+  border: "#e4e0d8",
+  borderLight: "#ece9e2",
+  cardBg: "#ffffff",
+  danger: "#a3392b",
+  dangerSoft: "rgba(163, 57, 43, 0.08)",
+  success: "#3d6849",
+  successSoft: "rgba(61, 104, 73, 0.08)",
+} as const;
+
+const FONT_SERIF = `Georgia, "Times New Roman", serif`;
+const FONT_SANS = `-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`;
+const FONT_MONO = `ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", monospace`;
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}
+
+function baseDocument(title: string, body: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>${escapeHtml(title)}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="referrer" content="no-referrer" />
+  <style>${STYLES}</style>
+</head>
+<body>
+  <main>
+${body}
+  </main>
+</body>
+</html>`;
+}
+
+function header(): string {
+  return `
+        <div class="brand">
+          <span class="brand-mark" aria-hidden="true">${brandMarkSvg(20, "account-2fa")}</span>
+          <span class="brand-name">${WORDMARK_TEXT}</span>
+          <span class="brand-tag">two-factor</span>
+        </div>`;
+}
+
+function errorBanner(msg: string | undefined): string {
+  return msg ? `<p class="error-banner">${escapeHtml(msg)}</p>` : "";
+}
+
+function noticeBanner(msg: string | undefined): string {
+  return msg ? `<p class="notice-banner">${escapeHtml(msg)}</p>` : "";
+}
+
+function shell(title: string, inner: string): string {
+  const body = `
+    <div class="card">
+      <div class="card-header">
+        ${header()}
+        <h1>Two-factor authentication</h1>
+        <p class="subtitle">Protect your hub sign-in with a one-time code from an authenticator app.</p>
+      </div>
+      ${inner}
+      <p class="footer-link"><a href="/account/">← Back to your account</a></p>
+    </div>`;
+  return baseDocument(title, body);
+}
+
+// --- not enrolled ---------------------------------------------------------
+
+export interface NotEnrolledProps {
+  csrfToken: string;
+  errorMessage?: string;
+  notice?: string;
+}
+
+export function renderTwoFactorNotEnrolled(props: NotEnrolledProps): string {
+  const inner = `
+      ${errorBanner(props.errorMessage)}
+      ${noticeBanner(props.notice)}
+      <section class="section">
+        <p class="status status-off"><span class="dot dot-off"></span>Two-factor authentication is <strong>off</strong>.</p>
+        <p>When enabled, signing in will require a 6-digit code from your authenticator
+           app (Google Authenticator, 1Password, Authy, …) in addition to your password.</p>
+        <form method="POST" action="/account/2fa" class="action-form">
+          ${renderCsrfHiddenInput(props.csrfToken)}
+          <input type="hidden" name="action" value="start" />
+          <button type="submit" class="btn btn-primary">Set up two-factor authentication</button>
+        </form>
+      </section>`;
+  return shell("Two-factor authentication — Parachute", inner);
+}
+
+// --- enrolling (show QR + confirm) ----------------------------------------
+
+export interface EnrollingProps {
+  csrfToken: string;
+  /** Inline SVG markup for the otpauth QR code. */
+  qrSvg: string;
+  /** Base32 secret for manual authenticator entry. */
+  secret: string;
+  errorMessage?: string;
+}
+
+export function renderTwoFactorEnrolling(props: EnrollingProps): string {
+  const inner = `
+      ${errorBanner(props.errorMessage)}
+      <section class="section">
+        <p>1. Scan this QR code with your authenticator app:</p>
+        <div class="qr" aria-label="TOTP QR code">${props.qrSvg}</div>
+        <p>Can't scan? Enter this key manually:</p>
+        <div class="copy-row">
+          <code data-testid="totp-secret">${escapeHtml(props.secret)}</code>
+        </div>
+        <p>2. Enter the 6-digit code your app shows to confirm:</p>
+        <form method="POST" action="/account/2fa" class="action-form">
+          ${renderCsrfHiddenInput(props.csrfToken)}
+          <input type="hidden" name="action" value="confirm" />
+          <input type="hidden" name="secret" value="${escapeAttr(props.secret)}" />
+          <label class="field">
+            <span class="field-label">Authentication code</span>
+            <input type="text" name="code" inputmode="numeric" autocomplete="one-time-code"
+                   autofocus required placeholder="123456" />
+          </label>
+          <button type="submit" class="btn btn-primary">Confirm and enable</button>
+        </form>
+      </section>`;
+  return shell("Set up two-factor authentication — Parachute", inner);
+}
+
+// --- backup codes (one-time display) --------------------------------------
+
+export interface BackupCodesProps {
+  codes: string[];
+}
+
+export function renderTwoFactorBackupCodes(props: BackupCodesProps): string {
+  const list = props.codes
+    .map((c) => `<li><code>${escapeHtml(c)}</code></li>`)
+    .join("\n          ");
+  const inner = `
+      <section class="section">
+        <p class="status status-on"><span class="dot dot-on"></span>Two-factor authentication is now <strong>on</strong>.</p>
+        <p class="warn-text"><strong>Save these backup codes now.</strong> Each can be used once to
+           sign in if you lose access to your authenticator app. They are shown only once —
+           store them somewhere safe.</p>
+        <ul class="backup-codes" data-testid="backup-codes">
+          ${list}
+        </ul>
+        <p class="footer-link"><a class="btn btn-secondary" href="/account/2fa">I've saved my codes</a></p>
+      </section>`;
+  return shell("Backup codes — Parachute", inner);
+}
+
+// --- enrolled (status + disenroll) ----------------------------------------
+
+export interface EnrolledProps {
+  csrfToken: string;
+  /** ISO-8601 enrollment timestamp, or null. */
+  enrolledAt: string | null;
+  /** Count of unused backup codes. */
+  backupCodesRemaining: number;
+  errorMessage?: string;
+  notice?: string;
+}
+
+export function renderTwoFactorEnrolled(props: EnrolledProps): string {
+  const since = props.enrolledAt ? ` (since ${escapeHtml(props.enrolledAt.slice(0, 10))})` : "";
+  const inner = `
+      ${errorBanner(props.errorMessage)}
+      ${noticeBanner(props.notice)}
+      <section class="section">
+        <p class="status status-on"><span class="dot dot-on"></span>Two-factor authentication is <strong>on</strong>${since}.</p>
+        <p>You have <strong data-testid="backup-remaining">${props.backupCodesRemaining}</strong>
+           backup code${props.backupCodesRemaining === 1 ? "" : "s"} remaining.</p>
+      </section>
+      <section class="section">
+        <h2>Turn off two-factor authentication</h2>
+        <p>Disabling 2FA removes the second-factor requirement from your sign-in.
+           Enter your current password to confirm.</p>
+        <form method="POST" action="/account/2fa" class="action-form">
+          ${renderCsrfHiddenInput(props.csrfToken)}
+          <input type="hidden" name="action" value="disable" />
+          <label class="field">
+            <span class="field-label">Current password</span>
+            <input type="password" name="password" autocomplete="current-password" required />
+          </label>
+          <button type="submit" class="btn btn-danger">Turn off two-factor authentication</button>
+        </form>
+      </section>`;
+  return shell("Two-factor authentication — Parachute", inner);
+}
+
+// --- styles ---------------------------------------------------------------
+
+const STYLES = `
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: ${FONT_SANS};
+    background: ${PALETTE.bg};
+    color: ${PALETTE.fg};
+    line-height: 1.55;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  main {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 2rem 1.5rem;
+  }
+  .card {
+    width: 100%;
+    max-width: 34rem;
+    background: ${PALETTE.cardBg};
+    border: 1px solid ${PALETTE.border};
+    border-radius: 12px;
+    padding: 2rem 1.75rem;
+    box-shadow: 0 1px 2px rgba(44, 42, 38, 0.04), 0 8px 24px rgba(44, 42, 38, 0.06);
+  }
+  .card-header { margin-bottom: 1.5rem; }
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: ${PALETTE.accent};
+    font-weight: 500;
+    font-size: 0.95rem;
+    margin-bottom: 1.25rem;
+  }
+  .brand-mark { display: inline-flex; line-height: 0; }
+  .brand-mark svg { width: 20px; height: 20px; }
+  .brand-name { letter-spacing: 0.01em; }
+  .brand-tag {
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 0.7rem;
+    color: ${PALETTE.fgMuted};
+    border: 1px solid ${PALETTE.borderLight};
+    padding: 0.05rem 0.4rem;
+    border-radius: 999px;
+  }
+  h1 {
+    font-family: ${FONT_SERIF};
+    font-weight: 400;
+    font-size: 1.6rem;
+    line-height: 1.2;
+    margin: 0 0 0.4rem;
+    color: ${PALETTE.fg};
+  }
+  h2 {
+    font-family: ${FONT_SERIF};
+    font-weight: 400;
+    font-size: 1.15rem;
+    line-height: 1.25;
+    margin: 0 0 0.6rem;
+    color: ${PALETTE.fg};
+  }
+  .subtitle { margin: 0; color: ${PALETTE.fgMuted}; font-size: 0.95rem; }
+
+  .section {
+    border-top: 1px solid ${PALETTE.borderLight};
+    padding-top: 1.25rem;
+    margin-top: 1.25rem;
+  }
+  .section p { margin: 0.5rem 0; }
+
+  .status { font-weight: 500; display: flex; align-items: center; gap: 0.5rem; }
+  .dot { display: inline-block; width: 0.6rem; height: 0.6rem; border-radius: 999px; }
+  .dot-on { background: ${PALETTE.success}; }
+  .dot-off { background: ${PALETTE.fgDim}; }
+  .status-on strong { color: ${PALETTE.success}; }
+
+  .qr {
+    width: 200px;
+    height: 200px;
+    margin: 0.75rem 0;
+    padding: 0.6rem;
+    background: #ffffff;
+    border: 1px solid ${PALETTE.borderLight};
+    border-radius: 8px;
+  }
+  .qr svg { width: 100%; height: 100%; display: block; }
+
+  .copy-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: ${PALETTE.bgSoft};
+    border: 1px solid ${PALETTE.borderLight};
+    border-radius: 6px;
+    padding: 0.5rem 0.6rem;
+    margin: 0.4rem 0 0.75rem;
+  }
+  .copy-row code {
+    flex: 1 1 auto;
+    overflow-x: auto;
+    white-space: nowrap;
+    background: transparent;
+    padding: 0;
+    font-size: 0.95rem;
+    letter-spacing: 0.08em;
+  }
+
+  .backup-codes {
+    list-style: none;
+    margin: 0.75rem 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.5rem;
+  }
+  .backup-codes code {
+    font-size: 0.95rem;
+    letter-spacing: 0.04em;
+    display: block;
+    text-align: center;
+    padding: 0.4rem;
+  }
+  .warn-text {
+    background: ${PALETTE.dangerSoft};
+    border: 1px solid ${PALETTE.danger};
+    border-radius: 6px;
+    color: ${PALETTE.danger};
+    padding: 0.6rem 0.8rem;
+  }
+
+  code {
+    font-family: ${FONT_MONO};
+    background: ${PALETTE.bgSoft};
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.88em;
+  }
+
+  .action-form { display: flex; flex-direction: column; gap: 0.9rem; margin-top: 0.75rem; }
+  .field { display: flex; flex-direction: column; gap: 0.35rem; }
+  .field-label {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: ${PALETTE.fgMuted};
+    letter-spacing: 0.01em;
+    font-family: ${FONT_MONO};
+  }
+  input[type=text], input[type=password] {
+    font: inherit;
+    width: 100%;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid ${PALETTE.border};
+    border-radius: 6px;
+    background: ${PALETTE.bg};
+    color: ${PALETTE.fg};
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  input[type=text]:focus, input[type=password]:focus {
+    outline: none;
+    border-color: ${PALETTE.accent};
+    background: ${PALETTE.cardBg};
+    box-shadow: 0 0 0 3px ${PALETTE.accentSoft};
+  }
+
+  .btn {
+    font: inherit;
+    font-weight: 500;
+    padding: 0.6rem 1.1rem;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    text-decoration: none;
+    display: inline-block;
+    align-self: flex-start;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  }
+  .btn-primary { background: ${PALETTE.accent}; color: ${PALETTE.cardBg}; }
+  .btn-primary:hover { background: ${PALETTE.accentHover}; }
+  .btn-secondary { background: transparent; color: ${PALETTE.fg}; border-color: ${PALETTE.border}; }
+  .btn-secondary:hover { background: ${PALETTE.bgSoft}; border-color: ${PALETTE.accent}; }
+  .btn-danger { background: ${PALETTE.danger}; color: ${PALETTE.cardBg}; }
+  .btn-danger:hover { background: #8a3023; }
+
+  .error-banner {
+    background: ${PALETTE.dangerSoft};
+    border: 1px solid ${PALETTE.danger};
+    border-radius: 6px;
+    color: ${PALETTE.danger};
+    padding: 0.6rem 0.8rem;
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+  }
+  .notice-banner {
+    background: ${PALETTE.successSoft};
+    border: 1px solid ${PALETTE.success};
+    border-radius: 6px;
+    color: ${PALETTE.success};
+    padding: 0.6rem 0.8rem;
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+  }
+
+  .footer-link { margin-top: 1.25rem; }
+  a { color: ${PALETTE.accent}; }
+  a:hover { color: ${PALETTE.accentHover}; }
+
+  @media (max-width: 480px) {
+    main { padding: 1rem 0.75rem; }
+    .card { padding: 1.5rem 1.25rem; border-radius: 10px; }
+    h1 { font-size: 1.4rem; }
+    .backup-codes { grid-template-columns: 1fr; }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    body { background: #1a1815; color: #e8e4dc; }
+    .card { background: #25221d; border-color: #3a362f; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3); }
+    h1, h2 { color: #f0ece4; }
+    .subtitle, .field-label { color: #a8a29a; }
+    code { background: #1f1c18; color: #e8e4dc; }
+    .copy-row { background: #1f1c18; border-color: #3a362f; }
+    .copy-row code { background: transparent; }
+    .section { border-top-color: #3a362f; }
+    .brand-tag { border-color: #3a362f; color: #a8a29a; }
+    input[type=text], input[type=password] {
+      background: #1f1c18; border-color: #3a362f; color: #e8e4dc;
+    }
+    input[type=text]:focus, input[type=password]:focus { background: #25221d; }
+    .btn-secondary { color: #e8e4dc; border-color: #3a362f; }
+    .btn-secondary:hover { background: #1f1c18; border-color: ${PALETTE.accent}; }
+  }
+`;

--- a/src/vault/auth-status.ts
+++ b/src/vault/auth-status.ts
@@ -18,11 +18,12 @@
  *   3. ~/.parachute/vault/data/<name>/vault.db (SQLite) → tokens table
  *      count, summed across every vault instance.
  *
- * The hub.db schema doesn't yet carry a TOTP column (2FA lands in a later
- * phase per the multi-user design doc); we always report `hasTotp: false`
- * when the hub.db path is the source of truth. That matches what's
- * actually shipped — pretending otherwise would whisper "you're covered"
- * when no second factor exists.
+ * As of hub#473 the hub.db `users` table carries TOTP columns
+ * (`totp_secret` et al.) and `/login` enforces a second factor when set, so
+ * `hasTotp` now reflects the hub.db state: true when any user has a non-empty
+ * `totp_secret`. The legacy vault `config.yaml` `totp_secret` (which never
+ * gated hub `/login`) is still read as a fallback for super-old installs whose
+ * hub.db is absent, but real hub-login 2FA is the hub.db signal.
  *
  * The YAML fallback path uses line-anchored regex parsing that matches
  * vault's own `readGlobalConfig()` semantics (parachute-vault src/config.ts):
@@ -99,6 +100,16 @@ export interface AuthStatusOpts {
    * want true "I can sign in" semantics get the OR of hub.db∪YAML.
    */
   probeHubDbHasUserPassword?: (dbPath: string) => boolean | undefined;
+  /**
+   * Probe hub.db for "does at least one user row have a non-empty
+   * `totp_secret`?" — the canonical "real hub-login 2FA is on" signal
+   * (hub#473). Same tri-state semantics as {@link probeHubDbHasUserPassword}:
+   *   - `true`  → at least one user has TOTP enrolled.
+   *   - `false` → hub.db opened cleanly but no user has a secret.
+   *   - `undefined` → hub.db missing / unreadable / column absent (pre-v11);
+   *                   caller falls back to the legacy YAML probe.
+   */
+  probeHubDbHasTotp?: (dbPath: string) => boolean | undefined;
 }
 
 interface Resolved {
@@ -108,6 +119,7 @@ interface Resolved {
   listVaultNames: (dataDir: string) => string[];
   countTokens: (dbPath: string) => number;
   probeHubDbHasUserPassword: (dbPath: string) => boolean | undefined;
+  probeHubDbHasTotp: (dbPath: string) => boolean | undefined;
 }
 
 function defaultVaultHome(): string {
@@ -203,6 +215,39 @@ function defaultProbeHubDbHasUserPassword(dbPath: string): boolean | undefined {
   }
 }
 
+/**
+ * Open hub.db readonly and ask "does at least one user have a non-empty
+ * `totp_secret`?" — the real hub-login 2FA signal (hub#473). Returns
+ * `undefined` on any failure (DB missing, locked, or the `totp_secret` column
+ * absent because migration v11 hasn't applied) — the caller then falls back to
+ * the legacy YAML probe. Readonly open (no migration side effects) mirrors
+ * {@link defaultProbeHubDbHasUserPassword}.
+ */
+function defaultProbeHubDbHasTotp(dbPath: string): boolean | undefined {
+  if (!existsSync(dbPath)) return undefined;
+  const { Database } = require("bun:sqlite");
+  let db: { prepare: (sql: string) => { get: () => unknown }; close: () => void } | undefined;
+  try {
+    db = new Database(dbPath, { readonly: true }) as typeof db;
+    const row = db
+      ?.prepare(
+        "SELECT COUNT(*) AS n FROM users WHERE totp_secret IS NOT NULL AND length(totp_secret) > 0",
+      )
+      .get() as { n: number } | null;
+    return (row?.n ?? 0) > 0;
+  } catch {
+    // Column absent (pre-v11) or DB unreadable — indistinguishable from
+    // "no hub.db"; let the YAML fallback decide.
+    return undefined;
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // ignore
+    }
+  }
+}
+
 function resolve(opts: AuthStatusOpts): Resolved {
   return {
     vaultHome: opts.vaultHome ?? defaultVaultHome(),
@@ -211,6 +256,7 @@ function resolve(opts: AuthStatusOpts): Resolved {
     listVaultNames: opts.listVaultNames ?? defaultListVaultNames,
     countTokens: opts.countTokens ?? defaultCountTokens,
     probeHubDbHasUserPassword: opts.probeHubDbHasUserPassword ?? defaultProbeHubDbHasUserPassword,
+    probeHubDbHasTotp: opts.probeHubDbHasTotp ?? defaultProbeHubDbHasTotp,
   };
 }
 
@@ -262,12 +308,14 @@ function readAuthSignals(r: Resolved): AuthSignals {
   const yaml = readYamlAuth(r);
   const hubDbHasUser = r.probeHubDbHasUserPassword(r.hubDbPath);
   const hasOwnerPassword = hubDbHasUser === true ? true : yaml.hasOwnerPassword;
-  return {
-    hasOwnerPassword,
-    // No hub-side TOTP column shipped yet (multi-user Phase 3). Until it
-    // lands, TOTP is YAML-only — matches what's actually true on disk.
-    hasTotp: yaml.hasTotp,
-  };
+  // Real hub-login 2FA (hub#473): read hub.db's totp_secret. `undefined` (DB
+  // missing / pre-v11 column absent) falls back to the legacy YAML totp_secret
+  // — that one never gated hub `/login`, but suppressing the warning for an
+  // operator who set it avoids nagging. A definitive hub.db `false` (column
+  // present, no user enrolled) overrides a stale YAML true.
+  const hubDbHasTotp = r.probeHubDbHasTotp(r.hubDbPath);
+  const hasTotp = hubDbHasTotp === undefined ? yaml.hasTotp : hubDbHasTotp;
+  return { hasOwnerPassword, hasTotp };
 }
 
 /**


### PR DESCRIPTION
Real TOTP two-factor auth at the hub `/login` layer + single-use backup codes. **Closes #473.** Bumps `0.5.14-rc.12` → `0.5.14-rc.13`.

`/login` is reachable from the public internet (Cloudflare). Until now there was no 2FA — rc.12 made the old `parachute auth 2fa` an honest stub pointing here. This builds the real thing.

## Schema migration (v11)
Adds nullable columns to hub.db `users`:
- `totp_secret` (TEXT, base32 RFC 6238 secret)
- `totp_backup_codes` (TEXT, JSON array of **argon2id-hashed** single-use codes)
- `totp_enrolled_at` (TEXT, ISO-8601)

Existing users backfill to NULL → 2FA off → **their login stays password-only, unchanged.** Migration is append-only via the existing `schema_version` mechanism; applies idempotently on an existing v10 hub.db (covered by a test that builds a v10 DB with a pre-existing user and confirms NULL totp + intact password-only login).

## Enroll (browser-first, headless-friendly)
- **Browser** `/account/2fa` (server-rendered, no JS): start → server generates a secret → shows a **QR code (inline SVG via `qrcode`, no external fetch)** + the manual base32 key → user enters a 6-digit code → server verifies (±1 window) → persists secret + mints **10 backup codes shown once**. Disenroll requires the current password. The secret rides a hidden field between start→confirm and is only persisted after a live code confirms (abandoned setup leaves no state).
- **CLI** `parachute auth 2fa enroll` (replaces the rc.12 stub): prints the `otpauth://` URI + base32 secret as **text** for manual authenticator entry (no QR scan on a server), prompts for the confirm code, prints the backup codes once. Plus `2fa status` and `2fa disenroll`.

## Login TOTP step (two-step)
In `handleAdminLoginPost`, after password verify, if the user has `totp_secret` set we do **not** mint a session — we stash a short-lived (5 min) pending-login (opaque cookie, process-local) and render a "enter your code" page. `POST /login/2fa` verifies a **TOTP code OR a backup code** (backup code consumed single-use, in a DB transaction), then mints the session. Wrong code re-renders the challenge (pending login survives for retry). **Login-flow shape: two-step** (cleaner than a combined form — password page never needs to know 2FA state ahead of time).

## Rate-limiting
New per-IP `totpRateLimiter` (5 attempts / 15 min), gated **before** the factor check, so an attacker who already has the password can't grind TOTP/backup codes. Separate bucket from `/login` but same per-IP floor.

## Account home
`/account/` shows a "Two-factor authentication: On/Off" badge + a Set-up/Manage link to `/account/2fa`.

## Encryption at rest
`totp_secret` is stored as **plaintext base32, NOT encrypted at rest.** hub.db already holds argon2id password hashes AND the OAuth signing **private keys in plaintext PEM** (`signing_keys.private_key_pem`) — encrypting one column while the signing key sits in the clear would be security theatre. The secret sits at the same operator-local trust boundary. **Follow-up:** a single at-rest-encryption pass should cover the recoverable secrets together (signing key + TOTP secret); password/backup-code hashes are already one-way. (Backup codes ARE hashed — argon2id, same as passwords.)

## TOTP library
`otpauth@9.5.1` — vetted RFC 6238 impl, verified Bun-compatible, the same library the old vault impl used. QR rendering via `qrcode@1.5.4` (self-contained SVG, no external fetch). Added `@types/qrcode` (dev).

## Copy cleanup (rc.12 follow-through)
Now that 2FA is real, `expose-2fa-warning`, `expose-auth-preflight`, `expose-cloudflare` guidance, and `vault/auth-status.ts` stop saying "coming (#473)" and point at `parachute auth 2fa enroll` / `/account/2fa`. `hasTotp` now reads hub.db `users.totp_secret` (the real signal), with the legacy vault YAML `totp_secret` as a fallback only when hub.db is absent.

## Gates
- `bun test ./src`: **2415 pass, 0 fail, 1 skip** (102 files).
- `bun run typecheck`: clean.
- `bunx biome check`: changed files clean (4 pre-existing warnings in untouched files).
- SPA not touched (all surfaces server-rendered) → no vitest run needed.
- **Live route-level smoke** through the real `hubFetch` router confirmed: password→challenge (no session)→TOTP→session minted→`/account/2fa` shows enrolled. Verified existing-users-still-login (password-only branch) and backup-code single-use directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)