### PR TITLE
release: hub 0.6.3-rc.4 — stale-unit auto-disable (#522/#523) + supervised hub binds 127.0.0.1 (#524)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.3-rc.3",
+  "version": "0.6.3-rc.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Version bump rc.3 → rc.4 (package.json only, per the established release-commit convention).

Ships on top of rc.3:
- **#523** — migrate/teardown detects + disables stale per-module autostart units (parachute-<short> systemd/launchd), killing the recurring 'port 1940 taken on upgrade' class. Validated live on the Hetzner box.
- **#524** — the supervised hub unit binds 127.0.0.1, not 0.0.0.0 (restores the loopback trust model the supervisor migration silently widened). Adversarial review: Medium, not a privesc; reviewer-LGTM.

@latest stays 0.6.2. After merge: tag v0.6.3-rc.4 → CI publishes @rc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)