### PR TITLE
feat(account): consolidate owner home — dedup connect, surface backup state, drop token-mint, build-your-own-UI hint

### DIFF
--- a/src/__tests__/account-home-ui.test.ts
+++ b/src/__tests__/account-home-ui.test.ts
@@ -303,6 +303,7 @@ describe("renderAccountHome", () => {
     expect(backedUp).toContain("/account/vault-admin-token/alice");
 
     // GitHub variant: when pushing, the line says so and the action is dropped.
+    // Suppression is gated on the `mirrorPushing` boolean (NOT the line string).
     const pushing = renderAccountHome({
       username: "alice",
       assignedVaults: ["alice"],
@@ -313,6 +314,7 @@ describe("renderAccountHome", () => {
       twoFactorEnabled: false,
       mintableVerbs: { alice: ["read", "write", "admin"] },
       mirrorLines: { alice: "Backed up — version history + GitHub" },
+      mirrorPushing: { alice: true },
     });
     expect(pushing).toContain("version history + GitHub");
     expect(pushing).not.toContain('data-testid="backup-github-button"');
@@ -330,6 +332,39 @@ describe("renderAccountHome", () => {
     });
     expect(noMirror).not.toContain('data-testid="backup-state-line"');
     expect(noMirror).not.toContain('data-testid="vault-backup"');
+  });
+
+  test("backup action — gated on the mirrorPushing boolean, not the line string", () => {
+    // Regression guard: the "Back up to GitHub ↗" suppression must follow the
+    // proper `mirrorPushing` boolean, NOT substring-match the display line.
+    // (a) line mentions "GitHub" but mirrorPushing is false → action STILL shows.
+    const lineLies = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["alice"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+      mintableVerbs: { alice: ["read", "write", "admin"] },
+      mirrorLines: { alice: "Backed up — full version history (GitHub disabled)" },
+      mirrorPushing: { alice: false },
+    });
+    expect(lineLies).toContain('data-testid="backup-github-button"');
+    // (b) mirrorPushing true but the line lacks "GitHub" → action suppressed.
+    const boolWins = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["alice"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+      mintableVerbs: { alice: ["read", "write", "admin"] },
+      mirrorLines: { alice: "Backed up — full version history" },
+      mirrorPushing: { alice: true },
+    });
+    expect(boolWins).not.toContain('data-testid="backup-github-button"');
   });
 
   test("account card — security actions collapse into a secondary <details>", () => {

--- a/src/__tests__/account-home-ui.test.ts
+++ b/src/__tests__/account-home-ui.test.ts
@@ -4,9 +4,11 @@
  * tests pin the load-bearing shape:
  *
  *   - Assigned-vault branch: Notes CTA href encodes the hub+vault URL,
- *     vault name shows in the body, AND a per-tile MCP connect block
- *     surfaces the endpoint + `claude mcp add` command (OAuth, no token)
- *     with copy buttons — the multi-user friend-connect surface.
+ *     vault name shows in the body, the backup-state line surfaces, and a
+ *     "build your own UI" hint links the surface-build starter. The connect
+ *     instructions live ONCE in the onboarding checklist (not duplicated in
+ *     the vault card); token-minting is gone from /account (OAuth-first);
+ *     a single "Advanced vault settings ↗" deep-link covers advanced needs.
  *   - Admin (no assigned vault) branch: link to /admin/ visible.
  *   - Defensive third branch (non-admin + no vault): "ask the operator"
  *     copy renders.
@@ -44,41 +46,87 @@ describe("renderAccountHome", () => {
     expect(html).toContain(`https://notes.parachute.computer/add?url=${encodedVaultUrl}`);
     expect(html).toContain('target="_blank"');
     expect(html).toContain('rel="noopener"');
-    // The friend-connect surface: MCP endpoint + `claude mcp add` command,
-    // each with a copy button. OAuth path (no token in the command).
-    expect(html).toContain(`${HUB_ORIGIN}/vault/alice/mcp`);
-    expect(html).toContain(
-      `claude mcp add --transport http parachute-alice ${HUB_ORIGIN}/vault/alice/mcp`,
-    );
-    expect(html).toContain('data-testid="copy-mcp-endpoint"');
-    expect(html).toContain('data-testid="copy-mcp-add-command"');
-    // The connect command must NOT embed a token — the OAuth path needs none.
-    expect(html).not.toContain("--header");
-    expect(html).not.toContain("Authorization: Bearer");
     // Copy-button progressive-enhancement script is present.
     expect(html).toContain("navigator.clipboard");
-    // Friendlier framing: the block leads with "connect your AI assistant"
-    // rather than MCP jargon up top.
-    expect(html).toContain('data-testid="connect-ai-heading"');
-    expect(html).toContain("Connect your AI");
-    // BOTH connect methods render as distinct, labelled blocks.
-    expect(html).toContain('data-testid="connect-method-claude-code"');
-    expect(html).toContain("Claude Code");
-    expect(html).toContain('data-testid="connect-method-claude-ai"');
-    expect(html).toContain("Claude.ai");
-    // The Claude.ai path mirrors the install.njk canonical phrasing
-    // (Settings → Connectors → Add custom connector, paste the endpoint).
-    expect(html).toContain("Connectors");
-    expect(html).toContain("Add custom connector");
-    // A brief "any other MCP client" line is present (no bloat — just one).
-    expect(html).toContain('data-testid="connect-any-client-hint"');
-    // Notes CTA still present, now framed as the browser-UI option.
+    // Notes CTA present, framed as the browser-UI option.
     expect(html).toContain('data-testid="open-notes-cta"');
     // Import-notes CTA deep-links to the Notes-UI /import route for the same
     // vault, mirroring the Open-Notes target-resolution (same hosted origin,
     // same `?url=${hubOrigin}/vault/<name>` vault-targeting param).
     expect(html).toContain(`https://notes.parachute.computer/import?url=${encodedVaultUrl}`);
     expect(html).toContain('data-testid="import-notes-cta"');
+  });
+
+  test("dedup — the full connect block lives ONCE (in the checklist), NOT in the vault card", () => {
+    const html = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["alice"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+      connectedVault: false,
+    });
+    // The checklist owns "Connect your AI" — the endpoint + the `claude mcp add`
+    // command (OAuth, no token) appear there.
+    expect(html).toContain('data-testid="onboarding-mcp-endpoint"');
+    expect(html).toContain('data-testid="onboarding-mcp-add-command"');
+    expect(html).toContain(`${HUB_ORIGIN}/vault/alice/mcp`);
+    // The vault card must NOT repeat the connect instructions. None of the
+    // old mcp-connect block markers may appear — no duplicated connect surface.
+    expect(html).not.toContain('data-testid="mcp-connect"');
+    expect(html).not.toContain('data-testid="connect-ai-heading"');
+    expect(html).not.toContain('data-testid="connect-method-claude-code"');
+    expect(html).not.toContain('data-testid="connect-method-claude-ai"');
+    expect(html).not.toContain('data-testid="connect-any-client-hint"');
+    // The connect instructions live only in the checklist, never duplicated in
+    // the vault card: split the page at the vault card and assert the endpoint
+    // doesn't reappear in that slice.
+    const cardIdx = html.indexOf('data-testid="vault-card"');
+    expect(cardIdx).toBeGreaterThan(-1);
+    const vaultCardSlice = html.slice(cardIdx);
+    expect(vaultCardSlice).not.toContain(`${HUB_ORIGIN}/vault/alice/mcp`);
+    expect(vaultCardSlice).not.toContain("claude mcp add");
+  });
+
+  test("token-mint — the mint affordance is gone from /account (OAuth-first)", () => {
+    const html = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["alice"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+      mintableVerbs: { alice: ["read", "write", "admin"] },
+    });
+    // No token-mint <details> block, no mint form, no verb radios — minting a
+    // header-auth token is a script/advanced concern that lives in the SPA.
+    expect(html).not.toContain('data-testid="token-mint"');
+    expect(html).not.toContain('data-testid="mint-form"');
+    expect(html).not.toContain('data-testid="mint-verb-read"');
+    expect(html).not.toContain('data-testid="mint-verb-admin"');
+    expect(html).not.toContain("Mint an access token");
+    // The single advanced entry point covers the advanced needs.
+    expect(html).toContain('data-testid="vault-admin-button"');
+    expect(html).toContain("Advanced vault settings");
+  });
+
+  test("build-your-own-UI — Notes is one way; the hint links the surface-build starter", () => {
+    const html = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["alice"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+    });
+    expect(html).toContain('data-testid="build-your-own-ui"');
+    expect(html).toContain('data-testid="build-your-own-ui-link"');
+    expect(html).toContain("https://parachute.computer/onboarding/surface-build/");
+    expect(html).toContain("build you a custom UI");
   });
 
   test("assigned-vault branch — import-notes CTA gated alongside open-notes (no dead link)", () => {
@@ -233,8 +281,8 @@ describe("renderAccountHome", () => {
     expect(noVault).toContain('data-testid="no-vault-card"');
   });
 
-  test("connect-any-client hint bridges MCP ↔ ChatGPT 'connector' terminology", () => {
-    const html = renderAccountHome({
+  test("backup state — renders the backup line + omits when no mirror entry", () => {
+    const backedUp = renderAccountHome({
       username: "alice",
       assignedVaults: ["alice"],
       passwordChanged: true,
@@ -242,14 +290,46 @@ describe("renderAccountHome", () => {
       isFirstAdmin: false,
       csrfToken: CSRF,
       twoFactorEnabled: false,
+      mintableVerbs: { alice: ["read", "write", "admin"] },
+      mirrorLines: { alice: "Backed up — full version history" },
     });
-    // The "any other client" hint now names the ChatGPT "connector" term so
-    // a friend who only knows that word can find the right place to paste.
-    // Assert the NEW hint string specifically — a bare toContain("connector")
-    // was already satisfied pre-PR by the Claude.ai "Connectors" block, so it
-    // wouldn't catch a regression that drops this bridging copy.
-    expect(html).toContain('data-testid="connect-any-client-hint"');
-    expect(html).toContain('call these "connectors."');
+    // The warm, plain-language backup line surfaces on the tile.
+    expect(backedUp).toContain('data-testid="backup-state-line"');
+    expect(backedUp).toContain("Backed up — full version history");
+    // Not pushing yet → a "Back up to GitHub ↗" action (reuses the
+    // vault-admin-token deep-link, gated on admin).
+    expect(backedUp).toContain('data-testid="backup-github-button"');
+    expect(backedUp).toContain("Back up to GitHub");
+    expect(backedUp).toContain("/account/vault-admin-token/alice");
+
+    // GitHub variant: when pushing, the line says so and the action is dropped.
+    const pushing = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["alice"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+      mintableVerbs: { alice: ["read", "write", "admin"] },
+      mirrorLines: { alice: "Backed up — version history + GitHub" },
+    });
+    expect(pushing).toContain("version history + GitHub");
+    expect(pushing).not.toContain('data-testid="backup-github-button"');
+
+    // Omitted silently when the mirror fetch returned nothing (no entry).
+    const noMirror = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["alice"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+      mintableVerbs: { alice: ["read", "write", "admin"] },
+    });
+    expect(noMirror).not.toContain('data-testid="backup-state-line"');
+    expect(noMirror).not.toContain('data-testid="vault-backup"');
   });
 
   test("account card — security actions collapse into a secondary <details>", () => {
@@ -347,18 +427,13 @@ describe("renderAccountHome", () => {
     const familyEncoded = encodeURIComponent(`${HUB_ORIGIN}/vault/family`);
     expect(html).toContain(`https://notes.parachute.computer/add?url=${personalEncoded}`);
     expect(html).toContain(`https://notes.parachute.computer/add?url=${familyEncoded}`);
-    // One per-vault MCP connect block per tile (endpoint + command).
-    expect(html).toContain(`${HUB_ORIGIN}/vault/personal/mcp`);
-    expect(html).toContain(`${HUB_ORIGIN}/vault/family/mcp`);
-    expect(html).toContain(
-      `claude mcp add --transport http parachute-personal ${HUB_ORIGIN}/vault/personal/mcp`,
-    );
-    expect(html).toContain(
-      `claude mcp add --transport http parachute-family ${HUB_ORIGIN}/vault/family/mcp`,
-    );
-    // Two tiles → two copy-endpoint buttons.
-    expect(html.split('data-testid="copy-mcp-endpoint"').length - 1).toBe(2);
-    // The copy script is emitted once at the section level, not per-tile.
+    // Two tiles → two Open-Notes CTAs.
+    expect(html.split('data-testid="open-notes-cta"').length - 1).toBe(2);
+    // The vault card does NOT repeat the connect block — that lives in the
+    // checklist (which uses the first/primary vault only).
+    expect(html).not.toContain('data-testid="mcp-connect"');
+    expect(html).not.toContain(`${HUB_ORIGIN}/vault/family/mcp`);
+    // The copy script is emitted once at the page level, not per-tile.
     expect(html.split("<script>").length - 1).toBe(1);
   });
 
@@ -396,56 +471,9 @@ describe("renderAccountHome", () => {
     expect(html).toContain("parachute-&lt;vault&gt;");
   });
 
-  // --- friend vault-token mint affordance (the new surface) ----------------
+  // --- single advanced entry point (gated on the admin verb) ---------------
 
-  test("mint affordance — read+write tile offers both verbs, POSTs to the right path", () => {
-    const html = renderAccountHome({
-      username: "alice",
-      assignedVaults: ["work"],
-      passwordChanged: true,
-      hubOrigin: HUB_ORIGIN,
-      isFirstAdmin: false,
-      csrfToken: CSRF,
-      twoFactorEnabled: false,
-      mintableVerbs: { work: ["read", "write"] },
-    });
-    // The collapsible mint block is present, framed as secondary (headless).
-    expect(html).toContain('data-testid="token-mint"');
-    expect(html).toContain("Mint an access token");
-    expect(html).toContain("for scripts / headless clients");
-    // Both verb radios render.
-    expect(html).toContain('data-testid="mint-verb-read"');
-    expect(html).toContain('data-testid="mint-verb-write"');
-    // Form POSTs to the per-vault endpoint with the CSRF token embedded.
-    expect(html).toContain('action="/account/vault-token/work"');
-    expect(html).toContain('method="POST"');
-    expect(html).toContain('data-testid="mint-form"');
-    expect(html).toContain(CSRF);
-    // Recommends the no-token path as default.
-    expect(html).toContain("no-token");
-  });
-
-  test("mint affordance — a read-only role offers ONLY the read verb", () => {
-    // Today every assignment is write-role, but the renderer is verb-blind to
-    // the role: it shows exactly the verbs it's handed. A read-only cap must
-    // never surface a write radio (the server would reject it anyway).
-    const html = renderAccountHome({
-      username: "alice",
-      assignedVaults: ["work"],
-      passwordChanged: true,
-      hubOrigin: HUB_ORIGIN,
-      isFirstAdmin: false,
-      csrfToken: CSRF,
-      twoFactorEnabled: false,
-      mintableVerbs: { work: ["read"] },
-    });
-    expect(html).toContain('data-testid="mint-verb-read"');
-    expect(html).not.toContain('data-testid="mint-verb-write"');
-  });
-
-  test("mint affordance — offers the admin verb when the user holds it", () => {
-    // 2026-05-30: assigned users hold read/write/admin on their vault, so the
-    // mint form offers admin (the live `vaultVerbsForUserVault` returns it).
+  test("advanced settings link — present + gated on the admin verb", () => {
     const html = renderAccountHome({
       username: "alice",
       assignedVaults: ["work"],
@@ -456,12 +484,32 @@ describe("renderAccountHome", () => {
       twoFactorEnabled: false,
       mintableVerbs: { work: ["read", "write", "admin"] },
     });
-    expect(html).toContain('value="admin"');
-    expect(html).toContain('data-testid="mint-verb-admin"');
+    // One clearly-labelled "Advanced vault settings ↗" link → the SPA deep-link.
+    expect(html).toContain('data-testid="vault-admin-form"');
+    expect(html).toContain('data-testid="vault-admin-button"');
+    expect(html).toContain("Advanced vault settings");
+    expect(html).toContain('action="/account/vault-admin-token/work"');
+    expect(html).toContain('method="POST"');
+    expect(html).toContain(CSRF);
+    // The old dual-purpose "Configure / back up this vault" label is gone.
+    expect(html).not.toContain("Configure / back up this vault");
   });
 
-  test("mint affordance — absent when no mintable verbs (admin / no-vault / unmapped role)", () => {
-    // Admin branch: no tiles at all, so no mint block.
+  test("advanced settings link — absent when the user lacks the admin verb", () => {
+    // A read/write-only assignment must not surface the admin deep-link (the
+    // POST handler would 403 the admin token mint).
+    const html = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["work"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+      mintableVerbs: { work: ["read", "write"] },
+    });
+    expect(html).not.toContain('data-testid="vault-admin-button"');
+    // Admin branch: no tiles at all, so no advanced link.
     const admin = renderAccountHome({
       username: "admin",
       assignedVaults: [],
@@ -471,19 +519,7 @@ describe("renderAccountHome", () => {
       csrfToken: CSRF,
       twoFactorEnabled: false,
     });
-    expect(admin).not.toContain('data-testid="token-mint"');
-    // Assigned vault but empty verb list (fail-closed unknown role) → no block.
-    const empty = renderAccountHome({
-      username: "alice",
-      assignedVaults: ["work"],
-      passwordChanged: true,
-      hubOrigin: HUB_ORIGIN,
-      isFirstAdmin: false,
-      csrfToken: CSRF,
-      twoFactorEnabled: false,
-      mintableVerbs: { work: [] },
-    });
-    expect(empty).not.toContain('data-testid="token-mint"');
+    expect(admin).not.toContain('data-testid="vault-admin-button"');
   });
 
   test("minted-token banner — shows the token once with a save-it warning, no revoke claim", () => {
@@ -645,8 +681,10 @@ describe("renderAccountHome", () => {
       connectedVault: false,
     });
     // The checklist's connect step references the first/primary vault; the
-    // per-vault tiles below still list every vault.
+    // per-vault tiles below still list every vault (by name + Notes CTA), but
+    // no longer repeat the connect endpoint (dedup — connect lives only here).
     expect(html).toMatch(/data-testid="onboarding-mcp-endpoint">[^<]*\/vault\/personal\/mcp</);
-    expect(html).toContain(`${HUB_ORIGIN}/vault/family/mcp`); // still present in the vault tiles
+    expect(html).toContain("<strong>family</strong>"); // second vault still has a tile
+    expect(html).not.toContain(`${HUB_ORIGIN}/vault/family/mcp`); // no duplicated connect
   });
 });

--- a/src/__tests__/account-mirror.test.ts
+++ b/src/__tests__/account-mirror.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for the `/account/` per-vault backup (mirror) status fetch +
+ * formatting (`account-mirror.ts`). The fetch mints an admin-scoped token + hits
+ * the vault's loopback `/.parachute/mirror` endpoint; it must be fault-tolerant
+ * (any failure → null) and shape-strict (a malformed body → null, not a render
+ * of `undefined`). Mirrors `account-usage.test.ts`'s posture.
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type VaultMirrorStat,
+  fetchVaultMirrorStatus,
+  formatMirrorLine,
+} from "../account-mirror.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+
+interface Harness {
+  db: Database;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-account-mirror-"));
+  const db = openHubDb(hubDbPath(dir));
+  return {
+    db,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+/** A stub signer — no real key needed; the fetch only carries the token string. */
+const stubSign = async () => ({
+  token: "stub.jwt.token",
+  jti: "jti-1",
+  expiresAt: new Date(Date.now() + 60000).toISOString(),
+});
+
+function baseDeps(fetchImpl: typeof fetch) {
+  return {
+    db: harness.db,
+    hubOrigin: "https://hub.test",
+    vaultPort: 1940,
+    userId: "user-1",
+    fetchImpl,
+    signToken: stubSign as never,
+  };
+}
+
+describe("fetchVaultMirrorStatus", () => {
+  test("returns enabled+not-pushing on a backed-up, local-only config", async () => {
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({
+          config: { enabled: true, location: "internal", auto_push: false },
+          status: { enabled: true, last_commit_sha: "abc", last_error: null },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as unknown as typeof fetch;
+    const stat = await fetchVaultMirrorStatus("work", baseDeps(fetchImpl));
+    expect(stat).toEqual({ enabled: true, pushing: false });
+  });
+
+  test("flags pushing when auto_push is configured", async () => {
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({ config: { enabled: true, location: "internal", auto_push: true } }),
+        { status: 200 },
+      )) as unknown as typeof fetch;
+    const stat = await fetchVaultMirrorStatus("work", baseDeps(fetchImpl));
+    expect(stat).toEqual({ enabled: true, pushing: true });
+  });
+
+  test("returns enabled:false when backup is off", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ config: { enabled: false, auto_push: false } }), {
+        status: 200,
+      })) as unknown as typeof fetch;
+    const stat = await fetchVaultMirrorStatus("work", baseDeps(fetchImpl));
+    expect(stat).toEqual({ enabled: false, pushing: false });
+  });
+
+  test("mints an ADMIN-scoped Bearer + hits the vault's loopback mirror endpoint", async () => {
+    let seenUrl = "";
+    let seenAuth = "";
+    let seenScope: string[] = [];
+    const captureSign = (async (_db: unknown, opts: { scopes: string[] }) => {
+      seenScope = opts.scopes;
+      return { token: "stub.jwt.token", jti: "j", expiresAt: new Date().toISOString() };
+    }) as never;
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      seenUrl = url;
+      seenAuth = (init?.headers as Record<string, string>)?.authorization ?? "";
+      return new Response(JSON.stringify({ config: { enabled: true, auto_push: false } }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+    await fetchVaultMirrorStatus("work", { ...baseDeps(fetchImpl), signToken: captureSign });
+    expect(seenUrl).toBe("http://127.0.0.1:1940/vault/work/.parachute/mirror");
+    expect(seenAuth).toBe("Bearer stub.jwt.token");
+    expect(seenScope).toEqual(["vault:work:admin"]);
+  });
+
+  test("returns null on a non-2xx response (vault down / 403 / 404)", async () => {
+    for (const status of [403, 404, 500]) {
+      const fetchImpl = (async () => new Response("nope", { status })) as unknown as typeof fetch;
+      const stat = await fetchVaultMirrorStatus("work", baseDeps(fetchImpl));
+      expect(stat).toBeNull();
+    }
+  });
+
+  test("returns null when the body is malformed (missing config.enabled)", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ config: {} }), { status: 200 })) as unknown as typeof fetch;
+    const stat = await fetchVaultMirrorStatus("work", baseDeps(fetchImpl));
+    expect(stat).toBeNull();
+  });
+
+  test("returns null when fetch throws (network error)", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const stat = await fetchVaultMirrorStatus("work", baseDeps(fetchImpl));
+    expect(stat).toBeNull();
+  });
+});
+
+describe("formatMirrorLine", () => {
+  test("warm plain-language line; GitHub variant when pushing", () => {
+    expect(formatMirrorLine({ enabled: true, pushing: false } as VaultMirrorStat)).toBe(
+      "Backed up — full version history",
+    );
+    expect(formatMirrorLine({ enabled: true, pushing: true } as VaultMirrorStat)).toBe(
+      "Backed up — version history + GitHub",
+    );
+  });
+
+  test("returns null when backup is off (the tile omits the line, never nags)", () => {
+    expect(formatMirrorLine({ enabled: false, pushing: false } as VaultMirrorStat)).toBeNull();
+  });
+});

--- a/src/__tests__/account-mirror.test.ts
+++ b/src/__tests__/account-mirror.test.ts
@@ -71,7 +71,7 @@ describe("fetchVaultMirrorStatus", () => {
         { status: 200, headers: { "content-type": "application/json" } },
       )) as unknown as typeof fetch;
     const stat = await fetchVaultMirrorStatus("work", baseDeps(fetchImpl));
-    expect(stat).toEqual({ enabled: true, pushing: false });
+    expect(stat).toEqual({ enabled: true, backedUpToRemote: false });
   });
 
   test("flags pushing when auto_push is configured", async () => {
@@ -81,7 +81,7 @@ describe("fetchVaultMirrorStatus", () => {
         { status: 200 },
       )) as unknown as typeof fetch;
     const stat = await fetchVaultMirrorStatus("work", baseDeps(fetchImpl));
-    expect(stat).toEqual({ enabled: true, pushing: true });
+    expect(stat).toEqual({ enabled: true, backedUpToRemote: true });
   });
 
   test("returns enabled:false when backup is off", async () => {
@@ -90,7 +90,7 @@ describe("fetchVaultMirrorStatus", () => {
         status: 200,
       })) as unknown as typeof fetch;
     const stat = await fetchVaultMirrorStatus("work", baseDeps(fetchImpl));
-    expect(stat).toEqual({ enabled: false, pushing: false });
+    expect(stat).toEqual({ enabled: false, backedUpToRemote: false });
   });
 
   test("mints an ADMIN-scoped Bearer + hits the vault's loopback mirror endpoint", async () => {
@@ -140,15 +140,17 @@ describe("fetchVaultMirrorStatus", () => {
 
 describe("formatMirrorLine", () => {
   test("warm plain-language line; GitHub variant when pushing", () => {
-    expect(formatMirrorLine({ enabled: true, pushing: false } as VaultMirrorStat)).toBe(
+    expect(formatMirrorLine({ enabled: true, backedUpToRemote: false } as VaultMirrorStat)).toBe(
       "Backed up — full version history",
     );
-    expect(formatMirrorLine({ enabled: true, pushing: true } as VaultMirrorStat)).toBe(
+    expect(formatMirrorLine({ enabled: true, backedUpToRemote: true } as VaultMirrorStat)).toBe(
       "Backed up — version history + GitHub",
     );
   });
 
   test("returns null when backup is off (the tile omits the line, never nags)", () => {
-    expect(formatMirrorLine({ enabled: false, pushing: false } as VaultMirrorStat)).toBeNull();
+    expect(
+      formatMirrorLine({ enabled: false, backedUpToRemote: false } as VaultMirrorStat),
+    ).toBeNull();
   });
 });

--- a/src/__tests__/api-account.test.ts
+++ b/src/__tests__/api-account.test.ts
@@ -955,11 +955,14 @@ describe("handleAccountHomeGet", () => {
       hubOrigin: HUB_ORIGIN,
       resolveVaultPort: () => 1940,
       // Stub the mirror fetch: resolves to a backed-up, GitHub-pushing config.
-      fetchMirror: async () => ({ enabled: true, pushing: true }),
+      fetchMirror: async () => ({ enabled: true, backedUpToRemote: true }),
     });
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain('data-testid="backup-state-line"');
+    // Already pushing → the handler threads mirrorPushing=true, so the
+    // "Back up to GitHub ↗" action is suppressed.
+    expect(html).not.toContain('data-testid="backup-github-button"');
     expect(html).toContain("version history + GitHub");
   });
 

--- a/src/__tests__/api-account.test.ts
+++ b/src/__tests__/api-account.test.ts
@@ -922,7 +922,7 @@ describe("handleAccountHomeGet", () => {
     expect(html).not.toContain('data-testid="vault-usage"');
   });
 
-  test("renders the 'Configure / back up this vault ↗' deep-link button for an assigned vault", async () => {
+  test("renders the 'Advanced vault settings ↗' deep-link button for an assigned vault", async () => {
     await createUser(harness.db, "admin", "admin-passphrase", { passwordChanged: true });
     const friend = await createUser(harness.db, "alice", "alice-passphrase", {
       allowMulti: true,
@@ -936,6 +936,53 @@ describe("handleAccountHomeGet", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain('data-testid="vault-admin-button"');
+    expect(html).toContain("Advanced vault settings");
     expect(html).toContain('action="/account/vault-admin-token/alice"');
+  });
+
+  test("renders the backup-state line when the mirror status resolves enabled", async () => {
+    await createUser(harness.db, "admin", "admin-passphrase", { passwordChanged: true });
+    const friend = await createUser(harness.db, "alice", "alice-passphrase", {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVaults: ["alice"],
+    });
+    const session = createSession(harness.db, { userId: friend.id });
+    const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+    const req = new Request(`${HUB_ORIGIN}/account/`, { headers: { cookie } });
+    const res = await handleAccountHomeGet(req, {
+      db: harness.db,
+      hubOrigin: HUB_ORIGIN,
+      resolveVaultPort: () => 1940,
+      // Stub the mirror fetch: resolves to a backed-up, GitHub-pushing config.
+      fetchMirror: async () => ({ enabled: true, pushing: true }),
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('data-testid="backup-state-line"');
+    expect(html).toContain("version history + GitHub");
+  });
+
+  test("omits the backup line gracefully when the mirror fetch fails (null)", async () => {
+    await createUser(harness.db, "admin", "admin-passphrase", { passwordChanged: true });
+    const friend = await createUser(harness.db, "alice", "alice-passphrase", {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVaults: ["alice"],
+    });
+    const session = createSession(harness.db, { userId: friend.id });
+    const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+    const req = new Request(`${HUB_ORIGIN}/account/`, { headers: { cookie } });
+    const res = await handleAccountHomeGet(req, {
+      db: harness.db,
+      hubOrigin: HUB_ORIGIN,
+      resolveVaultPort: () => 1940,
+      fetchMirror: async () => null,
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Tile still renders; just no backup line.
+    expect(html).toContain("<strong>alice</strong>");
+    expect(html).not.toContain('data-testid="backup-state-line"');
   });
 });

--- a/src/account-home-ui.ts
+++ b/src/account-home-ui.ts
@@ -150,17 +150,34 @@ export interface RenderAccountHomeOpts {
    */
   mirrorLines?: Record<string, string>;
   /**
+   * Per-vault "is backup already pushing to a remote?" flag (the vault's
+   * `config.auto_push`, threaded from `VaultMirrorStat.backedUpToRemote`). Maps
+   * `vaultName` → `true` when an auto-push remote is configured. Drives whether
+   * the tile suppresses the "Back up to GitHub ↗" action — gated on this proper
+   * boolean, NOT re-derived from the `mirrorLines` display string. A vault absent
+   * defaults to `false` (offer the action). Built alongside `mirrorLines` by the
+   * GET handler; omitted on the admin / no-vault branches.
+   */
+  mirrorPushing?: Record<string, boolean>;
+  /**
    * Set after a successful `POST /account/vault-token/<name>` to show the
    * freshly-minted token ONCE (the only time it's ever shown — the hub keeps
    * no plaintext copy). Drives the show-once banner at the top of the page.
    * Absent on the normal GET render.
+   *
+   * NOT vestigial after the 2026-06-04 token-mint-UI removal: the page no
+   * longer renders the mint *form*, but the `POST /account/vault-token/<name>`
+   * route still exists (a script/advanced path) and on success re-renders THIS
+   * page with `mintedToken` set, so the show-once banner still fires for that
+   * flow. The renderer keeps the prop + banner for it.
    */
   mintedToken?: MintedTokenView;
   /**
    * Set after a `POST /account/vault-token/<name>` that failed authorization
    * or validation, to surface an inline error banner on the re-rendered page
    * (e.g. unassigned vault, capped verb, rate-limited). Absent on success and
-   * on the normal GET render.
+   * on the normal GET render. Same non-vestigial note as `mintedToken`: the
+   * mint route still re-renders this page, so the error banner stays live.
    */
   mintError?: string;
   /**
@@ -222,6 +239,11 @@ export function renderAccountHome(opts: RenderAccountHomeOpts): string {
   // condenses to a quiet "you're connected" line so it stops nagging. Shown
   // only on the assigned-vault branch — the admin + no-vault branches have no
   // single "your vault" to connect, so the checklist would be misleading there.
+  // TODO(multi-vault): `connectedVault` is true if ANY of the user's vaults has
+  // a grant (handler uses `.some(...)`), but the checklist shows the connect step
+  // for the FIRST vault only. With multiple vaults, connecting vault B condenses
+  // the checklist even though the displayed primary vault A isn't connected. Fine
+  // today — single-vault is the live case; revisit if multi-vault ships.
   const checklist =
     assignedVaults.length > 0
       ? renderOnboardingChecklist({
@@ -239,6 +261,7 @@ export function renderAccountHome(opts: RenderAccountHomeOpts): string {
     mintableVerbs: opts.mintableVerbs ?? {},
     usageStats: opts.usageStats ?? {},
     mirrorLines: opts.mirrorLines ?? {},
+    mirrorPushing: opts.mirrorPushing ?? {},
   });
 
   const accountCard = renderAccountCard({
@@ -418,6 +441,8 @@ interface VaultCardOpts {
   usageStats: Record<string, string>;
   /** `vaultName` → pre-formatted backup line ("Backed up — full version history"). */
   mirrorLines: Record<string, string>;
+  /** `vaultName` → is backup already pushing to a remote (gates the GitHub action). */
+  mirrorPushing: Record<string, boolean>;
 }
 
 /**
@@ -449,7 +474,7 @@ export function accountClaudeMcpAddCommand(trimmedOrigin: string, vaultName: str
 function renderVaultCard(opts: VaultCardOpts): string {
   const { assignedVaults, trimmedOrigin, isFirstAdmin, csrfToken, mintableVerbs, usageStats } =
     opts;
-  const { mirrorLines } = opts;
+  const { mirrorLines, mirrorPushing } = opts;
 
   if (assignedVaults.length > 0) {
     // One vault tile per assignment (multi-user Phase 2 PR 2). The tile is the
@@ -487,7 +512,13 @@ function renderVaultCard(opts: VaultCardOpts): string {
         // deep-link that opens the vault config SPA. Omitted silently when the
         // mirror fetch failed / backup is off (the renderer just gets no entry).
         const mirrorLine = mirrorLines[vaultName];
-        const backupBlock = renderBackupBlock(vaultName, mirrorLine, holdsAdmin, csrfToken);
+        const backupBlock = renderBackupBlock(
+          vaultName,
+          mirrorLine,
+          mirrorPushing[vaultName] ?? false,
+          holdsAdmin,
+          csrfToken,
+        );
         return `
         <div class="vault-tile" data-testid="vault-tile" data-vault-name="${safeVault}">
           <p class="vault-name"><strong>${safeVault}</strong></p>
@@ -560,17 +591,19 @@ function renderVaultCard(opts: VaultCardOpts): string {
  * `/account/vault-admin-token/<name>` deep-link (the same POST `renderVaultAdminLink`
  * uses) — it mints a `vault:<name>:admin` token and opens the vault config SPA,
  * where the GitHub push is configured. We do NOT invent a new auth path. It's
- * shown only when the user holds admin AND the backup line says they're not
- * already pushing (no "+ GitHub").
+ * shown only when the user holds admin AND `pushing` is false (not already
+ * pushing to a remote) — `pushing` is a proper boolean threaded from the mirror
+ * status (`VaultMirrorStat.backedUpToRemote`), never re-derived from the
+ * display string.
  */
 function renderBackupBlock(
   vaultName: string,
   mirrorLine: string | undefined,
+  pushing: boolean,
   holdsAdmin: boolean,
   csrfToken: string,
 ): string {
   if (!mirrorLine) return "";
-  const pushing = mirrorLine.includes("GitHub");
   // "Back up to GitHub ↗" — only when admin (the deep-link mints admin) and not
   // already pushing. Reuses the vault-admin-token deep-link to open the SPA's
   // backup page; no new auth path.

--- a/src/account-home-ui.ts
+++ b/src/account-home-ui.ts
@@ -117,15 +117,16 @@ export interface RenderAccountHomeOpts {
    */
   twoFactorEnabled: boolean;
   /**
-   * Per-vault mintable verbs for the "mint an access token" affordance on
-   * each vault tile (friend headless-client path). Maps `vaultName` → the
-   * verbs the user's assignment role permits (today always
-   * `["read", "write"]` since every `user_vaults.role` is `'write'`). A
-   * vault absent from this map (or mapped to an empty list) renders no mint
-   * affordance — the UI never offers a verb the server would reject. The
-   * `/account/` GET handler builds this from `vaultVerbsForUserVault` for
-   * each assigned vault. Omitted (or empty) for the admin / no-vault
-   * branches, where no token-mint tile is shown.
+   * Per-vault verbs the user's assignment role permits. Maps `vaultName` → the
+   * verbs (today `["read", "write", "admin"]` since every `user_vaults.role` is
+   * `'write'`, which grants admin). Now used solely to GATE the per-tile
+   * "Advanced vault settings ↗" deep-link (and the "Back up to GitHub ↗" action)
+   * on the `admin` verb — the deep-link mints a `vault:<name>:admin` token, so
+   * the button never offers authority the POST handler would 403. (The old
+   * token-mint affordance this map also drove was dropped from `/account/`
+   * 2026-06-04 — OAuth-first; minting header-auth tokens is an advanced concern
+   * that lives in the vault config SPA.) Omitted (or empty) for the admin /
+   * no-vault branches, where no vault tile is shown.
    */
   mintableVerbs?: Record<string, VaultVerb[]>;
   /**
@@ -137,6 +138,17 @@ export interface RenderAccountHomeOpts {
    * that don't resolve). Omitted entirely on the admin / no-vault branches.
    */
   usageStats?: Record<string, string>;
+  /**
+   * Per-vault backup (mirror) line for each assigned vault tile. Maps
+   * `vaultName` → the warm, pre-formatted line ("Backed up — full version
+   * history", or "… + GitHub" when a push remote is configured). A vault absent
+   * from this map renders no backup line — the page tolerates a vault whose
+   * mirror endpoint failed / is unreachable / is backup-off (the `/account/` GET
+   * handler builds this map by fetching `/.parachute/mirror` per admin-held
+   * vault and omitting any that don't resolve or read backup-off). Omitted
+   * entirely on the admin / no-vault branches.
+   */
+  mirrorLines?: Record<string, string>;
   /**
    * Set after a successful `POST /account/vault-token/<name>` to show the
    * freshly-minted token ONCE (the only time it's ever shown — the hub keeps
@@ -226,6 +238,7 @@ export function renderAccountHome(opts: RenderAccountHomeOpts): string {
     csrfToken,
     mintableVerbs: opts.mintableVerbs ?? {},
     usageStats: opts.usageStats ?? {},
+    mirrorLines: opts.mirrorLines ?? {},
   });
 
   const accountCard = renderAccountCard({
@@ -352,7 +365,7 @@ function renderOnboardingChecklist(opts: OnboardingChecklistOpts): string {
         </li>
       </ol>
       <p class="onboarding-foot" data-testid="onboarding-foot">Your vault is
-         <code>${safeVault}</code>. Full connect details, Notes, backup, and access tokens are
+         <code>${safeVault}</code>. Its size, backup state, Notes, and advanced settings are
          just below.</p>
     </section>`;
 }
@@ -403,6 +416,8 @@ interface VaultCardOpts {
   mintableVerbs: Record<string, VaultVerb[]>;
   /** `vaultName` → pre-formatted usage stat ("X notes · Y MB"). */
   usageStats: Record<string, string>;
+  /** `vaultName` → pre-formatted backup line ("Backed up — full version history"). */
+  mirrorLines: Record<string, string>;
 }
 
 /**
@@ -434,84 +449,50 @@ export function accountClaudeMcpAddCommand(trimmedOrigin: string, vaultName: str
 function renderVaultCard(opts: VaultCardOpts): string {
   const { assignedVaults, trimmedOrigin, isFirstAdmin, csrfToken, mintableVerbs, usageStats } =
     opts;
+  const { mirrorLines } = opts;
 
   if (assignedVaults.length > 0) {
-    // One vault tile per assignment (multi-user Phase 2 PR 2). Each tile
-    // leads with a friendly "connect your AI assistant to this vault" block
-    // that covers BOTH connect paths a non-technical friend is likely to
-    // use — Claude Code (the `claude mcp add` CLI command) and Claude.ai on
-    // the web (Settings → Connectors → Add custom connector, pointed at the
-    // endpoint). Both are the OAuth path — no token to paste, the first
-    // connection opens a browser to sign in + approve. The Notes "Open" CTA
-    // sits alongside as the browser-UI option. Phrasing mirrors
-    // parachute.computer/install.njk's #connect-mcp-clients section so the
-    // operator docs and the friend's account page stay consistent.
-    //
-    // This closes the multi-user gap where the friend tile read as MCP
-    // jargon ("Connect an MCP client") rather than "here's how to connect
-    // this to your AI" — and where the web (Claude.ai) path was entirely
-    // missing, only the Claude Code CLI command was offered.
+    // One vault tile per assignment (multi-user Phase 2 PR 2). The tile is the
+    // everyday "here's your vault" detail card — name, size, backup state, a
+    // browser-UI on-ramp (Notes + "build your own"), and a single deep-link
+    // into the advanced vault settings SPA. It deliberately does NOT repeat the
+    // "Connect your AI" instructions: the onboarding checklist above owns that
+    // step (collapsing to "✓ You're connected" once a grant lands), so the
+    // page never shows the connect endpoint + both methods twice. Token minting
+    // + raw mirror config are advanced concerns that live in the vault config
+    // SPA, reached via "Advanced vault settings ↗" — not duplicated here.
     const heading = assignedVaults.length === 1 ? "<h2>Your vault</h2>" : "<h2>Your vaults</h2>";
     const tiles = assignedVaults
       .map((vaultName) => {
         const safeVault = escapeHtml(vaultName);
         const vaultUrlForAdd = encodeURIComponent(`${trimmedOrigin}/vault/${vaultName}`);
-        const endpoint = accountMcpEndpoint(trimmedOrigin, vaultName);
-        const addCmd = accountClaudeMcpAddCommand(trimmedOrigin, vaultName);
-        const safeEndpoint = escapeHtml(endpoint);
-        const safeAddCmd = escapeHtml(addCmd);
         const verbsForVault = mintableVerbs[vaultName] ?? [];
-        const tokenMintBlock = renderTokenMintBlock(vaultName, safeVault, verbsForVault, csrfToken);
-        // "Configure / back up this vault ↗" — only for users whose assignment
-        // grants `admin` (the verb the deep-link mints). Today every assigned
-        // user holds admin, but gate on the verb so the button never offers
-        // authority the POST handler would 403.
-        const manageBlock = verbsForVault.includes("admin")
-          ? renderVaultAdminLink(vaultName, csrfToken)
-          : "";
+        const holdsAdmin = verbsForVault.includes("admin");
+        // "Advanced vault settings ↗" — only for users whose assignment grants
+        // `admin` (the verb the deep-link mints). Today every assigned user
+        // holds admin, but gate on the verb so the button never offers
+        // authority the POST handler would 403. The single advanced entry point:
+        // schema, tokens, retention, raw mirror config all live in the SPA.
+        const manageBlock = holdsAdmin ? renderVaultAdminLink(vaultName, csrfToken) : "";
         // Compact usage stat ("X notes · Y MB"), when the vault's usage endpoint
         // resolved. Omitted gracefully otherwise.
         const usageStat = usageStats[vaultName];
         const usageLine = usageStat
           ? `<p class="vault-usage" data-testid="vault-usage">${escapeHtml(usageStat)}</p>`
           : "";
+        // Backup state line + a "Back up to GitHub ↗" deep-link when not already
+        // pushing. Both gated on admin: the backup line is only fetched for
+        // admin-held vaults (the mirror endpoint is admin-scoped), and the
+        // GitHub action reuses the same `/account/vault-admin-token/<name>`
+        // deep-link that opens the vault config SPA. Omitted silently when the
+        // mirror fetch failed / backup is off (the renderer just gets no entry).
+        const mirrorLine = mirrorLines[vaultName];
+        const backupBlock = renderBackupBlock(vaultName, mirrorLine, holdsAdmin, csrfToken);
         return `
         <div class="vault-tile" data-testid="vault-tile" data-vault-name="${safeVault}">
           <p class="vault-name"><strong>${safeVault}</strong></p>
           ${usageLine}
-          <div class="mcp-connect" data-testid="mcp-connect">
-            <p class="mcp-connect-label" data-testid="connect-ai-heading">Connect your AI
-               assistant to this vault</p>
-            <p class="mcp-connect-intro">Two common ways. Both sign you in to this hub over
-               HTTPS and ask you to approve access the first time — no token to copy.</p>
-
-            <div class="mcp-method" data-testid="connect-method-claude-code">
-              <p class="mcp-method-title">Claude Code (terminal)</p>
-              <p class="mcp-method-sub">Run this in your terminal:</p>
-              <div class="copy-row">
-                <code data-testid="mcp-add-command">${safeAddCmd}</code>
-                <button type="button" class="btn btn-copy" data-copy="${safeAddCmd}"
-                        data-testid="copy-mcp-add-command">Copy</button>
-              </div>
-            </div>
-
-            <div class="mcp-method" data-testid="connect-method-claude-ai">
-              <p class="mcp-method-title">Claude.ai (web)</p>
-              <p class="mcp-method-sub">In Claude.ai, open <strong>Settings → Connectors</strong>,
-                 choose <strong>Add custom connector</strong>, and paste this endpoint:</p>
-              <div class="copy-row">
-                <code data-testid="mcp-endpoint">${safeEndpoint}</code>
-                <button type="button" class="btn btn-copy" data-copy="${safeEndpoint}"
-                        data-testid="copy-mcp-endpoint">Copy</button>
-              </div>
-              <p class="mcp-method-note">Claude.ai then redirects you here to sign in and
-                 approve. (Your hub must be reachable from the web for this.)</p>
-            </div>
-
-            <p class="mcp-connect-hint" data-testid="connect-any-client-hint">Using something
-               else? Point any MCP client at the same endpoint above. (ChatGPT and some other
-               web UIs call these "connectors.")</p>
-          </div>
+          ${backupBlock}
           <p class="vault-notes-cta">
             <a class="btn btn-primary" href="https://notes.parachute.computer/add?url=${vaultUrlForAdd}"
                target="_blank" rel="noopener" data-testid="open-notes-cta">Open Notes ↗</a>
@@ -521,19 +502,21 @@ function renderVaultCard(opts: VaultCardOpts): string {
                capture in this vault — or jump straight to bulk-importing Markdown/Obsidian
                notes into it.</span>
           </p>
+          <p class="vault-build-ui" data-testid="build-your-own-ui">Notes is just one way to see
+             your vault — when you're ready, your AI can build you a custom UI for it in a few
+             minutes. <a href="https://parachute.computer/onboarding/surface-build/"
+             target="_blank" rel="noopener" data-testid="build-your-own-ui-link">Build your own ↗</a></p>
           ${manageBlock}
-          ${tokenMintBlock}
         </div>`;
       })
       .join("");
     return `
       <section class="section" data-testid="vault-card">
         ${heading}
-        <p>Connect Claude (or any AI assistant) to your vault${
+        <p>Your vault${
           assignedVaults.length === 1 ? "" : "s"
-        } — pick Claude Code or
-          Claude.ai below — or open Notes for a browser UI. The first connection signs you in
-          to your hub over HTTPS and asks you to approve access.</p>
+        } at a glance — size, backup, and a browser UI. You connect your AI from the
+          steps above; the deeper settings live one click away.</p>
         <div class="vault-tiles">${tiles}
         </div>
       </section>`;
@@ -563,83 +546,60 @@ function renderVaultCard(opts: VaultCardOpts): string {
 }
 
 /**
- * The "mint an access token (for scripts / headless clients)" affordance on a
- * vault tile. Sits BELOW the OAuth connect block + Notes CTA — the no-token
- * OAuth path stays the recommended default; this is the secondary, opt-in
- * path for clients that can't do an interactive browser sign-in (cron jobs,
- * headless agents, a `curl` script).
+ * The backup-state block on a vault tile: a warm, plain-language line telling
+ * the owner their vault is backed up (local version history, optionally pushed
+ * to GitHub), plus a "Back up to GitHub ↗" action when no push remote is set.
  *
- * Renders one radio per verb the user's assignment role permits (`verbs` —
- * today always `["read", "write"]`). The UI NEVER offers a verb the server
- * would reject: a read-only assignment shows only "Read". An empty `verbs`
- * list (unknown / unmappable role) renders nothing — fail-closed, matching
- * the server's `vaultVerbsForUserVault` returning `[]`.
+ * `mirrorLine` is the pre-formatted backup line ("Backed up — full version
+ * history" / "… + GitHub") the GET handler built from the vault's mirror status,
+ * or `undefined` when the mirror fetch failed / backup is off / the user doesn't
+ * hold admin. When absent, the whole block is omitted silently — the everyday
+ * home never nags with a "not backed up" warning.
  *
- * The form POSTs `application/x-www-form-urlencoded` to
- * `/account/vault-token/<name>` with the CSRF hidden field + a `verb` radio —
- * same no-JS-required posture as the change-password and sign-out forms. The
- * `<details>` keeps it collapsed by default so the tile leads with the
- * recommended OAuth path.
+ * The "Back up to GitHub ↗" action reuses the EXISTING
+ * `/account/vault-admin-token/<name>` deep-link (the same POST `renderVaultAdminLink`
+ * uses) — it mints a `vault:<name>:admin` token and opens the vault config SPA,
+ * where the GitHub push is configured. We do NOT invent a new auth path. It's
+ * shown only when the user holds admin AND the backup line says they're not
+ * already pushing (no "+ GitHub").
  */
-function renderTokenMintBlock(
+function renderBackupBlock(
   vaultName: string,
-  safeVault: string,
-  verbs: VaultVerb[],
+  mirrorLine: string | undefined,
+  holdsAdmin: boolean,
   csrfToken: string,
 ): string {
-  if (verbs.length === 0) return "";
-  // Path segment is URL-encoded; the action attribute is HTML-escaped on top.
-  const action = escapeHtml(`/account/vault-token/${encodeURIComponent(vaultName)}`);
-  const radios = verbs
-    .map((verb, i) => {
-      const checked = i === 0 ? " checked" : "";
-      const label =
-        verb === "read"
-          ? "Read-only"
-          : verb === "admin"
-            ? "Full (read, write, rotate tokens + config)"
-            : "Read + write";
-      return `
-              <label class="mint-verb-option">
-                <input type="radio" name="verb" value="${verb}"${checked}
-                       data-testid="mint-verb-${verb}" />
-                <span><strong>${verb}</strong> — ${label} access to <code>${safeVault}</code></span>
-              </label>`;
-    })
-    .join("");
+  if (!mirrorLine) return "";
+  const pushing = mirrorLine.includes("GitHub");
+  // "Back up to GitHub ↗" — only when admin (the deep-link mints admin) and not
+  // already pushing. Reuses the vault-admin-token deep-link to open the SPA's
+  // backup page; no new auth path.
+  const action = escapeHtml(`/account/vault-admin-token/${encodeURIComponent(vaultName)}`);
+  const githubAction =
+    holdsAdmin && !pushing
+      ? `
+            <form method="POST" action="${action}" class="vault-backup-github"
+                  data-testid="backup-github-form">
+              ${renderCsrfHiddenInput(csrfToken)}
+              <button type="submit" class="btn btn-secondary" data-testid="backup-github-button">
+                Back up to GitHub ↗
+              </button>
+            </form>`
+      : "";
   return `
-          <details class="token-mint" data-testid="token-mint">
-            <summary data-testid="token-mint-summary">Mint an access token
-              <span class="token-mint-sub">for scripts / headless clients</span></summary>
-            <div class="token-mint-body">
-              <p class="token-mint-intro">Most clients should use the no-token
-                connect options above — they sign you in over HTTPS and never
-                ask you to paste a secret. Mint a token only for a script or
-                headless client that can't open a browser to sign in. It's a
-                bearer for <code>vault:${safeVault}:&lt;verb&gt;</code>, scoped to
-                <strong>this vault only</strong>, and you'll see it once.</p>
-              <form method="POST" action="${action}" class="mint-form"
-                    data-testid="mint-form">
-                ${renderCsrfHiddenInput(csrfToken)}
-                <fieldset class="mint-verbs">
-                  <legend>Access level</legend>${radios}
-                </fieldset>
-                <button type="submit" class="btn btn-secondary"
-                        data-testid="mint-token-button">Mint token</button>
-              </form>
-            </div>
-          </details>`;
+          <div class="vault-backup" data-testid="vault-backup">
+            <p class="vault-backup-line" data-testid="backup-state-line">
+              <span class="vault-backup-check" aria-hidden="true">✓</span>${escapeHtml(mirrorLine)}</p>${githubAction}
+          </div>`;
 }
 
 /**
- * The "Configure / back up this vault ↗" affordance on a vault tile. A small
- * POST form to `/account/vault-admin-token/<name>` that mints a
- * `vault:<name>:admin` deep-link token and redirects into the vault's own admin
- * SPA — where the assigned user can rotate vault tokens AND set up Git backup /
- * mirror config. Shown only when the user's assignment grants `admin` (gated by
- * the caller). A plain form button (no `<details>`) — this is a primary admin
- * action for an individual user, more prominent than the headless-token mint
- * below it.
+ * The "Advanced vault settings ↗" affordance on a vault tile — the single
+ * advanced entry point. A small POST form to `/account/vault-admin-token/<name>`
+ * that mints a `vault:<name>:admin` deep-link token and redirects into the
+ * vault's own config SPA — where the assigned user can manage schema, rotate
+ * access tokens, set retention, and edit raw mirror/backup config. Shown only
+ * when the user's assignment grants `admin` (gated by the caller).
  *
  * No-JS posture: a same-origin form POST that 303-redirects on success, same
  * shape as the other `/account/*` forms. CSRF-gated via the hidden field.
@@ -652,10 +612,10 @@ function renderVaultAdminLink(vaultName: string, csrfToken: string): string {
                 data-testid="vault-admin-form">
             ${renderCsrfHiddenInput(csrfToken)}
             <button type="submit" class="btn btn-secondary" data-testid="vault-admin-button">
-              Configure / back up this vault ↗
+              Advanced vault settings ↗
             </button>
-            <span class="vault-admin-sub">Open this vault's admin tools — rotate access tokens,
-               and set up Git backup (mirror to a repository).</span>
+            <span class="vault-admin-sub">Open this vault's config — schema, access tokens,
+               retention, and raw backup settings.</span>
           </form>`;
 }
 
@@ -766,8 +726,8 @@ const COPY_SCRIPT = `
 //
 // Same brand palette + font stack as account-change-password-ui.ts so the
 // `/account/*` family is visually cohesive. Extra rules (.section, .kv,
-// .vault-name, .mcp-connect, .copy-row) describe the new card + MCP
-// connect-block shapes this page introduces.
+// .vault-name, .vault-backup, .vault-build-ui, .copy-row) describe the card +
+// backup-state + onboarding-checklist shapes this page introduces.
 
 const STYLES = `
   *, *::before, *::after { box-sizing: border-box; }
@@ -989,6 +949,36 @@ const STYLES = `
     color: ${PALETTE.fgMuted};
     margin: 0 0 0.5rem;
   }
+  .vault-backup { margin: 0 0 0.5rem; }
+  .vault-backup-line {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.85rem;
+    color: ${PALETTE.success};
+    margin: 0;
+  }
+  .vault-backup-check {
+    flex: 0 0 auto;
+    width: 1.1rem;
+    height: 1.1rem;
+    border-radius: 999px;
+    background: ${PALETTE.successSoft};
+    color: ${PALETTE.success};
+    border: 1px solid ${PALETTE.success};
+    font-size: 0.7rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .vault-backup-github { margin: 0.4rem 0 0; }
+  .vault-build-ui {
+    font-size: 0.82rem;
+    color: ${PALETTE.fgMuted};
+    margin: 0.6rem 0 0;
+    padding-top: 0.6rem;
+    border-top: 1px solid ${PALETTE.borderLight};
+  }
   .vault-tiles {
     display: flex;
     flex-direction: column;
@@ -1004,52 +994,6 @@ const STYLES = `
   .vault-tile p { margin: 0.2rem 0; }
   .vault-tile p:last-child { margin-top: 0.5rem; }
 
-  .mcp-connect {
-    margin-bottom: 0.75rem;
-  }
-  .mcp-connect-label {
-    font-family: ${FONT_SERIF};
-    font-size: 1.05rem;
-    font-weight: 400;
-    color: ${PALETTE.fg};
-    margin: 0 0 0.3rem;
-  }
-  .mcp-connect-intro {
-    font-size: 0.85rem;
-    color: ${PALETTE.fgMuted};
-    margin: 0 0 0.75rem;
-  }
-  .mcp-method {
-    margin: 0.75rem 0;
-    padding-top: 0.6rem;
-    border-top: 1px solid ${PALETTE.borderLight};
-  }
-  .mcp-method-title {
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: ${PALETTE.fg};
-    margin: 0 0 0.15rem;
-  }
-  .mcp-method-sub {
-    font-size: 0.82rem;
-    color: ${PALETTE.fgMuted};
-    margin: 0 0 0.4rem;
-  }
-  .mcp-method-note {
-    font-size: 0.78rem;
-    color: ${PALETTE.fgMuted};
-    margin: 0.35rem 0 0;
-  }
-  .mcp-field { margin: 0.5rem 0; }
-  .mcp-field-label {
-    display: block;
-    font-size: 0.7rem;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: ${PALETTE.fgMuted};
-    font-family: ${FONT_MONO};
-    margin-bottom: 0.2rem;
-  }
   .vault-notes-cta {
     margin: 0.9rem 0 0;
     padding-top: 0.6rem;
@@ -1090,11 +1034,6 @@ const STYLES = `
     border-color: ${PALETTE.border};
   }
   .btn-copy:hover { background: ${PALETTE.bgSoft}; border-color: ${PALETTE.accent}; }
-  .mcp-connect-hint {
-    font-size: 0.82rem;
-    color: ${PALETTE.fgMuted};
-    margin: 0.4rem 0 0;
-  }
 
   .vault-admin-link {
     margin: 0.9rem 0 0;
@@ -1110,53 +1049,6 @@ const STYLES = `
     color: ${PALETTE.fgMuted};
     flex: 1 1 12rem;
   }
-
-  .token-mint {
-    margin: 0.9rem 0 0;
-    padding-top: 0.6rem;
-    border-top: 1px solid ${PALETTE.borderLight};
-  }
-  .token-mint > summary {
-    cursor: pointer;
-    font-size: 0.88rem;
-    font-weight: 600;
-    color: ${PALETTE.fg};
-    list-style: revert;
-  }
-  .token-mint-sub {
-    font-weight: 400;
-    font-size: 0.8rem;
-    color: ${PALETTE.fgMuted};
-  }
-  .token-mint-body { margin-top: 0.6rem; }
-  .token-mint-intro {
-    font-size: 0.8rem;
-    color: ${PALETTE.fgMuted};
-    margin: 0 0 0.6rem;
-  }
-  .mint-verbs {
-    border: 1px solid ${PALETTE.borderLight};
-    border-radius: 6px;
-    padding: 0.5rem 0.7rem;
-    margin: 0 0 0.6rem;
-  }
-  .mint-verbs legend {
-    font-size: 0.7rem;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: ${PALETTE.fgMuted};
-    font-family: ${FONT_MONO};
-    padding: 0 0.3rem;
-  }
-  .mint-verb-option {
-    display: flex;
-    align-items: baseline;
-    gap: 0.5rem;
-    font-size: 0.85rem;
-    margin: 0.3rem 0;
-  }
-  .mint-verb-option input { margin: 0; }
-  .mint-form .btn { margin-top: 0.2rem; }
 
   .minted-banner {
     border: 1px solid ${PALETTE.accent};
@@ -1266,19 +1158,18 @@ const STYLES = `
     body { background: #1a1815; color: #e8e4dc; }
     .card { background: #25221d; border-color: #3a362f; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3); }
     h1, h2 { color: #f0ece4; }
-    .subtitle, .kv dt, .mcp-field-label, .mcp-connect-hint,
-    .mcp-connect-intro, .mcp-method-sub, .mcp-method-note,
-    .vault-notes-cta-sub, .vault-usage,
+    .subtitle, .kv dt,
+    .vault-notes-cta-sub, .vault-usage, .vault-build-ui,
     .onboarding-intro, .onboarding-step-sub, .onboarding-method,
     .onboarding-foot { color: #a8a29a; }
-    .vault-name strong, .mcp-connect-label, .mcp-method-title,
+    .vault-name strong,
     .onboarding-step-title, .onboarding-method strong,
     .onboarding-done-line { color: #f0ece4; }
     .onboarding-step-done .onboarding-step-title { color: #a8a29a; }
     code { background: #1f1c18; color: #e8e4dc; }
     .copy-row code { background: transparent; }
     .section { border-top-color: #3a362f; }
-    .mcp-method, .vault-notes-cta, .token-mint,
+    .vault-notes-cta, .vault-build-ui,
     .vault-admin-link, .account-security { border-top-color: #3a362f; }
     .vault-admin-sub { color: #a8a29a; }
     .get-started h3 { color: #f0ece4; }
@@ -1291,9 +1182,7 @@ const STYLES = `
     .copy-row { background: #1f1c18; border-color: #3a362f; }
     .btn-secondary, .btn-copy { color: #e8e4dc; border-color: #3a362f; }
     .btn-secondary:hover, .btn-copy:hover { background: #1f1c18; border-color: ${PALETTE.accent}; }
-    .token-mint > summary { color: #f0ece4; }
-    .token-mint-sub, .token-mint-intro, .mint-verbs legend, .minted-hint { color: #a8a29a; }
-    .mint-verbs { border-color: #3a362f; }
+    .minted-hint { color: #a8a29a; }
     .minted-title, .minted-warn { color: #f0ece4; }
   }
 `;

--- a/src/account-mirror.ts
+++ b/src/account-mirror.ts
@@ -33,8 +33,14 @@ import { signAccessToken } from "./jwt-sign.ts";
 export interface VaultMirrorStat {
   /** Backup is on — a version-history mirror is configured + bootstrapped. */
   enabled: boolean;
-  /** A GitHub (or any git remote) push is configured — backup leaves the box. */
-  pushing: boolean;
+  /**
+   * Backup leaves the box — an auto-push remote (GitHub or any git remote) is
+   * configured (`config.auto_push`). Drives the "+ GitHub" line variant AND
+   * gates the "Back up to GitHub ↗" action (suppressed once already pushing).
+   * Threaded through as a proper boolean so the renderer never has to re-derive
+   * "are we pushing?" from display-string content.
+   */
+  backedUpToRemote: boolean;
 }
 
 /** Short TTL for the admin token — used immediately for one loopback call. */
@@ -67,8 +73,8 @@ export interface FetchVaultMirrorStatusDeps {
  * "Backed up" is true when the persisted config says `enabled` (a version-
  * history mirror) — we read the persisted config, not just the runtime
  * `status.enabled`, so a freshly-configured-but-not-yet-bootstrapped vault still
- * reads as backed up. "Pushing" is true when an auto-push remote is configured
- * (the GitHub variant of backup).
+ * reads as backed up. `backedUpToRemote` is true when an auto-push remote is
+ * configured (the GitHub variant of backup).
  */
 export async function fetchVaultMirrorStatus(
   vaultName: string,
@@ -98,8 +104,8 @@ export async function fetchVaultMirrorStatus(
     };
     const enabled = body.config?.enabled;
     if (typeof enabled !== "boolean") return null;
-    const pushing = body.config?.auto_push === true;
-    return { enabled, pushing };
+    const backedUpToRemote = body.config?.auto_push === true;
+    return { enabled, backedUpToRemote };
   } catch {
     return null;
   }
@@ -114,5 +120,7 @@ export async function fetchVaultMirrorStatus(
  */
 export function formatMirrorLine(stat: VaultMirrorStat): string | null {
   if (!stat.enabled) return null;
-  return stat.pushing ? "Backed up — version history + GitHub" : "Backed up — full version history";
+  return stat.backedUpToRemote
+    ? "Backed up — version history + GitHub"
+    : "Backed up — full version history";
 }

--- a/src/account-mirror.ts
+++ b/src/account-mirror.ts
@@ -1,0 +1,118 @@
+/**
+ * Per-vault backup (mirror) status fetch for the friend-facing `/account/` home.
+ *
+ * Vault serves `GET /vault/<name>/.parachute/mirror` (ADMIN-scoped) returning
+ * the persisted mirror config + the runtime status the manager is tracking:
+ *   { config: { enabled, location, external_path, sync_mode, auto_push, ... },
+ *     status: { enabled, last_commit_sha, last_error, ... } }
+ *
+ * The `/account/` GET handler renders one tile per assigned vault; this module
+ * fetches each vault's mirror status so the tile can show a warm, plain-language
+ * backup line ("✓ Backed up — full version history", or "+ GitHub" when a push
+ * remote is configured). Backup is the local git version-history mirror vault
+ * stands up by default; the GitHub variant is the auto-push-to-a-remote setup.
+ *
+ * The endpoint gates on `vault:<name>:admin`, so this is only fetched for users
+ * who hold the admin verb on the vault (same gate as the "Advanced vault
+ * settings ↗" deep-link). We mint a short-lived `vault:<name>:admin` token —
+ * the same authority the OAuth issuer / admin path would grant them — and call
+ * the vault over loopback.
+ *
+ * Tolerant by design: any failure (vault down, endpoint absent on an older
+ * vault, mint failure, malformed JSON, insufficient scope) resolves to `null`
+ * so the tile simply omits the backup line rather than breaking the page —
+ * exactly the posture of `account-usage.ts`'s `fetchVaultUsage`.
+ *
+ * Injectable seams (`fetchImpl`, `signToken`) keep it unit-testable without a
+ * live vault or real signing key.
+ */
+import type { Database } from "bun:sqlite";
+import { signAccessToken } from "./jwt-sign.ts";
+
+/** The subset of vault's mirror report the `/account/` tile renders. */
+export interface VaultMirrorStat {
+  /** Backup is on — a version-history mirror is configured + bootstrapped. */
+  enabled: boolean;
+  /** A GitHub (or any git remote) push is configured — backup leaves the box. */
+  pushing: boolean;
+}
+
+/** Short TTL for the admin token — used immediately for one loopback call. */
+const MIRROR_READ_TOKEN_TTL_SECONDS = 60;
+
+export interface FetchVaultMirrorStatusDeps {
+  db: Database;
+  /** Hub origin — `iss` of the minted token. */
+  hubOrigin: string;
+  /** Loopback port the vault backend listens on (from services.json). */
+  vaultPort: number;
+  /** The user minting against their own admin authority — `sub` of the token. */
+  userId: string;
+  /** Test seam — `globalThis.fetch` in production. */
+  fetchImpl?: typeof fetch;
+  /** Test seam — defaults to the real `signAccessToken`. */
+  signToken?: typeof signAccessToken;
+  /** Test seam for the clock. */
+  now?: () => Date;
+}
+
+/**
+ * Fetch one vault's backup (mirror) status for the friend's tile, or `null` on
+ * any failure.
+ *
+ * Mints a `vault:<name>:admin` bearer for `userId` (capped to that one vault via
+ * `vaultScope`) and GETs the vault's loopback mirror endpoint. Never throws —
+ * the page renders without the backup line on any error.
+ *
+ * "Backed up" is true when the persisted config says `enabled` (a version-
+ * history mirror) — we read the persisted config, not just the runtime
+ * `status.enabled`, so a freshly-configured-but-not-yet-bootstrapped vault still
+ * reads as backed up. "Pushing" is true when an auto-push remote is configured
+ * (the GitHub variant of backup).
+ */
+export async function fetchVaultMirrorStatus(
+  vaultName: string,
+  deps: FetchVaultMirrorStatusDeps,
+): Promise<VaultMirrorStat | null> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const sign = deps.signToken ?? signAccessToken;
+  try {
+    const scope = `vault:${vaultName}:admin`;
+    const minted = await sign(deps.db, {
+      sub: deps.userId,
+      scopes: [scope],
+      audience: `vault.${vaultName}`,
+      clientId: "parachute-account",
+      issuer: deps.hubOrigin,
+      ttlSeconds: MIRROR_READ_TOKEN_TTL_SECONDS,
+      vaultScope: [vaultName],
+      ...(deps.now !== undefined ? { now: deps.now } : {}),
+    });
+    const url = `http://127.0.0.1:${deps.vaultPort}/vault/${vaultName}/.parachute/mirror`;
+    const res = await fetchImpl(url, {
+      headers: { authorization: `Bearer ${minted.token}`, accept: "application/json" },
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as {
+      config?: { enabled?: unknown; auto_push?: unknown };
+    };
+    const enabled = body.config?.enabled;
+    if (typeof enabled !== "boolean") return null;
+    const pushing = body.config?.auto_push === true;
+    return { enabled, pushing };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Format a mirror stat as the warm, plain-language backup line the tile shows,
+ * or `null` when backup is off (the tile then omits the line entirely — we
+ * don't nag with a "not backed up" warning on the everyday home).
+ *
+ * Exported for direct unit testing + reuse by the renderer.
+ */
+export function formatMirrorLine(stat: VaultMirrorStat): string | null {
+  if (!stat.enabled) return null;
+  return stat.pushing ? "Backed up — version history + GitHub" : "Backed up — full version history";
+}

--- a/src/api-account.ts
+++ b/src/api-account.ts
@@ -571,6 +571,10 @@ export async function handleAccountHomeGet(req: Request, deps: AccountHomeDeps):
   // Skipped entirely when the route didn't wire a port resolver (tests / older
   // callers).
   const mirrorLines: Record<string, string> = {};
+  // Whether each vault's backup is already pushing to a remote (`auto_push`).
+  // Threaded to the renderer as a proper boolean so it gates the "Back up to
+  // GitHub ↗" action without re-deriving "are we pushing?" from the line string.
+  const mirrorPushing: Record<string, boolean> = {};
   if (deps.resolveVaultPort && user.assignedVaults.length > 0) {
     const fetchMirror = deps.fetchMirror ?? fetchVaultMirrorStatus;
     const resolvePort = deps.resolveVaultPort;
@@ -588,7 +592,10 @@ export async function handleAccountHomeGet(req: Request, deps: AccountHomeDeps):
         });
         if (stat) {
           const line = formatMirrorLine(stat);
-          if (line) mirrorLines[vaultName] = line;
+          if (line) {
+            mirrorLines[vaultName] = line;
+            mirrorPushing[vaultName] = stat.backedUpToRemote;
+          }
         }
       }),
     );
@@ -612,6 +619,7 @@ export async function handleAccountHomeGet(req: Request, deps: AccountHomeDeps):
       mintableVerbs,
       usageStats,
       mirrorLines,
+      mirrorPushing,
       connectedVault,
     }),
     200,

--- a/src/api-account.ts
+++ b/src/api-account.ts
@@ -49,6 +49,7 @@ import type { Database } from "bun:sqlite";
 import { hash as argonHash } from "@node-rs/argon2";
 import { type ChangePasswordMode, renderChangePassword } from "./account-change-password-ui.ts";
 import { renderAccountHome } from "./account-home-ui.ts";
+import { fetchVaultMirrorStatus, formatMirrorLine } from "./account-mirror.ts";
 import { fetchVaultUsage, formatUsageStat } from "./account-usage.ts";
 import { POST_LOGIN_DEFAULT } from "./admin-handlers.ts";
 import { renderAdminError } from "./admin-login-ui.ts";
@@ -503,6 +504,13 @@ export interface AccountHomeDeps extends ApiAccountDeps {
    * vault.
    */
   fetchUsage?: typeof fetchVaultUsage;
+  /**
+   * Fetch one vault's backup (mirror) status, or `null` on any failure.
+   * Defaults to the real `fetchVaultMirrorStatus` (mints an admin-scoped token +
+   * hits the vault's loopback `/.parachute/mirror` endpoint). Injectable so
+   * tests assert the render without a live vault.
+   */
+  fetchMirror?: typeof fetchVaultMirrorStatus;
 }
 
 export async function handleAccountHomeGet(req: Request, deps: AccountHomeDeps): Promise<Response> {
@@ -554,6 +562,38 @@ export async function handleAccountHomeGet(req: Request, deps: AccountHomeDeps):
     );
   }
 
+  // Per-vault backup (mirror) line ("Backed up — full version history" / "…
+  // + GitHub"). The vault's mirror endpoint is ADMIN-scoped, so we only fetch
+  // for vaults where this user holds the admin verb (the same gate the
+  // "Advanced vault settings ↗" deep-link uses). Each fetch is independently
+  // fault-tolerant (returns null → no backup line on that tile) and backup-off
+  // formats to null too (we never nag with a "not backed up" warning here).
+  // Skipped entirely when the route didn't wire a port resolver (tests / older
+  // callers).
+  const mirrorLines: Record<string, string> = {};
+  if (deps.resolveVaultPort && user.assignedVaults.length > 0) {
+    const fetchMirror = deps.fetchMirror ?? fetchVaultMirrorStatus;
+    const resolvePort = deps.resolveVaultPort;
+    await Promise.all(
+      user.assignedVaults.map(async (vaultName) => {
+        if (!(mintableVerbs[vaultName] ?? []).includes("admin")) return;
+        const port = resolvePort(vaultName);
+        if (port === null) return;
+        const stat = await fetchMirror(vaultName, {
+          db: deps.db,
+          hubOrigin: deps.hubOrigin,
+          vaultPort: port,
+          userId: user.id,
+          ...(deps.now !== undefined ? { now: deps.now } : {}),
+        });
+        if (stat) {
+          const line = formatMirrorLine(stat);
+          if (line) mirrorLines[vaultName] = line;
+        }
+      }),
+    );
+  }
+
   // "Has this user connected an AI to any of their vaults yet?" — drives the
   // onboarding checklist's "Connect your AI" step (done/condensed when true).
   // A grant row only lands after the user clicks through an OAuth consent for a
@@ -571,6 +611,7 @@ export async function handleAccountHomeGet(req: Request, deps: AccountHomeDeps):
       twoFactorEnabled: isTotpEnrolled(deps.db, user.id),
       mintableVerbs,
       usageStats,
+      mirrorLines,
       connectedVault,
     }),
     200,


### PR DESCRIPTION
Make `/account/` a friendly **everyday owner home** with no duplication. The ownership split this PR commits to: **/account = friendly everyday owner surface; the vault config SPA = deep/advanced.** Walking the page surfaced four issues — the onboarding checklist and the "Your vault" card showed the *same* connect instructions twice, the card duplicated SPA functionality, backup state was invisible, and the Notes link didn't hint at building a custom UI.

### 1. Remove the connect duplication
`renderOnboardingChecklist` already owns "Connect your AI" (the `/vault/<name>/mcp` endpoint + both methods, collapsing to "✓ You're connected" once a grant lands). `renderVaultCard` no longer repeats the `mcp-connect` block — the full connect instructions now appear **exactly once** on the page (in the checklist). The vault card is a clean detail: name, usage, **backup state**, Notes + "build your own UI", and a single advanced link.

### 2. Drop token-mint from /account (OAuth-first)
Removed `renderTokenMintBlock` from the page. Minting header-auth tokens is a script/advanced concern that lives in the vault config SPA; the "Advanced vault settings ↗" link covers it. `mintableVerbs` is now used solely to gate the advanced link on the `admin` verb. The `/account/vault-token` POST route is untouched (still functions for scripts) — it's simply no longer surfaced on the page.

### 3. Surface backup state
New `src/account-mirror.ts` `fetchVaultMirrorStatus` mirrors `account-usage.ts`'s `fetchVaultUsage` shape (injectable `fetchImpl`/`signToken` seams for tests). **How backup state is read:** it mints a short-lived `vault:<name>:admin` token (the vault's `GET /vault/<name>/.parachute/mirror` endpoint is admin-scoped — same authority the OAuth issuer would grant the user) and reads the vault's loopback endpoint, which returns `{config:{enabled,auto_push,...}, status:{...}}`. We read the persisted **config** so a configured-but-not-yet-bootstrapped vault still reads as backed up.

On the tile:
- **"✓ Backed up — full version history"** when `config.enabled`; **"✓ Backed up — version history + GitHub"** when `config.auto_push` is also set.
- A **"Back up to GitHub ↗"** action (only when not already pushing) that reuses the existing `/account/vault-admin-token/<name>` deep-link into the SPA backup page — **no new auth path invented**.
- Fetched only for admin-held vaults; **omitted silently** on any fetch failure or backup-off (never nags with a "not backed up" warning) — exactly the posture `fetchVaultUsage` uses.

### 4. Notes + "build your own UI"
Keep the Notes/Import CTAs; add one warm line that Notes is one way to see your vault and your AI can build you a custom UI in a few minutes, linking the surface-build starter (`https://parachute.computer/onboarding/surface-build/`).

### 5. One advanced entry point
"Configure / back up this vault ↗" → a single clearly-labelled **"Advanced vault settings ↗"** (schema, tokens, retention, raw mirror config all in the SPA), still gated on the user's `admin` verb.

Server-rendered, no-JS-required throughout; copy buttons stay progressive enhancement. Pruned the now-dead `.mcp-*` / `.token-mint` / `.mint-*` CSS. Multi-vault and the first-admin/no-vault branches preserved.

### Tests
- New `account-mirror.test.ts` — the fetch (admin-scoped Bearer to the right loopback URL, fault-tolerant null on non-2xx / malformed / throw) + the formatter (warm line, GitHub variant, null when off).
- `account-home-ui.test.ts` reworked — connect block appears once (in the checklist, **not** the vault card); token-mint gone; backup line renders / shows GitHub variant / omitted on null; build-your-own-UI line links surface-build; single "Advanced vault settings ↗" link is admin-gated.
- `api-account.test.ts` — GET handler renders the backup line when the mirror resolves and omits it gracefully on null.

No version bump (stays `0.6.4-rc.4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)