### PR TITLE
feat(hub): single OAuth consent + grantable vault:<name>:admin with delegate-only-what-you-hold cap (+ rc.20)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.19",
+  "version": "0.5.14-rc.20",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-mint-token.test.ts
+++ b/src/__tests__/api-mint-token.test.ts
@@ -382,10 +382,14 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
     }
   });
 
-  // The de-escalation exception is gated on host:admin specifically. A
-  // bearer that only holds `parachute:host:auth` (the narrow auth scope-set)
-  // can mint verb scopes but NOT vault-admin — that would be an escalation.
-  test("400 invalid_scope when auth-only bearer mints vault:<name>:admin", async () => {
+  // Single-consent change (2026-05-29) — INTENTIONAL canGrant widening. Once
+  // `vault:<name>:admin` became requestable (`isNonRequestableScope` dropped
+  // the per-vault-admin clause), canGrant rule 1 (`!isNonRequestableScope` +
+  // bearer holds `parachute:host:auth`) now ADMITS it. A `parachute:host:auth`
+  // bearer is an on-box operator credential, so minting a vault-pinned admin
+  // from it is a de-escalation, not an escalation. Pinned here so the widening
+  // is deliberate, not an accidental regression.
+  test("200 when auth-only bearer mints vault:<name>:admin (intentional canGrant widening)", async () => {
     const h = makeHarness();
     try {
       const { db, userId } = await bootstrap(h.dir);
@@ -398,10 +402,12 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
           jsonRequest({ scope: "vault:work:admin" }, { authorization: `Bearer ${op.token}` }),
           { db, issuer: ISSUER },
         );
-        expect(resp.status).toBe(400);
-        const body = (await resp.json()) as { error: string; error_description: string };
-        expect(body.error).toBe("invalid_scope");
-        expect(body.error_description).toContain("vault:work:admin");
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as { scope: string; token: string };
+        expect(body.scope).toBe("vault:work:admin");
+        const validated = await validateAccessToken(db, body.token, ISSUER);
+        expect(validated.payload.aud).toBe("vault.work");
+        expect(validated.payload.scope).toBe("vault:work:admin");
       } finally {
         db.close();
       }
@@ -765,7 +771,10 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
       }
     });
 
-    test("host:auth-only bearer mints vault:work:admin → 400 (rule 1 doesn't cover admin)", async () => {
+    test("host:auth-only bearer mints vault:work:admin → 200 (single-consent: rule 1 now covers admin)", async () => {
+      // Single-consent change (2026-05-29): vault:<name>:admin is requestable
+      // now, so canGrant rule 1 admits it for a host:auth bearer. De-escalation
+      // from an on-box operator credential — intentional widening.
       const h = makeHarness();
       try {
         const { db, userId } = await bootstrap(h.dir);
@@ -775,9 +784,9 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
             jsonRequest({ scope: "vault:work:admin" }, { authorization: `Bearer ${op.token}` }),
             { db, issuer: ISSUER },
           );
-          expect(resp.status).toBe(400);
-          const body = (await resp.json()) as { error: string };
-          expect(body.error).toBe("invalid_scope");
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { scope: string };
+          expect(body.scope).toBe("vault:work:admin");
         } finally {
           db.close();
         }
@@ -993,10 +1002,12 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
       }
     });
 
-    // The existing non-requestable behaviour is unchanged: a host:auth-only
-    // bearer minting the well-formed `vault:work:admin` is still 400 (rule 1
-    // doesn't cover admin) — this path is reached AFTER the shape guard passes.
-    test("host:auth-only bearer minting vault:work:admin → 400 (non-requestable, unchanged)", async () => {
+    // Contrast with the malformed forms above: a WELL-FORMED `vault:work:admin`
+    // clears the shape guard, and (single-consent change, 2026-05-29) now mints
+    // 200 via canGrant rule 1 for a host:auth bearer. The malformed forms are
+    // rejected by the shape guard BEFORE canGrant; this one passes the guard
+    // and is admitted.
+    test("host:auth-only bearer minting well-formed vault:work:admin → 200 (clears shape guard, mints)", async () => {
       const h = makeHarness();
       try {
         const { db, userId } = await bootstrap(h.dir);
@@ -1006,11 +1017,9 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
             jsonRequest({ scope: "vault:work:admin" }, { authorization: `Bearer ${op.token}` }),
             { db, issuer: ISSUER },
           );
-          expect(resp.status).toBe(400);
-          const body = (await resp.json()) as { error: string; error_description: string };
-          expect(body.error).toBe("invalid_scope");
-          // Not the malformed-shape message — it cleared the shape guard.
-          expect(body.error_description).toContain("not grantable");
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { scope: string };
+          expect(body.scope).toBe("vault:work:admin");
         } finally {
           db.close();
         }

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -4296,7 +4296,14 @@ describe("inline approve button on pending /oauth/authorize (#208)", () => {
     }
   });
 
-  test("session valid + matching Origin → page renders WITH approve form + CSRF token", async () => {
+  test("session valid + matching Origin on pending client → auto-approves + renders CONSENT (single-consent change)", async () => {
+    // Single-consent change (2026-05-29): the separate inline operator-approve
+    // form is retired from the GET-on-pending path. A pending client + valid
+    // session now auto-approves (status → approved, audit-logged) and falls
+    // straight through to the user's consent screen — ONE consent, not a
+    // two-step approve-then-consent. The inline-approve POST endpoint
+    // (`handleApproveClientPost`) still exists for the SPA / cross-origin
+    // surfaces (tested below), but the GET path no longer renders the form.
     const { db, cleanup } = await makeDb();
     try {
       const user = await createUser(db, "owner", "pw");
@@ -4312,31 +4319,21 @@ describe("inline approve button on pending /oauth/authorize (#208)", () => {
           origin: ISSUER,
         },
       });
-      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
-      expect(res.status).toBe(403);
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      // Consent render (200) — NOT the old 403 approve-pending page.
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
       const html = await res.text();
-      expect(html).toContain("App not yet approved");
-      // The form posts to the approve endpoint
-      expect(html).toContain('action="/oauth/authorize/approve"');
-      expect(html).toContain('name="client_id"');
-      expect(html).toContain(`value="${reg.client.clientId}"`);
-      // CSRF token present in the form
-      expect(html).toContain(`value="${TEST_CSRF}"`);
-      // return_to carries the original authorize URL so the post-approve
-      // redirect lands the operator back on the same flow.
-      expect(html).toContain('name="return_to"');
-      expect(html).toContain("/oauth/authorize?");
-      expect(html).toContain("rt-208"); // state echoed via return_to URL
-      // Display fields present so operator can verify what they're approving.
+      expect(html).toContain("Approve");
       expect(html).toContain("MyApp");
-      expect(html).toContain(reg.client.clientId);
-      expect(html).toContain("https://app.example/cb");
-      // Authed branch shows only the one-click Approve form — the unauth
-      // Sign-in CTA and shareable-link block do NOT render here.
-      expect(html).not.toContain("Sign in as admin to approve");
-      expect(html).not.toContain("Or send this link to your hub admin");
-      // CLI hint also gone in this branch (approval-UX rc.19).
-      expect(html).not.toContain("parachute auth approve-client");
+      // The inline approve FORM is gone from this path.
+      expect(html).not.toContain('action="/oauth/authorize/approve"');
+      expect(html).not.toContain("App not yet approved");
+      // The pending client was auto-approved (consent IS the authorization).
+      expect(getClient(db, reg.client.clientId)?.status).toBe("approved");
     } finally {
       cleanup();
     }
@@ -4697,10 +4694,13 @@ describe("inline approve button on pending /oauth/authorize (#208)", () => {
     }
   });
 
-  test("end-to-end: GET (pending) → POST approve → GET (now approved) renders consent", async () => {
-    // The full redirect chain. Sessions and CSRF carry across all three
-    // requests in the same cookie. The final GET sees status=approved and
-    // renders the consent screen.
+  test("single-consent: GET (pending) + session → auto-approves + renders consent in ONE step", async () => {
+    // Single-consent change (2026-05-29): the old GET(pending)→POST approve→
+    // GET(approved) three-step chain collapses to ONE step. A pending client +
+    // valid session auto-approves on the first GET and lands the user directly
+    // on the consent screen. The separate POST approve endpoint still exists
+    // for the cross-origin SPA case (tested above) but the in-flow operator no
+    // longer needs it.
     const { db, cleanup } = await makeDb();
     try {
       const user = await createUser(db, "owner", "pw");
@@ -4713,57 +4713,19 @@ describe("inline approve button on pending /oauth/authorize (#208)", () => {
       const cookie = `${CSRF_COOKIE}; ${buildSessionCookie(session.id, SESSION_COOKIE_TTL_S)}`;
       const authorizeHref = pendingAuthorizeUrl(reg.client.clientId);
 
-      // Step 1: GET /oauth/authorize on a pending client renders the approve form.
-      const getRes = handleAuthorizeGet(
-        db,
-        new Request(authorizeHref, { headers: { cookie, origin: ISSUER } }),
-        { issuer: ISSUER },
-      );
-      expect(getRes.status).toBe(403);
-      const getHtml = await getRes.text();
-      expect(getHtml).toContain('action="/oauth/authorize/approve"');
-
-      // Pull the return_to value the form would submit. It's the path+search
-      // of the authorize URL.
-      const authorizeUrlParsed = new URL(authorizeHref);
-      const returnTo = `${authorizeUrlParsed.pathname}${authorizeUrlParsed.search}`;
-
-      // Step 2: POST the approve form.
-      const postForm = new URLSearchParams({
-        __csrf: TEST_CSRF,
-        client_id: reg.client.clientId,
-        return_to: returnTo,
-      });
-      const postRes = await handleApproveClientPost(
-        db,
-        new Request(`${ISSUER}/oauth/authorize/approve`, {
-          method: "POST",
-          body: postForm,
-          headers: {
-            "content-type": "application/x-www-form-urlencoded",
-            cookie,
-            origin: ISSUER,
-          },
-        }),
-        { issuer: ISSUER },
-      );
-      expect(postRes.status).toBe(302);
-      expect(postRes.headers.get("location")).toBe(returnTo);
-
-      // Step 3: GET /oauth/authorize again — now the client is approved, so
-      // the operator lands on the consent screen.
-      const reentryRes = handleAuthorizeGet(
+      const res = handleAuthorizeGet(
         db,
         new Request(authorizeHref, { headers: { cookie, origin: ISSUER } }),
         { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
       );
-      expect(reentryRes.status).toBe(200);
-      const consentHtml = await reentryRes.text();
-      // Consent screen markers (renderConsent uses these).
-      // Page h1: "Approve <client>?" per design-system.md §5 (was "Authorize").
+      // Consent screen, in one step — no 403 approve-pending, no POST needed.
+      expect(res.status).toBe(200);
+      const consentHtml = await res.text();
       expect(consentHtml).toContain('name="__action" value="consent"');
       expect(consentHtml).toContain("Approve");
       expect(consentHtml).toContain("RoundTrip");
+      // Client auto-approved as a side effect of the consent render.
+      expect(getClient(db, reg.client.clientId)?.status).toBe("approved");
     } finally {
       cleanup();
     }
@@ -7142,7 +7104,14 @@ describe("handleAuthorizeGet — trust-by-client_name auto-approve (hub#409)", (
     }
   });
 
-  test("falls through to approve-pending when requested scope is NOT covered by prior grant (superset)", async () => {
+  test("scope NOT covered by prior client_name grant (superset) → single CONSENT render (single-consent change)", async () => {
+    // Single-consent change (2026-05-29): the separate operator approval gate
+    // is retired. A pending client + valid session auto-approves and falls
+    // through. Trust-by-name carry-over only fires when the prior grant covers
+    // the new scopes; here WRITE wasn't covered, so no silent carry-over — the
+    // user sees ONE consent screen (200) instead of the old 403 approve-pending
+    // page. The fresh client_id is now approved (the user's consent is the
+    // authorization).
     const { db, cleanup } = await makeDb();
     try {
       const user = await createUser(db, "owner", "pw");
@@ -7181,11 +7150,12 @@ describe("handleAuthorizeGet — trust-by-client_name auto-approve (hub#409)", (
         issuer: ISSUER,
         loadServicesManifest: fixtureLoadServicesManifest,
       });
-      // Approve-pending render — 403 — because the new scope wasn't trusted
-      expect(res.status).toBe(403);
-      expect(await res.text()).toContain("App not yet approved");
-      // The fresh client_id stays pending
-      expect(getClient(db, fresh.client.clientId)?.status).toBe("pending");
+      // Consent render (200) — not the old 403 approve-pending page.
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
+      expect(await res.text()).toContain("vault:default:write");
+      // The fresh client_id is auto-approved (consent IS the authorization).
+      expect(getClient(db, fresh.client.clientId)?.status).toBe("approved");
     } finally {
       cleanup();
     }
@@ -7231,7 +7201,11 @@ describe("handleAuthorizeGet — trust-by-client_name auto-approve (hub#409)", (
     }
   });
 
-  test("falls through when client_name is missing/empty (can't match a prior grant)", async () => {
+  test("client_name missing → no trust carry-over, but session still auto-approves → single CONSENT (single-consent change)", async () => {
+    // Single-consent change (2026-05-29): with no client_name, the trust-by-
+    // name carry-over can't match, so there's no silent skip — but a valid
+    // session still auto-approves the pending client and falls through to ONE
+    // consent screen (200), rather than the old 403 approve-pending page.
     const { db, cleanup } = await makeDb();
     try {
       const user = await createUser(db, "owner", "pw");
@@ -7268,8 +7242,10 @@ describe("handleAuthorizeGet — trust-by-client_name auto-approve (hub#409)", (
         issuer: ISSUER,
         loadServicesManifest: fixtureLoadServicesManifest,
       });
-      expect(res.status).toBe(403);
-      expect(getClient(db, fresh.client.clientId)?.status).toBe("pending");
+      // Consent render (200), and the fresh client is auto-approved.
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
+      expect(getClient(db, fresh.client.clientId)?.status).toBe("approved");
     } finally {
       cleanup();
     }
@@ -7991,7 +7967,14 @@ describe("RFC 8707 resource binding — vault-bound MCP (fix #461)", () => {
     }
   });
 
-  test("non-requestable scope still refused even with a resource (vault:admin → vault:jon:admin blocked)", async () => {
+  test("resource-bound vault:admin → vault:jon:admin now requestable; OWNER consents (single-consent change)", async () => {
+    // Single-consent change (2026-05-29): `vault:<name>:admin` is requestable
+    // now. Narrowing turns the resource-bound `vault:admin` into
+    // `vault:jon:admin`, which reaches the consent screen rather than being
+    // refused at the non-requestable gate. The consenting user here is the
+    // owner (first user = isFirstAdmin), who holds admin everywhere, so the
+    // anti-privesc cap at the mint choke-point admits it. The consent screen
+    // renders the narrowed admin scope with its admin badge.
     const { db, cleanup } = await makeDb();
     try {
       const user = await createUser(db, "owner", "pw");
@@ -8018,12 +8001,576 @@ describe("RFC 8707 resource binding — vault-bound MCP (fix #461)", () => {
         ),
         RESOURCE_DEPS,
       );
-      // Narrowing turns vault:admin → vault:jon:admin which is NON-requestable;
-      // the gate rejects via redirect with invalid_scope.
-      expect(res.status).toBe(302);
-      const loc = res.headers.get("location") ?? "";
-      expect(loc).toContain("error=invalid_scope");
-      expect(loc).toContain("vault%3Ajon%3Aadmin");
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      // Consent renders the narrowed named admin scope with the admin badge.
+      expect(html).toContain("vault:jon:admin");
+      expect(html).toContain("badge-admin");
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Single OAuth consent + grantable vault:<name>:admin with delegate-only-what-
+// you-hold cap (2026-05-29). Three changes land together:
+//   1. The separate operator client-approval gate is retired — a pending
+//      client + valid session auto-approves and falls through to ONE consent.
+//   2. `vault:<name>:admin` is requestable via OAuth (capped at mint).
+//   3. Anti-privesc verb-cap at the SINGLE mint choke-point
+//      (`issueAuthCodeRedirect`): a non-owner may only delegate vault verbs
+//      they themselves hold; un-held verbs (notably admin) are DROPPED, and an
+//      admin-only request from a non-owner is REFUSED (never a zero-scope mint).
+// ───────────────────────────────────────────────────────────────────────────
+describe("single OAuth consent + grantable vault admin + delegate-only cap (2026-05-29)", () => {
+  const TTL_S = Math.floor(SESSION_TTL_MS / 1000);
+
+  // The hub manifest must contain the vaults the assigned users target.
+  const CAP_MANIFEST: ServicesManifest = {
+    services: [
+      {
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/vault/work", "/vault/other"],
+        health: "/health",
+        version: "0.6.0",
+      },
+    ],
+  };
+  const capDeps = {
+    issuer: ISSUER,
+    loadServicesManifest: () => CAP_MANIFEST,
+    hubBoundOrigins: () => [ISSUER],
+  };
+
+  // Build + submit a consent form, returning the raw Response. `userIsOwner`
+  // just documents intent; identity comes from the session cookie.
+  async function submitConsent(
+    db: Awaited<ReturnType<typeof makeDb>>["db"],
+    sessionId: string,
+    clientId: string,
+    scope: string,
+    challenge: string,
+    extra: Record<string, string> = {},
+  ): Promise<Response> {
+    const form = new URLSearchParams({
+      __action: "consent",
+      __csrf: TEST_CSRF,
+      approve: "yes",
+      client_id: clientId,
+      redirect_uri: "https://app.example/cb",
+      response_type: "code",
+      scope,
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+      ...extra,
+    });
+    return handleAuthorizePost(
+      db,
+      new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(sessionId, TTL_S)}`,
+        },
+      }),
+      capDeps,
+    );
+  }
+
+  async function redeemToScopeAud(
+    db: Awaited<ReturnType<typeof makeDb>>["db"],
+    code: string,
+    clientId: string,
+    verifier: string,
+  ): Promise<{ scope: string; aud: unknown }> {
+    const tokenForm = new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      client_id: clientId,
+      redirect_uri: "https://app.example/cb",
+      code_verifier: verifier,
+    });
+    const tokenRes = await handleToken(
+      db,
+      new Request(`${ISSUER}/oauth/token`, {
+        method: "POST",
+        body: tokenForm,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+      capDeps,
+    );
+    expect(tokenRes.status).toBe(200);
+    const body = (await tokenRes.json()) as { access_token: string; scope: string };
+    const { payload } = await validateAccessToken(db, body.access_token, ISSUER);
+    return { scope: body.scope, aud: payload.aud };
+  }
+
+  // Test 1 — pending client + session → consent renders (200), client flipped approved.
+  test("[1] pending client + session → consent renders (200) + client flipped approved", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "Claude",
+        status: "pending",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:work:read",
+        }),
+        { headers: { cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, TTL_S)}` } },
+      );
+      const res = handleAuthorizeGet(db, req, capDeps);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
+      expect(await res.text()).not.toContain("App not yet approved");
+      expect(getClient(db, reg.client.clientId)?.status).toBe("approved");
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Test 4 — post-login round-trip: a session-less GET renders the unauth
+  // pending page whose CTA points at /login?next=<authorize URL>; re-entering
+  // WITH a session lands on consent.
+  test("[4] post-login round-trip → unauth pending CTA, then consent after login", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "Claude",
+        status: "pending",
+      });
+      const { challenge } = makePkce();
+      const href = authorizeUrl({
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        response_type: "code",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        scope: "vault:work:read",
+        state: "rt-login",
+      });
+      // Session-less: unauth pending page with the login round-trip CTA.
+      const unauth = handleAuthorizeGet(db, new Request(href), capDeps);
+      expect(unauth.status).toBe(403);
+      const unauthHtml = await unauth.text();
+      expect(unauthHtml).toContain("App not yet approved");
+      const u = new URL(href);
+      const returnTo = `${u.pathname}${u.search}`;
+      expect(unauthHtml).toContain(`/login?next=${encodeURIComponent(returnTo)}`);
+      // After login (now carrying a session) → consent renders.
+      const authed = handleAuthorizeGet(
+        db,
+        new Request(href, {
+          headers: { cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, TTL_S)}` },
+        }),
+        capDeps,
+      );
+      expect(authed.status).toBe(200);
+      expect(getClient(db, reg.client.clientId)?.status).toBe("approved");
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Test 6 — owner + vault:<name>:admin → consent renders, admin badge shown.
+  test("[6] owner + scope=vault:work:admin → consent renders (no invalid_scope) + admin badge", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      const res = handleAuthorizeGet(
+        db,
+        new Request(
+          authorizeUrl({
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+            scope: "vault:work:admin",
+          }),
+          { headers: { cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, TTL_S)}` } },
+        ),
+        capDeps,
+      );
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("vault:work:admin");
+      expect(html).toContain("badge-admin");
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Test 7 — owner consents to vault:<name>:admin → token scope + aud correct.
+  test("[7] owner consents to vault:work:admin → token scope=vault:work:admin, aud=vault.work", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:work:admin",
+        challenge,
+      );
+      expect(consentRes.status).toBe(302);
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      expect(code).toBeTruthy();
+      const { scope, aud } = await redeemToScopeAud(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope).toBe("vault:work:admin");
+      expect(aud).toBe("vault.work");
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Test 9 — privesc: read/write assigned (non-owner) user requests
+  // vault:work:admin + vault:work:write → admin DROPPED, token has write only,
+  // recorded grant lacks admin.
+  test("[9] non-owner read/write user requests admin+write → admin DROPPED (write only), grant lacks admin", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "pw"); // first user = owner; consumes the admin slot.
+      const friend = await createUser(db, "friend", "pw", { allowMulti: true });
+      setUserVaults(db, friend.id, ["work"]); // role=write → verbs [read, write]
+      const session = createSession(db, { userId: friend.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:work:admin vault:work:write",
+        challenge,
+      );
+      expect(consentRes.status).toBe(302);
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const { scope, aud } = await redeemToScopeAud(db, code ?? "", reg.client.clientId, verifier);
+      // admin dropped; write kept.
+      expect(scope.split(" ").sort()).toEqual(["vault:work:write"]);
+      expect(aud).toBe("vault.work");
+      // Recorded grant lacks admin.
+      const grant = findGrant(db, friend.id, reg.client.clientId);
+      expect(grant?.scopes).toContain("vault:work:write");
+      expect(grant?.scopes).not.toContain("vault:work:admin");
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Test 10 — non-owner admin-ONLY request → REFUSED (clear error), no token.
+  test("[10] non-owner admin-only request → REFUSED with invalid_scope, no token minted", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "pw");
+      const friend = await createUser(db, "friend", "pw", { allowMulti: true });
+      setUserVaults(db, friend.id, ["work"]);
+      const session = createSession(db, { userId: friend.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:work:admin",
+        challenge,
+      );
+      // Capping leaves an EMPTY scope set → refuse (no zero-scope token).
+      expect(consentRes.status).toBe(302);
+      const loc = new URL(consentRes.headers.get("location") ?? "");
+      expect(loc.origin + loc.pathname).toBe("https://app.example/cb");
+      expect(loc.searchParams.get("error")).toBe("invalid_scope");
+      expect(loc.searchParams.get("code")).toBeNull();
+      // No grant recorded.
+      expect(findGrant(db, friend.id, reg.client.clientId)).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Test 11 — non-owner unnamed vault:admin + picks assigned vault → after
+  // narrowing, admin dropped (cap runs post-narrow).
+  test("[11] non-owner unnamed vault:admin + picks assigned vault → admin dropped post-narrow", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "pw");
+      const friend = await createUser(db, "friend", "pw", { allowMulti: true });
+      setUserVaults(db, friend.id, ["work"]);
+      const session = createSession(db, { userId: friend.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      // Unnamed vault:admin + vault:write, picker resolves to "work".
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:admin vault:write",
+        challenge,
+        { vault_pick: "work" },
+      );
+      // narrowVaultScopes → vault:work:admin + vault:work:write; cap drops
+      // admin (non-owner doesn't hold it), keeps write → mints write only.
+      expect(consentRes.status).toBe(302);
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      expect(code).toBeTruthy();
+      const { scope } = await redeemToScopeAud(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope.split(" ").sort()).toEqual(["vault:work:write"]);
+      const grant = findGrant(db, friend.id, reg.client.clientId);
+      expect(grant?.scopes).toContain("vault:work:write");
+      expect(grant?.scopes).not.toContain("vault:work:admin");
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Test 12 — owner same request as test 9 → admin GRANTED (contrast).
+  test("[12] owner requests admin+write → admin GRANTED (owner bypasses the cap)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:work:admin vault:work:write",
+        challenge,
+      );
+      expect(consentRes.status).toBe(302);
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const { scope } = await redeemToScopeAud(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope.split(" ").sort()).toEqual(["vault:work:admin", "vault:work:write"]);
+      const grant = findGrant(db, owner.id, reg.client.clientId);
+      expect(grant?.scopes).toContain("vault:work:admin");
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Test 13 — same-hub client + session + vault:<name>:admin → does NOT
+  // silently mint; consent renders (relies on scopeIsAdmin recognizing the
+  // named admin form).
+  test("[13] same-hub client + vault:work:admin → consent renders (not silent-mint)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+        sameHub: true,
+      });
+      const { challenge } = makePkce();
+      const res = handleAuthorizeGet(
+        db,
+        new Request(
+          authorizeUrl({
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+            scope: "vault:work:admin",
+          }),
+          { headers: { cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, TTL_S)}` } },
+        ),
+        capDeps,
+      );
+      // Consent (200), NOT a silent 302 redirect with code.
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
+      // No grant auto-recorded (the same-hub gate did not fire).
+      expect(findGrant(db, owner.id, reg.client.clientId)).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Test 14 — trust-by-name: a prior NON-admin same-name grant + a new request
+  // that ADDS vault:<name>:admin → does NOT auto-promote; consent renders.
+  test("[14] trust-by-name + new admin scope → no auto-promote, consent renders", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const prior = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+        clientName: "Claude",
+      });
+      // Prior NON-admin grant under the same client_name.
+      recordGrant(db, owner.id, prior.client.clientId, ["vault:work:read", "vault:work:admin"]);
+      const fresh = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "pending",
+        clientName: "Claude",
+      });
+      const { challenge } = makePkce();
+      // New request includes admin — even though a prior same-name grant
+      // happens to list it, the trust gate excludes admin (scopeIsAdmin), so
+      // it must not silently carry over.
+      const res = handleAuthorizeGet(
+        db,
+        new Request(
+          authorizeUrl({
+            client_id: fresh.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+            scope: "vault:work:read vault:work:admin",
+          }),
+          {
+            headers: {
+              cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, TTL_S)}`,
+              origin: ISSUER,
+            },
+          },
+        ),
+        capDeps,
+      );
+      // Consent (200), not a silent 302 redirect.
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Test 15 — bypass-proof: a non-owner with NO prior admin grant cannot reach
+  // issueAuthCodeRedirect with an admin scope via ANY path (skip-consent /
+  // same-hub / consent). Assert no grants row ever contains an un-held admin
+  // verb across each path.
+  test("[15] bypass-proof: no mint path ever records an un-held admin verb for a non-owner", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "pw");
+      const friend = await createUser(db, "friend", "pw", { allowMulti: true });
+      setUserVaults(db, friend.id, ["work"]); // verbs [read, write] only
+      const session = createSession(db, { userId: friend.id });
+
+      // Path A — consent-submit with admin+write → admin dropped, recorded grant
+      // lacks admin.
+      const regConsent = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      {
+        const { challenge } = makePkce();
+        await submitConsent(
+          db,
+          session.id,
+          regConsent.client.clientId,
+          "vault:work:admin vault:work:write",
+          challenge,
+        );
+        const g = findGrant(db, friend.id, regConsent.client.clientId);
+        expect(g?.scopes ?? []).not.toContain("vault:work:admin");
+      }
+
+      // Path B — same-hub client requesting admin → consent renders (admin gate
+      // blocks the silent path); no grant recorded with admin.
+      const regSameHub = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+        sameHub: true,
+      });
+      {
+        const { challenge } = makePkce();
+        const res = handleAuthorizeGet(
+          db,
+          new Request(
+            authorizeUrl({
+              client_id: regSameHub.client.clientId,
+              redirect_uri: "https://app.example/cb",
+              response_type: "code",
+              code_challenge: challenge,
+              code_challenge_method: "S256",
+              scope: "vault:work:admin",
+            }),
+            { headers: { cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, TTL_S)}` } },
+          ),
+          capDeps,
+        );
+        expect(res.status).toBe(200); // consent, not silent-mint
+        const g = findGrant(db, friend.id, regSameHub.client.clientId);
+        expect(g?.scopes ?? []).not.toContain("vault:work:admin");
+      }
+
+      // Path C — skip-consent: even if a grant row were somehow seeded with an
+      // admin verb, the cap at issueAuthCodeRedirect drops it before minting AND
+      // re-records the capped set. Seed a poisoned grant, drive skip-consent,
+      // and assert the minted token + the (re-recorded) grant carry no admin.
+      const regSkip = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      recordGrant(db, friend.id, regSkip.client.clientId, ["vault:work:write", "vault:work:admin"]);
+      {
+        const { verifier, challenge } = makePkce();
+        // Request only the held write scope so skip-consent fires (covered by
+        // the seeded grant) and routes through issueAuthCodeRedirect.
+        const res = handleAuthorizeGet(
+          db,
+          new Request(
+            authorizeUrl({
+              client_id: regSkip.client.clientId,
+              redirect_uri: "https://app.example/cb",
+              response_type: "code",
+              code_challenge: challenge,
+              code_challenge_method: "S256",
+              scope: "vault:work:write",
+            }),
+            { headers: { cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, TTL_S)}` } },
+          ),
+          capDeps,
+        );
+        expect(res.status).toBe(302); // skip-consent silent mint of the held scope
+        const code = new URL(res.headers.get("location") ?? "").searchParams.get("code");
+        const { scope } = await redeemToScopeAud(db, code ?? "", regSkip.client.clientId, verifier);
+        expect(scope.split(" ")).not.toContain("vault:work:admin");
+      }
     } finally {
       cleanup();
     }

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -8575,4 +8575,67 @@ describe("single OAuth consent + grantable vault admin + delegate-only cap (2026
       cleanup();
     }
   });
+
+  // Reviewer fold (security-relevant): test 15 path C only requested `write`
+  // against the poisoned client, which proves the cap doesn't *re-record* an
+  // un-held verb. This case requests `vault:work:admin` DIRECTLY against a
+  // client whose grant row ALREADY lists `vault:work:admin` (poisoned). The
+  // skip-consent gate fires (the requested admin scope IS covered by the
+  // poisoned grant) and routes through issueAuthCodeRedirect — where the CAP,
+  // not the grant lookup, drops the admin verb. Admin-only request → caps to
+  // EMPTY → invalid_scope refusal, no code, no token. This pins that the
+  // cap-before-issueAuthCode invariant holds even when a stale admin grant
+  // would otherwise satisfy the coverage check.
+  test("[15b] non-owner requests admin DIRECTLY against a POISONED-grant client → cap refuses, no admin token", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "pw");
+      const friend = await createUser(db, "friend", "pw", { allowMulti: true });
+      setUserVaults(db, friend.id, ["work"]); // verbs [read, write] only — never admin
+      const session = createSession(db, { userId: friend.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      // Poisoned grant: already lists vault:work:admin (so the skip-consent
+      // coverage check would pass for a direct admin request).
+      recordGrant(db, friend.id, reg.client.clientId, ["vault:work:write", "vault:work:admin"]);
+
+      const { challenge } = makePkce();
+      const res = handleAuthorizeGet(
+        db,
+        new Request(
+          authorizeUrl({
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+            scope: "vault:work:admin",
+            state: "poisoned-direct",
+          }),
+          { headers: { cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, TTL_S)}` } },
+        ),
+        capDeps,
+      );
+      // The cap leaves an EMPTY set (non-owner doesn't hold admin) → refuse.
+      // 302 to redirect_uri with invalid_scope and NO code — no token minted.
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.get("location") ?? "");
+      expect(loc.origin + loc.pathname).toBe("https://app.example/cb");
+      expect(loc.searchParams.get("error")).toBe("invalid_scope");
+      expect(loc.searchParams.get("code")).toBeNull();
+      expect(loc.searchParams.get("state")).toBe("poisoned-direct");
+
+      // The re-record with the capped (empty) set never happens on the refuse
+      // path, so the poisoned grant is untouched — but crucially, NO mint
+      // occurred. Verify no auth code row was issued for this client.
+      const codeRows = db
+        .query<{ n: number }, [string]>("SELECT COUNT(*) AS n FROM auth_codes WHERE client_id = ?")
+        .get(reg.client.clientId);
+      expect(codeRows?.n ?? 0).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
 });

--- a/src/__tests__/scope-explanations.test.ts
+++ b/src/__tests__/scope-explanations.test.ts
@@ -60,10 +60,18 @@ describe("explainScope", () => {
     expect(explainScope("vault:*:write")?.level).toBe("write");
   });
 
-  test("doesn't promote a per-vault admin (vault:<name>:admin) into an explained scope", () => {
-    // vault:<name>:admin is NON_REQUESTABLE — never appears on the consent
-    // screen. Explicitly not in the verb-pattern, so explainScope returns null.
-    expect(explainScope("vault:default:admin")).toBeNull();
+  // Single-consent change (2026-05-29): vault:<name>:admin is now REQUESTABLE
+  // and reaches the consent screen, so explainScope MUST resolve it to the
+  // vault:admin explanation (level "admin"). This is load-bearing: it makes
+  // scopeIsAdmin("vault:<name>:admin") return true, which the same-hub and
+  // trust-by-name auto-mint gates rely on to keep admin consent-gated.
+  test("resolves a per-vault admin (vault:<name>:admin) to the vault:admin explanation", () => {
+    expect(explainScope("vault:default:admin")?.label).toBe(
+      SCOPE_EXPLANATIONS["vault:admin"]?.label,
+    );
+    expect(explainScope("vault:default:admin")?.level).toBe("admin");
+    expect(explainScope("vault:my-techne_2:admin")?.level).toBe("admin");
+    expect(explainScope("vault:*:admin")?.level).toBe("admin");
   });
 });
 
@@ -72,6 +80,17 @@ describe("scopeIsAdmin", () => {
     expect(scopeIsAdmin("vault:admin")).toBe(true);
     expect(scopeIsAdmin("hub:admin")).toBe(true);
     expect(scopeIsAdmin("parachute:host:admin")).toBe(true);
+  });
+
+  // Single-consent change (2026-05-29): the named per-vault admin form must
+  // be recognized as admin. LOAD-BEARING — the same-hub auto-trust gate
+  // (`!hasAdminScope`) and the trust-by-client_name gate
+  // (`!requestedScopes.some(scopeIsAdmin)`) rely on this to keep a named admin
+  // grant consent-gated instead of silently auto-minting it.
+  test("true for named per-vault admin (vault:<name>:admin)", () => {
+    expect(scopeIsAdmin("vault:work:admin")).toBe(true);
+    expect(scopeIsAdmin("vault:default:admin")).toBe(true);
+    expect(scopeIsAdmin("vault:my-techne_2:admin")).toBe(true);
   });
 
   test("false for non-admin and unknown scopes", () => {
@@ -120,16 +139,26 @@ describe("isRequestableScope", () => {
     expect(isRequestableScope("notes:something-new")).toBe(true);
   });
 
-  // Per-vault admin scopes are pattern-matched as non-requestable so the
-  // public OAuth flow can never mint vault:<name>:admin — only the local
-  // session-cookie endpoint at /admin/vault-admin-token/<name> can.
-  test("false for any vault:<name>:admin scope", () => {
-    expect(isRequestableScope("vault:default:admin")).toBe(false);
-    expect(isRequestableScope("vault:work:admin")).toBe(false);
-    expect(isRequestableScope("vault:my-techne_2:admin")).toBe(false);
+  // Single-consent change (2026-05-29): per-vault admin scopes are now
+  // requestable via the public OAuth flow. The anti-privesc cap at the mint
+  // choke-point (`capScopesToUserAuthority`) keeps a non-owner from actually
+  // being granted admin — but the scope is no longer rejected up front, so
+  // Claude MCP (consenting as the owner) can mint a vault admin token.
+  test("true for any vault:<name>:admin scope (single-consent change)", () => {
+    expect(isRequestableScope("vault:default:admin")).toBe(true);
+    expect(isRequestableScope("vault:work:admin")).toBe(true);
+    expect(isRequestableScope("vault:my-techne_2:admin")).toBe(true);
   });
 
-  test("vault:<name>:read|write stays requestable (only :admin is locked down)", () => {
+  test("host-level operator scopes stay non-requestable", () => {
+    // The asymmetry the single-consent change preserved: per-vault admin is
+    // now requestable (capped at mint), but host-wide operator authority is
+    // still operator-only-mintable.
+    expect(isRequestableScope("parachute:host:admin")).toBe(false);
+    expect(isRequestableScope("parachute:host:auth")).toBe(false);
+  });
+
+  test("vault:<name>:read|write stays requestable", () => {
     expect(isRequestableScope("vault:default:read")).toBe(true);
     expect(isRequestableScope("vault:work:write")).toBe(true);
   });

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -12,12 +12,24 @@
  *     plaintext exactly once. The token endpoint enforces client_secret per
  *     RFC 6749 §3.2.1 (closes #72).
  *
- * Approval gate (closes #74): every row carries a `status` of `pending` or
- * `approved`. New self-registrations default to `pending`; only registrations
- * that authenticate with an operator token bearing `hub:admin` (the install-
- * time path for first-party modules) land as `approved`. The OAuth flow
- * rejects `pending` clients at `/oauth/authorize` and `/oauth/token`. An
- * operator promotes a pending client via `parachute auth approve-client`.
+ * Status column (`pending` | `approved`): every row carries one. New
+ * self-registrations default to `pending`; registrations that authenticate
+ * with an operator token bearing `hub:admin` (the install-time path for
+ * first-party modules) land as `approved`.
+ *
+ * Single-consent change (2026-05-29): the separate operator "approve this
+ * client" gate was retired. The user's OAuth consent IS the authorization —
+ * `handleAuthorizeGet` now session-gates a `pending` client: a request
+ * carrying a valid session auto-approves the client (status → `approved`,
+ * audit-logged) and FALLS THROUGH to the normal consent screen; a session-
+ * less request still renders the unauth "App not yet approved" page whose
+ * sign-in CTA round-trips back to authorize (after login the user re-enters
+ * with a session → auto-approve → consent). The `status` column, the DCR
+ * `pending` default, the `/oauth/token` pending rejection, and the
+ * `parachute auth approve-client` / SPA approve surfaces all persist but are
+ * near-vestigial — kept for defense-in-depth and back-compat. Motivation:
+ * Notes/Claude DCR a fresh `client_id` per instance, so a per-client_id
+ * approval gate re-prompted the operator constantly.
  */
 import type { Database } from "bun:sqlite";
 import { createHash, randomBytes, randomUUID } from "node:crypto";

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -87,7 +87,13 @@ import {
   parseSessionCookie,
 } from "./sessions.ts";
 import { isTotpEnrolled } from "./two-factor-store.ts";
-import { getUserById, getUserByUsername, isFirstAdmin, verifyPassword } from "./users.ts";
+import {
+  getUserById,
+  getUserByUsername,
+  isFirstAdmin,
+  vaultVerbsForUserVault,
+  verifyPassword,
+} from "./users.ts";
 import { listVaultNames } from "./vault-names.ts";
 import { isVaultEntry, shortName, vaultInstanceNameFor } from "./well-known.ts";
 
@@ -828,7 +834,7 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
       parsed.state,
     );
   }
-  const client = getClient(db, parsed.clientId);
+  let client = getClient(db, parsed.clientId);
   if (!client) {
     // Can't safely redirect — we don't trust the redirect_uri until we've
     // matched it against a registered client. Render an HTML error that
@@ -839,7 +845,71 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
     return unknownClientResponse(parsed.clientId, parsed.redirectUri, deps);
   }
   if (client.status !== "approved") {
-    return pendingClientResponse(db, req, client, url, deps);
+    // Single-consent change (2026-05-29): the separate operator "approve this
+    // client" gate is retired — the user's OAuth consent IS the authorization.
+    // A request carrying a valid session auto-approves the pending client and
+    // FALLS THROUGH into the normal consent path below (resource-narrow →
+    // non-requestable gate → skip-consent / same-hub → consent render). A
+    // session-less request still renders the unauth "App not yet approved"
+    // page (`pendingClientResponse`), whose sign-in CTA (`loginNextUrl`)
+    // round-trips back to this authorize URL; after login the user re-enters
+    // WITH a session → hits this auto-approve branch → consent.
+    //
+    // We resolve the session via the same `parseSessionCookie` + `findSession`
+    // pair the consent path uses below (not `findActiveSession`) so the
+    // auto-approve predicate and the consent render agree on session identity.
+    const earlySessionId = parseSessionCookie(req.headers.get("cookie"));
+    const earlySession = earlySessionId ? findSession(db, earlySessionId) : null;
+    if (!earlySession) {
+      return pendingClientResponse(db, req, client, url, deps);
+    }
+    console.log(
+      `[oauth] auto-approved client on user consent (single-consent) client_id=${client.clientId} user_id=${earlySession.userId} (2026-05-29)`,
+    );
+    approveClient(db, client.clientId);
+
+    // Trust-by-client_name carry-over (hub#409, preserved through the
+    // single-consent change). Notes/Claude DCR a fresh client_id per session;
+    // when the user has a prior grant under the SAME client_name that covers
+    // the requested scopes, re-link must stay SILENT. The skip-consent gate
+    // below keys on (user, client_id) and the fresh client_id has no grant
+    // yet — so we re-record that prior coverage onto the fresh client_id here.
+    // The mint downstream goes through `issueAuthCodeRedirect`, which caps to
+    // held authority, so this carry-over can never silently re-grant an
+    // un-held verb. Guarded identically to the in-`pendingClientResponse`
+    // block: same-origin + non-empty client_name + non-admin requested scopes
+    // (`scopeIsAdmin` recognizes the named admin form now — load-bearing) +
+    // prior-grant coverage. When it doesn't apply, fall through to the consent
+    // render (the single-consent payoff: one consent screen, then silent).
+    const earlyRequested = parsed.scope.split(" ").filter((s) => s.length > 0);
+    if (
+      isSameOriginRequest(req, resolveBoundOrigins(deps)) &&
+      client.clientName &&
+      earlyRequested.length > 0 &&
+      !earlyRequested.some(scopeIsAdmin) &&
+      isCoveredByGrantForClientName(db, earlySession.userId, client.clientName, earlyRequested)
+    ) {
+      console.log(
+        `[oauth] carried prior client_name trust onto fresh client_id=${client.clientId} client_name=${JSON.stringify(client.clientName)} user_id=${earlySession.userId} scopes=${earlyRequested.join(" ")} (hub#409)`,
+      );
+      recordGrant(
+        db,
+        earlySession.userId,
+        client.clientId,
+        earlyRequested,
+        deps.now?.() ?? new Date(),
+      );
+    }
+
+    // Re-fetch so `client.status` reflects `approved` for the rest of this
+    // function (the same-hub gate and consent props read `client`). Fall
+    // through on success; if the refresh somehow failed, render the unauth
+    // pending page defensively (should never happen given approveClient).
+    const refreshed = getClient(db, client.clientId);
+    if (!refreshed || refreshed.status !== "approved") {
+      return pendingClientResponse(db, req, client, url, deps);
+    }
+    client = refreshed;
   }
   try {
     requireRegisteredRedirectUri(client, parsed.redirectUri);
@@ -1033,10 +1103,13 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
     console.log(
       `[oauth] auto-approved same-hub client client_id=${client.clientId} user_id=${session.userId} scopes=${requestedScopes.join(" ")} (hub#312)`,
     );
-    // Record the grant so the next /authorize for this (user, client, scopes)
-    // hits the standard skip-consent path (#75) — keeps the audit story
-    // consistent between same-hub and externally-approved flows.
-    recordGrant(db, session.userId, client.clientId, requestedScopes);
+    // The grant is recorded INSIDE issueAuthCodeRedirect with the CAPPED
+    // scopes (single choke-point, single source of truth) so the next
+    // /authorize for this (user, client, scopes) hits the standard
+    // skip-consent path (#75) — and can never replay an un-held verb. The
+    // `!hasAdminScope` guard above already keeps admin scopes off this path
+    // (they fall through to consent), so the cap is a no-op here for the
+    // common case, but it still runs unconditionally for defense in depth.
     return issueAuthCodeRedirect(db, parsed, requestedScopes, session.userId, deps);
   }
 
@@ -1050,10 +1123,77 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
 }
 
 /**
- * Mint an auth code and redirect to the client's redirect_uri. Shared by
- * the consent-submit path (`handleConsentSubmit`) and the skip-consent path
- * in `handleAuthorizeGet` (#75). Caller is responsible for having already
- * validated the client + redirect_uri + scopes.
+ * Anti-privilege-escalation cap (THE security crux of the single-consent
+ * change, 2026-05-29). A user may only delegate authority they themselves
+ * hold: the OAuth consent that authorizes a client must never grant a named
+ * vault verb the consenting user doesn't actually hold on that vault.
+ *
+ * For each scope shaped `vault:<name>:<verb>` (verb ∈ VAULT_VERBS) when the
+ * user is NOT the hub owner, the verb is admitted only if it appears in
+ * `vaultVerbsForUserVault(db, userId, name)` (the verbs the user holds on
+ * that vault, derived from their `user_vaults` role). Otherwise the scope is
+ * DROPPED. Non-vault scopes and unnamed `vault:<verb>` (which never reach
+ * mint without picker-narrowing) pass through untouched.
+ *
+ * The owner (`isFirstAdmin`) bypasses the cap entirely — they hold admin on
+ * every vault by construction (admin posture is the unrestricted sentinel;
+ * see `vaultScopeForUser`). Owner=isFirstAdmin is the Phase-1 definition of
+ * "holds admin everywhere"; revisit when multi-admin lands.
+ *
+ * Security argument (documented at the call site too):
+ *   - The authority source of truth today is `isFirstAdmin` for owner-wide
+ *     authority and `user_vaults.role` (via `vaultVerbsForRole`) for assigned
+ *     users.
+ *   - `vaultVerbsForRole` provably never returns `admin` for an assigned user
+ *     (it maps write→[read,write], read→[read], unknown→[]), so this helper
+ *     drops `vault:<name>:admin` for every non-owner BY CONSTRUCTION — without
+ *     hardcoding "drop admin". It reads the held verb set and admits only
+ *     held verbs, so it's forward-compatible: if a future role ever granted
+ *     admin, the cap would admit it automatically.
+ *   - Applied inside `issueAuthCodeRedirect` (the single choke-point ALL mint
+ *     paths funnel through: consent-submit, skip-consent, and same-hub
+ *     auto-trust), the CAPPED set is what gets both recorded (`recordGrant`)
+ *     and minted (`issueAuthCode`). No mint path can bypass it, and a later
+ *     skip-consent flow can never replay an un-held admin verb because it was
+ *     never recorded.
+ */
+function capScopesToUserAuthority(
+  db: Database,
+  userId: string,
+  scopes: readonly string[],
+  opts: { userIsAdmin: boolean },
+): string[] {
+  if (opts.userIsAdmin) return [...scopes];
+  return scopes.filter((s) => {
+    const parts = s.split(":");
+    if (parts.length !== 3 || parts[0] !== "vault") return true; // non-named — pass through
+    const name = parts[1];
+    const verb = parts[2];
+    if (name === undefined || verb === undefined || !VAULT_VERBS.has(verb)) return true;
+    // Named vault verb requested by a non-owner: admit only if the user holds
+    // it. `vaultVerbsForUserVault` returns null for an unassigned vault (drop)
+    // or the held verb list (today read/write only — never admin).
+    const held = vaultVerbsForUserVault(db, userId, name);
+    return held !== null && (held as readonly string[]).includes(verb);
+  });
+}
+
+/**
+ * Mint an auth code and redirect to the client's redirect_uri. The SINGLE
+ * mint choke-point — shared by the consent-submit path (`handleConsentSubmit`),
+ * the skip-consent path (#75), and the same-hub auto-trust path (hub#312) in
+ * `handleAuthorizeGet`. Caller is responsible for having already validated the
+ * client + redirect_uri and for having narrowed unnamed `vault:<verb>` scopes
+ * to their named form (so the cap below sees final shapes).
+ *
+ * Two responsibilities live here so NO mint path can bypass them:
+ *   1. Anti-privilege-escalation cap (`capScopesToUserAuthority`): a non-owner
+ *      can only delegate vault verbs they hold; un-held verbs (notably admin)
+ *      are dropped. An admin-only request from a non-owner caps to EMPTY → we
+ *      refuse with `invalid_scope` rather than mint a zero-scope token.
+ *   2. Grant recording (`recordGrant`) with the CAPPED scopes — so a later
+ *      skip-consent flow can never replay an un-held verb. UNION semantics
+ *      make this idempotent for the skip-consent re-entry.
  */
 function issueAuthCodeRedirect(
   db: Database,
@@ -1062,11 +1202,37 @@ function issueAuthCodeRedirect(
   userId: string,
   deps: OAuthDeps,
 ): Response {
+  // Anti-privesc cap at the single choke-point. Runs AFTER any narrowing the
+  // callers did (unnamed `vault:admin` → `vault:<picked>:admin`), so it sees
+  // the final named shapes. Owner (isFirstAdmin) bypasses — holds admin
+  // everywhere by construction.
+  const userIsAdmin = isFirstAdmin(db, userId);
+  const cappedScopes = capScopesToUserAuthority(db, userId, scopes, { userIsAdmin });
+
+  // Drop-not-refuse UX, with one hard floor: if capping leaves an EMPTY set
+  // (e.g. a non-owner requested ONLY `vault:<name>:admin`, which they don't
+  // hold), never mint a zero-scope token — refuse with a clear invalid_scope.
+  // A request that started empty (no scopes at all) is a separate, legitimate
+  // "session token only" case the consent UI supports, so we only refuse when
+  // the cap itself removed every scope.
+  if (cappedScopes.length === 0 && scopes.length > 0) {
+    return oauthErrorRedirect(
+      params.redirectUri,
+      "invalid_scope",
+      "You can grant only the access you hold on this vault; an admin grant requires hub-owner authority.",
+      params.state,
+    );
+  }
+
+  // Record the grant with the CAPPED scopes (single source of truth) so
+  // skip-consent re-entry can never widen back to an un-held verb.
+  recordGrant(db, userId, params.clientId, cappedScopes, deps.now?.() ?? new Date());
+
   const code = issueAuthCode(db, {
     clientId: params.clientId,
     userId,
     redirectUri: params.redirectUri,
-    scopes,
+    scopes: cappedScopes,
     codeChallenge: params.codeChallenge,
     codeChallengeMethod: params.codeChallengeMethod,
     now: deps.now,
@@ -1456,12 +1622,12 @@ async function handleConsentSubmit(
     }
   }
 
-  // Record (or extend) the grant so the next /oauth/authorize for this
-  // (user, client) with these scopes — or any subset — can skip the consent
-  // screen (#75). UNION semantics: if the user previously granted [a, b, c]
-  // and now grants [a, d], the row becomes [a, b, c, d]. Subset re-flows
-  // still match.
-  recordGrant(db, session.userId, client.clientId, scopes, deps.now?.() ?? new Date());
+  // The grant is recorded (or extended) INSIDE issueAuthCodeRedirect with the
+  // CAPPED scopes — the single mint choke-point owns both the anti-privesc cap
+  // and the recordGrant so no path can record an un-held verb. UNION semantics
+  // there mean a subset re-flow still matches a prior grant, and an admin-only
+  // request from a non-owner caps to empty → refused (no zero-scope token).
+  // (#75 skip-consent depends on this recording.)
   return issueAuthCodeRedirect(db, params, scopes, session.userId, deps);
 }
 

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -1186,14 +1186,26 @@ function capScopesToUserAuthority(
  * client + redirect_uri and for having narrowed unnamed `vault:<verb>` scopes
  * to their named form (so the cap below sees final shapes).
  *
- * Two responsibilities live here so NO mint path can bypass them:
+ * This is the single choke-point for two responsibilities, so NO mint path can
+ * bypass them:
  *   1. Anti-privilege-escalation cap (`capScopesToUserAuthority`): a non-owner
  *      can only delegate vault verbs they hold; un-held verbs (notably admin)
  *      are dropped. An admin-only request from a non-owner caps to EMPTY → we
- *      refuse with `invalid_scope` rather than mint a zero-scope token.
- *   2. Grant recording (`recordGrant`) with the CAPPED scopes — so a later
- *      skip-consent flow can never replay an un-held verb. UNION semantics
- *      make this idempotent for the skip-consent re-entry.
+ *      refuse with `invalid_scope` rather than mint a zero-scope token. EVERY
+ *      auth code is minted through here, so the cap runs before every mint —
+ *      even when a stale `grants` row already lists an un-held admin verb (the
+ *      cap, not the grant lookup, is what blocks the mint).
+ *   2. Grant recording (`recordGrant`) with the CAPPED scopes for THIS mint —
+ *      so a later skip-consent flow re-entering with the same (user, client)
+ *      can never replay an un-held verb. UNION semantics make this idempotent.
+ *
+ * Not the ONLY `recordGrant` call in this module, though: two other guarded
+ * fast-path records exist — the trust-by-client_name auto-promote in
+ * `pendingClientResponse` (~L585) and the auto-approve carry-over in
+ * `handleAuthorizeGet` (~L895). Both are gated by `!some(scopeIsAdmin)`, so
+ * neither can ever record an admin verb, and any mint they unlock still flows
+ * back through this function's cap. So the invariant "no minted token, and no
+ * grant row, ever carries an un-held admin verb" holds across all paths.
  */
 function issueAuthCodeRedirect(
   db: Database,

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -138,23 +138,39 @@ export const NON_REQUESTABLE_SCOPES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Per-vault `vault:<name>:admin` scopes are also non-requestable via the
- * public OAuth flow: they let the holder mint, revoke, and rotate tokens
- * for a specific vault instance, which is operator-only territory.
+ * Per-vault `vault:<name>:admin` scopes ARE requestable via the public OAuth
+ * flow (single-consent change, 2026-05-29). A user may grant a named vault's
+ * admin scope to an OAuth client — e.g. Claude MCP minting an admin token for
+ * a vault — but only within the one guardrail that survives the simplification:
+ * a user may only delegate authority they themselves hold. That guardrail is
+ * enforced at the shared mint choke-point (`capScopesToUserAuthority` applied
+ * inside `issueAuthCodeRedirect` in `oauth-handlers.ts`): an OAuth flow caps
+ * named vault verbs to those the consenting user actually holds on that vault.
+ * `vaultVerbsForRole` never returns `admin` for an assigned (read/write) user,
+ * so admin is dropped for everyone except the hub owner (isFirstAdmin) — who
+ * holds admin everywhere by construction. An admin-only request from a
+ * non-owner is refused outright (never minted as a zero-scope token).
  *
- * They are mintable by operator-proving local paths, all of which require
- * already-established authority (never third-party consent):
+ * `vault:<name>:admin` also remains mintable by operator-proving local paths,
+ * all of which require already-established authority:
  *   - the session-cookie-gated `/admin/vault-admin-token/:name` endpoint
  *     (the vault SPA's Manage link + setup wizard); and
  *   - `POST /api/auth/mint-token` under the capability-attenuation model —
- *     a `parachute:host:admin` bearer (box-wide → one-vault) or a
- *     `vault:<name>:admin` bearer (same-vault subset). The same model governs
- *     `POST /api/auth/revoke-token` (revoke what you could mint). See
- *     `canGrant` in `scope-attenuation.ts` and the guards in
- *     `api-mint-token.ts` / `api-revoke-token.ts`.
+ *     a `parachute:host:auth` bearer (any requestable scope, now incl.
+ *     `vault:<name>:admin` — an intentional de-escalation widening that
+ *     landed with the single-consent change), a `parachute:host:admin`
+ *     bearer (box-wide → one-vault), or a `vault:<name>:admin` bearer
+ *     (same-vault subset). The same model governs `POST /api/auth/revoke-token`
+ *     (revoke what you could mint). See `canGrant` in `scope-attenuation.ts`
+ *     and the guards in `api-mint-token.ts` / `api-revoke-token.ts`.
  *
- * Pattern-based because the set is open-ended — every vault instance the
- * operator creates implies a new scope, and we don't want to enumerate them.
+ * The matcher is pattern-based because the set is open-ended — every vault
+ * instance the operator creates implies a new scope, and we don't want to
+ * enumerate them. It is still used by `isVaultAdminScope` (the mint-token
+ * de-escalation recognizer) and `explainScope` / `VAULT_VERB_RE` (so the
+ * consent screen renders the admin badge and `scopeIsAdmin` recognizes the
+ * named admin form — load-bearing: the same-hub and trust-by-name auto-mint
+ * gates rely on `scopeIsAdmin` to keep admin consent-gated).
  */
 const VAULT_ADMIN_RE = /^vault:[a-zA-Z0-9_-]+:admin$/;
 
@@ -240,7 +256,12 @@ export function isWellFormedOrNonVaultScope(scope: string): boolean {
 
 /** True when the scope is non-requestable via the public OAuth flow. */
 export function isNonRequestableScope(scope: string): boolean {
-  return NON_REQUESTABLE_SCOPES.has(scope) || VAULT_ADMIN_RE.test(scope);
+  // Per-vault `vault:<name>:admin` is NO LONGER globally non-requestable
+  // (single-consent change, 2026-05-29). It flows through the public OAuth
+  // consent path and through `canGrant` rule 1, capped to the consenting
+  // user's held authority at the `issueAuthCodeRedirect` choke-point. Only
+  // the host-level operator scopes stay non-requestable here.
+  return NON_REQUESTABLE_SCOPES.has(scope);
 }
 
 /** True when the scope can appear in a public `/oauth/authorize` request. */
@@ -261,17 +282,24 @@ export function isRequestableScope(scope: string): boolean {
  * shape we use on the operator approval page where no per-user vault has
  * been selected yet (a specific vault is chosen during sign-in).
  *
- * Verb-only — admin verbs on a per-vault basis (`vault:<name>:admin`) are
- * `NON_REQUESTABLE_SCOPES` by policy and never reach the consent screen, so
- * we don't substitute for them here. Read / write get the matching label.
+ * Includes `admin` (single-consent change, 2026-05-29). `vault:<name>:admin`
+ * is now requestable via OAuth, so it reaches the consent screen and MUST get
+ * the `vault:admin` explanation (level `"admin"`) — both so the consent UI
+ * renders the admin badge and so `scopeIsAdmin("vault:<name>:admin")` returns
+ * true. That second effect is LOAD-BEARING: the same-hub auto-trust gate
+ * (`!hasAdminScope`) and the trust-by-client_name gate
+ * (`!requestedScopes.some(scopeIsAdmin)`) rely on `scopeIsAdmin` recognizing
+ * the named admin form to keep admin grants consent-gated (never silently
+ * auto-minted). If this regex dropped `admin`, those gates would treat a
+ * named admin scope as non-admin and auto-mint it.
  */
-const VAULT_VERB_RE = /^vault:[a-zA-Z0-9_*-]+:(read|write)$/;
+const VAULT_VERB_RE = /^vault:[a-zA-Z0-9_*-]+:(read|write|admin)$/;
 
 export function explainScope(scope: string): ScopeExplanation | null {
   const direct = SCOPE_EXPLANATIONS[scope];
   if (direct) return direct;
   if (VAULT_VERB_RE.test(scope)) {
-    const verb = scope.split(":")[2] as "read" | "write";
+    const verb = scope.split(":")[2] as "read" | "write" | "admin";
     return SCOPE_EXPLANATIONS[`vault:${verb}`] ?? null;
   }
   return null;


### PR DESCRIPTION
## Why

The hub stacked **two** authorization gates: an operator "approve this client" step (clients start `status='pending'`, fires per fresh `client_id` — Notes/Claude DCR a new `client_id` per instance, so it re-prompted constantly) **plus** the normal user consent. And `vault:<name>:admin` was non-requestable via public OAuth, so Claude MCP couldn't mint admin tokens. This collapses to **ONE** consent screen, makes vault admin grantable, and preserves the one guardrail that matters.

## CHANGE 1 — single consent (drop the separate client-approval gate)
- `handleAuthorizeGet`'s `status !== "approved"` branch now **session-gates** a pending client: with a valid session it `approveClient` + audit-logs + **FALLS THROUGH** into the normal consent path (resource-narrow → non-requestable gate → skip-consent/same-hub → consent render). Session-less still renders the unauth `pendingClientResponse`, whose login CTA (`loginNextUrl`) round-trips back to authorize → after login the user re-enters with a session → auto-approve → consent.
- **Trust-by-client_name carry-over preserved** (replicated in the auto-approve branch): re-link with a new `client_id` + same name + covered non-admin scopes stays **silent**.
- The `pending` column, DCR pending default, `/oauth/token` pending rejection, consent-submit status check, CLI `approve-client`/`pending-clients`, and SPA approve surfaces all persist (near-vestigial but harmless) per the brief.

## CHANGE 2 — make `vault:<name>:admin` requestable
- `isNonRequestableScope` drops the `VAULT_ADMIN_RE` clause (only `parachute:host:*` operator scopes stay non-requestable).
- **LOAD-BEARING explainScope↔scopeIsAdmin pairing:** `VAULT_VERB_RE` / `explainScope` extended `(read|write)` → `(read|write|admin)` so `explainScope("vault:<name>:admin")` returns `level:"admin"`, making `scopeIsAdmin("vault:<name>:admin")` return **true**. The same-hub auto-trust gate (`!hasAdminScope`) and the trust-by-name gate (`!requestedScopes.some(scopeIsAdmin)`) **rely on this** to keep admin consent-gated — never silently auto-minted. The consent screen renders the admin badge for the named admin scope.
- **canGrant widening:** a `parachute:host:auth` bearer can now mint `vault:<N>:admin` via `scope-attenuation.ts` rule 1 — an intentional de-escalation, pinned by tests (3 api-mint-token tests flipped 400→200).

## CHANGE 3 — anti-privesc verb-cap at the SINGLE choke-point (security crux)
- New `capScopesToUserAuthority(db, userId, scopes, {userIsAdmin})`: for each named `vault:<name>:<verb>`, a non-owner is admitted only if `vaultVerbsForUserVault(db, userId, name)` includes the verb; else **DROPPED**. Owner (`isFirstAdmin`) bypasses — holds admin everywhere by construction. `vaultVerbsForRole` provably never returns `admin` for assigned users, so admin is dropped for every non-owner **by construction** — forward-compatible (reads held verbs, doesn't hardcode "drop admin").
- **Applied inside `issueAuthCodeRedirect`** — the single choke-point ALL three mint paths funnel through: **consent-submit, skip-consent, AND same-hub auto-trust**. The recorded grant (`recordGrant` moved inside) uses the CAPPED scopes, so a later skip-consent flow can never replay an un-held admin verb. The cap runs **after** scope narrowing (unnamed `vault:admin` → `vault:<picked>:admin`) so it sees final named shapes.
- **Drop-not-refuse** with a hard floor: an admin-only request from a non-owner caps to EMPTY → refused with `invalid_scope` (never a zero-scope token).

### Security argument
Authority source of truth today is `isFirstAdmin` (owner-wide) + `user_vaults.role` via `vaultVerbsForRole` (assigned). The cap reads the held verb set and admits only held verbs; the capped set is what's recorded **and** minted; no mint path bypasses the choke-point (verified — 3 call sites all route through `issueAuthCodeRedirect`). Owner=isFirstAdmin is the Phase-1 definition (revisit if multi-admin lands).

## Mint/audience (confirmed, no change)
`vault:<name>:admin` → `inferAudience` → `aud=vault.<name>` (VAULT_VERBS includes admin). Test 7 confirms the auth-code redemption stamps `scope=vault:work:admin`, `aud=vault.work`.

## Tests
- **scope-explanations:** `isRequestableScope("vault:work:admin")` true, `scopeIsAdmin("vault:work:admin")` true, `explainScope(...).level==="admin"`; `parachute:host:*` stays non-requestable.
- **api-mint-token:** 3 tests pinning the old "auth-only bearer can't mint `vault:<name>:admin`" flipped to 200 (intentional widening).
- **oauth-handlers:** pending-flow tests updated to single-consent; resource-bound `vault:admin → vault:jon:admin` now reaches consent (owner). New describe block covers plan tests **1, 4, 6, 7, 9–15**: privesc-drop, admin-only-refuse, post-narrow drop, owner-grant contrast, same-hub/trust-by-name admin-not-auto-minted, and the **bypass-proof** multi-path assertion (no grant row ever carries an un-held admin verb across consent/same-hub/skip-consent).

## Gates
- `bun test ./src` — **2514 pass / 0 fail** / 1 pre-existing skip (setup-wizard)
- `bun run typecheck` — clean
- `cd web/ui && bunx vitest run` — **258 pass / 0 fail** (17 files)
- `bunx biome check --write` on changed files — clean (2 remaining errors at `oauth-handlers.ts:1697` are **pre-existing on main**, in code this PR doesn't touch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)