### PR TITLE
fix(module-ops): structured errors for supervisor-op throws; status-bearing client fallback (#536)

### DIFF
--- a/src/__tests__/api-modules-ops.test.ts
+++ b/src/__tests__/api-modules-ops.test.ts
@@ -842,6 +842,31 @@ describe("POST /api/modules/:short/start", () => {
     expect(res.status).toBe(403);
   });
 
+  test("supervisor.start throw → structured 500 module_op_failed, not a naked 500 (hub#536)", async () => {
+    seedVault();
+    // Models the hub#536 wedge: Bun.spawn throwing because the module's
+    // installDir/cwd no longer exists (NOT a missing binary — the preflight
+    // + rethrowIfMissing nets don't catch it, so it propagates out of
+    // supervisor.start). Pre-fix this escaped the handler as a bodyless 500
+    // and the CLI showed an opaque "request failed".
+    const supervisor = new Supervisor({
+      spawnFn: () => {
+        throw new Error("simulated spawn failure: cwd /gone/parachute-app does not exist");
+      },
+    });
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleStart(
+      postReq("/api/modules/vault/start", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      { db: h.db, issuer: ISSUER, manifestPath: h.manifestPath, configDir: h.dir, supervisor },
+    );
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("module_op_failed");
+    expect(body.error_description).toContain("vault start failed");
+    expect(body.error_description).toContain("cwd /gone/parachute-app does not exist");
+  });
+
   test("pure supervisor.start of an installed module — NOT install (no bun add)", async () => {
     seedVault();
     const { supervisor, spawns } = makeIdleSupervisor();

--- a/src/__tests__/module-ops-client.test.ts
+++ b/src/__tests__/module-ops-client.test.ts
@@ -183,6 +183,27 @@ describe("driveModuleOp — auth + transport", () => {
     expect(calls).toHaveLength(0);
   });
 
+  test("non-2xx with NO error body → fallback names the HTTP status, not bare 'request failed' (hub#536)", async () => {
+    h = await makeHarnessWithToken();
+    // An empty `{}` body models a handler crash that produced a bodyless 500
+    // (pre-fix this collapsed to an unactionable "request failed").
+    const { fetch: f } = fakeFetch([{ status: 500, body: {} }]);
+    let err: unknown;
+    try {
+      await driveModuleOp("vault", "start", {
+        db: h.db,
+        issuer: ISSUER,
+        configDir: h.dir,
+        fetch: f,
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ModuleOpHttpError);
+    expect((err as ModuleOpHttpError).status).toBe(500);
+    expect((err as Error).message).toContain("hub returned HTTP 500 with no error detail");
+  });
+
   test("non-2xx hub response → ModuleOpHttpError carrying status + code", async () => {
     h = await makeHarnessWithToken();
     const { fetch: f } = fakeFetch([

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -821,8 +821,27 @@ export async function handleStart(
     ...(deps.spawnEnv ? { extraEnv: deps.spawnEnv } : {}),
   });
 
-  const state = await deps.supervisor.start(spawnReq);
+  let state: Awaited<ReturnType<typeof deps.supervisor.start>>;
+  try {
+    state = await deps.supervisor.start(spawnReq);
+  } catch (err) {
+    // A spawn-level throw (e.g. Bun.spawn ENOENT because the module's
+    // installDir/cwd no longer exists — the hub#536 wedge) used to escape the
+    // handler as a naked 500 with no JSON body; the CLI then surfaced an
+    // opaque "✗ <short>: request failed" with no actionable next step.
+    // Return the real reason instead.
+    return moduleOpFailure(short, "start", err);
+  }
   return jsonOk({ short, state });
+}
+
+/**
+ * Map a thrown supervisor-op failure to a structured 500 so the CLI/SPA can
+ * surface the real reason instead of an opaque "request failed" (hub#536).
+ */
+function moduleOpFailure(short: string, op: string, err: unknown): Response {
+  const msg = err instanceof Error ? err.message : String(err);
+  return jsonError(500, "module_op_failed", `${short} ${op} failed: ${msg}`);
 }
 
 /**
@@ -847,7 +866,12 @@ export async function handleStop(
   const authFail = await authorize(req, deps);
   if (authFail) return authFail;
 
-  const state = await deps.supervisor.stop(short);
+  let state: Awaited<ReturnType<typeof deps.supervisor.stop>>;
+  try {
+    state = await deps.supervisor.stop(short);
+  } catch (err) {
+    return moduleOpFailure(short, "stop", err);
+  }
   if (!state) {
     return jsonOk({ short, stopped: false });
   }
@@ -871,7 +895,12 @@ export async function handleRestart(
   const authFail = await authorize(req, deps);
   if (authFail) return authFail;
 
-  const state = await deps.supervisor.restart(short);
+  let state: Awaited<ReturnType<typeof deps.supervisor.restart>>;
+  try {
+    state = await deps.supervisor.restart(short);
+  } catch (err) {
+    return moduleOpFailure(short, "restart", err);
+  }
   if (!state) {
     return jsonError(
       404,

--- a/src/module-ops-client.ts
+++ b/src/module-ops-client.ts
@@ -183,7 +183,7 @@ export async function driveModuleOp(
   const body = await parseJsonSafe(res);
 
   if (res.status < 200 || res.status >= 300) {
-    const { error, error_description } = asErrorBody(body);
+    const { error, error_description } = asErrorBody(body, res.status);
     throw new ModuleOpHttpError(res.status, error, error_description);
   }
 
@@ -231,7 +231,7 @@ async function pollOperation(
     });
     const body = await parseJsonSafe(res);
     if (res.status < 200 || res.status >= 300) {
-      const { error, error_description } = asErrorBody(body);
+      const { error, error_description } = asErrorBody(body, res.status);
       throw new ModuleOpHttpError(res.status, error, error_description);
     }
     const status = extractOpStatus(body);
@@ -288,7 +288,7 @@ export async function fetchModuleLogs(
   });
   const body = await parseJsonSafe(res);
   if (res.status < 200 || res.status >= 300) {
-    const { error, error_description } = asErrorBody(body);
+    const { error, error_description } = asErrorBody(body, res.status);
     throw new ModuleOpHttpError(res.status, error, error_description);
   }
   const b = (body ?? {}) as { lines?: unknown; text?: unknown };
@@ -396,7 +396,7 @@ export async function fetchModuleStates(deps: DriveModuleOpDeps): Promise<Module
   }
   const body = await parseJsonSafe(res);
   if (res.status < 200 || res.status >= 300) {
-    const { error, error_description } = asErrorBody(body);
+    const { error, error_description } = asErrorBody(body, res.status);
     throw new ModuleOpHttpError(res.status, error, error_description);
   }
   const b = (body ?? {}) as {
@@ -437,15 +437,20 @@ async function parseJsonSafe(res: Response): Promise<unknown> {
   }
 }
 
-function asErrorBody(body: unknown): { error: string; error_description: string } {
+function asErrorBody(body: unknown, status: number): { error: string; error_description: string } {
+  // A bare/unparseable error response used to collapse to "request failed",
+  // which gave the operator nothing to act on (hub#536 — a spawn-throw
+  // escaping a handler produced exactly this). Carry the HTTP status so even
+  // the worst case names the failure class.
+  const fallback = `hub returned HTTP ${status} with no error detail`;
   if (body && typeof body === "object") {
     const b = body as Record<string, unknown>;
     const error = typeof b.error === "string" ? b.error : "error";
     const error_description =
-      typeof b.error_description === "string" ? b.error_description : "request failed";
+      typeof b.error_description === "string" ? b.error_description : fallback;
     return { error, error_description };
   }
-  return { error: "error", error_description: "request failed" };
+  return { error: "error", error_description: fallback };
 }
 
 function extractOperationId(body: unknown): string | undefined {


### PR DESCRIPTION
## What
The wedged-module half of #536. Two layers so a supervisor-op failure is never an opaque `request failed`:
1. **Server** — `handleStart`/`handleStop`/`handleRestart` wrap their supervisor call; a throw returns a structured `500 module_op_failed` carrying the real reason (`"<short> start failed: <err.message>"`).
2. **Client** — `asErrorBody` now takes the HTTP status; the no-detail fallback reads `hub returned HTTP <status> with no error detail` instead of the bare `request failed`.

## Why
During the dual-supervisor incident, `parachute start surface` / `stop surface` returned `✗ surface: error: request failed` — nothing actionable. Root-cause chain, verified in code:
- `supervisor.start()` only converts **missing-binary** spawn throws into a structured crashed state (`rethrowIfMissing` net); any other throw — the live case was `Bun.spawn` ENOENT because the module's `installDir`/cwd had been **deleted** out from under services.json — propagates.
- The route dispatch has no catch → bodyless 500.
- `asErrorBody` collapses a detail-less error response to the literal `"request failed"`.

With this PR the same incident reads: `✗ surface: surface start failed: No such file or directory … cwd /…/parachute-app` — the operator's next step is obvious.

## Scope note — the "reset" verb
Not needed: `supervisor.start()` already documents + implements "re-spawning a previously-crashed module clears the crash budget." The wedge was never a budget refusal — it was the swallowed spawn-throw. This PR + the orphan-prevention reorder (#540) + the late-bind watch (#544) complete #536.

## Tests
- handler: spawnFn throw (non-missing-binary, models the deleted-cwd wedge) → `500` + `module_op_failed` + the underlying message in `error_description`.
- client: 500 with empty `{}` body → `ModuleOpHttpError` whose message names `HTTP 500 with no error detail`.
- `bun test ./src` — **2823 pass / 1 skip / 0 fail**; typecheck + biome clean.

Closes #536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)