### PR TITLE
release: scope-guard 0.4.0 + depcheck 0.1.0 + hub 0.6.0 (stable cut)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.5.14-rc.21",
+  "version": "0.6.0",
   "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@node-rs/argon2": "^2.0.2",
-    "@openparachute/depcheck": "0.1.0-rc.2",
+    "@openparachute/depcheck": "0.1.0",
     "jose": "^6.2.2",
     "otpauth": "^9.5.0",
     "qrcode": "^1.5.4"

--- a/packages/depcheck/package.json
+++ b/packages/depcheck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/depcheck",
-  "version": "0.1.0-rc.2",
+  "version": "0.1.0",
   "description": "Canonical missing-dependency UX for Parachute modules: a dependency registry, a message formatter, and ENOENT spawn-error helpers shared across vault / scribe / runner / hub.",
   "license": "AGPL-3.0",
   "type": "module",
@@ -10,14 +10,18 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "//": "exports MUST match scope-guard: NO `bun` condition. npm does not honor publishConfig.exports, so a `bun`→src condition would ship in the published package, and Bun consumers (hub) would resolve src/index.ts which the tarball doesn't include (files: dist only) → 'Cannot find module'. dist is built locally + shipped, so `import`→dist resolves under both Bun and Node. (Caught on the rc.1→rc.2 deploy.)",
+  "//": "exports MUST match scope-guard: NO `bun` condition. npm does not honor publishConfig.exports, so a `bun`\u2192src condition would ship in the published package, and Bun consumers (hub) would resolve src/index.ts which the tarball doesn't include (files: dist only) \u2192 'Cannot find module'. dist is built locally + shipped, so `import`\u2192dist resolves under both Bun and Node. (Caught on the rc.1\u2192rc.2 deploy.)",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/ParachuteComputer/parachute-hub.git",

--- a/packages/scope-guard/package.json
+++ b/packages/scope-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scope-guard",
-  "version": "0.4.0-rc.2",
+  "version": "0.4.0",
   "description": "Hub-issued JWT validation for Parachute resource servers (vault, scribe, parachute-agent, third-party modules).",
   "license": "AGPL-3.0",
   "type": "module",
@@ -16,7 +16,11 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/ParachuteComputer/parachute-hub.git",


### PR DESCRIPTION
Stable @latest cut — drop -rc on the hub-repo packages. scope-guard 0.4.0, depcheck 0.1.0, hub 0.6.0 (re-pin depcheck->0.1.0). Pure version bumps of already-reviewed+rc-tested+deployed content, on Aaron's explicit ship. Tags follow in dependency order (depcheck-v0.1.0 -> scope-guard-v0.4.0 -> v0.6.0).