### PR TITLE
feat(hub): @openparachute/depcheck lib + hub adoption — friendly missing-dependency UX (#481-followon, #188) (+ rc.19)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,35 +1,41 @@
 # Release workflow — triggered by pushing a semver tag.
 #
-# This workflow publishes TWO packages on different tag namespaces:
+# This workflow publishes THREE packages on different tag namespaces:
 #
 #   - @openparachute/hub          ← tag prefix `v...`            (e.g. v0.5.13-rc.33)
 #   - @openparachute/scope-guard  ← tag prefix `scope-guard-v...` (e.g. scope-guard-v0.4.0-rc.2)
+#   - @openparachute/depcheck     ← tag prefix `depcheck-v...`    (e.g. depcheck-v0.1.0-rc.1)
 #
-# Both packages have npm Trusted Publisher rules pointing at this workflow
+# All packages have npm Trusted Publisher rules pointing at this workflow
 # file. The jobs below gate on the tag prefix so only one package publishes
 # per tag push. Independent release cadences; hub doesn't have to bump when
-# scope-guard ships and vice versa.
+# scope-guard / depcheck ship and vice versa.
 #
 # Tag conventions (matches parachute-patterns governance rule 2):
 #   - rc:     v<X>.<Y>.<Z>-rc.<N>   (e.g. v0.5.13-rc.33)
 #                                    (scope-guard-v0.4.0-rc.2)
+#                                    (depcheck-v0.1.0-rc.1)
 #   - stable: v<X>.<Y>.<Z>          (e.g. v0.5.13)
 #                                    (scope-guard-v0.4.0)
+#                                    (depcheck-v0.1.0)
 #
 # Release flow:
 #   1. When ready to ship: bump version in the relevant package.json on main
-#      (root for hub, packages/scope-guard/ for scope-guard).
+#      (root for hub, packages/scope-guard/ for scope-guard,
+#      packages/depcheck/ for depcheck).
 #   2. Push a matching tag:
 #        # for hub
 #        git tag v$(bun -e "console.log(require('./package.json').version)") && git push --tags
 #        # for scope-guard
 #        git tag scope-guard-v$(bun -e "console.log(require('./packages/scope-guard/package.json').version)") && git push --tags
+#        # for depcheck
+#        git tag depcheck-v$(bun -e "console.log(require('./packages/depcheck/package.json').version)") && git push --tags
 #   3. CI runs tests once (workspace-wide), then publishes the package matching
 #      the tag prefix. Hub also publishes a container image to ghcr.io.
 #
 # Operator setup (one-time) — see RELEASING.md:
-#   - npm Trusted Publisher rules: one per package (hub, scope-guard).
-#     Both rules point at: org=ParachuteComputer, repo=parachute-hub,
+#   - npm Trusted Publisher rules: one per package (hub, scope-guard, depcheck).
+#     All rules point at: org=ParachuteComputer, repo=parachute-hub,
 #     workflow=release.yml, env blank.
 #   - ghcr.io needs no secret (uses the runner's GITHUB_TOKEN).
 
@@ -44,6 +50,9 @@ on:
       # scope-guard release tags
       - 'scope-guard-v[0-9]+.[0-9]+.[0-9]+'
       - 'scope-guard-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+      # depcheck release tags
+      - 'depcheck-v[0-9]+.[0-9]+.[0-9]+'
+      - 'depcheck-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
 
 concurrency:
   # Don't let two releases race on the same tag.
@@ -61,6 +70,13 @@ jobs:
           bun-version: 1.3
       - name: install deps
         run: bun install --frozen-lockfile
+      - name: build depcheck
+        # hub's `tsc` typecheck resolves `@openparachute/depcheck`'s types from
+        # its built `dist/index.d.ts`. The workspace install doesn't build it
+        # (no prepare hook), so build it explicitly before typecheck. At
+        # runtime hub resolves depcheck via the `bun`→src export condition, so
+        # this is only needed for the type-level resolution.
+        run: bun run --cwd packages/depcheck build
       - name: typecheck
         run: bun run typecheck
       - name: hub tests
@@ -70,12 +86,16 @@ jobs:
         # for the safety of catching scope-guard regressions before
         # publishing scope-guard.
         run: bun test ./packages/scope-guard/src
+      - name: depcheck tests
+        # Same rationale — depcheck is consumed by hub, so a regression here
+        # would break hub too. Cheap to run on every tag.
+        run: bun test ./packages/depcheck/src
 
   publish-hub-npm:
     name: publish hub to npm
     needs: test
-    # Hub-only: skip on scope-guard tags.
-    if: ${{ !startsWith(github.ref_name, 'scope-guard-') }}
+    # Hub-only: skip on scope-guard / depcheck tags (a `v*` tag is hub's).
+    if: ${{ !startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -176,11 +196,61 @@ jobs:
           echo "publishing @openparachute/scope-guard with dist-tag=$DIST_TAG"
           npm publish --tag "$DIST_TAG" --access public --provenance
 
+  publish-depcheck-npm:
+    name: publish depcheck to npm
+    needs: test
+    # depcheck-only: skip on hub (`v*`) + scope-guard tags.
+    if: ${{ startsWith(github.ref_name, 'depcheck-') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        # All shell steps default to the depcheck package dir. Steps that need
+        # to run from the repo root explicitly override
+        # `working-directory: ${{ github.workspace }}`.
+        working-directory: packages/depcheck
+    steps:
+      - uses: actions/checkout@v4
+        # checkout has no working-directory option; runs from repo root.
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      - name: install deps
+        # Install at workspace root so hoisted deps resolve.
+        working-directory: ${{ github.workspace }}
+        run: bun install --frozen-lockfile
+      - name: verify package.json version matches tag
+        run: |
+          PKG_VERSION=$(bun -e "console.log(require('./package.json').version)")
+          # Strip the `depcheck-v` prefix from the tag.
+          TAG_VERSION="${GITHUB_REF_NAME#depcheck-v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::packages/depcheck/package.json version ($PKG_VERSION) doesn't match tag ($TAG_VERSION)"
+            exit 1
+          fi
+      - name: publish
+        # prepublishOnly runs `bun run build` (tsc → dist/) before the tarball
+        # is assembled, so the published package ships compiled JS + d.ts.
+        run: |
+          if [[ "$GITHUB_REF_NAME" =~ -rc\. ]]; then
+            DIST_TAG=rc
+          else
+            DIST_TAG=latest
+          fi
+          echo "publishing @openparachute/depcheck with dist-tag=$DIST_TAG"
+          npm publish --tag "$DIST_TAG" --access public --provenance
+
   publish-image:
     name: publish to ghcr.io
     needs: test
-    # Hub-only: scope-guard doesn't ship a container image.
-    if: ${{ !startsWith(github.ref_name, 'scope-guard-') }}
+    # Hub-only: scope-guard / depcheck don't ship a container image.
+    if: ${{ !startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,10 +50,11 @@ FROM oven/bun:${BUN_VERSION}-alpine AS builder
 WORKDIR /app
 
 # Copy manifests first so Docker layer-caches the install step across
-# source-only changes. Includes the scope-guard workspace package and the
-# web/ui frontend workspace.
+# source-only changes. Includes the scope-guard + depcheck workspace packages
+# and the web/ui frontend workspace.
 COPY package.json bun.lock ./
 COPY packages/scope-guard/package.json packages/scope-guard/
+COPY packages/depcheck/package.json packages/depcheck/
 COPY web/ui/package.json web/ui/bun.lock web/ui/
 
 # Install with the lockfile pinned. `--frozen-lockfile` matches CI; the

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@openparachute/hub",
       "dependencies": {
         "@node-rs/argon2": "^2.0.2",
+        "@openparachute/depcheck": "0.1.0-rc.1",
         "jose": "^6.2.2",
         "otpauth": "^9.5.0",
         "qrcode": "^1.5.4",
@@ -15,6 +16,13 @@
         "@types/bun": "latest",
         "@types/qrcode": "^1.5.6",
       },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+    "packages/depcheck": {
+      "name": "@openparachute/depcheck",
+      "version": "0.1.0-rc.1",
       "peerDependencies": {
         "typescript": "^5",
       },
@@ -88,6 +96,8 @@
     "@node-rs/argon2-win32-ia32-msvc": ["@node-rs/argon2-win32-ia32-msvc@2.0.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-GsE2ezwAYwh72f9gIjbGTZOf4HxEksb5M2eCaj+Y5rGYVwAdt7C12Q2e9H5LRYxWcFvLH4m4jiSZpQQ4upnPAQ=="],
 
     "@node-rs/argon2-win32-x64-msvc": ["@node-rs/argon2-win32-x64-msvc@2.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-cJxWXanH4Ew9CfuZ4IAEiafpOBCe97bzoKowHCGk5lG/7kR4WF/eknnBlHW9m8q7t10mKq75kruPLtbSDqgRTw=="],
+
+    "@openparachute/depcheck": ["@openparachute/depcheck@workspace:packages/depcheck"],
 
     "@openparachute/scope-guard": ["@openparachute/scope-guard@workspace:packages/scope-guard"],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.18",
+  "version": "0.5.14-rc.19",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {
@@ -11,15 +11,8 @@
   "bin": {
     "parachute": "src/cli.ts"
   },
-  "workspaces": [
-    "packages/*"
-  ],
-  "files": [
-    "src",
-    "web/ui/dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "workspaces": ["packages/*"],
+  "files": ["src", "web/ui/dist", "README.md", "LICENSE"],
   "repository": {
     "type": "git",
     "url": "https://github.com/ParachuteComputer/parachute-hub.git"
@@ -45,6 +38,7 @@
   },
   "dependencies": {
     "@node-rs/argon2": "^2.0.2",
+    "@openparachute/depcheck": "0.1.0-rc.1",
     "jose": "^6.2.2",
     "otpauth": "^9.5.0",
     "qrcode": "^1.5.4"

--- a/packages/depcheck/package.json
+++ b/packages/depcheck/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@openparachute/depcheck",
+  "version": "0.1.0-rc.1",
+  "description": "Canonical missing-dependency UX for Parachute modules: a dependency registry, a message formatter, and ENOENT spawn-error helpers shared across vault / scribe / runner / hub.",
+  "license": "AGPL-3.0",
+  "type": "module",
+  "publishConfig": {
+    "access": "public",
+    "//": "Override exports at publish time: the published tarball ships dist/ only (no src/), so the dev-only `bun`→src condition is dropped. Published Bun + Node consumers both resolve dist.",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "bun": "./src/index.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist", "README.md", "LICENSE"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ParachuteComputer/parachute-hub.git",
+    "directory": "packages/depcheck"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "bun run build",
+    "test": "bun test src",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/depcheck/src/error.test.ts
+++ b/packages/depcheck/src/error.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MissingDependencyError,
+  ensureExecutable,
+  isBinaryNotFoundError,
+  rethrowIfMissing,
+} from "./error.ts";
+import { lookupDep } from "./registry.ts";
+
+describe("MissingDependencyError", () => {
+  test("carries errorType, binary, spec; message is the formatted block", () => {
+    const err = new MissingDependencyError("git", lookupDep("git"), {
+      platform: "darwin",
+      arch: "arm64",
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.errorType).toBe("missing_dependency");
+    expect(err.binary).toBe("git");
+    expect(err.spec?.binary).toBe("git");
+    expect(err.message).toContain("git is required to mirror your vault to a git remote");
+    expect(err.message).toContain("brew install git");
+  });
+
+  test("toWire() returns the structured shape (no sysadmin trailer in description)", () => {
+    const err = new MissingDependencyError("git", lookupDep("git"), {
+      platform: "linux",
+      arch: "x64",
+    });
+    const wire = err.toWire();
+    expect(wire.error_type).toBe("missing_dependency");
+    expect(wire.binary).toBe("git");
+    expect(wire.install.linux).toContain("apt-get");
+    expect(wire.error_description).not.toContain("system administrator");
+  });
+
+  test("undefined spec → generic message + degraded wire", () => {
+    const err = new MissingDependencyError("frobnicate", undefined);
+    expect(err.spec).toBeUndefined();
+    expect(err.message).toContain("frobnicate is required but was not found on PATH");
+    expect(err.toWire().why).toBeNull();
+  });
+});
+
+describe("ensureExecutable", () => {
+  test("throws MissingDependencyError when which → null", () => {
+    expect(() => ensureExecutable("git", { which: () => null, platform: "darwin" })).toThrow(
+      MissingDependencyError,
+    );
+  });
+
+  test("the thrown error carries the looked-up spec", () => {
+    try {
+      ensureExecutable("tailscale", { which: () => null, platform: "linux", arch: "x64" });
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(MissingDependencyError);
+      const err = e as MissingDependencyError;
+      expect(err.binary).toBe("tailscale");
+      expect(err.spec?.why).toBe("expose your hub over a tailnet");
+    }
+  });
+
+  test("is silent when which → a path", () => {
+    expect(() => ensureExecutable("git", { which: () => "/usr/bin/git" })).not.toThrow();
+  });
+
+  test("unregistered binary still throws (spec undefined, generic message)", () => {
+    try {
+      ensureExecutable("frobnicate", { which: () => null });
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(MissingDependencyError);
+      expect((e as MissingDependencyError).spec).toBeUndefined();
+    }
+  });
+});
+
+describe("isBinaryNotFoundError", () => {
+  test("matches code === ENOENT", () => {
+    expect(isBinaryNotFoundError({ code: "ENOENT" })).toBe(true);
+  });
+
+  test("matches Bun 'Executable not found' message", () => {
+    expect(isBinaryNotFoundError(new Error('Executable not found in $PATH: "git"'))).toBe(true);
+  });
+
+  test("matches 'No such file' message", () => {
+    expect(isBinaryNotFoundError(new Error("spawn git ENOENT: No such file"))).toBe(true);
+  });
+
+  test("does NOT match EACCES (must propagate)", () => {
+    expect(isBinaryNotFoundError({ code: "EACCES", message: "permission denied" })).toBe(false);
+  });
+
+  test("does NOT match an unrelated error", () => {
+    expect(isBinaryNotFoundError(new Error("connection refused"))).toBe(false);
+    expect(isBinaryNotFoundError(null)).toBe(false);
+    expect(isBinaryNotFoundError("string")).toBe(false);
+  });
+
+  test("binary-scoped match: message-only match requires the binary name", () => {
+    const err = new Error('Executable not found in $PATH: "git"');
+    expect(isBinaryNotFoundError(err, "git")).toBe(true);
+    // a not-found message about a DIFFERENT binary doesn't attribute to ours
+    expect(isBinaryNotFoundError(err, "tailscale")).toBe(false);
+  });
+
+  test("bare ENOENT with no message still matches even when a binary is named", () => {
+    expect(isBinaryNotFoundError({ code: "ENOENT" }, "git")).toBe(true);
+  });
+
+  test("code===ENOENT matches even with a generic message + a named binary", () => {
+    // errno is the unambiguous signal; the message is often generic
+    // ("spawn failed") and must not gate attribution.
+    expect(
+      isBinaryNotFoundError(
+        Object.assign(new Error("spawn failed"), { code: "ENOENT" }),
+        "cloudflared",
+      ),
+    ).toBe(true);
+  });
+
+  test("ENOENT in the message string (no .code) is also a not-found signal", () => {
+    expect(isBinaryNotFoundError(new Error("ENOENT: cloudflared not on PATH"), "cloudflared")).toBe(
+      true,
+    );
+  });
+});
+
+describe("rethrowIfMissing", () => {
+  test("throws MissingDependencyError on a not-found spawn error", () => {
+    const spawnErr = new Error('Executable not found in $PATH: "tailscale"');
+    expect(() =>
+      rethrowIfMissing(spawnErr, "tailscale", { platform: "linux", arch: "x64" }),
+    ).toThrow(MissingDependencyError);
+  });
+
+  test("the rethrown error carries the registry spec", () => {
+    try {
+      rethrowIfMissing({ code: "ENOENT" }, "tailscale");
+      // no throw here means the helper returned — fail
+      // (we expect a throw)
+    } catch (e) {
+      expect(e).toBeInstanceOf(MissingDependencyError);
+      expect((e as MissingDependencyError).spec?.binary).toBe("tailscale");
+      return;
+    }
+    throw new Error("rethrowIfMissing should have thrown for ENOENT");
+  });
+
+  test("returns (does NOT throw) for a non-not-found error", () => {
+    expect(() => rethrowIfMissing({ code: "EACCES" }, "tailscale")).not.toThrow();
+    expect(() => rethrowIfMissing(new Error("boom"), "tailscale")).not.toThrow();
+  });
+});

--- a/packages/depcheck/src/error.ts
+++ b/packages/depcheck/src/error.ts
@@ -1,0 +1,143 @@
+/**
+ * `MissingDependencyError` + the ENOENT spawn-error helpers.
+ *
+ * This is the behavior layer over the data registry: it turns "the binary
+ * isn't on PATH" — detected either by a pre-spawn `Bun.which` check or by a
+ * post-spawn ENOENT catch — into a single typed error carrying the spec, so
+ * every call site renders the same message and the same wire shape.
+ *
+ * Generalizes vault's `git-preflight.ts` (`ensureGitAvailable` +
+ * `isGitNotFoundSpawnError`) and hub's `cloudflare/detect.ts`
+ * (`isBinaryNotFoundError`) into one place.
+ */
+
+import {
+  type FormatOpts,
+  type MissingDependencyWire,
+  formatMissingDependency,
+  toMissingDependencyWire,
+} from "./format.js";
+import { type DepSpec, lookupDep } from "./registry.js";
+
+/**
+ * Thrown when a required binary isn't resolvable on PATH. Carries the binary
+ * name + (looked-up) spec so any catch site can render the operator message
+ * (`.message` is already the formatted block) or the wire shape (`.toWire()`).
+ *
+ * `errorType` is a literal discriminant so a consumer can branch on it
+ * structurally (matches the wire's `error_type`).
+ */
+export class MissingDependencyError extends Error {
+  readonly errorType = "missing_dependency" as const;
+  readonly binary: string;
+  readonly spec: DepSpec | undefined;
+  private readonly formatOpts: FormatOpts;
+
+  constructor(
+    binary: string,
+    spec?: DepSpec,
+    opts?: { platform?: NodeJS.Platform; arch?: NodeJS.Architecture; interactive?: boolean },
+  ) {
+    const formatOpts: FormatOpts = {};
+    if (opts?.platform !== undefined) formatOpts.platform = opts.platform;
+    if (opts?.arch !== undefined) formatOpts.arch = opts.arch;
+    if (opts?.interactive !== undefined) formatOpts.interactive = opts.interactive;
+    super(formatMissingDependency(binary, spec, formatOpts));
+    this.name = "MissingDependencyError";
+    this.binary = binary;
+    this.spec = spec;
+    this.formatOpts = formatOpts;
+  }
+
+  /** Structured wire shape for an API/SPA consumer. Uses the same
+   * platform/arch the error was constructed with. */
+  toWire(): MissingDependencyWire {
+    return toMissingDependencyWire(this.binary, this.spec, this.formatOpts);
+  }
+}
+
+/**
+ * Throw `MissingDependencyError` if `binary` isn't resolvable on PATH.
+ *
+ * `which` is a TEST SEAM (default `Bun.which`) so tests can force the
+ * missing branch without uninstalling the binary from the host. The spec is
+ * looked up from the registry — an unregistered binary still throws (the
+ * error renders the generic "ask your sysadmin" message), never silently
+ * passes.
+ */
+export function ensureExecutable(
+  binary: string,
+  opts?: {
+    which?: (cmd: string) => string | null;
+    platform?: NodeJS.Platform;
+    arch?: NodeJS.Architecture;
+  },
+): void {
+  const which = opts?.which ?? Bun.which;
+  if (which(binary) === null) {
+    const errOpts: { platform?: NodeJS.Platform; arch?: NodeJS.Architecture } = {};
+    if (opts?.platform !== undefined) errOpts.platform = opts.platform;
+    if (opts?.arch !== undefined) errOpts.arch = opts.arch;
+    throw new MissingDependencyError(binary, lookupDep(binary), errOpts);
+  }
+}
+
+/**
+ * Heuristic: does this error look like the "executable not found on PATH"
+ * failure a spawn throws when it can't resolve the binary?
+ *
+ * Matches `code === "ENOENT"` OR a message mentioning `Executable not found`
+ * / `not found` / `No such file` (Bun's spawn-error message shape varies
+ * across versions; Node uses ENOENT). When `binary` is supplied, a
+ * message-only match additionally requires the message to mention the binary
+ * — so a `not found` message about some OTHER file doesn't get mis-attributed.
+ *
+ * CRITICAL: this matches ONLY not-found. EACCES (non-executable file),
+ * corrupt binaries, and every other error must propagate — we never want to
+ * report "not installed" when something more specific is wrong. (Mirrors the
+ * swallow-only-ENOENT contract in vault's git-preflight + hub's detect.ts.)
+ */
+export function isBinaryNotFoundError(err: unknown, binary?: string): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as { code?: unknown; message?: unknown };
+  // `code === "ENOENT"` is the unambiguous, structured not-found signal — a
+  // spawn that couldn't resolve the executable. We accept it regardless of
+  // the message (the errno IS the signal; the message is often generic like
+  // "spawn failed"). Binary attribution applies only to the looser
+  // message-string match below, where "not found" could be about anything.
+  if (e.code === "ENOENT") return true;
+  if (typeof e.message === "string") {
+    const msg = e.message;
+    // `ENOENT` in the message is also a not-found signal — some runtimes only
+    // surface the errno in the message string, not a `.code` field. (Matches
+    // the prior hub detect.ts matcher, which included ENOENT in this regex.)
+    const looksNotFound = /Executable not found|not found|No such file|ENOENT/i.test(msg);
+    if (!looksNotFound) return false;
+    if (binary) return msg.includes(binary);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * If `err` is a binary-not-found spawn error for `binary`, throw a
+ * `MissingDependencyError` (carrying the registry spec). Otherwise return —
+ * the caller's surrounding catch re-handles non-not-found errors.
+ *
+ * The belt-and-suspenders companion to `ensureExecutable`: a spawn that
+ * slips past the pre-flight (race where the binary is removed between check
+ * and spawn, or a path that didn't pre-flight) still surfaces the friendly
+ * error instead of the raw `Executable not found in $PATH` string.
+ */
+export function rethrowIfMissing(
+  err: unknown,
+  binary: string,
+  opts?: { platform?: NodeJS.Platform; arch?: NodeJS.Architecture },
+): void {
+  if (isBinaryNotFoundError(err, binary)) {
+    const errOpts: { platform?: NodeJS.Platform; arch?: NodeJS.Architecture } = {};
+    if (opts?.platform !== undefined) errOpts.platform = opts.platform;
+    if (opts?.arch !== undefined) errOpts.arch = opts.arch;
+    throw new MissingDependencyError(binary, lookupDep(binary), errOpts);
+  }
+}

--- a/packages/depcheck/src/format.test.ts
+++ b/packages/depcheck/src/format.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type FormatOpts,
+  formatMissingDependency,
+  resolveInstallCommands,
+  toMissingDependencyWire,
+} from "./format.ts";
+import { DEPENDENCY_REGISTRY, lookupDep } from "./registry.ts";
+
+const git = DEPENDENCY_REGISTRY.git;
+const cloudflared = DEPENDENCY_REGISTRY.cloudflared;
+const tailscale = DEPENDENCY_REGISTRY.tailscale;
+const claude = DEPENDENCY_REGISTRY.claude;
+const tar = DEPENDENCY_REGISTRY.tar;
+const bun = DEPENDENCY_REGISTRY.bun;
+
+const darwin: FormatOpts = { platform: "darwin", arch: "arm64" };
+const linuxX64: FormatOpts = { platform: "linux", arch: "x64" };
+const linuxArm: FormatOpts = { platform: "linux", arch: "arm64" };
+const win32: FormatOpts = { platform: "win32", arch: "x64" };
+
+describe("resolveInstallCommands", () => {
+  test("darwin → brew recipe only", () => {
+    expect(resolveInstallCommands(git, darwin)).toEqual(["brew install git"]);
+  });
+
+  test("linux → apt + dnf when no static binary", () => {
+    expect(resolveInstallCommands(git, linuxX64)).toEqual([
+      "sudo apt-get install -y git",
+      "sudo dnf install git",
+    ]);
+  });
+
+  test("linux static-binary recipe WINS over distro packages", () => {
+    const cmds = resolveInstallCommands(cloudflared, linuxX64);
+    expect(cmds).toHaveLength(1);
+    expect(cmds[0]).toContain("cloudflared-linux-amd64");
+    // never lists apt/dnf for cloudflared (it has none anyway, but the
+    // static binary must be the sole linux recipe)
+    expect(cmds[0]).not.toContain("apt-get");
+  });
+
+  test("linux static-binary arch mapping: arm64 → arm64 suffix", () => {
+    const cmds = resolveInstallCommands(cloudflared, linuxArm);
+    expect(cmds[0]).toContain("cloudflared-linux-arm64");
+  });
+
+  test("linux unknown arch drops static binary → docs (no fabricated URL)", () => {
+    // mips64 has no published cloudflared artifact → linuxBinaryUrl returns
+    // undefined → no distro fallback for cloudflared → empty install list
+    const cmds = resolveInstallCommands(cloudflared, {
+      platform: "linux",
+      arch: "mips64el" as NodeJS.Architecture,
+    });
+    expect(cmds).toEqual([]);
+  });
+
+  test("tailscale linux uses the curl install.sh recipe", () => {
+    const cmds = resolveInstallCommands(tailscale, linuxX64);
+    expect(cmds).toEqual(["curl -fsSL https://tailscale.com/install.sh | sh"]);
+  });
+
+  test("win32 / unknown platform lists ALL families", () => {
+    const cmds = resolveInstallCommands(git, win32);
+    expect(cmds).toContain("brew install git");
+    expect(cmds).toContain("sudo apt-get install -y git");
+    expect(cmds).toContain("sudo dnf install git");
+  });
+
+  test("generic-only spec (bun) on darwin falls back to generic", () => {
+    expect(resolveInstallCommands(bun, darwin)).toEqual([
+      "curl -fsSL https://bun.sh/install | bash",
+    ]);
+  });
+
+  test("foundational spec with no recipes (tar) → empty list", () => {
+    expect(resolveInstallCommands(tar, darwin)).toEqual([]);
+    expect(resolveInstallCommands(tar, linuxX64)).toEqual([]);
+    expect(resolveInstallCommands(tar, win32)).toEqual([]);
+  });
+});
+
+describe("formatMissingDependency — message anatomy", () => {
+  test("line 1 names binary + why + not-found-on-PATH", () => {
+    const msg = formatMissingDependency("git", git, darwin);
+    expect(msg.split("\n")[0]).toBe(
+      "git is required to mirror your vault to a git remote, but it was not found on PATH.",
+    );
+  });
+
+  test("includes an install block and the docs line", () => {
+    const msg = formatMissingDependency("git", git, darwin);
+    expect(msg).toContain("Install it (macOS):");
+    expect(msg).toContain("brew install git");
+    expect(msg).toContain("Docs: https://git-scm.com/downloads");
+  });
+
+  test("interactive: true includes the sysadmin trailer for foundational deps", () => {
+    const msg = formatMissingDependency("git", git, { ...darwin, interactive: true });
+    expect(msg).toContain("Or ask your system administrator to install it for you.");
+  });
+
+  test("interactive: false strips the sysadmin trailer", () => {
+    const msg = formatMissingDependency("git", git, { ...darwin, interactive: false });
+    expect(msg).not.toContain("system administrator");
+    // still carries the actionable parts
+    expect(msg).toContain("brew install git");
+    expect(msg).toContain("Docs:");
+  });
+
+  test("optional dep shows altHint instead of the sysadmin trailer", () => {
+    const msg = formatMissingDependency("claude", claude, { ...darwin, interactive: true });
+    expect(msg).toContain("or switch cleanup/job provider");
+    expect(msg).not.toContain("system administrator");
+  });
+
+  test("optional dep in non-interactive mode drops the altHint trailer too", () => {
+    const msg = formatMissingDependency("claude", claude, { ...darwin, interactive: false });
+    expect(msg).not.toContain("or switch cleanup/job provider");
+    expect(msg).not.toContain("system administrator");
+  });
+
+  test("linux static-binary recipe is indented under the install block", () => {
+    const msg = formatMissingDependency("cloudflared", cloudflared, linuxX64);
+    expect(msg).toContain("Install it (Linux):");
+    expect(msg).toContain("  curl -L -o /usr/local/bin/cloudflared");
+    expect(msg).toContain("  sudo chmod +x /usr/local/bin/cloudflared");
+  });
+
+  test("win32 (unknown) lists all families + still has docs", () => {
+    const msg = formatMissingDependency("git", git, win32);
+    expect(msg).toContain("Install it:");
+    expect(msg).toContain("brew install git");
+    expect(msg).toContain("sudo apt-get install -y git");
+    expect(msg).toContain("Docs:");
+  });
+
+  test("foundational dep with no recipe still shows docs + sysadmin", () => {
+    const msg = formatMissingDependency("tar", tar, linuxX64);
+    expect(msg).toContain("tar is required to compress your vault backups");
+    expect(msg).not.toContain("Install it");
+    expect(msg).toContain("Docs: https://www.gnu.org/software/tar/");
+    expect(msg).toContain("Or ask your system administrator");
+  });
+
+  test("unregistered binary → generic message, no fabricated install command", () => {
+    const msg = formatMissingDependency("frobnicate", undefined, darwin);
+    expect(msg).toBe(
+      "frobnicate is required but was not found on PATH. Ask your system administrator, or check the Parachute docs.",
+    );
+    expect(msg).not.toContain("brew");
+    expect(msg).not.toContain("apt-get");
+    expect(msg).not.toContain("Install it");
+  });
+
+  test("ANSI is stripped in non-interactive mode", () => {
+    // Inject a spec carrying ANSI so we exercise the stripper deterministically.
+    const ansiSpec = {
+      binary: "x",
+      why: "[1mtest[0m bold",
+      docsUrl: "https://example.com",
+      install: { generic: "[32minstall-x[0m" },
+    };
+    const msg = formatMissingDependency("x", ansiSpec, { platform: "linux", interactive: false });
+    expect(msg).not.toContain("[");
+    expect(msg).toContain("install-x");
+  });
+});
+
+describe("toMissingDependencyWire", () => {
+  test("shape + that error_description has no sysadmin trailer", () => {
+    const wire = toMissingDependencyWire("git", git, linuxX64);
+    expect(wire.error).toBe("missing_dependency");
+    expect(wire.error_type).toBe("missing_dependency");
+    expect(wire.binary).toBe("git");
+    expect(wire.why).toBe("mirror your vault to a git remote");
+    expect(wire.docs_url).toBe("https://git-scm.com/downloads");
+    expect(wire.install.linux).toBe("sudo apt-get install -y git\nsudo dnf install git");
+    expect(wire.sysadmin_hint).toBe("Or ask your system administrator to install it for you.");
+    // error_description is the headless render (linux platform here) — no
+    // "ask someone else" trailer, and the recipe is platform-scoped to linux.
+    expect(wire.error_description).not.toContain("system administrator");
+    expect(wire.error_description).toContain("sudo apt-get install -y git");
+  });
+
+  test("darwin install field carries the brew recipe", () => {
+    const wire = toMissingDependencyWire("git", git, darwin);
+    expect(wire.install.darwin).toBe("brew install git");
+  });
+
+  test("cloudflared wire linux = static binary recipe for the arch", () => {
+    const wire = toMissingDependencyWire("cloudflared", cloudflared, linuxX64);
+    expect(wire.install.linux).toContain("cloudflared-linux-amd64");
+  });
+
+  test("optional dep wire sysadmin_hint = altHint", () => {
+    const wire = toMissingDependencyWire("claude", claude, darwin);
+    expect(wire.sysadmin_hint).toBe("or switch cleanup/job provider");
+    expect(wire.install.generic).toBe("npm i -g @anthropic-ai/claude-code");
+  });
+
+  test("unregistered binary wire degrades: null why/docs, empty install", () => {
+    const wire = toMissingDependencyWire("frobnicate", undefined, darwin);
+    expect(wire.binary).toBe("frobnicate");
+    expect(wire.why).toBeNull();
+    expect(wire.docs_url).toBeNull();
+    expect(wire.install).toEqual({});
+    expect(wire.error_description).toContain("frobnicate is required but was not found");
+  });
+});
+
+describe("lookupDep", () => {
+  test("returns the spec for a registered binary", () => {
+    expect(lookupDep("git")?.binary).toBe("git");
+    expect(lookupDep("parakeet-mlx")?.optional).toBe(true);
+  });
+
+  test("returns undefined for an unregistered binary (never fabricates)", () => {
+    expect(lookupDep("frobnicate")).toBeUndefined();
+  });
+});

--- a/packages/depcheck/src/format.ts
+++ b/packages/depcheck/src/format.ts
@@ -1,0 +1,249 @@
+/**
+ * The message formatter. Turns a `DepSpec` (or a missing one) into the
+ * operator-facing "you're missing X, here's how to get it" block, plus the
+ * structured wire shape the SPA / API consumers render.
+ *
+ * Message anatomy (5 parts), in order:
+ *   1. line 1  — `<binary> is required to <why>, but it was not found on PATH.`
+ *   2. install — an `Install it:` block. The detected-OS line leads, but all
+ *                applicable families are listed so a headless reader on a
+ *                different box still has the recipe. `linuxBinaryUrl` (static
+ *                binary) wins over apt/dnf on Linux when it yields a recipe;
+ *                unknown arch drops to docs rather than fabricating a URL.
+ *   3. docs    — `Docs: <docsUrl>` — always present.
+ *   4. trailer — `Or ask your system administrator to install it for you.`,
+ *                REPLACED by `altHint` when the spec is `optional`.
+ *
+ * `interactive: false` (headless / API reader) strips ANSI and drops the
+ * sysadmin/alt trailer — the reader of a JSON error IS the admin, so it gets
+ * binary + why + install + docs only, no "ask someone else" noise.
+ *
+ * An unregistered binary (spec === undefined) yields a deliberately generic
+ * line with NO fabricated install command.
+ */
+
+import type { DepSpec } from "./registry.js";
+
+export interface FormatOpts {
+  /** Defaults to `process.platform`. */
+  platform?: NodeJS.Platform;
+  /** Defaults to `process.arch`. */
+  arch?: NodeJS.Architecture;
+  /**
+   * Whether the reader is a human at a terminal (default true). `false` ⇒
+   * strip ANSI + drop the sysadmin/alt trailer (headless reader IS the admin).
+   */
+  interactive?: boolean;
+}
+
+/** Structured wire shape — aligns hub's `proxy-error-ui.ts` envelope
+ * (`{ error, error_type, error_description }`) plus the dependency fields a
+ * UI needs to render a dedicated install card. */
+export interface MissingDependencyWire {
+  error: "missing_dependency";
+  error_type: "missing_dependency";
+  error_description: string;
+  binary: string;
+  why: string | null;
+  docs_url: string | null;
+  install: {
+    darwin?: string;
+    linux?: string;
+    generic?: string;
+  };
+  sysadmin_hint: string;
+}
+
+const SYSADMIN_TRAILER = "Or ask your system administrator to install it for you.";
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI SGR escapes is the point.
+const ANSI_PATTERN = /\[[0-9;]*m/g;
+
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_PATTERN, "");
+}
+
+/**
+ * Resolve the ordered list of install command lines for a spec, honoring the
+ * detected platform/arch. Used both by the human formatter and (in flattened
+ * form) by the wire shape.
+ *
+ *   - darwin            → the macOS recipe, else generic.
+ *   - linux             → static-binary recipe (linuxBinaryUrl) if it yields
+ *                         one for this arch; else apt + dnf; else generic.
+ *   - other / unknown   → every recipe we have (the reader's box is unknown,
+ *                         so list them all rather than guess).
+ *
+ * Returns `[]` when the spec carries no install recipe at all (foundational
+ * tools like `tar` / `tail` that are "almost always present" — the formatter
+ * then leans on the docs line + sysadmin trailer).
+ */
+export function resolveInstallCommands(spec: DepSpec, opts: FormatOpts = {}): string[] {
+  const platform = opts.platform ?? process.platform;
+  const arch = opts.arch ?? process.arch;
+  const { darwin, linuxApt, linuxDnf, linuxBinaryUrl, generic } = spec.install;
+
+  if (platform === "darwin") {
+    if (darwin) return [darwin];
+    if (generic) return [generic];
+    return [];
+  }
+
+  if (platform === "linux") {
+    // Static binary wins over distro packages when available for this arch.
+    const binaryRecipe = linuxBinaryUrl?.(arch);
+    if (binaryRecipe) return [binaryRecipe];
+    const distro: string[] = [];
+    if (linuxApt) distro.push(linuxApt);
+    if (linuxDnf) distro.push(linuxDnf);
+    if (distro.length > 0) return distro;
+    if (generic) return [generic];
+    return [];
+  }
+
+  // Unknown / non-darwin-non-linux platform (win32, etc.): we can't detect a
+  // package manager, so surface everything we have. linuxBinaryUrl is only
+  // listed when it yields a recipe for the (possibly unknown) arch — never
+  // fabricate a URL for an arch with no published artifact.
+  const all: string[] = [];
+  if (darwin) all.push(darwin);
+  const binaryRecipe = linuxBinaryUrl?.(arch);
+  if (binaryRecipe) all.push(binaryRecipe);
+  if (linuxApt) all.push(linuxApt);
+  if (linuxDnf) all.push(linuxDnf);
+  if (generic) all.push(generic);
+  return all;
+}
+
+/**
+ * Flatten a spec's install recipes into the wire shape's `install` map. The
+ * map's three keys mirror what a UI groups by (macOS / Linux / generic).
+ * Linux prefers the static-binary recipe for the given arch, falling back to
+ * the joined apt/dnf lines. Empty recipes are omitted.
+ */
+function wireInstall(spec: DepSpec, arch: NodeJS.Architecture): MissingDependencyWire["install"] {
+  const out: MissingDependencyWire["install"] = {};
+  if (spec.install.darwin) out.darwin = spec.install.darwin;
+  const binaryRecipe = spec.install.linuxBinaryUrl?.(arch);
+  if (binaryRecipe) {
+    out.linux = binaryRecipe;
+  } else {
+    const distro: string[] = [];
+    if (spec.install.linuxApt) distro.push(spec.install.linuxApt);
+    if (spec.install.linuxDnf) distro.push(spec.install.linuxDnf);
+    if (distro.length > 0) out.linux = distro.join("\n");
+  }
+  if (spec.install.generic) out.generic = spec.install.generic;
+  return out;
+}
+
+/** Human-readable label for the platform's install line lead. */
+function platformLabel(platform: NodeJS.Platform): string {
+  if (platform === "darwin") return "macOS";
+  if (platform === "linux") return "Linux";
+  return platform;
+}
+
+/**
+ * Build the operator-facing block. See module docstring for the anatomy.
+ *
+ * `spec === undefined` ⇒ unregistered binary ⇒ generic, no fabricated command.
+ */
+export function formatMissingDependency(
+  binary: string,
+  spec: DepSpec | undefined,
+  opts: FormatOpts = {},
+): string {
+  const interactive = opts.interactive ?? true;
+
+  if (!spec) {
+    const generic = `${binary} is required but was not found on PATH. Ask your system administrator, or check the Parachute docs.`;
+    return interactive ? generic : stripAnsi(generic);
+  }
+
+  const platform = opts.platform ?? process.platform;
+
+  const lines: string[] = [];
+  // 1. headline
+  lines.push(`${binary} is required to ${spec.why}, but it was not found on PATH.`);
+
+  // 2. install block
+  const cmds = resolveInstallCommands(spec, opts);
+  if (cmds.length > 0) {
+    lines.push("");
+    // Lead the install block with the detected OS for human readers; the
+    // resolveInstallCommands list is already platform-scoped so this is a
+    // label, not a second filter.
+    if (platform === "darwin" || platform === "linux") {
+      lines.push(`Install it (${platformLabel(platform)}):`);
+    } else {
+      lines.push("Install it:");
+    }
+    for (const cmd of cmds) {
+      // Multi-line recipes (cloudflared static binary) indent each line.
+      for (const sub of cmd.split("\n")) {
+        lines.push(`  ${sub}`);
+      }
+    }
+  }
+
+  // 3. docs — always
+  lines.push("");
+  lines.push(`Docs: ${spec.docsUrl}`);
+
+  // 4. trailer — sysadmin (foundational) or altHint (optional/provider).
+  //    Stripped entirely in non-interactive mode (the reader IS the admin).
+  if (interactive) {
+    lines.push("");
+    if (spec.optional && spec.altHint) {
+      lines.push(spec.altHint);
+    } else {
+      lines.push(SYSADMIN_TRAILER);
+    }
+  }
+
+  const out = lines.join("\n");
+  return interactive ? out : stripAnsi(out);
+}
+
+/**
+ * The structured wire shape for an API / SPA consumer. `error_description` is
+ * the headless (interactive:false) formatted block — no sysadmin trailer, no
+ * ANSI — so a generic error reader that only knows `error_description` still
+ * gets a usable message, while a missing_dependency-aware UI reads the typed
+ * fields and renders a dedicated card.
+ */
+export function toMissingDependencyWire(
+  binary: string,
+  spec: DepSpec | undefined,
+  opts: FormatOpts = {},
+): MissingDependencyWire {
+  const arch = opts.arch ?? process.arch;
+  // error_description is always the headless rendering — a JSON consumer is
+  // the admin, so no "ask someone else" trailer leaks into the wire.
+  const error_description = formatMissingDependency(binary, spec, { ...opts, interactive: false });
+
+  if (!spec) {
+    return {
+      error: "missing_dependency",
+      error_type: "missing_dependency",
+      error_description,
+      binary,
+      why: null,
+      docs_url: null,
+      install: {},
+      sysadmin_hint: SYSADMIN_TRAILER,
+    };
+  }
+
+  return {
+    error: "missing_dependency",
+    error_type: "missing_dependency",
+    error_description,
+    binary,
+    why: spec.why,
+    docs_url: spec.docsUrl,
+    install: wireInstall(spec, arch),
+    sysadmin_hint: spec.optional && spec.altHint ? spec.altHint : SYSADMIN_TRAILER,
+  };
+}

--- a/packages/depcheck/src/index.ts
+++ b/packages/depcheck/src/index.ts
@@ -1,0 +1,44 @@
+/**
+ * @openparachute/depcheck
+ *
+ * Canonical missing-dependency UX for Parachute modules. Three layers:
+ *
+ *   - REGISTRY (`registry.ts`)  — `DEPENDENCY_REGISTRY` / `lookupDep`: what
+ *     each external binary is for + how to install it, in one place.
+ *   - FORMATTER (`format.ts`)   — `formatMissingDependency` /
+ *     `resolveInstallCommands` / `toMissingDependencyWire`: turn a spec into
+ *     the operator-facing block or the structured wire shape.
+ *   - HELPERS (`error.ts`)      — `MissingDependencyError`, `ensureExecutable`,
+ *     `isBinaryNotFoundError`, `rethrowIfMissing`: pre-flight a spawn site or
+ *     classify a spawn failure into the typed error.
+ *
+ * Per-repo code calls these at spawn sites so the install strings + the
+ * ENOENT matcher stop drifting (vault's `git-preflight.ts` + hub's
+ * `cloudflare/detect.ts` were already divergent copies).
+ *
+ * Note: relative imports MUST carry `.js` extensions even though the source
+ * files are `.ts`. tsc emits the extension verbatim into dist, and NodeNext-
+ * strict consumers require it to resolve compiled JS. Bun + bundler-resolution
+ * consumers (hub workspace, vault, scribe) resolve `.js` back to `.ts`
+ * transparently. Mirrors scope-guard's convention (see its index.ts).
+ */
+
+export {
+  type DepSpec,
+  type LinuxBinaryUrl,
+  DEPENDENCY_REGISTRY,
+  lookupDep,
+} from "./registry.js";
+export {
+  type FormatOpts,
+  type MissingDependencyWire,
+  formatMissingDependency,
+  resolveInstallCommands,
+  toMissingDependencyWire,
+} from "./format.js";
+export {
+  MissingDependencyError,
+  ensureExecutable,
+  isBinaryNotFoundError,
+  rethrowIfMissing,
+} from "./error.js";

--- a/packages/depcheck/src/registry.ts
+++ b/packages/depcheck/src/registry.ts
@@ -1,0 +1,247 @@
+/**
+ * The dependency registry — the single source of truth for "what external
+ * binary does an operation need, why, and how does an operator install it?"
+ *
+ * Every Parachute module that shells out to a CLI tool (`git`, `tailscale`,
+ * `cloudflared`, transcription providers, …) used to carry its own ad-hoc
+ * "install git via …" string near the spawn site. Those strings drifted —
+ * vault's `git-preflight.ts` and hub's `cloudflare/detect.ts` had divergent
+ * copies of both the install recipe AND the ENOENT matcher. This registry
+ * + the formatter in `format.ts` are the one place each binary's metadata
+ * lives; per-repo code looks it up at the spawn site.
+ *
+ * A `DepSpec` is intentionally data, not behavior. The formatter
+ * (`formatMissingDependency`) turns it into the operator-facing block; the
+ * helpers (`ensureExecutable` / `isBinaryNotFoundError` / `rethrowIfMissing`)
+ * turn a spawn failure into a `MissingDependencyError` carrying the spec.
+ */
+
+/**
+ * Static-binary install recipe selector. Some tools (cloudflared, tailscale)
+ * are best installed from a pinned static binary keyed by CPU architecture
+ * rather than a distro package (distro packages churn / 404 across versions —
+ * see the cloudflared comment in hub's `cloudflare/detect.ts`). Returns a
+ * curl recipe string for the given arch, or `undefined` for arches without a
+ * published artifact (the formatter then drops to the docs URL rather than
+ * fabricating a download URL that 404s).
+ */
+export type LinuxBinaryUrl = (arch: NodeJS.Architecture) => string | undefined;
+
+export interface DepSpec {
+  /** PATH name, e.g. "git". */
+  readonly binary: string;
+  /** Lower-case verb phrase completing "<binary> is required to <why>". */
+  readonly why: string;
+  /** Docs URL — always shown in the formatted block. */
+  readonly docsUrl: string;
+  readonly install: {
+    /** macOS recipe, e.g. "brew install git". */
+    readonly darwin?: string;
+    /** Debian/Ubuntu apt recipe, e.g. "sudo apt-get install -y git". */
+    readonly linuxApt?: string;
+    /** Fedora/Amazon-Linux dnf recipe, e.g. "sudo dnf install git". */
+    readonly linuxDnf?: string;
+    /**
+     * Static-binary curl recipe keyed by arch. When set and it returns a
+     * recipe for the detected arch, it WINS over the apt/dnf distro lines on
+     * Linux — distro packages for these tools are unreliable across versions.
+     */
+    readonly linuxBinaryUrl?: LinuxBinaryUrl;
+    /**
+     * Cross-platform fallback (pip / uv / curl-installer). Shown when no
+     * platform-specific recipe applies — e.g. provider tooling installed via
+     * pip on every OS, or a one-liner curl installer.
+     */
+    readonly generic?: string;
+  };
+  /**
+   * Provider-style optional dependency. When true the formatter uses
+   * `altHint` instead of the "ask your system administrator" trailer — the
+   * fix is "switch provider", not "install a foundational tool" — and the
+   * caller's contract is to degrade the specific service, not the whole
+   * request.
+   */
+  readonly optional?: boolean;
+  /**
+   * Replaces the "or ask your system administrator to install it for you."
+   * trailer when `optional` is set. e.g. "or switch transcription provider".
+   */
+  readonly altHint?: string;
+}
+
+/**
+ * Map a Node `process.arch` to the suffix Cloudflare uses for its
+ * `cloudflared-linux-*` release artifacts. Lifted verbatim from hub's
+ * `src/cloudflare/detect.ts` `linuxArtifactSuffix` so the two can't drift —
+ * that file now consumes this registry instead of carrying its own copy.
+ * Returns undefined for arches with no published artifact.
+ */
+function cloudflaredLinuxSuffix(arch: NodeJS.Architecture): string | undefined {
+  switch (arch) {
+    case "x64":
+      return "amd64";
+    case "arm64":
+      return "arm64";
+    case "arm":
+      return "arm";
+    case "ia32":
+      return "386";
+    default:
+      return undefined;
+  }
+}
+
+const CLOUDFLARED_RELEASE_BASE =
+  "https://github.com/cloudflare/cloudflared/releases/latest/download";
+
+/**
+ * The seeded registry. Keyed by PATH binary name. Entries verified against
+ * the spawn-site audit across vault / scribe / runner / hub.
+ *
+ * Frozen so a consumer can't mutate a shared spec at runtime.
+ */
+export const DEPENDENCY_REGISTRY: Readonly<Record<string, DepSpec>> = Object.freeze({
+  git: {
+    binary: "git",
+    why: "mirror your vault to a git remote",
+    docsUrl: "https://git-scm.com/downloads",
+    install: {
+      darwin: "brew install git",
+      linuxApt: "sudo apt-get install -y git",
+      linuxDnf: "sudo dnf install git",
+    },
+  },
+  tailscale: {
+    binary: "tailscale",
+    why: "expose your hub over a tailnet",
+    docsUrl: "https://tailscale.com/download",
+    install: {
+      darwin: "brew install tailscale",
+      linuxBinaryUrl: () => "curl -fsSL https://tailscale.com/install.sh | sh",
+      generic: "curl -fsSL https://tailscale.com/install.sh | sh",
+    },
+  },
+  cloudflared: {
+    binary: "cloudflared",
+    why: "expose your hub publicly via a Cloudflare tunnel",
+    docsUrl: "https://github.com/cloudflare/cloudflared/releases/latest",
+    install: {
+      darwin: "brew install cloudflared",
+      // Static binary from GitHub releases — distro packages are unreliable
+      // across versions (Aaron hit `dnf install cloudflared` → 'No match' on
+      // Amazon Linux 2023). The arch mapping is lifted from the old
+      // `cloudflaredInstallHint`. Multi-line recipe matches what detect.ts
+      // emitted: download → chmod +x → version check.
+      linuxBinaryUrl: (arch) => {
+        const suffix = cloudflaredLinuxSuffix(arch);
+        if (!suffix) return undefined;
+        return [
+          "curl -L -o /usr/local/bin/cloudflared \\",
+          `  ${CLOUDFLARED_RELEASE_BASE}/cloudflared-linux-${suffix}`,
+          "sudo chmod +x /usr/local/bin/cloudflared",
+          "cloudflared --version",
+        ].join("\n");
+      },
+    },
+  },
+  bun: {
+    binary: "bun",
+    why: "run Parachute modules",
+    docsUrl: "https://bun.sh",
+    install: {
+      generic: "curl -fsSL https://bun.sh/install | bash",
+    },
+  },
+  claude: {
+    binary: "claude",
+    why: "clean up transcripts / run vault jobs via the Claude CLI",
+    docsUrl: "https://claude.com/claude-code",
+    install: {
+      generic: "npm i -g @anthropic-ai/claude-code",
+    },
+    optional: true,
+    altHint: "or switch cleanup/job provider",
+  },
+  ffmpeg: {
+    binary: "ffmpeg",
+    why: "convert non-WAV audio before transcription",
+    docsUrl: "https://ffmpeg.org/download.html",
+    install: {
+      darwin: "brew install ffmpeg",
+      linuxApt: "sudo apt-get install -y ffmpeg",
+      linuxDnf: "sudo dnf install ffmpeg",
+    },
+  },
+  tar: {
+    binary: "tar",
+    why: "compress your vault backups",
+    docsUrl: "https://www.gnu.org/software/tar/",
+    install: {},
+  },
+  tail: {
+    binary: "tail",
+    why: "stream service log files",
+    docsUrl: "https://www.gnu.org/software/coreutils/",
+    install: {},
+  },
+  systemctl: {
+    binary: "systemctl",
+    why: "manage the background service on Linux (systemd)",
+    docsUrl: "https://www.freedesktop.org/software/systemd/man/systemctl.html",
+    install: {},
+  },
+  launchctl: {
+    binary: "launchctl",
+    why: "manage the background service on macOS",
+    docsUrl: "https://ss64.com/mac/launchctl.html",
+    install: {},
+  },
+  "parakeet-mlx": {
+    binary: "parakeet-mlx",
+    why: "transcribe audio with the parakeet-mlx provider",
+    docsUrl: "https://github.com/senstella/parakeet-mlx",
+    install: {
+      generic: "uv tool install parakeet-mlx",
+    },
+    optional: true,
+    altHint: "or switch transcription provider",
+  },
+  "whisper-ctranslate2": {
+    binary: "whisper-ctranslate2",
+    why: "transcribe with the whisper provider",
+    docsUrl: "https://github.com/Softcatala/whisper-ctranslate2",
+    install: {
+      generic: "pip install whisper-ctranslate2",
+    },
+    optional: true,
+    altHint: "or switch transcription provider",
+  },
+  "onnx-asr": {
+    binary: "onnx-asr",
+    why: "transcribe with the onnx-asr provider",
+    docsUrl: "https://github.com/istupakov/onnx-asr",
+    install: {
+      generic: "pip install onnx-asr",
+    },
+    optional: true,
+    altHint: "or switch transcription provider",
+  },
+  "parachute-vault": {
+    binary: "parachute-vault",
+    why: "run the Vault module Hub supervises",
+    docsUrl: "https://parachute.computer",
+    install: {
+      generic: "parachute install vault",
+    },
+  },
+});
+
+/**
+ * Look up a `DepSpec` by binary name. Returns `undefined` for an unregistered
+ * binary — callers MUST treat that as "fail loud with a generic message",
+ * never fabricate an install command. The formatter does exactly this when
+ * handed an `undefined` spec.
+ */
+export function lookupDep(binary: string): DepSpec | undefined {
+  return DEPENDENCY_REGISTRY[binary];
+}

--- a/packages/depcheck/tsconfig.json
+++ b/packages/depcheck/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "allowImportingTsExtensions": false,
+    "verbatimModuleSyntax": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/src/__tests__/api-modules-ops.test.ts
+++ b/src/__tests__/api-modules-ops.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { MissingDependencyError, lookupDep } from "@openparachute/depcheck";
 import {
   API_MODULES_OPS_REQUIRED_SCOPE,
   _resetOperationsRegistryForTests,
@@ -627,6 +628,50 @@ describe("POST /api/modules/:short/install", () => {
     const op = (await opRes.json()) as { status: string; error?: string };
     expect(op.status).toBe("failed");
     expect(op.error).toMatch(/bun add -g exited 1/);
+  });
+
+  test("a MissingDependencyError during install attaches the structured error_detail wire", async () => {
+    const { supervisor } = makeIdleSupervisor();
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const deps = {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+      supervisor,
+      // Simulate `bun` not being on PATH: the install runner's shell-out
+      // throws the typed missing-dependency error.
+      run: async () => {
+        throw new MissingDependencyError("bun", lookupDep("bun"), {
+          platform: "linux",
+          arch: "x64",
+        });
+      },
+      findGlobalInstall: () => null,
+      isLinked: TEST_DEFAULT_NOT_LINKED,
+    };
+    const res = await handleInstall(
+      postReq("/api/modules/vault/install", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      deps,
+    );
+    const body = (await res.json()) as { operation_id: string };
+    await new Promise((r) => setTimeout(r, 10));
+    const opRes = await handleOperationGet(
+      getReq(`/api/modules/operations/${body.operation_id}`, {
+        authorization: `Bearer ${bearer}`,
+      }),
+      body.operation_id,
+      deps,
+    );
+    const op = (await opRes.json()) as {
+      status: string;
+      error?: string;
+      error_detail?: { error_type: string; binary: string };
+    };
+    expect(op.status).toBe("failed");
+    expect(op.error_detail?.error_type).toBe("missing_dependency");
+    expect(op.error_detail?.binary).toBe("bun");
   });
 
   test("skips bun add -g when package is already bun-linked (smoke 2026-05-27 finding 1)", async () => {

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -21,7 +21,7 @@ import {
   readOperatorTokenFile,
 } from "../operator-token.ts";
 import { ensureLogPath, logPath, readPid, writePid } from "../process-state.ts";
-import { upsertService } from "../services-manifest.ts";
+import { readManifest, upsertService } from "../services-manifest.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 
 interface Harness {
@@ -192,6 +192,87 @@ describe("parachute start", () => {
       expect(spawner.calls[0]?.logFile).toBe(logPath("vault", h.configDir));
       expect(readPid("vault", h.configDir)).toBe(4242);
       expect(logs.join("\n")).toMatch(/vault started \(pid 4242\)/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("missing startCmd binary → friendly missing-dependency message + no spawn", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const spawner = makeSpawner([4242]);
+      const logs: string[] = [];
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        // Force the preflight's missing-binary branch: parachute-vault not on PATH.
+        which: () => null,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(1);
+      // Preflight fired before the spawn — the stub spawner is never called.
+      expect(spawner.calls).toHaveLength(0);
+      const out = logs.join("\n");
+      expect(out).toMatch(/vault failed to start/);
+      // The friendly install block names the binary + its install path.
+      expect(out).toContain("parachute-vault is required to run the Vault module Hub supervises");
+      expect(out).toContain("parachute install vault");
+      expect(readPid("vault", h.configDir)).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("missing startCmd binary persists lastStartError so a later status surfaces it", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner: makeSpawner([4242]),
+        which: () => null,
+        log: () => {},
+      });
+      const entry = readManifest(h.manifestPath).services.find((s) => s.name === "parachute-vault");
+      expect(entry?.lastStartError?.error_type).toBe("missing_dependency");
+      expect(entry?.lastStartError?.binary).toBe("parachute-vault");
+      expect(entry?.lastStartError?.at).toBeDefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("a successful start clears a previously-recorded lastStartError", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      // First start fails (binary missing) → records the error.
+      await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner: makeSpawner([1]),
+        which: () => null,
+        log: () => {},
+      });
+      expect(
+        readManifest(h.manifestPath).services.find((s) => s.name === "parachute-vault")
+          ?.lastStartError,
+      ).toBeDefined();
+      // Second start succeeds (binary present via the permissive default which
+      // — stub spawner path) → clears the recorded error.
+      await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner: makeSpawner([4242]),
+        log: () => {},
+      });
+      expect(
+        readManifest(h.manifestPath).services.find((s) => s.name === "parachute-vault")
+          ?.lastStartError,
+      ).toBeUndefined();
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/services-manifest.test.ts
+++ b/src/__tests__/services-manifest.test.ts
@@ -6,9 +6,11 @@ import {
   type ServiceEntry,
   ServicesManifestError,
   type UiSubUnit,
+  clearStartError,
   findService,
   readManifest,
   readManifestLenient,
+  recordStartError,
   removeService,
   upsertService,
   writeManifest,
@@ -1410,9 +1412,27 @@ describe("readManifestLenient — skips bad entries instead of throwing (hub#406
         path,
         JSON.stringify({
           services: [
-            { name: "parachute-vault", port: 1940, paths: ["/vault/default"], health: "/vault/default/health", version: "0.4.8-rc.10" },
-            { name: "parachute-surface", port: 1946, paths: ["/surface"], health: "/surface/healthz", version: "0.2.0-rc.13" },
-            { name: "widget", port: 0, paths: ["/widget"], health: "/widget/health", version: "0.0.1" },
+            {
+              name: "parachute-vault",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.8-rc.10",
+            },
+            {
+              name: "parachute-surface",
+              port: 1946,
+              paths: ["/surface"],
+              health: "/surface/healthz",
+              version: "0.2.0-rc.13",
+            },
+            {
+              name: "widget",
+              port: 0,
+              paths: ["/widget"],
+              health: "/widget/health",
+              version: "0.0.1",
+            },
           ],
         }),
       );
@@ -1479,12 +1499,110 @@ describe("readManifestLenient — skips bad entries instead of throwing (hub#406
       writeFileSync(
         path,
         JSON.stringify({
-          services: [{ name: "widget", port: 0, paths: ["/widget"], health: "/widget/health", version: "0.0.1" }],
+          services: [
+            {
+              name: "widget",
+              port: 0,
+              paths: ["/widget"],
+              health: "/widget/health",
+              version: "0.0.1",
+            },
+          ],
         }),
       );
       expect(() => readManifest(path)).toThrow(ServicesManifestError);
     } finally {
       cleanup();
     }
+  });
+
+  describe("lastStartError", () => {
+    const wire = {
+      error_type: "missing_dependency",
+      error_description: "parachute-vault is required ...",
+      binary: "parachute-vault",
+      why: "run the Vault module Hub supervises",
+      docs_url: "https://parachute.computer",
+      install: { generic: "parachute install vault" },
+      sysadmin_hint: "Or ask your system administrator to install it for you.",
+    };
+
+    test("recordStartError persists the wire + stamps `at`", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        upsertService(vault, path);
+        recordStartError("parachute-vault", wire, path);
+        const entry = readManifest(path).services.find((s) => s.name === "parachute-vault");
+        expect(entry?.lastStartError?.error_type).toBe("missing_dependency");
+        expect(entry?.lastStartError?.binary).toBe("parachute-vault");
+        expect(entry?.lastStartError?.install?.generic).toBe("parachute install vault");
+        expect(entry?.lastStartError?.at).toBeDefined();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("recordStartError is a no-op when the row is absent", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        upsertService(vault, path);
+        recordStartError("parachute-scribe", wire, path);
+        const scribe = readManifest(path).services.find((s) => s.name === "parachute-scribe");
+        expect(scribe).toBeUndefined();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("clearStartError removes a recorded error", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        upsertService(vault, path);
+        recordStartError("parachute-vault", wire, path);
+        clearStartError("parachute-vault", path);
+        const entry = readManifest(path).services.find((s) => s.name === "parachute-vault");
+        expect(entry?.lastStartError).toBeUndefined();
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("lastStartError round-trips through validation", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        const withErr: ServiceEntry = {
+          ...vault,
+          lastStartError: { ...wire, at: "2026-05-29T00:00:00Z" },
+        };
+        upsertService(withErr, path);
+        const entry = readManifest(path).services.find((s) => s.name === "parachute-vault");
+        expect(entry?.lastStartError).toEqual({ ...wire, at: "2026-05-29T00:00:00Z" });
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("a malformed lastStartError is dropped, not thrown (diagnostic field)", () => {
+      const { path, cleanup } = makeTempPath();
+      try {
+        writeFileSync(
+          path,
+          JSON.stringify({
+            services: [
+              {
+                ...vault,
+                // missing error_description → invalid shape → dropped
+                lastStartError: { error_type: "missing_dependency" },
+              },
+            ],
+          }),
+        );
+        const entry = readManifest(path).services.find((s) => s.name === "parachute-vault");
+        expect(entry).toBeDefined();
+        expect(entry?.lastStartError).toBeUndefined();
+      } finally {
+        cleanup();
+      }
+    });
   });
 });

--- a/src/__tests__/status.test.ts
+++ b/src/__tests__/status.test.ts
@@ -76,6 +76,42 @@ describe("status", () => {
     }
   });
 
+  test("persisted lastStartError surfaces on a continuation line", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/"],
+          health: "/health",
+          version: "0.2.4",
+          lastStartError: {
+            error_type: "missing_dependency",
+            error_description: "parachute-vault is required ...",
+            binary: "parachute-vault",
+            install: { generic: "parachute install vault" },
+          },
+        },
+        path,
+      );
+      const lines: string[] = [];
+      await status({
+        manifestPath: path,
+        // Probe refuses (service down) — the row is failing, and the
+        // start-error note explains why.
+        fetchImpl: async () => {
+          throw new Error("ECONNREFUSED");
+        },
+        print: (l) => lines.push(l),
+      });
+      const out = lines.join("\n");
+      expect(out).toMatch(/failed to start: parachute-vault not installed/);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("any-failing returns 1 and surfaces probe detail on continuation line", async () => {
     const { path, cleanup } = makeTempPath();
     try {

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -35,6 +35,7 @@
 import type { Database } from "bun:sqlite";
 import { randomUUID } from "node:crypto";
 import { dirname } from "node:path";
+import { MissingDependencyError, type MissingDependencyWire } from "@openparachute/depcheck";
 import { CURATED_MODULES, type CuratedModuleShort } from "./api-modules.ts";
 import { isLinked as defaultIsLinked } from "./bun-link.ts";
 import { PARACHUTE_INSTALL_CHANNEL_ENV } from "./commands/install.ts";
@@ -49,11 +50,7 @@ import {
   getSpec,
   synthesizeManifestForKnownModule,
 } from "./service-spec.ts";
-import {
-  findService,
-  readManifestLenient,
-  removeService,
-} from "./services-manifest.ts";
+import { findService, readManifestLenient, removeService } from "./services-manifest.ts";
 import type { ModuleState, SpawnRequest, Supervisor } from "./supervisor.ts";
 import { WELL_KNOWN_PATH, type regenerateWellKnown } from "./well-known.ts";
 
@@ -81,6 +78,15 @@ export interface Operation {
   log: string[];
   /** Error message when status is `failed`. Mirrored from the underlying throw. */
   error?: string;
+  /**
+   * Structured error detail when the failure is a known typed error — today
+   * only `MissingDependencyError.toWire()` (a missing external binary like
+   * `bun` / `git` during install). The operations-polling SPA switches on
+   * `error_detail.error_type === "missing_dependency"` to render a dedicated
+   * install card; the plain `error` string is the fallback for everything
+   * else. Wire shape matches `@openparachute/depcheck`'s `MissingDependencyWire`.
+   */
+  error_detail?: MissingDependencyWire;
   startedAt: string;
   finishedAt?: string;
 }
@@ -89,7 +95,11 @@ export interface OperationsRegistry {
   create(kind: OperationKind, short: string): Operation;
   get(id: string): Operation | undefined;
   /** Append a log line + (optionally) advance status. */
-  update(id: string, patch: Partial<Pick<Operation, "status" | "error">>, logLine?: string): void;
+  update(
+    id: string,
+    patch: Partial<Pick<Operation, "status" | "error" | "error_detail">>,
+    logLine?: string,
+  ): void;
 }
 
 /**
@@ -122,11 +132,16 @@ class InMemoryOperationsRegistry implements OperationsRegistry {
     return this.ops.get(id);
   }
 
-  update(id: string, patch: Partial<Pick<Operation, "status" | "error">>, logLine?: string): void {
+  update(
+    id: string,
+    patch: Partial<Pick<Operation, "status" | "error" | "error_detail">>,
+    logLine?: string,
+  ): void {
     const op = this.ops.get(id);
     if (!op) return;
     if (patch.status) op.status = patch.status;
     if (patch.error !== undefined) op.error = patch.error;
+    if (patch.error_detail !== undefined) op.error_detail = patch.error_detail;
     if (logLine) op.log.push(logLine);
     if (patch.status === "succeeded" || patch.status === "failed") {
       op.finishedAt = this.clock().toISOString();
@@ -520,11 +535,35 @@ export async function handleInstall(
   // immediately + the work runs in the background. Errors get logged
   // to the operation; nothing throws back to the request handler.
   void runInstall(op.id, short, spec, deps, bodyChannel).catch((err) => {
-    const msg = err instanceof Error ? err.message : String(err);
-    registry.update(op.id, { status: "failed", error: msg }, `install failed: ${msg}`);
+    failOperation(registry, op.id, "install", err);
   });
 
   return acceptedOp(op.id);
+}
+
+/**
+ * Mark an async op failed, attaching the structured `error_detail` wire when
+ * the underlying throw is a `MissingDependencyError` (a missing external
+ * binary like `bun` / `git` during install). The operations-polling SPA reads
+ * `error_detail` to render the dedicated install card; the plain `error`
+ * string is the fallback for every other failure.
+ */
+function failOperation(
+  registry: OperationsRegistry,
+  opId: string,
+  verb: string,
+  err: unknown,
+): void {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (err instanceof MissingDependencyError) {
+    registry.update(
+      opId,
+      { status: "failed", error: msg, error_detail: err.toWire() },
+      `${verb} failed: ${err.binary} not installed`,
+    );
+    return;
+  }
+  registry.update(opId, { status: "failed", error: msg }, `${verb} failed: ${msg}`);
 }
 
 /**
@@ -722,8 +761,7 @@ export async function handleUpgrade(
   const spec = specFor(short);
 
   void runUpgrade(op.id, short, spec, deps).catch((err) => {
-    const msg = err instanceof Error ? err.message : String(err);
-    registry.update(op.id, { status: "failed", error: msg }, `upgrade failed: ${msg}`);
+    failOperation(registry, op.id, "upgrade", err);
   });
   return acceptedOp(op.id);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@
  * Run `parachute --help` or `parachute <subcommand> --help` for usage.
  */
 
+import { MissingDependencyError } from "@openparachute/depcheck";
 import pkg from "../package.json" with { type: "json" };
 import { CloudflaredStateError } from "./cloudflare/state.ts";
 import { auth } from "./commands/auth.ts";
@@ -784,6 +785,14 @@ async function run(argv: string[]): Promise<number> {
   try {
     return await main(argv);
   } catch (err) {
+    if (err instanceof MissingDependencyError) {
+      // A required external binary wasn't on PATH (git / tailscale / tail /
+      // …). Print the friendly install block to stderr. interactive:true so
+      // the operator at a terminal sees the "ask your sysadmin" trailer; the
+      // message was already formatted at construction, so we just emit it.
+      console.error(err.message);
+      return 1;
+    }
     if (err instanceof ServicesManifestError) {
       console.error(`services.json is malformed: ${err.message}`);
       console.error("Fix or remove the file, then re-run.");

--- a/src/cloudflare/detect.ts
+++ b/src/cloudflare/detect.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { isBinaryNotFoundError, lookupDep } from "@openparachute/depcheck";
 import type { Runner } from "../tailscale/run.ts";
 
 export const DEFAULT_CLOUDFLARED_HOME = join(homedir(), ".cloudflared");
@@ -10,28 +11,20 @@ export const DEFAULT_CLOUDFLARED_HOME = join(homedir(), ".cloudflared");
  * "binary not on PATH" errors — anything else (EACCES from a non-executable
  * file, corrupted binary, etc.) propagates so we don't silently report
  * "not installed" when something more specific is wrong.
+ *
+ * The not-found matcher is `@openparachute/depcheck`'s `isBinaryNotFoundError`
+ * — the single source of truth across the ecosystem (this used to be a local
+ * copy that drifted from vault's `git-preflight.ts`). Pass the binary name so
+ * a not-found message about an unrelated file isn't mis-attributed.
  */
 export async function isCloudflaredInstalled(runner: Runner): Promise<boolean> {
   try {
     const { code } = await runner(["cloudflared", "--version"]);
     return code === 0;
   } catch (err) {
-    if (isBinaryNotFoundError(err)) return false;
+    if (isBinaryNotFoundError(err, "cloudflared")) return false;
     throw err;
   }
-}
-
-function isBinaryNotFoundError(err: unknown): boolean {
-  if (!err || typeof err !== "object") return false;
-  const e = err as { code?: unknown; message?: unknown };
-  if (e.code === "ENOENT") return true;
-  // Bun.spawn's error shape varies across versions; fall back to message
-  // string matching so we catch "Executable not found in $PATH" and
-  // "ENOENT" variants without pinning to one runtime detail.
-  if (typeof e.message === "string") {
-    return /ENOENT|not found|No such file/i.test(e.message);
-  }
-  return false;
 }
 
 /**
@@ -61,30 +54,37 @@ export function isCloudflaredLoggedIn(cloudflaredHome: string = DEFAULT_CLOUDFLA
  *   other  → the binary-download path is still the best generic answer
  *
  * The `arch` parameter is the architecture string in `process.arch`
- * shape (`x64`, `arm64`, `arm`). Mapped to the suffix cloudflared uses
- * in its release artifacts (`amd64`, `arm64`, `arm`). Unknown arches
- * fall through to a generic pointer at the releases page.
+ * shape (`x64`, `arm64`, `arm`). The static-binary curl recipe + the arch
+ * mapping now live in `@openparachute/depcheck`'s `cloudflared` registry
+ * entry (`install.linuxBinaryUrl`) — the single source of truth shared with
+ * the structured `MissingDependencyError` UX. This function keeps its own
+ * prose (the surrounding "works across distros" framing the expose flow
+ * prints) but derives the URL + arch support from the registry so the two
+ * can't drift. A `undefined` recipe (arch with no published artifact) is the
+ * signal to fall through to the generic releases pointer rather than
+ * fabricating a 404-bound URL.
  */
 export function cloudflaredInstallHint(
   platform: NodeJS.Platform = process.platform,
   arch: NodeJS.Architecture = process.arch,
 ): string {
+  const releasesUrl = "https://github.com/cloudflare/cloudflared/releases/latest";
   if (platform === "darwin") {
     return [
       "Install cloudflared:",
       "  brew install cloudflared",
       "",
       "(or download a static binary from",
-      "  https://github.com/cloudflare/cloudflared/releases/latest)",
+      `  ${releasesUrl})`,
     ].join("\n");
   }
   if (platform === "linux") {
-    const suffix = linuxArtifactSuffix(arch);
-    if (suffix) {
+    const downloadUrl = cloudflaredLinuxDownloadUrl(arch);
+    if (downloadUrl) {
       return [
         "Install cloudflared (static binary — works across distros):",
-        `  curl -L -o /usr/local/bin/cloudflared \\`,
-        `    https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${suffix}`,
+        "  curl -L -o /usr/local/bin/cloudflared \\",
+        `    ${downloadUrl}`,
         "  sudo chmod +x /usr/local/bin/cloudflared",
         "  cloudflared --version",
         "",
@@ -93,33 +93,28 @@ export function cloudflaredInstallHint(
     }
     return [
       "Install cloudflared from the official binary release:",
-      "  https://github.com/cloudflare/cloudflared/releases/latest",
+      `  ${releasesUrl}`,
       `(pick the linux-* artifact matching your architecture; your arch is "${arch}")`,
     ].join("\n");
   }
-  return [
-    "Install cloudflared from the official binary release:",
-    "  https://github.com/cloudflare/cloudflared/releases/latest",
-  ].join("\n");
+  return ["Install cloudflared from the official binary release:", `  ${releasesUrl}`].join("\n");
 }
 
 /**
- * Map a Node `process.arch` to the suffix Cloudflare uses for its
- * cloudflared-linux-* release artifacts. Returns undefined for arches
- * that don't have a published artifact (we surface a generic pointer
- * in that case instead of fabricating a download URL that 404s).
+ * Pull the cloudflared-linux-<suffix> download URL for an arch out of the
+ * depcheck registry's static-binary recipe. The registry recipe is a
+ * multi-line `curl … / chmod … / version` block; we extract the single
+ * `https://…/cloudflared-linux-<suffix>` line so this function's own prose
+ * wraps the canonical URL. Returns undefined when the arch has no published
+ * artifact (registry recipe is undefined) — the caller then uses the generic
+ * pointer. Keeps the arch→suffix mapping in exactly one place (the registry).
  */
-function linuxArtifactSuffix(arch: NodeJS.Architecture): string | undefined {
-  switch (arch) {
-    case "x64":
-      return "amd64";
-    case "arm64":
-      return "arm64";
-    case "arm":
-      return "arm";
-    case "ia32":
-      return "386";
-    default:
-      return undefined;
-  }
+function cloudflaredLinuxDownloadUrl(arch: NodeJS.Architecture): string | undefined {
+  const recipe = lookupDep("cloudflared")?.install.linuxBinaryUrl?.(arch);
+  if (!recipe) return undefined;
+  const urlLine = recipe
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l.startsWith("https://"));
+  return urlLine;
 }

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -1,6 +1,11 @@
 import { existsSync, openSync, readFileSync } from "node:fs";
 import { Socket } from "node:net";
 import { join } from "node:path";
+import {
+  MissingDependencyError,
+  ensureExecutable,
+  rethrowIfMissing,
+} from "@openparachute/depcheck";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import { readEnvFileValues } from "../env-file.ts";
 import { readExposeState } from "../expose-state.ts";
@@ -35,7 +40,12 @@ import {
   knownServices,
   shortNameForManifest,
 } from "../service-spec.ts";
-import { type ServiceEntry, readManifest } from "../services-manifest.ts";
+import {
+  type ServiceEntry,
+  clearStartError,
+  readManifest,
+  recordStartError,
+} from "../services-manifest.ts";
 import { persistVaultHubOrigin, selfHealVaultHubOrigin } from "../vault-hub-origin-env.ts";
 
 /**
@@ -270,6 +280,21 @@ export interface LifecycleOpts {
    * `ensureHubRunning` and `lifecycle.stop("hub")` dispatches to
    * `stopHub`. Tests inject stubs to avoid spawning real bun processes.
    */
+  /**
+   * PATH-resolution seam for the start preflight (`@openparachute/depcheck`
+   * `ensureExecutable`). Production uses the real `Bun.which`; a missing
+   * startCmd binary then surfaces the friendly missing-dependency UX +
+   * persists it to services.json.
+   *
+   * Defaulting policy mirrors `startSettleMs`: when a stub `spawner` is
+   * injected (the test path) `which` defaults to a permissive resolver
+   * (`() => "<stub>"`) so existing stub-spawner tests don't trip the preflight
+   * against binaries that aren't on the test host's PATH (`parachute-vault`,
+   * `notes-serve`). Production (no spawner override) gets the real `Bun.which`.
+   * Tests that want to exercise the missing-binary branch inject `which`
+   * explicitly (e.g. `which: () => null`).
+   */
+  which?: (cmd: string) => string | null;
   hub?: {
     ensureRunning?: (opts: EnsureHubOpts) => Promise<EnsureHubResult>;
     stop?: (opts: StopHubOpts) => Promise<boolean>;
@@ -303,6 +328,7 @@ interface Resolved {
   portListening: PortListeningFn;
   startReadyMs: number;
   startReadyPollMs: number;
+  which: (cmd: string) => string | null;
   hubOrigin: string | undefined;
   ensureHub: (opts: EnsureHubOpts) => Promise<EnsureHubResult>;
   stopHubFn: (opts: StopHubOpts) => Promise<boolean>;
@@ -368,6 +394,12 @@ function resolve(opts: LifecycleOpts): Resolved {
       opts.startReadyMs ??
       (opts.spawner === undefined || opts.portListening !== undefined ? 4000 : 0),
     startReadyPollMs: opts.startReadyPollMs ?? 200,
+    // Same defaulting policy as startSettleMs/startReadyMs: production (no
+    // spawner override) preflights with the real Bun.which; stub-spawner tests
+    // get a permissive resolver so the preflight doesn't trip against binaries
+    // that aren't on the test host's PATH. Explicit `which` always wins.
+    which:
+      opts.which ?? (opts.spawner === undefined ? Bun.which : () => "/stub/bin/preflight-skipped"),
     hubOrigin: resolveHubOrigin(opts.hubOrigin, configDir),
     ensureHub: opts.hub?.ensureRunning ?? ensureHubRunning,
     stopHubFn: opts.hub?.stop ?? stopHub,
@@ -602,15 +634,57 @@ export async function start(svc: string | undefined, opts: LifecycleOpts = {}): 
     if (entry.installDir) spawnerOpts.cwd = entry.installDir;
     const passOpts =
       spawnerOpts.env !== undefined || spawnerOpts.cwd !== undefined ? spawnerOpts : undefined;
+
+    // Pre-flight the startCmd binary (`@openparachute/depcheck`) so a missing
+    // executable surfaces the friendly install UX inline AND is persisted onto
+    // the services.json row, so a *later* `parachute status` (a separate
+    // invocation that only reads the manifest) + the SPA modules pane show
+    // "vault: failed to start — parachute-vault not installed" with install
+    // info, rather than a bare "failed"/orphan-timeout. The binary is `cmd[0]`
+    // (e.g. `parachute-vault` for an npm install, `bun` for a bun-linked one).
+    const startBinary = cmd[0];
+    if (startBinary) {
+      try {
+        ensureExecutable(startBinary, { which: r.which });
+      } catch (err) {
+        if (err instanceof MissingDependencyError) {
+          failures++;
+          r.log(`✗ ${short} failed to start:`);
+          for (const line of err.message.split("\n")) r.log(`  ${line}`);
+          recordStartError(entry.name, err.toWire(), r.manifestPath);
+          continue;
+        }
+        throw err;
+      }
+    }
+
     let pid: number;
     try {
       pid = r.spawner.spawn(cmd, logFile, passOpts);
     } catch (err) {
+      // Belt-and-suspenders: a missing binary that slipped past the pre-flight
+      // (race) still becomes a MissingDependencyError via rethrowIfMissing.
+      if (startBinary) {
+        try {
+          rethrowIfMissing(err, startBinary);
+        } catch (missing) {
+          if (missing instanceof MissingDependencyError) {
+            failures++;
+            r.log(`✗ ${short} failed to start:`);
+            for (const line of missing.message.split("\n")) r.log(`  ${line}`);
+            recordStartError(entry.name, missing.toWire(), r.manifestPath);
+            continue;
+          }
+        }
+      }
       failures++;
       const msg = err instanceof Error ? err.message : String(err);
       r.log(`✗ ${short} failed to start: ${msg}`);
       continue;
     }
+    // A successful spawn clears any stale start-error recorded from a prior
+    // missing-dependency failure so `parachute status` doesn't keep showing it.
+    clearStartError(entry.name, r.manifestPath);
     writePid(short, pid, r.configDir);
 
     // Boot-readiness gating (hub#194 + hub#487). A spawn returning a pid only
@@ -946,11 +1020,19 @@ export async function logs(svc: string, opts: LogsOpts = {}): Promise<number> {
       spawn(cmd) {
         // Inherit env so `tail` sees PATH, etc. Bun.spawn defaults to empty
         // env — see api-modules-ops.ts:defaultRun.
-        const proc = Bun.spawn([...cmd], {
-          stdio: ["ignore", "inherit", "inherit"],
-          env: process.env,
-        });
-        return proc.pid;
+        try {
+          const proc = Bun.spawn([...cmd], {
+            stdio: ["ignore", "inherit", "inherit"],
+            env: process.env,
+          });
+          return proc.pid;
+        } catch (err) {
+          // A missing `tail` (minimal container without coreutils) surfaces
+          // the friendly install UX instead of a raw spawn throw. The CLI
+          // top-level catch in cli.ts renders the MissingDependencyError.
+          rethrowIfMissing(err, "tail");
+          throw err;
+        }
       },
     };
     spawner.spawn(["tail", "-n", String(lines), "-f", path], path);

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -146,6 +146,14 @@ interface StatusRow {
    * stale-after-rebuild row without comparing columns by eye.
    */
   staleNote?: string;
+  /**
+   * Persisted last-start failure (`lastStartError`, written by the lifecycle
+   * start preflight when a startCmd binary is missing). Surfaced on a
+   * continuation line so a *later* `parachute status` explains why the row
+   * isn't active — "failed to start: <binary> not installed" — rather than
+   * just showing it inactive. Cleared on the next successful start.
+   */
+  startErrorNote?: string;
 }
 
 /**
@@ -264,6 +272,17 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
         ? `STALE: services.json cached ${entry.version}; live package.json ${source.livePackageVersion}`
         : undefined;
 
+      // Persisted last-start failure (lifecycle preflight wrote a missing-
+      // dependency wire). Surface a one-line summary; the full install recipe
+      // lives in services.json + the admin SPA card. Keeps `parachute status`
+      // scannable while still telling the operator "this is why it's down."
+      const startErrorNote =
+        entry.lastStartError !== undefined
+          ? entry.lastStartError.binary !== undefined
+            ? `failed to start: ${entry.lastStartError.binary} not installed — run \`parachute status\` detail or see /admin/modules for install steps`
+            : `failed to start: ${entry.lastStartError.error_description.split("\n")[0]}`
+          : undefined;
+
       // Only skip probe when we know the process is dead (PID file was
       // present but kill(pid, 0) failed). "unknown" status (no PID file)
       // still probes — externally-managed services should report health.
@@ -287,6 +306,7 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
           skipped: true,
           driftWarning,
           staleNote,
+          startErrorNote,
         };
       }
 
@@ -324,6 +344,7 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
         skipped: false,
         driftWarning,
         staleNote,
+        startErrorNote,
       };
     }),
   );
@@ -378,6 +399,7 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
     }
     if (row.driftWarning) print(`  ! ${row.driftWarning}`);
     if (row.staleNote) print(`  ! ${row.staleNote}`);
+    if (row.startErrorNote) print(`  ! ${row.startErrorNote}`);
   }
 
   /**

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -185,6 +185,39 @@ export interface ServiceEntry {
    * with display metadata attached.
    */
   uis?: Record<string, UiSubUnit>;
+  /**
+   * Last `parachute start` failure that's still actionable, persisted so a
+   * *subsequent* `parachute status` (a separate invocation that only reads
+   * this manifest) + the admin SPA can surface it. Today the only writer is
+   * the lifecycle start preflight when a startCmd binary is missing from PATH
+   * (`@openparachute/depcheck` `MissingDependencyError.toWire()`): the row
+   * shows "failed to start — <binary> not installed" with the install info
+   * instead of a bare orphan-timeout. Cleared on the next successful start.
+   *
+   * Stored as the structured `missing_dependency` wire so the SPA can render
+   * the dedicated install card; `parachute status` reads `error_description`.
+   * Validated as a pass-through object (shape owned by depcheck) rather than
+   * re-typed field-by-field here.
+   */
+  lastStartError?: ServiceEntryStartError;
+}
+
+/**
+ * Persisted start-failure detail on a ServiceEntry. Mirrors depcheck's
+ * `MissingDependencyWire` for the missing-dependency case; `error_type` is
+ * left open so a future non-dependency start failure could reuse the field.
+ */
+export interface ServiceEntryStartError {
+  error_type: string;
+  error_description: string;
+  /** Present for `error_type: "missing_dependency"`. */
+  binary?: string;
+  why?: string | null;
+  docs_url?: string | null;
+  install?: { darwin?: string; linux?: string; generic?: string };
+  sysadmin_hint?: string;
+  /** ISO timestamp of when the failure was recorded. */
+  at?: string;
 }
 
 export interface ServicesManifest {
@@ -251,6 +284,7 @@ function validateEntry(raw: unknown, where: string): ServiceEntry {
   }
   const uis = e.uis;
   const validatedUis = validateUis(uis, where);
+  const validatedStartError = validateStartError(e.lastStartError, where);
   const entry: ServiceEntry = { name, port, paths: paths as string[], health, version };
   if (displayName !== undefined) entry.displayName = displayName;
   if (tagline !== undefined) entry.tagline = tagline;
@@ -258,7 +292,46 @@ function validateEntry(raw: unknown, where: string): ServiceEntry {
   if (installDir !== undefined) entry.installDir = installDir;
   if (stripPrefix !== undefined) entry.stripPrefix = stripPrefix;
   if (validatedUis !== undefined) entry.uis = validatedUis;
+  if (validatedStartError !== undefined) entry.lastStartError = validatedStartError;
   return entry;
+}
+
+/**
+ * Validate the optional `lastStartError` field. `undefined` round-trips
+ * unchanged. A present value must be an object carrying the two required
+ * string fields (`error_type`, `error_description`); the remaining fields
+ * (the missing-dependency detail) pass through with light type-narrowing so
+ * the SPA install card has them, but we never hard-fail an otherwise-valid
+ * row on a malformed start-error — it's diagnostic metadata, not a contract
+ * field. A malformed value is dropped rather than thrown.
+ */
+function validateStartError(raw: unknown, _where: string): ServiceEntryStartError | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.error_type !== "string" || typeof r.error_description !== "string") {
+    return undefined;
+  }
+  const out: ServiceEntryStartError = {
+    error_type: r.error_type,
+    error_description: r.error_description,
+  };
+  if (typeof r.binary === "string") out.binary = r.binary;
+  if (typeof r.why === "string" || r.why === null) out.why = r.why as string | null;
+  if (typeof r.docs_url === "string" || r.docs_url === null) {
+    out.docs_url = r.docs_url as string | null;
+  }
+  if (r.install && typeof r.install === "object" && !Array.isArray(r.install)) {
+    const ins = r.install as Record<string, unknown>;
+    const install: { darwin?: string; linux?: string; generic?: string } = {};
+    if (typeof ins.darwin === "string") install.darwin = ins.darwin;
+    if (typeof ins.linux === "string") install.linux = ins.linux;
+    if (typeof ins.generic === "string") install.generic = ins.generic;
+    out.install = install;
+  }
+  if (typeof r.sysadmin_hint === "string") out.sysadmin_hint = r.sysadmin_hint;
+  if (typeof r.at === "string") out.at = r.at;
+  return out;
 }
 
 /**
@@ -762,4 +835,43 @@ export function findService(
   // still 500'd after the bulk lenient-sweep because findService was
   // missed.
   return readManifestLenient(path).services.find((s) => s.name === name);
+}
+
+/**
+ * Persist a `lastStartError` onto the named row so a later `parachute status`
+ * + the admin SPA surface it. No-op if the row isn't present (e.g. a service
+ * that failed to start before its first self-registration wrote a row — the
+ * inline `parachute start` message already told the operator). Lenient read
+ * so a malformed sibling row doesn't block recording an unrelated failure.
+ */
+export function recordStartError(
+  name: string,
+  err: ServiceEntryStartError,
+  path: string = SERVICES_MANIFEST_PATH,
+): void {
+  if (!existsSync(path)) return;
+  const current = readManifestLenient(path);
+  const idx = current.services.findIndex((s) => s.name === name);
+  if (idx < 0) return;
+  const row = current.services[idx];
+  if (!row) return;
+  current.services[idx] = {
+    ...row,
+    lastStartError: { ...err, at: err.at ?? new Date().toISOString() },
+  };
+  writeManifest(current, path);
+}
+
+/** Clear a row's persisted `lastStartError` (called on a successful start).
+ * No-op when the row is absent or already clean. */
+export function clearStartError(name: string, path: string = SERVICES_MANIFEST_PATH): void {
+  if (!existsSync(path)) return;
+  const current = readManifestLenient(path);
+  const idx = current.services.findIndex((s) => s.name === name);
+  if (idx < 0) return;
+  const row = current.services[idx];
+  if (!row || row.lastStartError === undefined) return;
+  const { lastStartError: _drop, ...rest } = row;
+  current.services[idx] = rest;
+  writeManifest(current, path);
 }

--- a/src/tailscale/run.ts
+++ b/src/tailscale/run.ts
@@ -1,3 +1,5 @@
+import { ensureExecutable, rethrowIfMissing } from "@openparachute/depcheck";
+
 export interface CommandResult {
   code: number;
   stdout: string;
@@ -7,19 +9,34 @@ export interface CommandResult {
 export type Runner = (cmd: readonly string[]) => Promise<CommandResult>;
 
 export async function defaultRunner(cmd: readonly string[]): Promise<CommandResult> {
+  // Pre-flight the binary so a missing `tailscale` surfaces the friendly
+  // install UX (`@openparachute/depcheck`) instead of a raw spawn throw —
+  // closes the no-hint gap where `parachute expose tailnet` on a box without
+  // tailscale died with `Executable not found in $PATH: "tailscale"`.
+  // `cmd[0]` is always present for a real call; guard for the empty edge.
+  const binary = cmd[0];
+  if (binary) ensureExecutable(binary);
   // Inherit env so `tailscale` sees PATH (and HOME for state dir). Bun.spawn
   // defaults to empty env — see api-modules-ops.ts:defaultRun for rationale.
-  const proc = Bun.spawn([...cmd], {
-    stdout: "pipe",
-    stderr: "pipe",
-    env: process.env,
-  });
-  const [stdout, stderr, code] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
-  return { code, stdout, stderr };
+  try {
+    const proc = Bun.spawn([...cmd], {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: process.env,
+    });
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { code, stdout, stderr };
+  } catch (err) {
+    // Belt-and-suspenders: a spawn that slips past the pre-flight (binary
+    // removed between which() and spawn, or a race) still surfaces the
+    // friendly MissingDependencyError rather than the raw spawn throw.
+    if (binary) rethrowIfMissing(err, binary);
+    throw err;
+  }
 }
 
 export class TailscaleError extends Error {

--- a/web/ui/src/components/MissingDependencyCard.test.tsx
+++ b/web/ui/src/components/MissingDependencyCard.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * MissingDependencyCard tests — the dedicated install card the Modules
+ * operations banner renders when an install fails because a required external
+ * binary isn't on PATH.
+ *
+ * Covers:
+ *   - heading + why subhead from the structured wire;
+ *   - per-platform install commands rendered as copy blocks, with the
+ *     detected-OS line emphasized (navigator.platform);
+ *   - docs link + sysadmin hint;
+ *   - Copy writing the real command to the clipboard;
+ *   - the `renderOperationError` switch: install card for missing_dependency,
+ *     verbatim error_description for an unrecognized type, plain error string
+ *     when there's no structured detail.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MissingDependencyWire } from "../lib/api.ts";
+import { MissingDependencyCard, renderOperationError } from "./MissingDependencyCard.tsx";
+
+const wire: MissingDependencyWire = {
+  error: "missing_dependency",
+  error_type: "missing_dependency",
+  error_description: "git is required ...",
+  binary: "git",
+  why: "mirror your vault to a git remote",
+  docs_url: "https://git-scm.com/downloads",
+  install: {
+    darwin: "brew install git",
+    linux: "sudo apt-get install -y git\nsudo dnf install git",
+  },
+  sysadmin_hint: "Or ask your system administrator to install it for you.",
+};
+
+let writeText: ReturnType<typeof vi.fn<(text: string) => Promise<void>>>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function setPlatform(p: string) {
+  Object.defineProperty(navigator, "platform", { configurable: true, value: p });
+}
+
+describe("MissingDependencyCard", () => {
+  it("renders heading, why, install commands, docs, and sysadmin hint", () => {
+    setPlatform("MacIntel");
+    render(<MissingDependencyCard wire={wire} />);
+    expect(screen.getByText("git isn't installed")).toBeTruthy();
+    expect(screen.getByText(/mirror your vault to a git remote/)).toBeTruthy();
+    expect(screen.getByText("brew install git")).toBeTruthy();
+    expect(screen.getByText(/sudo apt-get install -y git/)).toBeTruthy();
+    expect(screen.getByText("Documentation").getAttribute("href")).toBe(
+      "https://git-scm.com/downloads",
+    );
+    expect(screen.getByText(/system administrator/)).toBeTruthy();
+  });
+
+  it("emphasizes the macOS line when navigator.platform is mac", () => {
+    setPlatform("MacIntel");
+    const { container } = render(<MissingDependencyCard wire={wire} />);
+    const preferred = container.querySelector(".depcard-install.preferred .depcard-os");
+    expect(preferred?.textContent).toBe("macOS");
+  });
+
+  it("emphasizes the Linux line when navigator.platform is linux", () => {
+    setPlatform("Linux x86_64");
+    const { container } = render(<MissingDependencyCard wire={wire} />);
+    const preferred = container.querySelector(".depcard-install.preferred .depcard-os");
+    expect(preferred?.textContent).toBe("Linux");
+  });
+
+  it("Copy writes the command to the clipboard", async () => {
+    setPlatform("MacIntel");
+    render(<MissingDependencyCard wire={wire} />);
+    const copyButtons = screen.getAllByRole("button", { name: /copy install command/i });
+    fireEvent.click(copyButtons[0] as HTMLElement);
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    // The first (preferred) copy block is macOS → brew install git.
+    expect(writeText).toHaveBeenCalledWith("brew install git");
+  });
+
+  it("omits the why/docs when the wire degrades them to null", () => {
+    setPlatform("Win32");
+    const degraded: MissingDependencyWire = {
+      ...wire,
+      binary: "frobnicate",
+      why: null,
+      docs_url: null,
+      install: {},
+    };
+    render(<MissingDependencyCard wire={degraded} />);
+    expect(screen.getByText("frobnicate isn't installed")).toBeTruthy();
+    expect(screen.queryByText("Documentation")).toBeNull();
+  });
+});
+
+describe("renderOperationError", () => {
+  it("renders the install card for a missing_dependency error", () => {
+    setPlatform("MacIntel");
+    const { container } = render(renderOperationError({ errorDetail: wire }));
+    expect(container.querySelector('[data-testid="missing-dependency-card"]')).toBeTruthy();
+  });
+
+  it("falls back to error_description for an unrecognized typed error", () => {
+    render(
+      renderOperationError({
+        errorDetail: {
+          error_type: "some_other_error",
+          error_description: "something else went wrong",
+        },
+      }),
+    );
+    expect(screen.getByText("something else went wrong")).toBeTruthy();
+  });
+
+  it("falls back to the plain error string when there's no structured detail", () => {
+    render(renderOperationError({ error: "bun add -g exited 1" }));
+    expect(screen.getByText("bun add -g exited 1")).toBeTruthy();
+  });
+
+  it("returns null when there's nothing to show", () => {
+    const { container } = render(renderOperationError({}));
+    expect(container.textContent).toBe("");
+  });
+});

--- a/web/ui/src/components/MissingDependencyCard.tsx
+++ b/web/ui/src/components/MissingDependencyCard.tsx
@@ -1,0 +1,135 @@
+/**
+ * Renders a structured missing-dependency error (`error_type ===
+ * "missing_dependency"`) as a dedicated install card: heading, why subhead,
+ * per-platform install commands as copy-to-clipboard blocks (keyed to
+ * `navigator.platform` so the operator's own OS leads), a docs link, and the
+ * muted sysadmin hint.
+ *
+ * Consumers (e.g. the Modules operations banner) should switch on
+ * `error_type === "missing_dependency"` and render this; for any unrecognized
+ * error type, fall back to the plain `error_description` (see
+ * `renderOperationError` below).
+ *
+ * Wire shape mirrors the hub's `@openparachute/depcheck` `MissingDependencyWire`.
+ */
+import { type ReactElement, useState } from "react";
+import type { MissingDependencyWire } from "../lib/api.ts";
+
+/** Best-effort OS detection from navigator.platform so we lead with the
+ * operator's own install line. Falls back to "generic" (lists everything). */
+function detectOs(): "darwin" | "linux" | "other" {
+  if (typeof navigator === "undefined") return "other";
+  const p = (navigator.platform || "").toLowerCase();
+  if (p.includes("mac")) return "darwin";
+  if (p.includes("linux")) return "linux";
+  return "other";
+}
+
+interface InstallLine {
+  label: string;
+  command: string;
+  /** True when this line matches the detected OS — rendered first + emphasized. */
+  preferred: boolean;
+}
+
+function installLines(
+  install: MissingDependencyWire["install"],
+  os: ReturnType<typeof detectOs>,
+): InstallLine[] {
+  const lines: InstallLine[] = [];
+  if (install.darwin) {
+    lines.push({ label: "macOS", command: install.darwin, preferred: os === "darwin" });
+  }
+  if (install.linux) {
+    lines.push({ label: "Linux", command: install.linux, preferred: os === "linux" });
+  }
+  if (install.generic) {
+    // "generic" applies anywhere; it's preferred only when no OS-specific line
+    // matched the detected OS (so the operator still gets a lead command).
+    const hasOsMatch = lines.some((l) => l.preferred);
+    lines.push({ label: "Any platform", command: install.generic, preferred: !hasOsMatch });
+  }
+  // Preferred line(s) first.
+  return lines.sort((a, b) => Number(b.preferred) - Number(a.preferred));
+}
+
+function CopyBlock({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard unavailable (insecure context / permissions) — the command
+      // is still visible + selectable, so this degrades gracefully.
+    }
+  }
+  return (
+    <div className="depcard-cmd">
+      <pre className="depcard-cmd-text">{command}</pre>
+      <button
+        type="button"
+        className="btn btn-secondary depcard-copy"
+        onClick={() => void copy()}
+        aria-label="Copy install command"
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}
+
+export function MissingDependencyCard({ wire }: { wire: MissingDependencyWire }) {
+  const os = detectOs();
+  const lines = installLines(wire.install, os);
+  return (
+    <div className="depcard" data-testid="missing-dependency-card">
+      <h3 className="depcard-heading">{wire.binary} isn't installed</h3>
+      {wire.why ? <p className="depcard-why muted">It's needed to {wire.why}.</p> : null}
+      {lines.length > 0 ? (
+        <div className="depcard-installs">
+          <p className="depcard-installs-label">Install it:</p>
+          {lines.map((l) => (
+            <div
+              key={l.label}
+              className={l.preferred ? "depcard-install preferred" : "depcard-install"}
+            >
+              <span className="depcard-os">{l.label}</span>
+              <CopyBlock command={l.command} />
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {wire.docs_url ? (
+        <p className="depcard-docs">
+          <a href={wire.docs_url} target="_blank" rel="noreferrer noopener">
+            Documentation
+          </a>
+        </p>
+      ) : null}
+      {wire.sysadmin_hint ? <p className="depcard-hint muted">{wire.sysadmin_hint}</p> : null}
+    </div>
+  );
+}
+
+/**
+ * Shared switch: render the dedicated install card for missing_dependency
+ * errors, FALL BACK to the verbatim `error_description` for any other typed
+ * error, and to the plain `error` string when there's no structured detail.
+ * Returns null when there's nothing to show.
+ */
+export function renderOperationError(opts: {
+  error?: string;
+  errorDetail?: { error_type: string } & Partial<Omit<MissingDependencyWire, "error_type">>;
+}): ReactElement | null {
+  const { error, errorDetail } = opts;
+  if (errorDetail?.error_type === "missing_dependency") {
+    return <MissingDependencyCard wire={errorDetail as unknown as MissingDependencyWire} />;
+  }
+  if (errorDetail?.error_description) {
+    return <span className="depcard-fallback">{errorDetail.error_description}</span>;
+  }
+  if (error) return <span className="depcard-fallback">{error}</span>;
+  return null;
+}

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -760,6 +760,24 @@ export async function listModules(): Promise<ModulesCatalog> {
 export type ModuleOperationKind = "install" | "upgrade" | "restart" | "uninstall";
 export type ModuleOperationStatus = "pending" | "running" | "succeeded" | "failed";
 
+/**
+ * Structured missing-dependency error wire (matches the hub's
+ * `@openparachute/depcheck` `MissingDependencyWire` + `proxy-error-ui.ts`
+ * envelope). When an install/op fails because a required external binary
+ * (`bun` / `git` / …) isn't on PATH, the operation carries this so the SPA
+ * renders a dedicated install card instead of a raw error string.
+ */
+export interface MissingDependencyWire {
+  error: "missing_dependency";
+  error_type: "missing_dependency";
+  error_description: string;
+  binary: string;
+  why: string | null;
+  docs_url: string | null;
+  install: { darwin?: string; linux?: string; generic?: string };
+  sysadmin_hint: string;
+}
+
 export interface ModuleOperation {
   id: string;
   kind: ModuleOperationKind;
@@ -767,6 +785,8 @@ export interface ModuleOperation {
   status: ModuleOperationStatus;
   log: string[];
   error?: string;
+  /** Structured error detail for typed failures (today: missing_dependency). */
+  error_detail?: MissingDependencyWire;
   startedAt: string;
   finishedAt?: string;
 }

--- a/web/ui/src/routes/Modules.test.tsx
+++ b/web/ui/src/routes/Modules.test.tsx
@@ -344,6 +344,50 @@ describe("Modules — install flow", () => {
     });
   });
 
+  it("renders the missing-dependency install card when an install op fails on a missing binary", async () => {
+    vi.mocked(api.listModules).mockResolvedValue({
+      modules: [moduleRow("vault")],
+      supervisor_available: true,
+      module_install_channel: "latest",
+    });
+    vi.mocked(api.installModule).mockResolvedValue("op-dep");
+    vi.mocked(api.getModuleOperation).mockResolvedValue({
+      id: "op-dep",
+      kind: "install",
+      short: "vault",
+      status: "failed",
+      log: ["install failed: bun not installed"],
+      error: "bun is required ...",
+      error_detail: {
+        error: "missing_dependency",
+        error_type: "missing_dependency",
+        error_description: "bun is required ...",
+        binary: "bun",
+        why: "run Parachute modules",
+        docs_url: "https://bun.sh",
+        install: { generic: "curl -fsSL https://bun.sh/install | bash" },
+        sysadmin_hint: "Or ask your system administrator to install it for you.",
+      },
+      startedAt: "2026-05-18T00:00:00Z",
+      finishedAt: "2026-05-18T00:00:01Z",
+    });
+
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("Vault")).toBeInTheDocument());
+    fireEvent.click(
+      within(screen.getByTestId("installable-section")).getByRole("button", { name: /install/i }),
+    );
+
+    // The structured failure renders the dedicated install card (and the
+    // missing_dependency op is PINNED — not auto-dropped — so the operator
+    // has time to copy the command).
+    await waitFor(() => expect(screen.getByTestId("missing-dependency-card")).toBeInTheDocument(), {
+      timeout: 2000,
+    });
+    expect(screen.getByText("bun isn't installed")).toBeInTheDocument();
+    expect(screen.getByText("curl -fsSL https://bun.sh/install | bash")).toBeInTheDocument();
+  });
+
   it("hides the install card while the install op is pending (avoids duplicate spawn)", async () => {
     // Catalog still shows vault as not-installed (the install hasn't
     // completed + the catalog hasn't been re-fetched yet). The pending

--- a/web/ui/src/routes/Modules.tsx
+++ b/web/ui/src/routes/Modules.tsx
@@ -28,6 +28,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
+import { renderOperationError } from "../components/MissingDependencyCard.tsx";
 import {
   type ModuleInstallChannel,
   type ModuleListing,
@@ -56,6 +57,8 @@ interface PendingOp {
   log: string[];
   status: ModuleOperation["status"];
   error?: string;
+  /** Structured error detail (missing_dependency) — drives the install card. */
+  errorDetail?: ModuleOperation["error_detail"];
 }
 
 const POLL_INTERVAL_MS = 1000;
@@ -105,17 +108,31 @@ export function Modules() {
             setPendingOps((prev) =>
               prev.map((q) =>
                 q.operationId === op.id
-                  ? { ...q, log: op.log, status: op.status, error: op.error }
+                  ? {
+                      ...q,
+                      log: op.log,
+                      status: op.status,
+                      error: op.error,
+                      errorDetail: op.error_detail,
+                    }
                   : q,
               ),
             );
             if (op.status === "succeeded" || op.status === "failed") {
-              // Terminal — drop after a beat so the operator can see
-              // the final log line, then refresh the catalog.
-              setTimeout(() => {
-                setPendingOps((prev) => prev.filter((q) => q.operationId !== op.id));
+              // A missing-dependency failure carries an install card the
+              // operator needs time to read + copy — keep it pinned (they
+              // dismiss it by acting + re-installing). Everything else drops
+              // after a beat so the final log line is visible, then refresh.
+              const pinned =
+                op.status === "failed" && op.error_detail?.error_type === "missing_dependency";
+              if (!pinned) {
+                setTimeout(() => {
+                  setPendingOps((prev) => prev.filter((q) => q.operationId !== op.id));
+                  void refreshCatalog();
+                }, 1500);
+              } else {
                 void refreshCatalog();
-              }, 1500);
+              }
             }
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
@@ -325,7 +342,13 @@ export function Modules() {
             {pendingOps.map((p) => (
               <li key={p.operationId}>
                 <code>{p.short}</code> · {p.kind} · status: {p.status}
-                {p.error ? ` · error: ${p.error}` : null}
+                {/* Structured missing-dependency failures render a dedicated
+                    install card; other errors fall back to the plain string. */}
+                {p.status === "failed" && (p.errorDetail || p.error) ? (
+                  <div className="depcard-wrap">
+                    {renderOperationError({ error: p.error, errorDetail: p.errorDetail })}
+                  </div>
+                ) : null}
                 {p.log.length > 0 && (
                   <details>
                     <summary>{p.log.length} log line(s)</summary>

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -1198,3 +1198,79 @@ a.btn:hover {
   font-size: 0.8rem;
   padding: 0.35rem 0.85rem;
 }
+
+/* Missing-dependency install card (MissingDependencyCard.tsx). Rendered in
+   the Modules operations banner when an install/op fails because a required
+   external binary isn't on PATH. Leans on the existing error/warn tokens so
+   it reads as "actionable problem" without a new palette. */
+.depcard-wrap {
+  margin-top: 0.6rem;
+}
+.depcard {
+  border: 1px solid var(--warn);
+  background: var(--warn-soft);
+  border-radius: 8px;
+  padding: 0.9rem 1rem;
+}
+.depcard-heading {
+  margin: 0 0 0.25rem;
+  font-size: 1rem;
+}
+.depcard-why {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+}
+.depcard-installs-label {
+  margin: 0 0 0.4rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+.depcard-install {
+  margin-bottom: 0.55rem;
+}
+.depcard-install.preferred .depcard-os {
+  color: var(--accent);
+  font-weight: 600;
+}
+.depcard-os {
+  display: block;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted);
+  margin-bottom: 0.2rem;
+}
+.depcard-cmd {
+  display: flex;
+  align-items: stretch;
+  gap: 0.4rem;
+}
+.depcard-cmd-text {
+  flex: 1;
+  margin: 0;
+  padding: 0.45rem 0.6rem;
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 0.82rem;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+.depcard-copy {
+  flex: 0 0 auto;
+  font-size: 0.8rem;
+  padding: 0.35rem 0.7rem;
+  align-self: flex-start;
+}
+.depcard-docs {
+  margin: 0.5rem 0 0.4rem;
+  font-size: 0.88rem;
+}
+.depcard-hint {
+  margin: 0;
+  font-size: 0.82rem;
+}
+.depcard-fallback {
+  color: var(--error);
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## What

Introduces a thin shared package **`@openparachute/depcheck`** (built in `packages/depcheck`, mirroring the `scope-guard` subpackage) — the canonical missing-dependency UX lib — AND wires hub's own spawn-site gaps to use it. Implements the normative contract in `parachute-patterns/patterns/missing-dependency-ux.md` (migration `2026-05-29-missing-dependency-ux.md`), generalizing vault's `git-preflight.ts` + hub's `cloudflare/detect.ts` (which had divergent copies of the install strings + ENOENT matcher) into one place.

## The lib surface (NodeNext, `.js` import extensions, AGPL-3.0, `0.1.0-rc.1`)

Three layers:
- **REGISTRY** — `DEPENDENCY_REGISTRY` / `lookupDep`. `DepSpec` data for: `git`, `tailscale`, `cloudflared`, `bun`, `claude` (optional), `ffmpeg`, `tar`, `tail`, `systemctl`, `launchctl`, `parakeet-mlx`/`whisper-ctranslate2`/`onnx-asr` (optional providers), `parachute-vault`. The cloudflared arch→suffix mapping + static-binary recipe is lifted from `detect.ts` so it's the single source of truth. `lookupDep` returns `undefined` for unregistered binaries → fail-loud generic message, never fabricated.
- **FORMATTER** — `formatMissingDependency` / `resolveInstallCommands` / `toMissingDependencyWire`. 5-part block (headline / `Install it:` / `Docs:` / sysadmin-or-altHint trailer). `linuxBinaryUrl` static recipe wins over apt/dnf; unknown arch drops to docs (never a 404 URL); `interactive:false` strips ANSI + trailer (headless reader IS the admin).
- **HELPERS** — `MissingDependencyError` (`errorType`/`binary`/`spec`/`toWire()`), `ensureExecutable` (`Bun.which` seam), `isBinaryNotFoundError` (ENOENT or message match; swallows ONLY not-found — EACCES/corrupt propagate), `rethrowIfMissing`.

Wire shape aligns hub's `proxy-error-ui.ts` envelope: `{ error, error_type: "missing_dependency", error_description, binary, why, docs_url, install:{darwin,linux,generic}, sysadmin_hint }`.

## How hub consumes depcheck — local workspace (bundled in this PR)

Hub uses `workspaces: ["packages/*"]`, so it consumes depcheck from the **local workspace** (not published npm) — therefore the lib + hub adoption ship together in this one PR. Dependency is pinned `"@openparachute/depcheck": "0.1.0-rc.1"` (npm-resolvable once published). A `"bun"`→`src/index.ts` export condition lets Bun resolve depcheck from source with **no dist build at runtime**; `publishConfig.exports` drops that condition for the published tarball. CI builds depcheck before hub's `tsc` typecheck (which resolves `.d.ts` from `dist`).

## hub sites wired

- **`tailscale/run.ts` `defaultRunner`** — `ensureExecutable` pre-flight + `rethrowIfMissing` catch (closes the no-hint gap on `parachute expose tailnet`). Liveness probes (`isTailscaleInstalled`/`isCloudflaredInstalled`) still swallow it correctly.
- **`commands/lifecycle.ts`** — preflight the supervisor `startCmd[0]` before the detached spawn; on `MissingDependencyError`, print the install block inline AND persist a `lastStartError` (`MissingDependencyWire`) onto the services.json row (new `ServiceEntry.lastStartError` field + lenient validation + `recordStartError`/`clearStartError` helpers) so a later `parachute status` shows "failed to start — `<bin>` not installed". `tail -f` follow spawn wrapped with `rethrowIfMissing`.
- **`commands/status.ts`** — surfaces the persisted `lastStartError` on a continuation line.
- **`cloudflare/detect.ts`** — `isCloudflaredInstalled` + `cloudflaredInstallHint` now consume depcheck's matcher + registry recipe (single source of truth); **external behavior identical** (the 13 existing detect tests pass unchanged). `upgrade.ts`'s git/bun/npm handling is unchanged (verified, not regressed).
- **`api-modules-ops.ts`** — install/upgrade ops attach a structured `error_detail` wire on a `MissingDependencyError` so the operations-polling UI renders the install card.
- **`cli.ts`** — top-level catch prints `formatMissingDependency(...{interactive:true})` to stderr, exit 1.

## The SPA card

`web/ui/src/components/MissingDependencyCard.tsx`: heading "`<binary>` isn't installed", why subhead, per-platform install commands as copy-to-clipboard blocks keyed to `navigator.platform` (operator's OS leads), docs link, muted sysadmin hint. `renderOperationError` switches on `error_type === "missing_dependency"` → card, falling back to `error_description` verbatim for unrecognized types. Wired into the Modules operations banner; missing_dependency failures are **pinned** (not auto-dropped) so the operator can copy the command.

## Publish mechanism

`release.yml` gains a `depcheck-v*` tag namespace: CI publishes `@openparachute/depcheck` to npm (`rc` dist-tag for `-rc.N` tags, `latest` for stable) via Trusted Publishing on tag push, mirroring scope-guard's job. The `test` job also builds depcheck + runs its suite. Dockerfile copies depcheck's `package.json` into the install layer (runtime resolves via `bun`→src).

## Follow-up

vault / scribe / runner adopt the **published** lib next (separate PRs, tracked in the migration's adoption checklist). `commands/install.ts`'s vault-init/bun-add spawn was left unwired (deferred — see the migration; the install runner captures exit codes, doesn't raw-crash the same way).

## Gates

- `bun test packages/depcheck/src` — **46 pass, 0 fail**
- `bun test ./src` (hub) — **2501 pass, 1 skip, 0 fail**
- `bun run typecheck` (hub) + depcheck `tsc --noEmit` — **clean**
- `cd web/ui && bunx vitest run` — **258 pass**
- `bunx biome check` — clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)