### PR TITLE
feat(expose): recommend enabling 2FA when exposing publicly

### DIFF
--- a/src/__tests__/expose-2fa-warning.test.ts
+++ b/src/__tests__/expose-2fa-warning.test.ts
@@ -87,13 +87,16 @@ describe("printPublic2FAWarning", () => {
     });
     expect(fired).toBe(true);
     const joined = logs.join("\n");
-    // hub#473: real hub-login 2FA. The warning now recommends the real
-    // `parachute auth 2fa enroll` path (+ the /account/2fa browser path) and
-    // still nudges a strong owner password.
-    expect(joined).toContain("/login is now reachable on the public internet");
+    // hub#473: real hub-login 2FA. The recommendation now leads with the
+    // friendly "strongly recommended" framing, points at both the /account/2fa
+    // browser path and the `parachute auth 2fa enroll` CLI path, makes clear
+    // it's not a requirement, and still nudges a strong owner password.
+    expect(joined).toContain("Strongly recommended: turn on two-factor authentication");
+    expect(joined).toContain("reachable from the public internet");
     expect(joined).toContain("https://vault.example.com/login");
+    expect(joined).toContain("https://vault.example.com/account/2fa");
     expect(joined).toContain("parachute auth 2fa enroll");
-    expect(joined).toContain("/account/2fa");
+    expect(joined).toContain("It's a recommendation, not a requirement");
     expect(joined).toContain("parachute auth set-password");
   });
 
@@ -120,9 +123,9 @@ describe("printPublic2FAWarning", () => {
       publicUrl: "https://vault.example.com",
     });
     expect(fired).toBe(true);
-    expect(logs.some((l) => l.includes("/login is now reachable on the public internet"))).toBe(
-      true,
-    );
+    expect(
+      logs.some((l) => l.includes("Strongly recommended: turn on two-factor authentication")),
+    ).toBe(true);
   });
 
   test("embeds the supplied publicUrl into the /login pointer", () => {

--- a/src/__tests__/expose-cloudflare.test.ts
+++ b/src/__tests__/expose-cloudflare.test.ts
@@ -1230,9 +1230,10 @@ describe("exposeCloudflareUp", () => {
 
         expect(code).toBe(0);
         const joined = logs.join("\n");
-        // hub#473: real hub-login 2FA — the warning now recommends the real
-        // `parachute auth 2fa enroll` path.
-        expect(joined).toContain("/login is now reachable on the public internet");
+        // hub#473: real hub-login 2FA — the recommendation now leads with the
+        // friendly "strongly recommended" framing and the real `parachute auth
+        // 2fa enroll` / `/account/2fa` paths.
+        expect(joined).toContain("Strongly recommended: turn on two-factor authentication");
         expect(joined).toContain("https://vault.example.com/login");
         expect(joined).toContain("parachute auth 2fa enroll");
       } finally {
@@ -1281,7 +1282,7 @@ describe("exposeCloudflareUp", () => {
 
         expect(code).toBe(0);
         const joined = logs.join("\n");
-        expect(joined).not.toContain("/login is now reachable on the public internet");
+        expect(joined).not.toContain("Strongly recommended: turn on two-factor authentication");
         // The contextual 2FA warning is suppressed (2FA already enrolled); the
         // always-shown owner-password guidance from `printAuthGuidance` still
         // appears, and it now (hub#473) also surfaces the real `2fa enroll`

--- a/src/__tests__/expose.test.ts
+++ b/src/__tests__/expose.test.ts
@@ -558,7 +558,9 @@ describe("expose tailnet up", () => {
         },
       });
       expect(code).toBe(0);
-      expect(logs.join("\n")).not.toContain("2FA is not enrolled");
+      expect(logs.join("\n")).not.toContain(
+        "Strongly recommended: turn on two-factor authentication",
+      );
     } finally {
       h.cleanup();
     }
@@ -931,9 +933,10 @@ describe("expose public up", () => {
       });
       expect(code).toBe(0);
       const joined = logs.join("\n");
-      // hub#473: real hub-login 2FA. The warning now recommends the real
-      // `parachute auth 2fa enroll` path.
-      expect(joined).toContain("/login is now reachable on the public internet");
+      // hub#473: real hub-login 2FA. The recommendation now leads with the
+      // friendly "strongly recommended" framing and the real `parachute auth
+      // 2fa enroll` path.
+      expect(joined).toContain("Strongly recommended: turn on two-factor authentication");
       expect(joined).toContain("parachute auth 2fa enroll");
       // /login pointer uses the canonical https://<fqdn> origin.
       expect(joined).toContain("https://parachute.taildf9ce2.ts.net/login");
@@ -966,7 +969,9 @@ describe("expose public up", () => {
         },
       });
       expect(code).toBe(0);
-      expect(logs.join("\n")).not.toContain("2FA is not enrolled");
+      expect(logs.join("\n")).not.toContain(
+        "Strongly recommended: turn on two-factor authentication",
+      );
     } finally {
       h.cleanup();
     }

--- a/src/commands/expose-2fa-warning.ts
+++ b/src/commands/expose-2fa-warning.ts
@@ -6,12 +6,15 @@
  * is the second wall.
  *
  * 2FA at the hub login layer is real as of hub#473: "password +
- * something-you-have." This warning recommends `parachute auth 2fa enroll`
- * (which now gates hub `/login` for real) when the operator hasn't enrolled.
+ * something-you-have." This prints a STRONG RECOMMENDATION to enroll — via the
+ * browser at `/account/2fa` or `parachute auth 2fa enroll` (which now gates hub
+ * `/login` for real) — when the operator hasn't enrolled.
  *
- * Why this is a warning, not a hard gate: hard-gating would surprise operators
- * mid-flow — they ran `parachute expose public` to expose, not to be told
- * "set up 2FA first." A loud, contextual warning + a clear remediation is the
+ * Why this is a recommendation, not a hard gate (Aaron's explicit call, 2026-06:
+ * "I don't think we need to require 2FA for public expose but we should strongly
+ * recommend it"): hard-gating would surprise operators mid-flow — they ran
+ * `parachute expose public` to expose, not to be told "set up 2FA first." A
+ * clear, friendly, contextual recommendation + an obvious remediation is the
  * right shape; the operator decides whether to act now or later. The tunnel is
  * up regardless.
  *
@@ -68,16 +71,17 @@ export function printPublic2FAWarning(opts: Public2FAWarningOpts): boolean {
     return false;
   }
   log("");
-  log("⚠ /login is now reachable on the public internet");
-  log(`  (${opts.publicUrl}/login). Anyone who guesses your password is in.`);
+  log("→ Strongly recommended: turn on two-factor authentication.");
+  log("  Your login page is now reachable from the public internet");
+  log(`  (${opts.publicUrl}/login) — anyone online can reach it, so your`);
+  log("  password is the only wall. A second factor (a one-time code from");
+  log("  your authenticator app) materially raises the bar:");
   log("");
-  log("  Turn on two-factor authentication — it adds a second wall (a one-time");
-  log("  code from your authenticator app) on top of your password:");
+  log(`    ${opts.publicUrl}/account/2fa     # scan a QR code in your browser`);
+  log("    parachute auth 2fa enroll         # or enroll from the terminal");
   log("");
-  log("    parachute auth 2fa enroll");
-  log("");
-  log("  (Or set it up in the browser at /account/2fa for a scannable QR code.)");
-  log("  Either way, also make sure your owner password is a strong one:");
+  log("  It's a recommendation, not a requirement — your hub is up either way.");
+  log("  While you're at it, make sure your owner password is a strong one:");
   log("");
   log("    parachute auth set-password");
   return true;


### PR DESCRIPTION
## What

When an operator exposes their hub to the **public internet**, the CLI now prints a clear, friendly **strong recommendation** to enable two-factor authentication — pointing them at both `/account/2fa` (browser QR enroll) and `parachute auth 2fa enroll` (terminal).

Aaron's explicit call: *"I don't think we need to require 2FA for public expose but we should strongly recommend it."*

## What prints

```
→ Strongly recommended: turn on two-factor authentication.
  Your login page is now reachable from the public internet
  (https://vault.example.com/login) — anyone online can reach it, so your
  password is the only wall. A second factor (a one-time code from
  your authenticator app) materially raises the bar:

    https://vault.example.com/account/2fa     # scan a QR code in your browser
    parachute auth 2fa enroll                 # or enroll from the terminal

  It's a recommendation, not a requirement — your hub is up either way.
  While you're at it, make sure your owner password is a strong one:

    parachute auth set-password
```

## On which layer

**Public only.** Fires from both public up-paths:
- Cloudflare tunnel — `exposeCloudflareUp` (`src/commands/expose-cloudflare.ts`)
- Tailscale Funnel — `exposeUp("public", …)` (`src/commands/expose.ts`), guarded by `if (layer === "public")`

The **tailnet** layer does NOT nudge — tailnet exposure is already access-controlled at the tailscale ingress, so the login page isn't on the open internet there.

## Why a recommendation, not a gate

Hard-gating would surprise operators mid-flow — they ran `expose public` to expose, not to be told "set up 2FA first." The expose **always succeeds** regardless; the copy says so explicitly. The nudge is also **suppressed when 2FA is already enrolled** (`is2FAEnrolled` consults the hub.db `users.totp_secret` column, with a legacy `config.yaml` fallback) so we don't nag operators who've already done it.

## Scope

This is a **copy/framing** change. The print infrastructure (`printPublic2FAWarning`, public-layer gating, already-enrolled suppression, `/account/2fa` pointer) already existed from #191 / hub#473 — this reframes the security *warning* into the friendly *strong recommendation* Aaron asked for. No SPA changes (the CLI output is the priority).

## Tests

- Updated assertions across `expose-2fa-warning.test.ts`, `expose.test.ts`, `expose-cloudflare.test.ts` for the new copy.
- The two previously-trivial suppression assertions (`not.toContain("2FA is not enrolled")` — a string that was never emitted) now assert on the real recommendation line, making the public-layer-only + already-enrolled suppression checks meaningful.

`bun run typecheck`: clean. `bun test` (expose-2fa-warning + expose + expose-cloudflare): **89 pass / 0 fail**. Version unchanged (0.6.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)