### PR TITLE
account surface: self-serve vault-admin-token unlock + per-vault usage

### DIFF
--- a/src/__tests__/account-usage.test.ts
+++ b/src/__tests__/account-usage.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for the `/account/` per-vault usage fetch + formatting
+ * (`account-usage.ts`). The fetch mints a read token + hits the vault's loopback
+ * `/.parachute/usage` endpoint; it must be fault-tolerant (any failure → null)
+ * and shape-strict (a malformed body → null, not a render of `undefined`).
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type VaultUsageStat,
+  fetchVaultUsage,
+  formatBytes,
+  formatUsageStat,
+} from "../account-usage.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+
+interface Harness {
+  db: Database;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-account-usage-"));
+  const db = openHubDb(hubDbPath(dir));
+  return {
+    db,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+/** A stub signer — no real key needed; the fetch only carries the token string. */
+const stubSign = async () => ({
+  token: "stub.jwt.token",
+  jti: "jti-1",
+  expiresAt: new Date(Date.now() + 60000).toISOString(),
+});
+
+function baseDeps(fetchImpl: typeof fetch) {
+  return {
+    db: harness.db,
+    hubOrigin: "https://hub.test",
+    vaultPort: 1940,
+    userId: "user-1",
+    fetchImpl,
+    signToken: stubSign as never,
+  };
+}
+
+describe("fetchVaultUsage", () => {
+  test("returns the stat on a well-formed usage report", async () => {
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({
+          counts: { notes: 42, attachments: 3, links: 5, tags: 2 },
+          bytes: { content: 1000, db: 2048, assets: 4096, total: 6144 },
+          computedAt: new Date().toISOString(),
+          cached: false,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as unknown as typeof fetch;
+    const stat = await fetchVaultUsage("work", baseDeps(fetchImpl));
+    expect(stat).toEqual({ notes: 42, totalBytes: 6144 });
+  });
+
+  test("calls the vault's loopback usage endpoint with a Bearer", async () => {
+    let seenUrl = "";
+    let seenAuth = "";
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      seenUrl = url;
+      seenAuth = (init?.headers as Record<string, string>)?.authorization ?? "";
+      return new Response(JSON.stringify({ counts: { notes: 1 }, bytes: { total: 10 } }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+    await fetchVaultUsage("work", baseDeps(fetchImpl));
+    expect(seenUrl).toBe("http://127.0.0.1:1940/vault/work/.parachute/usage");
+    expect(seenAuth).toBe("Bearer stub.jwt.token");
+  });
+
+  test("returns null on a non-2xx response (vault down / 403 / 404)", async () => {
+    for (const status of [403, 404, 500]) {
+      const fetchImpl = (async () => new Response("nope", { status })) as unknown as typeof fetch;
+      const stat = await fetchVaultUsage("work", baseDeps(fetchImpl));
+      expect(stat).toBeNull();
+    }
+  });
+
+  test("returns null when the body is malformed (missing counts/bytes)", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ counts: {}, bytes: {} }), {
+        status: 200,
+      })) as unknown as typeof fetch;
+    const stat = await fetchVaultUsage("work", baseDeps(fetchImpl));
+    expect(stat).toBeNull();
+  });
+
+  test("returns null when fetch throws (network error)", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const stat = await fetchVaultUsage("work", baseDeps(fetchImpl));
+    expect(stat).toBeNull();
+  });
+});
+
+describe("formatUsageStat / formatBytes", () => {
+  test("pluralizes notes + renders the byte size", () => {
+    expect(formatUsageStat({ notes: 1, totalBytes: 1024 } as VaultUsageStat)).toBe("1 note · 1 KB");
+    expect(formatUsageStat({ notes: 42, totalBytes: 6 * 1024 * 1024 } as VaultUsageStat)).toBe(
+      "42 notes · 6.0 MB",
+    );
+    expect(formatUsageStat({ notes: 0, totalBytes: 0 } as VaultUsageStat)).toBe("0 notes · 0 B");
+  });
+
+  test("formatBytes picks the largest sensible unit", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(2048)).toBe("2 KB");
+    expect(formatBytes(5 * 1024 * 1024)).toBe("5.0 MB");
+    expect(formatBytes(3 * 1024 * 1024 * 1024)).toBe("3.0 GB");
+    expect(formatBytes(-5)).toBe("0 B");
+  });
+});

--- a/src/__tests__/account-vault-admin-token.test.ts
+++ b/src/__tests__/account-vault-admin-token.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Security tests for the friend-facing vault-ADMIN deep-link mint —
+ * `POST /account/vault-admin-token/<name>` (`handleAccountVaultAdminTokenPost`).
+ *
+ * The non-admin sibling of `/admin/vault-admin-token/<name>` (which is
+ * first-admin-gated). This one is gated on ASSIGNMENT: an assigned user holds
+ * `admin` on their vault (2026-05-30) and may bootstrap the vault's own admin
+ * SPA — token rotation + Git backup config. Authorization is tested
+ * adversarially. The spine:
+ *   - No session              → 401.
+ *   - Assigned vault          → 303 → <vault-url><managementUrl>#token=<jwt>,
+ *                               token carries `vault:<name>:admin`,
+ *                               `aud=vault.<name>`, `iss=<hub>`, sub=user.
+ *   - UNassigned vault        → 403 (cross-vault blocked).
+ *   - First admin             → 403 (no user_vaults rows → uses SPA path).
+ *   - Unrotated user (item F) → 303 → /account/change-password, NO mint
+ *                               (does not reintroduce the #469 bypass).
+ *   - CSRF missing/mismatch   → 400.
+ *   - Invalid vault name      → 400.
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleAccountVaultAdminTokenPost } from "../account-vault-admin-token.ts";
+import { VAULT_ADMIN_TOKEN_TTL_SECONDS } from "../admin-vault-admin-token.ts";
+import { CSRF_FIELD_NAME, buildCsrfCookie, generateCsrfToken } from "../csrf.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { validateAccessToken } from "../jwt-sign.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "https://hub.test";
+
+interface Harness {
+  db: Database;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-account-vault-admin-token-"));
+  const db = openHubDb(hubDbPath(dir));
+  return {
+    db,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+const deps = (extra: { managementUrl?: string } = {}) => ({
+  db: harness.db,
+  hubOrigin: ISSUER,
+  ...extra,
+});
+
+/** A shared CSRF token + matching cookie value for the double-submit handshake. */
+function csrfPair(): { token: string; cookieFragment: string } {
+  const token = generateCsrfToken();
+  const cookie = buildCsrfCookie(token, { secure: false }).split(";")[0] ?? "";
+  return { token, cookieFragment: cookie };
+}
+
+/**
+ * First-admin operator + a friend assigned to `vaults`. `passwordChanged`
+ * defaults true (the precondition for minting now — item F gates an unrotated
+ * friend first). Pass `passwordChanged: false` to exercise the force-change gate.
+ */
+async function seedFriend(
+  vaults: string[],
+  opts: { passwordChanged?: boolean } = {},
+): Promise<{ friendId: string; cookie: string; csrfToken: string }> {
+  await createUser(harness.db, "operator", "operator-password-123");
+  const friend = await createUser(harness.db, "friend", "friend-password-123", {
+    assignedVaults: vaults,
+    allowMulti: true,
+    passwordChanged: opts.passwordChanged ?? true,
+  });
+  const session = createSession(harness.db, { userId: friend.id });
+  const { token, cookieFragment } = csrfPair();
+  const sessionCookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+  const cookie = `${sessionCookie}; ${cookieFragment}`;
+  return { friendId: friend.id, cookie, csrfToken: token };
+}
+
+function mintReq(
+  vaultName: string,
+  opts: { cookie?: string; csrfToken?: string; omitCsrf?: boolean; method?: string } = {},
+): Request {
+  const body = new URLSearchParams();
+  if (!opts.omitCsrf && opts.csrfToken !== undefined) body.set(CSRF_FIELD_NAME, opts.csrfToken);
+  const headers: Record<string, string> = {
+    "content-type": "application/x-www-form-urlencoded",
+  };
+  if (opts.cookie) headers.cookie = opts.cookie;
+  return new Request(`${ISSUER}/account/vault-admin-token/${encodeURIComponent(vaultName)}`, {
+    method: opts.method ?? "POST",
+    headers,
+    body: body.toString(),
+  });
+}
+
+/** Pull the `#token=<jwt>` out of a 303 Location fragment. */
+function tokenFromLocation(location: string): string {
+  const m = location.match(/[#&]token=([^&]+)$/);
+  expect(m).not.toBeNull();
+  return m![1] as string;
+}
+
+describe("handleAccountVaultAdminTokenPost — happy path (assigned vault)", () => {
+  test("303 → vault admin SPA with #token carrying vault:<name>:admin", async () => {
+    const { friendId, cookie, csrfToken } = await seedFriend(["work"]);
+    const res = await handleAccountVaultAdminTokenPost(
+      mintReq("work", { cookie, csrfToken }),
+      "work",
+      deps(),
+    );
+    expect(res.status).toBe(303);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    const location = res.headers.get("location") ?? "";
+    // Default managementUrl is /admin/ → lands on the vault admin SPA home.
+    expect(location.startsWith(`${ISSUER}/vault/work/admin/#token=`)).toBe(true);
+
+    const token = tokenFromLocation(location);
+    const validated = await validateAccessToken(harness.db, token, ISSUER);
+    expect(validated.payload.sub).toBe(friendId);
+    expect(validated.payload.iss).toBe(ISSUER);
+    expect(validated.payload.aud).toBe("vault.work");
+    const scopeClaim = (validated.payload as { scope?: string }).scope ?? "";
+    expect(scopeClaim.split(/\s+/)).toEqual(["vault:work:admin"]);
+    expect((validated.payload as { vault_scope?: string[] }).vault_scope).toEqual(["work"]);
+
+    // Short TTL (10 min, deep-link bootstrap token — not the 90-day headless one).
+    const expMs = new Date((validated.payload.exp ?? 0) * 1000).getTime();
+    const skew = expMs - Date.now();
+    expect(skew).toBeGreaterThan((VAULT_ADMIN_TOKEN_TTL_SECONDS - 60) * 1000);
+    expect(skew).toBeLessThan((VAULT_ADMIN_TOKEN_TTL_SECONDS + 60) * 1000);
+
+    // A revocable registry row was written for the friend.
+    const rows = harness.db.query<{ n: number }, []>("SELECT COUNT(*) AS n FROM tokens").get();
+    expect(rows?.n).toBe(1);
+  });
+
+  test("honors a vault-declared managementUrl (e.g. a custom admin path)", async () => {
+    const { cookie, csrfToken } = await seedFriend(["work"]);
+    const res = await handleAccountVaultAdminTokenPost(
+      mintReq("work", { cookie, csrfToken }),
+      "work",
+      deps({ managementUrl: "/manage/" }),
+    );
+    expect(res.status).toBe(303);
+    const location = res.headers.get("location") ?? "";
+    expect(location.startsWith(`${ISSUER}/vault/work/manage/#token=`)).toBe(true);
+  });
+
+  test("a friend assigned to multiple vaults can deep-link each, never cross-vault", async () => {
+    const { cookie, csrfToken } = await seedFriend(["work", "home"]);
+    for (const v of ["work", "home"]) {
+      const res = await handleAccountVaultAdminTokenPost(
+        mintReq(v, { cookie, csrfToken }),
+        v,
+        deps(),
+      );
+      expect(res.status).toBe(303);
+      const token = tokenFromLocation(res.headers.get("location") ?? "");
+      const validated = await validateAccessToken(harness.db, token, ISSUER);
+      expect(validated.payload.aud).toBe(`vault.${v}`);
+    }
+    const res = await handleAccountVaultAdminTokenPost(
+      mintReq("secret", { cookie, csrfToken }),
+      "secret",
+      deps(),
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("handleAccountVaultAdminTokenPost — authorization gates (adversarial)", () => {
+  test("401 when no session cookie is present", async () => {
+    const { token, cookieFragment } = csrfPair();
+    const res = await handleAccountVaultAdminTokenPost(
+      mintReq("work", { cookie: cookieFragment, csrfToken: token }),
+      "work",
+      deps(),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("403 for a vault the friend is NOT assigned to (cross-vault)", async () => {
+    const { cookie, csrfToken } = await seedFriend(["work"]);
+    const res = await handleAccountVaultAdminTokenPost(
+      mintReq("other", { cookie, csrfToken }),
+      "other",
+      deps(),
+    );
+    expect(res.status).toBe(403);
+    // No token minted.
+    const rows = harness.db.query<{ n: number }, []>("SELECT COUNT(*) AS n FROM tokens").get();
+    expect(rows?.n).toBe(0);
+  });
+
+  test("403 — the first admin cannot deep-link here (no user_vaults rows; uses SPA path)", async () => {
+    // Mirrors `/admin/vault-admin-token` being friend-blocked: the inverse, this
+    // friend surface refuses the unrestricted admin. Admins use the SPA's
+    // first-admin-gated /admin/vault-admin-token instead.
+    const admin = await createUser(harness.db, "operator", "operator-password-123");
+    const session = createSession(harness.db, { userId: admin.id });
+    const { token, cookieFragment } = csrfPair();
+    const cookie = `${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}; ${cookieFragment}`;
+    const res = await handleAccountVaultAdminTokenPost(
+      mintReq("work", { cookie, csrfToken: token }),
+      "work",
+      deps(),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("an invalid vault name is rejected before any mint", async () => {
+    const { cookie, csrfToken } = await seedFriend(["work"]);
+    for (const name of ["has..dots", "Work", "WORK"]) {
+      const res = await handleAccountVaultAdminTokenPost(
+        mintReq(name, { cookie, csrfToken }),
+        name,
+        deps(),
+      );
+      expect(res.status).toBe(400);
+    }
+  });
+
+  // Item F / hub#469 — force-change gate. An assigned user who has NOT rotated
+  // the admin-set temp password is redirected to change-password BEFORE minting,
+  // so the temp-password handoff can't be parlayed into a vault-admin deep-link.
+  // This is the SAME gate /account/vault-token applies (post-#550) — it does NOT
+  // reintroduce the bypass #469 closed. Fires AFTER authority (so an unassigned
+  // request still 403s) and BEFORE the mint.
+  test("authorized but unrotated user → 303 to /account/change-password, NO mint (item F)", async () => {
+    const { cookie, csrfToken } = await seedFriend(["work"], { passwordChanged: false });
+    const res = await handleAccountVaultAdminTokenPost(
+      mintReq("work", { cookie, csrfToken }),
+      "work",
+      deps(),
+    );
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toBe("/account/change-password");
+    // Critically: no token was minted and no deep-link token leaked.
+    const rows = harness.db.query<{ n: number }, []>("SELECT COUNT(*) AS n FROM tokens").get();
+    expect(rows?.n).toBe(0);
+  });
+
+  test("an UNASSIGNED unrotated user still 403s (authority precedes the force-change gate)", async () => {
+    const { cookie, csrfToken } = await seedFriend(["work"], { passwordChanged: false });
+    const res = await handleAccountVaultAdminTokenPost(
+      mintReq("other", { cookie, csrfToken }),
+      "other",
+      deps(),
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("handleAccountVaultAdminTokenPost — CSRF + method", () => {
+  test("405 on non-POST", async () => {
+    const { cookie } = await seedFriend(["work"]);
+    const res = await handleAccountVaultAdminTokenPost(
+      mintReq("work", { cookie, method: "GET" }),
+      "work",
+      deps(),
+    );
+    expect(res.status).toBe(405);
+  });
+
+  test("400 when the CSRF token is missing", async () => {
+    const { cookie } = await seedFriend(["work"]);
+    const res = await handleAccountVaultAdminTokenPost(
+      mintReq("work", { cookie, omitCsrf: true }),
+      "work",
+      deps(),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("400 when the CSRF form token does not match the cookie", async () => {
+    const { cookie } = await seedFriend(["work"]);
+    const res = await handleAccountVaultAdminTokenPost(
+      mintReq("work", { cookie, csrfToken: generateCsrfToken() }),
+      "work",
+      deps(),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/__tests__/api-account.test.ts
+++ b/src/__tests__/api-account.test.ts
@@ -801,7 +801,7 @@ describe("handleAccountHomeGet", () => {
 
   test("302 → /login when no session cookie is present", async () => {
     const req = new Request(`${HUB_ORIGIN}/account/`);
-    const res = handleAccountHomeGet(req, { db: harness.db, hubOrigin: HUB_ORIGIN });
+    const res = await handleAccountHomeGet(req, { db: harness.db, hubOrigin: HUB_ORIGIN });
     expect(res.status).toBe(302);
     const location = res.headers.get("location") ?? "";
     // Round-trip /account/ as the `next` param so post-login lands back.
@@ -820,7 +820,7 @@ describe("handleAccountHomeGet", () => {
     const session = createSession(harness.db, { userId: friend.id });
     const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
     const req = new Request(`${HUB_ORIGIN}/account/`, { headers: { cookie } });
-    const res = handleAccountHomeGet(req, { db: harness.db, hubOrigin: HUB_ORIGIN });
+    const res = await handleAccountHomeGet(req, { db: harness.db, hubOrigin: HUB_ORIGIN });
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
     const html = await res.text();
@@ -840,7 +840,7 @@ describe("handleAccountHomeGet", () => {
     const session = createSession(harness.db, { userId: admin.id });
     const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
     const req = new Request(`${HUB_ORIGIN}/account/`, { headers: { cookie } });
-    const res = handleAccountHomeGet(req, { db: harness.db, hubOrigin: HUB_ORIGIN });
+    const res = await handleAccountHomeGet(req, { db: harness.db, hubOrigin: HUB_ORIGIN });
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain("Welcome, admin");
@@ -871,8 +871,71 @@ describe("handleAccountHomeGet", () => {
       harness.db.exec("PRAGMA foreign_keys = ON");
     }
     const req = new Request(`${HUB_ORIGIN}/account/`, { headers: { cookie } });
-    const res = handleAccountHomeGet(req, { db: harness.db, hubOrigin: HUB_ORIGIN });
+    const res = await handleAccountHomeGet(req, { db: harness.db, hubOrigin: HUB_ORIGIN });
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe("/login");
+  });
+
+  test("renders the per-vault usage stat when usage resolves", async () => {
+    await createUser(harness.db, "admin", "admin-passphrase", { passwordChanged: true });
+    const friend = await createUser(harness.db, "alice", "alice-passphrase", {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVaults: ["alice"],
+    });
+    const session = createSession(harness.db, { userId: friend.id });
+    const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+    const req = new Request(`${HUB_ORIGIN}/account/`, { headers: { cookie } });
+    const res = await handleAccountHomeGet(req, {
+      db: harness.db,
+      hubOrigin: HUB_ORIGIN,
+      resolveVaultPort: () => 1940,
+      // Stub the fetch: resolves to a known stat.
+      fetchUsage: async () => ({ notes: 7, totalBytes: 2 * 1024 * 1024 }),
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('data-testid="vault-usage"');
+    expect(html).toContain("7 notes · 2.0 MB");
+  });
+
+  test("omits the usage stat gracefully when the fetch fails (null)", async () => {
+    await createUser(harness.db, "admin", "admin-passphrase", { passwordChanged: true });
+    const friend = await createUser(harness.db, "alice", "alice-passphrase", {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVaults: ["alice"],
+    });
+    const session = createSession(harness.db, { userId: friend.id });
+    const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+    const req = new Request(`${HUB_ORIGIN}/account/`, { headers: { cookie } });
+    const res = await handleAccountHomeGet(req, {
+      db: harness.db,
+      hubOrigin: HUB_ORIGIN,
+      resolveVaultPort: () => 1940,
+      fetchUsage: async () => null,
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Tile still renders; just no usage stat.
+    expect(html).toContain("<strong>alice</strong>");
+    expect(html).not.toContain('data-testid="vault-usage"');
+  });
+
+  test("renders the 'Configure / back up this vault ↗' deep-link button for an assigned vault", async () => {
+    await createUser(harness.db, "admin", "admin-passphrase", { passwordChanged: true });
+    const friend = await createUser(harness.db, "alice", "alice-passphrase", {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVaults: ["alice"],
+    });
+    const session = createSession(harness.db, { userId: friend.id });
+    const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+    const req = new Request(`${HUB_ORIGIN}/account/`, { headers: { cookie } });
+    const res = await handleAccountHomeGet(req, { db: harness.db, hubOrigin: HUB_ORIGIN });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('data-testid="vault-admin-button"');
+    expect(html).toContain('action="/account/vault-admin-token/alice"');
   });
 });

--- a/src/account-home-ui.ts
+++ b/src/account-home-ui.ts
@@ -129,6 +129,15 @@ export interface RenderAccountHomeOpts {
    */
   mintableVerbs?: Record<string, VaultVerb[]>;
   /**
+   * Per-vault usage stat (`"X notes · Y MB"`) for each assigned vault tile.
+   * Maps `vaultName` → the pre-formatted stat string. A vault absent from this
+   * map renders no stat — the page tolerates a vault whose usage endpoint
+   * failed / is unreachable / predates the feature (the `/account/` GET handler
+   * builds this map by fetching `/.parachute/usage` per vault and omitting any
+   * that don't resolve). Omitted entirely on the admin / no-vault branches.
+   */
+  usageStats?: Record<string, string>;
+  /**
    * Set after a successful `POST /account/vault-token/<name>` to show the
    * freshly-minted token ONCE (the only time it's ever shown — the hub keeps
    * no plaintext copy). Drives the show-once banner at the top of the page.
@@ -189,6 +198,7 @@ export function renderAccountHome(opts: RenderAccountHomeOpts): string {
     isFirstAdmin,
     csrfToken,
     mintableVerbs: opts.mintableVerbs ?? {},
+    usageStats: opts.usageStats ?? {},
   });
 
   const accountCard = renderAccountCard({
@@ -257,6 +267,8 @@ interface VaultCardOpts {
   isFirstAdmin: boolean;
   csrfToken: string;
   mintableVerbs: Record<string, VaultVerb[]>;
+  /** `vaultName` → pre-formatted usage stat ("X notes · Y MB"). */
+  usageStats: Record<string, string>;
 }
 
 /**
@@ -286,7 +298,8 @@ export function accountClaudeMcpAddCommand(trimmedOrigin: string, vaultName: str
 }
 
 function renderVaultCard(opts: VaultCardOpts): string {
-  const { assignedVaults, trimmedOrigin, isFirstAdmin, csrfToken, mintableVerbs } = opts;
+  const { assignedVaults, trimmedOrigin, isFirstAdmin, csrfToken, mintableVerbs, usageStats } =
+    opts;
 
   if (assignedVaults.length > 0) {
     // One vault tile per assignment (multi-user Phase 2 PR 2). Each tile
@@ -313,15 +326,25 @@ function renderVaultCard(opts: VaultCardOpts): string {
         const addCmd = accountClaudeMcpAddCommand(trimmedOrigin, vaultName);
         const safeEndpoint = escapeHtml(endpoint);
         const safeAddCmd = escapeHtml(addCmd);
-        const tokenMintBlock = renderTokenMintBlock(
-          vaultName,
-          safeVault,
-          mintableVerbs[vaultName] ?? [],
-          csrfToken,
-        );
+        const verbsForVault = mintableVerbs[vaultName] ?? [];
+        const tokenMintBlock = renderTokenMintBlock(vaultName, safeVault, verbsForVault, csrfToken);
+        // "Configure / back up this vault ↗" — only for users whose assignment
+        // grants `admin` (the verb the deep-link mints). Today every assigned
+        // user holds admin, but gate on the verb so the button never offers
+        // authority the POST handler would 403.
+        const manageBlock = verbsForVault.includes("admin")
+          ? renderVaultAdminLink(vaultName, csrfToken)
+          : "";
+        // Compact usage stat ("X notes · Y MB"), when the vault's usage endpoint
+        // resolved. Omitted gracefully otherwise.
+        const usageStat = usageStats[vaultName];
+        const usageLine = usageStat
+          ? `<p class="vault-usage" data-testid="vault-usage">${escapeHtml(usageStat)}</p>`
+          : "";
         return `
         <div class="vault-tile" data-testid="vault-tile" data-vault-name="${safeVault}">
           <p class="vault-name"><strong>${safeVault}</strong></p>
+          ${usageLine}
           <div class="mcp-connect" data-testid="mcp-connect">
             <p class="mcp-connect-label" data-testid="connect-ai-heading">Connect your AI
                assistant to this vault</p>
@@ -364,6 +387,7 @@ function renderVaultCard(opts: VaultCardOpts): string {
                capture in this vault — or jump straight to bulk-importing Markdown/Obsidian
                notes into it.</span>
           </p>
+          ${manageBlock}
           ${tokenMintBlock}
         </div>`;
       })
@@ -471,6 +495,34 @@ function renderTokenMintBlock(
               </form>
             </div>
           </details>`;
+}
+
+/**
+ * The "Configure / back up this vault ↗" affordance on a vault tile. A small
+ * POST form to `/account/vault-admin-token/<name>` that mints a
+ * `vault:<name>:admin` deep-link token and redirects into the vault's own admin
+ * SPA — where the assigned user can rotate vault tokens AND set up Git backup /
+ * mirror config. Shown only when the user's assignment grants `admin` (gated by
+ * the caller). A plain form button (no `<details>`) — this is a primary admin
+ * action for an individual user, more prominent than the headless-token mint
+ * below it.
+ *
+ * No-JS posture: a same-origin form POST that 303-redirects on success, same
+ * shape as the other `/account/*` forms. CSRF-gated via the hidden field.
+ */
+function renderVaultAdminLink(vaultName: string, csrfToken: string): string {
+  // Path segment is URL-encoded; the action attribute is HTML-escaped on top.
+  const action = escapeHtml(`/account/vault-admin-token/${encodeURIComponent(vaultName)}`);
+  return `
+          <form method="POST" action="${action}" class="vault-admin-link"
+                data-testid="vault-admin-form">
+            ${renderCsrfHiddenInput(csrfToken)}
+            <button type="submit" class="btn btn-secondary" data-testid="vault-admin-button">
+              Configure / back up this vault ↗
+            </button>
+            <span class="vault-admin-sub">Open this vault's admin tools — rotate access tokens,
+               and set up Git backup (mirror to a repository).</span>
+          </form>`;
 }
 
 /**
@@ -717,6 +769,11 @@ const STYLES = `
     margin: 0 0 0.6rem;
   }
   .vault-name strong { color: ${PALETTE.fg}; font-weight: 600; }
+  .vault-usage {
+    font-size: 0.8rem;
+    color: ${PALETTE.fgMuted};
+    margin: 0 0 0.5rem;
+  }
   .vault-tiles {
     display: flex;
     flex-direction: column;
@@ -822,6 +879,21 @@ const STYLES = `
     font-size: 0.82rem;
     color: ${PALETTE.fgMuted};
     margin: 0.4rem 0 0;
+  }
+
+  .vault-admin-link {
+    margin: 0.9rem 0 0;
+    padding-top: 0.6rem;
+    border-top: 1px solid ${PALETTE.borderLight};
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.4rem 0.75rem;
+  }
+  .vault-admin-sub {
+    font-size: 0.82rem;
+    color: ${PALETTE.fgMuted};
+    flex: 1 1 12rem;
   }
 
   .token-mint {
@@ -981,13 +1053,14 @@ const STYLES = `
     h1, h2 { color: #f0ece4; }
     .subtitle, .kv dt, .mcp-field-label, .mcp-connect-hint,
     .mcp-connect-intro, .mcp-method-sub, .mcp-method-note,
-    .vault-notes-cta-sub { color: #a8a29a; }
+    .vault-notes-cta-sub, .vault-usage { color: #a8a29a; }
     .vault-name strong, .mcp-connect-label, .mcp-method-title { color: #f0ece4; }
     code { background: #1f1c18; color: #e8e4dc; }
     .copy-row code { background: transparent; }
     .section { border-top-color: #3a362f; }
     .mcp-method, .vault-notes-cta, .token-mint,
-    .account-security { border-top-color: #3a362f; }
+    .vault-admin-link, .account-security { border-top-color: #3a362f; }
+    .vault-admin-sub { color: #a8a29a; }
     .get-started h3 { color: #f0ece4; }
     .starter-tile { border-color: #3a362f; background: #1f1c18; }
     .starter-tile:hover { border-color: ${PALETTE.accent}; }

--- a/src/account-usage.ts
+++ b/src/account-usage.ts
@@ -1,0 +1,118 @@
+/**
+ * Per-vault usage fetch for the friend-facing `/account/` home.
+ *
+ * Vault serves `GET /vault/<name>/.parachute/usage` (read-scoped) returning a
+ * footprint report (vault#437):
+ *   { counts: { notes, attachments, links, tags },
+ *     bytes:  { content, db, assets, mirror?, total },
+ *     computedAt, cached }
+ *
+ * The `/account/` GET handler renders one tile per assigned vault; this module
+ * fetches each vault's usage so the tile can show a compact "X notes · Y MB"
+ * stat. The READ scope means the assigned user's OWN authority suffices — we
+ * mint a short-lived `vault:<name>:read` token (the same authority the OAuth
+ * issuer would grant them) and call the vault over loopback.
+ *
+ * Tolerant by design: any failure (vault down, endpoint absent on an older
+ * vault, mint failure, malformed JSON) resolves to `null` so the tile simply
+ * omits the stat rather than breaking the page. Usage is a nice-to-have on a
+ * friend's home, never load-bearing.
+ *
+ * Injectable seams (`fetchImpl`, `signToken`) keep it unit-testable without a
+ * live vault or real signing key.
+ */
+import type { Database } from "bun:sqlite";
+import { signAccessToken } from "./jwt-sign.ts";
+
+/** The subset of vault's usage report the `/account/` tile renders. */
+export interface VaultUsageStat {
+  notes: number;
+  /** Physical footprint bytes (`bytes.total` from the vault report). */
+  totalBytes: number;
+}
+
+/** Short TTL for the read token — it's used immediately for one loopback call. */
+const USAGE_READ_TOKEN_TTL_SECONDS = 60;
+
+export interface FetchVaultUsageDeps {
+  db: Database;
+  /** Hub origin — `iss` of the minted read token. */
+  hubOrigin: string;
+  /** Loopback port the vault backend listens on (from services.json). */
+  vaultPort: number;
+  /** The user minting against their own read authority — `sub` of the token. */
+  userId: string;
+  /** Test seam — `globalThis.fetch` in production. */
+  fetchImpl?: typeof fetch;
+  /** Test seam — defaults to the real `signAccessToken`. */
+  signToken?: typeof signAccessToken;
+  /** Test seam for the clock. */
+  now?: () => Date;
+}
+
+/**
+ * Fetch one vault's usage stat for the friend's tile, or `null` on any failure.
+ *
+ * Mints a `vault:<name>:read` bearer for `userId` (capped to that one vault via
+ * `vaultScope`) and GETs the vault's loopback usage endpoint. Never throws —
+ * the page renders without the stat on any error.
+ */
+export async function fetchVaultUsage(
+  vaultName: string,
+  deps: FetchVaultUsageDeps,
+): Promise<VaultUsageStat | null> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const sign = deps.signToken ?? signAccessToken;
+  try {
+    const scope = `vault:${vaultName}:read`;
+    const minted = await sign(deps.db, {
+      sub: deps.userId,
+      scopes: [scope],
+      audience: `vault.${vaultName}`,
+      clientId: "parachute-account",
+      issuer: deps.hubOrigin,
+      ttlSeconds: USAGE_READ_TOKEN_TTL_SECONDS,
+      vaultScope: [vaultName],
+      ...(deps.now !== undefined ? { now: deps.now } : {}),
+    });
+    const url = `http://127.0.0.1:${deps.vaultPort}/vault/${vaultName}/.parachute/usage`;
+    const res = await fetchImpl(url, {
+      headers: { authorization: `Bearer ${minted.token}`, accept: "application/json" },
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as {
+      counts?: { notes?: unknown };
+      bytes?: { total?: unknown };
+    };
+    const notes = body.counts?.notes;
+    const totalBytes = body.bytes?.total;
+    if (typeof notes !== "number" || typeof totalBytes !== "number") return null;
+    return { notes, totalBytes };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Format a usage stat as the compact "X notes · Y MB" string the tile shows.
+ * Bytes render in the largest sensible unit (B / KB / MB / GB) with one
+ * decimal for MB+ and whole numbers below. Notes are pluralized.
+ *
+ * Exported for direct unit testing + reuse by the renderer.
+ */
+export function formatUsageStat(stat: VaultUsageStat): string {
+  const noteLabel = stat.notes === 1 ? "note" : "notes";
+  return `${stat.notes} ${noteLabel} · ${formatBytes(stat.totalBytes)}`;
+}
+
+/** Human-readable byte size — B / KB / MB / GB, one decimal for MB+. */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "0 B";
+  if (bytes < 1024) return `${Math.round(bytes)} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${Math.round(kb)} KB`;
+  const mb = kb / 1024;
+  if (mb < 1024) return `${mb.toFixed(1)} MB`;
+  const gb = mb / 1024;
+  return `${gb.toFixed(1)} GB`;
+}

--- a/src/account-vault-admin-token.ts
+++ b/src/account-vault-admin-token.ts
@@ -1,0 +1,242 @@
+/**
+ * `POST /account/vault-admin-token/<name>` — friend-facing vault ADMIN deep-link.
+ *
+ * The non-admin sibling of `GET /admin/vault-admin-token/<name>`
+ * (`admin-vault-admin-token.ts`). Both mint a `vault:<name>:admin` JWT and
+ * hand it to the vault's own admin SPA via a `#token=<jwt>` URL fragment — the
+ * SPA reads `location.hash` on bootstrap, then strips it. The admin sibling is
+ * gated `isFirstAdmin` and returns JSON for the hub SPA's fetch; THIS surface
+ * is gated on ASSIGNMENT (an individual user holds `admin` on a vault they're
+ * assigned to) and is a server-rendered POST → 303 redirect, matching the
+ * no-JS posture of the rest of `/account/*`.
+ *
+ * Why this exists: an assigned user is ALREADY authorized for `vault:<name>:admin`
+ * (`vaultVerbsForUserVault` returns `["read","write","admin"]` for their vault,
+ * 2026-05-30; vault gates mirror/backup config + token rotation on that scope).
+ * The authority existed; the only missing piece was a friend-reachable HTTP
+ * unlock + a button. With this, an individual user can open their vault's admin
+ * SPA — token mint/revoke, **and the Git-backup / mirror config** — without
+ * host-admin. The deep-link lands on the vault admin home (`managementUrl`,
+ * `/admin/` by default), whose "Git backup →" link reaches `VaultMirror`.
+ *
+ * Authorization — the same three-gate spine as `/account/vault-token/<name>`
+ * (`account-vault-token.ts`), here pinned to the single `admin` verb:
+ *
+ *   1. **Session.** A valid hub session cookie (the user's). No session → 401.
+ *   2. **Assignment.** `<name>` MUST be one of the user's `user_vaults`
+ *      assignments AND that assignment's role must grant `admin`. Read via
+ *      `vaultVerbsForUserVault` (`null` for an unassigned vault → 403; a role
+ *      that doesn't grant `admin` → 403). The first admin (empty
+ *      `assignedVaults`, no `user_vaults` rows) gets `null` here too — by
+ *      design, the same as `/account/vault-token`: admins use the SPA's
+ *      `/admin/vault-admin-token` path, not this friend surface.
+ *
+ * CSRF: double-submit cookie, same `__csrf` field + `verifyCsrfToken` as
+ * `/account/vault-token`, `/account/change-password`, and `/logout`. A
+ * cross-site POST without the matching cookie/form token → 400.
+ *
+ * Force-change-password gate (item F / hub#469): if `!user.passwordChanged`,
+ * 303 → `/account/change-password` BEFORE minting — identical to the gate
+ * `/account/vault-token` applies post-#550. An admin-created/reset user lands
+ * with a temp password and `password_changed: false`; without this gate they
+ * could mint a `vault:<name>:admin` deep-link token (10-min TTL, but still) and
+ * keep using the temp password instead of rotating it. Placed AFTER the
+ * authority gates (so an unassigned/garbage request still gets its 403/400) and
+ * BEFORE the mint. This does NOT reintroduce the bypass #469 closed.
+ *
+ * Mint: `signAccessToken` (the same machinery the OAuth issuer + admin paths
+ * use) with `scopes: ["vault:<name>:admin"]`, `audience: "vault.<name>"`,
+ * `iss`: the hub origin, `sub`: the user id, `vaultScope: [<name>]`, and the
+ * SAME short 10-min TTL as the admin sibling (`VAULT_ADMIN_TOKEN_TTL_SECONDS`):
+ * this is a deep-link bootstrap token, not a long-lived headless credential
+ * (that's `/account/vault-token`). A `tokens` registry row records it
+ * (`created_via='cli_mint'`, `userId` = the user) so it's revocable.
+ *
+ * Response: 303 → `<vault-url><managementUrl>#token=<jwt>`. 303 (See Other) so
+ * the browser re-issues the navigation as GET. The token rides the URL
+ * fragment, which is never sent to the server — same contract the hub SPA's
+ * `VaultsList` "Manage" button uses (vault PR #219).
+ */
+import type { Database } from "bun:sqlite";
+import { renderAdminError } from "./admin-login-ui.ts";
+import { VAULT_ADMIN_TOKEN_TTL_SECONDS } from "./admin-vault-admin-token.ts";
+import { CSRF_FIELD_NAME, verifyCsrfToken } from "./csrf.ts";
+import { recordTokenMint, signAccessToken } from "./jwt-sign.ts";
+import { findActiveSession } from "./sessions.ts";
+import { getUserById, vaultVerbsForUserVault } from "./users.ts";
+import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
+
+/** Lowercase-only vault-name charset — single source of truth in vault-name.ts. */
+const VAULT_NAME_RE = VAULT_NAME_CHARSET_RE;
+/** client_id stamped on the minted JWT + registry row. Matches the admin sibling. */
+const ACCOUNT_VAULT_ADMIN_CLIENT_ID = "parachute-hub-spa";
+
+export interface AccountVaultAdminTokenDeps {
+  db: Database;
+  /** Hub origin for this request — `iss` of the minted token + base of the redirect URL. */
+  hubOrigin: string;
+  /**
+   * The vault's declared `managementUrl` (from its `.parachute/module.json`),
+   * resolved by the route handler at request time. Either an absolute URL or a
+   * path relative to the vault's mounted URL. Defaults to `/admin/` (vault's
+   * canonical value) when the handler can't resolve one — that's where the
+   * admin sibling's deep-link lands too.
+   */
+  managementUrl?: string;
+  /** Test seam for the clock (mint). */
+  now?: () => Date;
+}
+
+function htmlResponse(body: string, status = 200, extra: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store", ...extra },
+  });
+}
+
+/**
+ * Resolve a vault's `managementUrl` against the vault's hub-mounted URL.
+ * Absolute URL → returned verbatim; path → joined onto the vault URL after
+ * trimming a trailing slash. Mirrors `resolveManagementUrl` in the SPA's
+ * `web/ui/src/lib/api.ts` so hub-server and SPA deep-links agree.
+ */
+function resolveManagementUrl(vaultUrl: string, managementUrl: string): string {
+  if (/^https?:\/\//i.test(managementUrl)) return managementUrl;
+  const base = vaultUrl.replace(/\/+$/, "");
+  const tail = managementUrl.startsWith("/") ? managementUrl : `/${managementUrl}`;
+  return `${base}${tail}`;
+}
+
+export async function handleAccountVaultAdminTokenPost(
+  req: Request,
+  vaultName: string,
+  deps: AccountVaultAdminTokenDeps,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return htmlResponse("method not allowed", 405);
+  }
+
+  // Gate 1 — session. No identity, no mint.
+  const session = findActiveSession(deps.db, req);
+  if (!session) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Not signed in",
+        message: "Please sign in before opening your vault's admin tools.",
+      }),
+      401,
+    );
+  }
+  const user = getUserById(deps.db, session.userId);
+  if (!user) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Account not found",
+        message: "The signed-in account no longer exists. Please sign in again.",
+      }),
+      401,
+    );
+  }
+
+  // CSRF — verify before any state change, same shape + 400 as the other
+  // `/account/*` POSTs.
+  const form = await req.formData();
+  const formCsrf = form.get(CSRF_FIELD_NAME);
+  if (!verifyCsrfToken(req, typeof formCsrf === "string" ? formCsrf : null)) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Invalid form submission",
+        message: "The form's CSRF token did not match. Reload the page and try again.",
+      }),
+      400,
+    );
+  }
+
+  // Vault-name shape guard — reject anything that can't be a services.json key
+  // before any DB / authority work. Same posture as the other vault-token mints.
+  if (!VAULT_NAME_RE.test(vaultName)) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Invalid vault name",
+        message: `"${vaultName}" is not a valid vault name.`,
+      }),
+      400,
+    );
+  }
+
+  // Gate 2 — assignment + admin-verb cap. `vaultVerbsForUserVault` returns:
+  //   - null  → no assignment for this vault → 403.
+  //   - [...] → the verbs the assignment role permits; must include `admin`.
+  // Assigned users hold read/write/admin on their vault (2026-05-30); the first
+  // admin has no `user_vaults` rows so gets `null` here and a 403 — by design,
+  // admins use the SPA path. This is the cap to the user's actual authority.
+  const allowed = vaultVerbsForUserVault(deps.db, user.id, vaultName);
+  if (allowed === null || !allowed.includes("admin")) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Not your vault to manage",
+        message: `You don't have admin access to a vault named "${vaultName}". Ask the hub operator if you think this is wrong.`,
+      }),
+      403,
+    );
+  }
+
+  // Force-change-password gate (item F / hub#469). An admin-created/reset user
+  // with `password_changed: false` is sent to the change-password rail BEFORE
+  // minting — same gate `/account/vault-token` applies, so a temp-password
+  // handoff can't be parlayed into a vault-admin deep-link. Placed AFTER the
+  // authority gates (an unassigned/garbage request still gets its 403/400) and
+  // BEFORE the mint. 303 so the browser re-issues as GET. Does NOT reintroduce
+  // the bypass #469 closed.
+  if (!user.passwordChanged) {
+    return new Response(null, {
+      status: 303,
+      headers: { location: "/account/change-password", "cache-control": "no-store" },
+    });
+  }
+
+  // Mint the vault-admin deep-link token. Short TTL (10 min, matching the admin
+  // sibling) — it's a bootstrap token the vault SPA trades for its session, not
+  // a long-lived headless credential (that's `/account/vault-token`).
+  const scope = `vault:${vaultName}:admin`;
+  const audience = `vault.${vaultName}`;
+  const minted = await signAccessToken(deps.db, {
+    sub: user.id,
+    scopes: [scope],
+    audience,
+    clientId: ACCOUNT_VAULT_ADMIN_CLIENT_ID,
+    issuer: deps.hubOrigin,
+    ttlSeconds: VAULT_ADMIN_TOKEN_TTL_SECONDS,
+    vaultScope: [vaultName],
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  });
+
+  recordTokenMint(deps.db, {
+    jti: minted.jti,
+    createdVia: "cli_mint",
+    subject: user.id,
+    // Anchor the registry row to the user's id so the operator's token registry
+    // + the revocation list attribute it correctly.
+    userId: user.id,
+    clientId: ACCOUNT_VAULT_ADMIN_CLIENT_ID,
+    scopes: [scope],
+    expiresAt: minted.expiresAt,
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  });
+
+  // Build the redirect target: <vault-url><managementUrl>#token=<jwt>. The
+  // vault URL is the hub-mounted path (`<hubOrigin>/vault/<name>`); the
+  // managementUrl (default `/admin/`) is the vault admin SPA entry point. The
+  // JWT rides the URL fragment — never sent to the server — exactly as the hub
+  // SPA's "Manage" button does (vault PR #219).
+  const trimmedOrigin = deps.hubOrigin.replace(/\/+$/, "");
+  const vaultUrl = `${trimmedOrigin}/vault/${vaultName}`;
+  const target = resolveManagementUrl(vaultUrl, deps.managementUrl ?? "/admin/");
+  const sep = target.includes("#") ? "&" : "#";
+  const location = `${target}${sep}token=${minted.token}`;
+
+  return new Response(null, {
+    status: 303,
+    headers: { location, "cache-control": "no-store" },
+  });
+}

--- a/src/api-account.ts
+++ b/src/api-account.ts
@@ -49,6 +49,7 @@ import type { Database } from "bun:sqlite";
 import { hash as argonHash } from "@node-rs/argon2";
 import { type ChangePasswordMode, renderChangePassword } from "./account-change-password-ui.ts";
 import { renderAccountHome } from "./account-home-ui.ts";
+import { fetchVaultUsage, formatUsageStat } from "./account-usage.ts";
 import { POST_LOGIN_DEFAULT } from "./admin-handlers.ts";
 import { renderAdminError } from "./admin-login-ui.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
@@ -486,9 +487,24 @@ export async function handleAccountChangePasswordPost(
 export interface AccountHomeDeps extends ApiAccountDeps {
   /** Canonical hub origin for this request (e.g. `https://my-hub.example`). */
   hubOrigin: string;
+  /**
+   * Resolve a vault's loopback port from services.json, or `null` when no vault
+   * is mounted under that name. Threaded in by the route handler (which reads
+   * the manifest) so this module stays free of services.json plumbing. Absent
+   * in tests / older callers → usage surfacing is skipped (tiles render without
+   * the stat, same as a failed fetch).
+   */
+  resolveVaultPort?: (vaultName: string) => number | null;
+  /**
+   * Fetch one vault's usage stat, or `null` on any failure. Defaults to the
+   * real `fetchVaultUsage` (mints a read token + hits the vault's loopback
+   * usage endpoint). Injectable so tests assert the render without a live
+   * vault.
+   */
+  fetchUsage?: typeof fetchVaultUsage;
 }
 
-export function handleAccountHomeGet(req: Request, deps: AccountHomeDeps): Response {
+export async function handleAccountHomeGet(req: Request, deps: AccountHomeDeps): Promise<Response> {
   const session = findActiveSession(deps.db, req);
   if (!session) {
     return redirect(`/login?next=${encodeURIComponent("/account/")}`);
@@ -511,6 +527,32 @@ export function handleAccountHomeGet(req: Request, deps: AccountHomeDeps): Respo
     const verbs = vaultVerbsForUserVault(deps.db, user.id, v);
     if (verbs && verbs.length > 0) mintableVerbs[v] = verbs;
   }
+
+  // Per-vault usage stat ("X notes · Y MB"). Fetched concurrently across the
+  // user's assigned vaults via the read-scoped vault endpoint; each fetch is
+  // independently fault-tolerant (returns null → that tile renders without a
+  // stat). Skipped entirely when the route didn't wire a port resolver (tests /
+  // older callers). The READ scope means the user's own authority suffices.
+  const usageStats: Record<string, string> = {};
+  if (deps.resolveVaultPort && user.assignedVaults.length > 0) {
+    const fetchUsage = deps.fetchUsage ?? fetchVaultUsage;
+    const resolvePort = deps.resolveVaultPort;
+    await Promise.all(
+      user.assignedVaults.map(async (vaultName) => {
+        const port = resolvePort(vaultName);
+        if (port === null) return;
+        const stat = await fetchUsage(vaultName, {
+          db: deps.db,
+          hubOrigin: deps.hubOrigin,
+          vaultPort: port,
+          userId: user.id,
+          ...(deps.now !== undefined ? { now: deps.now } : {}),
+        });
+        if (stat) usageStats[vaultName] = formatUsageStat(stat);
+      }),
+    );
+  }
+
   return htmlResponse(
     renderAccountHome({
       username: user.username,
@@ -521,6 +563,7 @@ export function handleAccountHomeGet(req: Request, deps: AccountHomeDeps): Respo
       csrfToken: csrf.token,
       twoFactorEnabled: isTotpEnrolled(deps.db, user.id),
       mintableVerbs,
+      usageStats,
     }),
     200,
     extra,

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -121,6 +121,7 @@ import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import pkg from "../package.json" with { type: "json" };
+import { handleAccountVaultAdminTokenPost } from "./account-vault-admin-token.ts";
 import { handleAccountVaultTokenPost } from "./account-vault-token.ts";
 import { handleApproveClient, handleGetClient } from "./admin-clients.ts";
 import { handleListGrants, handleRevokeGrant } from "./admin-grants.ts";
@@ -2290,6 +2291,50 @@ export function hubFetch(
       return new Response("method not allowed", { status: 405 });
     }
 
+    // /account/vault-admin-token/<name> — friend-facing vault ADMIN deep-link.
+    // POST-only, session-gated, assignment-capped to the `admin` verb: an
+    // assigned non-admin user mints a `vault:<name>:admin` bootstrap token and
+    // 303-redirects into the vault's own admin SPA (`#token=<jwt>`), where they
+    // can rotate vault tokens AND configure Git backup / mirror. The non-admin
+    // sibling of `/admin/vault-admin-token/<name>` (which is first-admin-gated
+    // and returns JSON for the hub SPA). The handler enforces session →
+    // assignment-grants-admin → CSRF → force-change-password (item F / #469)
+    // before minting. Must precede `/account/vault-token/` (it isn't a prefix
+    // of it, but keep the more-specific admin path first for clarity) and the
+    // `/account/` match below. See `account-vault-admin-token.ts`.
+    if (pathname.startsWith("/account/vault-admin-token/")) {
+      if (!getDb) return dbNotConfigured();
+      if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+      const vaultName = decodeURIComponent(pathname.slice("/account/vault-admin-token/".length));
+      const db = getDb();
+      const hubOrigin = resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin);
+      // Resolve the vault's declared `managementUrl` at request time (same
+      // source the well-known doc reads — `installDir/.parachute/module.json`)
+      // so the deep-link lands on the vault admin SPA's real entry point. Quiet
+      // on a malformed/absent manifest: the handler defaults to `/admin/`
+      // (vault's canonical value), the same target the admin sibling uses.
+      const readManifestFn = deps?.readModuleManifest ?? defaultReadModuleManifest;
+      const manifest = readManifestLenient(manifestPath);
+      let managementUrl: string | undefined;
+      for (const s of manifest.services) {
+        if (!isVaultEntry(s) || !s.installDir) continue;
+        const instanceNames = new Set(s.paths.map((p) => vaultInstanceNameFor(s.name, p)));
+        if (!instanceNames.has(vaultName)) continue;
+        try {
+          const m = await readManifestFn(s.installDir);
+          if (m?.managementUrl) managementUrl = m.managementUrl;
+        } catch {
+          // Leave undefined → handler defaults to /admin/.
+        }
+        break;
+      }
+      return handleAccountVaultAdminTokenPost(req, vaultName, {
+        db,
+        hubOrigin,
+        ...(managementUrl !== undefined ? { managementUrl } : {}),
+      });
+    }
+
     // /account/vault-token/<name> — friend-facing scoped vault token mint.
     // POST-only, session-gated, assignment-capped: a non-admin friend mints a
     // `vault:<name>:read|write` bearer for a vault they're ASSIGNED to, for
@@ -2322,7 +2367,16 @@ export function hubFetch(
       if (!getDb) return dbNotConfigured();
       const db = getDb();
       const hubOrigin = resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin);
-      return handleAccountHomeGet(req, { db, hubOrigin });
+      // Resolve each assigned vault's loopback port from services.json so the
+      // home can fetch per-vault usage. Read at request time (same dynamism as
+      // proxyToVault) — a vault created seconds ago surfaces a stat without a
+      // restart. Returns null for an unknown name → that tile skips the stat.
+      const resolveVaultPort = (vaultName: string): number | null => {
+        const services = readManifestLenient(manifestPath).services;
+        const match = findVaultUpstream(services, `/vault/${vaultName}`);
+        return match ? match.port : null;
+      };
+      return handleAccountHomeGet(req, { db, hubOrigin, resolveVaultPort });
     }
 
     // Legacy `/admin/config` (server-rendered module-config portal, #46)

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -377,6 +377,73 @@ describe("mintVaultAdminToken", () => {
   });
 });
 
+describe("getVaultUsage", () => {
+  // getVaultUsage mints a vault-admin token (admin ⊇ read) then GETs the vault's
+  // proxied /.parachute/usage. The mock routes by URL: the mint endpoint returns
+  // a token, the usage endpoint returns the footprint report.
+  function routedFetch(usage: { status: number; body: unknown }) {
+    return vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.startsWith("/admin/vault-admin-token/")) {
+        return jsonResponse(200, {
+          token: "vadmin-jwt",
+          expires_at: "2026-01-01T00:00:00.000Z",
+          scopes: ["vault:work:admin"],
+        });
+      }
+      // Usage request — assert it carried the minted Bearer.
+      expect((init?.headers as Record<string, string>)?.authorization).toBe("Bearer vadmin-jwt");
+      return jsonResponse(usage.status, usage.body);
+    });
+  }
+
+  it("mints an admin token then parses {counts, bytes} from the proxied endpoint", async () => {
+    const fetchMock = routedFetch({
+      status: 200,
+      body: {
+        counts: { notes: 12, attachments: 0, links: 3, tags: 1 },
+        bytes: { content: 100, db: 2048, assets: 0, total: 2048 },
+        computedAt: "2026-01-01T00:00:00.000Z",
+        cached: false,
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const api = await import("./api.ts");
+    const usage = await api.getVaultUsage("work");
+    expect(usage).toEqual({ notes: 12, totalBytes: 2048 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/vault/work/.parachute/usage",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("throws HttpError when the usage endpoint 403s (caller swallows → '—')", async () => {
+    vi.stubGlobal("fetch", routedFetch({ status: 403, body: { error: "forbidden" } }));
+    const api = await import("./api.ts");
+    await expect(api.getVaultUsage("work")).rejects.toMatchObject({
+      name: "HttpError",
+      status: 403,
+    });
+  });
+
+  it("throws HttpError on a malformed usage body", async () => {
+    vi.stubGlobal("fetch", routedFetch({ status: 200, body: { counts: {}, bytes: {} } }));
+    const api = await import("./api.ts");
+    await expect(api.getVaultUsage("work")).rejects.toMatchObject({ name: "HttpError" });
+  });
+});
+
+describe("formatBytes", () => {
+  it("picks the largest sensible unit", async () => {
+    const api = await import("./api.ts");
+    expect(api.formatBytes(0)).toBe("0 B");
+    expect(api.formatBytes(512)).toBe("512 B");
+    expect(api.formatBytes(2048)).toBe("2 KB");
+    expect(api.formatBytes(5 * 1024 * 1024)).toBe("5.0 MB");
+    expect(api.formatBytes(3 * 1024 * 1024 * 1024)).toBe("3.0 GB");
+    expect(api.formatBytes(-1)).toBe("0 B");
+  });
+});
+
 describe("listGrants", () => {
   it("sends Bearer + parses {grants: [...]} body", async () => {
     const fetchMock = vi.fn(async () =>

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -254,6 +254,62 @@ export async function mintVaultAdminToken(name: string): Promise<MintedVaultAdmi
 }
 
 /**
+ * Per-vault usage stat surfaced in the VaultsList row. Subset of the vault's
+ * `GET /vault/<name>/.parachute/usage` report (vault#437) — the full report
+ * carries more (links, tags, db/assets/mirror byte breakdown), but the row only
+ * needs note count + physical footprint.
+ */
+export interface VaultUsage {
+  notes: number;
+  /** Physical footprint bytes (`bytes.total` from the vault report). */
+  totalBytes: number;
+}
+
+/**
+ * Fetch one vault's usage report through the hub's `/vault/<name>/*` proxy.
+ *
+ * The endpoint is read-scoped; `parachute:host:admin` is NOT a vault scope and
+ * vault would 403 it, so we mint a `vault:<name>:admin` bearer (admin ⊇ read)
+ * via the existing session-cookie path — the same token the "Manage" button
+ * uses. The VaultsList fans this out per row (N small requests) and tolerates
+ * per-vault failure by rendering "—", so this throws on failure and the caller
+ * swallows it; it deliberately does NOT redirect-on-401 (that's the Manage
+ * button's job — a usage cell shouldn't hijack the page).
+ */
+export async function getVaultUsage(name: string): Promise<VaultUsage> {
+  const minted = await mintVaultAdminToken(name);
+  const res = await fetch(`/vault/${encodeURIComponent(name)}/.parachute/usage`, {
+    method: "GET",
+    headers: { accept: "application/json", authorization: `Bearer ${minted.token}` },
+  });
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  const body = (await res.json()) as {
+    counts?: { notes?: unknown };
+    bytes?: { total?: unknown };
+  };
+  const notes = body.counts?.notes;
+  const totalBytes = body.bytes?.total;
+  if (typeof notes !== "number" || typeof totalBytes !== "number") {
+    throw new HttpError(500, "/.parachute/usage returned malformed body");
+  }
+  return { notes, totalBytes };
+}
+
+/** Human-readable byte size — B / KB / MB / GB, one decimal for MB+. */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "0 B";
+  if (bytes < 1024) return `${Math.round(bytes)} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${Math.round(kb)} KB`;
+  const mb = kb / 1024;
+  if (mb < 1024) return `${mb.toFixed(1)} MB`;
+  const gb = mb / 1024;
+  return `${gb.toFixed(1)} GB`;
+}
+
+/**
  * Operator-visible OAuth grant from `GET /api/grants`. The hub returns a
  * snake_case row to keep the wire format aligned with the underlying
  * sqlite schema; the SPA reads it directly.

--- a/web/ui/src/routes/VaultsList.tsx
+++ b/web/ui/src/routes/VaultsList.tsx
@@ -14,6 +14,9 @@ import { McpConnectCard } from "../components/McpConnectCard.tsx";
 import {
   HttpError,
   type VaultListing,
+  type VaultUsage,
+  formatBytes,
+  getVaultUsage,
   listVaults,
   mintVaultAdminToken,
   resolveManagementUrl,
@@ -34,6 +37,15 @@ type ManageState =
   | { kind: "minting"; name: string }
   | { kind: "error"; name: string; message: string };
 
+/**
+ * Per-vault usage cell state. Client-side fan-out: one small request per row,
+ * each independently fault-tolerant — a vault whose usage endpoint fails (down,
+ * older vault without the endpoint, mint failure) shows "—" rather than
+ * breaking the list. `loading` while in flight, `ok` with the stat, `error`
+ * collapses to the "—" placeholder.
+ */
+type UsageCell = { kind: "loading" } | { kind: "ok"; usage: VaultUsage } | { kind: "error" };
+
 export function VaultsList() {
   const [state, setState] = useState<State>({ kind: "loading" });
   const [reload, setReload] = useState(0);
@@ -41,6 +53,9 @@ export function VaultsList() {
   // Which row's MCP-connect card is expanded. Single-open: clicking
   // Connect on another row swaps the open card rather than stacking them.
   const [connectFor, setConnectFor] = useState<string | null>(null);
+  // Per-vault usage cells, keyed by vault name. Populated by the fan-out effect
+  // below once the vault list resolves.
+  const [usage, setUsage] = useState<Record<string, UsageCell>>({});
 
   async function onManage(vault: VaultListing): Promise<void> {
     if (!vault.managementUrl) return;
@@ -89,6 +104,36 @@ export function VaultsList() {
       cancelled = true;
     };
   }, [reload]);
+
+  // Fan out per-vault usage once the list resolves. Each row's fetch is
+  // independent + fault-tolerant: success → its cell shows the stat, any failure
+  // → "—". Re-runs when the vault set changes (create / reload). The cell is
+  // seeded "loading" so the row shows a placeholder until its request settles.
+  useEffect(() => {
+    if (state.kind !== "ok") return;
+    const names = state.vaults.map((v) => v.name);
+    if (names.length === 0) return;
+    let cancelled = false;
+    setUsage((prev) => {
+      const next = { ...prev };
+      for (const name of names) if (!next[name]) next[name] = { kind: "loading" };
+      return next;
+    });
+    for (const name of names) {
+      getVaultUsage(name)
+        .then((u) => {
+          if (cancelled) return;
+          setUsage((prev) => ({ ...prev, [name]: { kind: "ok", usage: u } }));
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setUsage((prev) => ({ ...prev, [name]: { kind: "error" } }));
+        });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [state]);
 
   if (state.kind === "loading") {
     return (
@@ -179,6 +224,13 @@ export function VaultsList() {
             const isMinting = manage.kind === "minting" && manage.name === v.name;
             const rowError = manage.kind === "error" && manage.name === v.name ? manage : null;
             const isConnectOpen = connectFor === v.name;
+            const usageCell = usage[v.name];
+            const usageText =
+              usageCell?.kind === "ok"
+                ? `${usageCell.usage.notes} ${usageCell.usage.notes === 1 ? "note" : "notes"} · ${formatBytes(usageCell.usage.totalBytes)}`
+                : usageCell?.kind === "loading"
+                  ? "…"
+                  : "—";
             return (
               <div key={v.name} className="vault-row-group">
                 <div className="vault-row">
@@ -191,6 +243,9 @@ export function VaultsList() {
                     </div>
                     <div className="dim url">
                       <code>{v.url}</code>
+                    </div>
+                    <div className="dim vault-usage" data-testid={`vault-usage-${v.name}`}>
+                      {usageText}
                     </div>
                     {rowError ? (
                       <div className="error-banner" style={{ marginTop: "0.5rem" }}>


### PR DESCRIPTION
Two cohesive additions to the friend-facing `/account` surface that let an **assigned (non-host-admin) individual user** self-serve **manage + back up their own vault**, without host-admin. The authorization already existed — an assigned user holds `vault:<name>:admin` (`users.ts` `vaultVerbsForRole('write')` → `[read,write,admin]`; vault gates mirror config on `vault:<name>:admin`). The only missing pieces were the HTTP unlock + the UI.

## 1. The unlock — `POST /account/vault-admin-token/<name>`

The non-admin sibling of `/admin/vault-admin-token/<name>` (which is `isFirstAdmin`-gated and returns JSON for the hub SPA's fetch). New handler `account-vault-admin-token.ts`:

- **Gated on ASSIGNMENT, not first-admin** — `vaultVerbsForUserVault` must return a role that grants `admin` (mirrors the `/account/vault-token` security model). Unassigned vault → 403; the first admin (no `user_vaults` rows) → 403 by design (admins use the SPA path).
- **CSRF** double-submit, same `__csrf` field + same-origin posture as the other `/account/*` POSTs.
- Mints `vault:<name>:admin` (`aud=vault.<name>`, `vault_scope` pinned, `iss`=hub, `sub`=user), short **10-min bootstrap TTL** matching the admin sibling — a deep-link token, not the 90-day headless one. A revocable `tokens` registry row is recorded.
- **303 redirects into the vault's own admin SPA** via `<vault-url><managementUrl>#token=<jwt>` (managementUrl resolved from the vault's `module.json` at request time, default `/admin/`) — the same `#token` contract the hub SPA's "Manage" button uses (vault PR #219).
- A **"Configure / back up this vault ↗"** button on each `/account/` vault tile (`account-home-ui.ts` `renderVaultCard`) POSTs to the route, shown only when the assignment grants `admin`.

### Force-change gate (no #469 bypass) — confirmed

The new route applies the **hub#550 item F** force-change-password gate: if `!user.passwordChanged`, it `303`s to `/account/change-password` **BEFORE minting anything**. Placed *after* the authority gates (an unassigned/garbage request still gets its 403/400) and *before* the mint — byte-for-byte the same shape `/account/vault-token` uses post-#550. It does **not** reintroduce the bypass #469 closed. Pinned by a test: unrotated user → 303 to change-password, `COUNT(*) FROM tokens == 0`.

## 2. Per-vault usage surfacing (vault#437's read-scoped `/.parachute/usage`)

- **Admin SPA** — `getVaultUsage(name)` + `formatBytes` in `web/ui/src/lib/api.ts`; `VaultsList` renders a compact **"X notes · Y MB"** cell per row via client-side fan-out (one request per row, each fault-tolerant → `—` on failure). Mints a `vault:<name>:admin` bearer (admin ⊇ read; `parachute:host:admin` is not a vault scope and vault would 403 it).
- **`/account/`** — `handleAccountHomeGet` (now async) fetches usage per assigned vault over loopback with a **user-minted read token** (`account-usage.ts`, read scope = the user's own authority suffices), renders a one-line stat on each tile, omits gracefully on any failure.

`web/ui/dist` is gitignored (like other Parachute repos) → source-only, no bundle committed.

## Mirror-UI investigation — verdict: the backup config surface EXISTS and is reachable

The research disagreed on whether a mirror/backup CONFIG UI exists. It does — **not in hub, in the VAULT admin SPA**: `parachute-vault/web/ui/src/routes/VaultMirror.tsx` ("Git backup"), routed at `/vault/<name>/admin/mirror`, admin-gated server-side via `mirror-routes.ts` (`vault:<name>:admin`), with a **"Git backup →"** link right on the vault admin home (`VaultDetail.tsx`). The deep-link this PR adds lands on `/vault/<name>/admin/` → the owner is one click from backup config. So no mirror UI is needed in hub; the unlock + usage are the deliverable, and the unlock genuinely leads to backup config.

## Gates (fake-launchctl shim)

- hub `bun test ./src`: **2908 pass / 1 skip / 0 fail**
- scope-guard `bun test ./packages/scope-guard/src`: **115 pass / 0 fail**
- `bun run typecheck`: clean
- web/ui `bunx vitest run`: **270 pass / 0 fail**; SPA `tsc --noEmit` clean

No version bump (per program convention — tag when shipping).

## Files

New: `src/account-vault-admin-token.ts`, `src/account-usage.ts`, `src/__tests__/account-vault-admin-token.test.ts`, `src/__tests__/account-usage.test.ts`. Changed: `src/hub-server.ts` (route wiring + per-vault port resolver), `src/api-account.ts` (async home + usage fan-out), `src/account-home-ui.ts` (manage button + usage stat), `src/__tests__/api-account.test.ts`, `web/ui/src/lib/api.ts` (`getVaultUsage`/`formatBytes`), `web/ui/src/routes/VaultsList.tsx` (usage cell), `web/ui/src/lib/api.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)