### PR TITLE
fix(hub): supervised hub unit binds 127.0.0.1, not 0.0.0.0 (restore loopback trust model) [security]

### DIFF
--- a/src/__tests__/managed-unit.test.ts
+++ b/src/__tests__/managed-unit.test.ts
@@ -429,16 +429,30 @@ describe("buildHubManagedUnit — §4.1 hub-unit shape", () => {
     expect(() => hubUnit(f.deps)).toThrow(/'bun' not found on PATH/);
   });
 
-  test("env carries the 4 vars and INTENTIONALLY OMITS PARACHUTE_HUB_ORIGIN", () => {
+  test("env carries the 5 vars and INTENTIONALLY OMITS PARACHUTE_HUB_ORIGIN", () => {
     const f = fakeDeps({ platform: "linux" });
     const unit = hubUnit(f.deps);
     expect(unit.env).toEqual({
+      // Forced loopback (security): a self-hosted supervised hub must NOT inherit
+      // serve.ts's container-first 0.0.0.0 default and bare-serve all-interfaces.
+      PARACHUTE_BIND_HOST: "127.0.0.1",
       PARACHUTE_HOME: "/home/op/.parachute",
       PORT: "1939",
       PATH: "/home/op/.bun/bin:/usr/local/bin:/usr/bin:/bin",
       BUN_INSTALL: "/home/op/.bun",
     });
     expect(unit.env.PARACHUTE_HUB_ORIGIN).toBeUndefined();
+  });
+
+  test("env forces PARACHUTE_BIND_HOST=127.0.0.1 (loopback trust model — never 0.0.0.0)", () => {
+    const f = fakeDeps({ platform: "linux" });
+    const unit = hubUnit(f.deps);
+    // The whole point of the fix: the supervised hub unit binds loopback, NOT
+    // the serve.ts container-first 0.0.0.0 default. Covers both init + migrate
+    // (both route through buildHubManagedUnit) and both platforms (the env is
+    // platform-agnostic; systemd/launchd render shapes are asserted below).
+    expect(unit.env.PARACHUTE_BIND_HOST).toBe("127.0.0.1");
+    expect(unit.env.PARACHUTE_BIND_HOST).not.toBe("0.0.0.0");
   });
 
   test("PARACHUTE_HOME is the captured param, NOT the default (§4.2)", () => {
@@ -473,6 +487,9 @@ describe("buildHubManagedUnit — §4.1 hub-unit shape", () => {
     const unit = renderManagedSystemdUnit(hubUnit(f.deps), { root: true, userName: "op" });
     expect(unit).toContain("Description=Parachute hub (serve + supervisor)");
     expect(unit).toContain("User=op");
+    // Forced loopback bind (security): the supervised hub must bind 127.0.0.1.
+    expect(unit).toContain("Environment=PARACHUTE_BIND_HOST=127.0.0.1");
+    expect(unit).not.toContain("PARACHUTE_BIND_HOST=0.0.0.0");
     expect(unit).toContain("Environment=PARACHUTE_HOME=/home/op/.parachute");
     expect(unit).toContain("Environment=PORT=1939");
     expect(unit).toContain("Environment=PATH=/home/op/.bun/bin:/usr/local/bin:/usr/bin:/bin");
@@ -502,6 +519,9 @@ describe("buildHubManagedUnit — §4.1 hub-unit shape", () => {
     expect(plist).toContain("<string>/home/op/parachute-hub/src/cli.ts</string>");
     expect(plist).toContain("<string>serve</string>");
     expect(plist).toContain("<key>EnvironmentVariables</key>");
+    // Forced loopback bind (security): the supervised hub must bind 127.0.0.1.
+    expect(plist).toContain("<key>PARACHUTE_BIND_HOST</key>\n    <string>127.0.0.1</string>");
+    expect(plist).not.toContain("<string>0.0.0.0</string>");
     expect(plist).toContain("<key>PARACHUTE_HOME</key>\n    <string>/home/op/.parachute</string>");
     expect(plist).toContain("<key>PORT</key>\n    <string>1939</string>");
     expect(plist).toContain("<key>BUN_INSTALL</key>\n    <string>/home/op/.bun</string>");

--- a/src/__tests__/managed-unit.test.ts
+++ b/src/__tests__/managed-unit.test.ts
@@ -482,7 +482,7 @@ describe("buildHubManagedUnit — §4.1 hub-unit shape", () => {
     expect(unit.env.PORT).toBe("2939");
   });
 
-  test("rendered systemd SYSTEM unit: 4 Environment= vars, User= present, StartLimit present", () => {
+  test("rendered systemd SYSTEM unit: 5 Environment= vars, User= present, StartLimit present", () => {
     const f = fakeDeps({ platform: "linux", getuid: () => 0, userName: () => "op" });
     const unit = renderManagedSystemdUnit(hubUnit(f.deps), { root: true, userName: "op" });
     expect(unit).toContain("Description=Parachute hub (serve + supervisor)");
@@ -511,7 +511,7 @@ describe("buildHubManagedUnit — §4.1 hub-unit shape", () => {
     expect(unit).toContain("WantedBy=default.target");
   });
 
-  test("rendered launchd plist: EnvironmentVariables dict (4 vars) + ThrottleInterval + abs ProgramArguments", () => {
+  test("rendered launchd plist: EnvironmentVariables dict (5 vars) + ThrottleInterval + abs ProgramArguments", () => {
     const f = fakeDeps({ platform: "darwin" });
     const plist = renderManagedLaunchdPlist(hubUnit(f.deps));
     expect(plist).toContain("<key>Label</key>\n  <string>computer.parachute.hub</string>");

--- a/src/managed-unit.ts
+++ b/src/managed-unit.ts
@@ -648,10 +648,25 @@ export interface BuildHubManagedUnitOpts {
  *
  * Resolves the absolute `bun` path via the `which` seam (launchd/systemd don't
  * search `$PATH` — mirrors how the connector resolves cloudflared). The env
- * carries `PARACHUTE_HOME` / `PORT` / `PATH` / `BUN_INSTALL` — and INTENTIONALLY
- * OMITS `PARACHUTE_HUB_ORIGIN`: baking a stale origin here would re-create the
- * iss-mismatch class; `resolveStartupIssuer` derives it and start-hub self-heals
- * the operator token + vault `.env` to the current origin (design §4.1 comment).
+ * carries `PARACHUTE_BIND_HOST` / `PARACHUTE_HOME` / `PORT` / `PATH` /
+ * `BUN_INSTALL` — and INTENTIONALLY OMITS `PARACHUTE_HUB_ORIGIN`: baking a stale
+ * origin here would re-create the iss-mismatch class; `resolveStartupIssuer`
+ * derives it and start-hub self-heals the operator token + vault `.env` to the
+ * current origin (design §4.1 comment).
+ *
+ * BIND HOST — `PARACHUTE_BIND_HOST=127.0.0.1` is forced here so every
+ * self-hosted supervised hub binds loopback. `parachute serve` itself defaults
+ * the bind host to `0.0.0.0` (serve.ts), which is correct for the container
+ * shape (the platform's HTTP forwarder must reach the hub) but WRONG for a
+ * self-hosted box — bare `serve` would expose the admin/OAuth surfaces on every
+ * interface, contradicting the pre-supervisor detached behavior and the trust
+ * model `layerOf` (hub-server.ts) assumes (header-absent ⇒ "loopback"). The
+ * container path never calls this builder (the Dockerfile pins
+ * `ENV PARACHUTE_BIND_HOST=0.0.0.0` + runs `serve` directly), so it stays
+ * 0.0.0.0. The canonical expose path is unaffected: cloudflared/tailscale dial
+ * `127.0.0.1:<port>` from the same host, and the hub's own proxy targets
+ * `http://127.0.0.1:<port>` (hub-server.ts). An operator who genuinely wants
+ * all-interfaces can override the generated unit; the default is loopback.
  *
  * NOT called by any command in this PR (additive — Phase 3 wires it into `init`).
  */
@@ -676,6 +691,11 @@ export function buildHubManagedUnit(opts: BuildHubManagedUnitOpts): ManagedUnit 
     systemdDescription: "Parachute hub (serve + supervisor)",
     execStart: [bunPath, opts.cliPath, "serve"],
     env: {
+      // Force loopback on every self-hosted supervised hub. serve.ts defaults
+      // to 0.0.0.0 (container-first); a self-hosted box must NOT bare-serve
+      // all-interfaces. Container path bypasses this builder (Dockerfile pins
+      // its own 0.0.0.0). See the docstring for the full trust-model rationale.
+      PARACHUTE_BIND_HOST: "127.0.0.1",
       // PARACHUTE_HOME captured at install time (design §4.2) — NOT the default.
       PARACHUTE_HOME: opts.parachuteHome,
       PORT: String(port),


### PR DESCRIPTION
## Root cause

`parachute serve` defaults its bind host to `0.0.0.0` — `src/commands/serve.ts:251`, `env.PARACHUTE_BIND_HOST || "0.0.0.0"`, written container-first. The hub managed-unit env block emitted by `buildHubManagedUnit` (`src/managed-unit.ts`) carried `PARACHUTE_HOME` / `PORT` / `PATH` / `BUN_INSTALL` — but **no `PARACHUTE_BIND_HOST`**. So the supervised unit ran bare `serve`, which fell through to the `0.0.0.0` default and bound **all interfaces**.

Self-hosted boxes that ran `parachute init` or `parachute migrate --to-supervised` therefore went silently all-interfaces — a trust-model regression vs the pre-supervisor detached behavior, and vs the loopback posture `layerOf` (`src/hub-server.ts:443`) assumes (header-absent requests classify as `"loopback"`). Confirmed live + by an adversarial review.

(Note: the older `bun src/hub-server.ts` direct-boot path — `parseArgs` at `hub-server.ts:296` — already defaulted to `127.0.0.1`. The two boot paths had diverged: `serve` was written container-first with `0.0.0.0`, the supervised unit runs `serve`, so it inherited the unsafe default.)

## The fix

Force `PARACHUTE_BIND_HOST=127.0.0.1` in the env object `buildHubManagedUnit` constructs. One change covers:
- **systemd (Linux)** AND **launchd (Mac)** — both render shapes read the same `env` map.
- **both callers** — `parachute init` (`src/hub-unit.ts:673`) and `parachute migrate --to-supervised` (`src/commands/migrate-cutover.ts:246`) both route through the shared builder.

The `serve` default is deliberately left at `0.0.0.0` (the container needs it); the unit env override wins via `serve`'s `env.PARACHUTE_BIND_HOST || "0.0.0.0"`. Loopback-by-default; an operator who genuinely wants all-interfaces can override the generated unit.

## Why the container path is unaffected

The `Dockerfile` pins `ENV PARACHUTE_BIND_HOST=0.0.0.0` and runs `CMD ["bun", "src/cli.ts", "serve"]` directly — it **never** calls `buildHubManagedUnit`. Container stays `0.0.0.0` (correct — the platform's HTTP forwarder must reach the hub). Dockerfile and the serve default are untouched.

## Why expose is unaffected

The canonical expose path dials loopback from the same host:
- cloudflared / tailscale connectors target `127.0.0.1:<port>` on the same box.
- The hub's own reverse proxy targets `http://127.0.0.1:<port>` (`src/hub-server.ts:503`).

Forcing the hub to bind loopback breaks nothing in the expose chain.

## Review verdict

**Medium severity. Blocks `@latest`.** NOT a privilege escalation — privileged surfaces (admin SPA, OAuth issuance, module-ops) are token / session / bootstrap gated, not network-position gated. The exposure is that those surfaces were reachable from other hosts on the LAN at all, contradicting the documented loopback trust model.

## Test changes

- `buildHubManagedUnit` env `toEqual` updated from 4 → 5 vars (adds `PARACHUTE_BIND_HOST: "127.0.0.1"`).
- New focused assertion: the built env forces `127.0.0.1` and is never `0.0.0.0`.
- Explicit bind-host assertions added to both rendered-shape tests (systemd `Environment=PARACHUTE_BIND_HOST=127.0.0.1`; launchd `EnvironmentVariables` dict entry), each with a paired `not.toContain("0.0.0.0")`.
- **Connector (cloudflared) byte-identical goldens are UNTOUCHED** — `GOLDEN_PLIST`, `GOLDEN_SYSTEMD_USER`, `GOLDEN_SYSTEMD_ROOT` and their tests are unchanged (verified: no connector lines appear in the diff). No SHA256 literal regeneration was needed — the hub-unit tests use `.toContain`, only the connector tests are byte-identical and they did not change.

**Gates:** `bun test ./src` — **2763 pass, 1 skip, 0 fail** (baseline ~2762; +1 is the new focused test). `bun run typecheck` clean. `bunx biome check` clean on both touched files.

## Follow-ons (not in this PR)

1. **Defense-in-depth — `layerOf` should fail-closed.** `src/hub-server.ts:443` defaults header-absent requests to `"loopback"`. It should classify by the real peer address rather than treating absence-of-proxy-headers as loopback, so a misconfigured front end can't be spoofed into the trusted layer.
2. **`rate-limit.ts` header-less-peer shared bucket** — header-absent peers share one rate-limit bucket; should key on real peer address.
3. **`notes-serve.ts:~190` defaults `0.0.0.0`** — same container-first default in the Notes static server; audit whether it needs the same loopback treatment under the supervisor.
4. **`parachute-scribe` binds `0.0.0.0` + defaults open-auth** — cross-repo; scribe's listener + default auth posture should be reviewed against the same trust model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)