### PR TITLE
docs(hub): Phase 6 — rewrite Service-lifecycle + CLAUDE.md + help + headers for the supervised model (retire detached/launchd-removal framing)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Parachute Hub
 
-`@openparachute/hub` — the local hub for the Parachute ecosystem. The `parachute` binary is one of its surfaces; the long-running daemon (discovery on `:1939`, soon OAuth issuance) is another. Coordinator, not a service: each Parachute package (`vault`, `notes`, `scribe`, `channel`) stays standalone; the hub stitches them together.
+`@openparachute/hub` — the local hub for the Parachute ecosystem. The `parachute` binary is one of its surfaces; the long-running `parachute serve` process (discovery on `:1939`, soon OAuth issuance) is another — it runs under the platform's process manager (launchd / systemd / container runtime) and supervises every installed module as an attached child. Coordinator, not a service: each Parachute package (`vault`, `notes`, `scribe`, `channel`) stays standalone; the hub stitches them together.
 
 Renamed from `@openparachute/cli` / `parachute-cli` on 2026-04-26 — same binary name (`parachute`), same code, broader role. The "CLI" framing was always partial.
 
@@ -9,13 +9,17 @@ User-facing README is the right intro for operators. This file is for agents and
 ## Architecture
 
 ```
-parachute install <svc>   →  bun add -g + init + services.json seed   (src/commands/install.ts)
-parachute start/stop/...  →  spawn detached bun, pidfile + logs       (src/commands/lifecycle.ts)
-parachute status          →  read services.json + probe health        (src/commands/status.ts)
-parachute expose <layer>  →  tailscale serve/funnel + hub proxy       (src/commands/expose.ts)
-parachute migrate         →  sweep legacy ~/.parachute/ layout         (src/commands/migrate.ts)
-parachute vault <args>    →  exec parachute-vault (transparent)        (src/commands/vault.ts)
+parachute serve           →  hub foreground + in-process Supervisor    (src/commands/serve.ts + src/supervisor.ts)
+parachute install <svc>   →  bun add -g + init + services.json seed     (src/commands/install.ts)
+parachute init            →  install + start the hub unit, then wizard  (src/commands/init.ts + src/hub-unit.ts)
+parachute start/stop/...  →  ensure hub unit up, drive the supervisor   (src/commands/lifecycle.ts → module-ops API)
+parachute status          →  platform manager (hub) + supervisor.list() (src/commands/status.ts)
+parachute expose <layer>  →  tailscale serve/funnel (hub stays running) (src/commands/expose.ts)
+parachute migrate         →  --to-supervised cutover / archive sweep    (src/commands/migrate.ts)
+parachute vault <args>    →  exec parachute-vault (transparent)         (src/commands/vault.ts)
 ```
+
+**One runtime: `parachute serve` under a process manager.** The hub runs foreground with an in-process `Supervisor` (`src/supervisor.ts`) that spawns each installed module as an attached child, multiplexes their logs, and crash-restarts them on a budget. That `serve` process is kept alive by the platform's own process manager — **launchd** on a Mac, **systemd** on a Linux VM (installed by `parachute init` / `parachute migrate --to-supervised`), the **container runtime** on Render / Fly. There is **no detached-daemon model** anymore: the per-module `start/stop/restart <svc>` verbs are *clients* of the running supervisor — they ensure the hub unit is up (via `src/hub-unit.ts`), then drive it over the loopback module-ops HTTP API (`src/api-modules-ops.ts`, authenticated with the on-disk operator token, `src/module-ops-client.ts`). Per-module pidfile spawning was retired in Phase 5b; `src/process-state.ts` keeps pidfile *readers* only, for the `migrate` legacy-install detector.
 
 The flat shape matters: each command is a self-contained module in `src/commands/`, wired through `src/cli.ts`'s argv parser. No framework, no plugin system, no global state beyond a handful of pure module constants.
 
@@ -41,7 +45,7 @@ Three surface types sit outside the operator-facing table:
 
 - **`src/service-spec.ts`** — `SERVICE_SPECS` is the registry: which npm package backs each short name, what to run on install/start, the canonical seed entry. Adding a new service = one entry here.
 - **`src/services-manifest.ts`** — `~/.parachute/services.json` read/write. This file is the contract between the CLI and every service; services own the write side, the CLI owns read + exposure. Validation is strict on required fields; optional fields (`displayName`, `tagline`) pass through.
-- **`src/hub-server.ts`** — internal Bun server on port 1939. Serves `/` (discovery page) and `/.well-known/parachute.json`. Spawned by `parachute expose`, stopped when the last layer goes away. Tailscale serve can't directly serve files on macOS (sandboxed), so this loopback proxy is the portable shape.
+- **`src/hub-server.ts`** — the Bun server on port 1939, the thing `parachute serve` runs in the foreground. Serves `/` (discovery page) and `/.well-known/parachute.json`. It's a persistent managed unit (launchd / systemd / container runtime), running whether or not any exposure layer is up — `expose off` tears down only the exposure, not the hub. Tailscale serve can't directly serve files on macOS (sandboxed), so this loopback proxy is the portable shape.
 - **`src/expose-state.ts`** — which layers (tailnet/public) are currently up, persisted to `~/.parachute/expose-state.json`. Lets `expose <layer> off` be precise rather than blowing away everything.
 - **`src/tailscale/`** — thin wrappers around `tailscale serve` / `tailscale funnel`. Shape is pinned to 1.82+ (`funnel` as its own subcommand).
 - **`src/notes-serve.ts`** — tiny Bun static-file server for the @openparachute/notes PWA bundle. Invoked as `bun notes-serve.ts --port <n> [--dist <path>] [--mount <prefix>]`. The `--mount` arg (default `/notes`, derived from `entry.paths[0]` in the service spec) is the path prefix the reverse proxy hands us; the shim strips it before joining with `dist/`. Without the strip, requests for `/notes/sw.js` and `/notes/manifest.webmanifest` get SPA-shelled with `text/html`, the browser never sees them as the SW + manifest, and the PWA install prompt never fires. Pass `--mount ""` (or `--mount /`) when serving at the origin root.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `@openparachute/hub` — the local hub for the [Parachute](https://parachute.computer) ecosystem. The `parachute` binary is one of its surfaces.
 
-The hub coordinates the modules running on your machine: it installs them, runs them as background processes, exposes them over Tailscale, serves the discovery document at `/.well-known/parachute.json`, and (soon) issues OAuth tokens. Each module (vault, app, scribe, …) stays a standalone package; the hub stitches them together.
+The hub coordinates the modules running on your machine: it installs them, supervises them as child processes (the hub itself runs under your platform's process manager — launchd / systemd / the container runtime), exposes them over Tailscale, serves the discovery document at `/.well-known/parachute.json`, and (soon) issues OAuth tokens. Each module (vault, app, scribe, …) stays a standalone package; the hub stitches them together.
 
 > Previously published as `@openparachute/cli`. Renamed 2026-04-26 to better reflect the role — see [parachute-patterns/hub-as-issuer](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/hub-as-issuer.md). The `parachute` binary name is unchanged.
 
@@ -75,7 +75,9 @@ parachute init
 
 `parachute init` is idempotent — every re-run is safe. End to end it:
 
-1. **Starts the hub** if it isn't already running (port `1939`).
+1. **Installs and starts the hub** as a managed unit (launchd on a Mac,
+   systemd on a Linux VM) on port `1939`, so it survives reboots. Re-runs are
+   no-ops if the unit is already up.
 2. **Offers to expose it** so you can reach the wizard from other devices. In a
    terminal you pick: stay loopback-only, your **tailnet** (`tailscale serve` —
    private to your own Tailscale devices), or a **Cloudflare Tunnel** (public
@@ -108,9 +110,9 @@ UI. Verify the stack any time:
 
 ```sh
 parachute status
-# SERVICE          PORT  VERSION  PROCESS  PID    UPTIME  HEALTH  LATENCY
-# parachute-hub    1939  0.5.14   running  12344  20s     ok      1ms
-# parachute-vault  1940  0.4.5    running  12345  12s     ok      2ms
+# SERVICE          PORT  VERSION  STATE   PID    UPTIME  LATENCY  SOURCE
+# parachute-hub    1939  0.5.14   active  12344  20s     1ms      managed unit (launchd)
+# parachute-vault  1940  0.4.5    active  12345  12s     2ms      npm (0.4.5)
 ```
 
 Vault is up on `127.0.0.1:1940`; Claude Code picks up the MCP on your next
@@ -144,7 +146,7 @@ still work and are additive:
 ```sh
 parachute install vault   # install + register + create first vault + start one module
 parachute setup           # older interactive multi-pick: survey + install vault/notes/scribe
-parachute start vault     # PID + logs tracked under ~/.parachute/vault/
+parachute start vault     # start one module via the running hub's supervisor
 ```
 
 ### Expose across your tailnet
@@ -180,35 +182,77 @@ deleted or reset from the Users page — it changes its own password at
 
 ## Service lifecycle
 
-`parachute start`, `stop`, `restart`, and `logs` manage services as background processes — no launchd, no manual `bun serve`, no hunting for PIDs.
+Parachute runs **one runtime everywhere**: `parachute serve` — the hub in the
+foreground with an in-process supervisor that runs each module as an attached
+child, multiplexes their logs, and restarts crashed ones. That `serve` process
+runs under your platform's own process manager — **launchd** on a Mac,
+**systemd** on a Linux VM, the **container runtime** on Render / Fly — so the
+hub (and every module under it) survives reboots and crashes without you
+SSHing back in.
+
+`parachute init` installs and starts that managed hub unit for you; the
+lifecycle verbs then drive the running supervisor:
 
 ```sh
-parachute start               # start every installed service
-parachute start vault         # just one
-parachute stop                # SIGTERM, then SIGKILL after 10s if stuck
-parachute restart vault       # stop + start
+parachute start               # ensure the hub unit is up (boots every module)
+parachute start vault         # start one module via the running supervisor
+parachute stop vault          # stop one module via the supervisor
+parachute stop                # stop the hub unit (children stop with it)
+parachute restart vault       # restart one module via the supervisor
+parachute restart             # restart the hub unit (re-boots every module)
 parachute logs vault          # last 200 lines
 parachute logs vault -f       # tail (like `tail -f`)
 ```
 
-State lives under `~/.parachute/<service>/`:
+How the verbs map to the model:
 
-- `run/<service>.pid` — child PID; `parachute status` uses this to report running/stopped + uptime
-- `logs/<service>.log` — stdout + stderr (appended)
+- **`start` / `stop` / `restart <svc>`** are clients of the running hub. They
+  ensure the hub unit is up, then call its supervisor over a loopback
+  module-ops API (authenticated with your operator token) to start / stop /
+  restart that one module. There's no per-module daemon to track — the
+  supervisor owns module processes.
+- **`start` (no service)** ensures the hub unit is up; the hub boots every
+  installed module on start, so this brings the whole stack up.
+- **`stop` (no service)** stops the **hub unit** through the platform manager
+  (`launchctl bootout` / `systemctl stop`); the modules are attached children
+  and stop with it.
+- **`restart` (no service)** restarts the **hub unit** (`launchctl kickstart
+  -k` / `systemctl restart`), which re-boots every module — it is *not* a
+  fan-out of per-module restarts.
 
-`parachute start` is idempotent: if the service is already running, it's a no-op. Stale PID files (process died without cleanup) are cleared on the next start. Services whose PID file is absent are treated as *unknown* — status still probes their port, so externally-managed services (e.g. you ran `parachute-vault serve` directly) aren't misreported as stopped.
+`parachute status` shows a hub row even with zero modules installed — that row
+is derived from the platform manager (`launchctl print` / `systemctl
+is-active`, or "container runtime (managed)" on Render / Fly), since the
+supervisor runs the modules but the manager runs the hub.
 
-### Migrating from launchd (pre-launch beta)
+### No process manager installed yet?
 
-If you previously ran vault under launchd, switch to `parachute start`:
+If you've never run `parachute init` (or you're on a legacy install that used
+the old detached-daemon model), the lifecycle verbs will prompt you to run
+`parachute migrate --to-supervised`, which installs the hub unit and moves you
+onto the supervised model. See **Migrating a legacy install** below.
+
+On a host with no process manager at all (a bare container, an init-less
+image), there's no unit to install — run `parachute serve` in the foreground
+instead (this is exactly what the container `CMD` does).
+
+### Migrating a legacy install
+
+Earlier Parachute releases ran each service as an independent detached daemon
+(its own pidfile + log file under `~/.parachute/<service>/`), with no
+supervisor and no reboot survival. To move an existing box onto the supervised
+model:
 
 ```sh
-launchctl unload ~/Library/LaunchAgents/computer.parachute.vault.plist
-rm ~/Library/LaunchAgents/computer.parachute.vault.plist
-parachute start vault
+parachute migrate --to-supervised   # install + start the hub unit, cut over
 ```
 
-An at-login auto-start mode (`parachute start --boot`) is on the post-launch roadmap.
+The cutover is idempotent and re-runnable. It writes the platform unit, stops
+the old detached processes, verifies the canonical ports are free, then starts
+the hub unit and confirms the hub is healthy. To roll it back, `parachute
+migrate --teardown` removes the unit (run that *before* `bun remove -g
+@openparachute/hub` so a removed package doesn't leave a unit pointing at a
+deleted binary).
 
 ### Migrating from pre-CLI installs
 
@@ -225,17 +269,21 @@ Anything swept goes to `~/.parachute/.archive-<YYYY-MM-DD>/` with its original n
 ## Two supported layers (plus an exploratory third)
 
 Each additive; each can be turned off without affecting the layer below.
+Exposure is decoupled from the hub's own lifecycle: `expose` makes the
+already-running hub reachable on a network layer, and `expose <layer> off`
+tears down only that exposure — the hub keeps running as its managed unit
+either way.
 
-- **Local** — services on loopback. Zero config. Browsers treat `localhost` as a secure context, so OAuth, PKCE, and Web Crypto all just work out of the box.
+- **Local** — the hub on loopback. Zero config. Browsers treat `localhost` as a secure context, so OAuth, PKCE, and Web Crypto all just work out of the box.
 - **Tailnet** — `parachute expose tailnet` wraps `tailscale serve` for every registered service. HTTPS via Tailscale's MagicDNS cert. Only machines on your tailnet can reach the URL. **This is the documented shape for the hub today.** Tailnet is already authenticated at the network layer, every user's tailnet is their own, and the OAuth + module access work happening in the hub is being designed against this shape first.
 
 ### Public exposure (exploratory)
 
 `parachute expose public` exists for early testers. It routes each handler through `tailscale funnel` (or, with `--cloudflare`, a named Cloudflare tunnel) so the same URLs become reachable from the public internet. The code path is live and the flag still works, but the public-internet posture (DNS, cross-internet OAuth, Funnel quirks) hasn't been hardened the way tailnet has — expect rough edges.
 
-When the hub's OAuth issuer + per-module scope enforcement land, public will re-enter the documented narrative as "now safe." Until then, prefer tailnet.
+When the hub's OAuth issuer + per-module scope enforcement land, public will re-enter the documented narrative as "now safe." Until then, prefer tailnet. (If you route a public layer through Cloudflare, note their bot-protection / Browser Integrity Check can interfere with OAuth and MCP clients — see the caveat on [parachute.computer](https://parachute.computer).)
 
-Under the hood, tailnet mode uses `tailscale serve` and public mode uses `tailscale funnel`; both write into the same node-level serve config. The CLI records which layer is live so that `expose <other-layer> off` is a no-op rather than a surprise teardown of the active layer.
+Under the hood, tailnet mode uses `tailscale serve` and public mode uses `tailscale funnel`; both write into the same node-level serve config. The CLI records which layer is live so that `expose <other-layer> off` is a no-op rather than a surprise teardown of the active layer. `expose off` only ever tears down exposure — it never stops the hub (the platform manager owns the hub's lifecycle now).
 
 ## Path-routing (and why)
 
@@ -251,7 +299,9 @@ https://parachute.<tailnet>.ts.net/.well-known/parachute.json    ← discovery
 
 The hub page fetches the discovery doc at load, then each service's `/.parachute/info` endpoint for display name, tagline, and icon. Adding a new service is zero CLI code — drop in its manifest entry and the hub picks it up.
 
-Under the hood, `/` and `/.well-known/parachute.json` are proxied by a tiny internal HTTP server (`parachute-hub`) that `parachute expose` spawns on the loopback interface. Tailscale's file-serve mode is sandbox-restricted on macOS, so a localhost proxy is the portable shape. The hub process is stopped automatically when the last exposure layer is torn down; `parachute status` lists it under `(internal)`.
+Under the hood, `/` and `/.well-known/parachute.json` are served by the hub
+process on the loopback interface — the same `parachute serve` process the
+platform manager keeps running. Tailscale's file-serve mode is sandbox-restricted on macOS, so a localhost proxy is the portable shape. The hub is a persistent managed unit: it runs whether or not any exposure layer is up, so `expose tailnet off` / `expose public off` tears down only the *exposure*, leaving the hub serving on loopback. `parachute status` lists the hub row (manager-derived) at the top.
 
 The `/.well-known/parachute.json` document is an always-present descriptor — flat `services[]` array that the hub iterates, plus top-level keys for legacy clients:
 
@@ -402,19 +452,21 @@ Public-internet exposure (`parachute expose public`) is exploratory — see "Pub
 Run `parachute --help` for the top-level list, and `parachute <subcommand> --help` for details on any individual command.
 
 ```
-parachute init                    fresh-install front door: start hub, offer expose,
-                                  install vault module, open the setup wizard
+parachute init                    fresh-install front door: install + start the
+                                  managed hub, offer expose, install vault, wizard
 parachute setup-wizard --hub-url <url>
                                   in-terminal mirror of /admin/setup (Account/Vault/Expose)
 parachute setup                   older interactive multi-pick service installer
 parachute install <service>       install and register a service
-parachute status                  show installed services, process state, health
-parachute start   [service]       start services in the background
-parachute stop    [service]       stop services (SIGTERM → 10s → SIGKILL)
-parachute restart [service]       stop + start
+parachute status                  show installed services, run state, health
+parachute start   [service]       start a module via the supervisor (or ensure the hub is up)
+parachute stop    [service]       stop a module via the supervisor (or the hub unit)
+parachute restart [service]       restart a module via the supervisor (or the hub unit)
+parachute serve                   run the hub + supervisor foregrounded (the runtime)
 parachute logs <service> [-f]     print/tail service logs
 parachute expose tailnet [off]    HTTPS across your tailnet (supported)
 parachute expose public  [off]    HTTPS on the public internet (exploratory)
+parachute migrate --to-supervised move a legacy detached install to the managed hub
 parachute migrate [--dry-run]     archive legacy files at ecosystem root
 parachute vault <args...>         dispatch to parachute-vault
 ```

--- a/src/help.ts
+++ b/src/help.ts
@@ -16,15 +16,16 @@ Usage:
   parachute setup                   interactive walk-through: install services + configure
   parachute install <service>       install and register a service
                                     services: ${services}
-  parachute status                  show installed services, process state, health
-  parachute start   [service]       start all services (or one) in the background
-  parachute stop    [service]       stop all services (or one) — SIGTERM then SIGKILL
-  parachute restart [service]       stop + start
+  parachute status                  show installed services, run state, health
+  parachute start   [service]       start a module via the supervisor (or ensure the hub is up)
+  parachute stop    [service]       stop a module via the supervisor (or stop the hub unit)
+  parachute restart [service]       restart a module via the supervisor (or restart the hub unit)
   parachute upgrade [service]       pull / re-install + restart (skips if no changes)
   parachute logs <service> [-f]     print service logs; -f to tail
   parachute expose tailnet [off]    HTTPS across your tailnet (supported)
   parachute expose public  [off]    HTTPS on the public internet (exploratory)
-  parachute serve                   run hub HTTP server foregrounded (for containers)
+  parachute serve                   run the hub + supervisor foregrounded (the runtime)
+  parachute migrate --to-supervised move a legacy detached install to the managed hub
   parachute migrate [--dry-run]     archive legacy files at ecosystem root
   parachute auth <cmd>              identity (set password, manage 2FA)
   parachute vault <args...>         vault-specific ops (tokens, 2fa, config, init,
@@ -123,7 +124,9 @@ What it does:
   get you to that wizard.
 
   Idempotent — every re-run is safe:
-    1. If the hub isn't running, start it.
+    1. Install + start the hub as a managed unit (launchd on a Mac,
+       systemd on a Linux VM) so it survives reboots; no-op if it's
+       already up.
     2. If the hub isn't already exposed, in a terminal, offer to set up
        exposure (Tailscale Funnel, Cloudflare Tunnel, or stay loopback).
        The default highlights "no thanks" on laptops and Cloudflare on
@@ -273,10 +276,16 @@ Usage:
   parachute status
 
 What it does:
-  Reads ~/.parachute/services.json. For each registered service:
-    - checks PID file at ~/.parachute/<svc>/run/<svc>.pid
-    - probes http://localhost:<port><health> (skipped for known-stopped processes)
+  Reads ~/.parachute/services.json. For each registered module:
+    - reads its run state from the running hub's supervisor (supervisor.list())
+    - probes http://localhost:<port><health> (skipped for known-stopped modules)
     - classifies the install source as bun-linked (local checkout) or npm
+
+  The hub gets its own row, derived from the platform process manager
+  (launchd \`launchctl print\` / systemd \`systemctl is-active\`, or
+  "container runtime (managed)" on Render / Fly) — the supervisor runs the
+  modules, but the manager runs the hub. The hub row appears even with zero
+  modules installed.
 
   The STATE column rolls process state + probe result into one of four
   canonical labels (per parachute-patterns/patterns/design-system.md §6):
@@ -293,10 +302,10 @@ What it does:
   HEALTH (ok / down / http <code>). Workstream F collapsed them onto the
   single STATE column the SPA + well-known doc also speak.
 
-  Stopped services render as STATE=inactive and don't count toward the
+  Stopped modules render as STATE=inactive and don't count toward the
   exit code — they're an expected state after fresh install before
-  \`parachute start\`. Running or externally-managed services that fail
-  health checks render as STATE=failing and exit 1.
+  \`parachute start\`. Supervised modules that fail health checks render
+  as STATE=failing and exit 1.
 
   A "STALE: services.json cached … live package.json …" continuation line
   appears under a row when a bun-linked service has been rebuilt but the
@@ -409,39 +418,41 @@ Cloudflare tunnel requirements (--cloudflare):
 }
 
 export function startHelp(): string {
-  return `parachute start — spawn services in the background
+  return `parachute start — start a module via the running hub's supervisor
 
 Usage:
-  parachute start                   start every installed service
-  parachute start <service>         start just that one
-  parachute start hub               start the internal hub (port 1939)
+  parachute start                   ensure the hub is up (boots every module)
+  parachute start <service>         start just that one module
+  parachute start hub               ensure the hub unit is up
 
 What it does:
-  For each target service, spawns its start command detached, redirects
-  stdout+stderr to ~/.parachute/<service>/logs/<service>.log, and records
-  the child PID at ~/.parachute/<service>/run/<service>.pid.
+  \`parachute serve\` is the one runtime — the hub foreground with an
+  in-process supervisor that runs each module as an attached child. These
+  verbs are clients of that running hub:
 
-  Idempotent: if the service is already running, no-op.
-  If a stale PID file exists (process died without cleanup), it's cleared
-  and the service starts fresh.
+  - \`parachute start <service>\` ensures the hub unit is up, then asks its
+    supervisor to start that one module (over the loopback module-ops API,
+    authenticated with your operator token). No per-module daemon is
+    spawned — the supervisor owns the module process.
+  - \`parachute start\` (no service) ensures the hub unit is up. The hub
+    boots every installed module on start, so this brings the whole stack
+    up. On a box with no hub unit yet, it offers to run
+    \`parachute migrate --to-supervised\` (which installs + starts the unit).
+  - \`parachute start hub\` is the same "ensure the hub unit is up."
 
-  \`parachute start hub\` brings up the internal hub directly (normally
-  spawned implicitly by \`parachute expose\`). Useful when restarting a
-  hub that crashed without an active expose layer.
+  Idempotent: starting an already-running module is a no-op.
 
 Flags:
-  --hub-origin <url>    override PARACHUTE_HUB_ORIGIN passed to services
+  --hub-origin <url>    override the hub origin used as the operator token's
+                        \`iss\` validator on the loopback module-ops call
                         (default: current expose-state hub origin, else loopback).
-                        For \`start hub\`, also doubles as the hub's --issuer.
 
 Examples:
   parachute start                   bring everything up
-  parachute start vault             just vault
-  parachute start hub               just the internal hub
+  parachute start vault             just vault, via the supervisor
   parachute logs vault              watch what just started
 
-Start commands by service:
-  hub       bun <cli>/hub-server.ts --port <picked> ...
+Module start commands (run by the supervisor under \`serve\`):
   vault     parachute-vault serve
   scribe    parachute-scribe serve
   app       parachute-app serve
@@ -451,39 +462,45 @@ Start commands by service:
 }
 
 export function stopHelp(): string {
-  return `parachute stop — stop running services cleanly
+  return `parachute stop — stop a module (or the hub) cleanly
 
 Usage:
-  parachute stop                    stop every installed service
-  parachute stop <service>          stop just that one
-  parachute stop hub                stop the internal hub
+  parachute stop                    stop the hub unit (modules stop with it)
+  parachute stop <service>          stop just that one module
+  parachute stop hub                stop the hub unit
 
 What it does:
-  Sends SIGTERM, waits up to 10s for a clean exit, then escalates to
-  SIGKILL if the process is still alive. Removes the PID file on success.
-
-  No-op if the service wasn't running.
-
-  Bare \`parachute stop\` (no service) does NOT stop the hub — that's
-  managed by the active expose layer (or \`parachute stop hub\` directly).
+  - \`parachute stop <service>\` asks the running hub's supervisor to stop
+    that one module (SIGTERM to the module's process group, then SIGKILL if
+    it doesn't exit). No-op if it wasn't running.
+  - \`parachute stop\` (no service) and \`parachute stop hub\` stop the hub
+    UNIT through the platform process manager (\`launchctl bootout\` /
+    \`systemctl stop\`) — never a raw PID signal, which launchd's KeepAlive
+    would just undo. Modules are attached children and stop with the hub.
 
 Examples:
-  parachute stop                    stop everything before sleep
-  parachute stop vault              just vault
-  parachute stop hub                just the internal hub
+  parachute stop vault              just vault, via the supervisor
+  parachute stop                    stop the whole stack (the hub unit)
 `;
 }
 
 export function restartHelp(): string {
-  return `parachute restart — stop then start
+  return `parachute restart — restart a module (or the hub)
 
 Usage:
-  parachute restart                 restart every installed service
-  parachute restart <service>       restart just that one
-  parachute restart hub             restart the internal hub
+  parachute restart                 restart the hub unit (re-boots every module)
+  parachute restart <service>       restart just that one module
+  parachute restart hub             restart the hub unit
 
 What it does:
-  Equivalent to \`parachute stop <svc> && parachute start <svc>\`.
+  - \`parachute restart <service>\` asks the running hub's supervisor to
+    restart that one module. If the module isn't currently supervised
+    (e.g. it crashed out of its restart budget), this falls through to a
+    fresh \`start\` so the verb is total over module state.
+  - \`parachute restart\` (no service) and \`parachute restart hub\` restart
+    the hub UNIT via the platform manager (\`launchctl kickstart -k\` /
+    \`systemctl restart\`), which re-boots every module — it is NOT a
+    fan-out of per-module restarts.
 `;
 }
 
@@ -523,6 +540,13 @@ What it does:
   package.json version unchanged after bun add -g), the restart is skipped.
   Re-running on an up-to-date install is a fast no-op.
 
+  The "restart" step matches the supervised model: upgrading a MODULE
+  restarts it via the running hub's supervisor; \`parachute upgrade hub\`
+  rewrites the binary on disk, then restarts the hub UNIT through the
+  platform manager (\`launchctl kickstart -k\` / \`systemctl restart\`), which
+  re-boots every module onto the new code. From the admin SPA (the no-CLI
+  Render / Fly path) the same hub-upgrade runs via POST /api/hub/upgrade.
+
 Channel detection (hub#332):
   Pre-1.0 governance ships two channels — \`@rc\` (the development chain) and
   \`@latest\` (explicitly-promoted stable). \`parachute upgrade\` reads the
@@ -556,16 +580,23 @@ If no log file exists yet, prints a hint to \`parachute start <service>\`.
 }
 
 export function serveHelp(): string {
-  return `parachute serve — run the hub HTTP server foregrounded
+  return `parachute serve — run the hub + supervisor foregrounded (the runtime)
 
 Usage:
   parachute serve
 
-The container shape. The on-box CLI flow (\`parachute expose\`) spawns the
-hub-server detached and tracks it via pidfile; \`parachute serve\` is the
-inverse — the hub IS the foreground process, lives as long as its
-supervisor wants it to, and exits on signal. Built for Docker / Render /
-systemd, but works fine for a foregrounded local debug too.
+This is the one runtime everywhere. The hub IS the foreground process: it
+runs the HTTP server on port 1939 AND an in-process supervisor that spawns
+every installed module as an attached child, multiplexes their logs into
+its own stdout, and crash-restarts them on a budget. It runs until it gets
+a signal, then SIGTERMs its children and exits.
+
+You don't normally invoke \`serve\` by hand — \`parachute init\` (or
+\`parachute migrate --to-supervised\`) installs it as a managed unit so your
+platform's process manager keeps it alive across crashes and reboots:
+launchd on a Mac, systemd on a Linux VM, the container runtime's CMD on
+Render / Fly. Run it directly only for a foregrounded local debug, or on an
+init-less host that can't host a unit.
 
 Environment:
   PORT                              bind port (default 1939). Render injects

--- a/src/process-state.ts
+++ b/src/process-state.ts
@@ -77,12 +77,21 @@ export const defaultAlive: AliveFn = (pid: number) => {
 };
 
 /**
- * Three-state rather than two so we don't lie about services we can't see:
+ * Three-state, kept for legacy detection only.
+ *
+ * Phase 5b retired the detached spawners that wrote per-service pidfiles, so in
+ * the steady (supervised) state no module has a pidfile and module run-state
+ * comes from the supervisor (`supervisor.list()`), not from here. This reader
+ * survives so the `migrate` detector (`hasPriorDetachedInstall`) can still
+ * recognize a pre-cutover box, and so `serve` / `parachute stop hub` can find a
+ * serve-mode hub's own `hub` pidfile.
  *
  * - `running` — PID file present, `kill(pid, 0)` succeeds.
  * - `stopped` — PID file present, process gone (stale pidfile, or cleanly shut down).
- * - `unknown` — no PID file. Service may be externally managed (user ran
- *   `parachute-vault serve` directly, or legacy launchd-era). Don't claim stopped.
+ * - `unknown` — no PID file. In a supervised install this is the normal case
+ *   for modules (no pidfile is written); the "externally-managed / legacy
+ *   launchd-era" reading is now purely about detecting a *prior detached*
+ *   install, not a live signal. Don't claim stopped.
  */
 export interface ProcessState {
   status: "running" | "stopped" | "unknown";

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -1,32 +1,37 @@
 /**
- * Per-module child supervisor for container-mode hub.
+ * The hub's in-process module supervisor — the single runtime everywhere.
  *
- * The on-box flow (`parachute start <svc>`) spawns module daemons
- * detached + unref'd, writes a pidfile, and walks away — process
- * lifecycle becomes the operator's problem (launchd, systemd, or a
- * follow-up `parachute restart`). That shape doesn't work in a
- * container:
+ * As of Phase 5b there is ONE process model: `parachute serve` runs the hub
+ * in the foreground with this Supervisor, and the platform's process manager
+ * (launchd on a Mac, systemd on a Linux VM, the container runtime on Render /
+ * Fly) keeps that `serve` process alive across crashes and reboots. The old
+ * manager-less detached-daemon model (per-module `detached + unref()` spawns
+ * tracked by pidfiles) is retired — the on-box `parachute start/stop/restart
+ * <svc>` verbs are now clients of THIS supervisor, driving it over the
+ * loopback module-ops API (`api-modules-ops.ts` → `commands/lifecycle.ts`).
  *
- *   - There's no external supervisor watching the children. If vault
- *     crashes, nothing brings it back.
- *   - Render's log viewer only surfaces hub's stdout. A detached child
- *     whose stdout goes to `~/.parachute/<svc>/logs/<svc>.log` is
- *     invisible to the operator clicking through the dashboard.
+ * What this supervisor does:
  *
- * This supervisor solves both. It spawns each module attached (no
- * `detached: true`, no `unref()`), pipes their stdout/stderr through a
- * line-prefixing tap into hub's own stdout (`[vault] …`,
- * `[scribe] …`), watches `proc.exited`, and restarts crashed children
- * up to a small budget before giving up + marking the module
- * `crashed`. The budget keeps a wedged-on-boot module from chewing
- * forever; once it's exhausted the operator sees the crash via /api/modules
- * (or, post-1B, the per-module log view).
+ *   - Spawns each module as an attached child in its own process group
+ *     (`detached: true` for group-signalling only; stdio stays piped — see
+ *     `defaultSpawnFn` / `defaultKillGroup`), so a wrapped startCmd's
+ *     grandchildren are reaped on stop/restart (no EADDRINUSE-on-restart).
+ *   - Pipes each child's stdout/stderr through a line-prefixing tap into the
+ *     hub's own stdout (`[vault] …`, `[scribe] …`) and a bounded per-module
+ *     ring buffer, so the operator sees module output in the hub log /
+ *     platform log viewer and `parachute logs <svc>` can replay recent lines.
+ *   - Gates a freshly-spawned module to `running` only once its port binds
+ *     (port-readiness), and records a structured start-error on preflight
+ *     failure, so `status` / the SPA keep the friendly missing-dependency
+ *     surface.
+ *   - Watches `proc.exited` and crash-restarts children up to a small budget
+ *     before marking the module `crashed`. The budget keeps a wedged-on-boot
+ *     module from chewing forever; the hub unit's own StartLimit / Throttle
+ *     bounds the outer keeper.
  *
- * Out of scope for this module: spawning the hub HTTP server itself
- * (that's `Bun.serve` in the same process), driving the on-box
- * `parachute start <svc>` path (still uses `commands/lifecycle.ts`),
- * persisting child state to disk (transient — re-derived from
- * services.json on boot).
+ * Out of scope: supervising the hub HTTP server itself (that's `Bun.serve` in
+ * this same process — the platform manager is the hub's keeper) and persisting
+ * child state to disk (transient — re-derived from services.json on every boot).
  */
 
 import {


### PR DESCRIPTION
Phase 6 (docs) of the hub-as-supervisor unification (design: `parachute.computer/design/2026-06-01-hub-as-supervisor-unification.md` §8 Phase-6 row, §9 R14/R23, D2). Supervised is now the only runtime — Phase 5b (50cafa3) retired the detached spawners and the dual-dispatch bridge. These docs/comments/strings catch up to that reality.

**Docs-only, no version bump.** (Touched `src/help.ts` / `src/supervisor.ts` / `src/process-state.ts` — comments + help strings only, no logic.)

## The operator-facing correctness fixes (README "Service lifecycle")

Two reversals stand out — both were actively misleading operators:

1. **Dropped the "no launchd, no manual `bun serve`, no hunting for PIDs" selling point.** That's now *false*: the model installs a launchd unit (Mac) / systemd unit (Linux VM) at `init`. Leaving the old pitch in place sold operators on the exact opposite of what ships.

2. **Reversed the "Migrating from launchd" subsection.** It previously told operators to `launchctl unload` + `rm` a launchd agent — i.e. to *remove* the mechanism. It's now "Migrating a legacy install" via `parachute migrate --to-supervised`, which *installs* the hub unit and cuts a legacy detached box over.

Plus, in the same section:
- Retired the `run/<svc>.pid` + `logs/<svc>.log` state model and the `unknown`=externally-managed status semantics.
- Resolved the `parachute start --boot` roadmap line — this design *is* it; `start`/`init` now install + drive the managed unit.
- Described the new model: serve-under-a-process-manager; `start/stop/restart <svc>` drive the running supervisor; `init` installs the unit; `migrate --to-supervised` for legacy boxes; the no-unit case prompts `migrate`; `status` shows a manager-derived hub row even with zero modules.
- Reconciled expose: `expose` ensures the already-running hub on a layer; `expose off` tears down only the exposure, never the hub (D3). One-line Cloudflare bot-protection pointer to the site.
- Fixed the First-5-minutes init step + status example output (STATE columns, manager-derived hub row).

## Other corrections

- **`CLAUDE.md` Architecture** — rewrote the command table (the `start/stop → spawn detached bun, pidfile + logs` row was wrong) and framing to the supervised model; fixed the `hub-server.ts` shared-surface note ("spawned by expose, stopped when last layer goes away" → persistent managed unit).
- **`src/help.ts`** — corrected `start` / `stop` / `restart` / `serve` / `init` / `upgrade` / `status` help to the supervised model (clients of the running supervisor; `init` installs the unit; `serve` is the runtime under a process manager; hub stop/restart go through the platform manager, never a PID signal).
- **`src/supervisor.ts` header** — rewrote the two-model "walks away — lifecycle becomes the operator's problem" framing to the single supervised model.
- **`src/process-state.ts` docstring** — clarified the readers are retained for the `migrate` detector + the serve-mode hub pidfile; `unknown`/externally-managed is now legacy-detection only.
- Left the `// See #508` token-issuer drift comment untouched (consolidation is its own issue).

## Gates

- `bun test ./src`: **2725 pass / 1 skip / 0 fail**
- `bun run typecheck`: clean
- `bunx biome check` (src/help.ts, src/supervisor.ts, src/process-state.ts): clean

No help-string test needed updating (no test pins the edited strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)