### PR TITLE
supervisor/CLI residuals: restart env rebuild (#532) + teardown output (#534)

### DIFF
--- a/src/__tests__/api-modules-ops.test.ts
+++ b/src/__tests__/api-modules-ops.test.ts
@@ -1128,7 +1128,44 @@ describe("POST /api/modules/:short/restart", () => {
   });
   afterEach(() => h.cleanup());
 
-  test("404 not_supervised when module isn't running", async () => {
+  /** Seed a minimal installed vault row (in services.json). */
+  function seedVault(port = 1940): void {
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-vault",
+        port,
+        paths: ["/vault/default"],
+        health: "/vault/default/health",
+        version: "0.0.0-linked",
+      },
+    ]);
+  }
+
+  test("400 not_installed when the module isn't in services.json", async () => {
+    // restart rebuilds the spawn req from services.json (hub#532), so a
+    // missing row is a `not_installed` 400 (mirrors `start`) — before the
+    // supervisor is even consulted.
+    const { supervisor } = makeIdleSupervisor();
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleRestart(
+      postReq("/api/modules/vault/restart", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run: async () => 0,
+      },
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("not_installed");
+  });
+
+  test("404 not_supervised when installed but not currently running", async () => {
+    seedVault();
     const { supervisor } = makeIdleSupervisor();
     const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
     const res = await handleRestart(
@@ -1149,6 +1186,7 @@ describe("POST /api/modules/:short/restart", () => {
   });
 
   test("returns new state on success", async () => {
+    seedVault();
     const { supervisor } = makeIdleSupervisor();
     await supervisor.start({ short: "vault", cmd: ["parachute-vault", "serve"] });
 
@@ -1171,6 +1209,122 @@ describe("POST /api/modules/:short/restart", () => {
     // restart sets the state to either restarting or running depending
     // on timing — either is acceptable here as long as it's not crashed/stopped.
     expect(["restarting", "running", "starting"]).toContain(body.state.status);
+  });
+
+  test("re-injects the CURRENT hub origin on restart (hub#532)", async () => {
+    // The core hub#532 fix: a module first started under one issuer, then
+    // restarted after the canonical origin changed (e.g. post-expose), must
+    // re-spawn with the NEW PARACHUTE_HUB_ORIGIN — not replay the stale
+    // first-start snapshot. We drive the supervisor directly to control the
+    // first-start env, then restart through the handler with a different
+    // `deps.issuer` and assert the recorded spawn carries the new origin.
+    seedVault(1940);
+    const { supervisor, spawns } = makeIdleSupervisor();
+    // First start with the OLD origin baked in (as boot would have).
+    await supervisor.start({
+      short: "vault",
+      cmd: ["parachute-vault", "serve"],
+      env: { PORT: "1940", PARACHUTE_HUB_ORIGIN: "https://old.example" },
+    });
+    const spawnsBefore = spawns.length;
+
+    const NEW_ORIGIN = "https://new.example";
+    // The bearer was minted at the prior (loopback) ISSUER; the canonical
+    // origin has since moved to NEW_ORIGIN. `knownIssuers` accepts the older
+    // bearer iss while `deps.issuer` is the current canonical origin — exactly
+    // the post-expose scenario hub#532 describes.
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleRestart(
+      postReq("/api/modules/vault/restart", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      {
+        db: h.db,
+        issuer: NEW_ORIGIN,
+        knownIssuers: [ISSUER, NEW_ORIGIN],
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run: async () => 0,
+      },
+    );
+    expect(res.status).toBe(200);
+    // A fresh spawn happened, and it carries the NEW origin (rebuilt from the
+    // live deps.issuer), not the stale one from first start.
+    const reSpawn = spawns[spawnsBefore];
+    expect(reSpawn?.env?.PARACHUTE_HUB_ORIGIN).toBe(NEW_ORIGIN);
+    expect(reSpawn?.env?.PORT).toBe("1940");
+  });
+
+  test("crash-restart after a restart reuses the REFRESHED req (hub#532)", async () => {
+    // The refreshed SpawnRequest must become the supervisor entry's `req` so
+    // a SUBSEQUENT crash-restart (handleExit → spawnAndWatch, which replays
+    // `entry.req`) also carries the current env — not the original snapshot.
+    seedVault(1940);
+    // Controllable supervisor: spawns record env; each fake exposes a `crash()`
+    // resolving `exited` with code 1 (a crash, not an operator stop). `kill()`
+    // (driven by the injected group-aware `killFn`) resolves with 0 so the
+    // handler's restart-stop completes promptly. Distinct codes let us crash a
+    // specific child without tripping the stop path.
+    const spawns: SpawnRequest[] = [];
+    const procs: Array<{ pid: number; crash: () => void; kill: () => void }> = [];
+    let nextPid = 8000;
+    const spawnFn = (req: SpawnRequest): SupervisedProc => {
+      spawns.push(req);
+      const pid = nextPid++;
+      let resolveExit!: (c: number | null) => void;
+      const exited = new Promise<number | null>((r) => {
+        resolveExit = r;
+      });
+      const proc = {
+        pid,
+        exited,
+        stdout: null,
+        stderr: null,
+        kill: () => resolveExit(0),
+      };
+      procs.push({ pid, crash: () => resolveExit(1), kill: proc.kill });
+      return proc;
+    };
+    const killFn = (pid: number): void => {
+      procs.find((p) => p.pid === Math.abs(pid))?.kill();
+    };
+    const supervisor = new Supervisor({ spawnFn, killFn, restartDelayMs: 1, startReadyMs: 0 });
+
+    // First start with the OLD origin.
+    await supervisor.start({
+      short: "vault",
+      cmd: ["parachute-vault", "serve"],
+      env: { PORT: "1940", PARACHUTE_HUB_ORIGIN: "https://old.example" },
+    });
+
+    const NEW_ORIGIN = "https://new.example";
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    await handleRestart(
+      postReq("/api/modules/vault/restart", { authorization: `Bearer ${bearer}` }),
+      "vault",
+      {
+        db: h.db,
+        issuer: NEW_ORIGIN,
+        knownIssuers: [ISSUER, NEW_ORIGIN],
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run: async () => 0,
+      },
+    );
+    // The restart re-spawn is the most recent — confirm the NEW origin landed.
+    const restartSpawnIdx = spawns.length - 1;
+    expect(spawns[restartSpawnIdx]?.env?.PARACHUTE_HUB_ORIGIN).toBe(NEW_ORIGIN);
+
+    // Crash the restart-spawned child → the supervisor's crash-restart replays
+    // entry.req (which `start` stored from the refreshed req).
+    procs[restartSpawnIdx]?.crash();
+    // Wait for the crash watcher's restartDelay + respawn.
+    await new Promise((r) => setTimeout(r, 40));
+    expect(spawns.length).toBeGreaterThan(restartSpawnIdx + 1);
+    const crashRespawn = spawns[spawns.length - 1];
+    // The crash-restart inherited the REFRESHED req → still the new origin.
+    expect(crashRespawn?.env?.PARACHUTE_HUB_ORIGIN).toBe(NEW_ORIGIN);
   });
 });
 

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -374,6 +374,95 @@ describe("cli lazy-import isolation (feedback #9)", () => {
   });
 });
 
+// hub#534: `migrate --teardown` must surface teardownHubUnit's outcome — pre-fix
+// it ignored `removed` + `messages` and always exited 0, so a non-removal looked
+// like success. We exercise the REAL CLI arm via the in-repo sandbox (same shape
+// as the lazy-import suite above) so the arm's exit-code mapping runs end-to-end
+// without shelling out to real launchctl/systemctl: the sandboxed
+// `teardownHubUnit` is replaced with a stub keyed off an env var.
+describe("cli migrate --teardown exit-code policy (hub#534)", () => {
+  let sandbox: string;
+  let sandboxCli: string;
+
+  beforeAll(() => {
+    sandbox = mkdtempSync(join(REPO_ROOT, ".tmp-cli-teardown-"));
+    cpSync(join(REPO_ROOT, "src"), join(sandbox, "src"), { recursive: true });
+    cpSync(join(REPO_ROOT, "package.json"), join(sandbox, "package.json"));
+    sandboxCli = join(sandbox, "src", "cli.ts");
+    // Replace migrate-cutover.ts entirely with a minimal stub exporting only the
+    // `teardownHubUnit` the CLI arm calls. Its result is driven by
+    // `TEARDOWN_FAKE` so one rewrite covers all three outcomes. It logs the same
+    // human-facing lines the real function would (so the stdout assertions match
+    // real behavior), and the CLI owns the exit code.
+    writeFileSync(
+      join(sandbox, "src", "commands", "migrate-cutover.ts"),
+      [
+        "export function teardownHubUnit() {",
+        '  const mode = process.env.TEARDOWN_FAKE ?? "removed";',
+        '  if (mode === "removed") {',
+        '    console.log("Removed systemd unit parachute-hub.service — the hub no longer starts on boot.");',
+        "    return { removed: true, messages: [] };",
+        "  }",
+        '  if (mode === "failure") {',
+        '    console.log("Hub-unit teardown did not complete:");',
+        '    console.log("  systemctl disable failed: permission denied");',
+        '    return { removed: false, messages: ["systemctl disable failed: permission denied"] };',
+        "  }",
+        '  console.log("No hub unit was installed — nothing to tear down.");',
+        "  return { removed: false, messages: [] };",
+        "}",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  afterAll(() => {
+    if (sandbox) rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  async function runTeardown(
+    fake: string,
+  ): Promise<{ code: number; stdout: string; stderr: string }> {
+    const proc = Bun.spawn([process.execPath, sandboxCli, "migrate", "--teardown"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        HOME: "/tmp/parachute-hub-nonexistent-home",
+        PARACHUTE_HOME: "/tmp/parachute-hub-nonexistent-home",
+        TEARDOWN_FAKE: fake,
+      },
+    });
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { code, stdout, stderr };
+  }
+
+  test("removed → exit 0 with the removal message", async () => {
+    const { code, stdout } = await runTeardown("removed");
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/Removed systemd unit/);
+  });
+
+  test("nothing installed → informational exit 0", async () => {
+    const { code, stdout } = await runTeardown("nothing");
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/nothing to tear down/);
+  });
+
+  test("removal failure (messages present) → exit 1, reason on stderr", async () => {
+    const { code, stdout, stderr } = await runTeardown("failure");
+    expect(code).toBe(1);
+    // The function logged the failure header to stdout; the CLI re-surfaces the
+    // detail on stderr so a script's `2>` capture sees the reason.
+    expect(stdout).toMatch(/did not complete/);
+    expect(stderr).toMatch(/permission denied/);
+  });
+});
+
 describe("cli friendly errors", () => {
   test("malformed services.json prints friendly error not stack trace", async () => {
     const dir = mkdtempSync(join(tmpdir(), "pcli-bad-"));

--- a/src/__tests__/migrate-cutover.test.ts
+++ b/src/__tests__/migrate-cutover.test.ts
@@ -535,6 +535,29 @@ describe("teardownHubUnit (§7.4)", () => {
     expect(staleCalled).toBe(true);
     expect(log.join("\n")).toContain("nothing to tear down");
   });
+
+  test("removal failure (removed:false WITH messages) → surfaces the reason, not 'nothing installed' (hub#534)", () => {
+    // A future / defensive `removeManagedUnit` that returns removed:false WITH a
+    // failure reason must NOT be reported as the benign "nothing was installed"
+    // line — the operator (and the CLI's non-zero exit) need the real detail.
+    const log: string[] = [];
+    const res = teardownHubUnit({
+      log: (l) => log.push(l),
+      deps: fakeHubUnitDeps(),
+      remove: (): ManagedUnitRemoveResult => ({
+        removed: false,
+        messages: ["systemctl disable failed: permission denied"],
+      }),
+      disableStaleModuleUnits: () => ({ actions: [] }),
+    });
+    expect(res.removed).toBe(false);
+    expect(res.messages).toEqual(["systemctl disable failed: permission denied"]);
+    const out = log.join("\n");
+    expect(out).toContain("did not complete");
+    expect(out).toContain("permission denied");
+    // Must NOT claim nothing was installed when there was a real failure.
+    expect(out).not.toContain("nothing to tear down");
+  });
 });
 
 // ===========================================================================

--- a/src/__tests__/supervisor.test.ts
+++ b/src/__tests__/supervisor.test.ts
@@ -678,6 +678,30 @@ describe("Supervisor.restart", () => {
     sup.stop("vault");
     third.resolveExit(0);
   });
+
+  test("throws when nextReq.short mismatches the restarted short (state-corruption guard)", async () => {
+    const proc = makeFakeProc(101);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(proc);
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      killFn: noopKill,
+      restartDelayMs: 0,
+      sleep: () => Promise.resolve(),
+    });
+    await sup.start({ short: "vault", cmd: ["bun", "vault.ts"] });
+
+    // A nextReq for a DIFFERENT short would re-register under the wrong map key.
+    await expect(
+      sup.restart("vault", { short: "scribe", cmd: ["bun", "scribe.ts"] }),
+    ).rejects.toThrow(/nextReq\.short is "scribe"/);
+    // The original entry is untouched — no spurious stop/respawn happened.
+    expect(spawner.calls).toHaveLength(1);
+
+    proc.closeStreams();
+    sup.stop("vault");
+    proc.resolveExit(0);
+  });
 });
 
 describe("Supervisor output multiplexing", () => {

--- a/src/__tests__/supervisor.test.ts
+++ b/src/__tests__/supervisor.test.ts
@@ -595,6 +595,89 @@ describe("Supervisor.restart", () => {
     sup.stop("vault");
     second.resolveExit(0);
   });
+
+  test("replays entry.req when no nextReq is supplied", async () => {
+    const first = makeFakeProc(101);
+    const second = makeFakeProc(102);
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(first);
+    spawner.enqueue(second);
+
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      killFn: noopKill,
+      restartDelayMs: 0,
+      sleep: () => Promise.resolve(),
+    });
+    await sup.start({
+      short: "vault",
+      cmd: ["bun", "vault.ts"],
+      env: { PARACHUTE_HUB_ORIGIN: "https://origin.example" },
+    });
+
+    const restartPromise = sup.restart("vault");
+    first.closeStreams();
+    first.resolveExit(0);
+    await restartPromise;
+
+    // No nextReq → the re-spawn replays the original env (legacy behavior).
+    expect(spawner.calls[1]?.env?.PARACHUTE_HUB_ORIGIN).toBe("https://origin.example");
+    expect(spawner.calls[1]?.cmd).toEqual(["bun", "vault.ts"]);
+
+    second.closeStreams();
+    sup.stop("vault");
+    second.resolveExit(0);
+  });
+
+  test("nextReq re-spawns with the refreshed req AND propagates to crash-restart (hub#532)", async () => {
+    const first = makeFakeProc(101);
+    const second = makeFakeProc(102); // restart re-spawn
+    const third = makeFakeProc(103); // crash-restart respawn
+    const spawner = makeQueueSpawner();
+    spawner.enqueue(first);
+    spawner.enqueue(second);
+    spawner.enqueue(third);
+
+    const sup = new Supervisor({
+      spawnFn: spawner.spawn,
+      killFn: noopKill,
+      restartDelayMs: 0,
+      sleep: () => Promise.resolve(),
+    });
+    // First start with the OLD origin.
+    await sup.start({
+      short: "vault",
+      cmd: ["bun", "vault.ts"],
+      env: { PARACHUTE_HUB_ORIGIN: "https://old.example" },
+    });
+
+    // Restart WITH a refreshed req carrying the NEW origin.
+    const restartPromise = sup.restart("vault", {
+      short: "vault",
+      cmd: ["bun", "vault.ts"],
+      env: { PARACHUTE_HUB_ORIGIN: "https://new.example" },
+    });
+    first.closeStreams();
+    first.resolveExit(0);
+    await restartPromise;
+
+    // The restart re-spawn carries the NEW origin.
+    expect(spawner.calls[1]?.env?.PARACHUTE_HUB_ORIGIN).toBe("https://new.example");
+
+    // Now crash the restart-spawned child (resolveExit with a non-stop code).
+    // handleExit → spawnAndWatch replays entry.req, which `start` stored from
+    // the refreshed nextReq — so the crash-restart ALSO carries the new origin.
+    second.closeStreams();
+    second.resolveExit(1);
+    await tick(20);
+
+    expect(spawner.calls).toHaveLength(3);
+    expect(spawner.calls[2]?.env?.PARACHUTE_HUB_ORIGIN).toBe("https://new.example");
+
+    third.closeStreams();
+    sup.stop("vault");
+    third.resolveExit(0);
+  });
 });
 
 describe("Supervisor output multiplexing", () => {

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -384,6 +384,85 @@ async function resolveSpawnSpec(
   return composeKnownModuleSpec(km, manifest);
 }
 
+/**
+ * Outcome of `resolveSpawnRequest`: either a freshly-built `SpawnRequest`
+ * (carrying CURRENT env — live `deps.issuer` → `PARACHUTE_HUB_ORIGIN`,
+ * enriched PATH, re-resolved `cwd`) or a structured error the HTTP handler
+ * can return verbatim. A discriminated union so `handleStart` /
+ * `handleRestart` / `runUpgrade` share the resolve-and-rebuild path
+ * without duplicating the not-installed / no-start-cmd error shapes.
+ */
+type ResolveSpawnResult =
+  | { ok: true; req: SpawnRequest }
+  | { ok: false; status: number; code: string; message: string };
+
+/**
+ * Build a `SpawnRequest` for an already-installed module from CURRENT state,
+ * identically to the serve-boot path (PORT / per-service `.env` / live
+ * `PARACHUTE_HUB_ORIGIN` / enriched PATH via the shared
+ * `buildModuleSpawnRequest`). This is the single source of truth the start,
+ * restart, and post-upgrade-restart paths share so each re-injects the
+ * current hub origin + PATH rather than replaying a stale first-start
+ * snapshot (hub#532). `cwd` is re-resolved from the row's `installDir` too,
+ * so a post-upgrade relocation is picked up.
+ *
+ * Returns a structured `{ ok: false }` for the two operator-facing
+ * preconditions the start endpoint already surfaced: 400 `not_installed`
+ * (no services.json row) and 422 `no_start_cmd` (CLI-only / unreadable
+ * module.json). Callers map these to the response shape their surface wants.
+ */
+async function resolveSpawnRequest(
+  short: CuratedModuleShort,
+  deps: ApiModulesOpsDeps,
+): Promise<ResolveSpawnResult> {
+  const spec = specFor(short);
+
+  // The module must already be installed (present in services.json).
+  const entry = findService(spec.manifestName, deps.manifestPath);
+  if (!entry) {
+    return {
+      ok: false,
+      status: 400,
+      code: "not_installed",
+      message: `${short} is not installed (no services.json entry) — install it first via POST /api/modules/${short}/install`,
+    };
+  }
+
+  // KNOWN_MODULES shorts (vault / scribe / runner): module.json is the
+  // canonical source for startCmd. Re-resolve from
+  // `<installDir>/.parachute/module.json` when installDir is stamped so the
+  // module is authoritative for its own spawn cmd — mirroring runInstall's
+  // post-bun-add re-resolve. Falls back to the imperative `extras.startCmd`
+  // carried by `spec` when installDir is absent or module.json is unreadable.
+  let spawnSpec: ServiceSpec = spec;
+  if (entry.installDir && KNOWN_MODULES[short]) {
+    const resolved = await resolveSpawnSpec(short, entry.installDir);
+    if (resolved) spawnSpec = resolved;
+  }
+
+  const cmd = spawnSpec.startCmd?.(entry);
+  if (!cmd || cmd.length === 0) {
+    return {
+      ok: false,
+      status: 422,
+      code: "no_start_cmd",
+      message: `${short} has no resolvable startCmd (CLI-only module, or <installDir>/.parachute/module.json missing a startCmd)`,
+    };
+  }
+
+  // Build the SpawnRequest identically to the serve-boot path so start,
+  // restart, and post-upgrade-restart produce the same child env (PORT / .env
+  // / live HUB_ORIGIN / enriched PATH). The test-seam / first-boot `spawnEnv`
+  // rides the shared helper's `extraEnv` and wins last, matching
+  // `spawnSupervised`'s precedence.
+  const req = buildModuleSpawnRequest(short, entry, cmd, {
+    configDir: deps.configDir,
+    ...(deps.issuer ? { hubOrigin: deps.issuer } : {}),
+    ...(deps.spawnEnv ? { extraEnv: deps.spawnEnv } : {}),
+  });
+  return { ok: true, req };
+}
+
 function defaultRun(cmd: readonly string[]): Promise<number> {
   // Inherit env so child `bun add` sees TMPDIR, BUN_INSTALL, PARACHUTE_*,
   // etc. set by the Dockerfile / Render env. Bun.spawn defaults to empty
@@ -792,51 +871,16 @@ export async function handleStart(
   const authFail = await authorize(req, deps);
   if (authFail) return authFail;
 
-  const spec = specFor(short);
-
-  // Pure-spawn precondition: the module must already be installed
-  // (present in services.json). `start` never installs — that's the
-  // install endpoint's job, which is far heavier (bun add -g / seed /
-  // stamp). A missing row is an operator error worth a clear message.
-  const entry = findService(spec.manifestName, deps.manifestPath);
-  if (!entry) {
-    return jsonError(
-      400,
-      "not_installed",
-      `${short} is not installed (no services.json entry) — install it first via POST /api/modules/${short}/install`,
-    );
-  }
-
-  // KNOWN_MODULES shorts (vault / scribe / runner): module.json is the
-  // canonical source for startCmd. Re-resolve from
-  // `<installDir>/.parachute/module.json` when installDir is stamped so the
-  // module is authoritative for its own spawn cmd — mirroring runInstall's
-  // post-bun-add re-resolve. Falls back to the imperative `extras.startCmd`
-  // carried by `spec` when installDir is absent or module.json is unreadable.
-  let spawnSpec: ServiceSpec = spec;
-  if (entry.installDir && KNOWN_MODULES[short]) {
-    const resolved = await resolveSpawnSpec(short, entry.installDir);
-    if (resolved) spawnSpec = resolved;
-  }
-
-  const cmd = spawnSpec.startCmd?.(entry);
-  if (!cmd || cmd.length === 0) {
-    return jsonError(
-      422,
-      "no_start_cmd",
-      `${short} has no resolvable startCmd (CLI-only module, or <installDir>/.parachute/module.json missing a startCmd)`,
-    );
-  }
-
-  // Build the SpawnRequest identically to the serve-boot path so `start`
-  // and boot produce the same child env (PORT / .env / HUB_ORIGIN). The
-  // test-seam / first-boot `spawnEnv` rides the shared helper's `extraEnv`
-  // and wins last, matching `spawnSupervised`'s precedence.
-  const spawnReq = buildModuleSpawnRequest(short, entry, cmd, {
-    configDir: deps.configDir,
-    ...(deps.issuer ? { hubOrigin: deps.issuer } : {}),
-    ...(deps.spawnEnv ? { extraEnv: deps.spawnEnv } : {}),
-  });
+  // Build the SpawnRequest from CURRENT state (live issuer / PATH / .env /
+  // re-resolved startCmd), shared with the restart + post-upgrade-restart
+  // paths so each spawn carries the same fresh env (hub#532). The two
+  // operator-facing preconditions — 400 `not_installed` (no services.json
+  // row; `start` never installs, that's the heavier install endpoint's job)
+  // and 422 `no_start_cmd` (CLI-only / unreadable module.json) — surface as
+  // structured errors here.
+  const resolved = await resolveSpawnRequest(short, deps);
+  if (!resolved.ok) return jsonError(resolved.status, resolved.code, resolved.message);
+  const spawnReq = resolved.req;
 
   let state: Awaited<ReturnType<typeof deps.supervisor.start>>;
   try {
@@ -898,10 +942,19 @@ export async function handleStop(
 /**
  * POST /api/modules/:short/restart — synchronous.
  *
- * Routes through `supervisor.restart(short)` which does stop → await
- * exit → start with the same SpawnRequest. Returns the new state in
- * the body — the UI's spinner can clear as soon as the response
- * arrives, no operation poll needed.
+ * Rebuilds the SpawnRequest from CURRENT state (live `deps.issuer` →
+ * `PARACHUTE_HUB_ORIGIN`, enriched PATH, re-resolved cwd) — identically to
+ * `handleStart` via the shared `resolveSpawnRequest` — and hands it to
+ * `supervisor.restart(short, req)` so the re-spawn re-injects the current
+ * hub origin (hub#532). Before this, restart replayed the env captured at
+ * FIRST start, so an admin-UI restart / `parachute restart <svc>` never
+ * picked up a corrected hub origin (or, since #546, the enriched PATH) —
+ * only `start` and the `expose up` self-heal rebuilt env. The refreshed req
+ * also becomes the supervisor entry's `req`, so subsequent crash-restarts
+ * carry the current env too.
+ *
+ * Returns the new state in the body — the UI's spinner can clear as soon as
+ * the response arrives, no operation poll needed.
  */
 export async function handleRestart(
   req: Request,
@@ -912,9 +965,16 @@ export async function handleRestart(
   const authFail = await authorize(req, deps);
   if (authFail) return authFail;
 
+  // Rebuild the spawn env from current state. A `not_installed` row is a 400
+  // (same as `start`); `no_start_cmd` a 422. A module that's installed but
+  // not currently supervised falls through to the 404 `not_supervised` below
+  // (the supervisor returns `undefined`).
+  const resolved = await resolveSpawnRequest(short, deps);
+  if (!resolved.ok) return jsonError(resolved.status, resolved.code, resolved.message);
+
   let state: Awaited<ReturnType<typeof deps.supervisor.restart>>;
   try {
-    state = await deps.supervisor.restart(short);
+    state = await deps.supervisor.restart(short, resolved.req);
   } catch (err) {
     return moduleOpFailure(short, "restart", err);
   }
@@ -1103,7 +1163,16 @@ async function runUpgrade(
     });
   }
 
-  const state = await deps.supervisor.restart(short);
+  // Rebuild the spawn req from post-upgrade state before restarting: a major
+  // bump may have relocated installDir (re-stamped above), so the re-spawn's
+  // cwd must track it, and the restart should carry the live hub origin /
+  // enriched PATH like start does (hub#532). Fall back to a plain replay
+  // restart if the row can't be resolved into a fresh req (shouldn't happen
+  // mid-upgrade, but a missing startCmd shouldn't wedge the upgrade op).
+  const resolved = await resolveSpawnRequest(short, deps);
+  const state = resolved.ok
+    ? await deps.supervisor.restart(short, resolved.req)
+    : await deps.supervisor.restart(short);
   if (!state) {
     registry.update(
       opId,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -832,7 +832,21 @@ async function main(argv: string[]): Promise<number> {
         }
         const mod = await loadCommand("migrate", () => import("./commands/migrate-cutover.ts"));
         if (!mod) return 1;
-        mod.teardownHubUnit();
+        // teardownHubUnit logs the human-facing lines itself (the success
+        // guidance, or "nothing to tear down"). hub#534: the CLI must still
+        // own the EXIT CODE + surface any failure detail the function's
+        // false-branch doesn't print — pre-fix it ignored `removed` + `messages`
+        // and always exited 0, so a non-removal looked like success to a script.
+        const result = mod.teardownHubUnit();
+        if (result.removed) return 0;
+        // removed === false: either a clean no-op (nothing was installed —
+        // `messages` empty) or a real failure (the removal carried a reason in
+        // `messages` the internal log didn't surface). The no-op is informational
+        // (exit 0); a failure with detail is an error (print it, exit 1).
+        if (result.messages.length > 0) {
+          for (const line of result.messages) console.error(line);
+          return 1;
+        }
         return 0;
       }
       // §7.1 detached→supervised cutover. Opt-in surface (the archive sweep

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -843,6 +843,14 @@ async function main(argv: string[]): Promise<number> {
         // `messages` empty) or a real failure (the removal carried a reason in
         // `messages` the internal log didn't surface). The no-op is informational
         // (exit 0); a failure with detail is an error (print it, exit 1).
+        //
+        // DELIBERATE double-print on the failure path (not a bug): the function's
+        // own log() already wrote a human-readable summary ("Hub-unit teardown did
+        // not complete: …") to STDOUT; here we re-emit the raw reason(s) to STDERR.
+        // The split is intentional — a person reading the terminal sees the framed
+        // summary, while a script that captures `2>` gets the machine-parseable
+        // reason alongside the non-zero exit. Mirrors the streams convention the
+        // rest of the CLI uses (human guidance on stdout, error detail on stderr).
         if (result.messages.length > 0) {
           for (const line of result.messages) console.error(line);
           return 1;

--- a/src/commands/migrate-cutover.ts
+++ b/src/commands/migrate-cutover.ts
@@ -879,6 +879,12 @@ export function teardownHubUnit(opts: TeardownOpts = {}): { removed: boolean; me
     log("The supervised hub unit is gone. To run the hub now, either:");
     log("  - `parachute serve` (foreground), or");
     log("  - `parachute migrate --to-supervised` to reinstall the unit.");
+  } else if (res.messages.length > 0) {
+    // removed === false WITH detail: a real removal failure, not a clean
+    // no-op. Surface the reason rather than the misleading "nothing was
+    // installed" line (hub#534 — the CLI also maps this to a non-zero exit).
+    log("Hub-unit teardown did not complete:");
+    for (const m of res.messages) log(`  ${m}`);
   } else {
     log("No hub unit was installed — nothing to tear down.");
   }

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -606,10 +606,21 @@ export class Supervisor {
    * `req` — so subsequent CRASH-restarts (`handleExit` → `spawnAndWatch`,
    * which reuse `entry.req`) also carry the refreshed env, not the original
    * first-start snapshot. When omitted, the prior `entry.req` is replayed
-   * (legacy behavior, e.g. an internal restart with no state change). The
-   * short on `nextReq` must match `short` — a mismatch is a caller bug.
+   * (legacy behavior, e.g. an internal restart with no state change).
+   *
+   * `nextReq.short` MUST match `short`: `start(req)` keys the supervisor map
+   * on `req.short`, so a mismatch would silently register the restarted
+   * module under the WRONG key (orphaning the original entry + breaking every
+   * subsequent `get`/`stop`/`restart` lookup). Throws on mismatch rather than
+   * trusting the caller — a one-line invariant that turns a silent
+   * state-corruption bug into a loud one.
    */
   async restart(short: string, nextReq?: SpawnRequest): Promise<ModuleState | undefined> {
+    if (nextReq && nextReq.short !== short) {
+      throw new Error(
+        `restart(${short}): nextReq.short is "${nextReq.short}" — it must match the restarted short or the module re-registers under the wrong key`,
+      );
+    }
     const entry = this.modules.get(short);
     if (!entry) return undefined;
     const req = nextReq ?? entry.req;

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -595,21 +595,32 @@ export class Supervisor {
   }
 
   /**
-   * Restart a supervised module: stop, wait for exit, start with the
-   * same SpawnRequest. Used by the `/api/modules/:name/restart`
-   * handler. The on-box `parachute restart <svc>` path stays on
-   * `commands/lifecycle.ts` — different surface, different ownership.
+   * Restart a supervised module: stop, wait for exit, start again. Used by
+   * the `/api/modules/:name/restart` handler. The on-box
+   * `parachute restart <svc>` path stays on `commands/lifecycle.ts` —
+   * different surface, different ownership.
+   *
+   * `nextReq` (hub#532): when the caller supplies a freshly-rebuilt
+   * SpawnRequest (current `PARACHUTE_HUB_ORIGIN` / enriched PATH /
+   * re-resolved cwd), the re-spawn uses it AND it becomes the entry's new
+   * `req` — so subsequent CRASH-restarts (`handleExit` → `spawnAndWatch`,
+   * which reuse `entry.req`) also carry the refreshed env, not the original
+   * first-start snapshot. When omitted, the prior `entry.req` is replayed
+   * (legacy behavior, e.g. an internal restart with no state change). The
+   * short on `nextReq` must match `short` — a mismatch is a caller bug.
    */
-  async restart(short: string): Promise<ModuleState | undefined> {
+  async restart(short: string, nextReq?: SpawnRequest): Promise<ModuleState | undefined> {
     const entry = this.modules.get(short);
     if (!entry) return undefined;
-    const req = entry.req;
+    const req = nextReq ?? entry.req;
     entry.state = { ...entry.state, status: "restarting" };
     // stop() now awaits the prior process's exit (with SIGKILL
     // escalation) before returning, so the fresh spawn below doesn't
     // race on EADDRINUSE — no separate await needed here.
     await this.stop(short);
-    // Drop the entry so `start` treats this as a clean spawn.
+    // Drop the entry so `start` treats this as a clean spawn. `start` stores
+    // `req` as the new entry's `req`, so a refreshed `nextReq` propagates to
+    // the crash-restart path too.
     this.modules.delete(short);
     return this.start(req);
   }


### PR DESCRIPTION
Two small operator-facing residuals, one commit each.

## #532 — `supervisor.restart` replayed the stale spawn-env snapshot
`Supervisor.restart(short)` re-spawned by replaying the stored `entry.req` — the env captured at FIRST start — so an admin-UI restart / `parachute restart <svc>` never picked up a corrected hub origin (or, since #546, the enriched PATH). Only `handleStart` and the `expose up` self-heal rebuilt env.

**Fix.** `handleRestart` now routes through a new shared `resolveSpawnRequest` (extracted from `handleStart`) that rebuilds the `SpawnRequest` from current state — live `deps.issuer` → `PARACHUTE_HUB_ORIGIN`, enriched PATH, re-resolved cwd — and hands it to `Supervisor.restart(short, nextReq)`. Because `start` stores the fresh req as the entry's `req`, **subsequent crash-restarts** (which reuse `entry.req`) carry the current env too — not just the operator-driven restart.

`Supervisor.restart` gains an optional `nextReq` (replays `entry.req` when omitted → legacy behavior preserved). The post-upgrade restart in `runUpgrade` also rebuilds (a major bump may relocate `installDir` → fresh cwd), with a plain-replay fallback if the row can't resolve.

Restart now requires a services.json row (like start): missing row → 400 `not_installed`; installed-but-not-supervised stays 404 `not_supervised`. Port readiness, restart budget, and lifecycle states are unchanged.

**Scope note (part 2 of the issue).** The pre-expose-children / first-ever-expose asymmetry lives in the `expose up` flow, not the restart path — left out of scope here. This fix delivers the issue's fallback (b): a manual restart is now sufficient to re-inject the current origin.

## #534 — `migrate --teardown` silently discarded `teardownHubUnit` output
The CLI arm ignored both `removed` and `messages` and always exited 0, so a non-removal looked like success to a script.

**Fix.** The CLI now owns the exit code + surfaces failure detail the function's false-branch didn't print:
- `removed === true` → exit 0 (removal message already logged by the function).
- `removed === false`, no `messages` → clean no-op ("nothing to tear down"), informational **exit 0**.
- `removed === false` WITH `messages` → real removal failure; print the reason to stderr, **exit 1**.

Also fixed `teardownHubUnit` itself: its `else` branch printed "No hub unit was installed — nothing to tear down" even on a failure with a reason in `messages`; it now surfaces that reason instead of the misleading no-op line.

## Tests
- supervisor: `nextReq` override re-spawns with the new env; crash-restart after a `restart` inherits the refreshed req; replay-when-omitted.
- api-modules-ops: restart re-injects the NEW origin after the canonical origin moves (bearer minted at the old iss, accepted via `knownIssuers`); start/restart parity; not_installed / not_supervised.
- migrate-cutover: function-level `removed:false`-with-messages branch.
- cli: exit-code policy for all three teardown outcomes via the in-repo sandbox (no real launchctl/systemctl).

## Gates (fake-launchctl PATH shim)
- hub (`bun test ./src`): **2852 pass / 1 skip / 0 fail**
- scope-guard (`bun test ./packages/scope-guard/src`): **108 pass / 0 fail**
- `bun run typecheck`: clean

No version bump (per governance: tag-when-ready, not per-PR).

Closes #532
Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)