### PR TITLE
fix(supervisor): late-bind watch clears a stale started_but_unbound note

### DIFF
--- a/src/__tests__/supervisor.test.ts
+++ b/src/__tests__/supervisor.test.ts
@@ -833,6 +833,76 @@ describe("Supervisor port-readiness + structured start-error (§6.5)", () => {
     proc.resolveExit(0);
   });
 
+  test("(b2) late bind AFTER the window → the background watch clears the started-but-unbound note", async () => {
+    // Heavy modules (vault — SQLite + git mirror + well-known init) routinely
+    // bind a moment after the readiness window. Pre-fix, the note recorded at
+    // window-elapse stuck for the module's whole lifetime and `parachute
+    // status` showed a perpetual "failed to start" on a healthy module.
+    const proc = makeFakeProc(103);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(proc);
+    let bound = false;
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      killFn: noopKill,
+      portListening: async () => bound,
+      startReadyMs: 30,
+      startReadyPollMs: 5,
+      lateBindWatchMs: 2_000,
+      lateBindPollMs: 5,
+      sleep: () => Promise.resolve(),
+    });
+    const state = await sup.start(reqWithPort("vault", 1940));
+    // Window elapsed unbound → note recorded (status stays running)…
+    expect(state.startError?.error_type).toBe("started_but_unbound");
+
+    // …then the port binds late. The watch must clear the note.
+    bound = true;
+    let cleared = false;
+    const deadline = Date.now() + 1_500;
+    while (Date.now() < deadline) {
+      if (sup.list()[0]?.startError === undefined) {
+        cleared = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(cleared).toBe(true);
+    expect(sup.list()[0]?.status).toBe("running");
+
+    proc.closeStreams();
+    sup.stop("vault");
+    proc.resolveExit(0);
+  });
+
+  test("(b3) never binds → the watch gives up at its deadline and the note persists", async () => {
+    // A genuinely-unbound module must KEEP its diagnostic — the watch is a
+    // bounded grace window, not an eraser.
+    const proc = makeFakeProc(104);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(proc);
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      killFn: noopKill,
+      portListening: async () => false,
+      startReadyMs: 20,
+      startReadyPollMs: 5,
+      lateBindWatchMs: 40,
+      lateBindPollMs: 5,
+      sleep: () => Promise.resolve(),
+    });
+    const state = await sup.start(reqWithPort("vault", 1940));
+    expect(state.startError?.error_type).toBe("started_but_unbound");
+
+    // Let the 40ms watch budget expire; the note must remain.
+    await new Promise((r) => setTimeout(r, 120));
+    expect(sup.list()[0]?.startError?.error_type).toBe("started_but_unbound");
+
+    proc.closeStreams();
+    sup.stop("vault");
+    proc.resolveExit(0);
+  });
+
   test("(c) preflight MissingDependencyError → structured start-error, NO spawn", async () => {
     const spawner = makeQueueSpawner();
     // No proc enqueued — if start() tried to spawn, the queue spawner throws.

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -197,6 +197,19 @@ export interface SupervisorOpts {
   /** Poll interval while waiting for the port to bind, in ms. Default 200. */
   readonly startReadyPollMs?: number;
   /**
+   * How long the background late-bind watch keeps re-probing AFTER the
+   * readiness window elapsed with the port unbound, in ms. Heavy modules
+   * (vault — SQLite + git mirror + well-known init) can legitimately take
+   * longer than `startReadyMs` to bind; without a re-probe the recorded
+   * `started_but_unbound` note sticks for the module's whole lifetime and
+   * `parachute status` shows a perpetual "failed to start" on a healthy
+   * module. The watch clears the note once the port binds. Default 60s;
+   * `0` disables the watch (the note then behaves as before).
+   */
+  readonly lateBindWatchMs?: number;
+  /** Poll interval for the late-bind watch, in ms. Default 1000. */
+  readonly lateBindPollMs?: number;
+  /**
    * PATH-resolution seam for the pre-spawn `ensureExecutable` preflight
    * (`@openparachute/depcheck`). Production uses the real `Bun.which`; a
    * missing startCmd binary then aborts the spawn with a structured
@@ -242,6 +255,8 @@ const DEFAULT_KILL_TIMEOUT_MS = 5_000;
 const DEFAULT_LOG_BUFFER_BYTES = 64 * 1024;
 const DEFAULT_START_READY_MS = 4_000;
 const DEFAULT_START_READY_POLL_MS = 200;
+const DEFAULT_LATE_BIND_WATCH_MS = 60_000;
+const DEFAULT_LATE_BIND_POLL_MS = 1_000;
 
 /**
  * Bounded, line-oriented ring buffer (§6.5). Holds the most-recent lines of a
@@ -318,6 +333,8 @@ export class Supervisor {
       startReadyMs:
         opts.startReadyMs ?? (isProductionPath || readinessOptedIn ? DEFAULT_START_READY_MS : 0),
       startReadyPollMs: opts.startReadyPollMs ?? DEFAULT_START_READY_POLL_MS,
+      lateBindWatchMs: opts.lateBindWatchMs ?? DEFAULT_LATE_BIND_WATCH_MS,
+      lateBindPollMs: opts.lateBindPollMs ?? DEFAULT_LATE_BIND_POLL_MS,
       which: opts.which ?? (isProductionPath ? Bun.which : () => "/stub/bin/preflight-skipped"),
     };
   }
@@ -453,6 +470,36 @@ export class Supervisor {
           at: new Date(this.opts.now()).toISOString(),
         },
       };
+      // Keep watching in the background: heavy modules (vault) routinely bind
+      // a moment after the window. Without the re-probe the note above would
+      // stick for the module's whole lifetime — `parachute status` then shows
+      // a perpetual "failed to start" on a healthy module. Fire-and-forget so
+      // `start()`'s latency stays bounded by `startReadyMs`.
+      if (this.opts.lateBindWatchMs > 0) {
+        void this.lateBindWatch(entry, port).catch(() => {});
+      }
+    }
+  }
+
+  /**
+   * Background re-probe after `awaitPortReadiness` recorded a
+   * `started_but_unbound` note: poll (slower cadence, bounded window) and
+   * clear the note once the port binds. Exits early when the module stops,
+   * crashes, or the note is replaced by a different startError (a later
+   * crash-restart's missing-dependency note must not be wiped).
+   */
+  private async lateBindWatch(entry: ModuleEntry, port: number): Promise<void> {
+    const deadline = this.opts.now() + this.opts.lateBindWatchMs;
+    while (this.opts.now() < deadline) {
+      await this.opts.sleep(this.opts.lateBindPollMs);
+      if (entry.stopRequested || entry.state.status !== "running") return;
+      // Only OUR note is clearable — anything else was recorded after us.
+      if (entry.state.startError?.error_type !== "started_but_unbound") return;
+      if (await this.opts.portListening(port)) {
+        const { startError: _drop, ...rest } = entry.state;
+        entry.state = rest;
+        return;
+      }
     }
   }
 

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -487,6 +487,14 @@ export class Supervisor {
    * clear the note once the port binds. Exits early when the module stops,
    * crashes, or the note is replaced by a different startError (a later
    * crash-restart's missing-dependency note must not be wiped).
+   *
+   * Restart safety: a crash-auto-restart reuses the same `entry` object and
+   * clears `startError` on respawn — this watch's `error_type` guard then sees
+   * `undefined` and exits, so a stale watch from spawn-1 never clobbers
+   * spawn-2's state. If spawn-2 also misses its window, its own gate records a
+   * fresh note and launches its own watch; two live watches clearing the same
+   * note is idempotent. `stop()`/teardown set `stopRequested` before any entry
+   * removal, so a watch holding a stale entry ref exits cleanly.
    */
   private async lateBindWatch(entry: ModuleEntry, port: number): Promise<void> {
     const deadline = this.opts.now() + this.opts.lateBindWatchMs;


### PR DESCRIPTION
## What
After the post-spawn readiness window elapses with the port unbound, the supervisor now keeps re-probing in the background (slower cadence, bounded window) and **clears the `started_but_unbound` note once the port binds**.

## Why
vault's cold start (SQLite + git mirror + well-known init) routinely outlives the 4 s readiness window. The gate records the note and never re-probes — so a perfectly healthy vault shows `! failed to start: vault … not listening on port 1940` in `parachute status` for its **entire lifetime**, on every (re)start. Verified live: vault listening on 1940 + serving (`/vault/default/health` → 401 auth-gated) while the note persisted, reproducible via isolated `parachute restart vault`. Same status-trust-erosion family as #537 (scribe stale `.env` PORT) and #539 (surface missing from the curated catalog).

## How
- New `lateBindWatch(entry, port)`: fire-and-forget after the note is recorded; polls every `lateBindPollMs` (default 1 s) for up to `lateBindWatchMs` (default 60 s; `0` disables).
- Clears the note **only if** it's still the `started_but_unbound` one — a later crash-restart's missing-dependency note is never wiped.
- Exits early on stop/crash/non-running. `start()`'s blocking latency is unchanged (still bounded by `startReadyMs`); the watch is background-only.
- Both knobs injectable for deterministic tests; stub-spawner test path unaffected (no gate ⇒ no note ⇒ no watch).

## Tests
- **(b2)** port binds after the window → note recorded, then cleared by the watch; status stays `running`.
- **(b3)** never binds → the watch gives up at its deadline and the note **persists** (the diagnostic isn't an eraser).
- `bun test ./src` — **2821 pass / 1 skip / 0 fail**; typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)