### PR TITLE
fix(test-isolation): boundary-guard the default Runner against real launchctl under test (#535)

### DIFF
--- a/src/__tests__/launchctl-guard.test.ts
+++ b/src/__tests__/launchctl-guard.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import { defaultHubUnitDeps } from "../hub-unit.ts";
+import {
+  guardServiceManagerCommand,
+  isDestructiveServiceManagerCommand,
+} from "../launchctl-guard.ts";
+import { defaultManagedUnitDeps } from "../managed-unit.ts";
+
+// ===========================================================================
+// hub#535 — test-isolation boundary guard for destructive service-manager verbs.
+//
+// THE OUTAGE: a hub test on a LIVE machine reached the PRODUCTION default Runner
+// (`Bun.spawnSync(["launchctl","bootout","computer.parachute.hub"])`) — a daemon-
+// op helper was called with the default `deps`, not an injected fake — and
+// `launchctl bootout`'d the real running hub daemon, taking the whole ecosystem
+// down. The guard makes that impossible: under a test runner the default Runner
+// REFUSES destructive launchd/systemd verbs and THROWS, so a test that forgets to
+// inject a fake `run` fails loudly instead of nuking the operator's daemon.
+//
+// These tests run under `bun test` ⇒ NODE_ENV === "test" ⇒ the guard is ACTIVE.
+// ===========================================================================
+
+describe("isDestructiveServiceManagerCommand — classification", () => {
+  test("launchd destructive verbs are flagged", () => {
+    for (const verb of ["bootout", "bootstrap", "load", "unload", "kickstart"]) {
+      expect(
+        isDestructiveServiceManagerCommand(["launchctl", verb, "gui/501/computer.parachute.hub"]),
+      ).toBe(true);
+    }
+  });
+
+  test("launchd read-only verbs are NOT flagged", () => {
+    // `print` (state descriptor) and `list` are diagnostics — tests legitimately
+    // exercise these through the default deps, so the guard must leave them alone.
+    expect(
+      isDestructiveServiceManagerCommand(["launchctl", "print", "gui/501/computer.parachute.hub"]),
+    ).toBe(false);
+    expect(isDestructiveServiceManagerCommand(["launchctl", "list"])).toBe(false);
+  });
+
+  test("systemd destructive verbs are flagged (incl. --user / --now flags skipped)", () => {
+    expect(
+      isDestructiveServiceManagerCommand([
+        "systemctl",
+        "--user",
+        "enable",
+        "--now",
+        "parachute-hub.service",
+      ]),
+    ).toBe(true);
+    expect(
+      isDestructiveServiceManagerCommand([
+        "systemctl",
+        "disable",
+        "--now",
+        "parachute-vault.service",
+      ]),
+    ).toBe(true);
+    for (const verb of ["start", "stop", "restart", "daemon-reload", "mask"]) {
+      expect(
+        isDestructiveServiceManagerCommand(["systemctl", "--user", verb, "parachute-hub.service"]),
+      ).toBe(true);
+    }
+  });
+
+  test("systemd read-only verbs are NOT flagged", () => {
+    expect(
+      isDestructiveServiceManagerCommand([
+        "systemctl",
+        "--user",
+        "is-active",
+        "parachute-hub.service",
+      ]),
+    ).toBe(false);
+    expect(
+      isDestructiveServiceManagerCommand(["systemctl", "is-enabled", "parachute-vault.service"]),
+    ).toBe(false);
+  });
+
+  test("unrelated tools / loginctl / journalctl are NOT flagged", () => {
+    expect(isDestructiveServiceManagerCommand(["loginctl", "enable-linger", "op"])).toBe(false);
+    expect(
+      isDestructiveServiceManagerCommand(["journalctl", "--user", "-u", "parachute-hub.service"]),
+    ).toBe(false);
+    expect(isDestructiveServiceManagerCommand(["ps", "-o", "command=", "-p", "123"])).toBe(false);
+    expect(isDestructiveServiceManagerCommand([])).toBe(false);
+  });
+
+  test("absolute-path tool is still classified (basename match)", () => {
+    // Defense in depth: in this repo every invocation is bare, but if one ever
+    // used an absolute path the guard must still recognize it.
+    expect(
+      isDestructiveServiceManagerCommand([
+        "/bin/launchctl",
+        "bootout",
+        "gui/0/computer.parachute.hub",
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe("guardServiceManagerCommand — throws under a test runner", () => {
+  test("throws on launchctl bootout (the exact outage command)", () => {
+    expect(() =>
+      guardServiceManagerCommand(["launchctl", "bootout", "gui/501/computer.parachute.hub"]),
+    ).toThrow(/launchctl-guard.*Refusing to run a destructive service-manager command/s);
+  });
+
+  test("does NOT throw on a read-only command", () => {
+    expect(() =>
+      guardServiceManagerCommand(["launchctl", "print", "gui/501/computer.parachute.hub"]),
+    ).not.toThrow();
+  });
+
+  test("opt-out env var (PARACHUTE_ALLOW_REAL_LAUNCHCTL) lets a deliberate call through", () => {
+    const prev = process.env.PARACHUTE_ALLOW_REAL_LAUNCHCTL;
+    process.env.PARACHUTE_ALLOW_REAL_LAUNCHCTL = "1";
+    try {
+      expect(() =>
+        guardServiceManagerCommand(["launchctl", "bootout", "gui/501/computer.parachute.SAFE"]),
+      ).not.toThrow();
+    } finally {
+      // Restore — `= undefined` to clear (the codebase convention; biome flags
+      // `delete process.env.X` as a perf foot-gun. See hub-settings.test.ts).
+      if (prev === undefined) process.env.PARACHUTE_ALLOW_REAL_LAUNCHCTL = undefined;
+      else process.env.PARACHUTE_ALLOW_REAL_LAUNCHCTL = prev;
+    }
+  });
+});
+
+// ===========================================================================
+// THE REGRESSION TEST (hub#535 layer c): the PRODUCTION default deps — the ones a
+// daemon-op helper falls back to when a test forgets to inject a fake `run` — must
+// REFUSE the real launchctl under a test runner. If the guard regresses (someone
+// removes it from `defaultManagedUnitDeps.run`), these flip from "throws" to
+// "spawns the real launchctl" and this test fails — BEFORE the change can reach a
+// machine and bootout the live daemon.
+//
+// We assert via `defaultManagedUnitDeps.run` directly (the single chokepoint every
+// bare-launchctl call in the codebase routes through) and via `defaultHubUnitDeps`
+// (which spreads the same `run`), proving both seams are protected.
+// ===========================================================================
+describe("default Runner refuses real launchctl under test (regression — hub#535)", () => {
+  test("defaultManagedUnitDeps.run THROWS on `launchctl bootout` instead of spawning", () => {
+    expect(() =>
+      defaultManagedUnitDeps.run(["launchctl", "bootout", "gui/501/computer.parachute.hub"]),
+    ).toThrow(/launchctl-guard/);
+  });
+
+  test("defaultHubUnitDeps.run (inherits the guard via spread) THROWS on `launchctl kickstart`", () => {
+    expect(() =>
+      defaultHubUnitDeps.run(["launchctl", "kickstart", "-k", "gui/501/computer.parachute.hub"]),
+    ).toThrow(/launchctl-guard/);
+  });
+
+  test("default deps THROW on `systemctl --user disable --now` too", () => {
+    expect(() =>
+      defaultManagedUnitDeps.run([
+        "systemctl",
+        "--user",
+        "disable",
+        "--now",
+        "parachute-vault.service",
+      ]),
+    ).toThrow(/launchctl-guard/);
+  });
+
+  test("default deps still RUN a read-only `launchctl print` (guard is verb-scoped, not a blanket block)", () => {
+    // This proves the guard doesn't break the legitimate default-deps read paths
+    // (`queryHubUnitState`, the stale-unit `print` probe). Under the dev test-run
+    // PATH shim this hits the fake launchctl (exit 0); without it the real
+    // `launchctl print` of a non-loaded label returns nonzero — either way it does
+    // NOT throw, which is the property under test.
+    expect(() =>
+      defaultManagedUnitDeps.run(["launchctl", "print", "gui/501/computer.parachute.NONEXISTENT"]),
+    ).not.toThrow();
+  });
+});

--- a/src/__tests__/migrate-cutover.test.ts
+++ b/src/__tests__/migrate-cutover.test.ts
@@ -490,6 +490,12 @@ describe("teardownHubUnit (§7.4)", () => {
     const log: string[] = [];
     const res = teardownHubUnit({
       log: (l) => log.push(l),
+      // hub#535: inject fake deps so teardown NEVER falls back to the production
+      // default Runner (which would shell out to the real launchctl/systemctl).
+      // The injected fakes below mean no service-manager call is even attempted,
+      // but pinning `deps` removes the latent "forgot to inject → real bootout"
+      // hazard at the source.
+      deps: fakeHubUnitDeps(),
       remove: (opts): ManagedUnitRemoveResult => {
         removeArgs = { launchdLabel: opts.launchdLabel, systemdUnitName: opts.systemdUnitName };
         return { removed: true, messages: [opts.removedSystemdMessage(opts.systemdUnitName)] };
@@ -514,6 +520,9 @@ describe("teardownHubUnit (§7.4)", () => {
     const log: string[] = [];
     const res = teardownHubUnit({
       log: (l) => log.push(l),
+      // hub#535: inject fake deps (see the success-path test above) so this never
+      // reaches the production default Runner / real service manager.
+      deps: fakeHubUnitDeps(),
       remove: (): ManagedUnitRemoveResult => ({ removed: false, messages: [] }),
       disableStaleModuleUnits: () => {
         staleCalled = true;

--- a/src/launchctl-guard.ts
+++ b/src/launchctl-guard.ts
@@ -1,0 +1,131 @@
+/**
+ * Test-isolation boundary guard for destructive service-manager verbs (hub#535).
+ *
+ * THE OUTAGE (2026-06-03): a hub test running on a LIVE operator machine reached
+ * the production default Runner — `Bun.spawnSync(["launchctl", "bootout", …])` —
+ * with the real hub label, and `launchctl bootout computer.parachute.hub`'d the
+ * running `computer.parachute.hub` launchd daemon, taking hub + vault + scribe
+ * down under the operator's feet. Every daemon-op helper (`removeManagedUnit`,
+ * `installManagedUnit`, `stopHubUnit`/`restartHubUnit`, `disableStaleModuleUnits`,
+ * `teardownHubUnit`) shells launchctl through an injectable `deps.run([...])`
+ * whose PRODUCTION DEFAULT is a real spawn. A test that forgets to inject a fake
+ * `run` (or whose fake gets removed in a refactor) silently falls back to that
+ * real spawn → it drives the operator's actual service manager.
+ *
+ * THE GUARD: when running under a test runner (`NODE_ENV === "test"`, which Bun
+ * sets automatically for `bun test`), the production default Runner REFUSES the
+ * destructive launchd verbs — `bootout`, `bootstrap`, `load`, `kickstart` (and
+ * their systemd analogues `enable`/`disable`/`start`/`stop`/`restart` against a
+ * real systemctl) — and THROWS loudly instead of spawning. A test is thereby
+ * FORCED to inject a fake `run`; it can never reach the operator's live daemon by
+ * omission. Read-only verbs (`launchctl print`, `systemctl is-active`/
+ * `is-enabled`, `journalctl`, `loginctl`, `which`-style probes) are left alone —
+ * they're harmless and some tests intentionally exercise the default deps for
+ * them.
+ *
+ * PRODUCTION BEHAVIOR IS IDENTICAL: outside a test runner (`NODE_ENV !== "test"`)
+ * the guard is a no-op and the spawn proceeds exactly as before. There is also an
+ * explicit escape hatch — `PARACHUTE_ALLOW_REAL_LAUNCHCTL=1` — for the rare
+ * deliberate integration test that genuinely wants to drive a real (sandboxed)
+ * manager; it must opt IN, loudly, rather than reaching the daemon by accident.
+ *
+ * This is layer (a) of the hub#535 fix (the durable boundary guard). Layer (b) is
+ * the targeted fake-injection in the offending tests; layer (c) is the regression
+ * test that asserts the default deps throw here rather than spawn.
+ */
+
+/** Destructive launchd subcommands that mutate / tear down a loaded unit. */
+const DESTRUCTIVE_LAUNCHCTL_VERBS = new Set([
+  "bootout",
+  "bootstrap",
+  "load",
+  "unload",
+  "kickstart",
+]);
+
+/**
+ * Destructive systemd subcommands that mutate a unit's run/enable state. `enable`
+ * / `disable` may carry `--now` (which also starts/stops); `start`/`stop`/
+ * `restart` mutate run-state directly. Read-only `is-active` / `is-enabled` /
+ * `show` / `status` / `cat` are NOT here — tests use the default deps for those.
+ */
+const DESTRUCTIVE_SYSTEMCTL_VERBS = new Set([
+  "start",
+  "stop",
+  "restart",
+  "reload",
+  "enable",
+  "disable",
+  "daemon-reload",
+  "mask",
+  "unmask",
+]);
+
+/** True when we're executing under a test runner. Bun sets NODE_ENV=test for `bun test`. */
+function underTestRunner(): boolean {
+  return process.env.NODE_ENV === "test";
+}
+
+/** True when an operator has explicitly opted in to real service-manager calls under test. */
+function realCallsExplicitlyAllowed(): boolean {
+  const v = process.env.PARACHUTE_ALLOW_REAL_LAUNCHCTL;
+  return v === "1" || v === "true";
+}
+
+/**
+ * Find the first meaningful subcommand token after the tool name, skipping
+ * scope/option flags (`--user`, `-k`, `--now`, etc.) so we classify the VERB,
+ * not a flag. Returns undefined when there's nothing past the flags.
+ */
+function firstSubcommand(rest: readonly string[]): string | undefined {
+  for (const tok of rest) {
+    if (tok.startsWith("-")) continue;
+    return tok;
+  }
+  return undefined;
+}
+
+/**
+ * Decide whether a command (as the argv the default Runner is about to spawn) is
+ * a DESTRUCTIVE service-manager mutation that must be blocked under a test runner.
+ *
+ *   - `launchctl <verb> …` where verb ∈ {bootout, bootstrap, load, unload, kickstart}
+ *   - `systemctl [--user] <verb> …` where verb ∈ {start, stop, restart, reload,
+ *     enable, disable, daemon-reload, mask, unmask}
+ *
+ * The tool name is matched on the basename so an absolute path (`/bin/launchctl`)
+ * is classified too — though in this codebase every invocation is bare (the PATH
+ * shim's safety relies on that), this keeps the guard correct regardless.
+ */
+export function isDestructiveServiceManagerCommand(cmd: readonly string[]): boolean {
+  if (cmd.length === 0) return false;
+  const tool = (cmd[0] ?? "").split("/").pop() ?? "";
+  const rest = cmd.slice(1);
+  const verb = firstSubcommand(rest);
+  if (verb === undefined) return false;
+  if (tool === "launchctl") return DESTRUCTIVE_LAUNCHCTL_VERBS.has(verb);
+  if (tool === "systemctl") return DESTRUCTIVE_SYSTEMCTL_VERBS.has(verb);
+  return false;
+}
+
+/**
+ * The boundary guard the production default Runner calls before spawning. When
+ * running under a test runner and NOT explicitly opted in, a destructive
+ * service-manager command THROWS — forcing the test to inject a fake `run`
+ * instead of driving the operator's live daemon. A no-op everywhere else
+ * (production, or a non-destructive/read-only command, or explicit opt-in).
+ *
+ * The thrown error names the exact command and tells the author how to fix it,
+ * so a regressed test fails with an actionable message rather than a silent
+ * daemon teardown.
+ */
+export function guardServiceManagerCommand(cmd: readonly string[]): void {
+  if (!underTestRunner()) return; // production — spawn proceeds unchanged.
+  if (realCallsExplicitlyAllowed()) return; // deliberate integration test opted in.
+  if (!isDestructiveServiceManagerCommand(cmd)) return; // read-only / unrelated — fine.
+  throw new Error(
+    `[launchctl-guard] Refusing to run a destructive service-manager command under a test runner: \`${cmd.join(
+      " ",
+    )}\`. The default (production) Runner shells out to the REAL launchctl/systemctl — on a live machine this would tear down the operator's running daemon (this is the hub#535 outage class). Inject a fake \`run\` into this code path's deps so the test never touches the real service manager. (If you GENUINELY need a real, sandboxed manager call in this test, set PARACHUTE_ALLOW_REAL_LAUNCHCTL=1 to opt in.)`,
+  );
+}

--- a/src/managed-unit.ts
+++ b/src/managed-unit.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { guardServiceManagerCommand } from "./launchctl-guard.ts";
 
 /**
  * Platform-agnostic "managed unit" machinery — the reusable launchd/systemd
@@ -86,6 +87,12 @@ export const defaultManagedUnitDeps: ManagedUnitDeps = {
   userName: () => process.env.USER ?? process.env.LOGNAME ?? process.env.USERNAME ?? "",
   which: (binary) => Bun.which(binary),
   run: (cmd) => {
+    // hub#535 boundary guard: under a test runner, REFUSE destructive
+    // launchctl/systemctl verbs (bootout/bootstrap/load/kickstart, etc.) instead
+    // of spawning the REAL service manager — a test that forgot to inject a fake
+    // `run` must not be able to tear down the operator's live daemon by omission.
+    // No-op in production (NODE_ENV !== "test"); see src/launchctl-guard.ts.
+    guardServiceManagerCommand(cmd);
     const proc = Bun.spawnSync([...cmd], { env: process.env });
     return {
       code: proc.exitCode ?? 1,


### PR DESCRIPTION
## The outage (hub#535)

On **2026-06-03** a hub test running on a **live operator machine** reached the
**production default Runner** and `launchctl bootout computer.parachute.hub`'d the
real running hub launchd daemon — taking **hub + vault + scribe** down under the
operator while they were using it.

## The mechanism: bare launchctl via the default Runner

Every daemon-op helper goes through an injectable Runner `deps.run([...])` (the
house pattern). Its **production default** is a real `Bun.spawnSync`
(`defaultManagedUnitDeps.run` in `src/managed-unit.ts`). The helpers that shell
launchctl/systemctl — `removeManagedUnit` / `installManagedUnit` (managed-unit),
`stopHubUnit` / `restartHubUnit` / `installAndStartHubUnit` (hub-unit),
`disableStaleModuleUnits` (stale-module-units), `teardownHubUnit`
(migrate-cutover), and the cloudflared connector — invoke launchctl **bare**
(`deps.run(["launchctl", "bootout", …])`). A test that calls a helper with the
**default deps** (forgetting to inject a fake `run`, or whose fake is removed in a
refactor) silently shells out to the operator's **real** service manager.

**Audit confirmed every launchctl/systemctl invocation in the codebase is BARE —
none uses an absolute path** — so a PATH-resolved fake intercepts all of them.

## Offending test(s) found

A full suite run under a **fake-launchctl PATH shim** produced **zero**
`[FAKE-launchctl] bootout …` lines — i.e. **no currently-passing test actively
reaches the real launchctl path**; every existing daemon-op test injects a fake
`deps`. The danger is **latent / regression-class**: the codebase had **zero
structural protection** against a future (or refactored) test falling back to the
default Runner.

The closest fragile spot: the two `teardownHubUnit` tests in
`migrate-cutover.test.ts` called the helper **without injecting `deps`** (so it
fell back to `defaultHubUnitDeps`), safe today **only** because their fake
`remove` short-circuits before `deps.run` — and they target the **real hub label
`computer.parachute.hub`**, the exact outage path.

I proved the mechanism with a throwaway probe (a fake throwaway label, under the
shim): `removeManagedUnit` with **default deps** invoked bare `launchctl bootout`,
intercepted by the shim. With the real hub label and no shim, that is the outage.

## The fix — two layers, production-behavior-preserving

**(a) Boundary guard (durable).** New `src/launchctl-guard.ts`.
`guardServiceManagerCommand(cmd)` is called by `defaultManagedUnitDeps.run`
**before** spawning. Under a test runner it **refuses** destructive verbs
(launchctl `bootout`/`bootstrap`/`load`/`unload`/`kickstart`; systemctl
`start`/`stop`/`restart`/`reload`/`enable`/`disable`/`daemon-reload`/`mask`/`unmask`)
and **throws** an actionable error instead of spawning — a test that omits a fake
`run` fails loudly rather than nuking the live daemon. Read-only verbs (launchctl
`print`, systemctl `is-active`/`is-enabled`, `journalctl`, `loginctl`) are left
alone.

- **Test detection:** `NODE_ENV === "test"`, which **Bun sets automatically** for
  `bun test` (verified empirically; `undefined` for a plain `bun run`; nothing in
  hub source/`bunfig`/`package.json` overrides it). Plus a
  `PARACHUTE_ALLOW_REAL_LAUNCHCTL=1` **opt-in escape hatch** for a deliberate
  sandboxed integration test.
- **Production unchanged:** when `NODE_ENV !== "test"` the guard is a strict
  no-op — the spawn proceeds exactly as before.
- **Single chokepoint:** guarding `defaultManagedUnitDeps.run` covers
  managed-unit, hub-unit (spreads it into `defaultHubUnitDeps`),
  stale-module-units, migrate-cutover (`defaultCutoverDeps.hubUnitDeps =
  defaultHubUnitDeps`), and the cloudflared connector (`defaultServiceDeps =
  defaultManagedUnitDeps`) — every bare-launchctl path.

**(b) Fake injection (targeted).** The two `teardownHubUnit` tests in
`migrate-cutover.test.ts` now inject `fakeHubUnitDeps()` so they can never fall
back to the default Runner.

**(c) Regression test.** `src/__tests__/launchctl-guard.test.ts` asserts the
verb classification **and** that `defaultManagedUnitDeps.run` /
`defaultHubUnitDeps.run` **throw** on `launchctl bootout` / `kickstart` /
`systemctl disable --now` under the test runner — while still permitting
read-only `launchctl print`. If the guard regresses, these flip from "throws" to
"spawns the real launchctl" and **fail before the change can reach a machine**.

## Gates (all run with the fake-launchctl PATH shim)

- `PATH=/tmp/sg-fakebin:$PATH bun test ./src` → **2811 pass, 1 skip, 0 fail** (116 files)
- `PATH=/tmp/sg-fakebin:$PATH bun test ./packages/scope-guard/src` → **108 pass, 0 fail**
- `bun run typecheck` → clean
- **Zero `[FAKE-launchctl]` lines** in the hub run.

## Safety note

**All dev test runs used a fake-`launchctl` PATH shim** (`/tmp/sg-fakebin/launchctl`,
bare-name interception) so no test could ever reach the real
`computer.parachute.hub` daemon, which was running live throughout. A bare
`bun test ./src` without the shim was never run.

No version bump (test-isolation hardening; production behavior identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)