### PR TITLE
feat(hub): Phase 5a — migrate detached→supervised cutover + archive-guard fix + auto-offer (bridge intact)

### DIFF
--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -17,6 +17,7 @@ import { writeHubPort } from "../hub-control.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import type { HubUnitManagerOpResult } from "../hub-unit.ts";
 import { validateAccessToken } from "../jwt-sign.ts";
+import type { MigrateOfferOpts, MigrateOfferResult } from "../migrate-offer.ts";
 import {
   type ModuleOp,
   ModuleOpHttpError,
@@ -2280,6 +2281,181 @@ describe("Phase 3b dual-dispatch — restart", () => {
       expect(killed).toHaveLength(0); // stale pid → detached cleanup, no kill
       expect(spawner.calls).toHaveLength(1); // detached start ran (NOT the supervisor)
       expect(readPid("vault", h.configDir)).toBe(7777);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("§7.5 auto-detect-and-offer hook in start/stop/restart", () => {
+  /** A migrate-offer stub recording whether it was called + what it returns. */
+  function makeOfferStub(outcome: MigrateOfferResult["outcome"]): {
+    offer: (opts: MigrateOfferOpts) => Promise<MigrateOfferResult>;
+    calls: number;
+  } {
+    const state = { calls: 0 };
+    return {
+      get calls() {
+        return state.calls;
+      },
+      offer: async () => {
+        state.calls++;
+        return { outcome };
+      },
+    };
+  }
+
+  test("offer disabled by default (omitted) → detached arm, no offer", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const spawner = makeSpawner([4242]);
+      // No migrateOffer block → the §7.5 hook stays OFF (existing-test behavior).
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      // Took the detached arm — spawned vault.
+      expect(spawner.calls).toHaveLength(1);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("start: accept+migrate → re-dispatches through the supervisor (no detached spawn)", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const offerStub = makeOfferStub("migrated");
+      const sup = makeSupervisorStub();
+      // Start on the detached arm (unitInstalled:false), with the offer enabled
+      // and the supervisor stub ready for the post-migrate re-dispatch.
+      const spawner = makeSpawner([4242]);
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        log: () => {},
+        supervisor: { ...sup.opts, unitInstalled: false },
+        migrateOffer: { enabled: true, offer: offerStub.offer },
+      });
+      expect(code).toBe(0);
+      expect(offerStub.calls).toBe(1);
+      // The re-dispatch drove the supervisor (NOT a detached spawn).
+      expect(sup.driveCalls).toEqual([{ short: "vault", op: "start" }]);
+      expect(spawner.calls).toHaveLength(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("start: declined → falls through to the detached arm", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const offerStub = makeOfferStub("declined");
+      const spawner = makeSpawner([4242]);
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        log: () => {},
+        migrateOffer: { enabled: true, offer: offerStub.offer },
+      });
+      expect(code).toBe(0);
+      expect(offerStub.calls).toBe(1);
+      // Declined → detached spawn still happened.
+      expect(spawner.calls).toHaveLength(1);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("start: migrate-failed → falls through to the detached arm (fail-safe)", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const offerStub = makeOfferStub("migrate-failed");
+      const spawner = makeSpawner([4242]);
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        log: () => {},
+        migrateOffer: { enabled: true, offer: offerStub.offer },
+      });
+      // A failed cutover leaves the box detached → the original verb still runs
+      // the detached way (rather than re-dispatching into a supervisor that
+      // isn't up).
+      expect(code).toBe(0);
+      expect(spawner.calls).toHaveLength(1);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("stop: accept+migrate → re-dispatches through the supervisor", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const offerStub = makeOfferStub("migrated");
+      const sup = makeSupervisorStub();
+      const code = await stop("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        supervisor: { ...sup.opts, unitInstalled: false },
+        migrateOffer: { enabled: true, offer: offerStub.offer },
+      });
+      expect(code).toBe(0);
+      expect(offerStub.calls).toBe(1);
+      expect(sup.driveCalls).toEqual([{ short: "vault", op: "stop" }]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("restart: accept+migrate → re-dispatches through the supervisor", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const offerStub = makeOfferStub("migrated");
+      const sup = makeSupervisorStub();
+      const code = await restart("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        supervisor: { ...sup.opts, unitInstalled: false },
+        migrateOffer: { enabled: true, offer: offerStub.offer },
+      });
+      expect(code).toBe(0);
+      expect(offerStub.calls).toBe(1);
+      expect(sup.driveCalls).toEqual([{ short: "vault", op: "restart" }]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("offer is NOT made on the supervisor arm (unit already installed)", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const offerStub = makeOfferStub("migrated");
+      const sup = makeSupervisorStub(); // unitInstalled: true
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        supervisor: sup.opts,
+        migrateOffer: { enabled: true, offer: offerStub.offer },
+      });
+      expect(code).toBe(0);
+      // Supervisor arm taken directly → the offer hook (detached-arm only) never ran.
+      expect(offerStub.calls).toBe(0);
+      expect(sup.driveCalls).toEqual([{ short: "vault", op: "start" }]);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -2460,4 +2460,36 @@ describe("§7.5 auto-detect-and-offer hook in start/stop/restart", () => {
       h.cleanup();
     }
   });
+
+  test("restart: declined → offer fires EXACTLY ONCE, not three times (MUST-FIX 3)", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writePid("vault", 4242, h.configDir);
+      // The operator DECLINES the offer. The outer `restart` makes the single
+      // offer, then falls to the detached stop+start. WITHOUT the fix, the offer
+      // block flowed through `...opts` into both inner verbs → 3 offers/prints.
+      const offerStub = makeOfferStub("declined");
+      const spawner = makeSpawner([7777]);
+      const code = await restart("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        spawner,
+        // Stale 4242 dead (stop's stale-pid path skips the kill); spawned 7777
+        // alive past the post-spawn settle.
+        alive: (pid) => pid === 7777,
+        sleep: async () => {},
+        log: () => {},
+        migrateOffer: { enabled: true, offer: offerStub.offer },
+      });
+      expect(code).toBe(0);
+      // EXACTLY ONE offer — the outer restart's, not re-offered by inner stop+start.
+      expect(offerStub.calls).toBe(1);
+      // The detached restart still happened (declined → detached arm).
+      expect(spawner.calls).toHaveLength(1);
+      expect(readPid("vault", h.configDir)).toBe(7777);
+    } finally {
+      h.cleanup();
+    }
+  });
 });

--- a/src/__tests__/migrate-cutover.test.ts
+++ b/src/__tests__/migrate-cutover.test.ts
@@ -721,6 +721,53 @@ describe("MUST-FIX 2: orphan-sweep ownership check on module ports", () => {
       h.cleanup();
     }
   });
+
+  test("a process whose cmdline contains ONLY the bare module short-name (no 'parachute') is NOT attributed → not killed → port-stuck", async () => {
+    // Regression guard for the #507 re-review nit: the bare short-name needle was
+    // dropped because it false-attributed unrelated processes. The canonical
+    // footgun: a CI `gitlab-runner` squatting the `runner` module's port. Its
+    // cmdline contains the bare short-name "runner" but NOT "parachute", so under
+    // the old loose match the cutover would have KILLED it. Attribution now needs
+    // the `parachute` marker (or a recorded-pid / start-cmd-hint match).
+    const h = makeHarness();
+    try {
+      seedManifest(h.manifestPath, [{ name: "runner", port: 1943 }]);
+      const fc = makeFakeCutover({
+        // A genuine, unrelated CI runner — cmdline carries the bare short-name
+        // "runner" but nothing parachute-ish.
+        ownerOfPid: (pid) =>
+          pid === 8888
+            ? "/usr/local/bin/gitlab-runner run --config /etc/gitlab-runner/config.toml"
+            : undefined,
+      });
+      const w = getWorld(fc.deps);
+      w.listening.add(1939);
+      w.listening.add(1943);
+      // No runner pidfile (no recorded-pid match) — the squatter is 8888.
+      w.orphanPorts.set(1943, 8888);
+      w.alivePids.add(8888);
+      const log: string[] = [];
+      const result = await cutoverToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        deps: fc.deps,
+        log: (l) => log.push(l),
+        pollMs: 0,
+        timeoutMs: 0,
+      });
+      // Refused to kill → port stays held → port-stuck.
+      expect(result.outcome).toBe("port-stuck");
+      expect(fc.trace).not.toContain("kill 8888 SIGTERM");
+      expect(fc.trace).not.toContain("kill 8888 SIGKILL");
+      expect(getWorld(fc.deps).alivePids.has(8888)).toBe(true);
+      const out = log.join("\n");
+      expect(out).toContain("held by an unrelated process");
+      expect(out).toContain("8888");
+      expect(out).toContain("gitlab-runner");
+    } finally {
+      h.cleanup();
+    }
+  });
 });
 
 // ===========================================================================

--- a/src/__tests__/migrate-cutover.test.ts
+++ b/src/__tests__/migrate-cutover.test.ts
@@ -6,6 +6,7 @@ import {
   type CutoverDeps,
   type WriteUnitResult,
   cutoverToSupervised,
+  defaultCutoverDeps,
   teardownHubUnit,
 } from "../commands/migrate-cutover.ts";
 import type { HubUnitDeps, InstallAndStartHubUnitResult } from "../hub-unit.ts";
@@ -94,6 +95,9 @@ function makeFakeCutover(over: Partial<CutoverDeps> = {}): FakeCutover {
       world.alivePids.delete(pid);
     },
     pidOnPort: (port) => world.orphanPorts.get(port),
+    // Default ownership probe: unattributable (returns undefined) — hermetic, no
+    // real `ps` shell-out. Tests that exercise the ownership check override it.
+    ownerOfPid: () => undefined,
     portListening: async (port) => world.listening.has(port),
     stopHub: async () => {
       trace.push("stopHub");
@@ -274,7 +278,14 @@ describe("cutoverToSupervised — §7.2 orphan sweep", () => {
     const h = makeHarness();
     try {
       seedManifest(h.manifestPath, [{ name: "vault", port: 1940 }]);
-      const fc = makeFakeCutover();
+      // The orphan IS the stale vault module (its command line is attributable),
+      // so the ownership check (MUST-FIX 2) adopts + kills it.
+      const fc = makeFakeCutover({
+        ownerOfPid: (pid) =>
+          pid === 4242
+            ? "bun /home/op/.bun/install/global/@openparachute/vault/server.ts --port 1940"
+            : undefined,
+      });
       const w = getWorld(fc.deps);
       // vault's pidfile is gone, but an orphan PID 4242 still holds port 1940.
       w.listening.add(1939);
@@ -342,6 +353,7 @@ describe("cutoverToSupervised — fail-safe recovery states", () => {
         writeUnitWithoutStarting: () => ({
           written: false,
           outcome: "fallback",
+          cause: "write-failed",
           messages: ["cannot build hub unit: 'bun' not found on PATH"],
         }),
       });
@@ -354,8 +366,9 @@ describe("cutoverToSupervised — fail-safe recovery states", () => {
         log: () => {},
         pollMs: 0,
       });
-      // A write-fallback is treated as no-manager (can't host a unit here).
-      expect(result.outcome).toBe("no-manager");
+      // A write failure is distinct from no-manager (MUST-FIX NIT) — a manager
+      // may exist; we just couldn't compose/write the unit.
+      expect(result.outcome).toBe("write-failed");
       // FAIL-SAFE: nothing was stopped — we never reached step 3.
       expect(fc.trace).not.toContain("stopHub");
       expect(fc.trace).not.toContain("startUnit");
@@ -453,5 +466,328 @@ describe("teardownHubUnit (§7.4)", () => {
     });
     expect(res.removed).toBe(false);
     expect(log.join("\n")).toContain("nothing to tear down");
+  });
+});
+
+// ===========================================================================
+// MUST-FIX 1 — group-aware kill (hub#88 re-opened in the cutover).
+//
+// Modules are spawned `detached: true` → the recorded pid is a process-GROUP
+// leader. A wrapper startCmd (`pnpm exec tsx server.ts`) leaves the real server
+// as a GRANDCHILD in that group. The cutover used the BARE-pid kill, which
+// signals only the wrapper → the tsx grandchild survives, keeps holding the
+// module port → `waitPortFree` times out → `port-stuck` on the FIRST run. These
+// tests pin the fix: `defaultCutoverDeps.kill` is GROUP-aware (negative pid).
+// ===========================================================================
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("MUST-FIX 1: group-aware kill targets the process GROUP (negative pid)", () => {
+  test("defaultCutoverDeps.kill signals -pid (the whole group), with an ESRCH bare-pid fallback", () => {
+    const calls: Array<{ pid: number; signal: NodeJS.Signals | number }> = [];
+    const realKill = process.kill.bind(process);
+    const spy = (pid: number, signal?: NodeJS.Signals | number) => {
+      calls.push({ pid, signal: signal ?? 0 });
+      // Make the group send (negative pid) succeed so no fallback is taken.
+      return true as unknown as ReturnType<typeof process.kill>;
+    };
+    try {
+      // biome-ignore lint/suspicious/noExplicitAny: test spy on process.kill
+      (process as any).kill = spy;
+      defaultCutoverDeps.kill(4242, "SIGTERM");
+    } finally {
+      // biome-ignore lint/suspicious/noExplicitAny: restore
+      (process as any).kill = realKill;
+    }
+    // The group send fired with the NEGATIVE pid — not the bare pid.
+    expect(calls).toEqual([{ pid: -4242, signal: "SIGTERM" }]);
+  });
+
+  test("ESRCH on the group send falls back to a bare-pid signal (legacy pidfile)", () => {
+    const calls: Array<{ pid: number; signal: NodeJS.Signals | number }> = [];
+    const realKill = process.kill.bind(process);
+    const spy = (pid: number, signal?: NodeJS.Signals | number) => {
+      calls.push({ pid, signal: signal ?? 0 });
+      if (pid < 0) {
+        const err = new Error("no such process") as NodeJS.ErrnoException;
+        err.code = "ESRCH";
+        throw err;
+      }
+      return true as unknown as ReturnType<typeof process.kill>;
+    };
+    try {
+      // biome-ignore lint/suspicious/noExplicitAny: test spy on process.kill
+      (process as any).kill = spy;
+      defaultCutoverDeps.kill(777, "SIGKILL");
+    } finally {
+      // biome-ignore lint/suspicious/noExplicitAny: restore
+      (process as any).kill = realKill;
+    }
+    // First the group send (ESRCH), then the bare-pid fallback.
+    expect(calls).toEqual([
+      { pid: -777, signal: "SIGKILL" },
+      { pid: 777, signal: "SIGKILL" },
+    ]);
+  });
+
+  test("LOAD-BEARING: a wrapper-startCmd grandchild holding the module port is reaped → cutover migrates (NOT port-stuck)", async () => {
+    const h = makeHarness();
+    // Spawn a REAL detached wrapper that backgrounds a long-lived grandchild and
+    // prints the grandchild's pid — faithfully modeling `pnpm exec tsx server.ts`
+    // (a wrapper whose tsx grandchild is the thing actually holding the port). The
+    // wrapper is its own process-group leader (detached: true → pid == pgid).
+    const proc = Bun.spawn(["sh", "-c", "sleep 30 & echo $!; wait"], {
+      stdio: ["ignore", "pipe", "ignore"],
+      detached: true,
+      env: process.env,
+    });
+    const leaderPid = proc.pid; // group leader (the "wrapper")
+    let grandchildPid = -1;
+    try {
+      const { value } = await proc.stdout.getReader().read();
+      grandchildPid = Number.parseInt(
+        new TextDecoder().decode(value ?? new Uint8Array()).trim(),
+        10,
+      );
+      expect(Number.isInteger(grandchildPid)).toBe(true);
+      expect(pidAlive(grandchildPid)).toBe(true);
+
+      seedManifest(h.manifestPath, [{ name: "vault", port: 1940 }]);
+      // vault's pidfile points at the WRAPPER leader (what `parachute start`
+      // recorded); the GRANDCHILD is what actually holds port 1940.
+      writePid("vault", leaderPid, h.configDir);
+
+      const fc = makeFakeCutover({
+        // PRODUCTION group-aware kill + alive (the fix under test) — NOT the
+        // harness fakes. Everything else stays stubbed (no real unit / health).
+        kill: defaultCutoverDeps.kill,
+        alive: defaultCutoverDeps.alive,
+        // The module port reads as HELD while the grandchild is still alive, and
+        // FREE the instant the grandchild dies — real-process backed, so only a
+        // correct group-kill (which reaps the grandchild) frees it.
+        portListening: async (port) => (port === 1940 ? pidAlive(grandchildPid) : false),
+        // No lsof orphan beyond the pidfile path — the stop reaps the group.
+        pidOnPort: () => undefined,
+      });
+      const w = getWorld(fc.deps);
+      w.listening.add(1939); // hub port held; stopHub frees it.
+
+      const result = await cutoverToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        deps: fc.deps,
+        log: () => {},
+        pollMs: 1,
+        timeoutMs: 2000,
+      });
+
+      // The grandchild was reaped by the GROUP kill → port 1940 freed → the
+      // cutover proceeded. A bare-pid kill would have left the grandchild alive,
+      // 1940 held, and the outcome `port-stuck` (the hub#88 footgun).
+      expect(result.outcome).toBe("migrated");
+      expect(pidAlive(grandchildPid)).toBe(false);
+    } finally {
+      // Defensive cleanup — both should already be gone on the happy path.
+      try {
+        process.kill(-leaderPid, "SIGKILL");
+      } catch {}
+      if (grandchildPid > 0) {
+        try {
+          process.kill(grandchildPid, "SIGKILL");
+        } catch {}
+      }
+      h.cleanup();
+    }
+  });
+});
+
+// ===========================================================================
+// MUST-FIX 2 — ownership check in the per-module orphan sweep (no blind-kill).
+//
+// `sweepOrphanOnPort` must NOT kill whatever holds a declared MODULE port — only
+// processes plausibly attributable to that parachute module. An operator's own
+// dev server squatting a module port must survive (warning + port-stuck), not be
+// nuked.
+// ===========================================================================
+
+describe("MUST-FIX 2: orphan-sweep ownership check on module ports", () => {
+  test("an orphan attributable to the module (cmdline mentions it) is adopted + killed", async () => {
+    const h = makeHarness();
+    try {
+      seedManifest(h.manifestPath, [{ name: "vault", port: 1940 }]);
+      const fc = makeFakeCutover({
+        // The orphan's command line looks like a parachute vault process.
+        ownerOfPid: (pid) =>
+          pid === 4242
+            ? "bun /home/op/.bun/install/global/@openparachute/vault/server.ts"
+            : undefined,
+      });
+      const w = getWorld(fc.deps);
+      w.listening.add(1939);
+      w.listening.add(1940);
+      w.orphanPorts.set(1940, 4242);
+      w.alivePids.add(4242);
+      const baseKill = fc.deps.kill;
+      fc.deps.kill = (pid, signal) => {
+        baseKill?.(pid, signal);
+        if (pid === 4242) getWorld(fc.deps).listening.delete(1940);
+      };
+      const result = await cutoverToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        deps: fc.deps,
+        log: () => {},
+        pollMs: 0,
+      });
+      expect(result.outcome).toBe("migrated");
+      // Attributable → adopted + killed.
+      expect(fc.trace).toContain("kill 4242 SIGTERM");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("an UNATTRIBUTABLE process on a module port is NOT killed → warning + port-stuck", async () => {
+    const h = makeHarness();
+    try {
+      seedManifest(h.manifestPath, [{ name: "vault", port: 1940 }]);
+      const fc = makeFakeCutover({
+        // The orphan is an operator's own dev server — nothing parachute-ish.
+        ownerOfPid: (pid) => (pid === 7777 ? "node /Users/op/my-app/dev-server.js" : undefined),
+      });
+      const w = getWorld(fc.deps);
+      w.listening.add(1939);
+      w.listening.add(1940);
+      // No vault pidfile (so no recorded-pid match) — the squatter is 7777.
+      w.orphanPorts.set(1940, 7777);
+      w.alivePids.add(7777);
+      const log: string[] = [];
+      const result = await cutoverToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        deps: fc.deps,
+        log: (l) => log.push(l),
+        pollMs: 0,
+        timeoutMs: 0,
+      });
+      // The cutover refused to nuke the unrelated process → the port stays held →
+      // port-stuck (the operator resolves it).
+      expect(result.outcome).toBe("port-stuck");
+      // The squatter was NEVER signalled.
+      expect(fc.trace).not.toContain("kill 7777 SIGTERM");
+      expect(fc.trace).not.toContain("kill 7777 SIGKILL");
+      expect(getWorld(fc.deps).alivePids.has(7777)).toBe(true);
+      // A clear warning names the unrelated process + refuses.
+      const out = log.join("\n");
+      expect(out).toContain("held by an unrelated process");
+      expect(out).toContain("7777");
+      expect(out).toContain("dev-server.js");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("an orphan whose command line is unreadable is treated as UNATTRIBUTABLE", async () => {
+    const h = makeHarness();
+    try {
+      seedManifest(h.manifestPath, [{ name: "vault", port: 1940 }]);
+      const fc = makeFakeCutover({
+        // ps failed / pid gone → no cmdline, and the pid doesn't match a record.
+        ownerOfPid: () => undefined,
+      });
+      const w = getWorld(fc.deps);
+      w.listening.add(1939);
+      w.listening.add(1940);
+      w.orphanPorts.set(1940, 5050);
+      w.alivePids.add(5050);
+      const result = await cutoverToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        deps: fc.deps,
+        log: () => {},
+        pollMs: 0,
+        timeoutMs: 0,
+      });
+      expect(result.outcome).toBe("port-stuck");
+      expect(fc.trace).not.toContain("kill 5050 SIGTERM");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// ===========================================================================
+// MUST-FIX NIT — distinguish no-manager from write-failed in the cutover.
+// ===========================================================================
+
+describe("MUST-FIX NIT: no-manager vs write-failed are distinct outcomes", () => {
+  test("bun-not-found (write-failed cause) → write-failed outcome with an accurate message", async () => {
+    const h = makeHarness();
+    try {
+      seedManifest(h.manifestPath, []);
+      const fc = makeFakeCutover({
+        writeUnitWithoutStarting: () => ({
+          written: false,
+          outcome: "fallback",
+          cause: "write-failed",
+          messages: ["cannot build hub unit: 'bun' not found on PATH"],
+        }),
+      });
+      const w = getWorld(fc.deps);
+      w.listening.add(1939);
+      const result = await cutoverToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        deps: fc.deps,
+        log: () => {},
+        pollMs: 0,
+      });
+      expect(result.outcome).toBe("write-failed");
+      // NOT the "no service manager" message — names bun / the write failure.
+      const out = result.messages.join("\n");
+      expect(out).toContain("Could not write the hub unit file");
+      expect(out).not.toContain("This host has no service manager");
+      // FAIL-SAFE: nothing stopped (still before step 3).
+      expect(fc.trace).not.toContain("stopHub");
+      expect(fc.trace).not.toContain("startUnit");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("genuine no-manager (no systemd/launchd) → no-manager outcome + service-manager message", async () => {
+    const h = makeHarness();
+    try {
+      seedManifest(h.manifestPath, []);
+      const fc = makeFakeCutover({
+        writeUnitWithoutStarting: () => ({
+          written: false,
+          outcome: "fallback",
+          cause: "no-manager",
+          messages: ["no service manager (launchctl) found on this host"],
+        }),
+      });
+      const w = getWorld(fc.deps);
+      w.listening.add(1939);
+      const result = await cutoverToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        deps: fc.deps,
+        log: () => {},
+        pollMs: 0,
+      });
+      expect(result.outcome).toBe("no-manager");
+      expect(result.messages.join("\n")).toContain("This host has no service manager");
+      expect(fc.trace).not.toContain("stopHub");
+    } finally {
+      h.cleanup();
+    }
   });
 });

--- a/src/__tests__/migrate-cutover.test.ts
+++ b/src/__tests__/migrate-cutover.test.ts
@@ -1,0 +1,457 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type CutoverDeps,
+  type WriteUnitResult,
+  cutoverToSupervised,
+  teardownHubUnit,
+} from "../commands/migrate-cutover.ts";
+import type { HubUnitDeps, InstallAndStartHubUnitResult } from "../hub-unit.ts";
+import type { ManagedUnitRemoveResult } from "../managed-unit.ts";
+import { writePid } from "../process-state.ts";
+
+/**
+ * ALL destructive-path tests run in a FRESH sandbox `PARACHUTE_HOME` with stubbed
+ * seams — NO real Bun.spawn / systemctl / launchctl / lsof / process kills, NO
+ * touching the operator's `~/.parachute`. The sandbox dir is only used to seed
+ * services.json + pidfiles (real `writePid`) so the detector + per-module stop
+ * read genuine on-disk state; everything that would touch a live process is a
+ * fake.
+ */
+interface Harness {
+  configDir: string;
+  manifestPath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-cutover-"));
+  return {
+    configDir: dir,
+    manifestPath: join(dir, "services.json"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+function seedManifest(manifestPath: string, services: Array<{ name: string; port: number }>): void {
+  const full = services.map((s) => ({
+    name: s.name,
+    port: s.port,
+    paths: [`/${s.name}`],
+    health: "/health",
+    version: "1.0.0",
+  }));
+  Bun.write(manifestPath, JSON.stringify({ services: full }));
+}
+
+/** A trace-recording set of cutover deps, with sane defaults for the happy path. */
+interface FakeCutover {
+  deps: Partial<CutoverDeps>;
+  trace: string[];
+  hubUnitDeps: HubUnitDeps;
+}
+
+function fakeHubUnitDeps(): HubUnitDeps {
+  return {
+    platform: "linux",
+    getuid: () => 1000,
+    homeDir: () => "/home/op",
+    userName: () => "op",
+    which: (b) => (b === "bun" ? "/home/op/.bun/bin/bun" : `/usr/bin/${b}`),
+    run: () => ({ code: 0, stdout: "", stderr: "" }),
+    writeFile: () => {},
+    removeFile: () => {},
+    readFile: () => undefined,
+    exists: () => false,
+    probeHealth: async () => false,
+    portListening: async () => false,
+    sleep: async () => {},
+  };
+}
+
+function makeFakeCutover(over: Partial<CutoverDeps> = {}): FakeCutover {
+  const trace: string[] = [];
+  const hubUnitDeps = fakeHubUnitDeps();
+  // Mutable "world" the fakes read so we can model state transitions (a port
+  // that frees after the stop, a unit that becomes installed after a write).
+  const world = {
+    unitInstalled: false,
+    hubHealthy: false,
+    /** Ports currently "listening" (held). The verify-free step polls this. */
+    listening: new Set<number>(),
+    /** Ports an orphan (lsof) reports a pid on. */
+    orphanPorts: new Map<number, number>(),
+    alivePids: new Set<number>(),
+  };
+  const deps: Partial<CutoverDeps> = {
+    hubUnitDeps,
+    alive: (pid) => world.alivePids.has(pid),
+    kill: (pid, signal) => {
+      trace.push(`kill ${pid} ${signal}`);
+      // SIGKILL / SIGTERM removes the process from the world.
+      world.alivePids.delete(pid);
+    },
+    pidOnPort: (port) => world.orphanPorts.get(port),
+    portListening: async (port) => world.listening.has(port),
+    stopHub: async () => {
+      trace.push("stopHub");
+      world.listening.delete(1939);
+      return true;
+    },
+    isHubUnitInstalled: () => world.unitInstalled,
+    probeHealth: async () => world.hubHealthy,
+    sleep: async () => {},
+    writeUnitWithoutStarting: (): WriteUnitResult => {
+      trace.push("writeUnit");
+      world.unitInstalled = true;
+      return { written: true, outcome: "installed", messages: ["wrote unit (not started)"] };
+    },
+    installAndStartHubUnit: async (): Promise<InstallAndStartHubUnitResult> => {
+      trace.push("startUnit");
+      world.hubHealthy = true;
+      return {
+        outcome: "started",
+        port: 1939,
+        install: { outcome: "installed", kind: "systemd-user", messages: [] },
+        messages: ["started unit"],
+      };
+    },
+    ...over,
+  };
+  // Expose the world via closure for tests that want to manipulate it.
+  (deps as { _world?: typeof world })._world = world;
+  return { deps, trace, hubUnitDeps };
+}
+
+function getWorld(deps: Partial<CutoverDeps>): {
+  unitInstalled: boolean;
+  hubHealthy: boolean;
+  listening: Set<number>;
+  orphanPorts: Map<number, number>;
+  alivePids: Set<number>;
+} {
+  const w = (deps as { _world?: ReturnType<typeof Object> })._world;
+  if (!w) throw new Error("no world");
+  return w as ReturnType<typeof getWorld>;
+}
+
+describe("cutoverToSupervised — happy path (§7.1)", () => {
+  test("detached box with running hub + modules migrates end-to-end", async () => {
+    const h = makeHarness();
+    try {
+      seedManifest(h.manifestPath, [{ name: "vault", port: 1940 }]);
+      const fc = makeFakeCutover();
+      const w = getWorld(fc.deps);
+      // The detached hub + vault are alive + bound to their ports. vault is
+      // tracked by a real pidfile (pid 5555); stopping it frees port 1940.
+      w.listening.add(1939);
+      w.listening.add(1940);
+      w.alivePids.add(5555);
+      writePid("vault", 5555, h.configDir);
+      const baseKill = fc.deps.kill;
+      fc.deps.kill = (pid, signal) => {
+        baseKill?.(pid, signal);
+        if (pid === 5555) getWorld(fc.deps).listening.delete(1940);
+      };
+      const log: string[] = [];
+      const result = await cutoverToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        deps: fc.deps,
+        log: (l) => log.push(l),
+        pollMs: 0,
+      });
+      expect(result.outcome).toBe("migrated");
+      // ORDERING: write the unit BEFORE stopping detached, verify ports free
+      // BEFORE starting the unit, start AFTER stop. The trace proves the order.
+      const writeIdx = fc.trace.indexOf("writeUnit");
+      const stopIdx = fc.trace.indexOf("stopHub");
+      const startIdx = fc.trace.indexOf("startUnit");
+      expect(writeIdx).toBeGreaterThanOrEqual(0);
+      expect(writeIdx).toBeLessThan(stopIdx); // unit written before stop
+      expect(stopIdx).toBeLessThan(startIdx); // detached stopped before unit start
+      // The hub is now supervised + healthy.
+      expect(getWorld(fc.deps).hubHealthy).toBe(true);
+      expect(getWorld(fc.deps).unitInstalled).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("verify-ports-free runs before start (start never races a held port)", async () => {
+    const h = makeHarness();
+    try {
+      seedManifest(h.manifestPath, [{ name: "vault", port: 1940 }]);
+      const fc = makeFakeCutover();
+      const w = getWorld(fc.deps);
+      w.listening.add(1939);
+      w.listening.add(1940);
+      w.alivePids.add(5555);
+      writePid("vault", 5555, h.configDir);
+      const baseKill = fc.deps.kill;
+      fc.deps.kill = (pid, signal) => {
+        baseKill?.(pid, signal);
+        if (pid === 5555) getWorld(fc.deps).listening.delete(1940);
+      };
+      // Record the world's listening state at the instant startUnit is called.
+      let listeningAtStart: number[] = [];
+      const baseStart = fc.deps.installAndStartHubUnit;
+      fc.deps.installAndStartHubUnit = async (opts) => {
+        listeningAtStart = [...getWorld(fc.deps).listening];
+        return baseStart?.(opts) as Promise<InstallAndStartHubUnitResult>;
+      };
+      const result = await cutoverToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        deps: fc.deps,
+        log: () => {},
+        pollMs: 0,
+      });
+      expect(result.outcome).toBe("migrated");
+      // By the time the unit starts, both ports must be free.
+      expect(listeningAtStart).toEqual([]);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("cutoverToSupervised — idempotency + resumability", () => {
+  test("already-supervised box is a no-op (unit installed + /health answers)", async () => {
+    const h = makeHarness();
+    try {
+      const fc = makeFakeCutover();
+      const w = getWorld(fc.deps);
+      w.unitInstalled = true;
+      w.hubHealthy = true;
+      const result = await cutoverToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        deps: fc.deps,
+        log: () => {},
+        pollMs: 0,
+      });
+      expect(result.outcome).toBe("already-migrated");
+      // No destructive step ran.
+      expect(fc.trace).not.toContain("stopHub");
+      expect(fc.trace).not.toContain("startUnit");
+      expect(fc.trace).not.toContain("writeUnit");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("resumes a partial cutover (unit written but hub not healthy)", async () => {
+    const h = makeHarness();
+    try {
+      seedManifest(h.manifestPath, []);
+      const fc = makeFakeCutover();
+      const w = getWorld(fc.deps);
+      // Unit on disk from a prior aborted run, but the hub never came up.
+      w.unitInstalled = true;
+      w.hubHealthy = false;
+      const result = await cutoverToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        deps: fc.deps,
+        log: () => {},
+        pollMs: 0,
+      });
+      // NOT a no-op — it resumes (re-write idempotent, stop no-ops, start).
+      expect(result.outcome).toBe("migrated");
+      expect(fc.trace).toContain("writeUnit");
+      expect(fc.trace).toContain("startUnit");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("cutoverToSupervised — §7.2 orphan sweep", () => {
+  test("a process bound to a module port (stale pidfile) is adopted + killed before start", async () => {
+    const h = makeHarness();
+    try {
+      seedManifest(h.manifestPath, [{ name: "vault", port: 1940 }]);
+      const fc = makeFakeCutover();
+      const w = getWorld(fc.deps);
+      // vault's pidfile is gone, but an orphan PID 4242 still holds port 1940.
+      w.listening.add(1939);
+      w.listening.add(1940);
+      w.orphanPorts.set(1940, 4242);
+      w.alivePids.add(4242);
+      // When the orphan is killed, free its port (model the OS releasing it).
+      const baseKill = fc.deps.kill;
+      fc.deps.kill = (pid, signal) => {
+        baseKill?.(pid, signal);
+        if (pid === 4242) getWorld(fc.deps).listening.delete(1940);
+      };
+      const result = await cutoverToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        deps: fc.deps,
+        log: () => {},
+        pollMs: 0,
+      });
+      expect(result.outcome).toBe("migrated");
+      // The orphan was killed (adopted from lsof, not from a pidfile).
+      expect(fc.trace).toContain("kill 4242 SIGTERM");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("cutoverToSupervised — fail-safe recovery states", () => {
+  test("port-stuck: a port that won't free fails with the unit written-but-not-started", async () => {
+    const h = makeHarness();
+    try {
+      seedManifest(h.manifestPath, [{ name: "vault", port: 1940 }]);
+      const fc = makeFakeCutover();
+      const w = getWorld(fc.deps);
+      w.listening.add(1939);
+      w.listening.add(1940);
+      // stopHub frees 1939, but NOTHING frees 1940 (no orphan to adopt, the
+      // detached stop didn't release it) — the port stays held forever.
+      const result = await cutoverToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        deps: fc.deps,
+        log: () => {},
+        pollMs: 0,
+        timeoutMs: 0,
+      });
+      expect(result.outcome).toBe("port-stuck");
+      // FAIL-SAFE: the unit WAS written (recoverable), and the unit was NOT
+      // started (we never raced the held port).
+      expect(fc.trace).toContain("writeUnit");
+      expect(fc.trace).not.toContain("startUnit");
+      expect(getWorld(fc.deps).unitInstalled).toBe(true);
+      expect(result.messages.join("\n")).toContain("re-run");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("write-failed (bun unresolvable): bails BEFORE stopping anything", async () => {
+    const h = makeHarness();
+    try {
+      seedManifest(h.manifestPath, [{ name: "vault", port: 1940 }]);
+      const fc = makeFakeCutover({
+        writeUnitWithoutStarting: () => ({
+          written: false,
+          outcome: "fallback",
+          messages: ["cannot build hub unit: 'bun' not found on PATH"],
+        }),
+      });
+      const w = getWorld(fc.deps);
+      w.listening.add(1939);
+      const result = await cutoverToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        deps: fc.deps,
+        log: () => {},
+        pollMs: 0,
+      });
+      // A write-fallback is treated as no-manager (can't host a unit here).
+      expect(result.outcome).toBe("no-manager");
+      // FAIL-SAFE: nothing was stopped — we never reached step 3.
+      expect(fc.trace).not.toContain("stopHub");
+      expect(fc.trace).not.toContain("startUnit");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("start-failed: unit start degrades → recoverable (unit written, re-runnable)", async () => {
+    const h = makeHarness();
+    try {
+      seedManifest(h.manifestPath, []);
+      const fc = makeFakeCutover({
+        installAndStartHubUnit: async () => ({
+          outcome: "no-manager",
+          port: 1939,
+          install: { outcome: "fallback", messages: ["manager gone"] },
+          messages: ["manager gone"],
+        }),
+      });
+      const w = getWorld(fc.deps);
+      w.listening.add(1939);
+      const result = await cutoverToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        deps: fc.deps,
+        log: () => {},
+        pollMs: 0,
+      });
+      expect(result.outcome).toBe("start-failed");
+      expect(result.messages.join("\n")).toContain("re-run");
+      // The unit was written (recoverable); we stopped detached but the unit is
+      // on disk so a re-run is clean.
+      expect(getWorld(fc.deps).unitInstalled).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("verify-timeout: unit starts but /health never answers → recoverable", async () => {
+    const h = makeHarness();
+    try {
+      seedManifest(h.manifestPath, []);
+      const fc = makeFakeCutover({
+        // The unit "starts" but the world's hubHealthy stays false.
+        installAndStartHubUnit: async () => ({
+          outcome: "started",
+          port: 1939,
+          install: { outcome: "installed", kind: "systemd-user", messages: [] },
+          messages: ["started"],
+        }),
+      });
+      const w = getWorld(fc.deps);
+      w.listening.add(1939);
+      // Note: probeHealth reads world.hubHealthy which stays false.
+      const result = await cutoverToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        deps: fc.deps,
+        log: () => {},
+        pollMs: 0,
+        timeoutMs: 0,
+      });
+      expect(result.outcome).toBe("verify-timeout");
+      expect(result.messages.join("\n")).toContain("logs hub");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("teardownHubUnit (§7.4)", () => {
+  test("removes the hub unit (idempotent success path)", () => {
+    let removeArgs: { launchdLabel: string; systemdUnitName: string } | undefined;
+    const log: string[] = [];
+    const res = teardownHubUnit({
+      log: (l) => log.push(l),
+      remove: (opts): ManagedUnitRemoveResult => {
+        removeArgs = { launchdLabel: opts.launchdLabel, systemdUnitName: opts.systemdUnitName };
+        return { removed: true, messages: [opts.removedSystemdMessage(opts.systemdUnitName)] };
+      },
+    });
+    expect(res.removed).toBe(true);
+    expect(removeArgs?.launchdLabel).toBe("computer.parachute.hub");
+    expect(removeArgs?.systemdUnitName).toBe("parachute-hub.service");
+    // Surfaces the fallback hint.
+    expect(log.join("\n")).toContain("parachute serve");
+  });
+
+  test("no unit installed → no-op, friendly message", () => {
+    const log: string[] = [];
+    const res = teardownHubUnit({
+      log: (l) => log.push(l),
+      remove: (): ManagedUnitRemoveResult => ({ removed: false, messages: [] }),
+    });
+    expect(res.removed).toBe(false);
+    expect(log.join("\n")).toContain("nothing to tear down");
+  });
+});

--- a/src/__tests__/migrate-offer.test.ts
+++ b/src/__tests__/migrate-offer.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { CutoverResult } from "../commands/migrate-cutover.ts";
+import { hasPriorDetachedInstall, offerMigrateToSupervised } from "../migrate-offer.ts";
+import { writePid } from "../process-state.ts";
+
+/**
+ * Sandboxed §7.5 auto-detect-and-offer tests. Every offer runs against a fresh
+ * tmp `PARACHUTE_HOME` with stubbed unit-detection / cutover / prompt / TTY —
+ * no real prompt, no real cutover, no touching `~/.parachute`. The only real fs
+ * is seeding pidfiles + services.json (via `writePid`) so the DETECTOR reads
+ * genuine on-disk detached-era state.
+ */
+interface Harness {
+  configDir: string;
+  manifestPath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-offer-"));
+  return {
+    configDir: dir,
+    manifestPath: join(dir, "services.json"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+function seedManifest(manifestPath: string, services: Array<{ name: string; port: number }>): void {
+  const full = services.map((s) => ({
+    name: s.name,
+    port: s.port,
+    paths: [`/${s.name}`],
+    health: "/health",
+    version: "1.0.0",
+  }));
+  writeFileSync(manifestPath, JSON.stringify({ services: full }));
+}
+
+function seedHubPidfile(configDir: string, pid = 12345): void {
+  mkdirSync(join(configDir, "hub", "run"), { recursive: true });
+  writePid("hub", pid, configDir);
+}
+
+const migratedResult: CutoverResult = { outcome: "migrated", port: 1939, messages: ["✓ migrated"] };
+
+describe("hasPriorDetachedInstall (the §7.5 (b) detector)", () => {
+  test("true when a hub pidfile exists", () => {
+    const h = makeHarness();
+    try {
+      seedHubPidfile(h.configDir);
+      expect(hasPriorDetachedInstall(h.configDir, h.manifestPath)).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("true when a module pidfile exists", () => {
+    const h = makeHarness();
+    try {
+      seedManifest(h.manifestPath, [{ name: "parachute-vault", port: 1940 }]);
+      mkdirSync(join(h.configDir, "vault", "run"), { recursive: true });
+      writePid("vault", 999, h.configDir);
+      expect(hasPriorDetachedInstall(h.configDir, h.manifestPath)).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("FALSE on a clean/supervised box — services.json alone is NOT enough", () => {
+    const h = makeHarness();
+    try {
+      // A configured box with services.json but NO pidfiles (the supervised
+      // shape — children tracked in-process). Must not false-positive.
+      seedManifest(h.manifestPath, [{ name: "parachute-vault", port: 1940 }]);
+      expect(hasPriorDetachedInstall(h.configDir, h.manifestPath)).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("FALSE on a brand-new box (no services.json, no pidfiles)", () => {
+    const h = makeHarness();
+    try {
+      expect(hasPriorDetachedInstall(h.configDir, h.manifestPath)).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("offerMigrateToSupervised — when NOT to offer", () => {
+  test("no offer when a hub unit IS installed (already supervised)", async () => {
+    const h = makeHarness();
+    try {
+      seedHubPidfile(h.configDir);
+      let cutoverCalled = false;
+      const result = await offerMigrateToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        isHubUnitInstalled: () => true, // a unit exists
+        hasPriorDetached: () => true,
+        cutover: async () => {
+          cutoverCalled = true;
+          return migratedResult;
+        },
+        prompt: async () => "y",
+        isTty: true,
+      });
+      expect(result.outcome).toBe("no-offer");
+      expect(cutoverCalled).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("no offer when there is no prior-detached evidence (clean box)", async () => {
+    const h = makeHarness();
+    try {
+      const result = await offerMigrateToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        isHubUnitInstalled: () => false,
+        hasPriorDetached: () => false, // clean box
+        prompt: async () => {
+          throw new Error("prompt must not be called on a clean box");
+        },
+        isTty: true,
+      });
+      expect(result.outcome).toBe("no-offer");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("offerMigrateToSupervised — interactive (TTY)", () => {
+  test("accept → runs the cutover, reports migrated", async () => {
+    const h = makeHarness();
+    try {
+      let cutoverCalled = false;
+      const result = await offerMigrateToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        isHubUnitInstalled: () => false,
+        hasPriorDetached: () => true,
+        cutover: async () => {
+          cutoverCalled = true;
+          return migratedResult;
+        },
+        prompt: async () => "y",
+        isTty: true,
+      });
+      expect(cutoverCalled).toBe(true);
+      expect(result.outcome).toBe("migrated");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("decline → does NOT run the cutover", async () => {
+    const h = makeHarness();
+    try {
+      let cutoverCalled = false;
+      const log: string[] = [];
+      const result = await offerMigrateToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+        isHubUnitInstalled: () => false,
+        hasPriorDetached: () => true,
+        cutover: async () => {
+          cutoverCalled = true;
+          return migratedResult;
+        },
+        prompt: async () => "n",
+        isTty: true,
+      });
+      expect(cutoverCalled).toBe(false);
+      expect(result.outcome).toBe("declined");
+      expect(log.join("\n")).toContain("parachute migrate --to-supervised");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("accept but cutover fails → migrate-failed (NOT migrated)", async () => {
+    const h = makeHarness();
+    try {
+      const result = await offerMigrateToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        isHubUnitInstalled: () => false,
+        hasPriorDetached: () => true,
+        cutover: async () => ({ outcome: "port-stuck", port: 1939, messages: ["stuck"] }),
+        prompt: async () => "yes",
+        isTty: true,
+      });
+      expect(result.outcome).toBe("migrate-failed");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("offerMigrateToSupervised — non-interactive (no TTY)", () => {
+  test("PRINTS the exact command and NEVER runs the cutover", async () => {
+    const h = makeHarness();
+    try {
+      let cutoverCalled = false;
+      const log: string[] = [];
+      const result = await offerMigrateToSupervised({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+        isHubUnitInstalled: () => false,
+        hasPriorDetached: () => true,
+        cutover: async () => {
+          cutoverCalled = true;
+          return migratedResult;
+        },
+        prompt: async () => {
+          throw new Error("prompt must not be called in a non-TTY context");
+        },
+        isTty: false,
+      });
+      expect(result.outcome).toBe("printed");
+      expect(cutoverCalled).toBe(false);
+      expect(log.join("\n")).toContain("parachute migrate --to-supervised");
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/migrate.test.ts
+++ b/src/__tests__/migrate.test.ts
@@ -439,6 +439,62 @@ describe("migrate — interactive + flag behavior", () => {
     }
   });
 
+  test("§7.3 refuses while a UNIT-MANAGED hub runs (no pidfile, detected via manager)", async () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      // NO hub pidfile — this is a supervised/unit-managed hub. Before the §7.3
+      // fix the refuse-while-running guard FAILED OPEN here and migrate would
+      // archive ~/.parachute out from under the live hub.
+      touch(join(h.configDir, "daily.db"), "X");
+
+      const logs: string[] = [];
+      const code = await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: (l) => logs.push(l),
+        prompt: async () => {
+          throw new Error("prompt must not be called");
+        },
+        yes: true,
+        isTty: true,
+        // No pidfile alive; the manager reports the hub unit active.
+        alive: () => false,
+        hubUnitState: () => ({ state: "active" }),
+      });
+      expect(code).toBe(1);
+      expect(logs.join("\n")).toMatch(/services are currently running/i);
+      // No archive happened — the guard held.
+      expect(existsSync(join(h.configDir, ".archive-2026-04-19"))).toBe(false);
+      expect(existsSync(join(h.configDir, "daily.db"))).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("§7.3 archive PROCEEDS when the manager reports the hub inactive (no false-positive)", async () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      touch(join(h.configDir, "daily.db"), "X");
+
+      const code = await migrate({
+        configDir: h.configDir,
+        now: () => APRIL_19,
+        log: () => {},
+        yes: true,
+        isTty: true,
+        alive: () => false,
+        hubUnitState: () => ({ state: "inactive" }),
+      });
+      expect(code).toBe(0);
+      // The sweep ran — daily.db is archived.
+      expect(existsSync(join(h.configDir, ".archive-2026-04-19", "daily.db"))).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("refuses non-TTY without --yes (CI / pipe safety)", async () => {
     const h = makeHarness();
     try {
@@ -713,7 +769,83 @@ describe("listRunningServices", () => {
         h.configDir,
         join(h.configDir, "services.json"),
         () => false,
+        // Explicit no-unit stub so this stays deterministic even on a dev box
+        // that happens to have a hub unit installed (the §7.3 manager check).
+        () => ({ state: "no-unit" }),
       );
+      expect(running).toEqual([]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("§7.3 archive-guard: a unit-managed hub (no pidfile) is detected RUNNING via the manager", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      // NO hub pidfile (unit-managed hubs don't write one) → the pidfile check
+      // (alive => false) reports the hub as not-running. Before the fix this
+      // FAILED OPEN. The platform-manager check sees `active` and holds.
+      const running = listRunningServices(
+        h.configDir,
+        join(h.configDir, "services.json"),
+        () => false,
+        () => ({ state: "active" }),
+      );
+      expect(running).toContain("hub");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("§7.3 archive-guard: `activating` also reads as running", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      const running = listRunningServices(
+        h.configDir,
+        join(h.configDir, "services.json"),
+        () => false,
+        () => ({ state: "activating" }),
+      );
+      expect(running).toContain("hub");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("§7.3 archive-guard: `failed` / `inactive` / `no-manager` are NOT running", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      for (const state of ["failed", "inactive", "no-manager", "no-unit", "unknown"] as const) {
+        const running = listRunningServices(
+          h.configDir,
+          join(h.configDir, "services.json"),
+          () => false,
+          () => ({ state }),
+        );
+        expect(running).not.toContain("hub");
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("§7.3 archive-guard: a manager-query that throws never crashes the guard (fails closed-ish)", () => {
+    const h = makeHarness();
+    try {
+      seedSafelist(h.configDir);
+      const running = listRunningServices(
+        h.configDir,
+        join(h.configDir, "services.json"),
+        () => false,
+        () => {
+          throw new Error("systemctl exploded");
+        },
+      );
+      // The throw is swallowed; the pidfile check (no pid) governs → not running.
+      // (The guard must not crash; it just gets no extra signal from the manager.)
       expect(running).toEqual([]);
     } finally {
       h.cleanup();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import { exposePublic, exposeTailnet } from "./commands/expose.ts";
 import { init } from "./commands/init.ts";
 import { install } from "./commands/install.ts";
 import { logs, restart, start, stop } from "./commands/lifecycle.ts";
+import { cutoverToSupervised, teardownHubUnit } from "./commands/migrate-cutover.ts";
 import { migrate } from "./commands/migrate.ts";
 import { serve } from "./commands/serve.ts";
 import { setup } from "./commands/setup.ts";
@@ -668,8 +669,12 @@ async function main(argv: string[]): Promise<number> {
       // `supervisor: {}` opts into the Phase 3b dual-dispatch: on a box with a
       // hub unit installed, drive the running supervisor; on a legacy detached
       // box (no unit), fall through to the unchanged detached path (design §3.3).
+      // `migrateOffer: { enabled: true }` arms the §7.5 detect-and-offer on the
+      // detached arm (offers the supervised cutover when a prior detached
+      // install is found; never auto-migrates).
       const startOpts = {
         supervisor: {},
+        migrateOffer: { enabled: true },
         ...(hubExtract.hubOrigin ? { hubOrigin: hubExtract.hubOrigin } : {}),
       };
       return await start(hubExtract.rest[0], startOpts);
@@ -680,7 +685,7 @@ async function main(argv: string[]): Promise<number> {
         console.log(stopHelp());
         return 0;
       }
-      return await stop(rest[0], { supervisor: {} });
+      return await stop(rest[0], { supervisor: {}, migrateOffer: { enabled: true } });
     }
 
     case "restart": {
@@ -688,7 +693,7 @@ async function main(argv: string[]): Promise<number> {
         console.log(restartHelp());
         return 0;
       }
-      return await restart(rest[0], { supervisor: {} });
+      return await restart(rest[0], { supervisor: {}, migrateOffer: { enabled: true } });
     }
 
     case "upgrade": {
@@ -762,6 +767,33 @@ async function main(argv: string[]): Promise<number> {
         console.log(migrateHelp());
         return 0;
       }
+      // §7.4 teardown — remove the hub unit (the cutover rollback path).
+      if (rest.includes("--teardown")) {
+        const teardownUnknown = rest.find((a) => a !== "--teardown");
+        if (teardownUnknown !== undefined) {
+          console.error(`parachute migrate: unknown argument "${teardownUnknown}"`);
+          console.error("usage: parachute migrate --teardown");
+          return 1;
+        }
+        teardownHubUnit();
+        return 0;
+      }
+      // §7.1 detached→supervised cutover. Opt-in surface (the archive sweep
+      // below stays the bare `migrate` default — the cutover is destructive-
+      // adjacent and must be asked for, not implicit).
+      if (rest.includes("--to-supervised")) {
+        const cutoverUnknown = rest.find((a) => a !== "--to-supervised");
+        if (cutoverUnknown !== undefined) {
+          console.error(`parachute migrate: unknown argument "${cutoverUnknown}"`);
+          console.error("usage: parachute migrate --to-supervised");
+          return 1;
+        }
+        const result = await cutoverToSupervised();
+        for (const line of result.messages) console.log(line);
+        // "already-migrated" / "migrated" are success; every other outcome is a
+        // recoverable failure that should exit non-zero so scripts can retry.
+        return result.outcome === "migrated" || result.outcome === "already-migrated" ? 0 : 1;
+      }
       const dryRun = rest.includes("--dry-run");
       const list = rest.includes("--list");
       const yes = rest.includes("--yes") || rest.includes("-y");
@@ -770,7 +802,9 @@ async function main(argv: string[]): Promise<number> {
       );
       if (unknown !== undefined) {
         console.error(`parachute migrate: unknown argument "${unknown}"`);
-        console.error("usage: parachute migrate [--list] [--dry-run] [--yes]");
+        console.error(
+          "usage: parachute migrate [--list] [--dry-run] [--yes] [--to-supervised] [--teardown]",
+        );
         return 1;
       }
       return await migrate({ dryRun, list, yes });

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -31,6 +31,11 @@ import {
   restartHubUnit as restartHubUnitImpl,
   stopHubUnit as stopHubUnitImpl,
 } from "../hub-unit.ts";
+import {
+  type MigrateOfferOpts,
+  type MigrateOfferResult,
+  offerMigrateToSupervised,
+} from "../migrate-offer.ts";
 import { ModuleManifestError, readModuleManifest } from "../module-manifest.ts";
 import {
   type DriveModuleOpDeps,
@@ -358,6 +363,24 @@ export interface LifecycleOpts {
     /** Loopback hub base URL override (default derives from the hub port). */
     baseUrl?: string;
   };
+  /**
+   * §7.5 auto-detect-and-offer seam. When a verb takes the DETACHED arm (no hub
+   * unit installed) and a prior detached install is detected, the verb offers
+   * the supervised cutover (interactive) or prints the command (non-TTY) BEFORE
+   * doing detached work. Injectable so tests can (a) stub the offer to assert it
+   * fires / migrates / declines, and (b) DISABLE it entirely (`enabled:false`)
+   * so the hundreds of existing detached-arm lifecycle tests don't trip an
+   * interactive prompt. Production wires the real `offerMigrateToSupervised`.
+   *
+   * Default when OMITTED: disabled, so existing tests (which never opt in) stay
+   * deterministic. The production CLI dispatch passes `{ enabled: true }`.
+   */
+  migrateOffer?: {
+    /** Master switch. Default `false` when the whole block is omitted. */
+    enabled?: boolean;
+    /** The offer implementation (default `offerMigrateToSupervised`). */
+    offer?: (opts: MigrateOfferOpts) => Promise<MigrateOfferResult>;
+  };
 }
 
 interface Resolved {
@@ -385,6 +408,11 @@ interface Resolved {
     log: (line: string) => void;
   }) => Promise<OperatorIssuerHealStatus>;
   sup: ResolvedSupervisor;
+  /** §7.5 resolved auto-offer (enabled flag + the offer impl). */
+  migrateOffer: {
+    enabled: boolean;
+    offer: (opts: MigrateOfferOpts) => Promise<MigrateOfferResult>;
+  };
 }
 
 /** Resolved Phase 3b supervisor-path seams (see `LifecycleOpts.supervisor`). */
@@ -467,6 +495,13 @@ function resolve(opts: LifecycleOpts): Resolved {
     stopHubFn: opts.hub?.stop ?? stopHub,
     selfHealOperatorTokenFn: opts.hub?.selfHealOperatorToken ?? defaultSelfHealOperatorToken,
     sup: resolveSupervisor(opts.supervisor),
+    migrateOffer: {
+      // Default OFF when omitted so the existing detached-arm lifecycle tests
+      // (which never opt in) don't trip an interactive prompt. The production
+      // CLI dispatch passes `{ enabled: true }`.
+      enabled: opts.migrateOffer?.enabled ?? false,
+      offer: opts.migrateOffer?.offer ?? offerMigrateToSupervised,
+    },
   };
 }
 
@@ -504,6 +539,40 @@ function resolveSupervisor(opts: LifecycleOpts["supervisor"]): ResolvedSuperviso
     openDb: opts?.openDb ?? ((configDir) => openHubDb(hubDbPath(configDir))),
     baseUrl: opts?.baseUrl,
   };
+}
+
+/**
+ * §7.5 auto-detect-and-offer hook for the detached arm of start/stop/restart.
+ *
+ * Called only AFTER the `r.sup.unitInstalled` branch fell through (we're on the
+ * detached arm). When the offer is enabled, it runs `offerMigrateToSupervised`
+ * (which itself checks "no unit + prior detached" and prompts / prints). Returns
+ * `true` ONLY when the operator accepted AND the cutover succeeded — i.e. the
+ * box is NOW supervised, so the caller should re-dispatch through the supervisor
+ * path. Every other outcome (offer disabled, no-offer, declined, printed in a
+ * non-TTY, migrate-failed) returns `false` → the caller proceeds with the
+ * detached arm unchanged.
+ *
+ * The migrate-failed case deliberately returns `false`: a failed cutover leaves
+ * the box still on the detached model (the cutover is fail-safe + re-runnable),
+ * so the original verb should still run the detached way rather than re-dispatch
+ * into a supervisor that isn't up.
+ */
+async function maybeOfferAndMigrate(r: Resolved): Promise<boolean> {
+  if (!r.migrateOffer.enabled) return false;
+  const result = await r.migrateOffer.offer({
+    configDir: r.configDir,
+    manifestPath: r.manifestPath,
+    log: r.log,
+  });
+  if (result.outcome === "migrated") {
+    // The box is now supervised. Flip the resolved discriminant so the
+    // re-dispatched verb takes the supervisor arm (the unit is freshly
+    // installed; `r.sup.unitInstalled` was resolved as false before the offer).
+    r.sup.unitInstalled = true;
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -696,6 +765,11 @@ export async function start(svc: string | undefined, opts: LifecycleOpts = {}): 
   // detached arm below. Phase 5 deletes the else-arm — keep this a clean
   // top-level branch so that deletion is a one-liner.
   if (r.sup.unitInstalled) return startViaSupervisor(svc, r);
+  // §7.5 auto-detect-and-offer: a box on the detached model (no unit) with a
+  // prior detached install gets offered the supervised cutover. If the operator
+  // accepts + migrates, the box is now supervised — re-dispatch this verb
+  // through the supervisor path. Declined / printed / no-offer → fall through.
+  if (await maybeOfferAndMigrate(r)) return startViaSupervisor(svc, r);
   // --- no-unit detached fallback (unchanged; preserved until Phase 5) ---
   if (svc === HUB_SVC) return startHubSvc(r);
   const picked = await resolveTargets(svc, r.manifestPath);
@@ -941,6 +1015,9 @@ export async function stop(svc: string | undefined, opts: LifecycleOpts = {}): P
   // Phase 3b dual-dispatch (design §3.3). Unit-installed → drive the supervisor
   // / platform manager; else the unchanged detached arm below.
   if (r.sup.unitInstalled) return stopViaSupervisor(svc, r);
+  // §7.5 auto-detect-and-offer (see `start`). On accept+migrate, re-dispatch
+  // through the supervisor path.
+  if (await maybeOfferAndMigrate(r)) return stopViaSupervisor(svc, r);
   // --- no-unit detached fallback (unchanged; preserved until Phase 5) ---
   if (svc === HUB_SVC) return stopHubSvc(r);
   const picked = await resolveTargets(svc, r.manifestPath);
@@ -998,6 +1075,9 @@ export async function restart(svc: string | undefined, opts: LifecycleOpts = {})
   // / platform manager (with the 404-fallthrough for modules, §6.2); else the
   // unchanged detached stop-then-start below.
   if (r.sup.unitInstalled) return restartViaSupervisor(svc, r);
+  // §7.5 auto-detect-and-offer (see `start`). On accept+migrate, re-dispatch
+  // through the supervisor path.
+  if (await maybeOfferAndMigrate(r)) return restartViaSupervisor(svc, r);
   // --- no-unit detached fallback (unchanged; preserved until Phase 5) ---
   // Pass `supervisor: undefined` to the inner stop/start so their own
   // `resolveSupervisor` short-circuits to `unitInstalled: false` without

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -585,7 +585,7 @@ async function maybeOfferAndMigrate(r: Resolved): Promise<boolean> {
  * The fallback differs cosmetically — here `readHubPort(configDir) ??
  * HUB_UNIT_DEFAULT_PORT`, in auth.ts `127.0.0.1:${HUB_DEFAULT_PORT}` — but both
  * resolve to 1939 under canonical-ports today, so they agree in practice.
- * TODO: consolidate with auth.ts:resolveHubIssuer to prevent drift.
+ * See #508: consolidate with auth.ts:resolveHubIssuer to prevent drift.
  */
 function resolveOperatorTokenIssuer(hubOrigin: string | undefined, configDir: string): string {
   if (hubOrigin) return hubOrigin;
@@ -1084,7 +1084,14 @@ export async function restart(svc: string | undefined, opts: LifecycleOpts = {})
   // re-probing `isHubUnitInstalled` (two redundant `stat`s per call) — we
   // already resolved no-unit above, so both inner calls would re-take this
   // same detached arm regardless. Behavior-preserving; just drops the probes.
-  const detachedOpts = { ...opts, supervisor: undefined };
+  //
+  // Also DISABLE the auto-migrate offer on the inner stop+start: the OUTER
+  // `restart` already ran `maybeOfferAndMigrate` above (one offer). Without this,
+  // the offer block (`migrateOffer: { enabled: true }`) flows through `...opts`
+  // into both inner calls → an operator who declines is prompted 3× (TTY) / the
+  // command is printed 3× (non-TTY). `restart` owns the single offer; the inner
+  // verbs must not re-offer.
+  const detachedOpts = { ...opts, supervisor: undefined, migrateOffer: { enabled: false } };
   const stopCode = await stop(svc, detachedOpts);
   if (stopCode !== 0) return stopCode;
   return await start(svc, detachedOpts);

--- a/src/commands/migrate-cutover.ts
+++ b/src/commands/migrate-cutover.ts
@@ -440,11 +440,22 @@ async function stopDetachedModule(
  * operator's unrelated process that merely squats a declared port. Attributable
  * when ANY of:
  *   - the orphan pid equals the module's RECORDED pid (services.json/pidfile);
- *   - its command line mentions `parachute` (any parachute-managed process);
- *   - its command line mentions the module's short name (e.g. `vault`);
- *   - its command line mentions the module's start command (when known).
+ *   - its command line mentions `parachute` (any parachute-managed process —
+ *     the `~/.parachute/...` install path and the `@openparachute/<mod>`
+ *     package name both carry this marker, so it catches every genuine
+ *     parachute-managed module);
+ *   - its command line mentions the module's start command (when a hint is
+ *     supplied — currently always unset at the call site, the seam is kept
+ *     for a future services.json-derived start command).
  * An unreadable command line (probe returned undefined) + a non-matching pid is
  * NOT attributable — we refuse to kill it.
+ *
+ * NOTE: the bare module short-name needle (`vault`/`runner`/`scribe`/`notes`)
+ * was deliberately dropped — on the most destructive command (a process KILL),
+ * a bare short-name is too loose: a `runner` substring matches an unrelated CI
+ * runner squatting the port. The `parachute` marker already attributes every
+ * genuine parachute-managed process, so the short-name arm only widened the
+ * false-positive surface.
  */
 function orphanAttributable(args: {
   orphan: number;
@@ -453,18 +464,16 @@ function orphanAttributable(args: {
   startCmdHint: string | undefined;
   ownerOfPid: OwnerProbeFn;
 }): { attributable: boolean; cmdline: string | undefined } {
-  const { orphan, recordedPid, short, startCmdHint, ownerOfPid } = args;
+  const { orphan, recordedPid, startCmdHint, ownerOfPid } = args;
   if (recordedPid !== undefined && orphan === recordedPid) {
     return { attributable: true, cmdline: undefined };
   }
   const cmdline = ownerOfPid(orphan);
   if (cmdline === undefined) return { attributable: false, cmdline: undefined };
   const haystack = cmdline.toLowerCase();
-  const needles = [
-    "parachute",
-    short.toLowerCase(),
-    ...(startCmdHint ? [startCmdHint.toLowerCase()] : []),
-  ].filter((n) => n.length > 0);
+  const needles = ["parachute", ...(startCmdHint ? [startCmdHint.toLowerCase()] : [])].filter(
+    (n) => n.length > 0,
+  );
   const attributable = needles.some((n) => haystack.includes(n));
   return { attributable, cmdline };
 }

--- a/src/commands/migrate-cutover.ts
+++ b/src/commands/migrate-cutover.ts
@@ -52,6 +52,7 @@
  * launchctl / lsof / process kills.
  */
 
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import {
@@ -59,7 +60,6 @@ import {
   type KillFn,
   type PidOnPortFn,
   type StopHubOpts,
-  defaultKill,
   defaultPidOnPort,
   stopHub,
 } from "../hub-control.ts";
@@ -83,7 +83,7 @@ import {
   removeManagedUnit,
 } from "../managed-unit.ts";
 import { type PortListeningFn, defaultPortListening } from "../port-probe.ts";
-import { type AliveFn, clearPid, defaultAlive, readPid } from "../process-state.ts";
+import { type AliveFn, clearPid, readPid } from "../process-state.ts";
 import { shortNameForManifest } from "../service-spec.ts";
 import { type ServiceEntry, readManifestLenient } from "../services-manifest.ts";
 
@@ -98,6 +98,38 @@ export function defaultHubCliPath(): string {
 }
 
 /**
+ * Best-effort command-line probe for a pid (the orphan-sweep ownership check).
+ * Returns the process's command line, or undefined when it can't be read. See
+ * `CutoverDeps.ownerOfPid`.
+ */
+export type OwnerProbeFn = (pid: number) => string | undefined;
+
+/**
+ * Production `ownerOfPid`: `ps -o command= -p <pid>` returns the full argv of the
+ * process (one line). macOS + Linux both ship `ps` and accept `-o command=` (the
+ * trailing `=` suppresses the header). Any failure — `ps` missing, pid gone,
+ * permission, garbage — returns undefined so the caller treats the orphan as
+ * UNATTRIBUTABLE (and refuses to kill it). Mirrors `defaultPidOnPort`'s
+ * shell-out-and-swallow shape.
+ */
+export const defaultOwnerOfPid: OwnerProbeFn = (pid) => {
+  try {
+    const result = spawnSync("ps", ["-o", "command=", "-p", String(pid)], {
+      encoding: "utf8",
+      timeout: 2000,
+    });
+    if (result.status !== 0) return undefined;
+    const line = result.stdout
+      .split("\n")
+      .map((s) => s.trim())
+      .find((s) => s.length > 0);
+    return line === undefined || line.length === 0 ? undefined : line;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
  * Injectable side-effect seam for the cutover. Production wires the real
  * implementations; tests inject fakes so no real process is stopped, no real
  * unit installed, no real port probed.
@@ -105,10 +137,20 @@ export function defaultHubCliPath(): string {
 export interface CutoverDeps {
   /** Process-liveness probe (pidfile readers + this = "is the detached proc alive?"). */
   alive: AliveFn;
-  /** Send a signal to a pid (orphan-sweep kill). */
+  /** Send a signal to a pid (orphan-sweep kill). Group-aware (negative-pid) by default. */
   kill: KillFn;
   /** Which pid is bound to a port (orphan-sweep lsof). */
   pidOnPort: PidOnPortFn;
+  /**
+   * Best-effort command-line of a pid (the orphan-sweep ownership probe). Returns
+   * the process's argv joined (e.g. `bun .../server.ts --port 1940`) or undefined
+   * when it can't be read (pid gone, permission, no `ps`). Used by
+   * `sweepOrphanOnPort` to decide whether an orphan holding a MODULE port is
+   * plausibly that parachute module before adopting + killing it — so the cutover
+   * never blind-kills an operator's unrelated process that happens to squat a
+   * declared port. Injectable so tests drive attribution without shelling to `ps`.
+   */
+  ownerOfPid: OwnerProbeFn;
   /** TCP connect-probe for the verify-ports-free + verify-hub-ready steps. */
   portListening: PortListeningFn;
   /** Stop the detached hub (SIGTERM→SIGKILL + 1939 orphan adoption). */
@@ -152,6 +194,17 @@ export interface WriteUnitResult {
   written: boolean;
   /** "installed" (file on disk) or "fallback" (no manager / write failed). */
   outcome: "installed" | "fallback";
+  /**
+   * On a `fallback`, WHY — so the caller maps to the right `CutoverOutcome`
+   * instead of conflating the two causes (the MUST-FIX NIT: a bun-not-found /
+   * write failure previously surfaced as the wrong "no service manager" message,
+   * and the `write-failed` outcome was dead):
+   *   - "no-manager"  → no systemd/launchd here (the supervised model is impossible);
+   *   - "write-failed" → a manager exists but the unit couldn't be written (bun
+   *     unresolvable, write/daemon-reload failure).
+   * Undefined when `outcome === "installed"`.
+   */
+  cause?: "no-manager" | "write-failed";
   messages: string[];
 }
 
@@ -183,10 +236,13 @@ export function defaultWriteUnitWithoutStarting(opts: WriteUnitOpts): WriteUnitR
     });
   } catch (err) {
     // `bun` couldn't be resolved — refuse to bake a broken ExecStart. No unit on
-    // disk: not resumable from here (the caller surfaces it as a hard failure).
+    // disk: not resumable from here. A manager may well exist; this is a WRITE
+    // failure (can't compose a valid unit), NOT a no-manager host — surface it as
+    // such so the operator sees "bun not found / could not write the unit".
     return {
       written: false,
       outcome: "fallback",
+      cause: "write-failed",
       messages: [err instanceof Error ? err.message : String(err)],
     };
   }
@@ -196,21 +252,75 @@ export function defaultWriteUnitWithoutStarting(opts: WriteUnitOpts): WriteUnitR
     messages: hubUnitMessages(),
     start: false,
   });
-  // `installed` → the file is on disk (resumable). `fallback` → no manager /
-  // write failed; the messages explain. We treat a `fallback` whose cause is
-  // "no manager" as not-written (can't host a unit), and a write-failed fallback
-  // likewise — both leave no usable unit on disk.
+  // `installed` → the file is on disk (resumable). `fallback` → either no manager
+  // (host can't host a unit) or the install/write failed (manager present). Thread
+  // the manager's `reason` through so the caller distinguishes them; default to
+  // "write-failed" if (somehow) absent — the conservative non-no-manager message.
   return {
     written: res.outcome === "installed",
     outcome: res.outcome,
+    cause: res.outcome === "fallback" ? (res.reason ?? "write-failed") : undefined,
     messages: res.messages,
   };
 }
 
+/**
+ * Group-aware kill — INLINED from `lifecycle.ts`'s `defaultKill` (NOT imported,
+ * to avoid the import cycle `lifecycle.ts → migrate-offer.ts → migrate-cutover.ts`).
+ * MUST stay byte-equivalent to lifecycle's group-aware kill.
+ *
+ * Modules are spawned `detached: true` by `defaultSpawner` (lifecycle.ts), so the
+ * recorded pid is a process-GROUP leader (pid == pgid). A wrapper startCmd like
+ * `pnpm exec tsx server.ts` leaves the real server as a GRANDCHILD inside that
+ * group. The cutover originally used the BARE-PID `hub-control.ts:defaultKill`
+ * (`process.kill(pid, sig)`), which signals only the wrapper — the tsx grandchild
+ * survives, keeps holding the module's port, `waitPortFree` times out, and the
+ * cutover returns `port-stuck` on the FIRST run for any wrapper-startCmd module
+ * (the exact hub#88 footgun). `process.kill(-pid, sig)` signals the whole group;
+ * ESRCH (legacy pidfile written before detached-spawn, or the leader already
+ * exited and the group emptied) falls back to a bare-pid signal so the intent
+ * still lands when there's a positive-pid process to receive it.
+ */
+const groupAwareKill: KillFn = (pid, signal) => {
+  try {
+    process.kill(-pid, signal);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ESRCH") throw err;
+    process.kill(pid, signal);
+  }
+};
+
+/**
+ * Group-aware liveness — INLINED from `lifecycle.ts`'s `defaultAlive` (same
+ * import-cycle reason as `groupAwareKill`). Returns true if the process GROUP
+ * (pgid == pid) still has any member, so the stop-then-wait loop keeps polling
+ * until the wrapper AND its grandchild are both gone (the bare-pid
+ * `process-state.ts:defaultAlive` would report the leader dead while the
+ * grandchild lingers, prematurely clearing the pidfile + skipping the SIGKILL
+ * escalation, re-opening the hub#88 port hold). ESRCH on the group probe (legacy
+ * pidfile, or the leader exited and the group emptied) falls back to a bare-pid
+ * check so a positive-pid process is still honored.
+ */
+const groupAwareAlive: AliveFn = (pid) => {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ESRCH") return true;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 export const defaultCutoverDeps: CutoverDeps = {
-  alive: defaultAlive,
-  kill: defaultKill,
+  alive: groupAwareAlive,
+  kill: groupAwareKill,
   pidOnPort: defaultPidOnPort,
+  ownerOfPid: defaultOwnerOfPid,
   portListening: defaultPortListening,
   stopHub,
   installAndStartHubUnit,
@@ -325,26 +435,96 @@ async function stopDetachedModule(
 }
 
 /**
+ * Decide whether an orphan pid bound to a MODULE port is plausibly attributable
+ * to that parachute module — the MUST-FIX-2 guard against blind-killing an
+ * operator's unrelated process that merely squats a declared port. Attributable
+ * when ANY of:
+ *   - the orphan pid equals the module's RECORDED pid (services.json/pidfile);
+ *   - its command line mentions `parachute` (any parachute-managed process);
+ *   - its command line mentions the module's short name (e.g. `vault`);
+ *   - its command line mentions the module's start command (when known).
+ * An unreadable command line (probe returned undefined) + a non-matching pid is
+ * NOT attributable — we refuse to kill it.
+ */
+function orphanAttributable(args: {
+  orphan: number;
+  recordedPid: number | undefined;
+  short: string;
+  startCmdHint: string | undefined;
+  ownerOfPid: OwnerProbeFn;
+}): { attributable: boolean; cmdline: string | undefined } {
+  const { orphan, recordedPid, short, startCmdHint, ownerOfPid } = args;
+  if (recordedPid !== undefined && orphan === recordedPid) {
+    return { attributable: true, cmdline: undefined };
+  }
+  const cmdline = ownerOfPid(orphan);
+  if (cmdline === undefined) return { attributable: false, cmdline: undefined };
+  const haystack = cmdline.toLowerCase();
+  const needles = [
+    "parachute",
+    short.toLowerCase(),
+    ...(startCmdHint ? [startCmdHint.toLowerCase()] : []),
+  ].filter((n) => n.length > 0);
+  const attributable = needles.some((n) => haystack.includes(n));
+  return { attributable, cmdline };
+}
+
+/**
  * §7.2 orphan sweep: lsof a port, and if a live process is bound to it, adopt +
  * kill it (mirrors stopHub's 1939 orphan-adoption, per-module-port). A
  * stale-pidfile-but-alive module won't be found by `readPid` → without this it
  * stays bound → the supervised re-spawn hits EADDRINUSE.
+ *
+ * MUST-FIX 2 — OWNERSHIP CHECK (module ports only): for a declared MODULE port,
+ * we refuse to kill an orphan unless it's plausibly attributable to that
+ * parachute module (`orphanAttributable`). An operator's own dev server squatting
+ * a module's port must NOT be nuked by the cutover — we emit a clear warning and
+ * leave it; the subsequent verify-ports-free step turns the still-held port into
+ * a `port-stuck` outcome the operator resolves. The HUB port retains the
+ * pre-existing blind-adopt behavior (mirrors `stopHub`'s 1939 orphan-adoption) —
+ * that scope is unchanged; pass `attribute: undefined` for it.
+ *
+ * Returns true when the orphan was adopted + signalled (or there was no orphan),
+ * false when an UNATTRIBUTABLE process was found + deliberately left running.
  */
 function sweepOrphanOnPort(
   port: number,
   label: string,
   deps: CutoverDeps,
   log: (line: string) => void,
-): void {
+  attribute?: { recordedPid: number | undefined; short: string; startCmdHint: string | undefined },
+): boolean {
   const orphan = deps.pidOnPort(port);
-  if (orphan === undefined) return;
-  if (!deps.alive(orphan)) return;
+  if (orphan === undefined) return true;
+  if (!deps.alive(orphan)) return true;
+
+  if (attribute !== undefined) {
+    const { attributable, cmdline } = orphanAttributable({
+      orphan,
+      recordedPid: attribute.recordedPid,
+      short: attribute.short,
+      startCmdHint: attribute.startCmdHint,
+      ownerOfPid: deps.ownerOfPid,
+    });
+    if (!attributable) {
+      const desc = cmdline ? `${cmdline}` : "command line unavailable";
+      log(
+        `  ⚠ port ${port} for ${label} is held by an unrelated process (PID ${orphan}, ${desc}); refusing to kill it.`,
+      );
+      log(
+        "    The cutover only adopts processes it can attribute to this module. Stop that process yourself,",
+      );
+      log("    then re-run `parachute migrate --to-supervised`.");
+      return false;
+    }
+  }
+
   log(`  orphan on ${label} port ${port} (PID ${orphan}) — stopping it.`);
   try {
     deps.kill(orphan, "SIGTERM");
   } catch {
     // Already gone.
-    return;
+    return true;
   }
   // Best-effort SIGKILL follow-up if still alive (no long wait — the
   // verify-ports-free step below polls + escalates the failure if it persists).
@@ -355,6 +535,7 @@ function sweepOrphanOnPort(
       // Racing a just-exited process.
     }
   }
+  return true;
 }
 
 /**
@@ -444,10 +625,13 @@ export async function cutoverToSupervised(opts: CutoverOpts = {}): Promise<Cutov
   });
   for (const m of write.messages) log(`  ${m}`);
   if (!write.written) {
-    if (write.outcome === "fallback") {
+    // Distinguish the two fallback causes (MUST-FIX NIT). Both bail cleanly here —
+    // we're still BEFORE step 3, so nothing has been stopped — but with accurate
+    // messaging so a bun-not-found / write failure doesn't masquerade as a
+    // missing-service-manager host.
+    if (write.cause === "no-manager") {
       // No service manager on this host (container / init-less) — there is no
-      // unit to install; the runtime here is foreground `serve`. Bail cleanly
-      // WITHOUT having stopped anything (we're still before step 3).
+      // unit to install; the runtime here is foreground `serve`.
       return {
         outcome: "no-manager",
         port,
@@ -458,12 +642,15 @@ export async function cutoverToSupervised(opts: CutoverOpts = {}): Promise<Cutov
         ],
       };
     }
-    // The write itself failed (e.g. bun unresolvable). Nothing stopped yet —
-    // safe to bail.
+    // The write itself failed (bun unresolvable, or the manager errored writing
+    // the unit). A manager may exist — this is NOT a no-manager host.
     return {
       outcome: "write-failed",
       port,
-      messages: ["Could not write the hub unit file — no changes made.", ...write.messages],
+      messages: [
+        "Could not write the hub unit file (bun not found, or the service manager errored) — no changes made.",
+        ...write.messages,
+      ],
     };
   }
 
@@ -478,10 +665,21 @@ export async function cutoverToSupervised(opts: CutoverOpts = {}): Promise<Cutov
   }
 
   // --- Step 4: §7.2 ORPHAN SWEEP — per services.json port + the hub port. ---
+  // The HUB port keeps the pre-existing blind-adopt (mirrors stopHub's 1939
+  // orphan-adoption — out of scope for MUST-FIX 2). The MODULE ports get the
+  // ownership check: we read the module's recorded pid (so a still-alive process
+  // we already know about is trivially attributable) and only adopt+kill an
+  // orphan we can attribute to that parachute module; an UNATTRIBUTABLE squatter
+  // is left running with a warning, and the verify-ports-free step turns the
+  // still-held port into `port-stuck`.
   log("Sweeping orphaned processes still bound to declared ports…");
   sweepOrphanOnPort(port, "hub", deps, log);
   for (const target of targets) {
-    sweepOrphanOnPort(target.port, target.short, deps, log);
+    sweepOrphanOnPort(target.port, target.short, deps, log, {
+      recordedPid: readPid(target.short, configDir),
+      short: target.short,
+      startCmdHint: undefined,
+    });
   }
 
   // --- Step 5: VERIFY the hub port + each module port is free. ---

--- a/src/commands/migrate-cutover.ts
+++ b/src/commands/migrate-cutover.ts
@@ -1,0 +1,630 @@
+/**
+ * `parachute migrate --to-supervised` (and `--teardown`) — the idempotent
+ * detached→supervised CUTOVER, Phase 5a of the hub-as-supervisor unification
+ * (design `parachute.computer/design/2026-06-01-hub-as-supervisor-unification.md`
+ * §7.1–§7.5).
+ *
+ * This file is the MACHINERY; the BRIDGE stays intact. After 5a an un-migrated
+ * box still works on the detached path (`defaultSpawner` / `ensureHubRunning`
+ * remain — Phase 5b retires them). The cutover is opt-in (`--to-supervised`) or
+ * auto-offered (§7.5, in `lifecycle.ts`). It NEVER runs implicitly.
+ *
+ * The cutover is the most dangerous operation in the CLI: it stops real running
+ * services and installs a process-manager unit. So the ORDERING is load-bearing
+ * and the whole path is FAIL-SAFE + RESUMABLE:
+ *
+ *   §7.1 ordering (stop-detached-FIRST-then-start-unit, to dodge the port-1939
+ *   double-spawn race the canonical-ports 1939-pin would turn into a crash-loop):
+ *     1. DETECT the current model (detached hub alive? each module alive?). If a
+ *        hub unit already exists AND the hub is supervised → idempotent no-op.
+ *     2. WRITE the unit file WITHOUT starting it (`installManagedUnit start:false`
+ *        — daemon-reload but NOT enable --now / bootstrap). This is the §7.1
+ *        race-avoider: the unit is on disk + resumable, but no second hub is
+ *        started yet.
+ *     3. STOP the detached processes — `stopHub` for the hub, a per-module
+ *        pidfile stop for each module.
+ *     4. §7.2 ORPHAN SWEEP — lsof per services.json port + the hub port; adopt +
+ *        kill any process still bound to a declared port (mirrors stopHub's 1939
+ *        orphan-adoption, per-module-port).
+ *     5. VERIFY the hub port + each module port is free (bounded poll). If a port
+ *        won't free, FAIL leaving the unit written-but-not-started so a retry is
+ *        clean.
+ *     6. START the unit (`installManagedUnit start:true` / enable --now). The hub
+ *        comes up on a free 1939 and boots modules from services.json.
+ *     7. VERIFY the hub answers /health and the expected modules are running.
+ *     8. The cloudflared connector (if any) is left intact — it's its own unit.
+ *
+ * RESUMABILITY: a partial cutover (unit written, not started) is the canonical
+ * recoverable state. Re-running `--to-supervised` from there:
+ *   - DETECT sees a unit installed but the hub NOT supervised (no /health) → it
+ *     does NOT no-op; it re-runs steps 2-7. Step 2 (write start:false) is
+ *     idempotent (overwrites the same file), the stop steps are no-ops if the
+ *     detached procs already died, and step 6 brings the unit up.
+ *
+ * FAIL-SAFE: every failure leaves a recoverable state. The only states we refuse
+ * to leave the box in are (a) detached-stopped + unit-failed-to-start + no
+ * recovery path. Step 6's start-failure leaves the unit written (re-runnable);
+ * step 5's port-won't-free fails BEFORE stopping nothing-more and before
+ * starting, with the unit written for a clean retry.
+ *
+ * EVERYTHING is behind injectable seams (the `CutoverDeps`) so the destructive
+ * tests run in a sandbox `PARACHUTE_HOME` with NO real Bun.spawn / systemctl /
+ * launchctl / lsof / process kills.
+ */
+
+import { fileURLToPath } from "node:url";
+import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
+import {
+  HUB_DEFAULT_PORT,
+  type KillFn,
+  type PidOnPortFn,
+  type StopHubOpts,
+  defaultKill,
+  defaultPidOnPort,
+  stopHub,
+} from "../hub-control.ts";
+import {
+  type HubUnitDeps,
+  type InstallAndStartHubUnitOpts,
+  type InstallAndStartHubUnitResult,
+  defaultHubUnitDeps,
+  hubUnitMessages,
+  installAndStartHubUnit,
+  isHubUnitInstalled,
+} from "../hub-unit.ts";
+import {
+  HUB_LAUNCHD_LABEL,
+  HUB_SYSTEMD_UNIT_NAME,
+  type ManagedUnit,
+  type ManagedUnitDeps,
+  type ManagedUnitRemoveResult,
+  buildHubManagedUnit,
+  installManagedUnit,
+  removeManagedUnit,
+} from "../managed-unit.ts";
+import { type PortListeningFn, defaultPortListening } from "../port-probe.ts";
+import { type AliveFn, clearPid, defaultAlive, readPid } from "../process-state.ts";
+import { shortNameForManifest } from "../service-spec.ts";
+import { type ServiceEntry, readManifestLenient } from "../services-manifest.ts";
+
+/**
+ * Absolute path to this hub checkout's `src/cli.ts` — the entry the hub unit's
+ * `ExecStart`/`ProgramArguments` runs `serve` against. This file is
+ * `src/commands/migrate-cutover.ts`, so `cli.ts` is one directory up. Mirrors
+ * `init.ts`'s `defaultHubCliPath`.
+ */
+export function defaultHubCliPath(): string {
+  return fileURLToPath(new URL("../cli.ts", import.meta.url));
+}
+
+/**
+ * Injectable side-effect seam for the cutover. Production wires the real
+ * implementations; tests inject fakes so no real process is stopped, no real
+ * unit installed, no real port probed.
+ */
+export interface CutoverDeps {
+  /** Process-liveness probe (pidfile readers + this = "is the detached proc alive?"). */
+  alive: AliveFn;
+  /** Send a signal to a pid (orphan-sweep kill). */
+  kill: KillFn;
+  /** Which pid is bound to a port (orphan-sweep lsof). */
+  pidOnPort: PidOnPortFn;
+  /** TCP connect-probe for the verify-ports-free + verify-hub-ready steps. */
+  portListening: PortListeningFn;
+  /** Stop the detached hub (SIGTERM→SIGKILL + 1939 orphan adoption). */
+  stopHub: (opts: StopHubOpts) => Promise<boolean>;
+  /**
+   * Install + start the hub unit (the §7.1 step-6 start). Calls
+   * `installAndStartHubUnit` in production. The cutover does NOT call
+   * `installManagedUnit start:false` directly for the WRITE step — instead it
+   * reuses the higher-level builder so the env capture / bun resolution / readiness
+   * wait all match `init`. See `writeUnitWithoutStarting`.
+   */
+  installAndStartHubUnit: (
+    opts: InstallAndStartHubUnitOpts,
+  ) => Promise<InstallAndStartHubUnitResult>;
+  /**
+   * Write the hub unit file WITHOUT starting it (§7.1 step 2 — the race-avoider).
+   * Production builds the descriptor + calls `installManagedUnit(start:false)`;
+   * tests stub it. Returns true on a successful write (or fallback-but-recoverable),
+   * false when even the write failed (no unit on disk → not resumable here).
+   */
+  writeUnitWithoutStarting: (opts: WriteUnitOpts) => WriteUnitResult;
+  /** Is a hub unit file installed? (the §7.1 step-1 detect discriminant). */
+  isHubUnitInstalled: (deps: HubUnitDeps) => boolean;
+  /** Probe whether the loopback hub answers /health (detect "supervised" + verify). */
+  probeHealth: (port: number) => Promise<boolean>;
+  /** Sleep between port-free / readiness polls (tests pin to 0). */
+  sleep: (ms: number) => Promise<void>;
+  /** The hub-unit deps for install / detect / manager calls. */
+  hubUnitDeps: HubUnitDeps;
+}
+
+export interface WriteUnitOpts {
+  parachuteHome: string;
+  cliPath: string;
+  port: number;
+  deps: HubUnitDeps;
+}
+
+export interface WriteUnitResult {
+  /** True when the unit file is on disk (resumable). False = write failed. */
+  written: boolean;
+  /** "installed" (file on disk) or "fallback" (no manager / write failed). */
+  outcome: "installed" | "fallback";
+  messages: string[];
+}
+
+/**
+ * Production `writeUnitWithoutStarting`: build the hub `ManagedUnit` descriptor
+ * (captures the operator's current PARACHUTE_HOME per §4.2, resolves abs bun)
+ * and `installManagedUnit(start:false)` — daemon-reload / write-the-plist but
+ * NEVER enable --now / bootstrap. The §7.1 step-2 race-avoider.
+ */
+function defaultUnitPath(bunInstall: string): string {
+  return `${bunInstall}/bin:/usr/local/bin:/usr/bin:/bin`;
+}
+
+export function defaultWriteUnitWithoutStarting(opts: WriteUnitOpts): WriteUnitResult {
+  const { deps } = opts;
+  const bunInstall = `${deps.homeDir()}/.bun`;
+  const path = defaultUnitPath(bunInstall);
+  const logPath = `${opts.parachuteHome}/hub/logs/hub.log`;
+  let unit: ManagedUnit;
+  try {
+    unit = buildHubManagedUnit({
+      parachuteHome: opts.parachuteHome,
+      port: opts.port,
+      bunInstall,
+      path,
+      cliPath: opts.cliPath,
+      logPath,
+      deps,
+    });
+  } catch (err) {
+    // `bun` couldn't be resolved — refuse to bake a broken ExecStart. No unit on
+    // disk: not resumable from here (the caller surfaces it as a hard failure).
+    return {
+      written: false,
+      outcome: "fallback",
+      messages: [err instanceof Error ? err.message : String(err)],
+    };
+  }
+  const res = installManagedUnit({
+    unit,
+    deps,
+    messages: hubUnitMessages(),
+    start: false,
+  });
+  // `installed` → the file is on disk (resumable). `fallback` → no manager /
+  // write failed; the messages explain. We treat a `fallback` whose cause is
+  // "no manager" as not-written (can't host a unit), and a write-failed fallback
+  // likewise — both leave no usable unit on disk.
+  return {
+    written: res.outcome === "installed",
+    outcome: res.outcome,
+    messages: res.messages,
+  };
+}
+
+export const defaultCutoverDeps: CutoverDeps = {
+  alive: defaultAlive,
+  kill: defaultKill,
+  pidOnPort: defaultPidOnPort,
+  portListening: defaultPortListening,
+  stopHub,
+  installAndStartHubUnit,
+  writeUnitWithoutStarting: defaultWriteUnitWithoutStarting,
+  isHubUnitInstalled,
+  probeHealth: defaultHubUnitDeps.probeHealth,
+  sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+  hubUnitDeps: defaultHubUnitDeps,
+};
+
+export interface CutoverOpts {
+  configDir?: string;
+  manifestPath?: string;
+  /** Hub port (default 1939). */
+  port?: number;
+  /** Absolute cli.ts path the unit runs `serve` against (default resolved here). */
+  cliPath?: string;
+  log?: (line: string) => void;
+  deps?: Partial<CutoverDeps>;
+  /** Port-free / readiness budget in ms (default 15s). */
+  timeoutMs?: number;
+  /** Poll interval in ms (default 250). */
+  pollMs?: number;
+}
+
+export type CutoverOutcome =
+  /** A hub unit already exists AND the hub answers /health → nothing to do. */
+  | "already-migrated"
+  /** The full cutover ran end-to-end and the hub is supervised + healthy. */
+  | "migrated"
+  /** No service manager (container / init-less) — cutover is impossible here. */
+  | "no-manager"
+  /** A declared port wouldn't free; unit written-but-not-started, re-runnable. */
+  | "port-stuck"
+  /** The unit failed to start; written-but-not-started, re-runnable. */
+  | "start-failed"
+  /** The unit came up but never answered /health within the budget. */
+  | "verify-timeout"
+  /** Couldn't even write the unit file (e.g. bun unresolvable). */
+  | "write-failed";
+
+export interface CutoverResult {
+  outcome: CutoverOutcome;
+  /** The hub port. */
+  port: number;
+  messages: string[];
+}
+
+/** A module's short name + the port it declares in services.json. */
+interface ModuleTarget {
+  short: string;
+  port: number;
+}
+
+/** Read each services.json module's short name + declared port (lenient). */
+function moduleTargets(manifestPath: string): ModuleTarget[] {
+  let services: ServiceEntry[];
+  try {
+    services = readManifestLenient(manifestPath).services;
+  } catch {
+    return [];
+  }
+  const out: ModuleTarget[] = [];
+  for (const entry of services) {
+    const short = shortNameForManifest(entry.name) ?? entry.name;
+    out.push({ short, port: entry.port });
+  }
+  return out;
+}
+
+/**
+ * Stop a single detached module by its pidfile (mirrors lifecycle.ts's detached
+ * stop arm). SIGTERM → bounded wait → SIGKILL → clear pidfile. A missing/stale
+ * pidfile is a no-op. Returns true when the module is now stopped.
+ */
+async function stopDetachedModule(
+  target: ModuleTarget,
+  configDir: string,
+  deps: CutoverDeps,
+  killWaitMs: number,
+  pollMs: number,
+  log: (line: string) => void,
+): Promise<void> {
+  const pid = readPid(target.short, configDir);
+  if (pid === undefined) return;
+  if (!deps.alive(pid)) {
+    clearPid(target.short, configDir);
+    return;
+  }
+  try {
+    deps.kill(pid, "SIGTERM");
+  } catch {
+    // Gone between alive() and kill(); treat as stopped.
+    clearPid(target.short, configDir);
+    return;
+  }
+  const deadline = Date.now() + killWaitMs;
+  while (Date.now() < deadline && deps.alive(pid)) {
+    if (pollMs > 0) await deps.sleep(pollMs);
+    else break;
+  }
+  if (deps.alive(pid)) {
+    log(`  ${target.short} didn't exit; sending SIGKILL.`);
+    try {
+      deps.kill(pid, "SIGKILL");
+    } catch {
+      // Racing a just-exited process.
+    }
+  }
+  clearPid(target.short, configDir);
+  log(`  ✓ stopped ${target.short}`);
+}
+
+/**
+ * §7.2 orphan sweep: lsof a port, and if a live process is bound to it, adopt +
+ * kill it (mirrors stopHub's 1939 orphan-adoption, per-module-port). A
+ * stale-pidfile-but-alive module won't be found by `readPid` → without this it
+ * stays bound → the supervised re-spawn hits EADDRINUSE.
+ */
+function sweepOrphanOnPort(
+  port: number,
+  label: string,
+  deps: CutoverDeps,
+  log: (line: string) => void,
+): void {
+  const orphan = deps.pidOnPort(port);
+  if (orphan === undefined) return;
+  if (!deps.alive(orphan)) return;
+  log(`  orphan on ${label} port ${port} (PID ${orphan}) — stopping it.`);
+  try {
+    deps.kill(orphan, "SIGTERM");
+  } catch {
+    // Already gone.
+    return;
+  }
+  // Best-effort SIGKILL follow-up if still alive (no long wait — the
+  // verify-ports-free step below polls + escalates the failure if it persists).
+  if (deps.alive(orphan)) {
+    try {
+      deps.kill(orphan, "SIGKILL");
+    } catch {
+      // Racing a just-exited process.
+    }
+  }
+}
+
+/**
+ * Poll a port until nothing is listening on it (bounded). Returns true when the
+ * port is free, false on timeout. The §7.1 step-5 race-guard: the unit must not
+ * start until 1939 (and each module port) is released, or the new hub crash-loops
+ * on EADDRINUSE under Restart=always.
+ */
+async function waitPortFree(
+  port: number,
+  deps: CutoverDeps,
+  timeoutMs: number,
+  pollMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (!(await deps.portListening(port))) return true;
+    if (Date.now() >= deadline) break;
+    if (pollMs > 0) await deps.sleep(pollMs);
+    else break;
+  }
+  return !(await deps.portListening(port));
+}
+
+/**
+ * Poll the hub /health until it answers (bounded). The §7.1 step-7 verify.
+ */
+async function waitHubHealthy(
+  port: number,
+  deps: CutoverDeps,
+  timeoutMs: number,
+  pollMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await deps.probeHealth(port)) return true;
+    if (Date.now() >= deadline) break;
+    if (pollMs > 0) await deps.sleep(pollMs);
+    else break;
+  }
+  return deps.probeHealth(port);
+}
+
+/**
+ * The idempotent detached→supervised cutover (§7.1). See the file header for the
+ * ordering + fail-safe + resumability contract. Returns a structured outcome;
+ * the CLI maps it to an exit code + messaging.
+ */
+export async function cutoverToSupervised(opts: CutoverOpts = {}): Promise<CutoverResult> {
+  const configDir = opts.configDir ?? CONFIG_DIR;
+  const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const port = opts.port ?? HUB_DEFAULT_PORT;
+  const cliPath = opts.cliPath ?? defaultHubCliPath();
+  const log = opts.log ?? ((line) => console.log(line));
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+  const pollMs = opts.pollMs ?? 250;
+  const deps: CutoverDeps = { ...defaultCutoverDeps, ...(opts.deps ?? {}) };
+
+  const targets = moduleTargets(manifestPath);
+
+  // --- Step 1: DETECT the current model (and the idempotent no-op). ---
+  const unitInstalled = deps.isHubUnitInstalled(deps.hubUnitDeps);
+  const hubHealthy = await deps.probeHealth(port);
+  if (unitInstalled && hubHealthy) {
+    // A unit exists AND the hub answers /health → already supervised. No-op.
+    return {
+      outcome: "already-migrated",
+      port,
+      messages: ["Already migrated — a supervised hub unit is installed and healthy."],
+    };
+  }
+
+  log("Migrating to the supervised model (parachute serve under a process manager).");
+  if (unitInstalled) {
+    // A unit is on disk but the hub isn't answering — a partial/failed prior
+    // cutover (unit written, not started), or the unit is stopped. Resume.
+    log("Found a hub unit already written (resuming a prior cutover).");
+  }
+
+  // --- Step 2: WRITE the unit WITHOUT starting it (the §7.1 race-avoider). ---
+  log("Writing the hub unit file (not starting it yet)…");
+  const write = deps.writeUnitWithoutStarting({
+    parachuteHome: configDir,
+    cliPath,
+    port,
+    deps: deps.hubUnitDeps,
+  });
+  for (const m of write.messages) log(`  ${m}`);
+  if (!write.written) {
+    if (write.outcome === "fallback") {
+      // No service manager on this host (container / init-less) — there is no
+      // unit to install; the runtime here is foreground `serve`. Bail cleanly
+      // WITHOUT having stopped anything (we're still before step 3).
+      return {
+        outcome: "no-manager",
+        port,
+        messages: [
+          "This host has no service manager (systemd/launchd) — the supervised model needs one.",
+          "Run `parachute serve` in the foreground, or use a platform that provides a manager.",
+          ...write.messages,
+        ],
+      };
+    }
+    // The write itself failed (e.g. bun unresolvable). Nothing stopped yet —
+    // safe to bail.
+    return {
+      outcome: "write-failed",
+      port,
+      messages: ["Could not write the hub unit file — no changes made.", ...write.messages],
+    };
+  }
+
+  // --- Step 3: STOP the detached processes (hub FIRST is not required vs
+  // modules, but we stop the hub then each module so children of the detached
+  // hub, if any, are released before their ports are swept). ---
+  log("Stopping the detached hub + modules…");
+  const stopped = await deps.stopHub({ configDir, log: (l) => log(`  ${l}`) });
+  if (stopped) log("  ✓ stopped the detached hub");
+  for (const target of targets) {
+    await stopDetachedModule(target, configDir, deps, timeoutMs, pollMs, log);
+  }
+
+  // --- Step 4: §7.2 ORPHAN SWEEP — per services.json port + the hub port. ---
+  log("Sweeping orphaned processes still bound to declared ports…");
+  sweepOrphanOnPort(port, "hub", deps, log);
+  for (const target of targets) {
+    sweepOrphanOnPort(target.port, target.short, deps, log);
+  }
+
+  // --- Step 5: VERIFY the hub port + each module port is free. ---
+  // Fail leaving the unit written-but-not-started so a retry is clean (§7.1).
+  log("Verifying ports are free before starting the unit…");
+  const portsToCheck: Array<{ port: number; label: string }> = [
+    { port, label: "hub" },
+    ...targets.map((t) => ({ port: t.port, label: t.short })),
+  ];
+  for (const p of portsToCheck) {
+    const free = await waitPortFree(p.port, deps, timeoutMs, pollMs);
+    if (!free) {
+      return {
+        outcome: "port-stuck",
+        port,
+        messages: [
+          `Port ${p.port} (${p.label}) is still held after stopping the detached processes.`,
+          "The hub unit is written but NOT started — your box is unchanged except the unit file.",
+          `Find what's holding the port (\`lsof -iTCP:${p.port}\`), stop it, then re-run \`parachute migrate --to-supervised\`.`,
+        ],
+      };
+    }
+  }
+
+  // --- Step 6: START the unit (enable --now / bootstrap). ---
+  log("Starting the hub unit…");
+  const started = await deps.installAndStartHubUnit({
+    parachuteHome: configDir,
+    cliPath,
+    port,
+    log: (l) => log(`  ${l}`),
+  });
+  if (started.outcome === "no-manager") {
+    // The manager vanished between step 2 and step 6 (extremely unlikely), or
+    // the install degraded. The detached procs are stopped + the unit is on
+    // disk → re-runnable once the manager is available. Surface clearly.
+    return {
+      outcome: "start-failed",
+      port,
+      messages: [
+        "Could not start the hub unit via the service manager.",
+        "The unit file is written; re-run `parachute migrate --to-supervised` once the service manager is available,",
+        "or run `parachute serve` in the foreground.",
+        ...started.messages,
+      ],
+    };
+  }
+  if (started.outcome !== "started") {
+    // `timeout` / `start-failed` — the unit was (re)installed but the hub didn't
+    // become ready. Re-runnable; surface the unit log the helper tailed.
+    return {
+      outcome: started.outcome === "timeout" ? "verify-timeout" : "start-failed",
+      port,
+      messages: [
+        "The hub unit was started but the hub didn't come up cleanly.",
+        "Re-run `parachute migrate --to-supervised`, or check `parachute logs hub`.",
+        ...started.messages,
+      ],
+    };
+  }
+
+  // --- Step 7: VERIFY the hub answers /health. ---
+  log("Verifying the supervised hub is healthy…");
+  const healthy = await waitHubHealthy(port, deps, timeoutMs, pollMs);
+  if (!healthy) {
+    return {
+      outcome: "verify-timeout",
+      port,
+      messages: [
+        `The hub unit started but did not answer /health on 127.0.0.1:${port}.`,
+        "Re-run `parachute migrate --to-supervised`, or check `parachute logs hub`.",
+        ...started.messages,
+      ],
+    };
+  }
+
+  // --- Step 8: the cloudflared connector (if any) is left intact — it's its
+  // own unit; tailscale needs nothing. (Nothing to do here — documented for the
+  // reader; the connector unit is never touched by the hub cutover.) ---
+
+  return {
+    outcome: "migrated",
+    port,
+    messages: [
+      "✓ Migrated to the supervised model.",
+      "The hub now runs under your platform's process manager (it survives reboots),",
+      "and modules are supervised children that boot from services.json.",
+      "Per-module CLI verbs (`parachute start|stop|restart <svc>`) now drive the running hub.",
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// §7.4 teardown — the rollback path.
+// ---------------------------------------------------------------------------
+
+export interface TeardownOpts {
+  log?: (line: string) => void;
+  /** Injectable managed-unit deps (default production). */
+  deps?: ManagedUnitDeps;
+  /** Test seam: the removeManagedUnit implementation. */
+  remove?: (opts: {
+    launchdLabel: string;
+    systemdUnitName: string;
+    deps: ManagedUnitDeps;
+    removedLaunchdMessage: (label: string) => string;
+    removedSystemdMessage: (unitName: string) => string;
+  }) => ManagedUnitRemoveResult;
+}
+
+/**
+ * `parachute migrate --teardown` (§7.4) — remove the hub unit. Idempotent +
+ * best-effort: a missing unit is a no-op; tool failures never throw (the
+ * teardown must always succeed at clearing state). This is the ROLLBACK path if
+ * the cutover misbehaves: tear down the unit and the operator falls back to a
+ * foreground `serve` (or the still-intact detached path, until Phase 5b).
+ *
+ * NOTE: this removes the HUB unit only. It deliberately does NOT remove the
+ * cloudflared connector unit (independent; `expose off --cloudflare` owns that),
+ * and it does NOT re-spawn the detached hub — the operator decides what runtime
+ * to fall back to.
+ */
+export function teardownHubUnit(opts: TeardownOpts = {}): { removed: boolean; messages: string[] } {
+  const log = opts.log ?? ((line) => console.log(line));
+  const deps = opts.deps ?? defaultHubUnitDeps;
+  const remove = opts.remove ?? removeManagedUnit;
+  const res = remove({
+    launchdLabel: HUB_LAUNCHD_LABEL,
+    systemdUnitName: HUB_SYSTEMD_UNIT_NAME,
+    deps,
+    removedLaunchdMessage: (label) =>
+      `Removed launchd LaunchAgent ${label} — the hub no longer starts on login/boot.`,
+    removedSystemdMessage: (unitName) =>
+      `Removed systemd unit ${unitName} — the hub no longer starts on boot.`,
+  });
+  if (res.removed) {
+    for (const m of res.messages) log(m);
+    log("");
+    log("The supervised hub unit is gone. To run the hub now, either:");
+    log("  - `parachute serve` (foreground), or");
+    log("  - `parachute migrate --to-supervised` to reinstall the unit.");
+  } else {
+    log("No hub unit was installed — nothing to tear down.");
+  }
+  return res;
+}

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -3,6 +3,12 @@ import { join } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import { HUB_SVC } from "../hub-control.ts";
+import {
+  type HubUnitDeps,
+  type HubUnitState,
+  defaultHubUnitDeps,
+  queryHubUnitState,
+} from "../hub-unit.ts";
 import { type AliveFn, defaultAlive, processState } from "../process-state.ts";
 import { knownServices, shortNameForManifest } from "../service-spec.ts";
 import { readManifestLenient } from "../services-manifest.ts";
@@ -336,6 +342,31 @@ export async function defaultPrompt(question: string): Promise<string> {
 }
 
 /**
+ * Hub-unit-state query seam for the archive guard (§7.3). Production uses the
+ * real `queryHubUnitState` over `defaultHubUnitDeps`; tests inject a stub so the
+ * unit-managed-hub-detected-as-running path is exercised without a live
+ * systemctl/launchctl. Returns the platform manager's view of the hub unit.
+ */
+export type HubUnitStateQuery = (deps: HubUnitDeps) => { state: HubUnitState };
+
+/**
+ * The §7.3 archive-guard fix: a hub unit is "running, leave it alone" when the
+ * platform manager reports it `active` or `activating`. `failed` / `inactive` /
+ * `no-unit` / `no-manager` / `unknown` are NOT treated as running — those mean
+ * the unit isn't actively holding state at this moment.
+ *
+ * Deliberately conservative on `unknown`: an unparseable manager response is
+ * NOT a license to archive (that would re-introduce the silent fail-open), but
+ * it's also not a clear "running" signal — so we fall through to the pidfile
+ * check (which catches a detached-era hub) rather than blanket-refusing on a
+ * transient manager hiccup. `active`/`activating` is the unambiguous unit-up
+ * signal that the pidfile-only guard missed.
+ */
+function hubUnitReportsRunning(state: HubUnitState): boolean {
+  return state === "active" || state === "activating";
+}
+
+/**
  * Probe whether any managed service (or the hub) is currently running.
  * Returns the list of short names that are live; an empty list means the
  * sweep is safe to proceed.
@@ -343,15 +374,42 @@ export async function defaultPrompt(question: string): Promise<string> {
  * Reads services.json leniently so a malformed entry doesn't block the
  * pre-flight (better to surface "running: vault" + a corrupt-entry warning
  * elsewhere than to refuse migration on an unrelated parsing problem).
+ *
+ * §7.3 archive-guard fix: the hub liveness check is BOTH the pidfile
+ * (`processState(HUB_SVC)`, the detached-era signal) AND the platform manager
+ * (`queryHubUnitState`, the unit-era signal). A unit-managed hub writes NO
+ * pidfile, so `processState(HUB_SVC)` reports it not-running and the
+ * refuse-while-running guard would silently FAIL OPEN — `migrate` could archive
+ * `~/.parachute` out from under a live unit-managed hub. Querying the manager
+ * too closes that hole: an `active`/`activating` hub unit is correctly detected
+ * as running and the guard holds.
  */
 export function listRunningServices(
   configDir: string,
   manifestPath: string,
   alive: AliveFn,
+  hubUnitState: HubUnitStateQuery = queryHubUnitState,
+  hubUnitDeps: HubUnitDeps = defaultHubUnitDeps,
 ): string[] {
   const running: string[] = [];
+  // Detached-era signal: the hub pidfile.
   const hubState = processState(HUB_SVC, configDir, alive);
-  if (hubState.status === "running") running.push(HUB_SVC);
+  let hubRunning = hubState.status === "running";
+  // Unit-era signal (§7.3): the platform manager. A unit-managed hub has no
+  // pidfile, so without this it would fail open. Never throws — `queryHubUnitState`
+  // degrades to `unknown` on a manager hiccup; we only escalate to "running" on
+  // an unambiguous active/activating.
+  if (!hubRunning) {
+    try {
+      const unit = hubUnitState(hubUnitDeps);
+      if (hubUnitReportsRunning(unit.state)) hubRunning = true;
+    } catch {
+      // A manager-query failure must not crash the guard — fall through. The
+      // pidfile check already ran; treat an unqueryable manager as "no extra
+      // signal," neither forcing-running nor opening the gate.
+    }
+  }
+  if (hubRunning) running.push(HUB_SVC);
   let manifest: ReturnType<typeof readManifestLenient>;
   try {
     manifest = readManifestLenient(manifestPath);
@@ -385,6 +443,15 @@ export interface MigrateOpts {
    * non-interactive guard without manipulating real fds.
    */
   isTty?: boolean;
+  /**
+   * Test seam: the §7.3 platform-manager hub-unit-state query used by the
+   * archive guard. Production uses `queryHubUnitState`; tests inject a stub to
+   * exercise the unit-managed-hub-detected-as-running path without a live
+   * systemctl/launchctl.
+   */
+  hubUnitState?: HubUnitStateQuery;
+  /** Test seam: the hub-unit deps passed to `hubUnitState` (default production). */
+  hubUnitDeps?: HubUnitDeps;
 }
 
 export async function migrate(opts: MigrateOpts = {}): Promise<number> {
@@ -397,6 +464,8 @@ export async function migrate(opts: MigrateOpts = {}): Promise<number> {
   const yes = opts.yes ?? false;
   const alive = opts.alive ?? defaultAlive;
   const isTty = opts.isTty ?? Boolean(process.stdin.isTTY);
+  const hubUnitState = opts.hubUnitState ?? queryHubUnitState;
+  const hubUnitDeps = opts.hubUnitDeps ?? defaultHubUnitDeps;
 
   // Refuse-while-running: archiving a path a live daemon owns can corrupt
   // its state. Print the runners and bail before we read the directory.
@@ -404,7 +473,7 @@ export async function migrate(opts: MigrateOpts = {}): Promise<number> {
   // operator may explicitly want to see what would move while things are
   // up.
   if (!dryRun) {
-    const running = listRunningServices(configDir, manifestPath, alive);
+    const running = listRunningServices(configDir, manifestPath, alive, hubUnitState, hubUnitDeps);
     if (running.length > 0) {
       log("parachute migrate: services are currently running — refusing to sweep:");
       for (const short of running) log(`  - ${short}`);

--- a/src/help.ts
+++ b/src/help.ts
@@ -598,12 +598,14 @@ Examples:
 }
 
 export function migrateHelp(): string {
-  return `parachute migrate — archive known-legacy files at the ecosystem root
+  return `parachute migrate — archive legacy root files, or cut over to the supervised model
 
 Usage:
   parachute migrate [--list] [--dry-run] [--yes]
+  parachute migrate --to-supervised
+  parachute migrate --teardown
 
-What it does:
+What it does (the default archive sweep):
   Scans ~/.parachute/ for files and directories that match the
   known-legacy allowlist (daily.db*, server.yaml, channel.log/err,
   channel.start.sh, top-level logs/, tokens.db*, and the legacy lens/
@@ -619,9 +621,11 @@ What it does:
   Dotfiles at the root (.env, .DS_Store, prior .archive-* dirs) are
   never touched.
 
-Safety:
+Archive-sweep safety:
   - Refuses to sweep while any service is running — stop them first
-    (\`parachute stop\`) or preview with \`--list\`.
+    (\`parachute stop\`) or preview with \`--list\`. A hub running under a
+    process-manager unit (the supervised model) is detected as running
+    via the platform manager too, not just its pidfile.
   - SQLite-shape files (\`*.db\`, \`*.db-wal\`, \`*.db-shm\`) get a
     \`[live-db]\` label and pull an extra confirmation; wal/shm
     consistency depends on all three moving together.
@@ -629,14 +633,39 @@ Safety:
     \`[unknown — skipping]\`, with skipped items printed last.
   - In a non-TTY shell (CI / piped), refuses without \`--yes\`.
 
+--to-supervised (detached → supervised cutover):
+  Migrate a legacy detached install (independent \`parachute start\`-spawned
+  daemons) to the supervised model: the hub runs as \`parachute serve\`
+  under your platform's process manager (launchd on macOS, systemd on
+  Linux), survives reboots, and supervises modules as children. The
+  cutover is idempotent + re-runnable, and ordered so it never races the
+  canonical hub port: it writes the unit file WITHOUT starting it, stops
+  the detached hub + modules, sweeps any process still bound to a declared
+  port, verifies the ports are free, THEN starts the unit and verifies the
+  hub is healthy. If anything fails partway it leaves the box recoverable
+  (unit written but not started) and you can simply re-run it. A box with
+  no service manager (a container / init-less host) can't host a unit —
+  run \`parachute serve\` in the foreground there instead.
+
+--teardown (cutover rollback):
+  Remove the hub process-manager unit. Idempotent + best-effort. Use it to
+  roll back a cutover: the unit is removed and you fall back to running the
+  hub with \`parachute serve\` (or re-run \`--to-supervised\` to reinstall it).
+  Run this BEFORE \`bun remove -g @openparachute/hub\` so a removed package
+  doesn't leave a unit pointing at a deleted binary.
+
 Flags:
-  --list        print the plan; make no changes (friendly preview)
-  --dry-run     synonym for --list (kept for back-compat)
-  --yes, -y     skip the confirmation prompt; required in non-TTY shells
+  --list           print the plan; make no changes (friendly preview)
+  --dry-run        synonym for --list (kept for back-compat)
+  --yes, -y        skip the confirmation prompt; required in non-TTY shells
+  --to-supervised  cut over a detached install to the supervised model
+  --teardown       remove the hub unit (cutover rollback)
 
 Examples:
-  parachute migrate --list          see what would move, without touching anything
-  parachute migrate                 interactive sweep (prompts before acting)
-  parachute migrate --yes           sweep without prompting
+  parachute migrate --list            see what would move, without touching anything
+  parachute migrate                   interactive sweep (prompts before acting)
+  parachute migrate --yes             sweep without prompting
+  parachute migrate --to-supervised   move to the supervised (serve-under-manager) model
+  parachute migrate --teardown        remove the hub unit (roll back the cutover)
 `;
 }

--- a/src/managed-unit.ts
+++ b/src/managed-unit.ts
@@ -297,6 +297,18 @@ export interface ManagedUnitInstallResult {
    * what to do (the connector falls back to a transient `proc.unref()` spawn).
    */
   outcome: "installed" | "fallback";
+  /**
+   * On a `fallback`, WHY we fell back — so callers can give an accurate message
+   * instead of conflating the two causes:
+   *   - "no-manager" → no service manager is available here (launchctl/systemctl
+   *     missing, or an unsupported platform). Boot-persistence is impossible.
+   *   - "write-failed" → a manager exists but the install itself failed (couldn't
+   *     write the unit file, daemon-reload / enable / bootstrap returned non-zero).
+   * Undefined when `outcome === "installed"`. The connector ignores this (it only
+   * branches on `outcome`); the Phase 5 cutover reads it to pick `no-manager` vs
+   * `write-failed`.
+   */
+  reason?: "no-manager" | "write-failed";
   /** Which init system installed the service (when outcome === "installed"). */
   kind?: "launchd" | "systemd-user" | "systemd-system" | "unsupported";
   /** Path of the written service file (when outcome === "installed"). */
@@ -355,6 +367,7 @@ export function installManagedUnit(opts: InstallManagedUnitOpts): ManagedUnitIns
   if (deps.platform === "linux") return installSystemdUnit(opts);
   return {
     outcome: "fallback",
+    reason: "no-manager",
     messages: [
       `Boot-persistent unit isn't supported on ${deps.platform}; using a transient process.`,
     ],
@@ -365,7 +378,7 @@ function installLaunchdUnit(opts: InstallManagedUnitOpts): ManagedUnitInstallRes
   const { unit, deps, messages } = opts;
   const start = opts.start ?? true;
   if (deps.which("launchctl") === null) {
-    return { outcome: "fallback", messages: [messages.launchctlMissing] };
+    return { outcome: "fallback", reason: "no-manager", messages: [messages.launchctlMissing] };
   }
   const home = deps.homeDir();
   const plistPath = launchdPlistPathForLabel(unit.launchdLabel, home);
@@ -378,6 +391,7 @@ function installLaunchdUnit(opts: InstallManagedUnitOpts): ManagedUnitInstallRes
   } catch (err) {
     return {
       outcome: "fallback",
+      reason: "write-failed",
       messages: [
         `${messages.writeFailedPrefix} (${err instanceof Error ? err.message : String(err)}).`,
       ],
@@ -415,6 +429,7 @@ function installLaunchdUnit(opts: InstallManagedUnitOpts): ManagedUnitInstallRes
       deps.removeFile(plistPath);
       return {
         outcome: "fallback",
+        reason: "write-failed",
         messages: [
           `${messages.launchctlLoadFailedPrefix} (${boot.stderr.trim() || legacy.stderr.trim() || "unknown error"}).`,
         ],
@@ -436,7 +451,7 @@ function installSystemdUnit(opts: InstallManagedUnitOpts): ManagedUnitInstallRes
   const { unit, deps, messages } = opts;
   const start = opts.start ?? true;
   if (deps.which("systemctl") === null) {
-    return { outcome: "fallback", messages: [messages.systemctlMissing] };
+    return { outcome: "fallback", reason: "no-manager", messages: [messages.systemctlMissing] };
   }
   const root = (deps.getuid() ?? 1000) === 0;
   const home = deps.homeDir();
@@ -449,6 +464,7 @@ function installSystemdUnit(opts: InstallManagedUnitOpts): ManagedUnitInstallRes
   } catch (err) {
     return {
       outcome: "fallback",
+      reason: "write-failed",
       messages: [
         `${messages.writeFailedPrefix} (${err instanceof Error ? err.message : String(err)}).`,
       ],
@@ -487,6 +503,7 @@ function installSystemdUnit(opts: InstallManagedUnitOpts): ManagedUnitInstallRes
     deps.removeFile(unitPath);
     return {
       outcome: "fallback",
+      reason: "write-failed",
       messages: [
         `${messages.daemonReloadFailedPrefix} (${reload.stderr.trim() || "unknown error"}).`,
       ],
@@ -516,6 +533,7 @@ function installSystemdUnit(opts: InstallManagedUnitOpts): ManagedUnitInstallRes
     deps.run(["systemctl", ...scope, "daemon-reload"]);
     return {
       outcome: "fallback",
+      reason: "write-failed",
       messages: [`${messages.enableFailedPrefix} (${enable.stderr.trim() || "unknown error"}).`],
     };
   }

--- a/src/migrate-offer.ts
+++ b/src/migrate-offer.ts
@@ -1,0 +1,186 @@
+/**
+ * §7.5 auto-detect-and-offer — the safety net that keeps a box that landed the
+ * cutover code (via `bun add -g @openparachute/hub@<new>` / auto-upgrade) WITHOUT
+ * running `parachute migrate --to-supervised` from silently going dead.
+ *
+ * Design `parachute.computer/design/2026-06-01-hub-as-supervisor-unification.md`
+ * §7.5: the first time a lifecycle verb (start/stop/restart) runs and finds
+ *   (a) NO hub unit installed, AND
+ *   (b) evidence of a prior detached install (pidfiles / services.json),
+ * it OFFERS to run the cutover (interactive prompt) or, in a non-interactive
+ * context, PRINTS the exact command. It does NOT silently auto-migrate —
+ * archiving / stopping services is destructive-adjacent, so this is
+ * detect-and-offer only.
+ *
+ * This is the bridge's companion: Phase 5a keeps the detached spawners intact
+ * (un-migrated boxes still work), and keeps the pidfile READERS so this detector
+ * can see the old state. Phase 5b retires the spawners; the readers stay one
+ * release longer precisely so this detector keeps working.
+ *
+ * EVERYTHING is behind injectable seams so tests drive the offer without a real
+ * prompt, a real cutover, or touching the operator's `~/.parachute`.
+ */
+
+import { existsSync } from "node:fs";
+import {
+  type CutoverOpts,
+  type CutoverResult,
+  cutoverToSupervised,
+} from "./commands/migrate-cutover.ts";
+import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "./config.ts";
+import { HUB_SVC } from "./hub-control.ts";
+import { type HubUnitDeps, defaultHubUnitDeps, isHubUnitInstalled } from "./hub-unit.ts";
+import { readPid } from "./process-state.ts";
+import { shortNameForManifest } from "./service-spec.ts";
+import { readManifestLenient } from "./services-manifest.ts";
+
+/**
+ * Detect evidence of a prior DETACHED install — the §7.5 (b) condition. True
+ * when EITHER:
+ *   - a hub pidfile exists (`~/.parachute/hub/run/hub.pid`) — the clearest
+ *     detached-era fingerprint, written only by the detached `ensureHubRunning`
+ *     spawn; OR
+ *   - any services.json module has a pidfile (a module was `parachute start`-ed
+ *     the detached way).
+ *
+ * services.json EXISTING alone is NOT enough — a freshly `init`-ed supervised
+ * box also has a services.json. The discriminant is a PIDFILE, which only the
+ * detached path writes (the supervised path tracks children in-process, no
+ * pidfile). So this detects "a box that ran the detached daemons," not merely
+ * "a box that has been configured."
+ *
+ * Pure read; never mutates. Uses `readPid` (a reader the bridge keeps).
+ */
+export function hasPriorDetachedInstall(
+  configDir: string = CONFIG_DIR,
+  manifestPath: string = SERVICES_MANIFEST_PATH,
+): boolean {
+  // Hub pidfile — the detached-era fingerprint.
+  if (readPid(HUB_SVC, configDir) !== undefined) return true;
+  // Any module pidfile.
+  if (!existsSync(manifestPath)) return false;
+  let services: ReturnType<typeof readManifestLenient>["services"];
+  try {
+    services = readManifestLenient(manifestPath).services;
+  } catch {
+    return false;
+  }
+  for (const entry of services) {
+    const short = shortNameForManifest(entry.name) ?? entry.name;
+    if (readPid(short, configDir) !== undefined) return true;
+  }
+  return false;
+}
+
+/**
+ * The interactive-prompt seam (mirrors `migrate.ts`'s `defaultPrompt`). Tests
+ * inject a stub; production reads a line from stdin.
+ */
+export type OfferPrompt = (question: string) => Promise<string>;
+
+export async function defaultOfferPrompt(question: string): Promise<string> {
+  const { createInterface } = await import("node:readline/promises");
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await rl.question(question);
+  rl.close();
+  return answer;
+}
+
+export interface MigrateOfferOpts {
+  configDir?: string;
+  manifestPath?: string;
+  log?: (line: string) => void;
+  /** Injectable: is a hub unit installed? (default real probe). */
+  isHubUnitInstalled?: (deps: HubUnitDeps) => boolean;
+  hubUnitDeps?: HubUnitDeps;
+  /** Injectable: prior-detached-install detector (default `hasPriorDetachedInstall`). */
+  hasPriorDetached?: (configDir: string, manifestPath: string) => boolean;
+  /** Injectable: the cutover itself (default `cutoverToSupervised`). */
+  cutover?: (opts: CutoverOpts) => Promise<CutoverResult>;
+  /** Injectable interactive prompt (default reads stdin). */
+  prompt?: OfferPrompt;
+  /**
+   * TTY override. Production reads `process.stdin.isTTY`; tests pass true/false
+   * to drive the interactive-vs-print branch without manipulating real fds.
+   */
+  isTty?: boolean;
+}
+
+export type MigrateOfferOutcome =
+  /** No offer was made (a unit is installed, or no prior-detached evidence). */
+  | "no-offer"
+  /** Interactive: the operator declined the offer. */
+  | "declined"
+  /** Non-interactive: we printed the exact command (didn't run it). */
+  | "printed"
+  /** Interactive: the operator accepted and the cutover succeeded. */
+  | "migrated"
+  /** Interactive: the operator accepted but the cutover failed (recoverable). */
+  | "migrate-failed";
+
+export interface MigrateOfferResult {
+  outcome: MigrateOfferOutcome;
+  /** The cutover result, when one ran. */
+  cutover?: CutoverResult;
+}
+
+/**
+ * §7.5 detect-and-offer. Call this from a lifecycle verb's detached arm (before
+ * doing the detached work). Returns a structured outcome:
+ *
+ *   - `no-offer` — a hub unit IS installed (the supervised box; nothing to
+ *     offer), or there's no prior-detached evidence (a clean box). The caller
+ *     proceeds with whatever it was going to do.
+ *   - interactive (TTY) — prompt; on yes, RUN the cutover and return `migrated`
+ *     / `migrate-failed`; on no, return `declined`.
+ *   - non-interactive (no TTY) — PRINT the exact command and return `printed`.
+ *     NEVER auto-run in a non-TTY context (a cron/CI pipe must not stop services
+ *     unprompted).
+ *
+ * It NEVER silently migrates: the only path that runs the cutover is an explicit
+ * interactive "yes."
+ */
+export async function offerMigrateToSupervised(
+  opts: MigrateOfferOpts = {},
+): Promise<MigrateOfferResult> {
+  const configDir = opts.configDir ?? CONFIG_DIR;
+  const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const log = opts.log ?? ((line) => console.log(line));
+  const unitInstalledFn = opts.isHubUnitInstalled ?? isHubUnitInstalled;
+  const hubUnitDeps = opts.hubUnitDeps ?? defaultHubUnitDeps;
+  const hasPriorDetached = opts.hasPriorDetached ?? hasPriorDetachedInstall;
+  const cutover = opts.cutover ?? cutoverToSupervised;
+  const prompt = opts.prompt ?? defaultOfferPrompt;
+  const isTty = opts.isTty ?? Boolean(process.stdin.isTTY);
+
+  // (a) no hub unit installed — only offer on the detached box.
+  if (unitInstalledFn(hubUnitDeps)) return { outcome: "no-offer" };
+  // (b) prior-detached evidence — don't pester a clean box.
+  if (!hasPriorDetached(configDir, manifestPath)) return { outcome: "no-offer" };
+
+  log("");
+  log("This box is running the legacy detached model (independent daemons, no");
+  log("process manager). The current Parachute hub runs supervised — `parachute");
+  log("serve` under launchd/systemd, with reboot survival + UI module management.");
+
+  if (!isTty) {
+    // Non-interactive: print the exact command, never run it.
+    log("");
+    log("To migrate, run:");
+    log("  parachute migrate --to-supervised");
+    log("");
+    return { outcome: "printed" };
+  }
+
+  // Interactive: offer to run it now.
+  const answer = (await prompt("Migrate to the supervised model now? [y/N] ")).trim().toLowerCase();
+  if (answer !== "y" && answer !== "yes") {
+    log("Skipped. Run `parachute migrate --to-supervised` when you're ready.");
+    return { outcome: "declined" };
+  }
+
+  const result = await cutover({ configDir, manifestPath, log });
+  for (const line of result.messages) log(line);
+  const ok = result.outcome === "migrated" || result.outcome === "already-migrated";
+  return { outcome: ok ? "migrated" : "migrate-failed", cutover: result };
+}


### PR DESCRIPTION
Phase 5a of the hub-as-supervisor unification (design `parachute.computer/design/2026-06-01-hub-as-supervisor-unification.md` §7.1–§7.5): extends `parachute migrate` into the idempotent detached→supervised cutover, fixes the archive-guard fail-open, adds teardown, and wires auto-detect-and-offer. **No version bump** (stays `0.6.3-rc.1`).

## Deliverables

### (i) §7.1 cutover — stop-detached-FIRST-then-start-unit ordering + fail-safe
`parachute migrate --to-supervised` (`src/commands/migrate-cutover.ts`). The ordering is load-bearing: it dodges the canonical-port-1939 double-spawn race (the 1939-pin would turn an install-while-running into a crash-loop under `Restart=always`). Steps, in order:
1. **Detect** — if a hub unit exists AND the hub answers `/health` → idempotent **no-op** (`already-migrated`).
2. **Write the unit WITHOUT starting it** — `installManagedUnit(start:false)` (daemon-reload, not enable --now). The race-avoider: unit on disk + resumable, no second hub started.
3. **Stop the detached** hub (`stopHub`) + each module (per-module pidfile stop).
4. **§7.2 orphan sweep** — lsof per services.json port + the hub port; adopt+kill any process still bound to a declared port (mirrors stopHub's 1939 adoption, per-module-port).
5. **Verify ports free** — bounded poll of 1939 + each module port.
6. **Start the unit** — `installAndStartHubUnit` / enable --now.
7. **Verify** — hub answers `/health`.

**Fail-safe + resumable.** Any failure leaves a recoverable state — the unit is written-but-not-started, the box is re-runnable, and we never leave it `detached-stopped + unit-dead + no recovery`. A `port-stuck` fails BEFORE starting (unit written, nothing raced); `start-failed` / `verify-timeout` leave the unit written for a clean re-run. Re-running from a partial cutover (unit written, hub not healthy) is NOT a no-op — it resumes steps 2–7 (write is idempotent, stops no-op if already dead, then starts).

### (ii) §7.3 archive-guard fix (CRITICAL safety — silently-fails-open → fixed)
`listRunningServices` (`src/commands/migrate.ts`) checked `processState(HUB_SVC)` (pidfile only). A unit-managed hub writes **NO pidfile** → the refuse-while-running guard **silently failed open** → `migrate` could archive `~/.parachute` out from under a live unit-managed hub. **Fixed:** `listRunningServices` now also queries the platform manager (`queryHubUnitState`); an `active`/`activating` hub unit is detected as running and the guard holds. A manager-query throw is swallowed (never crashes the guard). Tested explicitly: unit-managed running hub → archive refuses; inactive → archive proceeds (no false-positive).

### (iii) §7.4 teardown
`parachute migrate --teardown` removes the hub unit (`removeManagedUnit`-shaped, idempotent, best-effort) — the cutover rollback path (fall back to foreground `serve` / the still-intact detached path).

### (iv) §7.5 auto-detect-and-offer
When a lifecycle verb (start/stop/restart) takes the **detached arm** (no hub unit) and finds evidence of a prior detached install (a hub/module **pidfile** — the detached-era fingerprint; services.json alone is NOT enough), it **offers** the cutover: interactive (TTY) → prompt, on yes run + re-dispatch through the supervisor; **non-interactive (no TTY) → PRINTS the exact command, never auto-runs**. It NEVER silently migrates (archiving is destructive-adjacent — detect-and-offer only). `src/migrate-offer.ts` + a `migrateOffer` seam in `src/commands/lifecycle.ts` (default OFF when omitted so existing detached-arm tests stay deterministic; production CLI passes `{ enabled: true }`).

## The bridge stays intact
This PR is the migrate **machinery** only. `defaultSpawner` / `ensureHubRunning` / `defaultHubSpawner` and the dual-dispatch else-arms are **untouched** — un-migrated boxes still work on the detached path; the cutover is opt-in / auto-offered. The pidfile **readers** stay (the §7.5 detector relies on them). **Spawners retire in the separate 5b PR.**

## All destructive tests are sandboxed
Every destructive-path test runs in a fresh tmp `PARACHUTE_HOME` with stubbed seams — **no real `Bun.spawn` / systemctl / launchctl / lsof / process kills, never touches `~/.parachute`**. The sandbox dir only seeds services.json + pidfiles (real `writePid`) so detectors read genuine on-disk state. Tests cover the cutover ordering (proven via a call-trace: write < stop < start), idempotency, resumability, the orphan sweep (a port-bound pid with no pidfile is adopted+killed before start), all four fail-safe recovery states, the §7.3 archive-guard, teardown, and the §7.5 offer (interactive accept/decline, non-TTY print-never-run, lifecycle re-dispatch).

## Gates
- `bun test ./src` — **2801 pass / 1 skip / 0 fail** (baseline 2767; +34 tests, zero regressions).
- `bun run typecheck` — clean. `bunx biome check` on touched files — clean.

## Surface choice
The cutover is a **flag** (`migrate --to-supervised`), not bare-`migrate` auto-detect: the bare-`migrate` archive sweep stays the default (it's destructive-adjacent and must be asked for). The detect-and-offer instead rides the lifecycle verbs (§7.5), which is where an un-migrated box naturally lands post-upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)