### PR TITLE
release: hub 0.6.4 stable (fresh-install onboarding overhaul)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.4-rc.10",
+  "version": "0.6.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Version-only bump 0.6.4-rc.10 → 0.6.4 stable, per Aaron's ship decision.

Tag v0.6.4 on the merge commit → CI publishes to npm dist-tag `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)