### PR TITLE
fix(serve): bind hub port before booting modules — kill the dual-supervisor crash loop (#536)

### DIFF
--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -6,11 +6,33 @@ import { _resetBootstrapTokenForTests, getBootstrapToken } from "../bootstrap-to
 import {
   formatBootstrapTokenBanner,
   formatListeningBanner,
+  hubPortConflictMessage,
   resolveStartupIssuer,
   seedInitialAdminIfNeeded,
 } from "../commands/serve.ts";
 import { openHubDb } from "../hub-db.ts";
 import { getUserByUsername, userCount } from "../users.ts";
+
+describe("hubPortConflictMessage (hub#536)", () => {
+  test("maps a port-in-use error to a clear duplicate-supervisor message", () => {
+    // Bun surfaces a port conflict as "...Is port 1939 in use?"; node-style is
+    // "EADDRINUSE: address already in use". Both must map to the clear message.
+    for (const m of [
+      "EADDRINUSE: address already in use 127.0.0.1:1939",
+      "Failed to start server. Is port 1939 in use?",
+    ]) {
+      const out = hubPortConflictMessage(new Error(m), 1939);
+      expect(out).toContain("already in use");
+      expect(out).toContain("duplicate supervisor");
+      expect(out).toContain("1939");
+    }
+  });
+
+  test("returns null for an unrelated error (caller re-throws the original)", () => {
+    expect(hubPortConflictMessage(new Error("permission denied"), 1939)).toBeNull();
+    expect(hubPortConflictMessage("not even an Error", 1939)).toBeNull();
+  });
+});
 
 describe("seedInitialAdminIfNeeded", () => {
   let dir: string;

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -103,6 +103,22 @@ export function formatListeningBanner(args: {
   return `parachute serve: listening on http://${displayHost}:${port}${boundNote} (PARACHUTE_HOME=${configDir}, db=${dbPath}, issuer=${issuer ?? "<request-origin>"}, admin=${adminBootstrap})`;
 }
 
+/**
+ * Map a `Bun.serve` bind failure to a clear "another supervisor is running"
+ * message when it's a port-in-use error, or `null` for any other error (so the
+ * caller re-throws the original). Keeps a duplicate-supervisor start from
+ * surfacing as a raw `EADDRINUSE` stack — the operator's actionable next step
+ * is "stop the other instance," not a backtrace. See hub#536. Exported for
+ * testing (the bind itself isn't seam-injectable).
+ */
+export function hubPortConflictMessage(err: unknown, port: number): string | null {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/EADDRINUSE|address already in use|in use/i.test(msg)) {
+    return `parachute serve: hub port ${port} is already in use — another hub/supervisor is running. Refusing to start a duplicate supervisor (it would fight the live one over module ports). Stop the other instance first, then retry.`;
+  }
+  return null;
+}
+
 function parsePort(raw: string | undefined): number | undefined {
   if (raw === undefined || raw === "") return undefined;
   const n = Number.parseInt(raw, 10);
@@ -334,8 +350,51 @@ export async function serve(opts: ServeOpts = {}): Promise<{
 
   const supervisor = opts.supervisor ?? new Supervisor();
 
-  // Boot already-installed modules from services.json. In a container,
-  // this is the path that re-spawns vault / notes / scribe after a
+  // Claim the hub port FIRST — before booting a single supervised module. If
+  // another hub/supervisor already owns it, `Bun.serve` throws here and we
+  // exit immediately. The prior order (boot modules, *then* bind) let a
+  // duplicate `serve` spawn + port-race the live hub's children over their
+  // module ports before it ever hit the hub-port conflict — the
+  // dual-supervisor crash loop in hub#536. Binding first makes a duplicate
+  // fail fast and cleanly, leaving the live hub's children untouched.
+  let server: ReturnType<typeof Bun.serve>;
+  try {
+    server = Bun.serve({
+      port,
+      hostname,
+      // Hold idle keep-alive connections for Bun's maximum 255s so reverse-
+      // proxy edges (Render, Cloudflare, fly.io) don't race us when reusing
+      // pooled connections. See `src/hub-server.ts` for the full rationale —
+      // this is the active code path for `bun src/cli.ts serve` (the Docker
+      // CMD), so the fix has to land here too. Closes hub#399.
+      idleTimeout: 255,
+      fetch: hubFetch(WELL_KNOWN_DIR, {
+        getDb: () => db,
+        issuer,
+        loopbackPort: port,
+        supervisor,
+      }),
+    });
+  } catch (err) {
+    const conflict = hubPortConflictMessage(err, port);
+    if (conflict) throw new Error(conflict);
+    throw err;
+  }
+
+  log(
+    formatListeningBanner({
+      hostname,
+      port,
+      configDir: CONFIG_DIR,
+      dbPath,
+      issuer,
+      adminBootstrap,
+    }),
+  );
+
+  // Boot already-installed modules from services.json — now that we own the
+  // hub port (above), we're guaranteed to be the sole supervisor. In a
+  // container, this is the path that re-spawns vault / notes / scribe after a
   // restart — the persistent disk preserved both the install (in
   // `$BUN_INSTALL/install/global/node_modules`) and the row that says
   // "this module is registered + active." Idempotent: the supervisor
@@ -361,34 +420,6 @@ export async function serve(opts: ServeOpts = {}): Promise<{
       );
     }
   }
-
-  const server = Bun.serve({
-    port,
-    hostname,
-    // Hold idle keep-alive connections for Bun's maximum 255s so reverse-
-    // proxy edges (Render, Cloudflare, fly.io) don't race us when reusing
-    // pooled connections. See `src/hub-server.ts` for the full rationale —
-    // this is the active code path for `bun src/cli.ts serve` (the Docker
-    // CMD), so the fix has to land here too. Closes hub#399.
-    idleTimeout: 255,
-    fetch: hubFetch(WELL_KNOWN_DIR, {
-      getDb: () => db,
-      issuer,
-      loopbackPort: port,
-      supervisor,
-    }),
-  });
-
-  log(
-    formatListeningBanner({
-      hostname,
-      port,
-      configDir: CONFIG_DIR,
-      dbPath,
-      issuer,
-      adminBootstrap,
-    }),
-  );
 
   return {
     result: {


### PR DESCRIPTION
## What
Reorder `serve()` so it claims the hub port (`Bun.serve`) **before** `bootSupervisedModules`, and map a port-in-use bind failure to a clear, actionable error instead of a raw `EADDRINUSE` stack.

## Why (the orphan/duplicate-supervisor half of #536)
A duplicate `parachute serve` — e.g. the orphaned manual one that, alongside the launchd-managed hub, caused the live crash loop I debugged earlier — used to **boot supervised modules first** and only hit the hub-port conflict afterward. So it spawned and port-raced the live hub's children (vault/scribe/surface) over *their* ports before failing, producing an endless dual-supervisor fight (modules flapping with `received SIGTERM` right after `started`, intermittent EADDRINUSE).

Binding the hub port first means a duplicate **fails fast on bind, before touching a single module** — the live hub's children are left untouched. And the operator gets a clear next step ("another hub/supervisor is running … stop the other instance first") rather than a backtrace.

## How
- `serve()`: `Bun.serve(...)` (+ listening banner) now runs **before** the `bootSupervisedModules` block; module boot happens once we own the port. The fetch handler references the (initially empty) supervisor, which fills in as modules boot — the hub HTTP is up a touch sooner, which the existing "hub HTTP server is still starting" comment already anticipated.
- New exported `hubPortConflictMessage(err, port)` classifies a port-in-use failure → clear message, else `null` (caller re-throws original). Exported because the `Bun.serve` bind itself isn't seam-injectable.

## Scope note
This is the **orphan/duplicate-prevention** half of #536. The other half (wedged-module — crash-budget-exhausted module returns an opaque `request failed` to `start/stop`, with no per-module reset short of a full hub restart) is a separate, larger change; left tracked in #536.

## Gates
- `bun test ./src` — **2801 pass / 1 skip / 0 fail**
- `bun run typecheck` — clean; `biome` — clean
- New `hubPortConflictMessage` unit tests: maps `EADDRINUSE` + Bun's `"Is port N in use?"` → clear message; returns `null` for unrelated errors.

Partially addresses #536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)