### PR TITLE
fix(supervisor): enrich spawned-module + hub-unit PATH so launchd hubs find operator tools

### DIFF
--- a/src/__tests__/api-modules-ops.test.ts
+++ b/src/__tests__/api-modules-ops.test.ts
@@ -323,6 +323,13 @@ describe("POST /api/modules/:short/install", () => {
     expect(manifest.services.some((s) => s.name === "parachute-vault")).toBe(true);
     // Supervisor was handed the spawn.
     expect(spawns.find((s) => s.short === "vault")?.cmd).toEqual(["parachute-vault", "serve"]);
+    // The install-time spawn path (spawnSupervised) injects the enriched PATH
+    // so a module installed via /admin/modules can find operator tools (scribe's
+    // parakeet-mlx / ffmpeg) — same fix as the serve-boot path, second spawn
+    // site (hub launchd-PATH regression). It must carry the inherited PATH.
+    const vaultEnv = spawns.find((s) => s.short === "vault")?.env;
+    expect(vaultEnv?.PATH).toBeDefined();
+    expect(vaultEnv?.PATH?.length).toBeGreaterThan(0);
   });
 
   test("idempotent: already-installed + running returns succeeded immediately", async () => {

--- a/src/__tests__/hub-unit.test.ts
+++ b/src/__tests__/hub-unit.test.ts
@@ -260,6 +260,10 @@ describe("installAndStartHubUnit — init bringup (§3.3 / §4.2)", () => {
     expect(written).toBeDefined();
     expect(written).toContain("Environment=PARACHUTE_HOME=/home/op/.parachute");
     expect(written).toContain("src/cli.ts serve");
+    // The default unit PATH is enriched with operator-tool dirs so the managed
+    // hub + its supervised children can find scribe's parakeet-mlx / ffmpeg
+    // (hub launchd-PATH regression). $HOME/.local/bin is the Linux operator dir.
+    expect(written).toContain("/home/op/.bun/bin:/usr/local/bin:/usr/bin:/bin:/home/op/.local/bin");
     // enable --now drove the start.
     expect(f.calls).toContainEqual([
       "systemctl",

--- a/src/__tests__/serve-boot.test.ts
+++ b/src/__tests__/serve-boot.test.ts
@@ -171,10 +171,7 @@ describe("bootSupervisedModules", () => {
     // injects + probes the wrong port and records a false `started_but_unbound`.
     writeManifest({ services: [VAULT_ENTRY] }, h.manifestPath);
     mkdirSync(join(h.dir, "vault"), { recursive: true });
-    writeFileSync(
-      join(h.dir, "vault", ".env"),
-      "PORT=1944\nSCRIBE_AUTH_TOKEN=secret-token\n",
-    );
+    writeFileSync(join(h.dir, "vault", ".env"), "PORT=1944\nSCRIBE_AUTH_TOKEN=secret-token\n");
 
     const recorder = makeRecorder();
     const sup = new Supervisor({ spawnFn: recorder.spawn });
@@ -199,6 +196,45 @@ describe("bootSupervisedModules", () => {
       extraEnv: { PORT: "9999" },
     });
     expect(req.env?.PORT).toBe("9999");
+  });
+
+  test("injects an enriched PATH carrying the inherited process PATH (hub launchd-PATH fix)", () => {
+    // The hub unit bakes a minimal PATH and Bun.spawn defaults to empty env, so
+    // without this injection the child can't find operator tools (scribe's
+    // parakeet-mlx / ffmpeg). The req must carry a PATH, and it must preserve
+    // whatever the hub process inherited.
+    const req = buildModuleSpawnRequest("vault", VAULT_ENTRY, ["parachute-vault", "serve"], {
+      configDir: h.dir,
+    });
+    expect(req.env?.PATH).toBeDefined();
+    expect(req.env?.PATH?.length).toBeGreaterThan(0);
+    // Every entry the hub inherited is still present (enrichment appends, never
+    // drops). process.env.PATH is always set in the test runner.
+    for (const entry of (process.env.PATH ?? "").split(":").filter((e) => e.length > 0)) {
+      expect(req.env?.PATH?.split(":")).toContain(entry);
+    }
+  });
+
+  test("a per-service .env PATH wins over the injected enrichment (operator intent)", () => {
+    mkdirSync(join(h.dir, "vault"), { recursive: true });
+    writeFileSync(join(h.dir, "vault", ".env"), "PATH=/operator/pinned/bin\n");
+    const req = buildModuleSpawnRequest("vault", VAULT_ENTRY, ["parachute-vault", "serve"], {
+      configDir: h.dir,
+    });
+    expect(req.env?.PATH).toBe("/operator/pinned/bin");
+  });
+
+  test("the API-start path (buildModuleSpawnRequest reuse) also carries the enriched PATH", () => {
+    // handleStart() in api-modules-ops.ts routes through buildModuleSpawnRequest,
+    // so the /api/modules/:short/start path inherits the same PATH fix. Assert
+    // the shared builder is the single source — extraEnv (the start handler's
+    // spawnEnv seam) does NOT clobber PATH unless it explicitly sets one.
+    const req = buildModuleSpawnRequest("vault", VAULT_ENTRY, ["parachute-vault", "serve"], {
+      configDir: h.dir,
+      extraEnv: { SOME_FLAG: "1" },
+    });
+    expect(req.env?.PATH).toBeDefined();
+    expect(req.env?.SOME_FLAG).toBe("1");
   });
 
   test("hubOrigin wins over a stale .env entry on collision", async () => {

--- a/src/__tests__/spawn-path.test.ts
+++ b/src/__tests__/spawn-path.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type EnrichedPathDeps,
+  enrichedPath,
+  enrichedUnitPath,
+  operatorToolDirs,
+} from "../spawn-path.ts";
+
+/**
+ * Build EnrichedPathDeps with a fake fs (set of existing paths) + pinned
+ * platform/arch/home so tests never touch the real disk or host.
+ */
+function fakeDeps(opts: {
+  home?: string;
+  platform?: NodeJS.Platform;
+  arch?: string;
+  existing?: string[];
+}): EnrichedPathDeps {
+  const existing = new Set(opts.existing ?? []);
+  return {
+    homeDir: () => opts.home ?? "/home/op",
+    exists: (p) => existing.has(p),
+    platform: opts.platform ?? "darwin",
+    arch: opts.arch ?? "arm64",
+  };
+}
+
+describe("enrichedPath — operator-tool PATH enrichment", () => {
+  test("preserves the inherited PATH and keeps its order", () => {
+    const deps = fakeDeps({ existing: [] });
+    const result = enrichedPath({ PATH: "/usr/bin:/bin" }, deps);
+    expect(result).toBe("/usr/bin:/bin");
+  });
+
+  test("appends operator-tool dirs only when they exist on disk", () => {
+    // .local/bin + brew exist; .bun/bin does NOT → only the two existing append.
+    const deps = fakeDeps({
+      home: "/home/op",
+      platform: "darwin",
+      arch: "arm64",
+      existing: ["/home/op/.local/bin", "/opt/homebrew/bin"],
+    });
+    const result = enrichedPath({ PATH: "/usr/bin" }, deps);
+    expect(result).toBe("/usr/bin:/home/op/.local/bin:/opt/homebrew/bin");
+    expect(result).not.toContain("/home/op/.bun/bin");
+  });
+
+  test("inherited PATH wins over appended defaults (append, not prepend)", () => {
+    const deps = fakeDeps({ existing: ["/home/op/.local/bin"] });
+    const result = enrichedPath({ PATH: "/first:/second" }, deps);
+    const parts = result.split(":");
+    expect(parts[0]).toBe("/first");
+    expect(parts[1]).toBe("/second");
+    expect(parts[2]).toBe("/home/op/.local/bin");
+  });
+
+  test("dedupes — an appended dir already in the inherited PATH is not duplicated", () => {
+    const deps = fakeDeps({ existing: ["/home/op/.local/bin"] });
+    const result = enrichedPath({ PATH: "/usr/bin:/home/op/.local/bin" }, deps);
+    expect(result).toBe("/usr/bin:/home/op/.local/bin");
+    expect(result.split(":").filter((p) => p === "/home/op/.local/bin")).toHaveLength(1);
+  });
+
+  test("PARACHUTE_EXTRA_PATH is PREPENDED so an operator can intentionally shadow", () => {
+    const deps = fakeDeps({ existing: ["/home/op/.local/bin"] });
+    const result = enrichedPath(
+      { PATH: "/usr/bin", PARACHUTE_EXTRA_PATH: "/opt/custom/bin:/opt/more" },
+      deps,
+    );
+    const parts = result.split(":");
+    expect(parts[0]).toBe("/opt/custom/bin");
+    expect(parts[1]).toBe("/opt/more");
+    expect(parts[2]).toBe("/usr/bin");
+    expect(parts[3]).toBe("/home/op/.local/bin");
+  });
+
+  test("PARACHUTE_EXTRA_PATH dedupes against inherited (extra-first wins position)", () => {
+    const deps = fakeDeps({ existing: [] });
+    const result = enrichedPath({ PATH: "/usr/bin:/dup", PARACHUTE_EXTRA_PATH: "/dup" }, deps);
+    expect(result).toBe("/dup:/usr/bin");
+  });
+
+  test("empty inherited PATH yields just the existing appended dirs", () => {
+    const deps = fakeDeps({
+      home: "/home/op",
+      platform: "darwin",
+      arch: "arm64",
+      existing: ["/home/op/.local/bin", "/opt/homebrew/bin", "/home/op/.bun/bin"],
+    });
+    const result = enrichedPath({ PATH: "" }, deps);
+    expect(result).toBe("/home/op/.local/bin:/opt/homebrew/bin:/home/op/.bun/bin");
+  });
+
+  describe("platform / arch branches", () => {
+    test("darwin arm64 → /opt/homebrew/bin", () => {
+      const deps = fakeDeps({
+        platform: "darwin",
+        arch: "arm64",
+        existing: ["/opt/homebrew/bin"],
+      });
+      expect(enrichedPath({ PATH: "/usr/bin" }, deps)).toBe("/usr/bin:/opt/homebrew/bin");
+    });
+
+    test("darwin x64 → /usr/local/bin (Intel brew)", () => {
+      const deps = fakeDeps({
+        platform: "darwin",
+        arch: "x64",
+        existing: ["/usr/local/bin"],
+      });
+      // /usr/local/bin is the brew bin on Intel macOS; here it's the only existing dir.
+      expect(enrichedPath({ PATH: "/usr/bin" }, deps)).toBe("/usr/bin:/usr/local/bin");
+    });
+
+    test("linux → only $HOME/.local/bin + $HOME/.bun/bin, no brew bin", () => {
+      const deps = fakeDeps({
+        home: "/home/op",
+        platform: "linux",
+        arch: "x64",
+        existing: ["/home/op/.local/bin", "/home/op/.bun/bin", "/opt/homebrew/bin"],
+      });
+      const result = enrichedPath({ PATH: "/usr/bin" }, deps);
+      expect(result).toBe("/usr/bin:/home/op/.local/bin:/home/op/.bun/bin");
+      // /opt/homebrew/bin exists in the fake fs but is NOT a Linux candidate dir.
+      expect(result).not.toContain("/opt/homebrew/bin");
+    });
+  });
+});
+
+describe("operatorToolDirs — candidate dir list", () => {
+  test("darwin arm64: .local/bin, /opt/homebrew/bin, .bun/bin (in order)", () => {
+    expect(operatorToolDirs("/home/op", "darwin", "arm64")).toEqual([
+      "/home/op/.local/bin",
+      "/opt/homebrew/bin",
+      "/home/op/.bun/bin",
+    ]);
+  });
+
+  test("darwin x64: brew is /usr/local/bin", () => {
+    expect(operatorToolDirs("/home/op", "darwin", "x64")).toEqual([
+      "/home/op/.local/bin",
+      "/usr/local/bin",
+      "/home/op/.bun/bin",
+    ]);
+  });
+
+  test("linux: no brew dir", () => {
+    expect(operatorToolDirs("/home/op", "linux", "x64")).toEqual([
+      "/home/op/.local/bin",
+      "/home/op/.bun/bin",
+    ]);
+  });
+});
+
+describe("enrichedUnitPath — launchd/systemd unit PATH", () => {
+  test("bun bin first, then system dirs, then operator-tool dirs (darwin arm64)", () => {
+    const result = enrichedUnitPath("/home/op/.bun", "/home/op", "darwin", "arm64", undefined);
+    expect(result).toBe(
+      "/home/op/.bun/bin:/usr/local/bin:/usr/bin:/bin:/home/op/.local/bin:/opt/homebrew/bin",
+    );
+  });
+
+  test("dedupes — Intel brew /usr/local/bin already present in the base is not duplicated", () => {
+    // darwin x64 brew dir == /usr/local/bin, which the base already carries.
+    const result = enrichedUnitPath("/home/op/.bun", "/home/op", "darwin", "x64", undefined);
+    expect(result.split(":").filter((p) => p === "/usr/local/bin")).toHaveLength(1);
+    expect(result).toBe("/home/op/.bun/bin:/usr/local/bin:/usr/bin:/bin:/home/op/.local/bin");
+  });
+
+  test("linux: appends $HOME/.local/bin (no brew dir)", () => {
+    const result = enrichedUnitPath("/home/op/.bun", "/home/op", "linux", "x64", undefined);
+    expect(result).toBe("/home/op/.bun/bin:/usr/local/bin:/usr/bin:/bin:/home/op/.local/bin");
+  });
+
+  test("includes operator-tool dirs unconditionally (no existence check)", () => {
+    // No fs seam here — the unit-side dirs are baked in even if absent on disk.
+    const result = enrichedUnitPath("/home/op/.bun", "/home/op", "darwin", "arm64", undefined);
+    expect(result).toContain("/home/op/.local/bin");
+    expect(result).toContain("/opt/homebrew/bin");
+  });
+
+  test("PARACHUTE_EXTRA_PATH is prepended", () => {
+    const result = enrichedUnitPath(
+      "/home/op/.bun",
+      "/home/op",
+      "darwin",
+      "arm64",
+      "/opt/custom/bin",
+    );
+    expect(result.split(":")[0]).toBe("/opt/custom/bin");
+  });
+});

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -59,6 +59,7 @@ import type { Database } from "bun:sqlite";
 import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import { findService, type readManifest, readManifestLenient } from "./services-manifest.ts";
+import { enrichedPath } from "./spawn-path.ts";
 import { type WellKnownVaultEntry, isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
 
 /** Scope required to call POST /vaults. */
@@ -230,9 +231,13 @@ function buildEntry(
 async function defaultRunCommand(cmd: readonly string[]): Promise<RunResult> {
   // Inherit env so the child sees PATH, HOME, BUN_INSTALL, etc. Bun.spawn
   // defaults to empty env — see api-modules-ops.ts:defaultRun for the rationale.
+  // PATH enrichment (hub launchd-PATH regression): a launchd-managed hub bakes
+  // a minimal PATH, so this shell-out (vault ops) inherits that thin PATH too;
+  // enrich it with operator-tool dirs (`$HOME/.local/bin`, brew bin). See
+  // `spawn-path.ts`.
   const proc = Bun.spawn([...cmd], {
     stdio: ["ignore", "pipe", "pipe"],
-    env: process.env,
+    env: { ...process.env, PATH: enrichedPath() },
   });
   // Drain both pipes in parallel — leaving stderr unread can deadlock long
   // installs once the OS pipe buffer fills (#97). Captured stderr is folded

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -389,6 +389,11 @@ function defaultRun(cmd: readonly string[]): Promise<number> {
   // etc. set by the Dockerfile / Render env. Bun.spawn defaults to empty
   // env — without this, bun-add fails with cross-mount rename errors on
   // Render (where TMPDIR points at the persistent disk). See hub#349.
+  // PATH: intentionally the raw `process.env` (no per-call `enrichedPath()`).
+  // This is `bun add`, not a module spawn — it doesn't need the operator-tool
+  // dirs (parakeet-mlx / ffmpeg). It still benefits from the serve-startup PATH
+  // enrichment: `serve.ts` applies `enrichedPath()` to `process.env.PATH` at
+  // boot, so the PATH inherited here is already enriched under a managed hub.
   const proc = Bun.spawn([...cmd], {
     stdio: ["ignore", "inherit", "inherit"],
     env: process.env,
@@ -496,6 +501,9 @@ async function spawnSupervised(
   // `parakeet-mlx` / `ffmpeg`. This is the SECOND, independently-built spawn
   // env; keep it in sync with serve-boot.ts:buildModuleSpawnRequest. `spawnEnv`
   // (test seam) still wins via the spread below. See `spawn-path.ts`.
+  // `process.env.PATH` may ALREADY be enriched by serve startup (serve.ts);
+  // re-enriching here is a harmless no-op — `enrichedPath` is idempotent
+  // (dedupe + append-only), so double-enrichment can't duplicate or reorder.
   const childEnv: Record<string, string> = {
     PATH: enrichedPath(),
     PORT: String(entry.port),

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -52,6 +52,7 @@ import {
   synthesizeManifestForKnownModule,
 } from "./service-spec.ts";
 import { findService, readManifestLenient, removeService } from "./services-manifest.ts";
+import { enrichedPath } from "./spawn-path.ts";
 import type { ModuleState, SpawnRequest, Supervisor } from "./supervisor.ts";
 import { WELL_KNOWN_PATH, type regenerateWellKnown } from "./well-known.ts";
 
@@ -488,7 +489,15 @@ async function spawnSupervised(
   // operator has had a chance to write `configDir/<short>/.env`, so install
   // spawns with install-env only. The per-service `.env` is layered in by
   // `buildModuleSpawnRequest` (serve-boot.ts) on the next `boot` or `start`.
+  // PATH enrichment (hub launchd-PATH regression): mirror the serve-boot path's
+  // `buildModuleSpawnRequest` so a module STARTED from the admin SPA gets the
+  // same operator-tool dirs (`$HOME/.local/bin`, brew bin) as one booted from
+  // services.json — otherwise scribe started via /admin/modules can't find
+  // `parakeet-mlx` / `ffmpeg`. This is the SECOND, independently-built spawn
+  // env; keep it in sync with serve-boot.ts:buildModuleSpawnRequest. `spawnEnv`
+  // (test seam) still wins via the spread below. See `spawn-path.ts`.
   const childEnv: Record<string, string> = {
+    PATH: enrichedPath(),
     PORT: String(entry.port),
     ...(deps.issuer ? { PARACHUTE_HUB_ORIGIN: deps.issuer } : {}),
     ...(deps.spawnEnv ?? {}),

--- a/src/commands/migrate-cutover.ts
+++ b/src/commands/migrate-cutover.ts
@@ -86,6 +86,7 @@ import { type PortListeningFn, defaultPortListening } from "../port-probe.ts";
 import { type AliveFn, clearPid, readPid } from "../process-state.ts";
 import { shortNameForManifest } from "../service-spec.ts";
 import { type ServiceEntry, readManifestLenient } from "../services-manifest.ts";
+import { enrichedUnitPath } from "../spawn-path.ts";
 import {
   type DisableStaleModuleUnitsOpts,
   type DisableStaleModuleUnitsResult,
@@ -232,14 +233,14 @@ export interface WriteUnitResult {
  * and `installManagedUnit(start:false)` — daemon-reload / write-the-plist but
  * NEVER enable --now / bootstrap. The §7.1 step-2 race-avoider.
  */
-function defaultUnitPath(bunInstall: string): string {
-  return `${bunInstall}/bin:/usr/local/bin:/usr/bin:/bin`;
-}
-
 export function defaultWriteUnitWithoutStarting(opts: WriteUnitOpts): WriteUnitResult {
   const { deps } = opts;
   const bunInstall = `${deps.homeDir()}/.bun`;
-  const path = defaultUnitPath(bunInstall);
+  // Shared with the init-bringup path (hub-unit.ts) so the two unit-generation
+  // sites can't drift — enriches the unit PATH with operator-tool dirs
+  // (`$HOME/.local/bin`, brew bin) so a migrated launchd/systemd hub can find
+  // scribe's `parakeet-mlx` + `ffmpeg`. See `spawn-path.ts`.
+  const path = enrichedUnitPath(bunInstall, deps.homeDir(), deps.platform);
   const logPath = `${opts.parachuteHome}/hub/logs/hub.log`;
   let unit: ManagedUnit;
   try {

--- a/src/commands/serve-boot.ts
+++ b/src/commands/serve-boot.ts
@@ -27,6 +27,7 @@ import {
   shortNameForManifest,
 } from "../service-spec.ts";
 import { type ServiceEntry, readManifestLenient } from "../services-manifest.ts";
+import { enrichedPath } from "../spawn-path.ts";
 import type { Supervisor } from "../supervisor.ts";
 
 export interface BootOpts {
@@ -106,7 +107,20 @@ export function buildModuleSpawnRequest(
   // own resolvePort ladder already prefers services.json, so this keeps the
   // injected PORT + probe in agreement with what the child actually binds.
   const { PORT: _staleEnvPort, ...fileEnvSansPort } = fileEnv;
-  const env: Record<string, string> = { PORT: String(entry.port), ...fileEnvSansPort };
+  // PATH enrichment (hub launchd-PATH regression): the hub unit bakes a minimal
+  // PATH and `Bun.spawn` defaults to empty env, so without this the child only
+  // ever sees the unit's PATH — which omits `$HOME/.local/bin` (scribe's
+  // `parakeet-mlx`) + the Homebrew bin (`ffmpeg`), killing transcription on
+  // canonical installs. `enrichedPath` appends those dirs (when they exist) to
+  // the inherited PATH; inherited entries keep their order. A per-service `.env`
+  // PATH (operator intent) still wins via the spread below. See `spawn-path.ts`.
+  // The API-start path builds its own env — see `api-modules-ops.ts`
+  // `spawnSupervised`, which calls `enrichedPath()` too (keep the two in sync).
+  const env: Record<string, string> = {
+    PATH: enrichedPath(),
+    PORT: String(entry.port),
+    ...fileEnvSansPort,
+  };
   if (opts.hubOrigin) env[HUB_ORIGIN_ENV] = opts.hubOrigin;
   if (opts.extraEnv) Object.assign(env, opts.extraEnv);
 

--- a/src/commands/serve-boot.ts
+++ b/src/commands/serve-boot.ts
@@ -116,6 +116,9 @@ export function buildModuleSpawnRequest(
   // PATH (operator intent) still wins via the spread below. See `spawn-path.ts`.
   // The API-start path builds its own env — see `api-modules-ops.ts`
   // `spawnSupervised`, which calls `enrichedPath()` too (keep the two in sync).
+  // `process.env.PATH` may ALREADY be enriched by serve startup (serve.ts);
+  // re-enriching here is a harmless no-op — `enrichedPath` is idempotent
+  // (dedupe + append-only), so double-enrichment can't duplicate or reorder.
   const env: Record<string, string> = {
     PATH: enrichedPath(),
     PORT: String(entry.port),

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -36,6 +36,7 @@ import { readExposeState } from "../expose-state.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { hubFetch } from "../hub-server.ts";
 import { writeHubFile } from "../hub.ts";
+import { enrichedPath } from "../spawn-path.ts";
 import { Supervisor } from "../supervisor.ts";
 import { createUser, userCount } from "../users.ts";
 import { sanitizePublicOrigin } from "../vault-hub-origin-env.ts";
@@ -315,6 +316,16 @@ export async function serve(opts: ServeOpts = {}): Promise<{
 }> {
   const env = opts.env ?? process.env;
   const log = opts.log ?? ((line) => console.log(line));
+
+  // PATH enrichment (hub launchd-PATH regression): the launchd/systemd hub unit
+  // bakes a minimal PATH. Enrich the hub's OWN process PATH so its `Bun.which`
+  // probes (cloudflared / tailscale detection, etc.) see operator-tool dirs
+  // (`$HOME/.local/bin`, brew bin) too — and so any child that inherits raw
+  // `process.env` (not the explicit per-child env) starts from the enriched
+  // PATH. The per-child spawn env is enriched independently in
+  // `buildModuleSpawnRequest` / `spawnSupervised`. See `spawn-path.ts`. Only
+  // mutate the live process env, never a test-injected `opts.env`.
+  if (!opts.env) process.env.PATH = enrichedPath(process.env);
 
   const envPort = parsePort(env.PORT);
   const port = opts.port ?? envPort ?? DEFAULT_PORT;

--- a/src/hub-unit.ts
+++ b/src/hub-unit.ts
@@ -53,6 +53,7 @@ import {
   systemdUnitPathForName,
 } from "./managed-unit.ts";
 import { type PortListeningFn, defaultPortListening } from "./port-probe.ts";
+import { enrichedUnitPath } from "./spawn-path.ts";
 
 /** Default canonical hub port (the 1939 pin). */
 export const HUB_UNIT_DEFAULT_PORT = 1939;
@@ -623,14 +624,8 @@ export function hubUnitMessages(): ManagedUnitMessages {
   };
 }
 
-/**
- * Sane default PATH for the hub unit when the caller doesn't supply one: bun's
- * global bin first (so supervised children resolve a bun-linked binary on cold
- * boot, R20), then the usual system dirs.
- */
-function defaultUnitPath(bunInstall: string): string {
-  return `${bunInstall}/bin:/usr/local/bin:/usr/bin:/bin`;
-}
+// The hub-unit PATH is built by `enrichedUnitPath` (src/spawn-path.ts) so this
+// init-bringup path and the `migrate --to-supervised` cutover path can't drift.
 
 /**
  * Build + install + start the hub unit, then wait for hub readiness (design
@@ -652,7 +647,7 @@ export async function installAndStartHubUnit(
   const deps = opts.deps ?? defaultHubUnitDeps;
   const port = opts.port ?? HUB_UNIT_DEFAULT_PORT;
   const bunInstall = opts.bunInstall ?? `${deps.homeDir()}/.bun`;
-  const path = opts.path ?? defaultUnitPath(bunInstall);
+  const path = opts.path ?? enrichedUnitPath(bunInstall, deps.homeDir(), deps.platform);
   const logPath = opts.logPath ?? `${opts.parachuteHome}/hub/logs/hub.log`;
   const log = opts.log ?? (() => {});
 

--- a/src/spawn-path.ts
+++ b/src/spawn-path.ts
@@ -1,0 +1,148 @@
+/**
+ * PATH enrichment for spawned modules + the hub's own boot env.
+ *
+ * The hub-as-supervisor unit bakes a hardcoded base PATH (see
+ * `enrichedUnitPath` below), and `Bun.spawn` defaults to an empty env, so
+ * supervised children only ever see the PATH the unit handed the hub. On a
+ * launchd-managed Mac that PATH omits the two dirs operator tools actually live
+ * in — `$HOME/.local/bin` (scribe's `parakeet-mlx`) and the Homebrew bin
+ * (`ffmpeg`, `/opt/homebrew/bin` on Apple Silicon). The result: scribe's
+ * `Bun.which("ffmpeg")` / `Bun.which("parakeet-mlx")` probes come up empty and
+ * transcription is dead on canonical installs.
+ *
+ * `enrichedPath` is the shared fix. It takes a base env (defaults to
+ * `process.env`), keeps whatever PATH was inherited, and APPENDS the operator-
+ * tool dirs that exist on disk and aren't already present. Inherited PATH wins
+ * (append, not prepend) so an operator's explicit PATH ordering is never
+ * reordered out from under them. `PARACHUTE_EXTRA_PATH` (colon-joined) is
+ * PREPENDED so an operator can intentionally shadow a system binary.
+ *
+ * Two consumers:
+ *   1. The spawn side (`buildModuleSpawnRequest` in `commands/serve-boot.ts` +
+ *      `spawnSupervised` in `api-modules-ops.ts`) injects `enrichedPath()` into
+ *      every supervised child's env. This is the PRIMARY fix — it self-heals
+ *      every existing install at the next hub restart, no re-init needed.
+ *   2. The hub's own `serve` startup enriches `process.env.PATH` so the hub's
+ *      own `Bun.which` probes (cloudflared / tailscale detection, etc.) also
+ *      see brew + `.local`.
+ *
+ * The unit generator (`enrichedUnitPath`, used by `hub-unit.ts` +
+ * `commands/migrate-cutover.ts`) bakes the same dirs into the launchd/systemd
+ * unit PATH as belt-and-suspenders for fresh installs.
+ */
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+
+/** Injectable seams so tests don't touch the real fs / os / platform. */
+export interface EnrichedPathDeps {
+  /** Operator home dir. */
+  homeDir: () => string;
+  /** True when `path` exists on disk. */
+  exists: (path: string) => boolean;
+  /** `process.platform` value (e.g. "darwin", "linux"). */
+  platform: NodeJS.Platform;
+  /** `process.arch` value (e.g. "arm64", "x64"). */
+  arch: string;
+}
+
+export const defaultEnrichedPathDeps: EnrichedPathDeps = {
+  homeDir: () => homedir(),
+  exists: (path) => existsSync(path),
+  platform: process.platform,
+  arch: process.arch,
+};
+
+/**
+ * The Homebrew bin dir for the current platform/arch, or null when there
+ * isn't a canonical one (non-darwin — Linux brew is opt-in + non-canonical, so
+ * we only contribute `$HOME/.local/bin` there).
+ *
+ * Apple Silicon brew installs under `/opt/homebrew`; Intel macOS brew under
+ * `/usr/local`.
+ */
+function brewBinDir(platform: NodeJS.Platform, arch: string): string | null {
+  if (platform !== "darwin") return null;
+  return arch === "arm64" ? "/opt/homebrew/bin" : "/usr/local/bin";
+}
+
+/**
+ * Operator-tool dirs to APPEND (in this order): `$HOME/.local/bin` (pipx /
+ * `pip install --user` — scribe's `parakeet-mlx`), the platform brew bin
+ * (`ffmpeg`), and `$HOME/.bun/bin` (bun-linked binaries on a cold boot). Order
+ * is deterministic and stable. Pure of fs — the runtime enrichment filters by
+ * existence, the unit generator includes them unconditionally.
+ */
+export function operatorToolDirs(home: string, platform: NodeJS.Platform, arch: string): string[] {
+  const dirs = [`${home}/.local/bin`];
+  const brew = brewBinDir(platform, arch);
+  if (brew) dirs.push(brew);
+  dirs.push(`${home}/.bun/bin`);
+  return dirs;
+}
+
+function candidateDirs(deps: EnrichedPathDeps): string[] {
+  return operatorToolDirs(deps.homeDir(), deps.platform, deps.arch);
+}
+
+function dedupe(entries: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const entry of entries) {
+    if (seen.has(entry)) continue;
+    seen.add(entry);
+    out.push(entry);
+  }
+  return out;
+}
+
+/**
+ * The PATH baked into the launchd/systemd hub unit at generation time.
+ *
+ * `${bunInstall}/bin` first (so supervised children resolve a bun-linked binary
+ * on cold boot, R20), then the usual system dirs, then the operator-tool dirs
+ * (`$HOME/.local/bin`, the platform brew bin) so a managed hub — and the modules
+ * it spawns — can find scribe's `parakeet-mlx` + `ffmpeg`. `PARACHUTE_EXTRA_PATH`
+ * (if set at generation time) is PREPENDED for intentional operator shadowing.
+ * Deduped end-to-end.
+ *
+ * Unlike `enrichedPath`, the unit-side dirs are included UNCONDITIONALLY (no
+ * existence check): the unit is generated once at install/migrate time but
+ * brew/tools may be installed afterward, and a non-existent PATH entry is simply
+ * skipped by the OS — so baking them in is the robust choice for fresh installs.
+ *
+ * Shared by `hub-unit.ts` (init bringup) + `commands/migrate-cutover.ts`
+ * (`--to-supervised` cutover) so the two unit-generation paths can't drift.
+ */
+export function enrichedUnitPath(
+  bunInstall: string,
+  home: string,
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+  extraPath: string | undefined = process.env.PARACHUTE_EXTRA_PATH,
+): string {
+  const extra = (extraPath ?? "").split(":").filter((e) => e.length > 0);
+  const base = [`${bunInstall}/bin`, "/usr/local/bin", "/usr/bin", "/bin"];
+  return dedupe([...extra, ...base, ...operatorToolDirs(home, platform, arch)]).join(":");
+}
+
+/**
+ * Build a PATH that enriches `env.PATH` with operator-tool dirs.
+ *
+ * Ordering: `PARACHUTE_EXTRA_PATH` (prepended) : inherited PATH : appended
+ * operator-tool dirs that exist and aren't already present. Deduped end-to-end
+ * (first occurrence wins, so an inherited entry is never reordered).
+ */
+export function enrichedPath(
+  env: NodeJS.ProcessEnv = process.env,
+  deps: EnrichedPathDeps = defaultEnrichedPathDeps,
+): string {
+  const inherited = (env.PATH ?? "").split(":").filter((e) => e.length > 0);
+  const extra = (env.PARACHUTE_EXTRA_PATH ?? "").split(":").filter((e) => e.length > 0);
+  const appended = candidateDirs(deps).filter((d) => deps.exists(d));
+
+  // PARACHUTE_EXTRA_PATH first (intentional operator shadow), then the
+  // inherited PATH (inherited wins over our appended defaults), then our
+  // appended operator-tool dirs.
+  return dedupe([...extra, ...inherited, ...appended]).join(":");
+}


### PR DESCRIPTION
## The regression

The hub-as-supervisor launchd/systemd unit baked a **hardcoded minimal PATH** — `${bunInstall}/bin:/usr/local/bin:/usr/bin:/bin` (`hub-unit.ts` / `managed-unit.ts`) — and **no spawn site enriched it**. `Bun.spawn` defaults to an empty env, so every launchd-managed hub handed its supervised children only that thin PATH.

The two dirs operator tools actually live in are omitted:
- `$HOME/.local/bin` — scribe's `parakeet-mlx` (pipx / `pip install --user`)
- the Homebrew bin — `ffmpeg` (`/opt/homebrew/bin` on Apple-Silicon brew)

So scribe's `Bun.which("ffmpeg")` / `Bun.which("parakeet-mlx")` probes came up empty and **transcription was dead on canonical launchd installs**.

## The two-layer fix

New `src/spawn-path.ts` with `enrichedPath()` (runtime) + `enrichedUnitPath()` (unit generation).

**1. Spawn-side (PRIMARY).** `enrichedPath()` starts from the inherited PATH and **APPENDS** the operator-tool dirs that exist on disk and aren't already present. Injected into both supervised-spawn env builders:
- `buildModuleSpawnRequest` (`commands/serve-boot.ts`) — covers the services.json **boot** path AND the `POST /api/modules/:short/start` handler (`handleStart` already routes through this shared builder).
- `spawnSupervised`'s `childEnv` (`api-modules-ops.ts`) — the independently-built **install-time** spawn env. Cross-referencing comments on both so the two sites can't silently drift.
- `admin-vaults.ts`'s vault shell-out (one-liner).

This is the **self-heal property**: every existing install picks up the fix at the **next hub restart** — no re-init, no migrate.

**2. Hub's own env.** `serve` startup enriches `process.env.PATH` so the hub's own `Bun.which` probes (cloudflared / tailscale detection, etc.) also see brew + `.local`. Guarded so a test-injected `opts.env` is never mutated.

**3. Unit generation (belt-and-suspenders).** `enrichedUnitPath()` extends the baked unit PATH with the same operator-tool dirs. Shared by `hub-unit.ts` (init bringup) + `commands/migrate-cutover.ts` (`--to-supervised` cutover) so the two unit-generation paths converge on one helper. Covers **fresh installs** + the hub's own boot PATH after a re-init/migrate.

## Dir list + ordering

`enrichedPath` (runtime, existence-filtered, append-not-prepend):

```
PARACHUTE_EXTRA_PATH (prepended)  :  inherited PATH  :  $HOME/.local/bin  :  <brew bin>  :  $HOME/.bun/bin
```

- Inherited PATH **wins** — appended, never reordered.
- `PARACHUTE_EXTRA_PATH` (colon-joined) is **PREPENDED** so an operator can intentionally shadow a system binary.
- Deduped end-to-end (first occurrence wins).
- Brew bin by platform/arch: `/opt/homebrew/bin` (darwin/arm64), `/usr/local/bin` (darwin/x64), **none on linux** (only `.local/bin` + `.bun/bin`).
- `enrichedUnitPath` (generation) is the same dirs but **unconditional** (no existence check — brew/tools may be installed after the unit is written; the OS skips a non-existent PATH entry), ordered `${bunInstall}/bin` first then system dirs then operator dirs.

## Tests + gates

New `src/__tests__/spawn-path.test.ts` (helper: inherited preserved + wins, existence-gated append via the fs seam, dedupe, `PARACHUTE_EXTRA_PATH` prepend, darwin-arm64 / darwin-x64 / linux branches). Plus injection-point coverage in `serve-boot.test.ts` (spawn-request carries enriched PATH; per-service `.env` PATH still wins; API-start path), `api-modules-ops.test.ts` (install-time spawn carries it), and `hub-unit.test.ts` (default unit PATH includes the operator dirs).

All run with a fake `launchctl` shimmed into PATH (belt-and-suspenders over the #541 test-guard, since this is a live machine):

- hub `bun test ./src` — **2841 pass / 1 skip / 0 fail**
- scope-guard `bun test ./packages/scope-guard/src` — **108 pass / 0 fail**
- `bun run typecheck` — clean

**No version bump** (per RC-when-ready governance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)