### PR TITLE
release: hub 0.6.4-rc.7 (light install + dual-lifecycle fixes #581)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.4-rc.6",
+  "version": "0.6.4-rc.7",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Version-only bump to 0.6.4-rc.7, shipping #581 (fixes #579, closes #580 hub-side).

Tag v0.6.4-rc.7 on the merge commit → CI publishes to npm dist-tag `rc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)