### PR TITLE
fix(status): report run-state for non-curated supervised modules (#539)

### DIFF
--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -317,6 +317,45 @@ describe("GET /api/modules", () => {
     expect(shorts).not.toContain("surface");
   });
 
+  test("non-curated supervised modules appear in `supervised` (not `modules`) — hub#539", async () => {
+    // surface (the UI host) is supervised but not curated. Its run-state must
+    // surface in `supervised` so `parachute status` reads it `active`, while it
+    // stays OUT of the curated `modules` catalog (which drives the install UI).
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/vault/default"],
+        health: "/vault/default/health",
+        version: "0.4.5",
+      },
+    ]);
+    const { supervisor } = makeIdleSupervisor();
+    await supervisor.start({ short: "vault", cmd: ["parachute-vault", "serve"] });
+    await supervisor.start({ short: "surface", cmd: ["parachute-surface", "serve"] });
+
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      supervisor,
+      fetchLatestVersion: async () => null,
+    });
+    const body = (await res.json()) as {
+      modules: Array<{ short: string }>;
+      supervised: Array<{ short: string; supervisor_status: string | null; pid: number | null }>;
+    };
+    // surface stays out of the curated catalog…
+    expect(body.modules.map((m) => m.short)).not.toContain("surface");
+    // …but its run-state is in `supervised`, marked running with a pid.
+    const surf = body.supervised.find((m) => m.short === "surface");
+    expect(surf?.supervisor_status).toBe("running");
+    expect(typeof surf?.pid).toBe("number");
+    // Curated modules appear in `supervised` too (consumers dedupe by short).
+    expect(body.supervised.find((m) => m.short === "vault")?.supervisor_status).toBe("running");
+  });
+
   test("surfaces installed_version from services.json", async () => {
     writeManifest(h.manifestPath, [
       {
@@ -716,10 +755,7 @@ describe("GET /api/modules", () => {
     // Second back-to-back request must not re-hit the registry. The
     // UI may poll this endpoint; we don't want it to slam npm.
     let calls = 0;
-    const probe = async (
-      _pkg: string,
-      _channel: "latest" | "rc",
-    ): Promise<string | null> => {
+    const probe = async (_pkg: string, _channel: "latest" | "rc"): Promise<string | null> => {
       calls++;
       return "0.5.0";
     };

--- a/src/__tests__/module-ops-client.test.ts
+++ b/src/__tests__/module-ops-client.test.ts
@@ -471,6 +471,53 @@ describe("fetchModuleStates", () => {
     expect((scribe?.supervisor_start_error as { binary?: string } | null)?.binary).toBe("scribe");
   });
 
+  test("parses the `supervised` array — non-curated modules' run-state (hub#539)", async () => {
+    h = await makeHarnessWithToken();
+    const { fetch: f } = fakeFetch([
+      {
+        status: 200,
+        body: {
+          supervisor_available: true,
+          modules: [], // curated catalog can omit a running module (e.g. surface)…
+          supervised: [
+            {
+              short: "surface",
+              installed: true,
+              installed_version: null,
+              supervisor_status: "running",
+              pid: 8739,
+              supervisor_start_error: null,
+            },
+          ],
+        },
+      },
+    ]);
+    const result = await fetchModuleStates({
+      db: h.db,
+      issuer: ISSUER,
+      configDir: h.dir,
+      fetch: f,
+    });
+    expect(result.supervised).toHaveLength(1);
+    const surf = result.supervised?.find((m) => m.short === "surface");
+    expect(surf?.supervisor_status).toBe("running");
+    expect(surf?.pid).toBe(8739);
+  });
+
+  test("omitted `supervised` (older hub) parses to [] — hub#539 forward-compat", async () => {
+    h = await makeHarnessWithToken();
+    const { fetch: f } = fakeFetch([
+      { status: 200, body: { supervisor_available: true, modules: [] } },
+    ]);
+    const result = await fetchModuleStates({
+      db: h.db,
+      issuer: ISSUER,
+      configDir: h.dir,
+      fetch: f,
+    });
+    expect(result.supervised).toEqual([]);
+  });
+
   test("no operator token → NoOperatorTokenError before any fetch", async () => {
     h = await makeHarnessNoToken();
     const { fetch: f, calls } = fakeFetch([{ status: 200, body: { modules: [] } }]);

--- a/src/__tests__/status.test.ts
+++ b/src/__tests__/status.test.ts
@@ -256,4 +256,68 @@ describe("status — per-module URL deep-links (manifestRowBase / urlForEntry)",
       cleanup();
     }
   });
+
+  test("non-curated supervised module reads `active` via the `supervised` fallback — hub#539", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      // surface is supervised but absent from the curated `modules` catalog
+      // (which only carries vault/scribe). Before hub#539 it mapped to
+      // `inactive` despite running; now `status` falls back to `supervised`.
+      upsertService(
+        {
+          name: "parachute-surface",
+          port: 1946,
+          paths: ["/surface"],
+          health: "/surface/healthz",
+          version: "0.2.2",
+        },
+        path,
+      );
+      const lines: string[] = [];
+      await status({
+        ...supervisorOpts(configDir, path, {
+          // `modules` empty (curated catalog omits surface); run-state ONLY in
+          // `supervised` — exactly the wire shape the live hub now returns.
+          moduleStates: {
+            supervisorAvailable: true,
+            modules: [],
+            supervised: [runningModule("surface")],
+          },
+        }),
+        print: (l) => lines.push(l),
+      });
+      const surfaceLine = lines.find((l) => l.includes("parachute-surface")) ?? "";
+      expect(surfaceLine).toMatch(/\bactive\b/);
+      expect(surfaceLine).not.toMatch(/\binactive\b/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("module absent from BOTH modules and supervised stays `inactive` — hub#539 boundary", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      upsertService(
+        {
+          name: "parachute-surface",
+          port: 1946,
+          paths: ["/surface"],
+          health: "/surface/healthz",
+          version: "0.2.2",
+        },
+        path,
+      );
+      const lines: string[] = [];
+      await status({
+        ...supervisorOpts(configDir, path, {
+          moduleStates: { supervisorAvailable: true, modules: [], supervised: [] },
+        }),
+        print: (l) => lines.push(l),
+      });
+      const surfaceLine = lines.find((l) => l.includes("parachute-surface")) ?? "";
+      expect(surfaceLine).toMatch(/\binactive\b/);
+    } finally {
+      cleanup();
+    }
+  });
 });

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -243,8 +243,32 @@ interface ModuleWireShape {
   management_url: string | null;
 }
 
+/**
+ * Per-module supervisor snapshot for the `supervised` array (hub#539). The
+ * supervisor-derived subset of `ModuleWireShape` — enough for `status` to
+ * render a run-state row for a module that isn't in the curated catalog.
+ */
+interface SupervisedSnapshotWire {
+  short: string;
+  installed: boolean;
+  installed_version: string | null;
+  supervisor_status: ModuleState["status"] | null;
+  pid: number | null;
+  supervisor_start_error: ModuleStartError | null;
+}
+
 interface ModulesResponse {
   modules: ModuleWireShape[];
+  /**
+   * Run-state for EVERY module the supervisor is currently tracking — not just
+   * the curated `modules` (vault/scribe). Non-curated supervised modules (e.g.
+   * the `surface` UI host) appear here so `parachute status` / the SPA can
+   * reflect their real run-state instead of mislabelling them `inactive`
+   * because they're absent from the curated catalog (hub#539). Curated modules
+   * also appear here (harmless — consumers dedupe by `short`, preferring the
+   * richer `modules` entry). Same supervisor-field shape as a `modules` entry.
+   */
+  supervised: SupervisedSnapshotWire[];
   /**
    * Whether the supervisor is wired into this hub. `false` under
    * `parachute expose` / on-box CLI; the UI greys out install/start
@@ -522,8 +546,20 @@ export async function handleApiModules(req: Request, deps: ApiModulesDeps): Prom
     });
   }
 
+  // Every supervised module's run-state — curated AND non-curated (hub#539).
+  // Built from the same supervisor.list() snapshot already in `stateByShort`.
+  const supervised: SupervisedSnapshotWire[] = Array.from(stateByShort.values()).map((s) => ({
+    short: s.short,
+    installed: installedByShort.has(s.short),
+    installed_version: installedByShort.get(s.short)?.version ?? null,
+    supervisor_status: s.status,
+    pid: s.pid ?? null,
+    supervisor_start_error: s.startError ?? null,
+  }));
+
   const body: ModulesResponse = {
     modules,
+    supervised,
     supervisor_available: supervisor !== undefined,
     module_install_channel: getModuleInstallChannel(deps.db),
   };

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -20,6 +20,7 @@ import {
 import {
   type DriveModuleOpDeps,
   type ModuleStatesResult,
+  type ModuleStateSnapshot,
   NoOperatorTokenError,
   OperatorTokenExpiredError,
   fetchModuleStates as fetchModuleStatesImpl,
@@ -487,7 +488,7 @@ async function buildSupervisorRows(args: BuildSupervisorRowsArgs): Promise<Statu
     }
   }
 
-  const stateByShort = new Map<string, ModuleStatesResult["modules"][number]>();
+  const stateByShort = new Map<string, ModuleStateSnapshot>();
   for (const m of states?.modules ?? []) {
     if (m.short) stateByShort.set(m.short, m);
   }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -491,6 +491,13 @@ async function buildSupervisorRows(args: BuildSupervisorRowsArgs): Promise<Statu
   for (const m of states?.modules ?? []) {
     if (m.short) stateByShort.set(m.short, m);
   }
+  // Fall back to the full `supervised` snapshot for modules the curated
+  // `modules` catalog omits — e.g. the `surface` UI host, which the supervisor
+  // runs but isn't a curated installable. Without this it'd map to `inactive`
+  // despite running (hub#539). Curated entries already in the map win (richer).
+  for (const m of states?.supervised ?? []) {
+    if (m.short && !stateByShort.has(m.short)) stateByShort.set(m.short, m);
+  }
 
   const rows: StatusRow[] = manifest.services.map((entry) => {
     const base = manifestRowBase(entry, installSourceDeps);

--- a/src/module-ops-client.ts
+++ b/src/module-ops-client.ts
@@ -330,6 +330,14 @@ export interface ModuleStatesResult {
   readonly supervisorAvailable: boolean;
   /** Per-module supervisor snapshots, keyed by short name in array order. */
   readonly modules: ModuleStateSnapshot[];
+  /**
+   * Run-state for ALL supervised modules — including non-curated ones the
+   * `modules` catalog omits (e.g. the `surface` UI host). `status` falls back
+   * to this so a running-but-non-curated module reads `active`, not `inactive`
+   * (hub#539). The live `fetchModuleStates` always populates it (`[]` against an
+   * older hub that predates the field); optional so test stubs may omit it.
+   */
+  readonly supervised?: ModuleStateSnapshot[];
 }
 
 /**
@@ -391,22 +399,34 @@ export async function fetchModuleStates(deps: DriveModuleOpDeps): Promise<Module
     const { error, error_description } = asErrorBody(body);
     throw new ModuleOpHttpError(res.status, error, error_description);
   }
-  const b = (body ?? {}) as { modules?: unknown; supervisor_available?: unknown };
+  const b = (body ?? {}) as {
+    modules?: unknown;
+    supervised?: unknown;
+    supervisor_available?: unknown;
+  };
   const supervisorAvailable = b.supervisor_available === true;
-  const modules: ModuleStateSnapshot[] = Array.isArray(b.modules)
-    ? b.modules
-        .filter((m): m is Record<string, unknown> => !!m && typeof m === "object")
-        .map((m) => ({
-          short: typeof m.short === "string" ? m.short : "",
-          installed: m.installed === true,
-          installed_version: typeof m.installed_version === "string" ? m.installed_version : null,
-          supervisor_status: typeof m.supervisor_status === "string" ? m.supervisor_status : null,
-          pid: typeof m.pid === "number" ? m.pid : null,
-          supervisor_start_error:
-            m.supervisor_start_error !== undefined ? (m.supervisor_start_error ?? null) : null,
-        }))
-    : [];
-  return { supervisorAvailable, modules };
+  const modules = parseSnapshots(b.modules);
+  // `supervised` (hub#539) carries run-state for ALL supervised modules,
+  // including non-curated ones absent from `modules` (e.g. the surface host).
+  // Older hubs without the field yield []; consumers tolerate that.
+  const supervised = parseSnapshots(b.supervised);
+  return { supervisorAvailable, modules, supervised };
+}
+
+/** Parse a `modules`/`supervised` array into validated snapshots (hub#539). */
+function parseSnapshots(raw: unknown): ModuleStateSnapshot[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((m): m is Record<string, unknown> => !!m && typeof m === "object")
+    .map((m) => ({
+      short: typeof m.short === "string" ? m.short : "",
+      installed: m.installed === true,
+      installed_version: typeof m.installed_version === "string" ? m.installed_version : null,
+      supervisor_status: typeof m.supervisor_status === "string" ? m.supervisor_status : null,
+      pid: typeof m.pid === "number" ? m.pid : null,
+      supervisor_start_error:
+        m.supervisor_start_error !== undefined ? (m.supervisor_start_error ?? null) : null,
+    }));
 }
 
 async function parseJsonSafe(res: Response): Promise<unknown> {


### PR DESCRIPTION
## What
`parachute status` (and the data behind it) now reflects the real run-state of supervised modules that aren't in the curated install catalog — e.g. the `surface` UI host, which showed `inactive` while running and serving.

## Root cause
`GET /api/modules` enumerates only `CURATED_MODULES = ["vault","scribe"]`. surface is supervised (the hub spawns it from services.json) but not curated, so its supervisor state was never exposed over HTTP. `status` enumerates services.json for rows, finds no supervisor state for surface, and maps absent→`inactive`. A code comment even claimed non-curated installed modules "are appended with `available:false`" — but that append was never implemented.

## Fix — approach A (additive, zero SPA-contract churn)
- **`/api/modules`** gains a `supervised[]` field: run-state (`short`, `supervisor_status`, `pid`, `supervisor_start_error`, …) for **every** module `supervisor.list()` tracks — curated *and* non-curated. Built from the snapshot already in scope. The curated `modules` array (consumed by the admin SPA's install/manage grid, where non-curated shorts would render broken action buttons) is **untouched**.
- **`module-ops-client.fetchModuleStates`** parses `supervised` (optional ⇒ forward-compatible with older hubs that omit it; refactored the snapshot parse into a shared `parseSnapshots`).
- **`status`** falls back to `supervised` for any services.json module absent from the curated `modules` map; curated entries still win on dedupe.

Net: surface reads `active`; curated catalog + SPA behavior unchanged. Cosmetic-only — surface was always serving (`/surface/notes` 200 throughout).

## Tests
- api-modules: a non-curated supervised module appears in `supervised`, **not** `modules`; curated still present in `supervised` (dedupe).
- status: non-curated supervised module reads `active` via the fallback; absent-from-both still `inactive` (boundary).
- module-ops-client: parses `supervised`; `[]` for an older hub that omits it.
- `bun test ./src` — **2819 pass / 1 skip / 0 fail**; typecheck + biome clean (2 pre-existing `noExplicitAny`/stale-suppression warnings in an unrelated legacy-OAuth test, untouched).

Closes #539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)