### PR TITLE
feat(hub): friend /account can mint a scoped vault token (read/write, assignment-gated) (+ rc.16)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.15",
+  "version": "0.5.14-rc.16",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/account-home-ui.test.ts
+++ b/src/__tests__/account-home-ui.test.ts
@@ -262,4 +262,138 @@ describe("renderAccountHome", () => {
     // The escaped vault name also flows into the connect command + endpoint.
     expect(html).toContain("parachute-&lt;vault&gt;");
   });
+
+  // --- friend vault-token mint affordance (the new surface) ----------------
+
+  test("mint affordance — read+write tile offers both verbs, POSTs to the right path", () => {
+    const html = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["work"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+      mintableVerbs: { work: ["read", "write"] },
+    });
+    // The collapsible mint block is present, framed as secondary (headless).
+    expect(html).toContain('data-testid="token-mint"');
+    expect(html).toContain("Mint an access token");
+    expect(html).toContain("for scripts / headless clients");
+    // Both verb radios render.
+    expect(html).toContain('data-testid="mint-verb-read"');
+    expect(html).toContain('data-testid="mint-verb-write"');
+    // Form POSTs to the per-vault endpoint with the CSRF token embedded.
+    expect(html).toContain('action="/account/vault-token/work"');
+    expect(html).toContain('method="POST"');
+    expect(html).toContain('data-testid="mint-form"');
+    expect(html).toContain(CSRF);
+    // Recommends the no-token path as default.
+    expect(html).toContain("no-token");
+  });
+
+  test("mint affordance — a read-only role offers ONLY the read verb", () => {
+    // Today every assignment is write-role, but the renderer is verb-blind to
+    // the role: it shows exactly the verbs it's handed. A read-only cap must
+    // never surface a write radio (the server would reject it anyway).
+    const html = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["work"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+      mintableVerbs: { work: ["read"] },
+    });
+    expect(html).toContain('data-testid="mint-verb-read"');
+    expect(html).not.toContain('data-testid="mint-verb-write"');
+  });
+
+  test("mint affordance — never offers an admin verb", () => {
+    const html = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["work"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+      mintableVerbs: { work: ["read", "write"] },
+    });
+    expect(html).not.toContain('value="admin"');
+    expect(html).not.toContain('data-testid="mint-verb-admin"');
+  });
+
+  test("mint affordance — absent when no mintable verbs (admin / no-vault / unmapped role)", () => {
+    // Admin branch: no tiles at all, so no mint block.
+    const admin = renderAccountHome({
+      username: "admin",
+      assignedVaults: [],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: true,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+    });
+    expect(admin).not.toContain('data-testid="token-mint"');
+    // Assigned vault but empty verb list (fail-closed unknown role) → no block.
+    const empty = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["work"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+      mintableVerbs: { work: [] },
+    });
+    expect(empty).not.toContain('data-testid="token-mint"');
+  });
+
+  test("minted-token banner — shows the token once with a save-it warning, no revoke claim", () => {
+    const html = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["work"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+      mintableVerbs: { work: ["read", "write"] },
+      mintedToken: {
+        vaultName: "work",
+        verb: "read",
+        token: "eyJhbGciOi.FAKE.TOKEN",
+        expiresInDays: 90,
+      },
+    });
+    expect(html).toContain('data-testid="minted-token-banner"');
+    expect(html).toContain("eyJhbGciOi.FAKE.TOKEN");
+    expect(html).toContain('data-testid="copy-minted-token"');
+    // Explicit "won't be shown again" + the scope + the TTL.
+    expect(html).toContain("won't be shown again");
+    expect(html).toContain("vault:work:read");
+    expect(html).toContain("90 days");
+    // No false revoke-yourself promise (no friend-facing revoke today).
+    expect(html).toContain("ask the hub operator");
+  });
+
+  test("mint error banner — surfaces an inline authorization error", () => {
+    const html = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["work"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+      mintableVerbs: { work: ["read", "write"] },
+      mintError: 'You\'re not assigned to a vault named "other".',
+    });
+    expect(html).toContain('data-testid="mint-error-banner"');
+    expect(html).toContain("not assigned");
+    // Error render must NOT also show a token.
+    expect(html).not.toContain('data-testid="minted-token-banner"');
+  });
 });

--- a/src/__tests__/account-vault-token.test.ts
+++ b/src/__tests__/account-vault-token.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Security tests for the friend-facing scoped vault token mint —
+ * `POST /account/vault-token/<name>` (`handleAccountVaultTokenPost`).
+ *
+ * This is a new auth-mint surface, so the authorization is tested
+ * adversarially. The spine:
+ *   - No session            → 401 (no mint).
+ *   - Assigned vault        → 200, token carries `vault:<name>:<verb>`,
+ *                             `aud=vault.<name>`, `iss=<hub>`, sub=user.
+ *   - UNassigned vault      → 403 (cannot mint for a vault not in the
+ *                             user's `user_vaults` assignment — blocks
+ *                             cross-vault).
+ *   - `admin` verb          → rejected (not in the form vocabulary).
+ *   - Broader/garbage verb  → rejected.
+ *   - First admin           → 403 (no `user_vaults` rows → unrestricted
+ *                             admins use the SPA path, not this one).
+ *   - CSRF missing/mismatch → 400.
+ *   - Rate limit            → 429 after the bucket fills.
+ *   - The minted token is a valid hub JWT the vault would accept.
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ACCOUNT_VAULT_TOKEN_TTL_SECONDS } from "../account-home-ui.ts";
+import { handleAccountVaultTokenPost } from "../account-vault-token.ts";
+import { CSRF_FIELD_NAME, buildCsrfCookie, generateCsrfToken } from "../csrf.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { validateAccessToken } from "../jwt-sign.ts";
+import { __resetForTests } from "../rate-limit.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "https://hub.test";
+
+interface Harness {
+  db: Database;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-account-vault-token-"));
+  const db = openHubDb(hubDbPath(dir));
+  return {
+    db,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+  __resetForTests();
+});
+afterEach(() => {
+  harness.cleanup();
+  __resetForTests();
+});
+
+const deps = () => ({ db: harness.db, hubOrigin: ISSUER });
+
+/** A shared CSRF token + matching cookie value for the double-submit handshake. */
+function csrfPair(): { token: string; cookieFragment: string } {
+  const token = generateCsrfToken();
+  // buildCsrfCookie(...) → "parachute_hub_csrf=<token>; HttpOnly; ...". We only
+  // need the name=value fragment to join with the session cookie.
+  const cookie = buildCsrfCookie(token, { secure: false }).split(";")[0] ?? "";
+  return { token, cookieFragment: cookie };
+}
+
+/** Build the first-admin operator + a friend assigned to `vaults`. */
+async function seedFriend(
+  vaults: string[],
+): Promise<{ friendId: string; cookie: string; csrfToken: string }> {
+  await createUser(harness.db, "operator", "operator-password-123");
+  const friend = await createUser(harness.db, "friend", "friend-password-123", {
+    assignedVaults: vaults,
+    allowMulti: true,
+  });
+  const session = createSession(harness.db, { userId: friend.id });
+  const { token, cookieFragment } = csrfPair();
+  const sessionCookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+  const cookie = `${sessionCookie}; ${cookieFragment}`;
+  return { friendId: friend.id, cookie, csrfToken: token };
+}
+
+function mintReq(
+  vaultName: string,
+  opts: { cookie?: string; csrfToken?: string; verb?: string; omitCsrf?: boolean } = {},
+): Request {
+  const body = new URLSearchParams();
+  if (!opts.omitCsrf && opts.csrfToken !== undefined) body.set(CSRF_FIELD_NAME, opts.csrfToken);
+  if (opts.verb !== undefined) body.set("verb", opts.verb);
+  const headers: Record<string, string> = {
+    "content-type": "application/x-www-form-urlencoded",
+  };
+  if (opts.cookie) headers.cookie = opts.cookie;
+  return new Request(`${ISSUER}/account/vault-token/${encodeURIComponent(vaultName)}`, {
+    method: "POST",
+    headers,
+    body: body.toString(),
+  });
+}
+
+describe("handleAccountVaultTokenPost — happy path (assigned vault)", () => {
+  test("200 mints vault:<name>:read for an assigned vault, valid hub JWT", async () => {
+    const { friendId, cookie, csrfToken } = await seedFriend(["work"]);
+    const res = await handleAccountVaultTokenPost(
+      mintReq("work", { cookie, csrfToken, verb: "read" }),
+      "work",
+      deps(),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    const html = await res.text();
+    expect(html).toContain('data-testid="minted-token-banner"');
+
+    // Pull the token out of the show-once banner and validate it as a hub JWT.
+    const m = html.match(/data-testid="minted-token-value">([^<]+)</);
+    expect(m).not.toBeNull();
+    const token = m![1] as string;
+    const validated = await validateAccessToken(harness.db, token, ISSUER);
+    expect(validated.payload.sub).toBe(friendId);
+    expect(validated.payload.iss).toBe(ISSUER);
+    expect(validated.payload.aud).toBe("vault.work");
+    const scopeClaim = (validated.payload as { scope?: string }).scope ?? "";
+    expect(scopeClaim.split(/\s+/)).toEqual(["vault:work:read"]);
+    // vault_scope pin — token can only ever be used against `work`.
+    expect((validated.payload as { vault_scope?: string[] }).vault_scope).toEqual(["work"]);
+
+    // TTL ≈ 90 days.
+    const expMs = new Date((validated.payload.exp ?? 0) * 1000).getTime();
+    const skew = expMs - Date.now();
+    expect(skew).toBeGreaterThan((ACCOUNT_VAULT_TOKEN_TTL_SECONDS - 60) * 1000);
+    expect(skew).toBeLessThan((ACCOUNT_VAULT_TOKEN_TTL_SECONDS + 60) * 1000);
+  });
+
+  test("200 mints vault:<name>:write when verb=write (default-role assignment)", async () => {
+    const { cookie, csrfToken } = await seedFriend(["work"]);
+    const res = await handleAccountVaultTokenPost(
+      mintReq("work", { cookie, csrfToken, verb: "write" }),
+      "work",
+      deps(),
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    const token = html.match(/data-testid="minted-token-value">([^<]+)</)?.[1] as string;
+    const validated = await validateAccessToken(harness.db, token, ISSUER);
+    const scopeClaim = (validated.payload as { scope?: string }).scope ?? "";
+    expect(scopeClaim.split(/\s+/)).toEqual(["vault:work:write"]);
+  });
+
+  test("a friend assigned to multiple vaults can mint for each, never cross-vault", async () => {
+    const { cookie, csrfToken } = await seedFriend(["work", "home"]);
+    for (const v of ["work", "home"]) {
+      const res = await handleAccountVaultTokenPost(
+        mintReq(v, { cookie, csrfToken, verb: "read" }),
+        v,
+        deps(),
+      );
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      const token = html.match(/data-testid="minted-token-value">([^<]+)</)?.[1] as string;
+      const validated = await validateAccessToken(harness.db, token, ISSUER);
+      expect(validated.payload.aud).toBe(`vault.${v}`);
+    }
+    // ...but a vault NOT in {work, home} is refused.
+    const res = await handleAccountVaultTokenPost(
+      mintReq("secret", { cookie, csrfToken, verb: "read" }),
+      "secret",
+      deps(),
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("handleAccountVaultTokenPost — authorization gates (adversarial)", () => {
+  test("401 when no session cookie is present", async () => {
+    // Even with a CSRF token, no session = no identity = no mint.
+    const { token, cookieFragment } = csrfPair();
+    const res = await handleAccountVaultTokenPost(
+      mintReq("work", { cookie: cookieFragment, csrfToken: token, verb: "read" }),
+      "work",
+      deps(),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("403 when minting for a vault the friend is NOT assigned to (cross-vault)", async () => {
+    // Friend is assigned to `work` only; attempts `other`.
+    const { cookie, csrfToken } = await seedFriend(["work"]);
+    const res = await handleAccountVaultTokenPost(
+      mintReq("other", { cookie, csrfToken, verb: "read" }),
+      "other",
+      deps(),
+    );
+    expect(res.status).toBe(403);
+    const html = await res.text();
+    expect(html).toContain('data-testid="mint-error-banner"');
+    expect(html).toContain("not assigned");
+    // Critically: no token was minted.
+    expect(html).not.toContain('data-testid="minted-token-banner"');
+  });
+
+  test("a non-assigned friend cannot mint even for a vault that EXISTS for another user", async () => {
+    // Two friends; friend B is assigned to `shared`, friend A is not.
+    await createUser(harness.db, "operator", "operator-password-123");
+    const friendB = await createUser(harness.db, "bee", "bee-password-12345", {
+      assignedVaults: ["shared"],
+      allowMulti: true,
+    });
+    expect(friendB.id).toBeTruthy();
+    const friendA = await createUser(harness.db, "aay", "aay-password-12345", {
+      assignedVaults: ["mine"],
+      allowMulti: true,
+    });
+    const sessionA = createSession(harness.db, { userId: friendA.id });
+    const { token, cookieFragment } = csrfPair();
+    const cookie = `${buildSessionCookie(sessionA.id, Math.floor(SESSION_TTL_MS / 1000))}; ${cookieFragment}`;
+    const res = await handleAccountVaultTokenPost(
+      mintReq("shared", { cookie, csrfToken: token, verb: "read" }),
+      "shared",
+      deps(),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("403 — the first admin cannot mint here (no user_vaults rows; uses SPA path)", async () => {
+    // The first-created user is the unrestricted admin: empty assignedVaults,
+    // so vaultVerbsForUserVault returns null for every vault → 403. Admins
+    // mint via /admin/vault-admin-token, not this friend surface.
+    const admin = await createUser(harness.db, "operator", "operator-password-123");
+    const session = createSession(harness.db, { userId: admin.id });
+    const { token, cookieFragment } = csrfPair();
+    const cookie = `${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}; ${cookieFragment}`;
+    const res = await handleAccountVaultTokenPost(
+      mintReq("work", { cookie, csrfToken: token, verb: "read" }),
+      "work",
+      deps(),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("admin verb is rejected — never mints vault:<name>:admin", async () => {
+    const { cookie, csrfToken } = await seedFriend(["work"]);
+    const res = await handleAccountVaultTokenPost(
+      mintReq("work", { cookie, csrfToken, verb: "admin" }),
+      "work",
+      deps(),
+    );
+    expect(res.status).toBe(400);
+    const html = await res.text();
+    expect(html).not.toContain('data-testid="minted-token-banner"');
+    expect(html).not.toContain("vault:work:admin");
+  });
+
+  test("a garbage / broader verb is rejected", async () => {
+    const { cookie, csrfToken } = await seedFriend(["work"]);
+    for (const verb of ["host", "delete", "read write", "*", ""]) {
+      const res = await handleAccountVaultTokenPost(
+        mintReq("work", { cookie, csrfToken, verb }),
+        "work",
+        deps(),
+      );
+      expect(res.status).toBe(400);
+    }
+  });
+
+  test("a syntactically invalid vault name is rejected before any mint", async () => {
+    const { cookie, csrfToken } = await seedFriend(["work"]);
+    const res = await handleAccountVaultTokenPost(
+      mintReq("has..dots", { cookie, csrfToken, verb: "read" }),
+      "has..dots",
+      deps(),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("handleAccountVaultTokenPost — CSRF + method + rate limit", () => {
+  test("405 on non-POST", async () => {
+    const { cookie } = await seedFriend(["work"]);
+    const req = new Request(`${ISSUER}/account/vault-token/work`, {
+      method: "GET",
+      headers: { cookie },
+    });
+    const res = await handleAccountVaultTokenPost(req, "work", deps());
+    expect(res.status).toBe(405);
+  });
+
+  test("400 when the CSRF token is missing", async () => {
+    const { cookie } = await seedFriend(["work"]);
+    const res = await handleAccountVaultTokenPost(
+      mintReq("work", { cookie, omitCsrf: true, verb: "read" }),
+      "work",
+      deps(),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("400 when the CSRF form token does not match the cookie", async () => {
+    const { cookie } = await seedFriend(["work"]);
+    // Send a different (non-matching) CSRF token in the form than the cookie.
+    const res = await handleAccountVaultTokenPost(
+      mintReq("work", { cookie, csrfToken: generateCsrfToken(), verb: "read" }),
+      "work",
+      deps(),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("429 once the per-user mint bucket fills (10 / 10 min)", async () => {
+    const { cookie, csrfToken } = await seedFriend(["work"]);
+    // 10 admitted, 11th denied.
+    for (let i = 0; i < 10; i++) {
+      const res = await handleAccountVaultTokenPost(
+        mintReq("work", { cookie, csrfToken, verb: "read" }),
+        "work",
+        deps(),
+      );
+      expect(res.status).toBe(200);
+    }
+    const denied = await handleAccountVaultTokenPost(
+      mintReq("work", { cookie, csrfToken, verb: "read" }),
+      "work",
+      deps(),
+    );
+    expect(denied.status).toBe(429);
+  });
+
+  test("CSRF failure does NOT burn a rate-limit slot", async () => {
+    // A cross-site POST with a bad CSRF token should 400 before the bucket is
+    // touched — otherwise an attacker could exhaust the victim's mint bucket.
+    const { cookie, csrfToken } = await seedFriend(["work"]);
+    for (let i = 0; i < 15; i++) {
+      const res = await handleAccountVaultTokenPost(
+        mintReq("work", { cookie, csrfToken: generateCsrfToken(), verb: "read" }),
+        "work",
+        deps(),
+      );
+      expect(res.status).toBe(400);
+    }
+    // The legitimate mint still succeeds — the bucket was never touched.
+    const ok = await handleAccountVaultTokenPost(
+      mintReq("work", { cookie, csrfToken, verb: "read" }),
+      "work",
+      deps(),
+    );
+    expect(ok.status).toBe(200);
+  });
+});

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { buildCsrfCookie, generateCsrfToken } from "../csrf.ts";
 import { HUB_SVC, hubPortPath } from "../hub-control.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import {
@@ -16,6 +17,7 @@ import { setNotesRedirectDisabled } from "../hub-settings.ts";
 import { clearNotesRedirectLogState } from "../notes-redirect.ts";
 import { pidPath } from "../process-state.ts";
 import { type ServiceEntry, writeManifest } from "../services-manifest.ts";
+import { buildSessionCookie, createSession } from "../sessions.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 import type { ModuleState, Supervisor } from "../supervisor.ts";
 import { createUser } from "../users.ts";
@@ -4167,6 +4169,101 @@ describe("hubFetch persistent chrome strip injection (workstream G)", () => {
       expect(body).toContain('href="/login?next=%2Fscribe%2Fadmin%3Fshow%3Dall"');
     } finally {
       upstream.stop();
+      h.cleanup();
+    }
+  });
+});
+
+describe("POST /account/vault-token/<name> — friend scoped mint (routed end-to-end)", () => {
+  // Drive the real dispatch (`hubFetch`) so the route wiring + precedence
+  // (the `/account/vault-token/` prefix must win over `/account/` and the
+  // SPA catch-all) is exercised, not just the handler in isolation.
+  async function seed(h: Harness, assignedVaults: string[]) {
+    const db = openHubDb(hubDbPath(h.dir));
+    rotateSigningKey(db); // mint needs an active signing key
+    await createUser(db, "operator", "operator-password-123");
+    const friend = await createUser(db, "friend", "friend-password-123", {
+      assignedVaults,
+      allowMulti: true,
+    });
+    const session = createSession(db, { userId: friend.id });
+    const csrf = generateCsrfToken();
+    const cookie = `${buildSessionCookie(session.id, 3600, { secure: false })}; ${
+      buildCsrfCookie(csrf, { secure: false }).split(";")[0]
+    }`;
+    return { db, friendId: friend.id, cookie, csrf };
+  }
+
+  function postBody(csrf: string, verb: string): string {
+    const b = new URLSearchParams();
+    b.set("__csrf", csrf);
+    b.set("verb", verb);
+    return b.toString();
+  }
+
+  test("assigned vault → 200 with a token banner, routed through hubFetch", async () => {
+    const h = makeHarness();
+    writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
+    const { db, cookie, csrf } = await seed(h, ["work"]);
+    try {
+      const res = await hubFetch(h.dir, {
+        getDb: () => db,
+        manifestPath: h.manifestPath,
+        issuer: "https://hub.test",
+      })(
+        req("/account/vault-token/work", {
+          method: "POST",
+          headers: { cookie, "content-type": "application/x-www-form-urlencoded" },
+          body: postBody(csrf, "read"),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain('data-testid="minted-token-banner"');
+      expect(html).toContain("vault:work:read");
+    } finally {
+      db.close();
+      h.cleanup();
+    }
+  });
+
+  test("unassigned vault → 403, no token, routed through hubFetch", async () => {
+    const h = makeHarness();
+    writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
+    const { db, cookie, csrf } = await seed(h, ["work"]);
+    try {
+      const res = await hubFetch(h.dir, {
+        getDb: () => db,
+        manifestPath: h.manifestPath,
+        issuer: "https://hub.test",
+      })(
+        req("/account/vault-token/other", {
+          method: "POST",
+          headers: { cookie, "content-type": "application/x-www-form-urlencoded" },
+          body: postBody(csrf, "read"),
+        }),
+      );
+      expect(res.status).toBe(403);
+      const html = await res.text();
+      expect(html).not.toContain('data-testid="minted-token-banner"');
+    } finally {
+      db.close();
+      h.cleanup();
+    }
+  });
+
+  test("GET on the mint path → 405 (POST-only)", async () => {
+    const h = makeHarness();
+    writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
+    const { db } = await seed(h, ["work"]);
+    try {
+      const res = await hubFetch(h.dir, {
+        getDb: () => db,
+        manifestPath: h.manifestPath,
+      })(req("/account/vault-token/work"));
+      expect(res.status).toBe(405);
+    } finally {
+      db.close();
       h.cleanup();
     }
   });

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -24,6 +24,8 @@ import {
   userCount,
   validatePassword,
   validateUsername,
+  vaultVerbsForRole,
+  vaultVerbsForUserVault,
   verifyPassword,
 } from "../users.ts";
 
@@ -730,6 +732,72 @@ describe("getFirstAdminId / isFirstAdmin", () => {
       deleteUser(db, friend.id);
       expect(getFirstAdminId(db)).toBe(admin.id);
       expect(isFirstAdmin(db, admin.id)).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("vaultVerbsForRole / vaultVerbsForUserVault (friend token-mint cap)", () => {
+  test("vaultVerbsForRole maps roles to verbs, fails closed on unknown", () => {
+    expect(vaultVerbsForRole("write")).toEqual(["read", "write"]);
+    expect(vaultVerbsForRole("read")).toEqual(["read"]);
+    // Unknown / future roles grant NO mintable verb — never silently
+    // default to write. `admin` is explicitly NOT a mintable role here.
+    expect(vaultVerbsForRole("admin")).toEqual([]);
+    expect(vaultVerbsForRole("owner")).toEqual([]);
+    expect(vaultVerbsForRole("")).toEqual([]);
+  });
+
+  test("vaultVerbsForUserVault returns the role's verbs for an assigned vault", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      await createUser(db, "admin", "pw1");
+      const friend = await createUser(db, "alice", "pw2", {
+        allowMulti: true,
+        assignedVaults: ["work"],
+      });
+      // createUser/setUserVaults insert role='write' today → read+write.
+      expect(vaultVerbsForUserVault(db, friend.id, "work")).toEqual(["read", "write"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("vaultVerbsForUserVault returns null for a vault NOT in the assignment", async () => {
+    // This null is the authorization spine of the friend mint path: a vault
+    // the user isn't assigned to → null → the handler 403s. No cross-vault.
+    const { db, cleanup } = makeDb();
+    try {
+      await createUser(db, "admin", "pw1");
+      const friend = await createUser(db, "alice", "pw2", {
+        allowMulti: true,
+        assignedVaults: ["work"],
+      });
+      expect(vaultVerbsForUserVault(db, friend.id, "other")).toBeNull();
+      // The unrestricted admin has no user_vaults rows → null for everything.
+      const admin = getUserById(db, getFirstAdminId(db) ?? "");
+      expect(vaultVerbsForUserVault(db, admin?.id ?? "", "work")).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("vaultVerbsForUserVault honors a hand-set read-only role (fail-closed forward-compat)", async () => {
+    // The schema reserves `role` for future granularity; if a row ever holds
+    // role='read', the cap must drop write. Simulate by direct UPDATE.
+    const { db, cleanup } = makeDb();
+    try {
+      await createUser(db, "admin", "pw1");
+      const friend = await createUser(db, "alice", "pw2", {
+        allowMulti: true,
+        assignedVaults: ["work"],
+      });
+      db.prepare("UPDATE user_vaults SET role = 'read' WHERE user_id = ? AND vault_name = ?").run(
+        friend.id,
+        "work",
+      );
+      expect(vaultVerbsForUserVault(db, friend.id, "work")).toEqual(["read"]);
     } finally {
       cleanup();
     }

--- a/src/account-home-ui.ts
+++ b/src/account-home-ui.ts
@@ -21,6 +21,7 @@
 import { WORDMARK_TEXT, brandMarkSvg } from "./brand.ts";
 import { renderCsrfHiddenInput } from "./csrf.ts";
 import { escapeHtml } from "./oauth-ui.ts";
+import type { VaultVerb } from "./users.ts";
 
 // --- shared chrome (mirrors account-change-password-ui.ts) ----------------
 
@@ -115,7 +116,49 @@ export interface RenderAccountHomeOpts {
    * `/account/2fa` either way — "Set up" when off, "Manage" when on.
    */
   twoFactorEnabled: boolean;
+  /**
+   * Per-vault mintable verbs for the "mint an access token" affordance on
+   * each vault tile (friend headless-client path). Maps `vaultName` → the
+   * verbs the user's assignment role permits (today always
+   * `["read", "write"]` since every `user_vaults.role` is `'write'`). A
+   * vault absent from this map (or mapped to an empty list) renders no mint
+   * affordance — the UI never offers a verb the server would reject. The
+   * `/account/` GET handler builds this from `vaultVerbsForUserVault` for
+   * each assigned vault. Omitted (or empty) for the admin / no-vault
+   * branches, where no token-mint tile is shown.
+   */
+  mintableVerbs?: Record<string, VaultVerb[]>;
+  /**
+   * Set after a successful `POST /account/vault-token/<name>` to show the
+   * freshly-minted token ONCE (the only time it's ever shown — the hub keeps
+   * no plaintext copy). Drives the show-once banner at the top of the page.
+   * Absent on the normal GET render.
+   */
+  mintedToken?: MintedTokenView;
+  /**
+   * Set after a `POST /account/vault-token/<name>` that failed authorization
+   * or validation, to surface an inline error banner on the re-rendered page
+   * (e.g. unassigned vault, capped verb, rate-limited). Absent on success and
+   * on the normal GET render.
+   */
+  mintError?: string;
 }
+
+/**
+ * The one-time view of a freshly-minted friend vault token. The hub stores
+ * only a hash-keyed registry row (no plaintext), so this is the single moment
+ * the token string is shown — the UI copy makes that explicit.
+ */
+export interface MintedTokenView {
+  vaultName: string;
+  verb: VaultVerb;
+  token: string;
+  /** Whole-day TTL for the "expires in N days" copy. */
+  expiresInDays: number;
+}
+
+/** Friend-mint token default lifetime: 90 days (matches the CLI/api-mint default). */
+export const ACCOUNT_VAULT_TOKEN_TTL_SECONDS = 90 * 24 * 60 * 60;
 
 export function renderAccountHome(opts: RenderAccountHomeOpts): string {
   const { username, assignedVaults, hubOrigin, isFirstAdmin, csrfToken } = opts;
@@ -124,10 +167,19 @@ export function renderAccountHome(opts: RenderAccountHomeOpts): string {
   // but defensively re-trim so a stray slash here doesn't break the CTA href.
   const trimmedOrigin = hubOrigin.replace(/\/+$/, "");
 
+  const mintedBanner = opts.mintedToken ? renderMintedTokenBanner(opts.mintedToken) : "";
+  const mintErrorBanner = opts.mintError
+    ? `<div class="mint-error-banner" data-testid="mint-error-banner" role="alert">${escapeHtml(
+        opts.mintError,
+      )}</div>`
+    : "";
+
   const vaultCard = renderVaultCard({
     assignedVaults,
     trimmedOrigin,
     isFirstAdmin,
+    csrfToken,
+    mintableVerbs: opts.mintableVerbs ?? {},
   });
 
   const accountCard = renderAccountCard({
@@ -143,9 +195,11 @@ export function renderAccountHome(opts: RenderAccountHomeOpts): string {
         <h1>Welcome, ${safeUsername}</h1>
         <p class="subtitle">Your Parachute account home.</p>
       </div>
+      ${mintedBanner}
+      ${mintErrorBanner}
       ${vaultCard}
       ${accountCard}
-    </div>`;
+    </div>${COPY_SCRIPT}`;
   return baseDocument(`${username} — Parachute`, body);
 }
 
@@ -153,6 +207,8 @@ interface VaultCardOpts {
   assignedVaults: string[];
   trimmedOrigin: string;
   isFirstAdmin: boolean;
+  csrfToken: string;
+  mintableVerbs: Record<string, VaultVerb[]>;
 }
 
 /**
@@ -182,7 +238,7 @@ export function accountClaudeMcpAddCommand(trimmedOrigin: string, vaultName: str
 }
 
 function renderVaultCard(opts: VaultCardOpts): string {
-  const { assignedVaults, trimmedOrigin, isFirstAdmin } = opts;
+  const { assignedVaults, trimmedOrigin, isFirstAdmin, csrfToken, mintableVerbs } = opts;
 
   if (assignedVaults.length > 0) {
     // One vault tile per assignment (multi-user Phase 2 PR 2). Each tile
@@ -209,6 +265,12 @@ function renderVaultCard(opts: VaultCardOpts): string {
         const addCmd = accountClaudeMcpAddCommand(trimmedOrigin, vaultName);
         const safeEndpoint = escapeHtml(endpoint);
         const safeAddCmd = escapeHtml(addCmd);
+        const tokenMintBlock = renderTokenMintBlock(
+          vaultName,
+          safeVault,
+          mintableVerbs[vaultName] ?? [],
+          csrfToken,
+        );
         return `
         <div class="vault-tile" data-testid="vault-tile" data-vault-name="${safeVault}">
           <p class="vault-name"><strong>${safeVault}</strong></p>
@@ -251,6 +313,7 @@ function renderVaultCard(opts: VaultCardOpts): string {
             <span class="vault-notes-cta-sub">Prefer a browser UI? Open Notes to browse +
                capture in this vault.</span>
           </p>
+          ${tokenMintBlock}
         </div>`;
       })
       .join("");
@@ -264,7 +327,7 @@ function renderVaultCard(opts: VaultCardOpts): string {
           to your hub over HTTPS and asks you to approve access.</p>
         <div class="vault-tiles">${tiles}
         </div>
-      </section>${COPY_SCRIPT}`;
+      </section>`;
   }
   if (isFirstAdmin) {
     return `
@@ -288,6 +351,103 @@ function renderVaultCard(opts: VaultCardOpts): string {
          any AI assistant) to it.</p>
       <p><strong>Ask the hub operator to assign you a vault.</strong></p>
     </section>`;
+}
+
+/**
+ * The "mint an access token (for scripts / headless clients)" affordance on a
+ * vault tile. Sits BELOW the OAuth connect block + Notes CTA — the no-token
+ * OAuth path stays the recommended default; this is the secondary, opt-in
+ * path for clients that can't do an interactive browser sign-in (cron jobs,
+ * headless agents, a `curl` script).
+ *
+ * Renders one radio per verb the user's assignment role permits (`verbs` —
+ * today always `["read", "write"]`). The UI NEVER offers a verb the server
+ * would reject: a read-only assignment shows only "Read". An empty `verbs`
+ * list (unknown / unmappable role) renders nothing — fail-closed, matching
+ * the server's `vaultVerbsForUserVault` returning `[]`.
+ *
+ * The form POSTs `application/x-www-form-urlencoded` to
+ * `/account/vault-token/<name>` with the CSRF hidden field + a `verb` radio —
+ * same no-JS-required posture as the change-password and sign-out forms. The
+ * `<details>` keeps it collapsed by default so the tile leads with the
+ * recommended OAuth path.
+ */
+function renderTokenMintBlock(
+  vaultName: string,
+  safeVault: string,
+  verbs: VaultVerb[],
+  csrfToken: string,
+): string {
+  if (verbs.length === 0) return "";
+  // Path segment is URL-encoded; the action attribute is HTML-escaped on top.
+  const action = escapeHtml(`/account/vault-token/${encodeURIComponent(vaultName)}`);
+  const radios = verbs
+    .map((verb, i) => {
+      const checked = i === 0 ? " checked" : "";
+      const label = verb === "read" ? "Read-only" : "Read + write";
+      return `
+              <label class="mint-verb-option">
+                <input type="radio" name="verb" value="${verb}"${checked}
+                       data-testid="mint-verb-${verb}" />
+                <span><strong>${verb}</strong> — ${label} access to <code>${safeVault}</code></span>
+              </label>`;
+    })
+    .join("");
+  return `
+          <details class="token-mint" data-testid="token-mint">
+            <summary data-testid="token-mint-summary">Mint an access token
+              <span class="token-mint-sub">for scripts / headless clients</span></summary>
+            <div class="token-mint-body">
+              <p class="token-mint-intro">Most clients should use the no-token
+                connect options above — they sign you in over HTTPS and never
+                ask you to paste a secret. Mint a token only for a script or
+                headless client that can't open a browser to sign in. It's a
+                bearer for <code>vault:${safeVault}:&lt;verb&gt;</code>, scoped to
+                <strong>this vault only</strong>, and you'll see it once.</p>
+              <form method="POST" action="${action}" class="mint-form"
+                    data-testid="mint-form">
+                ${renderCsrfHiddenInput(csrfToken)}
+                <fieldset class="mint-verbs">
+                  <legend>Access level</legend>${radios}
+                </fieldset>
+                <button type="submit" class="btn btn-secondary"
+                        data-testid="mint-token-button">Mint token</button>
+              </form>
+            </div>
+          </details>`;
+}
+
+/**
+ * The show-once banner for a freshly-minted friend vault token. Rendered at
+ * the top of `/account/` after a successful `POST /account/vault-token/<name>`.
+ * The token string appears here and NOWHERE else — the hub stores only a
+ * hash-keyed registry row. The copy is explicit about that ("save it now —
+ * it won't be shown again"). No revoke link: there's no friend-facing revoke
+ * surface today, so we don't claim one.
+ */
+function renderMintedTokenBanner(view: MintedTokenView): string {
+  const safeVault = escapeHtml(view.vaultName);
+  const scope = `vault:${view.vaultName}:${view.verb}`;
+  const safeScope = escapeHtml(scope);
+  // The token value goes in a data attribute for the copy button + as text.
+  // It's a hub-signed JWT (no HTML-significant chars in base64url + dots), but
+  // escape defensively all the same.
+  const safeToken = escapeHtml(view.token);
+  return `
+    <div class="minted-banner" data-testid="minted-token-banner" role="status">
+      <p class="minted-title">Your access token for <code>${safeVault}</code></p>
+      <p class="minted-warn"><strong>Save it now — it won't be shown again.</strong>
+        This is a bearer credential for <code>${safeScope}</code>. It expires in
+        ${view.expiresInDays} days. Treat it like a password; anyone who has it
+        can act on this vault at that access level.</p>
+      <div class="copy-row">
+        <code data-testid="minted-token-value">${safeToken}</code>
+        <button type="button" class="btn btn-copy" data-copy="${safeToken}"
+                data-testid="copy-minted-token">Copy</button>
+      </div>
+      <p class="minted-hint">Use it as <code>Authorization: Bearer &lt;token&gt;</code>
+        when calling this vault's MCP endpoint. To revoke it, ask the hub operator.</p>
+    </div>`;
 }
 
 interface AccountCardOpts {
@@ -328,14 +488,16 @@ function renderAccountCard(opts: AccountCardOpts): string {
 
 // --- copy-button script ---------------------------------------------------
 //
-// Tiny inline progressive-enhancement script for the per-tile copy buttons.
-// Delegated click handler reads the command/endpoint from the button's
-// `data-copy` attribute and writes it to the clipboard, flashing "Copied ✓"
-// for 2s. No-ops gracefully when the Clipboard API is unavailable (insecure
-// context, older browser) — the command text stays selectable in the
+// Tiny inline progressive-enhancement script for the page's copy buttons
+// (the per-tile MCP command/endpoint buttons AND the show-once minted-token
+// banner's Copy button). Delegated click handler reads the value from the
+// button's `data-copy` attribute and writes it to the clipboard, flashing
+// "Copied ✓" for 2s. No-ops gracefully when the Clipboard API is unavailable
+// (insecure context, older browser) — the value stays selectable in the
 // codebox. Mirrors the SPA `CopyButton` posture (McpConnectCard.tsx) for a
-// surface that has no React. Only emitted on the assigned-vault branch
-// (where copy buttons exist).
+// surface that has no React. Emitted once at the page body level so it covers
+// both the vault tiles and the minted-token banner (which lives above the
+// vault card).
 const COPY_SCRIPT = `
   <script>
     (function () {
@@ -546,6 +708,82 @@ const STYLES = `
     color: ${PALETTE.fgMuted};
     margin: 0.4rem 0 0;
   }
+
+  .token-mint {
+    margin: 0.9rem 0 0;
+    padding-top: 0.6rem;
+    border-top: 1px solid ${PALETTE.borderLight};
+  }
+  .token-mint > summary {
+    cursor: pointer;
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: ${PALETTE.fg};
+    list-style: revert;
+  }
+  .token-mint-sub {
+    font-weight: 400;
+    font-size: 0.8rem;
+    color: ${PALETTE.fgMuted};
+  }
+  .token-mint-body { margin-top: 0.6rem; }
+  .token-mint-intro {
+    font-size: 0.8rem;
+    color: ${PALETTE.fgMuted};
+    margin: 0 0 0.6rem;
+  }
+  .mint-verbs {
+    border: 1px solid ${PALETTE.borderLight};
+    border-radius: 6px;
+    padding: 0.5rem 0.7rem;
+    margin: 0 0 0.6rem;
+  }
+  .mint-verbs legend {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: ${PALETTE.fgMuted};
+    font-family: ${FONT_MONO};
+    padding: 0 0.3rem;
+  }
+  .mint-verb-option {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    margin: 0.3rem 0;
+  }
+  .mint-verb-option input { margin: 0; }
+  .mint-form .btn { margin-top: 0.2rem; }
+
+  .minted-banner {
+    border: 1px solid ${PALETTE.accent};
+    background: ${PALETTE.accentSoft};
+    border-radius: 8px;
+    padding: 0.9rem 1rem;
+    margin: 1.25rem 0 0;
+  }
+  .minted-title {
+    font-family: ${FONT_SERIF};
+    font-size: 1.05rem;
+    margin: 0 0 0.3rem;
+    color: ${PALETTE.fg};
+  }
+  .minted-warn { font-size: 0.85rem; margin: 0 0 0.6rem; color: ${PALETTE.fg}; }
+  .minted-banner .copy-row { margin: 0.4rem 0; }
+  .minted-banner .copy-row code { font-size: 0.72rem; }
+  .minted-hint { font-size: 0.8rem; color: ${PALETTE.fgMuted}; margin: 0.4rem 0 0; }
+
+  .mint-error-banner {
+    border: 1px solid ${PALETTE.danger};
+    background: ${PALETTE.dangerSoft};
+    color: ${PALETTE.danger};
+    border-radius: 8px;
+    padding: 0.7rem 1rem;
+    margin: 1.25rem 0 0;
+    font-size: 0.88rem;
+  }
+
   code {
     font-family: ${FONT_MONO};
     background: ${PALETTE.bgSoft};
@@ -633,10 +871,14 @@ const STYLES = `
     code { background: #1f1c18; color: #e8e4dc; }
     .copy-row code { background: transparent; }
     .section { border-top-color: #3a362f; }
-    .mcp-method, .vault-notes-cta { border-top-color: #3a362f; }
+    .mcp-method, .vault-notes-cta, .token-mint { border-top-color: #3a362f; }
     .brand-tag { border-color: #3a362f; color: #a8a29a; }
     .copy-row { background: #1f1c18; border-color: #3a362f; }
     .btn-secondary, .btn-copy { color: #e8e4dc; border-color: #3a362f; }
     .btn-secondary:hover, .btn-copy:hover { background: #1f1c18; border-color: ${PALETTE.accent}; }
+    .token-mint > summary { color: #f0ece4; }
+    .token-mint-sub, .token-mint-intro, .mint-verbs legend, .minted-hint { color: #a8a29a; }
+    .mint-verbs { border-color: #3a362f; }
+    .minted-title, .minted-warn { color: #f0ece4; }
   }
 `;

--- a/src/account-vault-token.ts
+++ b/src/account-vault-token.ts
@@ -1,0 +1,282 @@
+/**
+ * `POST /account/vault-token/<name>` — friend-facing scoped vault token mint.
+ *
+ * A non-admin friend with a hub session is ALREADY authorized for their
+ * assigned vault(s): the OAuth issuer mints `vault:<assigned>:read|write` for
+ * them on the no-token connect path. This endpoint lets the same friend mint
+ * that same authority *in token form* — a long-lived bearer for a script or
+ * headless client that can't open a browser to do interactive OAuth. It is
+ * the same authority, just materialized; no escalation.
+ *
+ * Authorization — the security spine of this surface. The mint is capped to
+ * the caller's own authority by three gates, in order:
+ *
+ *   1. **Session.** A valid, unexpired hub session cookie is required (the
+ *      friend's). No session → 401. (Resolved via `findActiveSession`, the
+ *      same gate `/account/change-password` uses.)
+ *   2. **Assignment.** The requested `<name>` MUST be one of the session
+ *      user's `user_vaults` assignments. A vault the user is not assigned to
+ *      → 403. This is what blocks "mint for a vault I'm not assigned" and
+ *      cross-vault minting. Read directly from `user_vaults` via
+ *      `vaultVerbsForUserVault` (which returns `null` for an unassigned
+ *      vault), NOT from the verb-blind `assignedVaults` array.
+ *   3. **Scope cap.** The requested verb MUST be one the user's assignment
+ *      role permits, and may only ever be `read` or `write` — NEVER `admin`,
+ *      never a broader scope than the user holds. `vaultVerbsForUserVault`
+ *      returns the role's verb set (today always `["read", "write"]` since
+ *      every assignment is `role = 'write'`); a verb outside that set → 403.
+ *      `admin` is not in the form's vocabulary at all and is rejected at the
+ *      parse step as an invalid verb.
+ *
+ * The first admin (unrestricted, empty `assignedVaults`) has no `user_vaults`
+ * rows, so gate 2 returns `null` for every vault and the admin gets a 403
+ * here too — by design. Admins mint vault tokens through the admin SPA's
+ * tokens page (`/admin/vault-admin-token/<name>` → `/api/auth/mint-token`),
+ * not this friend surface. This endpoint is exclusively the friend path.
+ *
+ * CSRF: double-submit cookie, same `__csrf` field + `verifyCsrfToken` as
+ * `/account/change-password` and `/logout`. A cross-site POST without the
+ * matching cookie/form token → 400.
+ *
+ * Rate limit: `vaultTokenMintRateLimiter`, per-user (10 / 10 min). Fires
+ * after CSRF (so a junk cross-site POST doesn't burn the victim's bucket)
+ * and before the mint. A floor against a stolen-cookie mint flood, not the
+ * primary defense.
+ *
+ * Mint: `signAccessToken` (the same machinery the OAuth issuer + admin paths
+ * use — no hand-rolled JWT signing) with:
+ *   - `scopes: ["vault:<name>:<verb>"]`
+ *   - `audience: "vault.<name>"` (via `inferAudience`; vault validates this
+ *     against its URL-derived name — identical to the OAuth + admin mints)
+ *   - `iss`: the hub origin
+ *   - `sub`: the friend's user id
+ *   - `vaultScope: [<name>]` — pins the token to that one vault (defense in
+ *     depth, mirrors the admin vault-token + the rule-2/3 mints in
+ *     `api-mint-token.ts`)
+ *   - `ttlSeconds`: 90 days (`ACCOUNT_VAULT_TOKEN_TTL_SECONDS`, matching the
+ *     CLI/api-mint default)
+ * and a `tokens` registry row via `recordTokenMint` (`created_via='cli_mint'`,
+ * `userId` = the friend) so the token shows up in the revocation list and the
+ * operator's token registry.
+ *
+ * Response: a re-render of `/account/` (server-rendered, no-JS posture) with
+ * the token shown ONCE in a banner. The hub keeps no plaintext copy, so this
+ * is the only moment the token string is visible.
+ */
+import type { Database } from "bun:sqlite";
+import {
+  ACCOUNT_VAULT_TOKEN_TTL_SECONDS,
+  type MintedTokenView,
+  renderAccountHome,
+} from "./account-home-ui.ts";
+import { renderAdminError } from "./admin-login-ui.ts";
+import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
+import { inferAudience } from "./jwt-audience.ts";
+import { recordTokenMint, signAccessToken } from "./jwt-sign.ts";
+import { vaultTokenMintRateLimiter } from "./rate-limit.ts";
+import { findActiveSession } from "./sessions.ts";
+import { isTotpEnrolled } from "./two-factor-store.ts";
+import { type VaultVerb, getUserById, isFirstAdmin, vaultVerbsForUserVault } from "./users.ts";
+
+/** Matches the manifest vault-name validator + `/admin/vault-admin-token`. */
+const VAULT_NAME_RE = /^[a-zA-Z0-9_-]+$/;
+/** Verbs this surface will ever mint. `admin` is deliberately absent. */
+const ALLOWED_VERBS: readonly VaultVerb[] = ["read", "write"];
+/** client_id stamped on the minted JWT + registry row. */
+const ACCOUNT_VAULT_TOKEN_CLIENT_ID = "parachute-account";
+
+export interface AccountVaultTokenDeps {
+  db: Database;
+  /** Hub origin for this request — `iss` of the minted token. */
+  hubOrigin: string;
+  /** Test seam for the clock (rate limiter + mint). */
+  now?: () => Date;
+}
+
+function htmlResponse(body: string, status = 200, extra: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store", ...extra },
+  });
+}
+
+/**
+ * Build the `mintableVerbs` map the account-home renderer needs: each of the
+ * user's assigned vaults → the verbs its role permits. Used both on the
+ * success re-render (so every tile keeps its mint affordance) and the error
+ * re-render. Mirrors the GET handler's construction.
+ */
+function buildMintableVerbs(
+  db: Database,
+  userId: string,
+  assignedVaults: readonly string[],
+): Record<string, VaultVerb[]> {
+  const map: Record<string, VaultVerb[]> = {};
+  for (const v of assignedVaults) {
+    const verbs = vaultVerbsForUserVault(db, userId, v);
+    if (verbs && verbs.length > 0) map[v] = verbs;
+  }
+  return map;
+}
+
+export async function handleAccountVaultTokenPost(
+  req: Request,
+  vaultName: string,
+  deps: AccountVaultTokenDeps,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return htmlResponse("method not allowed", 405);
+  }
+
+  // Gate 1 — session. No identity, no mint.
+  const session = findActiveSession(deps.db, req);
+  if (!session) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Not signed in",
+        message: "Please sign in before minting an access token.",
+      }),
+      401,
+    );
+  }
+  const user = getUserById(deps.db, session.userId);
+  if (!user) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Account not found",
+        message: "The signed-in account no longer exists. Please sign in again.",
+      }),
+      401,
+    );
+  }
+
+  // CSRF — verify before any state change / rate-limit bucket touch, same
+  // shape + 400 status as `/account/change-password`.
+  const form = await req.formData();
+  const formCsrf = form.get(CSRF_FIELD_NAME);
+  if (!verifyCsrfToken(req, typeof formCsrf === "string" ? formCsrf : null)) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Invalid form submission",
+        message: "The form's CSRF token did not match. Reload the page and try again.",
+      }),
+      400,
+    );
+  }
+
+  // Helper to re-render the account home (success banner or inline error).
+  // Re-resolves the CSRF token + 2FA state so the page stays fully usable.
+  const renderHome = (
+    status: number,
+    extras: { mintedToken?: MintedTokenView; mintError?: string },
+  ): Response => {
+    const csrf = ensureCsrfToken(req);
+    const setCookie: Record<string, string> = csrf.setCookie
+      ? { "set-cookie": csrf.setCookie }
+      : {};
+    const adminFlag = isFirstAdmin(deps.db, user.id);
+    return htmlResponse(
+      renderAccountHome({
+        username: user.username,
+        assignedVaults: user.assignedVaults,
+        passwordChanged: user.passwordChanged,
+        hubOrigin: deps.hubOrigin,
+        isFirstAdmin: adminFlag,
+        csrfToken: csrf.token,
+        twoFactorEnabled: isTotpEnrolled(deps.db, user.id),
+        mintableVerbs: buildMintableVerbs(deps.db, user.id, user.assignedVaults),
+        ...extras,
+      }),
+      status,
+      setCookie,
+    );
+  };
+
+  // Vault-name shape guard — reject anything that can't be a services.json
+  // key before any DB / authority work (router can hand us arbitrary path
+  // segments). Same posture as `/admin/vault-admin-token`.
+  if (!VAULT_NAME_RE.test(vaultName)) {
+    return renderHome(400, { mintError: `"${vaultName}" is not a valid vault name.` });
+  }
+
+  // Verb parse — must be exactly one of read/write. `admin` (or anything
+  // else) is not in this surface's vocabulary and is rejected here, well
+  // before authority is even consulted.
+  const verbRaw = form.get("verb");
+  const verb = typeof verbRaw === "string" ? verbRaw : "";
+  if (!ALLOWED_VERBS.includes(verb as VaultVerb)) {
+    return renderHome(400, {
+      mintError: "Pick an access level (read or write).",
+    });
+  }
+  const requestedVerb = verb as VaultVerb;
+
+  // Gate 2 + 3 — assignment + scope cap. `vaultVerbsForUserVault` returns:
+  //   - null  → the user has NO assignment for this vault (gate 2 fail): 403.
+  //   - []    → assignment exists but its role grants no mintable verb
+  //             (fail-closed for an unknown role): 403.
+  //   - [...] → the verbs the assignment role permits. The requested verb
+  //             must be in this set (gate 3): else 403.
+  // This is the cap to the user's actual authority — it blocks minting for
+  // an unassigned vault, a broader verb than the role grants, and (since the
+  // set never contains `admin`) any admin escalation.
+  const allowedForUser = vaultVerbsForUserVault(deps.db, user.id, vaultName);
+  if (allowedForUser === null) {
+    return renderHome(403, {
+      mintError: `You're not assigned to a vault named "${vaultName}", so you can't mint a token for it. Ask the hub operator if you think this is wrong.`,
+    });
+  }
+  if (!allowedForUser.includes(requestedVerb)) {
+    return renderHome(403, {
+      mintError: `Your access to "${vaultName}" doesn't allow minting a ${requestedVerb} token.`,
+    });
+  }
+
+  // Rate limit — after CSRF + authority shape, before the mint. Per-user.
+  const rlNow = (deps.now ?? (() => new Date()))();
+  const gate = vaultTokenMintRateLimiter.checkAndRecord(user.id, rlNow);
+  if (!gate.allowed) {
+    return renderHome(429, {
+      mintError: `Too many token-mint attempts. Try again in ${gate.retryAfterSeconds ?? 1} seconds.`,
+    });
+  }
+
+  // Mint — the same machinery the OAuth issuer + admin paths use. The scope
+  // is exactly the capped `vault:<name>:<verb>`; the audience binds the token
+  // to that one vault; `vaultScope` pins it as defense in depth.
+  const scope = `vault:${vaultName}:${requestedVerb}`;
+  const audience = inferAudience([scope]); // → `vault.<name>`
+  const minted = await signAccessToken(deps.db, {
+    sub: user.id,
+    scopes: [scope],
+    audience,
+    clientId: ACCOUNT_VAULT_TOKEN_CLIENT_ID,
+    issuer: deps.hubOrigin,
+    ttlSeconds: ACCOUNT_VAULT_TOKEN_TTL_SECONDS,
+    vaultScope: [vaultName],
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  });
+
+  recordTokenMint(deps.db, {
+    jti: minted.jti,
+    createdVia: "cli_mint",
+    subject: user.id,
+    // Anchor the registry row to the friend's user id so the operator's
+    // token registry + the revocation list attribute it correctly, and a
+    // future per-user revoke surface can find it.
+    userId: user.id,
+    clientId: ACCOUNT_VAULT_TOKEN_CLIENT_ID,
+    scopes: [scope],
+    expiresAt: minted.expiresAt,
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  });
+
+  return renderHome(200, {
+    mintedToken: {
+      vaultName,
+      verb: requestedVerb,
+      token: minted.token,
+      expiresInDays: Math.round(ACCOUNT_VAULT_TOKEN_TTL_SECONDS / (24 * 60 * 60)),
+    },
+  });
+}

--- a/src/api-account.ts
+++ b/src/api-account.ts
@@ -59,9 +59,11 @@ import { isTotpEnrolled } from "./two-factor-store.ts";
 import {
   PASSWORD_MAX_LEN,
   UserNotFoundError,
+  type VaultVerb,
   getUserById,
   isFirstAdmin,
   validatePassword,
+  vaultVerbsForUserVault,
   verifyPassword,
 } from "./users.ts";
 
@@ -490,6 +492,15 @@ export function handleAccountHomeGet(req: Request, deps: AccountHomeDeps): Respo
   const adminFlag = isFirstAdmin(deps.db, user.id);
   const csrf = ensureCsrfToken(req);
   const extra: Record<string, string> = csrf.setCookie ? { "set-cookie": csrf.setCookie } : {};
+  // Per-vault mintable verbs for the "mint an access token" affordance on each
+  // tile. Reads the assignment role (today always write → ["read", "write"])
+  // so the UI only ever offers a verb the POST handler would accept. Empty for
+  // the admin / no-vault branches (no assigned vaults to iterate).
+  const mintableVerbs: Record<string, VaultVerb[]> = {};
+  for (const v of user.assignedVaults) {
+    const verbs = vaultVerbsForUserVault(deps.db, user.id, v);
+    if (verbs && verbs.length > 0) mintableVerbs[v] = verbs;
+  }
   return htmlResponse(
     renderAccountHome({
       username: user.username,
@@ -499,6 +510,7 @@ export function handleAccountHomeGet(req: Request, deps: AccountHomeDeps): Respo
       isFirstAdmin: adminFlag,
       csrfToken: csrf.token,
       twoFactorEnabled: isTotpEnrolled(deps.db, user.id),
+      mintableVerbs,
     }),
     200,
     extra,

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -77,6 +77,10 @@
  *                                                 reachable directly to rotate)
  *   /account/2fa                  (GET + POST) → user self-service 2FA enroll/disenroll
  *                                                 (hub#473; QR + backup codes)
+ *   /account/vault-token/<name>   (POST)       → friend mints a scoped
+ *                                                 vault:<name>:read|write bearer for
+ *                                                 an ASSIGNED vault (headless clients;
+ *                                                 session + assignment + scope-capped)
  *   /admin/config*                             → 301 → /admin/vaults (legacy
  *                                                portal retired post-SPA-rework)
  *
@@ -113,6 +117,7 @@ import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import pkg from "../package.json" with { type: "json" };
+import { handleAccountVaultTokenPost } from "./account-vault-token.ts";
 import { handleApproveClient, handleGetClient } from "./admin-clients.ts";
 import { handleListGrants, handleRevokeGrant } from "./admin-grants.ts";
 import {
@@ -2084,6 +2089,23 @@ export function hubFetch(
       if (req.method === "GET") return handleTwoFactorGet(req, twoFactorDeps);
       if (req.method === "POST") return handleTwoFactorPost(req, twoFactorDeps);
       return new Response("method not allowed", { status: 405 });
+    }
+
+    // /account/vault-token/<name> — friend-facing scoped vault token mint.
+    // POST-only, session-gated, assignment-capped: a non-admin friend mints a
+    // `vault:<name>:read|write` bearer for a vault they're ASSIGNED to, for
+    // scripts / headless clients that can't do browser OAuth. The handler
+    // enforces session → assignment → scope-cap (never `:admin`, never a
+    // vault outside the assignment, never a broader verb than the role
+    // grants) + CSRF + per-user rate limit. Must precede the `/account/`
+    // match below (more specific prefix). See `account-vault-token.ts`.
+    if (pathname.startsWith("/account/vault-token/")) {
+      if (!getDb) return dbNotConfigured();
+      if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+      const vaultName = decodeURIComponent(pathname.slice("/account/vault-token/".length));
+      const db = getDb();
+      const hubOrigin = resolveIssuer(req, db, configuredIssuer);
+      return handleAccountVaultTokenPost(req, vaultName, { db, hubOrigin });
     }
 
     // /account/ — friend-facing user home (multi-user Phase 1 follow-up).

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -93,6 +93,22 @@ export const CHANGE_PASSWORD_MAX_ATTEMPTS = 3;
 export const TOTP_WINDOW_MS = 15 * 60 * 1000;
 /** `/login/2fa` attempts allowed per window. 6th within the window is denied. */
 export const TOTP_MAX_ATTEMPTS = 5;
+/**
+ * `POST /account/vault-token/<name>` window length: 10 minutes. The endpoint
+ * is session-gated and assignment-capped (a friend can only mint
+ * `vault:<assigned>:read|write`), so this limiter isn't the primary defense —
+ * it's a floor that stops a compromised session (stolen cookie) from
+ * machine-gunning the registry with mint rows. Keyed by user-id (identity is
+ * established by the session before the limiter is reached), same posture as
+ * the change-password limiter.
+ */
+export const VAULT_TOKEN_MINT_WINDOW_MS = 10 * 60 * 1000;
+/**
+ * `POST /account/vault-token/<name>` attempts allowed per window. A friend
+ * minting a token for a script does it a handful of times at most; 10 per 10
+ * minutes is generous for a human and still chokes a stolen-cookie flood.
+ */
+export const VAULT_TOKEN_MINT_MAX_ATTEMPTS = 10;
 /** Sentinel for the IP-extraction priority chain when nothing parsed. */
 export const UNKNOWN_IP_SENTINEL = "unknown";
 
@@ -219,6 +235,18 @@ export const changePasswordRateLimiter = new RateLimiter(
 export const totpRateLimiter = new RateLimiter(TOTP_MAX_ATTEMPTS, TOTP_WINDOW_MS);
 
 /**
+ * `POST /account/vault-token/<name>` rate limiter — per-user, 10 attempts /
+ * 10 min (friend vault-token mint). Keyed by user-id (session-gated endpoint,
+ * identity established before this limiter is reached). Separate bucket from
+ * change-password so a token-mint flurry and a password-change flurry don't
+ * share a window.
+ */
+export const vaultTokenMintRateLimiter = new RateLimiter(
+  VAULT_TOKEN_MINT_MAX_ATTEMPTS,
+  VAULT_TOKEN_MINT_WINDOW_MS,
+);
+
+/**
  * Backwards-compat shim for hub#188's call sites: the original
  * top-level `checkAndRecord` was the login limiter. New code should
  * reach into `loginRateLimiter.checkAndRecord` directly.
@@ -237,6 +265,7 @@ export function __resetForTests(): void {
   loginRateLimiter.reset();
   changePasswordRateLimiter.reset();
   totpRateLimiter.reset();
+  vaultTokenMintRateLimiter.reset();
 }
 
 /**

--- a/src/users.ts
+++ b/src/users.ts
@@ -144,6 +144,64 @@ function readVaultsForUser(db: Database, userId: string): string[] {
     .map((r) => r.vault_name);
 }
 
+/**
+ * The per-vault verbs a `user_vaults.role` grants. The schema's `role`
+ * column is `TEXT NOT NULL DEFAULT 'write'` and is reserved forward-compat
+ * for per-vault role granularity (see the v10 migration note in
+ * `hub-db.ts`). Today every assignment is created with `role = 'write'`, so
+ * the only live mapping is `write → {read, write}`. The function is the
+ * single place the verb-cap lives so a future role taxonomy (`read`-only,
+ * `admin`, etc.) lands here without the friend-mint path having to change.
+ *
+ * Mapping:
+ *   - `write` (today's only value)  → `["read", "write"]`
+ *   - `read`                        → `["read"]`
+ *   - anything else (unknown role)  → `[]` — fail closed. An unrecognised
+ *     role grants no minting authority rather than silently defaulting to
+ *     write. (Defense-in-depth: a hand-edited / future row with a role this
+ *     code doesn't understand should not be treated as broad write.)
+ *
+ * `admin` is intentionally NOT mapped to a `vault:<name>:admin` mint here —
+ * the friend-facing token mint is capped at read/write by design. A
+ * future per-vault-admin friend grant would route through the
+ * vault-admin-token path, not this one.
+ */
+export type VaultVerb = "read" | "write";
+
+export function vaultVerbsForRole(role: string): VaultVerb[] {
+  if (role === "write") return ["read", "write"];
+  if (role === "read") return ["read"];
+  return [];
+}
+
+/**
+ * Read the verbs a user may mint for one of their assigned vaults.
+ *
+ * Returns `null` when the user has NO `user_vaults` row for `vaultName` —
+ * i.e. the vault is not in their assignment. The caller treats `null` as a
+ * hard 403 (no minting for an unassigned vault). When a row exists, returns
+ * the verb list `vaultVerbsForRole` maps the stored role to (today always
+ * `["read", "write"]` since every assignment is `role = 'write'`).
+ *
+ * This reads the role column directly rather than going through
+ * `getUserById().assignedVaults` because that array is verb-blind — it
+ * names the vaults but not the role granted. The friend-mint authorization
+ * cap needs the role.
+ */
+export function vaultVerbsForUserVault(
+  db: Database,
+  userId: string,
+  vaultName: string,
+): VaultVerb[] | null {
+  const row = db
+    .query<{ role: string }, [string, string]>(
+      "SELECT role FROM user_vaults WHERE user_id = ? AND vault_name = ?",
+    )
+    .get(userId, vaultName);
+  if (!row) return null;
+  return vaultVerbsForRole(row.role);
+}
+
 export interface CreateUserOpts {
   /** Allow creating an additional user when one already exists. Off by default. */
   allowMulti?: boolean;


### PR DESCRIPTION
## What

Adds a **"mint an access token"** affordance to the friend `/account/` page so a non-admin user can mint a scoped bearer for **their assigned vault** — for scripts / headless clients that can't do browser OAuth. The no-token OAuth path stays the recommended default; the token is the secondary, opt-in path.

A non-admin friend with a hub session is already authorized for their assigned vault(s) (the OAuth issuer mints `vault:<assigned>:read|write` for them). Letting them mint that same authority **in token form** is no escalation — it's the same authority, materialized.

## Endpoint

`POST /account/vault-token/<name>` — session-gated (NOT admin-gated), form-encoded (`__csrf` + `verb`), re-renders `/account/` with the token shown once.

### Authorization rules (capped to the caller's actual authority, in order)

1. **Session** — active hub session cookie required, else **401**. (`findActiveSession`, same gate as `/account/change-password`.)
2. **Assignment** — the requested `<name>` MUST be in the user's `user_vaults` assignment, read via `vaultVerbsForUserVault` (returns `null` for an unassigned vault) — else **403**. Blocks minting for an unassigned vault and any cross-vault attempt. Reads the role column directly, not the verb-blind `assignedVaults` array.
3. **Scope cap** — the verb must be one the assignment **role** permits AND only ever `read`|`write`. `admin` is not in the form vocabulary (rejected at parse → **400**); a verb the role doesn't grant → **403**. **Never `:admin`, never a broader scope, never another vault.** Today every assignment is `role='write'` so the cap is `[read, write]`; a hand-set/future `role='read'` drops write (fail-closed; unknown role → `[]` → 403).
4. **CSRF** — double-submit cookie (`verifyCsrfToken`), verified **before** any state change / rate-limit bucket touch → **400** on mismatch/missing.
5. **Rate limit** — `vaultTokenMintRateLimiter`, per-user, 10 / 10 min → **429**.

The first admin (unrestricted, no `user_vaults` rows) gets **403** here by design — admins mint via the admin SPA path. This surface is friend-only.

### Mint
Uses the existing `signAccessToken` machinery (no hand-rolled JWT): scope `vault:<name>:<verb>`, `aud = vault.<name>` (`inferAudience`), `iss` = hub origin, `sub` = friend, `vault_scope: [<name>]` pin (defense in depth), **TTL 90d** (`ACCOUNT_VAULT_TOKEN_TTL_SECONDS`). Registry row via `recordTokenMint` (`created_via = cli_mint`, `userId` = friend) so it appears in the revocation list + operator token registry.

## UI

A collapsed **"Mint an access token (for scripts / headless clients)"** `<details>` block below the OAuth connect block on each vault tile (secondary to the recommended no-token path). A read/write radio + Mint button (POST, CSRF). On success the page re-renders with the token shown **once** — copy button + a clear "save it — won't be shown again; it's a bearer for `vault:<name>:<verb>`; expires in N days" warning. No revoke link (no friend-facing revoke exists today; the copy says "ask the hub operator"). The UI only ever offers a verb the server would accept (driven by `mintableVerbs`).

## Security tests

- assigned vault → 200, token carries the right scope/aud/iss/sub/vault_scope/TTL, validates as a hub JWT vault accepts;
- **unassigned vault → 403** (incl. a vault that exists for another user) — no token minted;
- **first admin → 403**;
- **`admin` verb → 400** (never mints `:admin`); garbage/broader verbs → 400;
- no session → 401; CSRF missing/mismatch → 400; CSRF failure does NOT burn a rate-limit slot; bucket fills → 429;
- routed end-to-end through `hubFetch` (route precedence over `/account/` + the SPA catch-all);
- unit tests for `vaultVerbsForRole` / `vaultVerbsForUserVault`; renderer tests for the mint affordance (both verbs / read-only / never-admin / absent), the show-once banner, the inline error banner.

## Verification

- `bun test ./src`: **2462 pass, 1 skip, 0 fail**
- `bun run typecheck`: clean
- `bunx biome check` on changed files: clean
- Version bumped `0.5.14-rc.15` → `0.5.14-rc.16`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)