### PR TITLE
release: hub 0.6.3-rc.3 — operator-token iss fix for exposed boxes (#516)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.3-rc.2",
+  "version": "0.6.3-rc.3",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Bumps to 0.6.3-rc.3 so the box migrations get the #517+#518 iss fixes (rc.2 predates them). Without these the supervised CLI verbs fail on exposed boxes (verified live). Version-only; routes to @rc (never @latest); @latest stays 0.6.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)