### PR TITLE
release: hub 0.6.3-rc.1 — supervisor unification Phases 1–3 to @rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.2",
+  "version": "0.6.3-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Bumps hub to **0.6.3-rc.1** to ship the supervisor-unification Phases 1–3 (PRs #495 #496 #497 #498 #499 #500, all on main) to the **`@rc`** dist-tag for validation.

- **`@latest` stays 0.6.2** — the `-rc.` tag routes to `DIST_TAG=rc` in release.yml (line 141-145), never latest.
- Version-only change; next-patch from the 0.6.2 stable per governance rule 2.
- On merge: tag `v0.6.3-rc.1` → CI publishes `@openparachute/hub@0.6.3-rc.1` to `@rc` + a `rc` ghcr.io image.
- Live boxes (gitcoin/our) are **not** touched — they run `@latest` 0.6.2; deploy is gated separately.

Phases 4–6 (expose decouple + SPA hub-upgrade D4, migrate cutover + bridge-collapse, docs) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)