### PR TITLE
release: hub 0.6.1 (stable @latest cut)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.1-rc.4",
-  "description": "parachute \u2014 the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
+  "version": "0.6.1",
+  "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Drop the `-rc` suffix (was 0.6.1-rc.4) to cut the stable `@latest` release. Carries the per-host Cloudflare tunnel fix (#491) plus the v0.6 auth / onboarding / multi-user arc. Pushing tag `v0.6.1` after merge triggers the CI publish to `@latest`. No code change — version field only.