### PR TITLE
fix(invites): reject existing-vault assignment (cross-tenant) + default vault name to username

### DIFF
--- a/src/__tests__/account-setup.test.ts
+++ b/src/__tests__/account-setup.test.ts
@@ -558,8 +558,13 @@ describe("POST /account/setup/<token> — concurrent redeem (N2)", () => {
     const [r1, r2] = await Promise.all([mk("alice", a), mk("bob", b)]);
 
     const statuses = [r1.status, r2.status].sort();
-    // Exactly one 302 (success) and one 410 (the loser's used-path).
-    expect(statuses).toEqual([302, 410]);
+    // Exactly one 302 (success). The loser is rejected — either at the
+    // FIX-1 existing-vault gate (409, it saw the name already created) or at
+    // the consume-inside-tx race (410, both raced past the existence check
+    // then one lost the invite-consume). Both are correct single-account
+    // outcomes; the only invariant is "exactly one success, one rejection".
+    expect(statuses[0]).toBe(302);
+    expect(statuses[1] === 409 || statuses[1] === 410).toBe(true);
     // EXACTLY one account was created from the invite — no orphan row.
     expect(userCount(harness.db) - before).toBe(1);
     const aliceExists = getUserByUsernameCI(harness.db, "alice") !== null;
@@ -605,5 +610,271 @@ describe("POST /account/setup/<token> — account-only invite (N3)", () => {
     expect(stub.calls.length).toBe(0);
     // Invite consumed.
     expect(findInviteByRawToken(harness.db, rawToken)?.usedAt).not.toBeNull();
+  });
+});
+
+/**
+ * Add a pre-existing vault (someone else's) directly to services.json so
+ * `provisionVault`'s existence check finds it WITHOUT a shell-out. Mirrors the
+ * shape the stub writes.
+ */
+function seedExistingVault(name: string): void {
+  const manifest = JSON.parse(readFileSync(harness.manifestPath, "utf8")) as {
+    services: { name: string; paths: string[] }[];
+  };
+  const vaultSvc = manifest.services.find((s) => s.name === "parachute-vault");
+  if (vaultSvc && !vaultSvc.paths.includes(`/vault/${name}`)) {
+    vaultSvc.paths.push(`/vault/${name}`);
+    writeFileSync(harness.manifestPath, JSON.stringify(manifest));
+  }
+}
+
+describe("POST /account/setup/<token> — cross-tenant: existing-vault rejection (FIX-1)", () => {
+  test("HEADLINE: invitee picks an EXISTING vault name → rejected, no account, owner unchanged", async () => {
+    // An owner already holds "shared-vault".
+    const owner = await createUser(harness.db, "owner", "owner-strong-password-1", {
+      assignedVaults: ["shared-vault"],
+      role: "write",
+    });
+    seedExistingVault("shared-vault");
+
+    // Unpinned invite: the invitee gets to type a vault name.
+    const admin = await createUser(harness.db, "operator", "operator-password-1", {
+      allowMulti: true,
+    });
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id }); // vault_name null
+    const before = userCount(harness.db);
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const stub = makeStubRunCommand();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "intruder",
+          password: "intruder-strong-password-1",
+          password_confirm: "intruder-strong-password-1",
+          vault_name: "shared-vault", // collides with the owner's vault
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+
+    // Rejected with a re-rendered form carrying the "already exists" error.
+    expect(res.status).toBe(409);
+    const html = await res.text();
+    expect(html).toContain("already exists");
+    expect(html).toContain("Choose a different name");
+
+    // NO account created.
+    expect(getUserByUsernameCI(harness.db, "intruder")).toBeNull();
+    expect(userCount(harness.db) - before).toBe(0);
+    // The invite is NOT consumed — the invitee can retry with a new name.
+    expect(findInviteByRawToken(harness.db, rawToken)?.usedAt).toBeNull();
+    // The pre-existing vault's owner/assignment is UNCHANGED.
+    expect(vaultVerbsForUserVault(harness.db, owner.id, "shared-vault")).toEqual([
+      "read",
+      "write",
+      "admin",
+    ]);
+    // No NEW user got authority over it.
+    const intruder = getUserByUsernameCI(harness.db, "intruder");
+    expect(intruder).toBeNull();
+  });
+
+  test("pinned EXISTING vault name (provision_vault=true) → rejected, no account", async () => {
+    await createUser(harness.db, "owner", "owner-strong-password-1", {
+      assignedVaults: ["taken"],
+      role: "write",
+    });
+    seedExistingVault("taken");
+    const admin = await createUser(harness.db, "operator", "operator-password-1", {
+      allowMulti: true,
+    });
+    // Admin pins an existing name with provision_vault=true (the redeem must
+    // still freshly CREATE — a pre-existing pinned name is rejected too).
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id, vaultName: "taken" });
+    const before = userCount(harness.db);
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "newbie",
+          password: "newbie-strong-password-1",
+          password_confirm: "newbie-strong-password-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(makeStubRunCommand().run),
+    );
+    expect(res.status).toBe(409);
+    expect(getUserByUsernameCI(harness.db, "newbie")).toBeNull();
+    expect(userCount(harness.db) - before).toBe(0);
+    expect(findInviteByRawToken(harness.db, rawToken)?.usedAt).toBeNull();
+  });
+
+  test("concurrent redeem on a FRESH name → exactly one account, the other rejected", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    // Pinned to a fresh name so both redeems target the SAME new vault.
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id, vaultName: "freshvault" });
+    const before = userCount(harness.db);
+    const a = csrfPair();
+    const b = csrfPair();
+    const mk = (uname: string, csrf: { token: string; cookieFragment: string }) =>
+      handleAccountSetupPost(
+        postReq(
+          rawToken,
+          {
+            [CSRF_FIELD_NAME]: csrf.token,
+            username: uname,
+            password: `${uname}-strong-password-1`,
+            password_confirm: `${uname}-strong-password-1`,
+          },
+          csrf.cookieFragment,
+        ),
+        rawToken,
+        deps(makeStubRunCommand().run),
+      );
+    const [r1, r2] = await Promise.all([mk("ann", a), mk("ben", b)]);
+    const statuses = [r1.status, r2.status].sort();
+    // Exactly one success; the other rejected (409 existing-vault gate or 410
+    // consume race — see the N2 test for why both are correct).
+    expect(statuses[0]).toBe(302);
+    expect(statuses[1] === 409 || statuses[1] === 410).toBe(true);
+    expect(userCount(harness.db) - before).toBe(1);
+  });
+
+  test("shared-vault invite that slipped through (provision_vault=false + pinned name) → rejected at redeem", async () => {
+    // Defense in depth: the admin API rejects creating this shape, but if one
+    // exists in the DB the redeem must still refuse to assign the existing vault.
+    await createUser(harness.db, "owner", "owner-strong-password-1", {
+      assignedVaults: ["legacy"],
+      role: "write",
+    });
+    seedExistingVault("legacy");
+    const admin = await createUser(harness.db, "operator", "operator-password-1", {
+      allowMulti: true,
+    });
+    const { rawToken } = issueInvite(harness.db, {
+      createdBy: admin.id,
+      vaultName: "legacy",
+      provisionVault: false,
+    });
+    const before = userCount(harness.db);
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const stub = makeStubRunCommand();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "wouldbe",
+          password: "wouldbe-strong-password-1",
+          password_confirm: "wouldbe-strong-password-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    expect(res.status).toBe(400);
+    expect(getUserByUsernameCI(harness.db, "wouldbe")).toBeNull();
+    expect(userCount(harness.db) - before).toBe(0);
+    // No vault shell-out — rejected before provisioning.
+    expect(stub.calls.length).toBe(0);
+    // Invite NOT consumed.
+    expect(findInviteByRawToken(harness.db, rawToken)?.usedAt).toBeNull();
+  });
+});
+
+describe("POST /account/setup/<token> — vault name defaults to username (FIX-2)", () => {
+  test("blank vault_name → vault created NAMED AFTER the username", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id }); // unpinned
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const stub = makeStubRunCommand();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "dana",
+          password: "dana-strong-password-12",
+          password_confirm: "dana-strong-password-12",
+          vault_name: "", // blank → defaults to username
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    expect(res.status).toBe(302);
+    const user = getUserByUsernameCI(harness.db, "dana");
+    expect(user?.assignedVaults).toEqual(["dana"]);
+    // The shell-out created a vault named "dana".
+    expect(stub.calls.some((c) => c[1] === "create" && c[2] === "dana")).toBe(true);
+  });
+
+  test("vault_name field OMITTED entirely → still defaults to username", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id });
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const stub = makeStubRunCommand();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "ezra",
+          password: "ezra-strong-password-12",
+          password_confirm: "ezra-strong-password-12",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    expect(res.status).toBe(302);
+    expect(getUserByUsernameCI(harness.db, "ezra")?.assignedVaults).toEqual(["ezra"]);
+  });
+
+  test("blank vault_name but the username collides with an EXISTING vault → rejected (FIX-1 still applies)", async () => {
+    await createUser(harness.db, "owner", "owner-strong-password-1", {
+      assignedVaults: ["fiona"],
+      role: "write",
+    });
+    seedExistingVault("fiona");
+    const admin = await createUser(harness.db, "operator", "operator-password-1", {
+      allowMulti: true,
+    });
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id });
+    const before = userCount(harness.db);
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "fiona", // username derives a vault that already exists
+          password: "fiona-strong-password-1",
+          password_confirm: "fiona-strong-password-1",
+          vault_name: "",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(makeStubRunCommand().run),
+    );
+    expect(res.status).toBe(409);
+    const html = await res.text();
+    expect(html).toContain("already exists");
+    expect(getUserByUsernameCI(harness.db, "fiona")).toBeNull();
+    expect(userCount(harness.db) - before).toBe(0);
+    expect(findInviteByRawToken(harness.db, rawToken)?.usedAt).toBeNull();
   });
 });

--- a/src/__tests__/api-invites.test.ts
+++ b/src/__tests__/api-invites.test.ts
@@ -120,6 +120,43 @@ describe("POST /api/invites", () => {
     );
     expect(res.status).toBe(400);
   });
+
+  test("400 rejects a shared-vault invite (provision_vault=false + vault_name)", async () => {
+    // Defense in depth (FIX-1): assigning a redeemer to a PRE-EXISTING vault
+    // as owner-admin is a cross-tenant breach; shared-vault invites aren't
+    // supported yet, so the create handler refuses this combination outright.
+    const bearer = await makeAdminBearer();
+    const res = await handleCreateInvite(
+      withBearer("/api/invites", bearer, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ provision_vault: false, vault_name: "someoneelse" }),
+      }),
+      deps(),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("invalid_request");
+    expect(body.error_description).toContain("shared-vault");
+  });
+
+  test("account-only invite (provision_vault=false, NO vault_name) is still allowed", async () => {
+    const bearer = await makeAdminBearer();
+    const res = await handleCreateInvite(
+      withBearer("/api/invites", bearer, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ provision_vault: false }),
+      }),
+      deps(),
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      invite: { provision_vault: boolean; vault_name: string | null };
+    };
+    expect(body.invite.provision_vault).toBe(false);
+    expect(body.invite.vault_name).toBeNull();
+  });
 });
 
 describe("GET /api/invites", () => {

--- a/src/account-setup.ts
+++ b/src/account-setup.ts
@@ -14,7 +14,8 @@
  * Redeem ORDERING (the re-usability guarantee, mirroring the wizard):
  *   1. lookup + validate the invite (not-found/expired/used/revoked)
  *   2. validate username/password (+ vault name)
- *   3. provision the vault (idempotent-safe)
+ *   3. provision the vault (must FRESHLY CREATE — reject a pre-existing name;
+ *      attaching the new user to someone else's vault is a cross-tenant breach)
  *   4. createUser (the commit point)
  *   5. consumeInvite — stamp used_at + redeemed_user_id ONLY AFTER (4) commits
  *   6. createSession + cookie + 302
@@ -250,20 +251,38 @@ export async function handleAccountSetupPost(
     if (invite.vaultName !== null) {
       vaultName = invite.vaultName;
     } else {
-      const chosen = String(form.get("vault_name") ?? "").trim();
+      // Unpinned name: the invitee names their own vault. The field is
+      // OPTIONAL (no-JS server-side default) — a blank submission defaults
+      // the vault name to the chosen username. Either way the resolved name
+      // runs through the full validator; a username that isn't a valid vault
+      // name (e.g. too long, disallowed chars) re-renders asking for an
+      // explicit vault name with the validator's error.
+      const submitted = String(form.get("vault_name") ?? "").trim();
+      const chosen = submitted === "" ? username : submitted;
       const v = validateVaultName(chosen);
       if (!v.ok) {
-        return rerender(400, v.error, chosen);
+        // Echo the resolved name only if the invitee typed one; a blank
+        // (username-derived) failure shouldn't pre-fill the vault box.
+        return rerender(400, v.error, submitted === "" ? undefined : submitted);
       }
       vaultName = v.name;
     }
   } else if (invite.vaultName !== null) {
-    // Account-only invite that assigns an existing vault.
-    vaultName = invite.vaultName;
+    // UNSUPPORTED shared-vault case: an account-only invite (provision_vault
+    // =false) that pins an EXISTING vault would assign the new user owner-
+    // admin on a pre-existing vault — a cross-tenant breach, and the owner-
+    // vs-shared role split isn't built. The admin API rejects creating such
+    // an invite (defense in depth); reject here too in case one slipped
+    // through. The legit account-only invite (vaultName === null) is unaffected.
+    return rerender(
+      400,
+      "This invite is not supported (shared-vault invites aren't available yet). Ask your hub operator for a new one.",
+    );
   }
 
-  // (3) Provision the vault (idempotent-safe). Routed through the SAME
-  // createVault path the wizard/SPA use, so the new vault gets the §3
+  // (3) Provision the vault — must FRESHLY CREATE it (see the security
+  // invariant on the `!provisioned.created` check below). Routed through the
+  // SAME createVault path the wizard/SPA use, so the new vault gets the §3
   // internal-live-mirror default for free. Done BEFORE createUser so a
   // provisioning failure doesn't leave a vault-less account; the invite is
   // still unconsumed at this point, so the invitee can retry.
@@ -281,6 +300,26 @@ export async function handleAccountSetupPost(
           ? provisioned.message
           : "Could not provision your vault. Please try again, or ask your hub operator.",
         invite.vaultName === null ? (vaultName ?? undefined) : undefined,
+      );
+    }
+    // SECURITY INVARIANT: an invite redeem may grant access ONLY to a vault
+    // that was FRESHLY CREATED during this redeem. `provisionVault` returns
+    // `created:true` (HTTP 201) for a new vault, `created:false` (HTTP 200)
+    // when the name ALREADY EXISTS — in which case it hands back SOMEONE
+    // ELSE'S vault. Attaching the new user there as owner would be a cross-
+    // tenant breach. Reject any non-created (already-existing) result; the
+    // invitee must choose a different, unused name. This also closes the
+    // concurrent-redeem race on a new name: first redeem 201, second 200 →
+    // second rejected.
+    if (!provisioned.created) {
+      return rerender(
+        409,
+        `A vault named "${vaultName}" already exists. Choose a different name.`,
+        // Echo the typed name only if the invitee chose it explicitly; a
+        // username-derived collision shouldn't pre-fill the vault box.
+        invite.vaultName === null && String(form.get("vault_name") ?? "").trim() !== ""
+          ? vaultName
+          : undefined,
       );
     }
   }

--- a/src/admin-login-ui.ts
+++ b/src/admin-login-ui.ts
@@ -196,17 +196,44 @@ export function renderInviteSetup(props: InviteSetupProps): string {
         </label>`;
     } else {
       const vaultAttr = vaultName ? ` value="${escapeAttr(vaultName)}"` : "";
+      // OPTIONAL (not `required`): a blank submission defaults the vault name
+      // to the chosen username, resolved server-side (this form is no-JS, so
+      // the server is the source of truth). The inline script below is a
+      // progressive-enhancement pre-fill only.
       vaultRow = `
         <label class="field">
           <span class="field-label">Name your vault</span>
-          <input type="text" name="vault_name" autocomplete="off"
-            required minlength="2" maxlength="32"
+          <input type="text" name="vault_name" id="vault_name" autocomplete="off"
+            minlength="2" maxlength="32"
             pattern="[a-z0-9_-]+" title="lowercase letters, digits, _ - (2–32 chars)"
-            spellcheck="false" autocapitalize="off"${vaultAttr} />
-          <span class="field-hint">lowercase letters, digits, <code>_</code>, <code>-</code> (2–32 chars)</span>
+            spellcheck="false" autocapitalize="off"
+            placeholder="defaults to your username"${vaultAttr} />
+          <span class="field-hint">lowercase letters, digits, <code>_</code>, <code>-</code> (2–32 chars). Leave blank to use your username.</span>
         </label>`;
     }
   }
+
+  // Progressive enhancement ONLY: mirror the username into the (empty) vault
+  // field as the user types, so they see the default before submitting. The
+  // server applies the same default with no JS (the field is optional), so
+  // this is purely cosmetic — it stops mirroring the moment the user edits the
+  // vault field directly. Shown only for the unpinned-provision case.
+  const vaultPrefillScript =
+    provisionVault && pinnedVaultName === null
+      ? `
+    <script>
+      (function () {
+        var u = document.getElementById("username");
+        var v = document.getElementById("vault_name");
+        if (!u || !v) return;
+        var dirty = v.value !== "";
+        v.addEventListener("input", function () { dirty = true; });
+        u.addEventListener("input", function () {
+          if (!dirty) v.value = u.value;
+        });
+      })();
+    </script>`
+      : "";
 
   const body = `
     <div class="card">
@@ -222,7 +249,7 @@ export function renderInviteSetup(props: InviteSetupProps): string {
         ${renderCsrfHiddenInput(csrfToken)}
         <label class="field">
           <span class="field-label">Username</span>
-          <input type="text" name="username" autocomplete="username" autofocus
+          <input type="text" name="username" id="username" autocomplete="username" autofocus
             required minlength="2" maxlength="32"
             pattern="[a-z0-9_-]+" title="lowercase letters, digits, _ - (2–32 chars)"
             spellcheck="false" autocapitalize="off"${usernameAttr} />
@@ -242,7 +269,7 @@ export function renderInviteSetup(props: InviteSetupProps): string {
         ${vaultRow}
         <button type="submit" class="btn btn-primary">Create my account</button>
       </form>
-    </div>`;
+    </div>${vaultPrefillScript}`;
   return baseDocument("Claim your invite — Parachute", body);
 }
 

--- a/src/api-invites.ts
+++ b/src/api-invites.ts
@@ -19,7 +19,6 @@
 import type { Database } from "bun:sqlite";
 import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
 import { HOST_ADMIN_SCOPE } from "./admin-vaults.ts";
-import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import {
   DEFAULT_INVITE_TTL_SECONDS,
   type Invite,
@@ -31,7 +30,6 @@ import {
   revokeInvite,
 } from "./invites.ts";
 import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
-import { listVaultNamesFromPath } from "./vault-names.ts";
 
 export interface ApiInvitesDeps {
   db: Database;
@@ -266,19 +264,19 @@ export async function handleCreateInvite(req: Request, deps: ApiInvitesDeps): Pr
   if (!parsed.ok) return jsonError(parsed.status, parsed.error, parsed.description);
   const { vaultName, role, provisionVault, defaultMirror, expiresInSeconds } = parsed.body;
 
-  // A pinned vault_name with provision_vault=false means "assign an existing
-  // vault" — validate it exists. (provision_vault=true with a pinned name
-  // provisions THAT name; provision_vault=false without a name is account-only.)
+  // SECURITY: a pinned vault_name with provision_vault=false would assign the
+  // redeeming user to a PRE-EXISTING vault as owner-admin — a cross-tenant
+  // breach, since the owner-vs-shared role split isn't built. Shared-vault
+  // invites aren't supported yet, so reject this combination outright (defense
+  // in depth — the redeem path rejects it too). The supported shapes are:
+  // provision_vault=true (+ optional pinned name → provisions THAT name), or
+  // provision_vault=false with NO name (account-only, assignedVaults=[]).
   if (vaultName !== null && !provisionVault) {
-    const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
-    const known = new Set(listVaultNamesFromPath(manifestPath));
-    if (!known.has(vaultName)) {
-      return jsonError(
-        400,
-        "vault_not_found",
-        `vault "${vaultName}" is not registered in services.json`,
-      );
-    }
+    return jsonError(
+      400,
+      "invalid_request",
+      "shared-vault invites (provision_vault=false with a vault_name) aren't supported yet — omit vault_name for an account-only invite, or set provision_vault=true to provision a new vault",
+    );
   }
 
   const issued = issueInvite(deps.db, {


### PR DESCRIPTION
Two fixes to the just-shipped invite redeem flow, found by walking the flow on a live box. No version bump (stays `0.6.4-rc.1`; re-tag/promote is the orchestrator's call).

## FIX 1 — SECURITY: cross-tenant vault access (CRITICAL)

**The bug.** The invite redeem let a new account gain **owner-admin access to a PRE-EXISTING vault** — a cross-tenant breach. `provisionVault` (`src/admin-vaults.ts`) is idempotent: it returns `created:true` (HTTP **201**) for a freshly-created vault but `created:false` (HTTP **200**) when the vault name **already exists**, handing back the *existing* entry rather than re-creating. The redeem treated both 200 and 201 as success and assigned the redeeming user to that vault as **owner**. So an invitee who typed an existing vault name was attached to **someone else's vault** as owner-admin.

**The invariant.** An invite redeem may grant the user access **only to a vault that was freshly CREATED during this redeem**. Any path that would attach the new user to a pre-existing vault is rejected.

**How the gate works (201-vs-200).** `provisionVault` exposes the 201/200 distinction programmatically as `ProvisionVaultResult.created` (`created:true` ⇔ 201 fresh, `created:false` ⇔ 200 already-exists). After `provisionVault(...)` succeeds, the redeem now checks `if (!provisioned.created)` and **rejects** — re-renders the setup form with `A vault named "<name>" already exists. Choose a different name.` (HTTP 409), creating **no account** and making **no assignment**. Only `created === true` proceeds to `createUser`. This also closes the concurrent-redeem race on a new name: first redeem gets 201, second gets 200 → second rejected.

**Defense in depth — the unsupported shared-vault case.** `provision_vault=false` + a non-null `vault_name` means "assign an existing vault" — owner-admin on a pre-existing vault, exactly the cross-tenant risk, and the owner-vs-shared role split isn't built. Rejected at **both** layers:
- **Admin API** (`src/api-invites.ts` create handler): rejects `provision_vault=false` + non-null `vault_name` → **400** (`invalid_request`, "shared-vault invites aren't supported yet"). (Replaces the old "validate the vault exists" path, which was the enabling step.)
- **Redeem** (`src/account-setup.ts`): if it nonetheless sees `provision_vault=false` + non-null `vaultName`, rejects (400) rather than assigning.

The **legit account-only invite** (`provision_vault=false`, `vault_name=null` → `assignedVaults:[]`) still works (N3 stays green).

The atomic create+consume (`withinTx`) is unchanged — provisioning still runs before `createUser`; only the assignment is gated on `created`.

## FIX 2 — UX: default the vault name to the username

The redeem form (`renderInviteSetup`, `src/admin-login-ui.ts`) now makes `vault_name` **optional** (not `required`) for the unpinned case, with a placeholder/hint that it defaults to your username. Server-side is the source of truth (the form is intentionally no-JS): when the invite didn't pin a name and the submitted `vault_name` is blank, the redeem sets `vaultName = username`, then runs it through the full `validateVaultName` (if the username isn't a valid vault name, re-render asking for an explicit one). The FIX-1 existing-name check still applies to the username-derived name. A tiny inline script mirrors username→vault as a progressive-enhancement pre-fill only; the server default stands alone.

## Tests

`src/__tests__/account-setup.test.ts` + `src/__tests__/api-invites.test.ts`:
- **HEADLINE**: invitee picks an existing vault name → rejected (409, "already exists"), no account, pre-existing owner/assignment unchanged, invite not consumed.
- Pinned existing name (provision_vault=true) → rejected.
- Fresh-name concurrency → exactly one account; the other rejected (409 or 410).
- Shared-vault invite that slipped into the DB → rejected at redeem (400).
- Admin API rejects `provision_vault=false` + `vault_name` → 400; account-only (no vault_name) still 201.
- Blank / omitted `vault_name` → vault created named after the username.
- Username→existing-vault collision → rejected.
- N3 account-only stays green; N2 concurrency updated (loser now 409 or 410).

## Gates

- `bun run typecheck` — clean.
- `bun test src/__tests__/account-setup.test.ts src/__tests__/api-invites.test.ts` — **30 pass, 0 fail** (103 expect() calls). Targeted files only (no lifecycle/migrate/uninstall tests on a live box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)