### PR TITLE
fix(test): make launchctl-guard print test CI-safe (unblocks v0.6.4-rc.1)

### DIFF
--- a/src/__tests__/launchctl-guard.test.ts
+++ b/src/__tests__/launchctl-guard.test.ts
@@ -166,13 +166,20 @@ describe("default Runner refuses real launchctl under test (regression — hub#5
   });
 
   test("default deps still RUN a read-only `launchctl print` (guard is verb-scoped, not a blanket block)", () => {
-    // This proves the guard doesn't break the legitimate default-deps read paths
-    // (`queryHubUnitState`, the stale-unit `print` probe). Under the dev test-run
-    // PATH shim this hits the fake launchctl (exit 0); without it the real
-    // `launchctl print` of a non-loaded label returns nonzero — either way it does
-    // NOT throw, which is the property under test.
-    expect(() =>
-      defaultManagedUnitDeps.run(["launchctl", "print", "gui/501/computer.parachute.NONEXISTENT"]),
-    ).not.toThrow();
+    // The property under test: the GUARD does not block a read-only `print`
+    // (verb-scoped, not a blanket launchctl block) — so it never throws the
+    // `/launchctl-guard/` error for it. What happens AFTER the guard allows it
+    // through is environment-dependent and NOT under test:
+    //   - dev Mac under the test PATH shim → fake launchctl, exit 0, no throw
+    //   - real Mac → `launchctl print` of a non-loaded label returns nonzero, no throw
+    //   - Linux CI (no launchctl on PATH) → the spawn throws ENOENT
+    //     ("Executable not found in $PATH") — which is NOT the guard, and still
+    //     proves the guard let the command reach the spawn.
+    // So: assert only that no error thrown here is a GUARD throw.
+    try {
+      defaultManagedUnitDeps.run(["launchctl", "print", "gui/501/computer.parachute.NONEXISTENT"]);
+    } catch (err) {
+      expect(String((err as { message?: unknown })?.message ?? err)).not.toMatch(/launchctl-guard/);
+    }
   });
 });


### PR DESCRIPTION
The release CI (`bun test ./src` on ubuntu) failed publishing **v0.6.4-rc.1** on one test: `launchctl-guard.test.ts:176` spawned a real `launchctl print` and asserted `.not.toThrow()`, but Linux has no launchctl → ENOENT throw. First hub release since #541 introduced it.

Fix: assert the real property — the **guard** doesn't block read-only `print` (never throws `/launchctl-guard/`). Any post-guard ENOENT on a launchctl-less host is fine. Verified locally with launchctl present (no throw) and unresolvable (ENOENT caught, asserted non-guard). 2950 pass / 1 fail → green. Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)