### PR TITLE
feat(hub): Phase 2a — supervisor hardening (process-group reaping + log ring buffer + port-readiness/structured start-error)

### DIFF
--- a/src/__tests__/api-modules-ops.test.ts
+++ b/src/__tests__/api-modules-ops.test.ts
@@ -7,6 +7,7 @@ import {
   API_MODULES_OPS_REQUIRED_SCOPE,
   _resetOperationsRegistryForTests,
   handleInstall,
+  handleLogs,
   handleOperationGet,
   handleRestart,
   handleStart,
@@ -90,6 +91,11 @@ function makeIdleSupervisor(): {
   spawns: SpawnRequest[];
 } {
   const spawns: SpawnRequest[] = [];
+  // Track each spawned proc by pid so the injected group-aware `killFn` can
+  // forward the signal to the right fake (post-hub#88, `stop()` signals via
+  // `killFn`, not `proc.kill` — so without this seam the fake's `exited` never
+  // resolves and `stop`/`restart` time out).
+  const byPid = new Map<number, SupervisedProc & { kill: () => void }>();
   const spawnFn = (req: SpawnRequest): SupervisedProc => {
     spawns.push(req);
     // The fake's `exited` resolves when kill() is called, mirroring a
@@ -99,15 +105,22 @@ function makeIdleSupervisor(): {
     const exited = new Promise<number | null>((r) => {
       resolveExit = r;
     });
-    return {
+    const proc: SupervisedProc & { kill: () => void } = {
       pid: 7777,
       exited,
       stdout: null,
       stderr: null,
       kill: () => resolveExit(0),
     };
+    byPid.set(proc.pid, proc);
+    return proc;
   };
-  return { supervisor: new Supervisor({ spawnFn }), spawns };
+  // Mirrors production's group-aware kill: the supervisor passes the leader
+  // pid, we forward to the matching fake's `kill` (which resolves `exited`).
+  const killFn = (pid: number): void => {
+    byPid.get(Math.abs(pid))?.kill();
+  };
+  return { supervisor: new Supervisor({ spawnFn, killFn }), spawns };
 }
 
 function writeManifest(path: string, services: unknown[]): void {
@@ -1627,5 +1640,134 @@ describe("well-known regen after module ops", () => {
     const second = readFileSync(wkPath, "utf8");
 
     expect(second).toBe(first);
+  });
+});
+
+describe("GET /api/modules/:short/logs (§6.5 ring-buffer tap)", () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+    _resetOperationsRegistryForTests();
+  });
+  afterEach(() => h.cleanup());
+
+  /**
+   * Supervisor whose child exposes a controllable stdout stream so the test
+   * can push lines into the ring buffer, then tap them through the endpoint.
+   */
+  function makeEmittingSupervisor(): {
+    supervisor: Supervisor;
+    emit: (chunk: string) => void;
+  } {
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    const stdout = new ReadableStream<Uint8Array>({
+      start(c) {
+        controller = c;
+      },
+    });
+    const enc = new TextEncoder();
+    const spawnFn = (): SupervisedProc => ({
+      pid: 4321,
+      exited: new Promise<number | null>(() => {}),
+      stdout,
+      stderr: null,
+      kill: () => {},
+    });
+    return {
+      supervisor: new Supervisor({ spawnFn, killFn: () => {} }),
+      emit: (chunk) => controller.enqueue(enc.encode(chunk)),
+    };
+  }
+
+  function logsDeps(supervisor: Supervisor) {
+    return { db: h.db, issuer: ISSUER, manifestPath: h.manifestPath, configDir: h.dir, supervisor };
+  }
+
+  test("401 on missing bearer", async () => {
+    const { supervisor } = makeEmittingSupervisor();
+    const res = await handleLogs(
+      getReq("/api/modules/vault/logs", {}),
+      "vault",
+      logsDeps(supervisor),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("403 on bearer without parachute:host:admin (host-admin gated)", async () => {
+    const { supervisor } = makeEmittingSupervisor();
+    const bearer = await mintBearer(h, ["parachute:host:auth"]);
+    const res = await handleLogs(
+      getReq("/api/modules/vault/logs", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      logsDeps(supervisor),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("405 on non-GET", async () => {
+    const { supervisor } = makeEmittingSupervisor();
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleLogs(
+      postReq("/api/modules/vault/logs", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      logsDeps(supervisor),
+    );
+    expect(res.status).toBe(405);
+  });
+
+  test("404 not_supervised for a module that isn't supervised", async () => {
+    const { supervisor } = makeEmittingSupervisor();
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleLogs(
+      getReq("/api/modules/vault/logs", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      logsDeps(supervisor),
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("not_supervised");
+  });
+
+  test("replays the ring buffer (lines emitted before the tap) as lines + text", async () => {
+    const { supervisor, emit } = makeEmittingSupervisor();
+    await supervisor.start({ short: "vault", cmd: ["parachute-vault", "serve"] });
+    // Output happens BEFORE the operator opens the logs view.
+    emit("booting\n");
+    emit("FATAL: boom\n");
+    await new Promise((r) => setTimeout(r, 20));
+
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleLogs(
+      getReq("/api/modules/vault/logs", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      logsDeps(supervisor),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { short: string; lines: string[]; text: string };
+    expect(body.short).toBe("vault");
+    expect(body.lines).toEqual(["[vault] booting\n", "[vault] FATAL: boom\n"]);
+    expect(body.text).toBe("[vault] booting\n[vault] FATAL: boom\n");
+  });
+
+  test("?follow=1 streams the buffered replay first (text/plain)", async () => {
+    const { supervisor, emit } = makeEmittingSupervisor();
+    await supervisor.start({ short: "vault", cmd: ["parachute-vault", "serve"] });
+    emit("pre-connect line\n");
+    await new Promise((r) => setTimeout(r, 20));
+
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleLogs(
+      getReq("/api/modules/vault/logs?follow=1", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      logsDeps(supervisor),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/plain");
+    // Read the first chunk — it must contain the replayed buffer line.
+    const reader = res.body!.getReader();
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+    expect(text).toContain("[vault] pre-connect line\n");
+    await reader.cancel();
   });
 });

--- a/src/__tests__/module-ops-client.test.ts
+++ b/src/__tests__/module-ops-client.test.ts
@@ -9,6 +9,7 @@ import {
   ModuleOpHttpError,
   NoOperatorTokenError,
   driveModuleOp,
+  fetchModuleLogs,
   resolveOperatorBearer,
 } from "../module-ops-client.ts";
 import { issueOperatorToken } from "../operator-token.ts";
@@ -327,5 +328,86 @@ describe("driveModuleOp — async operation polling", () => {
     });
     expect(calls[0]?.headers["content-type"]).toBe("application/json");
     expect(JSON.parse(calls[0]?.body ?? "{}")).toEqual({ channel: "rc" });
+  });
+});
+
+describe("fetchModuleLogs", () => {
+  let h: Harness;
+  afterEach(() => h.cleanup());
+
+  test("GETs the /logs endpoint with the operator bearer and returns lines + text", async () => {
+    h = await makeHarnessWithToken();
+    const { fetch: f, calls } = fakeFetch([
+      {
+        status: 200,
+        body: {
+          short: "vault",
+          lines: ["[vault] booting\n", "[vault] ready\n"],
+          text: "[vault] booting\n[vault] ready\n",
+        },
+      },
+    ]);
+    const result = await fetchModuleLogs("vault", {
+      db: h.db,
+      issuer: ISSUER,
+      configDir: h.dir,
+      fetch: f,
+    });
+
+    // Hit the right URL with a GET + Bearer.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe(`${DEFAULT_HUB_BASE_URL}/api/modules/vault/logs`);
+    expect(calls[0]?.method).toBe("GET");
+    expect(calls[0]?.headers.authorization).toMatch(/^Bearer /);
+
+    expect(result.short).toBe("vault");
+    expect(result.lines).toEqual(["[vault] booting\n", "[vault] ready\n"]);
+    expect(result.text).toBe("[vault] booting\n[vault] ready\n");
+  });
+
+  test("no operator token → NoOperatorTokenError before any fetch", async () => {
+    h = await makeHarnessNoToken();
+    const { fetch: f, calls } = fakeFetch([{ status: 200, body: { lines: [] } }]);
+    let err: unknown;
+    try {
+      await fetchModuleLogs("vault", { db: h.db, issuer: ISSUER, configDir: h.dir, fetch: f });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(NoOperatorTokenError);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("non-2xx (not_supervised) → ModuleOpHttpError carrying status + code", async () => {
+    h = await makeHarnessWithToken();
+    const { fetch: f } = fakeFetch([
+      {
+        status: 404,
+        body: { error: "not_supervised", error_description: "vault is not currently supervised" },
+      },
+    ]);
+    let err: unknown;
+    try {
+      await fetchModuleLogs("vault", { db: h.db, issuer: ISSUER, configDir: h.dir, fetch: f });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ModuleOpHttpError);
+    expect((err as ModuleOpHttpError).status).toBe(404);
+    expect((err as ModuleOpHttpError).code).toBe("not_supervised");
+  });
+
+  test("falls back to joining lines when the body omits text", async () => {
+    h = await makeHarnessWithToken();
+    const { fetch: f } = fakeFetch([
+      { status: 200, body: { short: "scribe", lines: ["a\n", "b\n"] } },
+    ]);
+    const result = await fetchModuleLogs("scribe", {
+      db: h.db,
+      issuer: ISSUER,
+      configDir: h.dir,
+      fetch: f,
+    });
+    expect(result.text).toBe("a\nb\n");
   });
 });

--- a/src/__tests__/port-probe.test.ts
+++ b/src/__tests__/port-probe.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { defaultPortListening } from "../port-probe.ts";
+
+describe("defaultPortListening", () => {
+  test("true when something is listening on the loopback port", async () => {
+    const server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("ok") });
+    try {
+      expect(await defaultPortListening(server.port as number)).toBe(true);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("false when nothing is bound (connection refused)", async () => {
+    // Grab a port, immediately release it, then probe — it's free.
+    const probe = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("x") });
+    const freePort = probe.port as number;
+    probe.stop(true);
+    // Brief settle so the kernel releases the port before we probe.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(await defaultPortListening(freePort)).toBe(false);
+  });
+});

--- a/src/__tests__/supervisor.test.ts
+++ b/src/__tests__/supervisor.test.ts
@@ -772,6 +772,149 @@ describe("Supervisor per-module log ring buffer (§6.5)", () => {
   });
 });
 
+describe("Supervisor port-readiness + structured start-error (§6.5)", () => {
+  const reqWithPort = (short: string, port: number): SpawnRequest => ({
+    short,
+    cmd: ["parachute-vault", "serve"],
+    env: { PORT: String(port) },
+  });
+
+  test("(a) module that never binds its port → started-but-unbound start-error, status stays running", async () => {
+    const proc = makeFakeProc(101);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(proc);
+    // portListening always false → the readiness gate times out. Short window +
+    // instant sleep so the test doesn't actually wait.
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      killFn: noopKill,
+      portListening: async () => false,
+      startReadyMs: 50,
+      startReadyPollMs: 5,
+      sleep: () => Promise.resolve(),
+    });
+    const state = await sup.start(reqWithPort("vault", 1940));
+
+    // Process IS up (we don't break the running enum — proxy-state/SPA read it)...
+    expect(state.status).toBe("running");
+    // ...but the structured start-error explains it's not actually listening.
+    expect(state.startError?.error_type).toBe("started_but_unbound");
+    expect(state.startError?.error_description).toContain("1940");
+    expect(state.startError?.at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    proc.closeStreams();
+    sup.stop("vault");
+    proc.resolveExit(0);
+  });
+
+  test("(b) module that binds promptly → no start-error, clean running", async () => {
+    const proc = makeFakeProc(102);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(proc);
+    let probes = 0;
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      killFn: noopKill,
+      // First probe says "not yet", second says "bound" — exercises the poll
+      // loop rather than an instant hit.
+      portListening: async () => ++probes >= 2,
+      startReadyMs: 1000,
+      startReadyPollMs: 5,
+      sleep: () => Promise.resolve(),
+    });
+    const state = await sup.start(reqWithPort("vault", 1940));
+
+    expect(state.status).toBe("running");
+    expect(state.startError).toBeUndefined();
+    expect(probes).toBeGreaterThanOrEqual(2);
+
+    proc.closeStreams();
+    sup.stop("vault");
+    proc.resolveExit(0);
+  });
+
+  test("(c) preflight MissingDependencyError → structured start-error, NO spawn", async () => {
+    const spawner = makeQueueSpawner();
+    // No proc enqueued — if start() tried to spawn, the queue spawner throws.
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      killFn: noopKill,
+      which: () => null, // binary not resolvable → preflight throws
+      portListening: async () => true,
+      startReadyMs: 50,
+      sleep: () => Promise.resolve(),
+    });
+    const state = await sup.start(reqWithPort("vault", 1940));
+
+    // Doomed spawn aborted: status crashed, structured missing-dependency error.
+    expect(state.status).toBe("crashed");
+    expect(state.startError?.error_type).toBe("missing_dependency");
+    expect(state.startError?.binary).toBe("parachute-vault");
+    // Crucially, the supervisor never called the spawner.
+    expect(spawner.calls).toHaveLength(0);
+  });
+
+  test("a clean re-start clears a prior started-but-unbound start-error", async () => {
+    const first = makeFakeProc(201);
+    const second = makeFakeProc(202);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(first);
+    spawner.enqueue(second);
+    let bound = false;
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      killFn: noopKill,
+      portListening: async () => bound,
+      startReadyMs: 30,
+      startReadyPollMs: 5,
+      sleep: () => Promise.resolve(),
+    });
+
+    // First start never binds → start-error recorded.
+    const s1 = await sup.start(reqWithPort("vault", 1940));
+    expect(s1.startError?.error_type).toBe("started_but_unbound");
+
+    // Restart with the port now binding → the stale error clears.
+    bound = true;
+    const restartP = sup.restart("vault");
+    first.closeStreams();
+    first.resolveExit(0);
+    const s2 = await restartP;
+    expect(s2?.status).toBe("running");
+    expect(s2?.startError).toBeUndefined();
+
+    second.closeStreams();
+    sup.stop("vault");
+    second.resolveExit(0);
+  });
+
+  test("readiness gate is skipped when the request carries no PORT", async () => {
+    const proc = makeFakeProc(101);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(proc);
+    let probed = false;
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      killFn: noopKill,
+      portListening: async () => {
+        probed = true;
+        return false;
+      },
+      startReadyMs: 1000,
+      sleep: () => Promise.resolve(),
+    });
+    // No env.PORT → nothing to probe; start returns running, no error, no probe.
+    const state = await sup.start({ short: "cli-only", cmd: ["parachute-vault", "serve"] });
+    expect(state.status).toBe("running");
+    expect(state.startError).toBeUndefined();
+    expect(probed).toBe(false);
+
+    proc.closeStreams();
+    sup.stop("cli-only");
+    proc.resolveExit(0);
+  });
+});
+
 describe("Supervisor.list + get", () => {
   test("list returns snapshot of all supervised modules", async () => {
     const vault = makeFakeProc(101);

--- a/src/__tests__/supervisor.test.ts
+++ b/src/__tests__/supervisor.test.ts
@@ -1,5 +1,39 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { type SpawnRequest, type SupervisedProc, Supervisor } from "../supervisor.ts";
+import { describe, expect, test } from "bun:test";
+import { Socket } from "node:net";
+import {
+  type KillFn,
+  type SpawnRequest,
+  type SupervisedProc,
+  Supervisor,
+  defaultKillGroup,
+} from "../supervisor.ts";
+
+/**
+ * A `killFn` stub that records every (pid, signal) it receives and forwards
+ * the signal to the matching fake proc's own `kill` (so fakes that model
+ * "only SIGKILL terminates me" still work). Mirrors how production's
+ * `defaultKillGroup` would signal the process group, but stays in-process +
+ * deterministic. Tests assert on `.calls` to prove a group send (negative
+ * pid) happened. `register` wires a fake's pid → its `kill`.
+ */
+function makeKillRecorder(): {
+  killFn: KillFn;
+  calls: Array<{ pid: number; signal: NodeJS.Signals | number }>;
+  register: (proc: FakeProc) => void;
+} {
+  const calls: Array<{ pid: number; signal: NodeJS.Signals | number }> = [];
+  const byPid = new Map<number, FakeProc>();
+  return {
+    calls,
+    register: (proc) => byPid.set(proc.pid, proc),
+    killFn: (pid, signal) => {
+      calls.push({ pid, signal });
+      // Production signals the group via the negative pid; the supervisor
+      // passes the positive leader pid, so map back to the fake by |pid|.
+      byPid.get(Math.abs(pid))?.kill(signal);
+    },
+  };
+}
 
 /**
  * Fake subprocess with controllable exited promise + injectable stdout
@@ -99,12 +133,20 @@ function tick(ms = 10): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+/**
+ * No-op kill seam for tests that exercise `stop()`/`restart()` only as
+ * lifecycle cleanup and don't assert on the signal. Keeps the default
+ * `defaultKillGroup` (which calls the real `process.kill`) from firing a
+ * signal at a fake pid that could collide with a real process on the host.
+ */
+const noopKill: KillFn = () => {};
+
 describe("Supervisor.start + status transitions", () => {
   test("transitions starting → running after spawn", async () => {
     const proc = makeFakeProc(123);
     const spawner = makeQueueSpawner();
     spawner.enqueue(proc);
-    const sup = new Supervisor({ spawnFn: spawner.spawn });
+    const sup = new Supervisor({ spawnFn: spawner.spawn, killFn: noopKill });
 
     const state = await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
     expect(state.status).toBe("running");
@@ -123,7 +165,7 @@ describe("Supervisor.start + status transitions", () => {
     const proc = makeFakeProc(123);
     const spawner = makeQueueSpawner();
     spawner.enqueue(proc);
-    const sup = new Supervisor({ spawnFn: spawner.spawn });
+    const sup = new Supervisor({ spawnFn: spawner.spawn, killFn: noopKill });
 
     await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
     await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
@@ -146,6 +188,7 @@ describe("Supervisor restart-on-crash", () => {
 
     const sup = new Supervisor({
       spawnFn: spawner.spawn,
+      killFn: noopKill,
       restartDelayMs: 0,
       sleep: () => Promise.resolve(),
     });
@@ -177,6 +220,7 @@ describe("Supervisor restart-on-crash", () => {
     const outputs: string[] = [];
     const sup = new Supervisor({
       spawnFn: spawner.spawn,
+      killFn: noopKill,
       maxRestarts: 3,
       restartDelayMs: 0,
       sleep: () => Promise.resolve(),
@@ -206,6 +250,7 @@ describe("Supervisor restart-on-crash", () => {
     let nowVal = 1_000_000;
     const sup = new Supervisor({
       spawnFn: spawner.spawn,
+      killFn: noopKill,
       maxRestarts: 2,
       restartWindowMs: 5_000,
       restartDelayMs: 0,
@@ -241,8 +286,11 @@ describe("Supervisor.stop", () => {
     const proc = makeFakeProc(101);
     const spawner = makeQueueSpawner();
     spawner.enqueue(proc);
+    const killer = makeKillRecorder();
+    killer.register(proc);
     const sup = new Supervisor({
       spawnFn: spawner.spawn,
+      killFn: killer.killFn,
       restartDelayMs: 0,
       sleep: () => Promise.resolve(),
     });
@@ -254,6 +302,9 @@ describe("Supervisor.stop", () => {
     const stopPromise = sup.stop("vault");
     expect(proc.killed).toBe(true);
     expect(proc.killSignal).toBe("SIGTERM");
+    // The signal is sent through the group-aware killFn seam (hub#88), with
+    // the child's leader pid.
+    expect(killer.calls).toEqual([{ pid: 101, signal: "SIGTERM" }]);
 
     proc.closeStreams();
     proc.resolveExit(0);
@@ -278,9 +329,12 @@ describe("Supervisor.stop", () => {
     };
     const spawner = makeQueueSpawner();
     spawner.enqueue(proc);
+    const killer = makeKillRecorder();
+    killer.register(proc);
     const outputs: string[] = [];
     const sup = new Supervisor({
       spawnFn: spawner.spawn,
+      killFn: killer.killFn,
       restartDelayMs: 0,
       sleep: () => Promise.resolve(),
       killTimeoutMs: 5, // Short timeout so the test doesn't pause for 5s.
@@ -291,8 +345,13 @@ describe("Supervisor.stop", () => {
     proc.closeStreams();
     await sup.stop("vault");
 
-    // SIGTERM first, then SIGKILL after the timeout.
+    // SIGTERM first, then SIGKILL after the timeout — both via the group-aware
+    // killFn seam with the leader pid.
     expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(killer.calls).toEqual([
+      { pid: 101, signal: "SIGTERM" },
+      { pid: 101, signal: "SIGKILL" },
+    ]);
     expect(outputs.some((l) => l.includes("escalating to SIGKILL"))).toBe(true);
     expect(sup.get("vault")?.status).toBe("stopped");
   });
@@ -311,8 +370,11 @@ describe("Supervisor.stop", () => {
     const signals: (NodeJS.Signals | number | undefined)[] = [];
     const spawner = makeQueueSpawner();
     spawner.enqueue(proc);
+    const killer = makeKillRecorder();
+    killer.register(proc);
     const sup = new Supervisor({
       spawnFn: spawner.spawn,
+      killFn: killer.killFn,
       restartDelayMs: 0,
       sleep: () => Promise.resolve(),
       killTimeoutMs: 1000, // Plenty of headroom for the 5ms simulated exit.
@@ -332,8 +394,174 @@ describe("Supervisor.stop", () => {
     // Microtask ordering guarantees they both run before await returns.)
     expect(exitObservedBeforeReturn).toBe(true);
     expect(signals).toEqual(["SIGTERM"]);
+    expect(killer.calls).toEqual([{ pid: 101, signal: "SIGTERM" }]);
     expect(sup.get("vault")?.status).toBe("stopped");
   });
+});
+
+describe("Supervisor process-group reaping (hub#88 — EADDRINUSE-on-restart regression)", () => {
+  /** Grab a free loopback port by opening + immediately closing a server. */
+  async function freeEphemeralPort(): Promise<number> {
+    const probe = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("x") });
+    // `port` is `number | undefined` in Bun's types, but a live Bun.serve()
+    // always has a bound port — assert it so the test stays type-clean.
+    const port = probe.port as number;
+    probe.stop(true);
+    return port;
+  }
+
+  /** Connect-probe loopback:port — true if something is accepting. */
+  function portListening(port: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      const socket = new Socket();
+      let settled = false;
+      const done = (v: boolean) => {
+        if (settled) return;
+        settled = true;
+        socket.destroy();
+        resolve(v);
+      };
+      socket.setTimeout(500);
+      socket.once("connect", () => done(true));
+      socket.once("timeout", () => done(false));
+      socket.once("error", () => done(false));
+      socket.connect(port, "127.0.0.1");
+    });
+  }
+
+  /** Poll until `pred()` is true or the deadline passes. Returns the outcome. */
+  async function waitFor(pred: () => Promise<boolean>, timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (await pred()) return true;
+      await tick(25);
+    }
+    return pred();
+  }
+
+  test("stop signals the whole process group, not just the leader (deterministic seam check)", async () => {
+    // The load-bearing contract: the supervisor hands `killFn` the child's
+    // LEADER pid, and production's `defaultKillGroup` translates that into a
+    // group send (`process.kill(-pid)`). A faithful stub records what `killFn`
+    // received; we assert the supervisor signalled with the leader pid so the
+    // group (wrapper + grandchildren) is reaped together. This is the
+    // deterministic counterpart to the real-process round-trip below.
+    const leader = makeFakeProc(4242);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(leader);
+    const killer = makeKillRecorder();
+    killer.register(leader);
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      killFn: killer.killFn,
+      restartDelayMs: 0,
+      sleep: () => Promise.resolve(),
+    });
+    await sup.start({ short: "wrapped", cmd: ["sh", "-c", "tsx server.ts"] });
+
+    const stopP = sup.stop("wrapped");
+    leader.closeStreams();
+    leader.resolveExit(0);
+    await stopP;
+
+    // killFn received the LEADER pid (4242) — production's defaultKillGroup
+    // turns this into `process.kill(-4242)`, reaping the wrapper's whole group
+    // incl. the tsx grandchild that would otherwise hold the port (hub#88).
+    expect(killer.calls).toEqual([{ pid: 4242, signal: "SIGTERM" }]);
+  });
+
+  test("defaultKillGroup sends to the negative (group) pid, falling back to bare pid on ESRCH", () => {
+    // Drive the real defaultKillGroup against a stubbed process.kill so we can
+    // assert the group-vs-bare-pid syscall shape without signalling anything.
+    const realKill = process.kill;
+    const calls: Array<{ pid: number; signal: string | number }> = [];
+    try {
+      // Case 1: group send succeeds → only the negative-pid call happens.
+      (process as { kill: typeof process.kill }).kill = ((
+        pid: number,
+        signal?: string | number,
+      ) => {
+        calls.push({ pid, signal: signal ?? 0 });
+        return true;
+      }) as typeof process.kill;
+      defaultKillGroup(555, "SIGTERM");
+      expect(calls).toEqual([{ pid: -555, signal: "SIGTERM" }]);
+
+      // Case 2: group send throws ESRCH (no group / pre-detached child) →
+      // fall back to a bare-pid send. Mirrors lifecycle.defaultKill.
+      calls.length = 0;
+      (process as { kill: typeof process.kill }).kill = ((
+        pid: number,
+        signal?: string | number,
+      ) => {
+        calls.push({ pid, signal: signal ?? 0 });
+        if (pid < 0) {
+          const err = new Error("no such process") as NodeJS.ErrnoException;
+          err.code = "ESRCH";
+          throw err;
+        }
+        return true;
+      }) as typeof process.kill;
+      defaultKillGroup(777, "SIGKILL");
+      expect(calls).toEqual([
+        { pid: -777, signal: "SIGKILL" },
+        { pid: 777, signal: "SIGKILL" },
+      ]);
+
+      // Case 3: a non-ESRCH error propagates (we never swallow EPERM etc.).
+      (process as { kill: typeof process.kill }).kill = (() => {
+        const err = new Error("operation not permitted") as NodeJS.ErrnoException;
+        err.code = "EPERM";
+        throw err;
+      }) as typeof process.kill;
+      expect(() => defaultKillGroup(888, "SIGTERM")).toThrow("operation not permitted");
+    } finally {
+      process.kill = realKill;
+    }
+  });
+
+  test("a wrapped startCmd's grandchild is reaped on restart → fresh spawn re-binds the same port (no EADDRINUSE)", async () => {
+    const port = await freeEphemeralPort();
+    // Wrapper (the leader the supervisor spawns) backgrounds a *grandchild*
+    // bun listener that holds the port, then `wait`s on it. Pre-hub#88, the
+    // supervisor killed only the leader (`sh`) — the bun grandchild kept the
+    // socket, so the restart's fresh spawn hit EADDRINUSE. With group-spawn
+    // (`detached: true`) + group-kill (`defaultKillGroup`), the whole group
+    // dies and the port frees.
+    const listener = [
+      "bun",
+      "-e",
+      `Bun.serve({ port: ${port}, hostname: "127.0.0.1", fetch: () => new Response("ok") }); setInterval(() => {}, 1e9);`,
+    ];
+    const wrapper = ["sh", "-c", `${listener.map((a) => `'${a}'`).join(" ")} & wait`];
+
+    // Real spawnFn + real defaultKillGroup (no seams) — this is the whole point.
+    const sup = new Supervisor({ restartDelayMs: 50 });
+    try {
+      await sup.start({ short: "wrapped", cmd: wrapper });
+
+      // Grandchild binds the port.
+      expect(await waitFor(() => portListening(port), 8000)).toBe(true);
+
+      // Restart: stop (group-kill reaps the grandchild) → wait for the port
+      // to FREE → fresh spawn re-binds it. If the grandchild leaked, the
+      // fresh listener would EADDRINUSE-crash and the port would either stay
+      // held by the orphan or flap — the round-trip below would fail.
+      const restarted = await sup.restart("wrapped");
+      expect(restarted?.status).toBe("running");
+
+      // The port answers again under the fresh spawn — proves no EADDRINUSE.
+      expect(await waitFor(() => portListening(port), 8000)).toBe(true);
+
+      // The discriminating signal: after a final stop, the port FREES. If the
+      // group-kill failed to reach the bun grandchild, an orphan would keep
+      // the socket and this would never go quiet.
+      await sup.stop("wrapped");
+      expect(await waitFor(async () => !(await portListening(port)), 8000)).toBe(true);
+    } finally {
+      await sup.stop("wrapped").catch(() => {});
+    }
+  }, 20_000);
 });
 
 describe("Supervisor.restart", () => {
@@ -346,6 +574,7 @@ describe("Supervisor.restart", () => {
 
     const sup = new Supervisor({
       spawnFn: spawner.spawn,
+      killFn: noopKill,
       restartDelayMs: 0,
       sleep: () => Promise.resolve(),
     });
@@ -376,6 +605,7 @@ describe("Supervisor output multiplexing", () => {
     const outputs: string[] = [];
     const sup = new Supervisor({
       spawnFn: spawner.spawn,
+      killFn: noopKill,
       output: (line) => outputs.push(line),
     });
     await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
@@ -400,6 +630,7 @@ describe("Supervisor output multiplexing", () => {
     const outputs: string[] = [];
     const sup = new Supervisor({
       spawnFn: spawner.spawn,
+      killFn: noopKill,
       output: (line) => outputs.push(line),
     });
     await sup.start({ short: "scribe", cmd: ["bun", "scribe.ts"] });
@@ -427,6 +658,7 @@ describe("Supervisor output multiplexing", () => {
     const outputs: string[] = [];
     const sup = new Supervisor({
       spawnFn: spawner.spawn,
+      killFn: noopKill,
       output: (line) => outputs.push(line),
     });
     await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
@@ -457,7 +689,7 @@ describe("Supervisor.list + get", () => {
     const spawner = makeQueueSpawner();
     spawner.enqueue(vault);
     spawner.enqueue(scribe);
-    const sup = new Supervisor({ spawnFn: spawner.spawn });
+    const sup = new Supervisor({ spawnFn: spawner.spawn, killFn: noopKill });
 
     await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
     await sup.start({ short: "scribe", cmd: ["bun", "scribe.ts"] });

--- a/src/__tests__/supervisor.test.ts
+++ b/src/__tests__/supervisor.test.ts
@@ -682,6 +682,96 @@ describe("Supervisor output multiplexing", () => {
   });
 });
 
+describe("Supervisor per-module log ring buffer (§6.5)", () => {
+  test("replays output emitted BEFORE the reader connects (boot/crash-line capture)", async () => {
+    const proc = makeFakeProc(101);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(proc);
+    const sup = new Supervisor({ spawnFn: spawner.spawn, killFn: noopKill });
+    await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+
+    // Lines arrive (incl. a "crash cause") BEFORE anyone taps the logs.
+    proc.emitStdout("booting vault\n");
+    proc.emitStderr("FATAL: port already in use\n");
+    await tick(20);
+
+    // Reader connects AFTER the fact — the buffer must still have them.
+    const logs = sup.logs("vault");
+    expect(logs).toEqual(["[vault] booting vault\n", "[vault] FATAL: port already in use\n"]);
+
+    proc.closeStreams();
+    sup.stop("vault");
+    proc.resolveExit(0);
+  });
+
+  test("buffer is bounded — oldest lines drop once the byte cap is exceeded", async () => {
+    const proc = makeFakeProc(101);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(proc);
+    // Tiny cap so a handful of lines overflows it. Each prefixed line below is
+    // well over a few bytes, so the cap evicts oldest-first.
+    const sup = new Supervisor({ spawnFn: spawner.spawn, killFn: noopKill, logBufferBytes: 40 });
+    await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+
+    proc.emitStdout("line-1\n");
+    proc.emitStdout("line-2\n");
+    proc.emitStdout("line-3\n");
+    proc.emitStdout("line-4\n");
+    await tick(20);
+
+    const logs = sup.logs("vault") ?? [];
+    // The oldest line(s) were evicted; the newest survives.
+    expect(logs.at(-1)).toBe("[vault] line-4\n");
+    expect(logs).not.toContain("[vault] line-1\n");
+    // Total buffered bytes stay at/under the cap (modulo the always-kept tail).
+    const totalBytes = logs.reduce((n, l) => n + Buffer.byteLength(l), 0);
+    expect(totalBytes).toBeLessThanOrEqual(40);
+
+    proc.closeStreams();
+    sup.stop("vault");
+    proc.resolveExit(0);
+  });
+
+  test("logs() returns undefined for a not-supervised module (404 contract)", () => {
+    const sup = new Supervisor({ spawnFn: () => makeFakeProc(0), killFn: noopKill });
+    expect(sup.logs("nope")).toBeUndefined();
+  });
+
+  test("buffer survives a crash-respawn so the crash cause stays replayable", async () => {
+    const first = makeFakeProc(101);
+    const second = makeFakeProc(102);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(first);
+    spawner.enqueue(second);
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      killFn: noopKill,
+      restartDelayMs: 0,
+      sleep: () => Promise.resolve(),
+    });
+    await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+
+    first.emitStderr("crash cause: boom\n");
+    await tick(20);
+    // Crash → supervisor respawns within budget (reuses the same entry/buffer).
+    first.closeStreams();
+    first.resolveExit(1);
+    await tick();
+
+    second.emitStdout("recovered\n");
+    await tick(20);
+
+    const logs = sup.logs("vault") ?? [];
+    // Both the pre-crash cause and the post-respawn line are present.
+    expect(logs).toContain("[vault] crash cause: boom\n");
+    expect(logs).toContain("[vault] recovered\n");
+
+    second.closeStreams();
+    sup.stop("vault");
+    second.resolveExit(0);
+  });
+});
+
 describe("Supervisor.list + get", () => {
   test("list returns snapshot of all supervised modules", async () => {
     const vault = makeFakeProc(101);

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -857,6 +857,109 @@ export async function handleRestart(
 }
 
 /**
+ * GET /api/modules/:short/logs — synchronous.
+ *
+ * Serves the supervisor's bounded per-module ring buffer (§6.5): the most
+ * recent output the child wrote, INCLUDING the boot/crash lines that happened
+ * before the caller connected — which a naive connect-time SSE tap would lose
+ * (and which are "likely the most important one — the exit cause"). This is
+ * the §6 endpoint Phase 3 will repoint `parachute logs <svc>` onto.
+ *
+ * Returns the buffer as both a joined `text` blob and a `lines` array (the CLI
+ * tail wants the blob; a structured consumer wants lines). A module that isn't
+ * supervised returns 404 `not_supervised`, matching the `restart` handler's
+ * error contract for the same state — the caller can fall through to `start`.
+ *
+ * `?follow=1` is accepted as a best-effort streaming tap: we replay the buffer
+ * first (the must-have), then stream subsequent lines as `text/plain` chunks.
+ * The buffer replay is what captures the crash cause; the follow tail is the
+ * nice-to-have. Without `follow`, it's a one-shot JSON snapshot.
+ */
+export async function handleLogs(
+  req: Request,
+  short: CuratedModuleShort,
+  deps: ApiModulesOpsDeps,
+): Promise<Response> {
+  if (req.method !== "GET") return jsonError(405, "method_not_allowed", "use GET");
+  const authFail = await authorize(req, deps);
+  if (authFail) return authFail;
+
+  const lines = deps.supervisor.logs(short);
+  if (lines === undefined) {
+    // Same shape + status as `restart` for a not-supervised module, so the
+    // CLI client can treat both identically (fall through to `start`).
+    return jsonError(
+      404,
+      "not_supervised",
+      `${short} is not currently supervised — install or start it first`,
+    );
+  }
+
+  const follow = new URL(req.url).searchParams.get("follow");
+  if (follow === "1" || follow === "true") {
+    return streamModuleLogs(short, lines, deps);
+  }
+
+  // One-shot snapshot: the buffered lines as both a joined blob + the array.
+  return jsonOk({ short, lines, text: lines.join("") });
+}
+
+/**
+ * Best-effort follow stream (§6.5 nice-to-have). Replays the buffered lines
+ * (the must-have — captures the boot/crash cause) then forwards subsequent
+ * output as `text/plain` chunks by subscribing to a tee of the supervisor's
+ * live tap. The buffer replay is guaranteed; the live tail is opportunistic
+ * (it ends when the client disconnects or the module stops). Implemented via
+ * a polling diff of the ring buffer so it stays decoupled from `pumpLines`'
+ * internal sink and needs no new supervisor wiring.
+ */
+function streamModuleLogs(
+  short: CuratedModuleShort,
+  initial: string[],
+  deps: ApiModulesOpsDeps,
+): Response {
+  const encoder = new TextEncoder();
+  let lastLen = initial.length;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      // Replay the buffered lines first — the boot/crash cause.
+      for (const line of initial) controller.enqueue(encoder.encode(line));
+      timer = setInterval(() => {
+        const current = deps.supervisor.logs(short);
+        if (current === undefined) {
+          // Module went away (uninstalled / never-supervised) — end the stream.
+          if (timer) clearInterval(timer);
+          try {
+            controller.close();
+          } catch {
+            // already closed
+          }
+          return;
+        }
+        // The ring buffer may have dropped old lines off the front; only
+        // forward genuinely-new tail lines. If the buffer shrank below our
+        // cursor (eviction), reset to its current length to avoid replaying.
+        if (current.length < lastLen) lastLen = current.length;
+        for (let i = lastLen; i < current.length; i++) {
+          const line = current[i];
+          if (line !== undefined) controller.enqueue(encoder.encode(line));
+        }
+        lastLen = current.length;
+      }, 500);
+    },
+    cancel() {
+      // Stop polling when the consumer disconnects.
+      if (timer) clearInterval(timer);
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/plain; charset=utf-8", "cache-control": "no-store" },
+  });
+}
+
+/**
  * POST /api/modules/:short/upgrade — async.
  *
  * Runs `bun add -g @openparachute/<svc>@latest` then restarts the

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -795,7 +795,7 @@ export async function handleStart(
     ...(deps.spawnEnv ? { extraEnv: deps.spawnEnv } : {}),
   });
 
-  const state = await deps.supervisor.start(spawnReq as SpawnRequest);
+  const state = await deps.supervisor.start(spawnReq);
   return jsonOk({ short, state });
 }
 
@@ -940,6 +940,9 @@ function streamModuleLogs(
         // The ring buffer may have dropped old lines off the front; only
         // forward genuinely-new tail lines. If the buffer shrank below our
         // cursor (eviction), reset to its current length to avoid replaying.
+        // Limitation: new lines written during a heavy eviction burst (a chatty
+        // module overflowing the 64KiB cap between two polls) may be skipped in
+        // the live tail — use the one-shot snapshot (no ?follow) for crash investigation.
         if (current.length < lastLen) lastLen = current.length;
         for (let i = lastLen; i < current.length; i++) {
           const line = current[i];

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -1,5 +1,4 @@
 import { existsSync, openSync, readFileSync } from "node:fs";
-import { Socket } from "node:net";
 import { join } from "node:path";
 import {
   MissingDependencyError,
@@ -22,6 +21,7 @@ import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { HUB_ORIGIN_ENV, deriveHubOrigin } from "../hub-origin.ts";
 import { ModuleManifestError, readModuleManifest } from "../module-manifest.ts";
 import { type OperatorIssuerHealStatus, selfHealOperatorTokenIssuer } from "../operator-token.ts";
+import { type PortListeningFn, defaultPortListening } from "../port-probe.ts";
 import {
   type AliveFn,
   clearPid,
@@ -98,42 +98,16 @@ export type KillFn = (pid: number, signal: NodeJS.Signals | number) => void;
 export type SleepFn = (ms: number) => Promise<void>;
 
 /**
- * "Is something listening on this TCP port on loopback?" seam. Pairs with the
- * spawn-then-die settle (hub#194) to catch the *other* silent-start failure
- * shape (hub#487): a service that lives long enough to clear the liveness
- * check but never binds its port because the port is already held (EADDRINUSE
- * from an orphan). The recorded pid stays alive (vault's process supervisor
- * retries / lingers) so `alive(pid)` says "running" while `parachute status`
- * shows it inactive because nothing answers on the port.
- *
- * Tests inject a deterministic stub; production uses `defaultPortListening`.
+ * Port-readiness probe seam + its production impl now live in `port-probe.ts`
+ * (design 2026-06-01 §6.5) so the supervisor can share the exact same TCP
+ * connect-probe without dragging lifecycle's heavy import graph. Re-exported
+ * here so this module's public API (and its tests) are unchanged. Pairs with
+ * the spawn-then-die settle (hub#194) to catch the alive-but-never-bound shape
+ * (hub#487): a service that clears the liveness check but never binds its port
+ * because it's already held — `alive(pid)` says "running" while `status` shows
+ * it inactive because nothing answers on the port.
  */
-export type PortListeningFn = (port: number) => Promise<boolean>;
-
-/**
- * Connect-probe: open a TCP socket to 127.0.0.1:<port> and see if it's
- * accepted. A successful connect means *something* is listening; we close
- * immediately. Connection refused / timeout means nothing is bound yet.
- * `node:net` rather than `Bun.connect` because the latter has no clean
- * "connection refused → false" without a custom socket handler, and the net
- * Socket's `error`/`connect` events map directly onto the boolean we want.
- */
-export const defaultPortListening: PortListeningFn = (port) =>
-  new Promise((resolve) => {
-    const socket = new Socket();
-    let settled = false;
-    const done = (listening: boolean) => {
-      if (settled) return;
-      settled = true;
-      socket.destroy();
-      resolve(listening);
-    };
-    socket.setTimeout(1000);
-    socket.once("connect", () => done(true));
-    socket.once("timeout", () => done(false));
-    socket.once("error", () => done(false));
-    socket.connect(port, "127.0.0.1");
-  });
+export { type PortListeningFn, defaultPortListening };
 
 /**
  * Group-aware liveness: returns true if the process group (pgid == pid)

--- a/src/commands/serve-boot.ts
+++ b/src/commands/serve-boot.ts
@@ -157,6 +157,13 @@ export async function bootSupervisedModules(
       ...(opts.hubOrigin !== undefined ? { hubOrigin: opts.hubOrigin } : {}),
     });
 
+    // Serial await, not Promise.all: `supervisor.start` now carries a bounded
+    // post-spawn port-readiness gate (DEFAULT_START_READY_MS), so boot latency
+    // is the SUM of each slow-binding module's gate wait before `Bun.serve`
+    // comes up. Intentional — sequential boot keeps the start-error/install-card
+    // surface ordered and avoids a thundering-herd of port probes. Don't switch
+    // to `Promise.all` without accounting for the gate (it'd overlap the waits
+    // but also fire N concurrent readiness probes mid-boot).
     await supervisor.start(req);
     log(`[supervisor] ${short}: started (cmd=${cmd.join(" ")}).`);
     results.push({ short, entryName: entry.name, status: "started" });

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -143,6 +143,7 @@ import { handleApiModulesConfig, parseModulesConfigPath } from "./api-modules-co
 import {
   getDefaultOperationsRegistry,
   handleInstall,
+  handleLogs,
   handleOperationGet,
   handleRestart,
   handleStart,
@@ -1875,6 +1876,8 @@ export function hubFetch(
           return handleStop(req, match.short, opsDeps);
         case "restart":
           return handleRestart(req, match.short, opsDeps);
+        case "logs":
+          return handleLogs(req, match.short, opsDeps);
         case "upgrade":
           return handleUpgrade(req, match.short, opsDeps);
         case "uninstall":

--- a/src/module-ops-client.ts
+++ b/src/module-ops-client.ts
@@ -234,6 +234,56 @@ async function pollOperation(
   }
 }
 
+/** Terminal shape returned by {@link fetchModuleLogs}. */
+export interface ModuleLogsResult {
+  /** The short name the logs belong to. */
+  readonly short: string;
+  /** Buffered lines, oldest-first (each includes its trailing newline). */
+  readonly lines: string[];
+  /** The same lines joined — the tail-blob shape `parachute logs` will print. */
+  readonly text: string;
+}
+
+/**
+ * Read a supervised module's recent output from the hub's per-module ring
+ * buffer (`GET /api/modules/:short/logs`, §6.5). Additive — this does NOT wire
+ * into the `parachute logs` CLI command (that cutover is Phase 3); it's the
+ * transport+credential seam Phase 3 will call.
+ *
+ * Reuses the same operator.token→Bearer path as {@link driveModuleOp} (read,
+ * never mint). The buffer replay includes the boot/crash lines that preceded
+ * the call — the must-have that a connect-time stream would miss.
+ *
+ * Throws:
+ *   - {@link NoOperatorTokenError} — no operator.token on disk.
+ *   - {@link OperatorTokenExpiredError} — token fully expired (actionable msg).
+ *   - {@link ModuleOpHttpError} — hub answered non-2xx (e.g. `not_supervised`).
+ */
+export async function fetchModuleLogs(
+  short: string,
+  deps: DriveModuleOpDeps,
+): Promise<ModuleLogsResult> {
+  const doFetch = deps.fetch ?? fetch;
+  const baseUrl = (deps.baseUrl ?? DEFAULT_HUB_BASE_URL).replace(/\/+$/, "");
+  const bearer = await resolveOperatorBearer(deps);
+
+  const res = await doFetch(`${baseUrl}/api/modules/${short}/logs`, {
+    method: "GET",
+    headers: { authorization: `Bearer ${bearer}` },
+  });
+  const body = await parseJsonSafe(res);
+  if (res.status < 200 || res.status >= 300) {
+    const { error, error_description } = asErrorBody(body);
+    throw new ModuleOpHttpError(res.status, error, error_description);
+  }
+  const b = (body ?? {}) as { lines?: unknown; text?: unknown };
+  const lines = Array.isArray(b.lines)
+    ? b.lines.filter((l): l is string => typeof l === "string")
+    : [];
+  const text = typeof b.text === "string" ? b.text : lines.join("");
+  return { short, lines, text };
+}
+
 async function parseJsonSafe(res: Response): Promise<unknown> {
   try {
     return await res.json();

--- a/src/port-probe.ts
+++ b/src/port-probe.ts
@@ -1,0 +1,50 @@
+/**
+ * Loopback TCP-port readiness probe — the tiny "is something listening on
+ * 127.0.0.1:<port>?" primitive shared by the detached `commands/lifecycle.ts`
+ * start path and the in-process `supervisor.ts` (design 2026-06-01 §6.5).
+ *
+ * Factored out of `lifecycle.ts` so the supervisor can reach the probe without
+ * importing all of lifecycle's heavy graph (hub-db, operator-token,
+ * services-manifest, …) into a module that hub-server / proxy-state / the
+ * module-ops API all depend on. `lifecycle.ts` re-exports `defaultPortListening`
+ * + `PortListeningFn` so its public API is unchanged; both files share THIS
+ * one implementation, so they can't drift.
+ *
+ * `node:net` rather than `Bun.connect` because the latter has no clean
+ * "connection refused → false" without a custom socket handler, and the net
+ * Socket's `error`/`connect` events map directly onto the boolean we want.
+ */
+
+import { Socket } from "node:net";
+
+/**
+ * "Is something listening on this TCP port on loopback?" seam. Pairs with the
+ * spawn-then-die settle to catch the alive-but-never-bound failure shape
+ * (hub#487): a service that lives long enough to clear a liveness check but
+ * never binds its port (port already held by an orphan / a bun-linked
+ * resolution failure that lingers). Tests inject a deterministic stub;
+ * production uses {@link defaultPortListening}.
+ */
+export type PortListeningFn = (port: number) => Promise<boolean>;
+
+/**
+ * Connect-probe: open a TCP socket to 127.0.0.1:<port> and see if it's
+ * accepted. A successful connect means *something* is listening; we close
+ * immediately. Connection refused / timeout means nothing is bound yet.
+ */
+export const defaultPortListening: PortListeningFn = (port) =>
+  new Promise((resolve) => {
+    const socket = new Socket();
+    let settled = false;
+    const done = (listening: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(listening);
+    };
+    socket.setTimeout(1000);
+    socket.once("connect", () => done(true));
+    socket.once("timeout", () => done(false));
+    socket.once("error", () => done(false));
+    socket.connect(port, "127.0.0.1");
+  });

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -722,15 +722,6 @@ const defaultSpawnFn: SpawnFn = (req) => {
 };
 
 /**
- * Production group-aware kill (hub#88). Sends `signal` to the entire process
- * group rooted at `pid` (the negative-pid syscall) so a wrapped startCmd's
- * grandchildren are reaped alongside the wrapper. Mirrors
- * `commands/lifecycle.ts`'s `defaultKill`: on ESRCH the group is already gone
- * (or the child predates the detached-spawn change and has no group with that
- * pgid) — fall back to a bare-pid signal so the caller's intent still lands
- * when there's a positive-pid process to receive it.
- */
-/**
  * Map a depcheck `MissingDependencyWire` onto the `ModuleStartError` shape
  * recorded on `ModuleState` (§6.5), stamping `at`. The wire's field names
  * already match (binary / why / docs_url / install / sysadmin_hint), so this
@@ -751,6 +742,15 @@ function startErrorFromWire(wire: MissingDependencyWire, now: () => number): Mod
   };
 }
 
+/**
+ * Production group-aware kill (hub#88). Sends `signal` to the entire process
+ * group rooted at `pid` (the negative-pid syscall) so a wrapped startCmd's
+ * grandchildren are reaped alongside the wrapper. Mirrors
+ * `commands/lifecycle.ts`'s `defaultKill`: on ESRCH the group is already gone
+ * (or the child predates the detached-spawn change and has no group with that
+ * pgid) — fall back to a bare-pid signal so the caller's intent still lands
+ * when there's a positive-pid process to receive it.
+ */
 export const defaultKillGroup: KillFn = (pid, signal) => {
   try {
     process.kill(-pid, signal);

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -98,6 +98,16 @@ export interface SupervisorOpts {
    */
   readonly output?: (line: string) => void;
   /**
+   * Cap, in bytes, of the per-module log ring buffer (§6.5). The supervisor
+   * keeps the most-recent ~`logBufferBytes` of each child's output so a
+   * `GET /api/modules/:short/logs` tap can replay the boot/crash lines that
+   * happened *before* the reader connected — the detached path got this for
+   * free via the per-service logfile; the supervisor streams-and-discards, so
+   * without a buffer the crash cause (the most important line) is lost. The
+   * oldest whole lines are dropped once the cap is exceeded. Default 64 KiB.
+   */
+  readonly logBufferBytes?: number;
+  /**
    * Test seam over `Bun.spawn`. Returns a Subprocess-shaped handle.
    */
   readonly spawnFn?: SpawnFn;
@@ -152,6 +162,44 @@ const DEFAULT_MAX_RESTARTS = 3;
 const DEFAULT_RESTART_WINDOW_MS = 60_000;
 const DEFAULT_RESTART_DELAY_MS = 500;
 const DEFAULT_KILL_TIMEOUT_MS = 5_000;
+const DEFAULT_LOG_BUFFER_BYTES = 64 * 1024;
+
+/**
+ * Bounded, line-oriented ring buffer (§6.5). Holds the most-recent lines of a
+ * module's output up to `maxBytes`; pushing past the cap drops whole lines
+ * from the front (oldest-first) until it fits. Bounding by bytes (not line
+ * count) keeps a chatty module from pinning unbounded memory regardless of
+ * line length. Each pushed string is already a single prefixed line from
+ * `pumpLines` (it includes its trailing newline).
+ */
+export class LogRingBuffer {
+  private readonly lines: string[] = [];
+  private bytes = 0;
+
+  constructor(private readonly maxBytes: number) {}
+
+  push(line: string): void {
+    this.lines.push(line);
+    this.bytes += Buffer.byteLength(line);
+    // Drop oldest whole lines until we're back under the cap. A single line
+    // larger than the cap is kept (we never split a line) — the alternative
+    // (dropping it) would lose exactly the long stack-trace we most want.
+    while (this.bytes > this.maxBytes && this.lines.length > 1) {
+      const dropped = this.lines.shift();
+      if (dropped !== undefined) this.bytes -= Buffer.byteLength(dropped);
+    }
+  }
+
+  /** Snapshot of the buffered lines, oldest-first. */
+  snapshot(): string[] {
+    return [...this.lines];
+  }
+
+  /** Buffered lines joined into a single string (the wire/tail shape). */
+  text(): string {
+    return this.lines.join("");
+  }
+}
 
 /**
  * Per-module supervisor. Owns the spawn → watch → restart loop.
@@ -174,6 +222,7 @@ export class Supervisor {
       restartDelayMs: opts.restartDelayMs ?? DEFAULT_RESTART_DELAY_MS,
       killTimeoutMs: opts.killTimeoutMs ?? DEFAULT_KILL_TIMEOUT_MS,
       output: opts.output ?? ((line) => process.stdout.write(line)),
+      logBufferBytes: opts.logBufferBytes ?? DEFAULT_LOG_BUFFER_BYTES,
       spawnFn: opts.spawnFn ?? defaultSpawnFn,
       killFn: opts.killFn ?? defaultKillGroup,
       now: opts.now ?? Date.now,
@@ -193,6 +242,9 @@ export class Supervisor {
       return existing.state;
     }
     // Crashed → operator intent is "try again." Wipe the budget.
+    // A fresh ring buffer per entry — `start` is a clean spawn (the crash-
+    // respawn path in `handleExit` reuses the existing entry + buffer, so a
+    // crashed module's boot/crash lines survive into the restart for replay).
     const entry: ModuleEntry = {
       req,
       state: {
@@ -201,6 +253,7 @@ export class Supervisor {
         restartsInWindow: 0,
       },
       crashStamps: [],
+      logs: new LogRingBuffer(this.opts.logBufferBytes),
     };
     this.modules.set(req.short, entry);
     this.spawnAndWatch(entry);
@@ -319,7 +372,7 @@ export class Supervisor {
       pid: proc.pid,
       startedAt: new Date(this.opts.now()).toISOString(),
     };
-    this.pipeOutput(entry.req.short, proc);
+    this.pipeOutput(entry, proc);
     void proc.exited.then((exitCode) => this.handleExit(entry, exitCode));
   }
 
@@ -374,16 +427,34 @@ export class Supervisor {
   }
 
   /**
-   * Tap a child's stdout + stderr into the supervisor's `output`
-   * callback (hub's stdout by default), prefixing each line with the
-   * module's short name. Line-buffered: partial chunks accumulate
-   * until a newline arrives so multi-byte log lines don't get
-   * scrambled across modules.
+   * Recent buffered output for a supervised module (§6.5), oldest-first, each
+   * element a prefixed line. Returns `undefined` for a module that isn't
+   * supervised (no entry) so a `GET /api/modules/:short/logs` handler can
+   * distinguish "not supervised" (404) from "supervised but quiet" (empty
+   * array). Survives a crash-respawn (same entry/buffer), so the boot/crash
+   * lines that preceded the reader connecting are replayable — the whole point.
    */
-  private pipeOutput(short: string, proc: SupervisedProc): void {
-    const prefix = `[${short}] `;
-    if (proc.stdout) void pumpLines(proc.stdout, prefix, this.opts.output);
-    if (proc.stderr) void pumpLines(proc.stderr, prefix, this.opts.output);
+  logs(short: string): string[] | undefined {
+    return this.modules.get(short)?.logs.snapshot();
+  }
+
+  /**
+   * Tap a child's stdout + stderr into the supervisor's `output` callback
+   * (hub's stdout by default) AND the per-module ring buffer (§6.5),
+   * prefixing each line with the module's short name. Line-buffered: partial
+   * chunks accumulate until a newline arrives so multi-byte log lines don't
+   * get scrambled across modules. The buffer is fed the same prefixed lines
+   * the live stream gets, so a later `/logs` tap replays exactly what hub's
+   * stdout already showed.
+   */
+  private pipeOutput(entry: ModuleEntry, proc: SupervisedProc): void {
+    const prefix = `[${entry.req.short}] `;
+    const sink = (line: string): void => {
+      this.opts.output(line);
+      entry.logs.push(line);
+    };
+    if (proc.stdout) void pumpLines(proc.stdout, prefix, sink);
+    if (proc.stderr) void pumpLines(proc.stderr, prefix, sink);
   }
 }
 
@@ -393,6 +464,8 @@ interface ModuleEntry {
   proc?: SupervisedProc;
   crashStamps: number[];
   stopRequested?: boolean;
+  /** Bounded ring buffer of recent prefixed output lines (§6.5). */
+  logs: LogRingBuffer;
 }
 
 async function pumpLines(

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -102,6 +102,17 @@ export interface SupervisorOpts {
    */
   readonly spawnFn?: SpawnFn;
   /**
+   * Group-aware kill seam (hub#88). Production sends the signal to the child's
+   * whole process group (`process.kill(-pid, signal)`) so wrapped startCmds
+   * like `pnpm exec tsx server.ts` reap the tsx grandchild — not just the
+   * wrapper that would otherwise leave the grandchild bound to the port →
+   * EADDRINUSE on restart. Pairs with `defaultSpawnFn`'s `detached: true`
+   * (each child is its own process-group leader, `pid === pgid`). Defaults to
+   * {@link defaultKillGroup}; tests inject a stub so they stay deterministic
+   * (no real signals) and can assert the negative pid (group send) was used.
+   */
+  readonly killFn?: KillFn;
+  /**
    * Test seam over wall-clock. Production passes `Date.now`.
    */
   readonly now?: () => number;
@@ -118,6 +129,12 @@ export interface SupervisorOpts {
  * and pipe-able stdout/stderr.
  */
 export type SpawnFn = (req: SpawnRequest) => SupervisedProc;
+
+/**
+ * Group-aware kill seam. Sends `signal` to the process group rooted at `pid`.
+ * Production uses {@link defaultKillGroup}; tests inject a stub.
+ */
+export type KillFn = (pid: number, signal: NodeJS.Signals | number) => void;
 
 /**
  * The minimal Subprocess shape the supervisor depends on. Bun's real
@@ -158,6 +175,7 @@ export class Supervisor {
       killTimeoutMs: opts.killTimeoutMs ?? DEFAULT_KILL_TIMEOUT_MS,
       output: opts.output ?? ((line) => process.stdout.write(line)),
       spawnFn: opts.spawnFn ?? defaultSpawnFn,
+      killFn: opts.killFn ?? defaultKillGroup,
       now: opts.now ?? Date.now,
       sleep: opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms))),
     };
@@ -216,7 +234,13 @@ export class Supervisor {
     const proc = entry.proc;
     if (proc) {
       try {
-        proc.kill("SIGTERM");
+        // Group-aware kill (hub#88): signal the child's whole process group
+        // via `killFn` (default `defaultKillGroup` → `process.kill(-pid)`) so
+        // a wrapped startCmd's grandchild is reaped too, not just the wrapper.
+        // Mirrors `commands/lifecycle.ts`'s `defaultKill` repointing of
+        // `defaultSpawner`'s detached children. Without it, the grandchild
+        // stays bound to the port → restart hits EADDRINUSE.
+        this.opts.killFn(proc.pid, "SIGTERM");
       } catch {
         // Process may already be dead — fall through.
       }
@@ -234,7 +258,9 @@ export class Supervisor {
             `[supervisor] ${entry.req.short} did not exit ${this.opts.killTimeoutMs}ms after SIGTERM — escalating to SIGKILL.\n`,
           );
           try {
-            proc.kill("SIGKILL");
+            // Group-aware SIGKILL escalation — same `killFn` seam as the
+            // SIGTERM above so the whole group is reaped, not just the leader.
+            this.opts.killFn(proc.pid, "SIGKILL");
           } catch {
             // Process may already be dead between the timeout firing
             // and us reaching kill() — fall through to the await.
@@ -402,7 +428,20 @@ async function pumpLines(
 
 const defaultSpawnFn: SpawnFn = (req) => {
   const spawnOpts: Parameters<typeof Bun.spawn>[1] = {
+    // Keep stdout/stderr explicitly piped — the supervisor pumps child output
+    // into hub's log (`pipeOutput`/`pumpLines`) + the per-module ring buffer.
+    // `detached: true` does NOT detach explicitly-piped stdio, so these stay
+    // wired even though the child gets its own process group below.
     stdio: ["ignore", "pipe", "pipe"],
+    // Spawn in a fresh process group (pid == pgid) so `killFn` (→
+    // `process.kill(-pid, sig)`) reaches every descendant, not just the
+    // wrapper. Without this, wrapped startCmds like `pnpm exec tsx server.ts`
+    // leave the tsx grandchild bound to the port after stop → restart hits
+    // EADDRINUSE (hub#88). Mirrors `commands/lifecycle.ts`'s `defaultSpawner`,
+    // which set `detached: true` for exactly this reason. We do NOT `unref()`:
+    // the supervisor must stay attached for the lifecycle (watch `exited`,
+    // pump output, reap on stop).
+    detached: true,
     // Inherit env so supervised module sees PATH, HOME, PARACHUTE_HOME, etc.
     // Bun.spawn defaults to empty env — see api-modules-ops.ts:defaultRun.
     // Per-call `req.env` overrides merge on top below.
@@ -412,4 +451,22 @@ const defaultSpawnFn: SpawnFn = (req) => {
   if (req.env) spawnOpts.env = { ...process.env, ...req.env };
   const proc = Bun.spawn([...req.cmd], spawnOpts);
   return proc as unknown as SupervisedProc;
+};
+
+/**
+ * Production group-aware kill (hub#88). Sends `signal` to the entire process
+ * group rooted at `pid` (the negative-pid syscall) so a wrapped startCmd's
+ * grandchildren are reaped alongside the wrapper. Mirrors
+ * `commands/lifecycle.ts`'s `defaultKill`: on ESRCH the group is already gone
+ * (or the child predates the detached-spawn change and has no group with that
+ * pgid) — fall back to a bare-pid signal so the caller's intent still lands
+ * when there's a positive-pid process to receive it.
+ */
+export const defaultKillGroup: KillFn = (pid, signal) => {
+  try {
+    process.kill(-pid, signal);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ESRCH") throw err;
+    process.kill(pid, signal);
+  }
 };

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -29,7 +29,36 @@
  * services.json on boot).
  */
 
+import {
+  MissingDependencyError,
+  type MissingDependencyWire,
+  ensureExecutable,
+  rethrowIfMissing,
+} from "@openparachute/depcheck";
+import { type PortListeningFn, defaultPortListening } from "./port-probe.ts";
+
 export type ModuleStatus = "starting" | "running" | "stopped" | "crashed" | "restarting";
+
+/**
+ * Structured start-failure detail recorded onto `ModuleState` (§6.5). Mirrors
+ * depcheck's `MissingDependencyWire` for the missing-dependency case and the
+ * services.json-row `ServiceEntryStartError` shape `commands/lifecycle.ts`
+ * records, so `status` / the SPA keep the SAME friendly missing-dependency
+ * surface whether a module was started via the detached path or the
+ * supervisor. `error_type` is left open for a future non-dependency failure.
+ */
+export interface ModuleStartError {
+  readonly error_type: string;
+  readonly error_description: string;
+  /** Present for `error_type: "missing_dependency"`. */
+  readonly binary?: string;
+  readonly why?: string | null;
+  readonly docs_url?: string | null;
+  readonly install?: { darwin?: string; linux?: string; generic?: string };
+  readonly sysadmin_hint?: string;
+  /** ISO timestamp of when the failure was recorded. */
+  readonly at: string;
+}
 
 export interface ModuleState {
   /** Short name (vault / notes / scribe / …). */
@@ -46,6 +75,15 @@ export interface ModuleState {
   readonly lastCrashAt?: string;
   /** Exit code of the most recent crash. */
   readonly lastExitCode?: number | null;
+  /**
+   * Structured start-failure detail (§6.5). Set when a preflight
+   * `MissingDependencyError` aborts the spawn, OR when a spawned child stays
+   * alive but never binds its port within the readiness window
+   * (started-but-unbound, hub#487). Cleared on a clean, port-confirmed start.
+   * The `status` enum is intentionally NOT extended (proxy-state Mode-1 + the
+   * SPA read `running`); this field carries the friendly diagnostic instead.
+   */
+  readonly startError?: ModuleStartError;
 }
 
 export interface SpawnRequest {
@@ -131,6 +169,40 @@ export interface SupervisorOpts {
    * with `setTimeout`. Tests stub to advance time deterministically.
    */
   readonly sleep?: (ms: number) => Promise<void>;
+  /**
+   * Port-readiness probe (§6.5). After a child spawns, the supervisor polls
+   * this until the module's port (from `req.env.PORT`) binds, to catch the
+   * alive-but-never-bound shape (hub#487). Defaults to `defaultPortListening`
+   * (a loopback TCP connect). Tests inject a deterministic stub.
+   *
+   * Defaulting policy (mirrors `commands/lifecycle.ts`): the readiness gate is
+   * SKIPPED unless this is the production path (no `spawnFn` override) OR a
+   * test explicitly opts in by injecting `portListening` / `startReadyMs`.
+   * Without that guard, every existing stub-spawner test (fake procs that
+   * never bind a real port) would block the full readiness window.
+   */
+  readonly portListening?: PortListeningFn;
+  /**
+   * How long the post-spawn port-readiness gate polls before recording a
+   * `started-but-unbound` start-error, in ms. Default 4000 on the production
+   * path; 0 (skipped) on the stub-spawner test path unless `portListening` /
+   * `startReadyMs` is set explicitly.
+   */
+  readonly startReadyMs?: number;
+  /** Poll interval while waiting for the port to bind, in ms. Default 200. */
+  readonly startReadyPollMs?: number;
+  /**
+   * PATH-resolution seam for the pre-spawn `ensureExecutable` preflight
+   * (`@openparachute/depcheck`). Production uses the real `Bun.which`; a
+   * missing startCmd binary then aborts the spawn with a structured
+   * `MissingDependencyError` recorded onto `ModuleState.startError`.
+   *
+   * Defaulting policy mirrors the readiness gate: a stub `spawnFn` (test path)
+   * gets a permissive resolver so the preflight doesn't trip on binaries
+   * absent from the test host's PATH; production gets the real `Bun.which`.
+   * Tests exercising the missing-binary branch inject `which: () => null`.
+   */
+  readonly which?: (cmd: string) => string | null;
 }
 
 /**
@@ -163,6 +235,8 @@ const DEFAULT_RESTART_WINDOW_MS = 60_000;
 const DEFAULT_RESTART_DELAY_MS = 500;
 const DEFAULT_KILL_TIMEOUT_MS = 5_000;
 const DEFAULT_LOG_BUFFER_BYTES = 64 * 1024;
+const DEFAULT_START_READY_MS = 4_000;
+const DEFAULT_START_READY_POLL_MS = 200;
 
 /**
  * Bounded, line-oriented ring buffer (§6.5). Holds the most-recent lines of a
@@ -216,6 +290,14 @@ export class Supervisor {
   private readonly modules = new Map<string, ModuleEntry>();
 
   constructor(opts: SupervisorOpts = {}) {
+    // Defaulting policy for the port-readiness gate + preflight (§6.5),
+    // mirroring `commands/lifecycle.ts`: production (no `spawnFn` override) gets
+    // the real 4s readiness window + `Bun.which` preflight. The stub-spawner
+    // test path gets 0 (skipped) + a permissive `which` UNLESS a test opts in
+    // explicitly (injecting `portListening` / `startReadyMs` / `which`) — so
+    // existing fake-proc tests (which never bind a real port) don't block.
+    const isProductionPath = opts.spawnFn === undefined;
+    const readinessOptedIn = opts.portListening !== undefined || opts.startReadyMs !== undefined;
     this.opts = {
       maxRestarts: opts.maxRestarts ?? DEFAULT_MAX_RESTARTS,
       restartWindowMs: opts.restartWindowMs ?? DEFAULT_RESTART_WINDOW_MS,
@@ -227,6 +309,11 @@ export class Supervisor {
       killFn: opts.killFn ?? defaultKillGroup,
       now: opts.now ?? Date.now,
       sleep: opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms))),
+      portListening: opts.portListening ?? defaultPortListening,
+      startReadyMs:
+        opts.startReadyMs ?? (isProductionPath || readinessOptedIn ? DEFAULT_START_READY_MS : 0),
+      startReadyPollMs: opts.startReadyPollMs ?? DEFAULT_START_READY_POLL_MS,
+      which: opts.which ?? (isProductionPath ? Bun.which : () => "/stub/bin/preflight-skipped"),
     };
   }
 
@@ -256,8 +343,112 @@ export class Supervisor {
       logs: new LogRingBuffer(this.opts.logBufferBytes),
     };
     this.modules.set(req.short, entry);
-    this.spawnAndWatch(entry);
+
+    // Pre-spawn preflight (§6.5): resolve the startCmd binary on PATH before
+    // spawning a doomed child. A missing binary records a structured
+    // `MissingDependencyError` onto state (the same friendly missing-dependency
+    // surface `commands/lifecycle.ts` records) and aborts — no spawn. Mirrors
+    // `lifecycle.start`'s `ensureExecutable` preflight.
+    const startBinary = req.cmd[0];
+    if (startBinary) {
+      try {
+        ensureExecutable(startBinary, { which: this.opts.which });
+      } catch (err) {
+        if (err instanceof MissingDependencyError) {
+          entry.state = {
+            ...entry.state,
+            status: "crashed",
+            pid: undefined,
+            startError: startErrorFromWire(err.toWire(), this.opts.now),
+          };
+          return entry.state;
+        }
+        throw err;
+      }
+    }
+
+    // Belt-and-suspenders for a spawn that slips past the preflight (binary
+    // removed between check + spawn, or a path that didn't preflight): a
+    // not-found spawn throw becomes the same structured MissingDependencyError
+    // recorded onto state, not a throw out of `start`. Mirrors
+    // `lifecycle.start`'s `rethrowIfMissing` catch.
+    try {
+      this.spawnAndWatch(entry);
+    } catch (err) {
+      if (startBinary) {
+        try {
+          rethrowIfMissing(err, startBinary);
+        } catch (missing) {
+          if (missing instanceof MissingDependencyError) {
+            entry.state = {
+              ...entry.state,
+              status: "crashed",
+              pid: undefined,
+              startError: startErrorFromWire(missing.toWire(), this.opts.now),
+            };
+            return entry.state;
+          }
+        }
+      }
+      throw err;
+    }
+
+    // Post-spawn port-readiness gate (§6.5, hub#487). A returned pid only
+    // proves the kernel forked the process; it says nothing about whether the
+    // module bound its port. Poll the port (from req.env.PORT) up to
+    // `startReadyMs`. On success: clear any prior startError. On timeout while
+    // the child is still alive: record a `started-but-unbound` structured
+    // start-error WITHOUT touching the `running` status enum (proxy-state
+    // Mode-1 + the SPA read `running`) — the friendly diagnostic rides the
+    // startError field. A child that died during the window is left to the
+    // crash watcher (`handleExit`), which owns the restart budget.
+    await this.awaitPortReadiness(entry);
     return entry.state;
+  }
+
+  /**
+   * Poll the module's port until it binds or `startReadyMs` elapses (§6.5).
+   * Skipped when the gate is disabled (stub-spawner test path) or the request
+   * carries no `PORT`. Records / clears `state.startError` accordingly; never
+   * mutates `state.status` (see `start`).
+   */
+  private async awaitPortReadiness(entry: ModuleEntry): Promise<void> {
+    if (this.opts.startReadyMs <= 0) return;
+    const portStr = entry.req.env?.PORT;
+    const port = portStr ? Number(portStr) : Number.NaN;
+    if (!Number.isFinite(port) || port <= 0) return; // No port to probe.
+
+    const deadline = this.opts.now() + this.opts.startReadyMs;
+    while (this.opts.now() < deadline) {
+      // The child may have crashed during the window — `handleExit` owns that
+      // (budget / restart). Stop probing; don't overwrite a crash with a
+      // port-readiness verdict.
+      if (entry.stopRequested || entry.state.status !== "running") return;
+      if (await this.opts.portListening(port)) {
+        // Bound → healthy. Clear any stale started-but-unbound error.
+        if (entry.state.startError) {
+          const { startError: _drop, ...rest } = entry.state;
+          entry.state = rest;
+        }
+        return;
+      }
+      await this.opts.sleep(this.opts.startReadyPollMs);
+    }
+
+    // Window elapsed, still alive but never bound — record the structured
+    // started-but-unbound error so `status` / the SPA show why, not a silently
+    // healthy `running`. Keep `running` (the process IS up); the diagnostic is
+    // the startError field.
+    if (entry.state.status === "running" && !entry.stopRequested) {
+      entry.state = {
+        ...entry.state,
+        startError: {
+          error_type: "started_but_unbound",
+          error_description: `${entry.req.short} started (pid ${entry.state.pid}) but is not listening on port ${port} after ${this.opts.startReadyMs}ms — it may still be coming up, or the port is held by another process.`,
+          at: new Date(this.opts.now()).toISOString(),
+        },
+      };
+    }
   }
 
   /**
@@ -366,8 +557,12 @@ export class Supervisor {
   private spawnAndWatch(entry: ModuleEntry): void {
     const proc = this.opts.spawnFn(entry.req);
     entry.proc = proc;
+    // Clear any stale startError from a prior attempt — a fresh running pid is
+    // the new ground truth; the readiness gate re-records if it still doesn't
+    // bind.
+    const { startError: _drop, ...prev } = entry.state;
     entry.state = {
-      ...entry.state,
+      ...prev,
       status: "running",
       pid: proc.pid,
       startedAt: new Date(this.opts.now()).toISOString(),
@@ -535,6 +730,27 @@ const defaultSpawnFn: SpawnFn = (req) => {
  * pgid) — fall back to a bare-pid signal so the caller's intent still lands
  * when there's a positive-pid process to receive it.
  */
+/**
+ * Map a depcheck `MissingDependencyWire` onto the `ModuleStartError` shape
+ * recorded on `ModuleState` (§6.5), stamping `at`. The wire's field names
+ * already match (binary / why / docs_url / install / sysadmin_hint), so this
+ * is a stamp + passthrough — keeping the supervisor's start-error surface
+ * identical to the services.json `ServiceEntryStartError` the detached path
+ * records, so the SPA renders the same install card from either source.
+ */
+function startErrorFromWire(wire: MissingDependencyWire, now: () => number): ModuleStartError {
+  return {
+    error_type: wire.error_type,
+    error_description: wire.error_description,
+    binary: wire.binary,
+    why: wire.why,
+    docs_url: wire.docs_url,
+    install: wire.install,
+    sysadmin_hint: wire.sysadmin_hint,
+    at: new Date(now()).toISOString(),
+  };
+}
+
 export const defaultKillGroup: KillFn = (pid, signal) => {
   try {
     process.kill(-pid, signal);


### PR DESCRIPTION
**Phase 2a of the hub-as-supervisor unification** ([design 2026-06-01 §6.1 + §6.5](../parachute.computer/design/2026-06-01-hub-as-supervisor-unification.md)) — supervisor hardening, the correctness-critical changes that MUST land before the Phase-3 cutover. **Additive — no command cutover, no version bump; blocks Phase 3 per §6.1.** It only improves the already-live `serve`/Supervisor path (container-safe); it does NOT touch `lifecycle.ts` start/stop/restart, does NOT wire the supervisor into `parachute start/stop/restart <svc>`, and does NOT touch `connector-service.ts` (separate later PR).

## Change 1 — Process-group reaping (§6.1) — the load-bearing fix
`defaultSpawnFn` spawned **attached with no process group** and `stop()` signalled the **leader only**. For a wrapped startCmd (e.g. `sh -c 'tsx server.ts'`) the grandchild stayed bound to the port after stop → restart hit **EADDRINUSE** — re-opening hub#88, which the detached `lifecycle.ts` path fixed via `detached:true`+`kill(-pid)`.

- `defaultSpawnFn` gains `detached: true` (each module its own process-group leader, `pid===pgid`); **stdio stays explicitly piped** so `pipeOutput`/`pumpLines` keep working (`detached` doesn't detach explicit pipes); **no `unref()`** (supervisor stays attached for lifecycle).
- New **`killFn` seam** on `SupervisorOpts`, defaulting to `defaultKillGroup` (`process.kill(-pid, sig)` with the same **ESRCH→bare-pid fallback** as `lifecycle.defaultKill`). `stop()`'s two `proc.kill` sites route through it with the leader pid; `restart()` inherits via `stop()`.

**Regression test:** a real-process round-trip — `sh -c` wrapper backgrounds a real `bun` grandchild holding a real ephemeral port → `restart` re-binds the **same** port, and the port **frees** after a final stop (the discriminating orphan-leak signal). Plus a deterministic seam check (stop signals with the leader pid) and a `defaultKillGroup` unit test (group send → ESRCH → bare-pid fallback; non-ESRCH propagates). See "flagged decisions" below for why both real + stub.

## Change 2 — Per-module log ring buffer (§6.5)
`pumpLines` streamed child output and **discarded** it, so a `/logs` tap could only show output from connect-time forward — losing the boot/crash lines (the exit cause).

- `LogRingBuffer`: bounded (default **64 KiB**, drops oldest whole lines), one per `ModuleEntry`, fed by `pipeOutput` alongside the existing `output` write. Survives a crash-respawn (same entry) so the crash cause stays replayable.
- `Supervisor.logs(short)` → buffered lines (`undefined` when not supervised → the 404 contract).
- **`GET /api/modules/:short/logs`** (host-admin gated, same `authorize()` as start/stop; wired into the dispatch next to start/stop) — replays the buffer as `{ short, lines, text }`; not-supervised → `404 not_supervised` (matches `restart`'s contract). `?follow=1` is a best-effort `text/plain` tail (buffer replay first — the must-have — then polled new lines).
- **`fetchModuleLogs(short, deps)`** client fn — additive, reuses the `operator.token`→Bearer path; **NOT** wired into the `parachute logs` CLI (Phase 3).

**Tests:** buffer replays pre-connect lines, is bounded, returns undefined when not supervised, survives crash-respawn; endpoint auth gates + 404 + replay + follow-stream; client GET+Bearer + error mapping.

## Change 3 — Post-spawn port-readiness + structured start-error (§6.5)
The supervisor marked a module `running` the instant `Bun.spawn` returned a pid — no port check, no preflight. A spawn-but-never-bind (hub#487) showed `running` while unreachable, with no structured cause.

- Factored the loopback TCP connect-probe out of `lifecycle.ts` into **`port-probe.ts`** (`node:net` only); `lifecycle.ts` re-exports `defaultPortListening`/`PortListeningFn` (public API + its tests unchanged). Reason: importing `lifecycle.ts` into the supervisor would drag its heavy graph (hub-db, operator-token, …) into a module hub-server/proxy-state/the module-ops API all import. The probe is now shared by one impl — can't drift.
- New seams on `SupervisorOpts`: `portListening` (default `defaultPortListening`), `startReadyMs`/`startReadyPollMs`, and a `which` preflight seam — all with `lifecycle.ts`'s defaulting policy (production gets the real 4s gate + `Bun.which`; the stub-spawner test path skips unless a test opts in, so existing fake-proc tests don't block).
- `start()`: `ensureExecutable` **preflight before spawn** (missing binary → structured `MissingDependencyError` on state, **no doomed spawn**) + `rethrowIfMissing` belt-and-suspenders; then a **bounded post-spawn port-readiness gate**. On timeout-while-alive it records a structured **`started_but_unbound`** start-error onto `ModuleState.startError` **WITHOUT touching the `running` status enum** (proxy-state Mode-1 + the SPA read `running`); a clean port-confirmed (re)start clears it. Port read from `req.env.PORT`.
- `ModuleState` gains a `startError` field mirroring depcheck's `MissingDependencyWire` / lifecycle's `ServiceEntryStartError`, so the SPA + `status` keep the same friendly missing-dependency surface from either path.

**Tests:** never-binds → `started_but_unbound` + status still running; binds-promptly → no error; preflight `MissingDependencyError` → structured error + **no spawn**; re-start clears a stale error; no-PORT skips the gate; `port-probe` util (real listening + refused).

## Gates
- `bun test ./src` — **2611 pass / 1 skip / 0 fail** (baseline after Phase 1 was 2587 pass / 1 skip / 0 fail; +24 new tests, **zero pre-existing regressions**).
- `bun run typecheck` — clean.
- `bunx biome check` on every touched file — clean; repo-wide still 23 pre-existing errors, **none in these files**.
- `package.json` untouched (no version bump).

## Flagged for the reviewer
1. **Reaping regression test shape (decision to scrutinize).** The fully-real-process round-trip passes with the fix, but in isolation it did **not** cleanly fail without `detached:true` (platform process-group nuance: a bare-pid kill + `sh`'s default signal handling can still let the grandchild get cleaned up within the 8s window — non-discriminating). Per the spec's "fall back to a faithful stub if the real test is irreducibly flaky," I kept the real round-trip as the happy-path smoke (asserting the port frees after stop) **and** added the deterministic discriminators it asked for: a seam check that `stop` signals the **leader pid** (which production turns into a group send) + a `defaultKillGroup` unit test proving the `-pid` group send with ESRCH→bare-pid fallback. The deterministic pair is the real guard.
2. **`running`-vs-substate choice for port-readiness.** I took the spec's default (structured `startError` field, do **not** extend the `ModuleStatus` enum) rather than a distinct `started-but-unbound` status, to avoid breaking the `running` consumers (proxy-state Mode-1, the SPA, `api-ready`).
3. **`port-probe.ts` extraction** instead of importing `defaultPortListening` from `lifecycle.ts` — to keep the supervisor's import graph light (it's imported by hub-server/proxy-state/api-modules/api-ready). `lifecycle.ts` re-exports so nothing downstream changed.
4. Existing supervisor + `makeIdleSupervisor` (api-modules-ops) tests were **adapted to the `killFn` seam** (not deleted) — they now inject a recorder/forwarder so the fakes' exit-on-kill still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
