### PR TITLE
release: hub 0.6.4-rc.4 (account onboarding checklist)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.4-rc.3",
+  "version": "0.6.4-rc.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Cuts **0.6.4-rc.4** to ship #561 (/account first-run onboarding checklist + connect-before-prompts reorder) to friends. Pure version bump; #561 reviewed + merged. Tag publishes to npm `rc`, `@latest` stays 0.6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)