### PR TITLE
fix(users): deleteUser clears auth_codes (500 deleting an OAuth-authorized user)

### DIFF
--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -304,6 +304,45 @@ describe("deleteUser", () => {
       cleanup();
     }
   });
+
+  test("deletes a user holding an auth_codes row (hub#559 — OAuth-authorize FK regression)", async () => {
+    // A user who completed an OAuth authorize has an `auth_codes` row whose
+    // NOT-NULL, non-cascading FK to users(id) outlives its 60s TTL. Before the
+    // fix, that pinned the FK and `DELETE FROM users` threw
+    // SQLITE_CONSTRAINT_FOREIGNKEY → a 500 on the admin "delete user" action.
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "ag", "ag-strong-passphrase");
+      // auth_codes.client_id FKs to clients — seed a minimal client first.
+      db.prepare(
+        "INSERT INTO clients (client_id, redirect_uris, scopes, registered_at) VALUES (?, ?, ?, ?)",
+      ).run("client-x", "https://app.example/cb", "vault:default:read", "2026-06-04T00:00:00.000Z");
+      db.prepare(
+        `INSERT INTO auth_codes
+           (code, client_id, user_id, redirect_uri, scopes, code_challenge, code_challenge_method, expires_at, used_at, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        "dead-code",
+        "client-x",
+        u.id,
+        "https://app.example/cb",
+        "vault:default:read",
+        "challenge",
+        "S256",
+        "2026-06-04T00:00:00.000Z", // long-expired
+        "2026-06-04T00:00:00.000Z", // already used
+        "2026-06-04T00:00:00.000Z",
+      );
+      expect(deleteUser(db, u.id)).toBe(true);
+      expect(getUserById(db, u.id)).toBeNull();
+      // The dead auth_code is gone too (hard-deleted with the user).
+      expect(db.query("SELECT COUNT(*) c FROM auth_codes WHERE user_id = ?").get(u.id)).toEqual({
+        c: 0,
+      });
+    } finally {
+      cleanup();
+    }
+  });
 });
 
 describe("validateUsername", () => {

--- a/src/users.ts
+++ b/src/users.ts
@@ -601,8 +601,10 @@ export async function resetUserPassword(
  *     parent users row. The audit trail survives via the `subject`
  *     column we backfill from the username plus the existing
  *     `created_at`, `scopes`, `client_id`, `revoked_at` fields.
- *   - `sessions.user_id` and `grants.user_id` are NOT NULL with a
- *     non-cascading FK. Both are deleted before the users row drops.
+ *   - `sessions.user_id`, `grants.user_id`, and `auth_codes.user_id` are
+ *     NOT NULL with a non-cascading (RESTRICT) FK. All three are deleted
+ *     before the users row drops — auth_codes are ephemeral OAuth codes
+ *     (60s TTL, no audit value), so a hard-delete is correct (hub#559).
  *   - `user_vaults.user_id` has `ON DELETE CASCADE` (migration v10), so
  *     vault assignments are dropped automatically when the parent row
  *     goes. No explicit cleanup needed.
@@ -630,10 +632,16 @@ export function deleteUser(db: Database, userId: string): boolean {
     db.prepare(
       "UPDATE tokens SET subject = COALESCE(subject, ?), user_id = NULL WHERE user_id = ?",
     ).run(row.username, userId);
-    // 2. Drop sessions + grants. Both have non-cascading FKs on user_id;
-    //    leaving rows behind would RESTRICT the users delete below.
+    // 2. Drop sessions + grants + auth_codes. All have NOT-NULL, non-cascading
+    //    (RESTRICT) FKs on user_id; leaving rows behind blocks the users delete
+    //    below with SQLITE_CONSTRAINT_FOREIGNKEY. auth_codes are short-lived
+    //    (60s TTL) OAuth authorization codes with no audit value — hard-delete,
+    //    same as sessions. (Omitting this 500'd a real delete of a user who had
+    //    completed an OAuth authorize: the code row outlived its TTL but still
+    //    pinned the FK. hub#559.)
     db.prepare("DELETE FROM sessions WHERE user_id = ?").run(userId);
     db.prepare("DELETE FROM grants WHERE user_id = ?").run(userId);
+    db.prepare("DELETE FROM auth_codes WHERE user_id = ?").run(userId);
     // 3. Drop the user row itself.
     db.prepare("DELETE FROM users WHERE id = ?").run(userId);
   })();


### PR DESCRIPTION
**Live bug:** deleting a user (the 'ag' user on friends.parachute.computer) 500'd with `SQLITE_CONSTRAINT_FOREIGNKEY`.

**Cause:** `deleteUser` clears sessions + grants and nulls tokens, but never `auth_codes` — whose `user_id` is a NOT-NULL, non-cascading (RESTRICT) FK to `users(id)`. Any user who completed an OAuth authorize has an auth_codes row that outlives its 60s TTL and pins the FK, so `DELETE FROM users` throws.

**Fix:** hard-delete `auth_codes` for the user inside the same transaction (ephemeral OAuth codes, no audit value — same posture as sessions). Updated the docstring's FK enumeration. Regression test seeds a client + dead auth_code, asserts delete succeeds, and was confirmed to fail with the exact FK error without the fix. 50 pass / 0 fail.

Latent bug (predates invites); surfaced now because 'ag' had connected an OAuth client. The stale row was also cleared on the live box so the immediate delete is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)