### PR TITLE
release: hub 0.6.4-rc.5 (account owner-home consolidation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.4-rc.4",
+  "version": "0.6.4-rc.5",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Cuts **0.6.4-rc.5** to ship #571 (/account owner-home consolidation — dedup connect, drop token-mint, surface backup state, single advanced link) to friends. Pure version bump; #571 reviewed + merged. Tag publishes to npm `rc`, `@latest` stays 0.6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)