### PR TITLE
fix(security): per-request force-change-password enforcement (#469)

### DIFF
--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -4342,7 +4342,12 @@ describe("POST /account/vault-token/<name> — friend scoped mint (routed end-to
   // Item F (#469) routed e2e — an assigned but unrotated friend is force-
   // redirected to the change-password rail before any mint, through the real
   // dispatch.
-  test("unrotated friend → 303 to change-password, routed through hubFetch (item F)", async () => {
+  test("unrotated friend is force-change-gated, routed through hubFetch (item F / #469)", async () => {
+    // As of hub#469 the broad per-request gate (forceChangePasswordGate) is the
+    // choke point and intercepts BEFORE the per-route mint handler. A browser
+    // request (Accept: text/html) is 302'd to the change-password rail; an
+    // API-style POST without that header is 403 force_change_password. Both
+    // prove the unrotated friend can't parlay the temp password into a mint.
     const h = makeHarness();
     writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
     const db = openHubDb(hubDbPath(h.dir));
@@ -4358,20 +4363,33 @@ describe("POST /account/vault-token/<name> — friend scoped mint (routed end-to
     const cookie = `${buildSessionCookie(session.id, 3600, { secure: false })}; ${
       buildCsrfCookie(csrf, { secure: false }).split(";")[0]
     }`;
+    const fetcher = hubFetch(h.dir, {
+      getDb: () => db,
+      manifestPath: h.manifestPath,
+      issuer: "https://hub.test",
+    });
     try {
-      const res = await hubFetch(h.dir, {
-        getDb: () => db,
-        manifestPath: h.manifestPath,
-        issuer: "https://hub.test",
-      })(
+      // The mint is a POST (non-GET) → the gate rejects with 403
+      // force_change_password regardless of Accept, per the spec ("redirect
+      // browser GETs, reject non-GET / API-style requests with 403"). A 302 on
+      // a POST wouldn't usefully re-issue the mint anyway.
+      const apiRes = await fetcher(
         req("/account/vault-token/work", {
           method: "POST",
           headers: { cookie, "content-type": "application/x-www-form-urlencoded" },
           body: postBody(csrf, "read"),
         }),
       );
-      expect(res.status).toBe(303);
-      expect(res.headers.get("location")).toBe("/account/change-password");
+      expect(apiRes.status).toBe(403);
+      expect(((await apiRes.json()) as { error: string }).error).toBe("force_change_password");
+
+      // The friend's browser GET of the account home IS bounced to the
+      // change-password rail — the surface they'd navigate to is gated.
+      const browserRes = await fetcher(
+        req("/account/", { headers: { cookie, accept: "text/html" } }),
+      );
+      expect(browserRes.status).toBe(302);
+      expect(browserRes.headers.get("location")).toBe("/account/change-password");
     } finally {
       db.close();
       h.cleanup();
@@ -4542,6 +4560,241 @@ describe("hubFetch routing — /api/hub/upgrade (D4 SPA hub-upgrade)", () => {
           req("/api/hub/upgrade", { method: "GET" }),
         );
         expect(res.status).not.toBe(404);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// Per-request force-change-password enforcement (P0-1 / hub#469). The redirect
+// at /login was never enough: a signed-in user holding an admin-set temp
+// password (`password_changed=false`) could navigate DIRECTLY to /account/* or
+// a per-vault proxy URL and operate indefinitely on the un-rotated secret.
+// These tests pin the broad per-request gate: pre-rotation users are bounced
+// off every /account/* surface AND the per-vault proxy, EXCEPT the rotation/exit
+// path (/account/change-password + /logout); after rotation all surfaces open.
+describe("force-change-password per-request gate (#469)", () => {
+  // Seed a signed-in user with a chosen password_changed flag and return a
+  // ready-to-use session cookie. Mirrors the seedFriend helpers in the
+  // account-vault-{token,admin-token} suites.
+  async function seedUser(
+    h: Harness,
+    db: ReturnType<typeof openHubDb>,
+    opts: { passwordChanged: boolean; assignedVaults?: string[] },
+  ): Promise<{ cookie: string }> {
+    const { SESSION_TTL_MS } = await import("../sessions.ts");
+    const user = await createUser(db, "friend", "temp-pw", {
+      allowMulti: true,
+      passwordChanged: opts.passwordChanged,
+      assignedVaults: opts.assignedVaults ?? [],
+    });
+    const session = createSession(db, { userId: user.id });
+    const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+    return { cookie };
+  }
+
+  test("(a) pre-rotation browser GET /account/ is 302'd to change-password", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const { cookie } = await seedUser(h, db, {
+          passwordChanged: false,
+          assignedVaults: ["work"],
+        });
+        const res = await hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath })(
+          req("/account/", { headers: { cookie, accept: "text/html" } }),
+        );
+        expect(res.status).toBe(302);
+        expect(res.headers.get("location")).toBe("/account/change-password");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("(a) pre-rotation API POST /account/vault-token/<name> is 403 force_change_password", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const { cookie } = await seedUser(h, db, {
+          passwordChanged: false,
+          assignedVaults: ["work"],
+        });
+        // No Accept: text/html → treated as an API client → 403 JSON, not a 302.
+        const res = await hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath })(
+          req("/account/vault-token/work", { method: "POST", headers: { cookie } }),
+        );
+        expect(res.status).toBe(403);
+        const body = (await res.json()) as { error: string };
+        expect(body.error).toBe("force_change_password");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("(a) pre-rotation browser GET of a per-vault proxy URL is 302'd to change-password", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const { cookie } = await seedUser(h, db, {
+          passwordChanged: false,
+          assignedVaults: ["work"],
+        });
+        const res = await hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath })(
+          req("/vault/work/notes/abc", { headers: { cookie, accept: "text/html" } }),
+        );
+        // Gated BEFORE the proxy ever runs — so this is the gate's 302, not a
+        // proxy 404/502.
+        expect(res.status).toBe(302);
+        expect(res.headers.get("location")).toBe("/account/change-password");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("(b) pre-rotation user CAN still reach /account/change-password (GET)", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const { cookie } = await seedUser(h, db, {
+          passwordChanged: false,
+          assignedVaults: ["work"],
+        });
+        const res = await hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath })(
+          req("/account/change-password", { headers: { cookie, accept: "text/html" } }),
+        );
+        // Reaches the real handler (200 form render) — NOT bounced to itself.
+        expect(res.status).toBe(200);
+        const body = await res.text();
+        expect(body.toLowerCase()).toContain("password");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("(b) pre-rotation user CAN still reach /logout (POST)", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const { cookie } = await seedUser(h, db, {
+          passwordChanged: false,
+          assignedVaults: ["work"],
+        });
+        // CSRF cookie + matching field so the logout POST passes its own gate;
+        // the point is the force-change gate does NOT intercept /logout.
+        const csrf = generateCsrfToken();
+        const form = new URLSearchParams();
+        form.set("__csrf", csrf);
+        const res = await hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath })(
+          req("/logout", {
+            method: "POST",
+            headers: {
+              cookie: `${cookie}; ${buildCsrfCookie(csrf)}`,
+              "content-type": "application/x-www-form-urlencoded",
+            },
+            body: form.toString(),
+          }),
+        );
+        // Logout succeeds (302 to /) — it is NOT the force-change 302 to
+        // /account/change-password and NOT a 403.
+        expect(res.status).toBe(302);
+        expect(res.headers.get("location")).not.toBe("/account/change-password");
+        expect(res.status).not.toBe(403);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("(c) after rotation, /account/ is reachable (not gated)", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const { cookie } = await seedUser(h, db, {
+          passwordChanged: true,
+          assignedVaults: ["work"],
+        });
+        const res = await hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath })(
+          req("/account/", { headers: { cookie, accept: "text/html" } }),
+        );
+        // Account home renders — not bounced.
+        expect(res.status).toBe(200);
+        expect(res.headers.get("location")).not.toBe("/account/change-password");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("(c) after rotation, a per-vault proxy URL is NOT gated (reaches the proxy)", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const { cookie } = await seedUser(h, db, {
+          passwordChanged: true,
+          assignedVaults: ["work"],
+        });
+        const res = await hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath })(
+          req("/vault/work/notes/abc", { headers: { cookie, accept: "text/html" } }),
+        );
+        // No upstream listening → the proxy returns a 404/502, NOT the gate's
+        // 302→change-password / 403. The point is the gate let it through.
+        expect(res.headers.get("location")).not.toBe("/account/change-password");
+        const body = res.status === 403 ? ((await res.json()) as { error?: string }) : null;
+        expect(body?.error).not.toBe("force_change_password");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("an UNAUTHENTICATED per-vault proxy request is NOT gated (no hub session)", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        // No cookie at all — the common Notes/MCP case carrying its own bearer.
+        // forceChangePasswordGate returns null (no session) → proxy handles it.
+        const res = await hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath })(
+          req("/vault/work/notes/abc", { headers: { accept: "text/html" } }),
+        );
+        expect(res.headers.get("location")).not.toBe("/account/change-password");
+        expect(res.status).not.toBe(403);
       } finally {
         db.close();
       }

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -4802,4 +4802,148 @@ describe("force-change-password per-request gate (#469)", () => {
       h.cleanup();
     }
   });
+
+  test("(b) pre-rotation user CAN POST /account/change-password (the rotation action itself)", async () => {
+    // The exempt POST: a pre-rotation user submitting their new password must
+    // NOT be intercepted by the gate — it's the only way out of force-change.
+    // `/account/change-password` is dispatched ABOVE the gate, so it never
+    // reaches the choke point. We assert the POST reaches its own handler (it
+    // fails CSRF here → its OWN 400/403, NOT the gate's 302→change-password).
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const { cookie } = await seedUser(h, db, {
+          passwordChanged: false,
+          assignedVaults: ["work"],
+        });
+        const csrf = generateCsrfToken();
+        const form = new URLSearchParams();
+        form.set("__csrf", csrf);
+        form.set("current_password", "temp-pw");
+        form.set("new_password", "rotated-password-123");
+        form.set("new_password_confirm", "rotated-password-123");
+        const res = await hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath })(
+          req("/account/change-password", {
+            method: "POST",
+            headers: {
+              cookie: `${cookie}; ${buildCsrfCookie(csrf)}`,
+              "content-type": "application/x-www-form-urlencoded",
+              accept: "text/html",
+            },
+            body: form.toString(),
+          }),
+        );
+        // Reaches its own handler (303 back to /account/ on success, or its own
+        // form re-render). The point: it is NOT the gate's 302 to
+        // change-password and NOT the gate's 403 force_change_password.
+        expect(res.status).not.toBe(403);
+        if (res.status === 302 || res.status === 303) {
+          expect(res.headers.get("location")).not.toBe("/account/change-password");
+        }
+        // And the rotation actually took: the user's flag flipped to true.
+        const { getUserById } = await import("../users.ts");
+        const friend = getUserById(
+          db,
+          db.query<{ id: string }, []>("SELECT id FROM users WHERE username = 'friend'").get()
+            ?.id ?? "",
+        );
+        expect(friend?.passwordChanged).toBe(true);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("(a) bare /account (no trailing slash) is gated on the FIRST hop for a pre-rotation user", async () => {
+    // The bare `/account` 301s to `/account/`; without an explicit match it
+    // would slip past `startsWith("/account/")` and only be gated on the second
+    // hop. The gate must intercept the first request.
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const { cookie } = await seedUser(h, db, {
+          passwordChanged: false,
+          assignedVaults: ["work"],
+        });
+        const res = await hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath })(
+          req("/account", { headers: { cookie, accept: "text/html" } }),
+        );
+        // Gated → 302 to change-password, NOT the 301 → /account/.
+        expect(res.status).toBe(302);
+        expect(res.headers.get("location")).toBe("/account/change-password");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("(a) pre-rotation session at /oauth/authorize is 302'd to change-password (no auth code issued)", async () => {
+    // The important one: a signed-in pre-rotation user must not ride the
+    // consent flow to an auth code → /oauth/token exchange for a vault token
+    // WITHOUT rotating. The gate intercepts /oauth/authorize before any client
+    // validation or code issuance, so no `code=` redirect can be produced.
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const { cookie } = await seedUser(h, db, {
+          passwordChanged: false,
+          assignedVaults: ["work"],
+        });
+        const res = await hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath })(
+          req(
+            "/oauth/authorize?client_id=x&response_type=code&redirect_uri=https://app.example/cb&scope=vault:work:read",
+            { headers: { cookie, accept: "text/html" } },
+          ),
+        );
+        expect(res.status).toBe(302);
+        const location = res.headers.get("location") ?? "";
+        expect(location).toBe("/account/change-password");
+        // No auth code was issued — the redirect is to the rotation rail, not a
+        // client callback carrying a `code=`.
+        expect(location).not.toContain("code=");
+        expect(location).not.toContain("app.example");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("(c) after rotation, /oauth/authorize is NOT gated (reaches the oauth handler)", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [vaultEntry("work")] }, h.manifestPath);
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const { cookie } = await seedUser(h, db, {
+          passwordChanged: true,
+          assignedVaults: ["work"],
+        });
+        const res = await hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath })(
+          req(
+            "/oauth/authorize?client_id=x&response_type=code&redirect_uri=https://app.example/cb&scope=vault:work:read",
+            { headers: { cookie, accept: "text/html" } },
+          ),
+        );
+        // Reaches the real authorize handler (login/consent/error) — NOT bounced
+        // to the change-password rail by the gate.
+        expect(res.headers.get("location")).not.toBe("/account/change-password");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
 });

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -1287,9 +1287,11 @@ interface PeerIpResolver {
  *
  * EXEMPT (NOT gated — the rotation/exit path; callers must route these BEFORE
  * invoking this gate): `/account/change-password` (GET+POST) and `/logout`.
- * Everything else under `/account/*` and the per-vault `/vault/<name>/*` proxy
- * is gated. The decision is deliberate: a pre-rotation user can ONLY rotate or
- * sign out — no vault reads, no token mints, no account home.
+ * Everything else under `/account/*`, the per-vault `/vault/<name>/*` proxy,
+ * and the session-backed `/oauth/authorize` consent path is gated. The decision
+ * is deliberate: a pre-rotation user can ONLY rotate or sign out — no vault
+ * reads, no token mints, no account home, and no OAuth authorize → auth code →
+ * `/oauth/token` exchange for a vault-scoped access token.
  *
  * Browser GETs (Accept: text/html) get a 302 to `/account/change-password`;
  * non-GET and API-style requests get a 403 with the same JSON error shape the
@@ -1845,6 +1847,17 @@ export function hubFetch(
     // See `src/cors.ts` for the wildcard-origin rationale.
     if (pathname === "/oauth/authorize") {
       if (!getDb) return applyCorsHeaders(req, dbNotConfigured());
+      // Per-request force-change-password gate (P0-1 / hub#469). CHOKE POINT 3:
+      // a signed-in pre-rotation user must NOT be able to ride the consent flow
+      // to an auth code → `/oauth/token` exchange → vault-scoped access token
+      // without rotating the temp password. Gating `/oauth/authorize` (the
+      // session-backed consent path) is sufficient — no code is issued without
+      // it, so `/oauth/token` (back-channel code exchange, no session cookie)
+      // is intentionally NOT gated (gating it would break the legitimate
+      // exchange). An UNAUTHENTICATED authorize request returns null from the
+      // gate and falls through to render the login form, unchanged.
+      const oauthGate = forceChangePasswordGate(getDb(), req);
+      if (oauthGate) return applyCorsHeaders(req, oauthGate);
       if (req.method === "GET") {
         // handleAuthorizeGet is sync (returns Response, not Promise<Response>).
         // handleAuthorizePost is async — keep the await on POST only.
@@ -2350,7 +2363,13 @@ export function hubFetch(
     // gate for the whole `/account/*` family rather than per-route. The
     // per-route mints in `account-vault-{token,admin-token}.ts` keep their own
     // gate as defence-in-depth (they're also reachable in tests directly).
-    if (getDb && pathname.startsWith("/account/")) {
+    //
+    // The bare `/account` (no trailing slash) is matched explicitly too —
+    // otherwise it would slip past `startsWith("/account/")` to its 301 →
+    // `/account/` below, and a pre-rotation user wouldn't be gated until the
+    // second hop. Exact-match `/account` (not `startsWith("/account")`) so
+    // unrelated paths like `/accounts-something` aren't caught.
+    if (getDb && (pathname === "/account" || pathname.startsWith("/account/"))) {
       const gate = forceChangePasswordGate(getDb(), req);
       if (gate) return gate;
     }

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -78,7 +78,13 @@
  *   /account/change-password      (GET + POST) → user self-service change-password
  *                                                 (force-redirect target for users
  *                                                 with password_changed=false; also
- *                                                 reachable directly to rotate)
+ *                                                 reachable directly to rotate). With
+ *                                                 hub#469, EVERY other /account/* route
+ *                                                 + the per-vault proxy is hard-gated
+ *                                                 per-request on password_changed===true
+ *                                                 (forceChangePasswordGate); only this
+ *                                                 route and /logout stay reachable
+ *                                                 pre-rotation.
  *   /account/2fa                  (GET + POST) → user self-service 2FA enroll/disenroll
  *                                                 (hub#473; QR + backup codes)
  *   /account/vault-token/<name>   (POST)       → friend mints a scoped
@@ -1262,6 +1268,60 @@ interface PeerIpResolver {
   requestIP(req: Request): { address: string } | null;
 }
 
+/**
+ * Per-request force-change-password gate (P0-1 / hub#469).
+ *
+ * Before #469, `password_changed === false` only triggered a redirect at the
+ * `/login` step. A signed-in user handed an admin-set temp password could then
+ * navigate DIRECTLY to `/account/`, `/account/vault-token/<name>`, a vault-admin
+ * deep-link, or any per-vault proxy URL and operate INDEFINITELY on the
+ * un-rotated secret. Invites = temp-credential handoff at scale, so that gap
+ * scales with every invited user. This makes the gate per-request.
+ *
+ * Returns a 302/403 Response when the request must be bounced; `null` when the
+ * request may proceed (no session, password already rotated, or — for callers
+ * that pre-check — an exempt path). Resolution is a single session→user lookup,
+ * mirroring the per-route gates in `account-vault-{token,admin-token}.ts` so we
+ * don't add a second DB read on those paths (they keep their own gate; this is
+ * the broad net for everything else under `/account/*` + the vault proxy).
+ *
+ * EXEMPT (NOT gated — the rotation/exit path; callers must route these BEFORE
+ * invoking this gate): `/account/change-password` (GET+POST) and `/logout`.
+ * Everything else under `/account/*` and the per-vault `/vault/<name>/*` proxy
+ * is gated. The decision is deliberate: a pre-rotation user can ONLY rotate or
+ * sign out — no vault reads, no token mints, no account home.
+ *
+ * Browser GETs (Accept: text/html) get a 302 to `/account/change-password`;
+ * non-GET and API-style requests get a 403 with the same JSON error shape the
+ * per-route mints use, so a scripted client gets a clear machine-readable
+ * refusal rather than an HTML redirect it can't follow.
+ */
+export function forceChangePasswordGate(db: Database, req: Request): Response | null {
+  const session = findActiveSession(db, req);
+  if (!session) return null; // unauthenticated → downstream handler decides (401/login)
+  const user = getUserById(db, session.userId);
+  if (!user || user.passwordChanged) return null; // rotated (or vanished) → proceed
+
+  const wantsHtml = req.method === "GET" && (req.headers.get("accept") ?? "").includes("text/html");
+  if (wantsHtml) {
+    return new Response(null, {
+      status: 302,
+      headers: { location: "/account/change-password", "cache-control": "no-store" },
+    });
+  }
+  return new Response(
+    JSON.stringify({
+      error: "force_change_password",
+      error_description:
+        "You must change your temporary password before using this surface. Visit /account/change-password.",
+    }),
+    {
+      status: 403,
+      headers: { "content-type": "application/json", "cache-control": "no-store" },
+    },
+  );
+}
+
 export function hubFetch(
   wellKnownDir: string,
   deps?: HubFetchDeps,
@@ -2279,6 +2339,22 @@ export function hubFetch(
       return new Response("method not allowed", { status: 405 });
     }
 
+    // Per-request force-change-password gate (P0-1 / hub#469). CHOKE POINT 1:
+    // every `/account/*` route BELOW this line is gated. `/logout` and
+    // `/account/change-password` (the rotation/exit path) ran above and already
+    // returned, so they're never reached here — they stay reachable
+    // pre-rotation by construction. A signed-in user with
+    // `password_changed === false` is bounced (302 → change-password for
+    // browsers, 403 JSON for API clients) before any account surface
+    // (2fa, vault-token, vault-admin-token, account home) resolves. DRY: one
+    // gate for the whole `/account/*` family rather than per-route. The
+    // per-route mints in `account-vault-{token,admin-token}.ts` keep their own
+    // gate as defence-in-depth (they're also reachable in tests directly).
+    if (getDb && pathname.startsWith("/account/")) {
+      const gate = forceChangePasswordGate(getDb(), req);
+      if (gate) return gate;
+    }
+
     // /account/2fa — user self-service TOTP 2FA enroll / disenroll (hub#473).
     // Both GET (render state) and POST (start/confirm/disable) require an
     // active session; the handler does the session check + 302 to /login when
@@ -2400,6 +2476,18 @@ export function hubFetch(
     // here anymore (the SPA moved to /admin), so we can't accidentally
     // mask a backend 404 with HTML.
     if (pathname.startsWith("/vault/")) {
+      // Per-request force-change-password gate (P0-1 / hub#469). CHOKE POINT 2:
+      // a pre-rotation signed-in user can't reach a per-vault user surface
+      // (Notes PWA, MCP, vault API) on the un-rotated temp password — they're
+      // bounced to change-password (browser) / 403 (API). Same posture as the
+      // `/account/*` gate above. An UNAUTHENTICATED proxy request (no hub
+      // session — the common Notes/MCP case carrying its own bearer) passes the
+      // gate untouched (`forceChangePasswordGate` returns null with no session)
+      // and is handled by the vault's own auth downstream.
+      if (getDb) {
+        const gate = forceChangePasswordGate(getDb(), req);
+        if (gate) return gate;
+      }
       const proxied = await proxyToVault(req, manifestPath, deps?.supervisor, peerAddr);
       if (proxied) return decorateWithChrome(proxied, req, pathname, getDb);
       return new Response("not found", { status: 404 });


### PR DESCRIPTION
## What

Makes force-change-password **per-request enforced**, not just a login-time redirect. This is **P0-1** in the [individual-users design doc](../parachute.computer/design/2026-06-04-individual-users-and-vault-operations.md) §6 — it gates the upcoming invites feature (temp-credential handoff at scale).

### The gap

Before this change, `password_changed === false` only triggered a redirect at the `/login` step. A signed-in user handed an admin-set temp password could navigate **directly** to `/account/`, `/account/vault-token/<name>`, a vault-admin deep-link, or any per-vault proxy URL and operate **indefinitely** on the un-rotated secret. Some specific mint endpoints already self-gated, but there was no broad net.

## The gate

New `forceChangePasswordGate(db, req)` in `hub-server.ts` — a **single per-request gate** wired at two DRY choke points in `hubFetch`'s dispatch:

1. **CHOKE POINT 1** — before every non-exempt `/account/*` route (`2fa`, `vault-token`, `vault-admin-token`, account home).
2. **CHOKE POINT 2** — in the `/vault/<name>/*` per-vault content proxy.

When the request resolves to a signed-in user with `password_changed === false`:
- **browser GETs** (`Accept: text/html`) → `302` to `/account/change-password`
- **non-GET / API-style requests** → `403 { "error": "force_change_password" }`

It's a single session→user lookup; the per-route mint handlers keep their own `!passwordChanged` gate as **defence-in-depth** (they're also reachable directly in tests). `resetUserPassword` already kills sessions in the same transaction (item G, `users.ts:563`) — left intact, not re-implemented.

## Exempt surfaces (reachable pre-rotation)

Only **`/account/change-password`** (GET+POST) and **`/logout`** — the rotation/exit path. They're dispatched **above** the choke point, so they stay reachable by construction. Everything else under `/account/*` and the vault proxy is gated. The decision is deliberate and documented in code: a pre-rotation user can only rotate or sign out — no vault reads, no token mints, no account home.

An **unauthenticated** proxy request (the common Notes/MCP bearer case — no hub session cookie) passes the gate untouched and is handled by the vault's own auth downstream.

## Tests

Added `describe("force-change-password per-request gate (#469)")` in `hub-server.test.ts`:
- **(a)** pre-rotation user hitting `/account/`, `/account/vault-token/<name>`, or a per-vault proxy URL is bounced (302 → change-password / 403 `force_change_password`)
- **(b)** the same user CAN still reach `/account/change-password` (200) and `/logout` (302 → `/`)
- **(c)** after rotation (`password_changed=true`), `/account/` and the per-vault proxy are reachable (not gated)
- unauthenticated proxy request is not gated

The existing item-F end-to-end test was updated to assert the new choke-point behavior (the broad gate now intercepts before the per-route mint).

## Gates

- `bun run typecheck` — clean
- `bun test src/__tests__/hub-server.test.ts` — **183 pass, 0 fail**
- `bun test` on the four account suites (`account-vault-token`, `account-vault-admin-token`, `account-home-ui`, `api-account`) — **85 pass, 0 fail**

Per the live-machine test-safety constraint, only targeted suites were run (no full `bun test ./src`, no lifecycle/migrate/uninstall tests). Version left at `0.6.3` (no rc bump per governance).

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)