### PR TITLE
release: hub 0.6.4-rc.2 (invite cross-tenant vault fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.4-rc.1",
+  "version": "0.6.4-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Cuts **0.6.4-rc.2** to ship #557 (invite cross-tenant vault fix + vault-name-defaults-to-username) to the rc boxes. Pure version bump (0.6.4-rc.1 → rc.2); #557 was reviewed + merged. Tag `v0.6.4-rc.2` publishes to npm `rc`, `@latest` stays 0.6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)