### PR TITLE
release: hub 0.6.3 (stable, @latest) — hub-as-supervisor unification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.3-rc.4",
+  "version": "0.6.3",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Promotes `0.6.3-rc.4` → stable `0.6.3`. Version bump only (package.json), per the release-commit convention.

**0.6.3 ships:**
- **Hub-as-supervisor unification (Phases 1–6)** — one `parachute serve` runtime under the platform process manager (launchd/systemd/container), modules as supervised children, reboot survival.
- **#516** — operator-token `iss` fix so the CLI works on tailnet/Cloudflare-exposed boxes.
- **#522/#523** — migrate auto-disables stale per-module units (the recurring 'port 1940 taken on upgrade' class).
- **#524** — supervised hub binds `127.0.0.1`, not `0.0.0.0` (loopback trust model).
- /account starter-prompts + simplification + connector terminology (#529).

**Validated live on three boxes** (gitcoin / our / friends), including a cold-boot survival test on a public-IP box, and the `0.0.0.0`→loopback fix closed a real internet exposure on the friends box. First stable since 0.6.2.

After merge: tag `v0.6.3` → CI publishes `@latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)