### PR TITLE
release: hub 0.6.3-rc.2 — full supervisor unification (Phases 1–6) to @rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.3-rc.1",
+  "version": "0.6.3-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Bumps hub to **0.6.3-rc.2** so the **complete** hub-as-supervisor arc is testable on `@rc`. rc.1 was Phases 1–3; this adds Phases 4–6 (all merged to main: #502 #504 #507 #510 #514). Version-only change.

- `@latest` stays **0.6.2** (the `-rc.` tag routes to `DIST_TAG=rc`, never latest).
- On merge: tag `v0.6.3-rc.2` → CI publishes `@openparachute/hub@0.6.3-rc.2` to `@rc` + a `rc` ghcr image.
- Live boxes are **not** touched — they run `@latest` 0.6.2 until you `bun add -g @openparachute/hub@rc` + `parachute migrate --to-supervised`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)