### PR TITLE
fix(onboarding): bootstrap-token first-claim, /account connected detection, phantom vault, expose label (#576 #583 #577 #459)

### DIFF
--- a/src/__tests__/account-home-ui.test.ts
+++ b/src/__tests__/account-home-ui.test.ts
@@ -660,6 +660,47 @@ describe("renderAccountHome", () => {
     expect(html).toContain('data-testid="vault-card"');
   });
 
+  test("onboarding condensed state keeps a 'Connect another AI' expander with the full instructions (hub#583)", () => {
+    const html = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["alice"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+      connectedVault: true,
+    });
+    // The expander itself...
+    expect(html).toContain('data-testid="onboarding-connect-another"');
+    expect(html).toContain('data-testid="onboarding-connect-another-summary"');
+    expect(html).toContain("Connect another AI");
+    // ...re-reveals the endpoint + BOTH connect methods that the condensed
+    // line used to delete entirely (the hub#583 defect).
+    expect(html).toContain('data-testid="onboarding-mcp-endpoint"');
+    expect(html).toContain('data-testid="onboarding-mcp-add-command"');
+    expect(html).toContain("Claude.ai (web)");
+    expect(html).toContain("Claude Code (terminal)");
+  });
+
+  test("onboarding NON-condensed (not connected) state has no 'Connect another AI' expander (hub#583)", () => {
+    const html = renderAccountHome({
+      username: "alice",
+      assignedVaults: ["alice"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+      connectedVault: false,
+    });
+    // Full checklist already shows the inline instructions in step 2, so the
+    // expander is condensed-state-only.
+    expect(html).not.toContain('data-testid="onboarding-connect-another"');
+    expect(html).toContain('data-testid="onboarding-step-2"');
+    expect(html).toContain('data-testid="onboarding-mcp-endpoint"');
+  });
+
   test("onboarding checklist — leads the page: BEFORE the vault card and the starter prompts", () => {
     const html = renderAccountHome({
       username: "alice",

--- a/src/__tests__/api-account.test.ts
+++ b/src/__tests__/api-account.test.ts
@@ -28,7 +28,9 @@ import {
   handleAccountHomeGet,
   markPasswordChanged,
 } from "../api-account.ts";
+import { registerClient } from "../clients.ts";
 import { CSRF_COOKIE_NAME, CSRF_FIELD_NAME } from "../csrf.ts";
+import { recordGrant } from "../grants.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { recordTokenMint } from "../jwt-sign.ts";
 import {
@@ -830,6 +832,65 @@ describe("handleAccountHomeGet", () => {
     // Notes CTA carries the hub-origin-encoded vault URL.
     const encoded = encodeURIComponent(`${HUB_ORIGIN}/vault/alice`);
     expect(html).toContain(`https://notes.parachute.computer/add?url=${encoded}`);
+  });
+
+  test("onboarding NOT condensed when only a first-party browser grant exists (hub#583, GET /account/)", async () => {
+    // The exact field report: create account → open Notes (a first-party OAuth
+    // client that writes a vault-scoped grant) → later visit /account/ to wire
+    // up Claude. The checklist must NOT already be condensed.
+    await createUser(harness.db, "admin", "admin-passphrase", { passwordChanged: true });
+    const friend = await createUser(harness.db, "alice", "alice-passphrase", {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVaults: ["alice"],
+    });
+    // Notes signs in via DCR (generated client_id, client_name "Notes") and
+    // records a vault-scoped grant.
+    const notes = registerClient(harness.db, {
+      redirectUris: ["https://hub.test/notes/cb"],
+      clientName: "Notes",
+    });
+    recordGrant(harness.db, friend.id, notes.client.clientId, ["vault:alice:read"]);
+
+    const session = createSession(harness.db, { userId: friend.id });
+    const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+    const req = new Request(`${HUB_ORIGIN}/account/`, { headers: { cookie } });
+    const res = await handleAccountHomeGet(req, { db: harness.db, hubOrigin: HUB_ORIGIN });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Full checklist (not condensed): the connect step is present, the
+    // "you're connected" done-line is NOT.
+    expect(html).toContain('data-connected="false"');
+    expect(html).toContain('data-testid="onboarding-step-2"');
+    expect(html).not.toContain('data-testid="onboarding-done-line"');
+  });
+
+  test("onboarding condensed when an external AI client grant exists (hub#583, GET /account/)", async () => {
+    await createUser(harness.db, "admin", "admin-passphrase", { passwordChanged: true });
+    const friend = await createUser(harness.db, "alice", "alice-passphrase", {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVaults: ["alice"],
+    });
+    // Claude Code: a genuine external MCP client.
+    const claude = registerClient(harness.db, {
+      redirectUris: ["https://claude.ai/cb"],
+      clientName: "Claude",
+    });
+    recordGrant(harness.db, friend.id, claude.client.clientId, ["vault:alice:read"]);
+
+    const session = createSession(harness.db, { userId: friend.id });
+    const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+    const req = new Request(`${HUB_ORIGIN}/account/`, { headers: { cookie } });
+    const res = await handleAccountHomeGet(req, { db: harness.db, hubOrigin: HUB_ORIGIN });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Condensed done-state.
+    expect(html).toContain('data-connected="true"');
+    expect(html).toContain('data-testid="onboarding-done-line"');
+    expect(html).toContain("You're connected");
+    // And it still keeps the "Connect another AI" expander.
+    expect(html).toContain('data-testid="onboarding-connect-another"');
   });
 
   test("200 + admin branch when the first-admin signs in (no vault assignments)", async () => {

--- a/src/__tests__/api-modules-ops.test.ts
+++ b/src/__tests__/api-modules-ops.test.ts
@@ -1671,13 +1671,19 @@ describe("well-known regen after module ops", () => {
     const vaultRow = manifest.services.find((s) => s.name === "parachute-vault");
     expect(vaultRow?.installDir).toBe(install.installDir);
 
-    // The on-disk well-known doc reflects the new module.
+    // The on-disk well-known doc reflects the new module in `services`...
     const doc = JSON.parse(readFileSync(wkPath, "utf8")) as {
       services: Array<{ name: string; version: string }>;
       vaults: Array<{ name: string }>;
     };
     expect(doc.services.some((s) => s.name === "parachute-vault")).toBe(true);
-    expect(doc.vaults.some((v) => v.name === "default")).toBe(true);
+    // ...but does NOT fabricate a phantom `default` vault row (hub#577). The
+    // install seeds the entry at SEED_VERSION ("module installed, no instance
+    // booted"); vault's own boot registers the real instance later. Until then
+    // the vaults[] list is honestly empty so the management page reads "No
+    // vaults yet" rather than showing a `default` that doesn't exist.
+    expect(doc.vaults.some((v) => v.name === "default")).toBe(false);
+    expect(doc.vaults).toEqual([]);
   });
 
   test("runInstall sets PORT in child env from services.json entry (hub#356)", async () => {

--- a/src/__tests__/grants.test.ts
+++ b/src/__tests__/grants.test.ts
@@ -8,9 +8,11 @@ import {
   findGrantByClientName,
   isCoveredByGrant,
   isCoveredByGrantForClientName,
+  isFirstPartyBrowserClient,
   listGrantsForUser,
   recordGrant,
   revokeGrant,
+  userHasExternalAiGrant,
   userHasVaultGrant,
 } from "../grants.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
@@ -390,6 +392,103 @@ describe("findGrantByClientName / isCoveredByGrantForClientName (hub#409)", () =
       recordGrant(h.db, h.userId, h.clientId, ["vault:default-2:read"]);
       expect(userHasVaultGrant(h.db, h.userId, "default")).toBe(false);
       expect(userHasVaultGrant(h.db, h.userId, "default-2")).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("userHasExternalAiGrant / isFirstPartyBrowserClient (hub#583)", () => {
+  test("isFirstPartyBrowserClient matches fixed first-party client_ids", () => {
+    expect(isFirstPartyBrowserClient("parachute-hub-spa", null)).toBe(true);
+    expect(isFirstPartyBrowserClient("parachute-account", null)).toBe(true);
+    expect(isFirstPartyBrowserClient("some-random-dcr-id", null)).toBe(false);
+  });
+
+  test("isFirstPartyBrowserClient matches Notes by client_name (case-insensitive)", () => {
+    expect(isFirstPartyBrowserClient("dcr-generated-id", "Notes")).toBe(true);
+    expect(isFirstPartyBrowserClient("dcr-generated-id", "notes")).toBe(true);
+    expect(isFirstPartyBrowserClient("dcr-generated-id", "Claude")).toBe(false);
+    expect(isFirstPartyBrowserClient("dcr-generated-id", null)).toBe(false);
+  });
+
+  test("a first-party browser grant does NOT count as a connected AI", async () => {
+    const h = await harness();
+    try {
+      // Notes signs in via DCR (generated client_id, client_name "Notes") and
+      // writes a vault-scoped grant — the exact false-positive in hub#583.
+      const notes = registerClient(h.db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "Notes",
+      });
+      recordGrant(h.db, h.userId, notes.client.clientId, ["vault:default:read"]);
+      // The coarse signal lights up...
+      expect(userHasVaultGrant(h.db, h.userId, "default")).toBe(true);
+      // ...but the AI-connection signal does NOT.
+      expect(userHasExternalAiGrant(h.db, h.userId, "default")).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("the fixed first-party SPA client_id does NOT count as a connected AI", async () => {
+    const h = await harness();
+    try {
+      registerClient(h.db, {
+        redirectUris: ["https://app.example/cb"],
+        clientId: "parachute-hub-spa",
+      });
+      recordGrant(h.db, h.userId, "parachute-hub-spa", ["vault:default:read"]);
+      expect(userHasExternalAiGrant(h.db, h.userId, "default")).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("an external AI/MCP client grant DOES count as connected", async () => {
+    const h = await harness();
+    try {
+      // Claude Code: DCR-registered, ordinary client_name, vault scope.
+      const claude = registerClient(h.db, {
+        redirectUris: ["https://claude.ai/cb"],
+        clientName: "Claude",
+      });
+      recordGrant(h.db, h.userId, claude.client.clientId, ["vault:default:read"]);
+      expect(userHasExternalAiGrant(h.db, h.userId, "default")).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("external grant is scoped to the named vault", async () => {
+    const h = await harness();
+    try {
+      const claude = registerClient(h.db, {
+        redirectUris: ["https://claude.ai/cb"],
+        clientName: "Claude",
+      });
+      recordGrant(h.db, h.userId, claude.client.clientId, ["vault:other:read"]);
+      expect(userHasExternalAiGrant(h.db, h.userId, "default")).toBe(false);
+      expect(userHasExternalAiGrant(h.db, h.userId, "other")).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("Notes + Claude both granted: still counts (the external one wins)", async () => {
+    const h = await harness();
+    try {
+      const notes = registerClient(h.db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "Notes",
+      });
+      const claude = registerClient(h.db, {
+        redirectUris: ["https://claude.ai/cb"],
+        clientName: "Claude",
+      });
+      recordGrant(h.db, h.userId, notes.client.clientId, ["vault:default:read"]);
+      recordGrant(h.db, h.userId, claude.client.clientId, ["vault:default:read"]);
+      expect(userHasExternalAiGrant(h.db, h.userId, "default")).toBe(true);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -485,6 +485,142 @@ describe("init", () => {
   });
 });
 
+describe("init bootstrap-token first-claim (hub#576)", () => {
+  function publicState(): ExposeState {
+    return {
+      version: 1,
+      layer: "public",
+      mode: "path",
+      canonicalFqdn: "demo.parachute.computer",
+      port: 443,
+      funnel: false,
+      entries: [],
+      hubOrigin: "https://demo.parachute.computer",
+    };
+  }
+
+  test("publicly-exposed + wizard mode: prints the bootstrap token in the terminal", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      const probed: string[] = [];
+      const logs: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => logs.push(l),
+        alive: () => true,
+        ensureHub: async () => ({ pid: 4321, port: 1939, started: false }),
+        readExposeStateFn: () => publicState(),
+        isTty: false,
+        platform: "linux",
+        installVaultModuleImpl: noopVaultInstall,
+        fetchBootstrapTokenImpl: async (loopbackUrl) => {
+          probed.push(loopbackUrl);
+          return "parachute-bootstrap-XYZ";
+        },
+      });
+      expect(code).toBe(0);
+      // Probed the LOOPBACK hub, not the public FQDN.
+      expect(probed).toEqual(["http://127.0.0.1:1939"]);
+      const joined = logs.join("\n");
+      expect(joined).toContain("parachute-bootstrap-XYZ");
+      expect(joined).toContain("bootstrap token");
+      // Still prints the public admin URL.
+      expect(joined).toContain("https://demo.parachute.computer/admin/");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("loopback-only install: does NOT probe or print a token", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      let probedCount = 0;
+      const logs: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => logs.push(l),
+        alive: () => true,
+        ensureHub: async () => ({ pid: 4321, port: 1939, started: false }),
+        readExposeStateFn: () => undefined, // no public exposure
+        isTty: false,
+        platform: "linux",
+        installVaultModuleImpl: noopVaultInstall,
+        fetchBootstrapTokenImpl: async () => {
+          probedCount++;
+          return "parachute-bootstrap-XYZ";
+        },
+      });
+      expect(code).toBe(0);
+      expect(probedCount).toBe(0);
+      expect(logs.join("\n")).not.toContain("parachute-bootstrap-");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("admin already exists (no token): prints the URL without a token block", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      const logs: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => logs.push(l),
+        alive: () => true,
+        ensureHub: async () => ({ pid: 4321, port: 1939, started: false }),
+        readExposeStateFn: () => publicState(),
+        isTty: false,
+        platform: "linux",
+        installVaultModuleImpl: noopVaultInstall,
+        // Hub returns undefined → already-claimed / no token to surface.
+        fetchBootstrapTokenImpl: async () => undefined,
+      });
+      expect(code).toBe(0);
+      const joined = logs.join("\n");
+      expect(joined).toContain("https://demo.parachute.computer/admin/");
+      expect(joined).not.toContain("bootstrap token");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("CLI wizard is driven against the LOOPBACK hub, not the public FQDN", async () => {
+    const h = makeHarness();
+    try {
+      writeHubPort(1939, h.configDir);
+      const wizardUrls: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => true,
+        ensureHub: async () => ({ pid: 4321, port: 1939, started: false }),
+        readExposeStateFn: () => publicState(),
+        isTty: false,
+        platform: "linux",
+        installVaultModuleImpl: noopVaultInstall,
+        wizardChoice: "cli",
+        fetchBootstrapTokenImpl: async () => "parachute-bootstrap-XYZ",
+        runCliWizardImpl: async ({ hubUrl }) => {
+          wizardUrls.push(hubUrl);
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      // The CLI wizard runs on-box → must use loopback (where the hub hands it
+      // the token transparently), never the public FQDN.
+      expect(wizardUrls).toEqual(["http://127.0.0.1:1939"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
 describe("looksLikeServer heuristic", () => {
   test("macOS is never a server", () => {
     expect(looksLikeServer("darwin", { SSH_CONNECTION: "1.2.3.4 22 5.6.7.8 22" })).toBe(false);

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -4051,6 +4051,116 @@ describe("setup-wizard JSON surface (hub#168 Cuts 2/3)", () => {
     }
   });
 
+  test("JSON probe hands the bootstrap token VALUE to a loopback caller (hub#576)", async () => {
+    const { generateBootstrapToken, _resetBootstrapTokenForTests } = await import(
+      "../bootstrap-token.ts"
+    );
+    _resetBootstrapTokenForTests();
+    const token = generateBootstrapToken();
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const res = handleSetupGet(req("/admin/setup", { headers: { accept: "application/json" } }), {
+        db,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
+        issuer: "http://127.0.0.1:1939",
+        registry: getDefaultOperationsRegistry(),
+        requestIsLoopback: true,
+      });
+      const body = (await res.json()) as {
+        requireBootstrapToken: boolean;
+        bootstrapToken?: string;
+      };
+      expect(body.requireBootstrapToken).toBe(true);
+      expect(body.bootstrapToken).toBe(token);
+    } finally {
+      _resetBootstrapTokenForTests();
+      db.close();
+    }
+  });
+
+  test("JSON probe withholds the token VALUE from a non-loopback caller (hub#576)", async () => {
+    const { generateBootstrapToken, _resetBootstrapTokenForTests } = await import(
+      "../bootstrap-token.ts"
+    );
+    _resetBootstrapTokenForTests();
+    generateBootstrapToken();
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const res = handleSetupGet(req("/admin/setup", { headers: { accept: "application/json" } }), {
+        db,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
+        issuer: "http://127.0.0.1:1939",
+        registry: getDefaultOperationsRegistry(),
+        requestIsLoopback: false,
+      });
+      const body = (await res.json()) as {
+        requireBootstrapToken: boolean;
+        bootstrapToken?: string;
+      };
+      // The boolean still tells a public browser a token is required...
+      expect(body.requireBootstrapToken).toBe(true);
+      // ...but the VALUE never leaks to it.
+      expect(body.bootstrapToken).toBeUndefined();
+    } finally {
+      _resetBootstrapTokenForTests();
+      db.close();
+    }
+  });
+
+  test("JSON probe fails CLOSED when loopback is unknown (hub#576)", async () => {
+    const { generateBootstrapToken, _resetBootstrapTokenForTests } = await import(
+      "../bootstrap-token.ts"
+    );
+    _resetBootstrapTokenForTests();
+    generateBootstrapToken();
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      // `requestIsLoopback` omitted entirely — must be treated as non-loopback.
+      const res = handleSetupGet(req("/admin/setup", { headers: { accept: "application/json" } }), {
+        db,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
+        issuer: "http://127.0.0.1:1939",
+        registry: getDefaultOperationsRegistry(),
+      });
+      const body = (await res.json()) as { bootstrapToken?: string };
+      expect(body.bootstrapToken).toBeUndefined();
+    } finally {
+      _resetBootstrapTokenForTests();
+      db.close();
+    }
+  });
+
+  test("JSON probe omits the token when no admin gate is active (hub#576)", async () => {
+    const { _resetBootstrapTokenForTests } = await import("../bootstrap-token.ts");
+    _resetBootstrapTokenForTests(); // no token minted → not in wizard mode
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const res = handleSetupGet(req("/admin/setup", { headers: { accept: "application/json" } }), {
+        db,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
+        issuer: "http://127.0.0.1:1939",
+        registry: getDefaultOperationsRegistry(),
+        requestIsLoopback: true,
+      });
+      const body = (await res.json()) as {
+        requireBootstrapToken: boolean;
+        bootstrapToken?: string;
+      };
+      expect(body.requireBootstrapToken).toBe(false);
+      expect(body.bootstrapToken).toBeUndefined();
+    } finally {
+      db.close();
+    }
+  });
+
   test("vault step skip mode short-circuits + persists setup_vault_skipped", async () => {
     const db = openHubDb(hubDbPath(h.dir));
     try {

--- a/src/__tests__/well-known.test.ts
+++ b/src/__tests__/well-known.test.ts
@@ -123,6 +123,31 @@ describe("buildWellKnown", () => {
     ]);
   });
 
+  test("SEED placeholder vault entry is NOT fabricated into a vault row (hub#577)", () => {
+    // `parachute init` installs the vault MODULE without creating an instance,
+    // seeding a services.json entry at version "0.0.0-linked" with the
+    // canonical /vault/default mount. That must NOT surface as a phantom
+    // `default` vault in the management page.
+    const seed: ServiceEntry = { ...vault, version: "0.0.0-linked" };
+    const doc = buildWellKnown({
+      services: [seed],
+      canonicalOrigin: "https://x.example",
+    });
+    // No phantom vault row...
+    expect(doc.vaults).toEqual([]);
+    // ...but the services entry stays so the SPA knows the module IS installed
+    // (offers "New vault", not "Install module").
+    expect(doc.services.map((s) => s.name)).toEqual(["parachute-vault"]);
+  });
+
+  test("a REAL (non-seed) vault entry still lands in vaults[] (hub#577 regression guard)", () => {
+    const doc = buildWellKnown({
+      services: [{ ...vault, version: "0.5.1", paths: ["/vault/techne"] }],
+      canonicalOrigin: "https://x.example",
+    });
+    expect(doc.vaults.map((v) => v.name)).toEqual(["techne"]);
+  });
+
   test("multiple installs of the same kind both land in the array (#92)", () => {
     const work: ServiceEntry = { ...notes, paths: ["/notes-work"], port: 5174 };
     const doc = buildWellKnown({

--- a/src/__tests__/wizard.test.ts
+++ b/src/__tests__/wizard.test.ts
@@ -32,6 +32,12 @@ interface FakeHubState {
   importParams?: { remoteUrl: string; pat?: string; mode: string };
   exposeMode?: string;
   posted: Array<{ path: string; body: unknown }>;
+  /** hub#576: when set, the fake GET /admin/setup reports requireBootstrapToken=true. */
+  requireBootstrapToken?: boolean;
+  /** hub#576: when set, the fake GET also returns it (loopback-probe behavior). */
+  bootstrapToken?: string;
+  /** hub#576: when true, the account POST 401s unless the right token is supplied. */
+  enforceBootstrapToken?: boolean;
 }
 
 function makeFakeHub(initialState?: Partial<FakeHubState>): {
@@ -86,8 +92,10 @@ function makeFakeHub(initialState?: Partial<FakeHubState>): {
         hasAdmin: state.hasAdmin,
         hasVault: state.hasVault,
         hasExposeMode: state.hasExposeMode,
-        requireBootstrapToken: false,
+        requireBootstrapToken: state.requireBootstrapToken ?? false,
         csrfToken: csrf,
+        // hub#576: a loopback probe carries the actual token value.
+        ...(state.bootstrapToken ? { bootstrapToken: state.bootstrapToken } : {}),
       });
       return new Response(respBody, {
         status: 200,
@@ -101,6 +109,17 @@ function makeFakeHub(initialState?: Partial<FakeHubState>): {
     // POST /admin/setup/account
     if (path === "/admin/setup/account" && method === "POST") {
       state.posted.push({ path, body: bodyJson });
+      // hub#576: reject when the gate is enforced and the supplied token is
+      // wrong / missing — proves the CLI wizard actually sends it.
+      if (state.enforceBootstrapToken) {
+        const supplied = (bodyJson as { bootstrap_token?: string })?.bootstrap_token;
+        if (supplied !== state.bootstrapToken) {
+          return new Response(JSON.stringify({ error: "bad bootstrap token" }), {
+            status: 401,
+            headers: { "content-type": "application/json; charset=utf-8" },
+          });
+        }
+      }
       state.hasAdmin = true;
       return new Response(JSON.stringify({ step: "vault", message: "admin created" }), {
         status: 200,
@@ -268,6 +287,58 @@ describe("runCliWizard", () => {
     expect(vaultBody.mode).toBe("create");
     expect(vaultBody.vault_name).toBe("default");
     expect(state.exposeMode).toBe("localhost");
+  });
+
+  test("loopback-probe bootstrap token is sent transparently (no prompt) — hub#576", async () => {
+    const { state, fetchImpl } = makeFakeHub({
+      requireBootstrapToken: true,
+      bootstrapToken: "parachute-bootstrap-LOOPBACK",
+      enforceBootstrapToken: true,
+    });
+    let prompted = false;
+    const code = await runCliWizard({
+      hubUrl: "http://127.0.0.1:1939",
+      log: () => {},
+      fetchImpl,
+      sleep: async () => {},
+      // No --bootstrap-token flag, no env: the value must come from the probe.
+      prompt: async () => {
+        prompted = true;
+        return "";
+      },
+      accountUsername: "admin",
+      accountPassword: "longpassword",
+      vaultMode: "skip",
+      exposeMode: "localhost",
+    });
+    expect(code).toBe(0);
+    // The account POST carried the probe-supplied token...
+    const accountBody = state.posted[0]?.body as Record<string, string>;
+    expect(accountBody.bootstrap_token).toBe("parachute-bootstrap-LOOPBACK");
+    // ...and the operator was never asked for it.
+    expect(prompted).toBe(false);
+  });
+
+  test("explicit --bootstrap-token flag still wins over the probe value — hub#576", async () => {
+    const { state, fetchImpl } = makeFakeHub({
+      requireBootstrapToken: true,
+      bootstrapToken: "parachute-bootstrap-PROBE",
+      enforceBootstrapToken: false,
+    });
+    const code = await runCliWizard({
+      hubUrl: "http://127.0.0.1:1939",
+      log: () => {},
+      fetchImpl,
+      sleep: async () => {},
+      bootstrapToken: "parachute-bootstrap-EXPLICIT",
+      accountUsername: "admin",
+      accountPassword: "longpassword",
+      vaultMode: "skip",
+      exposeMode: "localhost",
+    });
+    expect(code).toBe(0);
+    const accountBody = state.posted[0]?.body as Record<string, string>;
+    expect(accountBody.bootstrap_token).toBe("parachute-bootstrap-EXPLICIT");
   });
 
   test("vault import mode threads remote_url + pat + import_mode", async () => {

--- a/src/account-home-ui.ts
+++ b/src/account-home-ui.ts
@@ -327,8 +327,31 @@ function renderOnboardingChecklist(opts: OnboardingChecklistOpts): string {
   const safeEndpoint = escapeHtml(endpoint);
   const safeAddCmd = escapeHtml(addCmd);
 
-  // Condensed state — they've connected, so the checklist shrinks to a single
-  // reassuring line. The vault card below remains the place to actually work.
+  // The endpoint + both connect methods. Shared between the full checklist
+  // (step 2) and the condensed "Connect another AI" expander (hub#583) so a
+  // genuinely-connected user can still wire up a SECOND client without losing
+  // the instructions.
+  const connectMethods = `
+            <div class="copy-row">
+              <code data-testid="onboarding-mcp-endpoint">${safeEndpoint}</code>
+              <button type="button" class="btn btn-copy" data-copy="${safeEndpoint}"
+                      data-testid="copy-onboarding-endpoint">Copy</button>
+            </div>
+            <p class="onboarding-method"><strong>Claude.ai (web):</strong> open
+               Settings → Connectors → Add custom connector, and paste the address above.</p>
+            <p class="onboarding-method"><strong>Claude Code (terminal):</strong> run this command:</p>
+            <div class="copy-row">
+              <code data-testid="onboarding-mcp-add-command">${safeAddCmd}</code>
+              <button type="button" class="btn btn-copy" data-copy="${safeAddCmd}"
+                      data-testid="copy-onboarding-add-command">Copy</button>
+            </div>`;
+
+  // Condensed state — they've connected, so the checklist shrinks to a quiet
+  // reassuring line. But keep a "Connect another AI" expander (hub#583): the
+  // condensed line used to DELETE the endpoint + methods outright, leaving a
+  // connected user no way to wire up a second client. A <details> expander
+  // (server-rendered, no-JS-required — the copy buttons stay progressive
+  // enhancement) re-reveals the full inline instructions on demand.
   if (connected) {
     return `
     <section class="section onboarding onboarding-done" data-testid="onboarding-checklist"
@@ -336,6 +359,14 @@ function renderOnboardingChecklist(opts: OnboardingChecklistOpts): string {
       <p class="onboarding-done-line" data-testid="onboarding-done-line">
         <span class="onboarding-check" aria-hidden="true">✓</span>
         You're connected — here's your vault.</p>
+      <details class="onboarding-connect-another" data-testid="onboarding-connect-another">
+        <summary data-testid="onboarding-connect-another-summary">Connect another AI →</summary>
+        <div class="onboarding-step-body">
+          <p class="onboarding-step-sub">Point another AI client at your vault using this
+             address — you'll sign in and approve the first time:</p>
+          ${connectMethods}
+        </div>
+      </details>
     </section>`;
   }
 
@@ -360,19 +391,7 @@ function renderOnboardingChecklist(opts: OnboardingChecklistOpts): string {
             <p class="onboarding-step-title">Connect your AI</p>
             <p class="onboarding-step-sub">Point Claude (or another AI) at your vault using this
                address — no token to copy, you'll sign in and approve the first time:</p>
-            <div class="copy-row">
-              <code data-testid="onboarding-mcp-endpoint">${safeEndpoint}</code>
-              <button type="button" class="btn btn-copy" data-copy="${safeEndpoint}"
-                      data-testid="copy-onboarding-endpoint">Copy</button>
-            </div>
-            <p class="onboarding-method"><strong>Claude.ai (web):</strong> open
-               Settings → Connectors → Add custom connector, and paste the address above.</p>
-            <p class="onboarding-method"><strong>Claude Code (terminal):</strong> run this command:</p>
-            <div class="copy-row">
-              <code data-testid="onboarding-mcp-add-command">${safeAddCmd}</code>
-              <button type="button" class="btn btn-copy" data-copy="${safeAddCmd}"
-                      data-testid="copy-onboarding-add-command">Copy</button>
-            </div>
+            ${connectMethods}
           </div>
         </li>
 
@@ -955,6 +974,18 @@ const STYLES = `
     align-items: center;
     justify-content: center;
   }
+  .onboarding-connect-another { margin: 0.7rem 0 0; }
+  .onboarding-connect-another > summary {
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: ${PALETTE.accent};
+    list-style: none;
+    user-select: none;
+  }
+  .onboarding-connect-another > summary::-webkit-details-marker { display: none; }
+  .onboarding-connect-another[open] > summary { margin-bottom: 0.4rem; }
+  .onboarding-connect-another .copy-row { margin: 0.35rem 0; }
 
   .account-security {
     margin: 0.9rem 0 0;

--- a/src/account-vault-token.ts
+++ b/src/account-vault-token.ts
@@ -69,7 +69,7 @@ import {
 } from "./account-home-ui.ts";
 import { renderAdminError } from "./admin-login-ui.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
-import { userHasVaultGrant } from "./grants.ts";
+import { userHasExternalAiGrant } from "./grants.ts";
 import { inferAudience } from "./jwt-audience.ts";
 import { recordTokenMint, signAccessToken } from "./jwt-sign.ts";
 import { vaultTokenMintRateLimiter } from "./rate-limit.ts";
@@ -190,7 +190,14 @@ export async function handleAccountVaultTokenPost(
         csrfToken: csrf.token,
         twoFactorEnabled: isTotpEnrolled(deps.db, user.id),
         mintableVerbs: buildMintableVerbs(deps.db, user.id, user.assignedVaults),
-        connectedVault: user.assignedVaults.some((v) => userHasVaultGrant(deps.db, user.id, v)),
+        // hub#583: "connected" means an EXTERNAL AI/MCP client (Claude, Cursor,
+        // …) was wired to a vault — NOT a first-party browser sign-in. Notes /
+        // the admin SPA are OAuth clients too and write vault-scoped grants, so
+        // the old `userHasVaultGrant` lit "✓ You're connected" the moment the
+        // user opened Notes. `userHasExternalAiGrant` filters those out.
+        connectedVault: user.assignedVaults.some((v) =>
+          userHasExternalAiGrant(deps.db, user.id, v),
+        ),
         ...extras,
       }),
       status,

--- a/src/api-account.ts
+++ b/src/api-account.ts
@@ -54,7 +54,7 @@ import { fetchVaultUsage, formatUsageStat } from "./account-usage.ts";
 import { POST_LOGIN_DEFAULT } from "./admin-handlers.ts";
 import { renderAdminError } from "./admin-login-ui.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
-import { userHasVaultGrant } from "./grants.ts";
+import { userHasExternalAiGrant } from "./grants.ts";
 import { changePasswordRateLimiter } from "./rate-limit.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
 import { findActiveSession } from "./sessions.ts";
@@ -601,11 +601,18 @@ export async function handleAccountHomeGet(req: Request, deps: AccountHomeDeps):
     );
   }
 
-  // "Has this user connected an AI to any of their vaults yet?" — drives the
-  // onboarding checklist's "Connect your AI" step (done/condensed when true).
-  // A grant row only lands after the user clicks through an OAuth consent for a
-  // client wired to one of their vaults.
-  const connectedVault = user.assignedVaults.some((v) => userHasVaultGrant(deps.db, user.id, v));
+  // hub#583: "connected" means an EXTERNAL AI/MCP client (Claude, Cursor, …)
+  // was wired to a vault — NOT a first-party browser sign-in. This is the
+  // PRIMARY browser GET /account/ route — the exact page the field report
+  // describes — so it must use the same filtered check as the vault-token
+  // re-render (account-vault-token.ts:196): the old `userHasVaultGrant` lit
+  // "✓ You're connected" the moment the user opened Notes (a first-party OAuth
+  // client that writes a vault-scoped grant). `userHasExternalAiGrant` excludes
+  // first-party browser surfaces so the checklist only condenses on a real AI
+  // connection.
+  const connectedVault = user.assignedVaults.some((v) =>
+    userHasExternalAiGrant(deps.db, user.id, v),
+  );
 
   return htmlResponse(
     renderAccountHome({

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -480,16 +480,29 @@ async function defaultRunCliWizard(opts: {
  * surfacing the token is a convenience, never a hard dependency of init.
  */
 async function defaultFetchBootstrapToken(loopbackUrl: string): Promise<string | undefined> {
+  // Debug breadcrumb (gated on PARACHUTE_DEBUG so it never clutters the normal
+  // operator output). When the token doesn't print in the field, this tells a
+  // troubleshooter WHY — hub didn't answer, returned non-200, or the body
+  // carried no token (already-claimed / no-gate) — instead of a silent nothing.
+  const debug = (msg: string): void => {
+    if (process.env.PARACHUTE_DEBUG) console.error(`[init][bootstrap-token] ${msg}`);
+  };
   try {
     const res = await fetch(`${loopbackUrl.replace(/\/+$/, "")}/admin/setup`, {
       headers: { accept: "application/json" },
     });
-    if (!res.ok) return undefined;
+    if (!res.ok) {
+      debug(`probe returned ${res.status}; not printing a token`);
+      return undefined;
+    }
     const body = (await res.json()) as { bootstrapToken?: unknown };
-    return typeof body.bootstrapToken === "string" && body.bootstrapToken.length > 0
-      ? body.bootstrapToken
-      : undefined;
-  } catch {
+    if (typeof body.bootstrapToken === "string" && body.bootstrapToken.length > 0) {
+      return body.bootstrapToken;
+    }
+    debug("probe ok but no bootstrapToken in body (already-claimed or no gate active)");
+    return undefined;
+  } catch (err) {
+    debug(`probe failed: ${err instanceof Error ? err.message : String(err)}`);
     return undefined;
   }
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -162,6 +162,17 @@ export interface InitOpts {
    * already known so there's no question to ask).
    */
   noWizardPrompt?: boolean;
+  /**
+   * Test seam: probe the running hub for its first-claim bootstrap token
+   * (hub#576). Production hits `GET http://127.0.0.1:<port>/admin/setup` with
+   * `accept: application/json` and reads `bootstrapToken` (the hub returns it
+   * only to loopback callers). Returns the token string when the hub is in
+   * wizard mode (no admin yet), or `undefined` when there's no token to surface
+   * (admin already exists, or the probe failed). Init uses it to print the
+   * token next to the admin URL when the hub is publicly exposed, so a browser
+   * operator can claim the box without digging through the hub logs.
+   */
+  fetchBootstrapTokenImpl?: (loopbackUrl: string) => Promise<string | undefined>;
 }
 
 /**
@@ -462,6 +473,28 @@ async function defaultRunCliWizard(opts: {
 }
 
 /**
+ * Default impl for the bootstrap-token probe (hub#576). GETs the loopback hub's
+ * `/admin/setup` with `accept: application/json` and returns the `bootstrapToken`
+ * the hub hands to loopback callers. Returns `undefined` on any failure (hub
+ * not answering, no token because an admin already exists, malformed body) —
+ * surfacing the token is a convenience, never a hard dependency of init.
+ */
+async function defaultFetchBootstrapToken(loopbackUrl: string): Promise<string | undefined> {
+  try {
+    const res = await fetch(`${loopbackUrl.replace(/\/+$/, "")}/admin/setup`, {
+      headers: { accept: "application/json" },
+    });
+    if (!res.ok) return undefined;
+    const body = (await res.json()) as { bootstrapToken?: unknown };
+    return typeof body.bootstrapToken === "string" && body.bootstrapToken.length > 0
+      ? body.bootstrapToken
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Prompt for the wizard-choice question (hub#168 Cut 4). Returns the
  * picked option, or `undefined` if the operator quit. Default is
  * `browser` because (a) the browser flow is the canonical post-launch
@@ -547,6 +580,7 @@ export async function init(opts: InitOpts = {}): Promise<number> {
   const exposeCloudflareImpl = opts.exposeCloudflareImpl ?? defaultExposeCloudflare;
   const installVaultModuleImpl = opts.installVaultModuleImpl ?? defaultInstallVaultModule;
   const runCliWizardImpl = opts.runCliWizardImpl ?? defaultRunCliWizard;
+  const fetchBootstrapTokenImpl = opts.fetchBootstrapTokenImpl ?? defaultFetchBootstrapToken;
 
   log("Parachute init — getting your hub set up.");
   log("");
@@ -711,6 +745,19 @@ export async function init(opts: InitOpts = {}): Promise<number> {
     return 1;
   }
 
+  // hub#576: when the hub is publicly exposed AND still in wizard mode (no
+  // admin yet), the admin URL above is a public FQDN — whoever opens it first
+  // claims the box. Surface the first-claim bootstrap token in the operator's
+  // OWN terminal so the wizard's account step demands proof of box access. We
+  // only probe + print on the public-FQDN path: a loopback-only install needs
+  // no token (reaching 127.0.0.1 already proves access), and the CLI-wizard
+  // path picks the token up transparently over loopback (above). The probe is
+  // best-effort — a failure (or an already-claimed hub) just prints nothing.
+  let bootstrapToken: string | undefined;
+  if (exposeState?.canonicalFqdn) {
+    bootstrapToken = await fetchBootstrapTokenImpl(`http://127.0.0.1:${hubPort}`);
+  }
+
   log("");
   if (hasVault) {
     log("Looks good — your hub is up and a vault is configured.");
@@ -720,6 +767,17 @@ export async function init(opts: InitOpts = {}): Promise<number> {
   log("");
   log(`  ${adminUrl}`);
   log("");
+  if (bootstrapToken) {
+    log("Because this hub is reachable on the public internet, the wizard asks for a");
+    log("one-time bootstrap token before it lets anyone create the admin account —");
+    log("so whoever opens the URL first can't claim your hub. Paste this when asked:");
+    log("");
+    log(`  ${bootstrapToken}`);
+    log("");
+    log("(Valid until the admin is created or the hub restarts. Re-run `parachute init`");
+    log(" to mint a fresh one.)");
+    log("");
+  }
   // hub#565: when we're on the loopback URL (no public exposure active),
   // remind the operator they can expose later. Skipped once an FQDN is up.
   if (!exposeState?.canonicalFqdn) {
@@ -756,7 +814,13 @@ export async function init(opts: InitOpts = {}): Promise<number> {
   if (choice === "cli") {
     log("");
     log("Launching the CLI wizard. (You can also visit the URL above in a browser any time.)");
-    return await runCliWizardImpl({ hubUrl: adminUrl.replace(/\/admin\/?$/, ""), log });
+    // hub#576: drive the CLI wizard against the LOOPBACK hub, not the public
+    // FQDN in `adminUrl`. The wizard runs on this box, so loopback is both
+    // correct and what lets the hub hand it the bootstrap token transparently
+    // (the loopback-gated GET /admin/setup probe) — the operator never has to
+    // copy the token out of the startup logs.
+    const cliWizardUrl = `http://127.0.0.1:${hubPort}`;
+    return await runCliWizardImpl({ hubUrl: cliWizardUrl, log });
   }
 
   // Step 5: offer to open the browser. Skip in non-TTY shells (CI),

--- a/src/commands/wizard.ts
+++ b/src/commands/wizard.ts
@@ -255,6 +255,14 @@ interface WizardStateSnapshot {
   hasVault: boolean;
   hasExposeMode: boolean;
   requireBootstrapToken: boolean;
+  /**
+   * The actual bootstrap token, present ONLY when the wizard-state probe ran
+   * over loopback (the on-box operator's own shell — hub#576). The hub returns
+   * it so the CLI wizard can satisfy the first-claim gate transparently without
+   * the operator copy-pasting it from the startup logs. Absent on any
+   * public/tailnet probe.
+   */
+  bootstrapToken?: string;
   csrfToken: string;
   /** Optional URL to redirect to (when state is fully done — 301 to /login). */
   redirectTo?: string;
@@ -294,7 +302,7 @@ async function fetchWizardState(
     );
   }
   const body = res.json as Partial<WizardStateSnapshot> & { csrfToken?: string };
-  return {
+  const snapshot: WizardStateSnapshot = {
     step: body.step ?? "welcome",
     hasAdmin: Boolean(body.hasAdmin),
     hasVault: Boolean(body.hasVault),
@@ -302,6 +310,12 @@ async function fetchWizardState(
     requireBootstrapToken: Boolean(body.requireBootstrapToken),
     csrfToken: typeof body.csrfToken === "string" ? body.csrfToken : (jar.csrf ?? ""),
   };
+  // hub#576: the loopback probe carries the actual token. Thread it through so
+  // the account step can submit it without prompting the operator.
+  if (typeof body.bootstrapToken === "string" && body.bootstrapToken.length > 0) {
+    snapshot.bootstrapToken = body.bootstrapToken;
+  }
+  return snapshot;
 }
 
 /**
@@ -422,7 +436,27 @@ async function walkAccountStep(
     log(`  ✗ ${pwErr}`);
     return 1;
   }
-  let bootstrap = opts.bootstrapToken ?? process.env.PARACHUTE_BOOTSTRAP_TOKEN;
+  // Token resolution order (hub#576):
+  //   1. Explicit `--bootstrap-token` flag / `opts.bootstrapToken` (init passes
+  //      this when it fetched the token from the loopback probe).
+  //   2. `PARACHUTE_BOOTSTRAP_TOKEN` env.
+  //   3. The token carried on the loopback wizard-state probe itself — the
+  //      common on-box `parachute init` path: the hub handed us the value
+  //      because we reached it over loopback, so we satisfy the gate
+  //      transparently with no operator action.
+  //   4. Prompt — the fallback when none of the above apply (e.g. a remote
+  //      `parachute init --cli-wizard` against a public hub, where the probe
+  //      didn't carry the token). The operator reads it from the startup logs.
+  // Treat an empty / whitespace value at any level as "absent" so a falsy
+  // `PARACHUTE_BOOTSTRAP_TOKEN=` (exported-but-empty) doesn't suppress the
+  // loopback-probe token and silently submit a blank token.
+  const firstNonEmpty = (...vals: Array<string | undefined>): string | undefined =>
+    vals.find((v) => typeof v === "string" && v.trim().length > 0);
+  let bootstrap = firstNonEmpty(
+    opts.bootstrapToken,
+    process.env.PARACHUTE_BOOTSTRAP_TOKEN,
+    state.bootstrapToken,
+  );
   if (state.requireBootstrapToken && !bootstrap) {
     log("");
     log("  This hub is in container/serve mode and minted a one-time");

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -248,6 +248,15 @@ interface GrantWithClientNameRow extends GrantRow {
  * the coarse "any vault grant" signal lit up the `/account/` onboarding
  * checklist's "✓ You're connected" line even when no AI was ever connected.
  * This is the detection the checklist should use.
+ *
+ * Trade-off: this fetches ALL of the user's grants (joined to `clients` for
+ * `client_name`) and filters in JS, rather than pushing the first-party
+ * exclusion into a WHERE clause. Fine at current scale — a user has a handful
+ * of grants, and the scope/client-name discrimination is awkward to express in
+ * SQL (scopes are a space-joined column, first-party names are an in-process
+ * set). If the grants table grows large per-user, add an index on
+ * `grants(user_id)` (already the PK prefix) and consider a `client_name`-aware
+ * WHERE filter.
  */
 export function userHasExternalAiGrant(db: Database, userId: string, vaultName: string): boolean {
   const rows = db

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -191,6 +191,85 @@ export function isCoveredByGrantForClientName(
 const VAULT_SCOPE_PREFIX_RE = /^vault:([^:]+):/;
 
 /**
+ * Fixed `client_id`s the hub mints for its OWN first-party browser surfaces.
+ * A grant carrying one of these is a browser sign-in (the operator opened the
+ * admin SPA, the account-home friend surface, etc.) — NOT "the operator
+ * connected an AI to their vault." See `userHasExternalAiGrant` (hub#583).
+ *
+ *   - `parachute-hub-spa`   — hub admin SPA + vault admin SPA mints
+ *     (`admin-host-admin-token.ts`, `admin-vault-admin-token.ts`,
+ *     `account-vault-admin-token.ts`).
+ *   - `parachute-account`   — account-home friend-vault token mints
+ *     (`account-vault-token.ts`).
+ */
+const FIRST_PARTY_BROWSER_CLIENT_IDS = new Set(["parachute-hub-spa", "parachute-account"]);
+
+/**
+ * `client_name`s of first-party browser SPAs that register dynamically via DCR
+ * (so their `client_id` is generated per-registration and can't be enumerated).
+ * Notes registers with `client_name: "Notes"` (the @openparachute/notes-ui PWA
+ * signing into a vault). Matched case-insensitively. See hub#583.
+ */
+const FIRST_PARTY_BROWSER_CLIENT_NAMES = new Set(["notes"]);
+
+/**
+ * True when a grant belongs to one of the hub's own first-party browser
+ * surfaces (admin SPA, account home, Notes PWA) rather than an external AI/MCP
+ * client (Claude, Cursor, …). Used to keep a browser sign-in from
+ * false-positiving the "you've connected your AI" onboarding signal (hub#583).
+ *
+ * Discriminates two ways because first-party surfaces register two ways: the
+ * hub-minted SPAs use fixed `client_id`s; DCR-registered SPAs (Notes) get a
+ * generated id but a stable `client_name`.
+ */
+export function isFirstPartyBrowserClient(
+  clientId: string,
+  clientName: string | null | undefined,
+): boolean {
+  if (FIRST_PARTY_BROWSER_CLIENT_IDS.has(clientId)) return true;
+  if (clientName && FIRST_PARTY_BROWSER_CLIENT_NAMES.has(clientName.trim().toLowerCase())) {
+    return true;
+  }
+  return false;
+}
+
+interface GrantWithClientNameRow extends GrantRow {
+  client_name: string | null;
+}
+
+/**
+ * True when the user has approved at least one EXTERNAL AI/MCP client (Claude,
+ * Cursor, etc.) whose granted scopes touch `vaultName` — i.e. "has this person
+ * actually wired up an AI to this vault yet?" (hub#583).
+ *
+ * Stricter than {@link userHasVaultGrant}: it excludes grants from the hub's
+ * own first-party browser surfaces (admin SPA, account home, Notes PWA). Those
+ * are OAuth clients too — signing into Notes writes a vault-scoped grant — so
+ * the coarse "any vault grant" signal lit up the `/account/` onboarding
+ * checklist's "✓ You're connected" line even when no AI was ever connected.
+ * This is the detection the checklist should use.
+ */
+export function userHasExternalAiGrant(db: Database, userId: string, vaultName: string): boolean {
+  const rows = db
+    .prepare(
+      `SELECT g.user_id, g.client_id, g.scopes, g.granted_at, c.client_name
+         FROM grants g
+         LEFT JOIN clients c ON g.client_id = c.client_id
+        WHERE g.user_id = ?`,
+    )
+    .all(userId) as GrantWithClientNameRow[];
+  for (const row of rows) {
+    if (isFirstPartyBrowserClient(row.client_id, row.client_name)) continue;
+    const scopes = row.scopes.split(" ").filter((s) => s.length > 0);
+    for (const s of scopes) {
+      const m = s.match(VAULT_SCOPE_PREFIX_RE);
+      if (m && m[1] === vaultName) return true;
+    }
+  }
+  return false;
+}
+
+/**
  * True when the user has approved at least one OAuth client whose granted
  * scopes touch `vaultName` (any `vault:<name>:<verb>` scope). This is the
  * "has this person actually connected an AI to this vault yet?" signal — the

--- a/src/help.ts
+++ b/src/help.ts
@@ -160,7 +160,7 @@ Flags:
   --no-expose-prompt        skip the exposure question; fall through to localhost URL
   --expose <choice>         non-interactive exposure override:
                               none       — stay loopback-only
-                              tailnet    — set up Tailscale Funnel (private to your tailnet)
+                              tailnet    — set up Tailscale serve (private to your tailnet)
                               cloudflare — set up Cloudflare Tunnel (your own domain)
   --cli-wizard              skip the "browser or CLI?" prompt and walk the wizard
                             in this terminal (hub#168 Cut 4)

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -1553,6 +1553,11 @@ export function hubFetch(
         configDir: CONFIG_DIR,
         issuer: oauthDeps(req).issuer,
         registry: getDefaultOperationsRegistry(),
+        // hub#576: a loopback peer (the on-box operator's own shell) is allowed
+        // to read the actual bootstrap token from the GET /admin/setup JSON
+        // probe. `layerOf` fails closed to non-loopback when peerAddr is
+        // unknown, so a header-less caller never gets the token.
+        requestIsLoopback: layerOf(req, peerAddr) === "loopback",
       };
       if (deps?.supervisor !== undefined) wizardDeps.supervisor = deps.supervisor;
       if (pathname === "/admin/setup") {

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -182,7 +182,15 @@ const NOTES_SERVE_PATH = fileURLToPath(new URL("./notes-serve.ts", import.meta.u
  * telegraphs the state: the row is a stopgap, and the service's first boot
  * will overwrite with its own authoritative write.
  */
-const SEED_VERSION = "0.0.0-linked";
+/**
+ * Version string stamped on a CLI-seeded services.json entry — the
+ * "module installed, but its own daemon hasn't booted and registered a real
+ * row yet" placeholder. A real service boot overwrites this with the package's
+ * actual version (see "Services own their write side of services.json" in
+ * CLAUDE.md). Exported so consumers (e.g. well-known generation, hub#577) can
+ * tell a placeholder entry apart from a live one.
+ */
+export const SEED_VERSION = "0.0.0-linked";
 
 function pathBasedUrl(entry: ServiceEntry): string {
   const first = entry.paths[0] ?? "";

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -399,6 +399,18 @@ export interface SetupWizardDeps {
     userId: string,
     opts: MintOperatorTokenOpts & { dir?: string },
   ) => Promise<IssueOperatorTokenResult>;
+  /**
+   * Whether the in-flight request arrived over loopback (peer `127.0.0.1` /
+   * `::1`). Set by `hub-server.ts` from `layerOf(req, peerAddr)`. hub#576: a
+   * loopback caller already proves on-box access (it's the operator's own
+   * shell — `parachute init` driving the CLI wizard), so the GET `/admin/setup`
+   * JSON probe reveals the actual bootstrap token VALUE to it, not just the
+   * `requireBootstrapToken` boolean. Public / tailnet callers (any browser
+   * that found the FQDN) get only the boolean and must paste the token the
+   * operator copied from their terminal. Absent (undefined) is treated as
+   * NON-loopback — fail closed, never leak the token to a header-less caller.
+   */
+  requestIsLoopback?: boolean;
 }
 
 /**
@@ -1601,8 +1613,17 @@ export function handleSetupGet(req: Request, deps: SetupWizardDeps): Response {
   // the HTML rendering branches means the CLI gets the answer it needs
   // without the wizard having to render a 30KB HTML page per poll.
   if (wantsJson) {
-    const requireToken = getBootstrapToken() !== undefined;
-    const envelope = {
+    const activeToken = getBootstrapToken();
+    const requireToken = activeToken !== undefined;
+    const envelope: {
+      step: typeof state.step;
+      hasAdmin: boolean;
+      hasVault: boolean;
+      hasExposeMode: boolean;
+      requireBootstrapToken: boolean;
+      csrfToken: string;
+      bootstrapToken?: string;
+    } = {
       step: state.step,
       hasAdmin: state.hasAdmin,
       hasVault: state.hasVault,
@@ -1610,6 +1631,17 @@ export function handleSetupGet(req: Request, deps: SetupWizardDeps): Response {
       requireBootstrapToken: requireToken,
       csrfToken: csrf.token,
     };
+    // hub#576: hand the actual token to a LOOPBACK caller only. The on-box
+    // operator (`parachute init` → CLI wizard, or a curl from their own shell)
+    // already proves box access by reaching loopback — same trust level as
+    // reading the token off the startup banner in the hub log. This lets init
+    // surface the token in the operator's terminal and feed it to the CLI
+    // wizard transparently, instead of making them dig through `parachute logs
+    // hub`. A public / tailnet browser never gets the value — it stays gated on
+    // the operator pasting what they copied from their terminal.
+    if (requireToken && deps.requestIsLoopback === true && activeToken !== undefined) {
+      envelope.bootstrapToken = activeToken;
+    }
     const jsonHeaders: Record<string, string> = {
       "content-type": "application/json; charset=utf-8",
       "cache-control": "no-store",

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { CONFIG_DIR } from "./config.ts";
 import { type ModuleManifest, readModuleManifest } from "./module-manifest.ts";
+import { SEED_VERSION } from "./service-spec.ts";
 import {
   type ServiceEntry,
   type UiSubUnit,
@@ -315,6 +316,18 @@ export function buildWellKnown(opts: BuildWellKnownOpts): WellKnownDocument {
       }
       doc.services.push(entry);
       if (isVault) {
+        // hub#577: don't fabricate a phantom vault row from a SEED placeholder.
+        // `parachute init` installs the vault MODULE without creating an
+        // instance (hub#168 Cut 1: `noCreate`), seeding a services.json entry
+        // at SEED_VERSION with the canonical `/vault/default` mount. Vault's
+        // own boot overwrites that entry with the real instance path(s) once a
+        // vault is actually created. Until then, emitting a `vaults[]` row here
+        // makes the management page show a `default` vault that doesn't exist —
+        // it vanishes the moment a real vault registers. Keep the `services`
+        // entry (so the SPA knows the module IS installed and offers "New
+        // vault" rather than "Install module"), but suppress the vault row so
+        // the list honestly reads "No vaults yet."
+        if (s.version === SEED_VERSION) continue;
         const managementUrl = opts.managementUrlFor?.(s);
         const entry: WellKnownVaultEntry = {
           name: vaultInstanceNameFor(s.name, path),


### PR DESCRIPTION
Four onboarding-funnel fixes, one PR — surfaced during the techne 0.6.4-rc.6 field validation.

## #576 — Wizard first-claim bootstrap token for `parachute init`

`parachute init` printed a (possibly public Cloudflare) wizard URL with no first-claim gate — whoever opened it first claimed the admin. The Render deploy path already solves this: `parachute serve` mints an in-memory bootstrap token on wizard-mode boot and the wizard's account POST demands it (hub#297, `src/bootstrap-token.ts`). **This PR reuses that exact mechanism for the init path** rather than inventing a parallel one.

**Design decisions:**
- **Reuse, don't reinvent.** The bootstrap-token module, the wizard's `requireBootstrapToken` gate, and the CLI wizard's `bootstrapToken` plumbing were all already in place. The only gap was init UX: the token lived in the hub's process memory / log file, never surfaced to the operator's `init` terminal.
- **Loopback proves box access.** `GET /admin/setup` (`Accept: application/json`) now returns the actual `bootstrapToken` **value — only to a loopback caller**. A loopback request already proves on-box access (same trust as reading the token off the startup banner in the hub log). Public/tailnet callers still get only the `requireBootstrapToken` boolean; the value never leaks. `layerOf` **fails closed** to non-loopback when the peer address is unknown.
- **Gate stays uniform; the skip is only on *printing*.** The wizard gate fires for everyone when a token is active. Init only *prints* the token (and only probes) when the hub is **publicly exposed** + still in wizard mode. A loopback-only install reaches 127.0.0.1 to prove access, so nothing extra is printed.
- **CLI wizard satisfies the gate transparently.** Init drives the CLI wizard against the **loopback** hub (not the public FQDN) and the wizard picks the token up from the same loopback probe — no log-digging. Resolution order: `--bootstrap-token` flag → `PARACHUTE_BOOTSTRAP_TOKEN` env → loopback-probe token → prompt (empty/whitespace treated as absent at every level).
- **Security:** token is never persisted beyond the operator's terminal, consumed on first-admin creation, regenerated on every hub restart, re-minted by re-running init. No new secret storage.

Files: `src/setup-wizard.ts`, `src/hub-server.ts`, `src/commands/init.ts`, `src/commands/wizard.ts`.

## #583 — /account "you're connected" false-positive + lost MCP instructions

- **Detection:** `connectedVault` ← `userHasVaultGrant` counted ANY vault-scoped grant, including first-party browser surfaces (signing into Notes writes one). New `userHasExternalAiGrant` excludes first-party browser clients via `isFirstPartyBrowserClient` — fixed client_ids (`parachute-hub-spa`, `parachute-account`) + DCR client_name (`Notes`).
- **UI:** the condensed "✓ You're connected" line used to *delete* the endpoint + methods. It now keeps a **"Connect another AI →"** `<details>` expander (server-rendered, no-JS-required) that re-reveals the inline endpoint + both connection methods. Endpoint/methods markup shared between the full checklist and the expander.
- The `TODO(multi-vault)` at ~242 is a distinct concern (which vault the checklist displays) and was left in place.

Files: `src/grants.ts`, `src/account-vault-token.ts`, `src/account-home-ui.ts`.

## #577 — Phantom `default` vault in the management page

`parachute init` installs the vault module without an instance (hub#168 `noCreate`), seeding a services.json entry at `SEED_VERSION` (`0.0.0-linked`) with the canonical `/vault/default` mount. `buildWellKnown` iterated that mount and fabricated a `vaults[]` row named `default`. Fix: skip emitting a vault row when the entry is still at `SEED_VERSION`. The `services` entry stays (SPA shows "New vault", not "Install module"), but the vaults list honestly reads "No vaults yet" until a real instance registers. The admin SPA's empty state was already honest — the phantom was purely in the well-known data source.

Files: `src/well-known.ts`, `src/service-spec.ts` (exported `SEED_VERSION`).

## #459 — expose-interactive mislabel

The cited `expose-interactive.ts:353` was refactored by #574/#441 — that file is now solely the **public** provider picker, where "Tailscale Funnel" is correct. The surviving genuine mislabel was the `--expose tailnet` line in `help.ts` (tailnet uses `tailscale serve`, not Funnel). The `--tailnet` *flag* copy (which pins `expose public` to Funnel) is accurate and untouched.

File: `src/help.ts`.

## Test plan

`bun test ./src`: **3040 pass, 1 skip, 0 fail** (baseline 3019 → +21 new tests). `bun run typecheck`: clean. Live hub `/health`: ok (suite didn't boot out the daemon). No `web/ui` changes → SPA suite unaffected. No version bump.

New tests:
- **#576:** loopback probe returns token / non-loopback withholds it / fails-closed when loopback unknown / omits when no gate active (setup-wizard); CLI wizard sends probe token transparently with no prompt + explicit flag wins (wizard); init prints token on public+wizard / skips on loopback-only / no token-block when admin exists / CLI wizard driven against loopback (init).
- **#583:** first-party (Notes by name, `parachute-hub-spa` by id) grant → not connected; external (Claude) → connected; vault-scoped; Notes+Claude → connected; expander present in condensed state with full instructions, absent in full-checklist state.
- **#577:** SEED placeholder → no vault row but services entry present; real (non-seed) vault still emitted; updated the api-modules-ops regen-after-install test (was asserting the buggy phantom).
- **#459:** verified via `parachute init --help`.

Fixes #576
Fixes #583
Fixes #577
Fixes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)