### PR TITLE
fix(cli): per-arm lazy imports so one broken command module can't take down the whole CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 *.tsbuildinfo
 bun.lock.backup
 package/
+.tmp-cli-iso-*/

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -296,6 +296,16 @@ describe("cli lazy-import isolation (feedback #9)", () => {
   let sandboxCli: string;
 
   beforeAll(() => {
+    // The sandbox lives INSIDE the repo (`<repo>/.tmp-cli-iso-*`) on purpose: it
+    // copies `src/` + `package.json` but NOT `node_modules`. The sandboxed CLI
+    // still resolves workspace packages (`@openparachute/depcheck`, etc.) by Bun
+    // walking up the directory tree to the **repo-root** `node_modules` — the same
+    // walk a nested file uses. So this suite REQUIRES `node_modules` installed at
+    // the repo root. CI must `bun install` before running it; a fresh worktree
+    // without an install will see `Cannot find module '@openparachute/...'`
+    // failures that are worktree-resolution artifacts, NOT a regression in the
+    // code under test. (A temp dir under `os.tmpdir()` would break this walk and
+    // also break `cli.ts`'s `../package.json` import, hence the in-repo sandbox.)
     sandbox = mkdtempSync(join(REPO_ROOT, ".tmp-cli-iso-"));
     cpSync(join(REPO_ROOT, "src"), join(sandbox, "src"), { recursive: true });
     cpSync(join(REPO_ROOT, "package.json"), join(sandbox, "package.json"));

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { appendFileSync, cpSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const CLI = join(import.meta.dir, "..", "cli.ts");
+const REPO_ROOT = join(import.meta.dir, "..", "..");
 
 async function runCli(
   args: string[],
@@ -274,6 +275,92 @@ describe("cli per-subcommand help", () => {
     const [stderr, code] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
     expect(code).toBe(127);
     expect(stderr).toMatch(/parachute-vault not found on PATH/);
+  });
+});
+
+describe("cli lazy-import isolation (feedback #9)", () => {
+  // Regression for the eager-import fragility: `cli.ts` used to import every
+  // command module at top-level, so a module that THREW at eval-time (the 0.6.2
+  // `migrate-cutover.ts` ReferenceError) aborted the entire CLI load — even
+  // `parachute --help` — because top-level import evaluation runs before
+  // `run()`'s try/catch is reached. Per-arm lazy `await import()` isolates a
+  // broken module to its own command.
+  //
+  // We exercise the REAL dispatcher: copy the live `src/` tree (plus the repo
+  // `package.json`, which `cli.ts` imports as `../package.json`) into a sandbox
+  // *inside the repo* so workspace `node_modules` resolution still works, then
+  // corrupt one command module so it throws at module-eval. `node_modules` is
+  // NOT copied — Bun walks up to the repo's. The corruption never touches the
+  // real source tree, so concurrent suites are unaffected.
+  let sandbox: string;
+  let sandboxCli: string;
+
+  beforeAll(() => {
+    sandbox = mkdtempSync(join(REPO_ROOT, ".tmp-cli-iso-"));
+    cpSync(join(REPO_ROOT, "src"), join(sandbox, "src"), { recursive: true });
+    cpSync(join(REPO_ROOT, "package.json"), join(sandbox, "package.json"));
+    sandboxCli = join(sandbox, "src", "cli.ts");
+    // Append an unconditional throw so the module fails at eval. `migrate-cutover`
+    // is the canonical real-world case (the 0.6.2 bug) AND it's reachable by both
+    // eager paths the fix addresses: the direct `cli.ts` import and the transitive
+    // `cli.ts → lifecycle.ts → migrate-offer.ts → migrate-cutover.ts` chain.
+    appendFileSync(
+      join(sandbox, "src", "commands", "migrate-cutover.ts"),
+      '\nthrow new ReferenceError("boom: migrate-cutover failed at module eval");\n',
+    );
+  });
+
+  afterAll(() => {
+    if (sandbox) rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  async function runSandbox(
+    args: string[],
+  ): Promise<{ code: number; stdout: string; stderr: string }> {
+    const proc = Bun.spawn([process.execPath, sandboxCli, ...args], {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        HOME: "/tmp/parachute-hub-nonexistent-home",
+        PARACHUTE_HOME: "/tmp/parachute-hub-nonexistent-home",
+      },
+    });
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { code, stdout, stderr };
+  }
+
+  test("a command module that throws at eval does NOT abort --help", async () => {
+    const { code, stdout } = await runSandbox(["--help"]);
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/parachute install/);
+  });
+
+  test("an unrelated command still dispatches when one module is broken", async () => {
+    // `status` doesn't touch migrate-cutover at all — it must still run to
+    // completion (exit 0) rather than dying at top-level import.
+    const { code } = await runSandbox(["status"]);
+    expect(code).toBe(0);
+  });
+
+  test("lifecycle commands survive the broken transitive path", async () => {
+    // `stop` pulls in `migrate-offer.ts` (for the §7.5 detect-and-offer), which
+    // used to EAGERLY import the broken `migrate-cutover.ts`. With the import now
+    // `import type` + lazy, `stop --help` must not crash.
+    const { code, stdout } = await runSandbox(["stop", "--help"]);
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/parachute stop/);
+  });
+
+  test("the broken command itself exits 1 with a 'failed to load' message", async () => {
+    const { code, stderr } = await runSandbox(["migrate", "--to-supervised"]);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/parachute migrate: failed to load/);
+    expect(stderr).toMatch(/boom: migrate-cutover failed at module eval/);
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,19 +9,16 @@
 import { MissingDependencyError } from "@openparachute/depcheck";
 import pkg from "../package.json" with { type: "json" };
 import { CloudflaredStateError } from "./cloudflare/state.ts";
-import { auth } from "./commands/auth.ts";
-import { exposePublic, exposeTailnet } from "./commands/expose.ts";
-import { init } from "./commands/init.ts";
-import { install } from "./commands/install.ts";
-import { logs, restart, start, stop } from "./commands/lifecycle.ts";
-import { cutoverToSupervised, teardownHubUnit } from "./commands/migrate-cutover.ts";
-import { migrate } from "./commands/migrate.ts";
-import { serve } from "./commands/serve.ts";
-import { setup } from "./commands/setup.ts";
-import { status } from "./commands/status.ts";
-import { upgrade } from "./commands/upgrade.ts";
-import { dispatchVault } from "./commands/vault.ts";
-import { runSetupWizardCommand } from "./commands/wizard.ts";
+// Command-implementation modules are loaded LAZILY inside their switch arms (see
+// `loadCommand` + each `case`), so a module that throws at eval-time is isolated
+// to its own command instead of aborting the whole CLI at top-level import. The
+// `import type`s below are erased at compile time (they trigger no module
+// evaluation) and exist only so the arms can reference each command's options
+// type for `Parameters<typeof …>`.
+import type { init } from "./commands/init.ts";
+import type { install } from "./commands/install.ts";
+import type { setup } from "./commands/setup.ts";
+import type { upgrade } from "./commands/upgrade.ts";
 import { ExposeStateError } from "./expose-state.ts";
 import {
   exposeHelp,
@@ -273,6 +270,34 @@ function extractExposeProviderFlags(args: string[]): {
   return out;
 }
 
+/**
+ * Lazy-load a command-implementation module, isolating an eval-time throw to the
+ * command that asked for it.
+ *
+ * `cli.ts` used to eagerly `import` every command module at top-level. That made
+ * a single broken module (e.g. a half-built `migrate-cutover.ts` with a
+ * ReferenceError at eval) abort the *entire* CLI load — even `parachute --help`
+ * — because top-level import evaluation runs before `run()`'s try/catch is ever
+ * reached. Loading each module lazily inside its switch arm (the same pattern
+ * the expose subcommands already use, e.g. `await import("./commands/expose-
+ * cloudflare.ts")`) means an import rejection touches only its own command.
+ *
+ * On rejection we print `parachute <cmd>: failed to load (<err>)` and return
+ * `undefined`; the arm turns that into exit code 1. This keeps a broken module
+ * from surfacing as an unhandled promise rejection (which the top-level
+ * `run()` boundary doesn't shape — it wraps execution, not import).
+ */
+async function loadCommand<T>(cmd: string, importer: () => Promise<T>): Promise<T | undefined> {
+  try {
+    return await importer();
+  } catch (err) {
+    console.error(
+      `parachute ${cmd}: failed to load (${err instanceof Error ? err.message : String(err)})`,
+    );
+    return undefined;
+  }
+}
+
 async function main(argv: string[]): Promise<number> {
   const [command, ...rest] = argv;
 
@@ -309,7 +334,9 @@ async function main(argv: string[]): Promise<number> {
       const setupOpts: Parameters<typeof setup>[0] = {};
       if (tagExtract.tag) setupOpts.tag = tagExtract.tag;
       if (noStart) setupOpts.noStart = true;
-      return await setup(setupOpts);
+      const mod = await loadCommand("setup", () => import("./commands/setup.ts"));
+      if (!mod) return 1;
+      return await mod.setup(setupOpts);
     }
 
     case "setup-wizard": {
@@ -323,7 +350,9 @@ async function main(argv: string[]): Promise<number> {
         console.log(setupWizardHelp());
         return 0;
       }
-      return await runSetupWizardCommand(rest);
+      const mod = await loadCommand("setup-wizard", () => import("./commands/wizard.ts"));
+      if (!mod) return 1;
+      return await mod.runSetupWizardCommand(rest);
     }
 
     case "init": {
@@ -379,7 +408,9 @@ async function main(argv: string[]): Promise<number> {
       }
       if (cliWizard) initOpts.wizardChoice = "cli";
       else if (browserWizard) initOpts.wizardChoice = "browser";
-      return await init(initOpts);
+      const mod = await loadCommand("init", () => import("./commands/init.ts"));
+      if (!mod) return 1;
+      return await mod.init(initOpts);
     }
 
     case "install": {
@@ -438,16 +469,18 @@ async function main(argv: string[]): Promise<number> {
       if (noStart) installOpts.noStart = true;
       if (providerExtract.value) installOpts.scribeProvider = providerExtract.value;
       if (keyExtract.value) installOpts.scribeKey = keyExtract.value;
+      const mod = await loadCommand("install", () => import("./commands/install.ts"));
+      if (!mod) return 1;
       if (service === "all") {
         // Bootstrap the whole ecosystem to one dist-tag — the RC-testing payload.
         // Bail on first failure so a broken channel doesn't mask a working tag.
         for (const svc of knownServices()) {
-          const code = await install(svc, installOpts);
+          const code = await mod.install(svc, installOpts);
           if (code !== 0) return code;
         }
         return 0;
       }
-      return await install(service, installOpts);
+      return await mod.install(service, installOpts);
     }
 
     case "status":
@@ -459,7 +492,11 @@ async function main(argv: string[]): Promise<number> {
       // dual-dispatch: on a box with a hub unit installed it reads the platform
       // manager + the running supervisor; on a legacy detached box it falls back
       // to the pidfile readout (design §6.4). Tests drive the seams directly.
-      return await status({ supervisor: {} });
+      {
+        const mod = await loadCommand("status", () => import("./commands/status.ts"));
+        if (!mod) return 1;
+        return await mod.status({ supervisor: {} });
+      }
 
     case "expose": {
       const hubExtract = extractHubOrigin(rest);
@@ -585,6 +622,14 @@ async function main(argv: string[]): Promise<number> {
         ...(hubExtract.hubOrigin ? { hubOrigin: hubExtract.hubOrigin } : {}),
       };
 
+      // Lazy-load the Tailscale-Funnel entry points the same way the Cloudflare /
+      // interactive / auto-pick paths above load theirs. Reaching here means we're
+      // past the early Cloudflare returns, so `exposePublic` / `exposeTailnet` are
+      // about to be needed by one of the branches below.
+      const exposeMod = await loadCommand("expose", () => import("./commands/expose.ts"));
+      if (!exposeMod) return 1;
+      const { exposePublic, exposeTailnet } = exposeMod;
+
       // `--tailnet` is the explicit Tailscale Funnel pin — bypass both the
       // interactive picker and the non-TTY auto-pick. Goes straight to
       // exposePublic so today's Funnel flow keeps working unchanged.
@@ -677,7 +722,9 @@ async function main(argv: string[]): Promise<number> {
         migrateOffer: { enabled: true },
         ...(hubExtract.hubOrigin ? { hubOrigin: hubExtract.hubOrigin } : {}),
       };
-      return await start(hubExtract.rest[0], startOpts);
+      const mod = await loadCommand("start", () => import("./commands/lifecycle.ts"));
+      if (!mod) return 1;
+      return await mod.start(hubExtract.rest[0], startOpts);
     }
 
     case "stop": {
@@ -685,7 +732,9 @@ async function main(argv: string[]): Promise<number> {
         console.log(stopHelp());
         return 0;
       }
-      return await stop(rest[0], { supervisor: {}, migrateOffer: { enabled: true } });
+      const mod = await loadCommand("stop", () => import("./commands/lifecycle.ts"));
+      if (!mod) return 1;
+      return await mod.stop(rest[0], { supervisor: {}, migrateOffer: { enabled: true } });
     }
 
     case "restart": {
@@ -693,7 +742,9 @@ async function main(argv: string[]): Promise<number> {
         console.log(restartHelp());
         return 0;
       }
-      return await restart(rest[0], { supervisor: {}, migrateOffer: { enabled: true } });
+      const mod = await loadCommand("restart", () => import("./commands/lifecycle.ts"));
+      if (!mod) return 1;
+      return await mod.restart(rest[0], { supervisor: {}, migrateOffer: { enabled: true } });
     }
 
     case "upgrade": {
@@ -744,7 +795,9 @@ async function main(argv: string[]): Promise<number> {
         upgradeOpts.channel = channelExtract.value;
       }
       if (allowDowngrade) upgradeOpts.allowDowngrade = true;
-      return await upgrade(remaining[0], upgradeOpts);
+      const mod = await loadCommand("upgrade", () => import("./commands/upgrade.ts"));
+      if (!mod) return 1;
+      return await mod.upgrade(remaining[0], upgradeOpts);
     }
 
     case "logs": {
@@ -759,7 +812,9 @@ async function main(argv: string[]): Promise<number> {
         return 1;
       }
       const follow = rest.includes("-f") || rest.includes("--follow");
-      return await logs(svc, { follow });
+      const mod = await loadCommand("logs", () => import("./commands/lifecycle.ts"));
+      if (!mod) return 1;
+      return await mod.logs(svc, { follow });
     }
 
     case "migrate": {
@@ -775,7 +830,9 @@ async function main(argv: string[]): Promise<number> {
           console.error("usage: parachute migrate --teardown");
           return 1;
         }
-        teardownHubUnit();
+        const mod = await loadCommand("migrate", () => import("./commands/migrate-cutover.ts"));
+        if (!mod) return 1;
+        mod.teardownHubUnit();
         return 0;
       }
       // §7.1 detached→supervised cutover. Opt-in surface (the archive sweep
@@ -788,7 +845,9 @@ async function main(argv: string[]): Promise<number> {
           console.error("usage: parachute migrate --to-supervised");
           return 1;
         }
-        const result = await cutoverToSupervised();
+        const mod = await loadCommand("migrate", () => import("./commands/migrate-cutover.ts"));
+        if (!mod) return 1;
+        const result = await mod.cutoverToSupervised();
         for (const line of result.messages) console.log(line);
         // "already-migrated" / "migrated" are success; every other outcome is a
         // recoverable failure that should exit non-zero so scripts can retry.
@@ -807,7 +866,9 @@ async function main(argv: string[]): Promise<number> {
         );
         return 1;
       }
-      return await migrate({ dryRun, list, yes });
+      const mod = await loadCommand("migrate", () => import("./commands/migrate.ts"));
+      if (!mod) return 1;
+      return await mod.migrate({ dryRun, list, yes });
     }
 
     case "serve": {
@@ -824,7 +885,9 @@ async function main(argv: string[]): Promise<number> {
       // event loop alive until SIGINT/SIGTERM, at which point we stop the
       // server cleanly and exit. Container supervisor (tini, Render, Docker)
       // reaps us once the event loop drains.
-      const { stop: stopServer } = await serve();
+      const mod = await loadCommand("serve", () => import("./commands/serve.ts"));
+      if (!mod) return 1;
+      const { stop: stopServer } = await mod.serve();
       await new Promise<void>((resolve) => {
         const handler = async () => {
           await stopServer();
@@ -836,14 +899,19 @@ async function main(argv: string[]): Promise<number> {
       return 0;
     }
 
-    case "auth":
-      return await auth(rest);
+    case "auth": {
+      const mod = await loadCommand("auth", () => import("./commands/auth.ts"));
+      if (!mod) return 1;
+      return await mod.auth(rest);
+    }
 
     case "vault": {
+      const mod = await loadCommand("vault", () => import("./commands/vault.ts"));
+      if (!mod) return 1;
       // `parachute vault` with no args forwards --help to parachute-vault so
       // users see the actual vault surface, not a CLI-side stub. Anything
       // after `vault` (including --help) is passed through verbatim.
-      if (rest.length === 0) return await dispatchVault(["--help"]);
+      if (rest.length === 0) return await mod.dispatchVault(["--help"]);
 
       // Everything under `vault` forwards transparently to `parachute-vault`.
       // `vault tokens create` used to route through a guided interactive
@@ -852,7 +920,7 @@ async function main(argv: string[]): Promise<number> {
       // hub-issued JWTs; mint them with `parachute auth mint-token` or the
       // admin SPA Connect card. We forward verbatim so the operator sees
       // vault's own migration error rather than a hub-side stub.
-      return await dispatchVault(rest);
+      return await mod.dispatchVault(rest);
     }
 
     default:

--- a/src/migrate-offer.ts
+++ b/src/migrate-offer.ts
@@ -22,11 +22,15 @@
  */
 
 import { existsSync } from "node:fs";
-import {
-  type CutoverOpts,
-  type CutoverResult,
-  cutoverToSupervised,
-} from "./commands/migrate-cutover.ts";
+// `migrate-cutover.ts` is imported as a TYPE only (erased at compile time, no
+// module evaluation) and loaded LAZILY at the call site below. This breaks the
+// transitive eager-load chain `cli.ts` → `lifecycle.ts` → `migrate-offer.ts` →
+// `migrate-cutover.ts`: a broken `migrate-cutover` (e.g. the 0.6.2 eval-time
+// ReferenceError) must not crash the start/stop/restart/logs lifecycle commands
+// that pull in this module purely for the §7.5 detect-and-offer machinery. The
+// cutover is only ever evaluated when an operator interactively accepts the
+// offer, so deferring its import to that moment keeps the whole chain robust.
+import type { CutoverOpts, CutoverResult } from "./commands/migrate-cutover.ts";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "./config.ts";
 import { HUB_SVC } from "./hub-control.ts";
 import { type HubUnitDeps, defaultHubUnitDeps, isHubUnitInstalled } from "./hub-unit.ts";
@@ -149,7 +153,6 @@ export async function offerMigrateToSupervised(
   const unitInstalledFn = opts.isHubUnitInstalled ?? isHubUnitInstalled;
   const hubUnitDeps = opts.hubUnitDeps ?? defaultHubUnitDeps;
   const hasPriorDetached = opts.hasPriorDetached ?? hasPriorDetachedInstall;
-  const cutover = opts.cutover ?? cutoverToSupervised;
   const prompt = opts.prompt ?? defaultOfferPrompt;
   const isTty = opts.isTty ?? Boolean(process.stdin.isTTY);
 
@@ -179,6 +182,12 @@ export async function offerMigrateToSupervised(
     return { outcome: "declined" };
   }
 
+  // Resolve the cutover lazily: only import `migrate-cutover.ts` now that the
+  // operator has accepted, so the offer's mere availability never drags the
+  // cutover module into the lifecycle-command load graph (see the `import type`
+  // note at the top). Tests inject `opts.cutover` and never hit the import.
+  const cutover =
+    opts.cutover ?? (await import("./commands/migrate-cutover.ts")).cutoverToSupervised;
   const result = await cutover({ configDir, manifestPath, log });
   for (const line of result.messages) log(line);
   const ok = result.outcome === "migrated" || result.outcome === "already-migrated";


### PR DESCRIPTION
## The fragility

`src/cli.ts` eagerly imported all ~12 command modules at top-level (`cli.ts:12-24`). The CLI's only error boundary is `run()`'s try/catch (`cli.ts:870-903`), which wraps `main(argv)` — i.e. command **execution**. But top-level import **evaluation** happens *before* `run()` is ever reached. So if any one command module threw at module-eval — e.g. the 0.6.2 `migrate-cutover.ts` ReferenceError from a broken intermediate build — the entire `cli.ts` load aborted and **every** subcommand died, including `parachute --help`. The try/catch never got a chance to run because the throw happened at import time, not execution time.

The specific 0.6.2 bug is already fixed; this fixes the **structural** fragility so one broken command module can't take down the whole CLI again.

## The fix — per-arm lazy imports (the house pattern)

The codebase already uses lazy `await import()` for the expose subcommands (`cli.ts:533, 554, 600, 621, 635`). This follows that exact pattern: every command-implementation module is now loaded lazily via `await import("./commands/<x>.ts")` **inside its switch arm**, so:

- a broken/throwing command module is isolated to its own command (it's only imported when that command runs);
- `parachute --help` and unrelated commands keep working even if one module's eval throws;
- each lazy import is wrapped in a small `loadCommand` helper that, on an `import()` rejection, prints `parachute <cmd>: failed to load (<err>)` and returns exit code 1 — rather than surfacing an unhandled promise rejection (which `run()`'s boundary doesn't shape, since it wraps execution, not import).

### Two eager paths into `migrate-cutover.ts` — both addressed

1. **Direct** (`cli.ts:17`) — the `migrate --teardown` / `migrate --to-supervised` arms now `await import("./commands/migrate-cutover.ts")` lazily.
2. **Transitive** (`cli.ts:16` → `lifecycle.ts:25` → `migrate-offer.ts:29` → `migrate-cutover.ts`) — `migrate-offer.ts` now imports the cutover as an `import type` (erased, no module eval) and lazily resolves the real impl at the call site, which only runs when an operator **interactively accepts** the offer. So a broken `migrate-cutover` can no longer crash the `start`/`stop`/`restart`/`logs` lifecycle commands, which pull in `migrate-offer.ts` purely for the §7.5 detect-and-offer machinery.

## What stayed eager (and why)

Behavior is unchanged — only import timing moved. Left eager because they're needed up-front and aren't command modules: the error classes used by `run()`'s `instanceof` checks (`MissingDependencyError`, `ServicesManifestError`, `ExposeStateError`, `CloudflaredStateError`, `TailscaleError`), the help functions, `HUB_SVC`, `knownServices`, the argv extractors, and `pkg`. The four command-options *types* referenced via `Parameters<typeof …>` (setup/init/install/upgrade) are pulled in as `import type` (compile-time erased).

Argv parsing, exit codes, help text, and the `run()` error boundary are all preserved.

## Regression test

Added to the hub suite (`cli.test.ts`). It exercises the **real** dispatcher: copies the live `src/` tree (plus the repo `package.json`, which `cli.ts` imports as `../package.json`) into an in-repo sandbox so workspace `node_modules` resolution still works, corrupts `migrate-cutover.ts` so it throws at module-eval, then asserts:

- `--help` still exits 0 (the core regression — the 0.6.2 failure shape);
- an unrelated command (`status`) still dispatches (exit 0);
- a lifecycle command survives the broken **transitive** path (`stop --help` exits 0);
- the broken command itself exits 1 with `parachute migrate: failed to load (…)`.

## Gates

- `bun test ./src` — **2796 pass / 1 skip / 0 fail**
- `bun test ./packages/scope-guard/src` — **108 pass / 0 fail**
- `bun run typecheck` — clean

Resolves feedback item #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)