### PR TITLE
feat(hub): Phase 4 (SPA) — POST /api/hub/upgrade + detached one-shot helper + admin-SPA hub-upgrade (D4)

### DIFF
--- a/src/__tests__/api-hub-upgrade.test.ts
+++ b/src/__tests__/api-hub-upgrade.test.ts
@@ -1,0 +1,569 @@
+/**
+ * Tests for the SPA-driven hub self-upgrade (design 2026-06-01 §5.3 / D4):
+ *   - `POST /api/hub/upgrade` endpoint: auth gate, channel validation, 202
+ *     shape, the handler-spawns-the-helper-and-does-NOT-rewrite-inline
+ *     invariant, redeploy-required short-circuit, status pollability.
+ *   - The detached one-shot helper's rewrite-then-restart sequence (unit-
+ *     managed + container graceful-exit), via injected seams.
+ *   - The in-place-vs-redeploy mode detection (§5.3 heuristic).
+ *
+ * No real `bun add -g`, no real systemctl/launchctl, no real process signal —
+ * every side effect is a seam.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type SpawnHelperArgs,
+  handleHubUpgrade,
+  handleHubUpgradeStatus,
+} from "../api-hub-upgrade.ts";
+import type { UpgradeOpts } from "../commands/upgrade.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import type { HubUnitDeps, HubUnitManagerOpResult } from "../hub-unit.ts";
+import { runHubUpgradeHelper } from "../hub-upgrade-helper.ts";
+import { detectHubUpgradeMode } from "../hub-upgrade-mode.ts";
+import { readHubUpgradeStatus, writeHubUpgradeStatus } from "../hub-upgrade-status.ts";
+import { recordTokenMint, signAccessToken } from "../jwt-sign.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "http://127.0.0.1:1939";
+
+interface Harness {
+  dir: string;
+  db: ReturnType<typeof openHubDb>;
+  userId: string;
+  cleanup: () => void;
+}
+
+async function makeHarness(): Promise<Harness> {
+  const dir = mkdtempSync(join(tmpdir(), "phub-hub-upgrade-"));
+  const db = openHubDb(hubDbPath(dir));
+  rotateSigningKey(db);
+  const user = await createUser(db, "owner", "pw");
+  return {
+    dir,
+    db,
+    userId: user.id,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function mintBearer(h: Harness, scopes: string[]): Promise<string> {
+  const signed = await signAccessToken(h.db, {
+    sub: h.userId,
+    scopes,
+    audience: "parachute-hub",
+    clientId: "parachute-hub",
+    issuer: ISSUER,
+    ttlSeconds: 3600,
+  });
+  recordTokenMint(h.db, {
+    jti: signed.jti,
+    createdVia: "operator_mint",
+    subject: h.userId,
+    clientId: "parachute-hub",
+    scopes,
+    expiresAt: signed.expiresAt,
+  });
+  return signed.token;
+}
+
+function postReq(headers: Record<string, string>, body?: unknown): Request {
+  const init: RequestInit = { method: "POST", headers };
+  if (body !== undefined) {
+    init.headers = { ...headers, "content-type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  return new Request("http://localhost/api/hub/upgrade", init);
+}
+
+function getStatusReq(headers: Record<string, string>): Request {
+  return new Request("http://localhost/api/hub/upgrade/status", { method: "GET", headers });
+}
+
+/** Base deps that never spawn a real process / touch npm. */
+function baseDeps(h: Harness, overrides: Partial<Parameters<typeof handleHubUpgrade>[1]> = {}) {
+  const spawned: SpawnHelperArgs[] = [];
+  const deps = {
+    db: h.db,
+    issuer: ISSUER,
+    configDir: h.dir,
+    spawnHelper: (args: SpawnHelperArgs) => spawned.push(args),
+    resolveTargetVersion: async () => "0.6.3-rc.2",
+    currentVersion: () => "0.6.3-rc.1",
+    // Default: non-container, npm install → in-place. Tests that need
+    // redeploy-required override env + hubSrcDir.
+    env: { PARACHUTE_HOME: "/home/op/.parachute" } as Record<string, string | undefined>,
+    ...overrides,
+  };
+  return { deps, spawned };
+}
+
+let harness: Harness;
+beforeEach(async () => {
+  harness = await makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+describe("POST /api/hub/upgrade — auth gate", () => {
+  test("401 without a bearer", async () => {
+    const { deps } = baseDeps(harness, {
+      // Force in-place so we'd otherwise spawn — but auth must reject first.
+      hubSrcDir: "/nonexistent",
+    });
+    const res = await handleHubUpgrade(postReq({}), deps);
+    expect(res.status).toBe(401);
+  });
+
+  test("403 with a host:auth-only token (lacks host:admin)", async () => {
+    const bearer = await mintBearer(harness, ["parachute:host:auth"]);
+    const { deps, spawned } = baseDeps(harness);
+    const res = await handleHubUpgrade(postReq({ authorization: `Bearer ${bearer}` }), deps);
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("insufficient_scope");
+    // The handler must NOT have spawned the helper on an auth failure.
+    expect(spawned.length).toBe(0);
+  });
+
+  test("405 on non-POST", async () => {
+    const bearer = await mintBearer(harness, ["parachute:host:admin"]);
+    const req = new Request("http://localhost/api/hub/upgrade", {
+      method: "GET",
+      headers: { authorization: `Bearer ${bearer}` },
+    });
+    const { deps } = baseDeps(harness);
+    const res = await handleHubUpgrade(req, deps);
+    expect(res.status).toBe(405);
+  });
+});
+
+describe("POST /api/hub/upgrade — channel validation (closed enum)", () => {
+  test("rejects a non-enum channel with 400", async () => {
+    const bearer = await mintBearer(harness, ["parachute:host:admin"]);
+    const { deps, spawned } = baseDeps(harness);
+    const res = await handleHubUpgrade(
+      postReq({ authorization: `Bearer ${bearer}` }, { channel: "evil; rm -rf /" }),
+      deps,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_channel");
+    expect(spawned.length).toBe(0);
+  });
+
+  test("accepts channel: rc", async () => {
+    const bearer = await mintBearer(harness, ["parachute:host:admin"]);
+    const { deps, spawned } = baseDeps(harness);
+    const res = await handleHubUpgrade(
+      postReq({ authorization: `Bearer ${bearer}` }, { channel: "rc" }),
+      deps,
+    );
+    expect(res.status).toBe(202);
+    expect(spawned[0]?.channel).toBe("rc");
+  });
+
+  test("accepts channel: latest", async () => {
+    const bearer = await mintBearer(harness, ["parachute:host:admin"]);
+    const { deps, spawned } = baseDeps(harness);
+    const res = await handleHubUpgrade(
+      postReq({ authorization: `Bearer ${bearer}` }, { channel: "latest" }),
+      deps,
+    );
+    expect(res.status).toBe(202);
+    expect(spawned[0]?.channel).toBe("latest");
+  });
+
+  test("auto-detects channel from current version when none given (rc → rc)", async () => {
+    const bearer = await mintBearer(harness, ["parachute:host:admin"]);
+    const { deps, spawned } = baseDeps(harness, { currentVersion: () => "0.6.3-rc.1" });
+    const res = await handleHubUpgrade(postReq({ authorization: `Bearer ${bearer}` }), deps);
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { channel: string };
+    expect(body.channel).toBe("rc");
+    expect(spawned[0]?.channel).toBe("rc");
+  });
+
+  test("auto-detects channel from current version (stable → latest)", async () => {
+    const bearer = await mintBearer(harness, ["parachute:host:admin"]);
+    const { deps } = baseDeps(harness, { currentVersion: () => "0.6.2" });
+    const res = await handleHubUpgrade(postReq({ authorization: `Bearer ${bearer}` }), deps);
+    const body = (await res.json()) as { channel: string };
+    expect(body.channel).toBe("latest");
+  });
+});
+
+describe("POST /api/hub/upgrade — 202 + spawn-not-inline (in-place)", () => {
+  test("202 with operation_id/target_version/channel/mode", async () => {
+    const bearer = await mintBearer(harness, ["parachute:host:admin"]);
+    const { deps } = baseDeps(harness);
+    const res = await handleHubUpgrade(
+      postReq({ authorization: `Bearer ${bearer}` }, { channel: "rc" }),
+      deps,
+    );
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as {
+      operation_id: string;
+      target_version: string;
+      channel: string;
+      mode: string;
+    };
+    expect(typeof body.operation_id).toBe("string");
+    expect(body.operation_id.length).toBeGreaterThan(0);
+    expect(body.target_version).toBe("0.6.3-rc.2");
+    expect(body.channel).toBe("rc");
+    expect(body.mode).toBe("in-place");
+  });
+
+  test("spawns the detached helper (does NOT rewrite inline)", async () => {
+    const bearer = await mintBearer(harness, ["parachute:host:admin"]);
+    const { deps, spawned } = baseDeps(harness);
+    const res = await handleHubUpgrade(
+      postReq({ authorization: `Bearer ${bearer}` }, { channel: "rc" }),
+      deps,
+    );
+    const body = (await res.json()) as { operation_id: string };
+    // Exactly one helper spawn; its op id matches the 202; no inline rewrite
+    // (the handler has no UpgradeRunner — the only way to rewrite is the
+    // helper, which we recorded rather than executed).
+    expect(spawned.length).toBe(1);
+    expect(spawned[0]?.operationId).toBe(body.operation_id);
+    expect(spawned[0]?.configDir).toBe(harness.dir);
+  });
+
+  test("status file is seeded + pollable via GET /status", async () => {
+    const bearer = await mintBearer(harness, ["parachute:host:admin"]);
+    const { deps } = baseDeps(harness);
+    const post = await handleHubUpgrade(
+      postReq({ authorization: `Bearer ${bearer}` }, { channel: "rc" }),
+      deps,
+    );
+    const { operation_id } = (await post.json()) as { operation_id: string };
+
+    const statusRes = await handleHubUpgradeStatus(
+      getStatusReq({ authorization: `Bearer ${bearer}` }),
+      deps,
+    );
+    expect(statusRes.status).toBe(200);
+    const status = (await statusRes.json()) as {
+      operation_id: string;
+      phase: string;
+      mode: string;
+    };
+    expect(status.operation_id).toBe(operation_id);
+    expect(status.phase).toBe("pending");
+    expect(status.mode).toBe("in-place");
+  });
+
+  test("container in-place passes the hub pid to the helper (graceful-exit path)", async () => {
+    const bearer = await mintBearer(harness, ["parachute:host:admin"]);
+    // Inject a container/in-place mode result (the real source-detection would
+    // classify this test's checkout as bun-linked; we want the container arm).
+    const { deps, spawned } = baseDeps(harness, {
+      detectMode: () => ({
+        mode: "in-place",
+        source: "container",
+        reason: "container with $BUN_INSTALL on the persistent disk",
+      }),
+    });
+    const res = await handleHubUpgrade(
+      postReq({ authorization: `Bearer ${bearer}` }, { channel: "rc" }),
+      deps,
+    );
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { mode: string };
+    expect(body.mode).toBe("in-place");
+    // Container source → the handler hands the helper a hub pid to signal.
+    expect(spawned[0]?.hubPid).toBe(process.pid);
+  });
+});
+
+describe("POST /api/hub/upgrade — redeploy-required short-circuit (§5.3)", () => {
+  test("image-pinned container → 202 mode redeploy-required, NO helper spawned", async () => {
+    const bearer = await mintBearer(harness, ["parachute:host:admin"]);
+    // Inject the image-pinned (redeploy-required) detection result. (The mode
+    // heuristic itself is unit-tested separately in `detectHubUpgradeMode`;
+    // here we assert the endpoint's short-circuit behavior on that result.)
+    const { deps, spawned } = baseDeps(harness, {
+      detectMode: () => ({
+        mode: "redeploy-required",
+        source: "container",
+        reason: "container image-pinned ($BUN_INSTALL not on the persistent disk)",
+      }),
+    });
+    const res = await handleHubUpgrade(
+      postReq({ authorization: `Bearer ${bearer}` }, { channel: "rc" }),
+      deps,
+    );
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { mode: string };
+    expect(body.mode).toBe("redeploy-required");
+    // The honest path: NO helper, NO misleading no-op rewrite.
+    expect(spawned.length).toBe(0);
+    // Status file reflects redeploy-required (terminal) so the SPA renders the
+    // dashboard hint, not a spinner.
+    const status = readHubUpgradeStatus(harness.dir);
+    expect(status?.phase).toBe("redeploy-required");
+    expect(status?.mode).toBe("redeploy-required");
+  });
+});
+
+describe("GET /api/hub/upgrade/status", () => {
+  test("404 when no upgrade has been started", async () => {
+    const bearer = await mintBearer(harness, ["parachute:host:admin"]);
+    const { deps } = baseDeps(harness);
+    const res = await handleHubUpgradeStatus(
+      getStatusReq({ authorization: `Bearer ${bearer}` }),
+      deps,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  test("401 without bearer", async () => {
+    const { deps } = baseDeps(harness);
+    const res = await handleHubUpgradeStatus(getStatusReq({}), deps);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("detectHubUpgradeMode — §5.3 heuristic", () => {
+  test("bun-linked → in-place", () => {
+    const r = detectHubUpgradeMode({
+      env: { PARACHUTE_HOME: "/home/op/.parachute" },
+      source: { kind: "bun-linked", path: "/home/op/parachute-hub" },
+    });
+    expect(r.mode).toBe("in-place");
+    expect(r.source).toBe("bun-linked");
+  });
+
+  test("npm on a VM (non-container) → in-place", () => {
+    const r = detectHubUpgradeMode({
+      env: { PARACHUTE_HOME: "/home/op/.parachute" },
+      source: { kind: "npm", path: "/home/op/.bun/install/global/node_modules/@openparachute/hub" },
+    });
+    expect(r.mode).toBe("in-place");
+    expect(r.source).toBe("npm");
+  });
+
+  test("container + BUN_INSTALL on persistent disk → in-place", () => {
+    const r = detectHubUpgradeMode({
+      env: { PARACHUTE_HOME: "/parachute", BUN_INSTALL: "/parachute/.bun" },
+      source: { kind: "npm", path: "/parachute/.bun/install/global/node_modules" },
+    });
+    expect(r.mode).toBe("in-place");
+    expect(r.source).toBe("container");
+  });
+
+  test("container image-pinned (BUN_INSTALL off-mount) → redeploy-required", () => {
+    const r = detectHubUpgradeMode({
+      env: { PARACHUTE_HOME: "/parachute", BUN_INSTALL: "/root/.bun" },
+      source: { kind: "npm", path: "/app/src" },
+    });
+    expect(r.mode).toBe("redeploy-required");
+    expect(r.source).toBe("container");
+  });
+
+  test("container with BUN_INSTALL unset → redeploy-required (conservative)", () => {
+    const r = detectHubUpgradeMode({
+      env: { PARACHUTE_HOME: "/parachute" },
+      source: { kind: "bun-linked", path: "/app" },
+    });
+    // bun-linked wins even in a container (git pull persists on disk).
+    expect(r.mode).toBe("in-place");
+  });
+
+  test("unknown source (non-container) → redeploy-required (honest fallback)", () => {
+    const r = detectHubUpgradeMode({
+      env: { PARACHUTE_HOME: "/home/op/.parachute" },
+      source: { kind: "unknown" },
+    });
+    expect(r.mode).toBe("redeploy-required");
+    expect(r.source).toBe("unknown");
+  });
+
+  test("descendant-of guard: a stray /parachute path component is NOT on-mount", () => {
+    const r = detectHubUpgradeMode({
+      env: { PARACHUTE_HOME: "/parachute", BUN_INSTALL: "/parachute-other/.bun" },
+      source: { kind: "npm", path: "/app/src" },
+    });
+    // /parachute-other is NOT under /parachute/ → image-pinned.
+    expect(r.mode).toBe("redeploy-required");
+  });
+});
+
+describe("hub-upgrade helper — rewrite-then-restart sequence", () => {
+  function helperHarness() {
+    const dir = mkdtempSync(join(tmpdir(), "phub-helper-"));
+    writeHubUpgradeStatus(dir, {
+      operation_id: "op-test",
+      phase: "pending",
+      mode: "in-place",
+      current_version: "0.6.3-rc.1",
+      target_version: "0.6.3-rc.2",
+      channel: "rc",
+      log: [],
+      started_at: new Date().toISOString(),
+    });
+    return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+  }
+
+  test("unit-managed: rewrite (no upgrade-side restart) then restartHubUnit", async () => {
+    const { dir, cleanup } = helperHarness();
+    try {
+      const upgradeCalls: { svc: string; opts: UpgradeOpts }[] = [];
+      let restartUnitCalled = 0;
+      const code = await runHubUpgradeHelper(
+        { operationId: "op-test", channel: "rc", configDir: dir },
+        {
+          upgrade: async (svc, opts) => {
+            upgradeCalls.push({ svc, opts });
+            opts.log?.("fake bun add -g done");
+            return 0;
+          },
+          isHubUnitInstalled: () => true,
+          restartHubUnit: (): HubUnitManagerOpResult => {
+            restartUnitCalled++;
+            return { outcome: "ok", messages: ["restarted hub unit"] };
+          },
+        },
+      );
+      expect(code).toBe(0);
+      // upgrade was called for "hub" with a no-op restartFn (rewrite-only) and
+      // NO supervisor block (helper owns the restart, not upgrade's dual-dispatch).
+      expect(upgradeCalls.length).toBe(1);
+      expect(upgradeCalls[0]?.svc).toBe("hub");
+      expect(upgradeCalls[0]?.opts.channel).toBe("rc");
+      expect(upgradeCalls[0]?.opts.supervisor).toBeUndefined();
+      expect(typeof upgradeCalls[0]?.opts.restartFn).toBe("function");
+      // restartHubUnit was the restart authority.
+      expect(restartUnitCalled).toBe(1);
+      const status = readHubUpgradeStatus(dir);
+      expect(status?.phase).toBe("restarting");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("container (no unit): rewrite then SIGTERM the hub pid", async () => {
+    const { dir, cleanup } = helperHarness();
+    try {
+      const signals: [number, string][] = [];
+      const code = await runHubUpgradeHelper(
+        { operationId: "op-test", channel: "rc", configDir: dir, hubPid: 4242 },
+        {
+          upgrade: async () => 0,
+          isHubUnitInstalled: () => false,
+          signalHub: (pid, sig) => signals.push([pid, sig]),
+        },
+      );
+      expect(code).toBe(0);
+      expect(signals).toEqual([[4242, "SIGTERM"]]);
+      const status = readHubUpgradeStatus(dir);
+      expect(status?.phase).toBe("restarting");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rewrite failure → phase failed, NO restart fired", async () => {
+    const { dir, cleanup } = helperHarness();
+    try {
+      let restartUnitCalled = 0;
+      const signals: unknown[] = [];
+      const code = await runHubUpgradeHelper(
+        { operationId: "op-test", channel: "rc", configDir: dir, hubPid: 1 },
+        {
+          upgrade: async () => 1, // rewrite failed
+          isHubUnitInstalled: () => false,
+          restartHubUnit: () => {
+            restartUnitCalled++;
+            return { outcome: "ok", messages: [] };
+          },
+          signalHub: (pid, sig) => signals.push([pid, sig]),
+        },
+      );
+      expect(code).toBe(1);
+      expect(restartUnitCalled).toBe(0);
+      expect(signals.length).toBe(0);
+      const status = readHubUpgradeStatus(dir);
+      expect(status?.phase).toBe("failed");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("unit restart failure → phase failed", async () => {
+    const { dir, cleanup } = helperHarness();
+    try {
+      const code = await runHubUpgradeHelper(
+        { operationId: "op-test", channel: "rc", configDir: dir },
+        {
+          upgrade: async () => 0,
+          isHubUnitInstalled: () => true,
+          restartHubUnit: (): HubUnitManagerOpResult => ({
+            outcome: "failed",
+            messages: ["systemctl restart failed"],
+          }),
+        },
+      );
+      expect(code).toBe(1);
+      const status = readHubUpgradeStatus(dir);
+      expect(status?.phase).toBe("failed");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("container with no hub pid → still succeeds (relies on runtime restart)", async () => {
+    const { dir, cleanup } = helperHarness();
+    try {
+      const signals: unknown[] = [];
+      const code = await runHubUpgradeHelper(
+        { operationId: "op-test", channel: "rc", configDir: dir },
+        {
+          upgrade: async () => 0,
+          isHubUnitInstalled: () => false,
+          signalHub: (pid, sig) => signals.push([pid, sig]),
+        },
+      );
+      expect(code).toBe(0);
+      expect(signals.length).toBe(0);
+      const status = readHubUpgradeStatus(dir);
+      expect(status?.phase).toBe("restarting");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("status-file progress writes accumulate in order", async () => {
+    const { dir, cleanup } = helperHarness();
+    try {
+      await runHubUpgradeHelper(
+        { operationId: "op-test", channel: "rc", configDir: dir, hubPid: 99 },
+        {
+          upgrade: async (_svc, opts) => {
+            opts.log?.("running bun add -g @openparachute/hub@rc");
+            return 0;
+          },
+          isHubUnitInstalled: () => false,
+          signalHub: () => {},
+        },
+      );
+      const status = readHubUpgradeStatus(dir);
+      expect(status?.log[0]).toContain("helper started");
+      expect(status?.log.some((l) => l.includes("bun add -g"))).toBe(true);
+      expect(status?.log.some((l) => l.includes("signalling the hub"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/__tests__/api-hub-upgrade.test.ts
+++ b/src/__tests__/api-hub-upgrade.test.ts
@@ -25,7 +25,12 @@ import { hubDbPath, openHubDb } from "../hub-db.ts";
 import type { HubUnitDeps, HubUnitManagerOpResult } from "../hub-unit.ts";
 import { runHubUpgradeHelper } from "../hub-upgrade-helper.ts";
 import { detectHubUpgradeMode } from "../hub-upgrade-mode.ts";
-import { readHubUpgradeStatus, writeHubUpgradeStatus } from "../hub-upgrade-status.ts";
+import {
+  type HubUpgradeStatus,
+  appendHubUpgradeStatus,
+  readHubUpgradeStatus,
+  writeHubUpgradeStatus,
+} from "../hub-upgrade-status.ts";
 import { recordTokenMint, signAccessToken } from "../jwt-sign.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 import { createUser } from "../users.ts";
@@ -314,6 +319,122 @@ describe("POST /api/hub/upgrade — redeploy-required short-circuit (§5.3)", ()
     const status = readHubUpgradeStatus(harness.dir);
     expect(status?.phase).toBe("redeploy-required");
     expect(status?.mode).toBe("redeploy-required");
+  });
+});
+
+describe("POST /api/hub/upgrade — 409 in-flight guard (concurrent-upgrade)", () => {
+  /** Seed the status file with a prior op in the given phase. */
+  function seedStatus(dir: string, phase: HubUpgradeStatus["phase"], opId = "prior-op"): void {
+    writeHubUpgradeStatus(dir, {
+      operation_id: opId,
+      phase,
+      mode: "in-place",
+      current_version: "0.6.3-rc.1",
+      target_version: "0.6.3-rc.2",
+      channel: "rc",
+      log: [],
+      started_at: new Date().toISOString(),
+    });
+  }
+
+  for (const phase of ["pending", "running", "restarting"] as const) {
+    test(`rejects a second POST while phase=${phase} with 409, no second helper spawned`, async () => {
+      const bearer = await mintBearer(harness, ["parachute:host:admin"]);
+      seedStatus(harness.dir, phase);
+      const { deps, spawned } = baseDeps(harness);
+      const res = await handleHubUpgrade(
+        postReq({ authorization: `Bearer ${bearer}` }, { channel: "rc" }),
+        deps,
+      );
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("upgrade_in_flight");
+      // No second helper spawned; the prior op's status is untouched.
+      expect(spawned.length).toBe(0);
+      const status = readHubUpgradeStatus(harness.dir);
+      expect(status?.operation_id).toBe("prior-op");
+      expect(status?.phase).toBe(phase);
+    });
+  }
+
+  for (const phase of ["failed", "redeploy-required", "succeeded"] as const) {
+    test(`allows a new POST when the prior op is terminal (phase=${phase})`, async () => {
+      const bearer = await mintBearer(harness, ["parachute:host:admin"]);
+      seedStatus(harness.dir, phase);
+      const { deps, spawned } = baseDeps(harness);
+      const res = await handleHubUpgrade(
+        postReq({ authorization: `Bearer ${bearer}` }, { channel: "rc" }),
+        deps,
+      );
+      expect(res.status).toBe(202);
+      // A fresh operation took the slot + spawned its helper.
+      expect(spawned.length).toBe(1);
+      const status = readHubUpgradeStatus(harness.dir);
+      expect(status?.operation_id).not.toBe("prior-op");
+      expect(spawned[0]?.operationId).toBe(status?.operation_id);
+    });
+  }
+
+  test("no prior status file → POST proceeds normally", async () => {
+    const bearer = await mintBearer(harness, ["parachute:host:admin"]);
+    const { deps, spawned } = baseDeps(harness);
+    const res = await handleHubUpgrade(
+      postReq({ authorization: `Bearer ${bearer}` }, { channel: "rc" }),
+      deps,
+    );
+    expect(res.status).toBe(202);
+    expect(spawned.length).toBe(1);
+  });
+});
+
+describe("appendHubUpgradeStatus — operation_id guard (stale-helper isolation)", () => {
+  test("a mismatched operationId is a NO-OP (cannot overwrite a newer op's status)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "phub-append-guard-"));
+    try {
+      // The slot is owned by the NEWER operation "op-2".
+      writeHubUpgradeStatus(dir, {
+        operation_id: "op-2",
+        phase: "pending",
+        mode: "in-place",
+        current_version: "0.6.3-rc.2",
+        target_version: "0.6.3-rc.3",
+        channel: "rc",
+        log: ["op-2 accepted"],
+        started_at: new Date().toISOString(),
+      });
+      // A STALE helper from the superseded "op-1" tries to write — must no-op.
+      appendHubUpgradeStatus(dir, "op-1", { phase: "failed", error: "stale" }, "stale helper line");
+      const after = readHubUpgradeStatus(dir);
+      expect(after?.operation_id).toBe("op-2");
+      expect(after?.phase).toBe("pending"); // NOT "failed"
+      expect(after?.error).toBeUndefined();
+      expect(after?.log).toEqual(["op-2 accepted"]); // stale line NOT appended
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a matching operationId writes (phase advances + log appends)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "phub-append-match-"));
+    try {
+      writeHubUpgradeStatus(dir, {
+        operation_id: "op-1",
+        phase: "pending",
+        mode: "in-place",
+        current_version: "0.6.3-rc.1",
+        target_version: "0.6.3-rc.2",
+        channel: "rc",
+        log: ["accepted"],
+        started_at: new Date().toISOString(),
+      });
+      appendHubUpgradeStatus(dir, "op-1", { phase: "running" }, "helper started");
+      const after = readHubUpgradeStatus(dir);
+      expect(after?.operation_id).toBe("op-1");
+      expect(after?.phase).toBe("running");
+      expect(after?.log).toEqual(["accepted", "helper started"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -4268,3 +4268,67 @@ describe("POST /account/vault-token/<name> — friend scoped mint (routed end-to
     }
   });
 });
+
+describe("hubFetch routing — /api/hub/upgrade (D4 SPA hub-upgrade)", () => {
+  test("POST /api/hub/upgrade dispatches to the handler (401 without bearer, NOT 404)", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        await createUser(db, "owner", "pw");
+        // No bearer → the handler's auth gate returns 401. A 404 would mean
+        // the route never reached the handler (dispatch missing). The endpoint
+        // does NOT require a supervisor — assert it works without one.
+        const res = await hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath })(
+          req("/api/hub/upgrade", { method: "POST" }),
+        );
+        expect(res.status).toBe(401);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("GET /api/hub/upgrade/status dispatches to the handler (401 without bearer)", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        await createUser(db, "owner", "pw");
+        const res = await hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath })(
+          req("/api/hub/upgrade/status"),
+        );
+        expect(res.status).toBe(401);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("GET on /api/hub/upgrade → 405 (POST-only) once authenticated path is reached", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        await createUser(db, "owner", "pw");
+        // GET on the POST-only upgrade route: no bearer means auth runs first
+        // (401). The point of this case is the route is wired (not 404).
+        const res = await hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath })(
+          req("/api/hub/upgrade", { method: "GET" }),
+        );
+        expect(res.status).not.toBe(404);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/api-hub-upgrade.ts
+++ b/src/api-hub-upgrade.ts
@@ -1,0 +1,351 @@
+/**
+ * `POST /api/hub/upgrade` + `GET /api/hub/upgrade/status` — the SPA-driven
+ * hub self-upgrade (design 2026-06-01 §5 item 3 / §5.3 / D4).
+ *
+ * ── WHY A DEDICATED ENDPOINT (not /api/modules/hub/*) ──────────────────────
+ *
+ * The hub is NOT a supervised module — `CURATED_MODULES` rejects `hub`, so
+ * `parseModulesPath("/api/modules/hub/upgrade")` returns undefined and the
+ * module-ops switch never reaches a hub case. The hub needs its OWN endpoint
+ * because the constraint is unique: the hub can't restart itself synchronously
+ * (the request dies with the old process before it can report success). So:
+ *
+ *   1. Validate strictly + respond **202** immediately with
+ *      `{ operation_id, target_version, channel, mode }`.
+ *   2. Spawn a **detached one-shot helper** (`detached:true`+`unref()`) that
+ *      OUTLIVES the hub: it rewrites the binary then drives the platform
+ *      restart. The request handler does NOT do the rewrite/restart inline.
+ *   3. The SPA polls `GET /api/hub/upgrade/status` + `/health` + `/api/hub`
+ *      version until the new binary answers.
+ *
+ * ── SECURITY ───────────────────────────────────────────────────────────────
+ *
+ * - **Strict host-admin gate** — reuses the EXACT `authorize` path module-ops
+ *   uses (`parachute:host:admin`, validated against the hub DB + issuer). A
+ *   `:auth`-only token gets 403.
+ * - **Closed-enum channel** — the optional `channel` is `"rc" | "latest"` ONLY
+ *   (default: auto-detected from the current version). This value flows toward
+ *   `bun add -g @openparachute/hub@<channel>`, so it MUST be a closed enum,
+ *   never free input. There is no shell-string interpolation: the rewrite goes
+ *   through `upgrade.ts`'s `UpgradeRunner` (argv arrays), so even the enum is
+ *   defense-in-depth, not the only barrier.
+ *
+ * ── REDEPLOY-REQUIRED SHORT-CIRCUIT (§5.3) ─────────────────────────────────
+ *
+ * When the in-place-vs-redeploy detection (`hub-upgrade-mode.ts`) returns
+ * `redeploy-required` (image-pinned container), we DO NOT spawn a helper and
+ * DO NOT do a misleading no-op rewrite that's lost on the next container
+ * restart. We respond 202 with `mode: "redeploy-required"` + seed a status
+ * file in the `redeploy-required` phase; the SPA renders "redeploy from your
+ * platform dashboard" instead of a false "upgraded."
+ */
+
+import type { Database } from "bun:sqlite";
+import { randomUUID } from "node:crypto";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defaultRunner, detectChannel } from "./commands/upgrade.ts";
+import { HUB_PACKAGE } from "./hub-control.ts";
+import { type HubUpgradeMode, detectHubUpgradeMode } from "./hub-upgrade-mode.ts";
+import {
+  type HubUpgradeStatus,
+  readHubUpgradeStatus,
+  writeHubUpgradeStatus,
+} from "./hub-upgrade-status.ts";
+import { detectHubInstallSource } from "./install-source.ts";
+import { validateAccessToken } from "./jwt-sign.ts";
+
+/** Same scope module-ops gates on — destructive host-admin action. */
+export const HUB_UPGRADE_REQUIRED_SCOPE = "parachute:host:admin";
+
+export interface SpawnHelperArgs {
+  operationId: string;
+  channel: "rc" | "latest";
+  configDir: string;
+  /** Hub PID for the container graceful-exit path (undefined on unit-managed). */
+  hubPid?: number;
+}
+
+export interface ApiHubUpgradeDeps {
+  db: Database;
+  /** Hub origin — validates the bearer's `iss`. */
+  issuer: string;
+  /** PARACHUTE_HOME — where the status file is read/written. */
+  configDir: string;
+  /**
+   * Spawn the detached one-shot helper. Production wires
+   * `spawnDetachedHubUpgradeHelper`; tests inject a recorder so no real process
+   * is forked and the handler-does-not-rewrite-inline invariant is asserted.
+   */
+  spawnHelper?: (args: SpawnHelperArgs) => void;
+  /**
+   * Resolve `<pkg>@<channel>` → concrete version for the 202 `target_version`
+   * (best-effort; null on a registry miss). Production uses `npm view` via the
+   * upgrade runner; tests stub it.
+   */
+  resolveTargetVersion?: (channel: "rc" | "latest") => Promise<string | null>;
+  /** Read the hub's current version. Production reads the nearest package.json. */
+  currentVersion?: () => string;
+  /** Override the install-source dir + env for mode detection (test seam). */
+  hubSrcDir?: string;
+  env?: Record<string, string | undefined>;
+  /**
+   * Override the in-place-vs-redeploy detection (test seam). Production runs
+   * `detectHubUpgradeMode` against the real install source + env; tests inject
+   * a fixed result so the redeploy-required short-circuit can be exercised
+   * without faking a Render image's on-disk layout.
+   */
+  detectMode?: typeof detectHubUpgradeMode;
+  /** Override "now" (test seam). */
+  now?: () => Date;
+}
+
+interface ParsedBody {
+  channel?: "rc" | "latest";
+}
+
+async function authorize(req: Request, deps: ApiHubUpgradeDeps): Promise<Response | undefined> {
+  const auth = req.headers.get("authorization");
+  if (!auth || !auth.startsWith("Bearer ")) {
+    return jsonError(401, "unauthenticated", "Authorization: Bearer <token> required");
+  }
+  const bearer = auth.slice("Bearer ".length).trim();
+  if (!bearer) return jsonError(401, "unauthenticated", "empty bearer token");
+  try {
+    const validated = await validateAccessToken(deps.db, bearer, deps.issuer);
+    if (typeof validated.payload.sub !== "string" || validated.payload.sub.length === 0) {
+      return jsonError(401, "unauthenticated", "bearer token has no sub claim");
+    }
+    const scopes =
+      typeof validated.payload.scope === "string"
+        ? validated.payload.scope.split(/\s+/).filter((s) => s.length > 0)
+        : [];
+    if (!scopes.includes(HUB_UPGRADE_REQUIRED_SCOPE)) {
+      return jsonError(
+        403,
+        "insufficient_scope",
+        `bearer token lacks ${HUB_UPGRADE_REQUIRED_SCOPE}`,
+      );
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return jsonError(401, "unauthenticated", `bearer token invalid — ${msg}`);
+  }
+  return undefined;
+}
+
+/**
+ * Parse + STRICTLY validate the optional `{ channel }` body. A present-but-
+ * non-enum channel is a hard 400 (the operator typed something the rewrite
+ * can't honor — don't silently fall back). Empty / non-JSON / absent body all
+ * resolve to "auto-detect," signalled by `channel: undefined`.
+ */
+async function parseBody(req: Request): Promise<ParsedBody | Response> {
+  if (!req.headers.get("content-type")?.includes("application/json")) return {};
+  let body: { channel?: unknown };
+  try {
+    body = (await req.json()) as { channel?: unknown };
+  } catch {
+    return {}; // empty / unparseable — auto-detect
+  }
+  if (body && body.channel !== undefined) {
+    if (body.channel !== "rc" && body.channel !== "latest") {
+      return jsonError(
+        400,
+        "invalid_channel",
+        `channel must be "rc" or "latest" (got ${JSON.stringify(body.channel)})`,
+      );
+    }
+    return { channel: body.channel };
+  }
+  return {};
+}
+
+/**
+ * Default current-version reader: climb from the running source dir to the
+ * nearest package.json. Mirrors `api-hub.ts`'s `readHubVersion`.
+ */
+function defaultCurrentVersion(hubSrcDir: string): string {
+  // Lazy import to avoid a hot dependency; reuse the install-source detector's
+  // version read (it already climbs to the nearest package.json).
+  const source = detectHubInstallSource(hubSrcDir);
+  return source.livePackageVersion ?? "unknown";
+}
+
+/** Default target-version resolver via `npm view <pkg>@<channel> version`. */
+async function defaultResolveTargetVersion(channel: "rc" | "latest"): Promise<string | null> {
+  const { code, stdout } = await defaultRunner.capture([
+    "npm",
+    "view",
+    `${HUB_PACKAGE}@${channel}`,
+    "version",
+  ]);
+  if (code !== 0) return null;
+  const lines = stdout.trim().split("\n").filter(Boolean);
+  return lines[lines.length - 1] ?? null;
+}
+
+/**
+ * POST /api/hub/upgrade — accept + dispatch the detached helper. Returns 202
+ * with `{ operation_id, target_version, channel, mode }`. Never blocks on the
+ * upgrade itself.
+ */
+export async function handleHubUpgrade(req: Request, deps: ApiHubUpgradeDeps): Promise<Response> {
+  if (req.method !== "POST") return jsonError(405, "method_not_allowed", "use POST");
+  const authFail = await authorize(req, deps);
+  if (authFail) return authFail;
+
+  const parsed = await parseBody(req);
+  if (parsed instanceof Response) return parsed;
+
+  const hubSrcDir = deps.hubSrcDir ?? dirname(fileURLToPath(import.meta.url));
+  const env = deps.env ?? process.env;
+  const now = (deps.now ?? (() => new Date()))();
+
+  const currentVersion = (deps.currentVersion ?? (() => defaultCurrentVersion(hubSrcDir)))();
+  // Auto-detect the channel from the current version when not explicitly set —
+  // an rc operator stays on rc (governance rule 2), a stable operator on latest.
+  const channel: "rc" | "latest" =
+    parsed.channel ?? (currentVersion !== "unknown" ? detectChannel(currentVersion) : "latest");
+
+  // §5.3 detection — does an in-place rewrite persist, or is the hub image-pinned?
+  const detectMode = deps.detectMode ?? detectHubUpgradeMode;
+  const modeResult = detectMode({ env, hubSrcDir });
+  const mode: HubUpgradeMode = modeResult.mode;
+
+  const resolveTarget = deps.resolveTargetVersion ?? defaultResolveTargetVersion;
+  const targetVersion = await resolveTarget(channel).catch(() => null);
+
+  const operationId = randomUUID();
+
+  // ── redeploy-required: do NOT spawn a helper / do NOT no-op-rewrite (§5.3) ──
+  if (mode === "redeploy-required") {
+    const status: HubUpgradeStatus = {
+      operation_id: operationId,
+      phase: "redeploy-required",
+      mode,
+      current_version: currentVersion,
+      target_version: targetVersion,
+      channel,
+      log: [modeResult.reason],
+      started_at: now.toISOString(),
+      finished_at: now.toISOString(),
+    };
+    writeHubUpgradeStatus(deps.configDir, status);
+    return accepted({ operationId, targetVersion, channel, mode });
+  }
+
+  // ── in-place: seed the status file, then spawn the detached helper ─────────
+  const status: HubUpgradeStatus = {
+    operation_id: operationId,
+    phase: "pending",
+    mode,
+    current_version: currentVersion,
+    target_version: targetVersion,
+    channel,
+    log: [`accepted hub-upgrade (${mode}); ${modeResult.reason}`],
+    started_at: now.toISOString(),
+  };
+  writeHubUpgradeStatus(deps.configDir, status);
+
+  // On a container the helper must signal the (current) hub to exit so the
+  // runtime re-runs CMD on the new binary — pass our own PID. On a unit-managed
+  // box the manager owns the restart, so no pid is needed (the helper's
+  // `upgrade` dual-dispatch calls `restartHubUnit`).
+  const spawn = deps.spawnHelper ?? spawnDetachedHubUpgradeHelper;
+  const spawnArgs: SpawnHelperArgs = { operationId, channel, configDir: deps.configDir };
+  if (modeResult.source === "container") spawnArgs.hubPid = process.pid;
+  // CRITICAL: spawn-and-return. The handler does NOT await a rewrite/restart —
+  // that's the helper's job, and it must outlive this process.
+  spawn(spawnArgs);
+
+  return accepted({ operationId, targetVersion, channel, mode });
+}
+
+/**
+ * GET /api/hub/upgrade/status — poll the on-disk status file. Matches the
+ * module-ops operation-poll shape (status + log + timestamps) so the SPA's
+ * polling code reads consistently. 404 when no upgrade has been started.
+ */
+export async function handleHubUpgradeStatus(
+  req: Request,
+  deps: ApiHubUpgradeDeps,
+): Promise<Response> {
+  if (req.method !== "GET") return jsonError(405, "method_not_allowed", "use GET");
+  const authFail = await authorize(req, deps);
+  if (authFail) return authFail;
+
+  const status = readHubUpgradeStatus(deps.configDir);
+  if (!status) {
+    return jsonError(404, "not_found", "no hub upgrade has been started");
+  }
+  return new Response(JSON.stringify(status), {
+    status: 200,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+/**
+ * Production helper-spawn: `bun <abs hub-upgrade-helper.ts> --op … --channel …
+ * --config-dir … [--hub-pid …]`, **detached + unref'd** so it OUTLIVES the hub
+ * it's about to restart. This is the one legitimate detached process in the
+ * unified model (§5.3) — everything else stays supervised.
+ *
+ * `detached: true` puts it in its own process group + session leader, so the
+ * hub exiting does not deliver a death signal to it; `unref()` removes it from
+ * the parent's event-loop ref-count so the hub can exit without waiting on it.
+ */
+export function spawnDetachedHubUpgradeHelper(args: SpawnHelperArgs): void {
+  const helperPath = fileURLToPath(new URL("./hub-upgrade-helper.ts", import.meta.url));
+  const cmd = [
+    "bun",
+    helperPath,
+    "--op",
+    args.operationId,
+    "--channel",
+    args.channel,
+    "--config-dir",
+    args.configDir,
+  ];
+  if (args.hubPid !== undefined) {
+    cmd.push("--hub-pid", String(args.hubPid));
+  }
+  const proc = Bun.spawn(cmd, {
+    // Own process group/session so the hub's exit doesn't SIGHUP/SIGTERM us —
+    // we MUST outlive the hub to drive its restart.
+    detached: true,
+    // Inherit env so the helper's `bun add -g` / git sees PATH, BUN_INSTALL,
+    // PARACHUTE_HOME, TMPDIR — same rationale as commands/upgrade.ts's runner.
+    env: process.env,
+    // Detach stdio so the helper isn't tied to the hub's pipes (which close on
+    // hub exit). The helper records progress to the status FILE, not stdout.
+    stdio: ["ignore", "ignore", "ignore"],
+  });
+  // Remove from the parent's ref-count so the hub can exit cleanly while the
+  // helper keeps running.
+  proc.unref();
+}
+
+function accepted(body: {
+  operationId: string;
+  targetVersion: string | null;
+  channel: "rc" | "latest";
+  mode: HubUpgradeMode;
+}): Response {
+  return new Response(
+    JSON.stringify({
+      operation_id: body.operationId,
+      target_version: body.targetVersion,
+      channel: body.channel,
+      mode: body.mode,
+    }),
+    { status: 202, headers: { "content-type": "application/json", "cache-control": "no-store" } },
+  );
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}

--- a/src/api-hub-upgrade.ts
+++ b/src/api-hub-upgrade.ts
@@ -58,6 +58,14 @@ import { validateAccessToken } from "./jwt-sign.ts";
 /** Same scope module-ops gates on — destructive host-admin action. */
 export const HUB_UPGRADE_REQUIRED_SCOPE = "parachute:host:admin";
 
+/**
+ * Non-terminal phases — an upgrade in any of these is still in flight, so a
+ * second `POST /api/hub/upgrade` is rejected 409. The terminal phases
+ * (`failed`, `redeploy-required`, and the SPA-inferred `succeeded`) are NOT
+ * here, so a new upgrade may start once the prior op reached one of them.
+ */
+const IN_FLIGHT_PHASES = new Set<HubUpgradeStatus["phase"]>(["pending", "running", "restarting"]);
+
 export interface SpawnHelperArgs {
   operationId: string;
   channel: "rc" | "latest";
@@ -98,6 +106,12 @@ export interface ApiHubUpgradeDeps {
   detectMode?: typeof detectHubUpgradeMode;
   /** Override "now" (test seam). */
   now?: () => Date;
+  /**
+   * Read the current on-disk status (for the 409 in-flight guard). Defaults to
+   * `readHubUpgradeStatus`; injectable so a test can drive the guard without
+   * seeding a real file.
+   */
+  readStatus?: (configDir: string) => HubUpgradeStatus | null;
 }
 
 interface ParsedBody {
@@ -197,6 +211,25 @@ export async function handleHubUpgrade(req: Request, deps: ApiHubUpgradeDeps): P
 
   const parsed = await parseBody(req);
   if (parsed instanceof Response) return parsed;
+
+  // ── 409 in-flight guard ────────────────────────────────────────────────────
+  // The status file is single-slot (one hub, one upgrade). If a prior upgrade
+  // is still in a non-terminal phase (pending/running/restarting), starting a
+  // SECOND would overwrite its operation_id — and a still-running first helper
+  // would then either clobber the new op's status or be silently superseded.
+  // The SPA disables the button while upgrading, but the API must guard
+  // server-side too (a second tab, a stale page, a scripted POST). Reject with
+  // 409 unless the slot is free (no file) or the prior op reached a terminal
+  // phase (failed / redeploy-required / succeeded).
+  const readStatus = deps.readStatus ?? readHubUpgradeStatus;
+  const existing = readStatus(deps.configDir);
+  if (existing && IN_FLIGHT_PHASES.has(existing.phase)) {
+    return jsonError(
+      409,
+      "upgrade_in_flight",
+      `a hub upgrade is already ${existing.phase} (operation ${existing.operation_id}); poll GET /api/hub/upgrade/status or wait for it to finish before starting another`,
+    );
+  }
 
   const hubSrcDir = deps.hubSrcDir ?? dirname(fileURLToPath(import.meta.url));
   const env = deps.env ?? process.env;

--- a/src/api-hub.ts
+++ b/src/api-hub.ts
@@ -4,6 +4,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
 import { HOST_ADMIN_SCOPE } from "./admin-vaults.ts";
+import { CONTAINER_HOME } from "./hub-control.ts";
 import { detectHubInstallSource } from "./install-source.ts";
 
 /**
@@ -120,7 +121,7 @@ export async function handleApiHub(req: Request, deps: ApiHubDeps): Promise<Resp
   // would label this `bun-linked` (the image runs from /app/src, not bun
   // globals), which is technically true but misleading for the operator —
   // "container" is what they actually want to see.
-  const isContainer = env.PARACHUTE_HOME === "/parachute";
+  const isContainer = env.PARACHUTE_HOME === CONTAINER_HOME;
 
   const body: HubStatusResponse = {
     version,

--- a/src/hub-control.ts
+++ b/src/hub-control.ts
@@ -31,6 +31,14 @@ export const HUB_SVC = "hub";
 export const HUB_PACKAGE = "@openparachute/hub";
 export const HUB_DEFAULT_PORT = 1939;
 /**
+ * The container `PARACHUTE_HOME` — the Render Blueprint (and the shared Fly
+ * image) pins this exact path. `PARACHUTE_HOME === CONTAINER_HOME` is the most
+ * reliable container-mode signal the hub has. Single source of truth so the
+ * `/api/hub` status surface (`api-hub.ts`) and the in-place-vs-redeploy
+ * detection (`hub-upgrade-mode.ts`) can't drift on the magic path.
+ */
+export const CONTAINER_HOME = "/parachute";
+/**
  * Default fallback range is 1 — the hub binds 1939 or fails. Walking up would
  * steal another Parachute service's slot from the canonical 1939–1949 range.
  * Tests and debug tooling can pass a larger `fallbackRange` explicitly.

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -47,6 +47,8 @@
  *   /admin/vault-admin-token/<n>  (GET)        → per-vault bearer mint (cookie-gated)
  *   /api/me                       (GET)        → who-am-I (session+CSRF or hasSession:false)
  *   /api/hub                      (GET)        → hub version + uptime + install-source (host:admin)
+ *   /api/hub/upgrade              (POST)       → SPA-driven hub self-upgrade → 202 + detached helper (host:admin, §5.3/D4)
+ *   /api/hub/upgrade/status       (GET)        → poll the on-disk hub-upgrade status (host:admin)
  *   /api/modules                  (GET)        → curated + installed module catalog (host:auth)
  *   /api/modules/channel          (PUT)        → operator channel toggle (host:admin)
  *   /api/modules/:short/install   (POST)       → bun add + spawn (async op)
@@ -136,6 +138,7 @@ import {
   handleAccountChangePasswordPost,
   handleAccountHomeGet,
 } from "./api-account.ts";
+import { handleHubUpgrade, handleHubUpgradeStatus } from "./api-hub-upgrade.ts";
 import { handleApiHub } from "./api-hub.ts";
 import { handleApiMe } from "./api-me.ts";
 import { handleApiMintToken } from "./api-mint-token.ts";
@@ -1740,6 +1743,31 @@ export function hubFetch(
     if (pathname === "/api/me") {
       if (!getDb) return dbNotConfigured();
       return handleApiMe(req, { db: getDb() });
+    }
+
+    // SPA-driven hub self-upgrade (design 2026-06-01 §5.3 / D4). Dedicated
+    // endpoint — the hub is NOT a supervised module (no /api/modules/hub/*),
+    // so it gets its own route. Checked BEFORE the `/api/hub` exact match
+    // below (and the `/api/modules/*` switch) so the more-specific path wins.
+    // Does NOT require a supervisor: the hub upgrades itself via a detached
+    // helper, not the supervisor. Host-admin gated inside the handler (reuses
+    // the same validateAccessToken + scope check the module-ops API uses); the
+    // channel param is a closed enum (rc|latest) — no injection surface.
+    if (pathname === "/api/hub/upgrade") {
+      if (!getDb) return dbNotConfigured();
+      return handleHubUpgrade(req, {
+        db: getDb(),
+        issuer: oauthDeps(req).issuer,
+        configDir: CONFIG_DIR,
+      });
+    }
+    if (pathname === "/api/hub/upgrade/status") {
+      if (!getDb) return dbNotConfigured();
+      return handleHubUpgradeStatus(req, {
+        db: getDb(),
+        issuer: oauthDeps(req).issuer,
+        configDir: CONFIG_DIR,
+      });
     }
 
     // Hub version + uptime + install-source — drives the admin SPA's

--- a/src/hub-upgrade-helper.ts
+++ b/src/hub-upgrade-helper.ts
@@ -218,11 +218,12 @@ export async function runHubUpgradeHelper(
       // rewrite is done; the runtime will bring it back on the new binary
       // regardless. Record + succeed.
       const msg = err instanceof Error ? err.message : String(err);
-      append(configDir, {}, `hub graceful-exit signal noted as already-gone (${msg})`);
+      append(configDir, operationId, {}, `hub graceful-exit signal noted as already-gone (${msg})`);
     }
   } else {
     append(
       configDir,
+      operationId,
       {},
       "no hub pid provided — relying on the platform runtime's own restart to pick up the new binary",
     );
@@ -241,16 +242,20 @@ function parseArgs(argv: string[]): HubUpgradeHelperArgs | { error: string } {
     const arg = argv[i];
     const next = argv[i + 1];
     switch (arg) {
+      // Each value-bearing flag guards `next !== undefined` so a truncated argv
+      // (flag last in argv, no value) leaves the value unset — surfaced as a
+      // clear "required" error below — rather than silently consuming the next
+      // flag as its value.
       case "--op":
-        operationId = next;
+        if (next !== undefined) operationId = next;
         i++;
         break;
       case "--channel":
-        channel = next;
+        if (next !== undefined) channel = next;
         i++;
         break;
       case "--config-dir":
-        configDir = next;
+        if (next !== undefined) configDir = next;
         i++;
         break;
       case "--hub-pid":

--- a/src/hub-upgrade-helper.ts
+++ b/src/hub-upgrade-helper.ts
@@ -1,0 +1,291 @@
+#!/usr/bin/env bun
+/**
+ * The detached one-shot hub-upgrade helper (design 2026-06-01 §5.3 / D4).
+ *
+ * ── WHY A SEPARATE, DETACHED PROCESS ───────────────────────────────────────
+ *
+ * `POST /api/hub/upgrade` can't rewrite + restart the hub from inside the
+ * request handler: restarting the hub kills the very process serving the
+ * request, so the response would die with the old binary before it could
+ * report success. The resolution (§5.3): the endpoint spawns THIS helper with
+ * `detached: true` + `proc.unref()` — the ONE legitimate detached process in
+ * the unified model, *because it must outlive the hub it's upgrading*. The
+ * helper owns the restart; the request handler returns 202 immediately.
+ *
+ * Detached + unref'd means: no controlling terminal tie, its own process
+ * group, and the parent (hub) exiting does NOT deliver SIGHUP/SIGTERM to it.
+ * So when the helper later tears the hub down, it keeps running to completion.
+ *
+ * ── WHAT IT DOES ───────────────────────────────────────────────────────────
+ *
+ *   1. Mark the on-disk status file `running` (the SPA polls it — it's a FILE,
+ *      not the in-memory ops registry, precisely because the hub goes down
+ *      mid-upgrade; see hub-upgrade-status.ts).
+ *   2. Rewrite the hub binary — REUSES `upgrade("hub", …)` from commands/
+ *      upgrade.ts (the channel-aware `bun add -g @openparachute/hub@<channel>`
+ *      / linked git-pull + downgrade guard). No duplicated rewrite logic.
+ *   3. Trigger the platform-appropriate restart:
+ *      - **unit-managed (VM/Mac)** → `restartHubUnit` (systemctl restart /
+ *        launchctl kickstart -k). The manager tears the old hub down, starts
+ *        the new binary, which re-boots every module from services.json.
+ *      - **container (no unit manager)** → the runtime re-runs CMD on the
+ *        hub's exit, so the helper sends the old hub a graceful SIGTERM (the
+ *        `serve` loop's SIGTERM handler stops children + the server cleanly,
+ *        then the process exits → the runtime brings it back on the rewritten
+ *        binary). The hub PID is passed in via `--hub-pid`.
+ *
+ * The `upgrade("hub", …)` call ALSO does the unit restart itself on a
+ * unit-managed box (its Phase-4 dual-dispatch — `supervisor: {}` opts into the
+ * `restartHubUnit` arm). So on VM/Mac the helper's rewrite step already
+ * restarts the unit; the helper does NOT double-restart. On a container,
+ * `upgrade` finds no unit (its restart arm degrades to the no-unit fallback,
+ * which is a detached lifecycle restart we DON'T want here) — so the helper
+ * passes `restartFn: noop` to upgrade and owns the container restart itself
+ * via the SIGTERM path. This keeps the restart authority unambiguous per
+ * platform.
+ *
+ * ── TESTABILITY ────────────────────────────────────────────────────────────
+ *
+ * `runHubUpgradeHelper` is the pure, injectable core. Every side effect — the
+ * status writes, the `upgrade()` call, the unit restart, the container exit
+ * signal — is a seam, so the rewrite-then-restart sequence + the container
+ * graceful-exit path are unit-tested with NO real `bun add -g`, NO real
+ * systemctl, and NO real process signal. Only the thin argv-parsing `main()`
+ * at the bottom touches the real OS, and it's only reached when this file is
+ * the entrypoint (`import.meta.main`).
+ */
+
+import { type UpgradeOpts, upgrade as realUpgrade } from "./commands/upgrade.ts";
+import { CONFIG_DIR } from "./config.ts";
+import {
+  type HubUnitDeps,
+  type HubUnitManagerOpResult,
+  defaultHubUnitDeps,
+  isHubUnitInstalled,
+  restartHubUnit as realRestartHubUnit,
+} from "./hub-unit.ts";
+import {
+  type HubUpgradeStatus,
+  appendHubUpgradeStatus,
+  readHubUpgradeStatus,
+} from "./hub-upgrade-status.ts";
+
+export interface HubUpgradeHelperArgs {
+  /** Operation id (matches the status file's `operation_id`). */
+  operationId: string;
+  /** Closed-enum channel (validated by the endpoint before spawn). */
+  channel: "rc" | "latest";
+  /** PARACHUTE_HOME (where the status file + services.json live). */
+  configDir: string;
+  /**
+   * The PID of the hub process to gracefully terminate on the container path.
+   * Undefined on the unit-managed path (the manager owns the restart there).
+   */
+  hubPid?: number;
+}
+
+/** Injectable side-effect seams (production wires the real impls). */
+export interface HubUpgradeHelperDeps {
+  /** Rewrite the hub binary. Production proxies to `commands/upgrade.ts`. */
+  upgrade?: (svc: string, opts: UpgradeOpts) => Promise<number>;
+  /** Is a hub unit installed? (Decides unit-managed vs container restart.) */
+  isHubUnitInstalled?: (deps: HubUnitDeps) => boolean;
+  /** Restart the hub unit (unit-managed path). */
+  restartHubUnit?: (deps: HubUnitDeps) => HubUnitManagerOpResult;
+  /** Deps for the unit probes/ops. */
+  hubUnitDeps?: HubUnitDeps;
+  /**
+   * Send the graceful-exit signal to the hub (container path). Production
+   * `process.kill(pid, "SIGTERM")`; tests record the call.
+   */
+  signalHub?: (pid: number, signal: NodeJS.Signals) => void;
+  /** Append to the on-disk status file (test seam). */
+  appendStatus?: (
+    configDir: string,
+    patch: Partial<Pick<HubUpgradeStatus, "phase" | "error">>,
+    logLine?: string,
+  ) => void;
+}
+
+/**
+ * The pure helper core: rewrite the hub binary, then trigger the platform
+ * restart. Returns a terminal exit code (0 = restart dispatched / success).
+ * Records progress to the status file throughout.
+ */
+export async function runHubUpgradeHelper(
+  args: HubUpgradeHelperArgs,
+  deps: HubUpgradeHelperDeps = {},
+): Promise<number> {
+  const upgrade = deps.upgrade ?? realUpgrade;
+  const unitInstalledFn = deps.isHubUnitInstalled ?? isHubUnitInstalled;
+  const restartUnit = deps.restartHubUnit ?? realRestartHubUnit;
+  const hubUnitDeps = deps.hubUnitDeps ?? defaultHubUnitDeps;
+  const signalHub = deps.signalHub ?? ((pid, signal) => process.kill(pid, signal));
+  const append = deps.appendStatus ?? appendHubUpgradeStatus;
+  const { configDir } = args;
+
+  append(configDir, { phase: "running" }, `hub-upgrade helper started (op ${args.operationId})`);
+
+  const unitManaged = unitInstalledFn(hubUnitDeps);
+
+  // ── Rewrite the binary ───────────────────────────────────────────────────
+  // REUSE commands/upgrade.ts for the channel-aware rewrite (bun add -g
+  // @openparachute/hub@<channel> / linked git-pull + downgrade guard) — but
+  // REWRITE ONLY: suppress upgrade's own restart with a no-op `restartFn`. The
+  // HELPER owns the restart explicitly below (the spec's "the helper owns the
+  // restart"), so the restart authority is unambiguous per platform rather than
+  // buried in upgrade.ts's dual-dispatch. `supervisor` is intentionally omitted
+  // so upgrade takes its detached arm with our no-op restartFn (a pure rewrite,
+  // no lifecycle restart fired).
+  const upgradeOpts: UpgradeOpts = {
+    channel: args.channel,
+    configDir,
+    restartFn: async () => 0,
+    log: (line) => append(configDir, {}, line),
+  };
+
+  let code: number;
+  try {
+    code = await upgrade("hub", upgradeOpts);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    append(configDir, { phase: "failed", error: msg }, `hub-upgrade failed: ${msg}`);
+    return 1;
+  }
+
+  if (code !== 0) {
+    append(
+      configDir,
+      { phase: "failed", error: `upgrade exited ${code}` },
+      `hub-upgrade rewrite failed (exit ${code}) — binary NOT restarted`,
+    );
+    return code;
+  }
+
+  // ── Restart (helper-owned) ───────────────────────────────────────────────
+  if (unitManaged) {
+    // VM/Mac: restart the hub UNIT via the platform manager (systemctl restart
+    // / launchctl kickstart -k). The manager tears the old hub down (children
+    // die), starts the new binary, which re-boots every module from
+    // services.json. NEVER a PID signal — launchd KeepAlive / systemd
+    // Restart=always would fight it (R17). We mark `restarting`; we canNOT
+    // reliably write `succeeded` — the new hub's version is the SPA's success
+    // signal (it polls /health + /api/hub), not our file.
+    const res = restartUnit(hubUnitDeps);
+    for (const m of res.messages) append(configDir, {}, m);
+    if (res.outcome !== "ok") {
+      append(
+        configDir,
+        { phase: "failed", error: `hub unit restart ${res.outcome}` },
+        `hub binary rewritten but the unit restart ${res.outcome} — restart it manually`,
+      );
+      return 1;
+    }
+    append(
+      configDir,
+      { phase: "restarting" },
+      "hub unit restarted via the service manager — the SPA polls /health + version for the new binary",
+    );
+    return 0;
+  }
+
+  // Container path: the rewrite landed on the persistent disk (the endpoint
+  // already gated on mode === "in-place"; an image-pinned hub never spawns a
+  // helper). Now signal the hub to exit gracefully so the container runtime
+  // re-runs CMD (`serve`) on the rewritten binary. The hub's SIGTERM handler
+  // (cli.ts serve case) stops supervised children + the server cleanly, then
+  // the process exits and the runtime brings it back.
+  append(
+    configDir,
+    { phase: "restarting" },
+    "container: signalling the hub to exit gracefully so the runtime restarts it on the new binary",
+  );
+  if (args.hubPid !== undefined && Number.isFinite(args.hubPid) && args.hubPid > 0) {
+    try {
+      signalHub(args.hubPid, "SIGTERM");
+    } catch (err) {
+      // The hub may have already exited (a racing restart). Not fatal — the
+      // rewrite is done; the runtime will bring it back on the new binary
+      // regardless. Record + succeed.
+      const msg = err instanceof Error ? err.message : String(err);
+      append(configDir, {}, `hub graceful-exit signal noted as already-gone (${msg})`);
+    }
+  } else {
+    append(
+      configDir,
+      {},
+      "no hub pid provided — relying on the platform runtime's own restart to pick up the new binary",
+    );
+  }
+  return 0;
+}
+
+// ── Entrypoint (only runs when invoked directly as `bun hub-upgrade-helper.ts`) ──
+
+function parseArgs(argv: string[]): HubUpgradeHelperArgs | { error: string } {
+  let operationId: string | undefined;
+  let channel: string | undefined;
+  let configDir: string | undefined;
+  let hubPid: number | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    switch (arg) {
+      case "--op":
+        operationId = next;
+        i++;
+        break;
+      case "--channel":
+        channel = next;
+        i++;
+        break;
+      case "--config-dir":
+        configDir = next;
+        i++;
+        break;
+      case "--hub-pid":
+        if (next !== undefined) hubPid = Number(next);
+        i++;
+        break;
+      default:
+        return { error: `unexpected argument "${arg}"` };
+    }
+  }
+  if (!operationId) return { error: "--op <id> is required" };
+  if (channel !== "rc" && channel !== "latest") {
+    return { error: `--channel must be "rc" or "latest" (got "${channel ?? ""}")` };
+  }
+  const resolved: HubUpgradeHelperArgs = {
+    operationId,
+    channel,
+    configDir: configDir ?? CONFIG_DIR,
+  };
+  if (hubPid !== undefined && Number.isFinite(hubPid)) resolved.hubPid = hubPid;
+  return resolved;
+}
+
+async function main(): Promise<number> {
+  const parsed = parseArgs(process.argv.slice(2));
+  if ("error" in parsed) {
+    console.error(`hub-upgrade-helper: ${parsed.error}`);
+    return 2;
+  }
+  // If the endpoint never seeded the status file (it always should), bail
+  // visibly rather than silently no-op'ing.
+  if (!readHubUpgradeStatus(parsed.configDir)) {
+    console.error(
+      `hub-upgrade-helper: no status file for op ${parsed.operationId} under ${parsed.configDir}`,
+    );
+    return 2;
+  }
+  return await runHubUpgradeHelper(parsed);
+}
+
+if (import.meta.main) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error("hub-upgrade-helper: fatal", err);
+      process.exit(1);
+    });
+}

--- a/src/hub-upgrade-helper.ts
+++ b/src/hub-upgrade-helper.ts
@@ -102,6 +102,7 @@ export interface HubUpgradeHelperDeps {
   /** Append to the on-disk status file (test seam). */
   appendStatus?: (
     configDir: string,
+    operationId: string,
     patch: Partial<Pick<HubUpgradeStatus, "phase" | "error">>,
     logLine?: string,
   ) => void;
@@ -122,9 +123,14 @@ export async function runHubUpgradeHelper(
   const hubUnitDeps = deps.hubUnitDeps ?? defaultHubUnitDeps;
   const signalHub = deps.signalHub ?? ((pid, signal) => process.kill(pid, signal));
   const append = deps.appendStatus ?? appendHubUpgradeStatus;
-  const { configDir } = args;
+  const { configDir, operationId } = args;
 
-  append(configDir, { phase: "running" }, `hub-upgrade helper started (op ${args.operationId})`);
+  append(
+    configDir,
+    operationId,
+    { phase: "running" },
+    `hub-upgrade helper started (op ${operationId})`,
+  );
 
   const unitManaged = unitInstalledFn(hubUnitDeps);
 
@@ -141,7 +147,7 @@ export async function runHubUpgradeHelper(
     channel: args.channel,
     configDir,
     restartFn: async () => 0,
-    log: (line) => append(configDir, {}, line),
+    log: (line) => append(configDir, operationId, {}, line),
   };
 
   let code: number;
@@ -149,13 +155,14 @@ export async function runHubUpgradeHelper(
     code = await upgrade("hub", upgradeOpts);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    append(configDir, { phase: "failed", error: msg }, `hub-upgrade failed: ${msg}`);
+    append(configDir, operationId, { phase: "failed", error: msg }, `hub-upgrade failed: ${msg}`);
     return 1;
   }
 
   if (code !== 0) {
     append(
       configDir,
+      operationId,
       { phase: "failed", error: `upgrade exited ${code}` },
       `hub-upgrade rewrite failed (exit ${code}) — binary NOT restarted`,
     );
@@ -172,10 +179,11 @@ export async function runHubUpgradeHelper(
     // reliably write `succeeded` — the new hub's version is the SPA's success
     // signal (it polls /health + /api/hub), not our file.
     const res = restartUnit(hubUnitDeps);
-    for (const m of res.messages) append(configDir, {}, m);
+    for (const m of res.messages) append(configDir, operationId, {}, m);
     if (res.outcome !== "ok") {
       append(
         configDir,
+        operationId,
         { phase: "failed", error: `hub unit restart ${res.outcome}` },
         `hub binary rewritten but the unit restart ${res.outcome} — restart it manually`,
       );
@@ -183,6 +191,7 @@ export async function runHubUpgradeHelper(
     }
     append(
       configDir,
+      operationId,
       { phase: "restarting" },
       "hub unit restarted via the service manager — the SPA polls /health + version for the new binary",
     );
@@ -197,6 +206,7 @@ export async function runHubUpgradeHelper(
   // the process exits and the runtime brings it back.
   append(
     configDir,
+    operationId,
     { phase: "restarting" },
     "container: signalling the hub to exit gracefully so the runtime restarts it on the new binary",
   );

--- a/src/hub-upgrade-mode.ts
+++ b/src/hub-upgrade-mode.ts
@@ -73,6 +73,7 @@
 
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { CONTAINER_HOME } from "./hub-control.ts";
 import {
   type DetectInstallSourceDeps,
   type InstallSource,
@@ -111,10 +112,11 @@ export interface HubUpgradeModeResult {
 /**
  * The Render Blueprint pins `PARACHUTE_HOME=/parachute` — the single most
  * reliable container-mode signal the hub has (mirrors `api-hub.ts`'s
- * container override). Fly uses the same pin via the shared image.
+ * container override; both use the shared `CONTAINER_HOME` constant). Fly uses
+ * the same pin via the shared image.
  */
 function isContainer(env: Record<string, string | undefined>): boolean {
-  return env.PARACHUTE_HOME === "/parachute";
+  return env.PARACHUTE_HOME === CONTAINER_HOME;
 }
 
 /**

--- a/src/hub-upgrade-mode.ts
+++ b/src/hub-upgrade-mode.ts
@@ -1,0 +1,207 @@
+/**
+ * In-place-vs-redeploy detection for `POST /api/hub/upgrade` (design
+ * 2026-06-01 §5.3 — the OPEN implementation detail flagged for D4).
+ *
+ * The hub-upgrade endpoint must decide, BEFORE it spawns the detached helper,
+ * whether an on-disk binary rewrite (`bun add -g @openparachute/hub@<channel>`
+ * / a linked git-pull) will actually PERSIST across the next restart:
+ *
+ *   - **in-place** — the hub binary lives on a writable, persistent location
+ *     (a bun-linked checkout, or a `bun add -g` install under a $BUN_INSTALL
+ *     that survives restart). A rewrite + restart genuinely upgrades the hub.
+ *
+ *   - **redeploy-required** — the hub binary is baked into a container image
+ *     (Render/Fly image-pinned). `bun add -g` would write to the image's
+ *     ephemeral layer and be LOST on the next container restart, so the rewrite
+ *     is a misleading no-op. The honest path is a platform redeploy from the
+ *     operator's dashboard, NOT a false "upgraded."
+ *
+ * ── THE HEURISTIC (conservative; flagged for review) ───────────────────────
+ *
+ * Signals, in priority order:
+ *
+ *   1. **bun-linked** (`detectHubInstallSource` → `bun-linked`): the hub runs
+ *      from a git checkout on disk. A `git pull` in that checkout is always
+ *      persistent (the checkout is the operator's own filesystem, not an image
+ *      layer). → **in-place**. This is Aaron's dev box + every VM/Mac that
+ *      bun-linked the hub.
+ *
+ *   2. **container, BUN_INSTALL on the persistent disk**: a container (the
+ *      Render Blueprint pins `PARACHUTE_HOME=/parachute`) whose `$BUN_INSTALL`
+ *      points INSIDE the persistent mount (`/parachute/...` — the same place
+ *      runtime module installs land via `/api/modules/:short/install`). A
+ *      `bun add -g` there writes to the mounted volume, which survives a
+ *      container restart. → **in-place**. This is the "hub installed to the
+ *      persistent disk" arm §5.3 calls out.
+ *
+ *   3. **container, BUN_INSTALL NOT on the persistent disk** (or unset): the
+ *      hub is image-pinned — `bun add -g` writes to the ephemeral image layer
+ *      and is lost on restart. → **redeploy-required**. This is the default
+ *      Render/Fly image shape today (the Dockerfile `bun add`s the hub into the
+ *      image; $BUN_INSTALL defaults to `/root/.bun`, not the mount).
+ *
+ *   4. **npm, non-container**: a `bun add -g` install on a VM/Mac (not a
+ *      container). The global bun prefix is on the operator's own writable
+ *      filesystem → persistent. → **in-place**.
+ *
+ *   5. **unknown / anything else**: we couldn't classify the install source.
+ *      → **redeploy-required** (the honest fallback — §5.3: "When uncertain,
+ *      prefer redeploy-required over a silent no-op"). The SPA then tells the
+ *      operator to redeploy rather than promising an upgrade that may evaporate.
+ *
+ * ── FALSE-POSITIVE / FALSE-NEGATIVE RISK (for the reviewer) ─────────────────
+ *
+ *   - **False "in-place" (the dangerous direction)** would tell the operator
+ *     "upgraded" while the rewrite silently evaporates on the next restart.
+ *     The only path that risks this is signal #2: a container whose
+ *     `$BUN_INSTALL` is under the persistent mount but where the operator
+ *     mounted the disk read-only, or where the bun cache (not the install) is
+ *     what's on the mount. We mitigate by requiring `$BUN_INSTALL` to be a
+ *     descendant of the persistent-home prefix — the strictest signal available
+ *     without probing writability (which we can't do reliably from the request
+ *     handler before spawning the helper). A residual risk remains; see the
+ *     note in `detectHubUpgradeMode` on tightening this with a write-probe in
+ *     the helper if it proves wrong in the field.
+ *
+ *   - **False "redeploy-required" (the safe direction)** merely tells the
+ *     operator to redeploy when an in-place upgrade would have worked — annoying
+ *     but never destructive. Signals #3/#5 deliberately err here.
+ *
+ * Pure + injectable: no I/O beyond the (already-injectable) install-source
+ * detection. The env + srcDir are passed in so tests drive every branch.
+ */
+
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  type DetectInstallSourceDeps,
+  type InstallSource,
+  detectHubInstallSource,
+} from "./install-source.ts";
+
+/** The two upgrade modes the SPA branches on. */
+export type HubUpgradeMode = "in-place" | "redeploy-required";
+
+export interface DetectHubUpgradeModeArgs {
+  /** Override `process.env` lookups (test seam). */
+  env?: Record<string, string | undefined>;
+  /**
+   * Directory used to locate the hub's package.json + classify install source.
+   * Defaults to the running source dir. Test seam.
+   */
+  hubSrcDir?: string;
+  /** Pass-through deps for `detectHubInstallSource` (test seam). */
+  installSourceDeps?: DetectInstallSourceDeps;
+  /**
+   * Pre-classified install source — lets a caller that already ran
+   * `detectHubInstallSource` (e.g. the `/api/hub` handler) avoid a second
+   * filesystem walk. When set, `hubSrcDir`/`installSourceDeps` are ignored.
+   */
+  source?: InstallSource;
+}
+
+export interface HubUpgradeModeResult {
+  mode: HubUpgradeMode;
+  /** The classified install source (surfaced for diagnostics + the SPA copy). */
+  source: InstallSource["kind"] | "container";
+  /** Short human-readable reason — surfaced in the 202 body + SPA + tests. */
+  reason: string;
+}
+
+/**
+ * The Render Blueprint pins `PARACHUTE_HOME=/parachute` — the single most
+ * reliable container-mode signal the hub has (mirrors `api-hub.ts`'s
+ * container override). Fly uses the same pin via the shared image.
+ */
+function isContainer(env: Record<string, string | undefined>): boolean {
+  return env.PARACHUTE_HOME === "/parachute";
+}
+
+/**
+ * True when `$BUN_INSTALL` is a descendant of the persistent-home prefix —
+ * i.e. `bun add -g` writes land on the mounted volume that survives a
+ * container restart. The persistent home on the Render Blueprint is
+ * `/parachute`; we treat any `$BUN_INSTALL` under it as persistent.
+ *
+ * Strict (descendant-of), not a substring match, so a stray `/parachute` in
+ * an unrelated path component can't false-positive.
+ */
+function bunInstallOnPersistentDisk(env: Record<string, string | undefined>): boolean {
+  const bunInstall = env.BUN_INSTALL;
+  const home = env.PARACHUTE_HOME;
+  if (!bunInstall || !home) return false;
+  if (bunInstall === home) return true;
+  const prefix = home.endsWith("/") ? home : `${home}/`;
+  return bunInstall.startsWith(prefix);
+}
+
+/**
+ * Decide whether the hub is in-place-upgradable (rewrite + restart works) or
+ * image-pinned (redeploy-only). See the module docstring for the full
+ * heuristic + risk analysis.
+ */
+export function detectHubUpgradeMode(args: DetectHubUpgradeModeArgs = {}): HubUpgradeModeResult {
+  const env = args.env ?? process.env;
+  const hubSrcDir = args.hubSrcDir ?? dirname(fileURLToPath(import.meta.url));
+  const source = args.source ?? detectHubInstallSource(hubSrcDir, args.installSourceDeps);
+
+  const container = isContainer(env);
+
+  // Signal 1: bun-linked checkout. A `git pull` in the operator's own checkout
+  // is always persistent — even inside a container the checkout dir is on the
+  // operator's filesystem, not the ephemeral image layer. (In practice a
+  // container runs from /app/src image-pinned, not a checkout — but if it IS a
+  // checkout, in-place is correct.)
+  if (source.kind === "bun-linked") {
+    return {
+      mode: "in-place",
+      source: container ? "container" : "bun-linked",
+      reason: "bun-linked checkout — git pull + restart persists on disk",
+    };
+  }
+
+  if (container) {
+    // Signal 2: container with $BUN_INSTALL on the persistent mount → the
+    // `bun add -g` write survives a container restart.
+    if (bunInstallOnPersistentDisk(env)) {
+      return {
+        mode: "in-place",
+        source: "container",
+        reason:
+          "container with $BUN_INSTALL on the persistent disk — bun add -g persists across restart",
+      };
+    }
+    // Signal 3: container, image-pinned. `bun add -g` writes to the ephemeral
+    // image layer → lost on restart. The honest path is a platform redeploy.
+    //
+    // NOTE (reviewer): we could tighten signal-2 confidence by having the
+    // helper write-probe `$BUN_INSTALL` before committing to the rewrite. We
+    // deliberately do the cheaper env-based classification here and accept
+    // erring toward redeploy-required (the safe direction) when uncertain.
+    return {
+      mode: "redeploy-required",
+      source: "container",
+      reason:
+        "container image-pinned ($BUN_INSTALL not on the persistent disk) — bun add -g would be lost on the next container restart; redeploy from your platform dashboard instead",
+    };
+  }
+
+  // Signal 4: npm install on a VM/Mac (non-container). The global bun prefix is
+  // on the operator's own writable filesystem → persistent.
+  if (source.kind === "npm") {
+    return {
+      mode: "in-place",
+      source: "npm",
+      reason: "npm-installed on a persistent filesystem — bun add -g persists",
+    };
+  }
+
+  // Signal 5: unknown. Honest fallback — prefer redeploy-required over a silent
+  // no-op (§5.3).
+  return {
+    mode: "redeploy-required",
+    source: "unknown",
+    reason:
+      "could not classify the hub install source — redeploy from your platform dashboard to be safe",
+  };
+}

--- a/src/hub-upgrade-status.ts
+++ b/src/hub-upgrade-status.ts
@@ -36,7 +36,13 @@ export type HubUpgradeStatusPhase =
    * write a terminal state (the hub it would report to is being torn down).
    */
   | "restarting"
-  /** Terminal success the helper managed to record before the bounce. */
+  /**
+   * Terminal success. RESERVED / SPA-INFERRED: the helper does NOT write this —
+   * it can't reliably record `succeeded` before the hub bounce tears down the
+   * process. The SPA infers success from `/health` + the reported version
+   * (HubUpgradeCard), not from this phase. Kept in the enum so the SPA success
+   * detection + the 409 in-flight guard's terminal-phase check can reference it.
+   */
   | "succeeded"
   /** Terminal failure (rewrite failed, downgrade refused, etc.). */
   | "failed"
@@ -110,18 +116,33 @@ export function readHubUpgradeStatus(configDir: string): HubUpgradeStatus | null
  * Used by the helper to record progress the SPA polls. A missing file (the
  * endpoint should always seed it first) is a no-op rather than a throw — the
  * helper's job is the upgrade, not bookkeeping.
+ *
+ * OPERATION GUARD: `operationId` is the op the caller (helper) was spawned
+ * with. The status file is single-slot — a newer `POST /api/hub/upgrade` will
+ * overwrite it with a fresh `operation_id`. A still-running helper from the
+ * SUPERSEDED operation must not clobber the newer operation's status with its
+ * stale progress. So we only write when the on-disk `operation_id` still
+ * matches `operationId`; otherwise the append is a NO-OP (the newer operation
+ * owns the slot now). This makes concurrent-upgrade status-file corruption
+ * impossible from the helper side.
  */
 export function appendHubUpgradeStatus(
   configDir: string,
+  operationId: string,
   patch: Partial<Pick<HubUpgradeStatus, "phase" | "error">>,
   logLine?: string,
 ): void {
   const current = readHubUpgradeStatus(configDir);
   if (!current) return;
+  // A newer operation superseded this one — do NOT clobber its status.
+  if (current.operation_id !== operationId) return;
   const next: HubUpgradeStatus = { ...current };
   if (patch.phase) next.phase = patch.phase;
   if (patch.error !== undefined) next.error = patch.error;
   if (logLine) next.log = [...current.log, logLine];
+  // `succeeded` is reserved/SPA-inferred (see HubUpgradeStatusPhase) — the
+  // helper can't reliably write it before the hub bounce, so in practice only
+  // `failed` reaches this branch. Both terminal phases stamp `finished_at`.
   if (patch.phase === "succeeded" || patch.phase === "failed") {
     next.finished_at = new Date().toISOString();
   }

--- a/src/hub-upgrade-status.ts
+++ b/src/hub-upgrade-status.ts
@@ -1,0 +1,129 @@
+/**
+ * The on-disk status file for an in-flight `POST /api/hub/upgrade` operation
+ * (design 2026-06-01 §5.3 / D4).
+ *
+ * WHY A FILE, NOT THE IN-MEMORY OPERATIONS REGISTRY: a hub-upgrade tears the
+ * hub DOWN mid-operation (the whole point — the new binary has to take over).
+ * The module-ops `InMemoryOperationsRegistry` is process-local and evaporates
+ * when the hub restarts, so it CANNOT carry hub-upgrade progress across the
+ * restart the SPA is polling through. A JSON file under `PARACHUTE_HOME`
+ * survives the hub bounce: the detached helper writes progress to it while the
+ * old hub is dying, and the NEW hub reads it back to answer
+ * `GET /api/hub/upgrade/status`. (On a container the file lives on the
+ * persistent disk — same place the DB + module installs live.)
+ *
+ * The file is single-slot (one upgrade at a time — there is only one hub). A
+ * stale file from a prior upgrade is simply overwritten when a new one starts.
+ *
+ * Wire shape mirrors the module-ops `Operation` enough that the SPA's polling
+ * code reads familiarly: `status` + `log` + `error` + timestamps, plus the
+ * hub-specific `mode` / `target_version` / `channel` the SPA branches on.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { HubUpgradeMode } from "./hub-upgrade-mode.ts";
+
+/** Phases of a hub-upgrade, polled by the SPA. */
+export type HubUpgradeStatusPhase =
+  /** The endpoint accepted the request + spawned the helper; not started yet. */
+  | "pending"
+  /** The helper is rewriting the binary / about to restart. */
+  | "running"
+  /**
+   * The rewrite + restart were dispatched. The SPA now switches to polling
+   * `/health` + the reported version directly — the helper may not get to
+   * write a terminal state (the hub it would report to is being torn down).
+   */
+  | "restarting"
+  /** Terminal success the helper managed to record before the bounce. */
+  | "succeeded"
+  /** Terminal failure (rewrite failed, downgrade refused, etc.). */
+  | "failed"
+  /**
+   * The endpoint determined the hub is image-pinned (redeploy-required) and did
+   * NOT spawn a helper — there's no in-place upgrade to run. The SPA shows
+   * "redeploy from your platform dashboard" instead of a progress spinner.
+   */
+  | "redeploy-required";
+
+export interface HubUpgradeStatus {
+  /** Opaque id minted by the endpoint; echoed in the 202 body for polling. */
+  operation_id: string;
+  phase: HubUpgradeStatusPhase;
+  /** In-place vs redeploy-required (the §5.3 detection result). */
+  mode: HubUpgradeMode;
+  /** The version the operator is currently on (read at request time). */
+  current_version: string;
+  /** Best-effort resolved target version (`npm view`), or null if unknown. */
+  target_version: string | null;
+  /** Closed-enum channel the rewrite targets. */
+  channel: "rc" | "latest";
+  /** Sparse progress log, appended by the helper. */
+  log: string[];
+  /** Error message when `phase === "failed"`. */
+  error?: string;
+  started_at: string;
+  finished_at?: string;
+}
+
+/** Path of the single-slot hub-upgrade status file under `configDir`. */
+export function hubUpgradeStatusPath(configDir: string): string {
+  return join(configDir, "hub-upgrade-status.json");
+}
+
+/**
+ * Atomically write the status file (write-temp + rename) so a poll that lands
+ * mid-write never sees a half-serialized JSON. Creates the parent dir if
+ * absent (a never-initialized PARACHUTE_HOME).
+ */
+export function writeHubUpgradeStatus(configDir: string, status: HubUpgradeStatus): void {
+  const path = hubUpgradeStatusPath(configDir);
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(status, null, 2)}\n`, { mode: 0o600 });
+  renameSync(tmp, path);
+}
+
+/**
+ * Read the current status file, or null when none exists / is unreadable.
+ * Lenient: a malformed file reads as null (the SPA falls back to polling
+ * `/health` directly), never throws.
+ */
+export function readHubUpgradeStatus(configDir: string): HubUpgradeStatus | null {
+  const path = hubUpgradeStatusPath(configDir);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    if (parsed && typeof parsed === "object" && "operation_id" in parsed) {
+      return parsed as HubUpgradeStatus;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Append a log line + (optionally) advance the phase, persisting atomically.
+ * Used by the helper to record progress the SPA polls. A missing file (the
+ * endpoint should always seed it first) is a no-op rather than a throw — the
+ * helper's job is the upgrade, not bookkeeping.
+ */
+export function appendHubUpgradeStatus(
+  configDir: string,
+  patch: Partial<Pick<HubUpgradeStatus, "phase" | "error">>,
+  logLine?: string,
+): void {
+  const current = readHubUpgradeStatus(configDir);
+  if (!current) return;
+  const next: HubUpgradeStatus = { ...current };
+  if (patch.phase) next.phase = patch.phase;
+  if (patch.error !== undefined) next.error = patch.error;
+  if (logLine) next.log = [...current.log, logLine];
+  if (patch.phase === "succeeded" || patch.phase === "failed") {
+    next.finished_at = new Date().toISOString();
+  }
+  writeHubUpgradeStatus(configDir, next);
+}

--- a/web/ui/src/components/HubUpgradeCard.test.tsx
+++ b/web/ui/src/components/HubUpgradeCard.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * HubUpgradeCard component tests (design 2026-06-01 §5.3 / D4) — the four
+ * upgrade-flow states the no-shell operator sees:
+ *   - in-progress ("upgrading… the hub will restart")
+ *   - success (the new version answers)
+ *   - timeout ("the hub may still be coming up — refresh shortly")
+ *   - redeploy-required (image-pinned container → dashboard hint, NO spinner)
+ *
+ * The polling loop is driven with fake timers so the success/timeout paths are
+ * deterministic. `getHubStatus` / `startHubUpgrade` / `getHubUpgradeStatus` are
+ * mocked off `../lib/api.ts`.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { HubStatus, HubUpgradeAccepted } from "../lib/api.ts";
+import * as api from "../lib/api.ts";
+import { HubUpgradeCard } from "./HubUpgradeCard.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    getHubStatus: vi.fn(),
+    startHubUpgrade: vi.fn(),
+    getHubUpgradeStatus: vi.fn(),
+  };
+});
+
+const mkStatus = (overrides: Partial<HubStatus> = {}): HubStatus => ({
+  version: "0.6.3-rc.1",
+  started_at: "2026-06-01T00:00:00.000Z",
+  uptime_ms: 1000,
+  source: "container",
+  ...overrides,
+});
+
+const accepted = (overrides: Partial<HubUpgradeAccepted> = {}): HubUpgradeAccepted => ({
+  operation_id: "op-1",
+  target_version: "0.6.3-rc.2",
+  channel: "rc",
+  mode: "in-place",
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("HubUpgradeCard — initial render", () => {
+  it("renders nothing until the hub status resolves", () => {
+    vi.mocked(api.getHubStatus).mockReturnValue(new Promise(() => {}));
+    const { container } = render(<HubUpgradeCard />);
+    expect(container.querySelector("[data-testid=hub-upgrade-card]")).toBeNull();
+  });
+
+  it("renders current version + Upgrade button once status loads", async () => {
+    vi.mocked(api.getHubStatus).mockResolvedValue(mkStatus());
+    render(<HubUpgradeCard />);
+    await waitFor(() => expect(screen.getByTestId("hub-upgrade-card")).toBeInTheDocument());
+    expect(screen.getByTestId("hub-current-version")).toHaveTextContent("v0.6.3-rc.1");
+    expect(screen.getByTestId("hub-upgrade-button")).toHaveTextContent("Upgrade hub");
+  });
+});
+
+describe("HubUpgradeCard — in-progress + success", () => {
+  it("shows upgrading then success when the new version answers", async () => {
+    vi.useFakeTimers();
+    // First getHubStatus (mount) → current; subsequent polls → new version.
+    vi.mocked(api.getHubStatus)
+      .mockResolvedValueOnce(mkStatus({ version: "0.6.3-rc.1" }))
+      .mockResolvedValue(mkStatus({ version: "0.6.3-rc.2" }));
+    vi.mocked(api.startHubUpgrade).mockResolvedValue(accepted());
+    vi.mocked(api.getHubUpgradeStatus).mockResolvedValue(null);
+
+    render(<HubUpgradeCard />);
+    await vi.waitFor(() => expect(screen.getByTestId("hub-upgrade-card")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("hub-upgrade-button"));
+    // The POST resolves → "upgrading" state.
+    await vi.waitFor(() =>
+      expect(screen.getByTestId("hub-upgrade-state-upgrading")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("hub-upgrade-state-upgrading")).toHaveTextContent("0.6.3-rc.2");
+
+    // Advance the poll loop — the new version answers → success.
+    await vi.advanceTimersByTimeAsync(2100);
+    await vi.waitFor(() =>
+      expect(screen.getByTestId("hub-upgrade-state-success")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("hub-upgrade-state-success")).toHaveTextContent("0.6.3-rc.2");
+  });
+});
+
+describe("HubUpgradeCard — timeout", () => {
+  it("shows the timeout copy when the new version never answers", async () => {
+    vi.useFakeTimers();
+    // Mount → current; every poll → still the same version (never upgrades).
+    vi.mocked(api.getHubStatus).mockResolvedValue(mkStatus({ version: "0.6.3-rc.1" }));
+    vi.mocked(api.startHubUpgrade).mockResolvedValue(accepted());
+    vi.mocked(api.getHubUpgradeStatus).mockResolvedValue({
+      operation_id: "op-1",
+      phase: "restarting",
+      mode: "in-place",
+      current_version: "0.6.3-rc.1",
+      target_version: "0.6.3-rc.2",
+      channel: "rc",
+      log: ["hub unit restarted via the service manager"],
+      started_at: "2026-06-01T00:00:00.000Z",
+    });
+
+    render(<HubUpgradeCard />);
+    await vi.waitFor(() => expect(screen.getByTestId("hub-upgrade-card")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("hub-upgrade-button"));
+    await vi.waitFor(() =>
+      expect(screen.getByTestId("hub-upgrade-state-upgrading")).toBeInTheDocument(),
+    );
+
+    // Blow past the 120s bounded deadline.
+    await vi.advanceTimersByTimeAsync(125_000);
+    await vi.waitFor(() =>
+      expect(screen.getByTestId("hub-upgrade-state-timeout")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("hub-upgrade-state-timeout")).toHaveTextContent(
+      "may still be coming up",
+    );
+    // The last status log line is surfaced as the unit/platform hint.
+    expect(screen.getByTestId("hub-upgrade-state-timeout")).toHaveTextContent(
+      "hub unit restarted via the service manager",
+    );
+  });
+});
+
+describe("HubUpgradeCard — redeploy-required (image-pinned)", () => {
+  it("shows the dashboard hint and NO upgrade-progress spinner", async () => {
+    vi.mocked(api.getHubStatus).mockResolvedValue(mkStatus({ source: "container" }));
+    vi.mocked(api.startHubUpgrade).mockResolvedValue(
+      accepted({ mode: "redeploy-required", target_version: "0.6.3-rc.2" }),
+    );
+
+    render(<HubUpgradeCard />);
+    await waitFor(() => expect(screen.getByTestId("hub-upgrade-card")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("hub-upgrade-button"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("hub-upgrade-state-redeploy")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("hub-upgrade-state-redeploy")).toHaveTextContent(
+      /redeploy from your platform dashboard/i,
+    );
+    // The upgrade button is replaced by a redeploy hint (no no-op button).
+    expect(screen.queryByTestId("hub-upgrade-button")).toBeNull();
+    expect(screen.getByTestId("hub-redeploy-hint")).toBeInTheDocument();
+  });
+});
+
+describe("HubUpgradeCard — error", () => {
+  it("surfaces a POST failure", async () => {
+    vi.mocked(api.getHubStatus).mockResolvedValue(mkStatus());
+    vi.mocked(api.startHubUpgrade).mockRejectedValue(new Error("boom"));
+
+    render(<HubUpgradeCard />);
+    await waitFor(() => expect(screen.getByTestId("hub-upgrade-card")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("hub-upgrade-button"));
+    await waitFor(() => expect(screen.getByTestId("hub-upgrade-state-error")).toBeInTheDocument());
+    expect(screen.getByTestId("hub-upgrade-state-error")).toHaveTextContent("boom");
+  });
+});

--- a/web/ui/src/components/HubUpgradeCard.test.tsx
+++ b/web/ui/src/components/HubUpgradeCard.test.tsx
@@ -94,6 +94,33 @@ describe("HubUpgradeCard — in-progress + success", () => {
     );
     expect(screen.getByTestId("hub-upgrade-state-success")).toHaveTextContent("0.6.3-rc.2");
   });
+
+  it("resolves a NO-OP upgrade as success (version unchanged but == target)", async () => {
+    vi.useFakeTimers();
+    // The operator is ALREADY on the target version — the hub restarts on the
+    // SAME version, so the version-changed signal never fires. The
+    // healthy-and-==-target arm must resolve it as success (not a 120s timeout).
+    vi.mocked(api.getHubStatus).mockResolvedValue(mkStatus({ version: "0.6.3-rc.2" }));
+    // The accepted body's target_version equals the current version (no-op).
+    vi.mocked(api.startHubUpgrade).mockResolvedValue(accepted({ target_version: "0.6.3-rc.2" }));
+    vi.mocked(api.getHubUpgradeStatus).mockResolvedValue(null);
+
+    render(<HubUpgradeCard />);
+    await vi.waitFor(() => expect(screen.getByTestId("hub-upgrade-card")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("hub-upgrade-button"));
+    await vi.waitFor(() =>
+      expect(screen.getByTestId("hub-upgrade-state-upgrading")).toBeInTheDocument(),
+    );
+
+    // One poll cycle — healthy + version == target → success, NOT a timeout.
+    await vi.advanceTimersByTimeAsync(2100);
+    await vi.waitFor(() =>
+      expect(screen.getByTestId("hub-upgrade-state-success")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("hub-upgrade-state-success")).toHaveTextContent("0.6.3-rc.2");
+    expect(screen.queryByTestId("hub-upgrade-state-timeout")).toBeNull();
+  });
 });
 
 describe("HubUpgradeCard — timeout", () => {

--- a/web/ui/src/components/HubUpgradeCard.tsx
+++ b/web/ui/src/components/HubUpgradeCard.tsx
@@ -90,12 +90,22 @@ export function HubUpgradeCard() {
   }, []);
 
   /**
-   * Poll /api/hub for a version change + the upgrade status log. The hub is
+   * Poll /api/hub for the new version + the upgrade status log. The hub is
    * down mid-restart, so both fetches may throw — swallow and keep polling
-   * until the new version answers or the bounded deadline passes.
+   * until the new hub answers or the bounded deadline passes.
+   *
+   * Success is EITHER:
+   *   - the reported version differs from the pre-upgrade version (the common
+   *     case — an actual version bump), OR
+   *   - the hub is healthy again AND its version equals the resolved target
+   *     (handles a NO-OP upgrade: the operator was already on the target, so
+   *     the version never changes — without this arm such an upgrade would hit
+   *     the 120s timeout with misleading "may still be coming up" copy).
+   * When `targetVersion` is unknown (registry miss), we fall back to the
+   * version-changed signal only.
    */
   const pollForNewVersion = useCallback(
-    (previousVersion: string) => {
+    (previousVersion: string, targetVersion: string | null) => {
       deadlineRef.current = Date.now() + UPGRADE_TIMEOUT_MS;
       stopPolling();
       pollRef.current = setInterval(() => {
@@ -112,11 +122,17 @@ export function HubUpgradeCard() {
           } catch {
             // status endpoint unreachable mid-restart — expected.
           }
-          if (newStatus && newStatus.version !== previousVersion) {
-            stopPolling();
-            setHub(newStatus);
-            setState({ kind: "succeeded", newVersion: newStatus.version });
-            return;
+          if (newStatus) {
+            const versionChanged = newStatus.version !== previousVersion;
+            // No-op upgrade: healthy + already on the target version. `newStatus`
+            // answering at all means the hub is healthy (the fetch resolved).
+            const reachedTarget = targetVersion !== null && newStatus.version === targetVersion;
+            if (versionChanged || reachedTarget) {
+              stopPolling();
+              setHub(newStatus);
+              setState({ kind: "succeeded", newVersion: newStatus.version });
+              return;
+            }
           }
           if (upgradeStatus?.phase === "failed") {
             stopPolling();
@@ -149,7 +165,7 @@ export function HubUpgradeCard() {
         return;
       }
       setState({ kind: "upgrading", previousVersion, targetVersion: accepted.target_version });
-      pollForNewVersion(previousVersion);
+      pollForNewVersion(previousVersion, accepted.target_version);
     } catch (err) {
       setState({ kind: "error", message: err instanceof Error ? err.message : String(err) });
     }

--- a/web/ui/src/components/HubUpgradeCard.tsx
+++ b/web/ui/src/components/HubUpgradeCard.tsx
@@ -1,0 +1,259 @@
+/**
+ * "Upgrade hub" affordance for the admin SPA (design 2026-06-01 §5.3 / D4).
+ *
+ * The hub is NOT a supervised module, so it doesn't get a row in the Modules
+ * list — it's the host. This card sits at the TOP of /admin/modules (above
+ * "Installed modules"), the management surface alongside the per-module upgrade
+ * buttons, and gives the no-shell (Render/Fly) operator a way to upgrade the
+ * hub itself.
+ *
+ * THE FLOW:
+ *   1. Show current hub version + target version + channel + an Upgrade button.
+ *   2. On click → POST /api/hub/upgrade → 202 { mode }.
+ *      - `mode: "in-place"` → the detached helper rewrites + restarts the hub.
+ *        We enter the "upgrading…" state and POLL /api/hub (version) + the
+ *        upgrade status until the NEW version answers (bounded timeout). The
+ *        hub goes DOWN mid-upgrade, so fetches throw — that's expected; we
+ *        swallow and keep polling. Success = /api/hub reports a version that
+ *        differs from the pre-upgrade one (or matches the resolved target).
+ *      - `mode: "redeploy-required"` → the hub is image-pinned (Render/Fly).
+ *        We do NOT show a spinner; we show "redeploy from your platform
+ *        dashboard" with the target version, because an in-place rewrite would
+ *        be lost on the next container restart (§5.3).
+ *   3. Timeout → "the hub may still be coming up — refresh shortly," plus the
+ *      most recent status log line (the unit/platform hint) when available.
+ *
+ * Auth/Bearer rides the same `getHostAdminToken` mint-and-cache as every other
+ * /api/* call (via lib/api.ts).
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type HubStatus,
+  type HubUpgradeMode,
+  type HubUpgradeStatus,
+  getHubStatus,
+  getHubUpgradeStatus,
+  startHubUpgrade,
+} from "../lib/api.ts";
+
+/** Poll cadence while waiting for the new hub to answer. */
+const POLL_INTERVAL_MS = 2000;
+/** Bounded wait before we surface the "may still be coming up" timeout copy. */
+const UPGRADE_TIMEOUT_MS = 120_000;
+
+type CardState =
+  | { kind: "idle" }
+  /** POST sent; waiting on the 202 + detection. */
+  | { kind: "starting" }
+  /** in-place upgrade dispatched; polling for the new version. */
+  | { kind: "upgrading"; previousVersion: string; targetVersion: string | null }
+  /** new hub answered with a different version. */
+  | { kind: "succeeded"; newVersion: string }
+  /** bounded timeout elapsed without the new version answering. */
+  | { kind: "timeout"; lastLog: string | null }
+  /** image-pinned container — redeploy from the platform dashboard. */
+  | { kind: "redeploy-required"; targetVersion: string | null }
+  /** the upgrade failed before/at dispatch. */
+  | { kind: "error"; message: string };
+
+export function HubUpgradeCard() {
+  const [hub, setHub] = useState<HubStatus | null>(null);
+  const [state, setState] = useState<CardState>({ kind: "idle" });
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const deadlineRef = useRef<number>(0);
+
+  const loadHub = useCallback(async () => {
+    try {
+      setHub(await getHubStatus());
+    } catch {
+      // 401/403/network — the badge + this card collapse silently; the rest of
+      // the SPA drives the auth redirect.
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadHub();
+  }, [loadHub]);
+
+  // Clean up the poll timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, []);
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  /**
+   * Poll /api/hub for a version change + the upgrade status log. The hub is
+   * down mid-restart, so both fetches may throw — swallow and keep polling
+   * until the new version answers or the bounded deadline passes.
+   */
+  const pollForNewVersion = useCallback(
+    (previousVersion: string) => {
+      deadlineRef.current = Date.now() + UPGRADE_TIMEOUT_MS;
+      stopPolling();
+      pollRef.current = setInterval(() => {
+        void (async () => {
+          let newStatus: HubStatus | null = null;
+          let upgradeStatus: HubUpgradeStatus | null = null;
+          try {
+            newStatus = await getHubStatus();
+          } catch {
+            // hub still restarting — expected.
+          }
+          try {
+            upgradeStatus = await getHubUpgradeStatus();
+          } catch {
+            // status endpoint unreachable mid-restart — expected.
+          }
+          if (newStatus && newStatus.version !== previousVersion) {
+            stopPolling();
+            setHub(newStatus);
+            setState({ kind: "succeeded", newVersion: newStatus.version });
+            return;
+          }
+          if (upgradeStatus?.phase === "failed") {
+            stopPolling();
+            setState({
+              kind: "error",
+              message: upgradeStatus.error ?? "the hub upgrade failed — check the platform log",
+            });
+            return;
+          }
+          if (Date.now() >= deadlineRef.current) {
+            stopPolling();
+            const lastLog = upgradeStatus?.log.at(-1) ?? null;
+            setState({ kind: "timeout", lastLog });
+          }
+        })();
+      }, POLL_INTERVAL_MS);
+    },
+    [stopPolling],
+  );
+
+  async function onUpgrade() {
+    if (!hub) return;
+    const previousVersion = hub.version;
+    setState({ kind: "starting" });
+    try {
+      const accepted = await startHubUpgrade();
+      const mode: HubUpgradeMode = accepted.mode;
+      if (mode === "redeploy-required") {
+        setState({ kind: "redeploy-required", targetVersion: accepted.target_version });
+        return;
+      }
+      setState({ kind: "upgrading", previousVersion, targetVersion: accepted.target_version });
+      pollForNewVersion(previousVersion);
+    } catch (err) {
+      setState({ kind: "error", message: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  if (!hub) return null;
+
+  return (
+    <section className="hub-upgrade-card install-card" data-testid="hub-upgrade-card">
+      <div className="install-card-body">
+        <h3>
+          Hub <span className="muted">(@openparachute/hub)</span>
+        </h3>
+        <p className="install-card-meta muted">
+          Installed <code data-testid="hub-current-version">v{hub.version}</code> · source{" "}
+          <code>{hub.source}</code>
+        </p>
+        <HubUpgradeStatusLine state={state} />
+      </div>
+      <div className="install-card-actions">
+        <HubUpgradeAction state={state} onUpgrade={() => void onUpgrade()} />
+      </div>
+    </section>
+  );
+}
+
+function HubUpgradeAction({
+  state,
+  onUpgrade,
+}: {
+  state: CardState;
+  onUpgrade: () => void;
+}) {
+  // Redeploy-required: NO upgrade button that would no-op. Direct to the
+  // platform dashboard instead.
+  if (state.kind === "redeploy-required") {
+    return (
+      <span className="muted" data-testid="hub-redeploy-hint">
+        Redeploy from your platform dashboard
+      </span>
+    );
+  }
+  const busy = state.kind === "starting" || state.kind === "upgrading";
+  return (
+    <button type="button" onClick={onUpgrade} disabled={busy} data-testid="hub-upgrade-button">
+      {busy ? "Upgrading…" : "Upgrade hub"}
+    </button>
+  );
+}
+
+function HubUpgradeStatusLine({ state }: { state: CardState }) {
+  switch (state.kind) {
+    case "idle":
+      return null;
+    case "starting":
+      return (
+        <p className="muted" data-testid="hub-upgrade-state-starting">
+          Starting the hub upgrade…
+        </p>
+      );
+    case "upgrading":
+      return (
+        <p className="muted" data-testid="hub-upgrade-state-upgrading">
+          Upgrading{state.targetVersion ? ` to v${state.targetVersion}` : ""}… the hub will restart;
+          this page reconnects automatically.
+        </p>
+      );
+    case "succeeded":
+      return (
+        <p className="muted" data-testid="hub-upgrade-state-success">
+          Upgraded — the hub is now running <code>v{state.newVersion}</code>.
+        </p>
+      );
+    case "timeout":
+      return (
+        <p className="warn-banner" data-testid="hub-upgrade-state-timeout">
+          The hub may still be coming up — refresh shortly.
+          {state.lastLog ? (
+            <>
+              {" "}
+              <span className="dim">Last status: {state.lastLog}</span>
+            </>
+          ) : null}
+        </p>
+      );
+    case "redeploy-required":
+      return (
+        <p className="warn-banner" data-testid="hub-upgrade-state-redeploy">
+          This hub is baked into its container image, so an in-place upgrade wouldn't survive a
+          restart.{" "}
+          {state.targetVersion ? (
+            <>
+              Redeploy from your platform dashboard to move to <code>v{state.targetVersion}</code>.
+            </>
+          ) : (
+            <>Redeploy from your platform dashboard to pick up the latest hub.</>
+          )}
+        </p>
+      );
+    case "error":
+      return (
+        <p className="error-banner" data-testid="hub-upgrade-state-error">
+          Upgrade failed: {state.message}
+        </p>
+      );
+  }
+}

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1355,6 +1355,93 @@ export async function getHubStatus(): Promise<HubStatus> {
   return (await res.json()) as HubStatus;
 }
 
+/**
+ * SPA-driven hub self-upgrade (design 2026-06-01 §5.3 / D4). The hub is NOT a
+ * supervised module, so it has a dedicated endpoint pair:
+ *   - POST /api/hub/upgrade        → 202 { operation_id, target_version, channel, mode }
+ *   - GET  /api/hub/upgrade/status → poll the on-disk status the detached helper writes
+ *
+ * `mode` is the §5.3 in-place-vs-redeploy detection: `in-place` means the hub
+ * was rewritten + (about to be) restarted; `redeploy-required` means the hub is
+ * image-pinned (Render/Fly) and the operator must redeploy from their dashboard
+ * — the SPA shows that instead of a false "upgraded."
+ */
+export type HubUpgradeMode = "in-place" | "redeploy-required";
+export type HubUpgradeChannel = "rc" | "latest";
+
+export interface HubUpgradeAccepted {
+  operation_id: string;
+  target_version: string | null;
+  channel: HubUpgradeChannel;
+  mode: HubUpgradeMode;
+}
+
+export type HubUpgradePhase =
+  | "pending"
+  | "running"
+  | "restarting"
+  | "succeeded"
+  | "failed"
+  | "redeploy-required";
+
+export interface HubUpgradeStatus {
+  operation_id: string;
+  phase: HubUpgradePhase;
+  mode: HubUpgradeMode;
+  current_version: string;
+  target_version: string | null;
+  channel: HubUpgradeChannel;
+  log: string[];
+  error?: string;
+  started_at: string;
+  finished_at?: string;
+}
+
+/**
+ * POST /api/hub/upgrade — kick off the hub self-upgrade. Returns the 202 body.
+ * The optional `channel` is the closed enum the backend validates (rc|latest);
+ * omit it to let the hub auto-detect from its current version.
+ */
+export async function startHubUpgrade(channel?: HubUpgradeChannel): Promise<HubUpgradeAccepted> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch("/api/hub/upgrade", {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${bearer}`,
+      ...(channel ? { "content-type": "application/json" } : {}),
+    },
+    ...(channel ? { body: JSON.stringify({ channel }) } : {}),
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as HubUpgradeAccepted;
+}
+
+/**
+ * GET /api/hub/upgrade/status — poll the on-disk upgrade status. Returns null
+ * when no upgrade has been started (404) — the SPA treats that as "idle." A
+ * network error during the hub restart is expected (the hub is down); callers
+ * should swallow it and keep polling `/health` + `/api/hub` for the new version.
+ */
+export async function getHubUpgradeStatus(): Promise<HubUpgradeStatus | null> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch("/api/hub/upgrade/status", {
+    method: "GET",
+    headers: { accept: "application/json", authorization: `Bearer ${bearer}` },
+  });
+  if (res.status === 404) return null;
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as HubUpgradeStatus;
+}
+
 async function readError(res: Response): Promise<string> {
   try {
     const text = await res.text();

--- a/web/ui/src/routes/Modules.tsx
+++ b/web/ui/src/routes/Modules.tsx
@@ -28,6 +28,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
+import { HubUpgradeCard } from "../components/HubUpgradeCard.tsx";
 import { renderOperationError } from "../components/MissingDependencyCard.tsx";
 import {
   type ModuleInstallChannel,
@@ -320,6 +321,16 @@ export function Modules() {
         Install, upgrade, and manage Parachute modules. Available modules are pinned for the v0.6
         release; the marketplace is on the roadmap.
       </p>
+
+      {/*
+        Upgrade-hub affordance (design 2026-06-01 §5.3 / D4). The hub is NOT a
+        supervised module — it's the host — so it isn't a row in the lists
+        below; it sits at the top as its own card. This is the no-shell
+        (Render/Fly) operator's path to upgrade the hub itself. Unlike module
+        upgrades, it does NOT require a supervisor (the hub upgrades itself via
+        a detached helper), so it renders regardless of `supervisor_available`.
+      */}
+      <HubUpgradeCard />
 
       <ChannelToggle
         channel={module_install_channel}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -936,6 +936,24 @@ form .field-error {
 }
 
 /*
+ * Upgrade-hub card (design 2026-06-01 §5.3 / D4). Reuses the `.install-card`
+ * shape but sits at the top of /admin/modules as the host's own upgrade
+ * affordance. A subtle accent left-border marks it as the host (not a module
+ * row). The status line (upgrading / success / timeout / redeploy) wraps full
+ * width below the body via the existing `.warn-banner` / `.error-banner`.
+ */
+.hub-upgrade-card {
+  border-left: 3px solid var(--accent);
+  margin-top: 1.25rem;
+}
+.hub-upgrade-card .warn-banner,
+.hub-upgrade-card .error-banner {
+  flex-basis: 100%;
+  margin: 0.5rem 0 0;
+  font-size: 0.85rem;
+}
+
+/*
  * "Configure" link styled to match sibling action buttons on
  * `.module-row .actions`. React-router's <Link> renders an <a>, so
  * default `a` styles take over without these overrides — we want it


### PR DESCRIPTION
Phase 4 (SPA half) of the hub-as-supervisor unification — the SPA-driven `upgrade hub` (design `2026-06-01-hub-as-supervisor-unification.md` §5 item 3 + §5.3 + D4). This is the no-shell (Render/Fly) operator's path to upgrade the hub itself from the admin SPA — the whole reason the unification makes the SPA the management surface everywhere.

**No version bump** — stays `0.6.3-rc.1` (additive Phase-4 SPA work; the rc bump + tag happen together only when Aaron decides to ship).

## The four deliverables

### 1. `POST /api/hub/upgrade` (dedicated, host-admin gated) — §5 item 3
`src/api-hub-upgrade.ts` + dispatch in `src/hub-server.ts`. The hub is NOT a supervised module (`CURATED_MODULES` rejects `hub`; no `/api/modules/hub/*`), so it gets its own route pair, wired ahead of `/api/hub`. **Does NOT require a supervisor** (the hub upgrades itself via the helper).
- **Strict host-admin gate** — reuses the exact `validateAccessToken` + `parachute:host:admin` scope check `api-modules-ops.ts` uses. A `:auth`-only token gets 403; no spawn on auth failure.
- **Closed-enum channel** — optional `channel` is `rc | latest` ONLY (400 on anything else; default auto-detected from current version via `detectChannel`). This value flows toward `bun add -g @openparachute/hub@<channel>`, so it's a closed enum, never free input.
- Responds **202** immediately with `{ operation_id, target_version, channel, mode }`, spawns the detached helper via an injectable seam, and returns. **The handler does NOT rewrite/restart inline** (it would die mid-restart) — asserted by a test (the handler has no `UpgradeRunner`; the only rewrite path is the recorded helper spawn).
- `GET /api/hub/upgrade/status` polls the on-disk status, matching the module-ops operation-poll shape.

### 2. Detached one-shot helper — §5.3
`src/hub-upgrade-helper.ts`, spawned `detached:true`+`unref()`. **REUSES `commands/upgrade.ts`** for the channel-aware binary rewrite (no duplicated bun-add/git-pull). Rewrite-only (no-op `restartFn`, no `supervisor` block) so the **helper owns the restart explicitly**:
- VM/Mac (unit-managed) → `restartHubUnit` (reused from `hub-unit.ts`).
- container (no unit) → graceful `SIGTERM` to the hub pid → the runtime re-runs CMD on the new binary.

### 3. In-place-vs-redeploy detection — §5.3 (the OPEN impl detail)
`src/hub-upgrade-mode.ts` + `src/hub-upgrade-status.ts`. See the **flagged decisions** below.

### 4. Admin-SPA affordance — §5.3
`web/ui/src/components/HubUpgradeCard.tsx` (+ `lib/api.ts` clients), mounted at the TOP of `/admin/modules` (the hub is the host, not a module row), alongside the per-module upgrade UI. On click → POST → poll `/api/hub` version + status until the new binary answers (bounded 120s). States: starting / upgrading ("the hub will restart") / success / timeout ("may still be coming up — refresh shortly" + last status log) / redeploy-required (dashboard hint, NO no-op button) / error.

## 🚩 Flagged for review

**(a) Detached-helper-outlives-hub mechanism.** The helper is spawned `detached:true` + `proc.unref()` (own process group/session leader, stdio detached) so the hub's exit delivers no death signal and the hub can exit without waiting on it. It records progress to a **status FILE** under `PARACHUTE_HOME` (not the in-memory ops registry) precisely because the hub goes down mid-upgrade — the registry evaporates, the file survives. Container graceful-exit: the helper `SIGTERM`s the hub pid (passed via `--hub-pid`); the hub's existing `serve` SIGTERM handler stops children + the server, then the runtime re-runs CMD on the rewritten binary. **Residual risk:** the container path depends on the platform re-running CMD on exit (true for Render/Fly); on an init-less container with no restart policy the hub would stay down — but that's the same population §2/D1 already flags as foreground-serve-only.

**(b) In-place-vs-redeploy detection heuristic (§5.3 OPEN detail).** Reuses `detectHubInstallSource` + the `PARACHUTE_HOME=/parachute` container signal. Signals (priority order): bun-linked → in-place (git pull persists on disk); container + `$BUN_INSTALL` descendant-of the persistent-home prefix → in-place (bun add -g lands on the mounted volume); container image-pinned (`$BUN_INSTALL` off-mount/unset) → redeploy-required; npm-on-VM → in-place; unknown → redeploy-required. **False-"in-place" (the dangerous direction)** only risks the container-on-persistent-disk arm (we require `$BUN_INSTALL` to be a strict descendant of the home prefix, the strictest env-only signal short of a write-probe); **false-"redeploy-required" is safe** (merely tells the operator to redeploy when in-place would've worked). When uncertain we prefer redeploy-required (honest) over a silent no-op. A possible tightening (a write-probe in the helper) is noted in the code for the field. The endpoint's `redeploy-required` arm does NOT spawn a helper and does NOT do a misleading no-op rewrite — it seeds a terminal status and the SPA shows "redeploy from your platform dashboard."

**(c) SPA placement.** The card sits at the top of `/admin/modules` (`HubUpgradeCard` above the channel toggle + the Installed/Install sections), reusing the `.install-card` shape with an accent left-border to mark it as the host. The hub isn't a module so it can't be a row in the lists; the modules page is the management surface the spec points at, and it renders regardless of `supervisor_available` (the hub upgrades itself).

## Gates
- `bun test ./src` — **2758 pass / 1 skip / 0 fail** (baseline 2727; +31 new, zero regressions).
- `bun run typecheck` — clean.
- SPA: `bun run test` (web/ui) — **264 pass**; `bun run typecheck` — clean; `bun run build` — clean (verify-base passes, so `prepack` ships a fresh bundle).
- `bunx biome check` on all touched files — clean.

Scope guard: did NOT touch supervisor / lifecycle / expose / init / status from prior phases. Reused `upgrade.ts` (rewrite) + `restartHubUnit` (restart); no duplicated logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)