### PR TITLE
feat(hub): Phase 3c — status reads platform manager + running supervisor (dual-dispatch, detached fallback)

### DIFF
--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -325,6 +325,60 @@ describe("GET /api/modules", () => {
     expect(body.supervisor_available).toBe(true);
   });
 
+  test("projects the supervisor's structured startError onto supervisor_start_error (§6.4/#188)", async () => {
+    // The Phase 3c `parachute status` supervisor arm reads this field to show
+    // the SAME friendly missing-dependency note the detached path persists. A
+    // fake supervisor whose list() returns a `crashed` state carrying a
+    // structured `startError` exercises the projection.
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/vault/default"],
+        health: "/vault/default/health",
+        version: "0.4.5",
+      },
+    ]);
+    const fakeSupervisor = {
+      list: () => [
+        {
+          short: "vault",
+          status: "crashed" as const,
+          restartsInWindow: 1,
+          startError: {
+            error_type: "missing_dependency",
+            error_description: "parachute-vault is required",
+            binary: "parachute-vault",
+            at: "2026-06-01T00:00:00Z",
+          },
+        },
+      ],
+    } as unknown as Supervisor;
+
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      supervisor: fakeSupervisor,
+      fetchLatestVersion: async () => null,
+    });
+    const body = (await res.json()) as {
+      modules: Array<{
+        short: string;
+        supervisor_status: string | null;
+        supervisor_start_error: { binary?: string; error_type?: string } | null;
+      }>;
+    };
+    const vault = body.modules.find((m) => m.short === "vault");
+    expect(vault?.supervisor_status).toBe("crashed");
+    expect(vault?.supervisor_start_error?.binary).toBe("parachute-vault");
+    expect(vault?.supervisor_start_error?.error_type).toBe("missing_dependency");
+    // A module with no supervisor entry surfaces null (uniform wire shape).
+    const scribe = body.modules.find((m) => m.short === "scribe");
+    expect(scribe?.supervisor_start_error).toBeNull();
+  });
+
   test("populates management_url from a relative managementUrl + module mount (hub#342)", async () => {
     // Vault declares `managementUrl: "/admin"` in its module.json — hub
     // resolves that against the entry's mount path (`/vault/default`)

--- a/src/__tests__/hub-unit.test.ts
+++ b/src/__tests__/hub-unit.test.ts
@@ -5,6 +5,7 @@ import {
   NO_UNIT_MESSAGE,
   ensureHubUnit,
   installAndStartHubUnit,
+  queryHubUnitState,
   restartHubUnit,
   stopHubUnit,
 } from "../hub-unit.ts";
@@ -439,5 +440,135 @@ describe("restartHubUnit — manager-only hub restart (§3.3, R17)", () => {
     const res = restartHubUnit(f.deps);
     expect(res.outcome).toBe("failed");
     expect(res.messages.join("\n")).toContain("job failed");
+  });
+});
+
+describe("queryHubUnitState — §6.4 hub-row manager query", () => {
+  test("no service manager → no-manager (nothing to query)", () => {
+    const f = fakeDeps({ platform: "linux", which: () => null });
+    expect(queryHubUnitState(f.deps).state).toBe("no-manager");
+  });
+
+  test("manager present but no unit installed → no-unit", () => {
+    const f = fakeDeps({ platform: "linux", installedUnit: false });
+    expect(queryHubUnitState(f.deps).state).toBe("no-unit");
+  });
+
+  test("systemd is-active → active", () => {
+    const f = fakeDeps({
+      platform: "linux",
+      getuid: () => 1000,
+      installedUnit: true,
+      runResults: [{ code: 0, stdout: "active\n", stderr: "" }],
+    });
+    const r = queryHubUnitState(f.deps);
+    expect(r.state).toBe("active");
+    // user-scope is-active was driven.
+    expect(f.calls).toContainEqual(["systemctl", "--user", "is-active", HUB_UNIT]);
+  });
+
+  test("systemd is-active → failed (nonzero exit, stdout token classified)", () => {
+    const f = fakeDeps({
+      platform: "linux",
+      getuid: () => 1000,
+      installedUnit: true,
+      // is-active exits 3 for a failed unit; the state word is on stdout.
+      runResults: [{ code: 3, stdout: "failed\n", stderr: "" }],
+    });
+    expect(queryHubUnitState(f.deps).state).toBe("failed");
+  });
+
+  test("systemd is-active → inactive", () => {
+    const f = fakeDeps({
+      platform: "linux",
+      getuid: () => 1000,
+      installedUnit: true,
+      runResults: [{ code: 3, stdout: "inactive\n", stderr: "" }],
+    });
+    expect(queryHubUnitState(f.deps).state).toBe("inactive");
+  });
+
+  test("systemd is-active → activating maps to activating", () => {
+    const f = fakeDeps({
+      platform: "linux",
+      getuid: () => 1000,
+      installedUnit: true,
+      runResults: [{ code: 3, stdout: "activating\n", stderr: "" }],
+    });
+    expect(queryHubUnitState(f.deps).state).toBe("activating");
+  });
+
+  test("systemd root scope → no --user", () => {
+    const f = fakeDeps({
+      platform: "linux",
+      getuid: () => 0,
+      userName: () => "root",
+      installedUnit: true,
+      runResults: [{ code: 0, stdout: "active\n", stderr: "" }],
+    });
+    queryHubUnitState(f.deps);
+    expect(f.calls).toContainEqual(["systemctl", "is-active", HUB_UNIT]);
+  });
+
+  test("launchd print: state = running → active (+ last exit code parsed)", () => {
+    const f = fakeDeps({
+      platform: "darwin",
+      getuid: () => 501,
+      installedUnit: true,
+      runResults: [
+        {
+          code: 0,
+          stdout:
+            "computer.parachute.hub = {\n\tstate = running\n\tpid = 4242\n\tlast exit code = 0\n}",
+          stderr: "",
+        },
+      ],
+    });
+    const r = queryHubUnitState(f.deps);
+    expect(r.state).toBe("active");
+    expect(r.lastExitCode).toBe(0);
+    expect(f.calls).toContainEqual(["launchctl", "print", "gui/501/computer.parachute.hub"]);
+  });
+
+  test("launchd print: not running + nonzero last exit code → failed", () => {
+    const f = fakeDeps({
+      platform: "darwin",
+      getuid: () => 501,
+      installedUnit: true,
+      runResults: [
+        {
+          code: 0,
+          stdout: "computer.parachute.hub = {\n\tstate = not running\n\tlast exit code = 78\n}",
+          stderr: "",
+        },
+      ],
+    });
+    const r = queryHubUnitState(f.deps);
+    expect(r.state).toBe("failed");
+    expect(r.lastExitCode).toBe(78);
+  });
+
+  test("launchd print: label not loaded (empty stdout) → inactive, never throws", () => {
+    const f = fakeDeps({
+      platform: "darwin",
+      getuid: () => 501,
+      installedUnit: true,
+      runResults: [{ code: 1, stdout: "", stderr: "Could not find service" }],
+    });
+    expect(queryHubUnitState(f.deps).state).toBe("inactive");
+  });
+
+  test("a thrown manager run never escapes — degrades to unknown", () => {
+    const f = fakeDeps({
+      platform: "linux",
+      getuid: () => 1000,
+      installedUnit: true,
+      run: () => {
+        throw new Error("spawn EPERM");
+      },
+    });
+    const r = queryHubUnitState(f.deps);
+    expect(r.state).toBe("unknown");
+    expect(r.detail).toContain("spawn EPERM");
   });
 });

--- a/src/__tests__/module-ops-client.test.ts
+++ b/src/__tests__/module-ops-client.test.ts
@@ -10,6 +10,7 @@ import {
   NoOperatorTokenError,
   driveModuleOp,
   fetchModuleLogs,
+  fetchModuleStates,
   resolveOperatorBearer,
 } from "../module-ops-client.ts";
 import { issueOperatorToken } from "../operator-token.ts";
@@ -409,5 +410,105 @@ describe("fetchModuleLogs", () => {
       fetch: f,
     });
     expect(result.text).toBe("a\nb\n");
+  });
+});
+
+describe("fetchModuleStates", () => {
+  let h: Harness;
+  afterEach(() => h.cleanup());
+
+  test("GETs /api/modules with the operator bearer and parses the supervisor fields", async () => {
+    h = await makeHarnessWithToken();
+    const { fetch: f, calls } = fakeFetch([
+      {
+        status: 200,
+        body: {
+          supervisor_available: true,
+          modules: [
+            {
+              short: "vault",
+              installed: true,
+              installed_version: "0.6.2",
+              supervisor_status: "running",
+              pid: 4242,
+              supervisor_start_error: null,
+            },
+            {
+              short: "scribe",
+              installed: false,
+              installed_version: null,
+              supervisor_status: null,
+              pid: null,
+              supervisor_start_error: {
+                error_type: "missing_dependency",
+                binary: "scribe",
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    const result = await fetchModuleStates({
+      db: h.db,
+      issuer: ISSUER,
+      configDir: h.dir,
+      fetch: f,
+    });
+
+    // Hits GET /api/modules with a Bearer.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe(`${DEFAULT_HUB_BASE_URL}/api/modules`);
+    expect(calls[0]?.method).toBe("GET");
+    expect(calls[0]?.headers.authorization).toMatch(/^Bearer /);
+
+    expect(result.supervisorAvailable).toBe(true);
+    expect(result.modules).toHaveLength(2);
+    const vault = result.modules.find((m) => m.short === "vault");
+    expect(vault?.supervisor_status).toBe("running");
+    expect(vault?.pid).toBe(4242);
+    const scribe = result.modules.find((m) => m.short === "scribe");
+    expect(scribe?.supervisor_status).toBeNull();
+    expect((scribe?.supervisor_start_error as { binary?: string } | null)?.binary).toBe("scribe");
+  });
+
+  test("no operator token → NoOperatorTokenError before any fetch", async () => {
+    h = await makeHarnessNoToken();
+    const { fetch: f, calls } = fakeFetch([{ status: 200, body: { modules: [] } }]);
+    let err: unknown;
+    try {
+      await fetchModuleStates({ db: h.db, issuer: ISSUER, configDir: h.dir, fetch: f });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(NoOperatorTokenError);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("non-2xx → ModuleOpHttpError (so the status caller can degrade)", async () => {
+    h = await makeHarnessWithToken();
+    const { fetch: f } = fakeFetch([
+      { status: 403, body: { error: "insufficient_scope", error_description: "lacks scope" } },
+    ]);
+    let err: unknown;
+    try {
+      await fetchModuleStates({ db: h.db, issuer: ISSUER, configDir: h.dir, fetch: f });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ModuleOpHttpError);
+    expect((err as ModuleOpHttpError).status).toBe(403);
+  });
+
+  test("malformed body (no modules array) → empty modules, not a throw", async () => {
+    h = await makeHarnessWithToken();
+    const { fetch: f } = fakeFetch([{ status: 200, body: { supervisor_available: false } }]);
+    const result = await fetchModuleStates({
+      db: h.db,
+      issuer: ISSUER,
+      configDir: h.dir,
+      fetch: f,
+    });
+    expect(result.supervisorAvailable).toBe(false);
+    expect(result.modules).toEqual([]);
   });
 });

--- a/src/__tests__/module-ops-client.test.ts
+++ b/src/__tests__/module-ops-client.test.ts
@@ -511,4 +511,46 @@ describe("fetchModuleStates", () => {
     expect(result.supervisorAvailable).toBe(false);
     expect(result.modules).toEqual([]);
   });
+
+  test("wedged hub (fetch never resolves) → bounded timeout degrades, no hang", async () => {
+    h = await makeHarnessWithToken();
+    // A hub that accepts the connection but never answers: the fetch settles ONLY
+    // when its AbortSignal fires. With a short injected ceiling, fetchModuleStates
+    // must reject within the bound (degrade) rather than hang forever.
+    let signalRef: AbortSignal | undefined;
+    const neverResolving = ((_input: string | URL | Request, init?: RequestInit) => {
+      signalRef = init?.signal ?? undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        // Honor the abort signal the bounded fetch wires in — that's what frees us.
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const start = Date.now();
+    let err: unknown;
+    try {
+      await fetchModuleStates({
+        db: h.db,
+        issuer: ISSUER,
+        configDir: h.dir,
+        fetch: neverResolving,
+        statesFetchTimeoutMs: 25, // short injected ceiling — no real wall-clock wait
+      });
+    } catch (e) {
+      err = e;
+    }
+    const elapsed = Date.now() - start;
+
+    // The bounded fetch passed an AbortSignal through to our stub.
+    expect(signalRef).toBeInstanceOf(AbortSignal);
+    // Resolved within the bound (generous slack for runner jitter), did not hang.
+    expect(elapsed).toBeLessThan(2_000);
+    // Degrades through the SAME ModuleOpHttpError path the status caller already
+    // catches → "couldn't read live module state (…)" note + exit 0, never a hang.
+    expect(err).toBeInstanceOf(ModuleOpHttpError);
+    expect((err as ModuleOpHttpError).code).toBe("request_timeout");
+    expect((err as Error).message).toContain("timed out");
+  });
 });

--- a/src/__tests__/status-supervisor.test.ts
+++ b/src/__tests__/status-supervisor.test.ts
@@ -40,7 +40,15 @@ const STUB_INSTALL_SOURCE = {
   readGitHead: () => undefined,
 };
 
-/** A throwaway db handle the seams never actually read (fetchModuleStates is stubbed). */
+/**
+ * A throwaway db handle exposing ONLY `{ close }`. This is intentionally minimal:
+ * on the supervisor status path the db is never READ — module states come from
+ * the API (`fetchModuleStates`, stubbed here), and `buildSupervisorRows` only
+ * opens the handle to pass it through + `close()` it in `finally`. The
+ * `as unknown as Database` cast at the call site widens this to the full type;
+ * if a future change adds a real db read on this path, it will fail at RUNTIME
+ * (missing method) rather than typecheck — so wire the needed method in here.
+ */
 function fakeOpenDb(): { close: () => void } {
   return { close: () => {} };
 }

--- a/src/__tests__/status-supervisor.test.ts
+++ b/src/__tests__/status-supervisor.test.ts
@@ -1,0 +1,561 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { status } from "../commands/status.ts";
+import type { HubUnitDeps, HubUnitStateResult } from "../hub-unit.ts";
+import {
+  type ModuleStatesResult,
+  NoOperatorTokenError,
+  OperatorTokenExpiredError,
+} from "../module-ops-client.ts";
+import { upsertService } from "../services-manifest.ts";
+
+/**
+ * Phase 3c (design §6.4): on a UNIT-MANAGED box `status` reads the hub row from
+ * the platform manager + `/health` and the module rows from the running
+ * supervisor (`GET /api/modules`). Everything below is driven through the
+ * `supervisor` seams — no real launchd/systemd/socket/HTTP/db call. The detached
+ * arm is exercised separately in `status.test.ts` (those tests omit the
+ * `supervisor` block entirely, so they keep the pidfile readout unchanged).
+ */
+
+function makeTempPath(): { path: string; cleanup: () => void; configDir: string } {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-status-sup-"));
+  return {
+    path: join(dir, "services.json"),
+    configDir: dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+/**
+ * Install-source deps that never touch the real filesystem (so the hub row's +
+ * module rows' source classification is deterministic in the test runner).
+ */
+const STUB_INSTALL_SOURCE = {
+  bunGlobalPrefixes: () => [] as string[],
+  resolveBunGlobal: () => null,
+  readJson: () => ({ version: "0.6.2" }),
+  readGitHead: () => undefined,
+};
+
+/** A throwaway db handle the seams never actually read (fetchModuleStates is stubbed). */
+function fakeOpenDb(): { close: () => void } {
+  return { close: () => {} };
+}
+
+/**
+ * Minimal `HubUnitDeps` — only the fields the seams that ARE wired through deps
+ * touch. `queryHubUnitState` / `probeHubHealth` / `fetchModuleStates` are
+ * injected directly as the `supervisor` seams, so the deps here only need to be
+ * a well-typed placeholder.
+ */
+const FAKE_HUB_UNIT_DEPS = {
+  platform: "linux",
+  getuid: () => 1000,
+  homeDir: () => "/home/op",
+  userName: () => "op",
+  which: () => "/usr/bin/systemctl",
+  run: () => ({ code: 0, stdout: "", stderr: "" }),
+  writeFile: () => {},
+  removeFile: () => {},
+  readFile: () => undefined,
+  exists: () => false,
+  probeHealth: async () => true,
+  portListening: async () => true,
+  sleep: async () => {},
+} as unknown as HubUnitDeps;
+
+interface SupervisorArmOpts {
+  managerState: HubUnitStateResult;
+  hubHealthy: boolean;
+  moduleStates?: ModuleStatesResult;
+  fetchModuleStatesImpl?: () => Promise<ModuleStatesResult>;
+}
+
+/** Drive `status` through the supervisor arm with fully stubbed seams. */
+function supervisorOpts(configDir: string, path: string, o: SupervisorArmOpts) {
+  return {
+    manifestPath: path,
+    configDir,
+    installSourceDeps: STUB_INSTALL_SOURCE,
+    hubSrcDir: "/nonexistent/hub/src",
+    supervisor: {
+      unitInstalled: true,
+      hubUnitDeps: FAKE_HUB_UNIT_DEPS,
+      queryHubUnitState: () => o.managerState,
+      probeHubHealth: async () => o.hubHealthy,
+      fetchModuleStates:
+        o.fetchModuleStatesImpl ??
+        (async () => o.moduleStates ?? { supervisorAvailable: true, modules: [] }),
+      openDb: fakeOpenDb as unknown as (configDir: string) => import("bun:sqlite").Database,
+    },
+  };
+}
+
+describe("status — Phase 3c supervisor arm: hub row", () => {
+  test("manager active + /health OK → running (active) with port", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      const lines: string[] = [];
+      const code = await status({
+        ...supervisorOpts(configDir, path, {
+          managerState: { state: "active" },
+          hubHealthy: true,
+          moduleStates: { supervisorAvailable: true, modules: [] },
+        }),
+        print: (l) => lines.push(l),
+      });
+      // With no modules + the hub active, status exits 0.
+      expect(code).toBe(0);
+      const out = lines.join("\n");
+      expect(out).toMatch(/parachute-hub \(internal\)/);
+      // Hub row is `active` and shows the canonical port (no manifest entry).
+      const hubLine = lines.find((l) => l.includes("parachute-hub (internal)"));
+      expect(hubLine).toBeDefined();
+      expect(hubLine).toMatch(/\bactive\b/);
+      expect(hubLine).toMatch(/1939/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("manager failed → failing + surfaces last exit code", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      const lines: string[] = [];
+      const code = await status({
+        ...supervisorOpts(configDir, path, {
+          managerState: { state: "failed", lastExitCode: 7 },
+          hubHealthy: false,
+        }),
+        print: (l) => lines.push(l),
+      });
+      expect(code).toBe(1);
+      const out = lines.join("\n");
+      expect(out).toMatch(/\bfailing\b/);
+      expect(out).toMatch(/the hub unit failed/);
+      expect(out).toMatch(/last exit code 7/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("manager active but /health down → failing with starting/unhealthy nuance", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      const lines: string[] = [];
+      const code = await status({
+        ...supervisorOpts(configDir, path, {
+          managerState: { state: "active" },
+          hubHealthy: false,
+        }),
+        print: (l) => lines.push(l),
+      });
+      expect(code).toBe(1);
+      const out = lines.join("\n");
+      const hubLine = lines.find((l) => l.includes("parachute-hub (internal)"));
+      expect(hubLine).toMatch(/\bfailing\b/);
+      expect(out).toMatch(/\/health not answering yet \(starting or unhealthy\)/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("no on-box manager (container) → /health is liveness, 'container runtime (managed)' note", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      const lines: string[] = [];
+      const code = await status({
+        ...supervisorOpts(configDir, path, {
+          managerState: { state: "no-manager" },
+          hubHealthy: true,
+          moduleStates: { supervisorAvailable: true, modules: [] },
+        }),
+        print: (l) => lines.push(l),
+      });
+      expect(code).toBe(0);
+      const out = lines.join("\n");
+      const hubLine = lines.find((l) => l.includes("parachute-hub (internal)"));
+      expect(hubLine).toMatch(/\bactive\b/);
+      expect(out).toMatch(/container runtime \(managed\)/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("container with /health down → hub row failing", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      const lines: string[] = [];
+      const code = await status({
+        ...supervisorOpts(configDir, path, {
+          managerState: { state: "no-manager" },
+          hubHealthy: false,
+        }),
+        print: (l) => lines.push(l),
+      });
+      expect(code).toBe(1);
+      const hubLine = lines.find((l) => l.includes("parachute-hub (internal)"));
+      expect(hubLine).toMatch(/\bfailing\b/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("a thrown manager query never crashes status — degrades to /health verdict", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      const lines: string[] = [];
+      const code = await status({
+        ...supervisorOpts(configDir, path, {
+          managerState: { state: "active" }, // overridden by the throwing stub below
+          hubHealthy: true,
+          moduleStates: { supervisorAvailable: true, modules: [] },
+        }),
+        // Replace the query with one that throws — status must not crash.
+        supervisor: {
+          unitInstalled: true,
+          hubUnitDeps: FAKE_HUB_UNIT_DEPS,
+          queryHubUnitState: () => {
+            throw new Error("systemctl exploded");
+          },
+          probeHubHealth: async () => true,
+          fetchModuleStates: async () => ({ supervisorAvailable: true, modules: [] }),
+          openDb: fakeOpenDb as unknown as (configDir: string) => import("bun:sqlite").Database,
+        },
+        print: (l) => lines.push(l),
+      });
+      // /health answered → unknown manager state falls back to active.
+      expect(code).toBe(0);
+      const hubLine = lines.find((l) => l.includes("parachute-hub (internal)"));
+      expect(hubLine).toMatch(/\bactive\b/);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("status — Phase 3c supervisor arm: module rows", () => {
+  test("hub up → module states come from the stubbed GET /api/modules", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.6.2" },
+        path,
+      );
+      upsertService(
+        {
+          name: "parachute-scribe",
+          port: 3200,
+          paths: ["/scribe"],
+          health: "/scribe/health",
+          version: "0.6.2",
+        },
+        path,
+      );
+      const lines: string[] = [];
+      const code = await status({
+        ...supervisorOpts(configDir, path, {
+          managerState: { state: "active" },
+          hubHealthy: true,
+          moduleStates: {
+            supervisorAvailable: true,
+            modules: [
+              {
+                short: "vault",
+                installed: true,
+                installed_version: "0.6.2",
+                supervisor_status: "running",
+                pid: 5151,
+                supervisor_start_error: null,
+              },
+              {
+                short: "scribe",
+                installed: true,
+                installed_version: "0.6.2",
+                supervisor_status: "crashed",
+                pid: null,
+                supervisor_start_error: null,
+              },
+            ],
+          },
+        }),
+        print: (l) => lines.push(l),
+      });
+      // scribe crashed → failing → overall exit 1.
+      expect(code).toBe(1);
+      const vaultLine = lines.find((l) => l.includes("parachute-vault"));
+      const scribeLine = lines.find((l) => l.includes("parachute-scribe"));
+      expect(vaultLine).toMatch(/\bactive\b/);
+      expect(vaultLine).toMatch(/5151/); // pid from the supervisor snapshot
+      expect(scribeLine).toMatch(/\bfailing\b/);
+      // The failing row surfaces the supervisor status on a continuation line.
+      expect(lines.some((l) => l.includes("supervisor: crashed"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("module with a structured startError surfaces the missing-dependency note", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.6.2" },
+        path,
+      );
+      const lines: string[] = [];
+      await status({
+        ...supervisorOpts(configDir, path, {
+          managerState: { state: "active" },
+          hubHealthy: true,
+          moduleStates: {
+            supervisorAvailable: true,
+            modules: [
+              {
+                short: "vault",
+                installed: true,
+                installed_version: "0.6.2",
+                supervisor_status: "crashed",
+                pid: null,
+                supervisor_start_error: {
+                  error_type: "missing_dependency",
+                  error_description: "parachute-vault is required",
+                  binary: "parachute-vault",
+                  at: "2026-06-01T00:00:00Z",
+                },
+              },
+            ],
+          },
+        }),
+        print: (l) => lines.push(l),
+      });
+      const out = lines.join("\n");
+      expect(out).toMatch(/failed to start: parachute-vault not installed/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("hub DOWN → modules degrade to inactive + 'hub is down' note, no hang/crash, exit 0", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.6.2" },
+        path,
+      );
+      let fetched = false;
+      const lines: string[] = [];
+      const code = await status({
+        ...supervisorOpts(configDir, path, {
+          managerState: { state: "inactive" },
+          hubHealthy: false,
+          fetchModuleStatesImpl: async () => {
+            fetched = true;
+            return { supervisorAvailable: true, modules: [] };
+          },
+        }),
+        print: (l) => lines.push(l),
+      });
+      // Hub down → modules are `inactive` (expected, not a failure) → exit 0.
+      expect(code).toBe(0);
+      // We must NOT call the module-states API when the hub is down (children
+      // die with the hub; the call would just connection-refuse).
+      expect(fetched).toBe(false);
+      const vaultLine = lines.find((l) => l.includes("parachute-vault"));
+      expect(vaultLine).toMatch(/\binactive\b/);
+      expect(lines.some((l) => l.includes("hub is down — its modules are stopped"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("no operator token → graceful degrade (manifest rows + actionable hint), no 401 crash", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.6.2" },
+        path,
+      );
+      const lines: string[] = [];
+      const code = await status({
+        ...supervisorOpts(configDir, path, {
+          managerState: { state: "active" },
+          hubHealthy: true,
+          fetchModuleStatesImpl: async () => {
+            throw new NoOperatorTokenError();
+          },
+        }),
+        print: (l) => lines.push(l),
+      });
+      // We could not read run-state, but didn't crash. The module row falls back
+      // to `inactive` (no supervisor snapshot) — a stopped row is exit 0.
+      expect(code).toBe(0);
+      const out = lines.join("\n");
+      expect(out).toMatch(/parachute-vault/);
+      expect(out).toMatch(/run `parachute auth rotate-operator`/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("expired operator token → graceful degrade, no crash", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.6.2" },
+        path,
+      );
+      const lines: string[] = [];
+      const code = await status({
+        ...supervisorOpts(configDir, path, {
+          managerState: { state: "active" },
+          hubHealthy: true,
+          fetchModuleStatesImpl: async () => {
+            throw new OperatorTokenExpiredError(
+              "token expired — run `parachute auth rotate-operator`",
+            );
+          },
+        }),
+        print: (l) => lines.push(l),
+      });
+      expect(code).toBe(0);
+      expect(lines.some((l) => l.includes("rotate-operator"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("API error reading module states → degrade with the message, no crash", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.6.2" },
+        path,
+      );
+      const lines: string[] = [];
+      const code = await status({
+        ...supervisorOpts(configDir, path, {
+          managerState: { state: "active" },
+          hubHealthy: true,
+          fetchModuleStatesImpl: async () => {
+            throw new Error("the api blew up");
+          },
+        }),
+        print: (l) => lines.push(l),
+      });
+      expect(code).toBe(0);
+      expect(lines.some((l) => l.includes("couldn't read live module state"))).toBe(true);
+      expect(lines.some((l) => l.includes("the api blew up"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("starting/restarting supervisor status → pending, not a failure (exit 0)", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.6.2" },
+        path,
+      );
+      const lines: string[] = [];
+      const code = await status({
+        ...supervisorOpts(configDir, path, {
+          managerState: { state: "active" },
+          hubHealthy: true,
+          moduleStates: {
+            supervisorAvailable: true,
+            modules: [
+              {
+                short: "vault",
+                installed: true,
+                installed_version: "0.6.2",
+                supervisor_status: "starting",
+                pid: 9090,
+                supervisor_start_error: null,
+              },
+            ],
+          },
+        }),
+        print: (l) => lines.push(l),
+      });
+      expect(code).toBe(0);
+      const vaultLine = lines.find((l) => l.includes("parachute-vault"));
+      expect(vaultLine).toMatch(/\bpending\b/);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("status — Phase 3c discriminant", () => {
+  test("no supervisor block → detached arm (pidfile readout), supervisor seams untouched", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.6.2" },
+        path,
+      );
+      // No `supervisor` block at all → resolveStatusSupervisor returns
+      // unitInstalled:false → the detached arm. The probe (fetchImpl) runs,
+      // proving we took the pidfile/probe path, not the supervisor path.
+      let probed = false;
+      const lines: string[] = [];
+      const code = await status({
+        manifestPath: path,
+        configDir,
+        installSourceDeps: STUB_INSTALL_SOURCE,
+        hubSrcDir: "/nonexistent/hub/src",
+        fetchImpl: async () => {
+          probed = true;
+          return new Response(null, { status: 200 });
+        },
+        print: (l) => lines.push(l),
+      });
+      expect(code).toBe(0);
+      // The detached arm probes the service's /health endpoint.
+      expect(probed).toBe(true);
+      expect(lines.some((l) => l.includes("parachute-vault"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("supervisor block with unitInstalled:false → detached arm (probe runs)", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.6.2" },
+        path,
+      );
+      let probed = false;
+      let queried = false;
+      const code = await status({
+        manifestPath: path,
+        configDir,
+        installSourceDeps: STUB_INSTALL_SOURCE,
+        hubSrcDir: "/nonexistent/hub/src",
+        fetchImpl: async () => {
+          probed = true;
+          return new Response(null, { status: 200 });
+        },
+        supervisor: {
+          unitInstalled: false,
+          queryHubUnitState: () => {
+            queried = true;
+            return { state: "active" };
+          },
+        },
+        print: () => {},
+      });
+      expect(code).toBe(0);
+      // Detached arm: the per-service probe runs and the manager is NOT queried.
+      expect(probed).toBe(true);
+      expect(queried).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -42,8 +42,13 @@ import { FIRST_PARTY_FALLBACKS, KNOWN_MODULES } from "./service-spec.ts";
 // still required) and the latter for vault/scribe/runner (post-FALLBACK
 // retirement, hub#310). The local helper hides the split from the rest of
 // this file.
-import { type UiSubUnit, type UiSubUnitStatus, readManifest, readManifestLenient } from "./services-manifest.ts";
-import type { ModuleState, Supervisor } from "./supervisor.ts";
+import {
+  type UiSubUnit,
+  type UiSubUnitStatus,
+  readManifest,
+  readManifestLenient,
+} from "./services-manifest.ts";
+import type { ModuleStartError, ModuleState, Supervisor } from "./supervisor.ts";
 
 /**
  * Resolve a curated module to the display + install bootstrap data the
@@ -174,6 +179,16 @@ interface ModuleWireShape {
   latest_version: string | null;
   supervisor_status: ModuleState["status"] | null;
   pid: number | null;
+  /**
+   * Structured supervisor start-failure detail (§6.5 / §6.4), when the
+   * supervisor recorded one for this module — a preflight `MissingDependencyError`
+   * or the alive-but-never-bound shape (hub#487). Mirrors the services.json
+   * `lastStartError` the detached path persists, so `parachute status` and the
+   * SPA keep the SAME friendly missing-dependency surface (#188) whether a
+   * module was started via the supervisor or the detached path. Null when the
+   * module started cleanly (or the hub is in pidfile/CLI mode with no supervisor).
+   */
+  supervisor_start_error: ModuleStartError | null;
   /**
    * The path on disk where the module is installed, if known. Surfaces
    * the BUN_INSTALL or bun-link install location for operator debug —
@@ -477,6 +492,7 @@ export async function handleApiModules(req: Request, deps: ApiModulesDeps): Prom
       latest_version: latestByShort.get(short) ?? null,
       supervisor_status: state?.status ?? null,
       pid: state?.pid ?? null,
+      supervisor_start_error: state?.startError ?? null,
       install_dir: installed?.installDir ?? null,
       uis: toUisWireShape(installed?.uis),
       management_url: managementUrlByShort.get(short) ?? null,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -454,7 +454,11 @@ async function main(argv: string[]): Promise<number> {
         console.log(statusHelp());
         return 0;
       }
-      return await status();
+      // Pass an empty `supervisor` block so `status` takes the Phase 3c
+      // dual-dispatch: on a box with a hub unit installed it reads the platform
+      // manager + the running supervisor; on a legacy detached box it falls back
+      // to the pidfile readout (design §6.4). Tests drive the seams directly.
+      return await status({ supervisor: {} });
 
     case "expose": {
       const hubExtract = extractHubOrigin(rest);

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -642,9 +642,16 @@ function mapSupervisorStatus(status: string | null): {
       // (skipped) so a mid-restart module doesn't flip `status` to exit 1.
       return { stateLabel: "pending", healthy: true, skipped: true };
     default:
-      // stopped / null / unknown — operator-stopped or never started. Expected,
-      // not a failure (skipped) — same exit semantics as the detached arm's
-      // `inactive` rows.
+      // stopped / null / unknown — operator-stopped or never started. The
+      // `skipped: true` + `healthy: false` pairing is DELIBERATE, not a mismatch:
+      //   - `healthy: false` is honest — an inactive module is genuinely not
+      //     serving (so a detail renderer can style it as down, not green).
+      //   - `skipped: true` keeps the exit-code check (`rows.some(r => !r.skipped
+      //     && !r.healthy)` at the call site, ~:385) from counting an
+      //     operator-stopped module as a FAILURE — `parachute stop vault` then
+      //     `status` must still exit 0.
+      // This is the same combination + exit semantics the detached arm uses for
+      // its `inactive` (operator-stopped) rows.
       return { stateLabel: "inactive", healthy: false, skipped: true };
   }
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,5 +1,16 @@
+import type { Database } from "bun:sqlite";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import { HUB_SVC, readHubPort } from "../hub-control.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import {
+  HUB_UNIT_DEFAULT_PORT,
+  type HubUnitDeps,
+  type HubUnitState,
+  type HubUnitStateResult,
+  defaultHubUnitDeps,
+  isHubUnitInstalled,
+  queryHubUnitState as queryHubUnitStateImpl,
+} from "../hub-unit.ts";
 import {
   type DetectInstallSourceDeps,
   detectHubInstallSource,
@@ -7,6 +18,13 @@ import {
   formatInstallSourceLabel,
   isStale,
 } from "../install-source.ts";
+import {
+  type DriveModuleOpDeps,
+  type ModuleStatesResult,
+  NoOperatorTokenError,
+  OperatorTokenExpiredError,
+  fetchModuleStates as fetchModuleStatesImpl,
+} from "../module-ops-client.ts";
 import { type AliveFn, defaultAlive, formatUptime, processState } from "../process-state.ts";
 import { canonicalPortForManifest, getSpec, shortNameForManifest } from "../service-spec.ts";
 import { type ServiceEntry, readManifest } from "../services-manifest.ts";
@@ -34,6 +52,54 @@ export interface StatusOpts {
    * source classification doesn't depend on the test runner's location.
    */
   hubSrcDir?: string;
+  /**
+   * Phase 3c supervisor-path seams (design §6.4). When a hub UNIT is installed
+   * (launchd/systemd/container — detected via {@link isHubUnitInstalled}),
+   * `status` reads the hub row from the PLATFORM MANAGER (`queryHubUnitState`)
+   * + `/health`, and the module rows from the RUNNING supervisor (`GET
+   * /api/modules` via the operator-token→Bearer path). On a legacy detached box
+   * (no hub unit) it keeps the EXACT pidfile/`processState` behavior, unchanged
+   * until Phase 5 retires it.
+   *
+   * Everything here is injectable so tests force either arm without a real
+   * launchd/systemd/socket/HTTP call. Production wires the real machinery; the
+   * read paths are bounded + degrade gracefully on every failure (no manager,
+   * hub down, no token, API error) so `status` never hangs or crashes.
+   */
+  supervisor?: {
+    /**
+     * Is a hub unit installed (the dual-dispatch discriminant)? Production uses
+     * `isHubUnitInstalled(hubUnitDeps)`. Tests set this `true`/`false` directly
+     * to pick the branch deterministically. When set, it wins over the
+     * `hubUnitDeps`-derived detection.
+     *
+     * Defaulting: when the caller OMITS the `supervisor` block entirely (every
+     * existing status test), the arm defaults to detached — so those tests stay
+     * deterministic regardless of whether the test host has a real hub unit.
+     */
+    unitInstalled?: boolean;
+    /** Deps for `isHubUnitInstalled` + `queryHubUnitState` + the `/health` probe. */
+    hubUnitDeps?: HubUnitDeps;
+    /** Query the platform manager for the hub unit's run-state (§6.4 hub row). */
+    queryHubUnitState?: (deps: HubUnitDeps) => HubUnitStateResult;
+    /**
+     * Probe whether the loopback hub answers `/health`. The liveness signal for
+     * the hub row (§6.4) AND the gate for reading module states: if the hub is
+     * down, skip the API read and show modules degraded. Production reuses the
+     * hub-unit deps' bounded `probeHealth`.
+     */
+    probeHubHealth?: (port: number) => Promise<boolean>;
+    /** Read the running supervisor's module states (§6.4 module rows). */
+    fetchModuleStates?: (deps: DriveModuleOpDeps) => Promise<ModuleStatesResult>;
+    /**
+     * Open the hub DB used to validate/auto-rotate the operator token in
+     * `fetchModuleStates`. Production opens `<configDir>/hub.db`; tests inject a
+     * seeded db. Returns a handle the caller closes.
+     */
+    openDb?: (configDir: string) => Database;
+    /** Loopback hub base URL override (default derives from the hub port). */
+    baseUrl?: string;
+  };
 }
 
 export interface ProbeResult {
@@ -154,6 +220,16 @@ interface StatusRow {
    * just showing it inactive. Cleared on the next successful start.
    */
   startErrorNote?: string;
+  /**
+   * Hub-row-only manager-context note (Phase 3c, §6.4). Surfaces the platform
+   * manager's view when it adds signal the STATE column can't carry:
+   *   - "container runtime (managed)" on Render/Fly (no on-box manager).
+   *   - "service manager reports active; /health not answering yet (starting or
+   *     unhealthy)" when the unit is up but the hub isn't serving.
+   *   - the manager's failed-unit detail / last-exit code.
+   * Printed on a continuation line like the other notes.
+   */
+  managerNote?: string;
 }
 
 /**
@@ -168,6 +244,70 @@ function urlForEntry(entry: ServiceEntry, short: string | undefined): string | u
   if (fromSpec) return fromSpec;
   const first = entry.paths[0]?.replace(/\/+$/, "") ?? "";
   return `http://127.0.0.1:${entry.port}${first}`;
+}
+
+/**
+ * The MANIFEST-derived portion of a module row — identical regardless of
+ * whether the row's run-state comes from a pidfile (detached arm) or the
+ * supervisor (Phase 3c). Extracting it keeps the two arms in lockstep on
+ * port/version/URL/drift/source/stale and the persisted `lastStartError` note,
+ * so the only per-arm difference is the run-state fields (STATE / PID / UPTIME).
+ *
+ * Pure over the manifest entry + install-source deps; no process / network
+ * read. Shared so the detached arm stays behavior-identical (existing tests
+ * guard it) while the supervisor arm reuses the exact same derivation.
+ */
+interface ManifestRowBase {
+  short: string | undefined;
+  url: string | undefined;
+  driftWarning?: string;
+  sourceLabel: string;
+  staleNote?: string;
+  /** The persisted `lastStartError` note (detached preflight wrote it). */
+  manifestStartErrorNote?: string;
+}
+
+function manifestRowBase(
+  entry: ServiceEntry,
+  installSourceDeps: DetectInstallSourceDeps,
+): ManifestRowBase {
+  // Third-party rows (with `installDir`) live under `~/.parachute/<entry.name>/`,
+  // matching what `parachute start` uses as the short. First-party rows still
+  // map manifestName → short via the canonical fallback.
+  const short = shortNameForManifest(entry.name) ?? (entry.installDir ? entry.name : undefined);
+  const url = urlForEntry(entry, short);
+
+  // Canonical-port drift detection (hub#195). Only fires for known first-party
+  // services where we have a canonical assignment. Third-party rows have no
+  // canonical to compare against. Informational — operators may have moved a
+  // service off canonical deliberately.
+  const canonical = canonicalPortForManifest(entry.name);
+  const driftWarning =
+    canonical !== undefined && canonical !== entry.port
+      ? `canonical port is ${canonical}`
+      : undefined;
+
+  // Install-source detection (hub#243). One filesystem walk + maybe one
+  // `git rev-parse` per row. Failures degrade silently to `unknown`.
+  const detectArgs: { entryName: string; installDir?: string } = { entryName: entry.name };
+  if (entry.installDir !== undefined) detectArgs.installDir = entry.installDir;
+  const source = detectInstallSource(detectArgs, installSourceDeps);
+  const sourceLabel = formatInstallSourceLabel(source);
+  const staleNote = isStale(entry.version, source)
+    ? `STALE: services.json cached ${entry.version}; live package.json ${source.livePackageVersion}`
+    : undefined;
+
+  // Persisted last-start failure (lifecycle preflight wrote a missing-dependency
+  // wire onto services.json). Surface a one-line summary; the full install
+  // recipe lives in services.json + the admin SPA card.
+  const manifestStartErrorNote =
+    entry.lastStartError !== undefined
+      ? entry.lastStartError.binary !== undefined
+        ? `failed to start: ${entry.lastStartError.binary} not installed — run \`parachute status\` detail or see /admin/modules for install steps`
+        : `failed to start: ${entry.lastStartError.error_description.split("\n")[0]}`
+      : undefined;
+
+  return { short, url, driftWarning, sourceLabel, staleNote, manifestStartErrorNote };
 }
 
 function hubRow(
@@ -217,6 +357,36 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
   const hubSrcDir = opts.hubSrcDir ?? import.meta.dir;
 
   const manifest = readManifest(manifestPath);
+
+  // Phase 3c dual-dispatch (design §6.4). On a box with a hub unit installed
+  // (launchd/systemd/container), read the hub row from the platform manager +
+  // `/health` and the module rows from the RUNNING supervisor; otherwise fall
+  // through to the unchanged detached arm below. Phase 5 deletes the else-arm —
+  // keep this a clean top-level branch so that deletion is a one-liner.
+  //
+  // Branched BEFORE the detached arm's empty-manifest early return: on a
+  // unit-managed box the hub row is meaningful even with zero modules installed
+  // (the hub IS running under a unit), so the supervisor arm renders the hub row
+  // + a "no modules" table rather than the detached "No services installed yet."
+  const sup = resolveStatusSupervisor(opts.supervisor);
+  if (sup.unitInstalled) {
+    const rows = await buildSupervisorRows({
+      manifest,
+      configDir,
+      installSourceDeps,
+      hubSrcDir,
+      sup,
+    });
+    renderRows(rows, print);
+    // The supervisor arm marks a row `healthy: false` + `!skipped` only when the
+    // supervisor (or the hub-row manager/health composition) says so (crashed /
+    // failing) — same exit contract as the detached arm: a stopped/inactive row
+    // is expected (skipped, exit 0), a `failing` one exits 1.
+    const anyUnhealthy = rows.some((r) => !r.skipped && !r.healthy);
+    return anyUnhealthy ? 1 : 0;
+  }
+  // --- no-unit detached fallback (unchanged; preserved until Phase 5) ---
+
   if (manifest.services.length === 0) {
     print("No services installed yet.");
     print("Try: parachute install vault");
@@ -235,53 +405,22 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
    */
   const rows: StatusRow[] = await Promise.all(
     manifest.services.map(async (entry) => {
-      // Third-party rows (with `installDir`) live under `~/.parachute/<entry.name>/`,
-      // matching what `parachute start` uses as the short. First-party rows still
-      // map manifestName → short via the canonical fallback.
-      const short = shortNameForManifest(entry.name) ?? (entry.installDir ? entry.name : undefined);
+      // MANIFEST-derived fields shared with the supervisor arm (port/version/
+      // URL/drift/source/stale + the persisted lastStartError note).
+      const {
+        short,
+        url,
+        driftWarning,
+        sourceLabel,
+        staleNote,
+        manifestStartErrorNote: startErrorNote,
+      } = manifestRowBase(entry, installSourceDeps);
       const proc = short ? processState(short, configDir, alive) : undefined;
 
       const pidLabel =
         proc?.status === "running" && proc.pid !== undefined ? String(proc.pid) : "-";
       const uptimeLabel =
         proc?.status === "running" && proc.startedAt ? formatUptime(proc.startedAt, nowDate) : "-";
-
-      const url = urlForEntry(entry, short);
-
-      // Canonical-port drift detection (hub#195). Only fires for known
-      // first-party services where we have a canonical assignment. Third-party
-      // rows have no canonical to compare against. Warning is informational —
-      // operators may have moved a service off canonical deliberately.
-      // Note: multi-vault instance rows (`parachute-vault-<instance>`) don't
-      // match a canonical manifest name, so drift warnings don't fire for
-      // them. Intentional — see `canonicalPortForManifest` for the rationale.
-      const canonical = canonicalPortForManifest(entry.name);
-      const driftWarning =
-        canonical !== undefined && canonical !== entry.port
-          ? `canonical port is ${canonical}`
-          : undefined;
-
-      // Install-source detection (hub#243). One filesystem walk + maybe one
-      // `git rev-parse` per row. Failures degrade silently to `unknown` —
-      // status output should never error out on a missing checkout dir.
-      const detectArgs: { entryName: string; installDir?: string } = { entryName: entry.name };
-      if (entry.installDir !== undefined) detectArgs.installDir = entry.installDir;
-      const source = detectInstallSource(detectArgs, installSourceDeps);
-      const sourceLabel = formatInstallSourceLabel(source);
-      const staleNote = isStale(entry.version, source)
-        ? `STALE: services.json cached ${entry.version}; live package.json ${source.livePackageVersion}`
-        : undefined;
-
-      // Persisted last-start failure (lifecycle preflight wrote a missing-
-      // dependency wire). Surface a one-line summary; the full install recipe
-      // lives in services.json + the admin SPA card. Keeps `parachute status`
-      // scannable while still telling the operator "this is why it's down."
-      const startErrorNote =
-        entry.lastStartError !== undefined
-          ? entry.lastStartError.binary !== undefined
-            ? `failed to start: ${entry.lastStartError.binary} not installed — run \`parachute status\` detail or see /admin/modules for install steps`
-            : `failed to start: ${entry.lastStartError.error_description.split("\n")[0]}`
-          : undefined;
 
       // Only skip probe when we know the process is dead (PID file was
       // present but kill(pid, 0) failed). "unknown" status (no PID file)
@@ -354,6 +493,25 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
   const hub = hubRow(configDir, alive, nowDate, hubSrcDir, installSourceDeps);
   if (hub) rows.push(hub);
 
+  renderRows(rows, print);
+
+  /**
+   * Overall exit: non-zero if any *probed* service is unhealthy. A stopped
+   * service is expected ("I haven't started it yet"), not a failure — users
+   * want `parachute status` to return 0 after a fresh install before they
+   * `parachute start`. Health regressions among running services still 1.
+   */
+  const anyUnhealthy = rows.some((r) => !r.skipped && !r.healthy);
+  return anyUnhealthy ? 1 : 0;
+}
+
+/**
+ * Render the status table + continuation lines. Shared by the detached arm and
+ * the Phase 3c supervisor arm so the table shape (design-system.md §6 columns +
+ * the `→`/`!` continuation prefixes) is identical regardless of where each
+ * row's run-state was sourced. Pure over `rows` + the `print` sink.
+ */
+function renderRows(rows: StatusRow[], print: (line: string) => void): void {
   // Header per design-system.md §6 "CLI status column shape":
   //   SERVICE  PORT  VERSION  STATE   PID  UPTIME  LATENCY  SOURCE
   // Pre-F shape was SERVICE PORT VERSION PROCESS PID UPTIME HEALTH LATENCY
@@ -397,17 +555,399 @@ export async function status(opts: StatusOpts = {}): Promise<number> {
     if (row.stateLabel === "failing" && row.healthDetail !== "-" && row.healthDetail.length > 0) {
       print(`  ! probe: ${row.healthDetail}`);
     }
+    if (row.managerNote) print(`  ! ${row.managerNote}`);
     if (row.driftWarning) print(`  ! ${row.driftWarning}`);
     if (row.staleNote) print(`  ! ${row.staleNote}`);
     if (row.startErrorNote) print(`  ! ${row.startErrorNote}`);
   }
+}
 
-  /**
-   * Overall exit: non-zero if any *probed* service is unhealthy. A stopped
-   * service is expected ("I haven't started it yet"), not a failure — users
-   * want `parachute status` to return 0 after a fresh install before they
-   * `parachute start`. Health regressions among running services still 1.
-   */
-  const anyUnhealthy = rows.some((r) => !r.skipped && !r.healthy);
-  return anyUnhealthy ? 1 : 0;
+// ---------------------------------------------------------------------------
+// Phase 3c supervisor-path status (design §6.4).
+//
+// When a hub unit is installed, `status` reads the hub row from the PLATFORM
+// MANAGER (`queryHubUnitState`) + a `/health` probe, and the module rows from
+// the RUNNING supervisor (`GET /api/modules` via the operator-token→Bearer
+// path). Every read is bounded + degrades gracefully — `status` is a
+// diagnostic and must NEVER hang or crash regardless of hub/manager/token
+// state. The detached arm above is untouched; Phase 5 deletes it.
+// ---------------------------------------------------------------------------
+
+/** Resolved Phase 3c supervisor-path seams (see `StatusOpts.supervisor`). */
+interface ResolvedStatusSupervisor {
+  /** Whether a hub unit is installed — the dual-dispatch discriminant. */
+  unitInstalled: boolean;
+  hubUnitDeps: HubUnitDeps;
+  queryHubUnitState: (deps: HubUnitDeps) => HubUnitStateResult;
+  probeHubHealth: (port: number) => Promise<boolean>;
+  fetchModuleStates: (deps: DriveModuleOpDeps) => Promise<ModuleStatesResult>;
+  openDb: (configDir: string) => Database;
+  baseUrl: string | undefined;
+}
+
+/**
+ * Resolve the Phase 3c supervisor-path seams. Mirrors lifecycle.ts's
+ * `resolveSupervisor` discriminant policy:
+ *   - No `supervisor` block at all (every existing status test) → detached arm,
+ *     deterministically (no real-filesystem probe).
+ *   - A `supervisor` block present → explicit `unitInstalled` override if set,
+ *     else the real `isHubUnitInstalled` probe over the hub-unit deps.
+ */
+function resolveStatusSupervisor(opts: StatusOpts["supervisor"]): ResolvedStatusSupervisor {
+  const hubUnitDeps = opts?.hubUnitDeps ?? defaultHubUnitDeps;
+  const unitInstalled =
+    opts === undefined ? false : (opts.unitInstalled ?? isHubUnitInstalled(hubUnitDeps));
+  return {
+    unitInstalled,
+    hubUnitDeps,
+    queryHubUnitState: opts?.queryHubUnitState ?? queryHubUnitStateImpl,
+    probeHubHealth: opts?.probeHubHealth ?? hubUnitDeps.probeHealth,
+    fetchModuleStates: opts?.fetchModuleStates ?? fetchModuleStatesImpl,
+    openDb: opts?.openDb ?? ((configDir) => openHubDb(hubDbPath(configDir))),
+    baseUrl: opts?.baseUrl,
+  };
+}
+
+/**
+ * Resolve the issuer the operator token is validated against — the hub's
+ * current loopback origin. Mirrors lifecycle.ts's `resolveOperatorTokenIssuer`
+ * fallback (`readHubPort ?? HUB_UNIT_DEFAULT_PORT`); both resolve to 1939 under
+ * canonical-ports, so they agree with what `auth rotate-operator` minted under.
+ */
+function statusOperatorTokenIssuer(configDir: string): string {
+  return `http://127.0.0.1:${readHubPort(configDir) ?? HUB_UNIT_DEFAULT_PORT}`;
+}
+
+/**
+ * Map a supervisor `ModuleState.status` to the canonical STATE rollup
+ * (design-system.md §6). `running` is `active`; `crashed` is `failing`;
+ * `starting` / `restarting` are `pending` (in-flight operator-visible
+ * transition); `stopped` is `inactive`. An unknown/absent status (module not
+ * tracked by the supervisor — never booted, skipped at boot) is `inactive`.
+ */
+function mapSupervisorStatus(status: string | null): {
+  stateLabel: StateLabel;
+  healthy: boolean;
+  skipped: boolean;
+} {
+  switch (status) {
+    case "running":
+      return { stateLabel: "active", healthy: true, skipped: false };
+    case "crashed":
+      return { stateLabel: "failing", healthy: false, skipped: false };
+    case "starting":
+    case "restarting":
+      // In-flight transition — supervised, mid-operation. `pending` is the
+      // canonical "needs-attention transient" rollup; treat as not-a-failure
+      // (skipped) so a mid-restart module doesn't flip `status` to exit 1.
+      return { stateLabel: "pending", healthy: true, skipped: true };
+    default:
+      // stopped / null / unknown — operator-stopped or never started. Expected,
+      // not a failure (skipped) — same exit semantics as the detached arm's
+      // `inactive` rows.
+      return { stateLabel: "inactive", healthy: false, skipped: true };
+  }
+}
+
+/**
+ * Format a supervisor `startError` (the structured missing-dependency /
+ * started-but-unbound wire, §6.5) into the same one-line note the detached arm
+ * shows from `services.json.lastStartError` (#188). Returns undefined when
+ * there's no usable detail.
+ */
+function supervisorStartErrorNote(startError: unknown): string | undefined {
+  if (!startError || typeof startError !== "object") return undefined;
+  const e = startError as { binary?: unknown; error_description?: unknown };
+  if (typeof e.binary === "string" && e.binary.length > 0) {
+    return `failed to start: ${e.binary} not installed — see /admin/modules for install steps`;
+  }
+  if (typeof e.error_description === "string" && e.error_description.length > 0) {
+    return `failed to start: ${e.error_description.split("\n")[0]}`;
+  }
+  return undefined;
+}
+
+interface BuildSupervisorRowsArgs {
+  manifest: ReturnType<typeof readManifest>;
+  configDir: string;
+  installSourceDeps: DetectInstallSourceDeps;
+  hubSrcDir: string;
+  sup: ResolvedStatusSupervisor;
+}
+
+/**
+ * Build the full status rows on a UNIT-MANAGED box (design §6.4): module rows
+ * from the running supervisor, the hub row from the platform manager + /health.
+ * Never throws — every read is wrapped + degrades to a sensible readout.
+ */
+async function buildSupervisorRows(args: BuildSupervisorRowsArgs): Promise<StatusRow[]> {
+  const { manifest, configDir, installSourceDeps, hubSrcDir, sup } = args;
+  const port = readHubPort(configDir) ?? HUB_UNIT_DEFAULT_PORT;
+
+  // Probe the hub once: it's both the hub row's liveness signal AND the gate for
+  // whether the supervisor (module states) is reachable. Bounded; never throws.
+  let hubHealthy = false;
+  try {
+    hubHealthy = await sup.probeHubHealth(port);
+  } catch {
+    hubHealthy = false;
+  }
+
+  // Read the running supervisor's module states — ONLY when the hub answers
+  // (children die with the hub, so a down hub means every module is down; no
+  // point calling, and the call would just connection-refuse). Degrade on every
+  // failure path: no token, expired token, HTTP error, anything — `status`
+  // shows what it can rather than crashing.
+  let states: ModuleStatesResult | undefined;
+  let moduleReadNote: string | undefined;
+  if (hubHealthy) {
+    const db = sup.openDb(configDir);
+    try {
+      states = await sup.fetchModuleStates({
+        db,
+        issuer: statusOperatorTokenIssuer(configDir),
+        configDir,
+        ...(sup.baseUrl !== undefined ? { baseUrl: sup.baseUrl } : {}),
+      });
+    } catch (err) {
+      if (err instanceof NoOperatorTokenError || err instanceof OperatorTokenExpiredError) {
+        // No / expired operator token: we can't read module run-state, but the
+        // hub is up. Show the manifest-derived rows with an actionable note —
+        // do NOT 401-crash status (§6.4 graceful degradation).
+        moduleReadNote =
+          "couldn't read live module state — run `parachute auth rotate-operator` to mint an operator token";
+      } else {
+        // HTTP error / parse / anything else — degrade with the message.
+        moduleReadNote = `couldn't read live module state (${
+          err instanceof Error ? err.message : String(err)
+        })`;
+      }
+    } finally {
+      db.close();
+    }
+  }
+
+  const stateByShort = new Map<string, ModuleStatesResult["modules"][number]>();
+  for (const m of states?.modules ?? []) {
+    if (m.short) stateByShort.set(m.short, m);
+  }
+
+  const rows: StatusRow[] = manifest.services.map((entry) => {
+    const base = manifestRowBase(entry, installSourceDeps);
+    const snap = base.short ? stateByShort.get(base.short) : undefined;
+
+    if (!hubHealthy) {
+      // Hub is down → every supervised module is down with it. Show `inactive`
+      // (expected, not a failure) with a note rather than a probe failure.
+      return {
+        service: entry.name,
+        port: String(entry.port),
+        version: entry.version,
+        stateLabel: "inactive",
+        pidLabel: "-",
+        uptimeLabel: "-",
+        healthDetail: "-",
+        latencyLabel: "-",
+        sourceLabel: base.sourceLabel,
+        url: base.url,
+        healthy: false,
+        skipped: true,
+        ...(base.driftWarning ? { driftWarning: base.driftWarning } : {}),
+        ...(base.staleNote ? { staleNote: base.staleNote } : {}),
+        managerNote: "hub is down — its modules are stopped",
+      };
+    }
+
+    const { stateLabel, healthy, skipped } = mapSupervisorStatus(snap?.supervisor_status ?? null);
+    // Prefer the supervisor's structured start-error (live), else the persisted
+    // services.json note — same friendly surface either way (#188).
+    const startErrorNote =
+      supervisorStartErrorNote(snap?.supervisor_start_error) ?? base.manifestStartErrorNote;
+    const healthDetail =
+      stateLabel === "failing" ? `supervisor: ${snap?.supervisor_status ?? "crashed"}` : "-";
+
+    const row: StatusRow = {
+      service: entry.name,
+      port: String(entry.port),
+      version: entry.version,
+      stateLabel,
+      pidLabel: snap?.pid !== undefined && snap?.pid !== null ? String(snap.pid) : "-",
+      uptimeLabel: "-",
+      healthDetail,
+      latencyLabel: "-",
+      sourceLabel: base.sourceLabel,
+      url: base.url,
+      healthy,
+      skipped,
+    };
+    if (base.driftWarning) row.driftWarning = base.driftWarning;
+    if (base.staleNote) row.staleNote = base.staleNote;
+    if (startErrorNote) row.startErrorNote = startErrorNote;
+    // Surface the degraded-read note ONCE — on the first module row so the
+    // operator sees why run-state is missing, without repeating it on every row.
+    if (moduleReadNote) {
+      row.managerNote = moduleReadNote;
+      moduleReadNote = undefined;
+    }
+    return row;
+  });
+
+  const hub = buildSupervisorHubRow({
+    configDir,
+    hubSrcDir,
+    installSourceDeps,
+    sup,
+    port,
+    hubHealthy,
+  });
+  // If the degraded-read note never landed on a module row (empty manifest),
+  // surface it on the hub row so the operator still sees the actionable hint.
+  if (moduleReadNote && !hub.managerNote) hub.managerNote = moduleReadNote;
+  rows.push(hub);
+  return rows;
+}
+
+interface BuildSupervisorHubRowArgs {
+  configDir: string;
+  hubSrcDir: string;
+  installSourceDeps: DetectInstallSourceDeps;
+  sup: ResolvedStatusSupervisor;
+  port: number;
+  hubHealthy: boolean;
+}
+
+/**
+ * Build the hub row from the platform manager + /health (design §6.4). The
+ * manager's `queryHubUnitState` is the run-state; `/health` is the liveness
+ * signal. Composition:
+ *   - manager `active` + /health OK → `active` (running).
+ *   - manager `active` + /health down → `failing` with a "starting/unhealthy"
+ *     note (the unit is up but not serving yet).
+ *   - manager `failed` → `failing` (surface the last-exit code).
+ *   - manager `inactive` → `inactive`.
+ *   - no on-box manager (container/Render/Fly) → lean on /health for liveness;
+ *     report "container runtime (managed)".
+ * Never throws — a manager-query failure degrades to the /health verdict.
+ */
+function buildSupervisorHubRow(args: BuildSupervisorHubRowArgs): StatusRow {
+  const { configDir, hubSrcDir, installSourceDeps, sup, port, hubHealthy } = args;
+  const source = detectHubInstallSource(hubSrcDir, installSourceDeps);
+  const base: Omit<StatusRow, "stateLabel" | "pidLabel" | "uptimeLabel" | "healthy" | "skipped"> & {
+    healthDetail: string;
+  } = {
+    service: "parachute-hub (internal)",
+    port: String(port),
+    version: source.livePackageVersion ?? "-",
+    healthDetail: "-",
+    latencyLabel: "-",
+    sourceLabel: formatInstallSourceLabel(source),
+    url: `http://127.0.0.1:${port}`,
+  };
+
+  let managerState: HubUnitState;
+  let lastExitCode: number | undefined;
+  try {
+    const q = sup.queryHubUnitState(sup.hubUnitDeps);
+    managerState = q.state;
+    lastExitCode = q.lastExitCode;
+  } catch {
+    // The manager query must never crash status — fall back to /health only.
+    managerState = "unknown";
+  }
+
+  // No on-box manager (container / Render / Fly): there's nothing to query —
+  // `/health` is the sole liveness signal. Report the managed-runtime nuance.
+  if (managerState === "no-manager") {
+    return {
+      ...base,
+      stateLabel: hubHealthy ? "active" : "failing",
+      pidLabel: "-",
+      uptimeLabel: "-",
+      healthDetail: hubHealthy ? "-" : "down",
+      healthy: hubHealthy,
+      skipped: hubHealthy,
+      managerNote: "container runtime (managed)",
+    };
+  }
+
+  // Manager says failed: surface it as `failing` with the last-exit code even if
+  // a respawn happens to be answering /health right now.
+  if (managerState === "failed") {
+    return {
+      ...base,
+      stateLabel: "failing",
+      pidLabel: "-",
+      uptimeLabel: "-",
+      healthDetail: hubHealthy ? "service manager reports failed" : "down",
+      healthy: false,
+      skipped: false,
+      managerNote:
+        lastExitCode !== undefined
+          ? `service manager reports the hub unit failed (last exit code ${lastExitCode})`
+          : "service manager reports the hub unit failed",
+    };
+  }
+
+  // Manager says active.
+  if (managerState === "active") {
+    if (hubHealthy) {
+      return {
+        ...base,
+        stateLabel: "active",
+        pidLabel: "-",
+        uptimeLabel: "-",
+        healthy: true,
+        skipped: true,
+      };
+    }
+    // Active per the manager but not answering /health: starting up or wedged.
+    return {
+      ...base,
+      stateLabel: "failing",
+      pidLabel: "-",
+      uptimeLabel: "-",
+      healthDetail: "manager active, /health not answering",
+      healthy: false,
+      skipped: false,
+      managerNote:
+        "service manager reports active; /health not answering yet (starting or unhealthy)",
+    };
+  }
+
+  // Manager says activating: transient bring-up. If /health already answers,
+  // call it active; else show it as pending (in-flight).
+  if (managerState === "activating") {
+    return {
+      ...base,
+      stateLabel: hubHealthy ? "active" : "pending",
+      pidLabel: "-",
+      uptimeLabel: "-",
+      healthy: true,
+      skipped: true,
+      ...(hubHealthy ? {} : { managerNote: "service manager reports the hub unit is starting" }),
+    };
+  }
+
+  // Manager says inactive / unknown / no-unit (defensive — no-unit shouldn't
+  // reach here under the dual-dispatch). Trust /health as the tiebreaker: if the
+  // hub somehow answers, show active; else inactive.
+  if (hubHealthy) {
+    return {
+      ...base,
+      stateLabel: "active",
+      pidLabel: "-",
+      uptimeLabel: "-",
+      healthy: true,
+      skipped: true,
+    };
+  }
+  return {
+    ...base,
+    stateLabel: "inactive",
+    pidLabel: "-",
+    uptimeLabel: "-",
+    healthy: false,
+    skipped: true,
+    ...(managerState === "unknown" ? { managerNote: "service manager state unknown" } : {}),
+  };
 }

--- a/src/hub-unit.ts
+++ b/src/hub-unit.ts
@@ -342,6 +342,149 @@ export function restartHubUnit(deps: HubUnitDeps): HubUnitManagerOpResult {
 }
 
 /**
+ * Run-state of the hub UNIT as reported by the platform manager (design §6.4).
+ * This is the manager's view — NOT a liveness verdict. The hub answering
+ * `/health` is the liveness signal; the caller (`status`) composes the two
+ * (manager says `active` + `/health` answers → "running"; `active` but no
+ * `/health` yet → "starting/unhealthy"; `failed` → "failed").
+ */
+export type HubUnitState =
+  /** systemd `is-active` → `active`; launchd `print` → `state = running`. */
+  | "active"
+  /** systemd `is-active` → `activating` / `reloading`; launchd transient. */
+  | "activating"
+  /** systemd `is-active` → `failed`; launchd nonzero `last exit code`. */
+  | "failed"
+  /** systemd `is-active` → `inactive` / `dead`; launchd not-running, clean. */
+  | "inactive"
+  /** A hub unit is installed but the manager couldn't classify it. */
+  | "unknown"
+  /** No hub unit file is installed on this platform. */
+  | "no-unit"
+  /**
+   * No on-box service manager exists at all (container runtime / init-less
+   * host). There is nothing to query — `status` reports "container runtime
+   * (managed)" and leans on `/health` for liveness (§6.4).
+   */
+  | "no-manager";
+
+export interface HubUnitStateResult {
+  state: HubUnitState;
+  /** Last exit code, when the manager surfaced one (launchd / failed unit). */
+  lastExitCode?: number;
+  /** Raw manager output (trimmed), for diagnostics on `unknown` / `failed`. */
+  detail?: string;
+}
+
+/**
+ * Map a systemd `systemctl is-active` stdout token to a {@link HubUnitState}.
+ * `is-active` prints exactly one of: `active`, `activating`, `reloading`,
+ * `inactive`, `failed`, `deactivating`, `unknown`. We collapse the transient
+ * tokens onto our smaller vocabulary so `status` doesn't have to know them all.
+ */
+function mapSystemdActiveToken(token: string): HubUnitState {
+  switch (token.trim()) {
+    case "active":
+      return "active";
+    case "activating":
+    case "reloading":
+    case "deactivating":
+      return "activating";
+    case "failed":
+      return "failed";
+    case "inactive":
+    case "dead":
+      return "inactive";
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * Parse a launchd `launchctl print gui/<uid>/<label>` state descriptor into a
+ * {@link HubUnitStateResult}. The descriptor is multi-line key/value; we read
+ * the `state = …` line and the `last exit code = …` line. A nonzero last-exit
+ * with the service not running reads as `failed`; `state = running` reads as
+ * `active`; anything else with the unit loaded reads as `inactive`.
+ *
+ * `launchctl print` exits nonzero when the label isn't loaded at all — the
+ * caller treats that as `inactive` (unit installed on disk but not bootstrapped),
+ * since the descriptor body is empty.
+ */
+function parseLaunchctlPrint(stdout: string): HubUnitStateResult {
+  const stateMatch = stdout.match(/^\s*state\s*=\s*(\S+)/im);
+  const exitMatch = stdout.match(/last exit code\s*=\s*(-?\d+)/i);
+  const lastExitCode = exitMatch?.[1] !== undefined ? Number(exitMatch[1]) : undefined;
+  const stateToken = stateMatch?.[1]?.toLowerCase();
+  const detail = stdout.trim().length > 0 ? stdout.trim() : undefined;
+  if (stateToken === "running") {
+    return lastExitCode !== undefined
+      ? { state: "active", lastExitCode, ...(detail ? { detail } : {}) }
+      : { state: "active", ...(detail ? { detail } : {}) };
+  }
+  // Not running: a nonzero recorded last-exit means the unit crashed/failed; a
+  // zero / absent exit means it's loaded-but-idle (inactive). KeepAlive units
+  // that crash-loop surface a nonzero last-exit here even between respawns.
+  if (lastExitCode !== undefined && lastExitCode !== 0) {
+    return { state: "failed", lastExitCode, ...(detail ? { detail } : {}) };
+  }
+  if (lastExitCode !== undefined) {
+    return { state: "inactive", lastExitCode, ...(detail ? { detail } : {}) };
+  }
+  // No state and no exit-code line — the descriptor told us nothing usable.
+  return detail ? { state: "unknown", detail } : { state: "inactive" };
+}
+
+/**
+ * Query the platform manager for the hub unit's run-state (design §6.4 hub
+ * row). This is the `status`-side counterpart to {@link stopHubUnit} /
+ * {@link restartHubUnit}: a READ, never a mutation.
+ *
+ *   - No manager (container / init-less) → `no-manager`. `status` reports
+ *     "container runtime (managed)" — there's nothing on-box to query, and the
+ *     `/health` answer is the liveness signal.
+ *   - No unit file installed → `no-unit` (a legacy detached box that somehow
+ *     reached this read; the dual-dispatch branch in `status` guards against it).
+ *   - systemd → `systemctl [--user] is-active <unit>`; the token maps via
+ *     {@link mapSystemdActiveToken}. `is-active` exits nonzero for non-active
+ *     states, so we read stdout regardless of exit code.
+ *   - launchd → `launchctl print gui/<uid>/<label>`; parsed via
+ *     {@link parseLaunchctlPrint}.
+ *
+ * Never throws — a query failure degrades to `unknown` with the manager's
+ * stderr in `detail`, so `status` can render a sensible row rather than crash.
+ */
+export function queryHubUnitState(deps: HubUnitDeps): HubUnitStateResult {
+  if (!hasServiceManager(deps)) return { state: "no-manager" };
+  if (!isHubUnitInstalled(deps)) return { state: "no-unit" };
+  try {
+    if (deps.platform === "darwin") {
+      const uid = deps.getuid() ?? 0;
+      const r = deps.run(["launchctl", "print", `gui/${uid}/${HUB_LAUNCHD_LABEL}`]);
+      // A nonzero exit with empty stdout means the label isn't loaded — the
+      // unit file is on disk but never bootstrapped. Read as inactive.
+      if (r.stdout.trim().length === 0) {
+        const detail = r.stderr.trim();
+        return detail ? { state: "inactive", detail } : { state: "inactive" };
+      }
+      return parseLaunchctlPrint(r.stdout);
+    }
+    // linux / systemd. `is-active` exits 0 only when active; we classify from
+    // stdout (the state word) regardless of exit code.
+    const root = (deps.getuid() ?? 1000) === 0;
+    const scope = root ? [] : ["--user"];
+    const r = deps.run(["systemctl", ...scope, "is-active", HUB_SYSTEMD_UNIT_NAME]);
+    const token = r.stdout.trim() || r.stderr.trim();
+    if (token.length === 0) return { state: "unknown" };
+    const state = mapSystemdActiveToken(token);
+    return state === "unknown" ? { state, detail: token } : { state };
+  } catch (err) {
+    // A manager-query failure must never crash `status` — degrade to unknown.
+    return { state: "unknown", detail: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
  * Ensure the hub UNIT is up (design §3.2). Probe `/health`; if down, start the
  * unit via the platform manager; wait for readiness; surface the unit log on
  * timeout. Returns a structured outcome — the CALLER decides exit codes /

--- a/src/hub-unit.ts
+++ b/src/hub-unit.ts
@@ -388,6 +388,11 @@ function mapSystemdActiveToken(token: string): HubUnitState {
       return "active";
     case "activating":
     case "reloading":
+    // `deactivating` (an in-flight stop transition) deliberately maps to
+    // `activating` → our `pending` vocabulary: it's a transient transition, not
+    // a terminal state. During a `parachute stop hub` the unit may momentarily
+    // read `pending` here before settling to `inactive` — the next status poll
+    // resolves it. Better a brief "pending" than flapping to a false "active".
     case "deactivating":
       return "activating";
     case "failed":
@@ -432,6 +437,12 @@ function parseLaunchctlPrint(stdout: string): HubUnitStateResult {
     return { state: "inactive", lastExitCode, ...(detail ? { detail } : {}) };
   }
   // No state and no exit-code line — the descriptor told us nothing usable.
+  // Distinguish `unknown` (non-empty but unparseable stdout — e.g. a future
+  // macOS `launchctl print` field layout we don't recognize) from `inactive`
+  // (empty/absent body — the label isn't loaded). This is deliberate: a new
+  // layout must NOT be misread as a false `inactive` (which would tell the
+  // operator the hub is stopped when it may well be running) — `unknown` keeps
+  // the raw `detail` for diagnosis instead.
   return detail ? { state: "unknown", detail } : { state: "inactive" };
 }
 

--- a/src/module-ops-client.ts
+++ b/src/module-ops-client.ts
@@ -45,6 +45,14 @@ export const DEFAULT_HUB_BASE_URL = "http://127.0.0.1:1939";
 const DEFAULT_POLL_INTERVAL_MS = 1_000;
 const DEFAULT_POLL_TIMEOUT_MS = 120_000;
 
+/**
+ * Default ceiling for the single `GET /api/modules` read in {@link fetchModuleStates}.
+ * `status` is a read-only health snapshot — a hub whose request handler is wedged
+ * (accepts the TCP connection but never answers) must not hang it. Bounded so the
+ * caller degrades to a "couldn't read live module state" note instead of stalling.
+ */
+const DEFAULT_STATES_FETCH_TIMEOUT_MS = 3_000;
+
 /** Module-op verbs the client can drive against `POST /api/modules/:short/<op>`. */
 export type ModuleOp = "start" | "stop" | "restart" | "install" | "upgrade" | "uninstall";
 
@@ -118,6 +126,13 @@ export interface DriveModuleOpDeps {
   readonly pollIntervalMs?: number;
   /** Poll ceiling for async ops, ms. Default 120000. */
   readonly pollTimeoutMs?: number;
+  /**
+   * Per-request ceiling for the {@link fetchModuleStates} `GET /api/modules` read,
+   * ms. Default {@link DEFAULT_STATES_FETCH_TIMEOUT_MS} (3000). Bounds `status`
+   * against a wedged hub handler; tests inject a short value to exercise the
+   * timeout-degrade path without a real wall-clock wait.
+   */
+  readonly statesFetchTimeoutMs?: number;
 }
 
 /**
@@ -325,25 +340,52 @@ export interface ModuleStatesResult {
  * authenticates this read.
  *
  * Used by `parachute status` on a UNIT-MANAGED box to source module rows from
- * the live supervisor instead of pidfiles. It is read-only and bounded; the
- * CALLER is responsible for degrading gracefully (hub down → don't call this;
- * no token → catch {@link NoOperatorTokenError}) so `status` never hangs/crashes.
+ * the live supervisor instead of pidfiles. It is read-only and BOUNDED: the
+ * single `GET /api/modules` carries an `AbortSignal.timeout` (default
+ * {@link DEFAULT_STATES_FETCH_TIMEOUT_MS}) so a hub that accepts the TCP
+ * connection but never answers (wedged request handler) can't hang `status` —
+ * the preceding `/health` probe is bounded too, but this read needs its own
+ * ceiling. The CALLER is responsible for degrading gracefully (hub down → don't
+ * call this; no token → catch {@link NoOperatorTokenError}) so `status` never
+ * hangs/crashes.
  *
- * Throws:
+ * Throws (all caught + degraded to a "couldn't read live module state" note by
+ * the `status` caller — see `buildSupervisorRows`):
  *   - {@link NoOperatorTokenError} — no operator.token on disk.
  *   - {@link OperatorTokenExpiredError} — token fully expired (actionable msg).
- *   - {@link ModuleOpHttpError} — hub answered non-2xx.
+ *   - {@link ModuleOpHttpError} — hub answered non-2xx, OR the bounded fetch
+ *     timed out / aborted (surfaced as a synthetic `request_timeout` so the
+ *     caller degrades with a message via its existing non-2xx catch, exactly as
+ *     it does for a real HTTP error — never a hang).
  */
 export async function fetchModuleStates(deps: DriveModuleOpDeps): Promise<ModuleStatesResult> {
   const doFetch = deps.fetch ?? fetch;
   const baseUrl = (deps.baseUrl ?? DEFAULT_HUB_BASE_URL).replace(/\/+$/, "");
+  const timeoutMs = deps.statesFetchTimeoutMs ?? DEFAULT_STATES_FETCH_TIMEOUT_MS;
   const bearer = await resolveOperatorBearer(deps);
 
-  const res = await doFetch(`${baseUrl}/api/modules`, {
-    method: "GET",
-    // `/api/modules` parses the scheme-cased `Bearer ` prefix; match it exactly.
-    headers: { authorization: `Bearer ${bearer}` },
-  });
+  let res: Response;
+  try {
+    res = await doFetch(`${baseUrl}/api/modules`, {
+      method: "GET",
+      // `/api/modules` parses the scheme-cased `Bearer ` prefix; match it exactly.
+      headers: { authorization: `Bearer ${bearer}` },
+      // Bound the read so a wedged hub handler degrades `status` rather than
+      // hanging it. AbortSignal.timeout fires `AbortError` once the ceiling
+      // elapses (or the fetch errors for another transport reason).
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    // Timeout/abort or transport failure → re-shape as a ModuleOpHttpError so the
+    // `status` caller degrades through the SAME non-2xx catch it uses for an HTTP
+    // error (a "couldn't read live module state" note + exit 0), never hangs.
+    const aborted =
+      err instanceof Error && (err.name === "AbortError" || err.name === "TimeoutError");
+    const description = aborted
+      ? `module-states read timed out after ${timeoutMs}ms`
+      : `module-states read failed (${err instanceof Error ? err.message : String(err)})`;
+    throw new ModuleOpHttpError(0, "request_timeout", description);
+  }
   const body = await parseJsonSafe(res);
   if (res.status < 200 || res.status >= 300) {
     const { error, error_description } = asErrorBody(body);

--- a/src/module-ops-client.ts
+++ b/src/module-ops-client.ts
@@ -284,6 +284,89 @@ export async function fetchModuleLogs(
   return { short, lines, text };
 }
 
+/**
+ * One module's run-state as read from `GET /api/modules` — the subset
+ * `parachute status` needs to render a module row from the RUNNING supervisor
+ * (design §6.4 module rows). Snake-case mirrors the wire shape (`api-modules.ts`
+ * `ModuleWireShape`); we keep only the supervisor-derived fields here.
+ */
+export interface ModuleStateSnapshot {
+  readonly short: string;
+  readonly installed: boolean;
+  readonly installed_version: string | null;
+  /**
+   * Supervisor run-status (`running` / `stopped` / `crashed` / `starting` /
+   * `restarting`), or null when the module isn't tracked by the supervisor
+   * (e.g. never booted, skipped at boot, or no supervisor on this hub).
+   */
+  readonly supervisor_status: string | null;
+  readonly pid: number | null;
+  /**
+   * Structured start-error the supervisor recorded (missing-dependency /
+   * started-but-unbound). Passed through verbatim so `status` can render the
+   * SAME friendly missing-dependency note the detached path shows (#188).
+   */
+  readonly supervisor_start_error: unknown | null;
+}
+
+/** Terminal shape returned by {@link fetchModuleStates}. */
+export interface ModuleStatesResult {
+  /** Whether the running hub has a supervisor wired in (`supervisor_available`). */
+  readonly supervisorAvailable: boolean;
+  /** Per-module supervisor snapshots, keyed by short name in array order. */
+  readonly modules: ModuleStateSnapshot[];
+}
+
+/**
+ * Read the RUNNING hub's per-module supervisor states via `GET /api/modules`
+ * (design §6.4 module rows). The operator token's `admin` scope-set carries
+ * `parachute:host:auth` (the scope `/api/modules` gates on), so the same
+ * read-never-mint operator-token→Bearer path {@link driveModuleOp} uses
+ * authenticates this read.
+ *
+ * Used by `parachute status` on a UNIT-MANAGED box to source module rows from
+ * the live supervisor instead of pidfiles. It is read-only and bounded; the
+ * CALLER is responsible for degrading gracefully (hub down → don't call this;
+ * no token → catch {@link NoOperatorTokenError}) so `status` never hangs/crashes.
+ *
+ * Throws:
+ *   - {@link NoOperatorTokenError} — no operator.token on disk.
+ *   - {@link OperatorTokenExpiredError} — token fully expired (actionable msg).
+ *   - {@link ModuleOpHttpError} — hub answered non-2xx.
+ */
+export async function fetchModuleStates(deps: DriveModuleOpDeps): Promise<ModuleStatesResult> {
+  const doFetch = deps.fetch ?? fetch;
+  const baseUrl = (deps.baseUrl ?? DEFAULT_HUB_BASE_URL).replace(/\/+$/, "");
+  const bearer = await resolveOperatorBearer(deps);
+
+  const res = await doFetch(`${baseUrl}/api/modules`, {
+    method: "GET",
+    // `/api/modules` parses the scheme-cased `Bearer ` prefix; match it exactly.
+    headers: { authorization: `Bearer ${bearer}` },
+  });
+  const body = await parseJsonSafe(res);
+  if (res.status < 200 || res.status >= 300) {
+    const { error, error_description } = asErrorBody(body);
+    throw new ModuleOpHttpError(res.status, error, error_description);
+  }
+  const b = (body ?? {}) as { modules?: unknown; supervisor_available?: unknown };
+  const supervisorAvailable = b.supervisor_available === true;
+  const modules: ModuleStateSnapshot[] = Array.isArray(b.modules)
+    ? b.modules
+        .filter((m): m is Record<string, unknown> => !!m && typeof m === "object")
+        .map((m) => ({
+          short: typeof m.short === "string" ? m.short : "",
+          installed: m.installed === true,
+          installed_version: typeof m.installed_version === "string" ? m.installed_version : null,
+          supervisor_status: typeof m.supervisor_status === "string" ? m.supervisor_status : null,
+          pid: typeof m.pid === "number" ? m.pid : null,
+          supervisor_start_error:
+            m.supervisor_start_error !== undefined ? (m.supervisor_start_error ?? null) : null,
+        }))
+    : [];
+  return { supervisorAvailable, modules };
+}
+
 async function parseJsonSafe(res: Response): Promise<unknown> {
   try {
     return await res.json();


### PR DESCRIPTION
The last piece of **Phase 3** of the hub-as-supervisor unification (design [`2026-06-01-hub-as-supervisor-unification.md`](../parachute.computer/design/2026-06-01-hub-as-supervisor-unification.md) **§6.4** status / proxy-state + **§3.3** the `status` row). `parachute status` now dual-dispatches the same way Phase 3b's start/stop/restart do.

## The cutover (§6.4)

**Hub row** — on a unit-managed box, query the **platform manager** for the hub unit's run-state (`systemctl [--user] is-active parachute-hub.service` / `launchctl print gui/<uid>/computer.parachute.hub`) and compose it with a bounded `/health` probe (the liveness signal):
- manager `active` + `/health` OK → **active** (+ port)
- manager `active` + `/health` down → **failing**, with a "starting/unhealthy — /health not answering yet" continuation note
- manager `failed` → **failing**, surfacing the last-exit code
- **container / Render / Fly** (no on-box manager) → `/health` is the sole liveness signal; row reports **"container runtime (managed)"**

Reuses hub-unit.ts's manager dispatch/labels via a new read-only `queryHubUnitState`.

**Module rows** — when the hub is up, read states from the **running supervisor** via `GET /api/modules`, using the operator-token→Bearer reader (`fetchModuleStates`, reusing `resolveOperatorBearer`; the operator token's `admin` scope-set carries `parachute:host:auth`, the scope the endpoint gates on). Supervisor states map onto the existing STATE vocabulary (`running`→active, `crashed`→failing, `starting`/`restarting`→pending, `stopped`→inactive); the structured `startError`/missing-dependency info is surfaced on the existing start-error continuation line (#188). To carry it on the wire, `/api/modules` gained an additive `supervisor_start_error` field.

## Dual-dispatch + graceful degradation (the load-bearing part)

- **Detached arm unchanged.** No hub unit installed → the EXACT current `processState` pidfile readout for hub + module rows, byte-for-byte behind the no-unit branch. Phase 5 deletes that arm; it's a clean top-level branch (one-liner deletion). The existing detached status tests all still pass, proving behavior-identity. Un-migrated boxes keep working.
- **`status` never hangs or crashes** — it's a diagnostic, so every failure path degrades:
  - hub DOWN → modules read **inactive / "hub is down"** *without* calling the API (children die with the hub; the call would just connection-refuse)
  - no / expired operator token → manifest-derived rows + an actionable **"run `parachute auth rotate-operator`"** hint (no 401 crash)
  - API error / parse failure → degrade with the message
  - a thrown manager query → fall back to the `/health` verdict
  - All reads are bounded + wrapped.

## Notes

- **No new STATE vocabulary** was needed — every manager/supervisor state maps onto the existing `active`/`pending`/`inactive`/`failing` rollup. The manager nuances (container-managed, starting/unhealthy, failed-with-exit-code) ride on a new **hub-row-only `managerNote`** continuation line, so the renderer didn't need a new enum.
- `cli.ts` wires `status({ supervisor: {} })` so production takes the dual-dispatch; the seams (`unitInstalled`/`queryHubUnitState`/`probeHubHealth`/`fetchModuleStates`/`openDb`) are all injectable, mirroring lifecycle.ts's Phase 3b shape. Existing test seams (`alive`/`installSourceDeps`/`now`) preserved.
- **No version bump** — completes Phase 3.

## Gates

- `bun test ./src`: **2715 pass / 1 skip / 0 fail** (+31 vs the Phase 3b baseline of 2684/1/0 — zero regressions).
- `bun run typecheck`: clean.
- `bunx biome check` on touched source + new/edited test files: clean. (One pre-existing biome finding in `api-modules.test.ts` lines ~650/938/941, unrelated to this diff, left untouched.)

## Tests

- Hub row: manager active + /health OK → running+port; manager failed → failing+exit-code; manager active + /health down → failing+starting/unhealthy; container/no-manager → "container runtime (managed)"; thrown manager query → no crash.
- Module rows: hub up → states from a stubbed `GET /api/modules` (incl. a `crashed` module with a structured `startError` surfaced); `starting` → pending; hub down → degraded "inactive / hub is down" without calling the API; no/expired operator token → graceful hint (no crash); API error → degrade with the message.
- Discriminant: no `supervisor` block → detached arm (probe runs); `unitInstalled:false` → detached arm (manager NOT queried).
- Plumbing: `queryHubUnitState` (systemd active/failed/inactive/activating + scope, launchd running/failed/not-loaded, throw→unknown); `fetchModuleStates` (bearer+parse, no-token, non-2xx, malformed body); `/api/modules` startError projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)