### PR TITLE
feat(hub): Phase 3b — start/stop/restart cutover (supervisor when unit-managed, detached fallback) + fresh-box operator-token closure

### DIFF
--- a/src/__tests__/hub-unit.test.ts
+++ b/src/__tests__/hub-unit.test.ts
@@ -5,6 +5,8 @@ import {
   NO_UNIT_MESSAGE,
   ensureHubUnit,
   installAndStartHubUnit,
+  restartHubUnit,
+  stopHubUnit,
 } from "../hub-unit.ts";
 import {
   HUB_LAUNCHD_LABEL,
@@ -341,5 +343,101 @@ describe("installAndStartHubUnit — init bringup (§3.3 / §4.2)", () => {
     });
     expect(res.outcome).toBe("timeout");
     expect(res.messages.join("\n")).toContain("EADDRINUSE");
+  });
+});
+
+describe("stopHubUnit — manager-only hub stop (§3.3, R17)", () => {
+  test("systemd user: `systemctl --user stop` (NEVER a PID signal)", () => {
+    const f = fakeDeps({ platform: "linux", getuid: () => 1000, installedUnit: true });
+    const res = stopHubUnit(f.deps);
+    expect(res.outcome).toBe("ok");
+    expect(f.calls).toEqual([["systemctl", "--user", "stop", HUB_UNIT]]);
+    // No `kill`-shaped call — the manager is the only thing driven.
+    expect(f.calls.flat()).not.toContain("kill");
+  });
+
+  test("systemd root: `systemctl stop` (no --user scope)", () => {
+    const f = fakeDeps({
+      platform: "linux",
+      getuid: () => 0,
+      userName: () => "root",
+      installedUnit: true,
+    });
+    const res = stopHubUnit(f.deps);
+    expect(res.outcome).toBe("ok");
+    expect(f.calls).toEqual([["systemctl", "stop", HUB_UNIT]]);
+  });
+
+  test("launchd: `launchctl bootout gui/<uid>/<label>` (KeepAlive can't resurrect)", () => {
+    const f = fakeDeps({ platform: "darwin", getuid: () => 501, installedUnit: true });
+    const res = stopHubUnit(f.deps);
+    expect(res.outcome).toBe("ok");
+    expect(f.calls).toEqual([["launchctl", "bootout", `gui/501/${HUB_LABEL}`]]);
+    // Specifically NOT `launchctl kill` / a PID signal.
+    expect(f.calls.flat()).not.toContain("kill");
+  });
+
+  test("no unit installed → no-unit, no manager call", () => {
+    const f = fakeDeps({ platform: "linux", getuid: () => 1000 /* installedUnit: false */ });
+    const res = stopHubUnit(f.deps);
+    expect(res.outcome).toBe("no-unit");
+    expect(res.messages).toEqual([NO_UNIT_MESSAGE]);
+    expect(f.calls).toEqual([]);
+  });
+
+  test("no service manager → no-manager", () => {
+    const f = fakeDeps({ platform: "linux", which: () => null, installedUnit: true });
+    const res = stopHubUnit(f.deps);
+    expect(res.outcome).toBe("no-manager");
+    expect(res.messages).toEqual([NO_MANAGER_MESSAGE]);
+  });
+
+  test("manager rejects the command → failed, carries stderr", () => {
+    const f = fakeDeps({
+      platform: "linux",
+      getuid: () => 1000,
+      installedUnit: true,
+      runResults: [{ code: 1, stdout: "", stderr: "unit not loaded" }],
+    });
+    const res = stopHubUnit(f.deps);
+    expect(res.outcome).toBe("failed");
+    expect(res.messages.join("\n")).toContain("unit not loaded");
+  });
+});
+
+describe("restartHubUnit — manager-only hub restart (§3.3, R17)", () => {
+  test("systemd user: `systemctl --user restart` (NEVER a PID signal)", () => {
+    const f = fakeDeps({ platform: "linux", getuid: () => 1000, installedUnit: true });
+    const res = restartHubUnit(f.deps);
+    expect(res.outcome).toBe("ok");
+    expect(f.calls).toEqual([["systemctl", "--user", "restart", HUB_UNIT]]);
+    expect(f.calls.flat()).not.toContain("kill");
+  });
+
+  test("launchd: `launchctl kickstart -k gui/<uid>/<label>`", () => {
+    const f = fakeDeps({ platform: "darwin", getuid: () => 501, installedUnit: true });
+    const res = restartHubUnit(f.deps);
+    expect(res.outcome).toBe("ok");
+    expect(f.calls).toEqual([["launchctl", "kickstart", "-k", `gui/501/${HUB_LABEL}`]]);
+    expect(f.calls.flat()).not.toContain("kill");
+  });
+
+  test("no unit installed → no-unit", () => {
+    const f = fakeDeps({ platform: "linux", getuid: () => 1000 });
+    const res = restartHubUnit(f.deps);
+    expect(res.outcome).toBe("no-unit");
+    expect(f.calls).toEqual([]);
+  });
+
+  test("manager rejects → failed, carries stderr", () => {
+    const f = fakeDeps({
+      platform: "linux",
+      getuid: () => 1000,
+      installedUnit: true,
+      runResults: [{ code: 1, stdout: "", stderr: "job failed" }],
+    });
+    const res = restartHubUnit(f.deps);
+    expect(res.outcome).toBe("failed");
+    expect(res.messages.join("\n")).toContain("job failed");
   });
 });

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  type LifecycleOpts,
   defaultAlive,
   defaultKill,
   defaultSpawner,
@@ -14,7 +15,14 @@ import {
 import { readEnvFileValues } from "../env-file.ts";
 import { writeHubPort } from "../hub-control.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
+import type { HubUnitManagerOpResult } from "../hub-unit.ts";
 import { validateAccessToken } from "../jwt-sign.ts";
+import {
+  type ModuleOp,
+  ModuleOpHttpError,
+  type ModuleOpResult,
+  NoOperatorTokenError,
+} from "../module-ops-client.ts";
 import {
   OPERATOR_TOKEN_SCOPE_SET_CLAIM,
   issueOperatorToken,
@@ -1857,6 +1865,421 @@ describe("parachute start|stop|restart hub", () => {
       });
       expect(code).toBe(0);
       expect(log).toEqual(["hub line one", "hub line two"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 3b dual-dispatch (design §3.3): when a hub UNIT is installed, the verbs
+// drive the running supervisor / platform manager; when no unit is installed,
+// the existing detached arm is taken UNCHANGED. These suites exercise both arms
+// via injected `supervisor` seams (unit arm) and a stub spawner (detached arm).
+// ---------------------------------------------------------------------------
+
+interface SupervisorStub {
+  opts: NonNullable<LifecycleOpts["supervisor"]>;
+  driveCalls: Array<{ short: string; op: ModuleOp }>;
+  ensureCalls: Array<{ port?: number }>;
+  stopHubCalls: number;
+  restartHubCalls: number;
+  healthProbes: number;
+}
+
+/**
+ * Build a `supervisor` seam that forces the unit-installed arm and records the
+ * supervisor / manager calls. `driveResponder` lets a test return a result or
+ * throw a module-ops error per (short, op). The default responder returns a
+ * benign sync-op result. `health` controls `probeHubHealth`.
+ */
+function makeSupervisorStub(opts?: {
+  health?: boolean;
+  ensureOutcome?: "already-up" | "started" | "no-unit" | "no-manager" | "timeout" | "start-failed";
+  ensureMessages?: string[];
+  driveResponder?: (short: string, op: ModuleOp) => ModuleOpResult | Promise<ModuleOpResult>;
+  stopHubResult?: HubUnitManagerOpResult;
+  restartHubResult?: HubUnitManagerOpResult;
+}): SupervisorStub {
+  const driveCalls: Array<{ short: string; op: ModuleOp }> = [];
+  const ensureCalls: Array<{ port?: number }> = [];
+  const stub: SupervisorStub = {
+    driveCalls,
+    ensureCalls,
+    stopHubCalls: 0,
+    restartHubCalls: 0,
+    healthProbes: 0,
+    opts: {
+      unitInstalled: true,
+      // openDb is never exercised by the stub driveModuleOp, but the dispatch
+      // opens+closes it around the call — hand back a no-op closer.
+      openDb: () => ({ close() {} }) as unknown as import("bun:sqlite").Database,
+      driveModuleOp: async (short, op) => {
+        driveCalls.push({ short, op });
+        if (opts?.driveResponder) return await opts.driveResponder(short, op);
+        return { status: 200, body: { short, state: { status: "running" } } };
+      },
+      ensureHubUnit: async (o) => {
+        ensureCalls.push({ port: o.port });
+        return {
+          outcome: opts?.ensureOutcome ?? "already-up",
+          port: o.port ?? 1939,
+          messages: opts?.ensureMessages ?? [],
+        };
+      },
+      stopHubUnit: () => {
+        stub.stopHubCalls++;
+        return opts?.stopHubResult ?? { outcome: "ok", messages: [] };
+      },
+      restartHubUnit: () => {
+        stub.restartHubCalls++;
+        return opts?.restartHubResult ?? { outcome: "ok", messages: [] };
+      },
+      probeHubHealth: async () => {
+        stub.healthProbes++;
+        return opts?.health ?? true;
+      },
+    },
+  };
+  return stub;
+}
+
+describe("Phase 3b dual-dispatch — start", () => {
+  test("module svc, unit-installed → ensureHubUnit then driveModuleOp(start)", async () => {
+    const h = makeHarness();
+    try {
+      const sup = makeSupervisorStub();
+      const log: string[] = [];
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+        supervisor: sup.opts,
+      });
+      expect(code).toBe(0);
+      expect(sup.ensureCalls).toHaveLength(1);
+      expect(sup.driveCalls).toEqual([{ short: "vault", op: "start" }]);
+      expect(log.join("\n")).toMatch(/✓ vault started/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("no svc, unit-installed → ensureHubUnit only (boots all modules), no driveModuleOp", async () => {
+    const h = makeHarness();
+    try {
+      const sup = makeSupervisorStub();
+      const code = await start(undefined, {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        supervisor: sup.opts,
+      });
+      expect(code).toBe(0);
+      expect(sup.ensureCalls).toHaveLength(1);
+      expect(sup.driveCalls).toHaveLength(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("module svc, NO unit → existing detached spawner path (unchanged)", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const spawner = makeSpawner([4242]);
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        log: () => {},
+        // supervisor omitted → detached arm, deterministically.
+      });
+      expect(code).toBe(0);
+      expect(spawner.calls).toHaveLength(1);
+      expect(spawner.calls[0]?.cmd).toEqual(["parachute-vault", "serve"]);
+      expect(readPid("vault", h.configDir)).toBe(4242);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("module svc, NoOperatorTokenError → actionable message surfaced (not raw-thrown)", async () => {
+    const h = makeHarness();
+    try {
+      const sup = makeSupervisorStub({
+        driveResponder: () => {
+          throw new NoOperatorTokenError();
+        },
+      });
+      const log: string[] = [];
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+        supervisor: sup.opts,
+      });
+      expect(code).toBe(1);
+      expect(log.join("\n")).toMatch(/no operator token/);
+      expect(log.join("\n")).toMatch(/parachute auth rotate-operator/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("module svc, 400 not_installed → actionable install hint", async () => {
+    const h = makeHarness();
+    try {
+      const sup = makeSupervisorStub({
+        driveResponder: () => {
+          throw new ModuleOpHttpError(400, "not_installed", "vault is not installed");
+        },
+      });
+      const log: string[] = [];
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+        supervisor: sup.opts,
+      });
+      expect(code).toBe(1);
+      expect(log.join("\n")).toMatch(/not installed/);
+      expect(log.join("\n")).toMatch(/parachute install vault/);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("Phase 3b dual-dispatch — stop", () => {
+  test("module svc, hub UP → driveModuleOp(stop), no ensureHubUnit", async () => {
+    const h = makeHarness();
+    try {
+      const sup = makeSupervisorStub({ health: true });
+      const log: string[] = [];
+      const code = await stop("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+        supervisor: sup.opts,
+      });
+      expect(code).toBe(0);
+      expect(sup.healthProbes).toBe(1);
+      expect(sup.driveCalls).toEqual([{ short: "vault", op: "stop" }]);
+      expect(sup.ensureCalls).toHaveLength(0); // never start the hub just to stop a module
+      expect(log.join("\n")).toMatch(/✓ vault stopped/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("module svc, hub DOWN → success WITHOUT starting the hub or driving stop", async () => {
+    const h = makeHarness();
+    try {
+      const sup = makeSupervisorStub({ health: false });
+      const log: string[] = [];
+      const code = await stop("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+        supervisor: sup.opts,
+      });
+      expect(code).toBe(0);
+      expect(sup.healthProbes).toBe(1);
+      expect(sup.driveCalls).toHaveLength(0); // nothing to stop — module already down
+      expect(sup.ensureCalls).toHaveLength(0); // did NOT ensureHubUnit
+      expect(log.join("\n")).toMatch(/already stopped/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("stop hub → platform manager (stopHubUnit), never a PID signal", async () => {
+    const h = makeHarness();
+    try {
+      const sup = makeSupervisorStub();
+      // A kill seam that fails the test if ANY PID signal is sent.
+      const kill = () => {
+        throw new Error("stop hub must NOT signal a PID — it must go through the manager");
+      };
+      const log: string[] = [];
+      const code = await stop("hub", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+        kill,
+        supervisor: sup.opts,
+      });
+      expect(code).toBe(0);
+      expect(sup.stopHubCalls).toBe(1);
+      expect(sup.healthProbes).toBe(0);
+      expect(log.join("\n")).toMatch(/✓ hub stopped/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("no svc, unit-installed → stop the hub unit (manager)", async () => {
+    const h = makeHarness();
+    try {
+      const sup = makeSupervisorStub();
+      const code = await stop(undefined, {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        supervisor: sup.opts,
+      });
+      expect(code).toBe(0);
+      expect(sup.stopHubCalls).toBe(1);
+      expect(sup.driveCalls).toHaveLength(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("module svc, NO unit → existing detached stop path (unchanged)", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writePid("vault", 4242, h.configDir);
+      const killed: Array<{ pid: number; sig: NodeJS.Signals | number }> = [];
+      const code = await stop("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        kill: (pid, sig) => killed.push({ pid, sig }),
+        alive: (() => {
+          let n = 0;
+          return () => n++ < 1; // alive once (for the SIGTERM), then dead.
+        })(),
+        log: () => {},
+        // supervisor omitted → detached arm.
+      });
+      expect(code).toBe(0);
+      expect(killed[0]).toEqual({ pid: 4242, sig: "SIGTERM" });
+      expect(readPid("vault", h.configDir)).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("Phase 3b dual-dispatch — restart", () => {
+  test("module svc, unit-installed → ensureHubUnit then driveModuleOp(restart)", async () => {
+    const h = makeHarness();
+    try {
+      const sup = makeSupervisorStub();
+      const log: string[] = [];
+      const code = await restart("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+        supervisor: sup.opts,
+      });
+      expect(code).toBe(0);
+      expect(sup.ensureCalls).toHaveLength(1);
+      expect(sup.driveCalls).toEqual([{ short: "vault", op: "restart" }]);
+      expect(log.join("\n")).toMatch(/✓ vault restarted/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("404 not_supervised on restart → fall through to driveModuleOp(start)", async () => {
+    const h = makeHarness();
+    try {
+      const sup = makeSupervisorStub({
+        driveResponder: (_short, op) => {
+          if (op === "restart") {
+            throw new ModuleOpHttpError(404, "not_supervised", "vault is not currently supervised");
+          }
+          return { status: 200, body: { short: "vault", state: { status: "running" } } };
+        },
+      });
+      const log: string[] = [];
+      const code = await restart("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+        supervisor: sup.opts,
+      });
+      expect(code).toBe(0);
+      // restart was attempted, then start as the 404-fallthrough (§6.2).
+      expect(sup.driveCalls).toEqual([
+        { short: "vault", op: "restart" },
+        { short: "vault", op: "start" },
+      ]);
+      expect(log.join("\n")).toMatch(/✓ vault started/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("restart hub → platform manager (restartHubUnit), never a PID signal", async () => {
+    const h = makeHarness();
+    try {
+      const sup = makeSupervisorStub();
+      const kill = () => {
+        throw new Error("restart hub must NOT signal a PID — it must go through the manager");
+      };
+      const log: string[] = [];
+      const code = await restart("hub", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+        kill,
+        supervisor: sup.opts,
+      });
+      expect(code).toBe(0);
+      expect(sup.restartHubCalls).toBe(1);
+      expect(sup.driveCalls).toHaveLength(0); // NOT a per-module fan-out
+      expect(log.join("\n")).toMatch(/✓ hub restarted/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("no svc, unit-installed → restart the hub unit (manager), not a fan-out", async () => {
+    const h = makeHarness();
+    try {
+      const sup = makeSupervisorStub();
+      const code = await restart(undefined, {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        supervisor: sup.opts,
+      });
+      expect(code).toBe(0);
+      expect(sup.restartHubCalls).toBe(1);
+      expect(sup.driveCalls).toHaveLength(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("module svc, NO unit → existing detached stop-then-start path (unchanged)", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writePid("vault", 4242, h.configDir);
+      const spawner = makeSpawner([7777]);
+      const killed: Array<{ pid: number; sig: NodeJS.Signals | number }> = [];
+      const code = await restart("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        kill: (pid, sig) => killed.push({ pid, sig }),
+        // Stale 4242 is dead (stop's stale-pid path cleans up without a kill);
+        // freshly spawned 7777 is alive past the post-spawn settle (hub#194).
+        // Per-pid differentiation, mirroring the existing detached-restart test.
+        alive: (pid) => pid === 7777,
+        sleep: async () => {},
+        log: () => {},
+        // supervisor omitted → detached arm (stop then start).
+      });
+      expect(code).toBe(0);
+      expect(killed).toHaveLength(0); // stale pid → detached cleanup, no kill
+      expect(spawner.calls).toHaveLength(1); // detached start ran (NOT the supervisor)
+      expect(readPid("vault", h.configDir)).toBe(7777);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -27,6 +27,12 @@ import { type ExposeState, readExposeState, writeExposeState } from "../expose-s
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { hubFetch } from "../hub-server.ts";
 import { getSetting, setSetting } from "../hub-settings.ts";
+import { validateAccessToken } from "../jwt-sign.ts";
+import {
+  OPERATOR_TOKEN_SCOPE_SET_CLAIM,
+  readOperatorTokenFile,
+  writeOperatorTokenFile,
+} from "../operator-token.ts";
 import { writeManifest } from "../services-manifest.ts";
 import { SESSION_COOKIE_NAME } from "../sessions.ts";
 import {
@@ -39,6 +45,7 @@ import {
   handleSetupVaultPost,
   postVaultImportImpl,
 } from "../setup-wizard.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
 import { Supervisor } from "../supervisor.ts";
 import { createUser, getUserByUsername, userCount } from "../users.ts";
 
@@ -1001,6 +1008,129 @@ describe("handleSetupAccountPost", () => {
       expect(post.headers.get("location")).toBe("/admin/setup");
       // Idempotent — no second user got minted.
       expect(userCount(db)).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+// --- Phase 3b Deliverable A: fresh-box operator-token closure (§3.1) ------
+//
+// After the wizard creates the first admin, it persists ~/.parachute/operator.token
+// so the box has a CLI operator credential immediately — otherwise the Phase 3b
+// per-module verbs (start/stop/restart <svc> over the module-ops API) would 401.
+
+describe("handleSetupAccountPost — operator-token closure (Phase 3b §3.1)", () => {
+  let h: Harness;
+  beforeEach(() => {
+    h = makeHarness();
+    _resetOperationsRegistryForTests();
+  });
+  afterEach(() => h.cleanup());
+
+  /** Drive a valid account-creation POST against the given deps. */
+  async function createFirstAdmin(
+    db: ReturnType<typeof openHubDb>,
+    deps: Partial<Parameters<typeof handleSetupAccountPost>[1]> = {},
+    username = "ops",
+  ): Promise<Response> {
+    const baseDeps = {
+      db,
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+      readExposeStateFn: h.readExposeStateFn,
+      issuer: "https://hub.example",
+      registry: getDefaultOperationsRegistry(),
+    };
+    const get = handleSetupGet(req("/admin/setup"), baseDeps);
+    const csrf = setCookie(get, CSRF_COOKIE_NAME) ?? "";
+    const form = formBody({
+      username,
+      password: "correct horse battery",
+      password_confirm: "correct horse battery",
+      [CSRF_FIELD_NAME]: csrf,
+    });
+    return handleSetupAccountPost(
+      req("/admin/setup/account", {
+        method: "POST",
+        body: form.body,
+        headers: { ...form.headers, cookie: `${CSRF_COOKIE_NAME}=${csrf}` },
+      }),
+      { ...baseDeps, ...deps },
+    );
+  }
+
+  test("persists operator.token (admin scope-set, carries parachute:host:admin)", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      rotateSigningKey(db); // real issuance needs a signing key
+      const post = await createFirstAdmin(db);
+      expect(post.status).toBe(303);
+      // The token file now exists on disk…
+      const token = await readOperatorTokenFile(h.dir);
+      expect(token).not.toBeNull();
+      // …and decodes with the admin scope (the scope module-ops gates on).
+      // The JWT carries the OAuth `scope` claim as a space-delimited string.
+      const { payload } = await validateAccessToken(db, token ?? "", "https://hub.example");
+      const scopes = String(payload.scope ?? "").split(" ");
+      expect(scopes).toContain("parachute:host:admin");
+      expect((payload as Record<string, unknown>)[OPERATOR_TOKEN_SCOPE_SET_CLAIM]).toBe("admin");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("does NOT clobber an existing operator.token", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      rotateSigningKey(db);
+      // Plant a sentinel token before the wizard runs.
+      await writeOperatorTokenFile("sentinel.preexisting.token", h.dir);
+      // Use a stub issuer that fails the test if it's ever called.
+      const post = await createFirstAdmin(db, {
+        issueOperatorToken: async () => {
+          throw new Error("issueOperatorToken must NOT run when a token already exists");
+        },
+      });
+      expect(post.status).toBe(303);
+      // The pre-existing token is untouched.
+      expect(await readOperatorTokenFile(h.dir)).toBe("sentinel.preexisting.token");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("no admin created (already-bootstrapped guard) → no token written", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      rotateSigningKey(db);
+      // An admin already exists, so the wizard's already-bootstrapped guard
+      // returns early (303 to /admin/setup) WITHOUT reaching createUser — and
+      // therefore WITHOUT minting a token. The closure only fires for a
+      // genuinely-created first admin.
+      await createUser(db, "owner", "pw");
+      const post = await createFirstAdmin(db, {}, "interloper");
+      expect(post.status).toBe(303);
+      expect(await readOperatorTokenFile(h.dir)).toBeNull();
+    } finally {
+      db.close();
+    }
+  });
+
+  test("token-write failure is non-fatal — account creation still succeeds", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const post = await createFirstAdmin(db, {
+        issueOperatorToken: async () => {
+          throw new Error("disk full");
+        },
+      });
+      // The admin + session were committed despite the token-write failure.
+      expect(post.status).toBe(303);
+      expect(setCookie(post, SESSION_COOKIE_NAME)).toBeDefined();
+      expect(userCount(db)).toBe(1);
+      // No token landed (the issuer threw), but that didn't fail the request.
+      expect(await readOperatorTokenFile(h.dir)).toBeNull();
     } finally {
       db.close();
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -624,7 +624,13 @@ async function main(argv: string[]): Promise<number> {
         console.error(`parachute start: ${hubExtract.error}`);
         return 1;
       }
-      const startOpts = hubExtract.hubOrigin ? { hubOrigin: hubExtract.hubOrigin } : {};
+      // `supervisor: {}` opts into the Phase 3b dual-dispatch: on a box with a
+      // hub unit installed, drive the running supervisor; on a legacy detached
+      // box (no unit), fall through to the unchanged detached path (design §3.3).
+      const startOpts = {
+        supervisor: {},
+        ...(hubExtract.hubOrigin ? { hubOrigin: hubExtract.hubOrigin } : {}),
+      };
       return await start(hubExtract.rest[0], startOpts);
     }
 
@@ -633,7 +639,7 @@ async function main(argv: string[]): Promise<number> {
         console.log(stopHelp());
         return 0;
       }
-      return await stop(rest[0]);
+      return await stop(rest[0], { supervisor: {} });
     }
 
     case "restart": {
@@ -641,7 +647,7 @@ async function main(argv: string[]): Promise<number> {
         console.log(restartHelp());
         return 0;
       }
-      return await restart(rest[0]);
+      return await restart(rest[0], { supervisor: {} });
     }
 
     case "upgrade": {

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -513,6 +513,10 @@ function resolveSupervisor(opts: LifecycleOpts["supervisor"]): ResolvedSuperviso
  * token ALWAYS carries an `iss`, so this falls back to the canonical loopback
  * origin. Mirrors `commands/auth.ts`'s `resolveHubIssuer` so the issuer the CLI
  * validates the token against matches what `auth rotate-operator` minted under.
+ * The fallback differs cosmetically — here `readHubPort(configDir) ??
+ * HUB_UNIT_DEFAULT_PORT`, in auth.ts `127.0.0.1:${HUB_DEFAULT_PORT}` — but both
+ * resolve to 1939 under canonical-ports today, so they agree in practice.
+ * TODO: consolidate with auth.ts:resolveHubIssuer to prevent drift.
  */
 function resolveOperatorTokenIssuer(hubOrigin: string | undefined, configDir: string): string {
   if (hubOrigin) return hubOrigin;
@@ -995,9 +999,15 @@ export async function restart(svc: string | undefined, opts: LifecycleOpts = {})
   // unchanged detached stop-then-start below.
   if (r.sup.unitInstalled) return restartViaSupervisor(svc, r);
   // --- no-unit detached fallback (unchanged; preserved until Phase 5) ---
-  const stopCode = await stop(svc, opts);
+  // Pass `supervisor: undefined` to the inner stop/start so their own
+  // `resolveSupervisor` short-circuits to `unitInstalled: false` without
+  // re-probing `isHubUnitInstalled` (two redundant `stat`s per call) — we
+  // already resolved no-unit above, so both inner calls would re-take this
+  // same detached arm regardless. Behavior-preserving; just drops the probes.
+  const detachedOpts = { ...opts, supervisor: undefined };
+  const stopCode = await stop(svc, detachedOpts);
   if (stopCode !== 0) return stopCode;
-  return await start(svc, opts);
+  return await start(svc, detachedOpts);
 }
 
 // ---------------------------------------------------------------------------
@@ -1080,6 +1090,13 @@ async function ensureHubForOp(r: Resolved, port: number): Promise<boolean> {
     log: r.log,
   });
   if (ensured.outcome === "already-up" || ensured.outcome === "started") return true;
+  // Defensive / unreachable under dual-dispatch: this arm catches the `no-unit`
+  // outcome (and any other non-up outcome), but we only reach `ensureHubForOp`
+  // on the supervisor path, which is gated on `unitInstalled === true` — the
+  // same `isHubUnitInstalled` probe that makes `ensureHubUnit` return `no-unit`
+  // only when it's false. So `no-unit` can't surface here in production; it's
+  // harmless surface. Candidate for removal in the Phase 5 bridge-collapse —
+  // the deletion sweep should not overlook this branch.
   for (const m of ensured.messages) r.log(m);
   return false;
 }

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -19,7 +19,28 @@ import {
 } from "../hub-control.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { HUB_ORIGIN_ENV, deriveHubOrigin } from "../hub-origin.ts";
+import {
+  type EnsureHubUnitOpts,
+  type EnsureHubUnitResult,
+  HUB_UNIT_DEFAULT_PORT,
+  type HubUnitDeps,
+  type HubUnitManagerOpResult,
+  defaultHubUnitDeps,
+  ensureHubUnit as ensureHubUnitImpl,
+  isHubUnitInstalled,
+  restartHubUnit as restartHubUnitImpl,
+  stopHubUnit as stopHubUnitImpl,
+} from "../hub-unit.ts";
 import { ModuleManifestError, readModuleManifest } from "../module-manifest.ts";
+import {
+  type DriveModuleOpDeps,
+  type ModuleOp,
+  ModuleOpHttpError,
+  type ModuleOpResult,
+  NoOperatorTokenError,
+  OperatorTokenExpiredError,
+  driveModuleOp as driveModuleOpImpl,
+} from "../module-ops-client.ts";
 import { type OperatorIssuerHealStatus, selfHealOperatorTokenIssuer } from "../operator-token.ts";
 import { type PortListeningFn, defaultPortListening } from "../port-probe.ts";
 import {
@@ -285,6 +306,58 @@ export interface LifecycleOpts {
       log: (line: string) => void;
     }) => Promise<OperatorIssuerHealStatus>;
   };
+  /**
+   * Phase 3b supervisor-path seams (design §3.3). When a hub UNIT is installed
+   * (launchd/systemd/container — detected via {@link isHubUnitInstalled}),
+   * `start/stop/restart` drive the RUNNING hub's in-process Supervisor over the
+   * loopback module-ops API instead of spawning detached pidfile daemons. The
+   * detached arm (`spawner`/`hub.ensureRunning`/`hub.stop`) remains the no-unit
+   * fallback until Phase 5 retires it.
+   *
+   * Everything here is injectable so tests can (a) force the unit-installed
+   * branch without a real launchd/systemd, and (b) assert the module-ops /
+   * manager calls without a live hub. Production wires the real
+   * {@link driveModuleOp} / {@link ensureHubUnit} / {@link stopHubUnit} /
+   * {@link restartHubUnit} against an opened hub.db + the resolved hub origin.
+   */
+  supervisor?: {
+    /**
+     * Is a hub unit installed (the dual-dispatch discriminant)? Production
+     * uses `isHubUnitInstalled(hubUnitDeps)`. Tests set this `true`/`false`
+     * directly to pick the branch deterministically. When set, it wins over
+     * the `hubUnitDeps`-derived detection.
+     */
+    unitInstalled?: boolean;
+    /** Deps for the real `isHubUnitInstalled` probe + the hub-unit manager ops. */
+    hubUnitDeps?: HubUnitDeps;
+    /** Drive a per-module op against the running hub (reads operator.token). */
+    driveModuleOp?: (
+      short: string,
+      op: ModuleOp,
+      deps: DriveModuleOpDeps,
+    ) => Promise<ModuleOpResult>;
+    /** Ensure the hub unit is up before a module op (§3.2). */
+    ensureHubUnit?: (opts: EnsureHubUnitOpts) => Promise<EnsureHubUnitResult>;
+    /** Stop the hub unit via the platform manager (NEVER a PID signal, §3.3). */
+    stopHubUnit?: (deps: HubUnitDeps) => HubUnitManagerOpResult;
+    /** Restart the hub unit via the platform manager (NEVER a PID signal, §3.3). */
+    restartHubUnit?: (deps: HubUnitDeps) => HubUnitManagerOpResult;
+    /**
+     * Probe whether the loopback hub answers `/health`. Used by `stop <svc>`:
+     * if the hub is down, the supervised module is already down (children die
+     * with the hub) → report "already stopped" WITHOUT starting the hub.
+     * Production reuses the hub-unit deps' `probeHealth`.
+     */
+    probeHubHealth?: (port: number) => Promise<boolean>;
+    /**
+     * Open the hub DB used to validate/auto-rotate the operator token in
+     * `driveModuleOp`. Production opens `<configDir>/hub.db`; tests inject an
+     * in-memory/seeded db. Returns a handle the caller closes.
+     */
+    openDb?: (configDir: string) => import("bun:sqlite").Database;
+    /** Loopback hub base URL override (default derives from the hub port). */
+    baseUrl?: string;
+  };
 }
 
 interface Resolved {
@@ -311,6 +384,21 @@ interface Resolved {
     configDir: string;
     log: (line: string) => void;
   }) => Promise<OperatorIssuerHealStatus>;
+  sup: ResolvedSupervisor;
+}
+
+/** Resolved Phase 3b supervisor-path seams (see `LifecycleOpts.supervisor`). */
+interface ResolvedSupervisor {
+  /** Whether a hub unit is installed — the dual-dispatch discriminant. */
+  unitInstalled: boolean;
+  hubUnitDeps: HubUnitDeps;
+  driveModuleOp: (short: string, op: ModuleOp, deps: DriveModuleOpDeps) => Promise<ModuleOpResult>;
+  ensureHubUnit: (opts: EnsureHubUnitOpts) => Promise<EnsureHubUnitResult>;
+  stopHubUnit: (deps: HubUnitDeps) => HubUnitManagerOpResult;
+  restartHubUnit: (deps: HubUnitDeps) => HubUnitManagerOpResult;
+  probeHubHealth: (port: number) => Promise<boolean>;
+  openDb: (configDir: string) => import("bun:sqlite").Database;
+  baseUrl: string | undefined;
 }
 
 /**
@@ -378,7 +466,58 @@ function resolve(opts: LifecycleOpts): Resolved {
     ensureHub: opts.hub?.ensureRunning ?? ensureHubRunning,
     stopHubFn: opts.hub?.stop ?? stopHub,
     selfHealOperatorTokenFn: opts.hub?.selfHealOperatorToken ?? defaultSelfHealOperatorToken,
+    sup: resolveSupervisor(opts.supervisor),
   };
+}
+
+/**
+ * Resolve the Phase 3b supervisor-path seams (the dual-dispatch arm).
+ *
+ * The discriminant `unitInstalled` decides which arm a verb takes:
+ *   - When the caller PROVIDES a `supervisor` block (even `{}`, which the
+ *     production CLI dispatch passes), `unitInstalled` is the explicit override
+ *     if set, else the real `isHubUnitInstalled` probe over the hub-unit deps —
+ *     so on a box with a launchd/systemd hub unit the verbs drive the running
+ *     supervisor, and on a legacy detached box they take the detached arm.
+ *   - When the caller OMITS `supervisor` entirely (the shape of every existing
+ *     lifecycle test, which never opts into the new path), `unitInstalled`
+ *     defaults to `false` → the detached arm. This keeps those tests
+ *     DETERMINISTIC regardless of whether the test host happens to have a real
+ *     hub unit installed. New Phase 3b tests opt into the supervisor arm by
+ *     passing `supervisor: { unitInstalled: true, … }`.
+ */
+function resolveSupervisor(opts: LifecycleOpts["supervisor"]): ResolvedSupervisor {
+  const hubUnitDeps = opts?.hubUnitDeps ?? defaultHubUnitDeps;
+  // No `supervisor` block at all → detached arm, deterministically. Only probe
+  // the real filesystem when the caller opted into the new path (production CLI
+  // passes `supervisor: {}`; tests pass the seams they want to assert).
+  const unitInstalled =
+    opts === undefined ? false : (opts.unitInstalled ?? isHubUnitInstalled(hubUnitDeps));
+  return {
+    unitInstalled,
+    hubUnitDeps,
+    driveModuleOp: opts?.driveModuleOp ?? driveModuleOpImpl,
+    ensureHubUnit: opts?.ensureHubUnit ?? ensureHubUnitImpl,
+    stopHubUnit: opts?.stopHubUnit ?? stopHubUnitImpl,
+    restartHubUnit: opts?.restartHubUnit ?? restartHubUnitImpl,
+    probeHubHealth: opts?.probeHubHealth ?? hubUnitDeps.probeHealth,
+    openDb: opts?.openDb ?? ((configDir) => openHubDb(hubDbPath(configDir))),
+    baseUrl: opts?.baseUrl,
+  };
+}
+
+/**
+ * Resolve the hub origin used as the operator token's `iss` validator in the
+ * supervisor path. Unlike {@link resolveHubOrigin} (which returns `undefined`
+ * for pure loopback so the spawn env omits PARACHUTE_HUB_ORIGIN), the operator
+ * token ALWAYS carries an `iss`, so this falls back to the canonical loopback
+ * origin. Mirrors `commands/auth.ts`'s `resolveHubIssuer` so the issuer the CLI
+ * validates the token against matches what `auth rotate-operator` minted under.
+ */
+function resolveOperatorTokenIssuer(hubOrigin: string | undefined, configDir: string): string {
+  if (hubOrigin) return hubOrigin;
+  const port = readHubPort(configDir) ?? HUB_UNIT_DEFAULT_PORT;
+  return `http://127.0.0.1:${port}`;
 }
 
 /**
@@ -548,6 +687,12 @@ async function resolveTargets(
 
 export async function start(svc: string | undefined, opts: LifecycleOpts = {}): Promise<number> {
   const r = resolve(opts);
+  // Phase 3b dual-dispatch (design §3.3). On a box with a hub unit installed,
+  // drive the RUNNING supervisor; otherwise fall through to the unchanged
+  // detached arm below. Phase 5 deletes the else-arm — keep this a clean
+  // top-level branch so that deletion is a one-liner.
+  if (r.sup.unitInstalled) return startViaSupervisor(svc, r);
+  // --- no-unit detached fallback (unchanged; preserved until Phase 5) ---
   if (svc === HUB_SVC) return startHubSvc(r);
   const picked = await resolveTargets(svc, r.manifestPath);
   if ("error" in picked) {
@@ -789,6 +934,10 @@ function persistVaultHubOriginForStart(r: Resolved): void {
 
 export async function stop(svc: string | undefined, opts: LifecycleOpts = {}): Promise<number> {
   const r = resolve(opts);
+  // Phase 3b dual-dispatch (design §3.3). Unit-installed → drive the supervisor
+  // / platform manager; else the unchanged detached arm below.
+  if (r.sup.unitInstalled) return stopViaSupervisor(svc, r);
+  // --- no-unit detached fallback (unchanged; preserved until Phase 5) ---
   if (svc === HUB_SVC) return stopHubSvc(r);
   const picked = await resolveTargets(svc, r.manifestPath);
   if ("error" in picked) {
@@ -840,9 +989,197 @@ export async function stop(svc: string | undefined, opts: LifecycleOpts = {}): P
 }
 
 export async function restart(svc: string | undefined, opts: LifecycleOpts = {}): Promise<number> {
+  const r = resolve(opts);
+  // Phase 3b dual-dispatch (design §3.3). Unit-installed → drive the supervisor
+  // / platform manager (with the 404-fallthrough for modules, §6.2); else the
+  // unchanged detached stop-then-start below.
+  if (r.sup.unitInstalled) return restartViaSupervisor(svc, r);
+  // --- no-unit detached fallback (unchanged; preserved until Phase 5) ---
   const stopCode = await stop(svc, opts);
   if (stopCode !== 0) return stopCode;
   return await start(svc, opts);
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3b supervisor-path verb dispatch (design §3.3).
+//
+// These are the NEW arm of the dual-dispatch: when a hub unit is installed,
+// `start/stop/restart` drive the RUNNING hub's in-process Supervisor over the
+// loopback module-ops API (per-module verbs) or the platform manager (hub
+// verbs / no-svc). The detached arm above is untouched and Phase 5 deletes it
+// + this comment block's `unitInstalled` guard, collapsing to this path only.
+// ---------------------------------------------------------------------------
+
+/**
+ * Drive a single module-op against the running hub, mapping the module-ops
+ * client's errors to actionable CLI output (§3.1). Opens hub.db (to validate /
+ * auto-rotate the operator token), resolves the issuer the token was minted
+ * under, and closes the db afterward. Returns the result on success; on a
+ * surfaced error returns `undefined` so the caller can decide (e.g. the restart
+ * 404-fallthrough). Re-throws nothing the caller can't handle: the operator-
+ * token / HTTP errors are caught here and printed.
+ */
+async function driveSupervisorOp(
+  short: string,
+  op: ModuleOp,
+  r: Resolved,
+): Promise<{ result?: ModuleOpResult; httpError?: ModuleOpHttpError; failed: boolean }> {
+  const issuer = resolveOperatorTokenIssuer(r.hubOrigin, r.configDir);
+  const db = r.sup.openDb(r.configDir);
+  try {
+    const deps: DriveModuleOpDeps = {
+      db,
+      issuer,
+      configDir: r.configDir,
+      ...(r.sup.baseUrl !== undefined ? { baseUrl: r.sup.baseUrl } : {}),
+    };
+    const result = await r.sup.driveModuleOp(short, op, deps);
+    return { result, failed: false };
+  } catch (err) {
+    if (err instanceof NoOperatorTokenError || err instanceof OperatorTokenExpiredError) {
+      // Surface the already-actionable message (don't raw-throw a 401, §3.1).
+      r.log(`✗ ${short}: ${err.message}`);
+      return { failed: true };
+    }
+    if (err instanceof ModuleOpHttpError) {
+      // Return the typed HTTP error so the caller can branch (404-fallthrough,
+      // not_installed hint). Callers that don't branch print it via
+      // `surfaceModuleOpHttpError`.
+      return { httpError: err, failed: true };
+    }
+    // Unknown error — surface its message rather than crashing the CLI.
+    r.log(`✗ ${short}: ${err instanceof Error ? err.message : String(err)}`);
+    return { failed: true };
+  } finally {
+    db.close();
+  }
+}
+
+/** Print a module-ops HTTP error with an actionable hint for the known codes. */
+function surfaceModuleOpHttpError(short: string, err: ModuleOpHttpError, r: Resolved): void {
+  if (err.status === 400 && err.code === "not_installed") {
+    r.log(
+      `✗ ${short} is not installed — run \`parachute install ${short}\` first, then \`parachute start ${short}\`.`,
+    );
+    return;
+  }
+  r.log(`✗ ${short}: ${err.message}`);
+}
+
+/**
+ * Ensure the hub unit is up, mapping `ensureHubUnit`'s structured outcome to a
+ * CLI exit signal. Returns true when the hub is up (already-up / started),
+ * false when it isn't (and the messages were surfaced). The `no-unit` outcome
+ * shouldn't reach here under the dual-dispatch (we only take the supervisor arm
+ * when a unit IS installed), but it's handled defensively.
+ */
+async function ensureHubForOp(r: Resolved, port: number): Promise<boolean> {
+  const ensured = await r.sup.ensureHubUnit({
+    port,
+    deps: r.sup.hubUnitDeps,
+    log: r.log,
+  });
+  if (ensured.outcome === "already-up" || ensured.outcome === "started") return true;
+  for (const m of ensured.messages) r.log(m);
+  return false;
+}
+
+/** `start <svc>` / `start` (no svc) over the supervisor (§3.3). */
+async function startViaSupervisor(svc: string | undefined, r: Resolved): Promise<number> {
+  const port = readHubPort(r.configDir) ?? HUB_UNIT_DEFAULT_PORT;
+  // `start hub` / `start` (no svc): ensure the hub unit is up — it transitively
+  // boots every installed module from services.json via bootSupervisedModules.
+  if (svc === HUB_SVC || svc === undefined) {
+    const up = await ensureHubForOp(r, port);
+    if (!up) return 1;
+    r.log(svc === HUB_SVC ? "✓ hub is up." : "✓ hub is up (all installed modules booted).");
+    return 0;
+  }
+  // `start <svc>`: ensure the hub is up first (chicken-and-egg §3.2), then drive
+  // a pure supervisor.start of the already-installed module.
+  if (!(await ensureHubForOp(r, port))) return 1;
+  const { result, httpError, failed } = await driveSupervisorOp(svc, "start", r);
+  if (httpError) {
+    surfaceModuleOpHttpError(svc, httpError, r);
+    return 1;
+  }
+  if (failed || !result) return 1;
+  r.log(`✓ ${svc} started.`);
+  return 0;
+}
+
+/** `stop <svc>` / `stop` (no svc) over the supervisor / platform manager (§3.3). */
+async function stopViaSupervisor(svc: string | undefined, r: Resolved): Promise<number> {
+  const port = readHubPort(r.configDir) ?? HUB_UNIT_DEFAULT_PORT;
+  // `stop hub` / `stop` (no svc): stop the hub UNIT via the platform manager.
+  // MUST go through the manager — a PID signal would be undone by launchd
+  // KeepAlive / systemd Restart=always (R17). Children die with the hub.
+  if (svc === HUB_SVC || svc === undefined) {
+    const res = r.sup.stopHubUnit(r.sup.hubUnitDeps);
+    for (const m of res.messages) r.log(m);
+    if (res.outcome === "ok") {
+      r.log("✓ hub stopped (all supervised modules stopped with it).");
+      return 0;
+    }
+    return 1;
+  }
+  // `stop <svc>`: a supervised module dies WITH the hub. If the hub isn't
+  // reachable, the module is already down — report success WITHOUT starting the
+  // hub (do NOT ensureHubUnit just to stop one module). Only when the hub is up
+  // do we drive the supervisor's stop.
+  if (!(await r.sup.probeHubHealth(port))) {
+    r.log(`${svc} already stopped (the hub isn't running, so its modules are down).`);
+    return 0;
+  }
+  const { httpError, failed, result } = await driveSupervisorOp(svc, "stop", r);
+  if (httpError) {
+    surfaceModuleOpHttpError(svc, httpError, r);
+    return 1;
+  }
+  if (failed || !result) return 1;
+  r.log(`✓ ${svc} stopped.`);
+  return 0;
+}
+
+/** `restart <svc>` / `restart` (no svc) over the supervisor / manager (§3.3). */
+async function restartViaSupervisor(svc: string | undefined, r: Resolved): Promise<number> {
+  // `restart hub` / `restart` (no svc): restart the hub UNIT via the platform
+  // manager. NOT a per-module fan-out — restarting the hub re-boots all modules
+  // anyway. MUST go through the manager (never a PID signal, R17).
+  if (svc === HUB_SVC || svc === undefined) {
+    const res = r.sup.restartHubUnit(r.sup.hubUnitDeps);
+    for (const m of res.messages) r.log(m);
+    if (res.outcome === "ok") {
+      r.log("✓ hub restarted (all modules re-booted).");
+      return 0;
+    }
+    return 1;
+  }
+  // `restart <svc>`: ensure the hub is up, then drive supervisor.restart.
+  const port = readHubPort(r.configDir) ?? HUB_UNIT_DEFAULT_PORT;
+  if (!(await ensureHubForOp(r, port))) return 1;
+  const restartRes = await driveSupervisorOp(svc, "restart", r);
+  if (restartRes.httpError) {
+    // 404-fallthrough (§6.2): a module that isn't currently supervised (crashed
+    // out of budget, skipped at boot, installed out-of-band) returns 404
+    // `not_supervised`. `restart` must be total over module state (matching the
+    // detached stop+start), so fall through to a pure `start`.
+    if (restartRes.httpError.status === 404 && restartRes.httpError.code === "not_supervised") {
+      const startRes = await driveSupervisorOp(svc, "start", r);
+      if (startRes.httpError) {
+        surfaceModuleOpHttpError(svc, startRes.httpError, r);
+        return 1;
+      }
+      if (startRes.failed || !startRes.result) return 1;
+      r.log(`✓ ${svc} started.`);
+      return 0;
+    }
+    surfaceModuleOpHttpError(svc, restartRes.httpError, r);
+    return 1;
+  }
+  if (restartRes.failed || !restartRes.result) return 1;
+  r.log(`✓ ${svc} restarted.`);
+  return 0;
 }
 
 /**

--- a/src/hub-unit.ts
+++ b/src/hub-unit.ts
@@ -240,6 +240,107 @@ function tailHubUnitLog(deps: HubUnitDeps, lines: number): string[] {
   return out;
 }
 
+/** Outcome of a `stop hub` / `restart hub` via the platform manager (§3.3). */
+export type HubUnitManagerOpOutcome =
+  /** The manager command succeeded (the unit was stopped / restarted). */
+  | "ok"
+  /** No service manager (systemd/launchd) is available. */
+  | "no-manager"
+  /** No hub unit is installed. */
+  | "no-unit"
+  /** The platform manager rejected the command (carries its stderr). */
+  | "failed";
+
+export interface HubUnitManagerOpResult {
+  outcome: HubUnitManagerOpOutcome;
+  /** Human-readable lines the caller should surface. */
+  messages: string[];
+}
+
+/**
+ * Stop the hub UNIT via the platform manager (design §3.3 `stop hub` row).
+ *
+ * MUST go through the manager — NEVER a PID signal. launchd `KeepAlive` and
+ * systemd `Restart=always` would immediately respawn a killed PID (R17), so a
+ * `kill` would be silently undone. The manager call deregisters the unit's
+ * keep-alive intent so the hub actually stays down:
+ *   - launchd  → `launchctl bootout gui/<uid>/<label>` (unloads + stops; a
+ *     subsequent `start hub` re-bootstraps via the install path / `init`).
+ *   - systemd  → `systemctl [--user] stop <unit>` (Restart=always does not
+ *     re-trigger on an explicit `stop`).
+ *
+ * Children die with the hub (`serve`'s stop() SIGTERMs all supervised children
+ * before `server.stop()`), so stopping the unit stops every module too.
+ *
+ * Returns a structured outcome; the caller maps it to exit code + messaging.
+ * Does NOT install a unit when none exists, and does NOT signal any PID.
+ */
+export function stopHubUnit(deps: HubUnitDeps): HubUnitManagerOpResult {
+  if (!hasServiceManager(deps)) {
+    return { outcome: "no-manager", messages: [NO_MANAGER_MESSAGE] };
+  }
+  if (!isHubUnitInstalled(deps)) {
+    return { outcome: "no-unit", messages: [NO_UNIT_MESSAGE] };
+  }
+  let res: ServiceCommandResult;
+  if (deps.platform === "darwin") {
+    const uid = deps.getuid() ?? 0;
+    // bootout unloads + stops the LaunchAgent so KeepAlive can't resurrect it.
+    res = deps.run(["launchctl", "bootout", `gui/${uid}/${HUB_LAUNCHD_LABEL}`]);
+  } else {
+    const root = (deps.getuid() ?? 1000) === 0;
+    const scope = root ? [] : ["--user"];
+    res = deps.run(["systemctl", ...scope, "stop", HUB_SYSTEMD_UNIT_NAME]);
+  }
+  if (res.code !== 0) {
+    const detail = res.stderr.trim() || res.stdout.trim() || "unknown error";
+    return {
+      outcome: "failed",
+      messages: [`failed to stop the hub unit via the service manager (${detail})`],
+    };
+  }
+  return { outcome: "ok", messages: [] };
+}
+
+/**
+ * Restart the hub UNIT via the platform manager (design §3.3 `restart hub`
+ * row). MUST go through the manager — NEVER a PID signal (same R17 reasoning as
+ * {@link stopHubUnit}). NOT a per-module fan-out: restarting the hub tears down
+ * all supervised children and re-boots every module from `services.json`, so a
+ * unit restart is already a total restart of the box's modules.
+ *   - launchd  → `launchctl kickstart -k gui/<uid>/<label>` (force-restart;
+ *     the same command the start path uses, which on an already-loaded unit
+ *     kills + relaunches).
+ *   - systemd  → `systemctl [--user] restart <unit>`.
+ *
+ * Returns a structured outcome; the caller maps it to exit code + messaging.
+ */
+export function restartHubUnit(deps: HubUnitDeps): HubUnitManagerOpResult {
+  if (!hasServiceManager(deps)) {
+    return { outcome: "no-manager", messages: [NO_MANAGER_MESSAGE] };
+  }
+  if (!isHubUnitInstalled(deps)) {
+    return { outcome: "no-unit", messages: [NO_UNIT_MESSAGE] };
+  }
+  let res: ServiceCommandResult;
+  if (deps.platform === "darwin") {
+    const uid = deps.getuid() ?? 0;
+    res = deps.run(["launchctl", "kickstart", "-k", `gui/${uid}/${HUB_LAUNCHD_LABEL}`]);
+  } else {
+    const root = (deps.getuid() ?? 1000) === 0;
+    const scope = root ? [] : ["--user"];
+    res = deps.run(["systemctl", ...scope, "restart", HUB_SYSTEMD_UNIT_NAME]);
+  }
+  if (res.code !== 0) {
+    const detail = res.stderr.trim() || res.stdout.trim() || "unknown error";
+    return {
+      outcome: "failed",
+      messages: [`failed to restart the hub unit via the service manager (${detail})`],
+    };
+  }
+  return { outcome: "ok", messages: [] };
+}
+
 /**
  * Ensure the hub UNIT is up (design §3.2). Probe `/health`; if down, start the
  * unit via the platform manager; wait for readiness; surface the unit log on

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -67,7 +67,13 @@ import {
 } from "./hub-settings.ts";
 import { signAccessToken } from "./jwt-sign.ts";
 import { escapeHtml } from "./oauth-ui.ts";
-import { mintOperatorToken } from "./operator-token.ts";
+import {
+  type IssueOperatorTokenResult,
+  type MintOperatorTokenOpts,
+  issueOperatorToken,
+  mintOperatorToken,
+  readOperatorTokenFile,
+} from "./operator-token.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
 import { findService, readManifestLenient } from "./services-manifest.ts";
 import {
@@ -377,6 +383,22 @@ export interface SetupWizardDeps {
    * `readExposeStateFn` seam.
    */
   readExposeStateFn?: () => ExposeState | undefined;
+  /**
+   * Test seam for the fresh-box operator-token closure (design §3.1 /
+   * Phase 3b Deliverable A). After the wizard creates the first admin, it
+   * persists `~/.parachute/operator.token` so the box has a CLI operator
+   * credential the moment it gains an admin — without it, the Phase 3b
+   * per-module verbs (`parachute start/stop/restart <svc>` driving the
+   * supervisor) would 401 on a freshly-bootstrapped box. Production omits
+   * this and uses the real {@link issueOperatorToken}; tests inject a stub
+   * to assert the call (or to make it throw and prove a token-write failure
+   * never fails account creation).
+   */
+  issueOperatorToken?: (
+    db: Database,
+    userId: string,
+    opts: MintOperatorTokenOpts & { dir?: string },
+  ) => Promise<IssueOperatorTokenResult>;
 }
 
 /**
@@ -1888,6 +1910,16 @@ export async function handleSetupAccountPost(
     // any racer who saw it over the operator's shoulder during the
     // window between log-print and form-submit.
     if (requireToken) consumeBootstrapToken();
+    // Fresh-box operator-token closure (design §3.1 / Phase 3b Deliverable A).
+    // The box now has its first admin — persist `operator.token` so it has a
+    // CLI operator credential immediately. Without it, the Phase 3b per-module
+    // verbs (start/stop/restart <svc> driving the supervisor over the
+    // module-ops API) would 401 on a box bootstrapped purely through the
+    // wizard. Runs AFTER the admin row + bootstrap-token are committed so a
+    // half-written admin never gains a token; guarded so an existing token is
+    // never clobbered; wrapped so a token-write failure NEVER fails the
+    // account creation the operator just completed.
+    await ensureOperatorTokenForFirstAdmin(deps, user.id);
     const session = createSession(deps.db, { userId: user.id });
     const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000), {
       secure: isHttpsRequest(req),
@@ -1924,6 +1956,50 @@ export async function handleSetupAccountPost(
       }),
       400,
     );
+  }
+}
+
+/**
+ * Persist `~/.parachute/operator.token` for the just-created first admin
+ * (design §3.1 / Phase 3b Deliverable A). The 3a reviewer flagged that a fresh
+ * `init`→wizard flow ends with NO operator token on disk, so the Phase 3b
+ * per-module verbs — `parachute start/stop/restart <svc>`, which now drive the
+ * supervisor over the host-admin-gated module-ops API — would 401 on such a
+ * box. Minting the token here makes the box have a CLI operator credential the
+ * moment it gains an admin.
+ *
+ * Three invariants:
+ *   - Mints under the `admin` scope-set (the default), which carries
+ *     `parachute:host:admin` — exactly the scope `api-modules-ops.ts` gates on.
+ *     `issueOperatorToken` writes it 0600 (`writeOperatorTokenFile`).
+ *   - Guarded by `readOperatorTokenFile() === null`: never clobber a token an
+ *     operator already minted (`auth set-password` / `rotate-operator`, or a
+ *     prior init).
+ *   - Wrapped in try/catch so a token-write failure NEVER fails the account
+ *     creation the operator just completed — they have an admin row + session
+ *     either way, and `parachute auth rotate-operator` is the documented
+ *     recovery for a missing token.
+ *
+ * Uses `deps.issuer` as the `iss` claim — the same origin the rest of the
+ * wizard's mints use (`handleSetupExposePost`). `start hub` self-heals a stale
+ * `iss` later if the box is exposed after init (hub#481), so an init-at-loopback
+ * mint is correct here.
+ */
+async function ensureOperatorTokenForFirstAdmin(
+  deps: SetupWizardDeps,
+  userId: string,
+): Promise<void> {
+  const issue = deps.issueOperatorToken ?? issueOperatorToken;
+  try {
+    const existing = await readOperatorTokenFile(deps.configDir);
+    if (existing !== null) return;
+    await issue(deps.db, userId, { issuer: deps.issuer, dir: deps.configDir });
+  } catch (err) {
+    // Non-fatal: the admin + session were already committed. Log for the
+    // operator's debugging; they can recover with `parachute auth
+    // rotate-operator` from a shell on the box.
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[setup-wizard] operator-token closure skipped for new admin: ${msg}`);
   }
 }
 

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -1980,10 +1980,13 @@ export async function handleSetupAccountPost(
  *     either way, and `parachute auth rotate-operator` is the documented
  *     recovery for a missing token.
  *
- * Uses `deps.issuer` as the `iss` claim — the same origin the rest of the
- * wizard's mints use (`handleSetupExposePost`). `start hub` self-heals a stale
- * `iss` later if the box is exposed after init (hub#481), so an init-at-loopback
- * mint is correct here.
+ * Uses `deps.issuer` as the `iss` claim — the same pre-resolved origin the rest
+ * of the wizard's mints use (`handleSetupExposePost`). The hub-server derives
+ * that origin the same way `commands/auth.ts:resolveHubIssuer` does — semantically
+ * equivalent, structurally different: this path takes a pre-resolved `deps.issuer`
+ * while `auth.ts` reads expose-state inline at call time. `start hub` self-heals a
+ * stale `iss` later if the box is exposed after init (hub#481), so an
+ * init-at-loopback mint is correct here.
  */
 async function ensureOperatorTokenForFirstAdmin(
   deps: SetupWizardDeps,


### PR DESCRIPTION
Phase 3b of the hub-as-supervisor unification (design `2026-06-01-hub-as-supervisor-unification.md`). Repoints `start/stop/restart` onto the running supervisor when a hub unit is installed, and closes the fresh-box operator-token bootstrap gap the Phase 3a reviewer flagged. **No version bump; the detached path is preserved byte-for-byte as the no-unit fallback.**

## A — Fresh-box operator-token closure (§3.1)
A fresh `init`→wizard flow ended with **no** persisted `operator.token`, so the Phase 3b per-module verbs (now authenticated module-ops calls gated on `parachute:host:admin`) would **401** on a box bootstrapped purely through the wizard. `handleSetupAccountPost` now persists `~/.parachute/operator.token` via `issueOperatorToken` (admin scope-set → carries `parachute:host:admin`; written 0600) **immediately after the first admin is created**. Guarded by `readOperatorTokenFile() === null` (never clobbers an existing token); wrapped so a token-write failure **never** fails the account creation. `issueOperatorToken` added to the wizard deps seam for injectability. This directly fixes the 3a-flagged §3.1 gap.

## B — start/stop/restart verb cutover (§3.3) — the dual-dispatch safety bridge
Each verb branches **at the top** on `r.sup.unitInstalled`:
- **Hub unit installed** → drive the **running supervisor** (`driveModuleOp`) / the **platform manager** (the new path).
- **No unit installed** (legacy detached box, or Aaron's bun-linked laptop pre-migrate) → the **exact existing detached behavior** (`defaultSpawner` / `ensureHubRunning` / `stopHub`), **unchanged**.

This is the temporary §7.5 bridge: **un-migrated boxes keep working**, and **Phase 5 collapses it** by deleting the clean else-arm (each verb is structured so the deletion is mechanical). The discriminant defaults to `false` unless the caller passes a `supervisor` block, so every existing lifecycle test stays **deterministic** regardless of the test host's real unit state; the production CLI dispatch opts in with `supervisor: {}`. Other lifecycle callers (`expose`/`upgrade`/`install`/`auto-wire`) omit `supervisor` and keep the detached arm — their folds are Phase 4/5.

Supervisor-arm behavior:
- `start <svc>` → `ensureHubUnit` → `driveModuleOp(start)`; `NoOperatorTokenError` surfaces its actionable message (not a raw 401); 400 `not_installed` → "install it first" hint.
- `start` / `start hub` → `ensureHubUnit` (boots all modules transitively).
- `stop <svc>` → **probe the hub `/health` first**; if the hub is down the supervised module is already down → report "already stopped" **WITHOUT starting the hub**; hub up → `driveModuleOp(stop)`.
- `stop` / `stop hub` → `stopHubUnit` (platform manager — **never a PID signal**, R17).
- `restart <svc>` → `ensureHubUnit` → `driveModuleOp(restart)`; **404 `not_supervised` falls through to `start`** (§6.2 — total over module state, matching detached stop+start).
- `restart` / `restart hub` → `restartHubUnit` (manager; **not** a per-module fan-out — restarting the hub re-boots all modules anyway).

New `stopHubUnit` / `restartHubUnit` in `hub-unit.ts` go through `systemctl stop/restart` (launchd `bootout` / `kickstart -k`) **only** — never a `kill` — so launchd `KeepAlive` / systemd `Restart=always` can't resurrect a stopped hub.

## How the dual-dispatch is structured (for review + Phase 5)
`start`/`stop`/`restart` each begin with `if (r.sup.unitInstalled) return <verb>ViaSupervisor(svc, r);` then the unchanged detached body. Phase 5 deletes that guard line + the supervisor-path helpers' fallback wiring and removes the detached body. The supervisor seams live in `LifecycleOpts.supervisor` (all injectable) → `ResolvedSupervisor`.

## Gates
- `bun test ./src`: **2684 pass / 1 skip / 0 fail** (baseline after 3a was 2655/1/0 → +29 new tests, zero regressions).
- `bun run typecheck`: clean.
- `bunx biome check` on touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)