### PR TITLE
hotfix(depcheck): drop bun→src exports condition that broke published resolution (depcheck rc.2, hub rc.21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.20",
-  "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
+  "version": "0.5.14-rc.21",
+  "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {
     "access": "public"
@@ -11,8 +11,15 @@
   "bin": {
     "parachute": "src/cli.ts"
   },
-  "workspaces": ["packages/*"],
-  "files": ["src", "web/ui/dist", "README.md", "LICENSE"],
+  "workspaces": [
+    "packages/*"
+  ],
+  "files": [
+    "src",
+    "web/ui/dist",
+    "README.md",
+    "LICENSE"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/ParachuteComputer/parachute-hub.git"
@@ -38,7 +45,7 @@
   },
   "dependencies": {
     "@node-rs/argon2": "^2.0.2",
-    "@openparachute/depcheck": "0.1.0-rc.1",
+    "@openparachute/depcheck": "0.1.0-rc.2",
     "jose": "^6.2.2",
     "otpauth": "^9.5.0",
     "qrcode": "^1.5.4"

--- a/packages/depcheck/package.json
+++ b/packages/depcheck/package.json
@@ -1,26 +1,19 @@
 {
   "name": "@openparachute/depcheck",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "description": "Canonical missing-dependency UX for Parachute modules: a dependency registry, a message formatter, and ENOENT spawn-error helpers shared across vault / scribe / runner / hub.",
   "license": "AGPL-3.0",
   "type": "module",
   "publishConfig": {
-    "access": "public",
-    "//": "Override exports at publish time: the published tarball ships dist/ only (no src/), so the dev-only `bun`→src condition is dropped. Published Bun + Node consumers both resolve dist.",
-    "exports": {
-      ".": {
-        "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
-      }
-    }
+    "access": "public"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "//": "exports MUST match scope-guard: NO `bun` condition. npm does not honor publishConfig.exports, so a `bun`→src condition would ship in the published package, and Bun consumers (hub) would resolve src/index.ts which the tarball doesn't include (files: dist only) → 'Cannot find module'. dist is built locally + shipped, so `import`→dist resolves under both Bun and Node. (Caught on the rc.1→rc.2 deploy.)",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "bun": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },


### PR DESCRIPTION
## Deploy-blocking bug (caught live)
After `bun add -g @openparachute/hub@rc` (rc.20) on the EC2 box, the `parachute` CLI crashed on every call:
```
error: Cannot find module '@openparachute/depcheck' from '.../@openparachute/hub/src/cli.ts'
```
depcheck IS installed (dist present), but its published `exports["."]` kept a `"bun": "./src/index.ts"` condition while `files` ships **dist only**. Hub runs under Bun → Bun picks the `bun` condition → `src/index.ts` (not in the tarball) → module not found.

**Why the guard didn't work:** the `publishConfig.exports` override is a no-op — npm's `publishConfig` only overrides registry/access/tag, **not** the `exports` field. So the dev-only `bun`→src condition shipped.

## Fix
Match the working `scope-guard` precedent exactly: `exports["."]` = `{types, import}`, no `bun` condition. `dist` is built locally + via `prepublishOnly` and shipped, so `import`→`dist/index.js` resolves under both Bun and Node.

**Verified locally:** `bun -e 'import("@openparachute/depcheck")'` resolves the dist exports (`DEPENDENCY_REGISTRY, MissingDependencyError, ensureExecutable, …`). Typecheck clean; depcheck tests 46/0.

depcheck `0.1.0-rc.1` → `0.1.0-rc.2`; hub re-pins + bumps `0.5.14-rc.20` → `rc.21`.

## After merge
Tag `depcheck-v0.1.0-rc.2` (publish depcheck) → tag `v0.5.14-rc.21` (publish hub) → re-deploy boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)