### PR TITLE
fix: fresh-server onboarding dead-ends (vault gate, init abort, cloudflared install, hostname persistence, supervisor detection)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "format": "biome format --write .",
     "typecheck": "tsc --noEmit",
     "build:spa": "cd web/ui && bun install --frozen-lockfile && bun run build",
-    "postinstall": "if [ -d web/ui ]; then bun run build:spa; fi",
     "prepack": "bun run build:spa"
   },
   "devDependencies": {

--- a/src/__tests__/cloudflare-state.test.ts
+++ b/src/__tests__/cloudflare-state.test.ts
@@ -7,12 +7,15 @@ import {
   CloudflaredStateError,
   type CloudflaredTunnelRecord,
   clearCloudflaredState,
+  clearPendingHostname,
   findTunnelRecord,
   listTunnelRecords,
   readCloudflaredState,
+  readPendingHostname,
   withTunnelRecord,
   withoutTunnelRecord,
   writeCloudflaredState,
+  writePendingHostname,
 } from "../cloudflare/state.ts";
 
 function makeTempPath(): { path: string; cleanup: () => void } {
@@ -248,5 +251,87 @@ describe("cloudflared state — record helpers", () => {
     const both = withTunnelRecord(withTunnelRecord(undefined, recordB), recordA);
     expect(listTunnelRecords(both).map((r) => r.tunnelName)).toEqual(["alpha", "beta"]);
     expect(listTunnelRecords(undefined)).toEqual([]);
+  });
+});
+
+describe("hub#567 pending hostname", () => {
+  test("read returns undefined when no state file / no pending hostname", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      expect(readPendingHostname(path)).toBeUndefined();
+      writeCloudflaredState(sample, path);
+      expect(readPendingHostname(path)).toBeUndefined();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("write then read round-trips the pending hostname (seeds empty state)", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writePendingHostname("techne.parachute.computer", path);
+      expect(readPendingHostname(path)).toBe("techne.parachute.computer");
+      const state = readCloudflaredState(path);
+      expect(state?.pendingHostname).toBe("techne.parachute.computer");
+      expect(state?.tunnels).toEqual({});
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("write preserves existing tunnel records", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writeCloudflaredState(sample, path);
+      writePendingHostname("techne.parachute.computer", path);
+      const state = readCloudflaredState(path);
+      expect(state?.pendingHostname).toBe("techne.parachute.computer");
+      expect(state?.tunnels.parachute).toEqual(sampleRecord);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("clear drops the pending hostname but keeps tunnel records", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writeCloudflaredState({ ...sample, pendingHostname: "techne.parachute.computer" }, path);
+      clearPendingHostname(path);
+      const state = readCloudflaredState(path);
+      expect(state?.pendingHostname).toBeUndefined();
+      expect(state?.tunnels.parachute).toEqual(sampleRecord);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("clear removes the state file entirely when no tunnels remain", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      writePendingHostname("techne.parachute.computer", path);
+      expect(existsSync(path)).toBe(true);
+      clearPendingHostname(path);
+      expect(existsSync(path)).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("validate preserves a pending hostname round-tripped through the bytes", () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const withPending: CloudflaredState = { ...sample, pendingHostname: "a.example.com" };
+      writeCloudflaredState(withPending, path);
+      expect(readCloudflaredState(path)).toEqual(withPending);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("withTunnelRecord preserves an existing pending hostname", () => {
+    const seed: CloudflaredState = { version: 2, tunnels: {}, pendingHostname: "a.example.com" };
+    const next = withTunnelRecord(seed, sampleRecord);
+    expect(next.pendingHostname).toBe("a.example.com");
+    expect(next.tunnels.parachute).toEqual(sampleRecord);
   });
 });

--- a/src/__tests__/cloudflare-state.test.ts
+++ b/src/__tests__/cloudflare-state.test.ts
@@ -334,4 +334,23 @@ describe("hub#567 pending hostname", () => {
     expect(next.pendingHostname).toBe("a.example.com");
     expect(next.tunnels.parachute).toEqual(sampleRecord);
   });
+
+  test("withoutTunnelRecord carries the pending hostname when it's the only thing left", () => {
+    const seed: CloudflaredState = {
+      version: 2,
+      tunnels: { parachute: sampleRecord },
+      pendingHostname: "a.example.com",
+    };
+    // Removing the last tunnel must NOT discard a typed-but-not-routed hostname.
+    expect(withoutTunnelRecord(seed, "parachute")).toEqual({
+      version: 2,
+      tunnels: {},
+      pendingHostname: "a.example.com",
+    });
+  });
+
+  test("withoutTunnelRecord returns undefined when no tunnels AND no pending hostname remain", () => {
+    const seed: CloudflaredState = { version: 2, tunnels: { parachute: sampleRecord } };
+    expect(withoutTunnelRecord(seed, "parachute")).toBeUndefined();
+  });
 });

--- a/src/__tests__/expose-cloudflare.test.ts
+++ b/src/__tests__/expose-cloudflare.test.ts
@@ -509,16 +509,31 @@ describe("exposeCloudflareUp", () => {
     }
   });
 
-  test("errors out when vault isn't installed", async () => {
+  test("hub#564: continues (no vault gate) when vault isn't installed — routes the hub anyway", async () => {
     const env = makeEnv({ includeVault: false });
     try {
-      const { runner } = queueRunner([{ code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" }]);
-      const { spawner } = fakeSpawner(0);
+      const uuid = "3d2b8d8f-2345-6789-abcd-ef0123456789";
+      const derived = "parachute-vault-example-com";
+      // The full chain must run now that the vault gate is gone: version,
+      // tunnel list, tunnel create, route dns.
+      const { runner } = queueRunner([
+        { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" }, // --version
+        { code: 0, stdout: "[]", stderr: "" }, // tunnel list
+        {
+          code: 0,
+          stdout: `Created tunnel ${derived} with id ${uuid}\n`,
+          stderr: "",
+        }, // create
+        { code: 0, stdout: "", stderr: "" }, // route dns
+      ]);
+      const { spawner } = fakeSpawner(42000);
       const logs: string[] = [];
 
       const code = await exposeCloudflareUp("vault.example.com", {
         runner,
         spawner,
+        alive: () => false,
+        kill: () => {},
         log: (l) => logs.push(l),
         manifestPath: env.manifestPath,
         statePath: env.statePath,
@@ -528,10 +543,17 @@ describe("exposeCloudflareUp", () => {
         cloudflaredHome: env.cloudflaredHome,
         configDir: env.configDir,
         skipHub: true,
+        now: () => new Date("2026-04-22T12:00:00Z"),
       });
 
-      expect(code).toBe(1);
-      expect(logs.join("\n")).toContain("parachute install vault");
+      // The expose succeeds (the hub is what gets routed), with a courtesy
+      // note instead of a dead-end. No "install vault" gate, no Vault-URL
+      // footer (vault isn't there to point at).
+      expect(code).toBe(0);
+      const joined = logs.join("\n");
+      expect(joined).toContain("vault not installed yet");
+      expect(joined).not.toContain("nothing to route");
+      expect(joined).not.toMatch(/^\s*Vault:/m);
     } finally {
       env.cleanup();
     }

--- a/src/__tests__/expose-interactive.test.ts
+++ b/src/__tests__/expose-interactive.test.ts
@@ -658,10 +658,12 @@ describe("exposePublicInteractive — neither ready", () => {
         runAuthPreflightImpl: noopPreflight,
       });
       expect(code).toBe(0);
-      // Non-root prefixes both privileged steps with sudo.
-      expect(interactiveCmds[0]?.[0]).toBe("sudo");
+      // Non-root prefixes both privileged steps with non-interactive `sudo -n`
+      // (fails fast instead of hanging on a password prompt under a detached
+      // init).
+      expect(interactiveCmds[0]?.slice(0, 2)).toEqual(["sudo", "-n"]);
       expect(interactiveCmds[0]).toContain("curl");
-      expect(interactiveCmds[1]?.[0]).toBe("sudo");
+      expect(interactiveCmds[1]?.slice(0, 2)).toEqual(["sudo", "-n"]);
       expect(interactiveCmds[1]).toContain("chmod");
     } finally {
       env.cleanup();

--- a/src/__tests__/expose-interactive.test.ts
+++ b/src/__tests__/expose-interactive.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { readPendingHostname, writePendingHostname } from "../cloudflare/state.ts";
 import { exposePublicInteractive } from "../commands/expose-interactive.ts";
 import { readLastProvider, writeLastProvider } from "../expose-last-provider.ts";
 import type { CommandResult, Runner } from "../tailscale/run.ts";
@@ -15,6 +16,7 @@ const noopPreflight = async () => {};
 interface TestEnv {
   cloudflaredHome: string;
   lastProviderPath: string;
+  statePath: string;
   cleanup: () => void;
 }
 
@@ -28,6 +30,7 @@ function makeEnv(opts: { cloudflaredLoggedIn?: boolean } = {}): TestEnv {
   return {
     cloudflaredHome,
     lastProviderPath: join(dir, "expose-last-provider.json"),
+    statePath: join(dir, "cloudflared-state.json"),
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
   };
 }
@@ -189,6 +192,75 @@ describe("exposePublicInteractive — both ready", () => {
       expect(code).toBe(0);
       expect(cloudflareHostname).toBe("vault.example.com");
       expect(readLastProvider(env.lastProviderPath)?.provider).toBe("cloudflare");
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("hub#567: persists the typed hostname as soon as it validates", async () => {
+    const env = makeEnv({ cloudflaredLoggedIn: true });
+    try {
+      const { runner } = fixedRunner({
+        tailscaleInstalled: true,
+        tailscaleLoggedIn: true,
+        tailscaleFunnelCap: true,
+        cloudflaredInstalled: true,
+      });
+      const { prompt } = queuePrompt(["2", "vault.example.com"]);
+      // exposeCloudflareUpImpl FAILS — so the hostname must survive for a retry.
+      const code = await exposePublicInteractive({
+        runner,
+        prompt,
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        statePath: env.statePath,
+        log: () => {},
+        exposePublicImpl: async () => 0,
+        exposeCloudflareUpImpl: async () => 1,
+        runAuthPreflightImpl: noopPreflight,
+      });
+      expect(code).toBe(1);
+      // Stashed despite the downstream failure.
+      expect(readPendingHostname(env.statePath)).toBe("vault.example.com");
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("hub#567: pre-fills the hostname prompt from a stashed value; Enter accepts it", async () => {
+    const env = makeEnv({ cloudflaredLoggedIn: true });
+    try {
+      writePendingHostname("techne.parachute.computer", env.statePath);
+      const { runner } = fixedRunner({
+        tailscaleInstalled: true,
+        tailscaleLoggedIn: true,
+        tailscaleFunnelCap: true,
+        cloudflaredInstalled: true,
+      });
+      // Pick cloudflare, then press Enter (blank) at the hostname prompt.
+      const { prompt, asked } = queuePrompt(["2", ""]);
+      let cloudflareHostname: string | undefined;
+      const code = await exposePublicInteractive({
+        runner,
+        prompt,
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        statePath: env.statePath,
+        log: () => {},
+        exposePublicImpl: async () => 0,
+        exposeCloudflareUpImpl: async (h) => {
+          cloudflareHostname = h;
+          return 0;
+        },
+        runAuthPreflightImpl: noopPreflight,
+      });
+      expect(code).toBe(0);
+      // Enter accepted the stashed hostname.
+      expect(cloudflareHostname).toBe("techne.parachute.computer");
+      // The prompt surfaced the default in brackets.
+      expect(asked.some((q) => q.includes("[techne.parachute.computer]"))).toBe(true);
+      // Cleared once routing succeeded.
+      expect(readPendingHostname(env.statePath)).toBeUndefined();
     } finally {
       env.cleanup();
     }
@@ -440,11 +512,12 @@ describe("exposePublicInteractive — neither ready", () => {
     }
   });
 
-  test("user picks cloudflare on linux: prints manual install pointers and exits 1", async () => {
+  test("hub#566: cloudflare on linux, user DECLINES auto-install: prints manual + --cloudflare hint, exits 1", async () => {
     const env = makeEnv();
     try {
       const { runner } = fixedRunner({});
-      const { prompt } = queuePrompt(["2"]);
+      // "2" → cloudflare; "n" → decline the auto-install offer.
+      const { prompt } = queuePrompt(["2", "n"]);
       const logs: string[] = [];
       let interactiveCalled = false;
       let cloudflareCalled = false;
@@ -456,8 +529,10 @@ describe("exposePublicInteractive — neither ready", () => {
         },
         prompt,
         platform: "linux",
+        arch: "x64",
         cloudflaredHome: env.cloudflaredHome,
         lastProviderPath: env.lastProviderPath,
+        statePath: env.statePath,
         log: (l) => logs.push(l),
         exposePublicImpl: async () => 0,
         exposeCloudflareUpImpl: async () => {
@@ -466,19 +541,169 @@ describe("exposePublicInteractive — neither ready", () => {
         },
       });
       expect(code).toBe(1);
+      // Declining means no curl/chmod ran and we never reached the expose.
       expect(interactiveCalled).toBe(false);
       expect(cloudflareCalled).toBe(false);
       const joined = logs.join("\n");
-      // Post 2026-05-27 cloudflared-URL refresh: the install hint moved
-      // off apt-get / dnf / developers.cloudflare.com (all unreliable —
-      // Aaron hit `No match for argument: cloudflared` on AL2023 and
-      // 404s from the docs URL on the same box) onto the static binary
-      // from GitHub releases.
+      expect(joined).toContain("Skipped auto-install");
       expect(joined).toContain("github.com/cloudflare/cloudflared/releases/latest");
       expect(joined).toContain("curl -L -o /usr/local/bin/cloudflared");
+      // hub#566: re-run hint carries the --cloudflare flag (bare `expose
+      // public` defaults to Tailscale).
+      expect(joined).toContain("parachute expose public --cloudflare");
       expect(joined).not.toContain("developers.cloudflare.com");
       expect(joined).not.toContain("pkg.cloudflare.com");
       expect(joined).not.toContain("sudo dnf install cloudflared");
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("hub#566: cloudflare on linux as ROOT, accepts auto-install: runs bare curl+chmod (no sudo), then exposes", async () => {
+    const env = makeEnv();
+    try {
+      // cloudflared starts absent (so the install offer fires), then present
+      // after the install runs (so the verify probe + flow continue).
+      let cloudflaredPresent = false;
+      const runner: Runner = async (cmd) => {
+        if (cmd.slice(0, 2).join(" ") === "cloudflared --version") {
+          return cloudflaredPresent
+            ? { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" }
+            : { code: 127, stdout: "", stderr: "not found" };
+        }
+        if (cmd[0] === "tailscale") {
+          // Detection: tailscale absent (forces the cloudflare-only path).
+          return { code: 127, stdout: "", stderr: "not found" };
+        }
+        throw new Error(`unexpected runner call: ${cmd.join(" ")}`);
+      };
+      // "2" cloudflare → "Y" install → "Y" login → hostname. The login prompt
+      // fires because detection reported cloudflared absent (so loggedIn=false)
+      // even though cert.pem appears once login "runs".
+      const { prompt } = queuePrompt(["2", "y", "y", "vault.example.com"]);
+      const interactiveCmds: string[][] = [];
+      const logs: string[] = [];
+      let cloudflareHostname = "";
+      const code = await exposePublicInteractive({
+        runner,
+        interactiveRunner: async (cmd) => {
+          interactiveCmds.push([...cmd]);
+          // Install "succeeds": flip cloudflared to present. Login "succeeds":
+          // drop the cert so `isCloudflaredLoggedIn` reads true afterward.
+          if (cmd.includes("login")) writeFileSync(join(env.cloudflaredHome, "cert.pem"), "---");
+          else cloudflaredPresent = true;
+          return 0;
+        },
+        prompt,
+        platform: "linux",
+        arch: "x64",
+        getuid: () => 0, // root
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        statePath: env.statePath,
+        log: (l) => logs.push(l),
+        exposePublicImpl: async () => 0,
+        exposeCloudflareUpImpl: async (hostname) => {
+          cloudflareHostname = hostname;
+          return 0;
+        },
+        runAuthPreflightImpl: noopPreflight,
+      });
+      expect(code).toBe(0);
+      expect(cloudflareHostname).toBe("vault.example.com");
+      // Root runs curl + chmod WITHOUT a sudo prefix.
+      expect(interactiveCmds[0]?.[0]).toBe("curl");
+      expect(interactiveCmds[0]).toContain("/usr/local/bin/cloudflared");
+      expect(interactiveCmds[1]?.[0]).toBe("chmod");
+      expect(interactiveCmds.some((c) => c[0] === "sudo")).toBe(false);
+      expect(logs.join("\n")).toContain("✓ cloudflared installed.");
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("hub#566: cloudflare on linux NON-root, accepts auto-install: wraps curl+chmod in sudo", async () => {
+    const env = makeEnv();
+    try {
+      let cloudflaredPresent = false;
+      const runner: Runner = async (cmd) => {
+        if (cmd.slice(0, 2).join(" ") === "cloudflared --version") {
+          return cloudflaredPresent
+            ? { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" }
+            : { code: 127, stdout: "", stderr: "not found" };
+        }
+        if (cmd[0] === "tailscale") return { code: 127, stdout: "", stderr: "not found" };
+        throw new Error(`unexpected runner call: ${cmd.join(" ")}`);
+      };
+      const { prompt } = queuePrompt(["2", "y", "y", "vault.example.com"]);
+      const interactiveCmds: string[][] = [];
+      const code = await exposePublicInteractive({
+        runner,
+        interactiveRunner: async (cmd) => {
+          interactiveCmds.push([...cmd]);
+          if (cmd.includes("login")) writeFileSync(join(env.cloudflaredHome, "cert.pem"), "---");
+          else cloudflaredPresent = true;
+          return 0;
+        },
+        prompt,
+        platform: "linux",
+        arch: "arm64",
+        getuid: () => 1000, // non-root
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        statePath: env.statePath,
+        log: () => {},
+        exposePublicImpl: async () => 0,
+        exposeCloudflareUpImpl: async () => 0,
+        runAuthPreflightImpl: noopPreflight,
+      });
+      expect(code).toBe(0);
+      // Non-root prefixes both privileged steps with sudo.
+      expect(interactiveCmds[0]?.[0]).toBe("sudo");
+      expect(interactiveCmds[0]).toContain("curl");
+      expect(interactiveCmds[1]?.[0]).toBe("sudo");
+      expect(interactiveCmds[1]).toContain("chmod");
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  test("hub#566: cloudflare on linux, sudo curl FAILS: prints manual + --cloudflare hint, exits 1", async () => {
+    const env = makeEnv();
+    try {
+      const runner: Runner = async (cmd) => {
+        if (cmd.slice(0, 2).join(" ") === "cloudflared --version") {
+          return { code: 127, stdout: "", stderr: "not found" };
+        }
+        if (cmd[0] === "tailscale") return { code: 127, stdout: "", stderr: "not found" };
+        throw new Error(`unexpected runner call: ${cmd.join(" ")}`);
+      };
+      const { prompt } = queuePrompt(["2", "y"]);
+      const logs: string[] = [];
+      let cloudflareCalled = false;
+      const code = await exposePublicInteractive({
+        runner,
+        // Simulate sudo failing (no cached creds, no tty).
+        interactiveRunner: async () => 1,
+        prompt,
+        platform: "linux",
+        arch: "x64",
+        getuid: () => 1000,
+        cloudflaredHome: env.cloudflaredHome,
+        lastProviderPath: env.lastProviderPath,
+        statePath: env.statePath,
+        log: (l) => logs.push(l),
+        exposePublicImpl: async () => 0,
+        exposeCloudflareUpImpl: async () => {
+          cloudflareCalled = true;
+          return 0;
+        },
+      });
+      expect(code).toBe(1);
+      expect(cloudflareCalled).toBe(false);
+      const joined = logs.join("\n");
+      expect(joined).toContain("Download failed");
+      expect(joined).toContain("parachute expose public --cloudflare");
     } finally {
       env.cleanup();
     }

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -898,14 +898,15 @@ describe("init exposure chain", () => {
     }
   });
 
-  test("exposure chain non-zero exit propagates", async () => {
+  test("hub#565: a failed exposure chain does NOT abort init — warns, continues, exits 0", async () => {
     const h = makeHarness();
     try {
       writeHubPort(1939, h.configDir);
+      const logs: string[] = [];
       const code = await init({
         configDir: h.configDir,
         manifestPath: h.manifestPath,
-        log: () => {},
+        log: (l) => logs.push(l),
         alive: () => false,
         ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
         readExposeStateFn: () => undefined,
@@ -915,8 +916,46 @@ describe("init exposure chain", () => {
         exposeTailnetImpl: async () => 0,
         exposeCloudflareImpl: async () => 2,
         exposeChoice: "cloudflare",
+        installVaultModuleImpl: noopVaultInstall,
       });
-      expect(code).toBe(2);
+      // Init reaches the admin-URL/wizard handoff regardless of the expose
+      // failure (exposure is an enhancement, not a prerequisite).
+      expect(code).toBe(0);
+      const joined = logs.join("\n");
+      // Warned about the failure + printed the exact retry command (the
+      // `--cloudflare` flag matters — bare `expose public` defaults to
+      // Tailscale, hub#566).
+      expect(joined).toContain("Couldn't finish setting up public access");
+      expect(joined).toContain("parachute expose public --cloudflare");
+      // Fell through to the loopback admin URL.
+      expect(joined).toContain("http://127.0.0.1:1939/admin/");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("hub#565: tailnet expose failure prints the --tailnet retry command", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      const logs: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => logs.push(l),
+        alive: () => false,
+        ensureHub: async () => ({ pid: 7, port: 1939, started: true }),
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+        env: {},
+        exposeTailnetImpl: async () => 3,
+        exposeCloudflareImpl: async () => 0,
+        exposeChoice: "tailnet",
+        installVaultModuleImpl: noopVaultInstall,
+      });
+      expect(code).toBe(0);
+      expect(logs.join("\n")).toContain("parachute expose public --tailnet");
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { install } from "../commands/install.ts";
+import { defaultStartLifecycleOpts, install } from "../commands/install.ts";
 import { findService, upsertService } from "../services-manifest.ts";
 
 function makeTempPath(): { path: string; configDir: string; cleanup: () => void } {
@@ -1719,5 +1719,28 @@ describe("install", () => {
     } finally {
       cleanup();
     }
+  });
+});
+
+describe("hub#573 — install auto-start converges on supervised detection", () => {
+  test("the default start opts opt into real supervisor detection + the migrate offer", () => {
+    const log = () => {};
+    const opts = defaultStartLifecycleOpts({
+      manifestPath: "/tmp/services.json",
+      configDir: "/tmp/cfg",
+      log,
+    });
+    // `supervisor: {}` (present, even if empty) → lifecycle resolves
+    // `unitInstalled` via the real `isHubUnitInstalled` probe instead of the
+    // omitted-supervisor default of `false`. Pre-fix this block was absent, so
+    // the auto-start ALWAYS concluded "no unit" and printed the spurious
+    // "No supervised hub unit is installed" + "didn't start cleanly".
+    expect(opts.supervisor).toEqual({});
+    // The cutover offer is armed, matching `parachute start <svc>` (cli.ts).
+    expect(opts.migrateOffer).toEqual({ enabled: true });
+    // Plumbing preserved.
+    expect(opts.manifestPath).toBe("/tmp/services.json");
+    expect(opts.configDir).toBe("/tmp/cfg");
+    expect(opts.log).toBe(log);
   });
 });

--- a/src/cloudflare/detect.ts
+++ b/src/cloudflare/detect.ts
@@ -109,7 +109,7 @@ export function cloudflaredInstallHint(
  * artifact (registry recipe is undefined) — the caller then uses the generic
  * pointer. Keeps the arch→suffix mapping in exactly one place (the registry).
  */
-function cloudflaredLinuxDownloadUrl(arch: NodeJS.Architecture): string | undefined {
+export function cloudflaredLinuxDownloadUrl(arch: NodeJS.Architecture): string | undefined {
   const recipe = lookupDep("cloudflared")?.install.linuxBinaryUrl?.(arch);
   if (!recipe) return undefined;
   const urlLine = recipe

--- a/src/cloudflare/state.ts
+++ b/src/cloudflare/state.ts
@@ -257,9 +257,11 @@ export function clearPendingHostname(path: string = CLOUDFLARED_STATE_PATH): voi
 }
 
 /**
- * Pure: drop the named tunnel from state. Returns undefined when the result
- * would be empty so callers can `clearCloudflaredState` instead of writing
- * an empty file.
+ * Pure: drop the named tunnel from state. Returns undefined when NO tunnels AND
+ * no pending hostname remain, so callers can `clearCloudflaredState` instead of
+ * writing an empty file. A pending hostname (hub#567) is carried forward — both
+ * when other tunnels survive and when it's the only thing left — so removing a
+ * tunnel never discards a typed-but-not-routed hostname awaiting retry.
  */
 export function withoutTunnelRecord(
   state: CloudflaredState | undefined,
@@ -267,8 +269,10 @@ export function withoutTunnelRecord(
 ): CloudflaredState | undefined {
   if (!state) return undefined;
   const { [tunnelName]: _dropped, ...rest } = state.tunnels;
-  if (Object.keys(rest).length === 0) return undefined;
-  return { version: 2, tunnels: rest };
+  if (Object.keys(rest).length === 0 && !state.pendingHostname) return undefined;
+  return state.pendingHostname
+    ? { version: 2, tunnels: rest, pendingHostname: state.pendingHostname }
+    : { version: 2, tunnels: rest };
 }
 
 /** All tunnel records, in name-sorted order so output is deterministic. */

--- a/src/cloudflare/state.ts
+++ b/src/cloudflare/state.ts
@@ -45,6 +45,15 @@ export interface CloudflaredTunnelRecord {
 export interface CloudflaredState {
   version: 2;
   tunnels: Record<string, CloudflaredTunnelRecord>;
+  /**
+   * A hostname the operator typed in the interactive Cloudflare flow that
+   * hasn't been routed yet (hub#567). Persisted as soon as it validates so a
+   * mid-chain failure (cloudflared missing, login, tunnel/DNS error) doesn't
+   * discard it — the next interactive run pre-fills the hostname prompt with
+   * it. Cleared once routing succeeds (the tunnel record then carries the live
+   * hostname). Optional + free-floating from the per-tunnel records.
+   */
+  pendingHostname?: string;
 }
 
 export class CloudflaredStateError extends Error {
@@ -91,11 +100,21 @@ function validate(raw: unknown, path: string): CloudflaredState {
     throw new CloudflaredStateError(`${path}: root must be an object`);
   }
   const r = raw as Record<string, unknown>;
+  // hub#567: an optional top-level `pendingHostname` (a typed-but-not-yet-routed
+  // hostname). Non-string / empty values read as absent so older state files
+  // keep validating.
+  const pendingHostname =
+    typeof r.pendingHostname === "string" && r.pendingHostname.length > 0
+      ? r.pendingHostname
+      : undefined;
+  const withPending = (state: CloudflaredState): CloudflaredState =>
+    pendingHostname ? { ...state, pendingHostname } : state;
+
   if (r.version === 1) {
     // v1 — single record at top level. Migrate by wrapping it under its
     // tunnelName. Disk isn't rewritten until the next write.
     const record = validateRecord(r, path);
-    return { version: 2, tunnels: { [record.tunnelName]: record } };
+    return withPending({ version: 2, tunnels: { [record.tunnelName]: record } });
   }
   if (r.version !== 2) {
     throw new CloudflaredStateError(`${path}: unsupported version ${String(r.version)}`);
@@ -113,7 +132,7 @@ function validate(raw: unknown, path: string): CloudflaredState {
     }
     tunnels[key] = record;
   }
-  return { version: 2, tunnels };
+  return withPending({ version: 2, tunnels });
 }
 
 export function readCloudflaredState(
@@ -161,7 +180,80 @@ export function withTunnelRecord(
   record: CloudflaredTunnelRecord,
 ): CloudflaredState {
   const tunnels = { ...(state?.tunnels ?? {}), [record.tunnelName]: record };
-  return { version: 2, tunnels };
+  // Preserve any pending hostname (hub#567); the caller clears it explicitly
+  // via `clearPendingHostname` once routing fully succeeds.
+  return state?.pendingHostname
+    ? { version: 2, tunnels, pendingHostname: state.pendingHostname }
+    : { version: 2, tunnels };
+}
+
+/**
+ * Pure: set the pending (typed-but-not-routed) hostname on the state (hub#567).
+ * Seeds an empty v2 state when none exists yet.
+ */
+export function withPendingHostname(
+  state: CloudflaredState | undefined,
+  hostname: string,
+): CloudflaredState {
+  return { version: 2, tunnels: state?.tunnels ?? {}, pendingHostname: hostname };
+}
+
+/**
+ * Pure: drop the pending hostname (hub#567). Returns undefined when the result
+ * would carry no tunnels either, so the caller can `clearCloudflaredState`
+ * rather than write an empty file.
+ */
+export function withoutPendingHostname(
+  state: CloudflaredState | undefined,
+): CloudflaredState | undefined {
+  if (!state) return undefined;
+  if (Object.keys(state.tunnels).length === 0) return undefined;
+  return { version: 2, tunnels: state.tunnels };
+}
+
+/**
+ * Read the pending hostname from the on-disk state (hub#567). Returns undefined
+ * when there's no state file or no pending hostname. Swallows read/parse errors
+ * (a corrupt state file must not abort the prompt — we just don't pre-fill).
+ */
+export function readPendingHostname(path: string = CLOUDFLARED_STATE_PATH): string | undefined {
+  try {
+    return readCloudflaredState(path)?.pendingHostname;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Persist a typed-but-not-yet-routed hostname (hub#567), preserving existing
+ * tunnel records. Best-effort: a write failure must not abort the expose flow.
+ */
+export function writePendingHostname(
+  hostname: string,
+  path: string = CLOUDFLARED_STATE_PATH,
+): void {
+  try {
+    const state = readCloudflaredState(path);
+    writeCloudflaredState(withPendingHostname(state, hostname), path);
+  } catch {
+    // Non-fatal — persistence is a convenience, not a correctness requirement.
+  }
+}
+
+/**
+ * Clear the pending hostname once routing succeeds (hub#567). If no tunnel
+ * records remain, removes the state file entirely. Best-effort.
+ */
+export function clearPendingHostname(path: string = CLOUDFLARED_STATE_PATH): void {
+  try {
+    const state = readCloudflaredState(path);
+    if (!state?.pendingHostname) return;
+    const next = withoutPendingHostname(state);
+    if (next) writeCloudflaredState(next, path);
+    else clearCloudflaredState(path);
+  } catch {
+    // Non-fatal.
+  }
 }
 
 /**

--- a/src/commands/expose-cloudflare.ts
+++ b/src/commands/expose-cloudflare.ts
@@ -51,7 +51,7 @@ import { HUB_DEFAULT_PORT, readHubPort } from "../hub-control.ts";
 import { deriveHubOrigin } from "../hub-origin.ts";
 import { HUB_UNIT_DEFAULT_PORT } from "../hub-unit.ts";
 import { type AliveFn, defaultAlive } from "../process-state.ts";
-import { readManifest } from "../services-manifest.ts";
+import { readManifestLenient } from "../services-manifest.ts";
 import { type Runner, defaultRunner } from "../tailscale/run.ts";
 import type { VaultAuthStatus } from "../vault/auth-status.ts";
 import { printPublic2FAWarning } from "./expose-2fa-warning.ts";
@@ -89,6 +89,22 @@ export function isValidHostname(h: string): boolean {
   if (!h.includes(".")) return false;
   const labelRe = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/i;
   return h.split(".").every((label) => labelRe.test(label));
+}
+
+/**
+ * Best-effort "is this module registered in services.json?" check, used only
+ * for the courtesy note in the Cloudflare expose path (hub#564). Uses the
+ * LENIENT manifest reader on purpose: the strict `readManifest` can reject an
+ * older manifest shape (the #564 diagnostic — a manifest written by 0.6.3-era
+ * registration that the strict reader bounced), and a courtesy note must never
+ * throw. Any read error is swallowed and treated as "not installed".
+ */
+function serviceInstalled(manifestPath: string, name: string): boolean {
+  try {
+    return readManifestLenient(manifestPath).services.some((s) => s.name === name);
+  } catch {
+    return false;
+  }
 }
 
 export interface CloudflaredSpawner {
@@ -606,12 +622,18 @@ export async function exposeCloudflareUp(
     return 1;
   }
 
-  const manifest = readManifest(r.manifestPath);
-  const vaultEntry = manifest.services.find((s) => s.name === "parachute-vault");
-  if (!vaultEntry) {
-    r.log("parachute-vault is not installed; nothing to route.");
-    r.log("Run: parachute install vault");
-    return 1;
+  // No vault gate here (hub#564). cloudflared's ingress targets the HUB port
+  // (see `servicePort: hubPort` in `writeConfig` below + the long comment
+  // there) — the hub does ALL routing (discovery, admin, OAuth, well-known,
+  // per-vault proxy, generic /<svc>/* dispatch). Vault doesn't have to be
+  // installed for the tunnel to route anything. The old gate
+  // (`parachute-vault is not installed; nothing to route` → return 1) was a
+  // vestige of the pre-2026-05-27 vault-centric ingress, and it dead-ended
+  // fresh-server init: post-#168 init exposes (Step 2) BEFORE it installs the
+  // vault module (Step 2.5), so the gate always tripped on a fresh box and
+  // aborted the whole init. Courtesy note only — never block.
+  if (!serviceInstalled(r.manifestPath, "parachute-vault")) {
+    r.log("vault not installed yet — the admin wizard will set it up. Routing the hub anyway.");
   }
 
   // Resolve the public hub origin before spawning the hub server — it gets
@@ -897,45 +919,58 @@ export async function exposeCloudflareUp(
   // and makes the running vault re-read it immediately rather than waiting for
   // the next reboot.
   //
+  // hub#564: vault may not be installed yet (init exposes BEFORE installing the
+  // vault module). Resolve the entry once, here, and gate the vault-restart +
+  // the Vault-URL footer on it — restarting a not-installed vault would just
+  // fail and print a spurious warning. When present, a well-formed manifest
+  // always lists at least one mount path.
+  const vaultEntry = (() => {
+    try {
+      return readManifestLenient(r.manifestPath).services.find((s) => s.name === "parachute-vault");
+    } catch {
+      return undefined;
+    }
+  })();
+
   // §4.3c: drive the restart through the running Supervisor
   // (`driveModuleOp("vault", "restart")`), which re-injects the hub's current
   // origin; `restartHubDependentViaSupervisor` also persists the durable `.env`
   // + self-heals the operator-token issuer. Phase 5b retired the detached
-  // `lifecycle.restart` arm.
-  r.log("");
-  r.log("Restarting vault to pick up new hub origin…");
-  const rcode = await restartHubDependentViaSupervisor({
-    short: "vault",
-    hubOrigin,
-    configDir: r.configDir,
-    sup: r.sup,
-    log: r.log,
-  });
-  if (rcode !== 0) {
-    r.log(
-      "⚠ vault restart failed. Run manually once the issue is resolved: parachute restart vault",
-    );
+  // `lifecycle.restart` arm. Skipped entirely when vault isn't installed.
+  if (vaultEntry) {
+    r.log("");
+    r.log("Restarting vault to pick up new hub origin…");
+    const rcode = await restartHubDependentViaSupervisor({
+      short: "vault",
+      hubOrigin,
+      configDir: r.configDir,
+      sup: r.sup,
+      log: r.log,
+    });
+    if (rcode !== 0) {
+      r.log(
+        "⚠ vault restart failed. Run manually once the issue is resolved: parachute restart vault",
+      );
+    }
   }
 
   const baseUrl = `https://${hostname}`;
-  // A well-formed vault manifest always lists at least one mount path. If
-  // it's empty, something went sideways in `parachute install vault` — warn
-  // so the user can fix services.json rather than chasing a phantom 404 on
-  // /vault/default that may or may not exist.
-  if (!vaultEntry.paths[0]) {
-    r.log(
-      `⚠ vault entry in services.json has no paths[]; defaulting to "/vault/default". Check the manifest.`,
-    );
+  let vaultUrl: string | undefined;
+  if (vaultEntry) {
+    if (!vaultEntry.paths[0]) {
+      r.log(
+        `⚠ vault entry in services.json has no paths[]; defaulting to "/vault/default". Check the manifest.`,
+      );
+    }
+    vaultUrl = `${baseUrl}${vaultEntry.paths[0] ?? "/vault/default"}`;
   }
-  const vaultMount = vaultEntry.paths[0] ?? "/vault/default";
-  const vaultUrl = `${baseUrl}${vaultMount}`;
 
   r.log("");
   r.log(`✓ Cloudflare tunnel up (pid ${pid}).`);
   r.log(`  Tunnel:  ${r.tunnelName} (dedicated to this machine)`);
   r.log(`  Open:    ${baseUrl}/`);
   r.log(`  Admin:   ${baseUrl}/admin/`);
-  r.log(`  Vault:   ${vaultUrl}`);
+  if (vaultUrl) r.log(`  Vault:   ${vaultUrl}`);
   r.log(`  OAuth:   ${hubOrigin}`);
   r.log(`  Logs:    ${r.logPath}`);
   r.log("");
@@ -954,10 +989,14 @@ export async function exposeCloudflareUp(
     r.log("background but does NOT survive a reboot. After a reboot, re-run:");
     r.log(`  parachute expose public --cloudflare --domain ${hostname}`);
   }
-  r.log("");
-  r.log("Point a claude.ai / ChatGPT connector at:");
-  r.log(`  ${vaultUrl}`);
-  printAuthGuidance(r.log, vaultUrl);
+  // The connector guidance points at a vault MCP URL — only meaningful once a
+  // vault is installed (hub#564: it may not be yet, when init exposes first).
+  if (vaultUrl) {
+    r.log("");
+    r.log("Point a claude.ai / ChatGPT connector at:");
+    r.log(`  ${vaultUrl}`);
+    printAuthGuidance(r.log, vaultUrl);
+  }
   // 2FA-enrollment warning when /admin/login is now reachable on the public
   // internet but the operator hasn't enrolled TOTP. Cloudflare exposure is
   // always public; tailnet/funnel mirrors this in `expose.ts`. See #186.

--- a/src/commands/expose-interactive.ts
+++ b/src/commands/expose-interactive.ts
@@ -287,9 +287,12 @@ function printTailscaleSetupGuidance(r: Resolved, readiness: ProviderAvailabilit
  *
  *   - Confirm with `Install cloudflared now? [Y/n]` (Enter accepts).
  *   - Run the curl into /usr/local/bin/cloudflared + chmod +x. Root writes
- *     directly; non-root wraps each step in `sudo` (passwordless `sudo -n`
- *     succeeds non-interactively; an interactive sudo will prompt for the
- *     password under the inherit-stdio runner).
+ *     directly; non-root wraps each step in `sudo -n` (non-interactive — only
+ *     succeeds when sudo creds are already cached / passwordless). We use `-n`
+ *     deliberately: init often runs detached/unattended on a fresh server (SSH
+ *     + tmux, a cloud-init script), where a blocking interactive sudo password
+ *     prompt would hang the whole flow. `-n` fails fast instead, and we fall
+ *     back to printing the manual command.
  *   - Verify with `cloudflared --version`.
  *
  * Returns true only when cloudflared is on PATH afterward. On decline, missing
@@ -324,10 +327,12 @@ async function offerLinuxCloudflaredInstall(r: Resolved): Promise<boolean> {
 
   const isRoot = r.getuid() === 0;
   const dest = "/usr/local/bin/cloudflared";
-  // Root writes directly; non-root prefixes each privileged step with `sudo`.
-  // `sudo` with no cached creds + no tty will fail cleanly (non-zero exit) and
-  // we fall back to the printed instructions — never hang init.
-  const sudo = isRoot ? [] : ["sudo"];
+  // Root writes directly; non-root prefixes each privileged step with `sudo -n`
+  // (non-interactive). `-n` never prompts for a password: it exits non-zero
+  // when creds aren't cached, so a detached/unattended init (SSH + tmux, a
+  // cloud-init script) fails fast and falls back to the printed instructions
+  // rather than hanging on a password prompt nobody's there to answer.
+  const sudo = isRoot ? [] : ["sudo", "-n"];
   const curlCmd = [...sudo, "curl", "-L", "-o", dest, downloadUrl];
   const chmodCmd = [...sudo, "chmod", "+x", dest];
 
@@ -336,7 +341,11 @@ async function offerLinuxCloudflaredInstall(r: Resolved): Promise<boolean> {
   const curlCode = await r.interactiveRunner(curlCmd);
   if (curlCode !== 0) {
     r.log(`Download failed (exit ${curlCode}).`);
-    if (!isRoot) r.log("(If sudo needs a password, run the commands below manually.)");
+    if (!isRoot) {
+      r.log(
+        "(`sudo -n` needs cached credentials; run `sudo -v` first, or use the commands below.)",
+      );
+    }
     printManualAndBail();
     return false;
   }

--- a/src/commands/expose-interactive.ts
+++ b/src/commands/expose-interactive.ts
@@ -14,9 +14,16 @@ import { createInterface } from "node:readline/promises";
 import {
   DEFAULT_CLOUDFLARED_HOME,
   cloudflaredInstallHint,
+  cloudflaredLinuxDownloadUrl,
   isCloudflaredInstalled,
   isCloudflaredLoggedIn,
 } from "../cloudflare/detect.ts";
+import {
+  CLOUDFLARED_STATE_PATH,
+  clearPendingHostname,
+  readPendingHostname,
+  writePendingHostname,
+} from "../cloudflare/state.ts";
 import {
   EXPOSE_LAST_PROVIDER_PATH,
   type ExposeProvider,
@@ -73,6 +80,19 @@ export interface ExposeInteractiveOpts {
   prompt?: (question: string) => Promise<string>;
   cloudflaredHome?: string;
   platform?: NodeJS.Platform;
+  /** Test seam: `process.arch` — drives the Linux cloudflared download URL. */
+  arch?: NodeJS.Architecture;
+  /**
+   * Test seam: `process.getuid` — root (uid 0) can write
+   * /usr/local/bin/cloudflared directly; non-root needs `sudo`. Defaults to
+   * `process.getuid` (undefined on platforms without it → treated non-root).
+   */
+  getuid?: () => number;
+  /**
+   * Path to cloudflared-state.json (hub#567 pending-hostname persistence).
+   * Defaults to the canonical `CLOUDFLARED_STATE_PATH`.
+   */
+  statePath?: string;
   lastProviderPath?: string;
   now?: () => Date;
   log?: (line: string) => void;
@@ -110,6 +130,9 @@ interface Resolved {
   prompt: (question: string) => Promise<string>;
   cloudflaredHome: string;
   platform: NodeJS.Platform;
+  arch: NodeJS.Architecture;
+  getuid: () => number;
+  statePath: string;
   lastProviderPath: string;
   now: () => Date;
   log: (line: string) => void;
@@ -129,6 +152,10 @@ function resolve(opts: ExposeInteractiveOpts): Resolved {
     prompt: opts.prompt ?? defaultPrompt,
     cloudflaredHome: opts.cloudflaredHome ?? DEFAULT_CLOUDFLARED_HOME,
     platform: opts.platform ?? process.platform,
+    arch: opts.arch ?? process.arch,
+    // `process.getuid` is absent on Windows; treat missing as non-root (uid 1).
+    getuid: opts.getuid ?? (() => process.getuid?.() ?? 1),
+    statePath: opts.statePath ?? CLOUDFLARED_STATE_PATH,
     lastProviderPath: opts.lastProviderPath ?? EXPOSE_LAST_PROVIDER_PATH,
     now: opts.now ?? (() => new Date()),
     log: opts.log ?? ((line) => console.log(line)),
@@ -185,10 +212,25 @@ async function promptHostname(r: Resolved): Promise<string | undefined> {
   r.log("");
   r.log("Cloudflare needs a hostname under a domain you've added to your Cloudflare account.");
   r.log('Example: vault.example.com   (apex "example.com" must be a Cloudflare zone)');
+  // hub#567: pre-fill with a hostname the operator typed on a prior (failed)
+  // run so a retry is "press Enter", not "redo the whole interview".
+  const pending = readPendingHostname(r.statePath);
+  const promptText = pending
+    ? `Hostname [${pending}] (or blank to quit): `
+    : "Hostname (or blank to quit): ";
   for (let attempt = 0; attempt < 5; attempt++) {
-    const raw = (await r.prompt("Hostname (or blank to quit): ")).trim();
+    const raw = (await r.prompt(promptText)).trim();
+    // Enter on a pre-filled prompt accepts the stashed hostname.
+    if (raw === "" && pending) {
+      return pending;
+    }
     if (raw === "") return undefined;
-    if (isValidHostname(raw)) return raw;
+    if (isValidHostname(raw)) {
+      // Stash it the moment it validates so a downstream failure (cloudflared
+      // login, tunnel/DNS error) doesn't discard it. Cleared on success.
+      writePendingHostname(raw, r.statePath);
+      return raw;
+    }
     r.log(`"${raw}" doesn't look like a hostname. Expected something like vault.example.com.`);
   }
   r.log("Too many invalid entries; aborting.");
@@ -239,10 +281,89 @@ function printTailscaleSetupGuidance(r: Resolved, readiness: ProviderAvailabilit
 }
 
 /**
+ * hub#566: offer to install cloudflared on Linux in place (instead of printing
+ * the command and bailing). The install is a single static-binary download
+ * (curl + chmod) we already know how to do.
+ *
+ *   - Confirm with `Install cloudflared now? [Y/n]` (Enter accepts).
+ *   - Run the curl into /usr/local/bin/cloudflared + chmod +x. Root writes
+ *     directly; non-root wraps each step in `sudo` (passwordless `sudo -n`
+ *     succeeds non-interactively; an interactive sudo will prompt for the
+ *     password under the inherit-stdio runner).
+ *   - Verify with `cloudflared --version`.
+ *
+ * Returns true only when cloudflared is on PATH afterward. On decline, missing
+ * download URL (unknown arch), or any install/verify failure, prints the
+ * canonical manual instructions + the `--cloudflare` re-run hint and returns
+ * false. Per hub#565 the caller's `false` does NOT abort init.
+ */
+async function offerLinuxCloudflaredInstall(r: Resolved): Promise<boolean> {
+  r.log("");
+  r.log("Cloudflare Tunnel uses the `cloudflared` binary, which isn't installed yet.");
+  const downloadUrl = cloudflaredLinuxDownloadUrl(r.arch);
+
+  const printManualAndBail = () => {
+    r.log("");
+    for (const line of cloudflaredInstallHint("linux", r.arch).split("\n")) r.log(line);
+    r.log("");
+    r.log("After install, re-run: parachute expose public --cloudflare");
+  };
+
+  // No published artifact for this arch → can't auto-install; print + bail.
+  if (!downloadUrl) {
+    printManualAndBail();
+    return false;
+  }
+
+  const answer = (await r.prompt("Install cloudflared now? [Y/n] ")).trim().toLowerCase();
+  if (answer === "n" || answer === "no") {
+    r.log("Skipped auto-install.");
+    printManualAndBail();
+    return false;
+  }
+
+  const isRoot = r.getuid() === 0;
+  const dest = "/usr/local/bin/cloudflared";
+  // Root writes directly; non-root prefixes each privileged step with `sudo`.
+  // `sudo` with no cached creds + no tty will fail cleanly (non-zero exit) and
+  // we fall back to the printed instructions — never hang init.
+  const sudo = isRoot ? [] : ["sudo"];
+  const curlCmd = [...sudo, "curl", "-L", "-o", dest, downloadUrl];
+  const chmodCmd = [...sudo, "chmod", "+x", dest];
+
+  r.log("");
+  r.log(`Downloading cloudflared → ${dest} …`);
+  const curlCode = await r.interactiveRunner(curlCmd);
+  if (curlCode !== 0) {
+    r.log(`Download failed (exit ${curlCode}).`);
+    if (!isRoot) r.log("(If sudo needs a password, run the commands below manually.)");
+    printManualAndBail();
+    return false;
+  }
+  const chmodCode = await r.interactiveRunner(chmodCmd);
+  if (chmodCode !== 0) {
+    r.log(`chmod failed (exit ${chmodCode}).`);
+    printManualAndBail();
+    return false;
+  }
+
+  if (!(await isCloudflaredInstalled(r.runner))) {
+    r.log("Install ran but `cloudflared` still isn't on PATH.");
+    r.log(
+      "Open a fresh shell (so PATH picks up the new binary), then re-run: parachute expose public --cloudflare",
+    );
+    return false;
+  }
+  r.log("✓ cloudflared installed.");
+  return true;
+}
+
+/**
  * Walks the user through installing and logging in cloudflared. On macOS we
- * auto-install via brew (with confirmation); on Linux we print manual-install
- * pointers and bail so the user can pick apt/dnf/tarball. Returns true only
- * when cloudflared is both present and logged in afterwards.
+ * auto-install via brew (with confirmation); on Linux we auto-install the
+ * static binary (hub#566) with confirmation; everywhere else we print
+ * manual-install pointers and bail. Returns true only when cloudflared is
+ * both present and logged in afterwards.
  */
 async function guideCloudflareSetup(
   r: Resolved,
@@ -259,7 +380,11 @@ async function guideCloudflareSetup(
         .trim()
         .toLowerCase();
       if (answer === "n" || answer === "no") {
-        r.log("Skipped auto-install. Install manually, then re-run: parachute expose public");
+        // hub#566: re-run with `--cloudflare` (bare `expose public` defaults
+        // to Tailscale Funnel, the wrong provider for someone who chose CF).
+        r.log(
+          "Skipped auto-install. Install manually, then re-run: parachute expose public --cloudflare",
+        );
         return false;
       }
       const code = await r.interactiveRunner(["brew", "install", "cloudflared"]);
@@ -273,20 +398,26 @@ async function guideCloudflareSetup(
         r.log("Open a fresh shell (so PATH picks up the new binary) and re-run.");
         return false;
       }
+    } else if (r.platform === "linux") {
+      // hub#566: on Linux the install is a single static-binary download we
+      // already know how to do — offer to run it in place instead of dumping
+      // the operator back to a shell. Auto-install requires root (write to
+      // /usr/local/bin) or a working passwordless `sudo -n`. If we can't, or
+      // the operator declines, fall back to printing the instructions (and
+      // per hub#565 init continues regardless of the `false` return here).
+      installed = await offerLinuxCloudflaredInstall(r);
+      if (!installed) return false;
     } else {
-      // 2026-05-27 refresh: distro-package paths (`apt-get`, `dnf`) are
-      // unreliable across versions — Aaron hit `No match for argument:
-      // cloudflared` on Amazon Linux 2023 — and the
-      // pkg.cloudflare.com / developers.cloudflare.com paths the old hint
-      // pointed at now serve HTML/404. Defer to `cloudflaredInstallHint`,
-      // which writes the canonical GitHub-release static-binary path
-      // matching the host's architecture.
+      // Non-darwin/linux (e.g. Windows / misc): no auto-install path. Print
+      // the canonical pointer and bail (init continues per hub#565).
       r.log("");
       r.log("Cloudflare Tunnel uses the `cloudflared` binary, which isn't installed yet.");
       r.log("");
-      for (const line of cloudflaredInstallHint(r.platform).split("\n")) r.log(line);
+      for (const line of cloudflaredInstallHint(r.platform, r.arch).split("\n")) r.log(line);
       r.log("");
-      r.log("After install, re-run: parachute expose public");
+      // hub#566: the bare `parachute expose public` defaults to Tailscale
+      // Funnel — an operator who chose Cloudflare must re-run with the flag.
+      r.log("After install, re-run: parachute expose public --cloudflare");
       return false;
     }
   }
@@ -310,7 +441,7 @@ async function guideCloudflareSetup(
     loggedIn = isCloudflaredLoggedIn(r.cloudflaredHome);
     if (!loggedIn) {
       r.log("Login ran but cert.pem didn't appear in ~/.cloudflared.");
-      r.log("Check the browser flow completed, then re-run: parachute expose public");
+      r.log("Check the browser flow completed, then re-run: parachute expose public --cloudflare");
       return false;
     }
   }
@@ -391,7 +522,13 @@ export async function exposePublicInteractive(opts: ExposeInteractiveOpts = {}):
   }
   writeLastProvider("cloudflare", { path: r.lastProviderPath, now: r.now });
   const code = await r.exposeCloudflareUpImpl(hostname, r.cloudflareOpts);
-  if (code === 0) await runPreflightSafely(r);
+  if (code === 0) {
+    // hub#567: routing succeeded — the tunnel record now carries the live
+    // hostname, so drop the pending one (a retry shouldn't pre-fill a
+    // hostname that's already exposed).
+    clearPendingHostname(r.statePath);
+    await runPreflightSafely(r);
+  }
   return code;
 }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -801,9 +801,14 @@ export async function init(opts: InitOpts = {}): Promise<number> {
 /** The exact retry command for a given exposure choice (hub#565 / #566). */
 export function exposeRetryCommand(choice: ExposeChoice): string {
   if (choice === "tailnet") return "parachute expose public --tailnet";
-  // Default the bare command to `--cloudflare` so the operator who picked
-  // Cloudflare lands in the right provider on retry (the bare
-  // `parachute expose public` defaults to Tailscale Funnel — hub#566).
+  // `none` never reaches here in practice — `runExposureChoice("none")` always
+  // returns 0, so `warnExposeFailedContinue` (the only caller) is never invoked
+  // for it. It falls through to the `--cloudflare` branch below; harmless, and
+  // spelled out so the fallthrough isn't read as a bug.
+  // Cloudflare (and the unreachable `none`): default the bare command to
+  // `--cloudflare` so the operator who picked Cloudflare lands in the right
+  // provider on retry (bare `parachute expose public` defaults to Tailscale
+  // Funnel — hub#566).
   return "parachute expose public --cloudflare";
 }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -619,7 +619,12 @@ export async function init(opts: InitOpts = {}): Promise<number> {
       exposeTailnetImpl,
       exposeCloudflareImpl,
     });
-    if (code !== 0) return code;
+    // hub#565: exposure is an ENHANCEMENT, not a prerequisite. A failed
+    // expose chain must NOT abort init — warn + print the exact retry
+    // command, then fall through to vault install + the admin-URL/wizard
+    // handoff on the loopback URL. Init's contract is hub up → vault module
+    // installed → admin URL → wizard, ALWAYS.
+    if (code !== 0) warnExposeFailedContinue(opts.exposeChoice, log);
     // Refresh state — the chain may have brought up an FQDN.
     exposeState = readExposeStateFn();
   } else if (opts.noExposePrompt) {
@@ -642,7 +647,9 @@ export async function init(opts: InitOpts = {}): Promise<number> {
         exposeTailnetImpl,
         exposeCloudflareImpl,
       });
-      if (code !== 0) return code;
+      // hub#565: warn + continue on a failed expose chain rather than
+      // aborting init (same contract as the non-interactive branch above).
+      if (code !== 0) warnExposeFailedContinue(picked, log);
       exposeState = readExposeStateFn();
     }
   }
@@ -713,6 +720,13 @@ export async function init(opts: InitOpts = {}): Promise<number> {
   log("");
   log(`  ${adminUrl}`);
   log("");
+  // hub#565: when we're on the loopback URL (no public exposure active),
+  // remind the operator they can expose later. Skipped once an FQDN is up.
+  if (!exposeState?.canonicalFqdn) {
+    log("(Reachable on this machine. To expose it publicly later, run");
+    log(" `parachute expose public --cloudflare` or `parachute expose public --tailnet`.)");
+    log("");
+  }
 
   // Step 4.5: offer the operator the CLI wizard vs. the browser wizard
   // (hub#168 Cut 4). Aaron's 2026-05-28 directive: "we should be able to
@@ -782,6 +796,27 @@ export async function init(opts: InitOpts = {}): Promise<number> {
     log("(Couldn't launch a browser — open the URL above manually.)");
   }
   return 0;
+}
+
+/** The exact retry command for a given exposure choice (hub#565 / #566). */
+export function exposeRetryCommand(choice: ExposeChoice): string {
+  if (choice === "tailnet") return "parachute expose public --tailnet";
+  // Default the bare command to `--cloudflare` so the operator who picked
+  // Cloudflare lands in the right provider on retry (the bare
+  // `parachute expose public` defaults to Tailscale Funnel — hub#566).
+  return "parachute expose public --cloudflare";
+}
+
+/**
+ * hub#565: warn that the exposure chain failed but init is continuing anyway,
+ * and print the exact retry command. Exposure is an enhancement, not a
+ * prerequisite — init still installs the vault module and hands off to the
+ * wizard on the loopback URL.
+ */
+function warnExposeFailedContinue(choice: ExposeChoice, log: (line: string) => void): void {
+  log("");
+  log("⚠ Couldn't finish setting up public access — continuing without it.");
+  log(`  To expose publicly later, run: ${exposeRetryCommand(choice)}`);
 }
 
 /**

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -27,7 +27,7 @@ import {
 } from "../service-spec.ts";
 import { findService, readManifest, upsertService } from "../services-manifest.ts";
 import { WELL_KNOWN_PATH } from "../well-known.ts";
-import { start as lifecycleStart } from "./lifecycle.ts";
+import { type LifecycleOpts, start as lifecycleStart } from "./lifecycle.ts";
 import { migrateNotice } from "./migrate.ts";
 import {
   type InteractiveAvailability,
@@ -553,6 +553,39 @@ function resolveInstallTarget(
   return { kind: "npm", packageName: input };
 }
 
+/**
+ * Build the LifecycleOpts the install auto-start uses (hub#573).
+ *
+ * The auto-start MUST thread the SAME supervisor + migrate-offer opts the
+ * production CLI dispatch passes for `parachute start <svc>` (cli.ts:
+ * `supervisor: {}` + `migrateOffer: { enabled: true }`). Without them, `start`
+ * resolved `unitInstalled` to its omitted-supervisor default of `false` and
+ * `migrateOffer.enabled` to `false` — so the auto-start ALWAYS took the no-unit
+ * path, printed "No supervised hub unit is installed. Run `parachute migrate
+ * --to-supervised`…", and returned non-zero → the "⚠ didn't start cleanly"
+ * warning. Meanwhile `parachute migrate` (which DOES run the real
+ * `isHubUnitInstalled` probe + /health) reported the unit already installed +
+ * healthy: the two paths disagreed because only `migrate` opted into real
+ * detection. `supervisor: {}` makes the auto-start run the same probe;
+ * `migrateOffer: { enabled: true }` makes it offer the cutover on a genuinely-
+ * unmigrated box instead of dumping a bare error mid-install.
+ *
+ * Exported so the convergence is unit-testable without driving a real start.
+ */
+export function defaultStartLifecycleOpts(ctx: {
+  manifestPath: string;
+  configDir: string;
+  log: (line: string) => void;
+}): LifecycleOpts {
+  return {
+    manifestPath: ctx.manifestPath,
+    configDir: ctx.configDir,
+    log: ctx.log,
+    supervisor: {},
+    migrateOffer: { enabled: true },
+  };
+}
+
 export async function install(input: string, opts: InstallOpts = {}): Promise<number> {
   const runner = opts.runner ?? defaultRunner;
   const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
@@ -883,7 +916,8 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
   if (!opts.noStart && !opts.noCreate) {
     const startService =
       opts.startService ??
-      ((short: string) => lifecycleStart(short, { manifestPath, configDir, log }));
+      ((short: string) =>
+        lifecycleStart(short, defaultStartLifecycleOpts({ manifestPath, configDir, log })));
     const startCode = await startService(short);
     if (startCode !== 0) {
       log(`⚠ ${short} didn't start cleanly. Run manually: parachute start ${short}`);

--- a/web/ui/CLAUDE.md
+++ b/web/ui/CLAUDE.md
@@ -100,19 +100,21 @@ bun run test         # vitest run
 ```
 
 `web/ui/dist/` is gitignored — the hub serves it from a co-located bundle
-that Vite produces. The root `package.json` wires this for you: a
-`postinstall` hook runs `bun run build:spa` after every `bun install` in
-the repo root, and `prepack` rebuilds before `bun pack` / `bun publish`
+that Vite produces. The root `package.json` wires the publish side: a
+`prepack` hook runs `bun run build:spa` before `bun pack` / `bun publish`
 so the npm tarball always ships a fresh `web/ui/dist/`. The `files`
 array in the root `package.json` includes `web/ui/dist`, so consumers
 of the published `@openparachute/hub` package get the bundle even
 though they don't get the SPA source.
 
-If you ever need to manually rebuild, `cd web/ui && bun run build` still
-works. `src/hub-server.ts` handles a missing `dist/` by 503ing the
-`/vault/*` and `/hub/*` SPA routes with a hint to run the build —
-usually means the postinstall hasn't run yet, or fired with
-`--ignore-scripts` (which suppresses lifecycle hooks).
+In a dev checkout, build the bundle yourself with `bun run build:spa`
+from the repo root (or `cd web/ui && bun run build`). There is **no**
+`postinstall` hook anymore — it was removed (hub#568) because `prepack`
+already covers publishes, and a consumer-side `postinstall` was just dead
+weight bun blocked on every fresh `bun add -g @openparachute/hub`
+("Blocked 1 postinstall"). `src/hub-server.ts` handles a missing `dist/`
+by 503ing the `/vault/*` and `/hub/*` SPA routes with a hint to run the
+build — in a dev checkout that just means you haven't run `build:spa` yet.
 
 ## Pagination convention
 


### PR DESCRIPTION
Five fixes for the fresh-server `parachute init` → Cloudflare onboarding path, where each step could dead-end the operator.

## Per-issue summary

### #564 — vestigial vault gate dead-ended init (`src/commands/expose-cloudflare.ts`)
Deleted the gate that returned 1 with `parachute-vault is not installed; nothing to route`. cloudflared's ingress targets the **hub** port and the hub does all routing, so vault need not be installed. The gate also fired *before* init's Step 2.5 vault install (init exposes first post-#168), so it aborted the whole init on every fresh box. Now logs a courtesy note and continues. The vault-restart + Vault-URL footer resolve the entry lazily and skip when vault is absent. Uses the **lenient** manifest reader so an older 0.6.3-era manifest shape can't throw (the #564 diagnostic about strict `readManifest` rejecting valid older manifests).

### #565 — expose failure aborted init (`src/commands/init.ts`)
Both expose branches did `if (code !== 0) return code;`. Now they warn + print the exact retry command (`parachute expose public --cloudflare` / `--tailnet`) and continue to vault install + the admin-URL/wizard handoff on the loopback URL. Init exits 0. Added a "to expose later" note near the printed loopback URL.

### #566 — inline cloudflared install + stale re-run hints (`src/commands/expose-interactive.ts`)
On Linux the interactive flow now offers `Install cloudflared now? [Y/n]` and, on accept, runs the curl + chmod itself (bare as root, `sudo`-wrapped otherwise), verifies with `cloudflared --version`, and continues in place. Decline / unknown-arch / failure falls back to printing the instructions (and per #565 init continues regardless). Fixed the two stale hints at `:262`/`:289` (and the cloudflared-login hint) that said bare `parachute expose public` — they now carry `--cloudflare` (the bare command defaults to Tailscale Funnel). Exported `cloudflaredLinuxDownloadUrl` from `detect.ts`.

### #567 — persist typed hostname across failures (`src/cloudflare/state.ts` + `expose-interactive.ts`)
Added a top-level `pendingHostname` field to `cloudflared-state.json` (preserved through validate / v1-migration / `withTunnelRecord`) with read/write/clear helpers. The hostname is stashed the moment it validates, pre-fills the prompt on the next run (`Hostname [techne.parachute.computer] …` — Enter accepts), and is cleared once routing succeeds.

### #573 — install→start vs migrate detection disagreement (`src/commands/install.ts`)
**Root cause:** the install auto-start called `lifecycleStart(short, { manifestPath, configDir, log })` with **no `supervisor` block and no `migrateOffer`**. In `lifecycle.ts`, an omitted `supervisor` resolves `unitInstalled` to `false` and an omitted `migrateOffer` resolves `enabled` to `false` — so the auto-start *always* took the no-unit path: it printed `No supervised hub unit is installed. Run parachute migrate --to-supervised…` (lifecycle.ts:346), returned non-zero, and install printed `⚠ vault didn't start cleanly` (install.ts:889). Meanwhile `parachute migrate --to-supervised` ran the **real** `isHubUnitInstalled` (unit-file-on-disk) + `/health` probe and correctly reported "already migrated + healthy" (migrate-cutover.ts:629-637). Both paths *can* call the same `isHubUnitInstalled`, but only `migrate` (and the production `parachute start` CLI dispatch) opted into it; the install auto-start passed a bare opts object that defaulted detection off. Not a systemd-vs-launchd issue, not a stale read — purely the missing opts at the install call site.

**Fix:** thread the same opts the production `parachute start <svc>` dispatch passes (`supervisor: {}` + `migrateOffer: { enabled: true }`). `supervisor: {}` runs the real probe (a supervised box dispatches through the running supervisor); `migrateOffer: { enabled: true }` offers the cutover on a genuinely-unmigrated box instead of dumping a bare error mid-install. Extracted into an exported `defaultStartLifecycleOpts` so the convergence is unit-testable.

### #568 — consumer-blocked `postinstall` (`package.json`)
Deleted `"postinstall": "if [ -d web/ui ]; then bun run build:spa; fi"`. `prepack` already builds the SPA into the published tarball (and `files` ships `web/ui/dist`), so the consumer-side postinstall never ran for consumers — but bun blocks untrusted lifecycle scripts by default, so every fresh `bun add -g @openparachute/hub` opened with a scary "Blocked 1 postinstall" line. Verified via sandboxed `bun add -g @openparachute/hub@rc` + `bun pm -g untrusted`. No behavior change for consumers or publishes; dev checkouts build the SPA explicitly with `bun run build:spa`. Grep confirmed nothing depends on the hook (only the line + a historical CHANGELOG mention + the `web/ui/CLAUDE.md` doc, updated here). `prepack` untouched.

Fixes #564
Fixes #565
Fixes #566
Fixes #567
Fixes #573
Fixes #568

## Test plan

- New / adjusted unit tests for every behavior change: gate removal (now continues + routes), init continues-on-expose-failure (cloudflare → `--cloudflare`, tailnet → `--tailnet`), Linux cloudflared auto-install (decline / root-accept / non-root-`sudo -n` / sudo-fail), the `--cloudflare` re-run hints, hostname persist + prefill + clear + `withoutTunnelRecord` carry (interactive + state-helper unit tests incl. byte round-trip), and the #573 default-start-opts convergence. #568 is a build-script-only change (no test delta).
- `bun test ./src`: **3000 pass, 1 skip, 0 fail** (35452 expect() calls, 123 files).
- `bun run typecheck`: clean.
- `bunx biome check` on the changed files: clean.
- Sandboxed E2E in a fresh `PARACHUTE_HOME`: `init` with a failing Cloudflare expose exits 0, warns with the `--cloudflare` retry command, continues to vault install + prints the loopback `http://127.0.0.1:1939/admin/`, and writes nothing destructive.
- Daemon safety: live hub still answers `http://127.0.0.1:1939/health` after the suite.

## Out of scope (deliberately)
- The #564 diagnostic worry that `readManifest` (strict) could reject valid older manifests for *other* callers: not chased here beyond switching the expose-path courtesy check to the lenient reader. Worth a follow-up audit of strict-`readManifest` callers if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
