### PR TITLE
fix(supervisor): canonical services.json port wins over a stale .env PORT (#537)

### DIFF
--- a/src/__tests__/serve-boot.test.ts
+++ b/src/__tests__/serve-boot.test.ts
@@ -164,6 +164,32 @@ describe("bootSupervisedModules", () => {
     expect(recorder.calls[0]?.env?.SCRIBE_URL).toBe("http://127.0.0.1:3200");
   });
 
+  test("services.json entry.port wins over a stale .env PORT (hub#537)", async () => {
+    // Pre-hub#206 installs wrote `PORT=` into the per-service .env. A leftover
+    // PORT there that disagrees with services.json (e.g. scribe's stale 1944 vs
+    // canonical 1943) must NOT shadow entry.port — otherwise the supervisor
+    // injects + probes the wrong port and records a false `started_but_unbound`.
+    writeManifest({ services: [VAULT_ENTRY] }, h.manifestPath);
+    mkdirSync(join(h.dir, "vault"), { recursive: true });
+    writeFileSync(
+      join(h.dir, "vault", ".env"),
+      "PORT=1944\nSCRIBE_AUTH_TOKEN=secret-token\n",
+    );
+
+    const recorder = makeRecorder();
+    const sup = new Supervisor({ spawnFn: recorder.spawn });
+
+    await bootSupervisedModules(sup, {
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+    });
+
+    // entry.port (1940) wins; the stale .env PORT is dropped. Other .env
+    // values still merge.
+    expect(recorder.calls[0]?.env?.PORT).toBe("1940");
+    expect(recorder.calls[0]?.env?.SCRIBE_AUTH_TOKEN).toBe("secret-token");
+  });
+
   test("hubOrigin wins over a stale .env entry on collision", async () => {
     writeManifest({ services: [VAULT_ENTRY] }, h.manifestPath);
     mkdirSync(join(h.dir, "vault"), { recursive: true });

--- a/src/__tests__/serve-boot.test.ts
+++ b/src/__tests__/serve-boot.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { bootSupervisedModules } from "../commands/serve-boot.ts";
+import { bootSupervisedModules, buildModuleSpawnRequest } from "../commands/serve-boot.ts";
 import { type ServiceEntry, writeManifest } from "../services-manifest.ts";
 import { type SpawnRequest, type SupervisedProc, Supervisor } from "../supervisor.ts";
 
@@ -188,6 +188,17 @@ describe("bootSupervisedModules", () => {
     // values still merge.
     expect(recorder.calls[0]?.env?.PORT).toBe("1940");
     expect(recorder.calls[0]?.env?.SCRIBE_AUTH_TOKEN).toBe("secret-token");
+  });
+
+  test("extraEnv PORT still wins over entry.port (layer 4 — test seam / first-boot)", () => {
+    // Dropping a stale .env PORT must not affect the documented layer-4 override:
+    // an explicit `opts.extraEnv.PORT` (programmatic, not a stale on-disk file)
+    // still wins last.
+    const req = buildModuleSpawnRequest("vault", VAULT_ENTRY, ["parachute-vault", "serve"], {
+      configDir: h.dir,
+      extraEnv: { PORT: "9999" },
+    });
+    expect(req.env?.PORT).toBe("9999");
   });
 
   test("hubOrigin wins over a stale .env entry on collision", async () => {

--- a/src/commands/serve-boot.ts
+++ b/src/commands/serve-boot.ts
@@ -75,9 +75,14 @@ export interface BuildSpawnRequestOpts {
  * Env layering (later wins):
  *   1. `PORT` from the services.json `entry.port` — overrides hub's own PORT
  *      so supervised children honor their canonical port assignment
- *      (hub#356/#357).
+ *      (hub#356/#357). This is authoritative and is NOT overridable by a
+ *      `.env` `PORT` (see below) — services.json is the single source of truth
+ *      for the port (scribe#41 4-tier ladder; hub#206).
  *   2. per-service `.env` at `<configDir>/<short>/.env` — operator-configured
- *      values (e.g. scribe provider keys) override the bare PORT.
+ *      values (e.g. scribe provider keys) merge on top. A `PORT` key here is
+ *      dropped: a stale pre-#206 `.env` `PORT` must not shadow `entry.port`
+ *      (hub#537 — a leftover scribe `PORT=1944` ≠ services.json `1943` leaked
+ *      into the injected PORT and broke the supervisor's readiness probe).
  *   3. `PARACHUTE_HUB_ORIGIN` = `opts.hubOrigin` — anchors the child's `iss`
  *      expectation to the value hub mints with (hub#365).
  *   4. `opts.extraEnv` — test seam / first-boot pass-through; wins last.
@@ -93,7 +98,15 @@ export function buildModuleSpawnRequest(
   opts: BuildSpawnRequestOpts,
 ): SpawnReqShape {
   const fileEnv = readEnvFileValues(join(opts.configDir, short, ".env"));
-  const env: Record<string, string> = { PORT: String(entry.port), ...fileEnv };
+  // Drop a `PORT` from the per-service .env: services.json `entry.port` is the
+  // canonical port and must win (scribe#41 ladder; hub#206). A stale pre-#206
+  // `.env` PORT (e.g. scribe's `1944` vs services.json `1943`) would otherwise
+  // leak into the injected PORT and the supervisor's readiness probe would
+  // check the wrong port → false `started_but_unbound` (hub#537). The module's
+  // own resolvePort ladder already prefers services.json, so this keeps the
+  // injected PORT + probe in agreement with what the child actually binds.
+  const { PORT: _staleEnvPort, ...fileEnvSansPort } = fileEnv;
+  const env: Record<string, string> = { PORT: String(entry.port), ...fileEnvSansPort };
   if (opts.hubOrigin) env[HUB_ORIGIN_ENV] = opts.hubOrigin;
   if (opts.extraEnv) Object.assign(env, opts.extraEnv);
 

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -39,9 +39,14 @@ import type { ServiceEntry } from "./services-manifest.ts";
  *
  * Operator override is now "edit services.json" (or `parachute config`
  * once that lands), not "edit `.env`". Pre-#206 stale `.env` PORT lines on
- * existing operator machines stay where they are — harmless, since the
- * boot-time ladder reads services.json before falling through to the bare
- * PORT env tier — and future installs no longer touch them.
+ * existing operator machines stay where they are — harmless to the module's
+ * own resolvePort ladder, which reads services.json before falling through to
+ * the bare PORT env tier — and future installs no longer touch them. (Caveat,
+ * hub#537: the supervisor's spawn-env builder used to echo a stale `.env` PORT
+ * into the injected `PORT`, and its readiness probe trusted that — so a `.env`
+ * PORT disagreeing with services.json yielded a false `started_but_unbound`.
+ * Fixed by making `entry.port` authoritative: `buildModuleSpawnRequest` drops a
+ * `.env` PORT.)
  *
  * **No speculative reservations.** Future first-party modules claim a slot
  * the moment they ship, not before — pre-reservation for unbuilt things has


### PR DESCRIPTION
## What
`buildModuleSpawnRequest` (serve-boot) merged the per-service `.env` **over** the injected `PORT: String(entry.port)`, letting a leftover pre-hub#206 `PORT=` in `<configDir>/<short>/.env` shadow the canonical services.json port. This drops a `PORT` key from the `.env` so `entry.port` (the documented single source of truth) always wins.

## Why (closes #537)
Observed live on a supervised stack: `parachute status` perpetually showed
```
! failed to start: scribe started (pid …) but is not listening on port 1944 …
```
even though scribe was healthy and reachable through the hub (`/scribe/health` → 200). Root cause:
- `~/.parachute/scribe/.env` had a stale `PORT=1944` (pre-#206 installer artifact; services.json says `1943`).
- `buildModuleSpawnRequest` layered that `.env` PORT over `entry.port` → injected `PORT=1944`.
- scribe's own 4-tier resolvePort ladder prefers services.json, so it bound **1943**.
- The supervisor's readiness probe (`awaitPortReadiness`) polls the *injected* `entry.req.env.PORT` (1944) → never sees it bind → false `started_but_unbound`.

The service-spec note already calls a stale `.env` PORT "dead weight at best, a source of drift at worst," and says services.json wins — but the spawn-env layering contradicted that and the later-added readiness probe trusts the injected port. The hub proxy was unaffected (it routes via the self-registered services.json port), so this was cosmetic-but-persistent: it erodes trust in `parachute status` as a health signal.

## Fix
Drop `PORT` from the per-service `.env` before merging in `buildModuleSpawnRequest`; `entry.port` is authoritative. Other `.env` values still merge; `opts.extraEnv` still wins last. Mirrors the existing "hubOrigin wins over a stale .env entry" precedent.

Considered but not taken: making the probe re-read the self-registered port. The layering fix is the root cause (aligns injected PORT + probe + what the child binds) and is less invasive; the probe-robustness angle can be a separate hardening if a module ever binds a port unrelated to both entry.port and services.json.

## Gates
- `bun test ./src` — **2797 pass / 1 skip / 0 fail**
- `bun run typecheck` — clean; `biome` — clean
- New regression test: `services.json entry.port wins over a stale .env PORT (hub#537)` — asserts `entry.port` (1940) beats a planted `.env` `PORT=1944` while other `.env` keys still merge.

## Operator note
Existing boxes with a stale `.env` PORT are fixed automatically once on this code (no manual `.env` edit needed); the stale line becomes truly inert.

Closes #537.

🤖 Generated with [Claude Code](https://claude.com/claude-code)