### PR TITLE
release: hub 0.6.4-rc.8 (onboarding funnel fixes #585)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.4-rc.7",
+  "version": "0.6.4-rc.8",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Version-only bump to 0.6.4-rc.8, shipping #585 (fixes #576 #583 #577 #459).

Tag v0.6.4-rc.8 on the merge commit → CI publishes to npm dist-tag `rc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)