### PR TITLE
fix(hub): vault-bound consent scope-drop + container-boot dist build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,18 +70,20 @@ COPY . .
 # --ignore-scripts to keep the install layer source-independent).
 RUN bun run build:spa
 
-# Build the workspace package dists. `@openparachute/depcheck` is imported at
-# boot (src/cli.ts) and its `exports` resolve to `./dist/index.js`. The install
-# above ran `--ignore-scripts` (so no build hook fired) and the host's `dist/`
-# is `.dockerignore`d — without an explicit build here the runtime stage copies
-# a package with no `dist/`, Bun can't resolve the module, and the hub crashes
-# on boot before binding :1939 (caught by the container smoke after the depcheck
-# `bun`→src exports condition was dropped — that condition had been masking this
-# by resolving to `src/` under Bun). scope-guard built too for parity. Both are
-# tsc-only (no bundler), and the runtime stage's `COPY --from=builder packages`
-# carries the emitted `dist/` along (inter-stage COPY ignores `.dockerignore`).
-RUN (cd packages/depcheck && bun run build) \
- && (cd packages/scope-guard && bun run build)
+# Build every workspace package's `dist/` before the runtime stage copies
+# `packages/`. `@openparachute/depcheck` is imported at boot (src/cli.ts) and
+# its `exports` resolve to `./dist/index.js`; the install above ran
+# `--ignore-scripts` (no build hook) and the host's `dist/` is `.dockerignore`d,
+# so without a build here the runtime image ships a package with no `dist/`, Bun
+# can't resolve the module, and the hub crashes on boot before binding :1939
+# (the container smoke caught this after depcheck's `bun`→src exports condition
+# was dropped — that condition had masked it by resolving to `src/` under Bun).
+# Looping over every package keeps this self-healing as the workspace grows
+# rather than enumerating the one package that happens to be boot-imported today
+# (every package in `packages/` is a tsc-only lib with a `build` script). The
+# runtime stage's `COPY --from=builder packages` carries the emitted `dist/`
+# along (inter-stage COPY ignores `.dockerignore`).
+RUN for pkg in packages/*/; do (cd "$pkg" && bun run build); done
 
 # ---- Runtime stage --------------------------------------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,19 @@ COPY . .
 # --ignore-scripts to keep the install layer source-independent).
 RUN bun run build:spa
 
+# Build the workspace package dists. `@openparachute/depcheck` is imported at
+# boot (src/cli.ts) and its `exports` resolve to `./dist/index.js`. The install
+# above ran `--ignore-scripts` (so no build hook fired) and the host's `dist/`
+# is `.dockerignore`d — without an explicit build here the runtime stage copies
+# a package with no `dist/`, Bun can't resolve the module, and the hub crashes
+# on boot before binding :1939 (caught by the container smoke after the depcheck
+# `bun`→src exports condition was dropped — that condition had been masking this
+# by resolving to `src/` under Bun). scope-guard built too for parity. Both are
+# tsc-only (no bundler), and the runtime stage's `COPY --from=builder packages`
+# carries the emitted `dist/` along (inter-stage COPY ignores `.dockerignore`).
+RUN (cd packages/depcheck && bun run build) \
+ && (cd packages/scope-guard && bun run build)
+
 # ---- Runtime stage --------------------------------------------------------
 
 FROM oven/bun:${BUN_VERSION}-alpine AS runtime

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.0",
+  "version": "0.6.1-rc.1",
   "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -707,6 +707,107 @@ describe("handleAuthorizeGet — RFC 8707 resource binding drops foreign scopes 
       cleanup();
     }
   });
+
+  test("a vault-bound request of ONLY non-vault scopes narrows to empty (consent, not invalid_scope)", async () => {
+    // Edge: a client over-asks but names zero vault scopes against a vault
+    // resource. Narrowing drops everything → empty scope. We render consent
+    // (zero scope rows) rather than a 302 invalid_scope; an empty grant is
+    // harmless and the operator can simply deny.
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "Claude",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "scribe:transcribe channel:send",
+          resource: `${ISSUER}/vault/default/mcp`,
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).not.toContain("Send audio to Scribe for transcription.");
+      expect(html).not.toContain("Post messages to your Channel.");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("trust-by-client_name no longer re-prompts when the request over-asks the whole-hub catalog", async () => {
+    // Before the narrowing was moved ahead of the status branch, the
+    // trust-by-client_name coverage check compared the RAW request
+    // (`vault:read scribe:transcribe channel:send`) against a vault-only prior
+    // grant — never matched — re-prompting consent every session for a client
+    // the operator had already approved. Narrowing first makes the comparison
+    // vault-only-vs-vault-only, so the silent re-link fires.
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      // Prior approval under client_name "Claude" (an earlier DCR client_id).
+      const oldReg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "Claude",
+      });
+      const { recordGrant } = await import("../grants.ts");
+      recordGrant(db, user.id, oldReg.client.clientId, ["vault:default:read"]);
+      // Fresh per-session DCR: new client_id, same name, pending.
+      const newReg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "Claude",
+        status: "pending",
+      });
+      expect(newReg.client.clientId).not.toBe(oldReg.client.clientId);
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: newReg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:read scribe:transcribe channel:send",
+          resource: `${ISSUER}/vault/default/mcp`,
+        }),
+        {
+          headers: {
+            // Same-origin → the trust-by-client_name carry-over is allowed.
+            origin: ISSUER,
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      // Silent re-link: 302 back to the client with a code — NOT a 200 re-prompt.
+      expect(res.status).toBe(302);
+      const loc = res.headers.get("location") ?? "";
+      expect(loc).toContain("https://app.example/cb");
+      expect(loc).toContain("code=");
+    } finally {
+      cleanup();
+    }
+  });
 });
 
 describe("handleAuthorizePost — vault picker", () => {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -609,6 +609,106 @@ describe("handleAuthorizeGet — vault picker", () => {
   });
 });
 
+describe("handleAuthorizeGet — RFC 8707 resource binding drops foreign scopes (scary-consent fix)", () => {
+  // claude.ai connecting to ONE vault reads the hub's whole-hub AS-metadata
+  // `scopes_supported` and over-requests the full catalog. Bound to the vault
+  // resource (`aud=vault.<name>`), scribe/channel/hub scopes are unusable, so
+  // they must be DROPPED before consent — Aaron hit them as "a fuck ton of
+  // privileges that don't make sense" (scribe isn't even installed here).
+  const FOREIGN_AND_VAULT =
+    "vault:read vault:write scribe:transcribe scribe:admin channel:send hub:admin";
+
+  test("session consent for a vault MCP resource drops scribe/channel/hub scopes", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "Claude",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: FOREIGN_AND_VAULT,
+          resource: `${ISSUER}/vault/default/mcp`,
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      // Renders consent (200) — NOT a 302 invalid_scope. Pre-fix the
+      // pass-through left non-requestable `hub:admin` + `scribe:admin` in the
+      // request, which the gate would reject; dropping them clears the gate.
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      // Vault scopes survive, narrowed to the bound vault → picker is gone.
+      expect(html).not.toContain("Pick a vault");
+      expect(html).toContain("Create, edit, and delete notes, tags, and attachments."); // vault:write
+      // The foreign scopes are gone.
+      expect(html).not.toContain("Send audio to Scribe for transcription."); // scribe:transcribe
+      expect(html).not.toContain("Manage Scribe configuration"); // scribe:admin
+      expect(html).not.toContain("Post messages to your Channel."); // channel:send
+      expect(html).not.toContain("Manage hub identity"); // hub:admin
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("session-less 'App not yet approved' page also drops foreign scopes", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "Claude",
+        status: "pending",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:read scribe:transcribe channel:send",
+          resource: `${ISSUER}/vault/default/mcp`,
+        }),
+        // No session cookie → the unauth pending page renders.
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(403);
+      const html = await res.text();
+      expect(html).toContain("App not yet approved");
+      // Foreign scopes absent from the rendered rows...
+      expect(html).not.toContain("Send audio to Scribe for transcription.");
+      expect(html).not.toContain("Post messages to your Channel.");
+      // ...and from the login round-trip URL embedded in the page (the
+      // narrowed scope was written back onto `url` before this render).
+      expect(html).not.toContain("scribe:transcribe");
+      expect(html).not.toContain("channel:send");
+      expect(html).not.toContain("scribe%3Atranscribe");
+      expect(html).not.toContain("channel%3Asend");
+    } finally {
+      cleanup();
+    }
+  });
+});
+
 describe("handleAuthorizePost — vault picker", () => {
   test("approve with vault_pick narrows vault:read → vault:<picked>:read in the issued JWT", async () => {
     const { db, cleanup } = await makeDb();

--- a/src/__tests__/resource-binding.test.ts
+++ b/src/__tests__/resource-binding.test.ts
@@ -77,16 +77,42 @@ describe("narrowResourceVaultScopes", () => {
     expect(narrowResourceVaultScopes(["vault:other:read"], "jon")).toEqual(["vault:other:read"]);
   });
 
-  test("passes non-vault scopes through unchanged", () => {
-    expect(narrowResourceVaultScopes(["scribe:transcribe", "vault:read"], "jon")).toEqual([
-      "scribe:transcribe",
-      "vault:jon:read",
-    ]);
+  test("drops non-vault scopes — unusable in a vault-audience token", () => {
+    // A vault-bound flow mints `aud=vault.jon`; scribe/channel/hub scopes
+    // inside that token are dead weight, so they're removed rather than shown
+    // on the consent screen.
+    expect(
+      narrowResourceVaultScopes(
+        ["scribe:transcribe", "channel:send", "hub:admin", "vault:read"],
+        "jon",
+      ),
+    ).toEqual(["vault:jon:read"]);
   });
 
-  test("narrows the admin verb too (gate happens downstream)", () => {
-    // narrowResourceVaultScopes only rewrites shape; the non-requestable gate
-    // (`vault:<name>:admin`) blocks it afterward.
+  test("a one-vault connection drops the whole-hub catalog claude.ai over-requests", () => {
+    // claude.ai reads the hub AS-metadata `scopes_supported` (the full
+    // catalog) and requests all of it. Bound to one vault, only that vault's
+    // verbs survive — no scribe (uninstalled) or channel:send on the consent.
+    // Regression lock for the "scary consent" bug.
+    expect(
+      narrowResourceVaultScopes(
+        [
+          "vault:read",
+          "vault:write",
+          "vault:admin",
+          "scribe:admin",
+          "scribe:transcribe",
+          "channel:send",
+          "hub:admin",
+        ],
+        "default",
+      ),
+    ).toEqual(["vault:default:read", "vault:default:write", "vault:default:admin"]);
+  });
+
+  test("narrows the admin verb too (requestable-scope gate decides downstream)", () => {
+    // narrowResourceVaultScopes only rewrites shape; `vault:<name>:admin` is
+    // requestable post-#484, so this named form survives the downstream gate.
     expect(narrowResourceVaultScopes(["vault:admin"], "jon")).toEqual(["vault:jon:admin"]);
   });
 

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -844,6 +844,47 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
     // localStorage, the recovery is "clear that key and reload the SPA").
     return unknownClientResponse(parsed.clientId, parsed.redirectUri, deps);
   }
+
+  // RFC 8707 resource binding. When the client named a per-vault MCP resource
+  // (`<origin>/vault/<name>/mcp` or its PRM URL), narrow the requested scopes
+  // to that vault BEFORE the pending/consent branches below, so EVERY
+  // downstream consumer sees the narrowed set:
+  //
+  //   1. The consent screen — and the session-less "App not yet approved"
+  //      page (`pendingClientResponse`) — shows ONLY that vault's scopes
+  //      instead of the whole-hub catalog. Narrowing DROPS non-vault scopes
+  //      (`scribe:*`, `channel:send`, `hub:admin`) outright: the token this
+  //      flow mints is stamped `aud=vault.<name>`, so they're unusable inside
+  //      it and only inflate the consent surface — the exact "scary consent"
+  //      a friend hit connecting Claude to ONE vault (scribe isn't even
+  //      installed; `channel:send` is meaningless to them).
+  //   2. The minted token carries the named scope, so `inferAudience` stamps
+  //      `aud=vault.<name>` and a current-line vault accepts it (an unnamed
+  //      `vault:read` token is rejected by `findBroadVaultScopes`).
+  //   3. The trust-by-client_name coverage checks (the auto-approve branch
+  //      below + the one inside `pendingClientResponse`) compare the narrowed
+  //      request against the narrowed prior grant. Before this ran early they
+  //      compared the RAW whole-hub request against a vault-only grant, never
+  //      matched, and re-prompted consent every session for a client the
+  //      operator had already approved.
+  //
+  // We rewrite both `parsed.scope` (consent/grant/mint read it) AND the `url`
+  // scope param (`pendingClientResponse` + its login round-trip read it off
+  // the URL) so the two never diverge. Re-entry after login re-narrows
+  // idempotently (no foreign scopes left to drop).
+  //
+  // No resource, or one that isn't a per-vault MCP resource (off-origin,
+  // malformed, non-vault path) → `boundVault` is null and the flow is
+  // byte-for-byte the pre-#461 behavior (manual picker, etc.).
+  const boundVault = resolveResourceVault(parsed.resource, resolveBoundOrigins(deps));
+  if (boundVault) {
+    parsed.scope = narrowResourceVaultScopes(
+      parsed.scope.split(" ").filter((s) => s.length > 0),
+      boundVault,
+    ).join(" ");
+    url.searchParams.set("scope", parsed.scope);
+  }
+
   if (client.status !== "approved") {
     // Single-consent change (2026-05-29): the separate operator "approve this
     // client" gate is retired — the user's OAuth consent IS the authorization.
@@ -919,41 +960,6 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
       "The redirect_uri does not match any URI registered for this app.",
       400,
     );
-  }
-
-  // RFC 8707 resource binding. When the client named a per-vault MCP
-  // resource (`<origin>/vault/<name>/mcp` or its PRM URL), narrow the
-  // requested vault verbs to the named `vault:<name>:<verb>` form BEFORE any
-  // downstream processing. Two effects:
-  //
-  //   1. The consent screen shows ONLY that vault's scopes (the picker locks
-  //      to <name>) instead of the whole-hub catalog — a friend connecting to
-  //      one vault no longer sees `hub:admin`, `scribe:admin`, or every other
-  //      vault's verbs.
-  //   2. The minted token carries the named scope, so `inferAudience` stamps
-  //      `aud=vault.<name>` and a current-line vault accepts it (an unnamed
-  //      `vault:read` token is rejected by `findBroadVaultScopes`).
-  //
-  // Narrowing happens before the non-requestable gate (below) on purpose: if
-  // a resource-bound client somehow asked for `vault:admin`, narrowing makes
-  // it `vault:<name>:admin`, which IS non-requestable — so the gate correctly
-  // blocks it. Read/write narrow to the requestable named form. Non-vault
-  // scopes and already-named scopes for other vaults pass through unchanged.
-  //
-  // No resource, or a resource that isn't one of our per-vault MCP resources
-  // (off-origin, malformed, non-vault path) → `boundVault` is null and the
-  // flow is byte-for-byte the pre-#461 behavior (manual picker, etc.).
-  const boundVault = resolveResourceVault(parsed.resource, resolveBoundOrigins(deps));
-  if (boundVault) {
-    const narrowed = narrowResourceVaultScopes(
-      parsed.scope.split(" ").filter((s) => s.length > 0),
-      boundVault,
-    );
-    // Rewrite `parsed.scope` so the narrowed named scopes flow through every
-    // downstream consumer: the login-redirect query round-trip, the consent
-    // props + hidden inputs, the skip-consent grant lookup, and the
-    // auth-code mint.
-    parsed.scope = narrowed.join(" ");
   }
 
   // Operator-only scope gate (#96). Reject any request that names a scope

--- a/src/resource-binding.ts
+++ b/src/resource-binding.ts
@@ -109,26 +109,41 @@ function decodeVaultName(segment: string): string | null {
 }
 
 /**
- * Rewrite the requested scope list for a resource-bound vault flow.
+ * Rewrite the requested scope list for a resource-bound vault flow, returning
+ * ONLY scopes usable in the resulting vault-audience token:
  *
  *   - unnamed `vault:<verb>`        → `vault:<name>:<verb>` (the narrow,
  *     audience-correct shape vault accepts);
  *   - already-named `vault:<other>:<verb>` is LEFT UNTOUCHED — a client that
  *     explicitly named a different vault is not silently re-pointed; the
  *     downstream picker / assignment defenses decide whether that's allowed.
- *   - non-vault scopes (`scribe:transcribe`, `hub:admin`, …) pass through
- *     unchanged — resource-binding only narrows the vault verbs.
+ *   - non-vault scopes (`scribe:*`, `channel:send`, `hub:admin`, …) are
+ *     DROPPED. This flow mints a token stamped `aud=vault.<name>` (RFC 8707),
+ *     so a scribe/channel/hub scope inside it is unusable — keeping it only
+ *     inflates the consent surface a friend sees when connecting ONE vault.
+ *     That "scary consent" is the failure mode this module exists to kill
+ *     (see the header docstring): the verb-narrowing alone left the foreign
+ *     scopes riding through, so a client that over-requests the whole-hub
+ *     catalog (claude.ai reads it from the AS-metadata `scopes_supported`)
+ *     still surfaced `scribe:admin` + `channel:send` on the consent screen.
+ *     A client that genuinely wants a scribe token runs a separate flow
+ *     naming the scribe resource.
  *
- * Idempotent: a scope already shaped `vault:<name>:<verb>` for THIS name is
- * returned as-is, so re-running over a narrowed list is a no-op.
+ * Idempotent: an already-narrowed list contains only `vault:` scopes, so a
+ * second pass has nothing left to drop and `vault:<name>:<verb>` for THIS name
+ * is returned as-is.
  */
 export function narrowResourceVaultScopes(scopes: readonly string[], vaultName: string): string[] {
-  return scopes.map((s) => {
+  const out: string[] = [];
+  for (const s of scopes) {
     const parts = s.split(":");
+    if (parts[0] !== "vault") continue; // drop scribe:/channel:/hub:/… — foreign to a vault-audience token
     const verb = parts[1];
-    if (parts.length === 2 && parts[0] === "vault" && verb && VAULT_VERBS.has(verb)) {
-      return `vault:${vaultName}:${verb}`;
+    if (parts.length === 2 && verb && VAULT_VERBS.has(verb)) {
+      out.push(`vault:${vaultName}:${verb}`);
+    } else {
+      out.push(s); // already-named (incl. other vaults) or malformed vault scope — downstream defenses decide
     }
-    return s;
-  });
+  }
+  return out;
 }


### PR DESCRIPTION
## What

Connecting Claude (or any MCP client) to **one vault** was asking the everyday user to grant **Scribe** and **`channel:send`** privileges — services that often aren't even installed. Aaron hit this connecting Claude to his vault: *"a fuck ton of privileges that don't really make sense."*

## Root cause

A client bound to a per-vault MCP resource (RFC 8707 `resource=<origin>/vault/<name>/mcp`) over-requests the **whole-hub scope catalog** it read from the hub's AS-metadata `scopes_supported` (`vault:* scribe:* channel:send hub:admin`). claude.ai does exactly this. `resource-binding.ts`'s `narrowResourceVaultScopes` narrowed the *vault verbs* (`vault:read` → `vault:default:read`) but **passed non-vault scopes through unchanged** — so scribe/channel/hub rode straight onto the consent screen.

The token this flow mints is stamped `aud=vault.<name>`, so those foreign scopes are **unusable inside it** — they only inflated the consent surface. This is precisely the failure mode `resource-binding.ts`'s own docstring says it kills (*"scary consent — a friend connecting to ONE vault saw the whole hub's scope surface"*); the verb-only narrow never delivered on it.

## Fix

1. **`narrowResourceVaultScopes` now DROPS any non-`vault:` scope** for a bound flow (keeps + narrows vault scopes; already-named *other-vault* scopes still pass through for the picker defenses to decide).
2. **Relocated the narrowing in `handleAuthorizeGet` to run BEFORE the pending/status branch**, and write the narrowed scope back onto `url`. This fixes two more things the late-narrow missed:
   - the **session-less "App not yet approved" page** (`pendingClientResponse`, fed `url`) now shows narrowed scopes too;
   - the **trust-by-client_name coverage check** now compares narrowed-vs-narrowed. Previously it compared the *raw* whole-hub request against a vault-only grant, never matched, and **re-prompted consent every session** for a client the operator had already approved.

## Tests
- `narrowResourceVaultScopes` unit: drops scribe/channel/hub; the full claude.ai over-request collapses to vault-only; idempotent.
- `handleAuthorizeGet` integration: session consent renders 200 without foreign labels (pre-fix the pass-through left non-requestable `hub:admin`/`scribe:admin` and the gate would 302 `invalid_scope`); session-less pending page drops them too (incl. the login round-trip URL); empty-scope edge renders consent not error; **trust-by-client_name no longer re-prompts** on a whole-hub over-request.

**hub: 2520 pass / 0 fail; typecheck clean; biome clean.**

## Review
Independent reviewer: **LGTM with nits** — no critical issues; the three nits (empty-scope test, trust-by-name regression test, patterns doc) are folded inline here except the `oauth-scopes.md` note (separate parachute-patterns PR — docs-only repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)