### PR TITLE
feat(hub): Phase 3a — ensure-hub-unit helper + init installs/starts the hub unit (supervisor unification cutover)

### DIFF
--- a/src/__tests__/hub-unit.test.ts
+++ b/src/__tests__/hub-unit.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type HubUnitDeps,
+  NO_MANAGER_MESSAGE,
+  NO_UNIT_MESSAGE,
+  ensureHubUnit,
+  installAndStartHubUnit,
+} from "../hub-unit.ts";
+import {
+  type ServiceCommandResult,
+  launchdPlistPathForLabel,
+  systemdUnitPathForName,
+} from "../managed-unit.ts";
+
+const HUB_LABEL = "computer.parachute.hub";
+const HUB_UNIT = "parachute-hub.service";
+
+interface FakeState {
+  deps: HubUnitDeps;
+  calls: string[][];
+  files: Map<string, string>;
+}
+
+/**
+ * Build a fully-stubbed {@link HubUnitDeps}. No launchctl/systemctl/socket/HTTP
+ * call touches the real OS — every side effect is recorded in `calls` / `files`.
+ * `probeHealth` / `portListening` accept arrays so a test can script the
+ * "down at first, up after start" readiness sequence.
+ */
+function fakeDeps(
+  over: Partial<HubUnitDeps> & {
+    runResults?: ServiceCommandResult[];
+    healthSeq?: boolean[];
+    listeningSeq?: boolean[];
+    installedUnit?: boolean;
+  } = {},
+): FakeState {
+  const calls: string[][] = [];
+  const files = new Map<string, string>();
+  let runIdx = 0;
+  let healthIdx = 0;
+  let listeningIdx = 0;
+  const ok: ServiceCommandResult = { code: 0, stdout: "", stderr: "" };
+
+  const platform: NodeJS.Platform = over.platform ?? "linux";
+  const getuid = over.getuid ?? (() => 1000);
+  const homeDir = over.homeDir ?? (() => "/home/op");
+
+  // Optionally seed the unit file so isHubUnitInstalled() sees it.
+  if (over.installedUnit) {
+    const home = homeDir();
+    if (platform === "darwin") {
+      files.set(launchdPlistPathForLabel(HUB_LABEL, home), "<plist/>");
+    } else {
+      const root = (getuid() ?? 1000) === 0;
+      files.set(systemdUnitPathForName(HUB_UNIT, home, root), "[Unit]");
+    }
+  }
+
+  const deps: HubUnitDeps = {
+    platform,
+    getuid,
+    homeDir,
+    userName: over.userName ?? (() => "op"),
+    which:
+      over.which ??
+      ((b) => {
+        if (b === "bun") return "/home/op/.bun/bin/bun";
+        if (b === "launchctl" || b === "systemctl" || b === "loginctl" || b === "journalctl") {
+          return `/usr/bin/${b}`;
+        }
+        return null;
+      }),
+    run:
+      over.run ??
+      ((cmd) => {
+        calls.push([...cmd]);
+        const r = over.runResults?.[runIdx++];
+        return r ?? ok;
+      }),
+    writeFile: over.writeFile ?? ((p, c) => void files.set(p, c)),
+    removeFile: over.removeFile ?? ((p) => void files.delete(p)),
+    readFile: over.readFile ?? ((p) => files.get(p)),
+    exists: over.exists ?? ((p) => files.has(p)),
+    probeHealth:
+      over.probeHealth ??
+      (async () => {
+        const seq = over.healthSeq;
+        if (!seq) return false;
+        return seq[Math.min(healthIdx++, seq.length - 1)] ?? false;
+      }),
+    portListening:
+      over.portListening ??
+      (async () => {
+        const seq = over.listeningSeq;
+        if (!seq) return true;
+        return seq[Math.min(listeningIdx++, seq.length - 1)] ?? false;
+      }),
+    sleep: over.sleep ?? (async () => {}),
+  };
+  return { deps, calls, files };
+}
+
+describe("ensureHubUnit — §3.2 algorithm", () => {
+  test("hub already up: /health 200 → returns already-up, NO manager call", async () => {
+    const f = fakeDeps({ healthSeq: [true] });
+    const res = await ensureHubUnit({ port: 1939, deps: f.deps, readyPollMs: 0 });
+    expect(res.outcome).toBe("already-up");
+    expect(res.port).toBe(1939);
+    // No systemctl/launchctl invocation at all — the probe short-circuited.
+    expect(f.calls).toEqual([]);
+  });
+
+  test("hub down, unit present (systemd user): starts the unit + readiness poll succeeds", async () => {
+    const f = fakeDeps({
+      platform: "linux",
+      getuid: () => 1000,
+      installedUnit: true,
+      healthSeq: [false],
+      listeningSeq: [true],
+    });
+    const res = await ensureHubUnit({ port: 1939, deps: f.deps, readyPollMs: 0 });
+    expect(res.outcome).toBe("started");
+    // systemctl --user start parachute-hub.service was driven.
+    expect(f.calls).toContainEqual(["systemctl", "--user", "start", "parachute-hub.service"]);
+  });
+
+  test("hub down, unit present (systemd root): no --user scope", async () => {
+    const f = fakeDeps({
+      platform: "linux",
+      getuid: () => 0,
+      userName: () => "root",
+      installedUnit: true,
+      healthSeq: [false],
+      listeningSeq: [true],
+    });
+    const res = await ensureHubUnit({ port: 1939, deps: f.deps, readyPollMs: 0 });
+    expect(res.outcome).toBe("started");
+    expect(f.calls).toContainEqual(["systemctl", "start", "parachute-hub.service"]);
+  });
+
+  test("hub down, unit present (launchd): kickstart -k gui/<uid>/<label>", async () => {
+    const f = fakeDeps({
+      platform: "darwin",
+      getuid: () => 501,
+      installedUnit: true,
+      healthSeq: [false],
+      listeningSeq: [true],
+    });
+    const res = await ensureHubUnit({ port: 1939, deps: f.deps, readyPollMs: 0 });
+    expect(res.outcome).toBe("started");
+    expect(f.calls).toContainEqual([
+      "launchctl",
+      "kickstart",
+      "-k",
+      "gui/501/computer.parachute.hub",
+    ]);
+  });
+
+  test("no unit installed → actionable 'run parachute migrate' error, no manager call", async () => {
+    const f = fakeDeps({
+      platform: "linux",
+      installedUnit: false,
+      healthSeq: [false],
+    });
+    const res = await ensureHubUnit({ port: 1939, deps: f.deps, readyPollMs: 0 });
+    expect(res.outcome).toBe("no-unit");
+    expect(res.messages).toContain(NO_UNIT_MESSAGE);
+    // Did NOT try to start anything.
+    expect(f.calls).toEqual([]);
+  });
+
+  test("no manager at all (linux, no systemctl) → actionable foreground-serve message", async () => {
+    const f = fakeDeps({
+      platform: "linux",
+      installedUnit: true, // even with a unit file, no systemctl = no manager
+      healthSeq: [false],
+      which: () => null, // nothing resolvable
+    });
+    const res = await ensureHubUnit({ port: 1939, deps: f.deps, readyPollMs: 0 });
+    expect(res.outcome).toBe("no-manager");
+    expect(res.messages).toContain(NO_MANAGER_MESSAGE);
+    expect(f.calls).toEqual([]);
+  });
+
+  test("readiness timeout: surfaces the unit log (journald), does not hang", async () => {
+    const journalLog = "May 31 hub: boot failed: corrupt hub.db";
+    const f = fakeDeps({
+      platform: "linux",
+      getuid: () => 1000,
+      installedUnit: true,
+      healthSeq: [false],
+      listeningSeq: [false], // never binds
+      run: (cmd) => {
+        // journalctl tail returns the boot error; start returns ok.
+        if (cmd[0] === "journalctl") {
+          return { code: 0, stdout: journalLog, stderr: "" };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      },
+    });
+    const res = await ensureHubUnit({
+      port: 1939,
+      deps: f.deps,
+      readyTimeoutMs: 0, // immediate deadline → one poll then timeout
+      readyPollMs: 0,
+    });
+    expect(res.outcome).toBe("timeout");
+    const joined = res.messages.join("\n");
+    expect(joined).toContain("did not become ready");
+    expect(joined).toContain(journalLog);
+  });
+
+  test("manager start command fails → start-failed with stderr surfaced", async () => {
+    const f = fakeDeps({
+      platform: "linux",
+      getuid: () => 1000,
+      installedUnit: true,
+      healthSeq: [false],
+      run: (cmd) => {
+        if (cmd.includes("start")) {
+          return { code: 1, stdout: "", stderr: "Unit parachute-hub.service not found." };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      },
+    });
+    const res = await ensureHubUnit({ port: 1939, deps: f.deps, readyPollMs: 0 });
+    expect(res.outcome).toBe("start-failed");
+    expect(res.messages.join("\n")).toContain("Unit parachute-hub.service not found.");
+  });
+});
+
+describe("installAndStartHubUnit — init bringup (§3.3 / §4.2)", () => {
+  test("installs the hub unit (start:true) + waits readiness → started", async () => {
+    const f = fakeDeps({
+      platform: "linux",
+      getuid: () => 1000,
+      listeningSeq: [true],
+    });
+    const res = await installAndStartHubUnit({
+      parachuteHome: "/home/op/.parachute",
+      cliPath: "/home/op/parachute-hub/src/cli.ts",
+      port: 1939,
+      deps: f.deps,
+      readyPollMs: 0,
+    });
+    expect(res.outcome).toBe("started");
+    expect(res.install.outcome).toBe("installed");
+    // The systemd unit file was written, carrying the captured PARACHUTE_HOME
+    // and the serve ExecStart.
+    const unitPath = systemdUnitPathForName(HUB_UNIT, "/home/op", false);
+    const written = f.files.get(unitPath);
+    expect(written).toBeDefined();
+    expect(written).toContain("Environment=PARACHUTE_HOME=/home/op/.parachute");
+    expect(written).toContain("src/cli.ts serve");
+    // enable --now drove the start.
+    expect(f.calls).toContainEqual([
+      "systemctl",
+      "--user",
+      "enable",
+      "--now",
+      "parachute-hub.service",
+    ]);
+  });
+
+  test("launchd default on Mac (D2): writes the LaunchAgent plist + bootstraps", async () => {
+    const f = fakeDeps({
+      platform: "darwin",
+      getuid: () => 501,
+      homeDir: () => "/Users/op",
+      listeningSeq: [true],
+    });
+    const res = await installAndStartHubUnit({
+      parachuteHome: "/Users/op/.parachute",
+      cliPath: "/Users/op/parachute-hub/src/cli.ts",
+      port: 1939,
+      deps: f.deps,
+      readyPollMs: 0,
+    });
+    expect(res.outcome).toBe("started");
+    const plistPath = launchdPlistPathForLabel(HUB_LABEL, "/Users/op");
+    const plist = f.files.get(plistPath);
+    expect(plist).toBeDefined();
+    expect(plist).toContain("<string>serve</string>");
+    expect(plist).toContain("computer.parachute.hub");
+  });
+
+  test("captures a NON-default PARACHUTE_HOME (§4.2)", async () => {
+    const f = fakeDeps({ platform: "linux", getuid: () => 1000, listeningSeq: [true] });
+    await installAndStartHubUnit({
+      parachuteHome: "/custom/home/.parachute",
+      cliPath: "/home/op/parachute-hub/src/cli.ts",
+      deps: f.deps,
+      readyPollMs: 0,
+    });
+    const unitPath = systemdUnitPathForName(HUB_UNIT, "/home/op", false);
+    expect(f.files.get(unitPath)).toContain("Environment=PARACHUTE_HOME=/custom/home/.parachute");
+  });
+
+  test("no service manager → no-manager outcome, NOTHING installed or spawned", async () => {
+    const f = fakeDeps({
+      platform: "linux",
+      which: () => null, // no systemctl
+      listeningSeq: [true],
+    });
+    const res = await installAndStartHubUnit({
+      parachuteHome: "/home/op/.parachute",
+      cliPath: "/home/op/parachute-hub/src/cli.ts",
+      deps: f.deps,
+      readyPollMs: 0,
+    });
+    expect(res.outcome).toBe("no-manager");
+    expect(res.messages).toContain(NO_MANAGER_MESSAGE);
+    // No unit file written, no command run.
+    expect(f.files.size).toBe(0);
+    expect(f.calls).toEqual([]);
+  });
+
+  test("install succeeds but hub never binds → timeout with the unit log", async () => {
+    const f = fakeDeps({
+      platform: "linux",
+      getuid: () => 1000,
+      listeningSeq: [false], // never binds
+      run: (cmd) => {
+        if (cmd[0] === "journalctl") {
+          return { code: 0, stdout: "hub: EADDRINUSE 1939", stderr: "" };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      },
+    });
+    const res = await installAndStartHubUnit({
+      parachuteHome: "/home/op/.parachute",
+      cliPath: "/home/op/parachute-hub/src/cli.ts",
+      deps: f.deps,
+      readyTimeoutMs: 0,
+      readyPollMs: 0,
+    });
+    expect(res.outcome).toBe("timeout");
+    expect(res.messages.join("\n")).toContain("EADDRINUSE");
+  });
+});

--- a/src/__tests__/hub-unit.test.ts
+++ b/src/__tests__/hub-unit.test.ts
@@ -7,13 +7,17 @@ import {
   installAndStartHubUnit,
 } from "../hub-unit.ts";
 import {
+  HUB_LAUNCHD_LABEL,
+  HUB_SYSTEMD_UNIT_NAME,
   type ServiceCommandResult,
   launchdPlistPathForLabel,
   systemdUnitPathForName,
 } from "../managed-unit.ts";
 
-const HUB_LABEL = "computer.parachute.hub";
-const HUB_UNIT = "parachute-hub.service";
+// Use the SHARED exported unit identifiers (not local re-declarations) so the
+// assertions can't silently pass if the canonical label/unit name ever drifts.
+const HUB_LABEL = HUB_LAUNCHD_LABEL;
+const HUB_UNIT = HUB_SYSTEMD_UNIT_NAME;
 
 interface FakeState {
   deps: HubUnitDeps;

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -879,6 +879,180 @@ describe("init exposure chain", () => {
     }
   });
 
+  // -------------------------------------------------------------------------
+  // Phase 3a cutover (design §3.3 init row, §3.1, §4.1/§4.2): init installs +
+  // starts the hub UNIT (not a detached spawn) and guarantees an operator
+  // token. The `ensureHub` + `guaranteeOperatorToken` seams stay injectable;
+  // these tests drive them as stubs (and exercise the REAL operator-token
+  // guarantee against a seeded hub DB).
+  // -------------------------------------------------------------------------
+
+  test("calls guaranteeOperatorToken after the hub is up, then falls through to the wizard", async () => {
+    const h = makeHarness();
+    try {
+      const order: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => {
+          order.push("ensureHub");
+          writeHubPort(1939, h.configDir);
+          return { pid: 0, port: 1939, started: true };
+        },
+        guaranteeOperatorToken: async (ctx) => {
+          order.push("guaranteeOperatorToken");
+          // The hub is up before the token guarantee runs (§3.2 step 4 — read
+          // the token AFTER readiness so we don't race the start-hub iss
+          // self-heal).
+          expect(ctx.hubPort).toBe(1939);
+          return "present";
+        },
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+        installVaultModuleImpl: noopVaultInstall,
+      });
+      expect(code).toBe(0);
+      // hub-up first, then token guarantee — in that order.
+      expect(order).toEqual(["ensureHub", "guaranteeOperatorToken"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("real guarantee: MINTS the operator token when absent + a hub user exists", async () => {
+    const h = makeHarness();
+    try {
+      const { openHubDb, hubDbPath } = await import("../hub-db.ts");
+      const { createUser } = await import("../users.ts");
+      const { readOperatorTokenFile } = await import("../operator-token.ts");
+      // Seed a first-admin so the guarantee has someone to mint for.
+      const db = openHubDb(hubDbPath(h.configDir));
+      await createUser(db, "owner", "owner-password-123");
+      db.close();
+
+      // No operator.token yet.
+      expect(await readOperatorTokenFile(h.configDir)).toBeNull();
+
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => {
+          writeHubPort(1939, h.configDir);
+          return { pid: 0, port: 1939, started: true };
+        },
+        // No guaranteeOperatorToken seam → exercises the REAL default.
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+        installVaultModuleImpl: noopVaultInstall,
+      });
+      expect(code).toBe(0);
+      // The default minted + wrote the token.
+      expect(await readOperatorTokenFile(h.configDir)).not.toBeNull();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("real guarantee: does NOT double-mint when a token already exists", async () => {
+    const h = makeHarness();
+    try {
+      const { openHubDb, hubDbPath } = await import("../hub-db.ts");
+      const { createUser } = await import("../users.ts");
+      const { writeOperatorTokenFile, readOperatorTokenFile } = await import(
+        "../operator-token.ts"
+      );
+      const db = openHubDb(hubDbPath(h.configDir));
+      await createUser(db, "owner", "owner-password-123");
+      db.close();
+      // Plant a sentinel token on disk.
+      await writeOperatorTokenFile("SENTINEL.PRE-EXISTING.TOKEN", h.configDir);
+
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => {
+          writeHubPort(1939, h.configDir);
+          return { pid: 0, port: 1939, started: true };
+        },
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+        installVaultModuleImpl: noopVaultInstall,
+      });
+      expect(code).toBe(0);
+      // Untouched — the guarantee left the pre-existing token in place.
+      expect(await readOperatorTokenFile(h.configDir)).toBe("SENTINEL.PRE-EXISTING.TOKEN");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("real guarantee: no hub user yet → no token minted, init still succeeds (no-user, not an error)", async () => {
+    const h = makeHarness();
+    try {
+      const { readOperatorTokenFile } = await import("../operator-token.ts");
+      // No user seeded — the common fresh-box case where init runs before the
+      // wizard creates first-admin.
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        ensureHub: async () => {
+          writeHubPort(1939, h.configDir);
+          return { pid: 0, port: 1939, started: true };
+        },
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+        installVaultModuleImpl: noopVaultInstall,
+      });
+      expect(code).toBe(0);
+      // No token (the wizard mints it when the admin is created).
+      expect(await readOperatorTokenFile(h.configDir)).toBeNull();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("hub-unit bringup failure (e.g. no service manager) → init exits 1 with the actionable message", async () => {
+    const h = makeHarness();
+    try {
+      const logs: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => logs.push(l),
+        alive: () => false,
+        // Mirror what the production default throws when there's no manager.
+        ensureHub: async () => {
+          throw new Error(
+            "no service manager (systemd/launchd) found — run `parachute serve` in the foreground, or use a platform that provides one",
+          );
+        },
+        guaranteeOperatorToken: async () => "no-user",
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+        installVaultModuleImpl: noopVaultInstall,
+      });
+      expect(code).toBe(1);
+      const joined = logs.join("\n");
+      expect(joined).toContain("no service manager (systemd/launchd) found");
+      expect(joined).toContain("parachute logs hub");
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("after exposure runs, the admin URL re-reads expose state for the FQDN", async () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -103,10 +103,53 @@ describe("init", () => {
       expect(code).toBe(0);
       expect(calls).toEqual(["ensureHub"]);
       const joined = logs.join("\n");
-      expect(joined).toContain("Hub not running — starting it now");
-      expect(joined).toContain("Hub started (pid 5555, port 1939)");
+      // A genuinely-started unit reports the port only — no `pid 0` sentinel,
+      // no misleading "starting it now" preamble.
+      expect(joined).toContain("Hub unit started (port 1939)");
+      expect(joined).not.toContain("pid 0");
+      expect(joined).not.toContain("starting it now");
       expect(joined).toContain("http://127.0.0.1:1939/admin/");
       expect(joined).toContain("finish setup in the admin wizard");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("unit-managed re-run against a live hub logs 'already running', not 'pid 0'", async () => {
+    // A unit-managed hub writes no pidfile, so `processState(HUB_SVC)` reports
+    // not-running on every re-run — but `ensureHub` probes /health and returns
+    // started:false when the hub is already up. The log must be honest: no
+    // "starting it now", no "Hub unit started", no `pid 0` sentinel.
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      const calls: string[] = [];
+      const logs: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => logs.push(l),
+        // No pidfile (unit-managed) → processState reports not-running.
+        alive: () => false,
+        ensureHub: async () => {
+          calls.push("ensureHub");
+          // Hub already answered /health — ensureHubUnit's already-up arm.
+          return { pid: 0, port: 1939, started: false };
+        },
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "darwin",
+        installVaultModuleImpl: noopVaultInstall,
+      });
+      expect(code).toBe(0);
+      // ensureHub IS called (processState can't see a unit-managed hub) but
+      // reports started:false.
+      expect(calls).toEqual(["ensureHub"]);
+      const joined = logs.join("\n");
+      expect(joined).toContain("Hub already running (port 1939)");
+      expect(joined).not.toContain("pid 0");
+      expect(joined).not.toContain("starting it now");
+      expect(joined).not.toContain("Hub unit started");
     } finally {
       h.cleanup();
     }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -348,9 +348,11 @@ async function defaultEnsureHubViaUnit(opts: EnsureHubOpts): Promise<{
   if (result.outcome === "started") {
     return { pid: 0, port: result.port, started: true };
   }
-  if (result.outcome === "already-up") {
-    return { pid: 0, port: result.port, started: false };
-  }
+  // NB: `installAndStartHubUnit` never returns `already-up` — only the lighter
+  // `ensureHubUnit` probe (handled above) reports already-up. The "hub already
+  // running, started:false" signal is therefore produced solely by the
+  // `ensureHubUnit` arm above; reaching here means we genuinely tried to
+  // install + start the unit.
   // no-manager / timeout / start-failed → actionable error. The init caller
   // catches this and prints the message + `parachute logs hub` hint.
   throw new Error(result.messages.join("\n") || `hub unit bringup failed (${result.outcome}).`);
@@ -381,11 +383,17 @@ function resolveInitIssuer(configDir: string, hubPort: number): string {
  *   - No token + a hub user already exists → mint under the default (`admin`)
  *     scope-set + write it 0600 (`minted`).
  *   - No token + no hub user yet (the common fresh-box case — init runs BEFORE
- *     the wizard creates first-admin) → `no-user`. NOT an error: the wizard's
- *     account step / `auth set-password` mints it once the admin exists.
+ *     the wizard creates first-admin) → `no-user`. NOT an error. Note the
+ *     wizard's account step does NOT write this on-disk token — it mints an
+ *     in-DB single-use *display* token (deleted once the done-screen reads it).
+ *     Today the on-disk `operator.token` is written only by `parachute auth
+ *     set-password` / `auth rotate-operator`, so a fresh box that finishes the
+ *     wizard without running either still has no on-disk token. Phase 3b closes
+ *     this gap: the per-module verbs that require the operator token land there
+ *     and carry the fresh-box mint with them.
  *
  * Failures are non-fatal (`mint-failed`): a DB hiccup shouldn't block init when
- * the wizard or `auth rotate-operator` can retry.
+ * `auth rotate-operator` can retry.
  */
 async function defaultGuaranteeOperatorToken(ctx: {
   configDir: string;
@@ -544,17 +552,32 @@ export async function init(opts: InitOpts = {}): Promise<number> {
   log("");
 
   // Step 1: hub running?
+  // NB: under the Phase 3a unit-managed hub there is no pidfile, so
+  // `processState(HUB_SVC)` reports not-running on EVERY init re-run even when
+  // the hub is live. We therefore don't decide the "already running" message
+  // from `processState` here — `ensureHub` probes `/health` and reports the
+  // truth via `result.started` (false ⇒ already up, true ⇒ we started it). Only
+  // when `processState` finds a real (legacy detached) pidfile do we report the
+  // pid directly without a bringup call.
   const hubState = processState(HUB_SVC, configDir, alive);
   let hubPort: number | undefined;
   if (hubState.status === "running") {
     hubPort = readHubPort(configDir);
     log(`✓ Hub already running (pid ${hubState.pid}${hubPort ? `, port ${hubPort}` : ""}).`);
   } else {
-    log("Hub not running — starting it now…");
     try {
       const result = await ensureHub({ configDir, log: () => {} });
       hubPort = result.port;
-      log(`✓ Hub started (pid ${result.pid}, port ${result.port}).`);
+      if (result.started) {
+        // Genuinely installed/started the unit. A unit-managed hub has no
+        // meaningful CLI-visible pid, so report only the port (no misleading
+        // `pid 0` sentinel).
+        log(`✓ Hub unit started (port ${result.port}).`);
+      } else {
+        // The hub was already answering `/health` — `ensureHub` touched
+        // nothing. Honest re-run messaging: no "starting it now", no `pid 0`.
+        log(`✓ Hub already running (port ${result.port}).`);
+      }
     } catch (err) {
       log(`✗ Hub failed to start: ${err instanceof Error ? err.message : String(err)}`);
       log("");

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -33,17 +33,18 @@
  */
 
 import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import { type ExposeState, readExposeState } from "../expose-state.ts";
-import {
-  type EnsureHubOpts,
-  HUB_DEFAULT_PORT,
-  HUB_SVC,
-  ensureHubRunning,
-  readHubPort,
-} from "../hub-control.ts";
+import { type EnsureHubOpts, HUB_DEFAULT_PORT, HUB_SVC, readHubPort } from "../hub-control.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { deriveHubOrigin } from "../hub-origin.ts";
+import { ensureHubUnit, installAndStartHubUnit } from "../hub-unit.ts";
+import { issueOperatorToken, readOperatorTokenFile } from "../operator-token.ts";
 import { type AliveFn, defaultAlive, processState } from "../process-state.ts";
 import { findService, readManifestLenient } from "../services-manifest.ts";
+import { listUsers } from "../users.ts";
 import { type InstallOpts, install as defaultInstall } from "./install.ts";
 
 /** The three options the exposure prompt offers — also the `--expose` flag's domain. */
@@ -52,6 +53,17 @@ export type ExposeChoice = "none" | "tailnet" | "cloudflare";
 /** Where to continue setup after init finishes. CLI walks prompts in the terminal; browser opens /admin/setup. */
 export type WizardChoice = "browser" | "cli";
 
+/**
+ * Outcome of the post-bringup operator-token guarantee (design §3.1):
+ *   - `minted`     — no token on disk + a hub user existed → minted + wrote one.
+ *   - `present`    — a token already existed on disk → left it alone.
+ *   - `no-user`    — no token + no hub user yet (fresh box pre-wizard); the
+ *                    wizard's account step will mint it. NOT an error.
+ *   - `mint-failed`— a mint was attempted but failed (DB unavailable, etc.);
+ *                    non-fatal — the wizard / `auth rotate-operator` can retry.
+ */
+export type OperatorTokenGuaranteeStatus = "minted" | "present" | "no-user" | "mint-failed";
+
 export interface InitOpts {
   configDir?: string;
   manifestPath?: string;
@@ -59,10 +71,28 @@ export interface InitOpts {
   /** Test seam: `processState` liveness check. */
   alive?: AliveFn;
   /**
-   * Test seam: `ensureHubRunning` shim. Production uses the real one;
-   * tests pass a stub that records calls without spawning.
+   * Hub-bringup shim. Phase 3a cutover: production now INSTALLS + STARTS the
+   * hub *unit* (launchd on Mac, systemd on Linux) via `installAndStartHubUnit`
+   * and waits for readiness — it no longer spawns a detached `bun hub-server.ts`
+   * (`defaultEnsureHubViaUnit`). The return shape (`{ pid, port, started }`) is
+   * preserved so the downstream init flow (URL resolution, wizard hand-off) is
+   * unchanged; `pid` is `0` on the unit path (a unit-managed hub has no
+   * pidfile). Tests pass a stub that records the call without touching the OS.
+   * Design §3.3 (init row), §4.1/§4.2, appendix (c).
    */
   ensureHub?: (opts: EnsureHubOpts) => Promise<{ pid: number; port: number; started: boolean }>;
+  /**
+   * Test seam: guarantee an operator token exists once the hub is up (design
+   * §3.1 / §3.3). Production reads `operator.token`; if absent AND a hub user
+   * already exists, it mints + writes one so a later per-module verb never
+   * 401s. Returns a short status so init can log what happened. Tests stub it
+   * to assert the mint-when-absent / skip-when-present behavior without a DB.
+   */
+  guaranteeOperatorToken?: (ctx: {
+    configDir: string;
+    hubPort: number;
+    log: (line: string) => void;
+  }) => Promise<OperatorTokenGuaranteeStatus>;
   /** Test seam: expose-state reader. */
   readExposeStateFn?: () => ExposeState | undefined;
   /** Test seam: TTY check (production reads `process.stdin.isTTY`). */
@@ -245,6 +275,153 @@ async function defaultExposeCloudflare(): Promise<number> {
 }
 
 /**
+ * Absolute path to this hub checkout's `src/cli.ts` — the entry the hub unit's
+ * `ExecStart`/`ProgramArguments` runs `serve` against. Resolved from
+ * `import.meta.url` (this file is `src/commands/init.ts`, so `cli.ts` is one
+ * directory up). On the bun-linked dev path this points into the checkout; on
+ * an npm install it points into the installed package — either way the unit
+ * runs the same on-disk entry the operator is invoking right now.
+ */
+function defaultHubCliPath(): string {
+  return fileURLToPath(new URL("../cli.ts", import.meta.url));
+}
+
+/**
+ * Production hub-bringup for the Phase 3a cutover (design §3.3 init row,
+ * appendix c). REPLACES the detached `ensureHubRunning` spawn:
+ *
+ *   1. Probe the loopback hub. If it already answers, return started:false
+ *      WITHOUT touching the unit (init is idempotent — a re-run against a live
+ *      hub shouldn't reinstall/restart it).
+ *   2. Otherwise INSTALL + START the hub unit via `installAndStartHubUnit`:
+ *      `buildHubManagedUnit` captures the operator's CURRENT `PARACHUTE_HOME`
+ *      (§4.2 — derived from the resolved `configDir`, not the hard-coded
+ *      default), resolves abs bun + the abs cli.ts entry, launchd-by-default on
+ *      Mac (D2) / systemd-system-if-root-else-user+linger on Linux. Then waits
+ *      for hub readiness, surfacing the unit log on timeout (§3.2 step 5).
+ *   3. On a host with NO service manager (container / init-less), throw an
+ *      actionable error — the container runtime CMD is `serve`, not `init`
+ *      (§3.2 step 4). NEVER fall back to a detached spawn.
+ *
+ * Returns the `{ pid, port, started }` shape init's downstream flow expects;
+ * `pid` is `0` because a unit-managed hub has no pidfile (the platform manager
+ * owns the process).
+ */
+async function defaultEnsureHubViaUnit(opts: EnsureHubOpts): Promise<{
+  pid: number;
+  port: number;
+  started: boolean;
+}> {
+  const configDir = opts.configDir ?? CONFIG_DIR;
+  const port = opts.startPort ?? HUB_DEFAULT_PORT;
+  const log = opts.log ?? (() => {});
+
+  // First try the lighter ensure-path (§3.2): probe /health → if up, done with
+  // no install; if a unit is already installed but down, just start it. This
+  // keeps a re-run of `init` idempotent — it won't pointlessly rewrite the unit
+  // file when the hub is already answering or the unit already exists.
+  const ensured = await ensureHubUnit({ port, log });
+  if (ensured.outcome === "already-up") {
+    return { pid: 0, port: ensured.port, started: false };
+  }
+  if (ensured.outcome === "started") {
+    return { pid: 0, port: ensured.port, started: true };
+  }
+  if (ensured.outcome === "no-manager") {
+    // Container / init-less host — can't host a unit. Foreground `serve` is the
+    // runtime here, not `init` (§3.2 step 4). Surface + bail; never spawn.
+    throw new Error(ensured.messages.join("\n"));
+  }
+  // `no-unit` (the fresh-box case init exists to handle) → INSTALL + start the
+  // unit, then wait for readiness (§3.3 init row, §4.1/§4.2). `start-failed` /
+  // `timeout` from the start-existing-unit path also fall through to a clean
+  // (re)install attempt here — overwriting the unit file is idempotent.
+  const result = await installAndStartHubUnit({
+    // Capture the operator's CURRENT PARACHUTE_HOME (the resolved configDir),
+    // NOT the hard-coded default (§4.2).
+    parachuteHome: configDir,
+    cliPath: defaultHubCliPath(),
+    port,
+    log,
+  });
+
+  if (result.outcome === "started") {
+    return { pid: 0, port: result.port, started: true };
+  }
+  if (result.outcome === "already-up") {
+    return { pid: 0, port: result.port, started: false };
+  }
+  // no-manager / timeout / start-failed → actionable error. The init caller
+  // catches this and prints the message + `parachute logs hub` hint.
+  throw new Error(result.messages.join("\n") || `hub unit bringup failed (${result.outcome}).`);
+}
+
+/**
+ * Resolve the issuer to mint the operator token under. At init time the hub is
+ * reachable on loopback (just installed); prefer the live expose-state origin
+ * (rare during init, but honored if a prior `expose` ran), else the loopback
+ * origin. Mirrors `commands/auth.ts`'s `resolveHubIssuer` so a token minted at
+ * init validates the same way one minted by `auth rotate-operator` would.
+ */
+function resolveInitIssuer(configDir: string, hubPort: number): string {
+  const state = readExposeState(join(configDir, "expose-state.json"));
+  if (state?.hubOrigin) return state.hubOrigin;
+  return (
+    deriveHubOrigin({ exposeFqdn: state?.canonicalFqdn, hubPort }) ?? `http://127.0.0.1:${hubPort}`
+  );
+}
+
+/**
+ * Production operator-token guarantee (design §3.1 / §3.3). Under the unified
+ * model every per-module verb is an authenticated module-ops call, so the
+ * steady-state operator needs an `operator.token` on disk. init guarantees it:
+ *
+ *   - Token already on disk → leave it (`present`). The hub remains the sole
+ *     minter; we never mint-in-parallel (§3.1).
+ *   - No token + a hub user already exists → mint under the default (`admin`)
+ *     scope-set + write it 0600 (`minted`).
+ *   - No token + no hub user yet (the common fresh-box case — init runs BEFORE
+ *     the wizard creates first-admin) → `no-user`. NOT an error: the wizard's
+ *     account step / `auth set-password` mints it once the admin exists.
+ *
+ * Failures are non-fatal (`mint-failed`): a DB hiccup shouldn't block init when
+ * the wizard or `auth rotate-operator` can retry.
+ */
+async function defaultGuaranteeOperatorToken(ctx: {
+  configDir: string;
+  hubPort: number;
+  log: (line: string) => void;
+}): Promise<OperatorTokenGuaranteeStatus> {
+  const existing = await readOperatorTokenFile(ctx.configDir);
+  if (existing) return "present";
+
+  const db = openHubDb(hubDbPath(ctx.configDir));
+  try {
+    const owner = listUsers(db)[0];
+    if (!owner) {
+      // Fresh box: no first-admin yet. The wizard mints the token when it
+      // creates the admin. Nothing to do here, and definitely not an error.
+      return "no-user";
+    }
+    const issued = await issueOperatorToken(db, owner.id, {
+      dir: ctx.configDir,
+      issuer: resolveInitIssuer(ctx.configDir, ctx.hubPort),
+    });
+    ctx.log(`✓ Operator token written to ${issued.path} (mode 0600).`);
+    return "minted";
+  } catch (err) {
+    ctx.log(
+      `⚠ Couldn't mint an operator token (${
+        err instanceof Error ? err.message : String(err)
+      }); run \`parachute auth rotate-operator\` later if a CLI command reports a missing token.`,
+    );
+    return "mint-failed";
+  } finally {
+    db.close();
+  }
+}
+
+/**
  * Default impl for the vault-module install step (hub#168 Cut 1). Calls
  * install("vault", { noCreate: true, noStart: true, …}) with a quiet log
  * shim that re-emits each line under an `[install vault] ` prefix so the
@@ -347,7 +524,11 @@ export async function init(opts: InitOpts = {}): Promise<number> {
   const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
   const log = opts.log ?? ((line) => console.log(line));
   const alive = opts.alive ?? defaultAlive;
-  const ensureHub = opts.ensureHub ?? ensureHubRunning;
+  // Phase 3a cutover: production installs + starts the hub UNIT (not a detached
+  // spawn). The `ensureHub` seam is preserved for tests (and the return shape is
+  // unchanged); only the production default flipped.
+  const ensureHub = opts.ensureHub ?? defaultEnsureHubViaUnit;
+  const guaranteeOperatorToken = opts.guaranteeOperatorToken ?? defaultGuaranteeOperatorToken;
   const readExposeStateFn = opts.readExposeStateFn ?? (() => readExposeState());
   const isTty = opts.isTty ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
   const prompt = opts.prompt ?? defaultPrompt;
@@ -388,6 +569,15 @@ export async function init(opts: InitOpts = {}): Promise<number> {
   // that didn't write a port file). The hub binds 1939 unless explicitly
   // overridden, so the fallback is almost always correct.
   if (hubPort === undefined) hubPort = HUB_DEFAULT_PORT;
+
+  // Step 1.5: guarantee an operator token exists (design §3.1 / §3.3). Under
+  // the unified model every per-module verb is an authenticated module-ops
+  // call, so the steady-state operator needs an `operator.token` on disk — the
+  // mint-on-init guarantee closes the bootstrap so a later verb never 401s.
+  // On a fresh box (no first-admin yet) this is a no-op (`no-user`): the wizard
+  // mints it when it creates the admin. Non-fatal either way — init continues
+  // to the wizard regardless.
+  await guaranteeOperatorToken({ configDir, hubPort, log });
 
   // Step 2: exposure chain. Skipped when already exposed, in non-TTY,
   // or when --no-expose-prompt was passed. `--expose <choice>` jumps

--- a/src/hub-unit.ts
+++ b/src/hub-unit.ts
@@ -1,0 +1,473 @@
+/**
+ * "Ensure the hub UNIT is up" — the Phase 3a successor to the detached
+ * `ensureHubRunning` spawn (`hub-control.ts:200`).
+ *
+ * Under the hub-as-supervisor unification (design:
+ * `parachute.computer/design/2026-06-01-hub-as-supervisor-unification.md` §3.2)
+ * the hub no longer runs as a detached, `unref()`'d `bun hub-server.ts` tracked
+ * by a pidfile. It runs as `parachute serve` (foreground hub + in-process
+ * Supervisor) under a per-platform process manager — a launchd LaunchAgent on
+ * macOS, a systemd unit on Linux, the container runtime on Render/Fly. So
+ * "ensure the hub is up" becomes "ensure the hub UNIT is started", driven
+ * through the platform manager, NEVER a detached spawn.
+ *
+ * THE §3.2 ALGORITHM (`ensureHubUnit`):
+ *   1. Probe the loopback hub (`GET /health` on the configured port). If it
+ *      answers → return "already up".
+ *   2. If down, start the hub unit via the platform manager:
+ *      `systemctl [--user] start parachute-hub.service` (system vs user by
+ *      uid, mirroring `managed-unit.ts`) / `launchctl kickstart -k
+ *      gui/<uid>/computer.parachute.hub`.
+ *   3. If NO unit is installed → fail with an actionable "run `parachute
+ *      migrate`" message (or, from `init`, init installs it — see
+ *      `installAndStartHubUnit`). NEVER a detached fallback spawn.
+ *   4. If NO manager at all (no systemctl AND no launchctl) → clear
+ *      foreground-`serve`-only message (R19 / D1). Don't hang, don't spawn.
+ *   5. Wait for hub readiness by polling the hub port (`defaultPortListening`).
+ *      On timeout, surface the unit's recent log so a wedged hub is
+ *      diagnosable, not a silent hang.
+ *
+ * EVERYTHING behind the injectable {@link HubUnitDeps} seam (mirroring
+ * `ManagedUnitDeps` / `ensureHubRunning`'s seam) so it's unit-testable without
+ * touching the real OS.
+ *
+ * SCOPE (Phase 3a): this is a NEW helper. It does NOT replace
+ * `ensureHubRunning` — `expose` / `expose-cloudflare` / `lifecycle` keep using
+ * the old detached path until their phases (4/5). Only `init` adopts the new
+ * path in 3a (via `installAndStartHubUnit`), and 3b/Phase 4 will adopt
+ * `ensureHubUnit` for the per-module-verb bringup.
+ */
+
+import {
+  HUB_LAUNCHD_LABEL,
+  HUB_SYSTEMD_UNIT_NAME,
+  type ManagedUnit,
+  type ManagedUnitDeps,
+  type ManagedUnitInstallResult,
+  type ManagedUnitMessages,
+  type ServiceCommandResult,
+  buildHubManagedUnit,
+  defaultManagedUnitDeps,
+  installManagedUnit,
+  launchdPlistPathForLabel,
+  systemdUnitPathForName,
+} from "./managed-unit.ts";
+import { type PortListeningFn, defaultPortListening } from "./port-probe.ts";
+
+/** Default canonical hub port (the 1939 pin). */
+export const HUB_UNIT_DEFAULT_PORT = 1939;
+
+/**
+ * Injectable side-effect seam for the ensure-hub-unit machinery. EXTENDS
+ * `ManagedUnitDeps` (platform / getuid / homeDir / userName / which / run /
+ * file ops — so the same fake drives both `ensureHubUnit` AND the
+ * `installManagedUnit` call inside `installAndStartHubUnit` with no unsafe
+ * cast) plus the three extra probes ensure-hub needs: an HTTP `/health` probe,
+ * a TCP port-listening probe, and a `sleep` (all deterministically stubbable).
+ *
+ * Production wires {@link defaultHubUnitDeps}; tests inject fakes so no
+ * launchctl/systemctl/socket/HTTP call ever touches the real OS.
+ */
+export interface HubUnitDeps extends ManagedUnitDeps {
+  /**
+   * HTTP `/health` probe of the loopback hub. Resolves true when the hub
+   * answers 2xx, false on connection-refused / non-2xx / timeout. Production
+   * uses a bounded `fetch`; tests inject a deterministic stub.
+   */
+  probeHealth: (port: number) => Promise<boolean>;
+  /** TCP connect-probe for readiness polling (reuses `defaultPortListening`). */
+  portListening: PortListeningFn;
+  /** Sleep between readiness polls (tests pin to 0). */
+  sleep: (ms: number) => Promise<void>;
+}
+
+/**
+ * Default `/health` probe: a bounded `fetch` to `http://127.0.0.1:<port>/health`.
+ * Any non-2xx / network error / timeout → false (treated as "hub not up").
+ * 1.5s timeout so a wedged-but-listening socket doesn't hang the probe.
+ */
+async function defaultProbeHealth(port: number): Promise<boolean> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/health`, {
+      signal: AbortSignal.timeout(1500),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export const defaultHubUnitDeps: HubUnitDeps = {
+  ...defaultManagedUnitDeps,
+  probeHealth: defaultProbeHealth,
+  portListening: defaultPortListening,
+  sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+};
+
+export type HubUnitOutcome =
+  /** Hub already answered `/health` — no manager call was needed. */
+  | "already-up"
+  /** The manager was driven to start the unit and the hub became ready. */
+  | "started"
+  /** No unit is installed (actionable error). */
+  | "no-unit"
+  /** No service manager (systemd/launchd) is available (actionable error). */
+  | "no-manager"
+  /** The unit was started but the hub never answered within the timeout. */
+  | "timeout"
+  /** The platform manager rejected the start command. */
+  | "start-failed";
+
+export interface EnsureHubUnitResult {
+  outcome: HubUnitOutcome;
+  /** The hub port that was probed. */
+  port: number;
+  /** Human-readable lines the caller should surface (errors, log tails). */
+  messages: string[];
+}
+
+export interface EnsureHubUnitOpts {
+  /** Hub port to probe + wait on (default 1939). */
+  port?: number;
+  /** Injectable deps (defaults to production). */
+  deps?: HubUnitDeps;
+  /** Readiness budget in ms (default 15s). */
+  readyTimeoutMs?: number;
+  /** Poll interval in ms (default 250). */
+  readyPollMs?: number;
+  /** How many trailing log lines to surface on timeout (default 50). */
+  logTailLines?: number;
+  log?: (line: string) => void;
+}
+
+/** True when a hub unit file is present for this platform. */
+export function isHubUnitInstalled(deps: HubUnitDeps): boolean {
+  const home = deps.homeDir();
+  if (deps.platform === "darwin") {
+    return deps.exists(launchdPlistPathForLabel(HUB_LAUNCHD_LABEL, home));
+  }
+  if (deps.platform === "linux") {
+    const root = (deps.getuid() ?? 1000) === 0;
+    return deps.exists(systemdUnitPathForName(HUB_SYSTEMD_UNIT_NAME, home, root));
+  }
+  return false;
+}
+
+/**
+ * Is a service manager (systemd / launchd) available on this platform at all?
+ * macOS → launchctl; Linux → systemctl. A box with neither (a bare container,
+ * an init-less host) has no manager — the foreground-`serve`-only path (R19/D1).
+ */
+export function hasServiceManager(deps: HubUnitDeps): boolean {
+  if (deps.platform === "darwin") return deps.which("launchctl") !== null;
+  if (deps.platform === "linux") return deps.which("systemctl") !== null;
+  return false;
+}
+
+/** The "no service manager found" actionable message (R19 / D1). */
+export const NO_MANAGER_MESSAGE =
+  "no service manager (systemd/launchd) found — run `parachute serve` in the foreground, or use a platform that provides one";
+
+/** The "no hub unit installed" actionable message (§3.2 step 3). */
+export const NO_UNIT_MESSAGE = "no hub unit installed — run `parachute migrate` to install it";
+
+/**
+ * Start the hub unit via the platform manager. Returns the raw command result
+ * so the caller can surface stderr on failure. Branches exactly like
+ * `managed-unit.ts` / the connector: launchd uses `kickstart -k gui/<uid>/<label>`
+ * (force-restart-or-start); systemd uses `systemctl [--user] start <unit>`
+ * (system vs user by uid).
+ *
+ * NOTE: `launchctl kickstart` requires the unit to be bootstrapped already
+ * (the install path does that). If it isn't loaded, kickstart returns non-zero
+ * — which surfaces as a start-failure with the manager's stderr, not a hang.
+ */
+function startHubUnitViaManager(deps: HubUnitDeps): ServiceCommandResult {
+  if (deps.platform === "darwin") {
+    const uid = deps.getuid() ?? 0;
+    return deps.run(["launchctl", "kickstart", "-k", `gui/${uid}/${HUB_LAUNCHD_LABEL}`]);
+  }
+  // linux / systemd
+  const root = (deps.getuid() ?? 1000) === 0;
+  const scope = root ? [] : ["--user"];
+  return deps.run(["systemctl", ...scope, "start", HUB_SYSTEMD_UNIT_NAME]);
+}
+
+/**
+ * Best-effort tail of the hub unit's recent log so a wedged hub is diagnosable
+ * on a readiness timeout (§3.2 step 5). Tries the platform's native log first
+ * (journald on systemd, `launchctl print` on launchd), then falls back to the
+ * hub's own log file. Never throws — diagnostics must not mask the timeout.
+ */
+function tailHubUnitLog(deps: HubUnitDeps, lines: number): string[] {
+  const out: string[] = [];
+  try {
+    if (deps.platform === "linux" && deps.which("journalctl") !== null) {
+      const root = (deps.getuid() ?? 1000) === 0;
+      const scope = root ? [] : ["--user"];
+      const r = deps.run([
+        "journalctl",
+        ...scope,
+        "-u",
+        HUB_SYSTEMD_UNIT_NAME,
+        "-n",
+        String(lines),
+        "--no-pager",
+      ]);
+      if (r.code === 0 && r.stdout.trim().length > 0) {
+        out.push("Recent hub unit log (journalctl):", r.stdout.trimEnd());
+        return out;
+      }
+    }
+    if (deps.platform === "darwin") {
+      const uid = deps.getuid() ?? 0;
+      const r = deps.run(["launchctl", "print", `gui/${uid}/${HUB_LAUNCHD_LABEL}`]);
+      if (r.code === 0 && r.stdout.trim().length > 0) {
+        out.push("Hub unit state (launchctl print):", r.stdout.trimEnd());
+        return out;
+      }
+    }
+  } catch {
+    // The log tail is best-effort; fall through to the file tail below.
+  }
+  return out;
+}
+
+/**
+ * Ensure the hub UNIT is up (design §3.2). Probe `/health`; if down, start the
+ * unit via the platform manager; wait for readiness; surface the unit log on
+ * timeout. Returns a structured outcome — the CALLER decides exit codes /
+ * messaging (so `init` and the future per-module-verb path can present it
+ * differently).
+ *
+ * Does NOT install a unit when none exists — that's the caller's job (`init`
+ * installs; per-module verbs tell the operator to `parachute migrate`).
+ */
+export async function ensureHubUnit(opts: EnsureHubUnitOpts = {}): Promise<EnsureHubUnitResult> {
+  const deps = opts.deps ?? defaultHubUnitDeps;
+  const port = opts.port ?? HUB_UNIT_DEFAULT_PORT;
+  const readyTimeoutMs = opts.readyTimeoutMs ?? 15_000;
+  const readyPollMs = opts.readyPollMs ?? 250;
+  const logTailLines = opts.logTailLines ?? 50;
+  const log = opts.log ?? (() => {});
+
+  // Step 1: probe the loopback hub. If it answers, we're done — no manager call.
+  if (await deps.probeHealth(port)) {
+    return { outcome: "already-up", port, messages: [] };
+  }
+
+  // Step 4 (checked before 2/3): is there ANY manager? A box with neither
+  // systemctl nor launchctl can't run a background unit at all (R19/D1).
+  if (!hasServiceManager(deps)) {
+    return { outcome: "no-manager", port, messages: [NO_MANAGER_MESSAGE] };
+  }
+
+  // Step 3: is a unit installed? If not, we can't start it — fail actionably
+  // rather than silently spawning a detached hub.
+  if (!isHubUnitInstalled(deps)) {
+    return { outcome: "no-unit", port, messages: [NO_UNIT_MESSAGE] };
+  }
+
+  // Step 2: start the unit via the platform manager.
+  log("Hub not responding — starting the hub unit via the service manager…");
+  const started = startHubUnitViaManager(deps);
+  if (started.code !== 0) {
+    const detail = started.stderr.trim() || started.stdout.trim() || "unknown error";
+    return {
+      outcome: "start-failed",
+      port,
+      messages: [
+        `failed to start the hub unit via the service manager (${detail}) — run \`parachute migrate\` to (re)install it, or \`parachute serve\` in the foreground`,
+      ],
+    };
+  }
+
+  // Step 5: wait for readiness, polling the hub port. On timeout, surface the
+  // unit's recent log so a wedged hub is diagnosable rather than a silent hang.
+  const deadline = Date.now() + readyTimeoutMs;
+  for (;;) {
+    if (await deps.portListening(port)) {
+      return { outcome: "started", port, messages: [] };
+    }
+    if (Date.now() >= deadline) break;
+    if (readyPollMs > 0) await deps.sleep(readyPollMs);
+    else break;
+  }
+  // One final check after the loop (covers readyPollMs===0 / fast-forward).
+  if (await deps.portListening(port)) {
+    return { outcome: "started", port, messages: [] };
+  }
+
+  const messages = [
+    `hub unit started but did not become ready on 127.0.0.1:${port} within ${Math.round(
+      readyTimeoutMs / 1000,
+    )}s`,
+    ...tailHubUnitLog(deps, logTailLines),
+  ];
+  return { outcome: "timeout", port, messages };
+}
+
+export interface InstallAndStartHubUnitResult {
+  /** Outcome of the post-install readiness wait (see {@link HubUnitOutcome}). */
+  outcome: HubUnitOutcome;
+  /** The hub port. */
+  port: number;
+  /** Result of the unit-file install step. */
+  install: ManagedUnitInstallResult;
+  /** Human-readable lines the caller should surface. */
+  messages: string[];
+}
+
+export interface InstallAndStartHubUnitOpts {
+  /** The operator's CURRENT `PARACHUTE_HOME` (captured per §4.2). */
+  parachuteHome: string;
+  /**
+   * Absolute path to `parachute-hub`'s `src/cli.ts` the unit runs `serve`
+   * against. Caller resolves it (the bun-linked checkout or installed bin).
+   */
+  cliPath: string;
+  /** Hub port (default 1939). */
+  port?: number;
+  /** `$BUN_INSTALL` to bake into the unit env (default `$HOME/.bun`). */
+  bunInstall?: string;
+  /** PATH to bake into the unit env (default a bun-bin-first sane PATH). */
+  path?: string;
+  /** Log file the hub's stdout+stderr is written to (default the hub logPath). */
+  logPath?: string;
+  /** Injectable deps (defaults to production). */
+  deps?: HubUnitDeps;
+  /** Readiness budget in ms (default 15s). */
+  readyTimeoutMs?: number;
+  /** Poll interval in ms (default 250). */
+  readyPollMs?: number;
+  log?: (line: string) => void;
+}
+
+/** Messages for the hub-unit install (hub wording, mirroring the connector's). */
+export function hubUnitMessages(): ManagedUnitMessages {
+  return {
+    launchctlMissing: NO_MANAGER_MESSAGE,
+    systemctlMissing: NO_MANAGER_MESSAGE,
+    lingerWarning:
+      "Note: could not enable lingering (loginctl enable-linger) — the hub will run while you're logged in but may not start on a cold boot before login. Re-run as root (a system unit needs no linger) if you want cold-boot survival.",
+    writeFailedPrefix: "Failed to write the hub unit file",
+    launchctlLoadFailedPrefix: "launchctl could not load the hub unit",
+    daemonReloadFailedPrefix: "systemctl daemon-reload failed",
+    enableFailedPrefix: "systemctl enable --now failed",
+    launchdInstalled: (label, started) =>
+      `Installed launchd LaunchAgent ${label} — the hub ${started ? "now runs and " : ""}starts on login/boot.`,
+    systemdInstalled: (unitName, root, started) =>
+      `Installed systemd ${root ? "system" : "user"} unit ${unitName} — the hub ${started ? "now runs and " : ""}starts on boot.`,
+  };
+}
+
+/**
+ * Sane default PATH for the hub unit when the caller doesn't supply one: bun's
+ * global bin first (so supervised children resolve a bun-linked binary on cold
+ * boot, R20), then the usual system dirs.
+ */
+function defaultUnitPath(bunInstall: string): string {
+  return `${bunInstall}/bin:/usr/local/bin:/usr/bin:/bin`;
+}
+
+/**
+ * Build + install + start the hub unit, then wait for hub readiness (design
+ * §3.3 init row / appendix c). This is the `init`-side bringup that REPLACES
+ * the detached `ensureHubRunning` spawn:
+ *   1. `buildHubManagedUnit` (captures the operator's current PARACHUTE_HOME,
+ *      resolves abs bun via `which`, launchd-by-default on Mac per D2).
+ *   2. `installManagedUnit(unit, { start: true })`.
+ *   3. Wait for hub readiness (port poll, surface the unit log on timeout).
+ *
+ * Graceful: when the platform has no manager (`installManagedUnit` returns
+ * `{ outcome: "fallback" }`), this returns `outcome: "no-manager"` WITHOUT
+ * spawning anything — the container/init-less path is foreground `serve`, not
+ * `init` (§3.2 step 4 / Deliverable-1 nuance).
+ */
+export async function installAndStartHubUnit(
+  opts: InstallAndStartHubUnitOpts,
+): Promise<InstallAndStartHubUnitResult> {
+  const deps = opts.deps ?? defaultHubUnitDeps;
+  const port = opts.port ?? HUB_UNIT_DEFAULT_PORT;
+  const bunInstall = opts.bunInstall ?? `${deps.homeDir()}/.bun`;
+  const path = opts.path ?? defaultUnitPath(bunInstall);
+  const logPath = opts.logPath ?? `${opts.parachuteHome}/hub/logs/hub.log`;
+  const log = opts.log ?? (() => {});
+
+  // A platform with no manager can't host a unit — short-circuit to the clear
+  // foreground-serve message BEFORE building a unit we can't install (§3.2
+  // step 4). On a container the runtime CMD is `serve`, not `init`.
+  if (!hasServiceManager(deps)) {
+    return {
+      outcome: "no-manager",
+      port,
+      install: { outcome: "fallback", messages: [NO_MANAGER_MESSAGE] },
+      messages: [NO_MANAGER_MESSAGE],
+    };
+  }
+
+  let unit: ManagedUnit;
+  try {
+    unit = buildHubManagedUnit({
+      parachuteHome: opts.parachuteHome,
+      port,
+      bunInstall,
+      path,
+      cliPath: opts.cliPath,
+      logPath,
+      // HubUnitDeps extends ManagedUnitDeps — pass it straight through.
+      deps,
+    });
+  } catch (err) {
+    // `bun` couldn't be resolved to an absolute path — refuse to bake a broken
+    // ExecStart. Surface it; the caller treats this as a hard failure.
+    const detail = err instanceof Error ? err.message : String(err);
+    return {
+      outcome: "start-failed",
+      port,
+      install: { outcome: "fallback", messages: [detail] },
+      messages: [detail],
+    };
+  }
+
+  const install = installManagedUnit({
+    unit,
+    deps,
+    messages: hubUnitMessages(),
+    start: true,
+  });
+
+  if (install.outcome === "fallback") {
+    // The manager probe passed but install still degraded (write failed,
+    // enable failed, etc.). Surface the install messages; no unit is running.
+    return { outcome: "no-manager", port, install, messages: install.messages };
+  }
+
+  for (const m of install.messages) log(m);
+
+  // Wait for readiness. The unit's RunAtLoad/enable--now already started it;
+  // we poll the port + surface the unit log on timeout (§3.2 step 5).
+  const readyTimeoutMs = opts.readyTimeoutMs ?? 15_000;
+  const readyPollMs = opts.readyPollMs ?? 250;
+  const deadline = Date.now() + readyTimeoutMs;
+  for (;;) {
+    if (await deps.portListening(port)) {
+      return { outcome: "started", port, install, messages: install.messages };
+    }
+    if (Date.now() >= deadline) break;
+    if (readyPollMs > 0) await deps.sleep(readyPollMs);
+    else break;
+  }
+  if (await deps.portListening(port)) {
+    return { outcome: "started", port, install, messages: install.messages };
+  }
+
+  const messages = [
+    ...install.messages,
+    `hub unit installed but did not become ready on 127.0.0.1:${port} within ${Math.round(
+      readyTimeoutMs / 1000,
+    )}s`,
+    ...tailHubUnitLog(deps, 50),
+  ];
+  return { outcome: "timeout", port, install, messages };
+}

--- a/src/hub-unit.ts
+++ b/src/hub-unit.ts
@@ -220,6 +220,13 @@ function tailHubUnitLog(deps: HubUnitDeps, lines: number): string[] {
       }
     }
     if (deps.platform === "darwin") {
+      // NOTE: `launchctl print` emits the service STATE DESCRIPTOR (load state,
+      // last exit code, pid, env), NOT a log tail — unlike the systemd arm's
+      // `journalctl -n 50` which is a genuine tail of the unit's output. It's
+      // still diagnostically useful (a crash-looping unit shows its last exit
+      // code here), but it won't show the hub's recent stderr. The richer
+      // launchd equivalent is `log show --predicate 'process == "bun"' --last 5m`
+      // (or scoped by the unit's logPath) — a future refinement; not wired now.
       const uid = deps.getuid() ?? 0;
       const r = deps.run(["launchctl", "print", `gui/${uid}/${HUB_LAUNCHD_LABEL}`]);
       if (r.code === 0 && r.stdout.trim().length > 0) {


### PR DESCRIPTION
Phase 3a of the hub-as-supervisor unification (design: [`2026-06-01-hub-as-supervisor-unification.md`](../parachute.computer/design/2026-06-01-hub-as-supervisor-unification.md)). **This is the first behavior-cutover phase** — `parachute init` stops spawning a detached hub and instead installs + starts the hub *unit* (launchd / systemd) and guarantees an operator token. Builds directly on Phase 1 (#495), 2a (#496), 2b (#497).

## Deliverable 1 — `ensureHubUnit` helper (§3.2)

New `src/hub-unit.ts` implementing the §3.2 "ensure the hub UNIT is up" algorithm — the successor to the detached `ensureHubRunning` spawn:

1. **Probe loopback `/health`** → if up, `already-up` (no manager call).
2. **Down + unit installed** → start via the platform manager: `systemctl [--user] start parachute-hub.service` / `launchctl kickstart -k gui/<uid>/computer.parachute.hub` (system-vs-user by uid, same branch logic as `managed-unit.ts`; unit naming reused from `buildHubManagedUnit` so it can't drift).
3. **No unit installed** → actionable `"no hub unit installed — run \`parachute migrate\` to install it"`. Never a detached fallback spawn.
4. **No manager at all** (no systemctl AND no launchctl) → actionable `"no service manager (systemd/launchd) found — run \`parachute serve\` in the foreground…"` (R19 / D1). Doesn't hang, doesn't spawn.
5. **Wait for readiness** via `defaultPortListening` (bounded); on timeout, surface the unit's recent log (`journalctl` / `launchctl print`) so a wedged hub is diagnosable, not a silent hang (§3.2 step 5).

Also `installAndStartHubUnit` — the init-side bringup: `buildHubManagedUnit` (Phase 2b) → `installManagedUnit({ start: true })` → readiness wait. Captures the operator's current `PARACHUTE_HOME` (§4.2), launchd-by-default on Mac (**D2**), systemd-system-if-root-else-user+linger on Linux. Everything behind an injectable `HubUnitDeps` seam (extends `ManagedUnitDeps` + `probeHealth`/`portListening`/`sleep`) — fully unit-testable, no real OS calls.

## Deliverable 2 — `init` cutover (§3.3 init row, appendix c)

`parachute init` repointed:
- **Hub bringup** swaps the detached `ensureHubRunning` default for `defaultEnsureHubViaUnit`: `ensureHubUnit` first (probe → start an existing unit, keeps re-runs idempotent); on `no-unit` (the fresh-box case) → `installAndStartHubUnit` → readiness wait. No-manager (container / init-less) → init exits 1 with the clear foreground-`serve` message; never a detached spawn.
- **Operator-token guarantee** (§3.1 / §3.3): after the hub is ready, read `operator.token`; if absent **and** a hub user exists, mint + write it 0600 so a later per-module verb never 401s. Fresh box (no first-admin yet) → `no-user`, **not an error** (the wizard mints it when it creates the admin). Read **after** readiness, never minted in parallel — the hub stays the sole minter (no second SQLite writer racing it, no re-introduction of the iss-staleness class).
- Downstream (wizard / vault-install / browser-vs-CLI choice) **unchanged** — only the hub-bringup mechanism feeding them was swapped. All existing init test seams preserved (`ensureHub`, `installVaultModuleImpl`, the wizard shims) + a new injectable `guaranteeOperatorToken` seam.

**Flagged finding — init did NOT previously mint the operator token to disk.** The wizard's expose-step mint (`setup-wizard.ts:2660`) is single-use + deleted-after-read for the done-screen MCP command; `auth set-password` / `rotate-operator` write it but init never called those. So the mint-on-init guarantee genuinely closes the §3.1 bootstrap gap (it does not duplicate an existing mint).

## Additive — the other 3 call sites are untouched

`ensureHubRunning`'s body and the **expose.ts / expose-cloudflare.ts / lifecycle.ts** call sites are **unchanged** — they keep the detached path until their phases (4/5). **Only `init` adopts the new path in 3a.** **D2 (launchd-by-default on Mac) is now realized in init.** `package.json` untouched — **no version bump** (rc bump + tag happen at ship time per governance rule 2).

## Tests & gates

- `bun test ./src` — **2654 pass / 1 skip / 0 fail** (was 2636 baseline after Phase 2b; +18 = 13 `hub-unit` + 5 `init` cutover; zero regressions).
- `bun run typecheck` — clean.
- `bunx biome check` on touched files — clean.

New `hub-unit` tests: already-up (no manager call), down-unit-present (systemd user/root + launchd), no-unit, no-manager, readiness-timeout (surfaces the log), start-failed, install+readiness, launchd-default, non-default `PARACHUTE_HOME` capture. New `init` tests: hub-up-before-token ordering, real mint-when-absent, no-double-mint-when-present, no-user-not-an-error, no-manager-exits-1-with-message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)