### PR TITLE
feat(invites): one-time expiring invite links → account + own vault

### DIFF
--- a/src/__tests__/account-setup.test.ts
+++ b/src/__tests__/account-setup.test.ts
@@ -1,0 +1,496 @@
+/**
+ * Redemption-flow tests for one-time invite links —
+ * `GET|POST /account/setup/<token>` (`account-setup.ts`).
+ *
+ * Adversarial coverage of the redeem path + the security invariants:
+ *   - happy path: creates user + vault + session, invite marked used
+ *   - replay rejected (used_at set → 410)
+ *   - expired rejected (410)
+ *   - revoked rejected (410)
+ *   - tampered/unknown token → 404
+ *   - createUser fails → invite STILL re-usable (the ordering guarantee)
+ *   - INVARIANT: the redeemed user holds ONLY their one vault at the
+ *     invite's role — never host:admin, never another vault
+ *
+ * Vault provisioning is stubbed via `runCommand`: the stub appends the
+ * named vault to services.json (what `parachute-vault create` does) so
+ * `provisionVault`'s post-orchestrate re-read finds it — no real shell-out.
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleAccountSetupGet, handleAccountSetupPost } from "../account-setup.ts";
+import type { RunResult } from "../admin-vaults.ts";
+import { CSRF_FIELD_NAME, buildCsrfCookie, generateCsrfToken } from "../csrf.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { consumeInvite, findInviteByRawToken, issueInvite, revokeInvite } from "../invites.ts";
+import { __resetForTests } from "../rate-limit.ts";
+import { findActiveSession } from "../sessions.ts";
+import { createUser, getUserByUsernameCI, vaultVerbsForUserVault } from "../users.ts";
+
+const ISSUER = "https://hub.test";
+
+interface Harness {
+  db: Database;
+  manifestPath: string;
+  /** Names of vaults the stubbed `runCommand` has "created". */
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-account-setup-"));
+  const db = openHubDb(hubDbPath(dir));
+  const manifestPath = join(dir, "services.json");
+  // Seed with vault registered (one path) so the create branch runs
+  // `parachute-vault create <name>` rather than the bootstrap install.
+  writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      services: [
+        {
+          name: "parachute-vault",
+          port: 4101,
+          paths: ["/vault/seed"],
+          health: "/health",
+          version: "0.0.0-test",
+        },
+      ],
+    }),
+  );
+  return {
+    db,
+    manifestPath,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+  __resetForTests();
+});
+afterEach(() => {
+  harness.cleanup();
+  __resetForTests();
+});
+
+/** Stub vault create: append the named vault path to services.json, emit create JSON. */
+function makeStubRunCommand(opts: { fail?: boolean } = {}) {
+  const calls: string[][] = [];
+  const run = async (cmd: readonly string[]): Promise<RunResult> => {
+    calls.push([...cmd]);
+    if (opts.fail) return { exitCode: 1, stdout: "", stderr: "boom" };
+    // cmd = ["parachute-vault", "create", <name>, "--json", ...]
+    const name = cmd[2] ?? "";
+    const manifest = JSON.parse(readFileSync(harness.manifestPath, "utf8")) as {
+      services: { name: string; paths: string[] }[];
+    };
+    const vaultSvc = manifest.services.find((s) => s.name === "parachute-vault");
+    if (vaultSvc && !vaultSvc.paths.includes(`/vault/${name}`)) {
+      vaultSvc.paths.push(`/vault/${name}`);
+      writeFileSync(harness.manifestPath, JSON.stringify(manifest));
+    }
+    const createJson = {
+      name,
+      token: "",
+      paths: {
+        vault_dir: `/d/${name}`,
+        vault_db: `/d/${name}/v.db`,
+        vault_config: `/d/${name}/v.yaml`,
+      },
+      set_as_default: false,
+    };
+    return { exitCode: 0, stdout: JSON.stringify(createJson), stderr: "" };
+  };
+  return { run, calls };
+}
+
+function csrfPair(): { token: string; cookieFragment: string } {
+  const token = generateCsrfToken();
+  const cookie = buildCsrfCookie(token, { secure: false }).split(";")[0] ?? "";
+  return { token, cookieFragment: cookie };
+}
+
+function deps(runCommand?: (cmd: readonly string[]) => Promise<RunResult>) {
+  return {
+    db: harness.db,
+    hubOrigin: ISSUER,
+    manifestPath: harness.manifestPath,
+    ...(runCommand !== undefined ? { runCommand } : {}),
+  };
+}
+
+/** Build a POST request with CSRF cookie + form body. */
+function postReq(token: string, fields: Record<string, string>, csrfCookie: string): Request {
+  const form = new URLSearchParams(fields);
+  return new Request(`${ISSUER}/account/setup/${token}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      cookie: csrfCookie,
+    },
+    body: form.toString(),
+  });
+}
+
+describe("GET /account/setup/<token>", () => {
+  test("renders the claim form for a valid invite", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id, vaultName: "maya" });
+    const res = handleAccountSetupGet(
+      new Request(`${ISSUER}/account/setup/${rawToken}`),
+      rawToken,
+      deps(),
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Claim your invite");
+    // Pinned vault → shown read-only, not a name-it field.
+    expect(html).toContain("maya");
+  });
+
+  test("unknown token → 404", async () => {
+    const res = handleAccountSetupGet(new Request(`${ISSUER}/account/setup/nope`), "nope", deps());
+    expect(res.status).toBe(404);
+  });
+
+  test("expired invite → 410", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const now = new Date("2026-06-04T00:00:00Z");
+    const { rawToken } = issueInvite(harness.db, {
+      createdBy: admin.id,
+      expiresInSeconds: 60,
+      now: () => now,
+    });
+    const later = new Date(now.getTime() + 120_000);
+    const res = handleAccountSetupGet(
+      new Request(`${ISSUER}/account/setup/${rawToken}`),
+      rawToken,
+      { ...deps(), now: () => later },
+    );
+    expect(res.status).toBe(410);
+  });
+});
+
+describe("POST /account/setup/<token> — happy path", () => {
+  test("creates user + vault + session, marks invite used", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken, invite } = issueInvite(harness.db, {
+      createdBy: admin.id,
+      vaultName: "maya",
+    });
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const stub = makeStubRunCommand();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "maya",
+          password: "maya-strong-password-1",
+          password_confirm: "maya-strong-password-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    // 302 → /account/ with a session cookie.
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/account/");
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie.length).toBeGreaterThan(0);
+
+    // User created, password_changed=true (chose their own → no force-change).
+    const user = getUserByUsernameCI(harness.db, "maya");
+    expect(user).not.toBeNull();
+    expect(user?.passwordChanged).toBe(true);
+    expect(user?.assignedVaults).toEqual(["maya"]);
+
+    // Vault provisioned via the create branch.
+    expect(stub.calls.some((c) => c[0] === "parachute-vault" && c[1] === "create")).toBe(true);
+
+    // Invite consumed.
+    const after = findInviteByRawToken(harness.db, rawToken);
+    expect(after?.usedAt).not.toBeNull();
+    expect(after?.redeemedUserId).toBe(user?.id ?? "");
+
+    // Session is live for that user.
+    const sid = setCookie.split(";")[0]?.split("=")[1] ?? "";
+    const sessionReq = new Request(`${ISSUER}/account/`, {
+      headers: { cookie: `parachute_hub_session=${sid}` },
+    });
+    const session = findActiveSession(harness.db, sessionReq);
+    expect(session?.userId).toBe(user?.id ?? "");
+
+    void invite;
+  });
+
+  test("redeemer names their own vault when the invite doesn't pin one", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id }); // vault_name null
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const stub = makeStubRunCommand();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "sam",
+          password: "sam-strong-password-12",
+          password_confirm: "sam-strong-password-12",
+          vault_name: "sams-vault",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    expect(res.status).toBe(302);
+    const user = getUserByUsernameCI(harness.db, "sam");
+    expect(user?.assignedVaults).toEqual(["sams-vault"]);
+  });
+});
+
+describe("POST /account/setup/<token> — security invariants", () => {
+  test("redeemed user holds ONLY their vault at the invite role — NOT admin, NOT another vault", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id, vaultName: "maya" });
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const stub = makeStubRunCommand();
+    await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "maya",
+          password: "maya-strong-password-1",
+          password_confirm: "maya-strong-password-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    const user = getUserByUsernameCI(harness.db, "maya");
+    expect(user).not.toBeNull();
+    const id = user?.id ?? "";
+
+    // Exactly one vault assignment.
+    expect(user?.assignedVaults).toEqual(["maya"]);
+    // Role is 'write' (owner) → read/write/admin on THEIR vault only.
+    expect(vaultVerbsForUserVault(harness.db, id, "maya")).toEqual(["read", "write", "admin"]);
+    // No authority over any other vault.
+    expect(vaultVerbsForUserVault(harness.db, id, "seed")).toBeNull();
+    expect(vaultVerbsForUserVault(harness.db, id, "other")).toBeNull();
+    // The invited user is NOT the first admin (admin is the earliest row).
+    const firstId = harness.db
+      .query<{ id: string }, []>("SELECT id FROM users ORDER BY created_at ASC LIMIT 1")
+      .get()?.id;
+    expect(firstId).toBe(admin.id);
+    expect(firstId).not.toBe(id);
+  });
+
+  test("a 'read' invite lands a read-only assignment", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, {
+      createdBy: admin.id,
+      vaultName: "shared",
+      role: "read",
+    });
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const stub = makeStubRunCommand();
+    await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "guest",
+          password: "guest-strong-password-1",
+          password_confirm: "guest-strong-password-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    const user = getUserByUsernameCI(harness.db, "guest");
+    expect(vaultVerbsForUserVault(harness.db, user?.id ?? "", "shared")).toEqual(["read"]);
+  });
+});
+
+describe("POST /account/setup/<token> — rejection paths", () => {
+  test("replay (used invite) → 410", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken, invite } = issueInvite(harness.db, { createdBy: admin.id, vaultName: "x" });
+    consumeInvite(harness.db, invite.tokenHash, admin.id);
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "late",
+          password: "late-strong-password-1",
+          password_confirm: "late-strong-password-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(makeStubRunCommand().run),
+    );
+    expect(res.status).toBe(410);
+    // No new user created.
+    expect(getUserByUsernameCI(harness.db, "late")).toBeNull();
+  });
+
+  test("expired invite → 410", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const now = new Date("2026-06-04T00:00:00Z");
+    const { rawToken } = issueInvite(harness.db, {
+      createdBy: admin.id,
+      vaultName: "x",
+      expiresInSeconds: 60,
+      now: () => now,
+    });
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const later = new Date(now.getTime() + 120_000);
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "late",
+          password: "late-strong-password-1",
+          password_confirm: "late-strong-password-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      { ...deps(makeStubRunCommand().run), now: () => later },
+    );
+    expect(res.status).toBe(410);
+  });
+
+  test("revoked invite → 410", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken, invite } = issueInvite(harness.db, { createdBy: admin.id, vaultName: "x" });
+    revokeInvite(harness.db, invite.tokenHash);
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "late",
+          password: "late-strong-password-1",
+          password_confirm: "late-strong-password-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(makeStubRunCommand().run),
+    );
+    expect(res.status).toBe(410);
+  });
+
+  test("tampered/unknown token → 404", async () => {
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const res = await handleAccountSetupPost(
+      postReq(
+        "unknown-token",
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "x",
+          password: "xxxxxxxxxxxx",
+          password_confirm: "xxxxxxxxxxxx",
+        },
+        cookieFragment,
+      ),
+      "unknown-token",
+      deps(makeStubRunCommand().run),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  test("missing CSRF → 400, invite untouched", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id, vaultName: "x" });
+    const res = await handleAccountSetupPost(
+      // No CSRF cookie/field.
+      new Request(`${ISSUER}/account/setup/${rawToken}`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          username: "x",
+          password: "xxxxxxxxxxxx",
+          password_confirm: "xxxxxxxxxxxx",
+        }).toString(),
+      }),
+      rawToken,
+      deps(makeStubRunCommand().run),
+    );
+    expect(res.status).toBe(400);
+    expect(findInviteByRawToken(harness.db, rawToken)?.usedAt).toBeNull();
+  });
+});
+
+describe("POST /account/setup/<token> — re-usability on createUser failure (ordering)", () => {
+  test("createUser collision leaves the invite UNCONSUMED (re-usable)", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    // Pre-create a user with the username the invitee will pick → createUser
+    // raises UsernameTakenError, AFTER provisionVault has run.
+    await createUser(harness.db, "taken", "taken-password-12", { allowMulti: true });
+
+    const { rawToken, invite } = issueInvite(harness.db, {
+      createdBy: admin.id,
+      vaultName: "maya",
+    });
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "taken",
+          password: "another-strong-password-1",
+          password_confirm: "another-strong-password-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(makeStubRunCommand().run),
+    );
+    expect(res.status).toBe(409);
+    // The invite must NOT be consumed — the ordering guarantee.
+    const after = findInviteByRawToken(harness.db, rawToken);
+    expect(after?.usedAt).toBeNull();
+    expect(after?.redeemedUserId).toBeNull();
+
+    // And a SECOND attempt with a free username succeeds + consumes it.
+    __resetForTests();
+    const second = csrfPair();
+    const res2 = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: second.token,
+          username: "maya",
+          password: "maya-strong-password-12",
+          password_confirm: "maya-strong-password-12",
+        },
+        second.cookieFragment,
+      ),
+      rawToken,
+      deps(makeStubRunCommand().run),
+    );
+    expect(res2.status).toBe(302);
+    expect(findInviteByRawToken(harness.db, rawToken)?.usedAt).not.toBeNull();
+    void invite;
+  });
+});

--- a/src/__tests__/account-setup.test.ts
+++ b/src/__tests__/account-setup.test.ts
@@ -28,7 +28,7 @@ import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { consumeInvite, findInviteByRawToken, issueInvite, revokeInvite } from "../invites.ts";
 import { __resetForTests } from "../rate-limit.ts";
 import { findActiveSession } from "../sessions.ts";
-import { createUser, getUserByUsernameCI, vaultVerbsForUserVault } from "../users.ts";
+import { createUser, getUserByUsernameCI, userCount, vaultVerbsForUserVault } from "../users.ts";
 
 const ISSUER = "https://hub.test";
 
@@ -492,5 +492,118 @@ describe("POST /account/setup/<token> — re-usability on createUser failure (or
     expect(res2.status).toBe(302);
     expect(findInviteByRawToken(harness.db, rawToken)?.usedAt).not.toBeNull();
     void invite;
+  });
+});
+
+describe("POST /account/setup/<token> — vault-name validation (N1)", () => {
+  test("a 33-char invitee-chosen vault name → clear validation error, NOT a generic provision failure", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    // vault_name null → the redeemer names their own vault.
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id });
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const tooLong = "a".repeat(33); // passes the bare charset regex, exceeds the 32 cap
+    const stub = makeStubRunCommand();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "sam",
+          password: "sam-strong-password-12",
+          password_confirm: "sam-strong-password-12",
+          vault_name: tooLong,
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    // 400 with the validator's specific message — the vault CLI is never reached.
+    expect(res.status).toBe(400);
+    const html = await res.text();
+    expect(html).toContain("2–32 characters");
+    expect(html).not.toContain("Could not provision your vault");
+    expect(stub.calls.length).toBe(0);
+    // No account created.
+    expect(getUserByUsernameCI(harness.db, "sam")).toBeNull();
+  });
+});
+
+describe("POST /account/setup/<token> — concurrent redeem (N2)", () => {
+  test("two concurrent redeems of one invite create EXACTLY one account (no orphan)", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id, vaultName: "maya" });
+    const before = userCount(harness.db); // 1 (the admin)
+
+    // Two POSTs with DIFFERENT usernames, fired together. Each has its own
+    // CSRF pair. createUser awaits argon2 before its (synchronous) commit
+    // transaction; the consume-inside-tx guard is what serializes them.
+    const a = csrfPair();
+    const b = csrfPair();
+    const mk = (uname: string, csrf: { token: string; cookieFragment: string }) =>
+      handleAccountSetupPost(
+        postReq(
+          rawToken,
+          {
+            [CSRF_FIELD_NAME]: csrf.token,
+            username: uname,
+            password: `${uname}-strong-password-1`,
+            password_confirm: `${uname}-strong-password-1`,
+          },
+          csrf.cookieFragment,
+        ),
+        rawToken,
+        deps(makeStubRunCommand().run),
+      );
+    const [r1, r2] = await Promise.all([mk("alice", a), mk("bob", b)]);
+
+    const statuses = [r1.status, r2.status].sort();
+    // Exactly one 302 (success) and one 410 (the loser's used-path).
+    expect(statuses).toEqual([302, 410]);
+    // EXACTLY one account was created from the invite — no orphan row.
+    expect(userCount(harness.db) - before).toBe(1);
+    const aliceExists = getUserByUsernameCI(harness.db, "alice") !== null;
+    const bobExists = getUserByUsernameCI(harness.db, "bob") !== null;
+    // Exactly one of the two usernames landed.
+    expect(aliceExists !== bobExists).toBe(true);
+    // The invite is consumed, pinned to whichever user won.
+    const after = findInviteByRawToken(harness.db, rawToken);
+    expect(after?.usedAt).not.toBeNull();
+    const winner = getUserByUsernameCI(harness.db, aliceExists ? "alice" : "bob");
+    expect(after?.redeemedUserId).toBe(winner?.id ?? "");
+  });
+});
+
+describe("POST /account/setup/<token> — account-only invite (N3)", () => {
+  test("provision_vault=false, no vault_name → user with empty assignedVaults, no vault shell-out", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, {
+      createdBy: admin.id,
+      provisionVault: false,
+    });
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const stub = makeStubRunCommand();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "accountonly",
+          password: "accountonly-password-1",
+          password_confirm: "accountonly-password-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    expect(res.status).toBe(302);
+    const user = getUserByUsernameCI(harness.db, "accountonly");
+    expect(user).not.toBeNull();
+    expect(user?.assignedVaults).toEqual([]);
+    // No vault provisioning shell-out for an account-only invite.
+    expect(stub.calls.length).toBe(0);
+    // Invite consumed.
+    expect(findInviteByRawToken(harness.db, rawToken)?.usedAt).not.toBeNull();
   });
 });

--- a/src/__tests__/api-invites.test.ts
+++ b/src/__tests__/api-invites.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Admin API tests for `/api/invites*` (`api-invites.ts`).
+ *
+ *   - host:admin gate (403 without the scope)
+ *   - POST create → 201 with single-emit token + URL; defaults applied
+ *   - GET list → status-annotated, raw token NEVER present
+ *   - DELETE /:id → revoke; 409 when already terminal; 404 unknown
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleCreateInvite, handleListInvites, handleRevokeInvite } from "../api-invites.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { signAccessToken } from "../jwt-sign.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "https://hub.test";
+const HOST_ADMIN_SCOPE = "parachute:host:admin";
+
+interface Harness {
+  db: Database;
+  manifestPath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-api-invites-"));
+  const db = openHubDb(hubDbPath(dir));
+  const manifestPath = join(dir, "services.json");
+  writeFileSync(manifestPath, JSON.stringify({ services: [] }));
+  return {
+    db,
+    manifestPath,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+async function makeAdminBearer(scopes = [HOST_ADMIN_SCOPE]): Promise<string> {
+  const user = await createUser(harness.db, "operator", "operator-password-1", {
+    allowMulti: true,
+    passwordChanged: true,
+  });
+  const minted = await signAccessToken(harness.db, {
+    sub: user.id,
+    scopes,
+    audience: "hub",
+    clientId: "parachute-hub-spa",
+    issuer: ISSUER,
+    ttlSeconds: 600,
+  });
+  return minted.token;
+}
+
+function deps() {
+  return { db: harness.db, issuer: ISSUER, manifestPath: harness.manifestPath };
+}
+
+function withBearer(path: string, bearer: string, init: RequestInit = {}): Request {
+  const headers = new Headers(init.headers ?? {});
+  headers.set("authorization", `Bearer ${bearer}`);
+  return new Request(`${ISSUER}${path}`, { ...init, headers });
+}
+
+describe("/api/invites auth", () => {
+  test("403 without host:admin scope", async () => {
+    const bearer = await makeAdminBearer(["other:scope"]);
+    const res = await handleListInvites(withBearer("/api/invites", bearer), deps());
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/invites", () => {
+  test("201 with single-emit token + URL; defaults (write/provision/7d)", async () => {
+    const bearer = await makeAdminBearer();
+    const res = await handleCreateInvite(
+      withBearer("/api/invites", bearer, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+      deps(),
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      invite: { id: string; status: string; role: string; provision_vault: boolean };
+      token: string;
+      url: string;
+    };
+    expect(body.token.length).toBeGreaterThan(40);
+    expect(body.url).toBe(`${ISSUER}/account/setup/${body.token}`);
+    expect(body.invite.role).toBe("write");
+    expect(body.invite.provision_vault).toBe(true);
+    expect(body.invite.status).toBe("pending");
+    // The id is the sha256 hash — never the raw token.
+    expect(body.invite.id).not.toBe(body.token);
+  });
+
+  test("400 on a bad role", async () => {
+    const bearer = await makeAdminBearer();
+    const res = await handleCreateInvite(
+      withBearer("/api/invites", bearer, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ role: "admin" }),
+      }),
+      deps(),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/invites", () => {
+  test("lists invites; raw token NEVER present in the wire shape", async () => {
+    const bearer = await makeAdminBearer();
+    const created = await handleCreateInvite(
+      withBearer("/api/invites", bearer, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ vault_name: "maya" }),
+      }),
+      deps(),
+    );
+    const createdBody = (await created.json()) as { token: string };
+    const list = await handleListInvites(withBearer("/api/invites", bearer), deps());
+    const body = (await list.json()) as { invites: { id: string }[] };
+    expect(body.invites.length).toBe(1);
+    // The raw token must not be recoverable from the list.
+    const json = JSON.stringify(body);
+    expect(json).not.toContain(createdBody.token);
+  });
+});
+
+describe("DELETE /api/invites/:id", () => {
+  test("revokes a pending invite; 409 if already revoked; 404 unknown", async () => {
+    const bearer = await makeAdminBearer();
+    const created = await handleCreateInvite(
+      withBearer("/api/invites", bearer, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+      deps(),
+    );
+    const { invite } = (await created.json()) as { invite: { id: string } };
+
+    const ok = await handleRevokeInvite(
+      withBearer(`/api/invites/${invite.id}`, bearer, { method: "DELETE" }),
+      invite.id,
+      deps(),
+    );
+    expect(ok.status).toBe(200);
+
+    const again = await handleRevokeInvite(
+      withBearer(`/api/invites/${invite.id}`, bearer, { method: "DELETE" }),
+      invite.id,
+      deps(),
+    );
+    expect(again.status).toBe(409);
+
+    const unknown = await handleRevokeInvite(
+      withBearer("/api/invites/deadbeef", bearer, { method: "DELETE" }),
+      "deadbeef",
+      deps(),
+    );
+    expect(unknown.status).toBe(404);
+  });
+});

--- a/src/__tests__/invites.test.ts
+++ b/src/__tests__/invites.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Core invite-primitive tests (`src/invites.ts`). Mirrors the auth-codes
+ * test shape: issue, lookup-by-raw, status derivation, redeemable assertion
+ * (not-found / expired / used / revoked), single-use consume, revoke.
+ *
+ * Security invariants asserted here: 256-bit raw token, sha256 at rest (the
+ * raw token never appears in the row), single-use via used_at, expiry
+ * enforced at redeem, revocable.
+ */
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import {
+  DEFAULT_INVITE_TTL_SECONDS,
+  InviteExpiredError,
+  InviteNotFoundError,
+  InviteRevokedError,
+  InviteUsedError,
+  assertInviteRedeemable,
+  consumeInvite,
+  findInviteByRawToken,
+  hashInviteToken,
+  inviteStatus,
+  issueInvite,
+  listInvites,
+  revokeInvite,
+} from "../invites.ts";
+import { createUser } from "../users.ts";
+
+async function makeDb() {
+  const dir = mkdtempSync(join(tmpdir(), "phub-invites-"));
+  const db = openHubDb(hubDbPath(dir));
+  const admin = await createUser(db, "operator", "operator-password-1");
+  return {
+    db,
+    adminId: admin.id,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("issueInvite", () => {
+  test("returns a 256-bit raw token and stores ONLY its sha256", async () => {
+    const { db, adminId, cleanup } = await makeDb();
+    try {
+      const { rawToken, invite } = issueInvite(db, { createdBy: adminId, vaultName: "maya" });
+      // base64url of 32 bytes ≈ 43 chars — comfortably high entropy.
+      expect(rawToken.length).toBeGreaterThan(40);
+      expect(invite.tokenHash).toBe(hashInviteToken(rawToken));
+      expect(invite.tokenHash).not.toBe(rawToken);
+      // The row stores the hash, never the raw token.
+      const row = db
+        .query<{ token: string }, [string]>("SELECT token FROM invites WHERE token = ?")
+        .get(createHash("sha256").update(rawToken).digest("hex"));
+      expect(row?.token).toBe(invite.tokenHash);
+      const rawRow = db
+        .query<{ n: number }, [string]>("SELECT COUNT(*) AS n FROM invites WHERE token = ?")
+        .get(rawToken);
+      expect(rawRow?.n).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("defaults: role=write, provision_vault=1, 7-day expiry", async () => {
+    const { db, adminId, cleanup } = await makeDb();
+    try {
+      const now = new Date("2026-06-04T00:00:00Z");
+      const { invite } = issueInvite(db, { createdBy: adminId, now: () => now });
+      expect(invite.role).toBe("write");
+      expect(invite.provisionVault).toBe(true);
+      expect(invite.vaultName).toBeNull();
+      const expiry = new Date(invite.expiresAt).getTime() - now.getTime();
+      expect(Math.round(expiry / 1000)).toBe(DEFAULT_INVITE_TTL_SECONDS);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("findInviteByRawToken", () => {
+  test("hashes then finds; unknown/tampered token → null", async () => {
+    const { db, adminId, cleanup } = await makeDb();
+    try {
+      const { rawToken } = issueInvite(db, { createdBy: adminId });
+      expect(findInviteByRawToken(db, rawToken)).not.toBeNull();
+      expect(findInviteByRawToken(db, `${rawToken}x`)).toBeNull();
+      expect(findInviteByRawToken(db, "totally-unknown")).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("assertInviteRedeemable", () => {
+  test("unknown token → InviteNotFoundError", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      expect(() => assertInviteRedeemable(db, "nope")).toThrow(InviteNotFoundError);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("expired token → InviteExpiredError", async () => {
+    const { db, adminId, cleanup } = await makeDb();
+    try {
+      const now = new Date("2026-06-04T00:00:00Z");
+      const { rawToken } = issueInvite(db, {
+        createdBy: adminId,
+        expiresInSeconds: 60,
+        now: () => now,
+      });
+      const later = new Date(now.getTime() + 61_000);
+      expect(() => assertInviteRedeemable(db, rawToken, later)).toThrow(InviteExpiredError);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("used token → InviteUsedError", async () => {
+    const { db, adminId, cleanup } = await makeDb();
+    try {
+      const { rawToken, invite } = issueInvite(db, { createdBy: adminId });
+      consumeInvite(db, invite.tokenHash, adminId);
+      expect(() => assertInviteRedeemable(db, rawToken)).toThrow(InviteUsedError);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("revoked token → InviteRevokedError", async () => {
+    const { db, adminId, cleanup } = await makeDb();
+    try {
+      const { rawToken, invite } = issueInvite(db, { createdBy: adminId });
+      revokeInvite(db, invite.tokenHash);
+      expect(() => assertInviteRedeemable(db, rawToken)).toThrow(InviteRevokedError);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("consumeInvite — single-use", () => {
+  test("first consume wins; second returns false (replay rejected)", async () => {
+    const { db, adminId, cleanup } = await makeDb();
+    try {
+      const { invite } = issueInvite(db, { createdBy: adminId });
+      expect(consumeInvite(db, invite.tokenHash, adminId)).toBe(true);
+      expect(consumeInvite(db, invite.tokenHash, adminId)).toBe(false);
+      const fresh = db
+        .query<{ used_at: string | null; redeemed_user_id: string | null }, [string]>(
+          "SELECT used_at, redeemed_user_id FROM invites WHERE token = ?",
+        )
+        .get(invite.tokenHash);
+      expect(fresh?.used_at).not.toBeNull();
+      expect(fresh?.redeemed_user_id).toBe(adminId);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("revokeInvite", () => {
+  test("revokes a pending invite; refuses one already used", async () => {
+    const { db, adminId, cleanup } = await makeDb();
+    try {
+      const a = issueInvite(db, { createdBy: adminId });
+      expect(revokeInvite(db, a.invite.tokenHash)).toBe(true);
+      expect(revokeInvite(db, a.invite.tokenHash)).toBe(false); // already revoked
+
+      const b = issueInvite(db, { createdBy: adminId });
+      consumeInvite(db, b.invite.tokenHash, adminId);
+      expect(revokeInvite(db, b.invite.tokenHash)).toBe(false); // already used
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("inviteStatus / listInvites", () => {
+  test("derives pending / redeemed / expired / revoked", async () => {
+    const { db, adminId, cleanup } = await makeDb();
+    try {
+      const now = new Date("2026-06-04T00:00:00Z");
+      const pending = issueInvite(db, { createdBy: adminId, now: () => now });
+      const redeemed = issueInvite(db, { createdBy: adminId, now: () => now });
+      consumeInvite(db, redeemed.invite.tokenHash, adminId, now);
+      const revoked = issueInvite(db, { createdBy: adminId, now: () => now });
+      revokeInvite(db, revoked.invite.tokenHash, now);
+      const expired = issueInvite(db, {
+        createdBy: adminId,
+        expiresInSeconds: 10,
+        now: () => now,
+      });
+
+      const later = new Date(now.getTime() + 60_000);
+      // `consumeInvite`/`revokeInvite` mutate the DB row, not the in-memory
+      // snapshot — re-read each to assert status off persisted state.
+      const fresh = (raw: string) => findInviteByRawToken(db, raw);
+      expect(inviteStatus(fresh(pending.rawToken)!, later)).toBe("pending");
+      expect(inviteStatus(fresh(redeemed.rawToken)!, later)).toBe("redeemed");
+      expect(inviteStatus(fresh(revoked.rawToken)!, later)).toBe("revoked");
+      expect(inviteStatus(fresh(expired.rawToken)!, later)).toBe("expired");
+
+      const list = listInvites(db, later);
+      expect(list.length).toBe(4);
+      // listInvites annotates status + newest-first ordering.
+      const statuses = new Set(list.map((i) => i.status));
+      expect(statuses).toEqual(new Set(["pending", "redeemed", "revoked", "expired"]));
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/account-setup.ts
+++ b/src/account-setup.ts
@@ -33,7 +33,6 @@
 import type { Database } from "bun:sqlite";
 import { renderAdminError, renderInviteSetup } from "./admin-login-ui.ts";
 import { type RunResult, provisionVault } from "./admin-vaults.ts";
-import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
 import {
   InviteExpiredError,
@@ -54,7 +53,7 @@ import {
   validatePassword,
   validateUsername,
 } from "./users.ts";
-import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
+import { validateVaultName } from "./vault-name.ts";
 
 export interface AccountSetupDeps {
   db: Database;
@@ -242,16 +241,21 @@ export async function handleAccountSetupPost(
   }
 
   // Resolve the vault name: pinned by the invite, or chosen by the invitee.
+  // The invitee-chosen name goes through the FULL `validateVaultName` (the
+  // same 2–32 + charset + reserved contract vault's init enforces), not just
+  // the charset regex — otherwise a 33–64 char name slips past here and fails
+  // at the vault CLI with a generic provision error.
   let vaultName: string | null = null;
   if (invite.provisionVault) {
     if (invite.vaultName !== null) {
       vaultName = invite.vaultName;
     } else {
       const chosen = String(form.get("vault_name") ?? "").trim();
-      if (!VAULT_NAME_CHARSET_RE.test(chosen)) {
-        return rerender(400, "Vault name must be 2–64 lowercase letters, digits, _ or -.", chosen);
+      const v = validateVaultName(chosen);
+      if (!v.ok) {
+        return rerender(400, v.error, chosen);
       }
-      vaultName = chosen;
+      vaultName = v.name;
     }
   } else if (invite.vaultName !== null) {
     // Account-only invite that assigns an existing vault.
@@ -281,11 +285,23 @@ export async function handleAccountSetupPost(
     }
   }
 
-  // (4) Create the user — the COMMIT POINT. passwordChanged: TRUE because the
-  // invitee chose their own password (no force-change). assignedVaults pins
-  // them to exactly their one vault at the invite's role. allowMulti because
-  // the first admin already exists. The invite is NOT yet consumed — if this
-  // throws, the invite stays re-usable.
+  // (4) Create the user + consume the invite ATOMICALLY — the COMMIT POINT.
+  // The invite is consumed INSIDE createUser's transaction (the `withinTx`
+  // hook), so the two single-use guarantees compose:
+  //
+  //   - Single-use under concurrency: two redeems of one invite both pass
+  //     `assertInviteRedeemable` above, but only one's `consumeInvite` UPDATE
+  //     (`used_at IS NULL AND revoked_at IS NULL`) changes a row. The loser's
+  //     hook throws `InviteUsedError`, which rolls back ITS user insert — no
+  //     orphan account. Exactly one account results.
+  //   - Re-usable on failure: if createUser throws (UNIQUE collision, etc.)
+  //     before the hook, the invite was never touched; if the hook itself
+  //     throws (lost race), the consume + the user insert roll back together.
+  //     Either way nothing commits, so the invite stays re-usable.
+  //
+  // passwordChanged: TRUE (the invitee chose their own password → no force-
+  // change). assignedVaults pins them to exactly their one vault at the
+  // invite's role. allowMulti because the first admin already exists.
   let userId: string;
   try {
     const created = await createUser(deps.db, username, password, {
@@ -293,25 +309,25 @@ export async function handleAccountSetupPost(
       passwordChanged: true,
       assignedVaults: vaultName !== null ? [vaultName] : [],
       role: invite.role,
+      withinTx: (newUserId) => {
+        if (!consumeInvite(deps.db, invite.tokenHash, newUserId, now)) {
+          // Lost the redeem race (or a concurrent revoke landed). Throw to
+          // roll back this user insert; surfaced as the used/410 path below.
+          throw new InviteUsedError();
+        }
+      },
     });
     userId = created.id;
   } catch (err) {
+    if (err instanceof InviteUsedError) {
+      return rejectInvite(err);
+    }
     if (err instanceof UsernameTakenError) {
       return rerender(409, `The username "${username}" is already taken. Pick another.`);
     }
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(`[account-setup] createUser failed for "${username}": ${msg}`);
     return rerender(500, "Could not create your account. Please try again.");
-  }
-
-  // (5) Consume the invite — AFTER the user row committed. used_at IS NULL
-  // guard makes this single-use even under a redeem race; a false return means
-  // another redeem won, so reject this one (the account we just created is
-  // harmless — it has no session yet and the invitee can sign in with it, but
-  // we don't hand THIS request a session for a doubly-redeemed invite).
-  const consumed = consumeInvite(deps.db, invite.tokenHash, userId, now);
-  if (!consumed) {
-    return rejectInvite(new InviteUsedError());
   }
 
   // (6) Sign the invitee in + land them on /account/.

--- a/src/account-setup.ts
+++ b/src/account-setup.ts
@@ -1,0 +1,326 @@
+/**
+ * `/account/setup/<token>` — invite redemption (design
+ * 2026-06-04-individual-users-and-vault-operations.md §7).
+ *
+ * Server-rendered (NOT the SPA), mirroring `/login` + the setup wizard's
+ * account-claim flow (`setup-wizard.ts` `handleSetupAccountPost`). A brand-new
+ * invitee opens the link with no session and no JS:
+ *
+ *   GET  → render the "pick username + password (+ vault name)" form.
+ *   POST → redeem: look up the invite by sha256(token), validate it's still
+ *          redeemable, validate credentials, provision the vault, create the
+ *          user, stamp the invite used, mint a session, 302 → /account/.
+ *
+ * Redeem ORDERING (the re-usability guarantee, mirroring the wizard):
+ *   1. lookup + validate the invite (not-found/expired/used/revoked)
+ *   2. validate username/password (+ vault name)
+ *   3. provision the vault (idempotent-safe)
+ *   4. createUser (the commit point)
+ *   5. consumeInvite — stamp used_at + redeemed_user_id ONLY AFTER (4) commits
+ *   6. createSession + cookie + 302
+ *
+ * Because the invite is consumed only after the user row commits, a
+ * createUser exception (UNIQUE collision, disk full, anything) leaves the
+ * invite re-usable — the invitee can simply retry. `consumeInvite`'s
+ * `used_at IS NULL` guard makes the stamp itself single-use / race-free.
+ *
+ * What an invite pre-authorizes: EXACTLY one account + the one named/created
+ * vault at the baked-in role — NEVER host:admin, NEVER another vault. The new
+ * user gets `assignedVaults:[that vault]` with the invite's role; nothing
+ * grants admin posture (the first-admin-by-earliest-row heuristic is
+ * untouched — an invited user is never the earliest row).
+ */
+import type { Database } from "bun:sqlite";
+import { renderAdminError, renderInviteSetup } from "./admin-login-ui.ts";
+import { type RunResult, provisionVault } from "./admin-vaults.ts";
+import { SERVICES_MANIFEST_PATH } from "./config.ts";
+import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
+import {
+  InviteExpiredError,
+  InviteNotFoundError,
+  InviteRevokedError,
+  InviteUsedError,
+  assertInviteRedeemable,
+  consumeInvite,
+} from "./invites.ts";
+import { checkAndRecord, clientIpFromRequest } from "./rate-limit.ts";
+import { isHttpsRequest } from "./request-protocol.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession } from "./sessions.ts";
+import {
+  PASSWORD_MAX_LEN,
+  UsernameTakenError,
+  createUser,
+  getUserByUsernameCI,
+  validatePassword,
+  validateUsername,
+} from "./users.ts";
+import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
+
+export interface AccountSetupDeps {
+  db: Database;
+  /** Hub origin — JWT `iss` for any vault bootstrap mint + the URL base. */
+  hubOrigin: string;
+  manifestPath?: string;
+  /** Test seam: vault provisioning shell-out. */
+  runCommand?: (cmd: readonly string[]) => Promise<RunResult>;
+  /** Test seam: clock for the rate limiter. */
+  now?: () => Date;
+}
+
+function htmlResponse(body: string, status = 200, extra: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store", ...extra },
+  });
+}
+
+/**
+ * Map an invite-rejection error to a status + user-facing copy. Not-found →
+ * 404 (don't confirm the token shape); expired/used/revoked → 410 Gone (the
+ * link existed but is no longer redeemable).
+ */
+function rejectInvite(err: unknown): Response {
+  if (err instanceof InviteNotFoundError) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Invite not found",
+        message:
+          "This invite link is not valid. Check that you copied the whole link, or ask your hub operator for a new one.",
+      }),
+      404,
+    );
+  }
+  if (err instanceof InviteExpiredError) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Invite expired",
+        message: "This invite link has expired. Ask your hub operator for a new one.",
+      }),
+      410,
+    );
+  }
+  if (err instanceof InviteUsedError) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Invite already used",
+        message:
+          "This invite link has already been used to create an account. If that wasn't you, contact your hub operator.",
+      }),
+      410,
+    );
+  }
+  if (err instanceof InviteRevokedError) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Invite revoked",
+        message: "This invite link has been revoked by your hub operator. Ask them for a new one.",
+      }),
+      410,
+    );
+  }
+  // Unexpected — fail closed.
+  return htmlResponse(
+    renderAdminError({ title: "Invite error", message: "Could not process this invite link." }),
+    500,
+  );
+}
+
+/** GET /account/setup/<token> — render the claim form (or a rejection page). */
+export function handleAccountSetupGet(
+  req: Request,
+  rawToken: string,
+  deps: AccountSetupDeps,
+): Response {
+  const now = (deps.now ?? (() => new Date()))();
+  let invite: ReturnType<typeof assertInviteRedeemable>;
+  try {
+    invite = assertInviteRedeemable(deps.db, rawToken, now);
+  } catch (err) {
+    return rejectInvite(err);
+  }
+  const csrf = ensureCsrfToken(req);
+  const setCookie: Record<string, string> = csrf.setCookie ? { "set-cookie": csrf.setCookie } : {};
+  return htmlResponse(
+    renderInviteSetup({
+      token: rawToken,
+      csrfToken: csrf.token,
+      pinnedVaultName: invite.vaultName,
+      provisionVault: invite.provisionVault,
+    }),
+    200,
+    setCookie,
+  );
+}
+
+/** POST /account/setup/<token> — redeem the invite (see file docstring for ordering). */
+export async function handleAccountSetupPost(
+  req: Request,
+  rawToken: string,
+  deps: AccountSetupDeps,
+): Promise<Response> {
+  const now = (deps.now ?? (() => new Date()))();
+
+  // (1) Look up + validate the invite BEFORE any work.
+  let invite: ReturnType<typeof assertInviteRedeemable>;
+  try {
+    invite = assertInviteRedeemable(deps.db, rawToken, now);
+  } catch (err) {
+    return rejectInvite(err);
+  }
+
+  // CSRF — double-submit, same shape as /account/change-password + /login.
+  const form = await req.formData();
+  const formCsrf = form.get(CSRF_FIELD_NAME);
+  if (!verifyCsrfToken(req, typeof formCsrf === "string" ? formCsrf : null)) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Invalid form submission",
+        message: "The form's CSRF token did not match. Reload the page and try again.",
+      }),
+      400,
+    );
+  }
+
+  // Rate limit — reuse the /login IP bucket so a redeem flood and a login
+  // flood share the same throttle. After CSRF (so a junk cross-site POST
+  // doesn't burn the bucket), before any account/vault work.
+  const clientIp = clientIpFromRequest(req);
+  const gate = checkAndRecord(clientIp, now);
+  if (!gate.allowed) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Too many attempts",
+        message: `Please wait ${gate.retryAfterSeconds ?? 60} seconds and try again.`,
+      }),
+      429,
+    );
+  }
+
+  const username = String(form.get("username") ?? "").trim();
+  const password = String(form.get("password") ?? "");
+  const confirm = String(form.get("password_confirm") ?? "");
+
+  const csrf = ensureCsrfToken(req);
+  const setCookie: Record<string, string> = csrf.setCookie ? { "set-cookie": csrf.setCookie } : {};
+  // Re-render the form with an inline error, preserving what the invitee typed.
+  const rerender = (status: number, message: string, vaultNameEcho?: string): Response =>
+    htmlResponse(
+      renderInviteSetup({
+        token: rawToken,
+        csrfToken: csrf.token,
+        pinnedVaultName: invite.vaultName,
+        provisionVault: invite.provisionVault,
+        username,
+        ...(vaultNameEcho !== undefined ? { vaultName: vaultNameEcho } : {}),
+        errorMessage: message,
+      }),
+      status,
+      setCookie,
+    );
+
+  // (2) Validate credentials with the SAME validators as /api/users.
+  const u = validateUsername(username);
+  if (!u.valid) {
+    return rerender(
+      400,
+      "Username must be 2–32 lowercase letters, digits, _ or - (and not a reserved word).",
+    );
+  }
+  if (password.length > PASSWORD_MAX_LEN) {
+    return rerender(413, `Password must be ≤ ${PASSWORD_MAX_LEN} characters.`);
+  }
+  const p = validatePassword(password);
+  if (!p.valid) {
+    return rerender(400, "Password must be at least 12 characters.");
+  }
+  if (password !== confirm) {
+    return rerender(400, "The two passwords don't match.");
+  }
+  // Case-insensitive uniqueness — same gate as /api/users.
+  if (getUserByUsernameCI(deps.db, username) !== null) {
+    return rerender(409, `The username "${username}" is already taken. Pick another.`);
+  }
+
+  // Resolve the vault name: pinned by the invite, or chosen by the invitee.
+  let vaultName: string | null = null;
+  if (invite.provisionVault) {
+    if (invite.vaultName !== null) {
+      vaultName = invite.vaultName;
+    } else {
+      const chosen = String(form.get("vault_name") ?? "").trim();
+      if (!VAULT_NAME_CHARSET_RE.test(chosen)) {
+        return rerender(400, "Vault name must be 2–64 lowercase letters, digits, _ or -.", chosen);
+      }
+      vaultName = chosen;
+    }
+  } else if (invite.vaultName !== null) {
+    // Account-only invite that assigns an existing vault.
+    vaultName = invite.vaultName;
+  }
+
+  // (3) Provision the vault (idempotent-safe). Routed through the SAME
+  // createVault path the wizard/SPA use, so the new vault gets the §3
+  // internal-live-mirror default for free. Done BEFORE createUser so a
+  // provisioning failure doesn't leave a vault-less account; the invite is
+  // still unconsumed at this point, so the invitee can retry.
+  if (invite.provisionVault && vaultName !== null) {
+    const provisioned = await provisionVault(vaultName, {
+      issuer: deps.hubOrigin,
+      ...(deps.manifestPath !== undefined ? { manifestPath: deps.manifestPath } : {}),
+      ...(deps.runCommand !== undefined ? { runCommand: deps.runCommand } : {}),
+      ...(invite.defaultMirror !== null ? { defaultMirror: invite.defaultMirror } : {}),
+    });
+    if (!provisioned.ok) {
+      return rerender(
+        provisioned.status === 400 ? 400 : 502,
+        provisioned.status === 400
+          ? provisioned.message
+          : "Could not provision your vault. Please try again, or ask your hub operator.",
+        invite.vaultName === null ? (vaultName ?? undefined) : undefined,
+      );
+    }
+  }
+
+  // (4) Create the user — the COMMIT POINT. passwordChanged: TRUE because the
+  // invitee chose their own password (no force-change). assignedVaults pins
+  // them to exactly their one vault at the invite's role. allowMulti because
+  // the first admin already exists. The invite is NOT yet consumed — if this
+  // throws, the invite stays re-usable.
+  let userId: string;
+  try {
+    const created = await createUser(deps.db, username, password, {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVaults: vaultName !== null ? [vaultName] : [],
+      role: invite.role,
+    });
+    userId = created.id;
+  } catch (err) {
+    if (err instanceof UsernameTakenError) {
+      return rerender(409, `The username "${username}" is already taken. Pick another.`);
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[account-setup] createUser failed for "${username}": ${msg}`);
+    return rerender(500, "Could not create your account. Please try again.");
+  }
+
+  // (5) Consume the invite — AFTER the user row committed. used_at IS NULL
+  // guard makes this single-use even under a redeem race; a false return means
+  // another redeem won, so reject this one (the account we just created is
+  // harmless — it has no session yet and the invitee can sign in with it, but
+  // we don't hand THIS request a session for a doubly-redeemed invite).
+  const consumed = consumeInvite(deps.db, invite.tokenHash, userId, now);
+  if (!consumed) {
+    return rejectInvite(new InviteUsedError());
+  }
+
+  // (6) Sign the invitee in + land them on /account/.
+  const session = createSession(deps.db, { userId });
+  const sessionCookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000), {
+    secure: isHttpsRequest(req),
+  });
+  return new Response(null, {
+    status: 302,
+    headers: { location: "/account/", "cache-control": "no-store", "set-cookie": sessionCookie },
+  });
+}

--- a/src/admin-login-ui.ts
+++ b/src/admin-login-ui.ts
@@ -200,10 +200,10 @@ export function renderInviteSetup(props: InviteSetupProps): string {
         <label class="field">
           <span class="field-label">Name your vault</span>
           <input type="text" name="vault_name" autocomplete="off"
-            required minlength="2" maxlength="64"
-            pattern="[a-z0-9_-]+" title="lowercase letters, digits, _ - (2–64 chars)"
+            required minlength="2" maxlength="32"
+            pattern="[a-z0-9_-]+" title="lowercase letters, digits, _ - (2–32 chars)"
             spellcheck="false" autocapitalize="off"${vaultAttr} />
-          <span class="field-hint">lowercase letters, digits, <code>_</code>, <code>-</code></span>
+          <span class="field-hint">lowercase letters, digits, <code>_</code>, <code>-</code> (2–32 chars)</span>
         </label>`;
     }
   }

--- a/src/admin-login-ui.ts
+++ b/src/admin-login-ui.ts
@@ -152,6 +152,100 @@ export function renderTotpChallenge(props: TotpChallengeProps): string {
   return baseDocument("Two-factor authentication — Parachute", body);
 }
 
+// --- invite redemption ( /account/setup/<token> ) --------------------------
+
+export interface InviteSetupProps {
+  /** The raw token from the URL — POSTs back to the same path. */
+  token: string;
+  csrfToken: string;
+  /**
+   * When the invite pins a vault name the redeemer can't choose one — we show
+   * it read-only. When null the redeemer names their own vault (a text field).
+   */
+  pinnedVaultName: string | null;
+  /** Whether redemption provisions a vault at all (shows the vault row iff true). */
+  provisionVault: boolean;
+  username?: string;
+  vaultName?: string;
+  errorMessage?: string;
+}
+
+/**
+ * Server-rendered "claim your invite" form for `/account/setup/<token>`.
+ * Stands alone without the SPA (same posture as `/login` + the setup wizard):
+ * a brand-new invitee hits this with no session and no JS. Posts back to the
+ * same `/account/setup/<token>` path. Reuses the shared login chrome.
+ */
+export function renderInviteSetup(props: InviteSetupProps): string {
+  const { token, csrfToken, pinnedVaultName, provisionVault, username, vaultName, errorMessage } =
+    props;
+  const error = errorMessage ? `<p class="error-banner">${escapeHtml(errorMessage)}</p>` : "";
+  const usernameAttr = username ? ` value="${escapeAttr(username)}"` : "";
+
+  // Vault row: shown only when the invite provisions a vault. Pinned → a
+  // read-only display of the name the admin chose (redeemer can't squat names).
+  // Unpinned → a text field the redeemer fills.
+  let vaultRow = "";
+  if (provisionVault) {
+    if (pinnedVaultName !== null) {
+      vaultRow = `
+        <label class="field">
+          <span class="field-label">Your vault</span>
+          <input type="text" value="${escapeAttr(pinnedVaultName)}" readonly disabled />
+          <span class="field-hint">Your hub operator named this vault for you.</span>
+        </label>`;
+    } else {
+      const vaultAttr = vaultName ? ` value="${escapeAttr(vaultName)}"` : "";
+      vaultRow = `
+        <label class="field">
+          <span class="field-label">Name your vault</span>
+          <input type="text" name="vault_name" autocomplete="off"
+            required minlength="2" maxlength="64"
+            pattern="[a-z0-9_-]+" title="lowercase letters, digits, _ - (2–64 chars)"
+            spellcheck="false" autocapitalize="off"${vaultAttr} />
+          <span class="field-hint">lowercase letters, digits, <code>_</code>, <code>-</code></span>
+        </label>`;
+    }
+  }
+
+  const body = `
+    <div class="card">
+      <div class="card-header">
+        ${header()}
+        <h1>Claim your invite</h1>
+        <p class="subtitle">Pick a username and password to create your Parachute account${
+          provisionVault ? " and your own vault" : ""
+        }.</p>
+      </div>
+      ${error}
+      <form method="POST" action="/account/setup/${escapeAttr(token)}" class="auth-form">
+        ${renderCsrfHiddenInput(csrfToken)}
+        <label class="field">
+          <span class="field-label">Username</span>
+          <input type="text" name="username" autocomplete="username" autofocus
+            required minlength="2" maxlength="32"
+            pattern="[a-z0-9_-]+" title="lowercase letters, digits, _ - (2–32 chars)"
+            spellcheck="false" autocapitalize="off"${usernameAttr} />
+          <span class="field-hint">lowercase letters, digits, <code>_</code>, <code>-</code></span>
+        </label>
+        <label class="field">
+          <span class="field-label">Password</span>
+          <input type="password" name="password" autocomplete="new-password"
+            required minlength="12" />
+          <span class="field-hint">at least 12 characters</span>
+        </label>
+        <label class="field">
+          <span class="field-label">Confirm password</span>
+          <input type="password" name="password_confirm" autocomplete="new-password"
+            required minlength="12" />
+        </label>
+        ${vaultRow}
+        <button type="submit" class="btn btn-primary">Create my account</button>
+      </form>
+    </div>`;
+  return baseDocument("Claim your invite — Parachute", body);
+}
+
 // --- error page ------------------------------------------------------------
 
 export function renderAdminError(props: { title: string; message: string }): string {

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -279,10 +279,17 @@ async function orchestrate(
   manifestPath: string,
   name: string,
   runCommand: (cmd: readonly string[]) => Promise<RunResult>,
+  opts: { noMirror?: boolean } = {},
 ): Promise<OrchestrateOk | OrchestrateError> {
   const vaultRegistered = findService("parachute-vault", manifestPath) !== undefined;
+  // `--no-mirror` opts this create out of the default internal live mirror
+  // (§3 default_mirror knob). Only meaningful on the `create` branch — the
+  // bootstrap `install` path provisions the default vault and follows the
+  // server-wide knob.
   const cmd = vaultRegistered
-    ? ["parachute-vault", "create", name, "--json"]
+    ? opts.noMirror
+      ? ["parachute-vault", "create", name, "--json", "--no-mirror"]
+      : ["parachute-vault", "create", name, "--json"]
     : ["parachute", "install", "vault"];
   let result: RunResult;
   try {
@@ -331,6 +338,102 @@ async function orchestrate(
   return { ok: true, createJson };
 }
 
+/**
+ * Result of {@link provisionVault} — the programmatic vault-provisioning
+ * core shared by the authed HTTP handler and the invite-redeem path.
+ *
+ *   - `created: true`  — a fresh vault was provisioned this call. `entry`
+ *     describes it; `createJson` (when present) carries the single-emit
+ *     bootstrap creds.
+ *   - `created: false` — the vault already existed (idempotent). `entry`
+ *     describes the existing vault; no `createJson`.
+ */
+export type ProvisionVaultResult =
+  | {
+      ok: true;
+      created: boolean;
+      entry: WellKnownVaultEntry;
+      createJson: VaultCreateJson | null;
+    }
+  | { ok: false; status: number; message: string };
+
+/**
+ * Provision (or no-op if it exists) a vault by name — the auth-free core
+ * lifted out of {@link handleCreateVault} so the invite-redeem flow can
+ * provision a vault for a freshly-created account WITHOUT a host:admin
+ * bearer (the redeemer holds no admin authority; the invite IS the
+ * authorization). The HTTP handler keeps the host:admin gate in front of
+ * this; the invite path calls it directly after validating the invite.
+ *
+ * Idempotent-safe: if the vault already exists this returns
+ * `created:false` with the existing entry rather than re-running the CLI —
+ * a redeem retry (or a name collision) lands the user on the existing
+ * vault instead of erroring.
+ *
+ * Name validation matches `parachute-vault create`'s rules. Callers that
+ * accept an untrusted name (the invite redeemer naming their own vault)
+ * MUST pass it through here so the same regex + reserved-name gate the
+ * `/vaults` API edge enforces applies.
+ */
+export async function provisionVault(
+  name: string,
+  deps: {
+    issuer: string;
+    manifestPath?: string;
+    runCommand?: CreateVaultDeps["runCommand"];
+    /** `'off'` appends `--no-mirror`; anything else follows the server knob. */
+    defaultMirror?: string;
+  },
+): Promise<ProvisionVaultResult> {
+  const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const runCommand = deps.runCommand ?? defaultRunCommand;
+
+  if (!VAULT_NAME_PATTERN.test(name)) {
+    return {
+      ok: false,
+      status: 400,
+      message: "vault name must contain only lowercase letters, numbers, hyphens, and underscores",
+    };
+  }
+  if (RESERVED_VAULT_NAMES.has(name)) {
+    return { ok: false, status: 400, message: `"${name}" is a reserved vault name` };
+  }
+
+  // Idempotency: if the vault already exists, return the existing entry.
+  const existing = findExistingVault(manifestPath, name);
+  if (existing) {
+    return {
+      ok: true,
+      created: false,
+      entry: buildEntry(name, existing.path, existing.version, deps.issuer),
+      createJson: null,
+    };
+  }
+
+  const result = await orchestrate(manifestPath, name, runCommand, {
+    noMirror: deps.defaultMirror === "off",
+  });
+  if (!result.ok) {
+    return { ok: false, status: result.status, message: result.message };
+  }
+
+  // Re-read services.json: the CLI just wrote it.
+  const created = findExistingVault(manifestPath, name);
+  if (!created) {
+    return {
+      ok: false,
+      status: 500,
+      message: `vault "${name}" was provisioned but is not in services.json — manual recovery required`,
+    };
+  }
+  return {
+    ok: true,
+    created: true,
+    entry: buildEntry(name, created.path, created.version, deps.issuer),
+    createJson: result.createJson,
+  };
+}
+
 export async function handleCreateVault(req: Request, deps: CreateVaultDeps): Promise<Response> {
   if (req.method !== "POST") {
     return new Response("method not allowed", { status: 405 });
@@ -352,35 +455,29 @@ export async function handleCreateVault(req: Request, deps: CreateVaultDeps): Pr
   }
   const { name } = parsed.body;
 
-  // Idempotency: if the vault already exists, return 200 + existing entry.
-  // Skip the CLI shell-out — re-POST is usually a UI retry.
-  const existing = findExistingVault(manifestPath, name);
-  if (existing) {
-    return new Response(
-      JSON.stringify(buildEntry(name, existing.path, existing.version, deps.issuer)),
-      {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      },
-    );
+  const provisioned = await provisionVault(name, {
+    issuer: deps.issuer,
+    manifestPath,
+    runCommand,
+  });
+  if (!provisioned.ok) {
+    // parseBody already enforced the name regex/reserved gate, so a
+    // provisionVault 400 here would be a redundant re-check; map any
+    // non-ok to its status. invalid_request for 400, server_error otherwise.
+    const error = provisioned.status === 400 ? "invalid_request" : "server_error";
+    return jsonError(provisioned.status, error, provisioned.message);
   }
 
-  const result = await orchestrate(manifestPath, name, runCommand);
-  if (!result.ok) {
-    return jsonError(result.status, "server_error", result.message);
+  // Idempotent re-POST: existing vault → 200, no single-emit creds.
+  if (!provisioned.created) {
+    return new Response(JSON.stringify(provisioned.entry), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
   }
 
-  // Re-read services.json: the CLI just wrote it.
-  const created = findExistingVault(manifestPath, name);
-  if (!created) {
-    return jsonError(
-      500,
-      "server_error",
-      `vault "${name}" was provisioned but is not in services.json — manual recovery required`,
-    );
-  }
-
-  const entry = buildEntry(name, created.path, created.version, deps.issuer);
+  const entry = provisioned.entry;
+  const result = { createJson: provisioned.createJson };
   // Access token (a `vault:<name>:admin` JWT, possibly empty post-DROP) +
   // filesystem paths are single-emit at create time. We surface them here so
   // the caller can immediately bootstrap a connection to the new vault.

--- a/src/api-invites.ts
+++ b/src/api-invites.ts
@@ -1,0 +1,347 @@
+/**
+ * `/api/invites*` — admin endpoints for one-time invite links (design
+ * 2026-06-04-individual-users-and-vault-operations.md §7).
+ *
+ *   POST   /api/invites        create an invite → { invite, url } (host:admin)
+ *                              The `url` carries the raw token and is the ONLY
+ *                              time it's retrievable — the hub stores only its
+ *                              sha256.
+ *   GET    /api/invites        list invites with derived status (host:admin)
+ *   DELETE /api/invites/:id     revoke a pending invite by sha256 hash (host:admin)
+ *
+ * Auth: every endpoint requires a bearer carrying `parachute:host:admin` —
+ * the same gate as `/api/users` and `/vaults`. The SPA mints one via
+ * `/admin/host-admin-token` from the session cookie.
+ *
+ * Wire shape is snake_case (matches `/api/users`). An invite's raw token
+ * NEVER appears in a GET/list response — only in the POST-create `url`.
+ */
+import type { Database } from "bun:sqlite";
+import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
+import { HOST_ADMIN_SCOPE } from "./admin-vaults.ts";
+import { SERVICES_MANIFEST_PATH } from "./config.ts";
+import {
+  DEFAULT_INVITE_TTL_SECONDS,
+  type Invite,
+  type InviteStatus,
+  findInviteByHash,
+  inviteStatus,
+  issueInvite,
+  listInvites,
+  revokeInvite,
+} from "./invites.ts";
+import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
+import { listVaultNamesFromPath } from "./vault-names.ts";
+
+export interface ApiInvitesDeps {
+  db: Database;
+  /** Hub origin — JWT `iss` validation AND the base for the redemption URL. */
+  issuer: string;
+  manifestPath?: string;
+  now?: () => Date;
+}
+
+/** Roles an invite may grant. `'write'` = owner (full vault admin); `'read'` = read-only (shared). */
+const ALLOWED_ROLES = new Set(["read", "write"]);
+/** Cap an invite TTL so a typo can't mint a ~forever link. 90 days. */
+const MAX_INVITE_TTL_SECONDS = 90 * 24 * 60 * 60;
+
+interface InviteWireShape {
+  /** sha256 hash — the stable id for list/revoke. NOT the raw token. */
+  id: string;
+  status: InviteStatus;
+  vault_name: string | null;
+  role: string;
+  provision_vault: boolean;
+  default_mirror: string | null;
+  expires_at: string;
+  used_at: string | null;
+  redeemed_user_id: string | null;
+  revoked_at: string | null;
+  created_at: string;
+}
+
+function toWire(invite: Invite, status: InviteStatus): InviteWireShape {
+  return {
+    id: invite.tokenHash,
+    status,
+    vault_name: invite.vaultName,
+    role: invite.role,
+    provision_vault: invite.provisionVault,
+    default_mirror: invite.defaultMirror,
+    expires_at: invite.expiresAt,
+    used_at: invite.usedAt,
+    redeemed_user_id: invite.redeemedUserId,
+    revoked_at: invite.revokedAt,
+    created_at: invite.createdAt,
+  };
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function redeemUrl(issuer: string, rawToken: string): string {
+  const base = issuer.replace(/\/$/, "");
+  return `${base}/account/setup/${rawToken}`;
+}
+
+interface CreateInviteBody {
+  vaultName: string | null;
+  role: string;
+  provisionVault: boolean;
+  defaultMirror: string | null;
+  expiresInSeconds: number;
+}
+
+interface ParseErr {
+  ok: false;
+  status: number;
+  error: string;
+  description: string;
+}
+
+async function parseCreateBody(
+  req: Request,
+): Promise<{ ok: true; body: CreateInviteBody } | ParseErr> {
+  const ctype = req.headers.get("content-type") ?? "";
+  // Allow an empty body — every field has a default. Only enforce JSON when
+  // a body is actually present.
+  let raw: unknown = {};
+  if (ctype.toLowerCase().includes("application/json")) {
+    try {
+      const text = await req.text();
+      raw = text.trim() === "" ? {} : JSON.parse(text);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        ok: false,
+        status: 400,
+        error: "invalid_request",
+        description: `invalid JSON body: ${msg}`,
+      };
+    }
+  }
+  if (!raw || typeof raw !== "object") {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      description: "request body must be a JSON object",
+    };
+  }
+  const obj = raw as Record<string, unknown>;
+
+  // vault_name — optional. null/omitted = redeemer names their own vault.
+  let vaultName: string | null = null;
+  const rawVault =
+    Object.hasOwn(obj, "vault_name") && obj.vault_name !== undefined
+      ? obj.vault_name
+      : Object.hasOwn(obj, "vaultName") && obj.vaultName !== undefined
+        ? obj.vaultName
+        : undefined;
+  if (rawVault !== undefined && rawVault !== null) {
+    if (typeof rawVault !== "string" || rawVault.length === 0) {
+      return {
+        ok: false,
+        status: 400,
+        error: "invalid_request",
+        description: '"vault_name" must be a non-empty string or null',
+      };
+    }
+    if (!VAULT_NAME_CHARSET_RE.test(rawVault)) {
+      return {
+        ok: false,
+        status: 400,
+        error: "invalid_request",
+        description:
+          "vault name must contain only lowercase letters, numbers, hyphens, and underscores",
+      };
+    }
+    vaultName = rawVault;
+  }
+
+  // role — default 'write' (owner).
+  let role = "write";
+  const rawRole = obj.role;
+  if (rawRole !== undefined && rawRole !== null) {
+    if (typeof rawRole !== "string" || !ALLOWED_ROLES.has(rawRole)) {
+      return {
+        ok: false,
+        status: 400,
+        error: "invalid_request",
+        description: '"role" must be "read" or "write"',
+      };
+    }
+    role = rawRole;
+  }
+
+  // provision_vault — default true (the primary flow).
+  let provisionVault = true;
+  const rawProvision =
+    Object.hasOwn(obj, "provision_vault") && obj.provision_vault !== undefined
+      ? obj.provision_vault
+      : Object.hasOwn(obj, "provisionVault") && obj.provisionVault !== undefined
+        ? obj.provisionVault
+        : undefined;
+  if (rawProvision !== undefined) {
+    if (typeof rawProvision !== "boolean") {
+      return {
+        ok: false,
+        status: 400,
+        error: "invalid_request",
+        description: '"provision_vault" must be a boolean',
+      };
+    }
+    provisionVault = rawProvision;
+  }
+
+  // default_mirror — optional 'internal' | 'off'.
+  let defaultMirror: string | null = null;
+  const rawMirror =
+    Object.hasOwn(obj, "default_mirror") && obj.default_mirror !== undefined
+      ? obj.default_mirror
+      : Object.hasOwn(obj, "defaultMirror") && obj.defaultMirror !== undefined
+        ? obj.defaultMirror
+        : undefined;
+  if (rawMirror !== undefined && rawMirror !== null) {
+    if (rawMirror !== "internal" && rawMirror !== "off") {
+      return {
+        ok: false,
+        status: 400,
+        error: "invalid_request",
+        description: '"default_mirror" must be "internal" or "off"',
+      };
+    }
+    defaultMirror = rawMirror;
+  }
+
+  // expires_in — seconds; default 7 days; capped at 90 days.
+  let expiresInSeconds = DEFAULT_INVITE_TTL_SECONDS;
+  const rawExpiry =
+    Object.hasOwn(obj, "expires_in") && obj.expires_in !== undefined
+      ? obj.expires_in
+      : Object.hasOwn(obj, "expiresIn") && obj.expiresIn !== undefined
+        ? obj.expiresIn
+        : undefined;
+  if (rawExpiry !== undefined && rawExpiry !== null) {
+    if (typeof rawExpiry !== "number" || !Number.isFinite(rawExpiry) || rawExpiry <= 0) {
+      return {
+        ok: false,
+        status: 400,
+        error: "invalid_request",
+        description: '"expires_in" must be a positive number of seconds',
+      };
+    }
+    if (rawExpiry > MAX_INVITE_TTL_SECONDS) {
+      return {
+        ok: false,
+        status: 400,
+        error: "invalid_request",
+        description: `"expires_in" must be ≤ ${MAX_INVITE_TTL_SECONDS} seconds (90 days)`,
+      };
+    }
+    expiresInSeconds = Math.floor(rawExpiry);
+  }
+
+  return { ok: true, body: { vaultName, role, provisionVault, defaultMirror, expiresInSeconds } };
+}
+
+/** POST /api/invites — create an invite, return the single-emit URL + token. */
+export async function handleCreateInvite(req: Request, deps: ApiInvitesDeps): Promise<Response> {
+  if (req.method !== "POST") return jsonError(405, "method_not_allowed", "use POST");
+  let authUserId: string;
+  try {
+    // `requireScope` returns the validated claims; the admin's `sub` is the
+    // `created_by` audit anchor (guaranteed present — it throws otherwise).
+    const auth = await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    authUserId = auth.sub;
+  } catch (err) {
+    return adminAuthErrorResponse(err as AdminAuthError);
+  }
+  const parsed = await parseCreateBody(req);
+  if (!parsed.ok) return jsonError(parsed.status, parsed.error, parsed.description);
+  const { vaultName, role, provisionVault, defaultMirror, expiresInSeconds } = parsed.body;
+
+  // A pinned vault_name with provision_vault=false means "assign an existing
+  // vault" — validate it exists. (provision_vault=true with a pinned name
+  // provisions THAT name; provision_vault=false without a name is account-only.)
+  if (vaultName !== null && !provisionVault) {
+    const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
+    const known = new Set(listVaultNamesFromPath(manifestPath));
+    if (!known.has(vaultName)) {
+      return jsonError(
+        400,
+        "vault_not_found",
+        `vault "${vaultName}" is not registered in services.json`,
+      );
+    }
+  }
+
+  const issued = issueInvite(deps.db, {
+    createdBy: authUserId,
+    vaultName,
+    role,
+    provisionVault,
+    defaultMirror,
+    expiresInSeconds,
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  });
+  const status = inviteStatus(issued.invite, (deps.now ?? (() => new Date()))());
+  return new Response(
+    JSON.stringify({
+      invite: toWire(issued.invite, status),
+      // Single-emit: the raw token only ever appears here.
+      token: issued.rawToken,
+      url: redeemUrl(deps.issuer, issued.rawToken),
+    }),
+    { status: 201, headers: { "content-type": "application/json", "cache-control": "no-store" } },
+  );
+}
+
+/** GET /api/invites — list invites, newest first, status-annotated. */
+export async function handleListInvites(req: Request, deps: ApiInvitesDeps): Promise<Response> {
+  if (req.method !== "GET") return jsonError(405, "method_not_allowed", "use GET");
+  try {
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+  } catch (err) {
+    return adminAuthErrorResponse(err as AdminAuthError);
+  }
+  const now = (deps.now ?? (() => new Date()))();
+  const invites = listInvites(deps.db, now).map((i) => toWire(i, i.status));
+  return new Response(JSON.stringify({ invites }), {
+    status: 200,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+/** DELETE /api/invites/:id — revoke a pending invite by its sha256 hash. */
+export async function handleRevokeInvite(
+  req: Request,
+  id: string,
+  deps: ApiInvitesDeps,
+): Promise<Response> {
+  if (req.method !== "DELETE") return jsonError(405, "method_not_allowed", "use DELETE");
+  try {
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+  } catch (err) {
+    return adminAuthErrorResponse(err as AdminAuthError);
+  }
+  const existing = findInviteByHash(deps.db, id);
+  if (!existing) return jsonError(404, "not_found", `no invite with id "${id}"`);
+  const now = (deps.now ?? (() => new Date()))();
+  const revoked = revokeInvite(deps.db, id, now);
+  if (!revoked) {
+    // Already redeemed or revoked — nothing to do, but report the terminal
+    // state so the SPA can refresh rather than silently swallowing.
+    const status = inviteStatus(existing, now);
+    return jsonError(409, "invite_not_pending", `invite is already ${status}`);
+  }
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}

--- a/src/hub-db.ts
+++ b/src/hub-db.ts
@@ -2,8 +2,9 @@
  * Hub-local SQLite database. Opens `~/.parachute/hub.db` (overridable via
  * `$PARACHUTE_HOME`). Holds everything the hub owns as the ecosystem's OAuth
  * issuer — signing keys (v1), users + opaque refresh tokens (v2), OAuth
- * clients + auth-codes + grants + browser sessions (v3), and TOTP 2FA
- * enrollment on the users row (v11, hub#473).
+ * clients + auth-codes + grants + browser sessions (v3), TOTP 2FA
+ * enrollment on the users row (v11, hub#473), and one-time invite links
+ * (v12, the `invites` table).
  *
  * Each open() runs `migrate()` to bring the schema up to date. A
  * `schema_version` table records every applied migration so re-opens are
@@ -356,6 +357,73 @@ const MIGRATIONS: readonly Migration[] = [
       ALTER TABLE users ADD COLUMN totp_secret TEXT;
       ALTER TABLE users ADD COLUMN totp_backup_codes TEXT;
       ALTER TABLE users ADD COLUMN totp_enrolled_at TEXT;
+    `,
+  },
+  {
+    version: 12,
+    sql: `
+      -- One-time, expiring invite links (design
+      -- 2026-06-04-individual-users-and-vault-operations.md §7). An admin
+      -- generates a link; the recipient opens it, picks a username +
+      -- password, and gets their OWN freshly-provisioned vault as owner.
+      --
+      -- The row stores sha256(token), NOT the raw token. Invites are
+      -- longer-lived than the 60s OAuth auth-codes (default 7-day expiry),
+      -- so a DB read must not be enough to replay the link — the raw token
+      -- is emitted exactly once at creation and never persisted, exactly
+      -- like the bootstrap token. Lookup hashes the URL token and selects
+      -- by the hash; the hash is the primary key.
+      --
+      -- Columns:
+      --   * token (TEXT PK)        — sha256(raw token), hex. Never the raw value.
+      --   * created_by (TEXT)      — admin user id that issued the invite
+      --                              (FK users.id; ON DELETE SET NULL so
+      --                              deleting the issuer doesn't orphan-block
+      --                              the audit row).
+      --   * vault_name (TEXT)      — nullable. When set, the invite pins the
+      --                              vault name (redeemer can't squat names).
+      --                              When NULL + provision_vault=1 the redeemer
+      --                              names their own vault at redeem time.
+      --   * role (TEXT DEFAULT 'write') — the user_vaults role the redeemed
+      --                              user gets on their vault. 'write' = owner
+      --                              (full vault admin per vaultVerbsForRole).
+      --                              Carried so the shared-into-existing-vault
+      --                              case is a later policy change, not a
+      --                              migration.
+      --   * provision_vault (INTEGER) — 1 = provision a NEW vault for the
+      --                              redeemer (the primary flow); 0 = account
+      --                              only / assign an existing vault.
+      --   * default_mirror (TEXT)  — nullable; wires the §3 default-mirror knob
+      --                              ('internal' | 'off') through to the
+      --                              provisioned vault. NULL = vault's own
+      --                              default.
+      --   * expires_at (TEXT)      — ISO-8601; redeem rejects past this.
+      --   * used_at (TEXT)         — ISO-8601 stamp set at redeem. Single-use:
+      --                              a second redeem sees this set and is
+      --                              rejected. Stamped only AFTER the user row
+      --                              commits, so a createUser failure leaves
+      --                              the invite re-usable.
+      --   * redeemed_user_id (TEXT) — the user id the invite created (FK
+      --                              users.id; ON DELETE SET NULL).
+      --   * revoked_at (TEXT)      — ISO-8601 stamp when the admin revokes the
+      --                              invite before redemption.
+      --   * created_at (TEXT)      — ISO-8601.
+      --
+      -- No backfill — no invites pre-date this migration.
+      CREATE TABLE invites (
+        token TEXT PRIMARY KEY,
+        created_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+        vault_name TEXT,
+        role TEXT NOT NULL DEFAULT 'write',
+        provision_vault INTEGER NOT NULL DEFAULT 1,
+        default_mirror TEXT,
+        expires_at TEXT NOT NULL,
+        used_at TEXT,
+        redeemed_user_id TEXT REFERENCES users(id) ON DELETE SET NULL,
+        revoked_at TEXT,
+        created_at TEXT NOT NULL
+      );
+      CREATE INDEX invites_created_at ON invites (created_at);
     `,
   },
 ];

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -127,6 +127,7 @@ import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import pkg from "../package.json" with { type: "json" };
+import { handleAccountSetupGet, handleAccountSetupPost } from "./account-setup.ts";
 import { handleAccountVaultAdminTokenPost } from "./account-vault-admin-token.ts";
 import { handleAccountVaultTokenPost } from "./account-vault-token.ts";
 import { handleApproveClient, handleGetClient } from "./admin-clients.ts";
@@ -147,6 +148,7 @@ import {
 } from "./api-account.ts";
 import { handleHubUpgrade, handleHubUpgradeStatus } from "./api-hub-upgrade.ts";
 import { handleApiHub } from "./api-hub.ts";
+import { handleCreateInvite, handleListInvites, handleRevokeInvite } from "./api-invites.ts";
 import { handleApiMe } from "./api-me.ts";
 import { handleApiMintToken } from "./api-mint-token.ts";
 import { handleApiModulesConfig, parseModulesConfigPath } from "./api-modules-config.ts";
@@ -1091,6 +1093,13 @@ async function serveSpa(spaDistDir: string, pathname: string, mount: SpaMount): 
  * regular dispatch continues.
  */
 function shouldGateForSetup(pathname: string): boolean {
+  // Invite redemption (`/account/setup/<token>`) is an un-authed onboarding
+  // surface like the wizard — it must pass through the pre-admin lockout so a
+  // recipient can claim an invite. (In practice invites can only be issued
+  // after an admin exists, so the no-admin lockout rarely coincides; the
+  // explicit pass-through keeps the surface's posture clear + matches the
+  // wizard's `/admin/setup/*` exemption.)
+  if (pathname === "/account/setup" || pathname.startsWith("/account/setup/")) return false;
   if (pathname === "/login" || pathname === "/logout") return true;
   // The wizard itself + its POST endpoints are the *only* way to exit
   // the pre-admin lockout from a browser — they must pass through. Any
@@ -2301,6 +2310,29 @@ export function hubFetch(
       });
     }
 
+    // One-time invite links (design §7). host:admin-gated, same gate flavor
+    // as /api/users. POST creates (returns the single-emit token + URL), GET
+    // lists (status-annotated), DELETE /:id revokes by sha256 hash.
+    if (pathname === "/api/invites") {
+      if (!getDb) return dbNotConfigured();
+      const invitesDeps = { db: getDb(), issuer: oauthDeps(req).issuer, manifestPath };
+      if (req.method === "GET") return handleListInvites(req, invitesDeps);
+      if (req.method === "POST") return handleCreateInvite(req, invitesDeps);
+      return new Response("method not allowed", { status: 405 });
+    }
+    if (pathname.startsWith("/api/invites/")) {
+      if (!getDb) return dbNotConfigured();
+      const id = decodeURIComponent(pathname.slice("/api/invites/".length));
+      if (!id || id.includes("/")) {
+        return new Response("not found", { status: 404 });
+      }
+      return handleRevokeInvite(req, id, {
+        db: getDb(),
+        issuer: oauthDeps(req).issuer,
+        manifestPath,
+      });
+    }
+
     // Canonical login/logout. The handlers themselves are unchanged from
     // when they lived at /admin/login + /admin/logout; the rename surfaced
     // via #231-followup so the URL reflects the surface's actual scope
@@ -2329,6 +2361,27 @@ export function hubFetch(
       if (!getDb) return dbNotConfigured();
       if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
       return handleAdminLogoutPost(getDb(), req);
+    }
+
+    // Invite redemption — `/account/setup/<token>` (design §7). Un-authed
+    // onboarding surface (the invitee has no session yet); routed BEFORE the
+    // per-request force-change choke point and the `/account/` matches below.
+    // GET renders the claim form; POST redeems → creates account + own vault,
+    // mints a session, 302 → /account/. The handler validates the invite
+    // (sha256 lookup, expiry/used/revoked), CSRF, and rate-limits on the
+    // /login IP bucket. The invite alone is the authorization — no host:admin.
+    if (pathname.startsWith("/account/setup/")) {
+      if (!getDb) return dbNotConfigured();
+      const rawToken = decodeURIComponent(pathname.slice("/account/setup/".length));
+      if (!rawToken || rawToken.includes("/")) {
+        return new Response("not found", { status: 404 });
+      }
+      const db = getDb();
+      const hubOrigin = resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin);
+      const setupDeps = { db, hubOrigin, manifestPath };
+      if (req.method === "GET") return handleAccountSetupGet(req, rawToken, setupDeps);
+      if (req.method === "POST") return handleAccountSetupPost(req, rawToken, setupDeps);
+      return new Response("method not allowed", { status: 405 });
     }
 
     // Multi-user Phase 1 PR 3 — user self-service change-password surface

--- a/src/invites.ts
+++ b/src/invites.ts
@@ -253,14 +253,14 @@ export function assertInviteRedeemable(
 
 /**
  * Mark an invite consumed — stamp `used_at` + `redeemed_user_id`. Called
- * ONLY after the redeemed user row has committed (so a createUser exception
- * leaves the invite re-usable). Single-use is enforced by the
- * `used_at IS NULL` guard in the UPDATE: a racing second redeem updates zero
- * rows and the caller treats that as already-consumed.
+ * Called within the account-creation transaction (or after a committed user
+ * row). Single-use + not-revoked is enforced by the
+ * `used_at IS NULL AND revoked_at IS NULL` guard in the UPDATE: a racing
+ * second redeem — or a concurrent revoke — updates zero rows and the caller
+ * treats that as already-consumed/revoked. Race-safe because sqlite
+ * serializes writes.
  *
- * Returns `true` if THIS call consumed the invite, `false` if it was already
- * consumed (used_at already set) — race-safe because sqlite serializes
- * writes.
+ * Returns `true` if THIS call consumed the invite, `false` otherwise.
  */
 export function consumeInvite(
   db: Database,
@@ -270,7 +270,7 @@ export function consumeInvite(
 ): boolean {
   const res = db
     .prepare(
-      "UPDATE invites SET used_at = ?, redeemed_user_id = ? WHERE token = ? AND used_at IS NULL",
+      "UPDATE invites SET used_at = ?, redeemed_user_id = ? WHERE token = ? AND used_at IS NULL AND revoked_at IS NULL",
     )
     .run(now.toISOString(), redeemedUserId, tokenHash);
   return res.changes > 0;

--- a/src/invites.ts
+++ b/src/invites.ts
@@ -1,0 +1,291 @@
+/**
+ * One-time, expiring invite links (design
+ * 2026-06-04-individual-users-and-vault-operations.md §7). An admin issues
+ * a link; the recipient opens `/account/setup/<token>`, picks a username +
+ * password, and gets their OWN freshly-provisioned vault as owner.
+ *
+ * Token model — mirrors `auth-codes.ts` (single-use + expiring + sha256-at-
+ * rest), with the key difference that invites are LONGER-LIVED (default 7
+ * days vs the 60s auth-code TTL), so the row stores **sha256(token)**, never
+ * the raw value. The raw token is returned exactly ONCE from `issueInvite`
+ * and never persisted — a DB read alone can't replay the link (the same
+ * posture as the bootstrap token). Lookup hashes the URL token and selects
+ * by the hash.
+ *
+ * What an invite pre-authorizes: creating exactly ONE account + the one
+ * named/created vault at the baked-in role — NEVER host:admin, NEVER another
+ * vault. The redeemed user inherits only the `user_vaults` row's authority.
+ * The redemption flow (`/account/setup/<token>` in hub-server.ts) enforces
+ * the createUser-then-stamp ordering so a createUser failure leaves the
+ * invite re-usable.
+ *
+ * Single-use is enforced by stamping `used_at` on redemption — a replay
+ * attempt sees the row with `used_at` set and `redeemInvite` throws
+ * `InviteUsedError`. Revocation is a separate `revoked_at` stamp the admin
+ * sets before redemption. Expiry is enforced at redeem-time.
+ */
+import type { Database } from "bun:sqlite";
+import { createHash, randomBytes } from "node:crypto";
+
+/** Default invite lifetime — long enough to deliver out-of-band (no email), short enough to bound a leaked link. */
+export const DEFAULT_INVITE_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+/** Token entropy in bytes — 256 bits, matching the bootstrap / auth-code token. */
+const INVITE_TOKEN_BYTES = 32;
+
+export type InviteStatus = "pending" | "redeemed" | "expired" | "revoked";
+
+export interface Invite {
+  /** sha256(raw token), hex. The raw token is never stored. */
+  tokenHash: string;
+  createdBy: string | null;
+  /** Pinned vault name, or null when the redeemer names their own vault. */
+  vaultName: string | null;
+  /** `user_vaults.role` granted on redemption (`'write'` = owner). */
+  role: string;
+  /** Whether redemption provisions a NEW vault for the redeemer. */
+  provisionVault: boolean;
+  /** `'internal' | 'off'` mirror knob for the provisioned vault, or null. */
+  defaultMirror: string | null;
+  expiresAt: string;
+  usedAt: string | null;
+  redeemedUserId: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+}
+
+export class InviteNotFoundError extends Error {
+  constructor() {
+    super("invite not found");
+    this.name = "InviteNotFoundError";
+  }
+}
+
+export class InviteExpiredError extends Error {
+  constructor() {
+    super("invite has expired");
+    this.name = "InviteExpiredError";
+  }
+}
+
+export class InviteUsedError extends Error {
+  constructor() {
+    super("invite has already been redeemed");
+    this.name = "InviteUsedError";
+  }
+}
+
+export class InviteRevokedError extends Error {
+  constructor() {
+    super("invite has been revoked");
+    this.name = "InviteRevokedError";
+  }
+}
+
+interface Row {
+  token: string;
+  created_by: string | null;
+  vault_name: string | null;
+  role: string;
+  provision_vault: number;
+  default_mirror: string | null;
+  expires_at: string;
+  used_at: string | null;
+  redeemed_user_id: string | null;
+  revoked_at: string | null;
+  created_at: string;
+}
+
+function rowToInvite(r: Row): Invite {
+  return {
+    tokenHash: r.token,
+    createdBy: r.created_by,
+    vaultName: r.vault_name,
+    role: r.role,
+    provisionVault: r.provision_vault === 1,
+    defaultMirror: r.default_mirror,
+    expiresAt: r.expires_at,
+    usedAt: r.used_at,
+    redeemedUserId: r.redeemed_user_id,
+    revokedAt: r.revoked_at,
+    createdAt: r.created_at,
+  };
+}
+
+/** sha256 of the raw token, hex — the at-rest representation + PK. */
+export function hashInviteToken(rawToken: string): string {
+  return createHash("sha256").update(rawToken).digest("hex");
+}
+
+/** Derive an invite's status from its stamps + the current time. */
+export function inviteStatus(invite: Invite, now: Date = new Date()): InviteStatus {
+  if (invite.revokedAt) return "revoked";
+  if (invite.usedAt) return "redeemed";
+  if (now.getTime() > new Date(invite.expiresAt).getTime()) return "expired";
+  return "pending";
+}
+
+export interface IssueInviteOpts {
+  /** Admin user id issuing the invite (audit). */
+  createdBy: string;
+  /** Pinned vault name; omit/null to let the redeemer name their own. */
+  vaultName?: string | null;
+  /** `user_vaults` role granted on redemption. Default `'write'` (owner). */
+  role?: string;
+  /** Provision a new vault on redemption. Default `true` (the primary flow). */
+  provisionVault?: boolean;
+  /** `'internal' | 'off'` mirror knob for the provisioned vault. */
+  defaultMirror?: string | null;
+  /** Lifetime in seconds. Default {@link DEFAULT_INVITE_TTL_SECONDS} (7 days). */
+  expiresInSeconds?: number;
+  now?: () => Date;
+}
+
+export interface IssuedInvite {
+  /**
+   * The raw token — returned EXACTLY ONCE here and never persisted. The
+   * caller builds the redemption URL from it (`/account/setup/<rawToken>`)
+   * and shows it once; the hub keeps only `sha256(rawToken)`.
+   */
+  rawToken: string;
+  invite: Invite;
+}
+
+/**
+ * Mint an invite: generate a 256-bit raw token, store its sha256, return the
+ * raw token once. The row's PK is the hash, so a DB compromise can't replay
+ * the link.
+ */
+export function issueInvite(db: Database, opts: IssueInviteOpts): IssuedInvite {
+  const rawToken = randomBytes(INVITE_TOKEN_BYTES).toString("base64url");
+  const tokenHash = hashInviteToken(rawToken);
+  const now = opts.now?.() ?? new Date();
+  const createdAt = now.toISOString();
+  const ttl = opts.expiresInSeconds ?? DEFAULT_INVITE_TTL_SECONDS;
+  const expiresAt = new Date(now.getTime() + ttl * 1000).toISOString();
+  const role = opts.role ?? "write";
+  const vaultName = opts.vaultName ?? null;
+  const provisionVault = opts.provisionVault ?? true;
+  const defaultMirror = opts.defaultMirror ?? null;
+
+  db.prepare(
+    `INSERT INTO invites
+       (token, created_by, vault_name, role, provision_vault, default_mirror,
+        expires_at, used_at, redeemed_user_id, revoked_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?)`,
+  ).run(
+    tokenHash,
+    opts.createdBy,
+    vaultName,
+    role,
+    provisionVault ? 1 : 0,
+    defaultMirror,
+    expiresAt,
+    createdAt,
+  );
+
+  return {
+    rawToken,
+    invite: {
+      tokenHash,
+      createdBy: opts.createdBy,
+      vaultName,
+      role,
+      provisionVault,
+      defaultMirror,
+      expiresAt,
+      usedAt: null,
+      redeemedUserId: null,
+      revokedAt: null,
+      createdAt,
+    },
+  };
+}
+
+/** Look up an invite by its raw (URL) token. Hashes then selects. */
+export function findInviteByRawToken(db: Database, rawToken: string): Invite | null {
+  const hash = hashInviteToken(rawToken);
+  const row = db.query<Row, [string]>("SELECT * FROM invites WHERE token = ?").get(hash);
+  return row ? rowToInvite(row) : null;
+}
+
+/** Look up an invite by its sha256 hash (admin DELETE/revoke by id). */
+export function findInviteByHash(db: Database, tokenHash: string): Invite | null {
+  const row = db.query<Row, [string]>("SELECT * FROM invites WHERE token = ?").get(tokenHash);
+  return row ? rowToInvite(row) : null;
+}
+
+/** List every invite, newest first, with derived status. */
+export function listInvites(
+  db: Database,
+  now: Date = new Date(),
+): (Invite & { status: InviteStatus })[] {
+  const rows = db.query<Row, []>("SELECT * FROM invites ORDER BY created_at DESC").all();
+  return rows.map((r) => {
+    const invite = rowToInvite(r);
+    return { ...invite, status: inviteStatus(invite, now) };
+  });
+}
+
+/**
+ * Validate an invite for redemption WITHOUT consuming it. Throws on every
+ * not-redeemable branch (not-found / expired / used / revoked). Returns the
+ * invite when it's redeemable. The redemption handler calls this FIRST (so a
+ * bad token is rejected before any account/vault work), then does
+ * createUser, then `consumeInvite` AFTER the user row commits.
+ */
+export function assertInviteRedeemable(
+  db: Database,
+  rawToken: string,
+  now: Date = new Date(),
+): Invite {
+  const invite = findInviteByRawToken(db, rawToken);
+  if (!invite) throw new InviteNotFoundError();
+  // Revoked + used are terminal regardless of clock; check them before expiry
+  // so a revoked-then-expired invite reports the more specific reason.
+  if (invite.revokedAt) throw new InviteRevokedError();
+  if (invite.usedAt) throw new InviteUsedError();
+  if (now.getTime() > new Date(invite.expiresAt).getTime()) {
+    throw new InviteExpiredError();
+  }
+  return invite;
+}
+
+/**
+ * Mark an invite consumed — stamp `used_at` + `redeemed_user_id`. Called
+ * ONLY after the redeemed user row has committed (so a createUser exception
+ * leaves the invite re-usable). Single-use is enforced by the
+ * `used_at IS NULL` guard in the UPDATE: a racing second redeem updates zero
+ * rows and the caller treats that as already-consumed.
+ *
+ * Returns `true` if THIS call consumed the invite, `false` if it was already
+ * consumed (used_at already set) — race-safe because sqlite serializes
+ * writes.
+ */
+export function consumeInvite(
+  db: Database,
+  tokenHash: string,
+  redeemedUserId: string,
+  now: Date = new Date(),
+): boolean {
+  const res = db
+    .prepare(
+      "UPDATE invites SET used_at = ?, redeemed_user_id = ? WHERE token = ? AND used_at IS NULL",
+    )
+    .run(now.toISOString(), redeemedUserId, tokenHash);
+  return res.changes > 0;
+}
+
+/**
+ * Revoke a pending invite (admin DELETE). Stamps `revoked_at` only when the
+ * invite isn't already used or revoked. Returns `true` if this call revoked
+ * it, `false` if it was already consumed/revoked or not found.
+ */
+export function revokeInvite(db: Database, tokenHash: string, now: Date = new Date()): boolean {
+  const res = db
+    .prepare(
+      "UPDATE invites SET revoked_at = ? WHERE token = ? AND used_at IS NULL AND revoked_at IS NULL",
+    )
+    .run(now.toISOString(), tokenHash);
+  return res.changes > 0;
+}

--- a/src/users.ts
+++ b/src/users.ts
@@ -241,6 +241,17 @@ export interface CreateUserOpts {
    * existing call sites omit it and keep the historical `'write'` default.
    */
   role?: string;
+  /**
+   * Optional hook run INSIDE the same transaction as the user + user_vaults
+   * inserts, after them, with the new user's id. Throwing from it rolls the
+   * whole insert back (no orphan user row). The invite-redeem path uses this
+   * to atomically re-check + consume a single-use invite together with the
+   * account creation — so two concurrent redeems of one invite can't both
+   * create an account (the loser throws here and its user insert rolls back),
+   * while a failure still leaves the invite re-usable (nothing committed).
+   * Must be synchronous — bun:sqlite transactions can't await.
+   */
+  withinTx?: (userId: string) => void;
 }
 
 export async function createUser(
@@ -286,6 +297,9 @@ export async function createUser(
           insertVault.run(id, vaultName, role, stamp);
         }
       }
+      // In-transaction hook (e.g. consume a single-use invite). Throwing here
+      // rolls back the user + user_vaults inserts above — no orphan row.
+      opts.withinTx?.(id);
     })();
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/src/users.ts
+++ b/src/users.ts
@@ -232,6 +232,15 @@ export interface CreateUserOpts {
    * each name against `services.json` before passing through.
    */
   assignedVaults?: string[];
+  /**
+   * The `user_vaults.role` to write for every entry in `assignedVaults`.
+   * Default `'write'` (= owner; `vaultVerbsForRole('write')` grants the
+   * full read/write/admin triple). The invite-redeem path passes the
+   * invite's baked-in role so a future shared-into-existing-vault invite
+   * can land a narrower `'read'` role without a second migration. All
+   * existing call sites omit it and keep the historical `'write'` default.
+   */
+  role?: string;
 }
 
 export async function createUser(
@@ -268,12 +277,13 @@ export async function createUser(
          VALUES (?, ?, ?, ?, ?, ?)`,
       ).run(id, username, passwordHash, stamp, stamp, passwordChanged);
       if (assignedVaults.length > 0) {
+        const role = opts.role ?? "write";
         const insertVault = db.prepare(
           `INSERT INTO user_vaults (user_id, vault_name, role, created_at)
-           VALUES (?, ?, 'write', ?)`,
+           VALUES (?, ?, ?, ?)`,
         );
         for (const vaultName of assignedVaults) {
-          insertVault.run(id, vaultName, stamp);
+          insertVault.run(id, vaultName, role, stamp);
         }
       }
     })();

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1369,6 +1369,97 @@ export async function listUserVaults(): Promise<string[]> {
   return body.vaults ?? [];
 }
 
+// ---------------------------------------------------------------------------
+// Invite links (design §7). host:admin-gated; same Bearer pattern as users.
+// ---------------------------------------------------------------------------
+
+export type InviteStatus = "pending" | "redeemed" | "expired" | "revoked";
+
+/** Wire shape from `GET /api/invites`. `id` is the sha256 hash, NOT the raw token. */
+export interface InviteListing {
+  id: string;
+  status: InviteStatus;
+  vault_name: string | null;
+  role: string;
+  provision_vault: boolean;
+  default_mirror: string | null;
+  expires_at: string;
+  used_at: string | null;
+  redeemed_user_id: string | null;
+  revoked_at: string | null;
+  created_at: string;
+}
+
+/** Body for `POST /api/invites`. Every field is optional (server defaults apply). */
+export interface CreateInviteInput {
+  vault_name?: string | null;
+  role?: string;
+  provision_vault?: boolean;
+  default_mirror?: "internal" | "off" | null;
+  expires_in?: number;
+}
+
+/** `POST /api/invites` response — the raw token + URL are emitted ONCE here. */
+export interface CreatedInvite {
+  invite: InviteListing;
+  token: string;
+  url: string;
+}
+
+/** GET /api/invites — list invites, newest first, status-annotated. */
+export async function listInvites(): Promise<InviteListing[]> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch("/api/invites", {
+    method: "GET",
+    headers: { accept: "application/json", authorization: `Bearer ${bearer}` },
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  const body = (await res.json()) as { invites: InviteListing[] };
+  return body.invites ?? [];
+}
+
+/**
+ * POST /api/invites — create an invite. The response carries the raw token +
+ * full redemption URL, which the hub never stores and never returns again —
+ * the caller must surface them once.
+ */
+export async function createInvite(input: CreateInviteInput): Promise<CreatedInvite> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch("/api/invites", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json",
+      authorization: `Bearer ${bearer}`,
+    },
+    body: JSON.stringify(input),
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as CreatedInvite;
+}
+
+/** DELETE /api/invites/:id — revoke a pending invite by its sha256 id. */
+export async function revokeInvite(id: string): Promise<void> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch(`/api/invites/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    headers: { accept: "application/json", authorization: `Bearer ${bearer}` },
+  });
+  if (res.status === 401) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+}
+
 /**
  * Wire shape returned by `GET /api/hub`. Mirrors the snake_case payload
  * defined in `src/api-hub.ts:HubStatusResponse`. Drives the admin SPA's

--- a/web/ui/src/routes/InvitesSection.tsx
+++ b/web/ui/src/routes/InvitesSection.tsx
@@ -1,0 +1,247 @@
+/**
+ * Invite-links section for the Users admin view (design §7). An admin
+ * generates a one-time, expiring link; the recipient opens it, creates an
+ * account, and gets their OWN newly-provisioned vault as owner.
+ *
+ * Defaults to "provision a new vault for them" (the primary flow). The raw
+ * token + URL come back ONCE on create — the hub stores only its sha256 — so
+ * the create result is surfaced with a copy-URL affordance and is gone on the
+ * next render. List rows show status + a revoke button for pending invites.
+ *
+ * Self-contained (own state, own load) so it doesn't thread through the big
+ * Users component. Reuses the cached host-admin bearer (via the api client)
+ * and the confirm-before-revoke discipline the rest of the admin SPA uses.
+ */
+import { type FormEvent, useEffect, useState } from "react";
+import {
+  type CreatedInvite,
+  type InviteListing,
+  createInvite,
+  listInvites,
+  revokeInvite,
+} from "../lib/api";
+
+const DAY_SECONDS = 24 * 60 * 60;
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "ok"; invites: InviteListing[] };
+
+type CreateState =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "created"; result: CreatedInvite }
+  | { kind: "error"; message: string };
+
+export function InvitesSection({ hubOrigin }: { hubOrigin: string }) {
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+  const [reload, setReload] = useState(0);
+  const [vaultName, setVaultName] = useState("");
+  const [expiresDays, setExpiresDays] = useState("7");
+  const [createSt, setCreateSt] = useState<CreateState>({ kind: "idle" });
+  const [copied, setCopied] = useState(false);
+  const [revoking, setRevoking] = useState<string | null>(null);
+
+  useEffect(() => {
+    void reload;
+    let cancelled = false;
+    setState({ kind: "loading" });
+    listInvites()
+      .then((invites) => {
+        if (!cancelled) setState({ kind: "ok", invites });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setState({ kind: "error", message: err instanceof Error ? err.message : String(err) });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reload]);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (createSt.kind === "submitting") return;
+    setCreateSt({ kind: "submitting" });
+    setCopied(false);
+    const days = Number.parseInt(expiresDays, 10);
+    try {
+      const result = await createInvite({
+        // Pin the vault name when the admin typed one; otherwise the redeemer
+        // names their own vault at redeem time.
+        ...(vaultName.trim() !== "" ? { vault_name: vaultName.trim() } : {}),
+        provision_vault: true,
+        ...(Number.isFinite(days) && days > 0 ? { expires_in: days * DAY_SECONDS } : {}),
+      });
+      setCreateSt({ kind: "created", result });
+      setVaultName("");
+      setReload((n) => n + 1);
+    } catch (err: unknown) {
+      setCreateSt({ kind: "error", message: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  async function onRevoke(id: string) {
+    if (revoking) return;
+    setRevoking(id);
+    try {
+      await revokeInvite(id);
+      setReload((n) => n + 1);
+    } catch (err: unknown) {
+      setState({ kind: "error", message: err instanceof Error ? err.message : String(err) });
+    } finally {
+      setRevoking(null);
+    }
+  }
+
+  function copyUrl(url: string) {
+    void navigator.clipboard?.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <section style={{ marginTop: "2rem" }} data-testid="invites-section">
+      <div className="list-header">
+        <h2>Invite links</h2>
+      </div>
+      <p className="muted">
+        Generate a one-time, expiring link. The recipient opens it, picks a username and password,
+        and gets their own newly-provisioned vault (they become its owner). No admin-typed default
+        password. Leave the vault name blank to let them name it themselves.
+      </p>
+
+      <form onSubmit={(e) => void onSubmit(e)} style={{ marginBottom: "1rem" }}>
+        <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap", alignItems: "flex-end" }}>
+          <label className="field" style={{ flex: "1 1 14rem" }}>
+            <span className="field-label">Vault name (optional)</span>
+            <input
+              type="text"
+              value={vaultName}
+              onChange={(e) => setVaultName(e.target.value)}
+              placeholder="leave blank → they choose"
+              pattern="[a-z0-9_-]*"
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </label>
+          <label className="field" style={{ flex: "0 0 8rem" }}>
+            <span className="field-label">Expires (days)</span>
+            <input
+              type="number"
+              min={1}
+              max={90}
+              value={expiresDays}
+              onChange={(e) => setExpiresDays(e.target.value)}
+            />
+          </label>
+          <button type="submit" disabled={createSt.kind === "submitting"}>
+            {createSt.kind === "submitting" ? "Creating…" : "Create invite"}
+          </button>
+        </div>
+      </form>
+
+      {createSt.kind === "error" && (
+        <div className="error-banner" style={{ marginBottom: "1rem" }}>
+          {createSt.message}
+        </div>
+      )}
+
+      {createSt.kind === "created" && (
+        <output className="success-banner" style={{ display: "block", marginBottom: "1rem" }}>
+          <strong>Invite created.</strong> Copy this link now — it's shown only once and can't be
+          retrieved later. The hub stores only a hash.
+          <div
+            style={{
+              display: "flex",
+              gap: "0.5rem",
+              marginTop: "0.5rem",
+              alignItems: "center",
+              flexWrap: "wrap",
+            }}
+          >
+            <code style={{ wordBreak: "break-all", flex: "1 1 16rem" }}>{createSt.result.url}</code>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => copyUrl(createSt.result.url)}
+            >
+              {copied ? "Copied!" : "Copy link"}
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => setCreateSt({ kind: "idle" })}
+            >
+              Dismiss
+            </button>
+          </div>
+        </output>
+      )}
+
+      {state.kind === "loading" && <p className="muted">Loading invites…</p>}
+      {state.kind === "error" && (
+        <div className="error-banner">
+          {state.message}
+          <div style={{ marginTop: "0.5rem" }}>
+            <button type="button" className="secondary" onClick={() => setReload((n) => n + 1)}>
+              Retry
+            </button>
+          </div>
+        </div>
+      )}
+      {state.kind === "ok" && state.invites.length === 0 && (
+        <p className="muted">No invites yet.</p>
+      )}
+      {state.kind === "ok" && state.invites.length > 0 && (
+        <div className="table-scroll">
+          <table className="user-table">
+            <thead>
+              <tr>
+                <th>Vault</th>
+                <th>Role</th>
+                <th>Status</th>
+                <th>Expires</th>
+                <th>Created</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {state.invites.map((inv) => (
+                <tr key={inv.id}>
+                  <td>{inv.vault_name ?? <span className="muted">redeemer chooses</span>}</td>
+                  <td>{inv.role === "write" ? "owner" : inv.role}</td>
+                  <td>
+                    <span className={`status status-${inv.status}`}>{inv.status}</span>
+                  </td>
+                  <td className="muted">{new Date(inv.expires_at).toLocaleDateString()}</td>
+                  <td className="muted">{new Date(inv.created_at).toLocaleDateString()}</td>
+                  <td>
+                    {inv.status === "pending" ? (
+                      <button
+                        type="button"
+                        className="secondary"
+                        disabled={revoking === inv.id}
+                        onClick={() => void onRevoke(inv.id)}
+                      >
+                        {revoking === inv.id ? "Revoking…" : "Revoke"}
+                      </button>
+                    ) : null}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      {hubOrigin ? (
+        <p className="muted" style={{ marginTop: "0.5rem", fontSize: "0.85em" }}>
+          Redemption links are served from <code>{hubOrigin}/account/setup/&lt;token&gt;</code>.
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/web/ui/src/routes/Users.tsx
+++ b/web/ui/src/routes/Users.tsx
@@ -57,6 +57,7 @@ import {
   resetUserPassword,
   updateUserVaults,
 } from "../lib/api.ts";
+import { InvitesSection } from "./InvitesSection";
 
 /**
  * Server's password-floor. Mirrors `PASSWORD_MIN_LEN` in `users.ts`
@@ -400,6 +401,8 @@ export function Users() {
           onSubmit={onSubmitCreate}
         />
       )}
+
+      {state.kind === "ok" && <InvitesSection hubOrigin={state.data.hubOrigin} />}
     </div>
   );
 }

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -1108,6 +1108,23 @@ a.btn:hover {
   background: var(--bg-soft);
   color: var(--fg-dim);
 }
+/*
+ * Invite-link statuses (design §7). `pending` reuses `.status-pending`
+ * above. `redeemed` is a successful terminal state (success palette);
+ * `expired` + `revoked` are muted terminal states.
+ */
+.status-redeemed {
+  background: var(--success-soft);
+  color: var(--success);
+}
+.status-expired {
+  background: var(--bg-soft);
+  color: var(--fg-dim);
+}
+.status-revoked {
+  background: var(--bg-soft);
+  color: var(--fg-dim);
+}
 
 /*
  * Back-compat aliases for the pre-F vocabulary. Modules / SDKs that


### PR DESCRIPTION
Implements step 6 of the [individual-users design §7](https://github.com/ParachuteComputer/parachute.computer/blob/main/design/2026-06-04-individual-users-and-vault-operations.md): an admin generates a one-time, expiring link; the recipient opens it, picks a username + password, and gets their **OWN newly-provisioned vault** as owner. No admin-typed default password.

Per Aaron's clarification, the primary flow is **create account + provision the invitee's own new vault** (owner = role `write`). The schema carries the design's full field set (so the shared-into-existing-vault case is a later policy change), but the default create-invite UX provisions a new vault.

## The flow
1. Admin `POST /api/invites` (host:admin) → single-emit raw token + full URL (never retrievable later; only sha256 stored).
2. Recipient `GET /account/setup/<token>` → server-rendered claim form (reuses the `/login` chrome; works without JS). Rejects not-found → 404, expired/used/revoked → 410.
3. `POST /account/setup/<token>` → mirrors the wizard's `handleSetupAccountPost`: validate invite → validate username/password (shared `validateUsername`/`validatePassword`) → provision vault (idempotent-safe, via the shared createVault path → internal-live-mirror default for free) → `createUser(passwordChanged:true, assignedVaults:[vault], role)` → **consume invite (used_at + redeemed_user_id) only AFTER the user row commits** → createSession + cookie + 302 → `/account/`. CSRF-gated; rate-limited on the `/login` IP bucket.

## The table — migration v12 (no backfill)
`invites`: `token TEXT PK` (= sha256 of the raw token), `created_by`, `vault_name TEXT` (nullable), `role TEXT DEFAULT 'write'`, `provision_vault INTEGER`, `default_mirror TEXT`, `expires_at`, `used_at`, `redeemed_user_id`, `revoked_at`, `created_at`.

## Security invariants (asserted in tests)
- 256-bit random token, **sha256 at rest** (raw never persisted), single-use via `used_at`, expiry enforced at redeem (default 7 days, capped 90), revocable.
- An invite pre-authorizes **EXACTLY one account + the one named/created vault at the baked-in role — NEVER host:admin, NEVER another vault.** The redeemed user is never the earliest row (never first-admin); their `user_vaults` row is the sole authority.
- Vault-name inputs are anchored-regex validated (`^[a-z0-9_-]+$`) — no path-segment injection by a redeemer naming their own vault.

## Re-usability on failure (the ordering guarantee)
The invite is consumed **only after `createUser` commits** — a createUser exception (UNIQUE collision, disk full) leaves the invite re-usable so the invitee can retry. `consumeInvite`'s `used_at IS NULL` UPDATE guard makes the stamp single-use even under a redeem race.

## Reuse / refactors (no drive-by)
- `provisionVault` extracted from `handleCreateVault` (auth-free core; HTTP handler keeps its host:admin gate in front). Routes through the same `parachute-vault create` CLI path the wizard/SPA use.
- `createUser` gains an optional `role` for the `user_vaults` row (defaults to `'write'`; all existing call sites unchanged).

## Surfaces
- Admin API `/api/invites` (POST create / GET list status-annotated / DELETE :id revoke), host:admin-gated.
- Admin SPA: Invites section in `Users.tsx` (create-invite form defaulting to "provision a new vault for them"; list with copy-URL + revoke).

## Tests
- `invites.test.ts` — issue / lookup-by-raw / status derivation / single-use consume / revoke + sha256-at-rest invariant.
- `account-setup.test.ts` — happy path (user + vault + session, invite marked used); redeemer-names-own-vault; the security invariant (only their vault, not admin, not another vault; read-role lands read-only); replay → 410; expired → 410; revoked → 410; unknown → 404; missing-CSRF → 400; **createUser-fails → invite still re-usable** (ordering).
- `api-invites.test.ts` — host:admin gate; create defaults; raw token never in list; revoke + 409/404.

**Gates:** `bun run typecheck` clean (server + SPA). Targeted tests: hub `148 pass / 0 fail` (invites + account-setup + api-invites + admin-vaults + api-users + users), SPA `270 pass`. SPA bundle builds clean. Per test-safety constraints, the full `bun test ./src` and lifecycle/migrate suites were NOT run.

No version bump (stays 0.6.3; rc bump + tag at ship signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)