### PR TITLE
pre-multi-user security hardening (mint-token + force-change + scribe-auth + layerOf)

### DIFF
--- a/src/__tests__/account-vault-token.test.ts
+++ b/src/__tests__/account-vault-token.test.ts
@@ -292,6 +292,20 @@ describe("handleAccountVaultTokenPost — authorization gates (adversarial)", ()
     expect(res.status).toBe(400);
   });
 
+  // Item I — uppercase vault names are rejected at the hub edge (lowercase-only,
+  // matching vault's init; the old `[a-zA-Z0-9_-]` superset drifted from it).
+  test("an uppercase vault name is rejected (item I — lowercase-only)", async () => {
+    const { cookie, csrfToken } = await seedFriend(["work"]);
+    for (const name of ["Work", "WORK", "myVault"]) {
+      const res = await handleAccountVaultTokenPost(
+        mintReq(name, { cookie, csrfToken, verb: "read" }),
+        name,
+        deps(),
+      );
+      expect(res.status).toBe(400);
+    }
+  });
+
   // Item F / hub#469 — force-change gate. An assigned friend who has NOT yet
   // rotated the admin-set temp password is redirected to the change-password
   // rail instead of minting a long-lived token (which would outlive the

--- a/src/__tests__/account-vault-token.test.ts
+++ b/src/__tests__/account-vault-token.test.ts
@@ -321,9 +321,7 @@ describe("handleAccountVaultTokenPost — authorization gates (adversarial)", ()
     expect(res.status).toBe(303);
     expect(res.headers.get("location")).toBe("/account/change-password");
     // No token row was written for the friend.
-    const rows = harness.db
-      .query<{ n: number }, []>("SELECT COUNT(*) AS n FROM tokens")
-      .get();
+    const rows = harness.db.query<{ n: number }, []>("SELECT COUNT(*) AS n FROM tokens").get();
     expect(rows?.n).toBe(0);
   });
 

--- a/src/__tests__/account-vault-token.test.ts
+++ b/src/__tests__/account-vault-token.test.ts
@@ -73,14 +73,23 @@ function csrfPair(): { token: string; cookieFragment: string } {
   return { token, cookieFragment: cookie };
 }
 
-/** Build the first-admin operator + a friend assigned to `vaults`. */
+/**
+ * Build the first-admin operator + a friend assigned to `vaults`.
+ *
+ * `passwordChanged` defaults to true: the friend has already rotated the admin-
+ * set temp password, which is the precondition for minting a token now (item F
+ * / hub#469 — an unrotated friend is force-redirected before any mint). Pass
+ * `passwordChanged: false` to exercise the force-change gate.
+ */
 async function seedFriend(
   vaults: string[],
+  opts: { passwordChanged?: boolean } = {},
 ): Promise<{ friendId: string; cookie: string; csrfToken: string }> {
   await createUser(harness.db, "operator", "operator-password-123");
   const friend = await createUser(harness.db, "friend", "friend-password-123", {
     assignedVaults: vaults,
     allowMulti: true,
+    passwordChanged: opts.passwordChanged ?? true,
   });
   const session = createSession(harness.db, { userId: friend.id });
   const { token, cookieFragment } = csrfPair();
@@ -281,6 +290,37 @@ describe("handleAccountVaultTokenPost — authorization gates (adversarial)", ()
       deps(),
     );
     expect(res.status).toBe(400);
+  });
+
+  // Item F / hub#469 — force-change gate. An assigned friend who has NOT yet
+  // rotated the admin-set temp password is redirected to the change-password
+  // rail instead of minting a long-lived token (which would outlive the
+  // rotation). The gate fires AFTER the authority checks (so an unassigned
+  // request still 403s) and BEFORE the mint.
+  test("authorized but unrotated friend → 303 to /account/change-password, no mint (item F)", async () => {
+    const { cookie, csrfToken } = await seedFriend(["work"], { passwordChanged: false });
+    const res = await handleAccountVaultTokenPost(
+      mintReq("work", { cookie, csrfToken, verb: "read" }),
+      "work",
+      deps(),
+    );
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toBe("/account/change-password");
+    // No token row was written for the friend.
+    const rows = harness.db
+      .query<{ n: number }, []>("SELECT COUNT(*) AS n FROM tokens")
+      .get();
+    expect(rows?.n).toBe(0);
+  });
+
+  test("an UNASSIGNED unrotated friend still 403s (authority precedes the force-change gate)", async () => {
+    const { cookie, csrfToken } = await seedFriend(["work"], { passwordChanged: false });
+    const res = await handleAccountVaultTokenPost(
+      mintReq("other", { cookie, csrfToken, verb: "read" }),
+      "other",
+      deps(),
+    );
+    expect(res.status).toBe(403);
   });
 });
 

--- a/src/__tests__/admin-vault-admin-token.test.ts
+++ b/src/__tests__/admin-vault-admin-token.test.ts
@@ -121,6 +121,23 @@ describe("handleVaultAdminToken", () => {
     expect(res.status).toBe(400);
   });
 
+  // Item I — uppercase names are rejected at the hub edge (lowercase-only,
+  // matching vault's init). Rejected on shape (400) before the known-vault check.
+  test("400 when the vault name contains uppercase letters (item I)", async () => {
+    const { cookie } = await withSession();
+    for (const name of ["Work", "WORK", "myVault"]) {
+      const req = new Request(`${ISSUER}/admin/vault-admin-token/${name}`, {
+        headers: { cookie },
+      });
+      const res = await handleVaultAdminToken(req, name, {
+        db: harness.db,
+        issuer: ISSUER,
+        knownVaultNames: known(name, "work"),
+      });
+      expect(res.status).toBe(400);
+    }
+  });
+
   test("200 mints a JWT carrying vault:<name>:admin", async () => {
     const { cookie, userId } = await withSession();
     const req = new Request(`${ISSUER}/admin/vault-admin-token/work`, { headers: { cookie } });

--- a/src/__tests__/admin-vaults.test.ts
+++ b/src/__tests__/admin-vaults.test.ts
@@ -225,6 +225,26 @@ describe("POST /vaults — body validation", () => {
     }
   });
 
+  // Item I — uppercase is rejected at the hub edge (vault's init is
+  // lowercase-only `[a-z0-9_-]`; a hub `[a-zA-Z0-9_-]` superset drifted from it).
+  test("400 when name contains uppercase letters (item I — lowercase-only)", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        for (const name of ["Work", "MyVault", "FOO", "camelCase"]) {
+          const res = await call({ db, manifestPath: h.manifestPath, body: { name } });
+          expect(res.status).toBe(400);
+        }
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test('400 when name is the reserved "list"', async () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/api-account.test.ts
+++ b/src/__tests__/api-account.test.ts
@@ -35,6 +35,7 @@ import {
   CHANGE_PASSWORD_WINDOW_MS,
   changePasswordRateLimiter,
 } from "../rate-limit.ts";
+import { recordTokenMint } from "../jwt-sign.ts";
 import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
 import { createUser, getUserById, verifyPassword } from "../users.ts";
 
@@ -255,6 +256,67 @@ describe("POST /account/change-password", () => {
       expect(await verifyPassword(after, "user-chosen-strong-passphrase")).toBe(true);
       expect(await verifyPassword(after, "old-default-pw")).toBe(false);
     }
+  });
+
+  // Item F / hub#469 — a successful self-service password change revokes the
+  // user's still-active tokens (so a token minted under the admin's temp
+  // password dies with the rotation). Mirrors `resetUserPassword`'s admin-reset
+  // revoke. Tokens belonging to OTHER users are untouched.
+  test("self-change revokes the user's active tokens, leaves other users' tokens (item F)", async () => {
+    const { userId, cookie } = await sessionCookieFor(harness.db, "newbie", "old-default-pw", {
+      passwordChanged: false,
+    });
+    const other = await createUser(harness.db, "other", "other-strong-passphrase", {
+      passwordChanged: true,
+      allowMulti: true,
+    });
+    // Seed one active token for the changing user + one for another user.
+    recordTokenMint(harness.db, {
+      jti: "tok-self-1",
+      createdVia: "cli_mint",
+      subject: userId,
+      userId,
+      clientId: "parachute-account",
+      scopes: ["vault:work:read"],
+      expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+    });
+    recordTokenMint(harness.db, {
+      jti: "tok-other-1",
+      createdVia: "cli_mint",
+      subject: other.id,
+      userId: other.id,
+      clientId: "parachute-account",
+      scopes: ["vault:work:read"],
+      expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+    });
+
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      current_password: "old-default-pw",
+      new_password: "user-chosen-strong-passphrase",
+      new_password_confirm: "user-chosen-strong-passphrase",
+      next: "/account/",
+    });
+    const req = new Request("http://hub.test/account/change-password", {
+      method: "POST",
+      headers: { ...headers, cookie },
+      body,
+    });
+    const res = await handleAccountChangePasswordPost(req, { db: harness.db });
+    expect(res.status).toBe(302);
+
+    const selfTok = harness.db
+      .query<{ revoked_at: string | null }, [string]>(
+        "SELECT revoked_at FROM tokens WHERE jti = ?",
+      )
+      .get("tok-self-1");
+    const otherTok = harness.db
+      .query<{ revoked_at: string | null }, [string]>(
+        "SELECT revoked_at FROM tokens WHERE jti = ?",
+      )
+      .get("tok-other-1");
+    expect(selfTok?.revoked_at).not.toBeNull(); // changing user's token revoked
+    expect(otherTok?.revoked_at).toBeNull(); // other user's token untouched
   });
 
   test("non-admin user with no next defaults to /account/ (no admin-shell flash)", async () => {

--- a/src/__tests__/api-account.test.ts
+++ b/src/__tests__/api-account.test.ts
@@ -30,12 +30,12 @@ import {
 } from "../api-account.ts";
 import { CSRF_COOKIE_NAME, CSRF_FIELD_NAME } from "../csrf.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { recordTokenMint } from "../jwt-sign.ts";
 import {
   CHANGE_PASSWORD_MAX_ATTEMPTS,
   CHANGE_PASSWORD_WINDOW_MS,
   changePasswordRateLimiter,
 } from "../rate-limit.ts";
-import { recordTokenMint } from "../jwt-sign.ts";
 import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
 import { createUser, getUserById, verifyPassword } from "../users.ts";
 
@@ -306,14 +306,10 @@ describe("POST /account/change-password", () => {
     expect(res.status).toBe(302);
 
     const selfTok = harness.db
-      .query<{ revoked_at: string | null }, [string]>(
-        "SELECT revoked_at FROM tokens WHERE jti = ?",
-      )
+      .query<{ revoked_at: string | null }, [string]>("SELECT revoked_at FROM tokens WHERE jti = ?")
       .get("tok-self-1");
     const otherTok = harness.db
-      .query<{ revoked_at: string | null }, [string]>(
-        "SELECT revoked_at FROM tokens WHERE jti = ?",
-      )
+      .query<{ revoked_at: string | null }, [string]>("SELECT revoked_at FROM tokens WHERE jti = ?")
       .get("tok-other-1");
     expect(selfTok?.revoked_at).not.toBeNull(); // changing user's token revoked
     expect(otherTok?.revoked_at).toBeNull(); // other user's token untouched

--- a/src/__tests__/api-mint-token.test.ts
+++ b/src/__tests__/api-mint-token.test.ts
@@ -1215,6 +1215,91 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
     });
   });
 
+  // Item D / hub#450 — vault-existence check on vault:<name>:admin mints.
+  describe("vault-existence check on vault:<name>:admin (item D / #450)", () => {
+    test("vault:typo:admin for an unknown vault → 400 when knownVaultNames is wired", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "vault:typo:admin" }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER, knownVaultNames: new Set(["work", "default"]) },
+          );
+          expect(resp.status).toBe(400);
+          const body = (await resp.json()) as { error: string; error_description: string };
+          expect(body.error).toBe("invalid_scope");
+          expect(body.error_description).toContain("typo");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("vault:work:admin for a KNOWN vault → 200", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "vault:work:admin" }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER, knownVaultNames: new Set(["work", "default"]) },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { scope: string };
+          expect(body.scope).toBe("vault:work:admin");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("read/write for an unknown vault are NOT existence-checked (admin-only gate)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "vault:typo:read" }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER, knownVaultNames: new Set(["work"]) },
+          );
+          expect(resp.status).toBe(200);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("knownVaultNames omitted → existence check skipped (back-compat)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "vault:typo:admin" }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER },
+          );
+          // No knownVaultNames → the documented "caller responsible" fallback.
+          expect(resp.status).toBe(200);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+  });
+
   test("405 on non-POST", async () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/api-mint-token.test.ts
+++ b/src/__tests__/api-mint-token.test.ts
@@ -745,6 +745,122 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
         h.cleanup();
       }
     });
+
+    // Item A (subject-pin) — audit-attribution forgery. A non-operator
+    // (vault-admin-only) bearer may NOT override the minted token's `sub`:
+    // forging a foreign subject would mis-attribute the registry + revocation
+    // rows. It may still mint under its OWN sub (subject omitted / equal).
+    test("subject override by non-operator bearer → 403 (forgery blocked)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const bearer = await mintVaultAdminBearer(db, userId, "work");
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:read", subject: "someone-else" },
+              { authorization: `Bearer ${bearer}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(403);
+          const body = (await resp.json()) as { error: string; error_description: string };
+          expect(body.error).toBe("insufficient_scope");
+          expect(body.error_description).toContain("non-operator");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("subject equal to own sub by non-operator bearer → 200 (no forgery)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const bearer = await mintVaultAdminBearer(db, userId, "work");
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:read", subject: userId },
+              { authorization: `Bearer ${bearer}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { jti: string };
+          const row = db
+            .query<{ subject: string }, [string]>("SELECT subject FROM tokens WHERE jti = ?")
+            .get(body.jti);
+          expect(row?.subject).toBe(userId);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+  });
+
+  // Item A (subject-pin) — the operator carve-out: a host operator
+  // (parachute:host:auth / parachute:host:admin) MAY override `sub` to stamp a
+  // service-account subject. This is the documented service-account override
+  // that the non-operator pin above must NOT break.
+  describe("subject override — operator carve-out (item A)", () => {
+    test("host:auth operator overrides subject → 200, registry row carries override", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER, scopeSet: "auth" });
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:read", subject: "svc-account" },
+              { authorization: `Bearer ${op.token}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { jti: string; token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.sub).toBe("svc-account");
+          const row = db
+            .query<{ subject: string }, [string]>("SELECT subject FROM tokens WHERE jti = ?")
+            .get(body.jti);
+          expect(row?.subject).toBe("svc-account");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("host:admin operator overrides subject → 200", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:admin", subject: "svc-account" },
+              { authorization: `Bearer ${op.token}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.sub).toBe("svc-account");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
   });
 
   describe("capability attenuation — entry gate + regression", () => {

--- a/src/__tests__/api-mint-token.test.ts
+++ b/src/__tests__/api-mint-token.test.ts
@@ -416,13 +416,13 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
     }
   });
 
-  // A bare `vault:admin` (no vault name) is NOT a per-vault admin scope —
-  // the de-escalation exception only covers `vault:<name>:admin`. It isn't
-  // in the non-requestable set either, so it's treated as an ordinary
-  // (unnamed) scope and mints — but with the `vault` fallback audience, not
-  // a per-vault one. Pinned so a future regex loosening can't silently let
-  // an unnamed admin through the named-vault exemption.
-  test("bare vault:admin (no name) is not caught by the de-escalation exemption", async () => {
+  // Item B / hub#451 — bare `vault:admin` (no vault name) is NOT mintable on
+  // the headless path. The unnamed broad-admin form has no resource pin; the
+  // mint endpoint refuses it with 400 `invalid_scope` (even for a full host:admin
+  // operator). The legitimate path for a vault admin token is a resource-narrowed
+  // `vault:<name>:admin`. The OAuth flow still accepts bare `vault:admin` and
+  // narrows it via the picker — that path is unaffected (see oauth-handlers).
+  test("bare vault:admin (no name) → 400 (non-requestable headlessly, item B / #451)", async () => {
     const h = makeHarness();
     try {
       const { db, userId } = await bootstrap(h.dir);
@@ -432,9 +432,31 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
           jsonRequest({ scope: "vault:admin" }, { authorization: `Bearer ${op.token}` }),
           { db, issuer: ISSUER },
         );
-        // `vault:admin` isn't a per-vault admin scope and isn't in the
-        // non-requestable set, so it mints as an ordinary scope. The point
-        // of this test is that it does NOT get a per-vault audience/pin.
+        expect(resp.status).toBe(400);
+        const body = (await resp.json()) as { error: string; error_description: string };
+        expect(body.error).toBe("invalid_scope");
+        expect(body.error_description).toContain("vault:admin");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // Item B does NOT touch unnamed vault:read / vault:write — those carry no
+  // admin authority and remain mintable (regression guard for the narrow scope
+  // of the bare-admin block).
+  test("bare vault:read still mints headlessly (item B is admin-only)", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiMintToken(
+          jsonRequest({ scope: "vault:read" }, { authorization: `Bearer ${op.token}` }),
+          { db, issuer: ISSUER },
+        );
         expect(resp.status).toBe(200);
         const body = (await resp.json()) as { token: string };
         const validated = await validateAccessToken(db, body.token, ISSUER);

--- a/src/__tests__/api-mint-token.test.ts
+++ b/src/__tests__/api-mint-token.test.ts
@@ -317,6 +317,32 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
     }
   });
 
+  // Item C — case-insensitive non-requestable guard. An uppercase casing of a
+  // host-level scope must NOT bypass the non-requestable membership check (which
+  // was exact-string before). `PARACHUTE:HOST:AUTH` is now correctly rejected.
+  test("400 invalid_scope when minting an uppercase host scope (item C)", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        for (const variant of ["PARACHUTE:HOST:AUTH", "Parachute:Host:Admin"]) {
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: variant }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(400);
+          const body = (await resp.json()) as { error: string };
+          expect(body.error).toBe("invalid_scope");
+        }
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("400 invalid_scope when multi-scope includes a non-requestable", async () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/auto-wire.test.ts
+++ b/src/__tests__/auto-wire.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { SCRIBE_AUTH_ENV_KEY, SCRIBE_URL_ENV_KEY, autoWireScribeAuth } from "../auto-wire.ts";
+import {
+  SCRIBE_AUTH_ENV_KEY,
+  SCRIBE_URL_ENV_KEY,
+  autoWireScribeAuth,
+  selfHealScribeAuth,
+} from "../auto-wire.ts";
 import { writePid } from "../process-state.ts";
 
 function makeHarness(): { dir: string; cleanup: () => void } {
@@ -276,6 +281,101 @@ describe("autoWireScribeAuth", () => {
       });
       expect(result.restartedVault).toBe(false);
       expect(logs.join("\n")).toMatch(/vault restart failed.*parachute restart vault/);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// Item H — serve-boot self-heal of scribe's auth token from vault's .env.
+describe("selfHealScribeAuth", () => {
+  function seedVaultToken(dir: string, token: string): void {
+    mkdirSync(join(dir, "vault"), { recursive: true });
+    writeFileSync(join(dir, "vault", ".env"), `${SCRIBE_AUTH_ENV_KEY}=${token}\n`);
+  }
+  function seedScribeConfig(dir: string, config: Record<string, unknown>): void {
+    mkdirSync(join(dir, "scribe"), { recursive: true });
+    writeFileSync(join(dir, "scribe", "config.json"), `${JSON.stringify(config, null, 2)}\n`);
+  }
+  function readScribeConfig(dir: string): Record<string, unknown> {
+    return JSON.parse(readFileSync(join(dir, "scribe", "config.json"), "utf8"));
+  }
+
+  test("vault .env has token + scribe config missing auth → self-heal writes it", () => {
+    const h = makeHarness();
+    try {
+      seedVaultToken(h.dir, "shared-secret-xyz");
+      seedScribeConfig(h.dir, { provider: "openai", model: "whisper-1" });
+      const logs: string[] = [];
+      const result = selfHealScribeAuth({ configDir: h.dir, log: (l) => logs.push(l) });
+      expect(result.healed).toBe(true);
+      const cfg = readScribeConfig(h.dir);
+      expect((cfg.auth as Record<string, unknown>).required_token).toBe("shared-secret-xyz");
+      // Other config keys preserved (merge-don't-clobber).
+      expect(cfg.provider).toBe("openai");
+      expect(cfg.model).toBe("whisper-1");
+      expect(logs.join("\n")).toMatch(/Self-healed scribe auth/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("scribe config wholly absent → self-heal creates it with the token", () => {
+    const h = makeHarness();
+    try {
+      seedVaultToken(h.dir, "shared-secret-xyz");
+      // No scribe/config.json at all.
+      const result = selfHealScribeAuth({ configDir: h.dir });
+      expect(result.healed).toBe(true);
+      expect((readScribeConfig(h.dir).auth as Record<string, unknown>).required_token).toBe(
+        "shared-secret-xyz",
+      );
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("scribe token mismatches vault → re-synced to vault's value", () => {
+    const h = makeHarness();
+    try {
+      seedVaultToken(h.dir, "vault-token-NEW");
+      seedScribeConfig(h.dir, { auth: { required_token: "stale-token-OLD" }, model: "x" });
+      const result = selfHealScribeAuth({ configDir: h.dir });
+      expect(result.healed).toBe(true);
+      const cfg = readScribeConfig(h.dir);
+      expect((cfg.auth as Record<string, unknown>).required_token).toBe("vault-token-NEW");
+      expect(cfg.model).toBe("x");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("already in sync → no-op (idempotent), config untouched", () => {
+    const h = makeHarness();
+    try {
+      seedVaultToken(h.dir, "same-token");
+      seedScribeConfig(h.dir, { auth: { required_token: "same-token" }, extra: "keep" });
+      const before = readFileSync(join(h.dir, "scribe", "config.json"), "utf8");
+      const result = selfHealScribeAuth({ configDir: h.dir });
+      expect(result.healed).toBe(false);
+      expect(result.reason).toBe("already-synced");
+      // Byte-identical — no rewrite.
+      expect(readFileSync(join(h.dir, "scribe", "config.json"), "utf8")).toBe(before);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("vault has no SCRIBE_AUTH_TOKEN → no-op (nothing to sync)", () => {
+    const h = makeHarness();
+    try {
+      mkdirSync(join(h.dir, "vault"), { recursive: true });
+      writeFileSync(join(h.dir, "vault", ".env"), "FOO=bar\n");
+      const result = selfHealScribeAuth({ configDir: h.dir });
+      expect(result.healed).toBe(false);
+      expect(result.reason).toBe("no-token");
+      // Scribe config not created.
+      expect(existsSync(join(h.dir, "scribe", "config.json"))).toBe(false);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -4293,6 +4293,9 @@ describe("POST /account/vault-token/<name> — friend scoped mint (routed end-to
     const friend = await createUser(db, "friend", "friend-password-123", {
       assignedVaults,
       allowMulti: true,
+      // Item F (#469): the friend mints a token only after rotating the temp
+      // password; an unrotated friend is force-redirected before any mint.
+      passwordChanged: true,
     });
     const session = createSession(db, { userId: friend.id });
     const csrf = generateCsrfToken();
@@ -4329,6 +4332,45 @@ describe("POST /account/vault-token/<name> — friend scoped mint (routed end-to
       const html = await res.text();
       expect(html).toContain('data-testid="minted-token-banner"');
       expect(html).toContain("vault:work:read");
+    } finally {
+      db.close();
+      h.cleanup();
+    }
+  });
+
+  // Item F (#469) routed e2e — an assigned but unrotated friend is force-
+  // redirected to the change-password rail before any mint, through the real
+  // dispatch.
+  test("unrotated friend → 303 to change-password, routed through hubFetch (item F)", async () => {
+    const h = makeHarness();
+    writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
+    const db = openHubDb(hubDbPath(h.dir));
+    rotateSigningKey(db);
+    await createUser(db, "operator", "operator-password-123");
+    const friend = await createUser(db, "friend", "friend-password-123", {
+      assignedVaults: ["work"],
+      allowMulti: true,
+      passwordChanged: false, // not yet rotated
+    });
+    const session = createSession(db, { userId: friend.id });
+    const csrf = generateCsrfToken();
+    const cookie = `${buildSessionCookie(session.id, 3600, { secure: false })}; ${
+      buildCsrfCookie(csrf, { secure: false }).split(";")[0]
+    }`;
+    try {
+      const res = await hubFetch(h.dir, {
+        getDb: () => db,
+        manifestPath: h.manifestPath,
+        issuer: "https://hub.test",
+      })(
+        req("/account/vault-token/work", {
+          method: "POST",
+          headers: { cookie, "content-type": "application/x-www-form-urlencoded" },
+          body: postBody(csrf, "read"),
+        }),
+      );
+      expect(res.status).toBe(303);
+      expect(res.headers.get("location")).toBe("/account/change-password");
     } finally {
       db.close();
       h.cleanup();

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -3199,13 +3199,46 @@ describe("hubFetch /<svc>/* generic proxy dispatch (#182)", () => {
   });
 });
 
-describe("layerOf — classify trust layer from proxy headers", () => {
-  // Hub binds 127.0.0.1:1939; only trusted forwarders (cloudflared,
-  // tailscaled-serve, tailscaled-funnel) reach the listener. Spoofing isn't
-  // a concern. layerOf inspects the headers each forwarder injects.
+describe("layerOf — classify trust layer from proxy headers + peer (item E / #526)", () => {
+  // Proxy headers (cloudflared, tailscale serve/funnel) take precedence. When
+  // absent, the PEER ADDRESS is the loopback discriminator — header-absence is
+  // no longer a loopback signal (#526). The peer-address is the 2nd arg.
 
-  test("no proxy headers → loopback (direct localhost call)", () => {
-    expect(layerOf(req("/"))).toBe("loopback");
+  test("no proxy headers + loopback peer (127.0.0.1) → loopback (on-box CLI)", () => {
+    expect(layerOf(req("/"), "127.0.0.1")).toBe("loopback");
+  });
+
+  test("no proxy headers + IPv6 loopback peer (::1) → loopback", () => {
+    expect(layerOf(req("/"), "::1")).toBe("loopback");
+  });
+
+  test("no proxy headers + IPv4-mapped IPv6 loopback (::ffff:127.0.0.1) → loopback", () => {
+    expect(layerOf(req("/"), "::ffff:127.0.0.1")).toBe("loopback");
+  });
+
+  // THE FIX: a header-absent NON-loopback peer (the 0.0.0.0-bind direct-network
+  // case) must NOT be classified loopback — it would bypass the
+  // publicExposure:loopback 404-cloak. Fail to public (least-trusted).
+  test("no proxy headers + non-loopback peer → public (NOT loopback) [#526]", () => {
+    expect(layerOf(req("/"), "203.0.113.7")).toBe("public");
+    expect(layerOf(req("/"), "10.0.0.5")).toBe("public");
+    expect(layerOf(req("/"), "fd00::1234")).toBe("public");
+  });
+
+  // Fail-closed: an unknown peer (no Server threaded — null/undefined) is NOT
+  // loopback. A direct unit call to the fetch fn with no server lands here.
+  test("no proxy headers + unknown peer (null/undefined) → public (fail closed)", () => {
+    expect(layerOf(req("/"), null)).toBe("public");
+    expect(layerOf(req("/"), undefined)).toBe("public");
+    expect(layerOf(req("/"))).toBe("public");
+  });
+
+  // Headers still win over peer address — a tailnet/public forwarder sets the
+  // header and the peer (the local tailscaled/cloudflared) is loopback, but the
+  // header is authoritative.
+  test("Tailscale-User-Login → tailnet even from a loopback peer", () => {
+    const r = req("/", { headers: { "Tailscale-User-Login": "alice@example.com" } });
+    expect(layerOf(r, "127.0.0.1")).toBe("tailnet");
   });
 
   test("Tailscale-User-Login → tailnet (authed via tailscale serve)", () => {
@@ -3270,6 +3303,11 @@ describe("hubFetch publicExposure layer-gate (proxyToService)", () => {
     return { port: server.port as number, stop: () => server.stop(true) };
   }
 
+  // Fake Bun Server handle exposing only `requestIP` (item E / #526) so the
+  // fetch fn can resolve the peer address. The on-box CLI caller connects from
+  // 127.0.0.1; a network peer on a 0.0.0.0 bind connects from its real IP.
+  const fakeServer = (address: string) => ({ requestIP: () => ({ address }) });
+
   test("publicExposure: loopback + tailnet header → 404 (gate hides the route)", async () => {
     const h = makeHarness();
     const upstream = startUpstream("loopback-only");
@@ -3330,7 +3368,7 @@ describe("hubFetch publicExposure layer-gate (proxyToService)", () => {
     }
   });
 
-  test("publicExposure: loopback + no headers → reaches upstream (loopback layer)", async () => {
+  test("publicExposure: loopback + no headers + loopback peer → reaches upstream (loopback layer)", async () => {
     const h = makeHarness();
     const upstream = startUpstream("loopback-only");
     try {
@@ -3350,10 +3388,42 @@ describe("hubFetch publicExposure layer-gate (proxyToService)", () => {
         h.manifestPath,
       );
       const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
-      const res = await fetcher(req("/loopback-only/health"));
+      // On-box CLI caller: 127.0.0.1 peer, no proxy headers → loopback layer.
+      const res = await fetcher(req("/loopback-only/health"), fakeServer("127.0.0.1"));
       expect(res.status).toBe(200);
       const body = (await res.json()) as { tag: string };
       expect(body.tag).toBe("loopback-only");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  // Item E / #526 — the core fix. On a 0.0.0.0 bind a network peer reaches the
+  // listener with NO proxy headers; it must NOT be treated as loopback, so the
+  // loopback-exposure cloak still fires (404) rather than leaking the route.
+  test("publicExposure: loopback + no headers + NON-loopback peer → 404 (cloak fires) [#526]", async () => {
+    const h = makeHarness();
+    const upstream = startUpstream("loopback-only");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "loopback-only",
+              port: upstream.port,
+              paths: ["/loopback-only"],
+              health: "/loopback-only/health",
+              version: "0.1.0",
+              publicExposure: "loopback",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(req("/loopback-only/health"), fakeServer("203.0.113.9"));
+      expect(res.status).toBe(404);
     } finally {
       upstream.stop();
       h.cleanup();
@@ -3518,6 +3588,10 @@ describe("hubFetch publicExposure layer-gate (proxyToVault)", () => {
     return { port: server.port as number, stop: () => server.stop(true) };
   }
 
+  // Item E / #526 — fake Bun Server handle exposing `requestIP` for the peer-
+  // address discriminator (see the proxyToService block for the rationale).
+  const fakeServer = (address: string) => ({ requestIP: () => ({ address }) });
+
   test("vault publicExposure: loopback + tailnet header → 404", async () => {
     const h = makeHarness();
     const upstream = startVaultUpstream("vault-private");
@@ -3549,7 +3623,7 @@ describe("hubFetch publicExposure layer-gate (proxyToVault)", () => {
     }
   });
 
-  test("vault publicExposure: loopback + no headers → reaches vault backend", async () => {
+  test("vault publicExposure: loopback + no headers + loopback peer → reaches vault backend", async () => {
     const h = makeHarness();
     const upstream = startVaultUpstream("vault-private");
     try {
@@ -3569,10 +3643,40 @@ describe("hubFetch publicExposure layer-gate (proxyToVault)", () => {
         h.manifestPath,
       );
       const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
-      const res = await fetcher(req("/vault/private/health"));
+      const res = await fetcher(req("/vault/private/health"), fakeServer("127.0.0.1"));
       expect(res.status).toBe(200);
       const body = (await res.json()) as { tag: string };
       expect(body.tag).toBe("vault-private");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  // Item E / #526 — vault-path symmetry: a header-absent NON-loopback peer on a
+  // 0.0.0.0 bind must NOT reach a loopback-exposed vault (cloak fires).
+  test("vault publicExposure: loopback + no headers + NON-loopback peer → 404 [#526]", async () => {
+    const h = makeHarness();
+    const upstream = startVaultUpstream("vault-private");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault-private",
+              port: upstream.port,
+              paths: ["/vault/private"],
+              health: "/vault/private/health",
+              version: "0.4.0",
+              publicExposure: "loopback",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(req("/vault/private/health"), fakeServer("198.51.100.4"));
+      expect(res.status).toBe(404);
     } finally {
       upstream.stop();
       h.cleanup();

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../hub-server.ts";
 import { setNotesRedirectDisabled } from "../hub-settings.ts";
 import { clearNotesRedirectLogState } from "../notes-redirect.ts";
+import { mintOperatorToken } from "../operator-token.ts";
 import { pidPath } from "../process-state.ts";
 import { type ServiceEntry, writeManifest } from "../services-manifest.ts";
 import { buildSessionCookie, createSession } from "../sessions.ts";
@@ -4412,6 +4413,73 @@ describe("POST /account/vault-token/<name> — friend scoped mint (routed end-to
         manifestPath: h.manifestPath,
       })(req("/account/vault-token/work"));
       expect(res.status).toBe(405);
+    } finally {
+      db.close();
+      h.cleanup();
+    }
+  });
+});
+
+// Item D (#450) routed e2e — exercise the knownVaultNames threading from
+// services.json → hubFetch → handleApiMintToken (hub-server.ts dispatch),
+// which the unit-level handler tests can't cover. A `vault:<typo>:admin` mint
+// for an unregistered vault → 400 through the full stack; a known vault → 200.
+describe("POST /api/auth/mint-token — vault-existence threading (routed end-to-end, item D)", () => {
+  const ISSUER = "https://hub.test";
+
+  async function seedMint(
+    h: Harness,
+    vaultNames: string[],
+  ): Promise<{ db: ReturnType<typeof openHubDb>; bearer: string }> {
+    const db = openHubDb(hubDbPath(h.dir));
+    rotateSigningKey(db); // mint needs an active signing key
+    const owner = await createUser(db, "owner", "owner-password-123");
+    // The default operator scope-set carries parachute:host:admin, which mints
+    // vault:<name>:admin (canGrant rule 2).
+    const op = await mintOperatorToken(db, owner.id, { issuer: ISSUER });
+    writeManifest({ services: vaultNames.map((n) => vaultEntry(n)) }, h.manifestPath);
+    return { db, bearer: op.token };
+  }
+
+  function mintReq(scope: string, bearer: string): Request {
+    return req("/api/auth/mint-token", {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearer}`, "content-type": "application/json" },
+      body: JSON.stringify({ scope }),
+    });
+  }
+
+  test("vault:<typo>:admin for an unregistered vault → 400 (knownVaultNames from services.json)", async () => {
+    const h = makeHarness();
+    const { db, bearer } = await seedMint(h, ["work", "default"]);
+    try {
+      const res = await hubFetch(h.dir, {
+        getDb: () => db,
+        manifestPath: h.manifestPath,
+        issuer: ISSUER,
+      })(mintReq("vault:typo:admin", bearer));
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string; error_description: string };
+      expect(body.error).toBe("invalid_scope");
+      expect(body.error_description).toContain("typo");
+    } finally {
+      db.close();
+      h.cleanup();
+    }
+  });
+
+  test("vault:<name>:admin for a REGISTERED vault → 200 (proves the gate isn't over-blocking)", async () => {
+    const h = makeHarness();
+    const { db, bearer } = await seedMint(h, ["work", "default"]);
+    try {
+      const res = await hubFetch(h.dir, {
+        getDb: () => db,
+        manifestPath: h.manifestPath,
+        issuer: ISSUER,
+      })(mintReq("vault:work:admin", bearer));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { scope: string };
+      expect(body.scope).toBe("vault:work:admin");
     } finally {
       db.close();
       h.cleanup();

--- a/src/__tests__/scope-explanations.test.ts
+++ b/src/__tests__/scope-explanations.test.ts
@@ -4,6 +4,7 @@ import {
   NON_REQUESTABLE_SCOPES,
   SCOPE_EXPLANATIONS,
   explainScope,
+  isNonRequestableScope,
   isRequestableScope,
   isWellFormedOrNonVaultScope,
   scopeIsAdmin,
@@ -161,6 +162,21 @@ describe("isRequestableScope", () => {
   test("vault:<name>:read|write stays requestable", () => {
     expect(isRequestableScope("vault:default:read")).toBe(true);
     expect(isRequestableScope("vault:work:write")).toBe(true);
+  });
+
+  // Item C — case-insensitive guard. A casing variant of a host-level scope
+  // must NOT slip past the exact-string membership check as "requestable."
+  test("uppercase / mixed-case host scopes are non-requestable (item C)", () => {
+    expect(isRequestableScope("PARACHUTE:HOST:AUTH")).toBe(false);
+    expect(isRequestableScope("Parachute:Host:Admin")).toBe(false);
+    expect(isRequestableScope("parachute:HOST:vault")).toBe(false);
+    // And the direct predicate agrees.
+    expect(isNonRequestableScope("PARACHUTE:HOST:AUTH")).toBe(true);
+    expect(isNonRequestableScope("parachute:Host:Install")).toBe(true);
+    // Canonical lowercase still works unchanged.
+    expect(isNonRequestableScope("parachute:host:auth")).toBe(true);
+    // A non-host scope (even uppercased) stays requestable.
+    expect(isNonRequestableScope("HUB:ADMIN")).toBe(false);
   });
 });
 

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { recordTokenMint, signAccessToken } from "../jwt-sign.ts";
+import { createSession, findSession } from "../sessions.ts";
 import {
   PASSWORD_MIN_LEN,
   SingleUserModeError,
@@ -494,6 +495,32 @@ describe("resetUserPassword", () => {
         .get(minted.jti);
       expect(after?.revoked_at).not.toBeNull();
       expect(after?.user_id).toBe(user.id);
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Item G — a reset also kills active sessions (not just tokens), so the
+  // attacker/holder of a live session cookie must re-authenticate.
+  test("deletes the user's active sessions (item G)", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const alice = await createUser(db, "alice", "alice-strong-passphrase", {
+        passwordChanged: true,
+      });
+      const bob = await createUser(db, "bob", "bob-strong-passphrase", {
+        passwordChanged: true,
+        allowMulti: true,
+      });
+      const aliceSession = createSession(db, { userId: alice.id });
+      const bobSession = createSession(db, { userId: bob.id });
+      expect(findSession(db, aliceSession.id)).not.toBeNull();
+
+      expect(await resetUserPassword(db, alice.id, "new-temp-passphrase")).toBe(true);
+
+      // Alice's session is gone; Bob's (a different user) is untouched.
+      expect(findSession(db, aliceSession.id)).toBeNull();
+      expect(findSession(db, bobSession.id)).not.toBeNull();
     } finally {
       cleanup();
     }

--- a/src/account-vault-token.ts
+++ b/src/account-vault-token.ts
@@ -233,6 +233,25 @@ export async function handleAccountVaultTokenPost(
     });
   }
 
+  // Force-change-password gate (item F / hub#469, NARROW). A user the admin
+  // created/reset lands with `password_changed: false` and an admin-known temp
+  // password. Without this gate an authorized friend could mint a LONG-LIVED
+  // vault token here and then keep using (or never rotate) the temp password —
+  // the token outlives any later rotation, defeating the "temp password is a
+  // one-time handoff" model. So an authorized-but-unrotated friend is sent to
+  // the change-password rail BEFORE minting anything. Placed AFTER the
+  // authority gates (so an unassigned/garbage request still gets its 403/400,
+  // preserving those semantics) and BEFORE the rate-limit + mint. 303 (See
+  // Other) so the browser re-issues as GET. Narrow #469 fix — gates
+  // token-minting specifically; the broad per-request /account/* wall is
+  // deferred to Aaron's design call.
+  if (!user.passwordChanged) {
+    return new Response(null, {
+      status: 303,
+      headers: { location: "/account/change-password", "cache-control": "no-store" },
+    });
+  }
+
   // Rate limit — after CSRF + authority shape, before the mint. Per-user.
   const rlNow = (deps.now ?? (() => new Date()))();
   const gate = vaultTokenMintRateLimiter.checkAndRecord(user.id, rlNow);

--- a/src/account-vault-token.ts
+++ b/src/account-vault-token.ts
@@ -75,9 +75,15 @@ import { vaultTokenMintRateLimiter } from "./rate-limit.ts";
 import { findActiveSession } from "./sessions.ts";
 import { isTotpEnrolled } from "./two-factor-store.ts";
 import { type VaultVerb, getUserById, isFirstAdmin, vaultVerbsForUserVault } from "./users.ts";
+import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
 
-/** Matches the manifest vault-name validator + `/admin/vault-admin-token`. */
-const VAULT_NAME_RE = /^[a-zA-Z0-9_-]+$/;
+/**
+ * Lowercase-only vault-name charset (item I) — single source of truth in
+ * vault-name.ts, matching what vault's init enforces. Was `[a-zA-Z0-9_-]`; the
+ * uppercase superset let a mint name drift from vault's lowercase URL-derived
+ * name, so the minted token's `vault.<Name>` audience wouldn't validate.
+ */
+const VAULT_NAME_RE = VAULT_NAME_CHARSET_RE;
 /** Verbs this surface will ever mint. `admin` is deliberately absent. */
 const ALLOWED_VERBS: readonly VaultVerb[] = ["read", "write", "admin"];
 /** client_id stamped on the minted JWT + registry row. */

--- a/src/admin-vault-admin-token.ts
+++ b/src/admin-vault-admin-token.ts
@@ -28,13 +28,19 @@ import type { Database } from "bun:sqlite";
 import { signAccessToken } from "./jwt-sign.ts";
 import { findSession, parseSessionCookie } from "./sessions.ts";
 import { isFirstAdmin } from "./users.ts";
+import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
 
 /** Short TTL — matches host-admin-token. SPA re-fetches on near-expiry. */
 export const VAULT_ADMIN_TOKEN_TTL_SECONDS = 10 * 60;
 const VAULT_ADMIN_CLIENT_ID = "parachute-hub-spa";
 
-/** Same shape as the manifest name validator — keeps URL-injection out. */
-const VAULT_NAME_RE = /^[a-zA-Z0-9_-]+$/;
+/**
+ * Lowercase-only vault-name charset (item I) — single source of truth in
+ * vault-name.ts, matching vault's init. Keeps URL-injection out AND closes the
+ * case-drift class (an uppercased name minting `vault.<Name>` audience that
+ * vault's lowercase URL-derived name would never validate).
+ */
+const VAULT_NAME_RE = VAULT_NAME_CHARSET_RE;
 
 export interface MintVaultAdminTokenDeps {
   db: Database;

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -171,8 +171,7 @@ async function parseBody(req: Request): Promise<ParseResult | ParseError> {
     return {
       ok: false,
       status: 400,
-      message:
-        "vault name must contain only lowercase letters, numbers, hyphens, and underscores",
+      message: "vault name must contain only lowercase letters, numbers, hyphens, and underscores",
     };
   }
   if (RESERVED_VAULT_NAMES.has(name)) {

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -60,6 +60,7 @@ import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./adm
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import { findService, type readManifest, readManifestLenient } from "./services-manifest.ts";
 import { enrichedPath } from "./spawn-path.ts";
+import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
 import { type WellKnownVaultEntry, isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
 
 /** Scope required to call POST /vaults. */
@@ -73,7 +74,12 @@ export const HOST_ADMIN_SCOPE = "parachute:host:admin";
  * the hub rejects them at the API edge before a vault under those names
  * can register and capture the proxy path.
  */
-const VAULT_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+// Lowercase-only (item I) — single source of truth in vault-name.ts. Vault's
+// init enforces `[a-z0-9_-]`; a hub-side `[a-zA-Z0-9_-]` superset let an
+// uppercased name through that vault would then lowercase or reject, drifting
+// the hub's idea of the vault from vault's. The hub-only reservations (`new`,
+// `assets`) shadow SPA routes and stay on top of vault's `list`.
+const VAULT_NAME_PATTERN = VAULT_NAME_CHARSET_RE;
 const RESERVED_VAULT_NAMES = new Set(["list", "new", "assets"]);
 
 export interface CreateVaultRequest {
@@ -165,7 +171,8 @@ async function parseBody(req: Request): Promise<ParseResult | ParseError> {
     return {
       ok: false,
       status: 400,
-      message: "vault name must contain only letters, numbers, hyphens, and underscores",
+      message:
+        "vault name must contain only lowercase letters, numbers, hyphens, and underscores",
     };
   }
   if (RESERVED_VAULT_NAMES.has(name)) {

--- a/src/api-account.ts
+++ b/src/api-account.ts
@@ -419,6 +419,16 @@ export async function handleAccountChangePasswordPost(
         )
         .run(passwordHash, stamp, user.id);
       if (result.changes === 0) throw new UserNotFoundError(user.id);
+      // Revoke the user's still-active tokens on a self-service password change
+      // (item F / hub#469). The admin-reset path already revokes
+      // (`resetUserPassword`, users.ts); applying the same on self-change closes
+      // the "mint a token under the admin's temp password, then rotate but keep
+      // the token" gap — any token minted before the rotation dies with it. The
+      // user re-mints under their own (now-rotated) password if they need one.
+      // Same transaction as the hash write so the two are atomic.
+      deps.db
+        .prepare("UPDATE tokens SET revoked_at = ? WHERE user_id = ? AND revoked_at IS NULL")
+        .run(stamp, user.id);
     })();
   } catch (err) {
     // The user row vanished between the session-resolve check above and

--- a/src/api-mint-token.ts
+++ b/src/api-mint-token.ts
@@ -87,6 +87,21 @@ export interface ApiMintTokenDeps {
   db: Database;
   /** Hub origin — written into the JWT `iss` of minted tokens AND used to validate the bearer. */
   issuer: string;
+  /**
+   * Names of vault instances currently registered in services.json (item D /
+   * hub#450). When provided, a `vault:<name>:admin` mint whose `<name>` is not
+   * in this set is rejected with 400 — a typo'd name can no longer mint
+   * `vault:typo:admin` (an unusable token that authenticates against no real
+   * vault, only confusing automation that's debugging a typo). Mirrors the
+   * session-cookie path (`/admin/vault-admin-token/<name>`), which already
+   * 404s unknown vault names via `knownVaultNames.has`.
+   *
+   * Optional: when undefined the existence check is skipped (the documented
+   * "caller is responsible for a real vault name" fallback, and the shape used
+   * by unit tests that don't wire a manifest). Production wires it from
+   * services.json in hub-server.ts.
+   */
+  knownVaultNames?: ReadonlySet<string>;
   /** Test seam for time. */
   now?: () => Date;
 }
@@ -212,6 +227,31 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
       "invalid_scope",
       "bare vault:admin is not mintable headlessly; request a resource-narrowed vault:<name>:admin instead",
     );
+  }
+
+  // Item D / hub#450 — vault-existence check for `vault:<name>:admin` mints.
+  // The session-cookie path (`/admin/vault-admin-token/<name>`) already 404s an
+  // unknown vault name; this mirrors it for the bearer path so a typo can't mint
+  // `vault:typo:admin` — an unusable token (it authenticates against no real
+  // vault) that only confuses automation debugging a typo. Gated on `<name>:admin`
+  // (the one form #450 calls out); read/write are left alone (even more harmless,
+  // and the broad-requestable path). Skipped entirely when `knownVaultNames` is
+  // absent (the documented "caller responsible" fallback + unit-test shape).
+  if (deps.knownVaultNames !== undefined) {
+    const unknownAdminVaults = scopes.filter((s) => {
+      if (!isVaultAdminScope(s)) return false;
+      const name = vaultScopeName(s);
+      return name !== null && !deps.knownVaultNames!.has(name);
+    });
+    if (unknownAdminVaults.length > 0) {
+      return jsonError(
+        400,
+        "invalid_scope",
+        `no vault named ${unknownAdminVaults
+          .map((s) => `"${vaultScopeName(s)}"`)
+          .join(", ")} in this hub; create the vault before minting an admin token for it`,
+      );
+    }
   }
 
   // Capability-attenuation guard: every requested scope must be a subset of

--- a/src/api-mint-token.ts
+++ b/src/api-mint-token.ts
@@ -189,6 +189,31 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
     );
   }
 
+  // Item B / hub#451 — bare (unnamed) `vault:admin` is non-requestable on the
+  // HEADLESS mint path. The unnamed `vault:admin` form is a broad full-vault
+  // admin grant with no resource pin (`aud=vault`, `vault_scope=[]`); minting
+  // it via a host:auth bearer here would issue a surprising un-narrowed admin
+  // credential. Vault rejects broad `vault:admin` on hub-JWTs anyway (it forces
+  // resource-narrowing — `parachute-vault/src/auth.ts:428`), so the practical
+  // blast radius is low, but a headless caller should never be handed it.
+  //
+  // This is mint-side, NOT in the OAuth-shared `NON_REQUESTABLE_SCOPES`, on
+  // purpose: the public `/oauth/authorize` flow legitimately accepts an unnamed
+  // `vault:admin` and NARROWS it to `vault:<picked>:admin` via the vault picker
+  // (oauth-handlers.ts `narrowVaultScopes`) before any token is minted. Adding
+  // it to `NON_REQUESTABLE_SCOPES` would reject that narrowing flow (the
+  // requestability gate fires on the raw, pre-narrow scopes). Named
+  // `vault:<name>:admin` — the post-narrow form — stays mintable. `vault:read`
+  // / `vault:write` unnamed are unaffected (they carry no admin authority).
+  const bareVaultAdmin = scopes.filter((s) => s === "vault:admin");
+  if (bareVaultAdmin.length > 0) {
+    return jsonError(
+      400,
+      "invalid_scope",
+      "bare vault:admin is not mintable headlessly; request a resource-narrowed vault:<name>:admin instead",
+    );
+  }
+
   // Capability-attenuation guard: every requested scope must be a subset of
   // the bearer's own authority under `canGrant` (rules in the file docstring).
   // A `parachute:host:auth` bearer mints any requestable scope; a

--- a/src/api-mint-token.ts
+++ b/src/api-mint-token.ts
@@ -52,6 +52,7 @@ import {
   MINT_HOST_AUTH_SCOPE,
   canGrant,
   hasMintingAuthority,
+  isOperatorBearer,
 } from "./scope-attenuation.ts";
 import {
   isVaultAdminScope,
@@ -235,6 +236,21 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
   if (body.subject === undefined) {
     subject = bearerSub;
   } else if (typeof body.subject === "string" && body.subject.length > 0) {
+    // Subject override is an OPERATOR-only capability (audit-attribution
+    // forgery otherwise). A host operator (`parachute:host:auth` /
+    // `parachute:host:admin`) may stamp a service-account `sub` other than its
+    // own — the documented service-account override. A merely vault-scoped
+    // bearer (`vault:<N>:admin` only, no host authority) has no business
+    // forging the minted token's subject: it would let a vault admin mint a
+    // token the registry + revocation list attribute to a foreign subject. So
+    // a non-operator bearer may only mint tokens carrying its OWN `sub`.
+    if (!isOperatorBearer(bearerScopes) && body.subject !== bearerSub) {
+      return jsonError(
+        403,
+        "insufficient_scope",
+        "non-operator bearers may not override subject; omit `subject` to mint under your own identity",
+      );
+    }
     subject = body.subject;
   } else {
     return jsonError(400, "invalid_request", "subject must be a non-empty string when present");

--- a/src/auto-wire.ts
+++ b/src/auto-wire.ts
@@ -100,6 +100,26 @@ function writeScribeConfig(path: string, token: string): void {
 }
 
 /**
+ * Read scribe's current `auth.required_token` from `config.json`, or undefined
+ * when the file is absent / malformed / has no auth token. Used by the
+ * serve-boot self-heal to decide whether scribe's config is already in sync
+ * with vault's `.env`.
+ */
+function readScribeAuthToken(path: string): string | undefined {
+  if (!existsSync(path)) return undefined;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+    const auth = (parsed as Record<string, unknown>).auth;
+    if (!auth || typeof auth !== "object" || Array.isArray(auth)) return undefined;
+    const token = (auth as Record<string, unknown>).required_token;
+    return typeof token === "string" && token.length > 0 ? token : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Mint (or preserve) a shared secret and persist it to vault and scribe, plus
  * pin SCRIBE_URL on vault's side. Caller has already confirmed both services
  * are installed. Restarts vault if it's running so the worker re-reads .env.
@@ -181,4 +201,71 @@ export async function autoWireScribeAuth(opts: AutoWireOpts): Promise<AutoWireRe
     scribeConfigPath,
     restartedVault,
   };
+}
+
+export interface SelfHealScribeAuthResult {
+  /** True when scribe's config.json was written this call (was missing/out-of-sync). */
+  healed: boolean;
+  /**
+   * Why no heal happened (when `healed` is false): "no-token" (vault .env has
+   * no SCRIBE_AUTH_TOKEN — nothing to sync) or "already-synced" (scribe already
+   * carries the same token). Undefined when `healed` is true.
+   */
+  reason?: "no-token" | "already-synced";
+}
+
+/**
+ * Idempotent self-heal of scribe's `auth.required_token`, run on hub `serve`
+ * startup (item H — the loopback-open finding).
+ *
+ * The gap: `autoWireScribeAuth` only fires from `parachute install scribe` (and
+ * the vault↔scribe install pairing). An install that PREDATES auto-wire — or
+ * any path where scribe booted with no `auth.required_token` — leaves scribe
+ * accepting UNAUTHENTICATED transcription requests over loopback forever; the
+ * shared secret never lands in scribe's config even though vault's `.env`
+ * already carries `SCRIBE_AUTH_TOKEN`. Install-time wiring can't fix an
+ * already-installed box.
+ *
+ * The fix mirrors the issuer self-heal in `vault-hub-origin-env.ts`: run on
+ * every `serve` boot, fully idempotent. When vault's `.env` carries a
+ * `SCRIBE_AUTH_TOKEN` AND scribe's `config.json` either lacks
+ * `auth.required_token` or carries a DIFFERENT value, write/sync the vault
+ * value into scribe's config (via `writeScribeConfig`'s merge-don't-clobber
+ * logic — only the auth token is touched, every other config key is preserved).
+ * Vault's `.env` is treated as the source of truth (it's where the operator's
+ * worker reads the secret from). No-op when vault has no token (nothing to
+ * sync) or the two already match. Does NOT restart scribe — `serve` boots the
+ * supervised modules AFTER this runs, so the synced config is read on that
+ * first boot; an already-running scribe (manual start) is the operator's to
+ * restart, same posture as the issuer self-heal.
+ *
+ * Logs only when it actually heals.
+ */
+export function selfHealScribeAuth(opts: {
+  configDir: string;
+  log?: (line: string) => void;
+}): SelfHealScribeAuthResult {
+  const log = opts.log ?? (() => {});
+  const vaultEnvPath = join(opts.configDir, "vault", ".env");
+  const scribeConfigPath = join(opts.configDir, "scribe", "config.json");
+
+  const vaultToken = parseEnvFile(vaultEnvPath).values[SCRIBE_AUTH_ENV_KEY];
+  if (vaultToken === undefined || vaultToken.length === 0) {
+    // Nothing to sync — vault hasn't been wired with a scribe secret. (Either
+    // scribe isn't in use, or auto-wire never ran on either side.)
+    return { healed: false, reason: "no-token" };
+  }
+
+  const scribeToken = readScribeAuthToken(scribeConfigPath);
+  if (scribeToken === vaultToken) {
+    return { healed: false, reason: "already-synced" };
+  }
+
+  writeScribeConfig(scribeConfigPath, vaultToken);
+  log(
+    scribeToken === undefined
+      ? `Self-healed scribe auth: wrote required_token to ${scribeConfigPath} (scribe was running auth-OPEN; synced from vault ${SCRIBE_AUTH_ENV_KEY}).`
+      : `Self-healed scribe auth: re-synced required_token in ${scribeConfigPath} to match vault ${SCRIBE_AUTH_ENV_KEY}.`,
+  );
+  return { healed: true };
 }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -26,6 +26,7 @@
 
 import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
+import { selfHealScribeAuth } from "../auto-wire.ts";
 import { generateBootstrapToken } from "../bootstrap-token.ts";
 // NOTE: CONFIG_DIR/WELL_KNOWN_DIR/SERVICES_MANIFEST_PATH are evaluated at
 // import time from process.env.PARACHUTE_HOME. The `env` parameter on
@@ -402,6 +403,26 @@ export async function serve(opts: ServeOpts = {}): Promise<{
       adminBootstrap,
     }),
   );
+
+  // Self-heal scribe's auth token from vault's .env (item H) BEFORE booting
+  // modules, so scribe's first boot below reads the synced config. Closes the
+  // "scribe installed pre-auto-wire boots auth-OPEN over loopback" gap: every
+  // `serve` start re-syncs scribe's `auth.required_token` to vault's
+  // SCRIBE_AUTH_TOKEN. Fully idempotent — no-op when there's nothing to sync or
+  // the two already match; logs only when it heals. Mirrors the issuer
+  // self-heal pattern in vault-hub-origin-env.ts. Skipped in tests via
+  // `opts.skipModuleBoot` (which also gates the boot it feeds).
+  if (!opts.skipModuleBoot) {
+    try {
+      selfHealScribeAuth({ configDir: CONFIG_DIR, log });
+    } catch (err) {
+      // A self-heal failure must never block the hub from starting — scribe
+      // just keeps whatever auth state it had. Log and move on.
+      log(
+        `parachute serve: scribe auth self-heal failed (${err instanceof Error ? err.message : String(err)}); continuing.`,
+      );
+    }
+  }
 
   // Boot already-installed modules from services.json — now that we own the
   // hub port (above), we're guaranteed to be the sole supervisor. In a

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -429,19 +429,31 @@ export type RequestLayer = "loopback" | "tailnet" | "public";
  *   - `CF-Ray` and `CF-Connecting-IP` are set by Cloudflare's edge for
  *     anything proxied through a cloudflared tunnel.
  *
- * Spoofing isn't a concern: hub binds `127.0.0.1:1939`, so external requests
- * can't reach the listener except via these trusted forwarders. Tailscale
- * specifically strips the same headers from incoming requests before
- * re-injecting them, so even a malicious tailnet peer can't impersonate a
- * different user. We could mirror that strip-on-arrival defense, but it's
- * belt-and-braces given the bind shape.
+ * Spoofing isn't a concern for the proxy-injected layers: the trusted
+ * forwarders (tailscale serve/funnel, cloudflared) set these headers and a
+ * peer can't forge them past the forwarder. Tailscale specifically strips the
+ * same headers from incoming requests before re-injecting them, so even a
+ * malicious tailnet peer can't impersonate a different user.
  *
- * Default to "loopback" when no proxy headers are present — that's the
- * direct-localhost case. Funnel without `Tailscale-Funnel-Request` would
- * also fall here, but Tailscale always sets the header on funneled
- * requests, so this branch only fires for true loopback callers.
+ * Header-absence is NOT a loopback signal (item E / hub#526). The old default
+ * returned "loopback" — the most-trusted layer — for any request with no proxy
+ * headers, on the premise (true only on a loopback bind) that "external
+ * requests can't reach the listener." Containers / Render legitimately bind
+ * `0.0.0.0`, where a network peer can reach the listener directly with no proxy
+ * headers and would be misclassified `loopback`, bypassing the
+ * `publicExposure:"loopback"` 404-cloak on `proxyToService` / `proxyToVault`.
+ *
+ * Fix: derive loopback from the actual PEER ADDRESS (`peerAddr`, resolved by
+ * the caller from `server.requestIP(req)` — `requestIP` lives on the Bun
+ * Server, not the Request; see rate-limit.ts:282-285). A header-absent request
+ * is `loopback` ONLY when its peer is `127.0.0.1` / `::1` (the on-box CLI
+ * caller, which must stay loopback). A header-absent NON-loopback peer is the
+ * untrusted direct-network case and is classified `public` (least-trusted) so
+ * the cloak fires. When `peerAddr` is unknown (null/undefined — no Server
+ * threaded, e.g. a unit test calling `layerOf(req)` directly), we fail CLOSED
+ * to `public` rather than open to `loopback`.
  */
-export function layerOf(req: Request): RequestLayer {
+export function layerOf(req: Request, peerAddr?: string | null): RequestLayer {
   const h = req.headers;
   if (h.get("cf-ray") !== null || h.get("cf-connecting-ip") !== null) return "public";
   // Match the structured-header value (`?1`) rather than mere presence:
@@ -452,7 +464,25 @@ export function layerOf(req: Request): RequestLayer {
   // value to compare against, hence the presence-check above.
   if (h.get("tailscale-funnel-request") === "?1") return "public";
   if (h.get("tailscale-user-login") !== null) return "tailnet";
-  return "loopback";
+  // No proxy headers — classify by peer address, failing closed when unknown.
+  return isLoopbackPeer(peerAddr) ? "loopback" : "public";
+}
+
+/**
+ * True when `peerAddr` (a `server.requestIP(req)?.address`) is a loopback
+ * address. Handles the IPv4-mapped IPv6 form (`::ffff:127.0.0.1`) Bun can emit
+ * on a dual-stack listener. A null/undefined/unparseable address is NOT
+ * loopback — `layerOf` fails closed to `public` in that case.
+ */
+function isLoopbackPeer(peerAddr: string | null | undefined): boolean {
+  if (!peerAddr) return false;
+  const addr = peerAddr.trim().toLowerCase();
+  return (
+    addr === "127.0.0.1" ||
+    addr === "::1" ||
+    addr === "::ffff:127.0.0.1" ||
+    addr.startsWith("127.")
+  );
 }
 
 /**
@@ -587,6 +617,7 @@ async function proxyToVault(
   req: Request,
   manifestPath: string,
   supervisor: Supervisor | undefined,
+  peerAddr: string | null,
 ): Promise<Response | undefined> {
   // Lenient — see hub#406. One bad services.json row no longer takes
   // down vault routing the way it used to take down /admin/setup and
@@ -597,8 +628,10 @@ async function proxyToVault(
   if (!match) return undefined;
   // Layer-gate on `publicExposure: "loopback"` — hide the entry from non-
   // loopback callers as if it doesn't exist. "allowed" / "auth-required"
-  // pass through; the service does its own auth.
-  if (effectivePublicExposure(match.entry) === "loopback" && layerOf(req) !== "loopback") {
+  // pass through; the service does its own auth. `peerAddr` (item E / #526)
+  // is the loopback discriminator: a header-absent NON-loopback peer is NOT
+  // loopback, so the cloak fires on a 0.0.0.0 bind.
+  if (effectivePublicExposure(match.entry) === "loopback" && layerOf(req, peerAddr) !== "loopback") {
     return new Response("not found", { status: 404 });
   }
   // Symmetry with proxyToService (#196): honor `stripPrefix` with FIRST_-
@@ -672,6 +705,7 @@ async function proxyToService(
   req: Request,
   manifestPath: string,
   supervisor: Supervisor | undefined,
+  peerAddr: string | null,
 ): Promise<Response | undefined> {
   // Lenient read on the hot-path — a single malformed services.json
   // entry (e.g. a module installed at a buggy version that wrote
@@ -693,8 +727,8 @@ async function proxyToService(
   // tailnet/public caller, a loopback-only service must be indistinguishable
   // from "not installed" — 404, not 403, so we don't leak the existence of
   // the route. "allowed" / "auth-required" pass through; the service does
-  // its own auth.
-  if (effectivePublicExposure(match.entry) === "loopback" && layerOf(req) !== "loopback") {
+  // its own auth. `peerAddr` (item E / #526) is the loopback discriminator.
+  if (effectivePublicExposure(match.entry) === "loopback" && layerOf(req, peerAddr) !== "loopback") {
     return new Response("not found", { status: 404 });
   }
   // Consult FIRST_PARTY_FALLBACKS as a fallback for `stripPrefix` (#196).
@@ -1211,10 +1245,23 @@ export function resolveIssuerSource(
   return "request";
 }
 
+/**
+ * Minimal structural type for the Bun `Server` handle the fetch callback
+ * receives as its 2nd argument. We only need `requestIP` (item E / #526) to
+ * resolve the peer address for `layerOf`. Typed structurally (rather than
+ * importing Bun's full `Server`) so tests can pass a tiny fake and so the
+ * signature stays robust to Bun type-shape churn. Optional in the callback
+ * because a direct unit call to the returned fetch fn may omit it — in which
+ * case `peerAddr` is null and `layerOf` fails closed to `public`.
+ */
+interface PeerIpResolver {
+  requestIP(req: Request): { address: string } | null;
+}
+
 export function hubFetch(
   wellKnownDir: string,
   deps?: HubFetchDeps,
-): (req: Request) => Response | Promise<Response> {
+): (req: Request, server?: PeerIpResolver) => Response | Promise<Response> {
   const hubHtmlPath = join(wellKnownDir, "hub.html");
   const getDb = deps?.getDb;
   const configuredIssuer = deps?.issuer;
@@ -1261,9 +1308,17 @@ export function hubFetch(
     };
   };
 
-  return async (req) => {
+  return async (req, server) => {
     const url = new URL(req.url);
     const pathname = url.pathname;
+
+    // Resolve the peer address ONCE per request (item E / #526). Bun's
+    // `requestIP` lives on the Server handle, not the Request. It's the
+    // loopback discriminator for `layerOf` on the loopback-exposure cloak —
+    // a header-absent non-loopback peer must NOT be treated as loopback.
+    // `server` is absent when a unit test calls this fn directly; `peerAddr`
+    // is then null and `layerOf` fails closed to `public`.
+    const peerAddr = server?.requestIP(req)?.address ?? null;
 
     // 301 back-compat for the pre-hub#231 admin-SPA mounts:
     //
@@ -2288,7 +2343,7 @@ export function hubFetch(
     // here anymore (the SPA moved to /admin), so we can't accidentally
     // mask a backend 404 with HTML.
     if (pathname.startsWith("/vault/")) {
-      const proxied = await proxyToVault(req, manifestPath, deps?.supervisor);
+      const proxied = await proxyToVault(req, manifestPath, deps?.supervisor, peerAddr);
       if (proxied) return decorateWithChrome(proxied, req, pathname, getDb);
       return new Response("not found", { status: 404 });
     }
@@ -2315,7 +2370,7 @@ export function hubFetch(
     // here only after every hub-owned prefix above has had its turn — so
     // `/`, `/admin/*`, `/oauth/*`, `/.well-known/*`, `/hub/*`, `/vault/*`,
     // `/api/*` are excluded by ordering, not by an explicit denylist (#182).
-    const proxied = await proxyToService(req, manifestPath, deps?.supervisor);
+    const proxied = await proxyToService(req, manifestPath, deps?.supervisor, peerAddr);
     if (proxied) return decorateWithChrome(proxied, req, pathname, getDb);
 
     // Branded fall-through 404 (closes hub#392) — the operator who mistyped

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -2008,9 +2008,20 @@ export function hubFetch(
 
     if (pathname === "/api/auth/mint-token") {
       if (!getDb) return dbNotConfigured();
+      // Derive the set of registered vault names so the handler can reject a
+      // `vault:<typo>:admin` mint (item D / hub#450) — same source + shape the
+      // session-cookie `/admin/vault-admin-token/<name>` path uses. Lenient
+      // read so a malformed manifest doesn't 500 the mint endpoint.
+      const mintManifest = readManifestLenient(manifestPath);
+      const mintKnownVaultNames = new Set<string>();
+      for (const s of mintManifest.services) {
+        if (!isVaultEntry(s)) continue;
+        for (const path of s.paths) mintKnownVaultNames.add(vaultInstanceNameFor(s.name, path));
+      }
       return handleApiMintToken(req, {
         db: getDb(),
         issuer: oauthDeps(req).issuer,
+        knownVaultNames: mintKnownVaultNames,
       });
     }
 

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -478,10 +478,7 @@ function isLoopbackPeer(peerAddr: string | null | undefined): boolean {
   if (!peerAddr) return false;
   const addr = peerAddr.trim().toLowerCase();
   return (
-    addr === "127.0.0.1" ||
-    addr === "::1" ||
-    addr === "::ffff:127.0.0.1" ||
-    addr.startsWith("127.")
+    addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1" || addr.startsWith("127.")
   );
 }
 
@@ -631,7 +628,10 @@ async function proxyToVault(
   // pass through; the service does its own auth. `peerAddr` (item E / #526)
   // is the loopback discriminator: a header-absent NON-loopback peer is NOT
   // loopback, so the cloak fires on a 0.0.0.0 bind.
-  if (effectivePublicExposure(match.entry) === "loopback" && layerOf(req, peerAddr) !== "loopback") {
+  if (
+    effectivePublicExposure(match.entry) === "loopback" &&
+    layerOf(req, peerAddr) !== "loopback"
+  ) {
     return new Response("not found", { status: 404 });
   }
   // Symmetry with proxyToService (#196): honor `stripPrefix` with FIRST_-
@@ -728,7 +728,10 @@ async function proxyToService(
   // from "not installed" — 404, not 403, so we don't leak the existence of
   // the route. "allowed" / "auth-required" pass through; the service does
   // its own auth. `peerAddr` (item E / #526) is the loopback discriminator.
-  if (effectivePublicExposure(match.entry) === "loopback" && layerOf(req, peerAddr) !== "loopback") {
+  if (
+    effectivePublicExposure(match.entry) === "loopback" &&
+    layerOf(req, peerAddr) !== "loopback"
+  ) {
     return new Response("not found", { status: 404 });
   }
   // Consult FIRST_PARTY_FALLBACKS as a fallback for `stripPrefix` (#196).

--- a/src/managed-unit.ts
+++ b/src/managed-unit.ts
@@ -666,9 +666,12 @@ export interface BuildHubManagedUnitOpts {
  * the bind host to `0.0.0.0` (serve.ts), which is correct for the container
  * shape (the platform's HTTP forwarder must reach the hub) but WRONG for a
  * self-hosted box — bare `serve` would expose the admin/OAuth surfaces on every
- * interface, contradicting the pre-supervisor detached behavior and the trust
- * model `layerOf` (hub-server.ts) assumes (header-absent ⇒ "loopback"). The
- * container path never calls this builder (the Dockerfile pins
+ * interface, contradicting the pre-supervisor detached behavior. Forcing a
+ * loopback bind also keeps `layerOf` (hub-server.ts) precise: post-#526 it
+ * derives trust from the peer address (`server.requestIP`), failing closed to
+ * "public" for any non-loopback peer — so a 127.0.0.1-only listener is what
+ * lets a header-absent on-box CLI caller classify as "loopback". The container
+ * path never calls this builder (the Dockerfile pins
  * `ENV PARACHUTE_BIND_HOST=0.0.0.0` + runs `serve` directly), so it stays
  * 0.0.0.0. The canonical expose path is unaffected: cloudflared/tailscale dial
  * `127.0.0.1:<port>` from the same host, and the hub's own proxy targets

--- a/src/scope-attenuation.ts
+++ b/src/scope-attenuation.ts
@@ -83,3 +83,22 @@ export function hasMintingAuthority(bearerScopes: string[]): boolean {
     bearerScopes.some((s) => isVaultAdminScope(s))
   );
 }
+
+/**
+ * Is this an *operator* bearer — i.e. does it hold host-level minting authority
+ * (`parachute:host:auth` or `parachute:host:admin`)?
+ *
+ * The distinction matters for the `subject` override on the mint endpoint: an
+ * operator bearer is the on-box host administrator (or a service account it
+ * delegated to), so it may legitimately mint a token whose `sub` names a
+ * service account other than its own — the documented service-account override.
+ * A merely vault-scoped bearer (`vault:<N>:admin` only) has NO host authority,
+ * so letting it set an arbitrary `sub` is audit-attribution forgery: it could
+ * mint a token that the registry + revocation list attribute to a foreign
+ * subject. Non-operator bearers are therefore pinned to their own `sub`.
+ */
+export function isOperatorBearer(bearerScopes: string[]): boolean {
+  return (
+    bearerScopes.includes(MINT_HOST_AUTH_SCOPE) || bearerScopes.includes(MINT_HOST_ADMIN_SCOPE)
+  );
+}

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -270,7 +270,15 @@ export function isNonRequestableScope(scope: string): boolean {
   // consent path and through `canGrant` rule 1, capped to the consenting
   // user's held authority at the `issueAuthCodeRedirect` choke-point. Only
   // the host-level operator scopes stay non-requestable here.
-  return NON_REQUESTABLE_SCOPES.has(scope);
+  //
+  // Item C — case-insensitive guard. The membership check is exact-string,
+  // but Parachute scope tokens are canonically lowercase. A casing variant
+  // like `PARACHUTE:HOST:AUTH` would slip past a raw `Set.has` and be treated
+  // as requestable — minting a junk-but-harmless token today (consumers are
+  // case-sensitive + anchored, so it grants nothing), but a backstop against
+  // a future consumer that case-folds. Normalize to lowercase before the
+  // membership check so every casing of a host-level scope is refused.
+  return NON_REQUESTABLE_SCOPES.has(scope.toLowerCase());
 }
 
 /** True when the scope can appear in a public `/oauth/authorize` request. */

--- a/src/users.ts
+++ b/src/users.ts
@@ -468,7 +468,7 @@ export async function setPassword(
  * only Phase-1 recovery was delete+recreate, which is destructive-feeling
  * even though it's safe (vaults are independent of accounts).
  *
- * Three writes inside one transaction:
+ * Four writes inside one transaction:
  *
  *   1. Rotate `password_hash` to the new argon2id hash and flip
  *      `password_changed` back to 0 so the user is force-redirected
@@ -482,7 +482,15 @@ export async function setPassword(
  *      would defeat the purpose. We keep the rows (don't NULL `user_id`
  *      like `deleteUser` does) because the audit trail naturally re-
  *      anchors to the still-existing user row.
- *   3. Bump `updated_at` so the SPA's row reflects the rotation.
+ *   3. Delete every active SESSION for the user (item G). Revoking tokens
+ *      alone left a live session cookie valid — an attacker who already had
+ *      a session (the very "old password / stolen device" shape this reset
+ *      recovers from) kept browsing post-reset until the session aged out.
+ *      Killing sessions in the same transaction makes the reset a true cut:
+ *      the user (and any attacker) must re-authenticate with the new
+ *      password. Sessions carry no audit value (unlike tokens), so we hard-
+ *      delete — same shape as `deleteUser`'s `DELETE FROM sessions`.
+ *   4. Bump `updated_at` so the SPA's row reflects the rotation.
  *
  * Hash OUTSIDE the transaction — argon2id is async and `db.transaction()`
  * on bun:sqlite is sync; doing it inside silently breaks atomicity (same
@@ -547,6 +555,12 @@ export async function resetUserPassword(
       stamp,
       userId,
     );
+    // Item G — also kill active sessions in the same transaction. A token
+    // revoke alone left a live session cookie valid; an admin reset must
+    // force re-auth with the new password (the "old password leaked / stolen
+    // device" recovery shape). Sessions carry no audit value, so hard-delete
+    // (same shape as deleteUser).
+    db.prepare("DELETE FROM sessions WHERE user_id = ?").run(userId);
   })();
   return updated;
 }

--- a/src/vault-name.ts
+++ b/src/vault-name.ts
@@ -25,7 +25,19 @@
  * `/vault/list` endpoint.
  */
 
-const VAULT_NAME_RE = /^[a-z0-9_-]+$/;
+/**
+ * Canonical vault-name charset: lowercase alphanumerics + hyphen/underscore.
+ * Exported as the single source of truth for the hub edge sites that mint /
+ * create vaults (item I) — `admin-vaults.ts`, `account-vault-token.ts`,
+ * `admin-vault-admin-token.ts` historically accepted `[a-zA-Z0-9_-]`, a
+ * superset of what vault's init enforces. The case drift was a real bug class:
+ * a hub-side `Work` would never match vault's URL-derived `work`, so the minted
+ * token's audience (`vault.Work`) wouldn't validate, and a created vault name
+ * could diverge from what vault persisted. Pinning every hub edge to THIS
+ * lowercase-only regex closes the drift.
+ */
+export const VAULT_NAME_CHARSET_RE = /^[a-z0-9_-]+$/;
+const VAULT_NAME_RE = VAULT_NAME_CHARSET_RE;
 const VAULT_NAME_MIN_LEN = 2;
 const VAULT_NAME_MAX_LEN = 32;
 


### PR DESCRIPTION
Strictly-tightening, verification-confirmed security hardening ahead of opening the hub to more users. None of these change intended capability — each closes a gap. One clean commit per item (A–I), plus a test-fallout fix for F and a biome-format pass.

Gates (fake-launchctl PATH shim, literal counts):
- `bun test ./src` → **2884 pass / 1 skip / 0 fail** (baseline 2853 pass; +31 new tests)
- `bun test ./packages/scope-guard/src` → **115 pass / 0 fail**
- `bun run typecheck` → clean

---

### A. mint-token subject pin (audit-attribution forgery)
`POST /api/auth/mint-token` accepted `body.subject` verbatim for any bearer with minting authority — so a non-operator bearer (holds only `vault:<N>:admin`, NOT `host:auth`/`host:admin`) could forge the minted token's `sub`, mis-attributing the `tokens` registry row + revocation entry to a foreign subject. **Fix:** subject override is now operator-only (new `isOperatorBearer` helper); a non-operator bearer passing `subject !== bearerSub` → 403. Operators keep the documented service-account override.
Files: `src/scope-attenuation.ts`, `src/api-mint-token.ts`, `src/__tests__/api-mint-token.test.ts`.

### B. bare `vault:admin` non-requestable headlessly (closes #451)
Bare unnamed `vault:admin` minted as an ordinary scope via the bearer endpoint, even from a host:auth-only bearer. **Fix (judgment call):** the brief said add it to `NON_REQUESTABLE_SCOPES`, but that gate fires on the *raw pre-narrow* scopes in the OAuth flow, which legitimately accepts bare `vault:admin` and narrows it to `vault:<picked>:admin` via the vault picker — adding it there would break OAuth narrowing (and ~5 tests). Instead the **mint endpoint** rejects bare `vault:admin` with 400, achieving #451's goal ("should unnamed broad vault:admin be headlessly mintable at all") without touching the OAuth path. Named `vault:<name>:admin` and unnamed `vault:read`/`write` unaffected.
Files: `src/api-mint-token.ts`, `src/__tests__/api-mint-token.test.ts`.

### C. case-insensitive non-requestable guard
`isNonRequestableScope` did exact-string `Set.has`, so `PARACHUTE:HOST:AUTH` bypassed it as "requestable." **Fix:** lowercase-normalize before the membership check — every casing of a host scope is now refused at both the OAuth requestability gate and the headless mint endpoint.
Files: `src/scope-explanations.ts`, `src/__tests__/scope-explanations.test.ts`, `src/__tests__/api-mint-token.test.ts`.

### D. vault-existence on `vault:<name>:admin` mints (closes #450)
The bearer mint path minted `vault:<typo>:admin` without checking the vault exists — an unusable token that confuses automation. **Fix:** thread `knownVaultNames` (optional) into `ApiMintTokenDeps`, wired in hub-server from services.json with the same derivation the session path uses; an admin mint for an unregistered vault → 400. Gated to the admin form; absent `knownVaultNames` skips the check (documented "caller responsible" fallback + unit-test shape).
Files: `src/api-mint-token.ts`, `src/hub-server.ts`, `src/__tests__/api-mint-token.test.ts`.

### E. layerOf peer-address fix (closes #526)
`layerOf` returned `loopback` (most-trusted) for any header-absent request — falsifiable on 0.0.0.0 binds (containers/Render), where a network peer with no proxy headers was misclassified `loopback` and bypassed the `publicExposure:"loopback"` 404-cloak. **Fix (fail closed):** `layerOf` now takes the peer address (resolved once per request from Bun's `server.requestIP(req)` — the fetch callback's 2nd arg — threaded through `proxyToVault`/`proxyToService`). Proxy headers still win; absent them, a request is `loopback` only if the peer is `127.0.0.1`/`::1`/`::ffff:127.0.0.1` (the on-box CLI). A header-absent non-loopback **or unknown** peer → `public`. Defense-in-depth (no known privesc — privileged surfaces ignore network position).
Files: `src/hub-server.ts`, `src/__tests__/hub-server.test.ts`.

### F. force-change-password: gate token-minting + revoke-on-self-change (NARROW #469)
The force-change rail was session-redirect-only. Two narrow tightenings (NOT a broad `/account/*` wall — that posture is deferred to Aaron):
- `/account/vault-token/<name>` POST — an authorized-but-unrotated friend (`password_changed: false`) is redirected (303) to `/account/change-password` *before* minting, so they can't acquire a long-lived token under the admin's temp password. Gate sits *after* the authority checks (unassigned/garbage still 403/400) and *before* the mint. (No `/account/vault-admin-token/<name>` route exists — vault-admin mint is the first-admin-only `/admin/vault-admin-token`, where `password_changed` is always true.)
- `/account/change-password` POST — a *successful* self-change now revokes the user's active tokens in the same transaction as the hash write (mirrors the admin-reset revoke in `resetUserPassword`), so a temp-password-minted token dies with the rotation.
Files: `src/account-vault-token.ts`, `src/api-account.ts`, `src/__tests__/account-vault-token.test.ts`, `src/__tests__/api-account.test.ts` (+ a routed-e2e fallout fix in `src/__tests__/hub-server.test.ts`).

### G. reset-password → session-revoke cascade
`resetUserPassword` revoked tokens but left active **sessions** valid — an attacker holding a live session cookie (the "old password / stolen device" shape this reset recovers from) kept browsing post-reset. **Fix:** add `DELETE FROM sessions WHERE user_id = ?` to the same transaction. Tokens keep their audit row (revoked_at set); sessions hard-delete.
Files: `src/users.ts`, `src/__tests__/users.test.ts`.

### H. scribe-auth self-heal on hub start (loopback-open finding)
`autoWireScribeAuth` only runs at `parachute install scribe`, so an install predating it boots scribe **auth-OPEN** over loopback forever. **Fix (mirrors the issuer self-heal):** new `selfHealScribeAuth` runs on every `parachute serve` boot, *before* module boot. When vault's `.env` has `SCRIBE_AUTH_TOKEN` and scribe's `config.json` lacks/mismatches `auth.required_token`, it syncs the value via `writeScribeConfig`'s merge-don't-clobber logic. Fully idempotent; logs only when it heals; failure never blocks startup.
Files: `src/auto-wire.ts`, `src/commands/serve.ts`, `src/__tests__/auto-wire.test.ts`.

### I. lowercase vault-name unification (hub creation sites)
Hub's vault-create, friend vault-token mint, and SPA vault-admin-token mint accepted `[a-zA-Z0-9_-]`, but vault's init enforces lowercase-only `[a-z0-9_-]` — a case-drift / audience-mismatch class (hub `Work` ≠ vault's URL-derived `work`). **Fix:** export the canonical `VAULT_NAME_CHARSET_RE` from `vault-name.ts` as the single source of truth and wire it at all three edges. Lowercase names unaffected; uppercase now consistently rejected.
Files: `src/vault-name.ts`, `src/admin-vaults.ts`, `src/account-vault-token.ts`, `src/admin-vault-admin-token.ts`, + their tests.

---

Do **not** merge — a multi-lens reviewer will be dispatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)