### PR TITLE
feat(hub): Phase 4 (CLI) — expose decouple (D3) + upgrade-hub restarts the unit (supervisor unification)

### DIFF
--- a/src/__tests__/expose-cloudflare.test.ts
+++ b/src/__tests__/expose-cloudflare.test.ts
@@ -15,9 +15,12 @@ import {
   exposeCloudflareOff,
   exposeCloudflareUp,
 } from "../commands/expose-cloudflare.ts";
+import type { ExposeSupervisorOpts } from "../commands/expose-supervisor.ts";
 import { readEnvFileValues } from "../env-file.ts";
 import { readExposeState } from "../expose-state.ts";
 import { writeHubPort } from "../hub-control.ts";
+import type { EnsureHubUnitOpts } from "../hub-unit.ts";
+import { type ModuleOp, ModuleOpHttpError } from "../module-ops-client.ts";
 import type { CommandResult, Runner } from "../tailscale/run.ts";
 
 // Default seeded hub port used by tests with `skipHub: true`. The cloudflared
@@ -2012,6 +2015,157 @@ describe("reboot-persistent connector service wiring", () => {
       expect(killed).toContain(95000);
       expect(existsSync(env.statePath)).toBe(false);
       expect(logs.join("\n")).toContain("Removed launchd LaunchAgent");
+    } finally {
+      env.cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 4 dual-dispatch (design §4.3): unit-managed → "ensure the hub" ensures
+// the UNIT (not a detached spawn) and the post-route vault restart drives the
+// running Supervisor over the loopback module-ops API (firing the operator-
+// token self-heal). The cloudflared CONNECTOR unit is unchanged. The no-unit
+// arm keeps today's `persistVaultHubOrigin` + `restartService` behavior.
+// ---------------------------------------------------------------------------
+
+interface CfExposeSupervisorStub {
+  opts: ExposeSupervisorOpts;
+  ensureCalls: number;
+  driveCalls: Array<{ short: string; op: ModuleOp }>;
+  selfHealCalls: Array<{ issuer: string }>;
+}
+
+function makeCfSupervisorStub(opts?: {
+  ensureOutcome?: "already-up" | "started" | "no-manager";
+  driveThrows?: () => unknown;
+}): CfExposeSupervisorStub {
+  const stub: CfExposeSupervisorStub = {
+    ensureCalls: 0,
+    driveCalls: [],
+    selfHealCalls: [],
+    opts: {
+      unitInstalled: true,
+      openDb: () => ({ close() {} }) as unknown as import("bun:sqlite").Database,
+      ensureHubUnit: async (o: EnsureHubUnitOpts) => {
+        stub.ensureCalls++;
+        return { outcome: opts?.ensureOutcome ?? "already-up", port: o.port ?? 1939, messages: [] };
+      },
+      driveModuleOp: async (short, op) => {
+        stub.driveCalls.push({ short, op });
+        if (opts?.driveThrows) throw opts.driveThrows();
+        return { status: 200, body: { short, state: { status: "running" } } };
+      },
+      selfHealOperatorTokenIssuer: async (_db, o) => {
+        stub.selfHealCalls.push({ issuer: o.issuer });
+        return { kind: "fresh" };
+      },
+    },
+  };
+  return stub;
+}
+
+describe("Phase 4 cloudflare expose dual-dispatch — unit-managed", () => {
+  test("unit-managed → ensureHubUnit (not detached) + supervised vault restart + operator-token self-heal", async () => {
+    const env = makeEnv();
+    try {
+      const uuid = "ffffffff-0000-0000-0000-0000000000a4";
+      const { runner } = queueRunner([
+        { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" }, // --version
+        { code: 0, stdout: "[]", stderr: "" }, // tunnel list
+        {
+          code: 0,
+          stdout: `Tunnel credentials written to ${env.cloudflaredHome}/${uuid}.json.\nCreated tunnel parachute with id ${uuid}\n`,
+          stderr: "",
+        }, // tunnel create
+        { code: 0, stdout: "", stderr: "" }, // route dns
+      ]);
+      const { spawner } = fakeSpawner(42400);
+      const sup = makeCfSupervisorStub();
+      const restarted: string[] = [];
+      const logs: string[] = [];
+
+      const code = await exposeCloudflareUp("gitcoin-parachute.unforced.dev", {
+        runner,
+        spawner,
+        alive: () => false,
+        kill: () => {},
+        log: (l) => logs.push(l),
+        manifestPath: env.manifestPath,
+        statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
+        configPath: env.configPath,
+        logPath: env.logPath,
+        cloudflaredHome: env.cloudflaredHome,
+        configDir: env.configDir,
+        // No skipHub → the unit arm's ensureHubUnit runs (via the stub, no real hub).
+        // Inert connector install so the cloudflared connector path is unchanged.
+        installService: () => ({ outcome: "fallback", messages: [] }),
+        // This detached restart seam must NOT be called on the unit arm.
+        restartService: async (short) => {
+          restarted.push(short);
+          return 0;
+        },
+        supervisor: sup.opts,
+      });
+
+      expect(code).toBe(0);
+      // Ensured the hub UNIT (the stub), never the detached spawn.
+      expect(sup.ensureCalls).toBe(1);
+      // Vault restart drove the running Supervisor, NOT the detached restartService.
+      expect(sup.driveCalls).toEqual([{ short: "vault", op: "restart" }]);
+      expect(restarted).toEqual([]);
+      // Operator-token issuer self-heal fired toward the public origin.
+      expect(sup.selfHealCalls).toHaveLength(1);
+      expect(sup.selfHealCalls[0]?.issuer).toBe("https://gitcoin-parachute.unforced.dev");
+      // Durable .env still written (the helper persists it for vault).
+      expect(readEnvFileValues(join(env.configDir, "vault", ".env")).PARACHUTE_HUB_ORIGIN).toBe(
+        "https://gitcoin-parachute.unforced.dev",
+      );
+      expect(logs.join("\n")).toMatch(/hub unit up/);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("unit-managed: a not_supervised vault (404) is not a failure", async () => {
+    const env = makeEnv();
+    try {
+      const uuid = "ffffffff-0000-0000-0000-0000000000a5";
+      const { runner } = queueRunner([
+        { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
+        { code: 0, stdout: "[]", stderr: "" },
+        {
+          code: 0,
+          stdout: `Tunnel credentials written to ${env.cloudflaredHome}/${uuid}.json.\nCreated tunnel parachute with id ${uuid}\n`,
+          stderr: "",
+        },
+        { code: 0, stdout: "", stderr: "" },
+      ]);
+      const { spawner } = fakeSpawner(42401);
+      const sup = makeCfSupervisorStub({
+        driveThrows: () => new ModuleOpHttpError(404, "not_supervised", "vault is not supervised"),
+      });
+
+      const code = await exposeCloudflareUp("gitcoin-parachute.unforced.dev", {
+        runner,
+        spawner,
+        alive: () => false,
+        kill: () => {},
+        log: () => {},
+        manifestPath: env.manifestPath,
+        statePath: env.statePath,
+        exposeStatePath: env.exposeStatePath,
+        configPath: env.configPath,
+        logPath: env.logPath,
+        cloudflaredHome: env.cloudflaredHome,
+        configDir: env.configDir,
+        installService: () => ({ outcome: "fallback", messages: [] }),
+        supervisor: sup.opts,
+      });
+
+      expect(code).toBe(0);
+      expect(sup.driveCalls).toEqual([{ short: "vault", op: "restart" }]);
     } finally {
       env.cleanup();
     }

--- a/src/__tests__/expose-off-auto.test.ts
+++ b/src/__tests__/expose-off-auto.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { CloudflaredState } from "../cloudflare/state.ts";
+import type { ExposeCloudflareOpts } from "../commands/expose-cloudflare.ts";
 import {
   type ExposePublicOffAutoOpts,
   runExposePublicOffAutoDetect,
@@ -50,6 +51,7 @@ interface Harness {
   prompts: string[];
   tailscaleCalls: number;
   cloudflareCalls: number;
+  cloudflareOpts: ExposeCloudflareOpts[];
 }
 
 function makeHarness(
@@ -70,6 +72,7 @@ function makeHarness(
     prompts: [],
     tailscaleCalls: 0,
     cloudflareCalls: 0,
+    cloudflareOpts: [],
   };
   const answers = [...(input.promptAnswers ?? [])];
   let i = 0;
@@ -88,8 +91,9 @@ function makeHarness(
       harness.tailscaleCalls++;
       return input.tsExitCode ?? 0;
     },
-    exposeCloudflareOffImpl: async () => {
+    exposeCloudflareOffImpl: async (cfOpts) => {
       harness.cloudflareCalls++;
+      harness.cloudflareOpts.push(cfOpts);
       return input.cfExitCode ?? 0;
     },
   };
@@ -271,5 +275,26 @@ describe("runExposePublicOffAutoDetect — both live (non-TTY)", () => {
     expect(harness.tailscaleCalls).toBe(1);
     expect(harness.cloudflareCalls).toBe(1);
     expect(harness.logs).toContain("(non-TTY: tearing down both.)");
+  });
+});
+
+describe("runExposePublicOffAutoDetect — supervisor threading (Phase 4 consistency)", () => {
+  test("cloudflareOffOpts.supervisor reaches the cloudflare teardown leg", async () => {
+    // cli.ts threads `cloudflareOffOpts: { supervisor: {} }` into the
+    // auto-detect off path so the Phase 4 supervisor resolution is consistent
+    // across both providers (matching the explicit `--cloudflare off` branch).
+    // Assert the supervisor block survives the spread-with-tunnelName wrapper
+    // and arrives at the leaf cloudflare-off impl.
+    const { harness, opts } = makeHarness({ cfState: cloudflaredState() });
+    const code = await runExposePublicOffAutoDetect({
+      ...opts,
+      cloudflareOffOpts: { supervisor: {} },
+    });
+    expect(code).toBe(0);
+    expect(harness.cloudflareCalls).toBe(1);
+    expect(harness.cloudflareOpts).toHaveLength(1);
+    expect(harness.cloudflareOpts[0]?.supervisor).toEqual({});
+    // The per-record wrapper still stamps the tunnelName onto the leaf opts.
+    expect(harness.cloudflareOpts[0]?.tunnelName).toBe("vault-tunnel");
   });
 });

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ExposeSupervisorOpts } from "../commands/expose-supervisor.ts";
 import { exposePublic, exposeTailnet } from "../commands/expose.ts";
 import { readEnvFileValues } from "../env-file.ts";
 import { readExposeState, writeExposeState } from "../expose-state.ts";
 import type { EnsureHubOpts, HubSpawner, StopHubOpts } from "../hub-control.ts";
+import type { EnsureHubUnitOpts } from "../hub-unit.ts";
+import { type ModuleOp, ModuleOpHttpError } from "../module-ops-client.ts";
 import { writePid } from "../process-state.ts";
 import { upsertService } from "../services-manifest.ts";
 import type { Runner } from "../tailscale/run.ts";
@@ -1675,6 +1678,253 @@ describe("expose: vault routing fully internal to hub", () => {
         .filter((c) => c[0] === "tailscale" && c[1] === "serve" && c.includes("--bg"))
         .map((c) => c.find((a) => a.startsWith("--set-path=")));
       expect(mounts).toEqual(["--set-path=/"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 4 dual-dispatch (design §4.3): when a hub UNIT is installed, `expose`
+// ensures the hub UNIT (not a detached spawn), the post-expose vault restart
+// drives the running Supervisor over the loopback module-ops API (firing the
+// operator-token + vault `.env` self-heal), and `expose off` leaves the hub
+// RUNNING (D3 — a managed hub with Restart=always/KeepAlive would just respawn
+// a stopped one). The no-unit arm keeps today's behavior unchanged.
+// ---------------------------------------------------------------------------
+
+interface ExposeSupervisorStub {
+  opts: ExposeSupervisorOpts;
+  ensureCalls: Array<{ port?: number }>;
+  driveCalls: Array<{ short: string; op: ModuleOp }>;
+  selfHealCalls: Array<{ issuer: string }>;
+}
+
+/**
+ * Build an expose `supervisor` seam that forces the unit-installed arm and
+ * records the `ensureHubUnit` / `driveModuleOp` / operator-token-self-heal
+ * calls. `driveThrows` makes a module-op throw a chosen error; `ensureOutcome`
+ * controls the ensure-hub result.
+ */
+function makeExposeSupervisorStub(opts?: {
+  ensureOutcome?: "already-up" | "started" | "no-unit" | "no-manager" | "timeout" | "start-failed";
+  ensurePort?: number;
+  driveThrows?: (short: string, op: ModuleOp) => unknown;
+}): ExposeSupervisorStub {
+  const ensureCalls: Array<{ port?: number }> = [];
+  const driveCalls: Array<{ short: string; op: ModuleOp }> = [];
+  const selfHealCalls: Array<{ issuer: string }> = [];
+  return {
+    ensureCalls,
+    driveCalls,
+    selfHealCalls,
+    opts: {
+      unitInstalled: true,
+      // openDb is opened+closed around the drive/self-heal — hand back a no-op closer.
+      openDb: () => ({ close() {} }) as unknown as import("bun:sqlite").Database,
+      ensureHubUnit: async (o: EnsureHubUnitOpts) => {
+        ensureCalls.push({ port: o.port });
+        return {
+          outcome: opts?.ensureOutcome ?? "already-up",
+          port: opts?.ensurePort ?? o.port ?? 1939,
+          messages: [],
+        };
+      },
+      driveModuleOp: async (short, op) => {
+        driveCalls.push({ short, op });
+        if (opts?.driveThrows) throw opts.driveThrows(short, op);
+        return { status: 200, body: { short, state: { status: "running" } } };
+      },
+      selfHealOperatorTokenIssuer: async (_db, o) => {
+        selfHealCalls.push({ issuer: o.issuer });
+        return { kind: "fresh" };
+      },
+    },
+  };
+}
+
+describe("Phase 4 expose dual-dispatch — unit-managed", () => {
+  test("expose up unit-managed → ensureHubUnit (not detached spawn) + driveModuleOp(restart) for vault", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      const { runner } = makeRunner();
+      const sup = makeExposeSupervisorStub();
+      const logs: string[] = [];
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        servicePortProbe: allServicesUp,
+        supervisor: sup.opts,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      // Ensured the hub UNIT (the detached hub spawner was never invoked).
+      expect(sup.ensureCalls).toHaveLength(1);
+      // Post-expose vault restart drove the supervisor, not lifecycle.restart.
+      expect(sup.driveCalls).toEqual([{ short: "vault", op: "restart" }]);
+      // The operator-token issuer self-heal fired toward the public origin.
+      expect(sup.selfHealCalls).toHaveLength(1);
+      expect(sup.selfHealCalls[0]?.issuer).toMatch(/^https:\/\//);
+      expect(logs.join("\n")).toMatch(/hub unit up/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("expose up unit-managed: ensureHubUnit failure aborts before exposing", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      const { runner, calls } = makeRunner();
+      const sup = makeExposeSupervisorStub({ ensureOutcome: "no-manager" });
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        servicePortProbe: allServicesUp,
+        supervisor: sup.opts,
+        log: () => {},
+      });
+      expect(code).toBe(1);
+      // Never ran the tailscale bringup — we bailed on the failed ensure.
+      expect(calls.filter((c) => c[0] === "tailscale" && c[1] === "serve")).toHaveLength(0);
+      expect(sup.driveCalls).toHaveLength(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("expose up unit-managed: a not_supervised vault (404) is not a failure", async () => {
+    const h = makeHarness();
+    try {
+      seedServices(h.manifestPath);
+      const { runner } = makeRunner();
+      const sup = makeExposeSupervisorStub({
+        driveThrows: () => new ModuleOpHttpError(404, "not_supervised", "vault is not supervised"),
+      });
+      const code = await exposeTailnet("up", {
+        runner,
+        manifestPath: h.manifestPath,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        servicePortProbe: allServicesUp,
+        supervisor: sup.opts,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(sup.driveCalls).toEqual([{ short: "vault", op: "restart" }]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("expose off unit-managed → exposure torn down, hub NOT stopped, no 'hub stopped' line", async () => {
+    const h = makeHarness();
+    try {
+      writeExposeState(
+        {
+          version: 1,
+          layer: "tailnet",
+          mode: "path",
+          canonicalFqdn: "parachute.taildf9ce2.ts.net",
+          port: 443,
+          funnel: false,
+          entries: [{ kind: "proxy", mount: "/", target: "http://127.0.0.1:1939", service: "hub" }],
+        },
+        h.statePath,
+      );
+      writePid("hub", 4242, h.configDir);
+      const { runner, calls } = makeRunner();
+      const sup = makeExposeSupervisorStub();
+      // A kill / stopHub seam that fails the test if the hub is signalled.
+      const logs: string[] = [];
+      const code = await exposeTailnet("off", {
+        runner,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        // If the hub stop path ran, this kill seam would be called and throw.
+        hubStopOpts: {
+          kill: () => {
+            throw new Error("expose off unit-managed must NOT stop the hub");
+          },
+          alive: () => true,
+          sleep: async () => {},
+          now: () => 0,
+        },
+        supervisor: sup.opts,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      // The exposure layer was torn down…
+      expect(calls.every((c) => c[c.length - 1] === "off" || c[1] === "version")).toBe(true);
+      expect(existsSync(h.statePath)).toBe(false);
+      // …but the hub was left running: no stop, no "hub stopped" line.
+      expect(logs.join("\n")).not.toMatch(/hub stopped/);
+      expect(logs.join("\n")).toMatch(/exposure removed/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("expose off NO unit → hub stopped (detached arm unchanged)", async () => {
+    const h = makeHarness();
+    try {
+      writeExposeState(
+        {
+          version: 1,
+          layer: "tailnet",
+          mode: "path",
+          canonicalFqdn: "parachute.taildf9ce2.ts.net",
+          port: 443,
+          funnel: false,
+          entries: [{ kind: "proxy", mount: "/", target: "http://127.0.0.1:1939", service: "hub" }],
+        },
+        h.statePath,
+      );
+      writePid("hub", 4242, h.configDir);
+      const { runner } = makeRunner();
+      const signals: NodeJS.Signals[] = [];
+      let aliveNow = true;
+      const logs: string[] = [];
+      const code = await exposeTailnet("off", {
+        runner,
+        statePath: h.statePath,
+        wellKnownPath: h.wellKnownPath,
+        hubPath: h.hubPath,
+        wellKnownDir: h.wellKnownDir,
+        configDir: h.configDir,
+        hubStopOpts: {
+          kill: (_pid, sig) => {
+            signals.push(sig as NodeJS.Signals);
+            aliveNow = false;
+          },
+          alive: () => aliveNow,
+          sleep: async () => {},
+          now: () => 0,
+        },
+        // supervisor omitted → detached arm, deterministically.
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      // The detached arm still stops the hub.
+      expect(signals).toContain("SIGTERM");
+      expect(logs.join("\n")).toMatch(/hub stopped/);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/upgrade.test.ts
+++ b/src/__tests__/upgrade.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { UpgradeRunner } from "../commands/upgrade.ts";
 import { compareVersions, defaultRunner, detectChannel, upgrade } from "../commands/upgrade.ts";
+import type { HubUnitDeps, HubUnitManagerOpResult } from "../hub-unit.ts";
 import { upsertService } from "../services-manifest.ts";
 
 interface RunCall {
@@ -1213,6 +1214,205 @@ describe("parachute upgrade", () => {
       });
       const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
       expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@next"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 4 dual-dispatch (design §5): when a hub UNIT is installed, `upgrade hub`
+// rewrites the binary as usual then RESTARTS THE UNIT via the platform manager
+// (`restartHubUnit`), NOT the detached `restartFn` (stopHub/ensureHubRunning).
+// The manager tears down the old hub (children die) and starts the new binary,
+// which re-boots every module. No-unit → the unchanged detached restart.
+// ---------------------------------------------------------------------------
+
+describe("Phase 4 upgrade-hub dual-dispatch", () => {
+  test("upgrade hub unit-managed → binary rewrite + restartHubUnit (manager), NOT detached restartFn", async () => {
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.6.3-rc.1" });
+      const seenCmd: string[][] = [];
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          seenCmd.push([...cmd]);
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            // Channel auto-detected as @rc from the installed -rc version.
+            writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.6.3-rc.2" });
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          // Not a git checkout → npm-install branch.
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "fatal: not a git repository\n" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      let restartFnCalled = false;
+      let restartHubUnitCalls = 0;
+      const logs: string[] = [];
+      const code = await upgrade("hub", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        // The detached restart path must NOT be taken on the unit arm.
+        restartFn: async () => {
+          restartFnCalled = true;
+          return 0;
+        },
+        // Avoid a real registry round-trip in the downgrade guard.
+        resolveChannelVersion: async () => null,
+        supervisor: {
+          unitInstalled: true,
+          restartHubUnit: (_deps: HubUnitDeps): HubUnitManagerOpResult => {
+            restartHubUnitCalls++;
+            return { outcome: "ok", messages: [] };
+          },
+        },
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      // The binary was rewritten via bun add -g @rc…
+      const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
+      expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@rc"]);
+      // …and the restart went through the platform manager, not the detached PID path.
+      expect(restartHubUnitCalls).toBe(1);
+      expect(restartFnCalled).toBe(false);
+      expect(logs.join("\n")).toMatch(/restarted the hub unit/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("upgrade hub NO unit → detached restartFn (unchanged)", async () => {
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.8" });
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.5.9" });
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      let restartedShort: string | undefined;
+      let restartHubUnitCalls = 0;
+      const code = await upgrade("hub", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        restartFn: async (svc) => {
+          restartedShort = svc;
+          return 0;
+        },
+        resolveChannelVersion: async () => null,
+        // supervisor block present but unit NOT installed → detached arm.
+        supervisor: {
+          unitInstalled: false,
+          restartHubUnit: (_deps: HubUnitDeps): HubUnitManagerOpResult => {
+            restartHubUnitCalls++;
+            return { outcome: "ok", messages: [] };
+          },
+        },
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      // The detached restartFn ran; the manager restart did NOT.
+      expect(restartedShort).toBe("hub");
+      expect(restartHubUnitCalls).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("sweep stays hub-first; hub restart uses the manager, module restarts route through lifecycle", async () => {
+    const h = makeHarness();
+    try {
+      // Hub install dir + a vault module in services.json — sweep upgrades both.
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.6.3-rc.1" });
+      const vaultInstallDir = join(h.installRoot, "vault");
+      writePackageJson(vaultInstallDir, { name: "@openparachute/vault", version: "0.6.3-rc.1" });
+      seedVault(h.manifestPath, vaultInstallDir, "0.6.3-rc.1");
+
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            const spec = cmd[3] ?? "";
+            if (spec.startsWith("@openparachute/hub")) {
+              writePackageJson(hubInstallDir, {
+                name: "@openparachute/hub",
+                version: "0.6.3-rc.2",
+              });
+            } else if (spec.startsWith("@openparachute/vault")) {
+              writePackageJson(vaultInstallDir, {
+                name: "@openparachute/vault",
+                version: "0.6.3-rc.2",
+              });
+            }
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      const restartOrder: string[] = [];
+      let restartHubUnitCalls = 0;
+      const code = await upgrade(undefined, {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) => {
+          if (pkg === "@openparachute/hub") return join(hubInstallDir, "package.json");
+          if (pkg === "@openparachute/vault") return join(vaultInstallDir, "package.json");
+          return null;
+        },
+        // Module restarts (vault) go through lifecycle's restart with a
+        // supervisor block; the stub records the order so we can assert hub-first.
+        restartFn: async (svc) => {
+          restartOrder.push(svc);
+          return 0;
+        },
+        resolveChannelVersion: async () => null,
+        supervisor: {
+          unitInstalled: true,
+          restartHubUnit: (_deps: HubUnitDeps): HubUnitManagerOpResult => {
+            restartHubUnitCalls++;
+            restartOrder.push("hub-unit");
+            return { outcome: "ok", messages: [] };
+          },
+        },
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      // Hub-first: the hub unit restart precedes the vault module restart.
+      expect(restartOrder[0]).toBe("hub-unit");
+      expect(restartOrder).toContain("vault");
+      expect(restartOrder.indexOf("hub-unit")).toBeLessThan(restartOrder.indexOf("vault"));
+      expect(restartHubUnitCalls).toBe(1);
     } finally {
       h.cleanup();
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -632,7 +632,16 @@ async function main(argv: string[]): Promise<number> {
       // remember which provider they brought up last.
       if (layer === "public" && action === "off") {
         const { runExposePublicOffAutoDetect } = await import("./commands/expose-off-auto.ts");
-        return await runExposePublicOffAutoDetect({ tailscaleOffOpts: exposeOpts });
+        // `tailscaleOffOpts` carries `supervisor: {}`; thread it into the
+        // Cloudflare teardown leg too so the Phase 4 supervisor resolution is
+        // consistent across both providers on the auto-detect path (matching
+        // the explicit `--cloudflare off` branch above). Harmless today
+        // (exposeCloudflareOff has no stopHub call) but keeps `supervisor: {}`
+        // threaded everywhere.
+        return await runExposePublicOffAutoDetect({
+          tailscaleOffOpts: exposeOpts,
+          cloudflareOffOpts: { supervisor: {} },
+        });
       }
 
       // `--skip-provider-check` fallthrough: pin to today's Tailscale-Funnel

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -532,7 +532,14 @@ async function main(argv: string[]): Promise<number> {
         const { exposeCloudflareUp, exposeCloudflareOff } = await import(
           "./commands/expose-cloudflare.ts"
         );
-        const cfOpts = flagExtract.tunnelName ? { tunnelName: flagExtract.tunnelName } : {};
+        // `supervisor: {}` opts into the Phase 4 dual-dispatch (design §4.3): on
+        // a box with a hub unit installed, ensure the unit + drive the running
+        // supervisor for the post-expose vault restart, and leave the hub running
+        // on `off`; on a legacy detached box (no unit), the unchanged path.
+        const cfOpts = {
+          supervisor: {},
+          ...(flagExtract.tunnelName ? { tunnelName: flagExtract.tunnelName } : {}),
+        };
         if (action === "off") {
           return await exposeCloudflareOff(cfOpts);
         }
@@ -544,7 +551,14 @@ async function main(argv: string[]): Promise<number> {
           // doesn't block on an invisible prompt.
           if (isTtyInteractive()) {
             const { exposePublicInteractive } = await import("./commands/expose-interactive.ts");
-            return await exposePublicInteractive({ preselect: "cloudflare" });
+            // Thread `supervisor: {}` into BOTH provider opts so the interactive
+            // path takes the Phase 4 unit-arm on a unit-managed box regardless of
+            // which provider the operator picks (design §4.3).
+            return await exposePublicInteractive({
+              preselect: "cloudflare",
+              exposeOpts: { supervisor: {} },
+              cloudflareOpts: { supervisor: {} },
+            });
           }
           console.error("parachute expose public --cloudflare: --domain <hostname> is required.");
           console.error("Example: parachute expose public --cloudflare --domain vault.example.com");
@@ -561,7 +575,14 @@ async function main(argv: string[]): Promise<number> {
         return await exposeCloudflareUp(flagExtract.domain, cfOpts);
       }
 
-      const exposeOpts = hubExtract.hubOrigin ? { hubOrigin: hubExtract.hubOrigin } : {};
+      // `supervisor: {}` opts into the Phase 4 dual-dispatch (design §4.3): on a
+      // box with a hub unit installed, ensure the unit (not a detached spawn) +
+      // drive the running supervisor for the post-expose vault restart, and leave
+      // the hub running on `off`; on a legacy detached box, the unchanged path.
+      const exposeOpts = {
+        supervisor: {},
+        ...(hubExtract.hubOrigin ? { hubOrigin: hubExtract.hubOrigin } : {}),
+      };
 
       // `--tailnet` is the explicit Tailscale Funnel pin — bypass both the
       // interactive picker and the non-TTY auto-pick. Goes straight to
@@ -576,7 +597,9 @@ async function main(argv: string[]): Promise<number> {
       // hands back to the flag-driven entry points.
       if (layer === "public" && action === "up" && isTtyInteractive()) {
         const { exposePublicInteractive } = await import("./commands/expose-interactive.ts");
-        return await exposePublicInteractive({ exposeOpts });
+        // `exposeOpts` already carries `supervisor: {}`; thread it into the
+        // Cloudflare branch too so the unit-arm applies regardless of pick.
+        return await exposePublicInteractive({ exposeOpts, cloudflareOpts: { supervisor: {} } });
       }
 
       // Non-TTY auto-pick: detect which provider is configured and run it.
@@ -595,7 +618,12 @@ async function main(argv: string[]): Promise<number> {
       // guessing intent.
       if (layer === "public" && action === "up" && !flagExtract.skipProviderCheck) {
         const { exposePublicAutoPick } = await import("./commands/expose-public-auto.ts");
-        return await exposePublicAutoPick({ tailscaleOpts: exposeOpts });
+        // `tailscaleOpts` carries `supervisor: {}`; thread it into the Cloudflare
+        // branch too so the Phase 4 unit-arm applies regardless of auto-pick.
+        return await exposePublicAutoPick({
+          tailscaleOpts: exposeOpts,
+          cloudflareOpts: { supervisor: {} },
+        });
       }
 
       // `expose public off` (no `--cloudflare`) auto-detects which provider is
@@ -692,7 +720,11 @@ async function main(argv: string[]): Promise<number> {
         );
         return 1;
       }
-      const upgradeOpts: Parameters<typeof upgrade>[1] = {};
+      // `supervisor: {}` opts into the Phase 4 dual-dispatch (design §5): on a
+      // box with a hub unit installed, `upgrade hub` rewrites the binary then
+      // restarts the UNIT via the platform manager (children re-boot from
+      // services.json); on a legacy detached box, the unchanged restart path.
+      const upgradeOpts: Parameters<typeof upgrade>[1] = { supervisor: {} };
       if (tagExtract.tag) upgradeOpts.tag = tagExtract.tag;
       if (channelExtract.value === "rc" || channelExtract.value === "latest") {
         upgradeOpts.channel = channelExtract.value;

--- a/src/commands/expose-cloudflare.ts
+++ b/src/commands/expose-cloudflare.ts
@@ -54,6 +54,7 @@ import {
   readHubPort,
 } from "../hub-control.ts";
 import { deriveHubOrigin } from "../hub-origin.ts";
+import { HUB_UNIT_DEFAULT_PORT } from "../hub-unit.ts";
 import { type AliveFn, defaultAlive, processState } from "../process-state.ts";
 import { readManifest } from "../services-manifest.ts";
 import { type Runner, defaultRunner } from "../tailscale/run.ts";
@@ -61,6 +62,13 @@ import { persistVaultHubOrigin } from "../vault-hub-origin-env.ts";
 import type { VaultAuthStatus } from "../vault/auth-status.ts";
 import { WELL_KNOWN_DIR } from "../well-known.ts";
 import { printPublic2FAWarning } from "./expose-2fa-warning.ts";
+import {
+  type ExposeSupervisorOpts,
+  type ResolvedExposeSupervisor,
+  ensureHubUnitForExpose,
+  resolveExposeSupervisor,
+  restartHubDependentViaSupervisor,
+} from "./expose-supervisor.ts";
 import { restart } from "./lifecycle.ts";
 
 const AUTH_DOC_URL =
@@ -375,6 +383,21 @@ export interface ExposeCloudflareOpts {
    * service) and only when it's already running.
    */
   restartService?: (short: string) => Promise<number>;
+  /**
+   * Phase 4 supervisor-path seams (design §4.3). When a hub UNIT is installed,
+   * "ensure the hub" ensures the UNIT is up (not a detached spawn), and the
+   * post-route vault restart drives the running Supervisor over the loopback
+   * module-ops API (re-injecting the new public origin + firing the operator-
+   * token / vault `.env` self-heal). The cloudflared CONNECTOR unit is
+   * unchanged — it already installs/removes its own ManagedUnit
+   * (`installConnectorService` / `removeConnectorService`), independent of the
+   * hub's lifecycle. The detached arm (`hubEnsureOpts` / `lifecycle.restart`)
+   * remains the no-unit fallback until Phase 5.
+   *
+   * Production CLI dispatch passes `supervisor: {}` so the real
+   * `isHubUnitInstalled` probe decides the arm; omitting it is the detached arm.
+   */
+  supervisor?: ExposeSupervisorOpts;
 }
 
 interface Resolved {
@@ -407,6 +430,7 @@ interface Resolved {
   vaultHome: string | undefined;
   vaultAuthStatus: VaultAuthStatus | undefined;
   restartService: (short: string) => Promise<number>;
+  sup: ResolvedExposeSupervisor;
 }
 
 /**
@@ -502,6 +526,7 @@ function resolve(opts: ExposeCloudflareOpts, tunnelNameDefault: string): Resolve
           configDir,
           log: opts.log ?? (() => {}),
         })),
+    sup: resolveExposeSupervisor(opts.supervisor),
   };
 }
 
@@ -655,6 +680,15 @@ export async function exposeCloudflareUp(
       throw new Error("skipHub set but no hub.port on disk — tests must seed one");
     }
     hubPort = existing;
+  } else if (r.sup.unitInstalled) {
+    // Unit-managed (§4.3a): "ensure the hub" = ensure the hub UNIT is up. The
+    // unit pins the canonical 1939 (no walking fallback), so that's the target
+    // cloudflared's ingress proxies to.
+    const probePort = readHubPort(r.configDir) ?? HUB_UNIT_DEFAULT_PORT;
+    const ensured = await ensureHubUnitForExpose(r.sup, probePort, r.log);
+    if (!ensured.ok) return 1;
+    hubPort = ensured.port;
+    r.log(`✓ hub unit up (port ${hubPort}).`);
   } else {
     const hub = await ensureHubRunning({
       reservedPorts: manifest.services.map((s) => s.port),
@@ -913,15 +947,40 @@ export async function exposeCloudflareUp(
   // so a `--hub-origin http://127.0.0.1` override never bakes a dead issuer in);
   // the restart makes the running vault re-read it immediately rather than
   // waiting for the next reboot.
-  persistVaultHubOrigin(r.configDir, hubOrigin, r.log);
-  if (processState("vault", r.configDir, r.alive).status === "running") {
+  //
+  // Phase 4 dual-dispatch (design §4.3c). Unit-managed → drive the restart
+  // through the running Supervisor (`driveModuleOp("vault", "restart")`), which
+  // re-injects the hub's current origin; `restartHubDependentViaSupervisor`
+  // also persists the durable `.env` + self-heals the operator-token issuer, so
+  // we DON'T also call `persistVaultHubOrigin` on this arm (the helper owns it).
+  // No unit → the unchanged detached path: persist `.env` + `lifecycle.restart`
+  // gated on pidfile liveness. Phase 5 deletes the detached branch.
+  if (r.sup.unitInstalled) {
     r.log("");
     r.log("Restarting vault to pick up new hub origin…");
-    const rcode = await r.restartService("vault");
+    const rcode = await restartHubDependentViaSupervisor({
+      short: "vault",
+      hubOrigin,
+      configDir: r.configDir,
+      sup: r.sup,
+      log: r.log,
+    });
     if (rcode !== 0) {
       r.log(
         "⚠ vault restart failed. Run manually once the issue is resolved: parachute restart vault",
       );
+    }
+  } else {
+    persistVaultHubOrigin(r.configDir, hubOrigin, r.log);
+    if (processState("vault", r.configDir, r.alive).status === "running") {
+      r.log("");
+      r.log("Restarting vault to pick up new hub origin…");
+      const rcode = await r.restartService("vault");
+      if (rcode !== 0) {
+        r.log(
+          "⚠ vault restart failed. Run manually once the issue is resolved: parachute restart vault",
+        );
+      }
     }
   }
 

--- a/src/commands/expose-supervisor.ts
+++ b/src/commands/expose-supervisor.ts
@@ -148,7 +148,7 @@ export function resolveExposeSupervisor(
  * bearer against its per-request issuer — which for a loopback request is the
  * loopback origin — so the operator token must remain validatable there.
  */
-export function resolveExposeOperatorTokenIssuer(
+function resolveExposeOperatorTokenIssuer(
   hubOrigin: string | undefined,
   configDir: string,
 ): string {
@@ -228,8 +228,15 @@ export async function restartHubDependentViaSupervisor(args: {
       );
     }
     // Durable .env persistence + vault-side self-heal (parity with the detached
-    // `persistVaultHubOriginForStart`). `persistVaultHubOrigin` skips loopback /
-    // unchanged values itself.
+    // `persistVaultHubOriginForStart`). Both are called for parity with that
+    // detached path: `persistVaultHubOrigin` is the PRIMARY write — it stamps
+    // the new public origin into vault's `.env` (skipping loopback / unchanged
+    // values itself). `selfHealVaultHubOrigin` is a deliberate no-op in the
+    // normal case here — persist just wrote the public origin, so selfHeal's
+    // `current !== undefined && !isLoopbackOrigin(current)` guard short-circuits.
+    // It only fires for OLD installs where `.env` was left stale-loopback (the
+    // persist write can be skipped on edge cases), keeping the pair behaviorally
+    // identical to the detached path.
     if (short === "vault") {
       persistVaultHubOrigin(configDir, hubOrigin, log);
       selfHealVaultHubOrigin(configDir, log, `${configDir}/expose-state.json`);

--- a/src/commands/expose-supervisor.ts
+++ b/src/commands/expose-supervisor.ts
@@ -1,0 +1,266 @@
+/**
+ * Phase 4 expose-path dual-dispatch seams (design
+ * `parachute.computer/design/2026-06-01-hub-as-supervisor-unification.md` §4.3).
+ *
+ * Under the hub-as-supervisor unification, `expose` / `expose off` decouple
+ * from the hub's lifecycle:
+ *   - When a hub UNIT is installed (launchd/systemd/container), "ensure the hub"
+ *     means "ensure the hub UNIT is up" (`ensureHubUnit`), and the post-expose
+ *     hub-dependent service restart goes through the RUNNING hub's in-process
+ *     Supervisor over the loopback module-ops API (`driveModuleOp(short,
+ *     "restart")`), NOT `lifecycle.restart` / a detached spawn.
+ *   - When NO unit is installed (a legacy detached box, until Phase 5 retires
+ *     the detached spawners), the existing behavior is preserved UNCHANGED:
+ *     `ensureHubRunning` (the detached spawn) + `lifecycle.restart`.
+ *
+ * This module is the shared seam BOTH `expose.ts` (Tailscale) and
+ * `expose-cloudflare.ts` (cloudflared) use so the two paths can't drift, and so
+ * the unit-arm is a clean, separately-deletable branch when Phase 5 collapses
+ * to the supervisor-only path.
+ *
+ * THE SAFETY PRINCIPLE (same dual-dispatch bridge as Phase 3b): unit installed →
+ * drive the manager/supervisor (new path); no unit → keep the EXACT current
+ * detached behavior. The discriminant is `isHubUnitInstalled`, structured as a
+ * top-level branch in the callers.
+ */
+
+import { readHubPort } from "../hub-control.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import {
+  type EnsureHubUnitOpts,
+  type EnsureHubUnitResult,
+  HUB_UNIT_DEFAULT_PORT,
+  type HubUnitDeps,
+  defaultHubUnitDeps,
+  ensureHubUnit as ensureHubUnitImpl,
+  isHubUnitInstalled,
+} from "../hub-unit.ts";
+import {
+  type DriveModuleOpDeps,
+  type ModuleOp,
+  ModuleOpHttpError,
+  type ModuleOpResult,
+  NoOperatorTokenError,
+  OperatorTokenExpiredError,
+  driveModuleOp as driveModuleOpImpl,
+} from "../module-ops-client.ts";
+import {
+  type OperatorIssuerHealStatus,
+  selfHealOperatorTokenIssuer as selfHealOperatorTokenIssuerImpl,
+} from "../operator-token.ts";
+import { persistVaultHubOrigin, selfHealVaultHubOrigin } from "../vault-hub-origin-env.ts";
+
+/**
+ * Injectable Phase 4 supervisor-path seams shared by the Tailscale + cloudflared
+ * expose paths. Mirrors `LifecycleOpts.supervisor` (Phase 3b): everything is
+ * injectable so tests can (a) force the unit-installed branch without a real
+ * launchd/systemd, and (b) assert the `ensureHubUnit` / `driveModuleOp` /
+ * operator-token-self-heal calls without a live hub. Production wires the real
+ * impls against an opened hub.db + the resolved hub origin.
+ *
+ * When the caller OMITS this block entirely, the discriminant defaults to
+ * `false` (detached arm) — deterministic regardless of whether the test host
+ * happens to have a real hub unit installed. The production CLI dispatch passes
+ * `supervisor: {}` so the real `isHubUnitInstalled` probe decides the arm.
+ */
+export interface ExposeSupervisorOpts {
+  /**
+   * Is a hub unit installed (the dual-dispatch discriminant)? Production uses
+   * `isHubUnitInstalled(hubUnitDeps)`. Tests set this `true`/`false` directly to
+   * pick the branch deterministically. When set, it wins over the
+   * `hubUnitDeps`-derived detection.
+   */
+  unitInstalled?: boolean;
+  /** Deps for the real `isHubUnitInstalled` probe + the ensure-hub-unit call. */
+  hubUnitDeps?: HubUnitDeps;
+  /** Ensure the hub unit is up before / during expose (§3.2 / §4.3a). */
+  ensureHubUnit?: (opts: EnsureHubUnitOpts) => Promise<EnsureHubUnitResult>;
+  /** Drive a per-module op against the running hub (reads operator.token). */
+  driveModuleOp?: (short: string, op: ModuleOp, deps: DriveModuleOpDeps) => Promise<ModuleOpResult>;
+  /**
+   * Open the hub DB used to validate/auto-rotate the operator token in
+   * `driveModuleOp` + to self-heal its issuer. Production opens
+   * `<configDir>/hub.db`; tests inject an in-memory/seeded db. Returns a handle
+   * the caller closes.
+   */
+  openDb?: (configDir: string) => import("bun:sqlite").Database;
+  /**
+   * Self-heal the operator token's stale `iss` toward the new public origin
+   * BEFORE the supervised restart (§4.3c). After `expose up` the running hub
+   * re-resolves its issuer to the public origin, so a loopback-minted operator
+   * token must be re-minted under that origin or the CLI's own `driveModuleOp`
+   * would fail iss-validation. Mirrors lifecycle's `selfHealOperatorTokenOnStart`.
+   * Production delegates to `selfHealOperatorTokenIssuer`; tests inject a stub.
+   */
+  selfHealOperatorTokenIssuer?: (
+    db: import("bun:sqlite").Database,
+    opts: { issuer: string; configDir: string; log: (line: string) => void },
+  ) => Promise<OperatorIssuerHealStatus>;
+  /** Loopback hub base URL override (default derives from the hub port). */
+  baseUrl?: string;
+}
+
+/** Resolved Phase 4 expose supervisor-path seams (see {@link ExposeSupervisorOpts}). */
+export interface ResolvedExposeSupervisor {
+  /** Whether a hub unit is installed — the dual-dispatch discriminant. */
+  unitInstalled: boolean;
+  hubUnitDeps: HubUnitDeps;
+  ensureHubUnit: (opts: EnsureHubUnitOpts) => Promise<EnsureHubUnitResult>;
+  driveModuleOp: (short: string, op: ModuleOp, deps: DriveModuleOpDeps) => Promise<ModuleOpResult>;
+  openDb: (configDir: string) => import("bun:sqlite").Database;
+  selfHealOperatorTokenIssuer: (
+    db: import("bun:sqlite").Database,
+    opts: { issuer: string; configDir: string; log: (line: string) => void },
+  ) => Promise<OperatorIssuerHealStatus>;
+  baseUrl: string | undefined;
+}
+
+/**
+ * Resolve the Phase 4 expose supervisor seams. Same discriminant shape as
+ * lifecycle's `resolveSupervisor`: a `supervisor` block (even `{}`) opts into
+ * the real `isHubUnitInstalled` probe; omitting it entirely is the detached arm
+ * deterministically.
+ */
+export function resolveExposeSupervisor(
+  opts: ExposeSupervisorOpts | undefined,
+): ResolvedExposeSupervisor {
+  const hubUnitDeps = opts?.hubUnitDeps ?? defaultHubUnitDeps;
+  const unitInstalled =
+    opts === undefined ? false : (opts.unitInstalled ?? isHubUnitInstalled(hubUnitDeps));
+  return {
+    unitInstalled,
+    hubUnitDeps,
+    ensureHubUnit: opts?.ensureHubUnit ?? ensureHubUnitImpl,
+    driveModuleOp: opts?.driveModuleOp ?? driveModuleOpImpl,
+    openDb: opts?.openDb ?? ((configDir) => openHubDb(hubDbPath(configDir))),
+    selfHealOperatorTokenIssuer:
+      opts?.selfHealOperatorTokenIssuer ?? selfHealOperatorTokenIssuerImpl,
+    baseUrl: opts?.baseUrl,
+  };
+}
+
+/**
+ * Resolve the issuer the operator token's `iss` is validated against on the
+ * loopback module-ops call. Mirrors lifecycle's `resolveOperatorTokenIssuer`:
+ * the operator token ALWAYS carries an `iss`, so this falls back to the
+ * canonical loopback origin (`http://127.0.0.1:<hubPort>`) when no public
+ * origin is known. The CLI hits the hub on loopback, and the hub validates the
+ * bearer against its per-request issuer — which for a loopback request is the
+ * loopback origin — so the operator token must remain validatable there.
+ */
+export function resolveExposeOperatorTokenIssuer(
+  hubOrigin: string | undefined,
+  configDir: string,
+): string {
+  if (hubOrigin) return hubOrigin;
+  const port = readHubPort(configDir) ?? HUB_UNIT_DEFAULT_PORT;
+  return `http://127.0.0.1:${port}`;
+}
+
+/**
+ * Ensure the hub UNIT is up for an expose, mapping `ensureHubUnit`'s structured
+ * outcome to a simple ok/not-ok the caller turns into an exit code. Returns the
+ * probed port so the caller can plan tailscale/cloudflared against it (§4.3a:
+ * tailscale needs only the hub reachable on loopback, which the unit
+ * guarantees). On a non-up outcome the messages are surfaced.
+ */
+export async function ensureHubUnitForExpose(
+  sup: ResolvedExposeSupervisor,
+  port: number,
+  log: (line: string) => void,
+): Promise<{ ok: boolean; port: number }> {
+  const ensured = await sup.ensureHubUnit({ port, deps: sup.hubUnitDeps, log });
+  if (ensured.outcome === "already-up" || ensured.outcome === "started") {
+    return { ok: true, port: ensured.port };
+  }
+  for (const m of ensured.messages) log(m);
+  return { ok: false, port: ensured.port };
+}
+
+/**
+ * Restart a hub-dependent service (today: vault) via the running hub's
+ * Supervisor after an expose changed the public origin (§4.3c). The supervised
+ * restart re-injects the hub's current per-request-resolved origin into the
+ * module's env; this helper ALSO fires the durable origin self-heals that the
+ * detached `lifecycle.restart` path used to provide:
+ *   - `selfHealOperatorTokenIssuer` — re-mint the operator token under the new
+ *     public origin BEFORE the module-op, so the CLI's own `driveModuleOp`
+ *     bearer validates (and a later supervised restart's iss is current).
+ *   - `persistVaultHubOrigin` / `selfHealVaultHubOrigin` — write the public
+ *     origin into vault's `.env` so a future out-of-band boot also validates.
+ *
+ * Returns the module-op exit code (0 on success). Errors are surfaced as
+ * actionable lines (never a raw 401 / thrown HTTP error) and mapped to a
+ * non-zero code so the caller can warn-and-continue exactly as the detached
+ * restart path does.
+ */
+export async function restartHubDependentViaSupervisor(args: {
+  short: string;
+  hubOrigin: string;
+  configDir: string;
+  sup: ResolvedExposeSupervisor;
+  log: (line: string) => void;
+}): Promise<number> {
+  const { short, hubOrigin, configDir, sup, log } = args;
+  const issuer = resolveExposeOperatorTokenIssuer(hubOrigin, configDir);
+  const db = sup.openDb(configDir);
+  try {
+    // Self-heal the operator token's iss toward the NEW public origin first, so
+    // the bearer the CLI presents on the loopback module-op validates and a
+    // subsequent supervised restart's injected iss is current. The loopback /
+    // provenance guards live inside `selfHealOperatorTokenIssuer`, so passing
+    // the resolved (possibly loopback) origin is safe — it no-ops on loopback.
+    try {
+      const status = await sup.selfHealOperatorTokenIssuer(db, {
+        issuer: hubOrigin,
+        configDir,
+        log,
+      });
+      if (status.kind === "rotated") {
+        log(`  refreshed operator.token issuer → ${hubOrigin} (was stale after exposure)`);
+      }
+    } catch (err) {
+      // A self-heal failure must never block the restart — degrade to a note.
+      log(
+        `  note: operator.token issuer self-heal skipped (${
+          err instanceof Error ? err.message : String(err)
+        })`,
+      );
+    }
+    // Durable .env persistence + vault-side self-heal (parity with the detached
+    // `persistVaultHubOriginForStart`). `persistVaultHubOrigin` skips loopback /
+    // unchanged values itself.
+    if (short === "vault") {
+      persistVaultHubOrigin(configDir, hubOrigin, log);
+      selfHealVaultHubOrigin(configDir, log, `${configDir}/expose-state.json`);
+    }
+
+    const deps: DriveModuleOpDeps = {
+      db,
+      issuer,
+      configDir,
+      ...(sup.baseUrl !== undefined ? { baseUrl: sup.baseUrl } : {}),
+    };
+    try {
+      await sup.driveModuleOp(short, "restart", deps);
+      return 0;
+    } catch (err) {
+      if (err instanceof NoOperatorTokenError || err instanceof OperatorTokenExpiredError) {
+        log(`✗ ${short}: ${err.message}`);
+        return 1;
+      }
+      if (err instanceof ModuleOpHttpError) {
+        // A not-supervised module (404) after an expose just means it wasn't
+        // running — the detached path's `processState !== running` guard simply
+        // skips it. Treat 404 the same: nothing to restart, not a failure.
+        if (err.status === 404 && err.code === "not_supervised") return 0;
+        log(`✗ ${short}: ${err.message}`);
+        return 1;
+      }
+      log(`✗ ${short}: ${err instanceof Error ? err.message : String(err)}`);
+      return 1;
+    }
+  } finally {
+    db.close();
+  }
+}

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -17,6 +17,7 @@ import {
   stopHub,
 } from "../hub-control.ts";
 import { deriveHubOrigin } from "../hub-origin.ts";
+import { HUB_UNIT_DEFAULT_PORT } from "../hub-unit.ts";
 import { HUB_PATH, writeHubFile } from "../hub.ts";
 import { type AliveFn, processState } from "../process-state.ts";
 import { shortNameForManifest } from "../service-spec.ts";
@@ -35,6 +36,12 @@ import {
   writeWellKnownFile,
 } from "../well-known.ts";
 import { printPublic2FAWarning } from "./expose-2fa-warning.ts";
+import {
+  type ExposeSupervisorOpts,
+  ensureHubUnitForExpose,
+  resolveExposeSupervisor,
+  restartHubDependentViaSupervisor,
+} from "./expose-supervisor.ts";
 import { restart } from "./lifecycle.ts";
 
 /**
@@ -113,6 +120,21 @@ export interface ExposeOpts {
    * `<vaultHome>/config.yaml` from disk. (#186)
    */
   vaultAuthStatus?: VaultAuthStatus;
+  /**
+   * Phase 4 supervisor-path seams (design §4.3). When a hub UNIT is installed
+   * (launchd/systemd/container — detected via `isHubUnitInstalled`), `expose`
+   * "ensures the hub" by ensuring the UNIT is up (not a detached spawn), the
+   * post-expose hub-dependent restart drives the running Supervisor over the
+   * loopback module-ops API, and `expose off` leaves the hub RUNNING (a managed
+   * hub with Restart=always/KeepAlive would just respawn a stopped one — D3).
+   * The detached arm (`hubEnsureOpts` / `stopHub` / `lifecycle.restart`) remains
+   * the no-unit fallback until Phase 5 retires it.
+   *
+   * The production CLI dispatch passes `supervisor: {}` so the real
+   * `isHubUnitInstalled` probe decides the arm; omitting it entirely is the
+   * detached arm deterministically (the shape of every existing expose test).
+   */
+  supervisor?: ExposeSupervisorOpts;
 }
 
 /**
@@ -240,6 +262,10 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
   const port = opts.port ?? 443;
   const log = opts.log ?? ((line) => console.log(line));
   const funnel = layer === "public";
+  // Phase 4 dual-dispatch (design §4.3). Unit-installed → ensure the hub UNIT is
+  // up (the unit guarantees loopback reachability, §4.3a) + restart hub-dependent
+  // services via the Supervisor. No unit → the unchanged detached arm below.
+  const sup = resolveExposeSupervisor(opts.supervisor);
 
   if (!(await isTailscaleInstalled(runner))) {
     log("tailscale is not installed or not on PATH.");
@@ -319,6 +345,15 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
       throw new Error("skipHub set but no hub.port on disk — tests must seed one");
     }
     hubPort = existing;
+  } else if (sup.unitInstalled) {
+    // Unit-managed (§4.3a): "ensure the hub" = ensure the hub UNIT is up. The
+    // unit guarantees the hub is reachable on loopback (all tailscale needs);
+    // it pins the canonical 1939 (no walking fallback), so that's the target.
+    const probePort = readHubPort(configDir) ?? HUB_UNIT_DEFAULT_PORT;
+    const ensured = await ensureHubUnitForExpose(sup, probePort, log);
+    if (!ensured.ok) return 1;
+    hubPort = ensured.port;
+    log(`✓ hub unit up (port ${hubPort}).`);
   } else {
     const hub = await ensureHubRunning({
       reservedPorts: manifest.services.map((s) => s.port),
@@ -392,6 +427,30 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
   // claude.ai MCP failed with a cryptic "Couldn't reach the MCP server". The
   // old output told the user to restart manually; it got buried in the wall
   // of expose output. Do the restart ourselves.
+  // Phase 4 dual-dispatch (design §4.3c). Unit-managed → the hub-dependent
+  // restart goes through the running Supervisor (`driveModuleOp(short,
+  // "restart")`), which re-injects the hub's current origin; the origin
+  // self-heal (operator-token iss + vault `.env`) fires there. No-unit → the
+  // unchanged detached `lifecycle.restart` path, gated on pidfile liveness.
+  if (sup.unitInstalled) {
+    for (const short of HUB_DEPENDENT_SHORTS) {
+      log("");
+      log(`Restarting ${short} to pick up new hub origin…`);
+      const rcode = await restartHubDependentViaSupervisor({
+        short,
+        hubOrigin,
+        configDir,
+        sup,
+        log,
+      });
+      if (rcode !== 0) {
+        log(
+          `⚠ ${short} restart failed. Run manually once the issue is resolved: parachute restart ${short}`,
+        );
+      }
+    }
+    return 0;
+  }
   const doRestart =
     opts.restartService ?? ((short: string) => restart(short, { manifestPath, configDir, log }));
   for (const short of HUB_DEPENDENT_SHORTS) {
@@ -415,6 +474,11 @@ export async function exposeOff(layer: ExposeLayer, opts: ExposeOpts = {}): Prom
   const hubFilePath = opts.hubPath ?? HUB_PATH;
   const configDir = opts.configDir ?? CONFIG_DIR;
   const log = opts.log ?? ((line) => console.log(line));
+  // Phase 4 dual-dispatch (design §4.3a / D3). Unit-managed → leave the hub
+  // RUNNING (a managed hub with Restart=always/KeepAlive would just respawn a
+  // stopped one — stopping it is futile + wrong). No unit → the unchanged
+  // detached behavior (stop the hub when the last layer is torn down).
+  const sup = resolveExposeSupervisor(opts.supervisor);
 
   const state = readExposeState(statePath);
   if (!state || state.entries.length === 0) {
@@ -455,10 +519,16 @@ export async function exposeOff(layer: ExposeLayer, opts: ExposeOpts = {}): Prom
     unlinkSync(hubFilePath);
   }
 
-  // Hub lives only as long as some layer is exposed. State was just cleared,
-  // so no layer is active — stop the hub. (Layer switch doesn't go through
-  // here; that path reuses the running hub.)
-  if (!opts.skipHub) {
+  // Detached-arm only (no unit installed): the hub lived only as long as some
+  // layer was exposed. State was just cleared, so no layer is active — stop the
+  // hub. (Layer switch doesn't go through here; that path reuses the running
+  // hub.) Under a managed hub UNIT (the `sup.unitInstalled` arm), the hub is a
+  // persistent process the manager keeps alive whether or not a layer is
+  // exposed — the "hub exists only while exposed" invariant inverts (D3). We
+  // tear down ONLY the exposure layer above and leave the hub running; the CLI
+  // output drops the "hub stopped" line accordingly. Phase 5 deletes this whole
+  // detached branch.
+  if (!sup.unitInstalled && !opts.skipHub) {
     const stopped = await stopHub({ ...(opts.hubStopOpts ?? {}), configDir, log });
     if (stopped) log("✓ hub stopped.");
   }

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -51,6 +51,13 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import { HUB_PACKAGE, HUB_SVC } from "../hub-control.ts";
+import {
+  type HubUnitDeps,
+  type HubUnitManagerOpResult,
+  defaultHubUnitDeps,
+  isHubUnitInstalled,
+  restartHubUnit as restartHubUnitImpl,
+} from "../hub-unit.ts";
 import { ModuleManifestError } from "../module-manifest.ts";
 import {
   type ServiceSpec,
@@ -201,6 +208,31 @@ export interface UpgradeOpts {
    * flaky probe never blocks a legitimate upgrade.
    */
   resolveChannelVersion?: (pkg: string, channel: string) => Promise<string | null>;
+  /**
+   * Phase 4 supervisor-path seams (design §5). When a hub UNIT is installed
+   * (launchd/systemd/container — detected via `isHubUnitInstalled`), `upgrade
+   * hub` rewrites the binary as usual then RESTARTS THE UNIT via the platform
+   * manager (`restartHubUnit` — systemctl restart / launchctl kickstart -k),
+   * NOT the detached `stopHub`/`ensureHubRunning` restart: the manager tears
+   * down the old hub (children die), starts the new binary, which re-boots
+   * every module from services.json. Module-target restarts on the unit arm
+   * drive the running Supervisor (lifecycle's own Phase-3b dual-dispatch, fed a
+   * `supervisor` block here). The detached arm (`restartFn` → stopHub/
+   * ensureHubRunning) remains the no-unit fallback until Phase 5.
+   *
+   * Production CLI dispatch passes `supervisor: {}` so the real
+   * `isHubUnitInstalled` probe decides the arm; omitting it is the detached arm
+   * deterministically (the shape of every existing upgrade test). When set,
+   * `unitInstalled` wins over the `hubUnitDeps`-derived detection.
+   */
+  supervisor?: {
+    /** Dual-dispatch discriminant override; else the real `isHubUnitInstalled`. */
+    unitInstalled?: boolean;
+    /** Deps for the `isHubUnitInstalled` probe + the `restartHubUnit` manager op. */
+    hubUnitDeps?: HubUnitDeps;
+    /** Restart the hub unit via the platform manager (never a PID signal, §5). */
+    restartHubUnit?: (deps: HubUnitDeps) => HubUnitManagerOpResult;
+  };
 }
 
 interface ResolvedTarget {
@@ -226,6 +258,10 @@ interface Resolved {
   channelOverride: "rc" | "latest" | undefined;
   allowDowngrade: boolean;
   resolveChannelVersion: (pkg: string, channel: string) => Promise<string | null>;
+  /** Phase 4 dual-dispatch: is a hub unit installed? */
+  unitInstalled: boolean;
+  hubUnitDeps: HubUnitDeps;
+  restartHubUnit: (deps: HubUnitDeps) => HubUnitManagerOpResult;
 }
 
 function bunGlobalPrefixes(): string[] {
@@ -258,6 +294,27 @@ function resolve(opts: UpgradeOpts): Resolved {
     allowDowngrade: opts.allowDowngrade ?? false,
     resolveChannelVersion:
       opts.resolveChannelVersion ?? ((pkg, channel) => npmViewVersion(pkg, channel, runner)),
+    // Phase 4 dual-dispatch: same discriminant shape as lifecycle's
+    // `resolveSupervisor`. A `supervisor` block (even `{}`) opts into the real
+    // `isHubUnitInstalled` probe; omitting it entirely is the detached arm
+    // deterministically (every existing upgrade test).
+    ...resolveUpgradeSupervisor(opts.supervisor),
+  };
+}
+
+/** Resolve the Phase 4 supervisor seams for the upgrade path. */
+function resolveUpgradeSupervisor(opts: UpgradeOpts["supervisor"]): {
+  unitInstalled: boolean;
+  hubUnitDeps: HubUnitDeps;
+  restartHubUnit: (deps: HubUnitDeps) => HubUnitManagerOpResult;
+} {
+  const hubUnitDeps = opts?.hubUnitDeps ?? defaultHubUnitDeps;
+  const unitInstalled =
+    opts === undefined ? false : (opts.unitInstalled ?? isHubUnitInstalled(hubUnitDeps));
+  return {
+    unitInstalled,
+    hubUnitDeps,
+    restartHubUnit: opts?.restartHubUnit ?? restartHubUnitImpl,
   };
 }
 
@@ -422,6 +479,13 @@ async function resolveTargets(
   // Sweep mode: hub first, then everything in services.json. Hub-first means a
   // dispatcher upgrade can't be undermined mid-sweep by a service upgrade that
   // restarts hub for reasons unrelated to its own code change.
+  //
+  // Phase 4 note (design §5 item 4): on a unit-managed box, restarting the hub
+  // unit re-boots ALL modules from services.json. So the hub-first sweep already
+  // boots every module onto current code when the hub binary upgrades; each
+  // module target then upgrades its package + `supervisor.restart`s it
+  // individually (idempotent — a no-op restart if its code didn't change). The
+  // hub-first invariant still holds.
   const targets: ResolvedTarget[] = [hubTarget()];
   for (const entry of manifest.services) {
     const short = shortNameForManifest(entry.name);
@@ -515,6 +579,48 @@ function readPackageVersion(pkgJsonPath: string): string | null {
   }
 }
 
+/**
+ * Restart an upgraded target after its binary/package was rewritten (design §5).
+ * Dual-dispatch:
+ *   - Unit-managed + HUB target → restart the hub UNIT via the platform manager
+ *     (`restartHubUnit` — systemctl restart / launchctl kickstart -k). The
+ *     manager tears down the old hub (children die), starts the new binary,
+ *     which re-boots every module from services.json. NEVER stopHub/ensureHub
+ *     (a PID-signal restart launchd KeepAlive / systemd Restart=always would
+ *     fight). The command returns once the restart is dispatched; it does not
+ *     need to outlive the old hub.
+ *   - Unit-managed + MODULE target → drive the running Supervisor by handing
+ *     `lifecycle.restart` a `supervisor` block (its own Phase-3b dual-dispatch
+ *     then routes to `supervisor.restart` with the 404-fallthrough). The hub
+ *     unit was already restarted hub-first in the sweep, so it's up to answer.
+ *   - No unit (detached) → the unchanged `restartFn` (default `lifecycle.restart`
+ *     → stopHub/ensureHubRunning for hub, detached stop+start for modules).
+ *     Phase 5 deletes this branch.
+ */
+async function restartTarget(target: ResolvedTarget, r: Resolved): Promise<number> {
+  if (r.unitInstalled) {
+    if (target.short === HUB_SVC) {
+      const res = r.restartHubUnit(r.hubUnitDeps);
+      for (const m of res.messages) r.log(m);
+      if (res.outcome === "ok") {
+        r.log(`${target.short}: restarted the hub unit (all modules re-booted).`);
+        return 0;
+      }
+      return 1;
+    }
+    // Module target: route through lifecycle's supervisor arm. Passing
+    // `supervisor: {}` makes `lifecycle.restart` probe `isHubUnitInstalled`
+    // (true here) and drive `supervisor.restart` over the loopback module-ops
+    // API instead of a detached stop+start.
+    return await r.restartFn(target.short, {
+      manifestPath: r.manifestPath,
+      configDir: r.configDir,
+      supervisor: { unitInstalled: true, hubUnitDeps: r.hubUnitDeps },
+    });
+  }
+  return await r.restartFn(target.short, { manifestPath: r.manifestPath, configDir: r.configDir });
+}
+
 async function upgradeLinked(
   target: ResolvedTarget,
   sourceDir: string,
@@ -573,7 +679,7 @@ async function upgradeLinked(
   }
 
   r.log(`${target.short}: ${before.sha.slice(0, 7)} → ${after.sha.slice(0, 7)}; restarting…`);
-  return await r.restartFn(target.short, { manifestPath: r.manifestPath, configDir: r.configDir });
+  return await restartTarget(target, r);
 }
 
 /**
@@ -642,7 +748,7 @@ async function upgradeNpm(target: ResolvedTarget, sourceDir: string, r: Resolved
   }
 
   r.log(`${target.short}: ${beforeVersion ?? "?"} → ${afterVersion ?? "?"}; restarting…`);
-  return await r.restartFn(target.short, { manifestPath: r.manifestPath, configDir: r.configDir });
+  return await restartTarget(target, r);
 }
 
 async function upgradeOne(target: ResolvedTarget, r: Resolved): Promise<number> {


### PR DESCRIPTION
Phase 4 (CLI half) of the hub-as-supervisor unification (design [`2026-06-01-hub-as-supervisor-unification.md`](../parachute.computer/design/2026-06-01-hub-as-supervisor-unification.md)). Consumes the Phase 3a/3b primitives (`ensureHubUnit`, `restartHubUnit`, `isHubUnitInstalled`, `driveModuleOp`) and replicates the **same dual-dispatch bridge** Phase 3b established. **No version bump** — phase PRs don't bump rc (stays `0.6.3-rc.1`); we cut the next rc when Aaron says.

## The dual-dispatch safety principle (un-migrated boxes are untouched)
Phase 5's migrate doesn't exist yet; the detached spawners aren't retired until then. So every change is a clean top-level branch: **hub UNIT installed → drive the manager/supervisor (new path); no unit → the EXACT current detached behavior, unchanged.** The discriminant is `isHubUnitInstalled` via a `supervisor` opts block (`opts===undefined ? false : opts.unitInstalled ?? isHubUnitInstalled(deps)`), mirroring lifecycle's Phase-3b `resolveSupervisor`. Each detached arm is a separately-deletable block for Phase 5. Every existing expose/upgrade test omits the block → takes the detached arm → unchanged.

## Deliverable A — expose decouple (§4.3, D3)
New shared seam **`src/commands/expose-supervisor.ts`** used by BOTH the Tailscale and cloudflared paths (so they can't drift):
- `resolveExposeSupervisor` — the `unitInstalled` discriminant.
- `ensureHubUnitForExpose` — unit-arm "ensure the hub" = ensure the UNIT is up (§4.3a: tailscale only needs the hub reachable on loopback, which the unit guarantees). No-unit arm keeps `ensureHubRunning`.
- `restartHubDependentViaSupervisor` — unit-arm post-expose vault restart drives the running Supervisor (`driveModuleOp(svc, "restart")`); the **origin self-heal still fires** (operator-token `iss` re-mint toward the new public origin via `selfHealOperatorTokenIssuer` + durable vault `.env` via `persistVaultHubOrigin`/`selfHealVaultHubOrigin`) — the running hub re-resolves its issuer per-request, so a loopback-minted operator token must be re-minted or the CLI's own `driveModuleOp` bearer would fail iss-validation. A 404 `not_supervised` is "nothing to restart," not a failure.

- **`expose off` no longer stops the hub on the unit arm (D3, owner-visible).** A managed hub with `Restart=always`/`KeepAlive` would just respawn a stopped one — stopping it is futile + wrong, so the "hub exists only while exposed" invariant **inverts**. The CLI output drops the "hub stopped" line. No-unit path still stops the hub (unchanged).
- `expose.ts` (Tailscale): `ensureHubRunning` → dual-dispatch `ensureHubUnit` (`:323`); post-expose restart loop dual-dispatches; `exposeOff` guards `stopHub` on `!sup.unitInstalled`.
- `expose-cloudflare.ts`: `ensureHubRunning` → dual-dispatch `ensureHubUnit` (`:659`); post-route vault restart dual-dispatches.
- **Connector decision (flagged):** the cloudflared **connector unit is UNCHANGED.** It already installs/removes its own `ManagedUnit` (`installConnectorService`/`removeConnectorService`) independent of the hub lifecycle — the only hub-lifecycle coupling in `expose-cloudflare.ts` was the `ensureHubRunning` call. **No change needed to the live connector behavior** (it's in production on both boxes).

## Deliverable B — `upgrade hub` CLI cutover (§5 items 1,2,4,5)
- **Binary rewrite unchanged** (bun add -g `@<channel>` / linked git-pull + bun install; idempotent skip-restart heuristics preserved).
- **Restart the unit, not the process (item 2):** `restartTarget` replaces the two `restartFn` call sites. Unit-managed + HUB → `restartHubUnit` (systemctl restart / launchctl kickstart -k; **REUSES the Phase 3b helper**); never a PID signal (`KeepAlive`/`Restart=always` would fight it). The command returns once the restart is dispatched; it doesn't outlive the old hub. Unit-managed + MODULE → `lifecycle.restart` handed a `supervisor` block (its own Phase-3b dual-dispatch routes to `supervisor.restart`). No-unit → unchanged detached `restartFn`.
- **Sweep ordering (item 4):** hub-first preserved — restarting the hub unit re-boots ALL modules from services.json, then each module package upgrades + supervisor-restarts individually. Invariant holds.
- **bun-linked dev path (item 5):** linked git-pull + bun install + unit restart; the unit's `ExecStart` points at `src/cli.ts` so new code is live on next unit start (resolves the services.json stale-version-cache footgun, hub#243, on the unit path).

## Out of scope (separate **4-spa** PR)
The SPA `POST /api/hub/upgrade` endpoint + detached one-shot helper (§5 item 3 / §5.3) are intentionally NOT here. **CLI-only.**

`cli.ts`: passes `supervisor: {}` into the expose (tailscale/cloudflare/interactive/auto-pick) and upgrade opts so the real `isHubUnitInstalled` probe decides the arm in production.

## Gates
- `bun test ./src`: **2726 pass / 1 skip / 0 fail** (baseline 2716/1/0 → +10 new tests, zero regressions).
- `bun run typecheck`: clean.
- `bunx biome check` on touched files: clean.

New tests cover both arms: `expose off` unit-managed leaves the hub running (asserts no stopHub call + no "hub stopped" line) vs no-unit stops it; expose ensureHub unit→ensureHubUnit vs no-unit→ensureHubRunning; post-expose restart unit→driveModuleOp(restart) vs no-unit→lifecycle.restart; `upgrade hub` unit→restartHubUnit (manager, not PID) vs no-unit→detached restartFn; sweep hub-first preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)