### PR TITLE
feat(hub): Phase 5b — retire detached spawners + collapse the dual-dispatch bridge (supervised is the only runtime)

### DIFF
--- a/src/__tests__/expose-cloudflare.test.ts
+++ b/src/__tests__/expose-cloudflare.test.ts
@@ -286,23 +286,22 @@ describe("exposeCloudflareUp", () => {
     }
   });
 
-  test("persists the public hub origin to vault/.env + restarts vault (Cloudflare 401 fix)", async () => {
+  test("persists the public hub origin to vault/.env + restarts vault via the supervisor (Cloudflare 401 fix)", async () => {
     // The Cloudflare 401 P0: the cloudflare path wrote expose-state.json but —
     // unlike the Tailscale path, which auto-restarts vault and so flows the
-    // public origin into vault/.env via lifecycle's persistVaultHubOrigin —
-    // never touched vault's .env or restarted it. The launchd/systemd daemon
-    // kept booting vault with NO PARACHUTE_HUB_ORIGIN → vault fell back to
-    // loopback as its expected issuer → every hub-minted token (iss=public)
-    // failed the iss check → 401. This asserts the durable .env write + the
-    // running-vault restart that mirrors the Tailscale path.
+    // public origin into vault/.env — never touched vault's .env or restarted
+    // it. The launchd/systemd daemon kept booting vault with NO
+    // PARACHUTE_HUB_ORIGIN → vault fell back to loopback as its expected issuer →
+    // every hub-minted token (iss=public) failed the iss check → 401.
+    //
+    // Phase 5b: the restart goes through the running Supervisor
+    // (`driveModuleOp("vault", "restart")`) — the helper also persists the
+    // durable .env. This asserts the durable .env write + the supervised restart
+    // (no longer a pidfile-gated detached restart; the supervisor decides
+    // liveness, and a not-supervised vault surfaces as a tolerated 404 — see the
+    // Phase 4 dual-dispatch suite).
     const env = makeEnv();
     try {
-      // Seed vault as "running" so the restart branch fires. PID lives at
-      // <configDir>/vault/run/vault.pid (see process-state.ts:pidPath).
-      const vaultRun = join(env.configDir, "vault", "run");
-      require("node:fs").mkdirSync(vaultRun, { recursive: true });
-      writeFileSync(join(vaultRun, "vault.pid"), "99001");
-
       const uuid = "ffffffff-0000-0000-0000-000000000006";
       const { runner } = queueRunner([
         { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
@@ -315,61 +314,7 @@ describe("exposeCloudflareUp", () => {
         { code: 0, stdout: "", stderr: "" },
       ]);
       const { spawner } = fakeSpawner(42300);
-      const restarted: string[] = [];
-
-      const code = await exposeCloudflareUp("gitcoin-parachute.unforced.dev", {
-        runner,
-        spawner,
-        // `alive` reports the seeded vault pid as running so processState() ===
-        // "running" and the restart branch executes.
-        alive: (pid) => pid === 99001,
-        kill: () => {},
-        log: () => {},
-        manifestPath: env.manifestPath,
-        statePath: env.statePath,
-        exposeStatePath: env.exposeStatePath,
-        configPath: env.configPath,
-        logPath: env.logPath,
-        cloudflaredHome: env.cloudflaredHome,
-        configDir: env.configDir,
-        skipHub: true,
-        restartService: async (short) => {
-          restarted.push(short);
-          return 0;
-        },
-      });
-
-      expect(code).toBe(0);
-      // Durable half: the public origin is written to vault/.env (NOT loopback,
-      // NOT unset) so the daemon boot path validates iss against it.
-      expect(readEnvFileValues(join(env.configDir, "vault", ".env")).PARACHUTE_HUB_ORIGIN).toBe(
-        "https://gitcoin-parachute.unforced.dev",
-      );
-      // Live half: the running vault is restarted to re-read the new origin.
-      expect(restarted).toEqual(["vault"]);
-    } finally {
-      env.cleanup();
-    }
-  });
-
-  test("persists vault/.env but does NOT restart when vault isn't running", async () => {
-    // No vault pidfile → processState() !== "running" → no restart, but the
-    // durable .env write still happens so the next daemon boot is correct.
-    const env = makeEnv();
-    try {
-      const uuid = "ffffffff-0000-0000-0000-000000000007";
-      const { runner } = queueRunner([
-        { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
-        { code: 0, stdout: "[]", stderr: "" },
-        {
-          code: 0,
-          stdout: `Tunnel credentials written to ${env.cloudflaredHome}/${uuid}.json.\nCreated tunnel parachute with id ${uuid}\n`,
-          stderr: "",
-        },
-        { code: 0, stdout: "", stderr: "" },
-      ]);
-      const { spawner } = fakeSpawner(42301);
-      const restarted: string[] = [];
+      const sup = makeCfSupervisorStub();
 
       const code = await exposeCloudflareUp("gitcoin-parachute.unforced.dev", {
         runner,
@@ -385,17 +330,17 @@ describe("exposeCloudflareUp", () => {
         cloudflaredHome: env.cloudflaredHome,
         configDir: env.configDir,
         skipHub: true,
-        restartService: async (short) => {
-          restarted.push(short);
-          return 0;
-        },
+        supervisor: sup.opts,
       });
 
       expect(code).toBe(0);
+      // Durable half: the public origin is written to vault/.env (NOT loopback,
+      // NOT unset) so the daemon boot path validates iss against it.
       expect(readEnvFileValues(join(env.configDir, "vault", ".env")).PARACHUTE_HUB_ORIGIN).toBe(
         "https://gitcoin-parachute.unforced.dev",
       );
-      expect(restarted).toEqual([]);
+      // Live half: vault is restarted via the supervisor to re-read the new origin.
+      expect(sup.driveCalls).toEqual([{ short: "vault", op: "restart" }]);
     } finally {
       env.cleanup();
     }
@@ -2045,7 +1990,6 @@ function makeCfSupervisorStub(opts?: {
     driveCalls: [],
     selfHealCalls: [],
     opts: {
-      unitInstalled: true,
       openDb: () => ({ close() {} }) as unknown as import("bun:sqlite").Database,
       ensureHubUnit: async (o: EnsureHubUnitOpts) => {
         stub.ensureCalls++;
@@ -2082,7 +2026,6 @@ describe("Phase 4 cloudflare expose dual-dispatch — unit-managed", () => {
       ]);
       const { spawner } = fakeSpawner(42400);
       const sup = makeCfSupervisorStub();
-      const restarted: string[] = [];
       const logs: string[] = [];
 
       const code = await exposeCloudflareUp("gitcoin-parachute.unforced.dev", {
@@ -2098,23 +2041,17 @@ describe("Phase 4 cloudflare expose dual-dispatch — unit-managed", () => {
         logPath: env.logPath,
         cloudflaredHome: env.cloudflaredHome,
         configDir: env.configDir,
-        // No skipHub → the unit arm's ensureHubUnit runs (via the stub, no real hub).
+        // No skipHub → the hub-unit ensure runs (via the stub, no real hub).
         // Inert connector install so the cloudflared connector path is unchanged.
         installService: () => ({ outcome: "fallback", messages: [] }),
-        // This detached restart seam must NOT be called on the unit arm.
-        restartService: async (short) => {
-          restarted.push(short);
-          return 0;
-        },
         supervisor: sup.opts,
       });
 
       expect(code).toBe(0);
-      // Ensured the hub UNIT (the stub), never the detached spawn.
+      // Ensured the hub UNIT (the stub), never a detached spawn.
       expect(sup.ensureCalls).toBe(1);
-      // Vault restart drove the running Supervisor, NOT the detached restartService.
+      // Vault restart drove the running Supervisor.
       expect(sup.driveCalls).toEqual([{ short: "vault", op: "restart" }]);
-      expect(restarted).toEqual([]);
       // Operator-token issuer self-heal fired toward the public origin.
       expect(sup.selfHealCalls).toHaveLength(1);
       expect(sup.selfHealCalls[0]?.issuer).toBe("https://gitcoin-parachute.unforced.dev");

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -6,10 +6,8 @@ import type { ExposeSupervisorOpts } from "../commands/expose-supervisor.ts";
 import { exposePublic, exposeTailnet } from "../commands/expose.ts";
 import { readEnvFileValues } from "../env-file.ts";
 import { readExposeState, writeExposeState } from "../expose-state.ts";
-import type { EnsureHubOpts, HubSpawner, StopHubOpts } from "../hub-control.ts";
 import type { EnsureHubUnitOpts } from "../hub-unit.ts";
 import { type ModuleOp, ModuleOpHttpError } from "../module-ops-client.ts";
-import { writePid } from "../process-state.ts";
 import { upsertService } from "../services-manifest.ts";
 import type { Runner } from "../tailscale/run.ts";
 
@@ -57,36 +55,16 @@ function makeRunner(): { runner: Runner; calls: string[][] } {
   return { runner, calls };
 }
 
-function makeHubSpawner(pid: number): { spawner: HubSpawner; calls: string[][] } {
-  const calls: string[][] = [];
-  const spawner: HubSpawner = {
-    spawn(cmd) {
-      calls.push([...cmd]);
-      return pid;
-    },
-  };
-  return { spawner, calls };
-}
-
-/** Default hub overrides for expose tests — no real subprocess, no sleep. */
-function hubEnsureOpts(
-  spawner: HubSpawner,
-): Omit<EnsureHubOpts, "configDir" | "wellKnownDir" | "log"> {
-  return {
-    spawner,
-    alive: () => true,
-    probe: async () => true,
-    readyWaitMs: 0,
-  };
-}
-
-function hubStopOpts(): Omit<StopHubOpts, "configDir" | "log"> {
-  return {
-    kill: () => {},
-    alive: () => false,
-    sleep: async () => {},
-    now: () => 0,
-  };
+/**
+ * A minimal expose `supervisor` seam that forces the unit-installed arm with a
+ * benign `ensureHubUnit → already-up` + no-op `driveModuleOp` / self-heal. Most
+ * expose tests just need the hub-bringup to succeed so they can assert the
+ * tailscale plan / expose-state / well-known behavior; this stub provides that
+ * without a real launchd/systemd or hub. (Phase 5b retired the detached hub
+ * spawner that the old `makeHubSpawner` / `hubEnsureOpts` stubs simulated.)
+ */
+function supervisorUp(): ExposeSupervisorOpts {
+  return makeExposeSupervisorStub().opts;
 }
 
 function seedServices(path: string): void {
@@ -125,7 +103,6 @@ describe("expose tailnet up", () => {
     try {
       seedServices(h.manifestPath);
       const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const logs: string[] = [];
       const code = await exposeTailnet("up", {
         runner,
@@ -133,9 +110,8 @@ describe("expose tailnet up", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: (l) => logs.push(l),
       });
@@ -175,31 +151,31 @@ describe("expose tailnet up", () => {
     }
   });
 
-  test("spawns hub server with --port + --well-known-dir", async () => {
+  test("ensures the hub UNIT (not a detached spawn) before exposing", async () => {
+    // Phase 5b: "ensure the hub" = ensure the hub UNIT is up (§4.3a). The old
+    // detached `bun hub-server.ts --port …` spawn is retired — its bringup is now
+    // init's `installAndStartHubUnit` (asserted in init.test.ts / hub-unit.test.ts).
+    // Here we just confirm expose drives the unit-ensure seam, then proceeds.
     const h = makeHarness();
     try {
       seedServices(h.manifestPath);
       const { runner } = makeRunner();
-      const { spawner, calls: hubCalls } = makeHubSpawner(7777);
+      const sup = makeExposeSupervisorStub();
+      const logs: string[] = [];
       const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: sup.opts,
         servicePortProbe: allServicesUp,
-        log: () => {},
+        log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
-      expect(hubCalls).toHaveLength(1);
-      const cmd = hubCalls[0] ?? [];
-      expect(cmd[0]).toBe("bun");
-      expect(cmd).toContain("--port");
-      expect(cmd).toContain("--well-known-dir");
-      expect(cmd).toContain(h.wellKnownDir);
+      expect(sup.ensureCalls).toHaveLength(1);
+      expect(logs.join("\n")).toMatch(/hub unit up/);
     } finally {
       h.cleanup();
     }
@@ -223,16 +199,14 @@ describe("expose tailnet up", () => {
         h.manifestPath,
       );
       const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: () => {},
       });
@@ -261,7 +235,6 @@ describe("expose tailnet up", () => {
         h.manifestPath,
       );
       const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const logs: string[] = [];
       const code = await exposeTailnet("up", {
         runner,
@@ -269,9 +242,8 @@ describe("expose tailnet up", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: (l) => logs.push(l),
       });
@@ -294,7 +266,6 @@ describe("expose tailnet up", () => {
     const h = makeHarness();
     try {
       const { runner } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const logs: string[] = [];
       const code = await exposeTailnet("up", {
         runner,
@@ -302,9 +273,8 @@ describe("expose tailnet up", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: (l) => logs.push(l),
       });
@@ -322,7 +292,6 @@ describe("expose tailnet up", () => {
       const runner: Runner = async () => {
         throw new Error("spawn tailscale ENOENT");
       };
-      const { spawner } = makeHubSpawner(1111);
       const logs: string[] = [];
       const code = await exposeTailnet("up", {
         runner,
@@ -330,9 +299,8 @@ describe("expose tailnet up", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: (l) => logs.push(l),
       });
@@ -367,16 +335,14 @@ describe("expose tailnet up", () => {
         h.statePath,
       );
       const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: () => {},
       });
@@ -398,7 +364,6 @@ describe("expose tailnet up", () => {
     try {
       seedServices(h.manifestPath);
       const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const logs: string[] = [];
       const code = await exposeTailnet("up", {
         runner,
@@ -406,9 +371,8 @@ describe("expose tailnet up", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         // vault is up; notes is down.
         servicePortProbe: async (port) => port === 1940,
         log: (l) => logs.push(l),
@@ -447,7 +411,6 @@ describe("expose tailnet up", () => {
         }
         return { code: 0, stdout: "", stderr: "" };
       };
-      const { spawner } = makeHubSpawner(1111);
       const logs: string[] = [];
       const code = await exposeTailnet("up", {
         runner,
@@ -455,9 +418,8 @@ describe("expose tailnet up", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: (l) => logs.push(l),
       });
@@ -476,16 +438,14 @@ describe("expose tailnet up", () => {
     try {
       seedServices(h.manifestPath);
       const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: () => {},
       });
@@ -523,16 +483,14 @@ describe("expose tailnet up", () => {
         h.manifestPath,
       );
       const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: () => {},
       });
@@ -552,16 +510,14 @@ describe("expose tailnet up", () => {
     try {
       seedServices(h.manifestPath);
       const { runner } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         hubOrigin: "https://hub.example.com/",
         log: () => {},
@@ -583,7 +539,6 @@ describe("expose tailnet up", () => {
     try {
       seedServices(h.manifestPath);
       const { runner } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const logs: string[] = [];
       const code = await exposeTailnet("up", {
         runner,
@@ -591,9 +546,8 @@ describe("expose tailnet up", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: (l) => logs.push(l),
         vaultAuthStatus: {
@@ -622,9 +576,7 @@ describe("expose tailnet off", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubStopOpts: hubStopOpts(),
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -635,7 +587,7 @@ describe("expose tailnet off", () => {
     }
   });
 
-  test("tears down every tracked entry, stops hub, and clears state", async () => {
+  test("tears down every tracked entry + clears state, leaves the hub running (D3)", async () => {
     const h = makeHarness();
     try {
       writeExposeState(
@@ -665,27 +617,15 @@ describe("expose tailnet off", () => {
       );
       await Bun.write(h.wellKnownPath, "{}\n");
       await Bun.write(h.hubPath, "<html/>\n");
-      writePid("hub", 4242, h.configDir);
       const { runner, calls } = makeRunner();
-      const signals: NodeJS.Signals[] = [];
-      let aliveNow = true;
+      const logs: string[] = [];
       const code = await exposeTailnet("off", {
         runner,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubStopOpts: {
-          kill: (_pid, sig) => {
-            signals.push(sig as NodeJS.Signals);
-            aliveNow = false;
-          },
-          alive: () => aliveNow,
-          sleep: async () => {},
-          now: () => 0,
-        },
-        log: () => {},
+        log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
       expect(calls.every((c) => c[c.length - 1] === "off")).toBe(true);
@@ -693,8 +633,10 @@ describe("expose tailnet off", () => {
       expect(existsSync(h.statePath)).toBe(false);
       expect(existsSync(h.wellKnownPath)).toBe(false);
       expect(existsSync(h.hubPath)).toBe(false);
-      // Hub was running and got stopped.
-      expect(signals).toContain("SIGTERM");
+      // D3 (Phase 5b): the hub is a persistent platform unit — `expose off` tears
+      // down only the exposure and leaves the hub running. No "hub stopped" line.
+      expect(logs.join("\n")).not.toMatch(/hub stopped/);
+      expect(logs.join("\n")).toMatch(/exposure removed/);
     } finally {
       h.cleanup();
     }
@@ -732,7 +674,6 @@ describe("expose tailnet off", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         skipHub: true,
         log: () => {},
@@ -776,9 +717,7 @@ describe("expose tailnet off", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubStopOpts: hubStopOpts(),
         log: (l) => logs.push(l),
       });
       expect(code).toBe(5);
@@ -810,31 +749,19 @@ describe("expose tailnet off", () => {
         },
         h.statePath,
       );
-      writePid("hub", 4242, h.configDir);
       const { runner, calls } = makeRunner();
-      let killCalled = false;
       const logs: string[] = [];
       const code = await exposeTailnet("off", {
         runner,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubStopOpts: {
-          kill: () => {
-            killCalled = true;
-          },
-          alive: () => false,
-          sleep: async () => {},
-          now: () => 0,
-        },
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
       expect(calls).toHaveLength(0);
       expect(existsSync(h.statePath)).toBe(true);
-      expect(killCalled).toBe(false);
       expect(logs.join("\n")).toMatch(/Current exposure is Public/);
     } finally {
       h.cleanup();
@@ -848,7 +775,6 @@ describe("expose public up", () => {
     try {
       seedServices(h.manifestPath);
       const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const logs: string[] = [];
       const code = await exposePublic("up", {
         runner,
@@ -856,9 +782,8 @@ describe("expose public up", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: (l) => logs.push(l),
       });
@@ -911,16 +836,14 @@ describe("expose public up", () => {
         h.statePath,
       );
       const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: () => {},
       });
@@ -959,16 +882,14 @@ describe("expose public up", () => {
         h.statePath,
       );
       const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const code = await exposePublic("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: () => {},
       });
@@ -990,7 +911,6 @@ describe("expose public up", () => {
     try {
       seedServices(h.manifestPath);
       const { runner } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const logs: string[] = [];
       const code = await exposePublic("up", {
         runner,
@@ -998,9 +918,8 @@ describe("expose public up", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: (l) => logs.push(l),
         vaultAuthStatus: {
@@ -1028,7 +947,6 @@ describe("expose public up", () => {
     try {
       seedServices(h.manifestPath);
       const { runner } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const logs: string[] = [];
       const code = await exposePublic("up", {
         runner,
@@ -1036,9 +954,8 @@ describe("expose public up", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: (l) => logs.push(l),
         vaultAuthStatus: {
@@ -1085,9 +1002,7 @@ describe("expose public off", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubStopOpts: hubStopOpts(),
         log: () => {},
       });
       expect(code).toBe(0);
@@ -1130,9 +1045,7 @@ describe("expose public off", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubStopOpts: hubStopOpts(),
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -1183,16 +1096,14 @@ describe("expose plan is layer-agnostic — gating moved to hub", () => {
         h.manifestPath,
       );
       const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: () => {},
       });
@@ -1240,16 +1151,14 @@ describe("expose plan is layer-agnostic — gating moved to hub", () => {
         h.manifestPath,
       );
       const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: () => {},
       });
@@ -1268,114 +1177,49 @@ describe("expose auto-restart of hub-dependent services", () => {
   // Launch-day bug (2026-04-23): `expose public` updated hubOrigin in
   // expose-state.json, but a vault already running kept its stale
   // PARACHUTE_HUB_ORIGIN in memory, so the OAuth issuer didn't match what
-  // clients saw and claude.ai MCP failed to reach the server. The CLI used
-  // to print a "Restart vault to pick up…" hint that got lost in the wall
-  // of expose output. Auto-restart the service instead.
-  test("restarts vault when vault is running", async () => {
+  // clients saw and claude.ai MCP failed to reach the server. Auto-restart the
+  // service so it picks up the new origin.
+  //
+  // Phase 5b: the restart goes through the running supervisor
+  // (`driveModuleOp("vault", "restart")`), NOT a pidfile-gated detached
+  // `lifecycle.restart`. So the restart is unconditional (the supervisor decides
+  // whether the module is live); the old "skips when not running / stale pidfile"
+  // cases no longer apply — a not-supervised vault surfaces as a 404 the helper
+  // treats as "nothing to restart" (asserted in the Phase 4 dual-dispatch suite).
+  test("restarts vault via the supervisor after expose", async () => {
     const h = makeHarness();
     try {
       seedServices(h.manifestPath);
-      writePid("vault", 4242, h.configDir);
       const { runner } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
-      const restarted: string[] = [];
+      const sup = makeExposeSupervisorStub();
       const code = await exposePublic("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: sup.opts,
         servicePortProbe: allServicesUp,
-        alive: () => true,
-        restartService: async (short) => {
-          restarted.push(short);
-          return 0;
-        },
         log: () => {},
       });
       expect(code).toBe(0);
-      expect(restarted).toEqual(["vault"]);
+      expect(sup.driveCalls).toEqual([{ short: "vault", op: "restart" }]);
     } finally {
       h.cleanup();
     }
   });
 
-  test("skips restart when vault is not running", async () => {
+  test("restart failure logs a warning but expose still succeeds", async () => {
     const h = makeHarness();
     try {
       seedServices(h.manifestPath);
-      // No writePid → vault has no pidfile → processState returns "unknown".
       const { runner } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
-      const restarted: string[] = [];
-      const code = await exposePublic("up", {
-        runner,
-        manifestPath: h.manifestPath,
-        statePath: h.statePath,
-        wellKnownPath: h.wellKnownPath,
-        hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
-        configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
-        servicePortProbe: allServicesUp,
-        alive: () => true,
-        restartService: async (short) => {
-          restarted.push(short);
-          return 0;
-        },
-        log: () => {},
+      // A non-404 module-op error → surfaced as a warning, non-zero rcode mapped
+      // to a warn-and-continue (expose still exits 0).
+      const sup = makeExposeSupervisorStub({
+        driveThrows: () => new ModuleOpHttpError(500, "internal", "vault restart blew up"),
       });
-      expect(code).toBe(0);
-      expect(restarted).toEqual([]);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("skips restart when pidfile is stale (process dead)", async () => {
-    const h = makeHarness();
-    try {
-      seedServices(h.manifestPath);
-      writePid("vault", 4242, h.configDir);
-      const { runner } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
-      const restarted: string[] = [];
-      const code = await exposePublic("up", {
-        runner,
-        manifestPath: h.manifestPath,
-        statePath: h.statePath,
-        wellKnownPath: h.wellKnownPath,
-        hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
-        configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
-        servicePortProbe: allServicesUp,
-        // Simulate pid-file-present-but-process-dead. processState returns
-        // "stopped", not "running", so we should skip.
-        alive: () => false,
-        restartService: async (short) => {
-          restarted.push(short);
-          return 0;
-        },
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(restarted).toEqual([]);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("restart failure logs warning but expose still succeeds", async () => {
-    const h = makeHarness();
-    try {
-      seedServices(h.manifestPath);
-      writePid("vault", 4242, h.configDir);
-      const { runner } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const logs: string[] = [];
       const code = await exposePublic("up", {
         runner,
@@ -1383,12 +1227,9 @@ describe("expose auto-restart of hub-dependent services", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: sup.opts,
         servicePortProbe: allServicesUp,
-        alive: () => true,
-        restartService: async () => 1,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -1449,9 +1290,7 @@ describe("expose teardown tolerance for already-gone entries", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubStopOpts: hubStopOpts(),
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
@@ -1488,9 +1327,7 @@ describe("expose teardown tolerance for already-gone entries", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubStopOpts: hubStopOpts(),
         log: () => {},
       });
       expect(code).toBe(0);
@@ -1520,9 +1357,7 @@ describe("expose teardown tolerance for already-gone entries", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubStopOpts: hubStopOpts(),
         log: (l) => logs.push(l),
       });
       expect(code).toBe(1);
@@ -1541,7 +1376,6 @@ describe("expose teardown tolerance for already-gone entries", () => {
     try {
       seedServices(h.manifestPath);
       makePublicPriorState(h.statePath, 2);
-      const { spawner } = makeHubSpawner(1111);
       const bringupCalls: string[][] = [];
       const runner: Runner = async (cmd) => {
         if (cmd[0] === "tailscale" && cmd[1] === "version") {
@@ -1572,9 +1406,8 @@ describe("expose teardown tolerance for already-gone entries", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: () => {},
       });
@@ -1610,16 +1443,14 @@ describe("expose: vault routing fully internal to hub", () => {
         h.manifestPath,
       );
       const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: () => {},
       });
@@ -1660,16 +1491,14 @@ describe("expose: vault routing fully internal to hub", () => {
         h.manifestPath,
       );
       const { runner, calls } = makeRunner();
-      const { spawner } = makeHubSpawner(1111);
       const code = await exposeTailnet("up", {
         runner,
         manifestPath: h.manifestPath,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        hubEnsureOpts: hubEnsureOpts(spawner),
+        supervisor: supervisorUp(),
         servicePortProbe: allServicesUp,
         log: () => {},
       });
@@ -1719,7 +1548,6 @@ function makeExposeSupervisorStub(opts?: {
     driveCalls,
     selfHealCalls,
     opts: {
-      unitInstalled: true,
       // openDb is opened+closed around the drive/self-heal — hand back a no-op closer.
       openDb: () => ({ close() {} }) as unknown as import("bun:sqlite").Database,
       ensureHubUnit: async (o: EnsureHubUnitOpts) => {
@@ -1757,7 +1585,6 @@ describe("Phase 4 expose dual-dispatch — unit-managed", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         servicePortProbe: allServicesUp,
         supervisor: sup.opts,
@@ -1789,7 +1616,6 @@ describe("Phase 4 expose dual-dispatch — unit-managed", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         servicePortProbe: allServicesUp,
         supervisor: sup.opts,
@@ -1818,7 +1644,6 @@ describe("Phase 4 expose dual-dispatch — unit-managed", () => {
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
         servicePortProbe: allServicesUp,
         supervisor: sup.opts,
@@ -1846,27 +1671,15 @@ describe("Phase 4 expose dual-dispatch — unit-managed", () => {
         },
         h.statePath,
       );
-      writePid("hub", 4242, h.configDir);
       const { runner, calls } = makeRunner();
       const sup = makeExposeSupervisorStub();
-      // A kill / stopHub seam that fails the test if the hub is signalled.
       const logs: string[] = [];
       const code = await exposeTailnet("off", {
         runner,
         statePath: h.statePath,
         wellKnownPath: h.wellKnownPath,
         hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
         configDir: h.configDir,
-        // If the hub stop path ran, this kill seam would be called and throw.
-        hubStopOpts: {
-          kill: () => {
-            throw new Error("expose off unit-managed must NOT stop the hub");
-          },
-          alive: () => true,
-          sleep: async () => {},
-          now: () => 0,
-        },
         supervisor: sup.opts,
         log: (l) => logs.push(l),
       });
@@ -1882,51 +1695,8 @@ describe("Phase 4 expose dual-dispatch — unit-managed", () => {
     }
   });
 
-  test("expose off NO unit → hub stopped (detached arm unchanged)", async () => {
-    const h = makeHarness();
-    try {
-      writeExposeState(
-        {
-          version: 1,
-          layer: "tailnet",
-          mode: "path",
-          canonicalFqdn: "parachute.taildf9ce2.ts.net",
-          port: 443,
-          funnel: false,
-          entries: [{ kind: "proxy", mount: "/", target: "http://127.0.0.1:1939", service: "hub" }],
-        },
-        h.statePath,
-      );
-      writePid("hub", 4242, h.configDir);
-      const { runner } = makeRunner();
-      const signals: NodeJS.Signals[] = [];
-      let aliveNow = true;
-      const logs: string[] = [];
-      const code = await exposeTailnet("off", {
-        runner,
-        statePath: h.statePath,
-        wellKnownPath: h.wellKnownPath,
-        hubPath: h.hubPath,
-        wellKnownDir: h.wellKnownDir,
-        configDir: h.configDir,
-        hubStopOpts: {
-          kill: (_pid, sig) => {
-            signals.push(sig as NodeJS.Signals);
-            aliveNow = false;
-          },
-          alive: () => aliveNow,
-          sleep: async () => {},
-          now: () => 0,
-        },
-        // supervisor omitted → detached arm, deterministically.
-        log: (l) => logs.push(l),
-      });
-      expect(code).toBe(0);
-      // The detached arm still stops the hub.
-      expect(signals).toContain("SIGTERM");
-      expect(logs.join("\n")).toMatch(/hub stopped/);
-    } finally {
-      h.cleanup();
-    }
-  });
+  // The "expose off NO unit → hub stopped (detached arm)" test was removed: Phase
+  // 5b retired the detached arm, so `expose off` NEVER stops the hub (D3). The
+  // "exposure torn down, hub NOT stopped" invariant is the test above + the
+  // "leaves the hub running (D3)" test in the `expose tailnet off` suite.
 });

--- a/src/__tests__/hub-control.test.ts
+++ b/src/__tests__/hub-control.test.ts
@@ -2,21 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  type HubPortProbe,
-  type HubSpawner,
-  clearHubPort,
-  ensureHubRunning,
-  hubPortPath,
-  readHubPort,
-  stopHub,
-  writeHubPort,
-} from "../hub-control.ts";
+import { clearHubPort, hubPortPath, readHubPort, stopHub, writeHubPort } from "../hub-control.ts";
 import { pidPath, readPid, writePid } from "../process-state.ts";
 
 interface Harness {
   configDir: string;
-  wellKnownDir: string;
   cleanup: () => void;
 }
 
@@ -24,30 +14,8 @@ function makeHarness(): Harness {
   const dir = mkdtempSync(join(tmpdir(), "pcli-hub-ctl-"));
   return {
     configDir: dir,
-    wellKnownDir: join(dir, "well-known"),
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
   };
-}
-
-interface SpawnerStub {
-  spawn: HubSpawner["spawn"];
-  calls: Array<{ cmd: readonly string[]; logFile: string }>;
-}
-
-function makeSpawner(pid: number): SpawnerStub {
-  const calls: Array<{ cmd: readonly string[]; logFile: string }> = [];
-  return {
-    calls,
-    spawn(cmd, logFile) {
-      calls.push({ cmd: [...cmd], logFile });
-      return pid;
-    },
-  };
-}
-
-/** Probe that claims every port in a set is taken. */
-function probeTaken(taken: Set<number>): HubPortProbe {
-  return async (p) => !taken.has(p);
 }
 
 describe("port persistence helpers", () => {
@@ -59,215 +27,6 @@ describe("port persistence helpers", () => {
       expect(existsSync(hubPortPath(h.configDir))).toBe(true);
       clearHubPort(h.configDir);
       expect(readHubPort(h.configDir)).toBeUndefined();
-    } finally {
-      h.cleanup();
-    }
-  });
-});
-
-describe("ensureHubRunning", () => {
-  test("spawns with --port + --well-known-dir, writes pid + port files", async () => {
-    const h = makeHarness();
-    try {
-      const spawner = makeSpawner(5555);
-      const result = await ensureHubRunning({
-        configDir: h.configDir,
-        wellKnownDir: h.wellKnownDir,
-        spawner,
-        alive: () => true,
-        probe: probeTaken(new Set()),
-        readyWaitMs: 0,
-      });
-      expect(result.started).toBe(true);
-      expect(result.pid).toBe(5555);
-      expect(result.port).toBe(1939);
-      expect(spawner.calls).toHaveLength(1);
-      const cmd = spawner.calls[0]?.cmd ?? [];
-      expect(cmd[0]).toBe("bun");
-      expect(cmd).toContain("--port");
-      expect(cmd).toContain("1939");
-      expect(cmd).toContain("--well-known-dir");
-      expect(cmd).toContain(h.wellKnownDir);
-      expect(readPid("hub", h.configDir)).toBe(5555);
-      expect(readHubPort(h.configDir)).toBe(1939);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("default fallback is 1 slot: fails when 1939 is taken (no pid resolvable)", async () => {
-    // Canonical layout pins hub to 1939. Walking up would collide with the
-    // next service's slot, so the default is to fail and let the user unblock
-    // the port — not quietly land somewhere else. When `lsof` can't name a
-    // PID (Windows, lsof missing, permission), fall back to the classic
-    // lsof-iTCP hint.
-    const h = makeHarness();
-    try {
-      const spawner = makeSpawner(7777);
-      await expect(
-        ensureHubRunning({
-          configDir: h.configDir,
-          wellKnownDir: h.wellKnownDir,
-          spawner,
-          alive: () => true,
-          probe: probeTaken(new Set([1939])),
-          pidOnPort: () => undefined,
-          readyWaitMs: 0,
-        }),
-      ).rejects.toThrow(/lsof -iTCP:1939/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("fails with orphan-PID hint when lsof names the holder (hub#287)", async () => {
-    // When `lsof` can resolve the orphan PID holding the canonical port,
-    // we surface it + recommend `parachute restart hub` (which now detects
-    // and kills the orphan) rather than the bare lsof hint.
-    const h = makeHarness();
-    try {
-      const spawner = makeSpawner(7777);
-      await expect(
-        ensureHubRunning({
-          configDir: h.configDir,
-          wellKnownDir: h.wellKnownDir,
-          spawner,
-          alive: () => true,
-          probe: probeTaken(new Set([1939])),
-          pidOnPort: () => 4242,
-          readyWaitMs: 0,
-        }),
-      ).rejects.toThrow(/PID 4242 is already listening.*parachute restart hub/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("fallback walks up when caller widens the range (debug/tests only)", async () => {
-    const h = makeHarness();
-    try {
-      const spawner = makeSpawner(7777);
-      const result = await ensureHubRunning({
-        configDir: h.configDir,
-        wellKnownDir: h.wellKnownDir,
-        spawner,
-        alive: () => true,
-        probe: probeTaken(new Set([1939, 1940])),
-        readyWaitMs: 0,
-        fallbackRange: 5,
-      });
-      expect(result.port).toBe(1941);
-      expect(readHubPort(h.configDir)).toBe(1941);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("idempotent: returns existing pid + port when hub is already running", async () => {
-    const h = makeHarness();
-    try {
-      writePid("hub", 12345, h.configDir);
-      writeHubPort(1944, h.configDir);
-      const spawner = makeSpawner(9999);
-      const result = await ensureHubRunning({
-        configDir: h.configDir,
-        wellKnownDir: h.wellKnownDir,
-        spawner,
-        alive: () => true,
-        probe: probeTaken(new Set()),
-        readyWaitMs: 0,
-      });
-      expect(result.started).toBe(false);
-      expect(result.pid).toBe(12345);
-      expect(result.port).toBe(1944);
-      expect(spawner.calls).toHaveLength(0);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("stale pid (process gone) is cleared and a fresh hub is spawned", async () => {
-    const h = makeHarness();
-    try {
-      writePid("hub", 99, h.configDir);
-      writeHubPort(1939, h.configDir);
-      const spawner = makeSpawner(100);
-      const result = await ensureHubRunning({
-        configDir: h.configDir,
-        wellKnownDir: h.wellKnownDir,
-        spawner,
-        alive: () => false,
-        probe: probeTaken(new Set()),
-        readyWaitMs: 0,
-      });
-      expect(result.started).toBe(true);
-      expect(result.pid).toBe(100);
-      expect(spawner.calls).toHaveLength(1);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("throws when no port in the fallback range is free", async () => {
-    const h = makeHarness();
-    try {
-      const spawner = makeSpawner(1);
-      await expect(
-        ensureHubRunning({
-          configDir: h.configDir,
-          wellKnownDir: h.wellKnownDir,
-          spawner,
-          alive: () => true,
-          probe: async () => false,
-          pidOnPort: () => undefined,
-          readyWaitMs: 0,
-          fallbackRange: 3,
-        }),
-      ).rejects.toThrow(/unavailable/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("skips reserved service ports during fallback (widened range)", async () => {
-    // Fallback is off by default (range=1). When a caller opens it up for
-    // debug, reservedPorts must still be honored so the hub never steals a
-    // registered service's slot even if the service isn't yet bound.
-    const h = makeHarness();
-    try {
-      const spawner = makeSpawner(3333);
-      const result = await ensureHubRunning({
-        configDir: h.configDir,
-        wellKnownDir: h.wellKnownDir,
-        spawner,
-        alive: () => true,
-        probe: probeTaken(new Set([1939])), // default port is held
-        reservedPorts: [1940], // vault's reservation
-        readyWaitMs: 0,
-        fallbackRange: 5,
-      });
-      // 1939 is taken, 1940 is reserved → we get 1941.
-      expect(result.port).toBe(1941);
-      expect(readHubPort(h.configDir)).toBe(1941);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("honors startPort override", async () => {
-    const h = makeHarness();
-    try {
-      const spawner = makeSpawner(2222);
-      const result = await ensureHubRunning({
-        configDir: h.configDir,
-        wellKnownDir: h.wellKnownDir,
-        spawner,
-        alive: () => true,
-        probe: probeTaken(new Set()),
-        readyWaitMs: 0,
-        startPort: 18080,
-      });
-      expect(result.port).toBe(18080);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -1,22 +1,17 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, openSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   type LifecycleOpts,
   defaultAlive,
   defaultKill,
-  defaultSpawner,
   logs,
   restart,
   start,
   stop,
 } from "../commands/lifecycle.ts";
-import { readEnvFileValues } from "../env-file.ts";
-import { writeHubPort } from "../hub-control.ts";
-import { hubDbPath, openHubDb } from "../hub-db.ts";
 import type { HubUnitManagerOpResult } from "../hub-unit.ts";
-import { validateAccessToken } from "../jwt-sign.ts";
 import type { MigrateOfferOpts, MigrateOfferResult } from "../migrate-offer.ts";
 import {
   type ModuleOp,
@@ -24,14 +19,28 @@ import {
   type ModuleOpResult,
   NoOperatorTokenError,
 } from "../module-ops-client.ts";
-import {
-  OPERATOR_TOKEN_SCOPE_SET_CLAIM,
-  issueOperatorToken,
-  readOperatorTokenFile,
-} from "../operator-token.ts";
-import { ensureLogPath, logPath, readPid, writePid } from "../process-state.ts";
-import { readManifest, upsertService } from "../services-manifest.ts";
-import { rotateSigningKey } from "../signing-keys.ts";
+import { ensureLogPath, writePid } from "../process-state.ts";
+import { upsertService } from "../services-manifest.ts";
+
+// ---------------------------------------------------------------------------
+// Phase 5b: the supervised path is the ONLY runtime. The detached spawners were
+// retired, so these suites exercise (a) the supervisor-path dispatch (hub UNIT
+// installed → drive the running supervisor / platform manager), (b) the no-unit
+// path (§7.5 auto-offer / actionable error — NEVER a detached spawn), and (c)
+// the group-aware kill/alive primitives that survive for `logs` + future use.
+//
+// Coverage that MOVED with the retirement (no longer asserted here):
+//   - per-module spawn / env injection / PORT override / cwd / startCmd
+//     resolution / missing-dependency preflight → now the supervisor's job,
+//     asserted in `supervisor.test.ts` + `api-modules-ops.test.ts`.
+//   - hub#194 settle + hub#487 port-readiness → supervisor post-spawn readiness,
+//     asserted in `supervisor.test.ts`.
+//   - process-GROUP spawn (`detached: true`) → the supervisor's group-spawn,
+//     asserted in `supervisor.test.ts` (`defaultKillGroup` + the real round-trip).
+//   - `start|stop|restart hub` via `ensureHubRunning`/`stopHub` → now the
+//     platform-manager path (`ensureHubUnit`/`stopHubUnit`/`restartHubUnit`),
+//     asserted in the dual-dispatch suites below.
+// ---------------------------------------------------------------------------
 
 interface Harness {
   configDir: string;
@@ -60,1824 +69,6 @@ function seedVault(manifestPath: string): void {
     manifestPath,
   );
 }
-
-function seedNotes(manifestPath: string): void {
-  upsertService(
-    {
-      name: "parachute-notes",
-      port: 5173,
-      paths: ["/notes"],
-      health: "/notes/health",
-      version: "0.0.1",
-    },
-    manifestPath,
-  );
-}
-
-interface ThirdPartySeed {
-  installDir: string;
-  manifestName?: string;
-  startCmd?: readonly string[];
-  port?: number;
-}
-
-/**
- * Seed a third-party services.json row + write a `.parachute/module.json` at
- * `installDir`. Mirrors what `parachute install /tmp/foo` produces in
- * production: row carries `installDir`, lifecycle resolves spec from the
- * filesystem.
- */
-function seedThirdParty(
-  manifestPath: string,
-  configDirRoot: string,
-  name: string,
-  opts: ThirdPartySeed,
-): string {
-  const installDir = opts.installDir;
-  mkdirSync(join(installDir, ".parachute"), { recursive: true });
-  const manifest = {
-    name,
-    manifestName: opts.manifestName ?? name,
-    port: opts.port ?? 1944,
-    paths: [`/${name}`],
-    health: `/${name}/health`,
-    ...(opts.startCmd ? { startCmd: opts.startCmd } : {}),
-  };
-  writeFileSync(join(installDir, ".parachute", "module.json"), JSON.stringify(manifest));
-  upsertService(
-    {
-      name: opts.manifestName ?? name,
-      port: opts.port ?? 1944,
-      paths: [`/${name}`],
-      health: `/${name}/health`,
-      version: "0.0.1",
-      installDir,
-    },
-    manifestPath,
-  );
-  return configDirRoot;
-}
-
-interface SpawnerStub {
-  spawn: (
-    cmd: readonly string[],
-    logFile: string,
-    opts?: { env?: Record<string, string>; cwd?: string },
-  ) => number;
-  calls: Array<{
-    cmd: readonly string[];
-    logFile: string;
-    env?: Record<string, string>;
-    cwd?: string;
-  }>;
-}
-
-function makeSpawner(pidSequence: number[]): SpawnerStub {
-  const calls: Array<{
-    cmd: readonly string[];
-    logFile: string;
-    env?: Record<string, string>;
-    cwd?: string;
-  }> = [];
-  let i = 0;
-  return {
-    calls,
-    spawn(cmd, logFile, opts) {
-      calls.push({ cmd: [...cmd], logFile, env: opts?.env, cwd: opts?.cwd });
-      return pidSequence[i++] ?? 99999;
-    },
-  };
-}
-
-describe("parachute start", () => {
-  test("errors cleanly when no services installed", async () => {
-    const h = makeHarness();
-    try {
-      const logs: string[] = [];
-      const code = await start(undefined, {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        log: (l) => logs.push(l),
-      });
-      expect(code).toBe(1);
-      expect(logs.join("\n")).toMatch(/No services installed/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("errors cleanly when targeting an uninstalled service", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      const logs: string[] = [];
-      const code = await start("notes", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        log: (l) => logs.push(l),
-      });
-      expect(code).toBe(1);
-      expect(logs.join("\n")).toMatch(/notes isn't installed/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("spawns vault with parachute-vault serve, writes PID", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      const spawner = makeSpawner([4242]);
-      const logs: string[] = [];
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        log: (l) => logs.push(l),
-      });
-      expect(code).toBe(0);
-      expect(spawner.calls).toHaveLength(1);
-      expect(spawner.calls[0]?.cmd).toEqual(["parachute-vault", "serve"]);
-      expect(spawner.calls[0]?.logFile).toBe(logPath("vault", h.configDir));
-      expect(readPid("vault", h.configDir)).toBe(4242);
-      expect(logs.join("\n")).toMatch(/vault started \(pid 4242\)/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("missing startCmd binary → friendly missing-dependency message + no spawn", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      const spawner = makeSpawner([4242]);
-      const logs: string[] = [];
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        // Force the preflight's missing-binary branch: parachute-vault not on PATH.
-        which: () => null,
-        log: (l) => logs.push(l),
-      });
-      expect(code).toBe(1);
-      // Preflight fired before the spawn — the stub spawner is never called.
-      expect(spawner.calls).toHaveLength(0);
-      const out = logs.join("\n");
-      expect(out).toMatch(/vault failed to start/);
-      // The friendly install block names the binary + its install path.
-      expect(out).toContain("parachute-vault is required to run the Vault module Hub supervises");
-      expect(out).toContain("parachute install vault");
-      expect(readPid("vault", h.configDir)).toBeUndefined();
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("missing startCmd binary persists lastStartError so a later status surfaces it", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner: makeSpawner([4242]),
-        which: () => null,
-        log: () => {},
-      });
-      const entry = readManifest(h.manifestPath).services.find((s) => s.name === "parachute-vault");
-      expect(entry?.lastStartError?.error_type).toBe("missing_dependency");
-      expect(entry?.lastStartError?.binary).toBe("parachute-vault");
-      expect(entry?.lastStartError?.at).toBeDefined();
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("a successful start clears a previously-recorded lastStartError", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      // First start fails (binary missing) → records the error.
-      await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner: makeSpawner([1]),
-        which: () => null,
-        log: () => {},
-      });
-      expect(
-        readManifest(h.manifestPath).services.find((s) => s.name === "parachute-vault")
-          ?.lastStartError,
-      ).toBeDefined();
-      // Second start succeeds (binary present via the permissive default which
-      // — stub spawner path) → clears the recorded error.
-      await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner: makeSpawner([4242]),
-        log: () => {},
-      });
-      expect(
-        readManifest(h.manifestPath).services.find((s) => s.name === "parachute-vault")
-          ?.lastStartError,
-      ).toBeUndefined();
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("notes start command includes configured port and notes-serve shim path", async () => {
-    const h = makeHarness();
-    try {
-      seedNotes(h.manifestPath);
-      const spawner = makeSpawner([5151]);
-      const code = await start("notes", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      const cmd = spawner.calls[0]?.cmd ?? [];
-      expect(cmd[0]).toBe("bun");
-      expect(cmd.some((a) => a.endsWith("notes-serve.ts"))).toBe(true);
-      const portIdx = cmd.indexOf("--port");
-      expect(portIdx).toBeGreaterThan(-1);
-      expect(cmd[portIdx + 1]).toBe("5173");
-      const mountIdx = cmd.indexOf("--mount");
-      expect(mountIdx).toBeGreaterThan(-1);
-      expect(cmd[mountIdx + 1]).toBe("/notes");
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("no-op when already running", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      writePid("vault", 4242, h.configDir);
-      const spawner = makeSpawner([9999]);
-      const logs: string[] = [];
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        alive: () => true,
-        log: (l) => logs.push(l),
-      });
-      expect(code).toBe(0);
-      expect(spawner.calls).toHaveLength(0);
-      expect(logs.join("\n")).toMatch(/already running \(pid 4242\)/);
-      expect(readPid("vault", h.configDir)).toBe(4242);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("clears stale PID file before spawning fresh", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      writePid("vault", 4242, h.configDir);
-      const spawner = makeSpawner([7777]);
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        // Stale 4242 is dead; the freshly spawned 7777 is alive — the
-        // post-spawn settle (hub#194) calls alive(pid) on the new pid,
-        // so we differentiate per-pid rather than blanket-false.
-        alive: (pid) => pid === 7777,
-        sleep: async () => {},
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(spawner.calls).toHaveLength(1);
-      expect(readPid("vault", h.configDir)).toBe(7777);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("start (no svc) targets every installed + known service", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      seedNotes(h.manifestPath);
-      const spawner = makeSpawner([4242, 5151]);
-      const code = await start(undefined, {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(spawner.calls).toHaveLength(2);
-      expect(readPid("vault", h.configDir)).toBe(4242);
-      expect(readPid("notes", h.configDir)).toBe(5151);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("legacy parachute-lens manifest entry still starts under the notes spec", async () => {
-    // Users who installed during the brief Notes→Lens window (Apr 19–22)
-    // will still have `parachute-lens` in services.json until their notes
-    // package next boots and rewrites the row. Without the manifest alias,
-    // shortNameForManifest returns undefined, resolveTargets skips the
-    // entry, and they get "No manageable services" with no hint.
-    const h = makeHarness();
-    try {
-      upsertService(
-        {
-          name: "parachute-lens",
-          port: 5173,
-          paths: ["/lens"],
-          health: "/lens/health",
-          version: "0.0.1",
-        },
-        h.manifestPath,
-      );
-      const spawner = makeSpawner([5151]);
-      const code = await start(undefined, {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(spawner.calls).toHaveLength(1);
-      expect(spawner.calls[0]?.cmd.some((a) => a.endsWith("notes-serve.ts"))).toBe(true);
-      expect(readPid("notes", h.configDir)).toBe(5151);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("passes PARACHUTE_HUB_ORIGIN from expose-state when set", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      writeFileSync(
-        join(h.configDir, "expose-state.json"),
-        JSON.stringify({
-          version: 1,
-          layer: "tailnet",
-          mode: "path",
-          canonicalFqdn: "parachute.taildf9ce2.ts.net",
-          port: 443,
-          funnel: false,
-          entries: [],
-          hubOrigin: "https://parachute.taildf9ce2.ts.net",
-        }),
-      );
-      const spawner = makeSpawner([4242]);
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      // PORT is always set by `parachute start` (hub#356) from the
-      // services.json entry. PARACHUTE_HUB_ORIGIN comes from expose-state.
-      expect(spawner.calls[0]?.env).toEqual({
-        PORT: "1940",
-        PARACHUTE_HUB_ORIGIN: "https://parachute.taildf9ce2.ts.net",
-      });
-      // OAuth issuer-mismatch fix: the spawn-env injection above is ephemeral
-      // (lost on the next launchd / systemd boot). `start vault` ALSO persists
-      // the public origin into vault/.env so the out-of-band daemon validates
-      // hub-minted JWTs' `iss` against it. Without this, every reconnect after
-      // a reboot / crash-restart 401s.
-      expect(readEnvFileValues(join(h.configDir, "vault", ".env")).PARACHUTE_HUB_ORIGIN).toBe(
-        "https://parachute.taildf9ce2.ts.net",
-      );
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("self-heals a stale-loopback vault/.env from a cloudflare expose-state on restart", async () => {
-    // Existing-broken-deploy shape: a Cloudflare deploy whose vault/.env had a
-    // loopback PARACHUTE_HUB_ORIGIN baked in (or was unset and a prior run
-    // wrote loopback). expose-state.json carries the real public origin. A
-    // plain `parachute start vault` must rewrite vault/.env to the public
-    // origin so the daemon stops 401ing hub tokens — the self-heal half of the
-    // Cloudflare 401 fix.
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      writeFileSync(
-        join(h.configDir, "expose-state.json"),
-        JSON.stringify({
-          version: 1,
-          layer: "public",
-          mode: "subdomain",
-          canonicalFqdn: "gitcoin-parachute.unforced.dev",
-          port: 1939,
-          funnel: false,
-          entries: [{ kind: "proxy", mount: "/", target: "http://localhost:1939", service: "hub" }],
-          hubOrigin: "https://gitcoin-parachute.unforced.dev",
-        }),
-      );
-      // Pre-seed vault/.env with a stale loopback value (the broken state).
-      mkdirSync(join(h.configDir, "vault"), { recursive: true });
-      writeFileSync(
-        join(h.configDir, "vault", ".env"),
-        "PARACHUTE_HUB_ORIGIN=http://127.0.0.1:1939\n",
-      );
-      const spawner = makeSpawner([4242]);
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(readEnvFileValues(join(h.configDir, "vault", ".env")).PARACHUTE_HUB_ORIGIN).toBe(
-        "https://gitcoin-parachute.unforced.dev",
-      );
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("does NOT persist a loopback origin into vault/.env (would shadow a later exposure)", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      writeHubPort(1939, h.configDir);
-      const spawner = makeSpawner([4242]);
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      // Loopback is fine to inject into the ephemeral spawn env (local dev),
-      // but persisting it would brick the daemon path once exposure comes up:
-      // the baked loopback would shadow the real origin. So vault/.env stays
-      // absent of the key on a loopback-only start.
-      expect(existsSync(join(h.configDir, "vault", ".env"))).toBe(false);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("falls back to loopback origin from hub.port when not exposed", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      writeHubPort(1939, h.configDir);
-      const spawner = makeSpawner([4242]);
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(spawner.calls[0]?.env).toEqual({
-        PORT: "1940",
-        PARACHUTE_HUB_ORIGIN: "http://127.0.0.1:1939",
-      });
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("--hub-origin override wins over expose-state", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      writeFileSync(
-        join(h.configDir, "expose-state.json"),
-        JSON.stringify({
-          version: 1,
-          layer: "tailnet",
-          mode: "path",
-          canonicalFqdn: "parachute.taildf9ce2.ts.net",
-          port: 443,
-          funnel: false,
-          entries: [],
-          hubOrigin: "https://parachute.taildf9ce2.ts.net",
-        }),
-      );
-      const spawner = makeSpawner([4242]);
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        hubOrigin: "https://override.example.com/",
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(spawner.calls[0]?.env).toEqual({
-        PORT: "1940",
-        PARACHUTE_HUB_ORIGIN: "https://override.example.com",
-      });
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("omits env when no override, no exposure, no hub port", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      const spawner = makeSpawner([4242]);
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      // PORT is always set (hub#356) — even with no override, no exposure,
-      // and no hub.port file, the spawn env carries the canonical PORT
-      // from services.json. Test renamed from "omits env" to reflect
-      // the new minimum-env shape.
-      expect(spawner.calls[0]?.env).toEqual({ PORT: "1940" });
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("merges <configDir>/<svc>/.env into the spawn env", async () => {
-    // Scribe's API key prompt writes GROQ_API_KEY into ~/.parachute/scribe/.env.
-    // Scribe itself doesn't auto-load .env, so `parachute start scribe` has to
-    // forward the values into the child env or the API key won't take effect.
-    const h = makeHarness();
-    try {
-      upsertService(
-        {
-          name: "parachute-scribe",
-          port: 1943,
-          paths: ["/scribe"],
-          health: "/scribe/health",
-          version: "0.1.0",
-        },
-        h.manifestPath,
-      );
-      ensureLogPath("scribe", h.configDir);
-      writeFileSync(
-        join(h.configDir, "scribe", ".env"),
-        'GROQ_API_KEY=gsk_real_value\nQUOTED="quoted_val"\n',
-      );
-      const spawner = makeSpawner([7777]);
-      const code = await start("scribe", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(spawner.calls[0]?.env).toEqual({
-        PORT: "1943",
-        GROQ_API_KEY: "gsk_real_value",
-        QUOTED: "quoted_val",
-      });
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("hub-origin override wins over conflicting key in service .env", async () => {
-    // Defense: `start --hub-origin <url>` is the authoritative source for
-    // PARACHUTE_HUB_ORIGIN. If a service .env happens to have the same key
-    // (e.g. an old hand-edit), the live override should still apply.
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      ensureLogPath("vault", h.configDir);
-      writeFileSync(
-        join(h.configDir, "vault", ".env"),
-        "SCRIBE_AUTH_TOKEN=secret\nPARACHUTE_HUB_ORIGIN=http://stale.local\n",
-      );
-      const spawner = makeSpawner([4242]);
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        hubOrigin: "https://live.example.com",
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(spawner.calls[0]?.env).toEqual({
-        PORT: "1940",
-        SCRIBE_AUTH_TOKEN: "secret",
-        PARACHUTE_HUB_ORIGIN: "https://live.example.com",
-      });
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("third-party module starts via installDir module.json with cwd", async () => {
-    // hub#83: services.json rows that carry installDir resolve their spec
-    // from `<installDir>/.parachute/module.json` at lifecycle time. Spawn
-    // gets cwd=installDir so manifest-declared relative paths work.
-    const h = makeHarness();
-    try {
-      const installDir = join(h.configDir, "_pkg-someapp");
-      seedThirdParty(h.manifestPath, h.configDir, "someapp", {
-        installDir,
-        startCmd: ["bun", "web/server/src/server.ts"],
-        port: 1944,
-      });
-      const spawner = makeSpawner([8080]);
-      const code = await start("someapp", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(spawner.calls).toHaveLength(1);
-      expect(spawner.calls[0]?.cmd).toEqual(["bun", "web/server/src/server.ts"]);
-      expect(spawner.calls[0]?.cwd).toBe(installDir);
-      expect(readPid("someapp", h.configDir)).toBe(8080);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("start: installDir-less third-party row surfaces an actionable error", async () => {
-    // A services.json row whose name isn't first-party AND has no installDir
-    // can't yield a startCmd. Pre-fix this hit the generic "unknown service"
-    // path (misleading — the row exists, just with stale shape). Post-fix
-    // resolveTargets returns the entry with spec=undefined and start prints
-    // an actionable message that points at the real fix (re-install or
-    // upgrade-the-module).
-    const h = makeHarness();
-    try {
-      upsertService(
-        {
-          name: "mystery",
-          port: 1944,
-          paths: ["/mystery"],
-          health: "/mystery/health",
-          version: "0.0.1",
-        },
-        h.manifestPath,
-      );
-      const lines: string[] = [];
-      const code = await start("mystery", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(1);
-      const out = lines.join("\n");
-      expect(out).toMatch(/services\.json entry has no installDir/);
-      expect(out).toMatch(/parachute install <path-to-mystery>/);
-      expect(out).not.toMatch(/unknown service/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("start: name absent from services.json still errors as unknown service", async () => {
-    // The genuinely-unknown path: no first-party fallback, no row in
-    // services.json. Distinguish from the above (row exists but lacks
-    // installDir) so the error message is right-shaped for each.
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      const lines: string[] = [];
-      const code = await start("ghost", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(1);
-      expect(lines.join("\n")).toMatch(/unknown service "ghost"/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("start (no svc) sweeps both first-party and third-party rows", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      const installDir = join(h.configDir, "_pkg-someapp");
-      seedThirdParty(h.manifestPath, h.configDir, "someapp", {
-        installDir,
-        startCmd: ["bun", "server.ts"],
-        port: 1944,
-      });
-      const spawner = makeSpawner([4242, 8080]);
-      const code = await start(undefined, {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(spawner.calls).toHaveLength(2);
-      const cmds = spawner.calls.map((c) => c.cmd);
-      expect(cmds).toContainEqual(["parachute-vault", "serve"]);
-      expect(cmds).toContainEqual(["bun", "server.ts"]);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("third-party with malformed module.json fails clearly", async () => {
-    const h = makeHarness();
-    try {
-      const installDir = join(h.configDir, "_pkg-broken");
-      mkdirSync(join(installDir, ".parachute"), { recursive: true });
-      writeFileSync(join(installDir, ".parachute", "module.json"), "{ not valid json");
-      upsertService(
-        {
-          name: "broken",
-          port: 1944,
-          paths: ["/broken"],
-          health: "/broken/health",
-          version: "0.0.1",
-          installDir,
-        },
-        h.manifestPath,
-      );
-      const lines: string[] = [];
-      const code = await start("broken", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(1);
-      expect(lines.join("\n")).toMatch(/broken: invalid module\.json/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("hub#194: reports failure when child dies before the settle window", async () => {
-    // The bug: `parachute start notes` reported `✓ notes started (pid X)`
-    // but notes-serve crashed milliseconds later on a Bun.resolveSync
-    // failure, leaving tailnet `/notes/` 502'ing. Fix: after spawn, sleep
-    // ~250ms then re-check alive(pid). If dead, clear pidfile, log
-    // failure, return non-zero. This regression test pins the post-fix
-    // shape with a stub alive that always reports dead and a fast settle.
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      const spawner = makeSpawner([4242]);
-      const lines: string[] = [];
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        alive: () => false, // child dies immediately after spawn
-        sleep: async () => {}, // skip the real wait in tests
-        startSettleMs: 1, // any non-zero value engages the check
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(1);
-      expect(spawner.calls).toHaveLength(1);
-      // pidfile is cleared so a follow-up `start` doesn't report
-      // already-running against a corpse.
-      expect(readPid("vault", h.configDir)).toBeUndefined();
-      const out = lines.join("\n");
-      expect(out).toMatch(/✗ vault failed to start/);
-      expect(out).toMatch(/exited within 1ms/);
-      expect(out).toMatch(/Tail the log/);
-      expect(out).not.toMatch(/✓ vault started/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("hub#194: settle path passes when child stays alive past the window", async () => {
-    // Companion to the above — verifies the success-path shape doesn't
-    // regress. Stub alive returns true so the post-spawn check passes,
-    // and we still see the `✓ ... started` line.
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      const spawner = makeSpawner([4242]);
-      const lines: string[] = [];
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        alive: () => true,
-        sleep: async () => {},
-        startSettleMs: 1,
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(0);
-      expect(readPid("vault", h.configDir)).toBe(4242);
-      expect(lines.join("\n")).toMatch(/✓ vault started \(pid 4242\)/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("hub#194: settle skipped when startSettleMs is 0", async () => {
-    // Defense — don't regress the test-default policy. With a stub
-    // spawner and no `alive` override, the resolved settle is 0 (see
-    // resolve() in lifecycle.ts), so the post-spawn check is bypassed
-    // entirely and even an `alive: () => false` doesn't matter.
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      const spawner = makeSpawner([4242]);
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        startSettleMs: 0,
-        // intentionally omit alive — defaultAlive against a fake pid
-        // would normally report dead, but startSettleMs: 0 skips the
-        // call entirely.
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(readPid("vault", h.configDir)).toBe(4242);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("third-party with no startCmd in module.json reports lifecycle-unsupported", async () => {
-    const h = makeHarness();
-    try {
-      const installDir = join(h.configDir, "_pkg-noop");
-      seedThirdParty(h.manifestPath, h.configDir, "noop", {
-        installDir,
-        port: 1945,
-      });
-      const lines: string[] = [];
-      const code = await start("noop", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(1);
-      expect(lines.join("\n")).toMatch(/lifecycle not yet supported/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  // hub#487 — readiness gating beyond the bare liveness settle. Aaron hit this
-  // on a fresh EC2 box: `parachute start vault` printed "✓ vault started" while
-  // the process died ~instantly on EADDRINUSE (an orphan held 1940), and
-  // `parachute status` then showed it inactive.
-
-  /**
-   * A stub spawner that also seeds the service's log file with `content`, so
-   * the readiness-failure path's log-tail + EADDRINUSE detection can read a
-   * realistic boot error. Mirrors how the real spawner appends stdout/stderr
-   * to the logfile.
-   */
-  function makeSpawnerWithLog(pid: number, content: string): SpawnerStub {
-    const calls: SpawnerStub["calls"] = [];
-    return {
-      calls,
-      spawn(cmd, logFile, opts) {
-        calls.push({ cmd: [...cmd], logFile, env: opts?.env, cwd: opts?.cwd });
-        // The start path calls ensureLogPath() before spawn, so logFile's
-        // parent dir already exists — just write the simulated boot output.
-        writeFileSync(logFile, content);
-        return pid;
-      },
-    };
-  }
-
-  test("hub#487: EADDRINUSE in the log → port-in-use message + log tail, not ✓", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      const spawner = makeSpawnerWithLog(
-        4242,
-        "booting vault…\nerror: listen EADDRINUSE: address already in use 0.0.0.0:1940\n",
-      );
-      const lines: string[] = [];
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        alive: () => false, // process died right after the EADDRINUSE throw
-        sleep: async () => {},
-        startSettleMs: 1,
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(1);
-      expect(readPid("vault", h.configDir)).toBeUndefined();
-      const out = lines.join("\n");
-      expect(out).toMatch(/port 1940 is already in use/);
-      expect(out).toMatch(/lsof -ti:1940/);
-      // The real boot error is surfaced inline so the operator doesn't have to
-      // go tail the log themselves.
-      expect(out).toMatch(/EADDRINUSE/);
-      expect(out).not.toMatch(/✓ vault started/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("hub#487: process survives settle but never binds its port → failure with log tail", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      const spawner = makeSpawnerWithLog(4242, "vault crashed mid-boot\n");
-      const lines: string[] = [];
-      let aliveCalls = 0;
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        // Alive through the settle + first readiness poll, then dies — the
-        // slow-EADDRINUSE / crash-after-boot shape.
-        alive: () => {
-          aliveCalls++;
-          return aliveCalls <= 1;
-        },
-        sleep: async () => {},
-        startSettleMs: 1,
-        startReadyMs: 50,
-        startReadyPollMs: 1,
-        portListening: async () => false, // never binds
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(1);
-      expect(readPid("vault", h.configDir)).toBeUndefined();
-      const out = lines.join("\n");
-      expect(out).toMatch(/✗ vault failed to start/);
-      expect(out).toMatch(/exited during startup/);
-      expect(out).not.toMatch(/✓ vault started/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("hub#487: alive but port silent past the window → non-fatal warning, exit 0", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      const spawner = makeSpawner([4242]);
-      const lines: string[] = [];
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        alive: () => true, // stays up the whole time
-        sleep: async () => {},
-        startSettleMs: 1,
-        startReadyMs: 10,
-        startReadyPollMs: 1,
-        portListening: async () => false, // slow boot — not listening yet
-        log: (l) => lines.push(l),
-      });
-      // A slow-but-alive daemon isn't a hard failure — we warn rather than fail.
-      expect(code).toBe(0);
-      expect(readPid("vault", h.configDir)).toBe(4242);
-      const out = lines.join("\n");
-      expect(out).toMatch(/port 1940 isn't accepting connections yet/);
-      expect(out).not.toMatch(/✓ vault started/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("hub#487: alive + port listening → success", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      const spawner = makeSpawner([4242]);
-      const lines: string[] = [];
-      let probeCalls = 0;
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        alive: () => true,
-        sleep: async () => {},
-        startSettleMs: 1,
-        startReadyMs: 50,
-        startReadyPollMs: 1,
-        // Not listening on the first poll, bound on the second — exercises the
-        // poll loop rather than an instant true.
-        portListening: async () => {
-          probeCalls++;
-          return probeCalls >= 2;
-        },
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(0);
-      expect(readPid("vault", h.configDir)).toBe(4242);
-      expect(lines.join("\n")).toMatch(/✓ vault started \(pid 4242\)/);
-    } finally {
-      h.cleanup();
-    }
-  });
-});
-
-describe("parachute stop", () => {
-  test("no-op when nothing is running", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      const killed: Array<[number, string | number]> = [];
-      const logs: string[] = [];
-      const code = await stop("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        kill: (pid, sig) => killed.push([pid, sig]),
-        log: (l) => logs.push(l),
-      });
-      expect(code).toBe(0);
-      expect(killed).toHaveLength(0);
-      expect(logs.join("\n")).toMatch(/wasn't running/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("cleans stale PID file without sending any signal", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      writePid("vault", 4242, h.configDir);
-      const killed: Array<[number, string | number]> = [];
-      const code = await stop("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        kill: (pid, sig) => killed.push([pid, sig]),
-        alive: () => false,
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(killed).toHaveLength(0);
-      expect(readPid("vault", h.configDir)).toBeUndefined();
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("SIGTERM + clean exit within window clears PID", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      writePid("vault", 4242, h.configDir);
-      const killed: Array<[number, string | number]> = [];
-      let aliveCall = 0;
-      const code = await stop("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        kill: (pid, sig) => killed.push([pid, sig]),
-        alive: () => {
-          aliveCall++;
-          return aliveCall === 1;
-        },
-        sleep: async () => {},
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(killed).toEqual([[4242, "SIGTERM"]]);
-      expect(readPid("vault", h.configDir)).toBeUndefined();
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("escalates to SIGKILL when SIGTERM doesn't land", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      writePid("vault", 4242, h.configDir);
-      const killed: Array<[number, string | number]> = [];
-      let t = 0;
-      const code = await stop("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        kill: (pid, sig) => killed.push([pid, sig]),
-        alive: () => true,
-        sleep: async () => {},
-        now: () => {
-          // Jump past the kill-wait window so the polling loop exits fast.
-          t += 20_000;
-          return t;
-        },
-        killWaitMs: 10_000,
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(killed[0]).toEqual([4242, "SIGTERM"]);
-      expect(killed[killed.length - 1]).toEqual([4242, "SIGKILL"]);
-      expect(readPid("vault", h.configDir)).toBeUndefined();
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("third-party row without installDir: stops via pidfile", async () => {
-    // Graceful-degradation path: an installed-but-stale third-party row
-    // (no installDir field — pre-installDir-contract self-registration)
-    // should still be stoppable. stop only needs the short name to find
-    // the pidfile; spec resolution isn't on the critical path for stop.
-    const h = makeHarness();
-    try {
-      upsertService(
-        {
-          name: "mystery",
-          port: 1944,
-          paths: ["/mystery"],
-          health: "/mystery/health",
-          version: "0.0.1",
-        },
-        h.manifestPath,
-      );
-      writePid("mystery", 4242, h.configDir);
-      const killed: Array<[number, string | number]> = [];
-      let aliveCall = 0;
-      const code = await stop("mystery", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        kill: (pid, sig) => killed.push([pid, sig]),
-        alive: () => {
-          aliveCall++;
-          return aliveCall === 1;
-        },
-        sleep: async () => {},
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(killed).toEqual([[4242, "SIGTERM"]]);
-      expect(readPid("mystery", h.configDir)).toBeUndefined();
-    } finally {
-      h.cleanup();
-    }
-  });
-});
-
-describe("parachute restart", () => {
-  test("stops then starts in sequence", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      writePid("vault", 4242, h.configDir);
-      const spawner = makeSpawner([7777]);
-      const killed: Array<[number, string | number]> = [];
-      const code = await restart("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        kill: (pid, sig) => killed.push([pid, sig]),
-        // Stale 4242 is dead (stop's stale-pid path skips the kill);
-        // freshly spawned 7777 is alive past the post-spawn settle
-        // (hub#194). Per-pid differentiation rather than blanket-false.
-        alive: (pid) => pid === 7777,
-        sleep: async () => {},
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(killed).toHaveLength(0); // stale pid → cleanup without kill
-      expect(spawner.calls).toHaveLength(1);
-      expect(readPid("vault", h.configDir)).toBe(7777);
-    } finally {
-      h.cleanup();
-    }
-  });
-});
-
-describe("parachute logs", () => {
-  test("hint when no log file exists", async () => {
-    const h = makeHarness();
-    try {
-      const lines: string[] = [];
-      const code = await logs("vault", {
-        configDir: h.configDir,
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(0);
-      expect(lines.join("\n")).toMatch(/no logs yet/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("prints last N lines in one-shot mode", async () => {
-    const h = makeHarness();
-    try {
-      const p = ensureLogPath("vault", h.configDir);
-      const content = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join("\n");
-      writeFileSync(p, `${content}\n`);
-      const lines: string[] = [];
-      const code = await logs("vault", {
-        configDir: h.configDir,
-        lines: 3,
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(0);
-      expect(lines).toEqual(["line 8", "line 9", "line 10"]);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("unknown service errors cleanly", async () => {
-    const h = makeHarness();
-    try {
-      const lines: string[] = [];
-      const code = await logs("nope", {
-        configDir: h.configDir,
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(1);
-      expect(lines.join("\n")).toMatch(/unknown service/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("third-party module name with installDir is recognised", async () => {
-    const h = makeHarness();
-    try {
-      const installDir = join(h.configDir, "_pkg-someapp");
-      seedThirdParty(h.manifestPath, h.configDir, "someapp", {
-        installDir,
-        startCmd: ["bun", "server.ts"],
-      });
-      const p = ensureLogPath("someapp", h.configDir);
-      writeFileSync(p, "someapp line 1\nsomeapp line 2\n");
-      const lines: string[] = [];
-      const code = await logs("someapp", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(0);
-      expect(lines).toEqual(["someapp line 1", "someapp line 2"]);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("third-party row without installDir: tails by short name", async () => {
-    // Graceful-degradation path: log file is keyed by short name, written by
-    // start. installDir is irrelevant for tailing — the entry just needs to
-    // exist in services.json.
-    const h = makeHarness();
-    try {
-      upsertService(
-        {
-          name: "mystery",
-          port: 1944,
-          paths: ["/mystery"],
-          health: "/mystery/health",
-          version: "0.0.1",
-        },
-        h.manifestPath,
-      );
-      const p = ensureLogPath("mystery", h.configDir);
-      writeFileSync(p, "mystery line 1\nmystery line 2\n");
-      const lines: string[] = [];
-      const code = await logs("mystery", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(0);
-      expect(lines).toEqual(["mystery line 1", "mystery line 2"]);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("running daemon + missing log file: surfaces alive-but-no-log shape (hub#335)", async () => {
-    // Aaron's #335 reproducer shape: parachute-app daemon was running
-    // (curl proxied 200s, pidfile alive) but `parachute logs app` printed
-    // `parachute start app to begin` — telling the operator to start a
-    // service that was already up. The fix: when the log file is missing
-    // but a live pidfile exists, surface the running pid + the path we
-    // expected instead of the misleading start-hint.
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      writePid("vault", 9999, h.configDir);
-      const lines: string[] = [];
-      const code = await logs("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        // pid 9999 is "alive" — simulates the running daemon case.
-        alive: () => true,
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(0);
-      const out = lines.join("\n");
-      expect(out).toMatch(/vault is running \(pid 9999\)/);
-      expect(out).toMatch(/no log file/);
-      expect(out).not.toMatch(/parachute start vault/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("stale pidfile + missing log file: falls through to start hint", async () => {
-    // The other half of the disambiguation: pidfile exists but the process
-    // is gone (stale pidfile, or cleanly shut down). That's effectively
-    // "not running," so the original `parachute start` hint is still the
-    // right message.
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      writePid("vault", 9999, h.configDir);
-      const lines: string[] = [];
-      const code = await logs("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        // pid 9999 is "dead" — `processState` returns `stopped`.
-        alive: () => false,
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(0);
-      expect(lines.join("\n")).toMatch(/no logs yet for vault/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("log file exists: prints tail regardless of pidfile state (hub#335)", async () => {
-    // The happy path Aaron's title calls out: when the log file exists,
-    // we tail it — independent of whether the pidfile is present. A
-    // running daemon's logs are useful; a stopped daemon's prior logs are
-    // useful too (post-mortem). Pidfile state only changes the message
-    // when the file is missing.
-    const h = makeHarness();
-    try {
-      const p = ensureLogPath("vault", h.configDir);
-      writeFileSync(p, "vault line a\nvault line b\n");
-      // No pidfile written — verify we still print the tail.
-      const lines: string[] = [];
-      const code = await logs("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        alive: () => false,
-        log: (l) => lines.push(l),
-      });
-      expect(code).toBe(0);
-      expect(lines).toEqual(["vault line a", "vault line b"]);
-    } finally {
-      h.cleanup();
-    }
-  });
-});
-
-describe("process-group lifecycle (hub#88)", () => {
-  // Spawn a wrapper that forks a long-running grandchild (sleep), wait for
-  // both to come up, then check that the wrapper PID equals its PGID — the
-  // post-fix invariant that makes group-kill safe. Without `detached: true`
-  // the child inherits the test runner's PGID and group-kill would target
-  // the wrong tree.
-  test("defaultSpawner puts child in its own process group", async () => {
-    const h = makeHarness();
-    try {
-      const logFile = ensureLogPath("test", h.configDir);
-      const pid = defaultSpawner.spawn(["sh", "-c", "sleep 2 & wait"], logFile);
-      try {
-        // Resolve the child's PGID via ps; the kernel reports it as a
-        // numeric column. PGID == PID means our setsid-equivalent worked.
-        const ps = Bun.spawnSync(["ps", "-o", "pgid=", "-p", String(pid)]);
-        const pgid = Number.parseInt(ps.stdout.toString().trim(), 10);
-        expect(pgid).toBe(pid);
-      } finally {
-        try {
-          process.kill(-pid, "SIGKILL");
-        } catch {}
-      }
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  // The smoking-gun scenario from #88: a wrapper (sh) forks a grandchild
-  // (sleep) that keeps a resource — here, just stays alive. SIGKILL on the
-  // wrapper PID alone leaves the grandchild running. With detached spawn +
-  // group-kill, both go down. We assert by checking the grandchild's PID
-  // is no longer kill-able after `defaultKill`.
-  test("defaultKill takes down the wrapper and its grandchildren together", async () => {
-    const h = makeHarness();
-    try {
-      const logFile = ensureLogPath("test", h.configDir);
-      // Wrapper sh forks `sleep 30 & echo $!` so we capture the grandchild
-      // PID via the log file, then `wait` so the wrapper sticks around as
-      // a parent (mirrors `pnpm exec tsx`'s shape).
-      const wrapperPid = defaultSpawner.spawn(
-        ["sh", "-c", "sleep 30 & echo $! >&2; wait"],
-        logFile,
-      );
-      // Give the grandchild time to start and the log line to flush.
-      await new Promise((r) => setTimeout(r, 200));
-      const log = await Bun.file(logFile).text();
-      const grandchildPid = Number.parseInt(log.trim().split("\n").pop() ?? "", 10);
-      expect(grandchildPid).toBeGreaterThan(0);
-      expect(grandchildPid).not.toBe(wrapperPid);
-      // Both should be alive before kill.
-      expect(() => process.kill(grandchildPid, 0)).not.toThrow();
-
-      defaultKill(wrapperPid, "SIGKILL");
-
-      // Reap + wait for the grandchild to exit; on macOS the kernel may
-      // take a tick to deliver the signal.
-      await new Promise((r) => setTimeout(r, 200));
-      let grandchildStillAlive = true;
-      try {
-        process.kill(grandchildPid, 0);
-      } catch {
-        grandchildStillAlive = false;
-      }
-      expect(grandchildStillAlive).toBe(false);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  // defaultAlive's post-fix semantics: returns true while any group member
-  // is alive (the wrapper stays in the group as long as it's running),
-  // false after the group drains.
-  test("defaultAlive reports group liveness for detached children", async () => {
-    const h = makeHarness();
-    try {
-      const logFile = ensureLogPath("test", h.configDir);
-      const pid = defaultSpawner.spawn(["sh", "-c", "sleep 2"], logFile);
-      try {
-        expect(defaultAlive(pid)).toBe(true);
-      } finally {
-        try {
-          process.kill(-pid, "SIGKILL");
-        } catch {}
-      }
-      // Wait for the kill to drain the group, then re-check.
-      await new Promise((r) => setTimeout(r, 100));
-      expect(defaultAlive(pid)).toBe(false);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  // Legacy pidfile compatibility: a pre-detached pidfile holds a positive
-  // PID whose pgid is the parent shell, not the pid itself. defaultAlive
-  // must fall back to a bare-pid check so the next `stop` actually runs;
-  // defaultKill must fall back to a bare-pid signal so it can be reaped.
-  test("defaultAlive + defaultKill fall back to bare-pid for legacy (non-detached) processes", async () => {
-    // Spawn a non-detached child to simulate a legacy pidfile (pre-fix
-    // start). It shares the test runner's pgid, so kill(-pid, 0) will
-    // ESRCH and we should fall back.
-    const proc = Bun.spawn(["sh", "-c", "sleep 5"], { stdio: ["ignore", "ignore", "ignore"] });
-    const pid = proc.pid;
-    try {
-      expect(defaultAlive(pid)).toBe(true);
-      defaultKill(pid, "SIGKILL");
-      await new Promise((r) => setTimeout(r, 100));
-      expect(defaultAlive(pid)).toBe(false);
-    } finally {
-      try {
-        process.kill(pid, "SIGKILL");
-      } catch {}
-    }
-  });
-});
-
-/**
- * `parachute start|stop|restart hub` — the bug Aaron filed as hub#166. Hub
- * isn't a row in services.json, so the generic services-manifest path
- * surfaced "unknown service: hub". The fix dispatches `svc === "hub"`
- * straight to hub-control.ts. These tests inject `ensureRunning`/`stop`
- * stubs so we don't actually fork bun.
- */
-describe("parachute start|stop|restart hub", () => {
-  test("start hub: dispatches to ensureHubRunning, propagates configDir + issuer", async () => {
-    const h = makeHarness();
-    try {
-      const log: string[] = [];
-      const ensureCalls: Array<{ configDir?: string; issuer?: string }> = [];
-      const code = await start("hub", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        hubOrigin: "https://hub.example.com",
-        hub: {
-          ensureRunning: async (opts) => {
-            ensureCalls.push({ configDir: opts.configDir, issuer: opts.issuer });
-            return { pid: 4711, port: 1939, started: true };
-          },
-        },
-        log: (l) => log.push(l),
-      });
-      expect(code).toBe(0);
-      expect(ensureCalls).toHaveLength(1);
-      expect(ensureCalls[0]).toEqual({
-        configDir: h.configDir,
-        issuer: "https://hub.example.com",
-      });
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("start hub: reports already-running cleanly when ensureHubRunning returns started=false", async () => {
-    const h = makeHarness();
-    try {
-      const log: string[] = [];
-      const code = await start("hub", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        hub: {
-          ensureRunning: async () => ({ pid: 8888, port: 1939, started: false }),
-        },
-        log: (l) => log.push(l),
-      });
-      expect(code).toBe(0);
-      expect(log.join("\n")).toMatch(/hub already running \(pid 8888\) on port 1939/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("start hub: surfaces ensureHubRunning errors as exit 1", async () => {
-    const h = makeHarness();
-    try {
-      const log: string[] = [];
-      const code = await start("hub", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        hub: {
-          ensureRunning: async () => {
-            throw new Error("hub: port 1939 unavailable");
-          },
-        },
-        log: (l) => log.push(l),
-      });
-      expect(code).toBe(1);
-      expect(log.join("\n")).toMatch(/hub failed to start.*port 1939 unavailable/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  // hub#481 — `start hub` self-heals a stale operator-token issuer. Tests use
-  // the injectable `hub.selfHealOperatorToken` seam to assert the call happens
-  // (and to make it throw without failing start); a separate test drives the
-  // REAL self-heal against an on-disk operator token + hub.db.
-  test("start hub: invokes operator-token self-heal with the resolved issuer + configDir", async () => {
-    const h = makeHarness();
-    try {
-      const log: string[] = [];
-      const calls: Array<{ issuer: string; configDir: string }> = [];
-      const code = await start("hub", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        hubOrigin: "https://hub.example.com",
-        hub: {
-          ensureRunning: async () => ({ pid: 4711, port: 1939, started: true }),
-          selfHealOperatorToken: async (args) => {
-            calls.push({ issuer: args.issuer, configDir: args.configDir });
-            return {
-              kind: "rotated",
-              path: "/x/operator.token",
-              scopeSet: "admin",
-              expiresAt: "z",
-            };
-          },
-        },
-        log: (l) => log.push(l),
-      });
-      expect(code).toBe(0);
-      expect(calls).toEqual([{ issuer: "https://hub.example.com", configDir: h.configDir }]);
-      // Rotation emits an operator-facing line.
-      expect(log.join("\n")).toMatch(
-        /refreshed operator\.token issuer → https:\/\/hub\.example\.com/,
-      );
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("start hub: skips operator-token self-heal when no hub origin is resolvable", async () => {
-    const h = makeHarness();
-    try {
-      let called = false;
-      // No hubOrigin override, no expose-state, no hub.port file → resolveHubOrigin
-      // yields undefined, so the self-heal seam must NOT be called.
-      const code = await start("hub", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        hub: {
-          ensureRunning: async () => ({ pid: 4711, port: 1939, started: true }),
-          selfHealOperatorToken: async () => {
-            called = true;
-            return { kind: "absent" };
-          },
-        },
-        log: () => {},
-      });
-      expect(code).toBe(0);
-      expect(called).toBe(false);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("start hub: a thrown error inside operator-token self-heal does NOT fail start", async () => {
-    const h = makeHarness();
-    try {
-      const log: string[] = [];
-      const code = await start("hub", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        hubOrigin: "https://hub.example.com",
-        hub: {
-          ensureRunning: async () => ({ pid: 4711, port: 1939, started: true }),
-          selfHealOperatorToken: async () => {
-            throw new Error("hub.db is locked");
-          },
-        },
-        log: (l) => log.push(l),
-      });
-      expect(code).toBe(0);
-      // Degrades to a brief note, not a hard failure.
-      expect(log.join("\n")).toMatch(
-        /operator\.token issuer self-heal skipped \(hub\.db is locked\)/,
-      );
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("start hub: real self-heal re-mints a stale-iss operator token on disk", async () => {
-    const h = makeHarness();
-    try {
-      // Seed signing keys + a stale-iss operator token in the harness configDir's
-      // hub.db / operator.token, then drive the production self-heal seam.
-      const db = openHubDb(hubDbPath(h.configDir));
-      try {
-        rotateSigningKey(db);
-        await issueOperatorToken(db, "user-abc", {
-          dir: h.configDir,
-          issuer: "http://127.0.0.1:1939",
-          scopeSet: "start",
-        });
-      } finally {
-        db.close();
-      }
-
-      const log: string[] = [];
-      const code = await start("hub", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        hubOrigin: "https://gitcoin-parachute.unforced.dev",
-        // No selfHealOperatorToken override → exercises defaultSelfHealOperatorToken
-        // (opens hub.db at <configDir>/hub.db).
-        hub: {
-          ensureRunning: async () => ({ pid: 4711, port: 1939, started: true }),
-        },
-        log: (l) => log.push(l),
-      });
-      expect(code).toBe(0);
-      expect(log.join("\n")).toMatch(
-        /refreshed operator\.token issuer → https:\/\/gitcoin-parachute\.unforced\.dev/,
-      );
-
-      // The on-disk token now validates under the new issuer, scope-set preserved.
-      const verifyDb = openHubDb(hubDbPath(h.configDir));
-      try {
-        const onDisk = await readOperatorTokenFile(h.configDir);
-        expect(onDisk).not.toBeNull();
-        const validated = await validateAccessToken(
-          verifyDb,
-          onDisk as string,
-          "https://gitcoin-parachute.unforced.dev",
-        );
-        expect(validated.payload.iss).toBe("https://gitcoin-parachute.unforced.dev");
-        expect(validated.payload[OPERATOR_TOKEN_SCOPE_SET_CLAIM]).toBe("start");
-      } finally {
-        verifyDb.close();
-      }
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("stop hub: dispatches to stopHub, true → '✓ hub stopped'", async () => {
-    const h = makeHarness();
-    try {
-      const log: string[] = [];
-      const stopCalls: Array<{ configDir?: string }> = [];
-      const code = await stop("hub", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        hub: {
-          stop: async (opts) => {
-            stopCalls.push({ configDir: opts.configDir });
-            return true;
-          },
-        },
-        log: (l) => log.push(l),
-      });
-      expect(code).toBe(0);
-      expect(stopCalls).toHaveLength(1);
-      expect(stopCalls[0]?.configDir).toBe(h.configDir);
-      expect(log.join("\n")).toMatch(/✓ hub stopped/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("stop hub: false → 'wasn't running' (still exit 0)", async () => {
-    const h = makeHarness();
-    try {
-      const log: string[] = [];
-      const code = await stop("hub", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        hub: { stop: async () => false },
-        log: (l) => log.push(l),
-      });
-      expect(code).toBe(0);
-      expect(log.join("\n")).toMatch(/hub wasn't running/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("restart hub: chains stop then start through the same hub seam", async () => {
-    const h = makeHarness();
-    try {
-      const log: string[] = [];
-      const order: string[] = [];
-      const code = await restart("hub", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        hub: {
-          stop: async () => {
-            order.push("stop");
-            return true;
-          },
-          ensureRunning: async () => {
-            order.push("start");
-            return { pid: 5151, port: 1939, started: true };
-          },
-        },
-        log: (l) => log.push(l),
-      });
-      expect(code).toBe(0);
-      expect(order).toEqual(["stop", "start"]);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("logs hub: doesn't reject 'hub' as an unknown service", async () => {
-    const h = makeHarness();
-    try {
-      // No log file yet — exercise the "no logs yet" branch, which still
-      // returns 0. Goal of this test is just the unknown-service guard.
-      const log: string[] = [];
-      const code = await logs("hub", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        log: (l) => log.push(l),
-      });
-      expect(code).toBe(0);
-      expect(log.join("\n")).toMatch(/no logs yet for hub/);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("logs hub: prints the tail when a log file exists", async () => {
-    const h = makeHarness();
-    try {
-      const path = ensureLogPath("hub", h.configDir);
-      writeFileSync(path, "hub line one\nhub line two\n");
-      const log: string[] = [];
-      const code = await logs("hub", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        log: (l) => log.push(l),
-      });
-      expect(code).toBe(0);
-      expect(log).toEqual(["hub line one", "hub line two"]);
-    } finally {
-      h.cleanup();
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Phase 3b dual-dispatch (design §3.3): when a hub UNIT is installed, the verbs
-// drive the running supervisor / platform manager; when no unit is installed,
-// the existing detached arm is taken UNCHANGED. These suites exercise both arms
-// via injected `supervisor` seams (unit arm) and a stub spawner (detached arm).
-// ---------------------------------------------------------------------------
 
 interface SupervisorStub {
   opts: NonNullable<LifecycleOpts["supervisor"]>;
@@ -1945,7 +136,12 @@ function makeSupervisorStub(opts?: {
   return stub;
 }
 
-describe("Phase 3b dual-dispatch — start", () => {
+// ---------------------------------------------------------------------------
+// Supervisor-path dispatch (design §3.3): a hub UNIT is installed → the verbs
+// drive the running supervisor (per-module ops) / platform manager (hub verbs).
+// ---------------------------------------------------------------------------
+
+describe("start — supervisor path", () => {
   test("module svc, unit-installed → ensureHubUnit then driveModuleOp(start)", async () => {
     const h = makeHarness();
     try {
@@ -1979,27 +175,6 @@ describe("Phase 3b dual-dispatch — start", () => {
       expect(code).toBe(0);
       expect(sup.ensureCalls).toHaveLength(1);
       expect(sup.driveCalls).toHaveLength(0);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("module svc, NO unit → existing detached spawner path (unchanged)", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      const spawner = makeSpawner([4242]);
-      const code = await start("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        log: () => {},
-        // supervisor omitted → detached arm, deterministically.
-      });
-      expect(code).toBe(0);
-      expect(spawner.calls).toHaveLength(1);
-      expect(spawner.calls[0]?.cmd).toEqual(["parachute-vault", "serve"]);
-      expect(readPid("vault", h.configDir)).toBe(4242);
     } finally {
       h.cleanup();
     }
@@ -2052,7 +227,7 @@ describe("Phase 3b dual-dispatch — start", () => {
   });
 });
 
-describe("Phase 3b dual-dispatch — stop", () => {
+describe("stop — supervisor path", () => {
   test("module svc, hub UP → driveModuleOp(stop), no ensureHubUnit", async () => {
     const h = makeHarness();
     try {
@@ -2099,16 +274,11 @@ describe("Phase 3b dual-dispatch — stop", () => {
     const h = makeHarness();
     try {
       const sup = makeSupervisorStub();
-      // A kill seam that fails the test if ANY PID signal is sent.
-      const kill = () => {
-        throw new Error("stop hub must NOT signal a PID — it must go through the manager");
-      };
       const log: string[] = [];
       const code = await stop("hub", {
         configDir: h.configDir,
         manifestPath: h.manifestPath,
         log: (l) => log.push(l),
-        kill,
         supervisor: sup.opts,
       });
       expect(code).toBe(0);
@@ -2137,34 +307,9 @@ describe("Phase 3b dual-dispatch — stop", () => {
       h.cleanup();
     }
   });
-
-  test("module svc, NO unit → existing detached stop path (unchanged)", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      writePid("vault", 4242, h.configDir);
-      const killed: Array<{ pid: number; sig: NodeJS.Signals | number }> = [];
-      const code = await stop("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        kill: (pid, sig) => killed.push({ pid, sig }),
-        alive: (() => {
-          let n = 0;
-          return () => n++ < 1; // alive once (for the SIGTERM), then dead.
-        })(),
-        log: () => {},
-        // supervisor omitted → detached arm.
-      });
-      expect(code).toBe(0);
-      expect(killed[0]).toEqual({ pid: 4242, sig: "SIGTERM" });
-      expect(readPid("vault", h.configDir)).toBeUndefined();
-    } finally {
-      h.cleanup();
-    }
-  });
 });
 
-describe("Phase 3b dual-dispatch — restart", () => {
+describe("restart — supervisor path", () => {
   test("module svc, unit-installed → ensureHubUnit then driveModuleOp(restart)", async () => {
     const h = makeHarness();
     try {
@@ -2219,15 +364,11 @@ describe("Phase 3b dual-dispatch — restart", () => {
     const h = makeHarness();
     try {
       const sup = makeSupervisorStub();
-      const kill = () => {
-        throw new Error("restart hub must NOT signal a PID — it must go through the manager");
-      };
       const log: string[] = [];
       const code = await restart("hub", {
         configDir: h.configDir,
         manifestPath: h.manifestPath,
         log: (l) => log.push(l),
-        kill,
         supervisor: sup.opts,
       });
       expect(code).toBe(0);
@@ -2256,38 +397,17 @@ describe("Phase 3b dual-dispatch — restart", () => {
       h.cleanup();
     }
   });
-
-  test("module svc, NO unit → existing detached stop-then-start path (unchanged)", async () => {
-    const h = makeHarness();
-    try {
-      seedVault(h.manifestPath);
-      writePid("vault", 4242, h.configDir);
-      const spawner = makeSpawner([7777]);
-      const killed: Array<{ pid: number; sig: NodeJS.Signals | number }> = [];
-      const code = await restart("vault", {
-        configDir: h.configDir,
-        manifestPath: h.manifestPath,
-        spawner,
-        kill: (pid, sig) => killed.push({ pid, sig }),
-        // Stale 4242 is dead (stop's stale-pid path cleans up without a kill);
-        // freshly spawned 7777 is alive past the post-spawn settle (hub#194).
-        // Per-pid differentiation, mirroring the existing detached-restart test.
-        alive: (pid) => pid === 7777,
-        sleep: async () => {},
-        log: () => {},
-        // supervisor omitted → detached arm (stop then start).
-      });
-      expect(code).toBe(0);
-      expect(killed).toHaveLength(0); // stale pid → detached cleanup, no kill
-      expect(spawner.calls).toHaveLength(1); // detached start ran (NOT the supervisor)
-      expect(readPid("vault", h.configDir)).toBe(7777);
-    } finally {
-      h.cleanup();
-    }
-  });
 });
 
-describe("§7.5 auto-detect-and-offer hook in start/stop/restart", () => {
+// ---------------------------------------------------------------------------
+// §7.5 no-unit path: a box with NO hub unit gets the auto-offer (when enabled)
+// or the actionable "run `parachute migrate --to-supervised`" error — NEVER a
+// detached spawn (the spawners are retired in Phase 5b). Reworked from the
+// former "fall through to the detached arm" tests: the intent (what happens on
+// a no-unit box) is preserved, but the outcome inverted to single-runtime.
+// ---------------------------------------------------------------------------
+
+describe("§7.5 no-unit path in start/stop/restart", () => {
   /** A migrate-offer stub recording whether it was called + what it returns. */
   function makeOfferStub(outcome: MigrateOfferResult["outcome"]): {
     offer: (opts: MigrateOfferOpts) => Promise<MigrateOfferResult>;
@@ -2305,99 +425,92 @@ describe("§7.5 auto-detect-and-offer hook in start/stop/restart", () => {
     };
   }
 
-  test("offer disabled by default (omitted) → detached arm, no offer", async () => {
+  test("no unit + offer disabled (omitted) → actionable migrate error, exit 1, no spawn", async () => {
     const h = makeHarness();
     try {
       seedVault(h.manifestPath);
-      const spawner = makeSpawner([4242]);
-      // No migrateOffer block → the §7.5 hook stays OFF (existing-test behavior).
+      const log: string[] = [];
+      // No `supervisor` block → unitInstalled defaults to false; no migrateOffer
+      // → the offer hook stays OFF. There is no detached fallback anymore, so the
+      // verb surfaces the actionable command and exits non-zero.
       const code = await start("vault", {
         configDir: h.configDir,
         manifestPath: h.manifestPath,
-        spawner,
-        log: () => {},
+        log: (l) => log.push(l),
       });
-      expect(code).toBe(0);
-      // Took the detached arm — spawned vault.
-      expect(spawner.calls).toHaveLength(1);
+      expect(code).toBe(1);
+      expect(log.join("\n")).toMatch(/No supervised hub unit is installed/);
+      expect(log.join("\n")).toMatch(/parachute migrate --to-supervised/);
     } finally {
       h.cleanup();
     }
   });
 
-  test("start: accept+migrate → re-dispatches through the supervisor (no detached spawn)", async () => {
+  test("start: accept+migrate → dispatches through the supervisor (no detached spawn)", async () => {
     const h = makeHarness();
     try {
       seedVault(h.manifestPath);
       const offerStub = makeOfferStub("migrated");
       const sup = makeSupervisorStub();
-      // Start on the detached arm (unitInstalled:false), with the offer enabled
-      // and the supervisor stub ready for the post-migrate re-dispatch.
-      const spawner = makeSpawner([4242]);
+      // Start on the no-unit arm (unitInstalled:false), with the offer enabled
+      // and the supervisor stub ready for the post-migrate dispatch.
       const code = await start("vault", {
         configDir: h.configDir,
         manifestPath: h.manifestPath,
-        spawner,
         log: () => {},
         supervisor: { ...sup.opts, unitInstalled: false },
         migrateOffer: { enabled: true, offer: offerStub.offer },
       });
       expect(code).toBe(0);
       expect(offerStub.calls).toBe(1);
-      // The re-dispatch drove the supervisor (NOT a detached spawn).
+      // The migrate flipped the box to supervised → the verb drove the supervisor.
       expect(sup.driveCalls).toEqual([{ short: "vault", op: "start" }]);
-      expect(spawner.calls).toHaveLength(0);
     } finally {
       h.cleanup();
     }
   });
 
-  test("start: declined → falls through to the detached arm", async () => {
+  test("start: declined → actionable-error path, exit 1 (no spawn)", async () => {
     const h = makeHarness();
     try {
       seedVault(h.manifestPath);
       const offerStub = makeOfferStub("declined");
-      const spawner = makeSpawner([4242]);
       const code = await start("vault", {
         configDir: h.configDir,
         manifestPath: h.manifestPath,
-        spawner,
         log: () => {},
         migrateOffer: { enabled: true, offer: offerStub.offer },
       });
-      expect(code).toBe(0);
+      // Declined → no migrate, no detached spawn (retired) → non-zero exit. The
+      // offer itself surfaced its own decline guidance, so the verb just bails.
+      expect(code).toBe(1);
       expect(offerStub.calls).toBe(1);
-      // Declined → detached spawn still happened.
-      expect(spawner.calls).toHaveLength(1);
     } finally {
       h.cleanup();
     }
   });
 
-  test("start: migrate-failed → falls through to the detached arm (fail-safe)", async () => {
+  test("start: migrate-failed → actionable-error path, exit 1 (fail-safe, no spawn)", async () => {
     const h = makeHarness();
     try {
       seedVault(h.manifestPath);
       const offerStub = makeOfferStub("migrate-failed");
-      const spawner = makeSpawner([4242]);
       const code = await start("vault", {
         configDir: h.configDir,
         manifestPath: h.manifestPath,
-        spawner,
         log: () => {},
         migrateOffer: { enabled: true, offer: offerStub.offer },
       });
-      // A failed cutover leaves the box detached → the original verb still runs
-      // the detached way (rather than re-dispatching into a supervisor that
-      // isn't up).
-      expect(code).toBe(0);
-      expect(spawner.calls).toHaveLength(1);
+      // A failed cutover leaves the box un-migrated → the verb bails non-zero
+      // (rather than dispatching into a supervisor that isn't up). No spawn.
+      expect(code).toBe(1);
+      expect(offerStub.calls).toBe(1);
     } finally {
       h.cleanup();
     }
   });
 
-  test("stop: accept+migrate → re-dispatches through the supervisor", async () => {
+  test("stop: accept+migrate → dispatches through the supervisor", async () => {
     const h = makeHarness();
     try {
       seedVault(h.manifestPath);
@@ -2418,7 +531,7 @@ describe("§7.5 auto-detect-and-offer hook in start/stop/restart", () => {
     }
   });
 
-  test("restart: accept+migrate → re-dispatches through the supervisor", async () => {
+  test("restart: accept+migrate → dispatches through the supervisor", async () => {
     const h = makeHarness();
     try {
       seedVault(h.manifestPath);
@@ -2453,7 +566,7 @@ describe("§7.5 auto-detect-and-offer hook in start/stop/restart", () => {
         migrateOffer: { enabled: true, offer: offerStub.offer },
       });
       expect(code).toBe(0);
-      // Supervisor arm taken directly → the offer hook (detached-arm only) never ran.
+      // Supervisor arm taken directly → the offer hook (no-unit only) never ran.
       expect(offerStub.calls).toBe(0);
       expect(sup.driveCalls).toEqual([{ short: "vault", op: "start" }]);
     } finally {
@@ -2461,33 +574,257 @@ describe("§7.5 auto-detect-and-offer hook in start/stop/restart", () => {
     }
   });
 
-  test("restart: declined → offer fires EXACTLY ONCE, not three times (MUST-FIX 3)", async () => {
+  test("restart: declined → offer fires EXACTLY ONCE (MUST-FIX 3), exit 1", async () => {
     const h = makeHarness();
     try {
       seedVault(h.manifestPath);
-      writePid("vault", 4242, h.configDir);
-      // The operator DECLINES the offer. The outer `restart` makes the single
-      // offer, then falls to the detached stop+start. WITHOUT the fix, the offer
-      // block flowed through `...opts` into both inner verbs → 3 offers/prints.
+      // The operator DECLINES the offer. `restart` makes a single offer via the
+      // shared `requireSupervisedOrOffer` gate (no inner stop+start re-offer
+      // anymore — the detached stop-then-start arm is gone).
       const offerStub = makeOfferStub("declined");
-      const spawner = makeSpawner([7777]);
       const code = await restart("vault", {
         configDir: h.configDir,
         manifestPath: h.manifestPath,
-        spawner,
-        // Stale 4242 dead (stop's stale-pid path skips the kill); spawned 7777
-        // alive past the post-spawn settle.
-        alive: (pid) => pid === 7777,
-        sleep: async () => {},
         log: () => {},
         migrateOffer: { enabled: true, offer: offerStub.offer },
       });
-      expect(code).toBe(0);
-      // EXACTLY ONE offer — the outer restart's, not re-offered by inner stop+start.
+      expect(code).toBe(1);
+      // EXACTLY ONE offer.
       expect(offerStub.calls).toBe(1);
-      // The detached restart still happened (declined → detached arm).
-      expect(spawner.calls).toHaveLength(1);
-      expect(readPid("vault", h.configDir)).toBe(7777);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group-aware kill / liveness primitives (hub#88). The detached MODULE spawner
+// that created these process groups is retired (the supervisor's group-spawn +
+// `defaultKillGroup` carry that role now, asserted in `supervisor.test.ts`), but
+// `defaultKill` / `defaultAlive` survive as exported primitives — `logs` uses
+// `defaultAlive`, and the supervisor's reaper mirrors `defaultKill`'s group/
+// bare-pid fallback. These tests spawn a detached fixture process directly (not
+// via the retired spawner) to keep that behavior under test.
+// ---------------------------------------------------------------------------
+
+/** Spawn a detached fixture child (its own process group) for the kill/alive tests. */
+function spawnDetached(cmd: string[]): { pid: number; logFile: string } {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-grp-"));
+  const logFile = ensureLogPath("test", dir);
+  const fd = openSync(logFile, "a");
+  const proc = Bun.spawn(cmd, { stdio: ["ignore", fd, fd], detached: true, env: process.env });
+  proc.unref();
+  return { pid: proc.pid, logFile };
+}
+
+describe("group-aware kill / liveness (hub#88)", () => {
+  test("defaultKill takes down the wrapper and its grandchildren together", async () => {
+    // Wrapper sh forks `sleep 30 & echo $!` so we capture the grandchild PID via
+    // the log file, then `wait` so the wrapper sticks around (mirrors `pnpm exec
+    // tsx`'s shape). SIGKILL on the GROUP reaps both.
+    const { pid: wrapperPid, logFile } = spawnDetached([
+      "sh",
+      "-c",
+      "sleep 30 & echo $! >&2; wait",
+    ]);
+    await new Promise((r) => setTimeout(r, 200));
+    const logText = await Bun.file(logFile).text();
+    const grandchildPid = Number.parseInt(logText.trim().split("\n").pop() ?? "", 10);
+    expect(grandchildPid).toBeGreaterThan(0);
+    expect(grandchildPid).not.toBe(wrapperPid);
+    expect(() => process.kill(grandchildPid, 0)).not.toThrow();
+
+    defaultKill(wrapperPid, "SIGKILL");
+
+    await new Promise((r) => setTimeout(r, 200));
+    let grandchildStillAlive = true;
+    try {
+      process.kill(grandchildPid, 0);
+    } catch {
+      grandchildStillAlive = false;
+    }
+    expect(grandchildStillAlive).toBe(false);
+  });
+
+  test("defaultAlive reports group liveness for detached children", async () => {
+    const { pid } = spawnDetached(["sh", "-c", "sleep 2"]);
+    try {
+      expect(defaultAlive(pid)).toBe(true);
+    } finally {
+      try {
+        process.kill(-pid, "SIGKILL");
+      } catch {}
+    }
+    await new Promise((r) => setTimeout(r, 100));
+    expect(defaultAlive(pid)).toBe(false);
+  });
+
+  test("defaultAlive + defaultKill fall back to bare-pid for legacy (non-detached) processes", async () => {
+    // A non-detached child shares the test runner's pgid, so kill(-pid, 0) will
+    // ESRCH and both must fall back to a bare-pid path.
+    const proc = Bun.spawn(["sh", "-c", "sleep 5"], { stdio: ["ignore", "ignore", "ignore"] });
+    const pid = proc.pid;
+    try {
+      expect(defaultAlive(pid)).toBe(true);
+      defaultKill(pid, "SIGKILL");
+      await new Promise((r) => setTimeout(r, 100));
+      expect(defaultAlive(pid)).toBe(false);
+    } finally {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {}
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// `parachute logs <svc>` — unchanged by Phase 5b. Reads the per-service logfile
+// keyed by short name (the readers §7.5 keeps). Includes the internal `hub`.
+// ---------------------------------------------------------------------------
+
+describe("parachute logs", () => {
+  test("hint when no log file exists", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const log: string[] = [];
+      const code = await logs("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(log.join("\n")).toMatch(/no logs yet for vault/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("prints last N lines in one-shot mode", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const path = ensureLogPath("vault", h.configDir);
+      writeFileSync(path, "line one\nline two\nline three\n");
+      const log: string[] = [];
+      const code = await logs("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        lines: 2,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(log).toEqual(["line two", "line three"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("unknown service errors cleanly", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const log: string[] = [];
+      const code = await logs("nope", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(1);
+      expect(log.join("\n")).toMatch(/unknown service "nope"/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("running daemon + missing log file: surfaces alive-but-no-log shape (hub#335)", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      // A pidfile reader still resolves: seed a live pid (this process) so the
+      // running-but-no-logfile diagnostic fires.
+      writePid("vault", process.pid, h.configDir);
+      const log: string[] = [];
+      const code = await logs("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        alive: () => true,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(log.join("\n")).toMatch(/is running \(pid .*\) but no log file/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("stale pidfile + missing log file: falls through to start hint", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writePid("vault", 999999, h.configDir);
+      const log: string[] = [];
+      const code = await logs("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        alive: () => false,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(log.join("\n")).toMatch(/no logs yet for vault/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("log file exists: prints tail regardless of pidfile state (hub#335)", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const path = ensureLogPath("vault", h.configDir);
+      writeFileSync(path, "boot line\n");
+      const log: string[] = [];
+      const code = await logs("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(log).toEqual(["boot line"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("logs hub: doesn't reject 'hub' as an unknown service", async () => {
+    const h = makeHarness();
+    try {
+      const log: string[] = [];
+      const code = await logs("hub", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(log.join("\n")).toMatch(/no logs yet for hub/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("logs hub: prints the tail when a log file exists", async () => {
+    const h = makeHarness();
+    try {
+      const path = ensureLogPath("hub", h.configDir);
+      writeFileSync(path, "hub line one\nhub line two\n");
+      const log: string[] = [];
+      const code = await logs("hub", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(log).toEqual(["hub line one", "hub line two"]);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/status-supervisor.test.ts
+++ b/src/__tests__/status-supervisor.test.ts
@@ -12,12 +12,12 @@ import {
 import { upsertService } from "../services-manifest.ts";
 
 /**
- * Phase 3c (design §6.4): on a UNIT-MANAGED box `status` reads the hub row from
- * the platform manager + `/health` and the module rows from the running
- * supervisor (`GET /api/modules`). Everything below is driven through the
- * `supervisor` seams — no real launchd/systemd/socket/HTTP/db call. The detached
- * arm is exercised separately in `status.test.ts` (those tests omit the
- * `supervisor` block entirely, so they keep the pidfile readout unchanged).
+ * Phase 5b (design §6.4): `status` reads the hub row from the platform manager +
+ * `/health` and the module rows from the running supervisor (`GET /api/modules`)
+ * — the ONLY runtime now that the detached pidfile arm is retired. Everything
+ * below is driven through the `supervisor` seams — no real launchd/systemd/
+ * socket/HTTP/db call. The manifest-derived rendering (URLs, version, persisted
+ * start-error) is covered in `status.test.ts` (also supervised-arm now).
  */
 
 function makeTempPath(): { path: string; cleanup: () => void; configDir: string } {
@@ -90,7 +90,6 @@ function supervisorOpts(configDir: string, path: string, o: SupervisorArmOpts) {
     installSourceDeps: STUB_INSTALL_SOURCE,
     hubSrcDir: "/nonexistent/hub/src",
     supervisor: {
-      unitInstalled: true,
       hubUnitDeps: FAKE_HUB_UNIT_DEPS,
       queryHubUnitState: () => o.managerState,
       probeHubHealth: async () => o.hubHealthy,
@@ -224,7 +223,6 @@ describe("status — Phase 3c supervisor arm: hub row", () => {
         }),
         // Replace the query with one that throws — status must not crash.
         supervisor: {
-          unitInstalled: true,
           hubUnitDeps: FAKE_HUB_UNIT_DEPS,
           queryHubUnitState: () => {
             throw new Error("systemctl exploded");
@@ -498,72 +496,9 @@ describe("status — Phase 3c supervisor arm: module rows", () => {
   });
 });
 
-describe("status — Phase 3c discriminant", () => {
-  test("no supervisor block → detached arm (pidfile readout), supervisor seams untouched", async () => {
-    const { path, configDir, cleanup } = makeTempPath();
-    try {
-      upsertService(
-        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.6.2" },
-        path,
-      );
-      // No `supervisor` block at all → resolveStatusSupervisor returns
-      // unitInstalled:false → the detached arm. The probe (fetchImpl) runs,
-      // proving we took the pidfile/probe path, not the supervisor path.
-      let probed = false;
-      const lines: string[] = [];
-      const code = await status({
-        manifestPath: path,
-        configDir,
-        installSourceDeps: STUB_INSTALL_SOURCE,
-        hubSrcDir: "/nonexistent/hub/src",
-        fetchImpl: async () => {
-          probed = true;
-          return new Response(null, { status: 200 });
-        },
-        print: (l) => lines.push(l),
-      });
-      expect(code).toBe(0);
-      // The detached arm probes the service's /health endpoint.
-      expect(probed).toBe(true);
-      expect(lines.some((l) => l.includes("parachute-vault"))).toBe(true);
-    } finally {
-      cleanup();
-    }
-  });
-
-  test("supervisor block with unitInstalled:false → detached arm (probe runs)", async () => {
-    const { path, configDir, cleanup } = makeTempPath();
-    try {
-      upsertService(
-        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.6.2" },
-        path,
-      );
-      let probed = false;
-      let queried = false;
-      const code = await status({
-        manifestPath: path,
-        configDir,
-        installSourceDeps: STUB_INSTALL_SOURCE,
-        hubSrcDir: "/nonexistent/hub/src",
-        fetchImpl: async () => {
-          probed = true;
-          return new Response(null, { status: 200 });
-        },
-        supervisor: {
-          unitInstalled: false,
-          queryHubUnitState: () => {
-            queried = true;
-            return { state: "active" };
-          },
-        },
-        print: () => {},
-      });
-      expect(code).toBe(0);
-      // Detached arm: the per-service probe runs and the manager is NOT queried.
-      expect(probed).toBe(true);
-      expect(queried).toBe(false);
-    } finally {
-      cleanup();
-    }
-  });
-});
+// The "Phase 3c discriminant" block (no-supervisor / unitInstalled:false →
+// detached pidfile-probe arm) was removed in Phase 5b: the detached arm is
+// retired, so there is no discriminant — `status` always reads the platform
+// manager + supervisor. The supervisor-path readout is exercised throughout the
+// suites above; a box with no hub unit degrades gracefully (manager `no-unit` /
+// `/health` down → inactive rows), which the hub-row + module-row suites cover.

--- a/src/__tests__/status.test.ts
+++ b/src/__tests__/status.test.ts
@@ -3,8 +3,25 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { status } from "../commands/status.ts";
-import { writePid } from "../process-state.ts";
+import type { HubUnitDeps, HubUnitStateResult } from "../hub-unit.ts";
+import type { ModuleStatesResult } from "../module-ops-client.ts";
 import { upsertService } from "../services-manifest.ts";
+
+/**
+ * Phase 5b: `status` reads the hub row from the platform manager + `/health` and
+ * the module rows from the running supervisor (`GET /api/modules`). The detached
+ * pidfile/HTTP-probe arm was retired, so these tests — the table-rendering /
+ * per-module URL deep-link / persisted-start-error / state-rollup coverage that
+ * used to live on the detached arm — drive the supervised arm instead. The
+ * detached-specific cases that no longer exist (HTTP probe success/failure, the
+ * http-401-healthy carve-out, known-stopped-skips-probe) are not re-asserted: a
+ * module's run-state comes from the supervisor now, not an HTTP probe.
+ *
+ * The hub-row state machine + module-state degradation paths are covered in
+ * `status-supervisor.test.ts`; this file focuses on the manifest-derived
+ * rendering (URLs, version, persisted start-error) that `manifestRowBase`
+ * produces for each module row.
+ */
 
 function makeTempPath(): { path: string; cleanup: () => void; configDir: string } {
   const dir = mkdtempSync(join(tmpdir(), "pcli-status-"));
@@ -15,276 +32,120 @@ function makeTempPath(): { path: string; cleanup: () => void; configDir: string 
   };
 }
 
-describe("status", () => {
-  test("empty manifest prints hint and exits 0", async () => {
-    const { path, cleanup } = makeTempPath();
+/** Install-source deps that never touch the real filesystem. */
+const STUB_INSTALL_SOURCE = {
+  bunGlobalPrefixes: () => [] as string[],
+  resolveBunGlobal: () => null,
+  readJson: () => ({ version: "0.6.2" }),
+  readGitHead: () => undefined,
+};
+
+const FAKE_HUB_UNIT_DEPS = {
+  platform: "linux",
+  getuid: () => 1000,
+  homeDir: () => "/home/op",
+  userName: () => "op",
+  which: () => "/usr/bin/systemctl",
+  run: () => ({ code: 0, stdout: "", stderr: "" }),
+  writeFile: () => {},
+  removeFile: () => {},
+  readFile: () => undefined,
+  exists: () => false,
+  probeHealth: async () => true,
+  portListening: async () => true,
+  sleep: async () => {},
+} as unknown as HubUnitDeps;
+
+function fakeOpenDb(): { close: () => void } {
+  return { close: () => {} };
+}
+
+interface ArmOpts {
+  managerState?: HubUnitStateResult;
+  hubHealthy?: boolean;
+  moduleStates?: ModuleStatesResult;
+}
+
+/**
+ * Drive `status` through the supervised arm with a healthy hub + the given module
+ * states. Defaults: manager `active`, hub `/health` OK, no module rows.
+ */
+function supervisorOpts(configDir: string, path: string, o: ArmOpts = {}) {
+  return {
+    manifestPath: path,
+    configDir,
+    installSourceDeps: STUB_INSTALL_SOURCE,
+    hubSrcDir: "/nonexistent/hub/src",
+    supervisor: {
+      hubUnitDeps: FAKE_HUB_UNIT_DEPS,
+      queryHubUnitState: () => o.managerState ?? { state: "active" as const },
+      probeHubHealth: async () => o.hubHealthy ?? true,
+      fetchModuleStates: async () => o.moduleStates ?? { supervisorAvailable: true, modules: [] },
+      openDb: fakeOpenDb as unknown as (configDir: string) => import("bun:sqlite").Database,
+    },
+  };
+}
+
+/** A `running` supervisor snapshot for a short name (the happy-path module row). */
+function runningModule(short: string, version = "0.6.2") {
+  return {
+    short,
+    installed: true,
+    installed_version: version,
+    supervisor_status: "running" as const,
+    pid: 5151,
+    supervisor_start_error: null,
+  };
+}
+
+describe("status — table + hub row", () => {
+  test("empty manifest still renders the hub row (a unit-managed hub runs with zero modules)", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
     try {
       const lines: string[] = [];
       const code = await status({
-        manifestPath: path,
-        fetchImpl: async () => new Response(null, { status: 200 }),
+        ...supervisorOpts(configDir, path),
         print: (l) => lines.push(l),
       });
       expect(code).toBe(0);
-      expect(lines.join("\n")).toMatch(/No services installed/);
+      // The hub row is meaningful even with no modules installed.
+      expect(lines.some((l) => l.includes("parachute-hub (internal)"))).toBe(true);
     } finally {
       cleanup();
     }
   });
 
-  test("all-healthy returns 0 and prints table", async () => {
-    const { path, cleanup } = makeTempPath();
+  test("all-running modules return 0 and render the table with versions + state", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
     try {
       upsertService(
-        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.2.4" },
-        path,
-      );
-      upsertService(
         {
-          name: "parachute-scribe",
-          port: 3200,
-          paths: ["/scribe"],
-          health: "/scribe/health",
-          version: "0.1.0",
+          name: "parachute-vault",
+          port: 1940,
+          paths: ["/vault/default"],
+          health: "/vault/default/health",
+          version: "0.6.2",
         },
         path,
       );
-      const seen: string[] = [];
       const lines: string[] = [];
       const code = await status({
-        manifestPath: path,
-        fetchImpl: async (url) => {
-          seen.push(String(url));
-          return new Response(null, { status: 200 });
-        },
+        ...supervisorOpts(configDir, path, {
+          moduleStates: { supervisorAvailable: true, modules: [runningModule("vault")] },
+        }),
         print: (l) => lines.push(l),
       });
       expect(code).toBe(0);
-      expect(seen).toContain("http://localhost:1940/health");
-      expect(seen).toContain("http://localhost:3200/scribe/health");
-      // Header reflects the post-workstream-F column shape:
-      // SERVICE  PORT  VERSION  STATE  PID  UPTIME  LATENCY  SOURCE
-      expect(lines[0]).toMatch(/SERVICE/);
-      expect(lines[0]).toMatch(/STATE/);
-      expect(lines[0]).not.toMatch(/PROCESS/);
-      expect(lines[0]).not.toMatch(/HEALTH/);
-      expect(lines.some((l) => l.includes("parachute-vault"))).toBe(true);
-      // Healthy probe rolls up to `active` per design-system.md §6.
-      expect(lines.some((l) => /\bactive\b/.test(l))).toBe(true);
+      const vaultLine = lines.find((l) => l.includes("parachute-vault"));
+      expect(vaultLine).toMatch(/\bactive\b/);
+      expect(vaultLine).toMatch(/0\.6\.2/);
     } finally {
       cleanup();
     }
   });
 
   test("persisted lastStartError surfaces on a continuation line", async () => {
-    const { path, cleanup } = makeTempPath();
-    try {
-      upsertService(
-        {
-          name: "parachute-vault",
-          port: 1940,
-          paths: ["/"],
-          health: "/health",
-          version: "0.2.4",
-          lastStartError: {
-            error_type: "missing_dependency",
-            error_description: "parachute-vault is required ...",
-            binary: "parachute-vault",
-            install: { generic: "parachute install vault" },
-          },
-        },
-        path,
-      );
-      const lines: string[] = [];
-      await status({
-        manifestPath: path,
-        // Probe refuses (service down) — the row is failing, and the
-        // start-error note explains why.
-        fetchImpl: async () => {
-          throw new Error("ECONNREFUSED");
-        },
-        print: (l) => lines.push(l),
-      });
-      const out = lines.join("\n");
-      expect(out).toMatch(/failed to start: parachute-vault not installed/);
-    } finally {
-      cleanup();
-    }
-  });
-
-  test("any-failing returns 1 and surfaces probe detail on continuation line", async () => {
-    const { path, cleanup } = makeTempPath();
-    try {
-      upsertService(
-        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.2.4" },
-        path,
-      );
-      const lines: string[] = [];
-      const code = await status({
-        manifestPath: path,
-        fetchImpl: async () => {
-          throw new Error("ECONNREFUSED");
-        },
-        print: (l) => lines.push(l),
-      });
-      expect(code).toBe(1);
-      // STATE column rolls up to `failing`.
-      expect(lines.some((l) => /\bfailing\b/.test(l))).toBe(true);
-      // The pre-F HEALTH column's detail survives on a continuation line
-      // ("  ! probe: ECONNREFUSED") so the operator can still diagnose.
-      expect(lines.some((l) => l.includes("probe:") && l.includes("ECONNREFUSED"))).toBe(true);
-    } finally {
-      cleanup();
-    }
-  });
-
-  test("http non-2xx counts as failing and surfaces the code on the probe line", async () => {
-    const { path, cleanup } = makeTempPath();
-    try {
-      upsertService(
-        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.2.4" },
-        path,
-      );
-      const lines: string[] = [];
-      const code = await status({
-        manifestPath: path,
-        fetchImpl: async () => new Response(null, { status: 503 }),
-        print: (l) => lines.push(l),
-      });
-      expect(code).toBe(1);
-      expect(lines.some((l) => /\bfailing\b/.test(l))).toBe(true);
-      expect(lines.some((l) => l.includes("probe: http 503"))).toBe(true);
-    } finally {
-      cleanup();
-    }
-  });
-
-  test("http 401 counts as HEALTHY (auth-gated endpoint is responsive)", async () => {
-    // Vault's canonical health path `/vault/<name>/health` returns 401
-    // without an API key — that's the server replying "I'm up but you
-    // need auth," not "I'm down." `parachute status` used to roll 401
-    // into the failing bucket via `res.ok`, surfacing "failing" on every
-    // fresh install (vault was fine — the probe was just confused).
-    // Now: 401 specifically counts as healthy. Other 4xx (404, 400) stay
-    // unhealthy — those mean the configured health path is misshapen.
     const { path, configDir, cleanup } = makeTempPath();
-    try {
-      upsertService(
-        {
-          name: "parachute-vault",
-          port: 1940,
-          paths: ["/"],
-          health: "/vault/default/health",
-          version: "0.2.4",
-        },
-        path,
-      );
-      writePid("vault", 4242, configDir);
-      const lines: string[] = [];
-      const code = await status({
-        manifestPath: path,
-        configDir,
-        alive: () => true,
-        fetchImpl: async () => new Response(null, { status: 401 }),
-        print: (l) => lines.push(l),
-      });
-      expect(code).toBe(0);
-      expect(lines.some((l) => /\bactive\b/.test(l))).toBe(true);
-      // No "failing" rollup, no `! probe: http 401` continuation line.
-      expect(lines.some((l) => /\bfailing\b/.test(l))).toBe(false);
-      expect(lines.some((l) => l.includes("probe: http 401"))).toBe(false);
-    } finally {
-      cleanup();
-    }
-  });
-
-  test("running + healthy probe shows STATE=active, pid + uptime", async () => {
-    const { path, configDir, cleanup } = makeTempPath();
-    try {
-      upsertService(
-        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.2.4" },
-        path,
-      );
-      writePid("vault", 4242, configDir);
-      const lines: string[] = [];
-      const code = await status({
-        manifestPath: path,
-        configDir,
-        alive: () => true,
-        fetchImpl: async () => new Response(null, { status: 200 }),
-        print: (l) => lines.push(l),
-      });
-      expect(code).toBe(0);
-      // Pre-F: STATE was a two-column (PROCESS=running, HEALTH=ok) split.
-      // Post-F: collapsed to one column showing `active`.
-      expect(lines.some((l) => /\bactive\b/.test(l))).toBe(true);
-      expect(lines.some((l) => l.includes("4242"))).toBe(true);
-      // Probe-detail continuation line is suppressed for active rows
-      // (the rollup is sufficient — no need to repeat "ok").
-      expect(lines.some((l) => l.includes("probe:"))).toBe(false);
-    } finally {
-      cleanup();
-    }
-  });
-
-  test("known-stopped process renders STATE=inactive, skips probe, exits 0", async () => {
-    const { path, configDir, cleanup } = makeTempPath();
-    try {
-      upsertService(
-        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.2.4" },
-        path,
-      );
-      writePid("vault", 4242, configDir);
-      let probed = false;
-      const lines: string[] = [];
-      const code = await status({
-        manifestPath: path,
-        configDir,
-        alive: () => false,
-        fetchImpl: async () => {
-          probed = true;
-          return new Response(null, { status: 200 });
-        },
-        print: (l) => lines.push(l),
-      });
-      expect(code).toBe(0);
-      expect(probed).toBe(false);
-      // Pre-F: PROCESS=stopped. Post-F: STATE=inactive.
-      expect(lines.some((l) => /\binactive\b/.test(l))).toBe(true);
-    } finally {
-      cleanup();
-    }
-  });
-
-  test("unknown process state (no pid file) still probes — externally managed OK", async () => {
-    const { path, configDir, cleanup } = makeTempPath();
-    try {
-      upsertService(
-        { name: "parachute-vault", port: 1940, paths: ["/"], health: "/health", version: "0.2.4" },
-        path,
-      );
-      let probed = false;
-      const code = await status({
-        manifestPath: path,
-        configDir,
-        fetchImpl: async () => {
-          probed = true;
-          return new Response(null, { status: 200 });
-        },
-        print: () => {},
-      });
-      expect(code).toBe(0);
-      expect(probed).toBe(true);
-    } finally {
-      cleanup();
-    }
-  });
-
-  // URL column: the launch-day pain was a user staring at the table not
-  // knowing where to point Claude.ai or curl. Each row gets a "  → URL"
-  // continuation line so the next step is obvious.
-  test("vault row prints MCP URL beneath it (path + /mcp suffix)", async () => {
-    const { path, cleanup } = makeTempPath();
     try {
       upsertService(
         {
@@ -292,519 +153,107 @@ describe("status", () => {
           port: 1940,
           paths: ["/vault/default"],
           health: "/vault/default/health",
-          version: "0.2.4",
+          version: "0.6.2",
+          lastStartError: {
+            error_type: "missing_dependency",
+            error_description: "parachute-vault not installed",
+            binary: "parachute-vault",
+          },
         },
         path,
       );
       const lines: string[] = [];
-      await status({
-        manifestPath: path,
-        fetchImpl: async () => new Response(null, { status: 200 }),
+      const code = await status({
+        ...supervisorOpts(configDir, path, {
+          // No live supervisor start-error → falls back to the persisted manifest note.
+          moduleStates: {
+            supervisorAvailable: true,
+            modules: [
+              {
+                short: "vault",
+                installed: true,
+                installed_version: "0.6.2",
+                supervisor_status: "crashed",
+                pid: null,
+                supervisor_start_error: null,
+              },
+            ],
+          },
+        }),
         print: (l) => lines.push(l),
       });
-      expect(lines.some((l) => l.includes("→ http://127.0.0.1:1940/vault/default/mcp"))).toBe(true);
+      // crashed → failing → exit 1; the persisted missing-dependency note shows.
+      expect(code).toBe(1);
+      expect(lines.join("\n")).toMatch(/failed to start: parachute-vault not installed/);
     } finally {
       cleanup();
     }
   });
+});
 
-  test("scribe row prints root URL (API is at /, ignore path prefix)", async () => {
-    const { path, cleanup } = makeTempPath();
+describe("status — per-module URL deep-links (manifestRowBase / urlForEntry)", () => {
+  async function urlFor(name: string, port: number, paths: string[]): Promise<string> {
+    const { path, configDir, cleanup } = makeTempPath();
     try {
-      upsertService(
-        {
-          name: "parachute-scribe",
-          port: 1943,
-          paths: ["/scribe"],
-          health: "/scribe/health",
-          version: "0.1.0",
-        },
-        path,
-      );
+      const short = name.replace(/^parachute-/, "");
+      upsertService({ name, port, paths, health: `${paths[0]}/health`, version: "0.6.2" }, path);
       const lines: string[] = [];
       await status({
-        manifestPath: path,
-        fetchImpl: async () => new Response(null, { status: 200 }),
+        ...supervisorOpts(configDir, path, {
+          moduleStates: { supervisorAvailable: true, modules: [runningModule(short)] },
+        }),
         print: (l) => lines.push(l),
       });
-      expect(lines.some((l) => l === "  → http://127.0.0.1:1943")).toBe(true);
+      return lines.join("\n");
     } finally {
       cleanup();
     }
+  }
+
+  test("vault row prints the MCP URL (path + /mcp suffix)", async () => {
+    const out = await urlFor("parachute-vault", 1940, ["/vault/default"]);
+    expect(out).toMatch(/\/vault\/default\/mcp/);
   });
 
-  test("notes row prints UI URL (port + /notes mount)", async () => {
-    const { path, cleanup } = makeTempPath();
-    try {
-      upsertService(
-        {
-          name: "parachute-notes",
-          port: 1942,
-          paths: ["/notes"],
-          health: "/notes/health",
-          version: "0.0.1",
-        },
-        path,
-      );
-      const lines: string[] = [];
-      await status({
-        manifestPath: path,
-        fetchImpl: async () => new Response(null, { status: 200 }),
-        print: (l) => lines.push(l),
-      });
-      expect(lines.some((l) => l === "  → http://127.0.0.1:1942/notes")).toBe(true);
-    } finally {
-      cleanup();
-    }
+  test("scribe row prints the root URL (API is at /, ignore path prefix)", async () => {
+    const out = await urlFor("parachute-scribe", 3200, ["/scribe"]);
+    expect(out).toMatch(/127\.0\.0\.1:3200|localhost:3200/);
+  });
+
+  test("notes row prints the UI URL (port + /notes mount)", async () => {
+    const out = await urlFor("parachute-notes", 5173, ["/notes"]);
+    expect(out).toMatch(/:5173\/notes/);
   });
 
   test("channel row prints port + /channel mount", async () => {
-    const { path, cleanup } = makeTempPath();
-    try {
-      upsertService(
-        {
-          name: "parachute-channel",
-          port: 1941,
-          paths: ["/channel"],
-          health: "/channel/health",
-          version: "0.1.0",
-        },
-        path,
-      );
-      const lines: string[] = [];
-      await status({
-        manifestPath: path,
-        fetchImpl: async () => new Response(null, { status: 200 }),
-        print: (l) => lines.push(l),
-      });
-      expect(lines.some((l) => l === "  → http://127.0.0.1:1941/channel")).toBe(true);
-    } finally {
-      cleanup();
-    }
+    const out = await urlFor("parachute-channel", 1943, ["/channel"]);
+    expect(out).toMatch(/:1943\/channel/);
   });
 
-  test("unknown service falls back to bare host:port + paths[0]", async () => {
-    const { path, cleanup } = makeTempPath();
-    try {
-      upsertService(
-        {
-          name: "third-party-thing",
-          port: 9000,
-          paths: ["/widget"],
-          health: "/health",
-          version: "1.0.0",
-        },
-        path,
-      );
-      const lines: string[] = [];
-      await status({
-        manifestPath: path,
-        fetchImpl: async () => new Response(null, { status: 200 }),
-        print: (l) => lines.push(l),
-      });
-      expect(lines.some((l) => l === "  → http://127.0.0.1:9000/widget")).toBe(true);
-    } finally {
-      cleanup();
-    }
-  });
-
-  // Canonical-port drift warning (hub#195). When a known service ends up at
-  // a non-canonical port (because of an upgrade rewrite, a port-walk fallback,
-  // or an operator edit), surface it in `parachute status` so a silent miswire
-  // is operator-visible. Warning, not error — operators may have moved the
-  // service deliberately to dodge a third-party clash.
-  describe("canonical-port drift warning", () => {
-    test("warns when scribe is at non-canonical port (1944 instead of 1943)", async () => {
-      const { path, cleanup } = makeTempPath();
-      try {
-        upsertService(
-          {
-            name: "parachute-scribe",
-            port: 1944,
-            paths: ["/scribe"],
-            health: "/scribe/health",
-            version: "0.4.0",
-          },
-          path,
-        );
-        const lines: string[] = [];
-        await status({
-          manifestPath: path,
-          fetchImpl: async () => new Response(null, { status: 200 }),
-          print: (l) => lines.push(l),
-        });
-        expect(lines.some((l) => l.includes("canonical port is 1943"))).toBe(true);
-      } finally {
-        cleanup();
-      }
-    });
-
-    test("does not warn when service is on its canonical port", async () => {
-      const { path, cleanup } = makeTempPath();
-      try {
-        upsertService(
-          {
-            name: "parachute-scribe",
-            port: 1943,
-            paths: ["/scribe"],
-            health: "/scribe/health",
-            version: "0.4.0",
-          },
-          path,
-        );
-        const lines: string[] = [];
-        await status({
-          manifestPath: path,
-          fetchImpl: async () => new Response(null, { status: 200 }),
-          print: (l) => lines.push(l),
-        });
-        expect(lines.some((l) => l.includes("canonical port"))).toBe(false);
-      } finally {
-        cleanup();
-      }
-    });
-
-    test("does not warn for third-party services with no canonical port", async () => {
-      const { path, cleanup } = makeTempPath();
-      try {
-        upsertService(
-          {
-            name: "third-party-thing",
-            port: 9000,
-            paths: ["/widget"],
-            health: "/health",
-            version: "1.0.0",
-          },
-          path,
-        );
-        const lines: string[] = [];
-        await status({
-          manifestPath: path,
-          fetchImpl: async () => new Response(null, { status: 200 }),
-          print: (l) => lines.push(l),
-        });
-        expect(lines.some((l) => l.includes("canonical port"))).toBe(false);
-      } finally {
-        cleanup();
-      }
-    });
-
-    test("warning does not affect exit code (status stays 0 when healthy)", async () => {
-      const { path, cleanup } = makeTempPath();
-      try {
-        upsertService(
-          {
-            name: "parachute-scribe",
-            port: 1944,
-            paths: ["/scribe"],
-            health: "/scribe/health",
-            version: "0.4.0",
-          },
-          path,
-        );
-        const code = await status({
-          manifestPath: path,
-          fetchImpl: async () => new Response(null, { status: 200 }),
-          print: () => {},
-        });
-        // Drift is informational. A healthy probed service still returns 0
-        // even when the port has drifted off canonical.
-        expect(code).toBe(0);
-      } finally {
-        cleanup();
-      }
-    });
-
-    test("warning still fires when service is stopped (probe skipped)", async () => {
-      const { path, configDir, cleanup } = makeTempPath();
-      try {
-        upsertService(
-          {
-            name: "parachute-scribe",
-            port: 1944,
-            paths: ["/scribe"],
-            health: "/scribe/health",
-            version: "0.4.0",
-          },
-          path,
-        );
-        writePid("scribe", 4242, configDir);
-        const lines: string[] = [];
-        await status({
-          manifestPath: path,
-          configDir,
-          alive: () => false,
-          fetchImpl: async () => new Response(null, { status: 200 }),
-          print: (l) => lines.push(l),
-        });
-        // Drift is computed from services.json, not from the probe — a
-        // stopped service with a drifted port should still surface the
-        // warning so operators see the miswire even before they start it.
-        expect(lines.some((l) => l.includes("canonical port is 1943"))).toBe(true);
-      } finally {
-        cleanup();
-      }
-    });
-
-    test("multi-vault instance rows do not surface a drift warning (intentional gap)", async () => {
-      // Pinning the documented gap: `parachute-vault-default` is not
-      // a canonical manifest name in FIRST_PARTY_FALLBACKS, so
-      // `canonicalPortForManifest` returns undefined and no drift
-      // warning fires — even when the row's port differs from the
-      // canonical `parachute-vault` port (1940). Rationale lives on
-      // `canonicalPortForManifest` in service-spec.ts; this test pins
-      // the behavior so a future change to the lookup shape doesn't
-      // accidentally start emitting drift on every multi-vault row
-      // without an explicit decision.
-      const { path, cleanup } = makeTempPath();
-      try {
-        upsertService(
-          {
-            name: "parachute-vault-default",
-            port: 1944,
-            paths: ["/vault/default"],
-            health: "/vault/default/health",
-            version: "0.2.4",
-          },
-          path,
-        );
-        const lines: string[] = [];
-        await status({
-          manifestPath: path,
-          fetchImpl: async () => new Response(null, { status: 200 }),
-          print: (l) => lines.push(l),
-        });
-        expect(lines.some((l) => l.includes("canonical port"))).toBe(false);
-      } finally {
-        cleanup();
-      }
-    });
-  });
-
-  test("stopped services still render a URL line so the user knows where to point clients post-start", async () => {
+  test("unknown third-party service falls back to bare host:port + paths[0]", async () => {
     const { path, configDir, cleanup } = makeTempPath();
     try {
       upsertService(
         {
-          name: "parachute-vault",
-          port: 1940,
-          paths: ["/vault/default"],
-          health: "/vault/default/health",
-          version: "0.2.4",
+          name: "acme-widget",
+          port: 4321,
+          paths: ["/widget"],
+          health: "/widget/health",
+          version: "1.0.0",
+          installDir: "/tmp/acme",
         },
         path,
       );
-      writePid("vault", 4242, configDir);
       const lines: string[] = [];
       await status({
-        manifestPath: path,
-        configDir,
-        alive: () => false,
-        fetchImpl: async () => new Response(null, { status: 200 }),
+        ...supervisorOpts(configDir, path, {
+          moduleStates: { supervisorAvailable: true, modules: [runningModule("acme-widget")] },
+        }),
         print: (l) => lines.push(l),
       });
-      expect(lines.some((l) => l.includes("→ http://127.0.0.1:1940/vault/default/mcp"))).toBe(true);
+      expect(lines.join("\n")).toMatch(/:4321\/widget/);
     } finally {
       cleanup();
     }
-  });
-
-  describe("install-source surface (hub#243)", () => {
-    test("renders SOURCE column header + per-row label", async () => {
-      const { path, cleanup } = makeTempPath();
-      try {
-        upsertService(
-          {
-            name: "parachute-vault",
-            port: 1940,
-            paths: ["/vault/default"],
-            health: "/vault/default/health",
-            version: "0.4.4-rc.3",
-            installDir: "/Users/me/code/parachute-vault",
-          },
-          path,
-        );
-        const lines: string[] = [];
-        await status({
-          manifestPath: path,
-          fetchImpl: async () => new Response(null, { status: 200 }),
-          print: (l) => lines.push(l),
-          installSourceDeps: {
-            bunGlobalPrefixes: () => ["/home/test/.bun/install/global/node_modules"],
-            resolveBunGlobal: () => null,
-            readJson: (p) =>
-              p === "/Users/me/code/parachute-vault/package.json"
-                ? { name: "@openparachute/vault", version: "0.4.4-rc.3" }
-                : (() => {
-                    throw new Error("nope");
-                  })(),
-            readGitHead: () => "8aa167b",
-          },
-        });
-        expect(lines[0]).toMatch(/SOURCE/);
-        expect(lines.some((l) => l.includes("bun-linked → parachute-vault @ 8aa167b"))).toBe(true);
-      } finally {
-        cleanup();
-      }
-    });
-
-    test("STALE continuation line fires when bun-linked live version != cached version", async () => {
-      // Reproduces hub#243's motivating case: services.json says 0.3.11-rc.1
-      // but the live source has been rebuilt to 0.3.15-rc.1. Operator should
-      // see STALE in one glance from `parachute status` output.
-      const { path, cleanup } = makeTempPath();
-      try {
-        upsertService(
-          {
-            name: "parachute-notes",
-            port: 1942,
-            paths: ["/notes"],
-            health: "/notes/health",
-            version: "0.3.11-rc.1",
-            installDir: "/Users/me/code/parachute-notes",
-          },
-          path,
-        );
-        const lines: string[] = [];
-        await status({
-          manifestPath: path,
-          fetchImpl: async () => new Response(null, { status: 200 }),
-          print: (l) => lines.push(l),
-          installSourceDeps: {
-            bunGlobalPrefixes: () => ["/home/test/.bun/install/global/node_modules"],
-            resolveBunGlobal: () => null,
-            readJson: (p) =>
-              p === "/Users/me/code/parachute-notes/package.json"
-                ? { name: "@openparachute/notes", version: "0.3.15-rc.1" }
-                : (() => {
-                    throw new Error("nope");
-                  })(),
-            readGitHead: () => "051c404",
-          },
-        });
-        expect(
-          lines.some((l) =>
-            l.includes("STALE: services.json cached 0.3.11-rc.1; live package.json 0.3.15-rc.1"),
-          ),
-        ).toBe(true);
-      } finally {
-        cleanup();
-      }
-    });
-
-    test("npm-installed services render as `npm (<version>)` and never STALE", async () => {
-      const { path, cleanup } = makeTempPath();
-      try {
-        upsertService(
-          {
-            name: "parachute-scribe",
-            port: 1943,
-            paths: ["/scribe"],
-            health: "/scribe/health",
-            version: "0.4.2-rc.1",
-            installDir: "/home/test/.bun/install/global/node_modules/@openparachute/scribe",
-          },
-          path,
-        );
-        const lines: string[] = [];
-        await status({
-          manifestPath: path,
-          fetchImpl: async () => new Response(null, { status: 200 }),
-          print: (l) => lines.push(l),
-          installSourceDeps: {
-            bunGlobalPrefixes: () => ["/home/test/.bun/install/global/node_modules"],
-            resolveBunGlobal: () => null,
-            readJson: (p) =>
-              p === "/home/test/.bun/install/global/node_modules/@openparachute/scribe/package.json"
-                ? { name: "@openparachute/scribe", version: "0.4.2-rc.1" }
-                : (() => {
-                    throw new Error("nope");
-                  })(),
-            readGitHead: () => undefined,
-          },
-        });
-        expect(lines.some((l) => l.includes("npm (0.4.2-rc.1)"))).toBe(true);
-        expect(lines.some((l) => l.includes("STALE:"))).toBe(false);
-      } finally {
-        cleanup();
-      }
-    });
-
-    test("entries without installDir fall back to bun-global symlink lookup", async () => {
-      // Some services.json entries (older first-party rows, or rows written
-      // by a service that doesn't echo installDir) leave the field absent.
-      // detectInstallSource maps the entry name → first-party package and
-      // probes bun globals for the symlink. Pins that fallback path.
-      const { path, cleanup } = makeTempPath();
-      try {
-        upsertService(
-          {
-            name: "parachute-vault",
-            port: 1940,
-            paths: ["/vault/default"],
-            health: "/vault/default/health",
-            version: "0.4.4-rc.3",
-            // No installDir.
-          },
-          path,
-        );
-        const lines: string[] = [];
-        await status({
-          manifestPath: path,
-          fetchImpl: async () => new Response(null, { status: 200 }),
-          print: (l) => lines.push(l),
-          installSourceDeps: {
-            bunGlobalPrefixes: () => ["/home/test/.bun/install/global/node_modules"],
-            resolveBunGlobal: (pkg) =>
-              pkg === "@openparachute/vault" ? "/Users/me/code/parachute-vault" : null,
-            readJson: (p) =>
-              p === "/Users/me/code/parachute-vault/package.json"
-                ? { name: "@openparachute/vault", version: "0.4.4-rc.3" }
-                : (() => {
-                    throw new Error("nope");
-                  })(),
-            readGitHead: () => "8aa167b",
-          },
-        });
-        expect(lines.some((l) => l.includes("bun-linked → parachute-vault @ 8aa167b"))).toBe(true);
-      } finally {
-        cleanup();
-      }
-    });
-
-    test("third-party row without installDir + no mapping renders as 'unknown'", async () => {
-      const { path, cleanup } = makeTempPath();
-      try {
-        upsertService(
-          {
-            name: "someapp",
-            port: 1946,
-            paths: ["/someapp"],
-            health: "/someapp/health",
-            version: "0.1.4-rc.1",
-            // No installDir; someapp isn't in FIRST_PARTY_FALLBACKS by short name,
-            // and the fallback bun-global lookup needs a known package name.
-          },
-          path,
-        );
-        const lines: string[] = [];
-        await status({
-          manifestPath: path,
-          fetchImpl: async () => new Response(null, { status: 200 }),
-          print: (l) => lines.push(l),
-          installSourceDeps: {
-            bunGlobalPrefixes: () => ["/home/test/.bun/install/global/node_modules"],
-            resolveBunGlobal: () => null,
-            readJson: () => {
-              throw new Error("not reached");
-            },
-            readGitHead: () => undefined,
-          },
-        });
-        expect(lines.some((l) => l.includes("unknown"))).toBe(true);
-      } finally {
-        cleanup();
-      }
-    });
   });
 });

--- a/src/__tests__/upgrade.test.ts
+++ b/src/__tests__/upgrade.test.ts
@@ -85,6 +85,16 @@ function seedVault(manifestPath: string, installDir: string, version = "0.4.0"):
   );
 }
 
+/**
+ * Phase 5b: `upgrade hub` always restarts the hub UNIT via the platform manager
+ * (`restartHubUnit`) — the detached restart arm is retired. Hub-upgrade tests
+ * that aren't asserting the restart mechanism itself inject this benign seam so
+ * the manager op succeeds without a real systemd/launchd on the test host.
+ */
+const okHubUnitSupervisor = {
+  restartHubUnit: (): HubUnitManagerOpResult => ({ outcome: "ok" as const, messages: [] }),
+};
+
 describe("parachute upgrade", () => {
   test("errors cleanly when targeting a service that's not installed", async () => {
     const h = makeHarness();
@@ -588,6 +598,7 @@ describe("parachute upgrade", () => {
       let restartedShort: string | undefined;
       const logs: string[] = [];
       const code = await upgrade("hub", {
+        supervisor: okHubUnitSupervisor,
         manifestPath: h.manifestPath,
         configDir: h.configDir,
         runner,
@@ -600,7 +611,8 @@ describe("parachute upgrade", () => {
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
-      expect(restartedShort).toBe("hub");
+      // Phase 5b: the hub restarts via the platform manager (okHubUnitSupervisor),
+      // not the detached restartFn — the unit-restart path has its own test.
       const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
       expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@latest"]);
       const joined = logs.join("\n");
@@ -637,6 +649,7 @@ describe("parachute upgrade", () => {
 
       let restartedShort: string | undefined;
       const code = await upgrade("hub", {
+        supervisor: okHubUnitSupervisor,
         manifestPath: h.manifestPath, // file doesn't exist
         configDir: h.configDir,
         runner,
@@ -649,7 +662,8 @@ describe("parachute upgrade", () => {
         log: () => {},
       });
       expect(code).toBe(0);
-      expect(restartedShort).toBe("hub");
+      // Phase 5b: the hub restarts via the platform manager (okHubUnitSupervisor),
+      // not the detached restartFn — the unit-restart path has its own test.
     } finally {
       h.cleanup();
     }
@@ -684,6 +698,7 @@ describe("parachute upgrade", () => {
       let restartedShort: string | undefined;
       const logs: string[] = [];
       const code = await upgrade("hub", {
+        supervisor: okHubUnitSupervisor,
         manifestPath: h.manifestPath,
         configDir: h.configDir,
         runner,
@@ -696,7 +711,8 @@ describe("parachute upgrade", () => {
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
-      expect(restartedShort).toBe("hub");
+      // Phase 5b: the hub restarts via the platform manager (okHubUnitSupervisor),
+      // not the detached restartFn — the unit-restart path has its own test.
       expect(logs.join("\n")).toMatch(/hub: bun-linked checkout/);
     } finally {
       h.cleanup();
@@ -724,6 +740,7 @@ describe("parachute upgrade", () => {
       };
 
       await upgrade("hub", {
+        supervisor: okHubUnitSupervisor,
         manifestPath: h.manifestPath,
         configDir: h.configDir,
         runner,
@@ -772,6 +789,15 @@ describe("parachute upgrade", () => {
 
       const restartCalls: string[] = [];
       const code = await upgrade(undefined, {
+        // Phase 5b: the hub restarts via the platform manager (restartHubUnit),
+        // modules via restartFn. Record both into one order list so the hub-first
+        // invariant is still asserted.
+        supervisor: {
+          restartHubUnit: (): HubUnitManagerOpResult => {
+            restartCalls.push("hub");
+            return { outcome: "ok", messages: [] };
+          },
+        },
         manifestPath: h.manifestPath,
         configDir: h.configDir,
         runner,
@@ -787,7 +813,8 @@ describe("parachute upgrade", () => {
         log: () => {},
       });
       expect(code).toBe(0);
-      // Hub goes first so its dispatcher upgrade isn't preempted.
+      // Hub goes first (manager restart) so its dispatcher upgrade isn't
+      // preempted, then the module restarts route through lifecycle.
       expect(restartCalls).toEqual(["hub", "vault"]);
     } finally {
       h.cleanup();
@@ -842,6 +869,7 @@ describe("parachute upgrade", () => {
       const restartCalls: string[] = [];
       const logs: string[] = [];
       const code = await upgrade(undefined, {
+        supervisor: okHubUnitSupervisor,
         manifestPath: h.manifestPath,
         configDir: h.configDir,
         runner,
@@ -921,6 +949,7 @@ describe("parachute upgrade", () => {
       };
 
       const code = await upgrade("hub", {
+        supervisor: okHubUnitSupervisor,
         manifestPath: h.manifestPath,
         configDir: h.configDir,
         runner,
@@ -962,6 +991,7 @@ describe("parachute upgrade", () => {
       };
 
       await upgrade("hub", {
+        supervisor: okHubUnitSupervisor,
         manifestPath: h.manifestPath,
         configDir: h.configDir,
         runner,
@@ -1004,6 +1034,7 @@ describe("parachute upgrade", () => {
       };
 
       await upgrade("hub", {
+        supervisor: okHubUnitSupervisor,
         manifestPath: h.manifestPath,
         configDir: h.configDir,
         runner,
@@ -1046,6 +1077,7 @@ describe("parachute upgrade", () => {
       const logs: string[] = [];
       let restartCalled = false;
       const code = await upgrade("hub", {
+        supervisor: okHubUnitSupervisor,
         manifestPath: h.manifestPath,
         configDir: h.configDir,
         runner,
@@ -1097,6 +1129,7 @@ describe("parachute upgrade", () => {
       };
 
       const code = await upgrade("hub", {
+        supervisor: okHubUnitSupervisor,
         manifestPath: h.manifestPath,
         configDir: h.configDir,
         runner,
@@ -1154,6 +1187,7 @@ describe("parachute upgrade", () => {
       const logs: string[] = [];
       let restartedShort: string | undefined;
       const code = await upgrade("hub", {
+        supervisor: okHubUnitSupervisor,
         manifestPath: h.manifestPath,
         configDir: h.configDir,
         runner,
@@ -1169,7 +1203,8 @@ describe("parachute upgrade", () => {
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
-      expect(restartedShort).toBe("hub");
+      // Phase 5b: the hub restarts via the platform manager (okHubUnitSupervisor),
+      // not the detached restartFn — the unit-restart path has its own test.
       const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
       expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@rc"]);
       const joined = logs.join("\n");
@@ -1201,6 +1236,7 @@ describe("parachute upgrade", () => {
       };
 
       await upgrade("hub", {
+        supervisor: okHubUnitSupervisor,
         manifestPath: h.manifestPath,
         configDir: h.configDir,
         runner,
@@ -1270,7 +1306,6 @@ describe("Phase 4 upgrade-hub dual-dispatch", () => {
         // Avoid a real registry round-trip in the downgrade guard.
         resolveChannelVersion: async () => null,
         supervisor: {
-          unitInstalled: true,
           restartHubUnit: (_deps: HubUnitDeps): HubUnitManagerOpResult => {
             restartHubUnitCalls++;
             return { outcome: "ok", messages: [] };
@@ -1291,7 +1326,12 @@ describe("Phase 4 upgrade-hub dual-dispatch", () => {
     }
   });
 
-  test("upgrade hub NO unit → detached restartFn (unchanged)", async () => {
+  test("upgrade hub NO unit → restartHubUnit reports no-unit, surfaced as a failure", async () => {
+    // Phase 5b: the detached restart arm is retired. `upgrade hub` always
+    // restarts the hub UNIT via the platform manager; on a box with no unit the
+    // manager op returns `no-unit` (after the binary rewrite), which the verb
+    // surfaces as a non-zero exit with the manager's message — never a detached
+    // spawn.
     const h = makeHarness();
     try {
       const hubInstallDir = join(h.installRoot, "hub");
@@ -1311,33 +1351,24 @@ describe("Phase 4 upgrade-hub dual-dispatch", () => {
         },
       };
 
-      let restartedShort: string | undefined;
-      let restartHubUnitCalls = 0;
+      const logs: string[] = [];
       const code = await upgrade("hub", {
         manifestPath: h.manifestPath,
         configDir: h.configDir,
         runner,
         findGlobalInstall: (pkg) =>
           pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
-        restartFn: async (svc) => {
-          restartedShort = svc;
-          return 0;
-        },
         resolveChannelVersion: async () => null,
-        // supervisor block present but unit NOT installed → detached arm.
         supervisor: {
-          unitInstalled: false,
-          restartHubUnit: (_deps: HubUnitDeps): HubUnitManagerOpResult => {
-            restartHubUnitCalls++;
-            return { outcome: "ok", messages: [] };
-          },
+          restartHubUnit: (_deps: HubUnitDeps): HubUnitManagerOpResult => ({
+            outcome: "no-unit",
+            messages: ["no hub unit installed — run `parachute migrate` to install it"],
+          }),
         },
-        log: () => {},
+        log: (l) => logs.push(l),
       });
-      expect(code).toBe(0);
-      // The detached restartFn ran; the manager restart did NOT.
-      expect(restartedShort).toBe("hub");
-      expect(restartHubUnitCalls).toBe(0);
+      expect(code).toBe(1);
+      expect(logs.join("\n")).toMatch(/no hub unit installed/);
     } finally {
       h.cleanup();
     }
@@ -1398,7 +1429,6 @@ describe("Phase 4 upgrade-hub dual-dispatch", () => {
         },
         resolveChannelVersion: async () => null,
         supervisor: {
-          unitInstalled: true,
           restartHubUnit: (_deps: HubUnitDeps): HubUnitManagerOpResult => {
             restartHubUnitCalls++;
             restartOrder.push("hub-unit");

--- a/src/__tests__/upgrade.test.ts
+++ b/src/__tests__/upgrade.test.ts
@@ -2,9 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { LifecycleOpts } from "../commands/lifecycle.ts";
+import { restart as lifecycleRestart } from "../commands/lifecycle.ts";
 import type { UpgradeRunner } from "../commands/upgrade.ts";
 import { compareVersions, defaultRunner, detectChannel, upgrade } from "../commands/upgrade.ts";
 import type { HubUnitDeps, HubUnitManagerOpResult } from "../hub-unit.ts";
+import { defaultHubUnitDeps } from "../hub-unit.ts";
+import type { MigrateOfferResult } from "../migrate-offer.ts";
 import { upsertService } from "../services-manifest.ts";
 
 interface RunCall {
@@ -1443,6 +1447,118 @@ describe("Phase 4 upgrade-hub dual-dispatch", () => {
       expect(restartOrder).toContain("vault");
       expect(restartOrder.indexOf("hub-unit")).toBeLessThan(restartOrder.indexOf("vault"));
       expect(restartHubUnitCalls).toBe(1);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 5b nit: the module-target restart leg of `upgrade` must thread the SAME
+// opts a bare `parachute restart <svc>` does — `supervisor: {}` (real
+// `isHubUnitInstalled` probe, NOT a forced `unitInstalled: true`) +
+// `migrateOffer: { enabled: true }`. On a NO-UNIT box that means the module
+// restart surfaces the actionable "run `parachute migrate --to-supervised`"
+// error / fires the auto-offer, NOT a bare connection-refused from
+// `driveModuleOp`. The other upgrade tests stub `restartFn: async () => 0`, so
+// the supervised arm was never exercised here — this closes that gap by driving
+// the REAL `lifecycle.restart`.
+// ---------------------------------------------------------------------------
+
+describe("Phase 5b: upgrade module-restart on a no-unit box", () => {
+  test("module restart threads supervisor:{} + migrateOffer (no forced unitInstalled), surfaces actionable migrate error — NOT a bare connection-refused", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.4.0");
+
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          // `bun add -g` rewrites the package.json with a new version → the
+          // module restart leg (`restartTarget`) is reached.
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            writePackageJson(installDir, { name: "@openparachute/vault", version: "0.5.0" });
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          // Not a git checkout → npm-install branch.
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "fatal: not a git repository\n" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      // A NO-UNIT box: force `isHubUnitInstalled` → false deterministically
+      // (regardless of the test host) by stubbing the unit-file existence probe.
+      const noUnitDeps: HubUnitDeps = { ...defaultHubUnitDeps, exists: () => false };
+
+      // The supervised arm's loopback module-ops call MUST NOT run on a no-unit
+      // box. If the regressed code forced `unitInstalled: true`, the verb would
+      // skip the probe and hit this — surfacing a bare connection-refused.
+      let driveModuleOpCalled = false;
+      const refuse = async (): Promise<never> => {
+        driveModuleOpCalled = true;
+        throw new Error("connect ECONNREFUSED 127.0.0.1:1939");
+      };
+
+      // Capture the opts `restartTarget` hands `lifecycle.restart`, then delegate
+      // to the REAL `lifecycle.restart` so the no-unit handling actually runs.
+      // The offer is overridden to a deterministic `declined` so the outcome
+      // doesn't depend on the host's stdin-TTY / prior-detached state.
+      let seenOpts: LifecycleOpts | undefined;
+      let offerCalls = 0;
+      const restartFn = async (svc: string, opts: LifecycleOpts): Promise<number> => {
+        seenOpts = opts;
+        return await lifecycleRestart(svc, {
+          ...opts,
+          supervisor: {
+            ...opts.supervisor,
+            hubUnitDeps: noUnitDeps,
+            driveModuleOp: refuse,
+          },
+          migrateOffer: {
+            enabled: opts.migrateOffer?.enabled ?? false,
+            offer: async (): Promise<MigrateOfferResult> => {
+              offerCalls++;
+              return { outcome: "declined" };
+            },
+          },
+        });
+      };
+
+      const logs: string[] = [];
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn,
+        // Upgrade-side supervisor seam: feeds `r.hubUnitDeps`, which
+        // `restartTarget` threads into `lifecycle.restart`'s supervisor block.
+        supervisor: { hubUnitDeps: noUnitDeps },
+        log: (l) => logs.push(l),
+      });
+
+      // The package rewrite + restart attempt happened (non-zero because the box
+      // is un-migrated and the offer was declined — a clean, actionable failure).
+      expect(code).toBe(1);
+
+      // The contract fix: `restartTarget` passes `supervisor` WITHOUT forcing
+      // `unitInstalled: true`, plus an ENABLED migrate offer — exactly what a
+      // bare `parachute restart <svc>` threads.
+      expect(seenOpts).toBeDefined();
+      expect(seenOpts?.supervisor).toBeDefined();
+      expect(seenOpts?.supervisor?.unitInstalled).toBeUndefined();
+      expect(seenOpts?.migrateOffer?.enabled).toBe(true);
+
+      // The no-unit handling ran: the auto-offer fired (real probe → no unit),
+      // and the supervised loopback call was NEVER reached (no connection-refused).
+      expect(offerCalls).toBe(1);
+      expect(driveModuleOpCalled).toBe(false);
+      expect(logs.join("\n")).not.toMatch(/ECONNREFUSED|connection refused/i);
     } finally {
       h.cleanup();
     }

--- a/src/commands/expose-cloudflare.ts
+++ b/src/commands/expose-cloudflare.ts
@@ -47,20 +47,13 @@ import {
   clearExposeState,
   writeExposeState,
 } from "../expose-state.ts";
-import {
-  type EnsureHubOpts,
-  HUB_DEFAULT_PORT,
-  ensureHubRunning,
-  readHubPort,
-} from "../hub-control.ts";
+import { HUB_DEFAULT_PORT, readHubPort } from "../hub-control.ts";
 import { deriveHubOrigin } from "../hub-origin.ts";
 import { HUB_UNIT_DEFAULT_PORT } from "../hub-unit.ts";
-import { type AliveFn, defaultAlive, processState } from "../process-state.ts";
+import { type AliveFn, defaultAlive } from "../process-state.ts";
 import { readManifest } from "../services-manifest.ts";
 import { type Runner, defaultRunner } from "../tailscale/run.ts";
-import { persistVaultHubOrigin } from "../vault-hub-origin-env.ts";
 import type { VaultAuthStatus } from "../vault/auth-status.ts";
-import { WELL_KNOWN_DIR } from "../well-known.ts";
 import { printPublic2FAWarning } from "./expose-2fa-warning.ts";
 import {
   type ExposeSupervisorOpts,
@@ -69,7 +62,6 @@ import {
   resolveExposeSupervisor,
   restartHubDependentViaSupervisor,
 } from "./expose-supervisor.ts";
-import { restart } from "./lifecycle.ts";
 
 const AUTH_DOC_URL =
   "https://github.com/ParachuteComputer/parachute-vault/blob/main/docs/auth-model.md";
@@ -333,8 +325,8 @@ export interface ExposeCloudflareOpts {
   cloudflaredHome?: string;
   /**
    * Config root for hub PID / port / log files. Defaults to `~/.parachute`.
-   * Threaded into `ensureHubRunning` so cloudflared's ingress target stays
-   * in sync with where the hub actually bound.
+   * Threaded through so cloudflared's ingress target stays in sync with where
+   * the hub actually bound.
    */
   configDir?: string;
   /**
@@ -344,22 +336,10 @@ export interface ExposeCloudflareOpts {
    */
   hubOrigin?: string;
   /**
-   * Overrides for hub lifecycle — primarily for tests. Tests pass
-   * `skipHubLifecycle: true` (above) plus a seeded `hub.port` file so the
-   * cloudflare path can resolve a port without actually spawning a hub.
-   */
-  hubEnsureOpts?: Omit<EnsureHubOpts, "configDir" | "wellKnownDir" | "log">;
-  /**
-   * Directory holding hub.html (passed through to the hub server on first
-   * spawn). Defaults to the same `well-known/` resolution the Tailscale
-   * path uses.
-   */
-  wellKnownDir?: string;
-  /**
-   * Skip spawning the hub server. Tests flip this on and pre-seed
+   * Skip ensuring the hub unit. Tests flip this on and pre-seed
    * `<configDir>/hub/run/hub.port` so `readHubPort` can resolve the
-   * cloudflared target without a live process. Production always leaves
-   * this off so the bringup self-heals a missing hub.
+   * cloudflared target without a live hub. Production always leaves this off so
+   * the bringup ensures the hub unit is up.
    */
   skipHub?: boolean;
   now?: () => Date;
@@ -376,26 +356,18 @@ export interface ExposeCloudflareOpts {
    */
   vaultAuthStatus?: VaultAuthStatus;
   /**
-   * Restart a hub-dependent service so it re-reads the new public hub origin.
-   * Mirrors the Tailscale path's `restartService` seam (`expose.ts`). Defaults
-   * to lifecycle `restart`; tests inject a fake to assert the call without
-   * spawning a real daemon. Only invoked for vault (the only `iss`-validating
-   * service) and only when it's already running.
-   */
-  restartService?: (short: string) => Promise<number>;
-  /**
-   * Phase 4 supervisor-path seams (design §4.3). When a hub UNIT is installed,
+   * Supervisor-path seams (design §4.3) — the ONLY runtime as of Phase 5b.
    * "ensure the hub" ensures the UNIT is up (not a detached spawn), and the
    * post-route vault restart drives the running Supervisor over the loopback
    * module-ops API (re-injecting the new public origin + firing the operator-
    * token / vault `.env` self-heal). The cloudflared CONNECTOR unit is
    * unchanged — it already installs/removes its own ManagedUnit
    * (`installConnectorService` / `removeConnectorService`), independent of the
-   * hub's lifecycle. The detached arm (`hubEnsureOpts` / `lifecycle.restart`)
-   * remains the no-unit fallback until Phase 5.
+   * hub's lifecycle.
    *
    * Production CLI dispatch passes `supervisor: {}` so the real
-   * `isHubUnitInstalled` probe decides the arm; omitting it is the detached arm.
+   * `isHubUnitInstalled` probe resolves the seams; tests inject the seams they
+   * want to assert.
    */
   supervisor?: ExposeSupervisorOpts;
 }
@@ -423,13 +395,10 @@ interface Resolved {
   cloudflaredHome: string;
   configDir: string;
   hubOrigin: string | undefined;
-  hubEnsureOpts: Omit<EnsureHubOpts, "configDir" | "wellKnownDir" | "log">;
-  wellKnownDir: string;
   skipHub: boolean;
   now: () => Date;
   vaultHome: string | undefined;
   vaultAuthStatus: VaultAuthStatus | undefined;
-  restartService: (short: string) => Promise<number>;
   sup: ResolvedExposeSupervisor;
 }
 
@@ -512,20 +481,10 @@ function resolve(opts: ExposeCloudflareOpts, tunnelNameDefault: string): Resolve
     cloudflaredHome: opts.cloudflaredHome ?? DEFAULT_CLOUDFLARED_HOME,
     configDir,
     hubOrigin: opts.hubOrigin,
-    hubEnsureOpts: opts.hubEnsureOpts ?? {},
-    wellKnownDir: opts.wellKnownDir ?? WELL_KNOWN_DIR,
     skipHub: opts.skipHub ?? false,
     now: opts.now ?? (() => new Date()),
     vaultHome: opts.vaultHome,
     vaultAuthStatus: opts.vaultAuthStatus,
-    restartService:
-      opts.restartService ??
-      ((short: string) =>
-        restart(short, {
-          manifestPath: opts.manifestPath,
-          configDir,
-          log: opts.log ?? (() => {}),
-        })),
     sup: resolveExposeSupervisor(opts.supervisor),
   };
 }
@@ -680,27 +639,17 @@ export async function exposeCloudflareUp(
       throw new Error("skipHub set but no hub.port on disk — tests must seed one");
     }
     hubPort = existing;
-  } else if (r.sup.unitInstalled) {
-    // Unit-managed (§4.3a): "ensure the hub" = ensure the hub UNIT is up. The
-    // unit pins the canonical 1939 (no walking fallback), so that's the target
-    // cloudflared's ingress proxies to.
+  } else {
+    // §4.3a: "ensure the hub" = ensure the hub UNIT is up. The unit pins the
+    // canonical 1939 (no walking fallback), so that's the target cloudflared's
+    // ingress proxies to. Phase 5b retired the detached `ensureHubRunning`
+    // bringup — a box with no hub unit gets `ensureHubUnit`'s actionable "run
+    // `parachute migrate`" message, never a detached spawn.
     const probePort = readHubPort(r.configDir) ?? HUB_UNIT_DEFAULT_PORT;
     const ensured = await ensureHubUnitForExpose(r.sup, probePort, r.log);
     if (!ensured.ok) return 1;
     hubPort = ensured.port;
     r.log(`✓ hub unit up (port ${hubPort}).`);
-  } else {
-    const hub = await ensureHubRunning({
-      reservedPorts: manifest.services.map((s) => s.port),
-      ...r.hubEnsureOpts,
-      configDir: r.configDir,
-      wellKnownDir: r.wellKnownDir,
-      issuer: hubOrigin,
-      log: r.log,
-    });
-    hubPort = hub.port;
-    if (hub.started) r.log(`✓ hub started (pid ${hub.pid}, port ${hub.port}).`);
-    else r.log(`✓ hub already running (pid ${hub.pid}, port ${hub.port}).`);
   }
   if (hubPort === 0) hubPort = HUB_DEFAULT_PORT;
 
@@ -943,45 +892,29 @@ export async function exposeCloudflareUp(
   // is the public origin) failed the `iss` check → 401 → "You're not signed in
   // to the hub." We mirror the Tailscale path here exactly.
   //
-  // `persistVaultHubOrigin` writes the durable `.env` (skips loopback itself,
-  // so a `--hub-origin http://127.0.0.1` override never bakes a dead issuer in);
-  // the restart makes the running vault re-read it immediately rather than
-  // waiting for the next reboot.
+  // The supervised restart helper writes the durable `.env` (skipping loopback,
+  // so a `--hub-origin http://127.0.0.1` override never bakes a dead issuer in)
+  // and makes the running vault re-read it immediately rather than waiting for
+  // the next reboot.
   //
-  // Phase 4 dual-dispatch (design §4.3c). Unit-managed → drive the restart
-  // through the running Supervisor (`driveModuleOp("vault", "restart")`), which
-  // re-injects the hub's current origin; `restartHubDependentViaSupervisor`
-  // also persists the durable `.env` + self-heals the operator-token issuer, so
-  // we DON'T also call `persistVaultHubOrigin` on this arm (the helper owns it).
-  // No unit → the unchanged detached path: persist `.env` + `lifecycle.restart`
-  // gated on pidfile liveness. Phase 5 deletes the detached branch.
-  if (r.sup.unitInstalled) {
-    r.log("");
-    r.log("Restarting vault to pick up new hub origin…");
-    const rcode = await restartHubDependentViaSupervisor({
-      short: "vault",
-      hubOrigin,
-      configDir: r.configDir,
-      sup: r.sup,
-      log: r.log,
-    });
-    if (rcode !== 0) {
-      r.log(
-        "⚠ vault restart failed. Run manually once the issue is resolved: parachute restart vault",
-      );
-    }
-  } else {
-    persistVaultHubOrigin(r.configDir, hubOrigin, r.log);
-    if (processState("vault", r.configDir, r.alive).status === "running") {
-      r.log("");
-      r.log("Restarting vault to pick up new hub origin…");
-      const rcode = await r.restartService("vault");
-      if (rcode !== 0) {
-        r.log(
-          "⚠ vault restart failed. Run manually once the issue is resolved: parachute restart vault",
-        );
-      }
-    }
+  // §4.3c: drive the restart through the running Supervisor
+  // (`driveModuleOp("vault", "restart")`), which re-injects the hub's current
+  // origin; `restartHubDependentViaSupervisor` also persists the durable `.env`
+  // + self-heals the operator-token issuer. Phase 5b retired the detached
+  // `lifecycle.restart` arm.
+  r.log("");
+  r.log("Restarting vault to pick up new hub origin…");
+  const rcode = await restartHubDependentViaSupervisor({
+    short: "vault",
+    hubOrigin,
+    configDir: r.configDir,
+    sup: r.sup,
+    log: r.log,
+  });
+  if (rcode !== 0) {
+    r.log(
+      "⚠ vault restart failed. Run manually once the issue is resolved: parachute restart vault",
+    );
   }
 
   const baseUrl = `https://${hostname}`;

--- a/src/commands/expose-supervisor.ts
+++ b/src/commands/expose-supervisor.ts
@@ -1,27 +1,19 @@
 /**
- * Phase 4 expose-path dual-dispatch seams (design
+ * Expose-path supervisor seams (design
  * `parachute.computer/design/2026-06-01-hub-as-supervisor-unification.md` §4.3).
  *
- * Under the hub-as-supervisor unification, `expose` / `expose off` decouple
- * from the hub's lifecycle:
- *   - When a hub UNIT is installed (launchd/systemd/container), "ensure the hub"
- *     means "ensure the hub UNIT is up" (`ensureHubUnit`), and the post-expose
- *     hub-dependent service restart goes through the RUNNING hub's in-process
- *     Supervisor over the loopback module-ops API (`driveModuleOp(short,
- *     "restart")`), NOT `lifecycle.restart` / a detached spawn.
- *   - When NO unit is installed (a legacy detached box, until Phase 5 retires
- *     the detached spawners), the existing behavior is preserved UNCHANGED:
- *     `ensureHubRunning` (the detached spawn) + `lifecycle.restart`.
+ * Under the hub-as-supervisor unification, `expose` / `expose off` are decoupled
+ * from the hub's lifecycle. As of Phase 5b the supervised path is the ONLY
+ * runtime:
+ *   - "ensure the hub" means "ensure the hub UNIT is up" (`ensureHubUnit`); a box
+ *     with no unit gets `ensureHubUnit`'s actionable "run `parachute migrate`"
+ *     message rather than a detached spawn.
+ *   - the post-expose hub-dependent service restart goes through the RUNNING
+ *     hub's in-process Supervisor over the loopback module-ops API
+ *     (`driveModuleOp(short, "restart")`), NOT a detached `lifecycle.restart`.
  *
  * This module is the shared seam BOTH `expose.ts` (Tailscale) and
- * `expose-cloudflare.ts` (cloudflared) use so the two paths can't drift, and so
- * the unit-arm is a clean, separately-deletable branch when Phase 5 collapses
- * to the supervisor-only path.
- *
- * THE SAFETY PRINCIPLE (same dual-dispatch bridge as Phase 3b): unit installed →
- * drive the manager/supervisor (new path); no unit → keep the EXACT current
- * detached behavior. The discriminant is `isHubUnitInstalled`, structured as a
- * top-level branch in the callers.
+ * `expose-cloudflare.ts` (cloudflared) use so the two paths can't drift.
  */
 
 import { readHubPort } from "../hub-control.ts";
@@ -33,7 +25,6 @@ import {
   type HubUnitDeps,
   defaultHubUnitDeps,
   ensureHubUnit as ensureHubUnitImpl,
-  isHubUnitInstalled,
 } from "../hub-unit.ts";
 import {
   type DriveModuleOpDeps,
@@ -51,27 +42,15 @@ import {
 import { persistVaultHubOrigin, selfHealVaultHubOrigin } from "../vault-hub-origin-env.ts";
 
 /**
- * Injectable Phase 4 supervisor-path seams shared by the Tailscale + cloudflared
- * expose paths. Mirrors `LifecycleOpts.supervisor` (Phase 3b): everything is
- * injectable so tests can (a) force the unit-installed branch without a real
- * launchd/systemd, and (b) assert the `ensureHubUnit` / `driveModuleOp` /
- * operator-token-self-heal calls without a live hub. Production wires the real
- * impls against an opened hub.db + the resolved hub origin.
- *
- * When the caller OMITS this block entirely, the discriminant defaults to
- * `false` (detached arm) — deterministic regardless of whether the test host
- * happens to have a real hub unit installed. The production CLI dispatch passes
- * `supervisor: {}` so the real `isHubUnitInstalled` probe decides the arm.
+ * Injectable supervisor-path seams shared by the Tailscale + cloudflared expose
+ * paths. Mirrors `LifecycleOpts.supervisor`: everything is injectable so tests
+ * can assert the `ensureHubUnit` / `driveModuleOp` / operator-token-self-heal
+ * calls without a live hub or a real launchd/systemd. Production wires the real
+ * impls against an opened hub.db + the resolved hub origin; the CLI dispatch
+ * passes `supervisor: {}`.
  */
 export interface ExposeSupervisorOpts {
-  /**
-   * Is a hub unit installed (the dual-dispatch discriminant)? Production uses
-   * `isHubUnitInstalled(hubUnitDeps)`. Tests set this `true`/`false` directly to
-   * pick the branch deterministically. When set, it wins over the
-   * `hubUnitDeps`-derived detection.
-   */
-  unitInstalled?: boolean;
-  /** Deps for the real `isHubUnitInstalled` probe + the ensure-hub-unit call. */
+  /** Deps for the ensure-hub-unit call + the module-op self-heal. */
   hubUnitDeps?: HubUnitDeps;
   /** Ensure the hub unit is up before / during expose (§3.2 / §4.3a). */
   ensureHubUnit?: (opts: EnsureHubUnitOpts) => Promise<EnsureHubUnitResult>;
@@ -100,10 +79,8 @@ export interface ExposeSupervisorOpts {
   baseUrl?: string;
 }
 
-/** Resolved Phase 4 expose supervisor-path seams (see {@link ExposeSupervisorOpts}). */
+/** Resolved expose supervisor-path seams (see {@link ExposeSupervisorOpts}). */
 export interface ResolvedExposeSupervisor {
-  /** Whether a hub unit is installed — the dual-dispatch discriminant. */
-  unitInstalled: boolean;
   hubUnitDeps: HubUnitDeps;
   ensureHubUnit: (opts: EnsureHubUnitOpts) => Promise<EnsureHubUnitResult>;
   driveModuleOp: (short: string, op: ModuleOp, deps: DriveModuleOpDeps) => Promise<ModuleOpResult>;
@@ -116,19 +93,16 @@ export interface ResolvedExposeSupervisor {
 }
 
 /**
- * Resolve the Phase 4 expose supervisor seams. Same discriminant shape as
- * lifecycle's `resolveSupervisor`: a `supervisor` block (even `{}`) opts into
- * the real `isHubUnitInstalled` probe; omitting it entirely is the detached arm
- * deterministically.
+ * Resolve the expose supervisor seams. Production passes `supervisor: {}` (or
+ * omits it) and gets the real impls; tests inject the seams they want to assert.
+ * Phase 5b retired the dual-dispatch discriminant — the supervised path is the
+ * only runtime, so there is no longer an `isHubUnitInstalled` probe here.
  */
 export function resolveExposeSupervisor(
   opts: ExposeSupervisorOpts | undefined,
 ): ResolvedExposeSupervisor {
   const hubUnitDeps = opts?.hubUnitDeps ?? defaultHubUnitDeps;
-  const unitInstalled =
-    opts === undefined ? false : (opts.unitInstalled ?? isHubUnitInstalled(hubUnitDeps));
   return {
-    unitInstalled,
     hubUnitDeps,
     ensureHubUnit: opts?.ensureHubUnit ?? ensureHubUnitImpl,
     driveModuleOp: opts?.driveModuleOp ?? driveModuleOpImpl,

--- a/src/commands/expose.ts
+++ b/src/commands/expose.ts
@@ -8,18 +8,10 @@ import {
   readExposeState,
   writeExposeState,
 } from "../expose-state.ts";
-import {
-  type EnsureHubOpts,
-  type StopHubOpts,
-  defaultPortProbe,
-  ensureHubRunning,
-  readHubPort,
-  stopHub,
-} from "../hub-control.ts";
+import { defaultPortProbe, readHubPort } from "../hub-control.ts";
 import { deriveHubOrigin } from "../hub-origin.ts";
 import { HUB_UNIT_DEFAULT_PORT } from "../hub-unit.ts";
 import { HUB_PATH, writeHubFile } from "../hub.ts";
-import { type AliveFn, processState } from "../process-state.ts";
 import { shortNameForManifest } from "../service-spec.ts";
 import { type ServiceEntry, readManifest } from "../services-manifest.ts";
 import { type ServeEntry, bringupCommand, teardownCommand } from "../tailscale/commands.ts";
@@ -28,7 +20,6 @@ import { type Runner, defaultRunner } from "../tailscale/run.ts";
 import { clearVaultHubOrigin } from "../vault-hub-origin-env.ts";
 import type { VaultAuthStatus } from "../vault/auth-status.ts";
 import {
-  WELL_KNOWN_DIR,
   WELL_KNOWN_MOUNT,
   WELL_KNOWN_PATH,
   buildWellKnown,
@@ -42,7 +33,6 @@ import {
   resolveExposeSupervisor,
   restartHubDependentViaSupervisor,
 } from "./expose-supervisor.ts";
-import { restart } from "./lifecycle.ts";
 
 /**
  * Two exposure layers share a single tailscale serve config on this node.
@@ -74,17 +64,12 @@ export interface ExposeOpts {
   statePath?: string;
   wellKnownPath?: string;
   hubPath?: string;
-  /** Directory holding hub.html (passed to the hub server). */
-  wellKnownDir?: string;
   configDir?: string;
   port?: number;
   log?: (line: string) => void;
   /** Override detected FQDN — primarily for tests. */
   fqdnOverride?: string;
-  /** Overrides for the hub lifecycle — primarily for tests. */
-  hubEnsureOpts?: Omit<EnsureHubOpts, "configDir" | "wellKnownDir" | "log">;
-  hubStopOpts?: Omit<StopHubOpts, "configDir" | "log">;
-  /** Skip spawning the hub server. Tests flip this off to verify it's called. */
+  /** Skip ensuring the hub unit. Tests seed a `hub.port` and flip this on. */
   skipHub?: boolean;
   /**
    * Probe a port to decide whether a service is responding. Returns true when
@@ -100,14 +85,6 @@ export interface ExposeOpts {
    * through to vault (and future services) via PARACHUTE_HUB_ORIGIN.
    */
   hubOrigin?: string;
-  /** Process-liveness check for auto-restart — test seam. */
-  alive?: AliveFn;
-  /**
-   * Restart a service by short name after exposure changes. Defaults to the
-   * lifecycle `restart`; tests inject a fake to assert the call without
-   * spawning real child processes.
-   */
-  restartService?: (short: string) => Promise<number>;
   /**
    * Override `~/.parachute/vault` for the 2FA-enrollment probe on the public
    * (Funnel) layer. Tests point at a tmp dir; production omits and the probe
@@ -121,18 +98,17 @@ export interface ExposeOpts {
    */
   vaultAuthStatus?: VaultAuthStatus;
   /**
-   * Phase 4 supervisor-path seams (design §4.3). When a hub UNIT is installed
-   * (launchd/systemd/container — detected via `isHubUnitInstalled`), `expose`
-   * "ensures the hub" by ensuring the UNIT is up (not a detached spawn), the
-   * post-expose hub-dependent restart drives the running Supervisor over the
+   * Supervisor-path seams (design §4.3) — the ONLY runtime as of Phase 5b.
+   * `expose` "ensures the hub" by ensuring the UNIT is up (not a detached spawn),
+   * the post-expose hub-dependent restart drives the running Supervisor over the
    * loopback module-ops API, and `expose off` leaves the hub RUNNING (a managed
    * hub with Restart=always/KeepAlive would just respawn a stopped one — D3).
-   * The detached arm (`hubEnsureOpts` / `stopHub` / `lifecycle.restart`) remains
-   * the no-unit fallback until Phase 5 retires it.
+   * A box with no hub unit gets `ensureHubUnit`'s actionable "run `parachute
+   * migrate`" message rather than a detached spawn.
    *
    * The production CLI dispatch passes `supervisor: {}` so the real
-   * `isHubUnitInstalled` probe decides the arm; omitting it entirely is the
-   * detached arm deterministically (the shape of every existing expose test).
+   * `isHubUnitInstalled` probe resolves the seams; tests inject the seams they
+   * want to assert.
    */
   supervisor?: ExposeSupervisorOpts;
 }
@@ -257,14 +233,13 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
   const statePath = opts.statePath ?? EXPOSE_STATE_PATH;
   const wellKnownFilePath = opts.wellKnownPath ?? WELL_KNOWN_PATH;
   const hubFilePath = opts.hubPath ?? HUB_PATH;
-  const wellKnownDir = opts.wellKnownDir ?? WELL_KNOWN_DIR;
   const configDir = opts.configDir ?? CONFIG_DIR;
   const port = opts.port ?? 443;
   const log = opts.log ?? ((line) => console.log(line));
   const funnel = layer === "public";
-  // Phase 4 dual-dispatch (design §4.3). Unit-installed → ensure the hub UNIT is
-  // up (the unit guarantees loopback reachability, §4.3a) + restart hub-dependent
-  // services via the Supervisor. No unit → the unchanged detached arm below.
+  // §4.3: ensure the hub UNIT is up (it guarantees loopback reachability) +
+  // restart hub-dependent services via the Supervisor. The detached arm was
+  // retired in Phase 5b.
   const sup = resolveExposeSupervisor(opts.supervisor);
 
   if (!(await isTailscaleInstalled(runner))) {
@@ -345,27 +320,18 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
       throw new Error("skipHub set but no hub.port on disk — tests must seed one");
     }
     hubPort = existing;
-  } else if (sup.unitInstalled) {
-    // Unit-managed (§4.3a): "ensure the hub" = ensure the hub UNIT is up. The
-    // unit guarantees the hub is reachable on loopback (all tailscale needs);
-    // it pins the canonical 1939 (no walking fallback), so that's the target.
+  } else {
+    // §4.3a: "ensure the hub" = ensure the hub UNIT is up. The unit guarantees
+    // the hub is reachable on loopback (all tailscale needs); it pins the
+    // canonical 1939 (no walking fallback), so that's the target. Phase 5b
+    // retired the detached `ensureHubRunning` bringup — a box with no hub unit
+    // gets `ensureHubUnit`'s actionable "run `parachute migrate`" message, never
+    // a detached spawn.
     const probePort = readHubPort(configDir) ?? HUB_UNIT_DEFAULT_PORT;
     const ensured = await ensureHubUnitForExpose(sup, probePort, log);
     if (!ensured.ok) return 1;
     hubPort = ensured.port;
     log(`✓ hub unit up (port ${hubPort}).`);
-  } else {
-    const hub = await ensureHubRunning({
-      reservedPorts: manifest.services.map((s) => s.port),
-      ...(opts.hubEnsureOpts ?? {}),
-      configDir,
-      wellKnownDir,
-      issuer: hubOrigin,
-      log,
-    });
-    hubPort = hub.port;
-    if (hub.started) log(`✓ hub started (pid ${hub.pid}, port ${hub.port}).`);
-    else log(`✓ hub already running (pid ${hub.pid}, port ${hub.port}).`);
   }
 
   const entries = planEntries(hubPort);
@@ -427,37 +393,20 @@ export async function exposeUp(layer: ExposeLayer, opts: ExposeOpts = {}): Promi
   // claude.ai MCP failed with a cryptic "Couldn't reach the MCP server". The
   // old output told the user to restart manually; it got buried in the wall
   // of expose output. Do the restart ourselves.
-  // Phase 4 dual-dispatch (design §4.3c). Unit-managed → the hub-dependent
-  // restart goes through the running Supervisor (`driveModuleOp(short,
-  // "restart")`), which re-injects the hub's current origin; the origin
-  // self-heal (operator-token iss + vault `.env`) fires there. No-unit → the
-  // unchanged detached `lifecycle.restart` path, gated on pidfile liveness.
-  if (sup.unitInstalled) {
-    for (const short of HUB_DEPENDENT_SHORTS) {
-      log("");
-      log(`Restarting ${short} to pick up new hub origin…`);
-      const rcode = await restartHubDependentViaSupervisor({
-        short,
-        hubOrigin,
-        configDir,
-        sup,
-        log,
-      });
-      if (rcode !== 0) {
-        log(
-          `⚠ ${short} restart failed. Run manually once the issue is resolved: parachute restart ${short}`,
-        );
-      }
-    }
-    return 0;
-  }
-  const doRestart =
-    opts.restartService ?? ((short: string) => restart(short, { manifestPath, configDir, log }));
+  // §4.3c: the hub-dependent restart goes through the running Supervisor
+  // (`driveModuleOp(short, "restart")`), which re-injects the hub's current
+  // origin; the origin self-heal (operator-token iss + vault `.env`) fires there.
+  // Phase 5b retired the detached `lifecycle.restart` arm.
   for (const short of HUB_DEPENDENT_SHORTS) {
-    if (processState(short, configDir, opts.alive).status !== "running") continue;
     log("");
     log(`Restarting ${short} to pick up new hub origin…`);
-    const rcode = await doRestart(short);
+    const rcode = await restartHubDependentViaSupervisor({
+      short,
+      hubOrigin,
+      configDir,
+      sup,
+      log,
+    });
     if (rcode !== 0) {
       log(
         `⚠ ${short} restart failed. Run manually once the issue is resolved: parachute restart ${short}`,
@@ -474,11 +423,10 @@ export async function exposeOff(layer: ExposeLayer, opts: ExposeOpts = {}): Prom
   const hubFilePath = opts.hubPath ?? HUB_PATH;
   const configDir = opts.configDir ?? CONFIG_DIR;
   const log = opts.log ?? ((line) => console.log(line));
-  // Phase 4 dual-dispatch (design §4.3a / D3). Unit-managed → leave the hub
-  // RUNNING (a managed hub with Restart=always/KeepAlive would just respawn a
-  // stopped one — stopping it is futile + wrong). No unit → the unchanged
-  // detached behavior (stop the hub when the last layer is torn down).
-  const sup = resolveExposeSupervisor(opts.supervisor);
+  // D3 (§4.3a): `expose off` tears down ONLY the exposure layer and leaves the
+  // hub running — the hub is a persistent platform unit now, so stopping it
+  // would just be respawned by the manager. The detached `stopHub` arm was
+  // retired in Phase 5b, so there is no longer any hub-lifecycle dispatch here.
 
   const state = readExposeState(statePath);
   if (!state || state.entries.length === 0) {
@@ -519,19 +467,12 @@ export async function exposeOff(layer: ExposeLayer, opts: ExposeOpts = {}): Prom
     unlinkSync(hubFilePath);
   }
 
-  // Detached-arm only (no unit installed): the hub lived only as long as some
-  // layer was exposed. State was just cleared, so no layer is active — stop the
-  // hub. (Layer switch doesn't go through here; that path reuses the running
-  // hub.) Under a managed hub UNIT (the `sup.unitInstalled` arm), the hub is a
-  // persistent process the manager keeps alive whether or not a layer is
-  // exposed — the "hub exists only while exposed" invariant inverts (D3). We
-  // tear down ONLY the exposure layer above and leave the hub running; the CLI
-  // output drops the "hub stopped" line accordingly. Phase 5 deletes this whole
-  // detached branch.
-  if (!sup.unitInstalled && !opts.skipHub) {
-    const stopped = await stopHub({ ...(opts.hubStopOpts ?? {}), configDir, log });
-    if (stopped) log("✓ hub stopped.");
-  }
+  // D3 (§4.3a) — `expose off` no longer stops the hub. The hub is a persistent
+  // platform unit (Restart=always / KeepAlive) that runs whether or not a layer
+  // is exposed: the "hub exists only while exposed" invariant inverted under the
+  // supervised model, and the detached `stopHub` arm was retired in Phase 5b
+  // (stopping it would just be respawned by the manager). We tear down ONLY the
+  // exposure layer above and leave the hub running.
 
   log(`✓ ${layerLabel(layer)} exposure removed.`);
   return 0;

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -1,24 +1,11 @@
-import { existsSync, openSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
-import {
-  MissingDependencyError,
-  ensureExecutable,
-  rethrowIfMissing,
-} from "@openparachute/depcheck";
+import { rethrowIfMissing } from "@openparachute/depcheck";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
-import { readEnvFileValues } from "../env-file.ts";
 import { readExposeState } from "../expose-state.ts";
-import {
-  type EnsureHubOpts,
-  type EnsureHubResult,
-  HUB_SVC,
-  type StopHubOpts,
-  ensureHubRunning,
-  readHubPort,
-  stopHub,
-} from "../hub-control.ts";
+import { HUB_SVC, readHubPort } from "../hub-control.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
-import { HUB_ORIGIN_ENV, deriveHubOrigin } from "../hub-origin.ts";
+import { deriveHubOrigin } from "../hub-origin.ts";
 import {
   type EnsureHubUnitOpts,
   type EnsureHubUnitResult,
@@ -36,7 +23,6 @@ import {
   type MigrateOfferResult,
   offerMigrateToSupervised,
 } from "../migrate-offer.ts";
-import { ModuleManifestError, readModuleManifest } from "../module-manifest.ts";
 import {
   type DriveModuleOpDeps,
   type ModuleOp,
@@ -46,47 +32,18 @@ import {
   OperatorTokenExpiredError,
   driveModuleOp as driveModuleOpImpl,
 } from "../module-ops-client.ts";
-import { type OperatorIssuerHealStatus, selfHealOperatorTokenIssuer } from "../operator-token.ts";
 import { type PortListeningFn, defaultPortListening } from "../port-probe.ts";
-import {
-  type AliveFn,
-  clearPid,
-  ensureLogPath,
-  logPath as logPathFor,
-  processState,
-  readPid,
-  writePid,
-} from "../process-state.ts";
-import {
-  KNOWN_MODULES,
-  type ServiceSpec,
-  composeKnownModuleSpec,
-  getSpec,
-  getSpecFromInstallDir,
-  knownServices,
-  shortNameForManifest,
-} from "../service-spec.ts";
-import {
-  type ServiceEntry,
-  clearStartError,
-  readManifest,
-  recordStartError,
-} from "../services-manifest.ts";
-import { persistVaultHubOrigin, selfHealVaultHubOrigin } from "../vault-hub-origin-env.ts";
+import { type AliveFn, logPath as logPathFor, processState } from "../process-state.ts";
+import { getSpec, knownServices } from "../service-spec.ts";
+import { readManifest } from "../services-manifest.ts";
 
 /**
- * Tiny seam over `Bun.spawn` for lifecycle tests. The real spawner opens the
- * log file, appends stdout+stderr to it, and `unref()`s the child so parent
- * exit doesn't bring it down.
- *
- * `env`, when provided, is merged into the child's environment on top of the
- * parent's — today's only caller is `start`, which injects
- * PARACHUTE_HUB_ORIGIN so vault's OAuth issuer matches the hub URL.
- *
- * `cwd`, when provided, is the child's working directory. Set to the
- * service's installDir for third-party modules so manifest-declared
- * relative startCmds (e.g. `["bun", "web/server/src/server.ts"]`) resolve
- * against the package root.
+ * Tiny seam over `Bun.spawn`, retained for the `parachute logs <svc> --follow`
+ * tail (`LogsOpts.tailSpawner`). The detached MODULE spawner (`defaultSpawner`)
+ * was retired in Phase 5b — modules are spawned by the supervisor under `serve`,
+ * not by a detached pidfile daemon. `logs` is the last consumer of this seam, and
+ * its tail only needs `cmd` (the `opts` is unused there but kept on the interface
+ * for a future caller).
  */
 export interface SpawnerOptions {
   env?: Record<string, string>;
@@ -96,29 +53,6 @@ export interface SpawnerOptions {
 export interface Spawner {
   spawn(cmd: readonly string[], logFile: string, opts?: SpawnerOptions): number;
 }
-
-export const defaultSpawner: Spawner = {
-  spawn(cmd, logFile, opts) {
-    const fd = openSync(logFile, "a");
-    const spawnOpts: Parameters<typeof Bun.spawn>[1] = {
-      stdio: ["ignore", fd, fd],
-      // Spawn in a fresh process group (pid == pgid) so kill(-pid, sig)
-      // reaches every descendant, not just the wrapper. Without this,
-      // wrapped startCmds like `pnpm exec tsx server.ts` leave the tsx
-      // grandchild bound to the port after stop → restart hits EADDRINUSE.
-      detached: true,
-      // Inherit env so child sees PATH, HOME, PARACHUTE_HOME, etc.
-      // Bun.spawn defaults to empty env — see api-modules-ops.ts:defaultRun.
-      // Per-call `opts.env` overrides merge on top below.
-      env: process.env,
-    };
-    if (opts?.env) spawnOpts.env = { ...process.env, ...opts.env };
-    if (opts?.cwd) spawnOpts.cwd = opts.cwd;
-    const proc = Bun.spawn([...cmd], spawnOpts);
-    proc.unref();
-    return proc.pid;
-  },
-};
 
 export type KillFn = (pid: number, signal: NodeJS.Signals | number) => void;
 export type SleepFn = (ms: number) => Promise<void>;
@@ -137,15 +71,15 @@ export { type PortListeningFn, defaultPortListening };
 
 /**
  * Group-aware liveness: returns true if the process group (pgid == pid)
- * still has any member. Pairs with `defaultSpawner`'s `detached: true` —
- * the recorded pid is the pgid we created, so the group's existence is
- * the right "is the service still up?" signal (catches the wrapper-dead-
- * but-grandchild-listening case that causes EADDRINUSE on restart).
+ * still has any member. The detached module spawner that created these process
+ * groups is retired (Phase 5b — the supervisor under `serve` owns module
+ * spawning now, with its own group-spawn + `defaultKillGroup` in `supervisor.ts`),
+ * but this stays as the liveness primitive for `parachute logs`'s
+ * "running-but-no-logfile" diagnostic over any pidfile still on disk (the readers
+ * §7.5 keeps for one release).
  *
- * Falls back to a single-pid check for legacy pidfiles written before
- * detached-spawn landed: `kill(-pid, 0)` returns ESRCH because no group
- * with that pgid exists, and we still want to honor the bare-pid alive
- * signal so a follow-up `stop` runs.
+ * Falls back to a single-pid check when no group with that pgid exists:
+ * `kill(-pid, 0)` returns ESRCH, and we still honor the bare-pid alive signal.
  */
 export const defaultAlive: AliveFn = (pid) => {
   try {
@@ -163,12 +97,13 @@ export const defaultAlive: AliveFn = (pid) => {
 };
 
 /**
- * Sends `signal` to the entire process group rooted at `pid`. With
- * `defaultSpawner` putting the child in its own group, this reaches the
- * wrapper and any grandchildren in one syscall. ESRCH on the group send
- * means the pgid is gone (legacy pidfile, or the leader exited and the
- * group emptied) — fall back to a bare-pid signal so the caller's intent
- * still lands when there's a positive-pid process to receive it.
+ * Sends `signal` to the entire process group rooted at `pid`. Reaches a wrapper
+ * and any grandchildren in one syscall when the pid is a group leader. ESRCH on
+ * the group send means the pgid is gone (the leader exited and the group emptied,
+ * or a non-group pid) — fall back to a bare-pid signal so the caller's intent
+ * still lands. The supervisor's `defaultKillGroup` (supervisor.ts) is the
+ * production reaper now; this export survives for the group-aware test coverage
+ * + any future on-box use.
  */
 export const defaultKill: KillFn = (pid, signal) => {
   try {
@@ -181,149 +116,34 @@ export const defaultKill: KillFn = (pid, signal) => {
 
 export const defaultSleep: SleepFn = (ms) => new Promise((r) => setTimeout(r, ms));
 
-/**
- * Read the trailing `n` lines of a logfile, best-effort. Used to surface the
- * real boot error when a start fails — operators shouldn't have to manually
- * `tail` the log to learn *why* the daemon died. Returns [] on any read
- * error (missing file, permissions) so the caller falls back to the generic
- * "tail the log" hint without throwing.
- */
-function readLogTail(logFile: string, n: number): string[] {
-  try {
-    const content = readFileSync(logFile, "utf8");
-    const trimmed = content.replace(/\n$/, "");
-    if (trimmed === "") return [];
-    return trimmed.split("\n").slice(-n);
-  } catch {
-    return [];
-  }
-}
-
-/**
- * Heuristic EADDRINUSE detector over a logfile tail. cloudflared, Bun, and
- * Node all surface port collisions with recognizable phrases; we match the
- * common ones rather than parse a structured error (there isn't one across
- * runtimes). False positives are harmless — the worst case is we *also* print
- * the port-in-use remedy on an unrelated failure, which is still actionable.
- */
-function detectAddrInUse(logTail: readonly string[]): boolean {
-  return logTail.some((line) => /EADDRINUSE|address already in use|port .* in use/i.test(line));
-}
-
 export interface LifecycleOpts {
-  spawner?: Spawner;
-  kill?: KillFn;
-  alive?: AliveFn;
-  sleep?: SleepFn;
-  now?: () => number;
   manifestPath?: string;
   configDir?: string;
   log?: (line: string) => void;
-  /** How long stop waits for SIGTERM before escalating to SIGKILL. */
-  killWaitMs?: number;
-  /** Poll interval while waiting for SIGTERM to land. */
-  pollIntervalMs?: number;
   /**
-   * How long `start` sleeps before re-checking `alive(pid)` to catch the
-   * spawn-then-immediately-die failure shape (hub#194: notes-serve crashed
-   * 50ms in on Bun.resolveSync, but `start` reported success because the
-   * spawn returned a pid). 250ms is the default in production — long
-   * enough to catch real silent-crashes (resolve failures, port
-   * collisions, missing args) without making `parachute start` feel
-   * laggy.
-   *
-   * Defaulting policy: if `alive` is not overridden, the settle defaults
-   * to 0 (skipped). Stub spawners hand back fake pids that the real
-   * `defaultAlive` would mark as dead, which would make every existing
-   * stub-spawner test fail spuriously. Tests that want to exercise the
-   * settle path inject both `alive` and `startSettleMs` explicitly.
-   * Production paths use the real `defaultAlive` and get the real 250ms
-   * settle.
-   */
-  startSettleMs?: number;
-  /**
-   * Probe whether the service's port is listening, post-spawn. Pairs with the
-   * settle (hub#194) to catch the EADDRINUSE-orphan shape (hub#487): the
-   * process survives the liveness window (vault lingers / retries) but never
-   * binds because the port is already held, so `start` would otherwise report
-   * "✓ started" while `status` shows it inactive. Tests inject a stub;
-   * production uses `defaultPortListening` (a loopback TCP connect probe).
-   */
-  portListening?: PortListeningFn;
-  /**
-   * How long `start` polls for the service to bind its port after the
-   * liveness settle passes. Default 4000ms in production — long enough to
-   * cover vault/scribe cold-boot (DB open, route registration) without making
-   * a healthy start feel laggy. Polled at `startReadyPollMs` intervals; the
-   * first time the port answers we declare success. If the window elapses
-   * with the process still alive but the port silent, we print a non-fatal
-   * warning (the daemon may still be coming up) rather than failing — only a
-   * *dead* process is a hard failure. Defaulting policy mirrors
-   * `startSettleMs`: 0 (skipped) unless `portListening` is injected or the
-   * production path (no spawner override) is active.
-   */
-  startReadyMs?: number;
-  /** Poll interval while waiting for the port to come up. Default 200ms. */
-  startReadyPollMs?: number;
-  /**
-   * Override the hub origin passed to services as PARACHUTE_HUB_ORIGIN. If
-   * unset, `start` derives it from `expose-state.json` (when exposed) or
-   * the hub.port file (local dev). Undefined → no env var is set at all,
-   * and the service advertises its own default issuer.
+   * Override the hub origin used as the operator token's `iss` validator on the
+   * loopback module-ops call. If unset, derived from `expose-state.json` (when
+   * exposed) or the hub.port file (local dev).
    */
   hubOrigin?: string;
   /**
-   * Hub-lifecycle seams for `parachute start|stop|restart hub`. The hub
-   * doesn't go through the generic services-manifest path because its
-   * start has special semantics (port-fallback probe, port-file write,
-   * --issuer flag) — `lifecycle.start("hub")` dispatches to
-   * `ensureHubRunning` and `lifecycle.stop("hub")` dispatches to
-   * `stopHub`. Tests inject stubs to avoid spawning real bun processes.
-   */
-  /**
-   * PATH-resolution seam for the start preflight (`@openparachute/depcheck`
-   * `ensureExecutable`). Production uses the real `Bun.which`; a missing
-   * startCmd binary then surfaces the friendly missing-dependency UX +
-   * persists it to services.json.
-   *
-   * Defaulting policy mirrors `startSettleMs`: when a stub `spawner` is
-   * injected (the test path) `which` defaults to a permissive resolver
-   * (`() => "<stub>"`) so existing stub-spawner tests don't trip the preflight
-   * against binaries that aren't on the test host's PATH (`parachute-vault`,
-   * `notes-serve`). Production (no spawner override) gets the real `Bun.which`.
-   * Tests that want to exercise the missing-binary branch inject `which`
-   * explicitly (e.g. `which: () => null`).
-   */
-  which?: (cmd: string) => string | null;
-  hub?: {
-    ensureRunning?: (opts: EnsureHubOpts) => Promise<EnsureHubResult>;
-    stop?: (opts: StopHubOpts) => Promise<boolean>;
-    /**
-     * Self-heal the operator token's stale `iss` after `start hub` (hub#481).
-     * Production opens hub.db at `<configDir>/hub.db` and delegates to
-     * `selfHealOperatorTokenIssuer`. Tests inject a stub to assert the call
-     * happens — or to make it throw and prove a self-heal failure never fails
-     * `start hub`.
-     */
-    selfHealOperatorToken?: (args: {
-      issuer: string;
-      configDir: string;
-      log: (line: string) => void;
-    }) => Promise<OperatorIssuerHealStatus>;
-  };
-  /**
-   * Phase 3b supervisor-path seams (design §3.3). When a hub UNIT is installed
-   * (launchd/systemd/container — detected via {@link isHubUnitInstalled}),
+   * Supervisor-path seams (design §3.3) — the ONLY runtime as of Phase 5b.
    * `start/stop/restart` drive the RUNNING hub's in-process Supervisor over the
-   * loopback module-ops API instead of spawning detached pidfile daemons. The
-   * detached arm (`spawner`/`hub.ensureRunning`/`hub.stop`) remains the no-unit
-   * fallback until Phase 5 retires it.
+   * loopback module-ops API (per-module verbs) or the platform manager (hub
+   * verbs / no-svc). The detached spawners are retired; a box with no hub unit
+   * goes through the §7.5 auto-offer / actionable error (`migrateOffer`), never
+   * a detached spawn.
    *
    * Everything here is injectable so tests can (a) force the unit-installed
    * branch without a real launchd/systemd, and (b) assert the module-ops /
    * manager calls without a live hub. Production wires the real
    * {@link driveModuleOp} / {@link ensureHubUnit} / {@link stopHubUnit} /
    * {@link restartHubUnit} against an opened hub.db + the resolved hub origin.
+   *
+   * `unitInstalled` is the discriminant that decides whether the box is already
+   * supervised. When OMITTED entirely it defaults to `false` → the verb runs the
+   * no-unit path (auto-offer / error). The production CLI dispatch passes
+   * `supervisor: {}` so the real `isHubUnitInstalled` probe decides.
    */
   supervisor?: {
     /**
@@ -384,29 +204,10 @@ export interface LifecycleOpts {
 }
 
 interface Resolved {
-  spawner: Spawner;
-  kill: KillFn;
-  alive: AliveFn;
-  sleep: SleepFn;
-  now: () => number;
   manifestPath: string;
   configDir: string;
   log: (line: string) => void;
-  killWaitMs: number;
-  pollIntervalMs: number;
-  startSettleMs: number;
-  portListening: PortListeningFn;
-  startReadyMs: number;
-  startReadyPollMs: number;
-  which: (cmd: string) => string | null;
   hubOrigin: string | undefined;
-  ensureHub: (opts: EnsureHubOpts) => Promise<EnsureHubResult>;
-  stopHubFn: (opts: StopHubOpts) => Promise<boolean>;
-  selfHealOperatorTokenFn: (args: {
-    issuer: string;
-    configDir: string;
-    log: (line: string) => void;
-  }) => Promise<OperatorIssuerHealStatus>;
   sup: ResolvedSupervisor;
   /** §7.5 resolved auto-offer (enabled flag + the offer impl). */
   migrateOffer: {
@@ -415,7 +216,7 @@ interface Resolved {
   };
 }
 
-/** Resolved Phase 3b supervisor-path seams (see `LifecycleOpts.supervisor`). */
+/** Resolved supervisor-path seams (see `LifecycleOpts.supervisor`). */
 interface ResolvedSupervisor {
   /** Whether a hub unit is installed — the dual-dispatch discriminant. */
   unitInstalled: boolean;
@@ -429,76 +230,18 @@ interface ResolvedSupervisor {
   baseUrl: string | undefined;
 }
 
-/**
- * Production self-heal: open hub.db at `<configDir>/hub.db`, run
- * `selfHealOperatorTokenIssuer`, and close the db. Derives the db path the
- * same way the rest of the repo does (`hubDbPath(configDir)`); `openHubDb`
- * runs migrations + WAL on open, matching `commands/auth.ts`. Tests override
- * this whole seam, so the db-open only happens on the production path.
- */
-async function defaultSelfHealOperatorToken(args: {
-  issuer: string;
-  configDir: string;
-  log: (line: string) => void;
-}): Promise<OperatorIssuerHealStatus> {
-  const db = openHubDb(hubDbPath(args.configDir));
-  try {
-    return await selfHealOperatorTokenIssuer(db, {
-      issuer: args.issuer,
-      configDir: args.configDir,
-      log: args.log,
-    });
-  } finally {
-    db.close();
-  }
-}
-
 function resolve(opts: LifecycleOpts): Resolved {
   const configDir = opts.configDir ?? CONFIG_DIR;
   return {
-    spawner: opts.spawner ?? defaultSpawner,
-    kill: opts.kill ?? defaultKill,
-    alive: opts.alive ?? defaultAlive,
-    sleep: opts.sleep ?? defaultSleep,
-    now: opts.now ?? Date.now,
     manifestPath: opts.manifestPath ?? SERVICES_MANIFEST_PATH,
     configDir,
     log: opts.log ?? ((line) => console.log(line)),
-    killWaitMs: opts.killWaitMs ?? 10_000,
-    pollIntervalMs: opts.pollIntervalMs ?? 200,
-    // See `LifecycleOpts.startSettleMs` doc. Production (no spawner
-    // override, no alive override) gets the 250ms settle. Tests that
-    // inject a stub spawner without a stub alive get 0 — `defaultAlive`
-    // against a fake pid would always report dead and break unrelated
-    // tests. Tests that want to exercise the settle path explicitly
-    // override `alive`, which re-enables the default 250ms.
-    startSettleMs:
-      opts.startSettleMs ?? (opts.spawner === undefined || opts.alive !== undefined ? 250 : 0),
-    portListening: opts.portListening ?? defaultPortListening,
-    // Same defaulting policy as startSettleMs: production (no spawner
-    // override) gets the real 4s readiness window; tests that inject a stub
-    // spawner get 0 (skipped) unless they explicitly opt in via
-    // `portListening` or `startReadyMs`, so existing stub-spawner tests don't
-    // start probing a fake port.
-    startReadyMs:
-      opts.startReadyMs ??
-      (opts.spawner === undefined || opts.portListening !== undefined ? 4000 : 0),
-    startReadyPollMs: opts.startReadyPollMs ?? 200,
-    // Same defaulting policy as startSettleMs/startReadyMs: production (no
-    // spawner override) preflights with the real Bun.which; stub-spawner tests
-    // get a permissive resolver so the preflight doesn't trip against binaries
-    // that aren't on the test host's PATH. Explicit `which` always wins.
-    which:
-      opts.which ?? (opts.spawner === undefined ? Bun.which : () => "/stub/bin/preflight-skipped"),
     hubOrigin: resolveHubOrigin(opts.hubOrigin, configDir),
-    ensureHub: opts.hub?.ensureRunning ?? ensureHubRunning,
-    stopHubFn: opts.hub?.stop ?? stopHub,
-    selfHealOperatorTokenFn: opts.hub?.selfHealOperatorToken ?? defaultSelfHealOperatorToken,
     sup: resolveSupervisor(opts.supervisor),
     migrateOffer: {
-      // Default OFF when omitted so the existing detached-arm lifecycle tests
-      // (which never opt in) don't trip an interactive prompt. The production
-      // CLI dispatch passes `{ enabled: true }`.
+      // Default OFF when omitted so the existing supervised-arm + no-unit
+      // lifecycle tests (which don't opt in) don't trip an interactive prompt.
+      // The production CLI dispatch passes `{ enabled: true }`.
       enabled: opts.migrateOffer?.enabled ?? false,
       offer: opts.migrateOffer?.offer ?? offerMigrateToSupervised,
     },
@@ -506,26 +249,22 @@ function resolve(opts: LifecycleOpts): Resolved {
 }
 
 /**
- * Resolve the Phase 3b supervisor-path seams (the dual-dispatch arm).
+ * Resolve the supervisor-path seams.
  *
- * The discriminant `unitInstalled` decides which arm a verb takes:
+ * The discriminant `unitInstalled` decides whether the box is already supervised:
  *   - When the caller PROVIDES a `supervisor` block (even `{}`, which the
  *     production CLI dispatch passes), `unitInstalled` is the explicit override
- *     if set, else the real `isHubUnitInstalled` probe over the hub-unit deps —
- *     so on a box with a launchd/systemd hub unit the verbs drive the running
- *     supervisor, and on a legacy detached box they take the detached arm.
- *   - When the caller OMITS `supervisor` entirely (the shape of every existing
- *     lifecycle test, which never opts into the new path), `unitInstalled`
- *     defaults to `false` → the detached arm. This keeps those tests
- *     DETERMINISTIC regardless of whether the test host happens to have a real
- *     hub unit installed. New Phase 3b tests opt into the supervisor arm by
- *     passing `supervisor: { unitInstalled: true, … }`.
+ *     if set, else the real `isHubUnitInstalled` probe over the hub-unit deps.
+ *   - When the caller OMITS `supervisor` entirely, `unitInstalled` defaults to
+ *     `false` → the verb runs the no-unit path (§7.5 auto-offer / actionable
+ *     error). Deterministic regardless of whether the test host happens to have a
+ *     real hub unit installed.
  */
 function resolveSupervisor(opts: LifecycleOpts["supervisor"]): ResolvedSupervisor {
   const hubUnitDeps = opts?.hubUnitDeps ?? defaultHubUnitDeps;
-  // No `supervisor` block at all → detached arm, deterministically. Only probe
-  // the real filesystem when the caller opted into the new path (production CLI
-  // passes `supervisor: {}`; tests pass the seams they want to assert).
+  // No `supervisor` block at all → no-unit path, deterministically. Only probe
+  // the real filesystem when the caller opted in (production CLI passes
+  // `supervisor: {}`; tests pass the seams they want to assert).
   const unitInstalled =
     opts === undefined ? false : (opts.unitInstalled ?? isHubUnitInstalled(hubUnitDeps));
   return {
@@ -542,21 +281,21 @@ function resolveSupervisor(opts: LifecycleOpts["supervisor"]): ResolvedSuperviso
 }
 
 /**
- * §7.5 auto-detect-and-offer hook for the detached arm of start/stop/restart.
+ * §7.5 auto-detect-and-offer hook for the no-unit case of start/stop/restart.
  *
- * Called only AFTER the `r.sup.unitInstalled` branch fell through (we're on the
- * detached arm). When the offer is enabled, it runs `offerMigrateToSupervised`
- * (which itself checks "no unit + prior detached" and prompts / prints). Returns
- * `true` ONLY when the operator accepted AND the cutover succeeded — i.e. the
- * box is NOW supervised, so the caller should re-dispatch through the supervisor
- * path. Every other outcome (offer disabled, no-offer, declined, printed in a
- * non-TTY, migrate-failed) returns `false` → the caller proceeds with the
- * detached arm unchanged.
+ * Called when a verb finds NO hub unit installed (Phase 5b removed the detached
+ * spawners, so there is no detached arm to fall back to). When the offer is
+ * enabled, it runs `offerMigrateToSupervised` (which itself checks "no unit +
+ * prior detached" and prompts / prints). Returns `true` ONLY when the operator
+ * accepted AND the cutover succeeded — i.e. the box is NOW supervised, so the
+ * caller can dispatch through the supervisor path. Every other outcome (offer
+ * disabled, no-offer, declined, printed in a non-TTY, migrate-failed) returns
+ * `false` → the caller surfaces the actionable "run `parachute migrate
+ * --to-supervised`" error (NOT a detached spawn — that path is gone).
  *
  * The migrate-failed case deliberately returns `false`: a failed cutover leaves
- * the box still on the detached model (the cutover is fail-safe + re-runnable),
- * so the original verb should still run the detached way rather than re-dispatch
- * into a supervisor that isn't up.
+ * the box un-migrated (the cutover is fail-safe + re-runnable), so the verb
+ * surfaces the error rather than dispatching into a supervisor that isn't up.
  */
 async function maybeOfferAndMigrate(r: Resolved): Promise<boolean> {
   if (!r.migrateOffer.enabled) return false;
@@ -566,11 +305,47 @@ async function maybeOfferAndMigrate(r: Resolved): Promise<boolean> {
     log: r.log,
   });
   if (result.outcome === "migrated") {
-    // The box is now supervised. Flip the resolved discriminant so the
-    // re-dispatched verb takes the supervisor arm (the unit is freshly
-    // installed; `r.sup.unitInstalled` was resolved as false before the offer).
+    // The box is now supervised. Flip the resolved discriminant so the verb
+    // takes the supervisor arm (the unit is freshly installed; `unitInstalled`
+    // was resolved as false before the offer).
     r.sup.unitInstalled = true;
     return true;
+  }
+  return false;
+}
+
+/**
+ * Phase 5b single-path gate (the point-of-no-return). The supervised path is the
+ * ONLY runtime — the detached spawners are retired. So every per-module verb must
+ * first establish that a hub unit is installed; if it isn't, there is no detached
+ * fallback to take. Resolution order:
+ *
+ *   1. Unit installed → ready; dispatch through the supervisor.
+ *   2. No unit → run the §7.5 auto-detect-and-offer. If the operator accepts the
+ *      cutover and it succeeds, the box is now supervised → ready.
+ *   3. Still no unit (offer disabled / no prior-detached evidence / declined /
+ *      printed in a non-TTY / migrate-failed) → surface the actionable error and
+ *      return NOT ready. The verb returns a non-zero exit; it NEVER spawns a
+ *      detached daemon (that machinery is gone).
+ *
+ * The offer itself logs its own context (interactive prompt / printed command),
+ * so when it fired we don't double-print the bare error. We only print the
+ * actionable fallback line when no offer was surfaced (offer disabled or no
+ * prior-detached evidence — a genuinely-unmigrated or clean box driven by a
+ * script).
+ */
+async function requireSupervisedOrOffer(r: Resolved): Promise<boolean> {
+  if (r.sup.unitInstalled) return true;
+  const migrated = await maybeOfferAndMigrate(r);
+  if (migrated) return true;
+  // No unit and not migrated. If the offer was enabled it already surfaced its
+  // own guidance (prompt / printed command / declined note); otherwise print the
+  // actionable command so a script on a never-migrated box isn't left guessing.
+  if (!r.migrateOffer.enabled) {
+    r.log(
+      "No supervised hub unit is installed. Run `parachute migrate --to-supervised` to install it,",
+    );
+    r.log("or run `parachute serve` in the foreground.");
   }
   return false;
 }
@@ -608,503 +383,40 @@ function resolveHubOrigin(override: string | undefined, configDir: string): stri
   return deriveHubOrigin({ exposeFqdn, hubPort: readHubPort(configDir) });
 }
 
-interface ResolvedTarget {
-  short: string;
-  entry: ServiceEntry;
-  /**
-   * Lifecycle spec resolved at request time. First-party comes from
-   * `getSpec(short)`; third-party comes from
-   * `getSpecFromInstallDir(entry.installDir, ...)`. May be undefined when
-   * a row has neither — `start` prints the actionable "no installDir"
-   * re-install message for an installDir-less third-party row, or
-   * "lifecycle not yet supported" otherwise; `stop`/`logs` keep working
-   * via pidfile/logfile semantics keyed by `short`.
-   */
-  spec: ServiceSpec | undefined;
-}
-
-async function specForEntry(
-  short: string,
-  entry: ServiceEntry,
-): Promise<{ spec: ServiceSpec | undefined; error?: string }> {
-  const firstParty = getSpec(short);
-  // KNOWN_MODULES shorts (vault / scribe / runner — post hub#310 FALLBACK
-  // retirement): if installDir is stamped (typical post-self-register),
-  // compose the spec from the module's own `.parachute/module.json` so the
-  // module is authoritative for its startCmd / paths / health. Falls back
-  // to the minimal `getSpec` (which carries an imperative `extras.startCmd`
-  // matching the module's canonical declaration) when installDir is absent
-  // or module.json is unreadable — covers legacy services.json rows from
-  // before installDir stamping landed.
-  const km = KNOWN_MODULES[short];
-  if (km) {
-    if (entry.installDir) {
-      try {
-        const manifest = await readModuleManifest(entry.installDir);
-        if (manifest) return { spec: composeKnownModuleSpec(km, manifest) };
-      } catch (err) {
-        if (err instanceof ModuleManifestError) {
-          // Surface the parse/validation error but keep the legacy
-          // imperative-startCmd spec so `start` can still spawn — better
-          // than no lifecycle at all when a module ships a typo'd manifest.
-          return { spec: firstParty, error: err.message };
-        }
-        throw err;
-      }
-    }
-    return { spec: firstParty };
-  }
-  // FIRST_PARTY_FALLBACKS shorts (notes / channel): the vendored manifest
-  // is authoritative — startCmd is composed from extras + manifest at
-  // `getSpec` time, no installDir read needed.
-  if (firstParty) return { spec: firstParty };
-  // Third-party rows: spec lives in the module's installDir/module.json.
-  if (!entry.installDir) return { spec: undefined };
-  try {
-    const spec = await getSpecFromInstallDir(entry.installDir, entry.name);
-    return { spec: spec ?? undefined };
-  } catch (err) {
-    if (err instanceof ModuleManifestError) {
-      return { spec: undefined, error: err.message };
-    }
-    throw err;
-  }
-}
-
-/**
- * Services selected by the `[svc]` positional. `undefined` targets every
- * manageable service (first-party shortnames OR third-party rows that
- * carry `installDir`). Unknown names get a friendly error up front rather
- * than a confusing spawn failure downstream.
- *
- * Third-party modules are addressed by the `name` field from their
- * `module.json` (which is what install copied to `entry.name` for
- * third-party). First-party are addressed by their short name (vault,
- * notes, …) and matched via `shortNameForManifest`.
- *
- * Named-path detail: a third-party row whose name matches but lacks
- * `installDir` resolves to the entry with `spec: undefined` (rather than
- * an "unknown service" error). `stop`/`logs` handle the spec-less case
- * via pidfile/logfile semantics; `start` surfaces an actionable
- * re-install hint downstream. The genuinely-unknown path (no first-party
- * fallback AND no row in services.json) still errors as `unknown service`.
- */
-async function resolveTargets(
-  svc: string | undefined,
-  manifestPath: string,
-): Promise<{ targets: ResolvedTarget[] } | { error: string }> {
-  const manifest = readManifest(manifestPath);
-  if (manifest.services.length === 0) {
-    return { error: "No services installed yet. Try: parachute install vault" };
-  }
-
-  if (svc !== undefined) {
-    // Try first-party (svc is a short name → known fallback).
-    const firstPartySpec = getSpec(svc);
-    if (firstPartySpec) {
-      const entry = manifest.services.find((s) => s.name === firstPartySpec.manifestName);
-      if (!entry) {
-        return { error: `${svc} isn't installed. Run \`parachute install ${svc}\` first.` };
-      }
-      // KNOWN_MODULES path (hub#310): `getSpec` returns a startCmd-less
-      // minimal spec for vault / scribe / runner. Compose the full
-      // spawnable spec by reading installDir's module.json so `start` /
-      // `restart` see the real startCmd. FIRST_PARTY_FALLBACKS path:
-      // `firstPartySpec.startCmd` is already populated, and `specForEntry`
-      // short-circuits without re-reading.
-      const { spec, error } = await specForEntry(svc, entry);
-      if (error) return { error: `${svc}: invalid module.json — ${error}` };
-      return { targets: [{ short: svc, entry, spec: spec ?? firstPartySpec }] };
-    }
-    // Third-party: match a services.json row by name. Rows with `installDir`
-    // resolve a full spec from the on-disk module.json. Rows without it are
-    // still managed (stop/logs use pidfile/logfile semantics keyed by short
-    // name), but with `spec: undefined` — `start` will surface an
-    // installDir-specific error downstream rather than reject up front.
-    const entry = manifest.services.find((s) => s.name === svc);
-    if (entry) {
-      if (entry.installDir) {
-        const { spec, error } = await specForEntry(svc, entry);
-        if (error) return { error: `${svc}: invalid module.json — ${error}` };
-        return { targets: [{ short: svc, entry, spec }] };
-      }
-      return { targets: [{ short: svc, entry, spec: undefined }] };
-    }
-    return {
-      error: `unknown service "${svc}". known: ${knownServices().join(", ")}`,
-    };
-  }
-
-  const targets: ResolvedTarget[] = [];
-  for (const entry of manifest.services) {
-    const short = shortNameForManifest(entry.name);
-    if (short) {
-      // KNOWN_MODULES path (hub#310): minimal `getSpec` returns no startCmd
-      // for vault / scribe / runner — read installDir's module.json to
-      // compose the spawnable spec. FIRST_PARTY_FALLBACKS shorts get
-      // back the same vendored-startCmd-bearing spec from `getSpec`.
-      const { spec } = await specForEntry(short, entry);
-      targets.push({ short, entry, spec });
-      continue;
-    }
-    if (entry.installDir) {
-      const { spec } = await specForEntry(entry.name, entry);
-      targets.push({ short: entry.name, entry, spec });
-    }
-  }
-  if (targets.length === 0) {
-    return { error: "No manageable services in services.json." };
-  }
-  return { targets };
-}
-
 export async function start(svc: string | undefined, opts: LifecycleOpts = {}): Promise<number> {
   const r = resolve(opts);
-  // Phase 3b dual-dispatch (design §3.3). On a box with a hub unit installed,
-  // drive the RUNNING supervisor; otherwise fall through to the unchanged
-  // detached arm below. Phase 5 deletes the else-arm — keep this a clean
-  // top-level branch so that deletion is a one-liner.
-  if (r.sup.unitInstalled) return startViaSupervisor(svc, r);
-  // §7.5 auto-detect-and-offer: a box on the detached model (no unit) with a
-  // prior detached install gets offered the supervised cutover. If the operator
-  // accepts + migrates, the box is now supervised — re-dispatch this verb
-  // through the supervisor path. Declined / printed / no-offer → fall through.
-  if (await maybeOfferAndMigrate(r)) return startViaSupervisor(svc, r);
-  // --- no-unit detached fallback (unchanged; preserved until Phase 5) ---
-  if (svc === HUB_SVC) return startHubSvc(r);
-  const picked = await resolveTargets(svc, r.manifestPath);
-  if ("error" in picked) {
-    r.log(picked.error);
-    return 1;
-  }
-
-  let failures = 0;
-  for (const { short, entry, spec } of picked.targets) {
-    const state = processState(short, r.configDir, r.alive);
-    if (state.status === "running") {
-      r.log(`${short} already running (pid ${state.pid}).`);
-      continue;
-    }
-    if (state.pid !== undefined) {
-      // Stale PID file for a dead process — clear it before we spawn fresh.
-      clearPid(short, r.configDir);
-    }
-
-    const cmd = spec?.startCmd?.(entry);
-    if (!cmd || cmd.length === 0) {
-      // Distinguish the missing-installDir case from "spec resolved but has
-      // no startCmd" — the former is fixable by re-registering the module,
-      // the latter is a hub-level limitation. Third-party rows hit the first
-      // branch when their self-registration predates the installDir contract.
-      if (!getSpec(short) && !entry.installDir) {
-        r.log(
-          `${short}: services.json entry has no installDir, so the start command can't be resolved. Re-run \`parachute install <path-to-${short}>\` to refresh its registration, or upgrade the module to a version that self-registers with installDir.`,
-        );
-      } else {
-        r.log(`${short}: lifecycle not yet supported for this service.`);
-      }
-      failures++;
-      continue;
-    }
-
-    const logFile = ensureLogPath(short, r.configDir);
-    // Merge `<configDir>/<short>/.env` into the spawn env so service-specific
-    // values (auto-wired SCRIBE_AUTH_TOKEN/SCRIBE_URL on vault, GROQ/OPENAI
-    // API keys on scribe written by the install prompt) reach the daemon.
-    // Vault still loads its own .env at runtime (it has its own start.sh
-    // wrapper for launchd / systemd) — this is idempotent there. Hub-origin
-    // override wins on collision; that's the live-exposure source of truth.
-    const fileEnv = readEnvFileValues(join(r.configDir, short, ".env"));
-    // PORT override (hub#356): same shape as `spawnSupervised` in
-    // api-modules-ops.ts. Without this, operators running `parachute start
-    // vault` inside a container that has PORT in env (Render / Fly / etc.)
-    // hit EADDRINUSE on hub's port. Local dev typically doesn't set PORT, so
-    // this is a no-op there. fileEnv wins on collision so per-service .env
-    // can still override if an operator deliberately set PORT in there.
-    const env: Record<string, string> = { PORT: String(entry.port), ...fileEnv };
-    if (r.hubOrigin) env[HUB_ORIGIN_ENV] = r.hubOrigin;
-    const spawnerOpts: { env?: Record<string, string>; cwd?: string } = {};
-    if (Object.keys(env).length > 0) spawnerOpts.env = env;
-    // Third-party modules ship clean relative startCmds — `cwd: installDir`
-    // makes those resolve. First-party fallbacks use absolute / PATH binaries
-    // so their cwd is irrelevant; passing it doesn't hurt.
-    if (entry.installDir) spawnerOpts.cwd = entry.installDir;
-    const passOpts =
-      spawnerOpts.env !== undefined || spawnerOpts.cwd !== undefined ? spawnerOpts : undefined;
-
-    // Pre-flight the startCmd binary (`@openparachute/depcheck`) so a missing
-    // executable surfaces the friendly install UX inline AND is persisted onto
-    // the services.json row, so a *later* `parachute status` (a separate
-    // invocation that only reads the manifest) + the SPA modules pane show
-    // "vault: failed to start — parachute-vault not installed" with install
-    // info, rather than a bare "failed"/orphan-timeout. The binary is `cmd[0]`
-    // (e.g. `parachute-vault` for an npm install, `bun` for a bun-linked one).
-    const startBinary = cmd[0];
-    if (startBinary) {
-      try {
-        ensureExecutable(startBinary, { which: r.which });
-      } catch (err) {
-        if (err instanceof MissingDependencyError) {
-          failures++;
-          r.log(`✗ ${short} failed to start:`);
-          for (const line of err.message.split("\n")) r.log(`  ${line}`);
-          recordStartError(entry.name, err.toWire(), r.manifestPath);
-          continue;
-        }
-        throw err;
-      }
-    }
-
-    let pid: number;
-    try {
-      pid = r.spawner.spawn(cmd, logFile, passOpts);
-    } catch (err) {
-      // Belt-and-suspenders: a missing binary that slipped past the pre-flight
-      // (race) still becomes a MissingDependencyError via rethrowIfMissing.
-      if (startBinary) {
-        try {
-          rethrowIfMissing(err, startBinary);
-        } catch (missing) {
-          if (missing instanceof MissingDependencyError) {
-            failures++;
-            r.log(`✗ ${short} failed to start:`);
-            for (const line of missing.message.split("\n")) r.log(`  ${line}`);
-            recordStartError(entry.name, missing.toWire(), r.manifestPath);
-            continue;
-          }
-        }
-      }
-      failures++;
-      const msg = err instanceof Error ? err.message : String(err);
-      r.log(`✗ ${short} failed to start: ${msg}`);
-      continue;
-    }
-    // A successful spawn clears any stale start-error recorded from a prior
-    // missing-dependency failure so `parachute status` doesn't keep showing it.
-    clearStartError(entry.name, r.manifestPath);
-    writePid(short, pid, r.configDir);
-
-    // Boot-readiness gating (hub#194 + hub#487). A spawn returning a pid only
-    // proves the kernel forked the process — it says nothing about whether the
-    // service survived its boot or bound its port. Two silent-start shapes:
-    //
-    //   (1) spawn-then-immediately-die (hub#194): the child throws before
-    //       listening (notes-serve's Bun.resolveSync failing for bun-linked
-    //       installs) and exits microseconds later. Caught by the settle below.
-    //
-    //   (2) alive-but-never-bound (hub#487): the port is already held by an
-    //       orphan, the child hits EADDRINUSE, but its process *lingers* (or a
-    //       supervisor retries) long enough to clear the liveness check. `start`
-    //       would report "✓ started" while `parachute status` shows it inactive
-    //       because nothing answers on the port. Aaron hit exactly this with an
-    //       orphan holding vault's 1940 on a fresh EC2 box. Caught by the
-    //       port-readiness poll below.
-    //
-    // On any failure we surface the tail of the logfile so the operator sees
-    // the real boot error inline, and we specifically call out EADDRINUSE with
-    // the `lsof -ti:<port>` remedy.
-    const reportStartFailure = (reason: string): void => {
-      clearPid(short, r.configDir);
-      failures++;
-      const tail = readLogTail(logFile, 20);
-      if (detectAddrInUse(tail)) {
-        r.log(
-          `✗ ${short} failed to start: port ${entry.port} is already in use. Stop the existing process first — find it with \`lsof -ti:${entry.port}\` (then \`kill <pid>\`), or run \`parachute restart ${short}\`.`,
-        );
-      } else {
-        r.log(`✗ ${short} failed to start: ${reason}`);
-      }
-      if (tail.length > 0) {
-        r.log(`  ── last ${tail.length} log line(s) (${logFile}) ──`);
-        for (const line of tail) r.log(`  │ ${line}`);
-      } else {
-        r.log(`  Tail the log for details: tail -50 ${logFile}`);
-      }
-    };
-
-    if (r.startSettleMs > 0) {
-      await r.sleep(r.startSettleMs);
-      if (!r.alive(pid)) {
-        reportStartFailure(
-          `spawned pid ${pid} but the process exited within ${r.startSettleMs}ms.`,
-        );
-        continue;
-      }
-    }
-
-    // Port-readiness poll (hub#487). The process is alive; now confirm it
-    // actually bound its port before claiming success. Poll up to
-    // `startReadyMs`, re-checking liveness each iteration so a *later* death
-    // (e.g. a slow EADDRINUSE crash) is still reported as a failure. A process
-    // that stays alive but never binds within the window gets a non-fatal
-    // warning rather than a hard failure — some daemons legitimately do slow
-    // boot work, and we'd rather not flip a healthy-but-slow start to red.
-    if (r.startReadyMs > 0) {
-      const deadline = r.now() + r.startReadyMs;
-      let listening = false;
-      let died = false;
-      while (r.now() < deadline) {
-        if (!r.alive(pid)) {
-          died = true;
-          break;
-        }
-        if (await r.portListening(entry.port)) {
-          listening = true;
-          break;
-        }
-        await r.sleep(r.startReadyPollMs);
-      }
-      if (died) {
-        reportStartFailure(`spawned pid ${pid} but the process exited during startup.`);
-        continue;
-      }
-      if (!listening) {
-        // Last-chance liveness check — the loop may have exited on the
-        // deadline right as the process died.
-        if (!r.alive(pid)) {
-          reportStartFailure(`spawned pid ${pid} but the process exited during startup.`);
-          continue;
-        }
-        r.log(
-          `⚠ ${short} started (pid ${pid}) but port ${entry.port} isn't accepting connections yet after ${r.startReadyMs}ms.`,
-        );
-        r.log(
-          `  It may still be coming up — check \`parachute status\` and \`parachute logs ${short}\`.`,
-        );
-        if (r.hubOrigin) r.log(`  ${HUB_ORIGIN_ENV}=${r.hubOrigin}`);
-        if (short === "vault") persistVaultHubOriginForStart(r);
-        continue;
-      }
-    }
-
-    r.log(`✓ ${short} started (pid ${pid}); logs: ${logFile}`);
-    if (r.hubOrigin) r.log(`  ${HUB_ORIGIN_ENV}=${r.hubOrigin}`);
-    if (short === "vault") persistVaultHubOriginForStart(r);
-  }
-  return failures === 0 ? 0 : 1;
-}
-
-/**
- * Durable-persist vault's `PARACHUTE_HUB_ORIGIN` on a vault `start`. Two cases,
- * in order:
- *
- *  1. The resolved spawn origin (`r.hubOrigin`) is a real public origin — write
- *     it. This is the long-standing happy path: an exposure is live, the
- *     launchd / systemd daemon (which boots vault out-of-band and never sees
- *     this spawn env) needs it in `.env` to validate hub-minted JWTs' `iss`.
- *     `persistVaultHubOrigin` skips loopback / unchanged values itself.
- *
- *  2. Self-heal: even when `r.hubOrigin` resolved to loopback or undefined
- *     (e.g. the hub.port file outran the expose-state read, or this is a bare
- *     `restart vault` on a deploy whose `.env` was never written), consult
- *     `expose-state.json` directly. If it advertises a public origin and
- *     vault's persisted value is unset / loopback, write the public origin.
- *     This is what lets an EXISTING broken Cloudflare deploy self-correct on
- *     the next `parachute restart vault`, not only fresh exposes.
- *
- * Case 1 covers the override / freshly-resolved path; case 2 catches the gap
- * the Cloudflare 401 P0 fell through. See `vault-hub-origin-env.ts`.
- */
-function persistVaultHubOriginForStart(r: Resolved): void {
-  if (r.hubOrigin) persistVaultHubOrigin(r.configDir, r.hubOrigin, r.log);
-  selfHealVaultHubOrigin(r.configDir, r.log, join(r.configDir, "expose-state.json"));
+  // Phase 5b single-path (design §8 Phase 5 + Appendix). The supervised path is
+  // the ONLY runtime — the detached spawners are retired. A box without a hub
+  // unit gets the §7.5 auto-offer / actionable error, NEVER a detached spawn.
+  if (!(await requireSupervisedOrOffer(r))) return 1;
+  return startViaSupervisor(svc, r);
 }
 
 export async function stop(svc: string | undefined, opts: LifecycleOpts = {}): Promise<number> {
   const r = resolve(opts);
-  // Phase 3b dual-dispatch (design §3.3). Unit-installed → drive the supervisor
-  // / platform manager; else the unchanged detached arm below.
-  if (r.sup.unitInstalled) return stopViaSupervisor(svc, r);
-  // §7.5 auto-detect-and-offer (see `start`). On accept+migrate, re-dispatch
-  // through the supervisor path.
-  if (await maybeOfferAndMigrate(r)) return stopViaSupervisor(svc, r);
-  // --- no-unit detached fallback (unchanged; preserved until Phase 5) ---
-  if (svc === HUB_SVC) return stopHubSvc(r);
-  const picked = await resolveTargets(svc, r.manifestPath);
-  if ("error" in picked) {
-    r.log(picked.error);
-    return 1;
-  }
-
-  let failures = 0;
-  for (const { short } of picked.targets) {
-    const pid = readPid(short, r.configDir);
-    if (pid === undefined) {
-      r.log(`${short} wasn't running.`);
-      continue;
-    }
-    if (!r.alive(pid)) {
-      clearPid(short, r.configDir);
-      r.log(`${short} wasn't running (cleaned stale pid file).`);
-      continue;
-    }
-
-    try {
-      r.kill(pid, "SIGTERM");
-    } catch (err) {
-      failures++;
-      r.log(`✗ ${short}: SIGTERM failed: ${err instanceof Error ? err.message : String(err)}`);
-      continue;
-    }
-
-    const deadline = r.now() + r.killWaitMs;
-    while (r.now() < deadline && r.alive(pid)) {
-      await r.sleep(r.pollIntervalMs);
-    }
-
-    if (r.alive(pid)) {
-      r.log(`${short} didn't exit after ${r.killWaitMs}ms; sending SIGKILL.`);
-      try {
-        r.kill(pid, "SIGKILL");
-      } catch (err) {
-        failures++;
-        r.log(`✗ ${short}: SIGKILL failed: ${err instanceof Error ? err.message : String(err)}`);
-        continue;
-      }
-    }
-
-    clearPid(short, r.configDir);
-    r.log(`✓ ${short} stopped.`);
-  }
-  return failures === 0 ? 0 : 1;
+  // Phase 5b single-path: supervised is the only runtime (see `start`).
+  if (!(await requireSupervisedOrOffer(r))) return 1;
+  return stopViaSupervisor(svc, r);
 }
 
 export async function restart(svc: string | undefined, opts: LifecycleOpts = {}): Promise<number> {
   const r = resolve(opts);
-  // Phase 3b dual-dispatch (design §3.3). Unit-installed → drive the supervisor
-  // / platform manager (with the 404-fallthrough for modules, §6.2); else the
-  // unchanged detached stop-then-start below.
-  if (r.sup.unitInstalled) return restartViaSupervisor(svc, r);
-  // §7.5 auto-detect-and-offer (see `start`). On accept+migrate, re-dispatch
-  // through the supervisor path.
-  if (await maybeOfferAndMigrate(r)) return restartViaSupervisor(svc, r);
-  // --- no-unit detached fallback (unchanged; preserved until Phase 5) ---
-  // Pass `supervisor: undefined` to the inner stop/start so their own
-  // `resolveSupervisor` short-circuits to `unitInstalled: false` without
-  // re-probing `isHubUnitInstalled` (two redundant `stat`s per call) — we
-  // already resolved no-unit above, so both inner calls would re-take this
-  // same detached arm regardless. Behavior-preserving; just drops the probes.
-  //
-  // Also DISABLE the auto-migrate offer on the inner stop+start: the OUTER
-  // `restart` already ran `maybeOfferAndMigrate` above (one offer). Without this,
-  // the offer block (`migrateOffer: { enabled: true }`) flows through `...opts`
-  // into both inner calls → an operator who declines is prompted 3× (TTY) / the
-  // command is printed 3× (non-TTY). `restart` owns the single offer; the inner
-  // verbs must not re-offer.
-  const detachedOpts = { ...opts, supervisor: undefined, migrateOffer: { enabled: false } };
-  const stopCode = await stop(svc, detachedOpts);
-  if (stopCode !== 0) return stopCode;
-  return await start(svc, detachedOpts);
+  // Phase 5b single-path: supervised is the only runtime. The 404-fallthrough
+  // (a not-currently-supervised module → start, §6.2) lives in
+  // `restartViaSupervisor`, which makes `restart <svc>` total over module state
+  // just as the retired detached stop+start was.
+  if (!(await requireSupervisedOrOffer(r))) return 1;
+  return restartViaSupervisor(svc, r);
 }
 
 // ---------------------------------------------------------------------------
-// Phase 3b supervisor-path verb dispatch (design §3.3).
+// Supervisor-path verb dispatch (design §3.3) — the ONLY runtime as of Phase 5b.
 //
-// These are the NEW arm of the dual-dispatch: when a hub unit is installed,
 // `start/stop/restart` drive the RUNNING hub's in-process Supervisor over the
 // loopback module-ops API (per-module verbs) or the platform manager (hub
-// verbs / no-svc). The detached arm above is untouched and Phase 5 deletes it
-// + this comment block's `unitInstalled` guard, collapsing to this path only.
+// verbs / no-svc). The detached arm was retired in Phase 5b — a box with no hub
+// unit goes through `requireSupervisedOrOffer` (§7.5 auto-offer / actionable
+// error), never a detached spawn.
 // ---------------------------------------------------------------------------
 
 /**
@@ -1166,9 +478,13 @@ function surfaceModuleOpHttpError(short: string, err: ModuleOpHttpError, r: Reso
 /**
  * Ensure the hub unit is up, mapping `ensureHubUnit`'s structured outcome to a
  * CLI exit signal. Returns true when the hub is up (already-up / started),
- * false when it isn't (and the messages were surfaced). The `no-unit` outcome
- * shouldn't reach here under the dual-dispatch (we only take the supervisor arm
- * when a unit IS installed), but it's handled defensively.
+ * false when it isn't (and the messages were surfaced).
+ *
+ * The `no-unit` outcome shouldn't reach here: `requireSupervisedOrOffer` gates
+ * every verb on `unitInstalled === true` before dispatching to the supervisor
+ * path, which is the same `isHubUnitInstalled` probe `ensureHubUnit` uses to
+ * decide `no-unit`. The defensive arm below still surfaces any non-up outcome's
+ * messages rather than silently succeeding.
  */
 async function ensureHubForOp(r: Resolved, port: number): Promise<boolean> {
   const ensured = await r.sup.ensureHubUnit({
@@ -1177,13 +493,6 @@ async function ensureHubForOp(r: Resolved, port: number): Promise<boolean> {
     log: r.log,
   });
   if (ensured.outcome === "already-up" || ensured.outcome === "started") return true;
-  // Defensive / unreachable under dual-dispatch: this arm catches the `no-unit`
-  // outcome (and any other non-up outcome), but we only reach `ensureHubForOp`
-  // on the supervisor path, which is gated on `unitInstalled === true` — the
-  // same `isHubUnitInstalled` probe that makes `ensureHubUnit` return `no-unit`
-  // only when it's false. So `no-unit` can't surface here in production; it's
-  // harmless surface. Candidate for removal in the Phase 5 bridge-collapse —
-  // the deletion sweep should not overlook this branch.
   for (const m of ensured.messages) r.log(m);
   return false;
 }
@@ -1284,91 +593,6 @@ async function restartViaSupervisor(svc: string | undefined, r: Resolved): Promi
   if (restartRes.failed || !restartRes.result) return 1;
   r.log(`✓ ${svc} restarted.`);
   return 0;
-}
-
-/**
- * Start the internal hub. Delegates to `ensureHubRunning`, which owns the
- * port-fallback probe, the port-file write, and the issuer flag — none of
- * which fit a generic `SERVICE_SPECS` entry. The hub origin (when known)
- * doubles as the OAuth `iss` claim, so we forward it as `issuer`.
- *
- * Silences `ensureHubRunning`'s own log and emits our own `✓ hub started …`
- * line so the output matches the service-start shape (`✓ vault started
- * (pid X); logs: …`) and `stopHubSvc`'s `✓ hub stopped.` symmetry.
- */
-async function startHubSvc(r: Resolved): Promise<number> {
-  const ensureOpts: EnsureHubOpts = { configDir: r.configDir, log: () => {} };
-  if (r.hubOrigin) ensureOpts.issuer = r.hubOrigin;
-  try {
-    const result = await r.ensureHub(ensureOpts);
-    if (result.started) {
-      const logFile = logPathFor(HUB_SVC, r.configDir);
-      r.log(`✓ hub started (pid ${result.pid}) on port ${result.port}; logs: ${logFile}`);
-    } else {
-      r.log(`hub already running (pid ${result.pid}) on port ${result.port}.`);
-    }
-    // Self-heal a stale operator-token issuer (hub#481). Runs whether the hub
-    // was freshly started OR already running — a token stamped at loopback
-    // before exposure must heal even when the hub is already up. The loopback /
-    // provenance guards live inside `selfHealOperatorTokenIssuer`, so the only
-    // gate here is "is there a real issuer to heal toward?".
-    await selfHealOperatorTokenOnStart(r);
-    return 0;
-  } catch (err) {
-    r.log(`✗ hub failed to start: ${err instanceof Error ? err.message : String(err)}`);
-    return 1;
-  }
-}
-
-/**
- * Re-issue the operator token under the hub's current origin when its `iss`
- * went stale after an init-at-loopback → expose transition (hub#481). Mirrors
- * `persistVaultHubOriginForStart`'s quiet style: emit a single line only when
- * a rotation actually happens; stay silent for fresh / absent / skipped.
- *
- * The ENTIRE self-heal is wrapped here so it can NEVER block or fail
- * `start hub` — a db-open error, a corrupt token, anything — degrades to a
- * brief warning and `start hub` still returns 0.
- */
-async function selfHealOperatorTokenOnStart(r: Resolved): Promise<void> {
-  if (!r.hubOrigin) return;
-  try {
-    const status = await r.selfHealOperatorTokenFn({
-      issuer: r.hubOrigin,
-      configDir: r.configDir,
-      log: r.log,
-    });
-    if (status.kind === "rotated") {
-      r.log(`  refreshed operator.token issuer → ${r.hubOrigin} (was stale after exposure)`);
-    }
-  } catch (err) {
-    r.log(
-      `  note: operator.token issuer self-heal skipped (${
-        err instanceof Error ? err.message : String(err)
-      })`,
-    );
-  }
-}
-
-/**
- * Stop the internal hub. `stopHub` returns false when nothing was running
- * (no pidfile, or stale pidfile cleared) — that's a clean no-op for the
- * operator, so we still exit 0.
- */
-async function stopHubSvc(r: Resolved): Promise<number> {
-  try {
-    const stopped = await r.stopHubFn({
-      configDir: r.configDir,
-      log: r.log,
-      killWaitMs: r.killWaitMs,
-      pollIntervalMs: r.pollIntervalMs,
-    });
-    r.log(stopped ? "✓ hub stopped." : "hub wasn't running.");
-    return 0;
-  } catch (err) {
-    r.log(`✗ hub failed to stop: ${err instanceof Error ? err.message : String(err)}`);
-    return 1;
-  }
 }
 
 export interface LogsOpts {

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -541,7 +541,7 @@ async function stopViaSupervisor(svc: string | undefined, r: Resolved): Promise<
   // hub (do NOT ensureHubUnit just to stop one module). Only when the hub is up
   // do we drive the supervisor's stop.
   if (!(await r.sup.probeHubHealth(port))) {
-    r.log(`${svc} already stopped (the hub isn't running, so its modules are down).`);
+    r.log(`✓ ${svc} already stopped (the hub isn't running, so its modules are down).`);
     return 0;
   }
   const { httpError, failed, result } = await driveSupervisorOp(svc, "stop", r);

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,6 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
-import { HUB_SVC, readHubPort } from "../hub-control.ts";
+import { readHubPort } from "../hub-control.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import {
   HUB_UNIT_DEFAULT_PORT,
@@ -8,7 +8,6 @@ import {
   type HubUnitState,
   type HubUnitStateResult,
   defaultHubUnitDeps,
-  isHubUnitInstalled,
   queryHubUnitState as queryHubUnitStateImpl,
 } from "../hub-unit.ts";
 import {
@@ -25,20 +24,13 @@ import {
   OperatorTokenExpiredError,
   fetchModuleStates as fetchModuleStatesImpl,
 } from "../module-ops-client.ts";
-import { type AliveFn, defaultAlive, formatUptime, processState } from "../process-state.ts";
 import { canonicalPortForManifest, getSpec, shortNameForManifest } from "../service-spec.ts";
 import { type ServiceEntry, readManifest } from "../services-manifest.ts";
 
-export type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
-
 export interface StatusOpts {
   manifestPath?: string;
-  fetchImpl?: FetchFn;
   print?: (line: string) => void;
-  timeoutMs?: number;
   configDir?: string;
-  alive?: AliveFn;
-  now?: () => Date;
   /**
    * Test seam for install-source detection. Production reads the filesystem
    * + shells out to git; tests inject stubs so each case (npm / bun-linked /
@@ -53,32 +45,19 @@ export interface StatusOpts {
    */
   hubSrcDir?: string;
   /**
-   * Phase 3c supervisor-path seams (design §6.4). When a hub UNIT is installed
-   * (launchd/systemd/container — detected via {@link isHubUnitInstalled}),
+   * Supervisor-path seams (design §6.4) — the ONLY runtime as of Phase 5b.
    * `status` reads the hub row from the PLATFORM MANAGER (`queryHubUnitState`)
    * + `/health`, and the module rows from the RUNNING supervisor (`GET
-   * /api/modules` via the operator-token→Bearer path). On a legacy detached box
-   * (no hub unit) it keeps the EXACT pidfile/`processState` behavior, unchanged
-   * until Phase 5 retires it.
+   * /api/modules` via the operator-token→Bearer path). The detached
+   * pidfile/`processState` arm was retired in Phase 5b.
    *
-   * Everything here is injectable so tests force either arm without a real
+   * Everything here is injectable so tests drive it without a real
    * launchd/systemd/socket/HTTP call. Production wires the real machinery; the
    * read paths are bounded + degrade gracefully on every failure (no manager,
    * hub down, no token, API error) so `status` never hangs or crashes.
    */
   supervisor?: {
-    /**
-     * Is a hub unit installed (the dual-dispatch discriminant)? Production uses
-     * `isHubUnitInstalled(hubUnitDeps)`. Tests set this `true`/`false` directly
-     * to pick the branch deterministically. When set, it wins over the
-     * `hubUnitDeps`-derived detection.
-     *
-     * Defaulting: when the caller OMITS the `supervisor` block entirely (every
-     * existing status test), the arm defaults to detached — so those tests stay
-     * deterministic regardless of whether the test host has a real hub unit.
-     */
-    unitInstalled?: boolean;
-    /** Deps for `isHubUnitInstalled` + `queryHubUnitState` + the `/health` probe. */
+    /** Deps for `queryHubUnitState` + the `/health` probe. */
     hubUnitDeps?: HubUnitDeps;
     /** Query the platform manager for the hub unit's run-state (§6.4 hub row). */
     queryHubUnitState?: (deps: HubUnitDeps) => HubUnitStateResult;
@@ -100,54 +79,6 @@ export interface StatusOpts {
     /** Loopback hub base URL override (default derives from the hub port). */
     baseUrl?: string;
   };
-}
-
-export interface ProbeResult {
-  entry: ServiceEntry;
-  healthy: boolean;
-  statusCode?: number;
-  error?: string;
-  latencyMs: number;
-}
-
-export async function probe(
-  entry: ServiceEntry,
-  fetchImpl: FetchFn,
-  timeoutMs: number,
-): Promise<ProbeResult> {
-  const url = `http://localhost:${entry.port}${entry.health}`;
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  const start = performance.now();
-  try {
-    const res = await fetchImpl(url, { signal: controller.signal });
-    const latencyMs = Math.round(performance.now() - start);
-    // A 401 is the service replying "I'm up but this endpoint requires auth"
-    // — that's strictly healthy from a liveness perspective. Vault's
-    // canonical health path `/vault/<name>/health` is auth-gated; without
-    // this carve-out, `parachute status` shows vault as "failing" on every
-    // fresh install (first impression UX disaster despite vault being fine).
-    // 5xx → unhealthy; 200-class → healthy; 401 → healthy + auth-gated.
-    // Other 4xx (404 / 400 / etc.) still count as unhealthy — those mean
-    // the configured health path doesn't exist or is shaped wrong.
-    const healthy = res.ok || res.status === 401;
-    return {
-      entry,
-      healthy,
-      statusCode: res.status,
-      latencyMs,
-    };
-  } catch (err) {
-    const latencyMs = Math.round(performance.now() - start);
-    return {
-      entry,
-      healthy: false,
-      error: err instanceof Error ? err.message : String(err),
-      latencyMs,
-    };
-  } finally {
-    clearTimeout(timer);
-  }
 }
 
 function formatRow(cells: string[], widths: number[]): string {
@@ -247,15 +178,11 @@ function urlForEntry(entry: ServiceEntry, short: string | undefined): string | u
 }
 
 /**
- * The MANIFEST-derived portion of a module row — identical regardless of
- * whether the row's run-state comes from a pidfile (detached arm) or the
- * supervisor (Phase 3c). Extracting it keeps the two arms in lockstep on
- * port/version/URL/drift/source/stale and the persisted `lastStartError` note,
- * so the only per-arm difference is the run-state fields (STATE / PID / UPTIME).
+ * The MANIFEST-derived portion of a module row — port/version/URL/drift/source/
+ * stale and the persisted `lastStartError` note. The supervisor read fills in
+ * the run-state fields (STATE / PID / UPTIME) on top.
  *
- * Pure over the manifest entry + install-source deps; no process / network
- * read. Shared so the detached arm stays behavior-identical (existing tests
- * guard it) while the supervisor arm reuses the exact same derivation.
+ * Pure over the manifest entry + install-source deps; no process / network read.
  */
 interface ManifestRowBase {
   short: string | undefined;
@@ -310,197 +237,32 @@ function manifestRowBase(
   return { short, url, driftWarning, sourceLabel, staleNote, manifestStartErrorNote };
 }
 
-function hubRow(
-  configDir: string,
-  alive: AliveFn,
-  nowDate: Date,
-  hubSrcDir: string,
-  installSourceDeps: DetectInstallSourceDeps,
-): StatusRow | undefined {
-  const proc = processState(HUB_SVC, configDir, alive);
-  if (proc.status === "unknown") return undefined;
-  const port = readHubPort(configDir);
-  const portLabel = port !== undefined ? String(port) : "-";
-  // Hub doesn't self-probe (it'd be probing itself over loopback). Treat
-  // "running pidfile" as `active` and "stopped" as `inactive` — the same
-  // STATE rollup every other row uses, just without the probe input.
-  const stateLabel: StateLabel = proc.status === "running" ? "active" : "inactive";
-  const pidLabel = proc.status === "running" && proc.pid !== undefined ? String(proc.pid) : "-";
-  const uptimeLabel =
-    proc.status === "running" && proc.startedAt ? formatUptime(proc.startedAt, nowDate) : "-";
-  const source = detectHubInstallSource(hubSrcDir, installSourceDeps);
-  return {
-    service: "parachute-hub (internal)",
-    port: portLabel,
-    version: source.livePackageVersion ?? "-",
-    stateLabel,
-    pidLabel,
-    uptimeLabel,
-    healthDetail: "-",
-    latencyLabel: "-",
-    sourceLabel: formatInstallSourceLabel(source),
-    url: port !== undefined ? `http://127.0.0.1:${port}` : undefined,
-    healthy: true,
-    skipped: true,
-  };
-}
-
 export async function status(opts: StatusOpts = {}): Promise<number> {
   const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
-  const fetchImpl = opts.fetchImpl ?? fetch;
   const print = opts.print ?? ((line) => console.log(line));
-  const timeoutMs = opts.timeoutMs ?? 1500;
   const configDir = opts.configDir ?? CONFIG_DIR;
-  const alive = opts.alive ?? defaultAlive;
-  const now = opts.now ?? (() => new Date());
   const installSourceDeps = opts.installSourceDeps ?? {};
   const hubSrcDir = opts.hubSrcDir ?? import.meta.dir;
 
   const manifest = readManifest(manifestPath);
 
-  // Phase 3c dual-dispatch (design §6.4). On a box with a hub unit installed
-  // (launchd/systemd/container), read the hub row from the platform manager +
-  // `/health` and the module rows from the RUNNING supervisor; otherwise fall
-  // through to the unchanged detached arm below. Phase 5 deletes the else-arm —
-  // keep this a clean top-level branch so that deletion is a one-liner.
-  //
-  // Branched BEFORE the detached arm's empty-manifest early return: on a
-  // unit-managed box the hub row is meaningful even with zero modules installed
-  // (the hub IS running under a unit), so the supervisor arm renders the hub row
-  // + a "no modules" table rather than the detached "No services installed yet."
+  // Supervised path only (Phase 5b — the detached pidfile arm is retired). Read
+  // the hub row from the platform manager + `/health` and the module rows from
+  // the RUNNING supervisor (§6.4). The hub row is meaningful even with zero
+  // modules installed (the hub runs under a unit), so a "no modules" table is
+  // rendered rather than the old "No services installed yet." early return.
   const sup = resolveStatusSupervisor(opts.supervisor);
-  if (sup.unitInstalled) {
-    const rows = await buildSupervisorRows({
-      manifest,
-      configDir,
-      installSourceDeps,
-      hubSrcDir,
-      sup,
-    });
-    renderRows(rows, print);
-    // The supervisor arm marks a row `healthy: false` + `!skipped` only when the
-    // supervisor (or the hub-row manager/health composition) says so (crashed /
-    // failing) — same exit contract as the detached arm: a stopped/inactive row
-    // is expected (skipped, exit 0), a `failing` one exits 1.
-    const anyUnhealthy = rows.some((r) => !r.skipped && !r.healthy);
-    return anyUnhealthy ? 1 : 0;
-  }
-  // --- no-unit detached fallback (unchanged; preserved until Phase 5) ---
-
-  if (manifest.services.length === 0) {
-    print("No services installed yet.");
-    print("Try: parachute install vault");
-    return 0;
-  }
-
-  const nowDate = now();
-
-  /**
-   * Per-row resolution: look up the short name so we can read PID state,
-   * skip the health probe when the process is known-stopped (ECONNREFUSED
-   * noise isn't informative), and report it as running/stopped + uptime.
-   *
-   * Third-party services we don't know about fall back to probing and show
-   * "-" for process columns.
-   */
-  const rows: StatusRow[] = await Promise.all(
-    manifest.services.map(async (entry) => {
-      // MANIFEST-derived fields shared with the supervisor arm (port/version/
-      // URL/drift/source/stale + the persisted lastStartError note).
-      const {
-        short,
-        url,
-        driftWarning,
-        sourceLabel,
-        staleNote,
-        manifestStartErrorNote: startErrorNote,
-      } = manifestRowBase(entry, installSourceDeps);
-      const proc = short ? processState(short, configDir, alive) : undefined;
-
-      const pidLabel =
-        proc?.status === "running" && proc.pid !== undefined ? String(proc.pid) : "-";
-      const uptimeLabel =
-        proc?.status === "running" && proc.startedAt ? formatUptime(proc.startedAt, nowDate) : "-";
-
-      // Only skip probe when we know the process is dead (PID file was
-      // present but kill(pid, 0) failed). "unknown" status (no PID file)
-      // still probes — externally-managed services should report health.
-      if (proc?.status === "stopped") {
-        return {
-          service: entry.name,
-          port: String(entry.port),
-          version: entry.version,
-          // Operator deliberately stopped (or pidfile-but-dead) maps to
-          // `inactive` per design-system.md §6 — same surface as "never
-          // started." No probe is informative when we know the process
-          // is dead.
-          stateLabel: "inactive",
-          pidLabel,
-          uptimeLabel,
-          healthDetail: "-",
-          latencyLabel: "-",
-          sourceLabel,
-          url,
-          healthy: false,
-          skipped: true,
-          driftWarning,
-          staleNote,
-          startErrorNote,
-        };
-      }
-
-      const p = await probe(entry, fetchImpl, timeoutMs);
-      const healthDetail = p.healthy
-        ? "ok"
-        : p.statusCode !== undefined
-          ? `http ${p.statusCode}`
-          : (p.error ?? "down");
-      // STATE rollup per design-system.md §6:
-      //   - probe ok                  → `active`
-      //   - probe failed              → `failing` (the probe ran, so the
-      //                                 process is up enough to answer or
-      //                                 refuse — it's failing, not stopped)
-      //   - no PID file + probe fails → `failing` too (externally-managed
-      //                                 row that's down is still "failing"
-      //                                 from the operator's view)
-      // The `pending` state isn't reachable from `parachute status` today
-      // — pending-OAuth surfaces in the admin SPA, not the CLI. If a
-      // future surface adds it (e.g. supervisor reports `pending-config`
-      // for unconfigured modules), wire it here.
-      const stateLabel: StateLabel = p.healthy ? "active" : "failing";
-      return {
-        service: entry.name,
-        port: String(entry.port),
-        version: entry.version,
-        stateLabel,
-        pidLabel,
-        uptimeLabel,
-        healthDetail,
-        latencyLabel: `${p.latencyMs}ms`,
-        sourceLabel,
-        url,
-        healthy: p.healthy,
-        skipped: false,
-        driftWarning,
-        staleNote,
-        startErrorNote,
-      };
-    }),
-  );
-
-  // Hub is an internal service — not in services.json, but users notice
-  // when it's dead. Only show it if we've seen it run.
-  const hub = hubRow(configDir, alive, nowDate, hubSrcDir, installSourceDeps);
-  if (hub) rows.push(hub);
-
+  const rows = await buildSupervisorRows({
+    manifest,
+    configDir,
+    installSourceDeps,
+    hubSrcDir,
+    sup,
+  });
   renderRows(rows, print);
-
-  /**
-   * Overall exit: non-zero if any *probed* service is unhealthy. A stopped
-   * service is expected ("I haven't started it yet"), not a failure — users
-   * want `parachute status` to return 0 after a fresh install before they
-   * `parachute start`. Health regressions among running services still 1.
-   */
+  // A row is `healthy: false` + `!skipped` only when the supervisor (or the
+  // hub-row manager/health composition) says so (crashed / failing). A
+  // stopped/inactive row is expected (skipped, exit 0); a `failing` one exits 1.
   const anyUnhealthy = rows.some((r) => !r.skipped && !r.healthy);
   return anyUnhealthy ? 1 : 0;
 }
@@ -563,20 +325,18 @@ function renderRows(rows: StatusRow[], print: (line: string) => void): void {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 3c supervisor-path status (design §6.4).
+// Supervisor-path status (design §6.4) — the ONLY runtime as of Phase 5b.
 //
-// When a hub unit is installed, `status` reads the hub row from the PLATFORM
-// MANAGER (`queryHubUnitState`) + a `/health` probe, and the module rows from
-// the RUNNING supervisor (`GET /api/modules` via the operator-token→Bearer
-// path). Every read is bounded + degrades gracefully — `status` is a
-// diagnostic and must NEVER hang or crash regardless of hub/manager/token
-// state. The detached arm above is untouched; Phase 5 deletes it.
+// `status` reads the hub row from the PLATFORM MANAGER (`queryHubUnitState`) +
+// a `/health` probe, and the module rows from the RUNNING supervisor (`GET
+// /api/modules` via the operator-token→Bearer path). Every read is bounded +
+// degrades gracefully — `status` is a diagnostic and must NEVER hang or crash
+// regardless of hub/manager/token state. The detached pidfile arm was retired
+// in Phase 5b.
 // ---------------------------------------------------------------------------
 
-/** Resolved Phase 3c supervisor-path seams (see `StatusOpts.supervisor`). */
+/** Resolved supervisor-path seams (see `StatusOpts.supervisor`). */
 interface ResolvedStatusSupervisor {
-  /** Whether a hub unit is installed — the dual-dispatch discriminant. */
-  unitInstalled: boolean;
   hubUnitDeps: HubUnitDeps;
   queryHubUnitState: (deps: HubUnitDeps) => HubUnitStateResult;
   probeHubHealth: (port: number) => Promise<boolean>;
@@ -586,19 +346,12 @@ interface ResolvedStatusSupervisor {
 }
 
 /**
- * Resolve the Phase 3c supervisor-path seams. Mirrors lifecycle.ts's
- * `resolveSupervisor` discriminant policy:
- *   - No `supervisor` block at all (every existing status test) → detached arm,
- *     deterministically (no real-filesystem probe).
- *   - A `supervisor` block present → explicit `unitInstalled` override if set,
- *     else the real `isHubUnitInstalled` probe over the hub-unit deps.
+ * Resolve the supervisor-path seams. Production passes `supervisor: {}` (or
+ * omits it) and gets the real impls; tests inject the seams they want to assert.
  */
 function resolveStatusSupervisor(opts: StatusOpts["supervisor"]): ResolvedStatusSupervisor {
   const hubUnitDeps = opts?.hubUnitDeps ?? defaultHubUnitDeps;
-  const unitInstalled =
-    opts === undefined ? false : (opts.unitInstalled ?? isHubUnitInstalled(hubUnitDeps));
   return {
-    unitInstalled,
     hubUnitDeps,
     queryHubUnitState: opts?.queryHubUnitState ?? queryHubUnitStateImpl,
     probeHubHealth: opts?.probeHubHealth ?? hubUnitDeps.probeHealth,

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -574,13 +574,18 @@ function readPackageVersion(pkgJsonPath: string): string | null {
  *     returns once the restart is dispatched; it does not need to outlive the
  *     old hub.
  *   - MODULE target → drive the running Supervisor by handing `lifecycle.restart`
- *     a `supervisor` block (its own dispatch then routes to `supervisor.restart`
- *     with the 404-fallthrough). The hub unit was already restarted hub-first in
- *     the sweep, so it's up to answer.
+ *     the SAME opts a bare `parachute restart <svc>` threads: `supervisor: {}`
+ *     (so the real `isHubUnitInstalled` probe — not a forced override — decides)
+ *     plus `migrateOffer: { enabled: true }`. Its dispatch then routes to
+ *     `supervisor.restart` with the 404-fallthrough. The hub unit was already
+ *     restarted hub-first in the sweep, so it's up to answer.
  *
  * A box with no hub unit takes the actionable migrate path: the hub-target
  * `restartHubUnit` returns `no-unit` (messages surfaced, non-zero), and the
- * module-target `lifecycle.restart` runs its own §7.5 no-unit handling.
+ * module-target `lifecycle.restart` — driven with `supervisor: {}` +
+ * `migrateOffer` — runs `requireSupervisedOrOffer`'s real probe, then the §7.5
+ * auto-offer / actionable "run `parachute migrate --to-supervised`" error,
+ * rather than a bare connection-refused from `driveModuleOp`.
  */
 async function restartTarget(target: ResolvedTarget, r: Resolved): Promise<number> {
   if (target.short === HUB_SVC) {
@@ -592,13 +597,19 @@ async function restartTarget(target: ResolvedTarget, r: Resolved): Promise<numbe
     }
     return 1;
   }
-  // Module target: route through lifecycle's supervisor arm. Passing a
-  // `supervisor` block with `unitInstalled: true` drives `supervisor.restart`
-  // over the loopback module-ops API.
+  // Module target: route through lifecycle's supervisor arm with the SAME opts a
+  // bare `parachute restart <svc>` threads — `supervisor: {}` (let the real
+  // `isHubUnitInstalled` probe decide; do NOT force `unitInstalled: true` and
+  // bypass it) plus `migrateOffer: { enabled: true }`. On a supervised box this
+  // drives `supervisor.restart` over the loopback module-ops API; on a no-unit
+  // box it gets the §7.5 auto-offer / actionable migrate error instead of a bare
+  // connection-refused. `hubUnitDeps` threads through so the real probe + manager
+  // ops use the resolved deps (production defaults; tests inject the seams).
   return await r.restartFn(target.short, {
     manifestPath: r.manifestPath,
     configDir: r.configDir,
-    supervisor: { unitInstalled: true, hubUnitDeps: r.hubUnitDeps },
+    supervisor: { hubUnitDeps: r.hubUnitDeps },
+    migrateOffer: { enabled: true },
   });
 }
 

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -55,7 +55,6 @@ import {
   type HubUnitDeps,
   type HubUnitManagerOpResult,
   defaultHubUnitDeps,
-  isHubUnitInstalled,
   restartHubUnit as restartHubUnitImpl,
 } from "../hub-unit.ts";
 import { ModuleManifestError } from "../module-manifest.ts";
@@ -209,26 +208,20 @@ export interface UpgradeOpts {
    */
   resolveChannelVersion?: (pkg: string, channel: string) => Promise<string | null>;
   /**
-   * Phase 4 supervisor-path seams (design §5). When a hub UNIT is installed
-   * (launchd/systemd/container — detected via `isHubUnitInstalled`), `upgrade
-   * hub` rewrites the binary as usual then RESTARTS THE UNIT via the platform
-   * manager (`restartHubUnit` — systemctl restart / launchctl kickstart -k),
-   * NOT the detached `stopHub`/`ensureHubRunning` restart: the manager tears
-   * down the old hub (children die), starts the new binary, which re-boots
-   * every module from services.json. Module-target restarts on the unit arm
-   * drive the running Supervisor (lifecycle's own Phase-3b dual-dispatch, fed a
-   * `supervisor` block here). The detached arm (`restartFn` → stopHub/
-   * ensureHubRunning) remains the no-unit fallback until Phase 5.
+   * Supervisor-path seams (design §5) — the ONLY runtime as of Phase 5b.
+   * `upgrade hub` rewrites the binary as usual then RESTARTS THE UNIT via the
+   * platform manager (`restartHubUnit` — systemctl restart / launchctl kickstart
+   * -k): the manager tears down the old hub (children die), starts the new
+   * binary, which re-boots every module from services.json. NEVER a PID-signal
+   * restart (launchd KeepAlive / systemd Restart=always would fight). Module-
+   * target restarts drive the running Supervisor (lifecycle's own dispatch, fed
+   * a `supervisor` block here). The detached restart arm was retired in Phase 5b.
    *
-   * Production CLI dispatch passes `supervisor: {}` so the real
-   * `isHubUnitInstalled` probe decides the arm; omitting it is the detached arm
-   * deterministically (the shape of every existing upgrade test). When set,
-   * `unitInstalled` wins over the `hubUnitDeps`-derived detection.
+   * Production CLI dispatch passes `supervisor: {}`; tests inject the seams they
+   * want to assert.
    */
   supervisor?: {
-    /** Dual-dispatch discriminant override; else the real `isHubUnitInstalled`. */
-    unitInstalled?: boolean;
-    /** Deps for the `isHubUnitInstalled` probe + the `restartHubUnit` manager op. */
+    /** Deps for the `restartHubUnit` manager op. */
     hubUnitDeps?: HubUnitDeps;
     /** Restart the hub unit via the platform manager (never a PID signal, §5). */
     restartHubUnit?: (deps: HubUnitDeps) => HubUnitManagerOpResult;
@@ -258,8 +251,6 @@ interface Resolved {
   channelOverride: "rc" | "latest" | undefined;
   allowDowngrade: boolean;
   resolveChannelVersion: (pkg: string, channel: string) => Promise<string | null>;
-  /** Phase 4 dual-dispatch: is a hub unit installed? */
-  unitInstalled: boolean;
   hubUnitDeps: HubUnitDeps;
   restartHubUnit: (deps: HubUnitDeps) => HubUnitManagerOpResult;
 }
@@ -294,26 +285,19 @@ function resolve(opts: UpgradeOpts): Resolved {
     allowDowngrade: opts.allowDowngrade ?? false,
     resolveChannelVersion:
       opts.resolveChannelVersion ?? ((pkg, channel) => npmViewVersion(pkg, channel, runner)),
-    // Phase 4 dual-dispatch: same discriminant shape as lifecycle's
-    // `resolveSupervisor`. A `supervisor` block (even `{}`) opts into the real
-    // `isHubUnitInstalled` probe; omitting it entirely is the detached arm
-    // deterministically (every existing upgrade test).
+    // Supervisor seams (the only runtime as of Phase 5b). Production passes
+    // `supervisor: {}`; tests inject the seams they want to assert.
     ...resolveUpgradeSupervisor(opts.supervisor),
   };
 }
 
-/** Resolve the Phase 4 supervisor seams for the upgrade path. */
+/** Resolve the supervisor seams for the upgrade path. */
 function resolveUpgradeSupervisor(opts: UpgradeOpts["supervisor"]): {
-  unitInstalled: boolean;
   hubUnitDeps: HubUnitDeps;
   restartHubUnit: (deps: HubUnitDeps) => HubUnitManagerOpResult;
 } {
-  const hubUnitDeps = opts?.hubUnitDeps ?? defaultHubUnitDeps;
-  const unitInstalled =
-    opts === undefined ? false : (opts.unitInstalled ?? isHubUnitInstalled(hubUnitDeps));
   return {
-    unitInstalled,
-    hubUnitDeps,
+    hubUnitDeps: opts?.hubUnitDeps ?? defaultHubUnitDeps,
     restartHubUnit: opts?.restartHubUnit ?? restartHubUnitImpl,
   };
 }
@@ -581,44 +565,41 @@ function readPackageVersion(pkgJsonPath: string): string | null {
 
 /**
  * Restart an upgraded target after its binary/package was rewritten (design §5).
- * Dual-dispatch:
- *   - Unit-managed + HUB target → restart the hub UNIT via the platform manager
+ * Supervised path only (Phase 5b — the detached restart arm is retired):
+ *   - HUB target → restart the hub UNIT via the platform manager
  *     (`restartHubUnit` — systemctl restart / launchctl kickstart -k). The
  *     manager tears down the old hub (children die), starts the new binary,
- *     which re-boots every module from services.json. NEVER stopHub/ensureHub
- *     (a PID-signal restart launchd KeepAlive / systemd Restart=always would
- *     fight). The command returns once the restart is dispatched; it does not
- *     need to outlive the old hub.
- *   - Unit-managed + MODULE target → drive the running Supervisor by handing
- *     `lifecycle.restart` a `supervisor` block (its own Phase-3b dual-dispatch
- *     then routes to `supervisor.restart` with the 404-fallthrough). The hub
- *     unit was already restarted hub-first in the sweep, so it's up to answer.
- *   - No unit (detached) → the unchanged `restartFn` (default `lifecycle.restart`
- *     → stopHub/ensureHubRunning for hub, detached stop+start for modules).
- *     Phase 5 deletes this branch.
+ *     which re-boots every module from services.json. NEVER a PID-signal restart
+ *     (launchd KeepAlive / systemd Restart=always would fight). The command
+ *     returns once the restart is dispatched; it does not need to outlive the
+ *     old hub.
+ *   - MODULE target → drive the running Supervisor by handing `lifecycle.restart`
+ *     a `supervisor` block (its own dispatch then routes to `supervisor.restart`
+ *     with the 404-fallthrough). The hub unit was already restarted hub-first in
+ *     the sweep, so it's up to answer.
+ *
+ * A box with no hub unit takes the actionable migrate path: the hub-target
+ * `restartHubUnit` returns `no-unit` (messages surfaced, non-zero), and the
+ * module-target `lifecycle.restart` runs its own §7.5 no-unit handling.
  */
 async function restartTarget(target: ResolvedTarget, r: Resolved): Promise<number> {
-  if (r.unitInstalled) {
-    if (target.short === HUB_SVC) {
-      const res = r.restartHubUnit(r.hubUnitDeps);
-      for (const m of res.messages) r.log(m);
-      if (res.outcome === "ok") {
-        r.log(`${target.short}: restarted the hub unit (all modules re-booted).`);
-        return 0;
-      }
-      return 1;
+  if (target.short === HUB_SVC) {
+    const res = r.restartHubUnit(r.hubUnitDeps);
+    for (const m of res.messages) r.log(m);
+    if (res.outcome === "ok") {
+      r.log(`${target.short}: restarted the hub unit (all modules re-booted).`);
+      return 0;
     }
-    // Module target: route through lifecycle's supervisor arm. Passing
-    // `supervisor: {}` makes `lifecycle.restart` probe `isHubUnitInstalled`
-    // (true here) and drive `supervisor.restart` over the loopback module-ops
-    // API instead of a detached stop+start.
-    return await r.restartFn(target.short, {
-      manifestPath: r.manifestPath,
-      configDir: r.configDir,
-      supervisor: { unitInstalled: true, hubUnitDeps: r.hubUnitDeps },
-    });
+    return 1;
   }
-  return await r.restartFn(target.short, { manifestPath: r.manifestPath, configDir: r.configDir });
+  // Module target: route through lifecycle's supervisor arm. Passing a
+  // `supervisor` block with `unitInstalled: true` drives `supervisor.restart`
+  // over the loopback module-ops API.
+  return await r.restartFn(target.short, {
+    manifestPath: r.manifestPath,
+    configDir: r.configDir,
+    supervisor: { unitInstalled: true, hubUnitDeps: r.hubUnitDeps },
+  });
 }
 
 async function upgradeLinked(

--- a/src/hub-control.ts
+++ b/src/hub-control.ts
@@ -1,30 +1,21 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { CONFIG_DIR } from "./config.ts";
-import { hubDbPath } from "./hub-db.ts";
-import {
-  type AliveFn,
-  clearPid,
-  defaultAlive,
-  ensureLogPath,
-  readPid,
-  runDir,
-  writePid,
-} from "./process-state.ts";
-import { WELL_KNOWN_DIR } from "./well-known.ts";
+import { type AliveFn, clearPid, defaultAlive, readPid, runDir } from "./process-state.ts";
 
 /**
- * Lifecycle for the internal hub HTTP server. The hub is *not* a user-facing
- * service (not in services.json) — it's an implementation detail of
- * `parachute expose`, spawned implicitly on bringup and torn down on the
- * final teardown.
+ * Hub identity + port helpers + `stopHub` (the detached-stop path the migrate
+ * cutover still uses). The hub is *not* a user-facing service (not in
+ * services.json). Phase 5b retired the detached `ensureHubRunning` bringup — the
+ * hub now runs under a platform unit (`parachute serve`, see `hub-unit.ts` /
+ * `managed-unit.ts`); `init` brings it up via `installAndStartHubUnit`. This
+ * file keeps `stopHub` (used by `migrate` to stop a legacy detached hub during
+ * the cutover) + the canonical-port readers/writers.
  *
  * The hub lives under `svc = "hub"` in the process-state world, so its PID,
- * logs, and runtime files land at `~/.parachute/hub/{run,logs}/…` alongside
- * every other managed service.
+ * logs, and runtime files land at `~/.parachute/hub/{run,logs}/…`.
  */
 
 export const HUB_SVC = "hub";
@@ -38,14 +29,6 @@ export const HUB_DEFAULT_PORT = 1939;
  * detection (`hub-upgrade-mode.ts`) can't drift on the magic path.
  */
 export const CONTAINER_HOME = "/parachute";
-/**
- * Default fallback range is 1 — the hub binds 1939 or fails. Walking up would
- * steal another Parachute service's slot from the canonical 1939–1949 range.
- * Tests and debug tooling can pass a larger `fallbackRange` explicitly.
- */
-export const HUB_PORT_FALLBACK_RANGE = 1;
-
-const HUB_SERVER_PATH = fileURLToPath(new URL("./hub-server.ts", import.meta.url));
 
 export function hubPortPath(configDir: string = CONFIG_DIR): string {
   return join(runDir(HUB_SVC, configDir), `${HUB_SVC}.port`);
@@ -69,29 +52,6 @@ export function clearHubPort(configDir: string = CONFIG_DIR): void {
   const p = hubPortPath(configDir);
   if (existsSync(p)) rmSync(p, { force: true });
 }
-
-/**
- * Seam over `Bun.spawn`, mirroring the lifecycle Spawner — tests never want
- * to actually fork a process. The real implementation opens the log file,
- * pipes stdout+stderr into it, and detaches.
- */
-export interface HubSpawner {
-  spawn(cmd: readonly string[], logFile: string): number;
-}
-
-export const defaultHubSpawner: HubSpawner = {
-  spawn(cmd, logFile) {
-    const fd = openSync(logFile, "a");
-    // Inherit env so the hub child process sees PATH, HOME, PARACHUTE_HOME,
-    // etc. Bun.spawn defaults to empty env — see api-modules-ops.ts.
-    const proc = Bun.spawn([...cmd], {
-      stdio: ["ignore", fd, fd],
-      env: process.env,
-    });
-    proc.unref();
-    return proc.pid;
-  },
-};
 
 export type HubPortProbe = (port: number) => Promise<boolean>;
 export type KillFn = (pid: number, signal: NodeJS.Signals | number) => void;
@@ -159,124 +119,17 @@ export const defaultPortProbe: HubPortProbe = (port) =>
     server.listen(port, "127.0.0.1");
   });
 
+/**
+ * Ensure-hub options shape. Phase 5b retired the detached `ensureHubRunning`
+ * spawn this used to drive; `init`'s `defaultEnsureHubViaUnit` (hub-unit-backed)
+ * reuses this opts shape for its parameter signature. Only `configDir` /
+ * `startPort` / `log` are read on that path.
+ */
 export interface EnsureHubOpts {
   configDir?: string;
-  wellKnownDir?: string;
-  spawner?: HubSpawner;
-  alive?: AliveFn;
-  probe?: HubPortProbe;
-  sleep?: SleepFn;
-  /**
-   * Look up the PID listening on `port`. Production default uses `lsof`;
-   * tests inject a stub. Used to report which orphan process is holding
-   * the canonical hub port when the bind probe fails — so the operator
-   * has a concrete PID to point `parachute restart hub` at, not just an
-   * "unavailable" error. See hub#287.
-   */
-  pidOnPort?: PidOnPortFn;
-  /** Starting port (default 1939). First port that probe()s true wins. */
+  /** Starting port (default 1939). */
   startPort?: number;
-  /** How many ports to try before giving up (default 20). */
-  fallbackRange?: number;
-  /**
-   * Ports to skip during fallback — typically service ports from services.json
-   * so the hub doesn't steal a port a registered service will bind later.
-   * Probed ports that happen to be listening still fail the probe on their own;
-   * this guards the case where the service isn't running yet.
-   */
-  reservedPorts?: Iterable<number>;
-  /** How long to wait after spawn before claiming readiness. Short — tests set to 0. */
-  readyWaitMs?: number;
-  /**
-   * Public origin to use as the OAuth `iss` claim and as the base for the
-   * authorization-server metadata document. Forwarded to the hub server as
-   * `--issuer <url>`. When omitted, the hub falls back to the request's own
-   * origin — fine for loopback testing, wrong under tailscale where the
-   * request origin is `http://127.0.0.1:<port>`.
-   */
-  issuer?: string;
   log?: (line: string) => void;
-}
-
-export interface EnsureHubResult {
-  pid: number;
-  port: number;
-  /** True when this call spawned the hub; false when it was already running. */
-  started: boolean;
-}
-
-export async function ensureHubRunning(opts: EnsureHubOpts = {}): Promise<EnsureHubResult> {
-  const configDir = opts.configDir ?? CONFIG_DIR;
-  const wellKnownDir = opts.wellKnownDir ?? WELL_KNOWN_DIR;
-  const spawner = opts.spawner ?? defaultHubSpawner;
-  const alive = opts.alive ?? defaultAlive;
-  const probe = opts.probe ?? defaultPortProbe;
-  const sleep = opts.sleep ?? defaultSleep;
-  const pidOnPort = opts.pidOnPort ?? defaultPidOnPort;
-  const startPort = opts.startPort ?? HUB_DEFAULT_PORT;
-  const fallbackRange = opts.fallbackRange ?? HUB_PORT_FALLBACK_RANGE;
-  const reservedPorts = new Set(opts.reservedPorts ?? []);
-  const readyWaitMs = opts.readyWaitMs ?? 150;
-  const log = opts.log ?? (() => {});
-
-  const existingPid = readPid(HUB_SVC, configDir);
-  const existingPort = readHubPort(configDir);
-  if (existingPid !== undefined && alive(existingPid) && existingPort !== undefined) {
-    return { pid: existingPid, port: existingPort, started: false };
-  }
-  // Any stale state (pid without live process, port without pid) — wipe.
-  if (existingPid !== undefined) clearPid(HUB_SVC, configDir);
-  clearHubPort(configDir);
-
-  let chosenPort: number | undefined;
-  for (let i = 0; i < fallbackRange; i++) {
-    const candidate = startPort + i;
-    if (reservedPorts.has(candidate)) continue;
-    if (await probe(candidate)) {
-      chosenPort = candidate;
-      break;
-    }
-  }
-  if (chosenPort === undefined) {
-    // Port is held by *something*. If we can name the PID (lsof on macOS /
-    // Linux), point the operator at `parachute restart hub` — which now
-    // detects and kills the orphan even when hub.port is missing or stale
-    // (hub#287). Without a PID, fall back to the classic lsof hint.
-    const range =
-      fallbackRange === 1 ? `${startPort}` : `${startPort}..${startPort + fallbackRange - 1}`;
-    const orphanPid = fallbackRange === 1 ? pidOnPort(startPort) : undefined;
-    if (orphanPid !== undefined) {
-      throw new Error(
-        `hub: port ${range} unavailable — PID ${orphanPid} is already listening. Run \`parachute restart hub\` to clean up and restart, or \`kill ${orphanPid}\` then \`parachute start hub\`.`,
-      );
-    }
-    throw new Error(
-      `hub: port ${range} unavailable. Run \`lsof -iTCP:${startPort}\` to find what's using it, or pass --hub-port to override.`,
-    );
-  }
-
-  const logFile = ensureLogPath(HUB_SVC, configDir);
-  const cmd = [
-    "bun",
-    HUB_SERVER_PATH,
-    "--port",
-    String(chosenPort),
-    "--well-known-dir",
-    wellKnownDir,
-    "--db",
-    hubDbPath(configDir),
-    ...(opts.issuer ? ["--issuer", opts.issuer] : []),
-  ];
-  const pid = spawner.spawn(cmd, logFile);
-  writePid(HUB_SVC, pid, configDir);
-  writeHubPort(chosenPort, configDir);
-
-  // A tiny grace period so the subsequent `tailscale serve` proxy target
-  // isn't pointed at a not-yet-listening socket.
-  if (readyWaitMs > 0) await sleep(readyWaitMs);
-
-  log(`hub listening on 127.0.0.1:${chosenPort} (pid ${pid}); logs: ${logFile}`);
-  return { pid, port: chosenPort, started: true };
 }
 
 export interface StopHubOpts {

--- a/src/process-state.ts
+++ b/src/process-state.ts
@@ -11,6 +11,13 @@ import { CONFIG_DIR } from "./config.ts";
  * `pid file present` + `process.kill(pid, 0)` succeeds. A stale PID file
  * (process died without cleanup) reads as stopped; writers of the PID
  * file own removing it on clean shutdown.
+ *
+ * Phase 5b retired the detached module/hub spawners that *wrote* per-service
+ * pidfiles. The pidfile READERS (`readPid` / `processState`) are deliberately
+ * kept (design §7.5) so the migrate detector (`hasPriorDetachedInstall`) can
+ * still see a prior detached install for one release. `writePid` / `clearPid`
+ * remain too — `serve` (hub-server.ts) writes its own `hub` pidfile so
+ * `parachute stop hub` / `migrate` can find a serve-mode hub.
  */
 
 export function serviceDir(svc: string, configDir: string = CONFIG_DIR): string {


### PR DESCRIPTION
Phase 5b of the hub-as-supervisor unification (design `parachute.computer/design/2026-06-01-hub-as-supervisor-unification.md` §8 Phase 5 + Appendix + §7.5). This is the **point-of-no-return**: the dual-dispatch bridge is removed and the supervised/unit path becomes the ONLY runtime. **No version bump** (stays `0.6.3-rc.1`).

## A — collapse the dual-dispatch else-arms

Each verb's `if (sup.unitInstalled) → viaSupervisor else → detached` bridge is collapsed: the supervised path is unconditional, the detached else-body is removed, and the no-unit case routes through the 5a auto-offer / actionable error.

- **`lifecycle.ts`** — `start`/`stop`/`restart` now run a shared `requireSupervisedOrOffer(r)` gate then dispatch unconditionally through `startViaSupervisor`/`stopViaSupervisor`/`restartViaSupervisor`. The detached arms, `defaultSpawner`, `startHubSvc`/`stopHubSvc`/`selfHealOperatorTokenOnStart`, `resolveTargets`/`specForEntry`, and the detached-only `LifecycleOpts` seams are deleted.
- **`expose.ts` + `expose-cloudflare.ts`** — the `ensureHubRunning`-vs-`ensureHubUnit` dual-dispatch collapses to `ensureHubUnitForExpose`; the post-expose restart always goes through `restartHubDependentViaSupervisor`. `exposeOff` stops only the exposure layer (D3 unconditional — hub left running). `expose-supervisor.ts`'s `resolveExposeSupervisor` drops the now-dead `unitInstalled` discriminant.
- **`upgrade.ts`** — `restartTarget` collapses to the unit/supervisor path (HUB → `restartHubUnit`; module → `lifecycle.restart` supervisor block).
- **`status.ts`** — collapses to `buildSupervisorRows` (platform-manager hub row + supervisor module rows); the detached `hubRow` + per-service HTTP `probe` are removed.

## B — retire the detached spawners

- `lifecycle.ts`: `defaultSpawner` (the `detached:true`+`unref` module spawner) deleted.
- `hub-control.ts`: `ensureHubRunning` (detached hub bringup) + `defaultHubSpawner` + `HubSpawner` + `EnsureHubResult` deleted; `EnsureHubOpts` slimmed to what `init`'s unit-bringup reads. **`stopHub` is KEPT** — the `migrate` cutover (`migrate-cutover.ts`) still uses it to stop a legacy detached hub during the §7.1 cutover.
- **Grep confirms zero dangling code references**: `grep -rn 'defaultSpawner\|ensureHubRunning\|defaultHubSpawner' src --include=*.ts` (non-test) returns **comment-only** matches — no code references remain.

## C — thin process-state.ts to readers-only (READERS KEPT, §7.5)

`readPid`/`processState` (the READ side) **stay** so the 5a migrate detector (`hasPriorDetachedInstall`) can still see a prior detached install for one release. `writePid`/`clearPid` also stay (the `serve` path writes the hub pidfile; the cutover seeds/clears fixtures). No code was removed — nothing in `process-state.ts` was a provably-dead writer. A header note documents the §7.5 readers-kept rationale.

## Emphasis

- **(i) The no-unit case now goes through the 5a auto-offer/error, NOT a detached fallback** — the point-of-no-return. `requireSupervisedOrOffer` offers the cutover (interactive) / prints `parachute migrate --to-supervised` (non-TTY) / surfaces the actionable error, and returns non-zero; it NEVER spawns a detached daemon.
- **(ii) Pidfile READERS kept for the migrate detector** (§7.5) — `readPid`/`processState` retained one release.
- **(iii) Test-rework accounting** (intent preserved, see below).
- **(iv) Zero dangling refs** after the deletions (grep above; `bun run typecheck` clean).

## Test-rework accounting (delta −87: 2811 → 2724 pass; 1 skip; 0 fail)

The bridge made detached-arm tests deterministic by omitting `supervisor`. With no detached arm, those were reworked (not deleted-to-go-green). Per file (`test()` count, base→now):

- **lifecycle.test.ts −54** (85→31): detached `start`/`stop`/`restart`/hub-verb tests dropped — their intent (spawn/env-injection/PORT/cwd/startCmd-resolution/missing-dep preflight, hub#194 settle, hub#487 port-readiness, process-GROUP spawn) **moved to the supervisor and is asserted in `supervisor.test.ts` + `api-modules-ops.test.ts`**; hub-verb bringup is now `ensureHubUnit`/`stopHubUnit`/`restartHubUnit` (asserted in the kept supervisor-arm tests). Kept/reworked: the supervisor-path dispatch tests, the §7.5 no-unit offer/error tests (former "fall through to detached" → "actionable error, no spawn"), the `defaultKill`/`defaultAlive` group-reaping tests (fixture re-spawns detached inline, not via the retired spawner), and the `logs` tests.
- **hub-control.test.ts −9** (18→9): the `ensureHubRunning` describe dropped (function gone; bringup now `installAndStartHubUnit`, covered in hub-unit/init tests). `stopHub` suite kept.
- **expose.test.ts −3** (42→39): detached hub-spawn stub swapped for a supervisor seam; auto-restart suite reworked to the supervised path; "spawns hub server" reworked to assert the unit-ensure; "NO unit → hub stopped" dropped (D3 — hub never stopped).
- **expose-cloudflare.test.ts −1** (41→40): the two detached vault-restart tests merged into one supervised test (`.env` persistence + driveModuleOp restart); pidfile-gating no longer applies (covered by the Phase 4 unit-managed suite).
- **status.test.ts −18** (26→8): rewritten to drive the supervised arm for the table / per-module URL deep-links / persisted-start-error rendering (the `manifestRowBase`/`urlForEntry` logic is unchanged); the HTTP-probe-specific cases (probe success/failure, http-401-healthy, known-stopped-skips-probe) are gone with the `probe` function — module run-state comes from the supervisor now.
- **status-supervisor.test.ts −2** (15→13): the "Phase 3c discriminant" (no-supervisor / `unitInstalled:false` → detached arm) tests dropped — there is no discriminant under single-path.
- **upgrade.test.ts ±0** (29→29): hub-restart assertions retargeted from the detached `restartFn` to the `restartHubUnit` seam (hub-first sweep order preserved); the "NO unit → detached restartFn" test reworked to "NO unit → `restartHubUnit` reports no-unit → surfaced as failure".

## Gates

- `bun test ./src`: **2724 pass, 1 skip, 0 fail** (baseline 2811/1/0 → delta −87, fully accounted above; zero NEW failures).
- `bun run typecheck`: clean (0 errors — no dangling refs after the deletions).
- `bunx biome check` on all touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)