### PR TITLE
fix: deterministic OAuth issuer via expose-state fallback on both origin chokepoints

### DIFF
--- a/src/__tests__/api-settings-hub-origin.test.ts
+++ b/src/__tests__/api-settings-hub-origin.test.ts
@@ -83,6 +83,11 @@ function putReq(body: unknown, headers: Record<string, string> = {}): Request {
   });
 }
 
+// Stub "no exposure recorded" so resolveIssuer / resolveIssuerSource don't
+// pick up the host's real ~/.parachute/expose-state.json (the hub#532 expose
+// tier would otherwise shadow the request-origin source these tests assert).
+const noExpose = (): string | undefined => undefined;
+
 function deps(
   h: Harness,
   overrides: Partial<Parameters<typeof handleApiSettingsHubOrigin>[1]> = {},
@@ -90,8 +95,8 @@ function deps(
   return {
     db: h.db,
     issuer: ISSUER,
-    resolvedIssuer: resolveIssuer(getReq(), h.db, undefined),
-    resolvedSource: resolveIssuerSource(h.db, undefined),
+    resolvedIssuer: resolveIssuer(getReq(), h.db, undefined, noExpose),
+    resolvedSource: resolveIssuerSource(h.db, undefined, noExpose),
     ...overrides,
   };
 }
@@ -414,8 +419,8 @@ describe("change takes effect on the next request (no restart needed)", () => {
     const g1 = await handleApiSettingsHubOrigin(getReq({ authorization: `Bearer ${bearer}` }), {
       db: h.db,
       issuer: ISSUER,
-      resolvedIssuer: resolveIssuer(getReq(), h.db, undefined),
-      resolvedSource: resolveIssuerSource(h.db, undefined),
+      resolvedIssuer: resolveIssuer(getReq(), h.db, undefined, noExpose),
+      resolvedSource: resolveIssuerSource(h.db, undefined, noExpose),
     });
     const b1 = (await g1.json()) as { source: string; resolved_issuer: string };
     expect(b1.source).toBe("request");
@@ -426,8 +431,8 @@ describe("change takes effect on the next request (no restart needed)", () => {
       {
         db: h.db,
         issuer: ISSUER,
-        resolvedIssuer: resolveIssuer(putReq({}), h.db, undefined),
-        resolvedSource: resolveIssuerSource(h.db, undefined),
+        resolvedIssuer: resolveIssuer(putReq({}), h.db, undefined, noExpose),
+        resolvedSource: resolveIssuerSource(h.db, undefined, noExpose),
       },
     );
     expect(p.status).toBe(200);
@@ -437,8 +442,8 @@ describe("change takes effect on the next request (no restart needed)", () => {
     const g2 = await handleApiSettingsHubOrigin(getReq({ authorization: `Bearer ${bearer}` }), {
       db: h.db,
       issuer: ISSUER,
-      resolvedIssuer: resolveIssuer(getReq(), h.db, undefined),
-      resolvedSource: resolveIssuerSource(h.db, undefined),
+      resolvedIssuer: resolveIssuer(getReq(), h.db, undefined, noExpose),
+      resolvedSource: resolveIssuerSource(h.db, undefined, noExpose),
     });
     const b2 = (await g2.json()) as {
       hub_origin: string | null;

--- a/src/__tests__/api-settings-hub-origin.test.ts
+++ b/src/__tests__/api-settings-hub-origin.test.ts
@@ -84,7 +84,7 @@ function putReq(body: unknown, headers: Record<string, string> = {}): Request {
 }
 
 // Stub "no exposure recorded" so resolveIssuer / resolveIssuerSource don't
-// pick up the host's real ~/.parachute/expose-state.json (the hub#532 expose
+// pick up the host's real ~/.parachute/expose-state.json (the #531 expose
 // tier would otherwise shadow the request-origin source these tests assert).
 const noExpose = (): string | undefined => undefined;
 

--- a/src/__tests__/hub-origin-resolution.test.ts
+++ b/src/__tests__/hub-origin-resolution.test.ts
@@ -226,7 +226,7 @@ describe("resolveIssuerSource — attribution for SPA", () => {
 });
 
 /**
- * The expose-state tier (hub#532). On the reboot-persistent owner-operated
+ * The expose-state tier (#531). On the reboot-persistent owner-operated
  * path the launchd plist / systemd unit carries no PARACHUTE_HUB_ORIGIN, so
  * the hub boots with no `configuredIssuer`. Without this tier it would stamp
  * `iss` from the per-request origin (loopback) and exposed resource servers
@@ -235,7 +235,7 @@ describe("resolveIssuerSource — attribution for SPA", () => {
  * env tier and the request-origin fallback. The `readExpose` seam (4th /
  * 3rd param) drives this without touching the real ~/.parachute.
  */
-describe("resolveIssuer — expose-state tier (hub#532)", () => {
+describe("resolveIssuer — expose-state tier (#531)", () => {
   const EXPOSED = "https://parachute.taildf9ce2.ts.net";
   // Simulates the reported bug: token minted under loopback, request arrives
   // at loopback, but the canonical exposed origin lives in expose-state.
@@ -283,15 +283,17 @@ describe("resolveIssuer — expose-state tier (hub#532)", () => {
   });
 
   test("malformed expose-state falls through to request without throwing", () => {
-    // The injected reader throwing simulates a corrupt expose-state.json.
-    // resolveIssuer must NOT propagate it — fall through to request origin.
+    // A reader that throws simulates a corrupt expose-state.json. The
+    // `exposeIssuerOrigin` wrapper guards the `readExpose()` call itself in
+    // try/catch, so even an injected non-swallowing reader can NEVER
+    // propagate into the request path — resolveIssuer falls through to the
+    // request origin instead of 500ing the hub.
     const throwing = () => {
       throw new Error("malformed expose-state.json");
     };
-    expect(() => resolveIssuer(loopbackReq(), db, undefined, throwing)).toThrow();
-    // ...but the *default* reader swallows malformed-file throws. Verify the
-    // exposeIssuerOrigin wrapper used by default is malformed-safe by going
-    // through it directly: a reader that returns undefined (post-swallow)
+    expect(() => resolveIssuer(loopbackReq(), db, undefined, throwing)).not.toThrow();
+    expect(resolveIssuer(loopbackReq(), db, undefined, throwing)).toBe("http://127.0.0.1:1939");
+    // A reader that returns undefined (the default's post-swallow shape) also
     // yields the request origin.
     expect(resolveIssuer(loopbackReq(), db, undefined, () => undefined)).toBe(
       "http://127.0.0.1:1939",
@@ -326,7 +328,7 @@ describe("resolveIssuer — expose-state tier (hub#532)", () => {
   });
 });
 
-describe("resolveIssuerSource — expose attribution (hub#532)", () => {
+describe("resolveIssuerSource — expose attribution (#531)", () => {
   const EXPOSED = "https://parachute.taildf9ce2.ts.net";
 
   test('"expose" when resolved from expose-state (settings+env absent)', () => {

--- a/src/__tests__/hub-origin-resolution.test.ts
+++ b/src/__tests__/hub-origin-resolution.test.ts
@@ -31,9 +31,20 @@ function req(url: string): Request {
   return new Request(url, { method: "GET" });
 }
 
+/**
+ * Stub the expose-state reader to "no exposure recorded" so these
+ * settings/env/request-tier tests are isolated from the host's real
+ * `~/.parachute/expose-state.json`. Without this, the default reader picks
+ * up a live exposure on the dev box and the expose tier shadows the
+ * request-origin fallback these tests assert. (The expose tier itself is
+ * exercised in the dedicated describe blocks below with its own injected
+ * origins.)
+ */
+const noExpose = (): string | undefined => undefined;
+
 describe("resolveIssuer — precedence chain", () => {
   test("falls back to request origin when no settings + no env", () => {
-    const got = resolveIssuer(req("http://127.0.0.1:1939/oauth/token"), db, undefined);
+    const got = resolveIssuer(req("http://127.0.0.1:1939/oauth/token"), db, undefined, noExpose);
     expect(got).toBe("http://127.0.0.1:1939");
   });
 
@@ -42,6 +53,7 @@ describe("resolveIssuer — precedence chain", () => {
       req("http://127.0.0.1:1939/oauth/token"),
       db,
       "https://hub.from-env.example",
+      noExpose,
     );
     expect(got).toBe("https://hub.from-env.example");
   });
@@ -52,13 +64,14 @@ describe("resolveIssuer — precedence chain", () => {
       req("http://127.0.0.1:1939/oauth/token"),
       db,
       "https://hub.from-env.example",
+      noExpose,
     );
     expect(got).toBe("https://hub.from-settings.example");
   });
 
   test("hub_settings wins over request origin (no env)", () => {
     setHubOrigin(db, "https://hub.from-settings.example");
-    const got = resolveIssuer(req("http://127.0.0.1:1939/oauth/token"), db, undefined);
+    const got = resolveIssuer(req("http://127.0.0.1:1939/oauth/token"), db, undefined, noExpose);
     expect(got).toBe("https://hub.from-settings.example");
   });
 
@@ -69,6 +82,7 @@ describe("resolveIssuer — precedence chain", () => {
       req("http://127.0.0.1:1939/oauth/token"),
       db,
       "https://hub.from-env.example",
+      noExpose,
     );
     expect(got).toBe("https://hub.from-env.example");
   });
@@ -76,7 +90,7 @@ describe("resolveIssuer — precedence chain", () => {
   test("clearing hub_settings + no env reverts to request origin", () => {
     setHubOrigin(db, "https://hub.from-settings.example");
     setHubOrigin(db, null);
-    const got = resolveIssuer(req("http://127.0.0.1:1939/oauth/token"), db, undefined);
+    const got = resolveIssuer(req("http://127.0.0.1:1939/oauth/token"), db, undefined, noExpose);
     expect(got).toBe("http://127.0.0.1:1939");
   });
 
@@ -84,13 +98,14 @@ describe("resolveIssuer — precedence chain", () => {
     // The wellknown / discovery surfaces may hit oauthDeps before a DB
     // is wired; resolveIssuer must not throw — just skip the settings
     // layer.
-    const got = resolveIssuer(req("http://127.0.0.1:1939/"), undefined, undefined);
+    const got = resolveIssuer(req("http://127.0.0.1:1939/"), undefined, undefined, noExpose);
     expect(got).toBe("http://127.0.0.1:1939");
 
     const gotEnv = resolveIssuer(
       req("http://127.0.0.1:1939/"),
       undefined,
       "https://hub.from-env.example",
+      noExpose,
     );
     expect(gotEnv).toBe("https://hub.from-env.example");
   });
@@ -103,19 +118,19 @@ describe("resolveIssuer — precedence chain", () => {
     const baseUrl = "http://127.0.0.1:1939/oauth/token";
 
     // Pass 1 — no settings, no env → request origin.
-    expect(resolveIssuer(req(baseUrl), db, undefined)).toBe("http://127.0.0.1:1939");
+    expect(resolveIssuer(req(baseUrl), db, undefined, noExpose)).toBe("http://127.0.0.1:1939");
 
     // Mid-flight write.
     setHubOrigin(db, "https://hub.example.com");
 
     // Pass 2 — settings wins immediately.
-    expect(resolveIssuer(req(baseUrl), db, undefined)).toBe("https://hub.example.com");
+    expect(resolveIssuer(req(baseUrl), db, undefined, noExpose)).toBe("https://hub.example.com");
 
     // Mid-flight clear.
     setHubOrigin(db, null);
 
     // Pass 3 — back to request origin.
-    expect(resolveIssuer(req(baseUrl), db, undefined)).toBe("http://127.0.0.1:1939");
+    expect(resolveIssuer(req(baseUrl), db, undefined, noExpose)).toBe("http://127.0.0.1:1939");
   });
 
   test("X-Forwarded-Proto: https upgrades the request-origin fallback", () => {
@@ -124,11 +139,14 @@ describe("resolveIssuer — precedence chain", () => {
     // `http://...` in OAuth discovery — mixed-content blocked when the
     // page loaded over https://. See hub#355 (the notes app's
     // /oauth/register call surfaced this).
-    const r = new Request("http://parachute-hub.onrender.com/.well-known/oauth-authorization-server", {
-      method: "GET",
-      headers: { "X-Forwarded-Proto": "https" },
-    });
-    expect(resolveIssuer(r, db, undefined)).toBe("https://parachute-hub.onrender.com");
+    const r = new Request(
+      "http://parachute-hub.onrender.com/.well-known/oauth-authorization-server",
+      {
+        method: "GET",
+        headers: { "X-Forwarded-Proto": "https" },
+      },
+    );
+    expect(resolveIssuer(r, db, undefined, noExpose)).toBe("https://parachute-hub.onrender.com");
   });
 
   test("X-Forwarded-Proto with comma-separated values takes the first", () => {
@@ -138,14 +156,14 @@ describe("resolveIssuer — precedence chain", () => {
       method: "GET",
       headers: { "X-Forwarded-Proto": "https, http" },
     });
-    expect(resolveIssuer(r, db, undefined)).toBe("https://hub.internal");
+    expect(resolveIssuer(r, db, undefined, noExpose)).toBe("https://hub.internal");
   });
 
   test("missing X-Forwarded-Proto leaves the URL scheme as-is (localhost dev)", () => {
     // No reverse proxy → no header → keep http for the local-dev shape.
     // Operators on plain HTTP localhost depend on this.
     const r = new Request("http://127.0.0.1:1939/oauth/token", { method: "GET" });
-    expect(resolveIssuer(r, db, undefined)).toBe("http://127.0.0.1:1939");
+    expect(resolveIssuer(r, db, undefined, noExpose)).toBe("http://127.0.0.1:1939");
   });
 
   test("X-Forwarded-Proto is IGNORED when hub_settings or env wins", () => {
@@ -161,26 +179,28 @@ describe("resolveIssuer — precedence chain", () => {
 
     // Env layer wins, even though the header says https — the env value
     // is returned verbatim (preserving whatever scheme the operator set).
-    expect(resolveIssuer(r, db, "http://configured.example")).toBe("http://configured.example");
+    expect(resolveIssuer(r, db, "http://configured.example", noExpose)).toBe(
+      "http://configured.example",
+    );
 
     // Settings layer wins above env, also verbatim.
     setHubOrigin(db, "http://settings.example");
-    expect(resolveIssuer(r, db, "https://env.example")).toBe("http://settings.example");
+    expect(resolveIssuer(r, db, "https://env.example", noExpose)).toBe("http://settings.example");
   });
 });
 
 describe("resolveIssuerSource — attribution for SPA", () => {
   test('"request" when nothing is configured', () => {
-    expect(resolveIssuerSource(db, undefined)).toBe("request");
+    expect(resolveIssuerSource(db, undefined, noExpose)).toBe("request");
   });
 
   test('"env" when configuredIssuer is set + no settings row', () => {
-    expect(resolveIssuerSource(db, "https://hub.from-env.example")).toBe("env");
+    expect(resolveIssuerSource(db, "https://hub.from-env.example", noExpose)).toBe("env");
   });
 
   test('"settings" when hub_settings row is set, even if env is also set', () => {
     setHubOrigin(db, "https://hub.from-settings.example");
-    expect(resolveIssuerSource(db, "https://hub.from-env.example")).toBe("settings");
+    expect(resolveIssuerSource(db, "https://hub.from-env.example", noExpose)).toBe("settings");
   });
 
   test("attribution matches resolved value across the chain", () => {
@@ -189,16 +209,148 @@ describe("resolveIssuerSource — attribution for SPA", () => {
     // settings layer is what got returned.
     setHubOrigin(db, "https://hub.example.com");
     const r1 = req("http://127.0.0.1:1939/oauth/token");
-    expect(resolveIssuer(r1, db, "https://hub.from-env.example")).toBe("https://hub.example.com");
-    expect(resolveIssuerSource(db, "https://hub.from-env.example")).toBe("settings");
+    expect(resolveIssuer(r1, db, "https://hub.from-env.example", noExpose)).toBe(
+      "https://hub.example.com",
+    );
+    expect(resolveIssuerSource(db, "https://hub.from-env.example", noExpose)).toBe("settings");
 
     setHubOrigin(db, null);
-    expect(resolveIssuer(r1, db, "https://hub.from-env.example")).toBe(
+    expect(resolveIssuer(r1, db, "https://hub.from-env.example", noExpose)).toBe(
       "https://hub.from-env.example",
     );
-    expect(resolveIssuerSource(db, "https://hub.from-env.example")).toBe("env");
+    expect(resolveIssuerSource(db, "https://hub.from-env.example", noExpose)).toBe("env");
 
-    expect(resolveIssuer(r1, db, undefined)).toBe("http://127.0.0.1:1939");
-    expect(resolveIssuerSource(db, undefined)).toBe("request");
+    expect(resolveIssuer(r1, db, undefined, noExpose)).toBe("http://127.0.0.1:1939");
+    expect(resolveIssuerSource(db, undefined, noExpose)).toBe("request");
+  });
+});
+
+/**
+ * The expose-state tier (hub#532). On the reboot-persistent owner-operated
+ * path the launchd plist / systemd unit carries no PARACHUTE_HUB_ORIGIN, so
+ * the hub boots with no `configuredIssuer`. Without this tier it would stamp
+ * `iss` from the per-request origin (loopback) and exposed resource servers
+ * (vault) reject the token with `unexpected "iss" claim value`. The exposed
+ * origin recorded in expose-state.json's hubOrigin is consulted between the
+ * env tier and the request-origin fallback. The `readExpose` seam (4th /
+ * 3rd param) drives this without touching the real ~/.parachute.
+ */
+describe("resolveIssuer — expose-state tier (hub#532)", () => {
+  const EXPOSED = "https://parachute.taildf9ce2.ts.net";
+  // Simulates the reported bug: token minted under loopback, request arrives
+  // at loopback, but the canonical exposed origin lives in expose-state.
+  const loopbackReq = () => req("http://127.0.0.1:1939/oauth/token");
+
+  test("REGRESSION: expose origin used (NOT request origin) when settings+env both absent", () => {
+    const got = resolveIssuer(loopbackReq(), db, undefined, () => EXPOSED);
+    expect(got).toBe(EXPOSED);
+    expect(got).not.toBe("http://127.0.0.1:1939");
+  });
+
+  test("settings wins over expose", () => {
+    setHubOrigin(db, "https://hub.from-settings.example");
+    const got = resolveIssuer(loopbackReq(), db, undefined, () => EXPOSED);
+    expect(got).toBe("https://hub.from-settings.example");
+  });
+
+  test("env wins over expose", () => {
+    const got = resolveIssuer(loopbackReq(), db, "https://hub.from-env.example", () => EXPOSED);
+    expect(got).toBe("https://hub.from-env.example");
+  });
+
+  test("expose wins over request origin", () => {
+    // settings + env both absent → expose beats the per-request loopback origin.
+    const got = resolveIssuer(loopbackReq(), db, undefined, () => EXPOSED);
+    expect(got).toBe(EXPOSED);
+  });
+
+  test("full precedence: settings > env > expose > request", () => {
+    // request-only
+    expect(resolveIssuer(loopbackReq(), db, undefined, () => undefined)).toBe(
+      "http://127.0.0.1:1939",
+    );
+    // expose beats request
+    expect(resolveIssuer(loopbackReq(), db, undefined, () => EXPOSED)).toBe(EXPOSED);
+    // env beats expose
+    expect(resolveIssuer(loopbackReq(), db, "https://env.example", () => EXPOSED)).toBe(
+      "https://env.example",
+    );
+    // settings beats env (and expose)
+    setHubOrigin(db, "https://settings.example");
+    expect(resolveIssuer(loopbackReq(), db, "https://env.example", () => EXPOSED)).toBe(
+      "https://settings.example",
+    );
+  });
+
+  test("malformed expose-state falls through to request without throwing", () => {
+    // The injected reader throwing simulates a corrupt expose-state.json.
+    // resolveIssuer must NOT propagate it — fall through to request origin.
+    const throwing = () => {
+      throw new Error("malformed expose-state.json");
+    };
+    expect(() => resolveIssuer(loopbackReq(), db, undefined, throwing)).toThrow();
+    // ...but the *default* reader swallows malformed-file throws. Verify the
+    // exposeIssuerOrigin wrapper used by default is malformed-safe by going
+    // through it directly: a reader that returns undefined (post-swallow)
+    // yields the request origin.
+    expect(resolveIssuer(loopbackReq(), db, undefined, () => undefined)).toBe(
+      "http://127.0.0.1:1939",
+    );
+  });
+
+  test("loopback expose origin ignored (never re-pin the degraded mode)", () => {
+    expect(resolveIssuer(loopbackReq(), db, undefined, () => "http://127.0.0.1:1939")).toBe(
+      "http://127.0.0.1:1939",
+    );
+    expect(resolveIssuer(loopbackReq(), db, undefined, () => "http://localhost:1939")).toBe(
+      "http://127.0.0.1:1939",
+    );
+    expect(resolveIssuer(loopbackReq(), db, undefined, () => "http://0.0.0.0:1939")).toBe(
+      "http://127.0.0.1:1939",
+    );
+  });
+
+  test("non-http(s) / empty expose origin ignored", () => {
+    expect(resolveIssuer(loopbackReq(), db, undefined, () => "ftp://x.example")).toBe(
+      "http://127.0.0.1:1939",
+    );
+    expect(resolveIssuer(loopbackReq(), db, undefined, () => "")).toBe("http://127.0.0.1:1939");
+    expect(resolveIssuer(loopbackReq(), db, undefined, () => "not-a-url")).toBe(
+      "http://127.0.0.1:1939",
+    );
+  });
+
+  test("undefined db (pre-config gate) still consults expose before request", () => {
+    const got = resolveIssuer(loopbackReq(), undefined, undefined, () => EXPOSED);
+    expect(got).toBe(EXPOSED);
+  });
+});
+
+describe("resolveIssuerSource — expose attribution (hub#532)", () => {
+  const EXPOSED = "https://parachute.taildf9ce2.ts.net";
+
+  test('"expose" when resolved from expose-state (settings+env absent)', () => {
+    expect(resolveIssuerSource(db, undefined, () => EXPOSED)).toBe("expose");
+  });
+
+  test('"settings" wins over expose', () => {
+    setHubOrigin(db, "https://settings.example");
+    expect(resolveIssuerSource(db, undefined, () => EXPOSED)).toBe("settings");
+  });
+
+  test('"env" wins over expose', () => {
+    expect(resolveIssuerSource(db, "https://env.example", () => EXPOSED)).toBe("env");
+  });
+
+  test('"request" when no settings/env and no (valid) expose origin', () => {
+    expect(resolveIssuerSource(db, undefined, () => undefined)).toBe("request");
+    expect(resolveIssuerSource(db, undefined, () => "http://127.0.0.1:1939")).toBe("request");
+  });
+
+  test("attribution matches resolved value for the expose tier", () => {
+    // Pair the source label with the resolved value so they can't drift.
+    const r = req("http://127.0.0.1:1939/oauth/token");
+    expect(resolveIssuer(r, db, undefined, () => EXPOSED)).toBe(EXPOSED);
+    expect(resolveIssuerSource(db, undefined, () => EXPOSED)).toBe("expose");
   });
 });

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -533,7 +533,7 @@ describe("hubFetch routing", () => {
       const res = await hubFetch(h.dir, {
         manifestPath: h.manifestPath,
         // No exposure recorded — isolate from the host's real expose-state.json
-        // so the request-origin fallback (not the hub#532 expose tier) is what
+        // so the request-origin fallback (not the #531 expose tier) is what
         // this test exercises.
         loadExposeHubOrigin: () => undefined,
       })(new Request("http://127.0.0.1:1939/.well-known/parachute.json"));

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -530,9 +530,13 @@ describe("hubFetch routing", () => {
     const h = makeHarness();
     try {
       writeManifest({ services: [vaultEntry("default")] }, h.manifestPath);
-      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(
-        new Request("http://127.0.0.1:1939/.well-known/parachute.json"),
-      );
+      const res = await hubFetch(h.dir, {
+        manifestPath: h.manifestPath,
+        // No exposure recorded — isolate from the host's real expose-state.json
+        // so the request-origin fallback (not the hub#532 expose tier) is what
+        // this test exercises.
+        loadExposeHubOrigin: () => undefined,
+      })(new Request("http://127.0.0.1:1939/.well-known/parachute.json"));
       const body = (await res.json()) as { vaults: Array<{ url: string }> };
       expect(body.vaults[0]?.url).toBe("http://127.0.0.1:1939/vault/default");
     } finally {

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -251,7 +251,7 @@ describe("resolveStartupIssuer — precedence chain (hub#365)", () => {
   // Stub "no exposure recorded" so the undefined-asserting tests are
   // isolated from the host's real ~/.parachute/expose-state.json — the
   // default reader picks up a live exposure on the dev box and the expose
-  // tier (hub#532) would otherwise shadow the "no source → undefined" cases.
+  // tier (#531) would otherwise shadow the "no source → undefined" cases.
   // The expose tier itself is exercised in its own describe block below.
   const noExpose = (): string | undefined => undefined;
 
@@ -357,7 +357,7 @@ describe("resolveStartupIssuer — precedence chain (hub#365)", () => {
   });
 });
 
-describe("resolveStartupIssuer — expose-state fallback (hub#532)", () => {
+describe("resolveStartupIssuer — expose-state fallback (#531)", () => {
   // The reboot-persistent bug: the launchd plist / systemd unit that keeps
   // `parachute serve` alive carries no PARACHUTE_HUB_ORIGIN, so on every
   // reboot the hub boots with no flag/env/platform origin and would stamp
@@ -427,5 +427,17 @@ describe("resolveStartupIssuer — expose-state fallback (hub#532)", () => {
     // exposure recorded under the test PARACHUTE_HOME it just yields
     // undefined → undefined issuer. The key assertion is "doesn't throw."
     expect(() => resolveStartupIssuer({}, {})).not.toThrow();
+  });
+
+  test("a throwing injected reader can't crash startup (returns undefined)", () => {
+    // The readExpose() call is try/catch-wrapped so even a non-swallowing
+    // reader can't propagate into boot. With no flag/env/platform origin set
+    // and a throwing reader, the issuer resolves to undefined (the degraded
+    // request-origin mode) rather than crashing `parachute serve`.
+    const throwing = () => {
+      throw new Error("malformed expose-state.json");
+    };
+    expect(() => resolveStartupIssuer({}, {}, throwing)).not.toThrow();
+    expect(resolveStartupIssuer({}, {}, throwing)).toBeUndefined();
   });
 });

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -248,6 +248,13 @@ describe("bootstrap-token wiring under needs-setup", () => {
 });
 
 describe("resolveStartupIssuer — precedence chain (hub#365)", () => {
+  // Stub "no exposure recorded" so the undefined-asserting tests are
+  // isolated from the host's real ~/.parachute/expose-state.json — the
+  // default reader picks up a live exposure on the dev box and the expose
+  // tier (hub#532) would otherwise shadow the "no source → undefined" cases.
+  // The expose tier itself is exercised in its own describe block below.
+  const noExpose = (): string | undefined => undefined;
+
   test("explicit opts.issuer wins over everything", () => {
     const got = resolveStartupIssuer(
       { issuer: "https://override.example" },
@@ -296,9 +303,9 @@ describe("resolveStartupIssuer — precedence chain (hub#365)", () => {
   });
 
   test("returns undefined when no source has a value", () => {
-    expect(resolveStartupIssuer({}, {})).toBeUndefined();
-    expect(resolveStartupIssuer({}, { RENDER_EXTERNAL_URL: "" })).toBeUndefined();
-    expect(resolveStartupIssuer({}, { PARACHUTE_HUB_ORIGIN: "" })).toBeUndefined();
+    expect(resolveStartupIssuer({}, {}, noExpose)).toBeUndefined();
+    expect(resolveStartupIssuer({}, { RENDER_EXTERNAL_URL: "" }, noExpose)).toBeUndefined();
+    expect(resolveStartupIssuer({}, { PARACHUTE_HUB_ORIGIN: "" }, noExpose)).toBeUndefined();
   });
 
   test("empty string after slash-strip collapses to undefined (defensive)", () => {
@@ -306,7 +313,7 @@ describe("resolveStartupIssuer — precedence chain (hub#365)", () => {
     // Guards against a misconfigured env where someone sets the var to "/"
     // expecting it to mean "root" (it doesn't — leaves hub without a usable
     // origin, which is the same as not setting it at all).
-    expect(resolveStartupIssuer({}, { PARACHUTE_HUB_ORIGIN: "/" })).toBeUndefined();
+    expect(resolveStartupIssuer({}, { PARACHUTE_HUB_ORIGIN: "/" }, noExpose)).toBeUndefined();
   });
 
   // Fly.io self-host path (patterns#100). resolveStartupIssuer is the
@@ -341,11 +348,84 @@ describe("resolveStartupIssuer — precedence chain (hub#365)", () => {
   });
 
   test("FLY_APP_NAME with slash rejected (defensive — Fly slugs don't contain /)", () => {
-    expect(resolveStartupIssuer({}, { FLY_APP_NAME: "a/b" })).toBeUndefined();
-    expect(resolveStartupIssuer({}, { FLY_APP_NAME: "../etc/passwd" })).toBeUndefined();
+    expect(resolveStartupIssuer({}, { FLY_APP_NAME: "a/b" }, noExpose)).toBeUndefined();
+    expect(resolveStartupIssuer({}, { FLY_APP_NAME: "../etc/passwd" }, noExpose)).toBeUndefined();
   });
 
   test("FLY_APP_NAME empty string → no fallback", () => {
-    expect(resolveStartupIssuer({}, { FLY_APP_NAME: "" })).toBeUndefined();
+    expect(resolveStartupIssuer({}, { FLY_APP_NAME: "" }, noExpose)).toBeUndefined();
+  });
+});
+
+describe("resolveStartupIssuer — expose-state fallback (hub#532)", () => {
+  // The reboot-persistent bug: the launchd plist / systemd unit that keeps
+  // `parachute serve` alive carries no PARACHUTE_HUB_ORIGIN, so on every
+  // reboot the hub boots with no flag/env/platform origin and would stamp
+  // iss from the per-request origin — which exposed resource servers (vault)
+  // reject until they restart. Reading expose-state.json's hubOrigin makes
+  // iss deterministic across reboots. The readExpose seam lets us drive this
+  // without touching the real ~/.parachute.
+  const EXPOSED = "https://parachute.taildf9ce2.ts.net";
+
+  test("returns expose-state.hubOrigin when no flag/env/platform set", () => {
+    const got = resolveStartupIssuer({}, {}, () => EXPOSED);
+    expect(got).toBe(EXPOSED);
+  });
+
+  test("explicit opts.issuer wins over expose-state", () => {
+    const got = resolveStartupIssuer({ issuer: "https://override.example" }, {}, () => EXPOSED);
+    expect(got).toBe("https://override.example");
+  });
+
+  test("PARACHUTE_HUB_ORIGIN wins over expose-state", () => {
+    const got = resolveStartupIssuer(
+      {},
+      { PARACHUTE_HUB_ORIGIN: "https://env.example" },
+      () => EXPOSED,
+    );
+    expect(got).toBe("https://env.example");
+  });
+
+  test("RENDER_EXTERNAL_URL wins over expose-state", () => {
+    const got = resolveStartupIssuer(
+      {},
+      { RENDER_EXTERNAL_URL: "https://app.onrender.com" },
+      () => EXPOSED,
+    );
+    expect(got).toBe("https://app.onrender.com");
+  });
+
+  test("FLY_APP_NAME wins over expose-state", () => {
+    const got = resolveStartupIssuer({}, { FLY_APP_NAME: "my-parachute" }, () => EXPOSED);
+    expect(got).toBe("https://my-parachute.fly.dev");
+  });
+
+  test("returns undefined when expose-state is absent (no hubOrigin recorded)", () => {
+    expect(resolveStartupIssuer({}, {}, () => undefined)).toBeUndefined();
+  });
+
+  test("strips trailing slashes from the expose origin", () => {
+    expect(resolveStartupIssuer({}, {}, () => `${EXPOSED}/`)).toBe(EXPOSED);
+    expect(resolveStartupIssuer({}, {}, () => `${EXPOSED}//`)).toBe(EXPOSED);
+  });
+
+  test("ignores a loopback expose hubOrigin (never re-pin the degraded mode)", () => {
+    expect(resolveStartupIssuer({}, {}, () => "http://127.0.0.1:1939")).toBeUndefined();
+    expect(resolveStartupIssuer({}, {}, () => "http://localhost:1939")).toBeUndefined();
+    expect(resolveStartupIssuer({}, {}, () => "http://[::1]:1939")).toBeUndefined();
+    expect(resolveStartupIssuer({}, {}, () => "http://0.0.0.0:1939")).toBeUndefined();
+  });
+
+  test("ignores a non-http(s) or malformed expose origin", () => {
+    expect(resolveStartupIssuer({}, {}, () => "ftp://parachute.example")).toBeUndefined();
+    expect(resolveStartupIssuer({}, {}, () => "not-a-url")).toBeUndefined();
+    expect(resolveStartupIssuer({}, {}, () => "")).toBeUndefined();
+  });
+
+  test("default reader is swallowed-safe (no real ~/.parachute) — does not throw", () => {
+    // The default readExpose swallows a malformed-file throw; with no
+    // exposure recorded under the test PARACHUTE_HOME it just yields
+    // undefined → undefined issuer. The key assertion is "doesn't throw."
+    expect(() => resolveStartupIssuer({}, {})).not.toThrow();
   });
 });

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -32,11 +32,13 @@ import { generateBootstrapToken } from "../bootstrap-token.ts";
 // `serve()` cannot reroute them — set PARACHUTE_HOME before importing for
 // path isolation.
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
+import { readExposeState } from "../expose-state.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { hubFetch } from "../hub-server.ts";
 import { writeHubFile } from "../hub.ts";
 import { Supervisor } from "../supervisor.ts";
 import { createUser, userCount } from "../users.ts";
+import { isLoopbackOrigin } from "../vault-hub-origin-env.ts";
 import { WELL_KNOWN_DIR } from "../well-known.ts";
 import { bootSupervisedModules } from "./serve-boot.ts";
 
@@ -124,7 +126,21 @@ function parsePort(raw: string | undefined): number | undefined {
  *      operator can't know the URL at deploy time. Without this, supervised
  *      modules' iss-validation breaks on hub-minted tokens (iss-mismatch
  *      every time).
- *   4. None (returns undefined). Hub falls back to per-request derivation
+ *   4. `expose-state.json`'s `hubOrigin` — the canonical public origin a
+ *      live tailscale/cloudflare exposure recorded (e.g.
+ *      `https://parachute.taildf9ce2.ts.net`). This is the load-bearing
+ *      tier for the **owner-operated reboot-persistent path**: the launchd
+ *      plist / systemd unit that keeps `parachute serve` alive carries no
+ *      `PARACHUTE_HUB_ORIGIN` env, so on every reboot the hub would
+ *      otherwise boot issuer-less (tier 5), stamp `iss` from the per-request
+ *      origin, and inject nothing into children — vault then defaults to
+ *      loopback and rejects hub-minted tokens with `unexpected "iss" claim
+ *      value` until it restarts. Reading the exposed origin off disk makes
+ *      `iss` deterministic across reboots with zero operator action. Guarded
+ *      to a non-loopback `http(s)` origin (a loopback value here would
+ *      re-pin the degraded mode; expose-state should never carry one, but we
+ *      defend anyway).
+ *   5. None (returns undefined). Hub falls back to per-request derivation
  *      via `resolveIssuer` in hub-server.ts — works for `/.well-known`
  *      discovery but supervised modules with cached iss expectations
  *      won't have a static value to validate against, so OAuth flows
@@ -136,18 +152,60 @@ function parsePort(raw: string | undefined): number | undefined {
  *
  * Trailing slashes are stripped for canonical-form comparison; empty
  * strings collapse to undefined.
+ *
+ * `readExpose` is injectable so tests exercise the expose-state tier
+ * without touching the real `~/.parachute`. The default reads
+ * `expose-state.json` and swallows a malformed-file throw (a corrupt state
+ * file must never crash startup — fall through to the request-origin mode).
  */
 export function resolveStartupIssuer(
   opts: { issuer?: string },
   env: NodeJS.ProcessEnv,
+  readExpose: () => string | undefined = defaultReadExposeHubOrigin,
 ): string | undefined {
   const flyOrigin = flyDefaultOriginFromEnv(env);
-  return (
-    (opts.issuer ?? env.PARACHUTE_HUB_ORIGIN ?? env.RENDER_EXTERNAL_URL ?? flyOrigin)?.replace(
-      /\/+$/,
-      "",
-    ) || undefined
-  );
+  const explicit = (
+    opts.issuer ??
+    env.PARACHUTE_HUB_ORIGIN ??
+    env.RENDER_EXTERNAL_URL ??
+    flyOrigin
+  )?.replace(/\/+$/, "");
+  if (explicit) return explicit;
+  // No flag / env / platform origin set — fall back to the exposed origin
+  // recorded on disk. Guard it to a non-loopback http(s) origin so a stray
+  // loopback value never pins the degraded request-origin mode.
+  const exposed = readExpose()?.replace(/\/+$/, "");
+  if (exposed && isHttpOrigin(exposed) && !isLoopbackOrigin(exposed)) {
+    return exposed;
+  }
+  return undefined;
+}
+
+/**
+ * Read `expose-state.json`'s `hubOrigin` for the startup-issuer fallback,
+ * swallowing a malformed-file throw. Kept separate so it can be passed as
+ * the default `readExpose` arg and stubbed in tests.
+ */
+function defaultReadExposeHubOrigin(): string | undefined {
+  try {
+    return readExposeState()?.hubOrigin;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * True iff `origin` parses as an absolute http(s) URL. Defends the
+ * expose-state fallback against a non-URL or wrong-scheme value sneaking in
+ * as the issuer.
+ */
+function isHttpOrigin(origin: string): boolean {
+  try {
+    const proto = new URL(origin).protocol;
+    return proto === "http:" || proto === "https:";
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -38,7 +38,7 @@ import { hubFetch } from "../hub-server.ts";
 import { writeHubFile } from "../hub.ts";
 import { Supervisor } from "../supervisor.ts";
 import { createUser, userCount } from "../users.ts";
-import { isLoopbackOrigin } from "../vault-hub-origin-env.ts";
+import { sanitizePublicOrigin } from "../vault-hub-origin-env.ts";
 import { WELL_KNOWN_DIR } from "../well-known.ts";
 import { bootSupervisedModules } from "./serve-boot.ts";
 
@@ -156,7 +156,18 @@ function parsePort(raw: string | undefined): number | undefined {
  * `readExpose` is injectable so tests exercise the expose-state tier
  * without touching the real `~/.parachute`. The default reads
  * `expose-state.json` and swallows a malformed-file throw (a corrupt state
- * file must never crash startup — fall through to the request-origin mode).
+ * file must never crash startup — fall through to the request-origin mode);
+ * the `readExpose()` call is additionally try/catch-wrapped here so even an
+ * injected non-swallowing reader can't crash startup.
+ *
+ * KNOWN ASTERISK (tracked in #532): this resolves the issuer at boot, so a
+ * child module spawned during a *pre-expose* boot — hub started before the
+ * first-ever `parachute expose` — gets no `PARACHUTE_HUB_ORIGIN` injected
+ * until it's restarted after the exposure exists. Once an exposure is
+ * recorded, every subsequent reboot picks it up here automatically. The
+ * remaining gap (rebuild the live spawn-env on `supervisor.restart` so the
+ * first exposure propagates to already-running children without a manual
+ * restart) is the deferred #532 follow-up; not implemented in this PR.
  */
 export function resolveStartupIssuer(
   opts: { issuer?: string },
@@ -172,13 +183,16 @@ export function resolveStartupIssuer(
   )?.replace(/\/+$/, "");
   if (explicit) return explicit;
   // No flag / env / platform origin set — fall back to the exposed origin
-  // recorded on disk. Guard it to a non-loopback http(s) origin so a stray
-  // loopback value never pins the degraded request-origin mode.
-  const exposed = readExpose()?.replace(/\/+$/, "");
-  if (exposed && isHttpOrigin(exposed) && !isLoopbackOrigin(exposed)) {
-    return exposed;
+  // recorded on disk. `sanitizePublicOrigin` applies the same non-loopback
+  // http(s) guard as the hub-server chokepoint (#531) so a stray loopback
+  // value never pins the degraded request-origin mode.
+  let raw: string | undefined;
+  try {
+    raw = readExpose();
+  } catch {
+    return undefined;
   }
-  return undefined;
+  return sanitizePublicOrigin(raw);
 }
 
 /**
@@ -191,20 +205,6 @@ function defaultReadExposeHubOrigin(): string | undefined {
     return readExposeState()?.hubOrigin;
   } catch {
     return undefined;
-  }
-}
-
-/**
- * True iff `origin` parses as an absolute http(s) URL. Defends the
- * expose-state fallback against a non-URL or wrong-scheme value sneaking in
- * as the issuer.
- */
-function isHttpOrigin(origin: string): boolean {
-  try {
-    const proto = new URL(origin).protocol;
-    return proto === "http:" || proto === "https:";
-  } catch {
-    return false;
   }
 }
 

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -220,6 +220,7 @@ import { getAllPublicKeys } from "./signing-keys.ts";
 import type { Supervisor } from "./supervisor.ts";
 import { handleTwoFactorGet, handleTwoFactorPost } from "./two-factor-handlers.ts";
 import { getUserById, userCount } from "./users.ts";
+import { isLoopbackOrigin } from "./vault-hub-origin-env.ts";
 import {
   WELL_KNOWN_DIR,
   buildWellKnown,
@@ -788,12 +789,20 @@ export interface HubFetchDeps {
    */
   loopbackPort?: number;
   /**
-   * Test seam for reading `expose-state.json`. Production reads the operator's
-   * `~/.parachute/expose-state.json` via `readExposeState`; tests inject a
-   * fake to drive tailnet/funnel origins into the bound set without standing
-   * up real exposes. Returns `undefined` when no state file is present
-   * (pre-`parachute expose` state — fine, the issuer + loopback still cover
-   * legitimate access).
+   * Test seam for reading `expose-state.json`'s `hubOrigin`. Production reads
+   * the operator's `~/.parachute/expose-state.json` via `readExposeState`;
+   * tests inject a fake to drive tailnet/funnel origins into the bound set
+   * without standing up real exposes. Returns `undefined` when no state file
+   * is present (pre-`parachute expose` state — fine, the issuer + loopback
+   * still cover legitimate access).
+   *
+   * This single seam now feeds BOTH (a) the same-origin bound set via
+   * `buildHubBoundOrigins`, and (b) the issuer resolution via `resolveIssuer`
+   * (hub#532): on the reboot-persistent owner-operated path the launchd /
+   * systemd unit carries no `PARACHUTE_HUB_ORIGIN`, so the hub boots with no
+   * `configuredIssuer` and falls back to this exposed origin rather than
+   * stamping `iss` from the per-request (loopback) origin — which exposed
+   * resource servers (vault) reject until they restart.
    */
   loadExposeHubOrigin?: () => string | undefined;
   /**
@@ -1069,37 +1078,92 @@ function dbNotConfigured(): Response {
 }
 
 /**
+ * Read the exposed public origin off `expose-state.json` for the issuer
+ * fallback, guarded to a non-loopback http(s) origin and malformed-safe.
+ * Returns undefined when no exposure is recorded, the file is corrupt, or
+ * the recorded origin is loopback / not an http(s) URL (a loopback value
+ * here would re-pin the degraded request-origin mode — expose-state should
+ * never carry one, but we defend anyway). This is the seam the launchd /
+ * systemd reboot path leans on: those units carry no `PARACHUTE_HUB_ORIGIN`,
+ * so without it the hub boots issuer-less and stamps `iss` from the
+ * per-request origin, which exposed resource servers (vault) reject.
+ *
+ * Trailing slashes stripped for canonical form, mirroring resolveStartupIssuer.
+ */
+export function exposeIssuerOrigin(
+  readExpose: () => string | undefined = defaultExposeHubOriginRead,
+): string | undefined {
+  const raw = readExpose()?.replace(/\/+$/, "");
+  if (!raw) return undefined;
+  let proto: string;
+  try {
+    proto = new URL(raw).protocol;
+  } catch {
+    return undefined;
+  }
+  if (proto !== "http:" && proto !== "https:") return undefined;
+  if (isLoopbackOrigin(raw)) return undefined;
+  return raw;
+}
+
+function defaultExposeHubOriginRead(): string | undefined {
+  try {
+    return readExposeState()?.hubOrigin;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Resolve the OAuth issuer URL for this request. Precedence, highest
- * first (hub#298):
+ * first (hub#298, expose tier added hub#532):
  *
  *   1. `hub_settings.hub_origin` — operator-set canonical URL from the
  *      admin SPA. Wins when present.
  *   2. `configuredIssuer` — `--issuer` flag or `PARACHUTE_HUB_ORIGIN`
  *      env var captured at hub start. The deploy-time setting.
- *   3. `new URL(req.url).origin` — the request's own origin. Local dev
+ *   3. `expose-state.json`'s `hubOrigin` — the canonical public origin a
+ *      live tailscale/cloudflare exposure recorded. Load-bearing for the
+ *      reboot-persistent owner-operated path: the launchd plist / systemd
+ *      unit carries no `PARACHUTE_HUB_ORIGIN`, so a hub booted off it has
+ *      no `configuredIssuer` and would otherwise stamp `iss` from the
+ *      per-request origin — which exposed resource servers (vault) reject
+ *      with `unexpected "iss" claim value` until they restart. Reading the
+ *      exposed origin off disk closes that. Guarded non-loopback http(s)
+ *      (see `exposeIssuerOrigin`).
+ *   4. `new URL(req.url).origin` — the request's own origin. Local dev
  *      + Render-assigned subdomains land here when nothing's been
  *      configured.
  *
  * Per-request (not cached at hub start) so a PUT to
  * `/api/settings/hub-origin` takes effect on the next request without a
- * restart. The hub_settings read is a single small SQLite query — cheap
- * relative to JWT signing on the same request path.
+ * restart. Both the hub_settings read and the expose-state read are cheap
+ * (a small SQLite query / a small JSON parse) relative to JWT signing on
+ * the same request path — and the expose read is per-request so an operator
+ * who runs `parachute expose` while the hub is up gets the new origin on the
+ * next request without a restart.
  *
  * `db` is optional because the wellknown / discovery surfaces are
  * reachable on a hub with no DB configured (the dbNotConfigured 503
  * gate sits behind these in the dispatcher). In that case we skip the
- * settings layer and fall through to env/request precedence.
+ * settings layer and fall through to env/expose/request precedence.
+ *
+ * `readExpose` is injectable so tests exercise the expose tier without
+ * touching the real `~/.parachute`.
  */
 export function resolveIssuer(
   req: Request,
   db: Database | undefined,
   configuredIssuer: string | undefined,
+  readExpose: () => string | undefined = defaultExposeHubOriginRead,
 ): string {
   if (db !== undefined) {
     const stored = getHubOrigin(db);
     if (stored) return stored;
   }
   if (configuredIssuer) return configuredIssuer;
+  const exposed = exposeIssuerOrigin(readExpose);
+  if (exposed) return exposed;
   // Reverse-proxy aware: Render / Tailscale Funnel / cloudflared terminate
   // TLS at the edge and forward plain HTTP to hub. Without X-Forwarded-Proto
   // honoring, `req.url.origin` is `http://...` and hub publishes mixed-content
@@ -1128,16 +1192,20 @@ export function resolveIssuer(
 /**
  * Where did the resolved issuer come from? Drives the source-label
  * surfaced in the admin SPA so operators can tell which precedence
- * layer they're on without inspecting the DB or env.
+ * layer they're on without inspecting the DB or env. Mirrors the
+ * precedence in `resolveIssuer` exactly — settings > env > expose >
+ * request — so the attribution can't drift from the resolved value.
  */
-export type IssuerSource = "settings" | "env" | "request";
+export type IssuerSource = "settings" | "env" | "expose" | "request";
 
 export function resolveIssuerSource(
   db: Database | undefined,
   configuredIssuer: string | undefined,
+  readExpose: () => string | undefined = defaultExposeHubOriginRead,
 ): IssuerSource {
   if (db !== undefined && getHubOrigin(db)) return "settings";
   if (configuredIssuer) return "env";
+  if (exposeIssuerOrigin(readExpose)) return "expose";
   return "request";
 }
 
@@ -1164,7 +1232,7 @@ export function hubFetch(
     });
 
   const oauthDeps = (req: Request) => {
-    const issuer = resolveIssuer(req, getDb?.(), configuredIssuer);
+    const issuer = resolveIssuer(req, getDb?.(), configuredIssuer, loadExposeHubOrigin);
     return {
       issuer,
       // Per-request resolution (closes #245): expose-state.json can change
@@ -1525,7 +1593,12 @@ export function hubFetch(
         // `/.well-known/parachute.json` while their JWTs carry the
         // canonical URL, and discovery clients would split-brain on
         // which one to trust.
-        const canonicalOrigin = resolveIssuer(req, getDb?.(), configuredIssuer);
+        const canonicalOrigin = resolveIssuer(
+          req,
+          getDb?.(),
+          configuredIssuer,
+          loadExposeHubOrigin,
+        );
         const readManifestFn = deps?.readModuleManifest ?? defaultReadModuleManifest;
         const [managementUrlByName, serviceUiMeta] = await Promise.all([
           loadManagementUrls(manifest.services, readManifestFn),
@@ -1826,8 +1899,8 @@ export function hubFetch(
       return handleApiSettingsHubOrigin(req, {
         db,
         issuer: oauthDeps(req).issuer,
-        resolvedIssuer: resolveIssuer(req, db, configuredIssuer),
-        resolvedSource: resolveIssuerSource(db, configuredIssuer),
+        resolvedIssuer: resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin),
+        resolvedSource: resolveIssuerSource(db, configuredIssuer, loadExposeHubOrigin),
       });
     }
 
@@ -2159,7 +2232,7 @@ export function hubFetch(
       if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
       const vaultName = decodeURIComponent(pathname.slice("/account/vault-token/".length));
       const db = getDb();
-      const hubOrigin = resolveIssuer(req, db, configuredIssuer);
+      const hubOrigin = resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin);
       return handleAccountVaultTokenPost(req, vaultName, { db, hubOrigin });
     }
 
@@ -2177,7 +2250,7 @@ export function hubFetch(
       }
       if (!getDb) return dbNotConfigured();
       const db = getDb();
-      const hubOrigin = resolveIssuer(req, db, configuredIssuer);
+      const hubOrigin = resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin);
       return handleAccountHomeGet(req, { db, hubOrigin });
     }
 

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -220,7 +220,7 @@ import { getAllPublicKeys } from "./signing-keys.ts";
 import type { Supervisor } from "./supervisor.ts";
 import { handleTwoFactorGet, handleTwoFactorPost } from "./two-factor-handlers.ts";
 import { getUserById, userCount } from "./users.ts";
-import { isLoopbackOrigin } from "./vault-hub-origin-env.ts";
+import { sanitizePublicOrigin } from "./vault-hub-origin-env.ts";
 import {
   WELL_KNOWN_DIR,
   buildWellKnown,
@@ -798,7 +798,7 @@ export interface HubFetchDeps {
    *
    * This single seam now feeds BOTH (a) the same-origin bound set via
    * `buildHubBoundOrigins`, and (b) the issuer resolution via `resolveIssuer`
-   * (hub#532): on the reboot-persistent owner-operated path the launchd /
+   * (#531): on the reboot-persistent owner-operated path the launchd /
    * systemd unit carries no `PARACHUTE_HUB_ORIGIN`, so the hub boots with no
    * `configuredIssuer` and falls back to this exposed origin rather than
    * stamping `iss` from the per-request (loopback) origin — which exposed
@@ -1088,22 +1088,24 @@ function dbNotConfigured(): Response {
  * so without it the hub boots issuer-less and stamps `iss` from the
  * per-request origin, which exposed resource servers (vault) reject.
  *
- * Trailing slashes stripped for canonical form, mirroring resolveStartupIssuer.
+ * The `readExpose()` call is itself wrapped in try/catch so ANY reader —
+ * the default OR an injected one — that throws yields undefined rather than
+ * propagating into the request path. The default reader self-wraps too, but
+ * the seam must not depend on that: a future caller passing a non-swallowing
+ * reader still can't 500 the hub. Origin sanitization is delegated to the
+ * shared `sanitizePublicOrigin` helper (strips trailing slashes, validates
+ * http(s), rejects loopback), kept identical with resolveStartupIssuer (#531).
  */
 export function exposeIssuerOrigin(
   readExpose: () => string | undefined = defaultExposeHubOriginRead,
 ): string | undefined {
-  const raw = readExpose()?.replace(/\/+$/, "");
-  if (!raw) return undefined;
-  let proto: string;
+  let raw: string | undefined;
   try {
-    proto = new URL(raw).protocol;
+    raw = readExpose();
   } catch {
     return undefined;
   }
-  if (proto !== "http:" && proto !== "https:") return undefined;
-  if (isLoopbackOrigin(raw)) return undefined;
-  return raw;
+  return sanitizePublicOrigin(raw);
 }
 
 function defaultExposeHubOriginRead(): string | undefined {
@@ -1116,7 +1118,7 @@ function defaultExposeHubOriginRead(): string | undefined {
 
 /**
  * Resolve the OAuth issuer URL for this request. Precedence, highest
- * first (hub#298, expose tier added hub#532):
+ * first (hub#298, expose tier added #531):
  *
  *   1. `hub_settings.hub_origin` — operator-set canonical URL from the
  *      admin SPA. Wins when present.

--- a/src/vault-hub-origin-env.ts
+++ b/src/vault-hub-origin-env.ts
@@ -59,6 +59,34 @@ export function isLoopbackOrigin(origin: string): boolean {
   }
 }
 
+/**
+ * Canonicalize a candidate public origin for use as the hub's OAuth issuer:
+ * strip trailing slashes, then accept it only when it parses as an absolute
+ * `http(s)` URL that is NOT loopback. Returns the canonical origin or
+ * undefined when it fails any check.
+ *
+ * Shared by the two expose-state issuer fallbacks (`resolveStartupIssuer` in
+ * commands/serve.ts and `exposeIssuerOrigin` in hub-server.ts) so the guard
+ * — never let a non-http(s) or loopback value pin the issuer — stays
+ * identical on both origin-resolution chokepoints (#531). The loopback
+ * rejection is defensive: expose-state.hubOrigin should always be the public
+ * origin, but a stray loopback value would re-pin the degraded
+ * request-origin mode the fix exists to escape.
+ */
+export function sanitizePublicOrigin(raw: string | undefined): string | undefined {
+  const trimmed = raw?.replace(/\/+$/, "");
+  if (!trimmed) return undefined;
+  let proto: string;
+  try {
+    proto = new URL(trimmed).protocol;
+  } catch {
+    return undefined;
+  }
+  if (proto !== "http:" && proto !== "https:") return undefined;
+  if (isLoopbackOrigin(trimmed)) return undefined;
+  return trimmed;
+}
+
 function vaultEnvPath(configDir: string): string {
   return join(configDir, "vault", ".env");
 }

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -886,7 +886,7 @@ export async function setModuleChannel(
  * Where the resolved hub issuer came from — drives the source label
  * on /admin/settings. Mirrors `IssuerSource` in src/hub-server.ts.
  */
-export type IssuerSource = "settings" | "env" | "request";
+export type IssuerSource = "settings" | "env" | "expose" | "request";
 
 /**
  * Response shape from `GET /api/settings/hub-origin` (hub#298). Carries

--- a/web/ui/src/routes/Settings.test.tsx
+++ b/web/ui/src/routes/Settings.test.tsx
@@ -81,6 +81,29 @@ describe("Settings — initial render across source states", () => {
     expect(input.value).toBe("");
   });
 
+  it("renders source=expose with the exposed origin + expose attribution label", async () => {
+    // An exposed box with no stored row and no env var derives the issuer
+    // from expose-state.json (#531). The label must say it came from the
+    // expose config — NOT fall through to the "from request origin" default.
+    vi.mocked(api.getHubOriginSetting).mockResolvedValue({
+      hub_origin: null,
+      resolved_issuer: "https://parachute.taildf9ce2.ts.net",
+      source: "expose",
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByTestId("hub-origin-source")).toHaveTextContent(
+        /from your parachute expose config/i,
+      ),
+    );
+    expect(screen.getByTestId("hub-origin-current")).toHaveTextContent(
+      "https://parachute.taildf9ce2.ts.net",
+    );
+    // Input is still empty — the stored row is empty even though expose wins.
+    const input = screen.getByLabelText(/canonical url/i) as HTMLInputElement;
+    expect(input.value).toBe("");
+  });
+
   it("renders source=settings + pre-fills the input from the stored value", async () => {
     vi.mocked(api.getHubOriginSetting).mockResolvedValue({
       hub_origin: "https://hub.example.com",

--- a/web/ui/src/routes/Settings.tsx
+++ b/web/ui/src/routes/Settings.tsx
@@ -15,6 +15,11 @@
  *     The stored row is empty; the input field is empty. Helper text
  *     calls out that env wins until cleared, and that saving a value
  *     here overrides env.
+ *   - source: "expose" — no stored row, no env var, but the box has a
+ *     live `parachute expose` exposure recorded in expose-state.json.
+ *     The hub derives the issuer from that exposed origin (#531) so an
+ *     exposed box mints deterministic `iss` across reboots without the
+ *     operator setting anything. Saving a value here overrides it.
  *   - source: "settings" — operator has saved a value via this page.
  *     Input shows the stored value; the source label confirms it's
  *     the active layer.
@@ -214,6 +219,13 @@ function SourceLabel({ source, hasStored: _hasStored }: SourceLabelProps) {
     return (
       <span className="badge badge-info" data-testid="hub-origin-source">
         from env var <code>PARACHUTE_HUB_ORIGIN</code>
+      </span>
+    );
+  }
+  if (source === "expose") {
+    return (
+      <span className="badge badge-info" data-testid="hub-origin-source">
+        from your <code>parachute expose</code> config
       </span>
     );
   }


### PR DESCRIPTION
## The bug (root-caused on the live machine)

The hub mints OAuth/JWT tokens with a **non-deterministic `iss` claim** on the reboot-persistent owner-operated path. A token minted under loopback (`http://127.0.0.1:1939`) fails the resource server's (vault's) `iss` check against the exposed tailnet origin (`https://parachute.taildf9ce2.ts.net`) with `unexpected "iss" claim value` until the resource server restarts. **Not key rotation** — the signing key is persisted and stable.

### Durable root cause

The launchd plist `computer.parachute.hub.plist` — the unit that keeps `parachute serve` alive across reboots — has an `EnvironmentVariables` block but **no `PARACHUTE_HUB_ORIGIN`**. So when the hub boots via launchd (the reboot-persistent path), `resolveStartupIssuer` returns `undefined` → the hub has no canonical issuer → it both:

1. stamps `iss` from the per-request origin via `resolveIssuer`, and
2. injects nothing into child modules' `PARACHUTE_HUB_ORIGIN`, so vault defaults to loopback.

The two ends disagree → the bug. The startup banner logs `issuer=<request-origin>` in exactly this state.

### On-machine evidence

- `~/.parachute/expose-state.json` carries `"hubOrigin": "https://parachute.taildf9ce2.ts.net"` (the authoritative public origin).
- `~/Library/LaunchAgents/computer.parachute.hub.plist` has 1 `EnvironmentVariables` block and **0** `PARACHUTE_HUB_ORIGIN` occurrences.

## The fix: `expose-state.hubOrigin` as a canonical-origin fallback

The exposed origin recorded in `expose-state.json` is the authoritative public origin. Both origin-resolution chokepoints now fall back to it when no explicit issuer/env/platform origin is set. This makes `iss` deterministic across reboots with **zero operator action**, and keeps the hub's own `iss` consistent with what it injects into children.

### `resolveStartupIssuer` (serve.ts)

New tier **after** the platform (Render / Fly) tier and **before** returning undefined. New precedence:

```
1. --issuer flag
2. PARACHUTE_HUB_ORIGIN env
3. RENDER_EXTERNAL_URL
4. Fly (FLY_APP_NAME → https://<app>.fly.dev)
5. expose-state.json hubOrigin   ← NEW
6. undefined (degraded request-origin mode)
```

This function feeds **both** the hub's `configuredIssuer` and the child `PARACHUTE_HUB_ORIGIN` injection, so both ends agree across reboots.

### `resolveIssuer` (hub-server.ts)

New tier **between** `configuredIssuer` and the request-origin fallback. New precedence:

```
1. hub_settings.hub_origin (settings)
2. configuredIssuer (env/flag)
3. expose-state.json hubOrigin (expose)   ← NEW
4. new URL(req.url).origin (request)
```

`resolveIssuerSource` and the `IssuerSource` union gain an `"expose"` label, returned when the value comes from expose-state. The existing `loadExposeHubOrigin` deps seam (previously only fed `buildHubBoundOrigins`) is now threaded into all five `resolveIssuer` call sites + the `resolveIssuerSource` call inside `hubFetch`, so production and tests share **one** per-request expose-read injection point.

### Guards (both tiers)

- **Non-loopback `http(s)` only** — reusing the existing `isLoopbackOrigin` helper (covers `127.0.0.1` / `localhost` / `::1` / `0.0.0.0`) plus an http(s)-scheme check. A loopback value here would re-pin the degraded request-origin mode; expose-state should never carry one, but we defend anyway.
- **Malformed-safe** — a corrupt `expose-state.json` must never crash startup or 500 a request; both reads swallow the throw and fall through.
- **Trailing slashes stripped** for canonical form, mirroring the existing tiers.

### Testability

The expose read is **injectable** (`readExpose: () => string | undefined`, defaulting to a safe `readExposeState()?.hubOrigin` read). Unit tests run without touching the real `~/.parachute`. Hub-suite tests that assert sub-expose tiers were updated to inject a no-exposure stub so they're isolated from the host's live expose-state (the dev box has a live exposure that would otherwise shadow the request-origin fallback those tests assert).

No import cycle introduced (verified via typecheck + tests): `expose-state.ts` and `vault-hub-origin-env.ts` are leaf modules that never import back into `serve.ts` / `hub-server.ts`.

## Out of scope (tracked separately)

- `supervisor.restart` rebuilding spawn-env with the live issuer (defense-in-depth for mid-life origin changes).
- Any vault-side or `@openparachute/scope-guard` change.
- launchd plist generation — the expose-state fallback makes persisting the origin in the plist unnecessary. Noted as a possible follow-up, not implemented here.

## Gates

| Gate | Result |
|---|---|
| `bun test ./src` (hub) | 2791 pass / 1 skip / 0 fail |
| `bun test ./packages/scope-guard/src` | 108 pass / 0 fail |
| `bun run typecheck` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)