### PR TITLE
release: hub 0.6.4-rc.9 (expose-off origin clear + bare-MCP-URL redirect #587)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.4-rc.8",
+  "version": "0.6.4-rc.9",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Version-only bump to 0.6.4-rc.9, shipping #587 (fixes #503 #525).

Tag v0.6.4-rc.9 on the merge commit → CI publishes to npm dist-tag `rc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)