### PR TITLE
release: hub 0.6.4-rc.6 (fresh-server onboarding fixes #574)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.4-rc.5",
+  "version": "0.6.4-rc.6",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Version-only bump to 0.6.4-rc.6, shipping #574 (fixes #564 #565 #566 #567 #568 #573 — the fresh-server onboarding dead-ends from the techne transcripts).

Tag v0.6.4-rc.6 on the merge commit → CI publishes to npm dist-tag `rc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)