### PR TITLE
release: hub 0.6.4-rc.1 (rc cut)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.3",
+  "version": "0.6.4-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Cuts hub **0.6.4-rc.1** — the first rc of the 0.6.4 chain — so the post-0.6.3 work on main can be deployed to the our./friends.parachute.computer boxes for validation before promoting to `@latest`.

Pure version bump (0.6.3 → 0.6.4-rc.1). The substantive code was reviewed PR-by-PR (#531, #541–#547, #549–#554). Tag `v0.6.4-rc.1` publishes to npm dist-tag `rc`, leaving `@latest` at 0.6.3.

Carries: #552 force-change (#469) + oauth gate · #553 invite links (v12) · #554 2FA-recommend · #531 issuer determinism · #550/#551 hardening + admin-token unlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)