### PR TITLE
fix(hub): client-side operator-token validation accepts the hub's known issuers (status works on exposed boxes) [#516]

### DIFF
--- a/src/__tests__/operator-token.test.ts
+++ b/src/__tests__/operator-token.test.ts
@@ -3,6 +3,8 @@ import { chmodSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ExposeState } from "../expose-state.ts";
+import { writeExposeState } from "../expose-state.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { signAccessToken, validateAccessToken } from "../jwt-sign.ts";
 import {
@@ -14,6 +16,7 @@ import {
   OPERATOR_TOKEN_SCOPE_SETS,
   OPERATOR_TOKEN_SCOPE_SET_CLAIM,
   OPERATOR_TOKEN_TTL_SECONDS,
+  buildKnownIssuersForOperatorToken,
   issueOperatorToken,
   mintOperatorToken,
   operatorTokenPath,
@@ -475,6 +478,280 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
     } finally {
       h.cleanup();
     }
+  });
+});
+
+// hub#516 — the operator token's `iss` is the hub's PUBLIC origin after
+// `parachute expose`, but callers resolve `issuer` inconsistently (status →
+// loopback, lifecycle → public). The client-side validation now accepts the
+// token if its `iss` is ANY of the hub's known origins (loopback aliases ∪
+// expose-state public origin ∪ env), gated FIRST on the JWKS signature. These
+// tests pin the four-corner matrix: public-iss accepted with loopback config
+// (the status bug), loopback-iss accepted, foreign-iss rejected, and
+// foreign-SIGNATURE rejected even when its iss is in the known set.
+const PUBLIC_ISSUER = "https://parachute.taildf9ce2.ts.net";
+
+/** Minimal valid expose-state advertising `hubOrigin` (the public origin). */
+function exposeStateForOrigin(hubOrigin: string): ExposeState {
+  return {
+    version: 1,
+    layer: "tailnet",
+    mode: "path",
+    canonicalFqdn: new URL(hubOrigin).host,
+    port: 1939,
+    funnel: false,
+    entries: [],
+    hubOrigin,
+  };
+}
+
+describe("useOperatorTokenWithAutoRotate known-issuer set (hub#516)", () => {
+  // The PARACHUTE_HUB_ORIGIN / RENDER_EXTERNAL_URL / FLY_APP_NAME env vars feed
+  // the platform-origin seed of the known-issuer set. Tests that assert a
+  // public-iss is REJECTED when expose-state is absent must not have a stray
+  // env public origin leaking the iss back in — clear them around each test.
+  function withCleanPlatformEnv<T>(fn: () => T): T {
+    const saved = {
+      hub: process.env.PARACHUTE_HUB_ORIGIN,
+      render: process.env.RENDER_EXTERNAL_URL,
+      fly: process.env.FLY_APP_NAME,
+    };
+    // Computed-key delete (not `delete process.env.FOO`) so biome's noDelete
+    // doesn't fire — matches spawn-env-propagation.test.ts. A `= undefined`
+    // assignment would coerce to the string "undefined" and leak a bogus
+    // origin into the known-issuer set, so a real delete is required here.
+    for (const k of ["PARACHUTE_HUB_ORIGIN", "RENDER_EXTERNAL_URL", "FLY_APP_NAME"]) {
+      delete process.env[k];
+    }
+    try {
+      return fn();
+    } finally {
+      if (saved.hub !== undefined) process.env.PARACHUTE_HUB_ORIGIN = saved.hub;
+      if (saved.render !== undefined) process.env.RENDER_EXTERNAL_URL = saved.render;
+      if (saved.fly !== undefined) process.env.FLY_APP_NAME = saved.fly;
+    }
+  }
+
+  test("accepts a PUBLIC-iss operator token when config resolves loopback (the status bug)", async () => {
+    await withCleanPlatformEnv(async () => {
+      const h = makeHarness();
+      try {
+        const db = openHubDb(hubDbPath(h.dir));
+        try {
+          rotateSigningKey(db);
+          // Mint the operator token under the hub's PUBLIC origin — what
+          // happens on an exposed box (selfHealOperatorTokenIssuer re-mints to
+          // the public iss).
+          const issued = await issueOperatorToken(db, "user-abc", {
+            dir: h.dir,
+            issuer: PUBLIC_ISSUER,
+          });
+          // Expose-state advertises the public origin (so it lands in the
+          // known set). The CALLER resolves loopback (status's hardcoded path).
+          writeExposeState(exposeStateForOrigin(PUBLIC_ISSUER), join(h.dir, "expose-state.json"));
+
+          const used = await useOperatorTokenWithAutoRotate(db, {
+            configDir: h.dir,
+            issuer: TEST_ISSUER, // loopback — the status scenario
+          });
+          expect(used).not.toBeNull();
+          expect(used?.status.kind).toBe("fresh");
+          expect(used?.token).toBe(issued.token);
+          expect(used?.payload.iss).toBe(PUBLIC_ISSUER);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+  });
+
+  test("accepts a loopback-iss operator token with loopback config", async () => {
+    await withCleanPlatformEnv(async () => {
+      const h = makeHarness();
+      try {
+        const db = openHubDb(hubDbPath(h.dir));
+        try {
+          rotateSigningKey(db);
+          const issued = await issueOperatorToken(db, "user-abc", {
+            dir: h.dir,
+            issuer: TEST_ISSUER,
+          });
+          // No expose-state — known set is loopback aliases only.
+          const used = await useOperatorTokenWithAutoRotate(db, {
+            configDir: h.dir,
+            issuer: TEST_ISSUER,
+          });
+          expect(used).not.toBeNull();
+          expect(used?.status.kind).toBe("fresh");
+          expect(used?.token).toBe(issued.token);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+  });
+
+  test("rejects a token whose iss is FOREIGN to the known set", async () => {
+    await withCleanPlatformEnv(async () => {
+      const h = makeHarness();
+      try {
+        const db = openHubDb(hubDbPath(h.dir));
+        try {
+          rotateSigningKey(db);
+          // Hub-SIGNED (so the signature gate passes) but stamped with an iss
+          // that's neither loopback nor in expose-state nor env. Must reject.
+          const issued = await issueOperatorToken(db, "user-abc", {
+            dir: h.dir,
+            issuer: "https://evil.example.com",
+          });
+          expect(issued.token.length).toBeGreaterThan(0);
+          // expose-state advertises the PUBLIC origin (not the evil one), so
+          // the foreign iss is not in the known set.
+          writeExposeState(exposeStateForOrigin(PUBLIC_ISSUER), join(h.dir, "expose-state.json"));
+
+          await expect(
+            useOperatorTokenWithAutoRotate(db, { configDir: h.dir, issuer: TEST_ISSUER }),
+          ).rejects.toThrow(/unexpected "iss" claim value/);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+  });
+
+  test("rejects a FOREIGN-SIGNED token even when its iss is in the known set (signature gate first)", async () => {
+    await withCleanPlatformEnv(async () => {
+      const h = makeHarness();
+      const foreign = makeHarness();
+      try {
+        const db = openHubDb(hubDbPath(h.dir));
+        // A DIFFERENT hub (different signing key) mints a token stamped with an
+        // iss that IS in our known set. The signature won't verify against our
+        // JWKS, so it must be rejected at the signature gate regardless of iss.
+        const foreignDb = openHubDb(hubDbPath(foreign.dir));
+        try {
+          rotateSigningKey(db);
+          rotateSigningKey(foreignDb);
+          const foreignToken = await mintOperatorToken(foreignDb, "user-abc", {
+            issuer: PUBLIC_ISSUER,
+          });
+          await writeOperatorTokenFile(foreignToken.token, h.dir);
+          // Our expose-state advertises PUBLIC_ISSUER — so the iss WOULD pass
+          // the belt-and-suspenders check. The signature gate must still reject.
+          writeExposeState(exposeStateForOrigin(PUBLIC_ISSUER), join(h.dir, "expose-state.json"));
+
+          await expect(
+            useOperatorTokenWithAutoRotate(db, { configDir: h.dir, issuer: TEST_ISSUER }),
+          ).rejects.toThrow();
+        } finally {
+          db.close();
+          foreignDb.close();
+        }
+      } finally {
+        h.cleanup();
+        foreign.cleanup();
+      }
+    });
+  });
+
+  test("expose-state absent: loopback-iss accepted, public-iss rejected (no public origin known)", async () => {
+    await withCleanPlatformEnv(async () => {
+      const h = makeHarness();
+      try {
+        const db = openHubDb(hubDbPath(h.dir));
+        try {
+          rotateSigningKey(db);
+          // A loopback-iss token is accepted (loopback alias is always in the set).
+          const loopbackTok = await issueOperatorToken(db, "user-abc", {
+            dir: h.dir,
+            issuer: TEST_ISSUER,
+          });
+          const usedLoopback = await useOperatorTokenWithAutoRotate(db, {
+            configDir: h.dir,
+            issuer: TEST_ISSUER,
+          });
+          expect(usedLoopback?.token).toBe(loopbackTok.token);
+
+          // Overwrite with a public-iss token. No expose-state, no env public
+          // origin → the public iss is NOT known → reject. (Correct: with no
+          // exposure configured, the hub doesn't legitimately answer on it.)
+          const publicTok = await issueOperatorToken(db, "user-abc", {
+            dir: h.dir,
+            issuer: PUBLIC_ISSUER,
+          });
+          expect(publicTok.token.length).toBeGreaterThan(0);
+          await expect(
+            useOperatorTokenWithAutoRotate(db, { configDir: h.dir, issuer: TEST_ISSUER }),
+          ).rejects.toThrow(/unexpected "iss" claim value/);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+  });
+
+  test("auto-rotate still fires for a near-expiry token validated via the known set", async () => {
+    await withCleanPlatformEnv(async () => {
+      const h = makeHarness();
+      try {
+        const db = openHubDb(hubDbPath(h.dir));
+        try {
+          rotateSigningKey(db);
+          // Public-iss + 1-day TTL (below the 7d threshold). Validates via the
+          // known set (expose-state public origin), then auto-rotates.
+          const original = await issueOperatorToken(db, "user-abc", {
+            dir: h.dir,
+            issuer: PUBLIC_ISSUER,
+            scopeSet: "start",
+            ttlSeconds: 24 * 60 * 60,
+          });
+          writeExposeState(exposeStateForOrigin(PUBLIC_ISSUER), join(h.dir, "expose-state.json"));
+
+          const used = await useOperatorTokenWithAutoRotate(db, {
+            configDir: h.dir,
+            issuer: PUBLIC_ISSUER, // lifecycle's public-origin scenario
+          });
+          expect(used).not.toBeNull();
+          expect(used?.status.kind).toBe("rotated");
+          expect(used?.rotated?.scopeSet).toBe("start");
+          expect(used?.token).not.toBe(original.token);
+          // Re-mint stamps opts.issuer as the new iss; still validates.
+          const validated = await validateAccessToken(db, used!.token, PUBLIC_ISSUER);
+          expect(validated.payload.iss).toBe(PUBLIC_ISSUER);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+  });
+
+  test("buildKnownIssuersForOperatorToken includes loopback aliases + expose-state public origin", async () => {
+    await withCleanPlatformEnv(() => {
+      const h = makeHarness();
+      try {
+        writeExposeState(exposeStateForOrigin(PUBLIC_ISSUER), join(h.dir, "expose-state.json"));
+        const set = buildKnownIssuersForOperatorToken(h.dir, TEST_ISSUER);
+        expect(set).toContain("http://127.0.0.1:1939");
+        expect(set).toContain("http://localhost:1939");
+        expect(set).toContain(PUBLIC_ISSUER);
+        // The seed issuer is included too.
+        expect(set).toContain(TEST_ISSUER);
+        // A foreign origin is NOT present.
+        expect(set).not.toContain("https://evil.example.com");
+      } finally {
+        h.cleanup();
+      }
+    });
   });
 });
 

--- a/src/operator-token.ts
+++ b/src/operator-token.ts
@@ -30,7 +30,12 @@ import type { Database } from "bun:sqlite";
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { configDir } from "./config.ts";
+import { EXPOSE_STATE_PATH, readExposeState } from "./expose-state.ts";
+import { validateHostAdminToken } from "./host-admin-token-validation.ts";
+import { readHubPort } from "./hub-control.ts";
+import { HUB_UNIT_DEFAULT_PORT } from "./hub-unit.ts";
 import { recordTokenMint, signAccessToken, validateAccessToken } from "./jwt-sign.ts";
+import { buildHubBoundOrigins } from "./origin-check.ts";
 import { isLoopbackOrigin } from "./vault-hub-origin-env.ts";
 
 export const OPERATOR_TOKEN_FILENAME = "operator.token";
@@ -279,7 +284,14 @@ export class OperatorTokenExpiredError extends Error {
 }
 
 export interface UseOperatorTokenOpts {
-  /** Hub origin used as `iss` validator. Required. */
+  /**
+   * Hub origin the caller resolved. Required. As of hub#516 this is a SEED of
+   * the known-issuer SET the token's `iss` is validated against
+   * ({@link buildKnownIssuersForOperatorToken}), not the sole `iss` validator —
+   * so a caller that resolves loopback (`status`) still accepts a public-`iss`
+   * operator token from `expose-state.json`, and vice versa. It also remains
+   * the `iss` stamped on an auto-rotated re-mint.
+   */
   issuer: string;
   /** configDir override (where operator.token lives). Defaults to `configDir()`. */
   configDir?: string;
@@ -346,8 +358,77 @@ export interface UsedOperatorToken {
 }
 
 /**
+ * Compose the Fly.io default public origin from `FLY_APP_NAME`, mirroring the
+ * server-side `flyDefaultOrigin` (hub-server.ts) so the client-side
+ * known-issuer set matches the origin the hub stamps tokens with on Fly. Kept
+ * local (a one-liner) rather than imported to avoid pulling hub-server.ts /
+ * serve.ts into the CLI auth path. Fly slugs never contain `/`; anything with
+ * one is spoofed or malformed.
+ */
+function flyDefaultOrigin(env: NodeJS.ProcessEnv): string | undefined {
+  const app = env.FLY_APP_NAME;
+  if (typeof app !== "string" || app.length === 0 || app.includes("/")) return undefined;
+  return `https://${app}.fly.dev`;
+}
+
+/**
+ * Assemble the SET of origins this hub legitimately answers on, from on-disk
+ * client state — the client-side mirror of hub-server.ts's per-request
+ * `buildHubBoundOrigins` call (hub#516). The operator token's `iss` is
+ * validated against this set rather than a single issuer, so a token whose
+ * `iss` is the hub's PUBLIC origin (stamped after `parachute expose`) is
+ * accepted even when the CLI command resolved a loopback `issuer` (the
+ * `status` case) — and vice versa.
+ *
+ * The set is:
+ *   - `seedIssuer` — the issuer the caller resolved (loopback for `status`,
+ *     `r.hubOrigin` / public for lifecycle). Kept as a seed so callers that
+ *     pass a value still contribute it; never the sole gate.
+ *   - loopback aliases — `http://127.0.0.1:<port>` AND `http://localhost:<port>`
+ *     for the hub's port (`readHubPort(configDir) ?? HUB_UNIT_DEFAULT_PORT`),
+ *     matching the hub's own loopback alias set (`buildHubBoundOrigins`).
+ *   - the expose-state public origin — `expose-state.json`'s `hubOrigin`, the
+ *     public URL the hub stamps on tokens once exposed.
+ *   - the platform/env public origin — `PARACHUTE_HUB_ORIGIN` ∪
+ *     `RENDER_EXTERNAL_URL` ∪ the composed Fly default — for container deploys
+ *     where the public origin comes from the platform, not expose-state.
+ *
+ * Provenance is NOT established here: `validateHostAdminToken` runs the JWKS
+ * signature check FIRST and unconditionally. This set is the belt-and-suspenders
+ * `iss` allowlist layered on top — a foreign `iss` (not loopback / expose /
+ * env) is rejected, and an empty set fails closed.
+ */
+export function buildKnownIssuersForOperatorToken(
+  configDirOverride: string | undefined,
+  seedIssuer: string,
+): readonly string[] {
+  const dir = configDirOverride ?? configDir();
+  const loopbackPort = readHubPort(dir) ?? HUB_UNIT_DEFAULT_PORT;
+  let exposeHubOrigin: string | undefined;
+  try {
+    exposeHubOrigin = readExposeState(join(dir, "expose-state.json"))?.hubOrigin;
+  } catch {
+    // A malformed expose-state.json must never lock the operator out of the
+    // CLI — the seed issuer + loopback aliases already cover legitimate
+    // loopback access; treat it as "no public origin known."
+    exposeHubOrigin = undefined;
+  }
+  const platformOrigin =
+    process.env.PARACHUTE_HUB_ORIGIN ??
+    process.env.RENDER_EXTERNAL_URL ??
+    flyDefaultOrigin(process.env);
+  return buildHubBoundOrigins({
+    issuer: seedIssuer,
+    loopbackPort,
+    ...(exposeHubOrigin !== undefined ? { exposeHubOrigin } : {}),
+    ...(platformOrigin !== undefined ? { platformOrigin } : {}),
+  });
+}
+
+/**
  * The canonical "use the operator token in a CLI flow" helper. Reads
- * `~/.parachute/operator.token`, validates against `db` + `issuer`, and:
+ * `~/.parachute/operator.token`, validates against `db` + the hub's
+ * known-issuer SET, and:
  *
  *   - If the token has fully expired: throws `OperatorTokenExpiredError`
  *     with an actionable message. Does NOT auto-rotate from a dead token —
@@ -397,9 +478,19 @@ export async function useOperatorTokenWithAutoRotate(
   if (!token) return null;
   const now = opts.now ?? (() => new Date());
 
-  // Validation failures (signature mismatch, wrong issuer, missing kid,
-  // expired-by-jose) bubble out for the caller to render the right message.
-  const validated = await validateAccessToken(db, token, opts.issuer);
+  // Validate against the hub's KNOWN-ISSUER SET, not a single `opts.issuer`
+  // (hub#516). The operator token is the hub's OWN self-issued credential; its
+  // `iss` is the hub's loopback origin before `expose` and its PUBLIC origin
+  // after. Callers resolve `opts.issuer` inconsistently — `status` hardcodes
+  // loopback, lifecycle uses `r.hubOrigin` (public when exposed) — so a single
+  // per-issuer check rejected the public-`iss` operator token on `status` even
+  // though `restart` worked. `validateHostAdminToken` (the #517 helper) gates
+  // on the JWKS SIGNATURE first+unconditionally (provenance), then accepts the
+  // `iss` if it's ANY origin the hub legitimately answers on. Validation
+  // failures (signature mismatch, missing kid, expired-by-jose, revoked, or an
+  // `iss` foreign to the whole set) bubble out for the caller to render.
+  const knownIssuers = buildKnownIssuersForOperatorToken(opts.configDir, opts.issuer);
+  const validated = await validateHostAdminToken(db, token, knownIssuers);
   const { payload } = validated;
 
   const exp = typeof payload.exp === "number" ? payload.exp : 0;


### PR DESCRIPTION
## The second surface (post-#517)

#517 fixed the **HUB-side** validation; this fixes the **CLIENT-side** operator-token read — the second surface caught live. After #517 merged, `parachute restart vault` works on an exposed box, but `parachute status` still showed:

```
! couldn't read live module state (unexpected "iss" claim value)
```

### Root cause

`useOperatorTokenWithAutoRotate` (`src/operator-token.ts`) is the single client-side chokepoint that `status`, `start/stop/restart <svc>`, and the auth verbs all route through (via `module-ops-client.ts` / `auth.ts`). It validated the on-disk operator token via `validateAccessToken(db, token, opts.issuer)` against **one** issuer that callers resolved **inconsistently**:

- `status` → `statusOperatorTokenIssuer` = hardcoded loopback `http://127.0.0.1:<port>` → **rejected** the public-`iss` (tailnet) operator token on an exposed box.
- lifecycle/`restart` → `resolveOperatorTokenIssuer(r.hubOrigin, …)` = the public origin when exposed → **matched** → worked.

A direct `curl /api/modules` with the same operator token returns 200 (the hub accepts it post-#517), proving this was purely the CLI's single-issuer check — not the hub.

## The fix (mirrors #517)

`useOperatorTokenWithAutoRotate` now validates via **`validateHostAdminToken(db, token, knownIssuers)`** — the same #517 helper — where `knownIssuers` is the hub's known-origin SET, assembled **client-side** from on-disk state by a new `buildKnownIssuersForOperatorToken(configDir, seedIssuer)`:

- reuses **`buildHubBoundOrigins`** (the same helper the hub uses server-side, so client + server stay in lockstep),
- loopback aliases — both `http://127.0.0.1:<port>` **and** `http://localhost:<port>` for `readHubPort(configDir) ?? HUB_UNIT_DEFAULT_PORT`,
- expose-state `hubOrigin` (the public origin from `<configDir>/expose-state.json`),
- env public origin (`PARACHUTE_HUB_ORIGIN` / `RENDER_EXTERNAL_URL` / composed Fly default),
- the caller's `opts.issuer` kept as one **seed** of the set.

**Caller-threading choice: option (a)** — the helper assembles the set itself from `opts.configDir` + `opts.issuer`. This fixes `status` + `restart` + every auth verb uniformly with **zero per-call-site changes**, and removes the status-vs-lifecycle inconsistency at the root rather than patching one symptom.

## Security

- The **JWKS signature is the unconditional first gate** — `validateHostAdminToken` verifies provenance (only this hub's key produces a JWS that verifies against its JWKS) **before** `iss` is ever consulted. A **foreign-signed** token is rejected regardless of its `iss`, even when that `iss` is in the known set.
- A **foreign `iss`** (not loopback, not expose-state, not env) is rejected — belt-and-suspenders on top of the signature gate.
- **Empty set fails closed.**
- **Scope is the operator-token path only.** OAuth/access-token validation (vault/MCP/resource tokens) stays strict per-issuer on its own code paths — untouched. `useOperatorTokenWithAutoRotate` is operator-token-specific.
- Auto-rotate, the `aud:"operator"` privilege guard, and the `no-sub`/`no-scope-set` hardening are all preserved. Re-mint on auto-rotation still stamps `opts.issuer` as the new `iss` (fine now — both client and hub accept the known set).

## Tests (+7, `src/__tests__/operator-token.test.ts`)

- public-`iss` token + loopback config (the `status` scenario) → **accepted** (was rejected)
- loopback-`iss` token + loopback config → accepted
- **foreign `iss`** (not in the known set) → rejected (`unexpected "iss" claim value`)
- **foreign-SIGNED** token whose `iss` IS in the known set → rejected (signature gate first)
- expose-state absent → loopback-`iss` accepted, public-`iss` rejected (no public origin known — correct)
- auto-rotate still fires for a near-expiry token validated via the known set
- `buildKnownIssuersForOperatorToken` set contents (loopback aliases + expose-state origin + seed; foreign excluded)

## Gates

- `bun test ./src`: **2747 pass / 1 skip / 0 fail** (baseline 2740/1/0; **+7**, zero regressions)
- `bun run typecheck` clean; `bunx biome check` clean on touched files

**No version bump.** Completes #516 with #517.

Patterns: touches the host-admin-token validation pattern established in #517 (known-issuer-set, signature-gated). Conforms — extends it to the client side without changing the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)