### PR TITLE
release: hub 0.6.4-rc.3 (deleteUser auth_codes fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.4-rc.2",
+  "version": "0.6.4-rc.3",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Cuts **0.6.4-rc.3** to ship #559 (deleteUser clears auth_codes — fixes the 500 deleting an OAuth-authorized user). Pure version bump; #559 reviewed + merged. Tag publishes to npm `rc`, `@latest` stays 0.6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)