### PR TITLE
feat(oauth): native-app support — custom-scheme redirect URIs (RFC 8252) + response_mode=fragment

### DIFF
--- a/src/__tests__/clients.test.ts
+++ b/src/__tests__/clients.test.ts
@@ -74,7 +74,7 @@ describe("registerClient", () => {
     }
   });
 
-  test("rejects non-http(s) redirect_uri", () => {
+  test("rejects denylisted-scheme + relative redirect_uri", () => {
     const { db, cleanup } = makeDb();
     try {
       expect(() => registerClient(db, { redirectUris: ["javascript:alert(1)"] })).toThrow(
@@ -83,6 +83,18 @@ describe("registerClient", () => {
       expect(() => registerClient(db, { redirectUris: ["/relative/path"] })).toThrow(
         /invalid redirect_uri/,
       );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("accepts a private-use custom-scheme redirect_uri (RFC 8252 §7.1)", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const r = registerClient(db, { redirectUris: ["pebblejs://close"] });
+      expect(r.client.redirectUris).toEqual(["pebblejs://close"]);
+      const r2 = registerClient(db, { redirectUris: ["com.example.myapp://callback"] });
+      expect(r2.client.redirectUris).toEqual(["com.example.myapp://callback"]);
     } finally {
       cleanup();
     }
@@ -255,9 +267,23 @@ describe("isValidRedirectUri", () => {
     expect(isValidRedirectUri("http://localhost:3000/cb")).toBe(true);
     expect(isValidRedirectUri("https://example.com/cb")).toBe(true);
   });
-  test("rejects javascript:, data:, relative paths, garbage", () => {
+  test("accepts private-use custom schemes (RFC 8252 §7.1)", () => {
+    // Native apps register a private-use URI scheme they control as the
+    // redirect target — the Pebble watchapp uses pebblejs://close.
+    expect(isValidRedirectUri("pebblejs://close")).toBe(true);
+    expect(isValidRedirectUri("myapp://callback")).toBe(true);
+    // Reverse-DNS scheme name (the RFC 8252 recommendation).
+    expect(isValidRedirectUri("com.example.app://oauth/redirect")).toBe(true);
+  });
+  test("rejects denylisted schemes", () => {
     expect(isValidRedirectUri("javascript:alert(1)")).toBe(false);
     expect(isValidRedirectUri("data:text/html,x")).toBe(false);
+    expect(isValidRedirectUri("file:///etc/passwd")).toBe(false);
+    expect(isValidRedirectUri("vbscript:msgbox(1)")).toBe(false);
+    expect(isValidRedirectUri("blob:https://example.com/uuid")).toBe(false);
+    expect(isValidRedirectUri("about:blank")).toBe(false);
+  });
+  test("rejects relative paths and garbage (unparseable)", () => {
     expect(isValidRedirectUri("/relative")).toBe(false);
     expect(isValidRedirectUri("not a url")).toBe(false);
   });

--- a/src/__tests__/clients.test.ts
+++ b/src/__tests__/clients.test.ts
@@ -281,6 +281,12 @@ describe("isValidRedirectUri", () => {
     expect(isValidRedirectUri("file:///etc/passwd")).toBe(false);
     expect(isValidRedirectUri("vbscript:msgbox(1)")).toBe(false);
     expect(isValidRedirectUri("blob:https://example.com/uuid")).toBe(false);
+    expect(isValidRedirectUri("intent:android.intent.action.VIEW")).toBe(false);
+    expect(isValidRedirectUri("ms-appx://app/page")).toBe(false);
+    expect(isValidRedirectUri("market://details?id=x")).toBe(false);
+    expect(isValidRedirectUri("tel:+15551234567")).toBe(false);
+    expect(isValidRedirectUri("sms:+15551234567")).toBe(false);
+    expect(isValidRedirectUri("mailto:a@b.c")).toBe(false);
     expect(isValidRedirectUri("about:blank")).toBe(false);
   });
   test("rejects relative paths and garbage (unparseable)", () => {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -1091,6 +1091,195 @@ describe("handleAuthorizePost — vault picker", () => {
   });
 });
 
+describe("response_mode (OAuth 2.0 Multiple Response Type Encoding Practices)", () => {
+  // Helper: build a consent POST that mints a code, used by the success cases.
+  function consentForm(reg: ReturnType<typeof registerClient>, extra: Record<string, string>) {
+    const { challenge } = makePkce();
+    return new URLSearchParams({
+      __action: "consent",
+      __csrf: TEST_CSRF,
+      approve: "yes",
+      client_id: reg.client.clientId,
+      redirect_uri: reg.client.redirectUris[0] ?? "",
+      response_type: "code",
+      scope: "",
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+      ...extra,
+    });
+  }
+
+  test("default (no response_mode): success redirect puts code+state in the query", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const form = consentForm(reg, { state: "st-query" });
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+        },
+      });
+      const res = await handleAuthorizePost(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(302);
+      const target = new URL(res.headers.get("location") ?? "");
+      // Code + state live in the query; no fragment.
+      expect(target.searchParams.get("code")).toBeTruthy();
+      expect(target.searchParams.get("state")).toBe("st-query");
+      expect(target.hash).toBe("");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("response_mode=fragment: success redirect puts code+state in the fragment", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      // Custom-scheme native-app client (the Pebble shape).
+      const reg = registerClient(db, { redirectUris: ["pebblejs://close"] });
+      const form = consentForm(reg, { state: "st-frag", response_mode: "fragment" });
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+        },
+      });
+      const res = await handleAuthorizePost(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(302);
+      const loc = res.headers.get("location") ?? "";
+      expect(loc.startsWith("pebblejs://close#")).toBe(true);
+      const target = new URL(loc);
+      // Nothing in the query — code + state are in the fragment.
+      expect(target.search).toBe("");
+      const frag = new URLSearchParams(target.hash.slice(1));
+      expect(frag.get("code")).toBeTruthy();
+      expect(frag.get("state")).toBe("st-frag");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("response_mode=fragment: consent-deny error redirect lands in the fragment", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["pebblejs://close"] });
+      const { challenge } = makePkce();
+      const form = new URLSearchParams({
+        __action: "consent",
+        __csrf: TEST_CSRF,
+        approve: "no",
+        client_id: reg.client.clientId,
+        redirect_uri: "pebblejs://close",
+        response_type: "code",
+        scope: "vault:read",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        state: "deny-frag",
+        response_mode: "fragment",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+        },
+      });
+      const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(302);
+      const target = new URL(res.headers.get("location") ?? "");
+      expect(target.search).toBe("");
+      const frag = new URLSearchParams(target.hash.slice(1));
+      expect(frag.get("error")).toBe("access_denied");
+      expect(frag.get("state")).toBe("deny-frag");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("GET /oauth/authorize with an unknown response_mode → invalid_request 400", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          scope: "vault:read",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          response_mode: "form_post",
+        }),
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      // Malformed request param → HTML 400 (we can't trust the redirect_uri
+      // pairing enough to bounce a structured error, same as other parse
+      // failures in this handler).
+      expect(res.status).toBe(400);
+      const html = await res.text();
+      expect(html).toContain("response_mode");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("GET /oauth/authorize with response_mode=fragment is accepted (round-trips to consent)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["pebblejs://close"] });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "pebblejs://close",
+          response_type: "code",
+          scope: "scribe:transcribe",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          response_mode: "fragment",
+          state: "rt-frag",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      // Consent screen renders (200 HTML) and round-trips response_mode through
+      // a hidden input so the eventual success redirect honors fragment mode.
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain('name="response_mode" value="fragment"');
+    } finally {
+      cleanup();
+    }
+  });
+});
+
 describe("handleAuthorizePost — login submit", () => {
   test("sets session cookie and redirects to GET on valid credentials", async () => {
     const { db, cleanup } = await makeDb();
@@ -5202,6 +5391,53 @@ describe("inline approve button on pending /oauth/authorize (#208)", () => {
       expect(res.status).toBe(302);
       expect(res.headers.get("location")).toBe(returnTo);
       expect(getClient(db, reg.client.clientId)?.status).toBe("approved");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("deny POST with response_mode=fragment → error params in the URL fragment", async () => {
+    // Native-app path: a custom-scheme client that requested
+    // response_mode=fragment must get the access_denied error in the fragment
+    // (the Pebble watchapp only sees the fragment of a pebblejs://close deep
+    // link). The approve-pending form round-trips response_mode as a hidden
+    // input so the deny handler honors it.
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["pebblejs://close"],
+        status: "pending",
+      });
+      const form = new URLSearchParams({
+        __csrf: TEST_CSRF,
+        client_id: reg.client.clientId,
+        return_to: `/oauth/authorize?client_id=${reg.client.clientId}`,
+        decision: "deny",
+        redirect_uri: "pebblejs://close",
+        state: "deny-frag-state",
+        response_mode: "fragment",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize/approve`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, SESSION_COOKIE_TTL_S)}`,
+          origin: ISSUER,
+        },
+      });
+      const res = await handleApproveClientPost(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(302);
+      const loc = res.headers.get("location") ?? "";
+      // No query-form error params — they live in the fragment.
+      expect(loc).not.toContain("?error=");
+      const target = new URL(loc);
+      expect(target.search).toBe("");
+      const frag = new URLSearchParams(target.hash.slice(1));
+      expect(frag.get("error")).toBe("access_denied");
+      expect(frag.get("state")).toBe("deny-frag-state");
     } finally {
       cleanup();
     }

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -1139,6 +1139,72 @@ describe("response_mode (OAuth 2.0 Multiple Response Type Encoding Practices)", 
     }
   });
 
+  test("explicit response_mode=query behaves identically to absent", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const form = consentForm(reg, { state: "st-explicit-query", response_mode: "query" });
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+        },
+      });
+      const res = await handleAuthorizePost(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(302);
+      const target = new URL(res.headers.get("location") ?? "");
+      expect(target.searchParams.get("code")).toBeTruthy();
+      expect(target.searchParams.get("state")).toBe("st-explicit-query");
+      expect(target.hash).toBe("");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("response_mode=fragment merges into a pre-existing fragment on the registered URI", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["pebblejs://close#session=abc"] });
+      const form = consentForm(reg, {
+        state: "st-merge",
+        response_mode: "fragment",
+        redirect_uri: "pebblejs://close#session=abc",
+      });
+      const req = new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+        },
+      });
+      const res = await handleAuthorizePost(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(302);
+      const loc = res.headers.get("location") ?? "";
+      const frag = loc.split("#")[1] ?? "";
+      const fragParams = new URLSearchParams(frag);
+      // Pre-existing fragment data survives alongside code + state.
+      expect(fragParams.get("session")).toBe("abc");
+      expect(fragParams.get("code")).toBeTruthy();
+      expect(fragParams.get("state")).toBe("st-merge");
+      expect(loc.split("#")[0]?.includes("code=")).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("response_mode=fragment: success redirect puts code+state in the fragment", async () => {
     const { db, cleanup } = await makeDb();
     try {

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -21,6 +21,7 @@ const PARAMS: AuthorizeFormParams = {
   codeChallengeMethod: "S256",
   state: "xyz",
   resource: null,
+  responseMode: null,
 };
 
 const CSRF = "csrf-token-fixture";
@@ -48,6 +49,18 @@ describe("renderHiddenInputs", () => {
   test("omits state input when state is null", () => {
     const html = renderHiddenInputs({ ...PARAMS, state: null });
     expect(html).not.toContain('name="state"');
+  });
+
+  test("omits response_mode input by default (query mode), emits it for fragment", () => {
+    // Null = query mode (the default): no hidden input, so the success redirect
+    // falls back to query encoding.
+    expect(renderHiddenInputs({ ...PARAMS, responseMode: null })).not.toContain(
+      'name="response_mode"',
+    );
+    // fragment mode round-trips so the consent POST's success redirect honors it.
+    expect(renderHiddenInputs({ ...PARAMS, responseMode: "fragment" })).toContain(
+      'name="response_mode" value="fragment"',
+    );
   });
 
   test("escapes hostile values into hidden inputs", () => {

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -231,14 +231,38 @@ function timingSafeEqualHex(a: string, b: string): boolean {
 }
 
 /**
- * Light validation — refuses obviously-wrong shapes (relative paths, javascript:
- * URIs). Doesn't try to match a registered URI; that's `requireRegisteredRedirectUri`.
+ * Light validation — refuses obviously-wrong shapes (relative paths,
+ * `javascript:`/`data:` URIs). Doesn't try to match a registered URI; that's
+ * `requireRegisteredRedirectUri`.
+ *
+ * Accepts `http:`/`https:` AND private-use custom schemes (RFC 8252 §7.1) so
+ * native apps can register a redirect URI like `pebblejs://close` or
+ * `myapp://callback` and complete the auth-code flow with no hosted web page.
+ * RFC 8252 §7.1 recommends native apps use a private-use URI scheme they
+ * control (typically a reverse-DNS name) as the redirect target. We allow any
+ * parseable URL whose scheme is NOT in a denylist of schemes that are either
+ * script-execution / data-embedding vectors (`javascript:`, `data:`,
+ * `vbscript:`, `blob:`, `about:`) or local-resource references (`file:`).
+ * Anything unparseable (relative paths, scheme-less strings) is still refused.
+ *
+ * NOTE: this is a registration-time sanity filter only. The far stronger
+ * defense is exact-match at redirect time (`requireRegisteredRedirectUri`,
+ * unchanged + still strict per RFC 8252/6749) — a custom-scheme URI is only
+ * ever a redirect target if the client registered that exact string.
  */
+const REDIRECT_URI_SCHEME_DENYLIST: ReadonlySet<string> = new Set([
+  "javascript:",
+  "data:",
+  "file:",
+  "vbscript:",
+  "blob:",
+  "about:",
+]);
+
 export function isValidRedirectUri(uri: string): boolean {
   try {
     const u = new URL(uri);
-    if (u.protocol === "javascript:" || u.protocol === "data:") return false;
-    return u.protocol === "http:" || u.protocol === "https:";
+    return !REDIRECT_URI_SCHEME_DENYLIST.has(u.protocol);
   } catch {
     return false;
   }

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -257,6 +257,16 @@ const REDIRECT_URI_SCHEME_DENYLIST: ReadonlySet<string> = new Set([
   "vbscript:",
   "blob:",
   "about:",
+  // OS deep-link / system schemes with known hijack or side-effect potential —
+  // not legitimate OAuth redirect targets (RFC 8252 private-use schemes are
+  // reverse-domain app schemes, not these).
+  "intent:",
+  "ms-appx:",
+  "ms-appx-web:",
+  "market:",
+  "tel:",
+  "sms:",
+  "mailto:",
 ]);
 
 export function isValidRedirectUri(uri: string): boolean {

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -1884,6 +1884,7 @@ export async function handleApproveClientPost(
       );
     }
     const stateRaw = form.get("state");
+    // null (not undefined) on purpose: buildAuthorizeRedirectLocation filters nulls.
     const denyState = typeof stateRaw === "string" && stateRaw.length > 0 ? stateRaw : null;
     // `response_mode` round-trips through the approve-pending form just like
     // redirect_uri/state (hidden input) so the Deny error redirect honors the

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -353,17 +353,61 @@ function htmlError(title: string, message: string, status: number): Response {
   return htmlResponse(renderError({ title, message, status }), status);
 }
 
+/**
+ * Build the authorize redirect location, encoding the response parameters per
+ * the OAuth 2.0 Multiple Response Type Encoding Practices `response_mode`:
+ *
+ *   - `"query"` (the default — null normalizes to it): append to the query
+ *     string (`<redirect_uri>?code=...&state=...`). Unchanged historical
+ *     behavior.
+ *   - `"fragment"`: append to the URL fragment (`<redirect_uri>#code=...&
+ *     state=...`), preserving any fragment the redirect_uri already carries.
+ *     The native-app path — the Pebble phone app delivers the fragment of a
+ *     `pebblejs://close#...` deep link to the watchapp JS but drops query-form
+ *     params, so query-mode `code` never arrives.
+ *
+ * `params` is an ordered list of [key, value] pairs (skipping null values) so
+ * the emitted ordering is stable (`code` before `state`, `error` before
+ * `error_description` before `state`) — easier to assert in tests and matches
+ * what clients expect.
+ */
+function buildAuthorizeRedirectLocation(
+  redirectUri: string,
+  params: ReadonlyArray<readonly [key: string, value: string | null]>,
+  responseMode: "query" | "fragment" | null,
+): string {
+  const u = new URL(redirectUri);
+  const present = params.filter((p): p is [string, string] => p[1] !== null);
+  if (responseMode === "fragment") {
+    // Build the fragment params on top of any fragment the redirect_uri
+    // already carries (rare, but RFC-permitted). `URLSearchParams` gives us
+    // correct percent-encoding for the fragment body.
+    const frag = new URLSearchParams(u.hash.startsWith("#") ? u.hash.slice(1) : u.hash);
+    for (const [k, v] of present) frag.set(k, v);
+    u.hash = frag.toString();
+  } else {
+    for (const [k, v] of present) u.searchParams.set(k, v);
+  }
+  return u.toString();
+}
+
 function oauthErrorRedirect(
   redirectUri: string,
   error: string,
   description: string,
   state: string | null,
+  responseMode: "query" | "fragment" | null = null,
 ): Response {
-  const u = new URL(redirectUri);
-  u.searchParams.set("error", error);
-  u.searchParams.set("error_description", description);
-  if (state) u.searchParams.set("state", state);
-  return redirectResponse(u.toString());
+  const location = buildAuthorizeRedirectLocation(
+    redirectUri,
+    [
+      ["error", error],
+      ["error_description", description],
+      ["state", state],
+    ],
+    responseMode,
+  );
+  return redirectResponse(location);
 }
 
 // --- /.well-known/oauth-protected-resource ---------------------------------
@@ -505,6 +549,22 @@ function parseAuthorizeFormParams(url: URL): AuthorizeFormParams | { error: stri
   if (!responseType) return { error: "missing response_type" };
   if (!codeChallenge) return { error: "missing code_challenge" };
   if (!codeChallengeMethod) return { error: "missing code_challenge_method" };
+  // OAuth 2.0 Multiple Response Type Encoding Practices `response_mode`.
+  // Optional; absent → null (defaults to query at redirect time). Only the two
+  // values meaningful for the authorization-code flow are accepted —
+  // `query` (explicit default) and `fragment` (native-app path). Any other
+  // value is rejected with the standard invalid_request error rather than
+  // silently ignored, so a client asking for an unsupported encoding
+  // (e.g. form_post, web_message) learns the request was malformed.
+  const responseModeRaw = url.searchParams.get("response_mode");
+  let responseMode: "query" | "fragment" | null;
+  if (responseModeRaw === null || responseModeRaw === "") {
+    responseMode = null;
+  } else if (responseModeRaw === "query" || responseModeRaw === "fragment") {
+    responseMode = responseModeRaw;
+  } else {
+    return { error: `unsupported response_mode "${responseModeRaw}"` };
+  }
   return {
     clientId,
     redirectUri,
@@ -516,6 +576,7 @@ function parseAuthorizeFormParams(url: URL): AuthorizeFormParams | { error: stri
     // RFC 8707 resource indicator (optional). When present and resolvable to
     // a per-vault MCP resource, drives the narrow-consent + named-scope path.
     resource: url.searchParams.get("resource"),
+    responseMode,
   };
 }
 
@@ -664,6 +725,10 @@ function pendingClientResponse(
     // state lives in the query string by design).
     const requestRedirectUri = authorizeUrl.searchParams.get("redirect_uri") ?? "";
     const requestState = authorizeUrl.searchParams.get("state") ?? undefined;
+    // Only `"fragment"` is plumbed; the default query mode is left undefined
+    // (the deny handler treats absent/anything-else as query).
+    const requestResponseMode =
+      authorizeUrl.searchParams.get("response_mode") === "fragment" ? "fragment" : undefined;
     return htmlResponse(
       renderApprovePending({
         clientName: client.clientName ?? client.clientId,
@@ -677,6 +742,7 @@ function pendingClientResponse(
           returnTo,
           redirectUri: requestRedirectUri,
           ...(requestState !== undefined && { state: requestState }),
+          ...(requestResponseMode !== undefined && { responseMode: requestResponseMode }),
         },
         loginNextUrl: returnTo,
       }),
@@ -867,6 +933,7 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
       "unsupported_response_type",
       "only response_type=code is supported",
       parsed.state,
+      parsed.responseMode,
     );
   }
   if (parsed.codeChallengeMethod !== "S256") {
@@ -875,6 +942,7 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
       "invalid_request",
       "PKCE S256 is required",
       parsed.state,
+      parsed.responseMode,
     );
   }
   let client = getClient(db, parsed.clientId);
@@ -1017,6 +1085,7 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
       "invalid_scope",
       `requested scopes are not available via the public authorization endpoint: ${blocked.join(", ")}`,
       parsed.state,
+      parsed.responseMode,
     );
   }
 
@@ -1284,6 +1353,7 @@ function issueAuthCodeRedirect(
       "invalid_scope",
       "You can grant only the access you hold on this vault; an admin grant requires hub-owner authority.",
       params.state,
+      params.responseMode,
     );
   }
 
@@ -1300,10 +1370,15 @@ function issueAuthCodeRedirect(
     codeChallengeMethod: params.codeChallengeMethod,
     now: deps.now,
   });
-  const u = new URL(params.redirectUri);
-  u.searchParams.set("code", code.code);
-  if (params.state) u.searchParams.set("state", params.state);
-  return redirectResponse(u.toString());
+  const location = buildAuthorizeRedirectLocation(
+    params.redirectUri,
+    [
+      ["code", code.code],
+      ["state", params.state],
+    ],
+    params.responseMode,
+  );
+  return redirectResponse(location);
 }
 
 /**
@@ -1492,6 +1567,7 @@ async function handleConsentSubmit(
       "access_denied",
       "user denied the authorization request",
       params.state,
+      params.responseMode,
     );
   }
   let scopes = params.scope.split(" ").filter((s) => s.length > 0);
@@ -1505,6 +1581,7 @@ async function handleConsentSubmit(
       "invalid_scope",
       `requested scopes are not available via the public authorization endpoint: ${blockedHere.join(", ")}`,
       params.state,
+      params.responseMode,
     );
   }
   // Multi-user Phase 2 PR 2: non-admin users are pinned to a list of one
@@ -1807,14 +1884,19 @@ export async function handleApproveClientPost(
       );
     }
     const stateRaw = form.get("state");
-    const denyState = typeof stateRaw === "string" && stateRaw.length > 0 ? stateRaw : undefined;
+    const denyState = typeof stateRaw === "string" && stateRaw.length > 0 ? stateRaw : null;
+    // `response_mode` round-trips through the approve-pending form just like
+    // redirect_uri/state (hidden input) so the Deny error redirect honors the
+    // native-app fragment encoding the client asked for. Anything other than
+    // the literal `"fragment"` falls back to query (the default + back-compat
+    // for forms that don't carry the field).
+    const denyResponseMode = form.get("response_mode") === "fragment" ? "fragment" : null;
     // `new URL()` could in principle throw if a legacy code path bypassed
-    // `isValidRedirectUri` at registration and wrote a non-http(s) URI.
+    // `isValidRedirectUri` at registration and wrote an unparseable URI.
     // Current DCR enforces validity at write time, so this catch is
     // belt-and-suspenders, but cost is near-zero.
-    let target: URL;
     try {
-      target = new URL(denyRedirectUri);
+      new URL(denyRedirectUri);
     } catch {
       return htmlError(
         "Invalid form submission",
@@ -1822,10 +1904,16 @@ export async function handleApproveClientPost(
         400,
       );
     }
-    target.searchParams.set("error", "access_denied");
-    target.searchParams.set("error_description", "The user denied the authorization request.");
-    if (denyState !== undefined) target.searchParams.set("state", denyState);
-    return redirectResponse(target.toString());
+    const location = buildAuthorizeRedirectLocation(
+      denyRedirectUri,
+      [
+        ["error", "access_denied"],
+        ["error_description", "The user denied the authorization request."],
+        ["state", denyState],
+      ],
+      denyResponseMode,
+    );
+    return redirectResponse(location);
   }
 
   // Approve branch (default — also the back-compat path for any form that
@@ -1869,6 +1957,10 @@ export function isSafeAuthorizeReturnTo(value: string): boolean {
 }
 
 function paramsFromForm(form: Awaited<ReturnType<Request["formData"]>>): AuthorizeFormParams {
+  // `response_mode` round-trips through the consent form's hidden inputs.
+  // Only the literal `"fragment"` flips the encoding; everything else (absent,
+  // empty, or the explicit `"query"`) normalizes to null = query mode.
+  const responseModeRaw = form.get("response_mode");
   return {
     clientId: String(form.get("client_id") ?? ""),
     redirectUri: String(form.get("redirect_uri") ?? ""),
@@ -1878,6 +1970,7 @@ function paramsFromForm(form: Awaited<ReturnType<Request["formData"]>>): Authori
     codeChallengeMethod: String(form.get("code_challenge_method") ?? "S256"),
     state: (form.get("state") as string | null) ?? null,
     resource: (form.get("resource") as string | null) ?? null,
+    responseMode: responseModeRaw === "fragment" ? "fragment" : null,
   };
 }
 
@@ -1895,6 +1988,11 @@ function authorizeParamsToQuery(p: AuthorizeFormParams): Record<string, string> 
   // the resource-bound narrowing survives a sign-in (it re-enters GET
   // /oauth/authorize with the original params).
   if (p.resource) q.resource = p.resource;
+  // Round-trip response_mode (OAuth 2.0 Multiple Response Type Encoding
+  // Practices) through the login redirect so a native app's fragment request
+  // survives sign-in (re-enters GET /oauth/authorize with the original
+  // params). Null = query mode, which we omit (it's the default).
+  if (p.responseMode) q.response_mode = p.responseMode;
   return q;
 }
 

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -20,7 +20,7 @@
  *     module scopes that the hub doesn't know about) render verbatim.
  *   - **No JavaScript.** Entirely form-based. Submit is the only interaction.
  */
-import { brandMarkSvg, WORDMARK_TEXT } from "./brand.ts";
+import { WORDMARK_TEXT, brandMarkSvg } from "./brand.ts";
 import { renderCsrfHiddenInput } from "./csrf.ts";
 import { type ScopeExplanation, explainScope } from "./scope-explanations.ts";
 
@@ -68,6 +68,17 @@ export interface AuthorizeFormParams {
    * sign-in redirect. Null when the client sent no `resource` param.
    */
   resource: string | null;
+  /**
+   * OAuth 2.0 Multiple Response Type Encoding Practices `response_mode`.
+   * `"query"` (the default, and what we emit when null) appends `code`/`state`
+   * to the redirect_uri query string; `"fragment"` appends them to the URL
+   * fragment instead. Native apps (e.g. the Pebble watchapp) that only receive
+   * the fragment of a custom-scheme deep link request `response_mode=fragment`.
+   * Carried through the login → consent → form-post round-trip exactly like
+   * `resource`/`state` so the chosen mode survives a sign-in redirect. Null
+   * when the client sent no `response_mode` param (defaults to query).
+   */
+  responseMode: "query" | "fragment" | null;
 }
 
 export interface LoginViewProps {
@@ -248,12 +259,17 @@ export interface ApprovePendingViewProps {
    * calling client (`<redirect_uri>?error=access_denied&state=<state>`).
    * `redirectUri` is required because deny must signal back to the client;
    * `state` may be undefined (OAuth clients sometimes omit it).
+   *
+   * `responseMode` (OAuth 2.0 Multiple Response Type Encoding Practices) is
+   * plumbed through too so the Deny error redirect honors the native-app
+   * fragment encoding the client requested. Undefined → query mode (default).
    */
   approveForm?: {
     csrfToken: string;
     returnTo: string;
     redirectUri: string;
     state?: string;
+    responseMode?: "query" | "fragment";
   };
   /**
    * Same-origin hub-relative URL (path + search) to send the operator to
@@ -539,6 +555,7 @@ export function renderApprovePending(props: ApprovePendingViewProps): string {
         <input type="hidden" name="return_to" value="${escapeHtml(approveForm.returnTo)}" />
         <input type="hidden" name="redirect_uri" value="${escapeHtml(approveForm.redirectUri)}" />
         ${approveForm.state !== undefined ? `<input type="hidden" name="state" value="${escapeHtml(approveForm.state)}" />` : ""}
+        ${approveForm.responseMode !== undefined ? `<input type="hidden" name="response_mode" value="${escapeHtml(approveForm.responseMode)}" />` : ""}
         <div class="approve-actions">
           <button type="submit" name="decision" value="approve" class="btn btn-primary">Approve</button>
           <button type="submit" name="decision" value="deny" class="btn btn-secondary">Deny</button>
@@ -942,6 +959,11 @@ export function renderHiddenInputs(p: AuthorizeFormParams): string {
   // the resource-bound vault narrowing survives the POST (the consent submit
   // path re-derives the bound vault from it).
   if (p.resource) fields.push(["resource", p.resource]);
+  // response_mode (OAuth 2.0 Multiple Response Type Encoding Practices) —
+  // round-tripped through the consent form so the success redirect after the
+  // consent POST honors the native-app fragment encoding. Null = query mode,
+  // which we omit (the default).
+  if (p.responseMode) fields.push(["response_mode", p.responseMode]);
   return fields
     .map(([k, v]) => `<input type="hidden" name="${k}" value="${escapeHtml(v)}" />`)
     .join("\n        ");


### PR DESCRIPTION
Two small, RFC-backed OAuth additions that let a **native app** (e.g. the Pebble watch app) complete the authorization-code flow with **zero hosted web pages**.

## 1. Custom-scheme redirect URIs (RFC 8252 §7.1 private-use schemes)

`isValidRedirectUri()` (`src/clients.ts`) previously allowed only `http:`/`https:`. It now accepts **any parseable URL whose scheme is NOT in a denylist** — `{javascript:, data:, file:, vbscript:, blob:, about:}` — so a native app can register `pebblejs://close`, `myapp://callback`, `com.example.app://oauth/redirect`, etc. Unparseable strings (relative paths, scheme-less) are still refused.

RFC 8252 §7.1 recommends native apps use a private-use URI scheme they control (typically a reverse-DNS name) as the redirect target. The DCR endpoint (`POST /oauth/register`, `oauth-handlers.ts ~L2461`) picks this up via the same helper.

This is a **registration-time sanity filter only**. The strong defense is the unchanged **exact-match** `requireRegisteredRedirectUri` at redirect time (still strict per RFC 8252/6749) — a custom-scheme URI is only ever a redirect target if the client registered that exact string.

## 2. `response_mode=fragment` (OAuth 2.0 Multiple Response Type Encoding Practices)

When the authorize request carries `response_mode=fragment`, the success redirect appends `code`+`state` in the URL **fragment** (`<redirect_uri>#code=...&state=...`) instead of the query; all error/deny redirects honor it too. Default behavior (no `response_mode`, or `response_mode=query`) is **byte-for-byte unchanged**. Unknown values (e.g. `form_post`) are rejected with the standard `invalid_request` error at the GET handler.

The mode **round-trips** through the login redirect and the consent/approve forms (hidden input) exactly like `redirect_uri`/`state`/`resource`, so it survives a sign-in and the consent POST. New shared helper `buildAuthorizeRedirectLocation()` is the single choke-point for query-vs-fragment encoding; every authorize redirect builder (success mint, `oauthErrorRedirect`, consent-deny, approve-form-deny) routes through it.

## Why (the load-bearing motivation)

The Pebble phone app delivers `pebblejs://close#<fragment>` to the watchapp's JS but **silently drops query-form params** — verified in `coredevices/mobileapp` source: `WatchappSettingsScreen.kt`'s `SettingsRequestInterceptor` regex accepts `close#…|close/?…|close/…`, and `PebbleDeepLinkHandler.kt` reads only `encodedFragment`. **Fragment `response_mode` + custom-scheme registration = a native app completes OAuth with no hosted pages.**

## Files changed

- `src/clients.ts` — `isValidRedirectUri()` now denylist-based; doc comment cites RFC 8252 §7.1 (`~L233-264`).
- `src/oauth-handlers.ts` — `parseAuthorizeFormParams` parses + validates `response_mode` (rejects unknown); new `buildAuthorizeRedirectLocation` helper; `oauthErrorRedirect` + `issueAuthCodeRedirect` + all consent/GET error redirects + the approve-form deny path honor the mode; `paramsFromForm`/`authorizeParamsToQuery` round-trip it.
- `src/oauth-ui.ts` — `AuthorizeFormParams.responseMode`; `renderHiddenInputs` + the approve-pending form emit a `response_mode` hidden input for fragment mode.
- `src/__tests__/{clients,oauth-handlers,oauth-ui}.test.ts` — focused coverage for both features.

## Tests

- `bun test ./src`: **2981 pass / 1 skip / 0 fail** (the 1 skip is pre-existing, unrelated).
- `bun run typecheck`: **clean** (`tsc --noEmit`).

New coverage: custom-scheme DCR accepted + `javascript:`/`data:`/`file:`/`vbscript:`/`blob:`/`about:` still rejected; authorize success puts `code`+`state` in fragment on fragment-mode and in query on default; consent-deny + approve-form-deny error redirects land in the fragment; unknown `response_mode` → 400; default query behavior unchanged; consent form round-trips the `response_mode` hidden input.

Verified the WHATWG URL behavior on custom schemes by runtime probe: `new URL("pebblejs://close")` + `.hash = "code=...&state=..."` yields `pebblejs://close#code=...&state=...` (matches the Pebble `close#…` regex), pre-existing fragments are preserved/merged, and query/https baselines are unchanged.

No version bump (tag-when-ready governance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)