### PR TITLE
fix(hub): bind RFC 8707 resource into access-token aud (array) — unblocks Claude MCP connector [#511] + rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.3-rc.1",
+  "version": "0.6.3-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/packages/scope-guard/src/__tests__/validate.test.ts
+++ b/packages/scope-guard/src/__tests__/validate.test.ts
@@ -284,6 +284,44 @@ describe("createScopeGuard — audience strict-check", () => {
     expect(claims.aud).toBe("vault.first");
     guard.resetJwksCache();
   });
+
+  // hub#511 vault-compat invariant. The hub now widens `aud` to the array
+  // `[vault.<name>, <resource-url>]` when an RFC 8707 `resource` is bound at
+  // the token step (Claude's MCP connector echoes the resource URL). The vault
+  // passes `expectedAudience = "vault.<name>"` and this validator checks
+  // membership — so the array MUST be accepted. This pins the "no vault change
+  // needed" claim: if the validator stopped accepting the array, the hub fix
+  // would ship a token the vault rejects, and this test would fail.
+  test("hub#511: array aud [vault.default, <resource-url>] passes for expectedAudience vault.default", async () => {
+    const guard = makeGuard();
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: ["vault.default", "https://hub.example/vault/default/mcp"],
+    });
+    const claims = await guard.validateHubJwt(token, { expectedAudience: "vault.default" });
+    expect(claims.aud).toBe("vault.default");
+    guard.resetJwksCache();
+  });
+
+  test("hub#511: array aud lacking vault.default still rejected for expectedAudience vault.default", async () => {
+    const guard = makeGuard();
+    // A resource-only array (the vault-name entry missing) must NOT authenticate
+    // — the membership check is what keeps a bound resource from substituting
+    // for the scope-derived audience.
+    const token = await signJwt(kp, {
+      iss: fixture.origin,
+      aud: ["vault.other", "https://hub.example/vault/default/mcp"],
+    });
+    let caught: HubJwtError | undefined;
+    try {
+      await guard.validateHubJwt(token, { expectedAudience: "vault.default" });
+    } catch (e) {
+      caught = e as HubJwtError;
+    }
+    expect(caught).toBeInstanceOf(HubJwtError);
+    expect(caught?.code).toBe("audience");
+    guard.resetJwksCache();
+  });
 });
 
 describe("createScopeGuard — failure modes (HubJwtError.code)", () => {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -2494,6 +2494,203 @@ describe("handleToken — full OAuth dance", () => {
   });
 });
 
+// closes #511 — RFC 8707 resource binding at the token step. Claude's MCP
+// connector (Claude Desktop / claude.ai / mobile) sends
+// `resource=<origin>/vault/<name>/mcp` on the token request and validates the
+// returned access token's `aud` against that exact URL. Pre-#511 the hub minted
+// `aud` purely from scopes ("vault.default") and dropped `resource` at the
+// token step, so the connector rejected the credential client-side and never
+// called /mcp. The fix widens `aud` to the array `[scopeAud, resource]` when
+// the resource resolves to the SAME vault the scope-derived aud names — which
+// still satisfies the vault's `aud.includes("vault.<name>")` check (no vault
+// change) AND matches the connector's resource check.
+describe("handleToken — RFC 8707 resource → aud binding (#511)", () => {
+  // Drive a full authorize→token dance with `resource` set on the token form,
+  // returning the validated JWT payload. `tokenResource` is what we send on the
+  // token (and refresh) request; `consentResource` narrows consent so the auth
+  // code carries the named `vault:<name>:read` scope.
+  async function dance(opts: {
+    db: import("bun:sqlite").Database;
+    scope?: string;
+    consentResource?: string;
+    tokenResource?: string;
+  }) {
+    const { db } = opts;
+    const user = await createUser(db, "owner", "pw");
+    const session = createSession(db, { userId: user.id });
+    const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+    const { verifier, challenge } = makePkce();
+    const consentForm = new URLSearchParams({
+      __action: "consent",
+      __csrf: TEST_CSRF,
+      approve: "yes",
+      client_id: reg.client.clientId,
+      redirect_uri: "https://app.example/cb",
+      response_type: "code",
+      scope: opts.scope ?? "vault:default:read",
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+    });
+    if (opts.consentResource) consentForm.set("resource", opts.consentResource);
+    const consentRes = await handleAuthorizePost(
+      db,
+      new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: consentForm,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+        },
+      }),
+      { issuer: ISSUER, hubBoundOrigins: () => [ISSUER] },
+    );
+    const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+    expect(code).toBeTruthy();
+
+    const tokenForm = new URLSearchParams({
+      grant_type: "authorization_code",
+      code: code ?? "",
+      client_id: reg.client.clientId,
+      redirect_uri: "https://app.example/cb",
+      code_verifier: verifier,
+    });
+    if (opts.tokenResource) tokenForm.set("resource", opts.tokenResource);
+    const tokenRes = await handleToken(
+      db,
+      new Request(`${ISSUER}/oauth/token`, {
+        method: "POST",
+        body: tokenForm,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+      { issuer: ISSUER, hubBoundOrigins: () => [ISSUER] },
+    );
+    return { tokenRes, reg, userId: user.id };
+  }
+
+  test("authorization_code + resolving resource → aud is an array of [vault.<name>, resourceUrl]", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const resource = `${ISSUER}/vault/default/mcp`;
+      const { tokenRes } = await dance({
+        db,
+        consentResource: resource,
+        tokenResource: resource,
+      });
+      expect(tokenRes.status).toBe(200);
+      const body = (await tokenRes.json()) as { access_token: string; scope: string };
+      // scope unchanged by the resource binding (narrowed to the named vault scope).
+      expect(body.scope).toBe("vault:default:read");
+      const { payload } = await validateAccessToken(db, body.access_token, ISSUER);
+      // aud is the array [vault.default, <resource-url>] — both present.
+      expect(Array.isArray(payload.aud)).toBe(true);
+      const auds = payload.aud as string[];
+      expect(auds).toContain("vault.default");
+      expect(auds).toContain(resource);
+      expect(auds).toHaveLength(2);
+      // iss unchanged.
+      expect(payload.iss).toBe(ISSUER);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("refresh_token + resource → SAME array aud (the load-bearing refresh case)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const resource = `${ISSUER}/vault/default/mcp`;
+      const { tokenRes, reg } = await dance({
+        db,
+        consentResource: resource,
+        tokenResource: resource,
+      });
+      const initial = (await tokenRes.json()) as { refresh_token: string };
+
+      // Claude re-sends `resource` on refresh (RFC 8707 SHOULD). The refreshed
+      // access token MUST re-bind the array aud — otherwise the connector
+      // breaks ~15min after it started working.
+      const refreshForm = new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: initial.refresh_token,
+        client_id: reg.client.clientId,
+        resource,
+      });
+      const refreshRes = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: refreshForm,
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER, hubBoundOrigins: () => [ISSUER] },
+      );
+      expect(refreshRes.status).toBe(200);
+      const rotated = (await refreshRes.json()) as { access_token: string };
+      const { payload } = await validateAccessToken(db, rotated.access_token, ISSUER);
+      expect(Array.isArray(payload.aud)).toBe(true);
+      const auds = payload.aud as string[];
+      expect(auds).toContain("vault.default");
+      expect(auds).toContain(resource);
+      expect(auds).toHaveLength(2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("no resource on the token request → bare scope-derived string aud preserved (no regression)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      // No tokenResource → the pre-#511 path: aud is the bare string.
+      const { tokenRes } = await dance({ db });
+      expect(tokenRes.status).toBe(200);
+      const body = (await tokenRes.json()) as { access_token: string };
+      const { payload } = await validateAccessToken(db, body.access_token, ISSUER);
+      expect(payload.aud).toBe("vault.default");
+      expect(Array.isArray(payload.aud)).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("resource that does NOT resolve to the scope's vault → ignored, bare scope aud (the guard)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      // Scope/consent bind vault.default, but the token request supplies a
+      // resource naming a DIFFERENT vault. The guard ignores it: bare scope aud.
+      const { tokenRes } = await dance({
+        db,
+        consentResource: `${ISSUER}/vault/default/mcp`,
+        tokenResource: `${ISSUER}/vault/other/mcp`,
+      });
+      expect(tokenRes.status).toBe(200);
+      const body = (await tokenRes.json()) as { access_token: string };
+      const { payload } = await validateAccessToken(db, body.access_token, ISSUER);
+      // No junk aud, no foreign URL: bare scope string.
+      expect(payload.aud).toBe("vault.default");
+      expect(Array.isArray(payload.aud)).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("off-origin / garbage resource → ignored, bare scope aud (the guard)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const { tokenRes } = await dance({
+        db,
+        consentResource: `${ISSUER}/vault/default/mcp`,
+        tokenResource: "https://evil.example/vault/default/mcp",
+      });
+      expect(tokenRes.status).toBe(200);
+      const body = (await tokenRes.json()) as { access_token: string };
+      const { payload } = await validateAccessToken(db, body.access_token, ISSUER);
+      expect(payload.aud).toBe("vault.default");
+      expect(Array.isArray(payload.aud)).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
 // closes #72 — RFC 6749 §3.2.1 + §2.3.1: confidential clients must
 // authenticate at /oauth/token via Authorization: Basic header (preferred)
 // or form-body client_secret. Public clients (PKCE-only) are unaffected

--- a/src/jwt-audience.ts
+++ b/src/jwt-audience.ts
@@ -38,3 +38,48 @@ export function inferAudience(scopes: readonly string[]): string {
   }
   return "hub";
 }
+
+/**
+ * RFC 8707 resource → `aud` binding for the token endpoint (#511).
+ *
+ * Background: Claude's MCP connector (Claude Desktop / claude.ai / mobile)
+ * sends `resource=<origin>/vault/<name>/mcp` on the token request and then
+ * validates the returned access token's `aud` *equals that exact resource
+ * URL* (RFC 8707 §2 + the MCP auth spec). Pre-#511 the hub minted `aud`
+ * purely from scopes (`inferAudience` → `"vault.default"`) and dropped the
+ * `resource` param at the token step, so the connector rejected the
+ * credential client-side and never called `/mcp`.
+ *
+ * Fix: when the request carries a `resource` that (a) resolves — via the
+ * caller-supplied `resolveResource` (the existing `resolveResourceVault`
+ * partial-applied with the hub's bound origins) — to a hub-fronted per-vault
+ * MCP resource, AND (b) that resource's vault matches the scope-derived
+ * audience (`vault.<name>`), we widen `aud` to the array
+ * `[scopeAudience, resourceUrl]`. RFC 7519 §4.1.3 allows `aud` to be an
+ * array; the vault's scope-guard checks membership (`auds.includes`), so the
+ * array still satisfies the vault's `expectedAudience = "vault.<name>"` while
+ * also matching the connector's `resource` check.
+ *
+ * GUARD (security-critical): a `resource` that does NOT resolve to the same
+ * vault as the scope-derived aud is IGNORED — we mint the bare scope string,
+ * exactly as today. An arbitrary or foreign `resource` value must never be
+ * able to stamp a junk audience into the token. Ignore, never error.
+ *
+ * Returns the bare `scopeAudience` string when there's no resource, the
+ * resource doesn't resolve, or it resolves to a different vault. Returns the
+ * two-element array `[scopeAudience, resourceUrl]` only on a clean match.
+ */
+export function bindResourceAudience(
+  scopeAudience: string,
+  resource: string | null | undefined,
+  resolveResource: (resource: string | null | undefined) => string | null,
+): string | string[] {
+  if (!resource) return scopeAudience;
+  const resourceVault = resolveResource(resource);
+  // Only bind when the resource resolves to a hub-fronted per-vault MCP
+  // resource AND its vault name matches the scope-derived `vault.<name>`.
+  if (resourceVault && `vault.${resourceVault}` === scopeAudience) {
+    return [scopeAudience, resource];
+  }
+  return scopeAudience;
+}

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -37,8 +37,15 @@ export interface SignAccessTokenOpts {
   /** Subject — the user id. */
   sub: string;
   scopes: string[];
-  /** Module short name (vault, notes, …) or "hub" — sets `aud`. */
-  audience: string;
+  /**
+   * Sets the `aud` claim. Either a single module short name (vault, notes, …)
+   * or "hub" — the scope-derived audience — OR an array (RFC 7519 §4.1.3) when
+   * an RFC 8707 `resource` was bound at the token step (#511): the array is
+   * `[scopeAudience, resourceUrl]`, e.g. `["vault.default", "https://…/mcp"]`.
+   * jose's `.setAudience()` accepts both shapes. All non-OAuth callers (CLI
+   * mint-token, operator-token, the manual picker) keep passing a bare string.
+   */
+  audience: string | string[];
   clientId: string;
   /**
    * Hub origin — sets the `iss` claim. Required: every consumer (vault,

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -47,7 +47,7 @@ import {
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
 import { isCoveredByGrant, isCoveredByGrantForClientName, recordGrant } from "./grants.ts";
 import { consumeFirstClientAutoApproveWindow } from "./hub-settings.ts";
-import { VAULT_VERBS, inferAudience } from "./jwt-audience.ts";
+import { VAULT_VERBS, bindResourceAudience, inferAudience } from "./jwt-audience.ts";
 import {
   ACCESS_TOKEN_TTL_SECONDS,
   RefreshTokenInsertError,
@@ -2057,7 +2057,19 @@ async function handleTokenAuthorizationCode(
       400,
     );
   }
-  const audience = inferAudience(redeemed.scopes);
+  // RFC 8707 resource → aud binding (#511). Claude's MCP connector sends
+  // `resource=<origin>/vault/<name>/mcp` on the token request and validates
+  // the returned token's `aud` against that exact URL. When the resource
+  // resolves (hub-fronted per-vault MCP resource) to the SAME vault the
+  // scope-derived aud names, widen `aud` to the array `[scopeAud, resource]`
+  // so the connector's check passes AND the vault's `aud.includes(vault.<name>)`
+  // check still passes. A foreign/non-resolving resource is ignored (bare
+  // scope aud minted, as pre-#511) — the guard lives in `bindResourceAudience`.
+  const audience = bindResourceAudience(
+    inferAudience(redeemed.scopes),
+    (form.get("resource") as string | null) ?? null,
+    (resource) => resolveResourceVault(resource, resolveBoundOrigins(deps)),
+  );
   const access = await signAccessToken(db, {
     sub: redeemed.userId,
     scopes: redeemed.scopes,
@@ -2183,7 +2195,18 @@ async function handleTokenRefresh(
   // (revoke old) + INSERT (mint new refresh row) commit or roll back as
   // a unit, so a mid-rotation crash can't dead-old-without-replacement
   // (#107).
-  const audience = inferAudience(row.scopes);
+  // RFC 8707 resource → aud binding on refresh (#511) — LOAD-BEARING. Claude's
+  // access token is short-lived (~15min); the connector refreshes with
+  // `resource` re-sent (RFC 8707 SHOULD; Claude does). If the refreshed token
+  // reverted to the bare scope aud, the connector would break ~15min after it
+  // started working. So re-apply the SAME binding the authcode path uses: when
+  // `resource` resolves to the scope's vault, widen `aud` to `[scopeAud,
+  // resource]`; otherwise (no/foreign resource) keep the bare scope aud.
+  const audience = bindResourceAudience(
+    inferAudience(row.scopes),
+    (form.get("resource") as string | null) ?? null,
+    (resource) => resolveResourceVault(resource, resolveBoundOrigins(deps)),
+  );
   const access = await signAccessToken(db, {
     sub: refreshUserId,
     scopes: row.scopes,


### PR DESCRIPTION
## Root cause (code-confirmed, #511)

`/oauth/token` minted the access-token `aud` purely from scopes —
`inferAudience(redeemed.scopes)` → `"vault.default"` (`src/oauth-handlers.ts`,
`src/jwt-audience.ts`, `src/jwt-sign.ts`). It NEVER read the RFC 8707 `resource`
param at the token step (resource was read only at authorize/consent for
scope-narrowing, then dropped).

Claude's MCP connector (Claude Desktop / claude.ai / mobile) sends
`resource=https://<origin>/vault/<name>/mcp` and then validates the returned
token's `aud` **equals that resource URL** (RFC 8707 §2 + the MCP auth spec).
It got `"vault.default"` → rejected the credential **client-side** → never
called `/mcp`. (Claude Code works because a pasted static bearer skips this
check.) This blocked the connector for every public-exposed vault.

## Fix — bind the requested resource into `aud` as an array (no vault change)

Read `resource` from the token request and, when it resolves — via the existing
`resolveResourceVault(resource, boundOrigins)` (the helper already used at
authorize) — to a hub-fronted per-vault MCP resource whose vault **matches** the
scope-derived `vault.<name>` audience, widen `aud` to the array
`[scopeAud, resourceUrl]` (RFC 7519 §4.1.3 allows array `aud`). Otherwise keep
the current bare-string behavior.

- **Authorization_code path** (`handleTokenAuthorizationCode`): binds `resource`.
- **Refresh path** (`handleTokenRefresh`) — **LOAD-BEARING**: Claude's access
  token is ~15min and it re-sends `resource` on refresh (RFC 8707 SHOULD), so
  the refresh path re-binds the array aud identically. Without this the
  connector would break ~15min after it started working.
- **`SignAccessTokenOpts.audience`** widened to `string | string[]`; jose's
  `.setAudience()` accepts arrays natively. All non-OAuth callers (CLI
  mint-token, operator-token, manual picker) keep passing a bare string — no
  regression.

The binding logic lives in `bindResourceAudience` (`src/jwt-audience.ts`) so the
authcode + refresh paths can't diverge.

## Security guard (critical)

`bindResourceAudience` only adds the resource to `aud` when it resolves via
`resolveResourceVault` to the **same vault** as the scope-derived aud
(`vault.<name>` === scopeAud). A foreign / off-origin / different-vault /
garbage `resource` is **ignored** — the bare scope aud is minted, exactly as
before. An arbitrary `resource` can never stamp a junk audience. Ignore, never
error.

## Vault compatibility — verified, no vault change

The vault's scope-guard checks audience by membership:
`auds.includes(expectedAudience)` (`packages/scope-guard/src/validate.ts` ~301),
and the vault passes `expectedAudience = "vault.<name>"`
(`parachute-vault/src/auth.ts` ~266-268). So `["vault.default", "<url>"]`
satisfies the vault (`includes("vault.default")` → true). Pinned by two new
scope-guard tests: the array containing `vault.default` passes; an array lacking
it (resource-only or a different vault) is still rejected. **No vault change.**

## Tests

`src/__tests__/oauth-handlers.test.ts` (new describe block):
- authorization_code + resolving resource → array aud containing BOTH
  `vault.default` AND the resource URL; `scope`/`iss` unchanged.
- refresh_token + resource → same array aud (the load-bearing refresh case).
- NO resource → bare scope-derived string aud (`"vault.default"`) preserved.
- resource for a DIFFERENT vault → ignored, bare scope aud (the guard).
- off-origin / garbage resource → ignored, bare scope aud (the guard).

`packages/scope-guard/src/__tests__/validate.test.ts`:
- array aud `[vault.default, <url>]` accepted for `expectedAudience: vault.default`.
- array aud lacking `vault.default` still rejected.

## Gates

- `bun test ./src`: **2816 pass, 1 skip, 0 fail**
- `bun test ./packages/scope-guard/src`: **110 pass, 0 fail**
- `bun run typecheck`: clean
- `bunx biome check` on the 4 authored files: clean (2 pre-existing
  `useTemplate`/`noUnusedTemplateLiteral` warnings in `oauth-handlers.ts` line
  1760 are outside this diff's hunks)

## Version

Bumps `0.6.3-rc.1` → `0.6.3-rc.2`. This PR **is** rc.2. (Not tagged — tagging
happens after merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)