### PR TITLE
fix(expose): per-hostname Cloudflare tunnels (multi-machine collision) + CLI clarity

### DIFF
--- a/src/__tests__/cloudflare-config.test.ts
+++ b/src/__tests__/cloudflare-config.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { renderConfig, writeConfig } from "../cloudflare/config.ts";
+import { deriveTunnelName, renderConfig, writeConfig } from "../cloudflare/config.ts";
+import { isValidTunnelName } from "../commands/expose-cloudflare.ts";
 
 describe("cloudflare config", () => {
   test("renderConfig produces a valid cloudflared YAML with one-hostname ingress + catch-all 404", () => {
@@ -50,5 +51,68 @@ describe("cloudflare config", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("deriveTunnelName (#491 — per-hostname dedicated tunnels)", () => {
+  test("prefixes parachute- and turns dots into hyphens", () => {
+    expect(deriveTunnelName("our.parachute.computer")).toBe("parachute-our-parachute-computer");
+    expect(deriveTunnelName("vault.example.com")).toBe("parachute-vault-example-com");
+  });
+
+  test("lowercases and strips characters outside [a-z0-9_-]", () => {
+    // Uppercase → lowercase; a stray char that an over-permissive hostname
+    // validator might let through is dropped so the result stays a valid
+    // tunnel name. (Dots are already mapped to hyphens before stripping.)
+    expect(deriveTunnelName("Vault.Example.COM")).toBe("parachute-vault-example-com");
+    expect(deriveTunnelName("a_b-c.example.com")).toBe("parachute-a_b-c-example-com");
+  });
+
+  test("every derived name satisfies isValidTunnelName", () => {
+    for (const host of [
+      "our.parachute.computer",
+      "vault.example.com",
+      "Vault.Example.COM",
+      "a_b-c.example.com",
+      `${"x".repeat(200)}.example.com`,
+    ]) {
+      const name = deriveTunnelName(host);
+      expect(isValidTunnelName(name)).toBe(true);
+    }
+  });
+
+  test("truncates + appends a stable 8-hex suffix when the name would exceed 64 chars", () => {
+    const longHost = `${"sub.".repeat(20)}example.com`; // way over 64 once prefixed
+    const name = deriveTunnelName(longHost);
+    expect(name.length).toBeLessThanOrEqual(64);
+    expect(name.startsWith("parachute-")).toBe(true);
+    // 8-hex stable suffix on the end.
+    expect(name).toMatch(/-[0-9a-f]{8}$/);
+  });
+
+  test("is deterministic — same hostname always derives the same name (idempotent re-expose)", () => {
+    const longHost = `${"sub.".repeat(20)}example.com`;
+    expect(deriveTunnelName(longHost)).toBe(deriveTunnelName(longHost));
+    expect(deriveTunnelName("our.parachute.computer")).toBe(
+      deriveTunnelName("our.parachute.computer"),
+    );
+  });
+
+  test("two distinct long hostnames whose truncated bodies are identical don't collide", () => {
+    // Identical leading labels long enough that the body truncation
+    // (parachute- + body-slice + -<8hex>, capped at 64) cuts BEFORE the
+    // differing tail — so the truncated bodies are byte-identical and only the
+    // full-hostname hash distinguishes them. Verifies the suffix disambiguates.
+    const sharedPrefix = "x".repeat(80); // single long label, well past the truncation point
+    const a = `${sharedPrefix}.alpha.example.com`;
+    const b = `${sharedPrefix}.beta.example.com`;
+    const nameA = deriveTunnelName(a);
+    const nameB = deriveTunnelName(b);
+    expect(nameA.length).toBeLessThanOrEqual(64);
+    expect(nameB.length).toBeLessThanOrEqual(64);
+    // Bodies before the suffix are identical (truncation cut inside the shared
+    // prefix), so the names can only differ in the trailing 8-hex hash.
+    expect(nameA.slice(0, -8)).toBe(nameB.slice(0, -8));
+    expect(nameA).not.toBe(nameB);
   });
 });

--- a/src/__tests__/expose-cloudflare.test.ts
+++ b/src/__tests__/expose-cloudflare.test.ts
@@ -119,12 +119,16 @@ describe("exposeCloudflareUp", () => {
     const env = makeEnv();
     try {
       const uuid = "2c1a7c7e-1234-5678-9abc-def012345678";
+      // Default tunnel name is now per-hostname (#491): vault.example.com →
+      // parachute-vault-example-com. Each machine gets its own dedicated tunnel
+      // so account-wide tunnels don't collide across boxes.
+      const derived = "parachute-vault-example-com";
       const { runner, calls } = queueRunner([
         { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" }, // --version preflight
         { code: 0, stdout: "[]", stderr: "" }, // tunnel list (none yet)
         {
           code: 0,
-          stdout: `Tunnel credentials written to ${env.cloudflaredHome}/${uuid}.json.\nCreated tunnel parachute with id ${uuid}\n`,
+          stdout: `Tunnel credentials written to ${env.cloudflaredHome}/${uuid}.json.\nCreated tunnel ${derived} with id ${uuid}\n`,
           stderr: "",
         }, // tunnel create
         { code: 0, stdout: "", stderr: "" }, // route dns
@@ -158,14 +162,14 @@ describe("exposeCloudflareUp", () => {
       ]);
       expect(calls[0]!.cmd).toEqual(["cloudflared", "--version"]);
       expect(calls[1]!.cmd).toEqual(["cloudflared", "tunnel", "list", "--output", "json"]);
-      expect(calls[2]!.cmd).toEqual(["cloudflared", "tunnel", "create", "parachute"]);
+      expect(calls[2]!.cmd).toEqual(["cloudflared", "tunnel", "create", derived]);
       expect(calls[3]!.cmd).toEqual([
         "cloudflared",
         "tunnel",
         "route",
         "dns",
         "--overwrite-dns",
-        "parachute",
+        derived,
         "vault.example.com",
       ]);
       expect(seen[0]).toEqual(["cloudflared", "tunnel", "--config", env.configPath, "run"]);
@@ -174,10 +178,10 @@ describe("exposeCloudflareUp", () => {
       expect(state).toEqual({
         version: 2,
         tunnels: {
-          parachute: {
+          [derived]: {
             pid: 42000,
             tunnelUuid: uuid,
-            tunnelName: "parachute",
+            tunnelName: derived,
             hostname: "vault.example.com",
             startedAt: "2026-04-22T12:00:00.000Z",
             configPath: env.configPath,
@@ -248,6 +252,10 @@ describe("exposeCloudflareUp", () => {
         cloudflaredHome: env.cloudflaredHome,
         configDir: env.configDir,
         skipHub: true,
+        // Pin the legacy shared name so this test's substance (expose-state
+        // write) is isolated from the per-hostname-derivation change (#491);
+        // the queued runner output names the "parachute" tunnel.
+        tunnelName: "parachute",
       });
 
       expect(code).toBe(0);
@@ -419,6 +427,10 @@ describe("exposeCloudflareUp", () => {
         cloudflaredHome: env.cloudflaredHome,
         configDir: env.configDir,
         skipHub: true,
+        // Pin the legacy name: the queued `tunnel list` reports a "parachute"
+        // tunnel, so reuse only happens when we look it up by that name. The
+        // per-hostname default (#491) is exercised in the happy-path test.
+        tunnelName: "parachute",
       });
       expect(code).toBe(0);
       // No `tunnel create` — only list + route.
@@ -604,6 +616,10 @@ describe("exposeCloudflareUp", () => {
         cloudflaredHome: env.cloudflaredHome,
         configDir: env.configDir,
         skipHub: true,
+        // Pin the legacy name so reuse (queued "parachute" list) drives the
+        // route-dns failure under test, not a tunnel-create from the
+        // per-hostname default (#491).
+        tunnelName: "parachute",
       });
 
       expect(code).toBe(1);
@@ -656,6 +672,10 @@ describe("exposeCloudflareUp", () => {
         cloudflaredHome: env.cloudflaredHome,
         configDir: env.configDir,
         skipHub: true,
+        // Pin the legacy name so the prior record (keyed "parachute") matches
+        // this invocation's tunnel — the orphan-sweep behavior under test is
+        // independent of the per-hostname-derivation change (#491).
+        tunnelName: "parachute",
       });
 
       expect(code).toBe(0);
@@ -712,6 +732,9 @@ describe("exposeCloudflareUp", () => {
         cloudflaredHome: env.cloudflaredHome,
         configDir: env.configDir,
         skipHub: true,
+        // Pin the legacy name so the prior record (keyed "parachute") matches —
+        // the orphan-sweep behavior under test is independent of #491.
+        tunnelName: "parachute",
       });
 
       expect(code).toBe(0);
@@ -757,6 +780,9 @@ describe("exposeCloudflareUp", () => {
         cloudflaredHome: env.cloudflaredHome,
         configDir: env.configDir,
         skipHub: true,
+        // Pin the legacy name so reuse drives the DNS-diagnosis path under test
+        // (queued "parachute" list), not a create from the #491 default.
+        tunnelName: "parachute",
       });
 
       expect(code).toBe(0); // non-fatal — the expose still completes
@@ -801,6 +827,9 @@ describe("exposeCloudflareUp", () => {
         cloudflaredHome: env.cloudflaredHome,
         configDir: env.configDir,
         skipHub: true,
+        // Pin the legacy name so reuse drives the shadowed-DNS path under test
+        // (queued "parachute" list), not a create from the #491 default.
+        tunnelName: "parachute",
       });
 
       expect(code).toBe(0);
@@ -841,6 +870,9 @@ describe("exposeCloudflareUp", () => {
         cloudflaredHome: env.cloudflaredHome,
         configDir: env.configDir,
         skipHub: true,
+        // Pin the legacy name so reuse drives the no-warning path under test
+        // (queued "parachute" list), not a create from the #491 default.
+        tunnelName: "parachute",
       });
 
       expect(code).toBe(0);
@@ -857,13 +889,15 @@ describe("exposeCloudflareUp", () => {
     try {
       const uuidA = "aaaa1111-aaaa-1111-aaaa-111111111111";
       const uuidB = "bbbb2222-bbbb-2222-bbbb-222222222222";
-      // Up #1 — default name "parachute"
+      // Up #1 — per-hostname default (#491): alpha.example.com →
+      // parachute-alpha-example-com.
+      const derivedA = "parachute-alpha-example-com";
       const r1 = queueRunner([
         { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
         { code: 0, stdout: "[]", stderr: "" },
         {
           code: 0,
-          stdout: `Created tunnel parachute with id ${uuidA}\n`,
+          stdout: `Created tunnel ${derivedA} with id ${uuidA}\n`,
           stderr: "",
         },
         { code: 0, stdout: "", stderr: "" },
@@ -881,10 +915,11 @@ describe("exposeCloudflareUp", () => {
         cloudflaredHome: env.cloudflaredHome,
         configDir: env.configDir,
         skipHub: true,
-        // Omit configPath/logPath so they're per-tunnel-derived — but the
-        // derivation now resolves against the tmp `configDir` above, so the
-        // generated config.yml lands under tmp, not the operator's real
-        // ~/.parachute/cloudflared/parachute/.
+        // Omit configPath/logPath AND tunnelName so the name is the per-hostname
+        // derived default (#491) and the paths are per-tunnel-derived against
+        // the tmp `configDir` above — so the generated config.yml lands under
+        // tmp/cloudflared/parachute-alpha-example-com/, not the operator's real
+        // ~/.parachute.
       });
       expect(code1).toBe(0);
 
@@ -916,25 +951,227 @@ describe("exposeCloudflareUp", () => {
       });
       expect(code2).toBe(0);
 
-      // Both tunnels should be present in state, keyed by tunnel name.
+      // Both tunnels should be present in state, keyed by tunnel name: the
+      // per-hostname derived name for #1, the explicit override for #2.
       const state = readCloudflaredState(env.statePath);
-      expect(Object.keys(state?.tunnels ?? {}).sort()).toEqual(["parachute", "second"]);
-      expect(findTunnelRecord(state, "parachute")?.hostname).toBe("alpha.example.com");
+      expect(Object.keys(state?.tunnels ?? {}).sort()).toEqual([derivedA, "second"]);
+      expect(findTunnelRecord(state, derivedA)?.hostname).toBe("alpha.example.com");
       expect(findTunnelRecord(state, "second")?.hostname).toBe("beta.example.com");
       expect(findTunnelRecord(state, "second")?.pid).toBe(50002);
 
       // Each tunnel should have written its own config file at the per-tunnel
       // path under `~/.parachute/cloudflared/<tunnelName>/config.yml`.
-      const cfgA = findTunnelRecord(state, "parachute")?.configPath ?? "";
+      const cfgA = findTunnelRecord(state, derivedA)?.configPath ?? "";
       const cfgB = findTunnelRecord(state, "second")?.configPath ?? "";
       expect(cfgA).not.toBe(cfgB);
-      expect(cfgA.endsWith("/parachute/config.yml")).toBe(true);
+      expect(cfgA.endsWith(`/${derivedA}/config.yml`)).toBe(true);
       expect(cfgB.endsWith("/second/config.yml")).toBe(true);
       expect(existsSync(cfgA)).toBe(true);
       expect(existsSync(cfgB)).toBe(true);
     } finally {
       env.cleanup();
     }
+  });
+
+  describe("#491: per-hostname tunnel naming + legacy migration", () => {
+    test("explicit --tunnel-name overrides the per-hostname default", async () => {
+      const env = makeEnv();
+      try {
+        const uuid = "11112222-3333-4444-5555-666677778888";
+        const { runner, calls } = queueRunner([
+          { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
+          { code: 0, stdout: "[]", stderr: "" },
+          { code: 0, stdout: `Created tunnel custom-name with id ${uuid}\n`, stderr: "" },
+          { code: 0, stdout: "", stderr: "" },
+        ]);
+        const { spawner } = fakeSpawner(43000);
+
+        const code = await exposeCloudflareUp("our.parachute.computer", {
+          runner,
+          spawner,
+          alive: () => false,
+          kill: () => {},
+          log: () => {},
+          manifestPath: env.manifestPath,
+          statePath: env.statePath,
+          exposeStatePath: env.exposeStatePath,
+          configPath: env.configPath,
+          logPath: env.logPath,
+          cloudflaredHome: env.cloudflaredHome,
+          configDir: env.configDir,
+          skipHub: true,
+          tunnelName: "custom-name",
+        });
+
+        expect(code).toBe(0);
+        // The explicit name wins — NOT the derived parachute-our-parachute-computer.
+        expect(calls[2]!.cmd).toEqual(["cloudflared", "tunnel", "create", "custom-name"]);
+        const state = readCloudflaredState(env.statePath);
+        expect(findTunnelRecord(state, "custom-name")?.hostname).toBe("our.parachute.computer");
+        expect(findTunnelRecord(state, "parachute-our-parachute-computer")).toBeUndefined();
+      } finally {
+        env.cleanup();
+      }
+    });
+
+    test("legacy-sweep: stops a live shared 'parachute' connector when migrating to a derived name", async () => {
+      const env = makeEnv();
+      try {
+        // A box that was exposed under the old shared "parachute" tunnel.
+        const legacy: CloudflaredTunnelRecord = {
+          pid: 70001,
+          tunnelUuid: "legacy-uuid",
+          tunnelName: "parachute",
+          hostname: "our.parachute.computer",
+          startedAt: "2026-05-01T00:00:00.000Z",
+          configPath: "/tmp/legacy/parachute/config.yml",
+        };
+        writeCloudflaredState({ version: 2, tunnels: { parachute: legacy } }, env.statePath);
+
+        const uuid = "99990000-1111-2222-3333-444455556666";
+        const { runner } = queueRunner([
+          { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
+          { code: 0, stdout: "[]", stderr: "" }, // new derived tunnel doesn't exist yet
+          {
+            code: 0,
+            stdout: `Created tunnel parachute-our-parachute-computer with id ${uuid}\n`,
+            stderr: "",
+          },
+          { code: 0, stdout: "", stderr: "" }, // route dns (--overwrite-dns repoints the CNAME)
+        ]);
+        const { spawner } = fakeSpawner(70100);
+        const killed: number[] = [];
+        const logs: string[] = [];
+
+        const code = await exposeCloudflareUp("our.parachute.computer", {
+          runner,
+          spawner,
+          // The legacy connector (70001) is alive; the new spawn is 70100.
+          alive: (pid) => pid === 70001,
+          kill: (pid) => killed.push(pid),
+          connectorPids: () => [],
+          resolveHost: async () => ["104.16.0.1"],
+          log: (l) => logs.push(l),
+          manifestPath: env.manifestPath,
+          statePath: env.statePath,
+          exposeStatePath: env.exposeStatePath,
+          configPath: env.configPath,
+          logPath: env.logPath,
+          cloudflaredHome: env.cloudflaredHome,
+          configDir: env.configDir,
+          skipHub: true,
+        });
+
+        expect(code).toBe(0);
+        // The legacy shared connector got SIGTERM'd.
+        expect(killed).toContain(70001);
+        const joined = logs.join("\n");
+        expect(joined).toContain("Stopped legacy shared-tunnel connector");
+        expect(joined).toContain("migrated our.parachute.computer to dedicated tunnel");
+        // The legacy "parachute" record is gone; only the new derived one remains.
+        const state = readCloudflaredState(env.statePath);
+        expect(findTunnelRecord(state, "parachute")).toBeUndefined();
+        expect(findTunnelRecord(state, "parachute-our-parachute-computer")?.pid).toBe(70100);
+      } finally {
+        env.cleanup();
+      }
+    });
+
+    test("legacy-sweep: does NOT fire when no legacy 'parachute' record exists", async () => {
+      const env = makeEnv();
+      try {
+        const uuid = "aaaa9999-1111-2222-3333-444455556666";
+        const { runner } = queueRunner([
+          { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
+          { code: 0, stdout: "[]", stderr: "" },
+          {
+            code: 0,
+            stdout: `Created tunnel parachute-our-parachute-computer with id ${uuid}\n`,
+            stderr: "",
+          },
+          { code: 0, stdout: "", stderr: "" },
+        ]);
+        const { spawner } = fakeSpawner(70200);
+        const logs: string[] = [];
+
+        const code = await exposeCloudflareUp("our.parachute.computer", {
+          runner,
+          spawner,
+          alive: () => false,
+          kill: () => {},
+          connectorPids: () => [],
+          resolveHost: async () => ["104.16.0.1"],
+          log: (l) => logs.push(l),
+          manifestPath: env.manifestPath,
+          statePath: env.statePath,
+          exposeStatePath: env.exposeStatePath,
+          configPath: env.configPath,
+          logPath: env.logPath,
+          cloudflaredHome: env.cloudflaredHome,
+          configDir: env.configDir,
+          skipHub: true,
+        });
+
+        expect(code).toBe(0);
+        expect(logs.join("\n")).not.toContain("Stopped legacy shared-tunnel connector");
+      } finally {
+        env.cleanup();
+      }
+    });
+
+    test("legacy-sweep: does NOT fire when the derived name IS 'parachute' (no migration)", async () => {
+      // A live "parachute" record AND an invocation that resolves to the
+      // "parachute" name (here via explicit --tunnel-name parachute) must not
+      // self-sweep — the connector we'd kill is the very one we're about to
+      // reuse. Reuse-flow: queued list reports the parachute tunnel.
+      const env = makeEnv();
+      try {
+        const uuid = "bbbb8888-1111-2222-3333-444455556666";
+        const legacy: CloudflaredTunnelRecord = {
+          pid: 71001,
+          tunnelUuid: uuid,
+          tunnelName: "parachute",
+          hostname: "our.parachute.computer",
+          startedAt: "2026-05-01T00:00:00.000Z",
+          configPath: env.configPath,
+        };
+        writeCloudflaredState({ version: 2, tunnels: { parachute: legacy } }, env.statePath);
+
+        const { runner } = queueRunner([
+          { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
+          { code: 0, stdout: JSON.stringify([{ id: uuid, name: "parachute" }]), stderr: "" },
+          { code: 0, stdout: "", stderr: "" }, // route dns
+        ]);
+        const { spawner } = fakeSpawner(71100);
+        const logs: string[] = [];
+
+        const code = await exposeCloudflareUp("our.parachute.computer", {
+          runner,
+          spawner,
+          alive: () => true,
+          kill: () => {},
+          connectorPids: () => [],
+          resolveHost: async () => ["104.16.0.1"],
+          log: (l) => logs.push(l),
+          manifestPath: env.manifestPath,
+          statePath: env.statePath,
+          exposeStatePath: env.exposeStatePath,
+          configPath: env.configPath,
+          logPath: env.logPath,
+          cloudflaredHome: env.cloudflaredHome,
+          configDir: env.configDir,
+          skipHub: true,
+          tunnelName: "parachute",
+        });
+
+        expect(code).toBe(0);
+        // No legacy-migration log line: we resolved TO "parachute", so there's
+        // nothing to migrate away from.
+        expect(logs.join("\n")).not.toContain("Stopped legacy shared-tunnel connector");
+      } finally {
+        env.cleanup();
+      }
+    });
   });
 
   // 2FA-enrollment warning (#186). The cloudflare path is always public —
@@ -1347,5 +1584,104 @@ describe("exposeCloudflareOff", () => {
     } finally {
       env.cleanup();
     }
+  });
+
+  describe("#491: state-driven off (no --tunnel-name)", () => {
+    test("0 tunnels → 'Nothing to tear down' (exit 0)", async () => {
+      const env = makeEnv();
+      try {
+        const logs: string[] = [];
+        const code = await exposeCloudflareOff({
+          statePath: env.statePath,
+          exposeStatePath: env.exposeStatePath,
+          log: (l) => logs.push(l),
+        });
+        expect(code).toBe(0);
+        expect(logs.join("\n")).toContain("Nothing to tear down");
+      } finally {
+        env.cleanup();
+      }
+    });
+
+    test("exactly 1 tunnel → tears it down by reading state (even a derived non-'parachute' name)", async () => {
+      const env = makeEnv();
+      try {
+        const record: CloudflaredTunnelRecord = {
+          pid: 80001,
+          tunnelUuid: "derived-uuid",
+          tunnelName: "parachute-our-parachute-computer",
+          hostname: "our.parachute.computer",
+          startedAt: "2026-05-20T10:00:00.000Z",
+          configPath: "/tmp/derived/config.yml",
+        };
+        writeCloudflaredState(
+          { version: 2, tunnels: { "parachute-our-parachute-computer": record } },
+          env.statePath,
+        );
+
+        const killed: number[] = [];
+        const code = await exposeCloudflareOff({
+          statePath: env.statePath,
+          exposeStatePath: env.exposeStatePath,
+          alive: () => true,
+          kill: (pid) => killed.push(pid),
+          log: () => {},
+          // No tunnelName — resolved from state.
+        });
+        expect(code).toBe(0);
+        expect(killed).toEqual([80001]);
+        expect(existsSync(env.statePath)).toBe(false);
+      } finally {
+        env.cleanup();
+      }
+    });
+
+    test("≥2 tunnels → tears down ALL of them and lists each", async () => {
+      const env = makeEnv();
+      try {
+        const recordA: CloudflaredTunnelRecord = {
+          pid: 81001,
+          tunnelUuid: "aaaa-uuid",
+          tunnelName: "parachute-alpha-example-com",
+          hostname: "alpha.example.com",
+          startedAt: "2026-05-20T10:00:00.000Z",
+          configPath: "/tmp/alpha/config.yml",
+        };
+        const recordB: CloudflaredTunnelRecord = {
+          pid: 81002,
+          tunnelUuid: "bbbb-uuid",
+          tunnelName: "parachute-beta-example-com",
+          hostname: "beta.example.com",
+          startedAt: "2026-05-20T11:00:00.000Z",
+          configPath: "/tmp/beta/config.yml",
+        };
+        writeCloudflaredState(
+          withTunnelRecord(withTunnelRecord(undefined, recordA), recordB),
+          env.statePath,
+        );
+
+        const killed: number[] = [];
+        const logs: string[] = [];
+        const code = await exposeCloudflareOff({
+          statePath: env.statePath,
+          exposeStatePath: env.exposeStatePath,
+          alive: () => true,
+          kill: (pid) => killed.push(pid),
+          log: (l) => logs.push(l),
+          // No tunnelName — bare `off` means "stop all public Cloudflare exposure".
+        });
+        expect(code).toBe(0);
+        // Both connectors stopped.
+        expect(killed.sort()).toEqual([81001, 81002]);
+        // State fully cleared (no tunnels remain).
+        expect(existsSync(env.statePath)).toBe(false);
+        const joined = logs.join("\n");
+        expect(joined).toContain("Tearing down all 2 recorded Cloudflare tunnels");
+        expect(joined).toContain("parachute-alpha-example-com");
+        expect(joined).toContain("parachute-beta-example-com");
+      } finally {
+        env.cleanup();
+      }
+    });
   });
 });

--- a/src/__tests__/expose-cloudflare.test.ts
+++ b/src/__tests__/expose-cloudflare.test.ts
@@ -1119,6 +1119,66 @@ describe("exposeCloudflareUp", () => {
       }
     });
 
+    test("legacy-sweep: drops a DEAD legacy 'parachute' record without killing, when migrating", async () => {
+      const env = makeEnv();
+      try {
+        // A leftover shared-tunnel record whose connector is no longer running.
+        const deadLegacy: CloudflaredTunnelRecord = {
+          pid: 72001,
+          tunnelUuid: "dead-legacy-uuid",
+          tunnelName: "parachute",
+          hostname: "our.parachute.computer",
+          startedAt: "2026-05-01T00:00:00.000Z",
+          configPath: "/tmp/legacy/parachute/config.yml",
+        };
+        writeCloudflaredState({ version: 2, tunnels: { parachute: deadLegacy } }, env.statePath);
+
+        const uuid = "cccc7777-1111-2222-3333-444455556666";
+        const { runner } = queueRunner([
+          { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
+          { code: 0, stdout: "[]", stderr: "" },
+          {
+            code: 0,
+            stdout: `Created tunnel parachute-our-parachute-computer with id ${uuid}\n`,
+            stderr: "",
+          },
+          { code: 0, stdout: "", stderr: "" },
+        ]);
+        const { spawner } = fakeSpawner(72100);
+        const killed: number[] = [];
+        const logs: string[] = [];
+
+        const code = await exposeCloudflareUp("our.parachute.computer", {
+          runner,
+          spawner,
+          alive: () => false, // nothing alive — including the dead legacy pid
+          kill: (pid) => killed.push(pid),
+          connectorPids: () => [],
+          resolveHost: async () => ["104.16.0.1"],
+          log: (l) => logs.push(l),
+          manifestPath: env.manifestPath,
+          statePath: env.statePath,
+          exposeStatePath: env.exposeStatePath,
+          configPath: env.configPath,
+          logPath: env.logPath,
+          cloudflaredHome: env.cloudflaredHome,
+          configDir: env.configDir,
+          skipHub: true,
+        });
+
+        expect(code).toBe(0);
+        // Connector wasn't alive → nothing killed, no sweep log.
+        expect(killed).not.toContain(72001);
+        expect(logs.join("\n")).not.toContain("Stopped legacy shared-tunnel connector");
+        // …but the stale dead record is cleared, leaving only the new derived one.
+        const state = readCloudflaredState(env.statePath);
+        expect(findTunnelRecord(state, "parachute")).toBeUndefined();
+        expect(findTunnelRecord(state, "parachute-our-parachute-computer")?.pid).toBe(72100);
+      } finally {
+        env.cleanup();
+      }
+    });
+
     test("legacy-sweep: does NOT fire when the derived name IS 'parachute' (no migration)", async () => {
       // A live "parachute" record AND an invocation that resolves to the
       // "parachute" name (here via explicit --tunnel-name parachute) must not

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -159,7 +159,8 @@ function extractNamedFlag(
  *                                       fall through to today's Tailscale
  *                                       default (CI escape hatch, #29)
  *   --domain=<host>           hostname for the Cloudflare path
- *   --tunnel-name=<name>      named tunnel override (#32)
+ *   --tunnel-name=<name>      named tunnel override (#32); defaults to a
+ *                                       per-hostname dedicated name (#491)
  *
  * Returns the stripped argv so the layer/action parser sees `[layer, action?]`
  * regardless of flag placement. `--tailnet` + `--cloudflare` together is

--- a/src/cloudflare/config.ts
+++ b/src/cloudflare/config.ts
@@ -64,7 +64,10 @@ export function deriveTunnelName(hostname: string): string {
   // the full hostname. Reserve room for the prefix + "-" + 8 hex chars.
   const suffix = `-${shortStableHash(hostname)}`;
   const room = MAX_TUNNEL_NAME - TUNNEL_NAME_PREFIX.length - suffix.length;
-  return `${TUNNEL_NAME_PREFIX}${body.slice(0, room)}${suffix}`;
+  // Strip any trailing hyphen the truncation left behind (e.g. a slice that
+  // lands on a dot-turned-hyphen) so the body doesn't abut the suffix as `--`.
+  const truncated = body.slice(0, room).replace(/-+$/, "");
+  return `${TUNNEL_NAME_PREFIX}${truncated}${suffix}`;
 }
 
 /**

--- a/src/cloudflare/config.ts
+++ b/src/cloudflare/config.ts
@@ -2,18 +2,81 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { CONFIG_DIR } from "../config.ts";
 
+/**
+ * The legacy shared tunnel name. Pre-#491, every machine defaulted its
+ * Cloudflare tunnel to this single constant — but Cloudflare tunnels are
+ * account-wide, so a second machine exposing a *different* hostname found and
+ * reused the SAME tunnel, both connectors registered on one UUID, and the edge
+ * load-balanced requests across them → a request for host B could land on host
+ * A's connector (whose config.yml only routes host A) → ~50% cross-host 404s.
+ *
+ * The default is now a per-hostname derived name (`deriveTunnelName`). This
+ * constant's role narrows to "the legacy shared name we migrate away from":
+ *   - the up-path legacy-sweep kills a stale `"parachute"` connector on the box
+ *     so running deploys self-heal on the next expose, and
+ *   - the off-path reuse-hint compares against it (records no longer equal it,
+ *     so the hint always includes `--tunnel-name`, which is now correct).
+ */
 export const DEFAULT_TUNNEL_NAME = "parachute";
+
+/**
+ * Derive a dedicated, per-hostname tunnel name from a hostname. Cloudflare
+ * tunnels are account-wide, so each machine/hostname needs its OWN tunnel —
+ * sharing one name across boxes collides their connectors (#491). The name is
+ * deterministic (same hostname → same name) so re-exposing the same hostname
+ * is idempotent: it finds and reuses the tunnel it created last time.
+ *
+ * Sanitization: lowercase, dots → hyphens, drop anything outside `[a-z0-9_-]`,
+ * then prefix `parachute-`. Examples:
+ *   `our.parachute.computer` → `parachute-our-parachute-computer`
+ *   `vault.example.com`      → `parachute-vault-example-com`
+ *
+ * Length: tunnel names must satisfy `isValidTunnelName` (≤64 chars). When the
+ * derived name would exceed 64, truncate the sanitized body and append a short
+ * stable suffix (`-<8-hex>`) computed deterministically from the FULL hostname
+ * so two long hostnames sharing a 64-char prefix can't collide on the same
+ * tunnel. The hash is a non-crypto FNV-1a-style fold — deterministic, no
+ * Math.random / Date dependency (those would break idempotent re-expose).
+ */
+const TUNNEL_NAME_PREFIX = "parachute-";
+const MAX_TUNNEL_NAME = 64;
+
+function shortStableHash(input: string): string {
+  // FNV-1a 32-bit. Deterministic, dependency-free, good enough to disambiguate
+  // two hostnames that sanitize to the same truncated prefix. >>> 0 keeps it
+  // unsigned so the hex is stable across runtimes.
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
+}
+
+export function deriveTunnelName(hostname: string): string {
+  const body = hostname
+    .toLowerCase()
+    .replace(/\./g, "-")
+    .replace(/[^a-z0-9_-]/g, "");
+  const full = `${TUNNEL_NAME_PREFIX}${body}`;
+  if (full.length <= MAX_TUNNEL_NAME) return full;
+  // Too long — truncate the body and append a stable 8-hex suffix derived from
+  // the full hostname. Reserve room for the prefix + "-" + 8 hex chars.
+  const suffix = `-${shortStableHash(hostname)}`;
+  const room = MAX_TUNNEL_NAME - TUNNEL_NAME_PREFIX.length - suffix.length;
+  return `${TUNNEL_NAME_PREFIX}${body.slice(0, room)}${suffix}`;
+}
 
 /**
  * Per-tunnel config + log file paths. Each tunnel gets its own subdirectory
  * under `~/.parachute/cloudflared/<tunnelName>/` so multiple tunnels on one
  * box don't trample each other's config.yml or interleave log lines.
  *
- * The default tunnel ("parachute") lives at
- * `~/.parachute/cloudflared/parachute/{config.yml,cloudflared.log}` — a
- * location change from pre-#32 (`~/.parachute/cloudflared/config.yml`).
+ * The per-hostname tunnel (`deriveTunnelName(host)`, e.g.
+ * `parachute-our-parachute-computer`) lives at
+ * `~/.parachute/cloudflared/<tunnelName>/{config.yml,cloudflared.log}`.
  * Re-running `parachute expose public --cloudflare` regenerates the file
- * at the new path; the legacy file is left in place but unused.
+ * at that path; any legacy `parachute/` file is left in place but unused.
  *
  * `configDir` overrides the base (`~/.parachute` by default). Tests pass a
  * tmp dir so per-tunnel-derived paths never resolve against the operator's

--- a/src/commands/expose-cloudflare.ts
+++ b/src/commands/expose-cloudflare.ts
@@ -275,9 +275,12 @@ export interface ExposeCloudflareOpts {
    */
   exposeStatePath?: string;
   /**
-   * Tunnel name targeted by this invocation. Defaults to `parachute` —
-   * the canonical single-tunnel name. Override to run multiple tunnels on
-   * one box (#32).
+   * Tunnel name targeted by this invocation. The up-path defaults to a
+   * per-hostname derived name (`deriveTunnelName(hostname)`) so each machine
+   * gets its own tunnel and account-wide tunnels don't collide across boxes
+   * (#491). Override to pin a specific name (e.g. multiple tunnels on one
+   * box, #32). The off-path resolves the name from `cloudflared-state.json`
+   * when omitted (it has no hostname to derive from).
    */
   tunnelName?: string;
   /**
@@ -714,16 +717,21 @@ export async function exposeCloudflareUp(
   let migratedState = stateBefore;
   if (r.tunnelName !== DEFAULT_TUNNEL_NAME) {
     const legacy = findTunnelRecord(stateBefore, DEFAULT_TUNNEL_NAME);
-    if (legacy && r.alive(legacy.pid)) {
-      try {
-        r.kill(legacy.pid, "SIGTERM");
-      } catch {
-        // Already gone between read and kill — fine; we drop the record below.
+    if (legacy) {
+      if (r.alive(legacy.pid)) {
+        try {
+          r.kill(legacy.pid, "SIGTERM");
+        } catch {
+          // Already gone between read and kill — fine; we drop the record below.
+        }
+        r.log(
+          `Stopped legacy shared-tunnel connector (migrated ${hostname} to dedicated tunnel ${r.tunnelName}).`,
+        );
       }
+      // Drop the legacy shared-tunnel record whether or not its connector was
+      // still alive. A dead record would otherwise linger across re-exposes
+      // until the next `off`; clearing it here keeps state tidy (#491 review).
       migratedState = withoutTunnelRecord(stateBefore, DEFAULT_TUNNEL_NAME);
-      r.log(
-        `Stopped legacy shared-tunnel connector (migrated ${hostname} to dedicated tunnel ${r.tunnelName}).`,
-      );
     }
   }
 
@@ -888,8 +896,15 @@ function teardownOne(
   r.log(
     `  Tunnel "${record.tunnelName}" (${record.tunnelUuid}) remains defined in Cloudflare; re-running`,
   );
+  // Only suggest `--tunnel-name` for a custom name. The auto-derived name
+  // (and the legacy shared "parachute" name) need no flag — re-running with
+  // just --domain re-derives the per-hostname name (and migrates a legacy
+  // record off the shared tunnel), which is exactly what we want.
+  const isAutoName =
+    record.tunnelName === deriveTunnelName(record.hostname) ||
+    record.tunnelName === DEFAULT_TUNNEL_NAME;
   r.log(
-    `  \`parachute expose public --cloudflare --domain ${record.hostname}${record.tunnelName === DEFAULT_TUNNEL_NAME ? "" : ` --tunnel-name ${record.tunnelName}`}\` reuses it.`,
+    `  \`parachute expose public --cloudflare --domain ${record.hostname}${isAutoName ? "" : ` --tunnel-name ${record.tunnelName}`}\` reuses it.`,
   );
   return { state: withoutTunnelRecord(state, record.tunnelName), code: 0 };
 }

--- a/src/commands/expose-cloudflare.ts
+++ b/src/commands/expose-cloudflare.ts
@@ -1,7 +1,12 @@
 import { spawnSync } from "node:child_process";
 import { mkdirSync, openSync } from "node:fs";
 import { dirname } from "node:path";
-import { DEFAULT_TUNNEL_NAME, cloudflaredPathsFor, writeConfig } from "../cloudflare/config.ts";
+import {
+  DEFAULT_TUNNEL_NAME,
+  cloudflaredPathsFor,
+  deriveTunnelName,
+  writeConfig,
+} from "../cloudflare/config.ts";
 import {
   DEFAULT_CLOUDFLARED_HOME,
   cloudflaredInstallHint,
@@ -10,6 +15,7 @@ import {
 } from "../cloudflare/detect.ts";
 import {
   CLOUDFLARED_STATE_PATH,
+  type CloudflaredState,
   type CloudflaredTunnelRecord,
   clearCloudflaredState,
   findTunnelRecord,
@@ -366,8 +372,20 @@ interface Resolved {
   restartService: (short: string) => Promise<number>;
 }
 
-function resolve(opts: ExposeCloudflareOpts): Resolved {
-  const tunnelName = opts.tunnelName ?? DEFAULT_TUNNEL_NAME;
+/**
+ * Resolve options into the fully-defaulted `Resolved` shape.
+ *
+ * `tunnelNameDefault` is the fallback tunnel name when the caller didn't pass
+ * an explicit `opts.tunnelName`. The up-path passes `deriveTunnelName(hostname)`
+ * so each machine/hostname gets its OWN dedicated tunnel (#491) — sharing one
+ * account-wide tunnel across boxes collides their connectors. An explicit
+ * `--tunnel-name` always wins (operators can override). The off-path has no
+ * hostname to derive from, so it resolves the name from state before calling
+ * in (see `exposeCloudflareOff`) and only relies on this default as a last
+ * resort.
+ */
+function resolve(opts: ExposeCloudflareOpts, tunnelNameDefault: string): Resolved {
+  const tunnelName = opts.tunnelName ?? tunnelNameDefault;
   const configDir = opts.configDir ?? CONFIG_DIR;
   // Derive per-tunnel config/log paths from the *resolved* configDir, not the
   // real `CONFIG_DIR`. When a test threads a tmp `configDir` but omits explicit
@@ -489,7 +507,12 @@ export async function exposeCloudflareUp(
   hostname: string,
   opts: ExposeCloudflareOpts = {},
 ): Promise<number> {
-  const r = resolve(opts);
+  // Default to a per-hostname dedicated tunnel (#491). An explicit
+  // `--tunnel-name` still wins (handled inside `resolve`). Deriving from the
+  // hostname keeps re-expose idempotent (same hostname → same name → reuse the
+  // tunnel created last time) and stops two machines from colliding on the
+  // single account-wide `"parachute"` tunnel.
+  const r = resolve(opts, deriveTunnelName(hostname));
 
   if (!isValidTunnelName(r.tunnelName)) {
     r.log(
@@ -591,6 +614,9 @@ export async function exposeCloudflareUp(
       return reportCloudflaredError(err, r.log);
     }
     r.log(`✓ Created tunnel ${tunnel.id}`);
+    r.log(
+      "  Each machine gets its own dedicated tunnel — you don't need to run `cloudflared tunnel create` separately; expose does it.",
+    );
   } else {
     r.log(`✓ Reusing existing tunnel "${r.tunnelName}" (${tunnel.id})`);
   }
@@ -672,6 +698,35 @@ export async function exposeCloudflareUp(
     }
   }
 
+  // Legacy shared-tunnel migration sweep (#491). Aaron's running boxes were
+  // exposed under the old single account-wide `"parachute"` tunnel; the bug
+  // was that a second box reusing that name collided connectors. Now that the
+  // default is per-hostname, a box upgrading and re-exposing will create/route
+  // a NEW dedicated tunnel — but the OLD `"parachute"` connector is still
+  // running, still registered on the shared tunnel, still able to pick up
+  // load-balanced requests for OTHER hosts. Kill it + drop its state record so
+  // the box self-heals immediately on this expose instead of at the next
+  // reboot. Only fires when (a) we actually migrated AWAY from "parachute"
+  // (the new derived name differs) and (b) a live legacy record exists.
+  // `routeDns` above already used `--overwrite-dns`, so this hostname's CNAME
+  // has been repointed to the new tunnel — the legacy connector can't serve it
+  // anymore regardless; this just stops it from serving anyone else's.
+  let migratedState = stateBefore;
+  if (r.tunnelName !== DEFAULT_TUNNEL_NAME) {
+    const legacy = findTunnelRecord(stateBefore, DEFAULT_TUNNEL_NAME);
+    if (legacy && r.alive(legacy.pid)) {
+      try {
+        r.kill(legacy.pid, "SIGTERM");
+      } catch {
+        // Already gone between read and kill — fine; we drop the record below.
+      }
+      migratedState = withoutTunnelRecord(stateBefore, DEFAULT_TUNNEL_NAME);
+      r.log(
+        `Stopped legacy shared-tunnel connector (migrated ${hostname} to dedicated tunnel ${r.tunnelName}).`,
+      );
+    }
+  }
+
   const pid = r.spawner.spawn(
     ["cloudflared", "tunnel", "--config", r.configPath, "run"],
     r.logPath,
@@ -685,7 +740,7 @@ export async function exposeCloudflareUp(
     startedAt: r.now().toISOString(),
     configPath: r.configPath,
   };
-  writeCloudflaredState(withTunnelRecord(stateBefore, record), r.statePath);
+  writeCloudflaredState(withTunnelRecord(migratedState, record), r.statePath);
 
   // Persist the shared cross-provider expose record. Without this, the
   // Tailscale path was the only one writing expose-state.json — so after a
@@ -763,11 +818,19 @@ export async function exposeCloudflareUp(
 
   r.log("");
   r.log(`✓ Cloudflare tunnel up (pid ${pid}).`);
+  r.log(`  Tunnel:  ${r.tunnelName} (dedicated to this machine)`);
   r.log(`  Open:    ${baseUrl}/`);
   r.log(`  Admin:   ${baseUrl}/admin/`);
   r.log(`  Vault:   ${vaultUrl}`);
   r.log(`  OAuth:   ${hubOrigin}`);
   r.log(`  Logs:    ${r.logPath}`);
+  r.log("");
+  // Honest reboot caveat: the connector is a detached background process, not
+  // yet a launchd/systemd service, so it does NOT survive a reboot (durable
+  // connector is a tracked follow-up). Re-running the same command brings it
+  // back idempotently — same hostname → same dedicated tunnel.
+  r.log("Note: the connector runs in the background but does not survive a reboot yet. After a");
+  r.log(`reboot, re-run:  parachute expose public --cloudflare --domain ${hostname}`);
   r.log("");
   r.log("Point a claude.ai / ChatGPT connector at:");
   r.log(`  ${vaultUrl}`);
@@ -784,30 +847,27 @@ export async function exposeCloudflareUp(
   return 0;
 }
 
-export async function exposeCloudflareOff(opts: ExposeCloudflareOpts = {}): Promise<number> {
-  const r = resolve(opts);
-  const stateBefore = readCloudflaredState(r.statePath);
-  const record = findTunnelRecord(stateBefore, r.tunnelName);
-  if (!record) {
-    if (stateBefore && Object.keys(stateBefore.tunnels).length > 0) {
-      const others = listTunnelRecords(stateBefore)
-        .map((t) => t.tunnelName)
-        .join(", ");
-      r.log(
-        `No Cloudflare exposure recorded for tunnel "${r.tunnelName}". Other tunnels: ${others}.`,
-      );
-    } else {
-      r.log("No Cloudflare exposure recorded. Nothing to tear down.");
-    }
-    return 0;
-  }
+/**
+ * Tear down ONE tunnel record: SIGTERM its connector, sweep any orphan
+ * connectors for it (hub#487), drop its state record, and emit the
+ * reuse-hint copy. Pure-ish over `r` + the current state: returns the state
+ * with the record removed (or undefined when that empties it) plus an exit
+ * code, so the caller commits the disk write once after tearing down one or
+ * many tunnels. The connector kill is non-fatal-on-already-gone, fatal only
+ * when SIGTERM itself errors on a live pid.
+ */
+function teardownOne(
+  r: Resolved,
+  state: CloudflaredState | undefined,
+  record: CloudflaredTunnelRecord,
+): { state: CloudflaredState | undefined; code: number } {
   if (r.alive(record.pid)) {
     try {
       r.kill(record.pid, "SIGTERM");
-      r.log(`✓ Stopped cloudflared (pid ${record.pid}).`);
+      r.log(`✓ Stopped cloudflared (pid ${record.pid}, tunnel "${record.tunnelName}").`);
     } catch (err) {
       r.log(`✗ Failed to stop cloudflared: ${err instanceof Error ? err.message : String(err)}`);
-      return 1;
+      return { state, code: 1 };
     }
   } else {
     r.log(`cloudflared (pid ${record.pid}) wasn't running; clearing stale state.`);
@@ -824,19 +884,6 @@ export async function exposeCloudflareOff(opts: ExposeCloudflareOpts = {}): Prom
       // Already gone between probe and kill — fine.
     }
   }
-  const stateAfter = withoutTunnelRecord(stateBefore, r.tunnelName);
-  if (stateAfter) {
-    writeCloudflaredState(stateAfter, r.statePath);
-  } else {
-    clearCloudflaredState(r.statePath);
-  }
-  // Clear the shared expose-state.json when no Cloudflare tunnels remain, so
-  // downstream consumers stop resolving the now-dead public URL (mirrors the
-  // up-path write above + the Tailscale off-path's expose-state teardown). When
-  // other tunnels survive we leave it — a later off for the last one clears it.
-  if (!stateAfter) {
-    clearExposeState(r.exposeStatePath);
-  }
   r.log(`  ${record.hostname} is no longer reachable through this machine.`);
   r.log(
     `  Tunnel "${record.tunnelName}" (${record.tunnelUuid}) remains defined in Cloudflare; re-running`,
@@ -844,7 +891,77 @@ export async function exposeCloudflareOff(opts: ExposeCloudflareOpts = {}): Prom
   r.log(
     `  \`parachute expose public --cloudflare --domain ${record.hostname}${record.tunnelName === DEFAULT_TUNNEL_NAME ? "" : ` --tunnel-name ${record.tunnelName}`}\` reuses it.`,
   );
-  return 0;
+  return { state: withoutTunnelRecord(state, record.tunnelName), code: 0 };
+}
+
+export async function exposeCloudflareOff(opts: ExposeCloudflareOpts = {}): Promise<number> {
+  // The off-path has no hostname to derive a name from. When `--tunnel-name`
+  // is set we use it; otherwise we resolve from cloudflared-state.json (below).
+  // `DEFAULT_TUNNEL_NAME` is only the inert `resolve` fallback here — the
+  // state-driven branch never relies on it.
+  const r = resolve(opts, DEFAULT_TUNNEL_NAME);
+  const stateBefore = readCloudflaredState(r.statePath);
+  const records = listTunnelRecords(stateBefore);
+
+  // Decide which records to tear down.
+  //   - explicit `--tunnel-name` → exactly that one (or a not-found message).
+  //   - no flag, 0 tunnels        → nothing to do.
+  //   - no flag, exactly 1        → that one.
+  //   - no flag, ≥2               → ALL of them. A bare `expose public
+  //     --cloudflare off` means "stop all public Cloudflare exposure on this
+  //     machine"; tearing down only one would leave the box half-exposed with
+  //     no obvious signal which tunnel survived.
+  let targets: CloudflaredTunnelRecord[];
+  if (opts.tunnelName !== undefined) {
+    const record = findTunnelRecord(stateBefore, r.tunnelName);
+    if (!record) {
+      if (records.length > 0) {
+        const others = records.map((t) => t.tunnelName).join(", ");
+        r.log(
+          `No Cloudflare exposure recorded for tunnel "${r.tunnelName}". Other tunnels: ${others}.`,
+        );
+      } else {
+        r.log("No Cloudflare exposure recorded. Nothing to tear down.");
+      }
+      return 0;
+    }
+    targets = [record];
+  } else {
+    if (records.length === 0) {
+      r.log("No Cloudflare exposure recorded. Nothing to tear down.");
+      return 0;
+    }
+    if (records.length > 1) {
+      r.log(
+        `Tearing down all ${records.length} recorded Cloudflare tunnels: ${records
+          .map((t) => t.tunnelName)
+          .join(", ")}.`,
+      );
+    }
+    targets = records;
+  }
+
+  let state = stateBefore;
+  let failed = false;
+  for (const record of targets) {
+    const result = teardownOne(r, state, record);
+    state = result.state;
+    if (result.code !== 0) failed = true;
+  }
+
+  if (state) {
+    writeCloudflaredState(state, r.statePath);
+  } else {
+    clearCloudflaredState(r.statePath);
+  }
+  // Clear the shared expose-state.json when no Cloudflare tunnels remain, so
+  // downstream consumers stop resolving the now-dead public URL (mirrors the
+  // up-path write above + the Tailscale off-path's expose-state teardown). When
+  // other tunnels survive we leave it — a later off for the last one clears it.
+  if (!state) {
+    clearExposeState(r.exposeStatePath);
+  }
+  return failed ? 1 : 0;
 }
 
 function reportCloudflaredError(err: unknown, log: (line: string) => void): number {

--- a/src/help.ts
+++ b/src/help.ts
@@ -369,8 +369,13 @@ Flags:
   --domain <hostname>     fully-qualified hostname to route through the tunnel
                           (e.g. vault.example.com). The apex must be a zone on
                           your Cloudflare account.
-  --tunnel-name <name>    Cloudflare tunnel name (default: \`parachute\`).
-                          Use to coexist multiple named tunnels on one box.
+  --tunnel-name <name>    Cloudflare tunnel name. Defaults to a per-hostname
+                          name (e.g. vault.example.com → parachute-vault-example-com)
+                          so each machine gets its OWN dedicated tunnel —
+                          Cloudflare tunnels are account-wide, and sharing one
+                          across machines collides their connectors. You don't
+                          need to create the tunnel yourself; expose does it.
+                          Override only to pin a specific name.
   --skip-provider-check   bypass non-TTY auto-detect, default to Tailscale
                           Funnel as before. Intended for CI / scripts whose
                           environment is already pre-flighted.


### PR DESCRIPTION
## The bug (confirmed on two boxes)

Cloudflare tunnels are **account-wide**, but `parachute expose public --cloudflare --domain <host>` defaulted the tunnel name to a single shared constant `DEFAULT_TUNNEL_NAME = "parachute"` (`src/cloudflare/config.ts`).

When a *second* machine exposed a *different* hostname, `findTunnelByName("parachute")` found the **same** tunnel. Both machines registered connectors on one tunnel UUID, and Cloudflare load-balanced requests across them. A request for hostname B could land on machine A's connector — whose `config.yml` only has an ingress rule for hostname A — so it fell through to `http_status:404`. Result: nondeterministic ~50% cross-host failures on each box. Hit on `gitcoin.parachute.computer` + `our.parachute.computer`; the manual workaround was a dedicated per-machine tunnel.

## The fix: per-hostname dedicated tunnels

- **`deriveTunnelName(hostname)`** (new, exported, unit-tested): lowercase, dots→hyphens, strip anything outside `[a-z0-9_-]`, prefix `parachute-`. Deterministic so re-expose is idempotent (same hostname → same name → reuse the tunnel created last time). When the name would exceed 64 chars it truncates the body and appends a stable 8-hex FNV-1a fold of the *full* hostname so two long hostnames can't collide. No `Math.random`/`Date`.
  - `our.parachute.computer` → `parachute-our-parachute-computer`
  - `vault.example.com` → `parachute-vault-example-com`
  - `Vault.Example.COM` → `parachute-vault-example-com`
  - `<200 x's>.example.com` → `parachute-xxxxx…-<8hex>` (≤64, deterministic)
- **`exposeCloudflareUp`** defaults the tunnel name to `deriveTunnelName(hostname)`; explicit `--tunnel-name` still wins. Per-tunnel config/log paths (`cloudflaredPathsFor`) follow the resolved name.
- **`exposeCloudflareOff`** (no hostname → can't derive): now **state-driven** from `cloudflared-state.json`. Explicit `--tunnel-name` targets one as before. Otherwise: 0 tunnels → "Nothing to tear down" (exit 0); exactly 1 → tear it down; **≥2 → tear down ALL recorded tunnels** (a bare `expose public --cloudflare off` means "stop all public Cloudflare exposure"), logging each. Per-tunnel orphan-connector sweep + expose-state clearing preserved.
- **Legacy-tunnel migration sweep**: on up, when the derived name differs from `"parachute"` **and** `cloudflared-state.json` has a live record named exactly `"parachute"`, kill that connector and drop its state record, logging `Stopped legacy shared-tunnel connector (migrated <host> to dedicated tunnel <name>).` So running boxes self-heal immediately instead of at the next reboot.

## Migration story

A box on the old shared `"parachute"` tunnel that upgrades and re-runs `expose public --cloudflare --domain <host>`:
1. `routeDns` already uses `--overwrite-dns` → the hostname's CNAME repoints to the new dedicated tunnel cleanly.
2. The legacy sweep stops the old shared connector so it can't keep serving (and mis-serving) other hosts' load-balanced traffic.

## CLI clarity (Aaron's ask)

- On create: `Each machine gets its own dedicated tunnel — you don't need to run \`cloudflared tunnel create\` separately; expose does it.`
- Success summary adds an honest note: the connector is a background process that does **not** survive a reboot yet — after a reboot, re-run the command. (Durable launchd/systemd connector is a tracked follow-up.)
- `expose --help` now says `--tunnel-name` defaults to a per-hostname name (no longer a shared "parachute").

`DEFAULT_TUNNEL_NAME` is kept (the legacy sweep + the off reuse-hint reference it); its docstring is narrowed to "the legacy shared name we migrate away from."

## Out of scope (explicit)

- Persistent connector (launchd/systemd) — separate follow-up; just the honest reboot note here.
- No version bump (rc bump happens at ship time per governance, not per PR).
- No docs-site changes (install/deploy pages handled separately).

## Tests / gate

- `bun test ./src` → **2537 pass, 1 skip, 0 fail** (the skip is the pre-existing `setup-wizard.test.ts` `test.skip` for the done-screen tiles — unrelated to this change).
- `bun run typecheck` (`tsc --noEmit`) → clean.
- `bunx biome check` → clean.

New/updated tests: `deriveTunnelName` (sanitization, prefix, ≥64-char truncate+hash, determinism, collision-avoidance, `isValidTunnelName` conformance); up uses derived name when `--tunnel-name` omitted (happy-path) and explicit `--tunnel-name` wins; off 0/1/≥2-tunnel state resolution; legacy-sweep fires on a live legacy record, and does NOT fire with no legacy record or when the resolved name is "parachute". Existing expose-cloudflare tests that assumed the `"parachute"` default were updated (derived-name expectations) or pinned `tunnelName: "parachute"` where the test's substance is unrelated to naming.

## For the reviewer to scrutinize

- **off-path ≥2 behavior**: a bare `--cloudflare off` tears down *all* recorded tunnels. Note the auto-detect path (`expose public off` without `--cloudflare`, in `expose-off-auto.ts`) already iterates all records passing an explicit `tunnelName` per tunnel, so it hits the explicit-name branch — consistent.
- **legacy-sweep heuristic**: keys off a state record named exactly `"parachute"` with a live pid, only when the resolved name differs from `"parachute"`. It does not touch a `"parachute"`-named tunnel that the operator explicitly re-selects via `--tunnel-name parachute`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)