### PR TITLE
fix: verify Cloudflare tunnel creds/connection (#593) + hub self-heal on dead SQLite handle (#594)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,112 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
+> **Backfill note (2026-06-06).** The entire 0.6.x line (0.6.0 → 0.6.4) shipped without changelog entries — the file stopped at `0.5.13-rc.48`. The block below backfills it retroactively at **stable granularity**: one entry per published stable, each summarizing its rc chain rather than logging every `rc.N` as the governance preamble prescribes. This mirrors the file's existing honesty about the 0.3.6 drift. Per-rc detail lives in the git history and tags (`git log v0.6.0..v0.6.1`, etc.); the [v0.6.4 GitHub Release](https://github.com/ParachuteComputer/parachute-hub/releases/tag/v0.6.4) is the only one with curated release notes. All five stables (0.6.0, 0.6.1, 0.6.2, 0.6.3, 0.6.4) published to npm; no intermediate stable was skipped.
+
+## [0.6.4] - 2026-06-06
+
+**Fresh-install onboarding overhaul + a multi-user/account security wave.** The 0.6.4-rc chain (rc.1–rc.10) promoted to stable. Driven by real field transcripts of operators hitting dead-ends on fresh boxes.
+
+### Security & multi-user
+
+- **Per-request force-change-password enforcement** (closes #469, PR #552). A signed-in user on an admin-set temporary password could navigate around the change gate and operate indefinitely — the gate was session-redirect-only, not enforced per request. Now every request re-checks; an OAuth gate complement landed alongside.
+- **First-claim bootstrap token** (#576, PR #585). On a public expose with no admin yet, `init` prints a one-time terminal token the wizard requires before creating the first admin (Render-style). Whoever finds your URL first can no longer claim your hub.
+- **One-time expiring invite links** that provision an account + its own vault (#553); cross-tenant invite assignment rejected, invite vault name defaults to the username (#557).
+- **2FA recommended when exposing publicly** — enrollment pointers shown on `expose` (#554).
+- **Pre-multi-user hardening** across mint-token, layer detection, and scribe auth (#550); scope-guard force-reloads JWKS and retries once on rotation-class verification failures (#549).
+- `deleteUser` no longer 500s on OAuth-authorized users (clears `auth_codes`) (#559).
+
+### Install & init
+
+- `parachute init` never dead-ends: expose failures warn and continue to the wizard URL instead of aborting; the Cloudflare flow no longer requires a vault to route; typed hostnames persist across retries (#564–#567, #574).
+- **`parachute install <svc>` is light** — install → register → start → "manage it in the admin UI." The interactive interview is opt-in via `--interactive` (#579). The "Blocked 1 postinstall" warning on `bun add -g` is gone (#568).
+
+### Lifecycle robustness
+
+- **Dual-lifecycle race closed**: install sweeps stale per-module units; the supervisor names port squatters with pid + command instead of crash-looping (#580, #581).
+- **`init`/`expose` version-check the running hub** and restart the unit when it's stale (#590, PR #591) — no more wiring a tunnel to a months-old zombie process.
+- Deterministic OAuth issuer via expose-state fallback on both origin chokepoints (#531); supervisor restarts rebuild spawn env (#532); canonical `services.json` port wins over a stale `.env` PORT (#537, #538); hub binds its port before booting modules + structured errors from module-ops (#536, #540, #545); launchd hubs find operator tools via enriched PATH (#546); status reports run-state for non-curated supervised modules (#539, #542); per-arm lazy imports so one broken command module can't take down the whole CLI (#533); test-isolation guards against real `launchctl` under test (#535, #541, #556).
+- `expose off --cloudflare` clears the propagated hub origin, ending the post-teardown iss-mismatch class (#503, PR #587).
+
+### Account & connect UX
+
+- `/account` is a **first-run onboarding checklist** (account → connect your AI → vault) (#561), with a consolidated owner home that dedups connect, surfaces backup state, drops the token-mint, and hints at building your own UI (#571).
+- Self-serve vault-admin-token unlock + per-vault usage on the account surface (#551).
+- "You're connected" no longer false-positives on a Notes browser sign-in, and a "Connect another AI" expander stays available once connected (#583).
+- POSTs to a bare `/vault/<name>` URL 308-redirect to `/vault/<name>/mcp` — pasting the URL without the suffix into an MCP client just works (#525, PR #587).
+- Phantom `default` vault row removed from discovery on fresh boxes (#577).
+
+## [0.6.3] - 2026-06-02
+
+**Supervisor unification completed (Phases 1–6) + the loopback trust-model restoration.** The 0.6.3-rc chain landed the long-running "hub-as-supervisor, modules = children" arc: there is now one runtime (`parachute serve` under a process manager), no detached-daemon model.
+
+### Changed
+
+- **Supervisor unification, Phases 1–6** (#495–#510, #514). Module-ops start/stop endpoints + a CLI module-ops client (Phase 1); supervisor hardening — process-group reaping, per-module log ring buffer, port-readiness + structured start-errors (Phase 2a); a generalized `ManagedUnit` with env block + install-without-start (Phase 2b); `ensureHubUnit` + `init` installs/starts the hub unit (Phase 3a); start/stop/restart cutover to drive the supervisor with a detached fallback + fresh-box operator-token closure (Phase 3b); `status` reads the platform manager + running supervisor (Phase 3c); expose decouple + `upgrade-hub` restarts the unit (Phase 4 CLI); `POST /api/hub/upgrade` + detached one-shot helper + admin-SPA hub-upgrade affordance (Phase 4 SPA); migrate detached→supervised cutover + archive-guard fix + auto-offer (Phase 5a); **retire the detached spawners + collapse the dual-dispatch bridge — supervised is the only runtime** (Phase 5b); doc rewrite across Service-lifecycle, CLAUDE.md, help, and route headers (Phase 6).
+
+### Fixed
+
+- **Supervised hub unit binds `127.0.0.1`, not `0.0.0.0`** — restores the loopback trust model (security, #524). The supervised unit had been binding all interfaces.
+- **`migrate`/`teardown` disables stale per-module autostart units** (`parachute-<short>` systemd/launchd) so they can't race the supervisor (#522, #523).
+- **Operator-token validation accepts the hub's known issuers** so loopback CLI + `status` work on exposed boxes (#516, #517, #518).
+
+### Added
+
+- `/account` starter-prompts card + connector-terminology cleanup (#529).
+
+## [0.6.2] - 2026-05-31
+
+**Reboot survival for the public connector + the import-notes deep-link.**
+
+### Added
+
+- **Reboot-persistent `cloudflared` connector** — the public-expose connector is installed as a managed unit so it survives a host reboot (#493). Headless non-root Linux boxes need `loginctl enable-linger` to cold-boot cleanly.
+- **`/account` "Import notes" deep-link** to the Notes import flow (#493).
+
+## [0.6.1] - 2026-05-31
+
+**Per-hostname Cloudflare tunnels + the scripting token + OAuth scope hygiene.**
+
+### Fixed
+
+- **Per-hostname Cloudflare tunnels** — a fixed shared tunnel name made two machines share one tunnel UUID; Cloudflare load-balances connectors across them, producing cross-host 404s. Each host now gets its own tunnel; CLI messaging clarified (#491).
+- **Vault-bound consent scope-drop + container-boot dist build** (#487) — the published container now builds its `web/ui` dist on boot.
+
+### Added
+
+- **`--ephemeral` short-TTL `mint-token`** for scripting — ideal for cron/CI credentials (#488).
+- **Assigned (non-admin) users can grant `vault:<name>:admin` to their own OAuth client** for vaults they're assigned to (#490).
+
+### Changed
+
+- **OAuth advertises optional-module scopes only when the module is installed** — scribe/channel scopes no longer appear in metadata on hubs that don't run them (#489).
+
+## [0.6.0] - 2026-05-29
+
+**Single OAuth consent + the pvt_* retirement endgame + first-vault import + real 2FA.** Closes out the capability-attenuation auth arc (started in the 0.5.14-rc chain) and ships the unified `parachute init` setup flow.
+
+### Added
+
+- **Single OAuth consent with grantable `vault:<name>:admin`** under a delegate-only-what-you-hold capability model (#484). One consent screen mints the named, vault-bound scope a client actually needs.
+- **`@openparachute/depcheck` library + hub adoption** — friendly missing-dependency UX (the systematic version of the cloudflared/git/tailscale guidance) (#483, follow-on to #481, #188).
+- **Friend-facing `/account` connect-your-vault UX** for Claude.ai + Claude Code, plus a slimmed signed-out discovery page (#478); friends can mint a scoped (read/write, assignment-gated) vault token from `/account` (#479).
+- **Real TOTP 2FA at hub login** with backup codes (#473, #475).
+- **Capability attenuation throughout mint/revoke** — host-admin bearers mint `vault:<name>:admin`; that token mints same-vault subtokens; revoke can revoke what it could mint; malformed vault-shaped scopes rejected at mint (#449, #452, #454, #455, #461; scope-guard surfaces the `permissions` claim, #453).
+- **Wizard parity + first-vault import-from-git** — the wizard always installs the vault module, has a CLI variant, and can seed the first vault from a git repo; `parachute init` extends to the optional exposure chain so a laptop ≈ a server in one command (#445, #447).
+- **Per-vault "MCP connection" card** in the admin SPA (#463); multi-vault membership per user + admin password reset (multi-user Phase 2, #427, #429); friend-facing `/account/` home with a first-admin gate on `/admin/host-admin-token` (#425, #426).
+
+### Fixed
+
+- **Self-heal stale credentials on Cloudflare deploys** — persist the public hub origin into the vault `.env` (vault was 401ing hub tokens, #480); self-heal the stale operator-token issuer on `start hub` (#481); inject the hub public origin into the supervised vault env to fix the OAuth iss-mismatch 401-on-reconnect (#460).
+- **`upgrade` no longer crashes when git is absent** (#472); `start` readiness / `EADDRINUSE` handling + cloudflared orphan cleanup + expose DNS self-diagnosis (#476).
+- **RFC 8707 resource honored** — narrow consent + named-scope mint for vault-bound MCP, fixing scary broad scopes + broad-scope rejection (#461); setup-flow 404 after vault-create + wizard honors live expose-state (#462).
+- **Honest first-admin/2FA/expose-state labeling** on Cloudflare (#474); init expose prompt no longer mislabels tailnet as "Tailscale Funnel" (#458).
+
+### Changed
+
+- **`app` → `surface` rename, hub side** (Phase 1.5 of patterns#102, #422); curated modules trimmed to `[vault, scribe]` for launch focus (#436); README leads with the unified `parachute init` setup flow (#456); Fly.io added as a peer self-host option (#420).
+- **Hotfix**: dropped the `bun`→src exports condition that broke published resolution under Bun (#485).
+
 ## [0.5.13-rc.48] - 2026-05-26
 
 **Hotfix.** /admin/setup + /api/modules + every other hot-path read site now uses readManifestLenient (#411). #406 only patched ONE call site; Aaron hit 500s when a stale services.json row from an old @openparachute/app@0.2.0-rc.4 install threw the strict validator on /admin/setup. Now: one bad row in services.json no longer 500s the entire admin SPA + wizard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to `@openparachute/hub` are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/) loosely; versions follow [SemVer](https://semver.org/) with the pre-1.0 RC governance described in [`parachute-patterns/patterns/governance.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/governance.md).
 
-> **Backfill note (2026-06-06).** The entire 0.6.x line (0.6.0 → 0.6.4) shipped without changelog entries — the file stopped at `0.5.13-rc.48`. The block below backfills it retroactively at **stable granularity**: one entry per published stable, each summarizing its rc chain rather than logging every `rc.N` as the governance preamble prescribes. This mirrors the file's existing honesty about the 0.3.6 drift. Per-rc detail lives in the git history and tags (`git log v0.6.0..v0.6.1`, etc.); the [v0.6.4 GitHub Release](https://github.com/ParachuteComputer/parachute-hub/releases/tag/v0.6.4) is the only one with curated release notes. All five stables (0.6.0, 0.6.1, 0.6.2, 0.6.3, 0.6.4) published to npm; no intermediate stable was skipped.
+> **Backfill note (2026-06-06).** The entire 0.6.x line (0.6.0 → 0.6.4) shipped without changelog entries — the file stopped at `0.5.13-rc.48`. The block below backfills it retroactively at **stable granularity**: one entry per published stable, each summarizing its rc chain rather than logging every `rc.N` as the governance preamble prescribes. Per-rc detail lives in the git history and tags (`git log v0.6.0..v0.6.1`, etc.); the [v0.6.4 GitHub Release](https://github.com/ParachuteComputer/parachute-hub/releases/tag/v0.6.4) is the only one with curated release notes. All five stables (0.6.0, 0.6.1, 0.6.2, 0.6.3, 0.6.4) published to npm; no intermediate stable was skipped.
+>
+> This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
 ## [0.6.4] - 2026-06-06
 
@@ -19,7 +21,7 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 
 ### Install & init
 
-- `parachute init` never dead-ends: expose failures warn and continue to the wizard URL instead of aborting; the Cloudflare flow no longer requires a vault to route; typed hostnames persist across retries (#564–#567, #574).
+- `parachute init` never dead-ends: expose failures warn and continue to the wizard URL instead of aborting; the Cloudflare flow no longer requires a vault to route; an inline `cloudflared` install offer (macOS via brew, Linux via static binary) lands when it's missing; typed hostnames persist across retries (#564, #566, #567, #574).
 - **`parachute install <svc>` is light** — install → register → start → "manage it in the admin UI." The interactive interview is opt-in via `--interactive` (#579). The "Blocked 1 postinstall" warning on `bun add -g` is gone (#568).
 
 ### Lifecycle robustness
@@ -43,7 +45,7 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 
 ### Changed
 
-- **Supervisor unification, Phases 1–6** (#495–#510, #514). Module-ops start/stop endpoints + a CLI module-ops client (Phase 1); supervisor hardening — process-group reaping, per-module log ring buffer, port-readiness + structured start-errors (Phase 2a); a generalized `ManagedUnit` with env block + install-without-start (Phase 2b); `ensureHubUnit` + `init` installs/starts the hub unit (Phase 3a); start/stop/restart cutover to drive the supervisor with a detached fallback + fresh-box operator-token closure (Phase 3b); `status` reads the platform manager + running supervisor (Phase 3c); expose decouple + `upgrade-hub` restarts the unit (Phase 4 CLI); `POST /api/hub/upgrade` + detached one-shot helper + admin-SPA hub-upgrade affordance (Phase 4 SPA); migrate detached→supervised cutover + archive-guard fix + auto-offer (Phase 5a); **retire the detached spawners + collapse the dual-dispatch bridge — supervised is the only runtime** (Phase 5b); doc rewrite across Service-lifecycle, CLAUDE.md, help, and route headers (Phase 6).
+- **Supervisor unification, Phases 1–6** (#495, #496, #497, #498, #499, #500, #502, #504, #507, #510, #514). Module-ops start/stop endpoints + a CLI module-ops client (Phase 1); supervisor hardening — process-group reaping, per-module log ring buffer, port-readiness + structured start-errors (Phase 2a); a generalized `ManagedUnit` with env block + install-without-start (Phase 2b); `ensureHubUnit` + `init` installs/starts the hub unit (Phase 3a); start/stop/restart cutover to drive the supervisor with a detached fallback + fresh-box operator-token closure (Phase 3b); `status` reads the platform manager + running supervisor (Phase 3c); expose decouple + `upgrade-hub` restarts the unit (Phase 4 CLI); `POST /api/hub/upgrade` + detached one-shot helper + admin-SPA hub-upgrade affordance (Phase 4 SPA); migrate detached→supervised cutover + archive-guard fix + auto-offer (Phase 5a); **retire the detached spawners + collapse the dual-dispatch bridge — supervised is the only runtime** (Phase 5b); doc rewrite across Service-lifecycle, CLAUDE.md, help, and route headers (Phase 6).
 
 ### Fixed
 
@@ -89,7 +91,7 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 ### Added
 
 - **Single OAuth consent with grantable `vault:<name>:admin`** under a delegate-only-what-you-hold capability model (#484). One consent screen mints the named, vault-bound scope a client actually needs.
-- **`@openparachute/depcheck` library + hub adoption** — friendly missing-dependency UX (the systematic version of the cloudflared/git/tailscale guidance) (#483, follow-on to #481, #188).
+- **`@openparachute/depcheck` library + hub adoption** — friendly missing-dependency UX (the systematic version of the cloudflared/git/tailscale guidance) (#483, follow-on to #481). (The originating commit message also cited #188; that reference was erroneous — #188 is an unrelated login rate-limit change — and is omitted here.)
 - **Friend-facing `/account` connect-your-vault UX** for Claude.ai + Claude Code, plus a slimmed signed-out discovery page (#478); friends can mint a scoped (read/write, assignment-gated) vault token from `/account` (#479).
 - **Real TOTP 2FA at hub login** with backup codes (#473, #475).
 - **Capability attenuation throughout mint/revoke** — host-admin bearers mint `vault:<name>:admin`; that token mints same-vault subtokens; revoke can revoke what it could mint; malformed vault-shaped scopes rejected at mint (#449, #452, #454, #455, #461; scope-guard surfaces the `permissions` claim, #453).

--- a/src/__tests__/cloudflare-tunnel.test.ts
+++ b/src/__tests__/cloudflare-tunnel.test.ts
@@ -3,9 +3,11 @@ import {
   CloudflaredError,
   createTunnel,
   credentialsPath,
+  deleteTunnel,
   findTunnelByName,
   listTunnels,
   routeDns,
+  tunnelConnectionCount,
 } from "../cloudflare/tunnel.ts";
 import type { CommandResult, Runner } from "../tailscale/run.ts";
 
@@ -203,5 +205,81 @@ describe("cloudflare tunnel", () => {
 
   test("credentialsPath joins uuid under the cloudflared home", () => {
     expect(credentialsPath("abc", "/Users/x/.cloudflared")).toBe("/Users/x/.cloudflared/abc.json");
+  });
+
+  test("deleteTunnel passes --force and surfaces failures (#593)", async () => {
+    const { runner, seen } = makeRunner(
+      [["cloudflared", "tunnel", "delete", "--force", "parachute"]],
+      [{ code: 0, stdout: "Deleted tunnel parachute\n", stderr: "" }],
+    );
+    await deleteTunnel(runner, "parachute");
+    expect(seen[0]).toEqual(["cloudflared", "tunnel", "delete", "--force", "parachute"]);
+
+    const fail = makeRunner(
+      [["cloudflared", "tunnel", "delete", "--force", "parachute"]],
+      [{ code: 1, stdout: "", stderr: "tunnel has active connections" }],
+    );
+    await expect(deleteTunnel(fail.runner, "parachute")).rejects.toMatchObject({
+      message: expect.stringContaining("active connections"),
+    });
+  });
+
+  describe("tunnelConnectionCount (#593)", () => {
+    function infoRunner(result: CommandResult): Runner {
+      return async (cmd) => {
+        expect([...cmd]).toEqual([
+          "cloudflared",
+          "tunnel",
+          "info",
+          "--output",
+          "json",
+          "parachute",
+        ]);
+        return result;
+      };
+    }
+
+    test("counts connector entries under `conns`", async () => {
+      const runner = infoRunner({
+        code: 0,
+        stdout: JSON.stringify({ conns: [{ id: "a" }, { id: "b" }] }),
+        stderr: "",
+      });
+      expect(await tunnelConnectionCount(runner, "parachute")).toBe(2);
+    });
+
+    test("counts connector entries under the legacy `connections` shape", async () => {
+      const runner = infoRunner({
+        code: 0,
+        stdout: JSON.stringify({ connections: [{ id: "a" }] }),
+        stderr: "",
+      });
+      expect(await tunnelConnectionCount(runner, "parachute")).toBe(1);
+    });
+
+    test("returns 0 on empty conns, non-zero exit, unparseable JSON, or a runner throw", async () => {
+      expect(
+        await tunnelConnectionCount(
+          infoRunner({ code: 0, stdout: '{"conns":[]}', stderr: "" }),
+          "parachute",
+        ),
+      ).toBe(0);
+      expect(
+        await tunnelConnectionCount(
+          infoRunner({ code: 1, stdout: "", stderr: "not found" }),
+          "parachute",
+        ),
+      ).toBe(0);
+      expect(
+        await tunnelConnectionCount(
+          infoRunner({ code: 0, stdout: "not json", stderr: "" }),
+          "parachute",
+        ),
+      ).toBe(0);
+      const thrower: Runner = async () => {
+        throw new Error("spawn failed");
+      };
+      expect(await tunnelConnectionCount(thrower, "parachute")).toBe(0);
+    });
   });
 });

--- a/src/__tests__/expose-cloudflare.test.ts
+++ b/src/__tests__/expose-cloudflare.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../cloudflare/state.ts";
 import {
   type CloudflaredSpawner,
+  defaultVerifyConnection,
   exposeCloudflareOff,
   exposeCloudflareUp,
 } from "../commands/expose-cloudflare.ts";
@@ -116,6 +117,16 @@ function fakeSpawner(pid: number): { spawner: CloudflaredSpawner; seen: string[]
     },
   };
   return { spawner, seen };
+}
+
+/**
+ * Write a fake `~/.cloudflared/<uuid>.json` credentials file so the reuse-path
+ * credentials check (#593) sees a healthy local tunnel and reuses it instead of
+ * triggering the delete+recreate self-heal. Reuse-path tests that want to
+ * exercise the plain reuse behavior call this after `makeEnv()`.
+ */
+function seedCreds(env: TestEnv, uuid: string): void {
+  writeFileSync(join(env.cloudflaredHome, `${uuid}.json`), "{}");
 }
 
 describe("exposeCloudflareUp", () => {
@@ -350,6 +361,7 @@ describe("exposeCloudflareUp", () => {
     const env = makeEnv();
     try {
       const uuid = "bbbbbbbb-0000-0000-0000-000000000002";
+      seedCreds(env, uuid); // healthy local creds → plain reuse, no recreate (#593)
       const { runner, calls } = queueRunner([
         { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
         {
@@ -563,6 +575,7 @@ describe("exposeCloudflareUp", () => {
     const env = makeEnv();
     try {
       const uuid = "2c1a7c7e-1234-5678-9abc-def012345678";
+      seedCreds(env, uuid); // healthy local creds → plain reuse, no recreate (#593)
       const { runner } = queueRunner([
         { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
         { code: 0, stdout: JSON.stringify([{ id: uuid, name: "parachute" }]), stderr: "" },
@@ -605,6 +618,8 @@ describe("exposeCloudflareUp", () => {
   test("stops a prior cloudflared process before spawning a new one", async () => {
     const env = makeEnv();
     try {
+      // Healthy local creds for the reused tunnel → plain reuse, no recreate (#593).
+      seedCreds(env, "cccccccc-0000-0000-0000-000000000003");
       const priorRecord: CloudflaredTunnelRecord = {
         pid: 99999,
         tunnelUuid: "old-tunnel-uuid",
@@ -668,6 +683,7 @@ describe("exposeCloudflareUp", () => {
     const env = makeEnv();
     try {
       const uuid = "cccccccc-0000-0000-0000-000000000003";
+      seedCreds(env, uuid); // healthy local creds → plain reuse, no recreate (#593)
       const priorRecord: CloudflaredTunnelRecord = {
         pid: 99999,
         tunnelUuid: uuid,
@@ -727,6 +743,7 @@ describe("exposeCloudflareUp", () => {
     const env = makeEnv();
     try {
       const uuid = "dddddddd-0000-0000-0000-000000000004";
+      seedCreds(env, uuid); // healthy local creds → plain reuse, no recreate (#593)
       const { runner } = queueRunner([
         { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
         { code: 0, stdout: JSON.stringify([{ id: uuid, name: "parachute" }]), stderr: "" },
@@ -774,6 +791,7 @@ describe("exposeCloudflareUp", () => {
     const env = makeEnv();
     try {
       const uuid = "eeeeeeee-0000-0000-0000-000000000006";
+      seedCreds(env, uuid); // healthy local creds → plain reuse, no recreate (#593)
       const { runner } = queueRunner([
         { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
         { code: 0, stdout: JSON.stringify([{ id: uuid, name: "parachute" }]), stderr: "" },
@@ -817,6 +835,7 @@ describe("exposeCloudflareUp", () => {
     const env = makeEnv();
     try {
       const uuid = "ffffffff-0000-0000-0000-000000000007";
+      seedCreds(env, uuid); // healthy local creds → plain reuse, no recreate (#593)
       const { runner } = queueRunner([
         { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
         { code: 0, stdout: JSON.stringify([{ id: uuid, name: "parachute" }]), stderr: "" },
@@ -1158,6 +1177,7 @@ describe("exposeCloudflareUp", () => {
       const env = makeEnv();
       try {
         const uuid = "bbbb8888-1111-2222-3333-444455556666";
+        seedCreds(env, uuid); // healthy local creds → plain reuse, no recreate (#593)
         const legacy: CloudflaredTunnelRecord = {
           pid: 71001,
           tunnelUuid: uuid,
@@ -1377,6 +1397,239 @@ describe("exposeCloudflareUp", () => {
       } finally {
         env.cleanup();
       }
+    });
+  });
+
+  describe("#593: reuse-path credentials self-heal", () => {
+    test("recreates the tunnel when the local credentials file is missing", async () => {
+      const env = makeEnv();
+      try {
+        const staleUuid = "11110000-0000-0000-0000-0000000005aa";
+        const freshUuid = "22220000-0000-0000-0000-0000000005bb";
+        // NO seedCreds → the reused tunnel's local creds file is absent, the
+        // exact field state (account-side tunnel survives, local creds lost).
+        const { runner, calls } = queueRunner([
+          { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" }, // --version
+          {
+            code: 0,
+            stdout: JSON.stringify([{ id: staleUuid, name: "parachute" }]),
+            stderr: "",
+          }, // tunnel list (exists account-side)
+          { code: 0, stdout: "Deleted tunnel parachute\n", stderr: "" }, // tunnel delete --force
+          {
+            code: 0,
+            stdout: `Created tunnel parachute with id ${freshUuid}\n`,
+            stderr: "",
+          }, // tunnel create (fresh creds)
+          { code: 0, stdout: "", stderr: "" }, // route dns
+        ]);
+        const { spawner } = fakeSpawner(43000);
+        const logs: string[] = [];
+
+        const code = await exposeCloudflareUp("vault.example.com", {
+          runner,
+          spawner,
+          alive: () => false,
+          kill: () => {},
+          log: (l) => logs.push(l),
+          manifestPath: env.manifestPath,
+          statePath: env.statePath,
+          exposeStatePath: env.exposeStatePath,
+          configPath: env.configPath,
+          logPath: env.logPath,
+          cloudflaredHome: env.cloudflaredHome,
+          configDir: env.configDir,
+          skipHub: true,
+          tunnelName: "parachute",
+        });
+
+        expect(code).toBe(0);
+        const cmds = calls.map((c) => c.cmd.join(" "));
+        expect(cmds).toContain("cloudflared tunnel delete --force parachute");
+        expect(cmds).toContain("cloudflared tunnel create parachute");
+        // State + config reflect the FRESH uuid, not the stale one.
+        const state = readCloudflaredState(env.statePath);
+        expect(findTunnelRecord(state, "parachute")?.tunnelUuid).toBe(freshUuid);
+        const yaml = readFileSync(env.configPath, "utf8");
+        expect(yaml).toContain(`tunnel: ${freshUuid}`);
+        const joined = logs.join("\n");
+        expect(joined).toContain("local credentials");
+        expect(joined).toContain("Recreated tunnel");
+      } finally {
+        env.cleanup();
+      }
+    });
+
+    test("fails with recovery commands when the stale-tunnel delete itself fails", async () => {
+      const env = makeEnv();
+      try {
+        const staleUuid = "11110000-0000-0000-0000-0000000005cc";
+        const { runner, calls } = queueRunner([
+          { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" }, // --version
+          {
+            code: 0,
+            stdout: JSON.stringify([{ id: staleUuid, name: "parachute" }]),
+            stderr: "",
+          }, // tunnel list
+          { code: 1, stdout: "", stderr: "tunnel has active connections" }, // delete fails
+        ]);
+        const { spawner } = fakeSpawner(43001);
+        const logs: string[] = [];
+
+        const code = await exposeCloudflareUp("vault.example.com", {
+          runner,
+          spawner,
+          alive: () => false,
+          kill: () => {},
+          log: (l) => logs.push(l),
+          manifestPath: env.manifestPath,
+          statePath: env.statePath,
+          exposeStatePath: env.exposeStatePath,
+          configPath: env.configPath,
+          logPath: env.logPath,
+          cloudflaredHome: env.cloudflaredHome,
+          configDir: env.configDir,
+          skipHub: true,
+          tunnelName: "parachute",
+        });
+
+        expect(code).toBe(1);
+        // No connector spawned, no success print.
+        const joined = logs.join("\n");
+        expect(joined).toContain("Couldn't delete the stale tunnel");
+        expect(joined).toContain("cloudflared tunnel delete --force parachute");
+        expect(joined).not.toContain("Cloudflare tunnel up");
+        // create + route never ran.
+        const cmds = calls.map((c) => c.cmd.join(" "));
+        expect(cmds.some((c) => c.startsWith("cloudflared tunnel create"))).toBe(false);
+      } finally {
+        env.cleanup();
+      }
+    });
+  });
+
+  describe("#593: post-start connection verification", () => {
+    test("fails loudly when the connector never registers a connection (timeout)", async () => {
+      const env = makeEnv();
+      try {
+        const uuid = "33330000-0000-0000-0000-0000000005dd";
+        seedCreds(env, uuid);
+        const { runner } = queueRunner([
+          { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
+          { code: 0, stdout: JSON.stringify([{ id: uuid, name: "parachute" }]), stderr: "" },
+          { code: 0, stdout: "", stderr: "" }, // route dns
+        ]);
+        const { spawner } = fakeSpawner(43002);
+        const logs: string[] = [];
+
+        const code = await exposeCloudflareUp("vault.example.com", {
+          runner,
+          spawner,
+          alive: () => false,
+          kill: () => {},
+          log: (l) => logs.push(l),
+          manifestPath: env.manifestPath,
+          statePath: env.statePath,
+          exposeStatePath: env.exposeStatePath,
+          configPath: env.configPath,
+          logPath: env.logPath,
+          cloudflaredHome: env.cloudflaredHome,
+          configDir: env.configDir,
+          skipHub: true,
+          tunnelName: "parachute",
+          // Drive the timeout branch directly (no real cloudflared/poll).
+          verifyConnection: async () => false,
+        });
+
+        expect(code).toBe(1);
+        const joined = logs.join("\n");
+        expect(joined).toContain("never registered a tunnel connection");
+        expect(joined).toContain("error 1033");
+        expect(joined).toContain(env.logPath); // names the connector log
+        expect(joined).not.toContain("✓ Cloudflare tunnel up");
+      } finally {
+        env.cleanup();
+      }
+    });
+
+    test("prints success when the connector verifies connected", async () => {
+      const env = makeEnv();
+      try {
+        const uuid = "44440000-0000-0000-0000-0000000005ee";
+        seedCreds(env, uuid);
+        const { runner } = queueRunner([
+          { code: 0, stdout: "cloudflared 2024.1.0\n", stderr: "" },
+          { code: 0, stdout: JSON.stringify([{ id: uuid, name: "parachute" }]), stderr: "" },
+          { code: 0, stdout: "", stderr: "" }, // route dns
+        ]);
+        const { spawner } = fakeSpawner(43003);
+        const logs: string[] = [];
+
+        const code = await exposeCloudflareUp("vault.example.com", {
+          runner,
+          spawner,
+          alive: () => false,
+          kill: () => {},
+          log: (l) => logs.push(l),
+          manifestPath: env.manifestPath,
+          statePath: env.statePath,
+          exposeStatePath: env.exposeStatePath,
+          configPath: env.configPath,
+          logPath: env.logPath,
+          cloudflaredHome: env.cloudflaredHome,
+          configDir: env.configDir,
+          skipHub: true,
+          tunnelName: "parachute",
+          verifyConnection: async () => true,
+        });
+
+        expect(code).toBe(0);
+        const joined = logs.join("\n");
+        expect(joined).toContain("Connector connected.");
+        expect(joined).toContain("✓ Cloudflare tunnel up");
+      } finally {
+        env.cleanup();
+      }
+    });
+
+    test("defaultVerifyConnection polls tunnelConnectionCount and returns true once connected", async () => {
+      // Drives the real default poll loop against a queued runner — first
+      // `tunnel info` reports no conns, the second reports one. No real sleep.
+      let infoCalls = 0;
+      const runner: Runner = async (cmd) => {
+        if (cmd.join(" ").startsWith("cloudflared tunnel info")) {
+          infoCalls += 1;
+          return infoCalls === 1
+            ? { code: 0, stdout: JSON.stringify({ conns: [] }), stderr: "" }
+            : { code: 0, stdout: JSON.stringify({ conns: [{ id: "c1" }] }), stderr: "" };
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      };
+      const connected = await defaultVerifyConnection({
+        runner,
+        tunnelName: "parachute",
+        timeoutMs: 5_000,
+        pollMs: 1,
+        sleep: async () => {},
+      });
+      expect(connected).toBe(true);
+      expect(infoCalls).toBe(2);
+    });
+
+    test("defaultVerifyConnection returns false when the budget elapses with no connection", async () => {
+      const runner: Runner = async () => ({
+        code: 0,
+        stdout: JSON.stringify({ conns: [] }),
+        stderr: "",
+      });
+      const connected = await defaultVerifyConnection({
+        runner,
+        tunnelName: "parachute",
+        timeoutMs: 0, // immediate deadline → one probe then false
+        pollMs: 1,
+        sleep: async () => {},
+      });
+      expect(connected).toBe(false);
     });
   });
 });

--- a/src/__tests__/hub-db-liveness.test.ts
+++ b/src/__tests__/hub-db-liveness.test.ts
@@ -1,0 +1,139 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { classifyDbError, createDbHolder, probeDbLiveness } from "../hub-db-liveness.ts";
+
+/** Build a `SQLiteError`-shaped object with the given code + message. */
+function sqliteErr(code: string, message: string): Error & { code: string } {
+  const e = new Error(message) as Error & { code: string };
+  e.name = "SQLiteError";
+  e.code = code;
+  return e;
+}
+
+describe("classifyDbError (#594)", () => {
+  test("the persistent-corruption class is fatal", () => {
+    expect(classifyDbError(sqliteErr("SQLITE_IOERR", "disk I/O error"))).toBe("fatal");
+    expect(classifyDbError(new Error("disk I/O error"))).toBe("fatal");
+    expect(classifyDbError(sqliteErr("SQLITE_CORRUPT", "database disk image is malformed"))).toBe(
+      "fatal",
+    );
+    expect(classifyDbError(sqliteErr("SQLITE_NOTADB", "file is not a database"))).toBe("fatal");
+  });
+
+  test("transient locks are NOT fatal", () => {
+    expect(classifyDbError(sqliteErr("SQLITE_BUSY", "database is locked"))).toBe("transient");
+    expect(classifyDbError(sqliteErr("SQLITE_LOCKED", "database table is locked"))).toBe(
+      "transient",
+    );
+  });
+
+  test("unrelated errors classify as other", () => {
+    expect(classifyDbError(new Error("UNIQUE constraint failed: users.id"))).toBe("other");
+    expect(classifyDbError(new TypeError("undefined is not a function"))).toBe("other");
+    expect(classifyDbError(null)).toBe("other");
+  });
+});
+
+describe("probeDbLiveness (#594)", () => {
+  test("returns ok on a live in-memory db", () => {
+    const db = new Database(":memory:");
+    expect(probeDbLiveness(db)).toBe("ok");
+    db.close();
+  });
+
+  test("returns error: <class> on a closed handle, never throws", () => {
+    const db = new Database(":memory:");
+    db.close();
+    const result = probeDbLiveness(db);
+    expect(result.startsWith("error:")).toBe(true);
+  });
+});
+
+describe("createDbHolder (#594)", () => {
+  test("non-fatal errors are ignored (no reopen, no exit)", () => {
+    const initial = new Database(":memory:");
+    let reopens = 0;
+    let exits = 0;
+    const holder = createDbHolder(initial, {
+      reopen: () => {
+        reopens += 1;
+        return new Database(":memory:");
+      },
+      exit: () => {
+        exits += 1;
+      },
+      log: () => {},
+    });
+    expect(holder.healOrExit(sqliteErr("SQLITE_BUSY", "database is locked"))).toBe("ignored");
+    expect(holder.healOrExit(new Error("UNIQUE constraint failed"))).toBe("ignored");
+    expect(reopens).toBe(0);
+    expect(exits).toBe(0);
+    expect(holder.get()).toBe(initial);
+  });
+
+  test("a fatal error reopens the handle ONCE and swaps it in", () => {
+    const initial = new Database(":memory:");
+    const fresh = new Database(":memory:");
+    let reopens = 0;
+    let exits = 0;
+    let closedOld = false;
+    const holder = createDbHolder(initial, {
+      reopen: () => {
+        reopens += 1;
+        return fresh;
+      },
+      exit: () => {
+        exits += 1;
+      },
+      closeOld: () => {
+        closedOld = true;
+      },
+      log: () => {},
+    });
+    expect(holder.healOrExit(sqliteErr("SQLITE_IOERR", "disk I/O error"))).toBe("healed");
+    expect(reopens).toBe(1);
+    expect(exits).toBe(0);
+    expect(closedOld).toBe(true);
+    expect(holder.get()).toBe(fresh);
+    fresh.close();
+  });
+
+  test("a fatal error exits(1) when reopen throws", () => {
+    const initial = new Database(":memory:");
+    let exitCode: number | undefined;
+    const holder = createDbHolder(initial, {
+      reopen: () => {
+        throw sqliteErr("SQLITE_IOERR", "disk I/O error");
+      },
+      // Non-exiting spy so the test process survives.
+      exit: (code) => {
+        exitCode = code;
+      },
+      log: () => {},
+    });
+    expect(holder.healOrExit(sqliteErr("SQLITE_IOERR", "disk I/O error"))).toBe("exited");
+    expect(exitCode).toBe(1);
+    // Handle is unchanged (we couldn't reopen).
+    expect(holder.get()).toBe(initial);
+    initial.close();
+  });
+
+  test("a fatal error exits(1) when the REOPENED handle is also dead", () => {
+    const initial = new Database(":memory:");
+    // Reopen returns an already-closed handle → the holder's SELECT 1 verify
+    // throws → exit. This is the "state dir still gone after reopen" case.
+    const deadFresh = new Database(":memory:");
+    deadFresh.close();
+    let exitCode: number | undefined;
+    const holder = createDbHolder(initial, {
+      reopen: () => deadFresh,
+      exit: (code) => {
+        exitCode = code;
+      },
+      log: () => {},
+    });
+    expect(holder.healOrExit(sqliteErr("SQLITE_IOERR", "disk I/O error"))).toBe("exited");
+    expect(exitCode).toBe(1);
+    initial.close();
+  });
+});

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -1240,14 +1240,10 @@ describe("hubFetch routing", () => {
   // open shouldn't cascade into a restart loop. The body advertises the
   // running version so a deploy verifier can confirm the rolled-out
   // image is the one it expected.
-  test("/health returns 200 JSON without invoking the db", async () => {
+  test("/health returns 200 JSON; unconfigured db field when no getDb", async () => {
     const h = makeHarness();
     try {
-      const res = await hubFetch(h.dir, {
-        getDb: () => {
-          throw new Error("getDb must not be called by /health");
-        },
-      })(req("/health"));
+      const res = await hubFetch(h.dir)(req("/health"));
       expect(res.status).toBe(200);
       expect(res.headers.get("content-type")).toContain("application/json");
       expect(res.headers.get("cache-control")).toBe("no-store");
@@ -1255,6 +1251,95 @@ describe("hubFetch routing", () => {
       expect(body.status).toBe("ok");
       expect(body.service).toBe("parachute-hub");
       expect(typeof body.version).toBe("string");
+      expect(body.db).toBe("unconfigured");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/health db field is ok on a live db (#594)", async () => {
+    const h = makeHarness();
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const res = await hubFetch(h.dir, { getDb: () => db })(req("/health"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.status).toBe("ok");
+      expect(body.db).toBe("ok");
+    } finally {
+      db.close();
+      h.cleanup();
+    }
+  });
+
+  test("/health db field reports error: <class> on a dead handle, still 200 (#594)", async () => {
+    const h = makeHarness();
+    const db = openHubDb(hubDbPath(h.dir));
+    db.close(); // dead handle — every SELECT throws
+    try {
+      const res = await hubFetch(h.dir, { getDb: () => db })(req("/health"));
+      // Always 200 while the process is up — the HTTP status is process
+      // liveness, the db field is the readiness signal.
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.status).toBe("ok");
+      expect(typeof body.db).toBe("string");
+      expect((body.db as string).startsWith("error:")).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("a fatal DB throw escaping a handler returns a structured body + invokes onDbError (#594)", async () => {
+    const h = makeHarness();
+    try {
+      const fatal = Object.assign(new Error("disk I/O error"), {
+        name: "SQLiteError",
+        code: "SQLITE_IOERR",
+      });
+      let onDbErrorCalls = 0;
+      // A non-/health, DB-touching route (`/`) whose getDb throws the fatal
+      // class. The top-level self-heal wrapper catches it, calls onDbError,
+      // and returns a structured db_unavailable body (not a bare 500).
+      const res = await hubFetch(h.dir, {
+        manifestPath: h.manifestPath,
+        getDb: () => {
+          throw fatal;
+        },
+        onDbError: () => {
+          onDbErrorCalls += 1;
+          return "healed";
+        },
+      })(req("/", { headers: { accept: "text/html" } }));
+      expect(onDbErrorCalls).toBe(1);
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("db_unavailable");
+      expect(typeof body.error_description).toBe("string");
+      expect(body.error_description as string).toContain("reopened");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("a non-DB throw still propagates (not swallowed by the self-heal wrapper) (#594)", async () => {
+    const h = makeHarness();
+    try {
+      let onDbErrorCalls = 0;
+      const handler = hubFetch(h.dir, {
+        manifestPath: h.manifestPath,
+        getDb: () => {
+          throw new Error("some unrelated programming error");
+        },
+        onDbError: () => {
+          onDbErrorCalls += 1;
+          return "ignored";
+        },
+      });
+      await expect(handler(req("/", { headers: { accept: "text/html" } }))).rejects.toThrow(
+        "some unrelated programming error",
+      );
+      expect(onDbErrorCalls).toBe(0);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildCsrfCookie, generateCsrfToken } from "../csrf.ts";
 import { HUB_SVC, hubPortPath } from "../hub-control.ts";
+import { createDbHolder } from "../hub-db-liveness.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import {
   findServiceUpstream,
@@ -1341,6 +1342,59 @@ describe("hubFetch routing", () => {
       );
       expect(onDbErrorCalls).toBe(0);
     } finally {
+      h.cleanup();
+    }
+  });
+
+  test("a transient SQLITE_BUSY escaping a handler → 503, does NOT exit the hub (#594)", async () => {
+    const h = makeHarness();
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      // Wire a REAL DbHolder so this pins the end-to-end transient path: the
+      // wrapper catches the throw, routes it to the holder's healOrExit, and
+      // the holder must classify SQLITE_BUSY as transient → "ignored" → NO
+      // reopen, NO exit. A spy `exit` that fails the test if ever called is the
+      // regression guard ("a momentary lock never kills the hub").
+      let exited = false;
+      let reopened = false;
+      const holder = createDbHolder(db, {
+        reopen: () => {
+          reopened = true;
+          return db;
+        },
+        exit: () => {
+          exited = true;
+        },
+        log: () => {},
+      });
+      const busy = Object.assign(new Error("database is locked"), {
+        name: "SQLiteError",
+        code: "SQLITE_BUSY",
+      });
+      // First getDb() (the wizard-redirect userCount read) throws BUSY; the
+      // wrapper's catch routes it through the holder.
+      let firstCall = true;
+      const res = await hubFetch(h.dir, {
+        manifestPath: h.manifestPath,
+        getDb: () => {
+          if (firstCall) {
+            firstCall = false;
+            throw busy;
+          }
+          return holder.get();
+        },
+        onDbError: (err) => holder.healOrExit(err),
+      })(req("/", { headers: { accept: "text/html" } }));
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("db_unavailable");
+      // Transient class is named in the structured body, not "reopened".
+      expect(body.error_description as string).toContain("transient");
+      // The crux: the hub did NOT exit and did NOT reopen on a transient lock.
+      expect(exited).toBe(false);
+      expect(reopened).toBe(false);
+    } finally {
+      db.close();
       h.cleanup();
     }
   });

--- a/src/__tests__/hub-unit.test.ts
+++ b/src/__tests__/hub-unit.test.ts
@@ -783,6 +783,33 @@ describe("ensureHubVersionMatches — version-check-and-restart at adoption (#59
     expect(restarts).toHaveLength(1);
   });
 
+  // #594: a SUSTAINED transient fault visible in /health (e.g. a write lock
+  // that never clears) is still an "error:" verdict, so the adoption probe
+  // treats it as needing a restart — same as the fatal case. Pins that
+  // `healthReportsDbFault` keys on the "error:" prefix, not the fatal class.
+  test("version matches but /health reports db error: transient → restart-once (#594)", async () => {
+    const f = fakeDeps({
+      platform: "darwin",
+      getuid: () => 501,
+      installedUnit: true,
+      // first probe: right version, sustained transient DB fault; after the
+      // restart the re-probe sees a live DB.
+      healthVersionSeq: [
+        { ok: true, version: INSTALLED, db: "error: transient" },
+        { ok: true, version: INSTALLED, db: "ok" },
+      ],
+    });
+    const res = await ensureHubVersionMatches({
+      installedVersion: INSTALLED,
+      port: 1939,
+      deps: f.deps,
+      readyPollMs: 0,
+    });
+    expect(res.outcome).toBe("restarted");
+    const restarts = f.calls.filter((c) => c.includes("kickstart"));
+    expect(restarts).toHaveLength(1);
+  });
+
   test("version + db both ok → match, NO restart (#594 doesn't fire on a healthy hub)", async () => {
     const f = fakeDeps({
       platform: "darwin",

--- a/src/__tests__/hub-unit.test.ts
+++ b/src/__tests__/hub-unit.test.ts
@@ -44,7 +44,7 @@ function fakeDeps(
      * `null` (hub not answering) or `{ ok, version }`. Drives
      * `probeHealthVersion` across the version-check + post-restart re-probe.
      */
-    healthVersionSeq?: ({ ok: boolean; version?: string } | null)[];
+    healthVersionSeq?: ({ ok: boolean; version?: string; db?: string } | null)[];
     listeningSeq?: boolean[];
     installedUnit?: boolean;
   } = {},
@@ -755,5 +755,87 @@ describe("ensureHubVersionMatches — version-check-and-restart at adoption (#59
     });
     expect(res.outcome).toBe("restart-failed");
     expect(res.messages.join("\n")).toContain("Unit parachute-hub.service not found.");
+  });
+
+  // #594: a hub whose VERSION matches but whose /health reports a db fault
+  // (dead handle — state dir deleted under it) must be treated as needing a
+  // restart, through the same restart-once machinery.
+  test("version matches but /health reports db fault → restart-once → restarted when db heals", async () => {
+    const f = fakeDeps({
+      platform: "darwin",
+      getuid: () => 501,
+      installedUnit: true,
+      // first probe: right version but dead DB handle; after the restart the
+      // re-probe sees a live DB.
+      healthVersionSeq: [
+        { ok: true, version: INSTALLED, db: "error: fatal" },
+        { ok: true, version: INSTALLED, db: "ok" },
+      ],
+    });
+    const res = await ensureHubVersionMatches({
+      installedVersion: INSTALLED,
+      port: 1939,
+      deps: f.deps,
+      readyPollMs: 0,
+    });
+    expect(res.outcome).toBe("restarted");
+    const restarts = f.calls.filter((c) => c.includes("kickstart"));
+    expect(restarts).toHaveLength(1);
+  });
+
+  test("version + db both ok → match, NO restart (#594 doesn't fire on a healthy hub)", async () => {
+    const f = fakeDeps({
+      platform: "darwin",
+      getuid: () => 501,
+      installedUnit: true,
+      healthVersionSeq: [{ ok: true, version: INSTALLED, db: "ok" }],
+    });
+    const res = await ensureHubVersionMatches({
+      installedVersion: INSTALLED,
+      port: 1939,
+      deps: f.deps,
+      readyPollMs: 0,
+    });
+    expect(res.outcome).toBe("match");
+    expect(f.calls).toEqual([]);
+  });
+
+  test("db fault persists after the restart → still-mismatched with a db-specific message (#594)", async () => {
+    const f = fakeDeps({
+      platform: "darwin",
+      getuid: () => 501,
+      installedUnit: true,
+      // Every probe reports the dead handle (state dir still gone). Restart
+      // once, then settle — no loop.
+      healthVersionSeq: [{ ok: true, version: INSTALLED, db: "error: fatal" }],
+    });
+    const res = await ensureHubVersionMatches({
+      installedVersion: INSTALLED,
+      port: 1939,
+      deps: f.deps,
+      readyTimeoutMs: 0,
+      readyPollMs: 0,
+    });
+    expect(res.outcome).toBe("still-mismatched");
+    const restarts = f.calls.filter((c) => c.includes("kickstart"));
+    expect(restarts).toHaveLength(1);
+    expect(res.messages.join("\n")).toContain("database still reports a fault");
+  });
+
+  test("a hub with NO db field (pre-#594) on a version match → match, not treated as a fault", async () => {
+    const f = fakeDeps({
+      platform: "darwin",
+      getuid: () => 501,
+      installedUnit: true,
+      healthVersionSeq: [{ ok: true, version: INSTALLED /* no db field */ }],
+    });
+    const res = await ensureHubVersionMatches({
+      installedVersion: INSTALLED,
+      port: 1939,
+      deps: f.deps,
+      readyPollMs: 0,
+    });
+    expect(res.outcome).toBe("match");
+    expect(f.calls).toEqual([]);
   });
 });

--- a/src/cloudflare/tunnel.ts
+++ b/src/cloudflare/tunnel.ts
@@ -133,3 +133,73 @@ export async function routeDns(
 export function credentialsPath(uuid: string, cloudflaredHome: string): string {
   return join(cloudflaredHome, `${uuid}.json`);
 }
+
+/**
+ * `cloudflared tunnel delete <name>` removes the account-side tunnel. Used by
+ * the reuse-path self-heal (#593): when an existing tunnel's local credentials
+ * file is missing, the tunnel is unusable from this machine — we delete the
+ * account-side tunnel and recreate it so `tunnel create` re-writes a fresh
+ * `~/.cloudflared/<uuid>.json`.
+ *
+ * `--force` makes the delete non-interactive and tears down any lingering
+ * connector record cloudflared still has registered for the tunnel — without
+ * it, `tunnel delete` refuses ("tunnel has active connections") when a stale
+ * connector is registered account-side, which is exactly the crash-loop state
+ * #593 self-heals. Deleting a tunnel with no live local connector is safe: the
+ * field repro showed `tunnel delete` + re-run worked cleanly.
+ */
+export async function deleteTunnel(runner: Runner, name: string): Promise<void> {
+  const cmd = ["cloudflared", "tunnel", "delete", "--force", name];
+  const result = await runner(cmd);
+  if (result.code !== 0) {
+    throw new CloudflaredError(
+      `cloudflared tunnel delete failed: ${combineErrStreams(result)}`,
+      cmd,
+      result,
+    );
+  }
+}
+
+/**
+ * Count the active connector connections cloudflared reports for a tunnel via
+ * `cloudflared tunnel info --output json <name>`. Used by the post-start
+ * connection verification (#593): a spawned connector pid existing ≠ the
+ * connector actually registered an edge connection (the error-1033 field
+ * repro — pid alive, connector crash-looping on a missing creds file, every
+ * request 1033).
+ *
+ * The JSON shape is `{ conns: [ { ... }, … ] }` (or a top-level `connections`
+ * array on some cloudflared versions). We count entries defensively across
+ * both shapes and treat any parse/CLI failure as `0` (not-yet-connected) — the
+ * caller polls, so a transient miss just costs one more poll. Returns the
+ * connector count; `> 0` means at least one edge connection is live.
+ */
+export async function tunnelConnectionCount(runner: Runner, name: string): Promise<number> {
+  const cmd = ["cloudflared", "tunnel", "info", "--output", "json", name];
+  let result: CommandResult;
+  try {
+    result = await runner(cmd);
+  } catch {
+    return 0;
+  }
+  if (result.code !== 0) return 0;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    return 0;
+  }
+  if (!parsed || typeof parsed !== "object") return 0;
+  const obj = parsed as Record<string, unknown>;
+  // `cloudflared tunnel info --output json` reports per-connector entries under
+  // `conns` on current versions; older shapes used a flat `connections` array.
+  // Count whichever is present.
+  const conns = obj.conns ?? obj.connections;
+  if (Array.isArray(conns)) {
+    // Each entry may itself carry a nested `conns` array (per-colo connector
+    // detail). Count an entry as a live connection when it exists; that's the
+    // signal we need ("the connector registered at least one edge connection").
+    return conns.length;
+  }
+  return 0;
+}

--- a/src/commands/expose-cloudflare.ts
+++ b/src/commands/expose-cloudflare.ts
@@ -300,7 +300,10 @@ export const defaultVerifyConnection: VerifyConnectionFn = async ({
   const deadline = Date.now() + timeoutMs;
   // Probe immediately, then poll until a connector registers or the budget
   // elapses. `tunnelConnectionCount` swallows its own CLI/parse errors → 0, so
-  // a not-yet-ready connector just costs another poll.
+  // a not-yet-ready connector just costs another poll. Worst case is roughly
+  // ceil(timeoutMs / pollMs) iterations (each = one `cloudflared tunnel info`
+  // call + one sleep) before the deadline check returns false — with the
+  // production defaults (25_000 / 1_000) that's ~25 probes over ~25s.
   for (;;) {
     if ((await tunnelConnectionCount(runner, tunnelName)) > 0) return true;
     if (Date.now() >= deadline) return false;

--- a/src/commands/expose-cloudflare.ts
+++ b/src/commands/expose-cloudflare.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync, openSync } from "node:fs";
+import { existsSync, mkdirSync, openSync } from "node:fs";
 import { dirname } from "node:path";
 import {
   DEFAULT_TUNNEL_NAME,
@@ -37,8 +37,10 @@ import {
   type Tunnel,
   createTunnel,
   credentialsPath,
+  deleteTunnel,
   findTunnelByName,
   routeDns,
+  tunnelConnectionCount,
 } from "../cloudflare/tunnel.ts";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import {
@@ -267,6 +269,45 @@ export function looksLikeCloudflare(addresses: readonly string[]): boolean {
   return false;
 }
 
+/**
+ * Poll for the spawned connector establishing a live edge connection, bounded
+ * by `timeoutMs` (#593). Resolves true the first time `cloudflared tunnel
+ * info` reports ≥1 connector connection; false when the budget elapses with
+ * none. The pid existing is NOT proof of connection — the field repro had a
+ * live pid crash-looping on a missing creds file, every request returning
+ * Cloudflare error 1033. This is the loud verification that turns that silent
+ * false-success into an actionable failure.
+ *
+ * Injectable so tests drive both branches deterministically without a real
+ * cloudflared. Production uses `defaultVerifyConnection` (a bounded
+ * `tunnelConnectionCount` poll).
+ */
+export type VerifyConnectionFn = (args: {
+  runner: Runner;
+  tunnelName: string;
+  timeoutMs: number;
+  pollMs: number;
+  sleep: (ms: number) => Promise<void>;
+}) => Promise<boolean>;
+
+export const defaultVerifyConnection: VerifyConnectionFn = async ({
+  runner,
+  tunnelName,
+  timeoutMs,
+  pollMs,
+  sleep,
+}) => {
+  const deadline = Date.now() + timeoutMs;
+  // Probe immediately, then poll until a connector registers or the budget
+  // elapses. `tunnelConnectionCount` swallows its own CLI/parse errors → 0, so
+  // a not-yet-ready connector just costs another poll.
+  for (;;) {
+    if ((await tunnelConnectionCount(runner, tunnelName)) > 0) return true;
+    if (Date.now() >= deadline) return false;
+    await sleep(pollMs);
+  }
+};
+
 export interface ExposeCloudflareOpts {
   runner?: Runner;
   spawner?: CloudflaredSpawner;
@@ -307,6 +348,23 @@ export interface ExposeCloudflareOpts {
    * Tests inject a stub; production uses `defaultResolveHost` (Bun DNS).
    */
   resolveHost?: ResolveHostFn;
+  /**
+   * Verify the spawned connector actually established an edge connection
+   * before claiming "✓ Cloudflare tunnel up" (#593). Production polls
+   * `cloudflared tunnel info` for a live connector (bounded). Tests inject a
+   * stub to drive the success / timeout branches without a real cloudflared.
+   * Returns true once at least one connection is live, false on timeout.
+   * Default policy mirrors `connectorPids`/`resolveHost`: when a test injects a
+   * stub `spawner` (and no explicit seam), default to an inert "connected"
+   * stub so existing stub-spawner suites don't have to model the probe.
+   */
+  verifyConnection?: VerifyConnectionFn;
+  /** Connection-verify budget in ms (default 25_000). */
+  verifyTimeoutMs?: number;
+  /** Poll interval for the connection-verify probe in ms (default 1_000). */
+  verifyPollMs?: number;
+  /** Sleep between connection-verify polls. Tests pin to a no-op. */
+  sleep?: (ms: number) => Promise<void>;
   log?: (line: string) => void;
   manifestPath?: string;
   statePath?: string;
@@ -402,6 +460,10 @@ interface Resolved {
   }) => InstallResult;
   removeService: (args: { tunnelName: string }) => RemoveResult;
   resolveHost: ResolveHostFn;
+  verifyConnection: VerifyConnectionFn;
+  verifyTimeoutMs: number;
+  verifyPollMs: number;
+  sleep: (ms: number) => Promise<void>;
   log: (line: string) => void;
   manifestPath: string;
   statePath: string;
@@ -488,6 +550,17 @@ function resolve(opts: ExposeCloudflareOpts, tunnelNameDefault: string): Resolve
     resolveHost:
       opts.resolveHost ??
       (opts.spawner === undefined ? defaultResolveHost : async () => ["104.16.0.1"]),
+    // Connection-verify seam (#593). Same defaulting policy as
+    // `connectorPids`/`resolveHost`: when a test injects a stub `spawner` (and
+    // no explicit seam), default to an inert "connected" stub so existing
+    // stub-spawner suites don't have to model the `tunnel info` probe.
+    // Production (no spawner override) gets the real bounded poll.
+    verifyConnection:
+      opts.verifyConnection ??
+      (opts.spawner === undefined ? defaultVerifyConnection : async () => true),
+    verifyTimeoutMs: opts.verifyTimeoutMs ?? 25_000,
+    verifyPollMs: opts.verifyPollMs ?? 1_000,
+    sleep: opts.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms))),
     log: opts.log ?? ((line) => console.log(line)),
     manifestPath: opts.manifestPath ?? SERVICES_MANIFEST_PATH,
     statePath: opts.statePath ?? CLOUDFLARED_STATE_PATH,
@@ -694,7 +767,50 @@ export async function exposeCloudflareUp(
       "  Each machine gets its own dedicated tunnel — you don't need to run `cloudflared tunnel create` separately; expose does it.",
     );
   } else {
-    r.log(`✓ Reusing existing tunnel "${r.tunnelName}" (${tunnel.id})`);
+    // Reuse-path credentials verification + self-heal (#593). `findTunnelByName`
+    // only proves the tunnel exists ACCOUNT-side. The connector needs the LOCAL
+    // credentials file (`~/.cloudflared/<uuid>.json`, written at `tunnel create`
+    // time) to authenticate — and that file gets lost on clean-slate flows
+    // (`rm -rf ~/.parachute` and friends) while the account-side tunnel
+    // survives. The field repro: tunnel reused, "✓ tunnel up" printed, connector
+    // crash-looping on "credentials file … doesn't exist", every request → 1033.
+    //
+    // If the creds file is missing we recreate the tunnel: delete the
+    // account-side tunnel by name (`--force`, so a stale registered connector
+    // doesn't block it), then `tunnel create` re-writes a fresh creds file. The
+    // new tunnel gets a new UUID; `routeDns` below uses `--overwrite-dns`, so the
+    // hostname's CNAME is repointed at the new UUID even though it pointed at the
+    // old one. The field case confirmed `tunnel delete` + re-run heals cleanly.
+    const existingCreds = credentialsPath(tunnel.id, r.cloudflaredHome);
+    if (existsSync(existingCreds)) {
+      r.log(`✓ Reusing existing tunnel "${r.tunnelName}" (${tunnel.id})`);
+    } else {
+      r.log(
+        `⚠ Tunnel "${r.tunnelName}" (${tunnel.id}) exists in Cloudflare, but its local credentials`,
+      );
+      r.log(`  file is missing (${existingCreds}) — the connector can't authenticate from this`);
+      r.log("  machine. Recreating the tunnel so a fresh credentials file is written…");
+      try {
+        await deleteTunnel(r.runner, r.tunnelName);
+      } catch (err) {
+        if (err instanceof CloudflaredError) {
+          r.log("");
+          r.log(`✗ Couldn't delete the stale tunnel automatically: ${err.message}`);
+          r.log("");
+          r.log("Recover manually, then re-run this command:");
+          r.log(`    cloudflared tunnel delete --force ${r.tunnelName}`);
+          r.log(`    parachute expose public --cloudflare --domain ${hostname}`);
+          return 1;
+        }
+        throw err;
+      }
+      try {
+        tunnel = await createTunnel(r.runner, r.tunnelName);
+      } catch (err) {
+        return reportCloudflaredError(err, r.log);
+      }
+      r.log(`✓ Recreated tunnel ${tunnel.id} (fresh credentials written).`);
+    }
   }
 
   r.log(`Routing DNS: ${hostname} → tunnel ${tunnel.id}…`);
@@ -954,6 +1070,42 @@ export async function exposeCloudflareUp(
       );
     }
   }
+
+  // Post-start connection verification (#593). The connector pid existing is
+  // NOT proof it connected — the field repro had a live pid crash-looping on a
+  // missing creds file, with every public request returning Cloudflare error
+  // 1033 (tunnel registered, no connector) while the CLI printed "✓ tunnel up".
+  // Poll `cloudflared tunnel info` for a live edge connection, bounded. On
+  // timeout, fail LOUDLY with the connector log path + the crash-loop signature
+  // to grep for, instead of claiming success.
+  r.log("");
+  r.log("Verifying the connector established a tunnel connection…");
+  const connected = await r.verifyConnection({
+    runner: r.runner,
+    tunnelName: r.tunnelName,
+    timeoutMs: r.verifyTimeoutMs,
+    pollMs: r.verifyPollMs,
+    sleep: r.sleep,
+  });
+  if (!connected) {
+    r.log("");
+    r.log(
+      `✗ The cloudflared connector (pid ${pid}) started but never registered a tunnel connection`,
+    );
+    r.log(`  within ${Math.round(r.verifyTimeoutMs / 1000)}s. Public requests to ${hostname} will`);
+    r.log("  return Cloudflare error 1033 (tunnel registered, no connector) until this resolves.");
+    r.log("");
+    r.log("Check the connector log for the crash-loop cause:");
+    r.log(`    tail -n 50 ${r.logPath}`);
+    r.log('  A repeating "credentials file … doesn\'t exist" line means the local credentials are');
+    r.log(
+      "  gone — re-run this command (it auto-recreates the tunnel). Other repeating errors point",
+    );
+    r.log("  at the specific failure. Confirm the connector once it's healthy with:");
+    r.log(`    cloudflared tunnel info ${r.tunnelName}`);
+    return 1;
+  }
+  r.log("✓ Connector connected.");
 
   const baseUrl = `https://${hostname}`;
   let vaultUrl: string | undefined;

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -34,6 +34,7 @@ import { generateBootstrapToken } from "../bootstrap-token.ts";
 // path isolation.
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import { readExposeState } from "../expose-state.ts";
+import { createDbHolder } from "../hub-db-liveness.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { hubFetch } from "../hub-server.ts";
 import { writeHubFile } from "../hub.ts";
@@ -345,8 +346,16 @@ export async function serve(opts: ServeOpts = {}): Promise<{
   if (!existsSync(hubHtmlPath)) writeHubFile(hubHtmlPath);
 
   const dbPath = hubDbPath();
-  const db = openHubDb(dbPath);
-  const adminBootstrap = await seedInitialAdminIfNeeded(db, env, log);
+  // Self-heal-or-die DB holder (#594). The handle lives behind a mutable
+  // holder so a request that hits the persistent-corruption class (disk I/O
+  // error / malformed image — e.g. the state dir deleted under a running hub)
+  // can reopen the handle once, or exit(1) for the platform manager to restart
+  // us with a fresh one. `getDb` reads the current handle from the holder.
+  const dbHolder = createDbHolder(openHubDb(dbPath), {
+    reopen: () => openHubDb(dbPath),
+    log,
+  });
+  const adminBootstrap = await seedInitialAdminIfNeeded(dbHolder.get(), env, log);
 
   if (adminBootstrap === "needs-setup") {
     log(
@@ -381,7 +390,8 @@ export async function serve(opts: ServeOpts = {}): Promise<{
       // CMD), so the fix has to land here too. Closes hub#399.
       idleTimeout: 255,
       fetch: hubFetch(WELL_KNOWN_DIR, {
-        getDb: () => db,
+        getDb: () => dbHolder.get(),
+        onDbError: (err) => dbHolder.healOrExit(err),
         issuer,
         loopbackPort: port,
         supervisor,
@@ -468,7 +478,7 @@ export async function serve(opts: ServeOpts = {}): Promise<{
         await supervisor.stop(state.short);
       }
       await server.stop();
-      db.close();
+      dbHolder.get().close();
     },
   };
 }

--- a/src/hub-db-liveness.ts
+++ b/src/hub-db-liveness.ts
@@ -1,0 +1,194 @@
+import type { Database } from "bun:sqlite";
+
+/**
+ * SQLite-handle liveness + self-heal policy (#594).
+ *
+ * Field repro: an operator deleted `~/.parachute` while the hub unit was
+ * running. The process kept an fd to the now-unlinked `hub.db` inode — cached
+ * reads half-worked, every write / WAL op threw `SQLiteError: disk I/O error`.
+ * Result: `/health` stayed 200 (it never touched the DB), every DB-touching
+ * route 500'd indefinitely, and operator-facing CLI checks lied (served from
+ * the dead handle's cached pages). An hour of clean 500s behind a green
+ * /health is the worst possible failure shape — a crash-restart would have
+ * self-healed in seconds (the platform manager re-`openHubDb`s a fresh handle).
+ *
+ * The policy here: on a request that hits the persistent-corruption error
+ * class, attempt ONE reopen of the handle; if reopen fails OR the error
+ * recurs immediately, log loudly and `process.exit(1)` so the platform
+ * manager (launchd / systemd / container runtime) restarts with a fresh
+ * handle. We are careful to scope "fatal" to the persistent class — a
+ * transient `SQLITE_BUSY` (a momentary write lock) must NOT kill the hub.
+ */
+
+/**
+ * How a thrown DB error should be treated.
+ *   - `fatal`     → persistent corruption / dead handle (disk I/O error,
+ *                   database disk image is malformed, NOTADB, CORRUPT, IOERR).
+ *                   Triggers the reopen-once-or-exit machinery.
+ *   - `transient` → a momentary lock (SQLITE_BUSY / SQLITE_LOCKED). Never
+ *                   fatal; the caller surfaces it as an ordinary error and
+ *                   the next request likely succeeds.
+ *   - `other`     → not a recognized SQLite-handle failure (e.g. a constraint
+ *                   violation, a programming error). Not the liveness concern;
+ *                   the caller handles it as a normal error.
+ */
+export type DbErrorClass = "fatal" | "transient" | "other";
+
+/**
+ * Pull a lowercase "<code> <message>" string out of an unknown thrown value
+ * for substring matching. `bun:sqlite` throws `SQLiteError` with a `code`
+ * (e.g. `SQLITE_IOERR`, `SQLITE_BUSY`) and a `message` (e.g. "disk I/O
+ * error"). We match on both so a runtime that surfaces one but not the other
+ * still classifies correctly.
+ */
+function errorSignature(err: unknown): string {
+  if (err && typeof err === "object") {
+    const e = err as { code?: unknown; message?: unknown; name?: unknown };
+    const code = typeof e.code === "string" ? e.code : "";
+    const message = typeof e.message === "string" ? e.message : "";
+    const name = typeof e.name === "string" ? e.name : "";
+    return `${code} ${name} ${message}`.toLowerCase();
+  }
+  return String(err).toLowerCase();
+}
+
+/**
+ * Classify a thrown DB error. Order matters: a transient BUSY/LOCKED is
+ * checked FIRST so it's never mistaken for the fatal class, even if a future
+ * message happened to share a substring.
+ */
+export function classifyDbError(err: unknown): DbErrorClass {
+  const sig = errorSignature(err);
+  if (sig.length === 0) return "other";
+
+  // Transient locks — explicitly NON-fatal. SQLITE_BUSY is a momentary write
+  // lock under WAL contention; killing the hub on it would turn ordinary
+  // concurrency into a restart loop. SQLITE_LOCKED is the same class.
+  if (sig.includes("sqlite_busy") || sig.includes("sqlite_locked")) return "transient";
+  if (/\bdatabase is locked\b/.test(sig) || /\bdatabase table is locked\b/.test(sig)) {
+    return "transient";
+  }
+
+  // Persistent-corruption / dead-handle class → fatal (reopen-once-or-exit).
+  // `disk I/O error` is the exact field message (state dir deleted under a
+  // running hub); the malformed-image + corrupt + notadb codes are the
+  // related on-disk-corruption shapes the issue calls out.
+  if (
+    sig.includes("disk i/o error") ||
+    sig.includes("sqlite_ioerr") ||
+    sig.includes("database disk image is malformed") ||
+    sig.includes("sqlite_corrupt") ||
+    sig.includes("sqlite_notadb") ||
+    sig.includes("file is not a database")
+  ) {
+    return "fatal";
+  }
+
+  return "other";
+}
+
+/**
+ * Cheap DB liveness probe for `/health` (#594). Runs `SELECT 1`. Returns
+ * `"ok"` on success, or `"error: <class>"` where class is the
+ * {@link classifyDbError} verdict, so a monitor can tell "hub up but DB dead"
+ * apart from "hub up, DB fine". NEVER throws — a probe that threw would make
+ * /health itself 500, defeating the point (/health must stay fast + reliable).
+ */
+export function probeDbLiveness(db: Database): "ok" | string {
+  try {
+    db.query("SELECT 1").get();
+    return "ok";
+  } catch (err) {
+    return `error: ${classifyDbError(err)}`;
+  }
+}
+
+/**
+ * A mutable holder for the hub's `Database` handle so a request handler that
+ * hits the fatal error class can swap in a freshly-reopened handle without
+ * re-threading the closure-captured `db` through every call site. `getDb()`
+ * in hub-server reads `holder.get()`; the self-heal path calls
+ * `holder.healOrExit(err)`.
+ */
+export interface DbHolder {
+  /** The current live handle. */
+  get(): Database;
+  /**
+   * React to a thrown DB error per the liveness policy:
+   *   - `transient`/`other` → return `"ignored"` (caller surfaces a normal error).
+   *   - `fatal`, reopen succeeds + a `SELECT 1` passes on the new handle →
+   *     swap the handle in, return `"healed"` (caller retries / surfaces a
+   *     transient error the next request clears).
+   *   - `fatal`, reopen fails OR the new handle still fails `SELECT 1` →
+   *     log loudly + `exit(1)`. Returns `"exited"` only in tests (the injected
+   *     exit fn doesn't actually exit the process).
+   *
+   * Reopen-once semantics: a single fatal error triggers one reopen attempt.
+   * If the *reopened* handle is also dead (e.g. the underlying dir is still
+   * gone), we exit rather than loop — the platform manager owns the restart.
+   */
+  healOrExit(err: unknown): "ignored" | "healed" | "exited";
+}
+
+export interface DbHolderDeps {
+  /** Open a fresh handle (production: `() => openHubDb(dbPath)`). */
+  reopen: () => Database;
+  /** Loud log sink (default `console.error`). */
+  log?: (line: string) => void;
+  /** Process-exit fn (default `process.exit`; tests inject a spy). */
+  exit?: (code: number) => void;
+  /** Close a (presumed-dead) handle best-effort before swapping (default `db.close()`). */
+  closeOld?: (db: Database) => void;
+}
+
+/**
+ * Build a {@link DbHolder} over an initial handle. Production wires
+ * `reopen: () => openHubDb(dbPath)` and the default exit/log; tests inject a
+ * fake reopen + a non-exiting `exit` spy so the fatal branch is exercised
+ * without killing the test process.
+ */
+export function createDbHolder(initial: Database, deps: DbHolderDeps): DbHolder {
+  let current = initial;
+  const log = deps.log ?? ((line) => console.error(line));
+  const exit = deps.exit ?? ((code) => process.exit(code));
+  const closeOld =
+    deps.closeOld ??
+    ((db) => {
+      try {
+        db.close();
+      } catch {
+        // Best-effort — a dead handle may throw on close; we're replacing it.
+      }
+    });
+
+  return {
+    get: () => current,
+    healOrExit(err: unknown) {
+      const klass = classifyDbError(err);
+      if (klass !== "fatal") return "ignored";
+
+      const detail = err instanceof Error ? err.message : String(err);
+      log(`parachute hub: persistent SQLite failure (${detail}). Attempting one DB handle reopen…`);
+
+      let reopened: Database;
+      try {
+        reopened = deps.reopen();
+        // Confirm the fresh handle is actually live before trusting it.
+        reopened.query("SELECT 1").get();
+      } catch (reopenErr) {
+        const rd = reopenErr instanceof Error ? reopenErr.message : String(reopenErr);
+        log(
+          `parachute hub: DB reopen failed (${rd}); exiting so the platform manager restarts the hub with a fresh handle.`,
+        );
+        exit(1);
+        return "exited";
+      }
+
+      // Reopen succeeded + verified. Swap it in; the old handle is dead.
+      closeOld(current);
+      current = reopened;
+      log("parachute hub: DB handle reopened successfully; continuing.");
+      return "healed";
+    },
+  };
+}

--- a/src/hub-db-liveness.ts
+++ b/src/hub-db-liveness.ts
@@ -68,11 +68,28 @@ export function classifyDbError(err: unknown): DbErrorClass {
   if (/\bdatabase is locked\b/.test(sig) || /\bdatabase table is locked\b/.test(sig)) {
     return "transient";
   }
+  // A handful of SQLITE_IOERR *sub-codes* are contention, not corruption:
+  // SQLITE_IOERR_BLOCKED (a legacy busy variant) and SQLITE_IOERR_LOCK (a
+  // lock-acquisition failure). The generic `sqlite_ioerr` substring match
+  // below would otherwise sweep these into the fatal class and exit the hub on
+  // transient I/O contention. Check them FIRST so they classify as transient.
+  if (sig.includes("sqlite_ioerr_blocked") || sig.includes("sqlite_ioerr_lock")) {
+    return "transient";
+  }
 
   // Persistent-corruption / dead-handle class → fatal (reopen-once-or-exit).
   // `disk I/O error` is the exact field message (state dir deleted under a
   // running hub); the malformed-image + corrupt + notadb codes are the
   // related on-disk-corruption shapes the issue calls out.
+  //
+  // `sqlite_ioerr` matches the GENERIC `SQLITE_IOERR` code, which is what Bun
+  // surfaces for the dead-handle case (the unlinked-inode field repro reports
+  // exactly `code: "SQLITE_IOERR", message: "disk I/O error"`, not a
+  // sub-code). The two transient IOERR sub-codes are already filtered out
+  // above, so reaching this `includes` means either the generic code or a
+  // corruption sub-code — both fatal. (`disk i/o error` is also matched
+  // directly so a runtime that surfaces the message but not the code still
+  // classifies.)
   if (
     sig.includes("disk i/o error") ||
     sig.includes("sqlite_ioerr") ||

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -184,6 +184,7 @@ import { applyCorsHeaders, corsPreflightResponse, isCorsAllowedRoute } from "./c
 import { ensureCsrfToken } from "./csrf.ts";
 import { readExposeState } from "./expose-state.ts";
 import { HUB_DEFAULT_PORT, HUB_SVC, clearHubPort, writeHubPort } from "./hub-control.ts";
+import { classifyDbError, createDbHolder, probeDbLiveness } from "./hub-db-liveness.ts";
 import { hubDbPath, openHubDb } from "./hub-db.ts";
 import { getHubOrigin } from "./hub-settings.ts";
 import { type RenderHubOpts, renderHub } from "./hub.ts";
@@ -832,6 +833,16 @@ export interface HubFetchDeps {
    */
   getDb?: () => Database;
   /**
+   * React to a thrown SQLite error per the self-heal-or-die policy (#594).
+   * Production wires the {@link DbHolder}'s `healOrExit` so a request that
+   * hits the persistent-corruption class (disk I/O error / malformed image)
+   * triggers ONE reopen attempt, then `process.exit(1)` if reopen fails — the
+   * platform manager restarts the hub with a fresh handle. Returns the holder
+   * verdict (`"healed"` / `"ignored"` / `"exited"`) so the handler can shape
+   * the response. Absent in tests that don't exercise the DB-error path.
+   */
+  onDbError?: (err: unknown) => "ignored" | "healed" | "exited";
+  /**
    * Hub origin used as the OAuth `iss` claim and to build the authorization-
    * server metadata document. When omitted, OAuth endpoints fall back to the
    * request's own origin — fine for local dev, surprising under a reverse
@@ -1429,1219 +1440,1272 @@ export function hubFetch(
     // is then null and `layerOf` fails closed to `public`.
     const peerAddr = server?.requestIP(req)?.address ?? null;
 
-    // 301 back-compat for the pre-hub#231 admin-SPA mounts:
-    //
-    //   `/vault`            → `/admin/vaults`
-    //   `/vault/new`        → `/admin/vaults/new`
-    //   `/hub/vaults*`      → `/admin/vaults*` (this redirect predates #231;
-    //                        it now retargets at the new admin mount instead
-    //                        of the interim `/vault` mount)
-    //   `/hub/permissions`  → `/admin/permissions`
-    //   `/hub/tokens`       → `/admin/tokens`
-    //   `/hub` (bare)       → `/admin/vaults`
-    //
-    // Permanent redirect so cached operator URLs keep working without
-    // leaving dangling SPA routes. Query string preserved; fragment is
-    // client-side and survives the redirect at the browser. Method-agnostic
-    // — even a misrouted POST gets the redirect; none of these paths host a
-    // POST endpoint to protect.
-    //
-    // `/vault/<name>/*` is INTENTIONALLY excluded — that's the per-vault
-    // content proxy (Notes PWA, etc.), not the admin SPA. Stays where it is.
-    if (pathname === "/vault" || pathname === "/vault/" || pathname === "/vault/new") {
-      const sub = pathname === "/vault/new" ? "/new" : "";
-      return new Response("", {
-        status: 301,
-        headers: { location: `/admin/vaults${sub}${url.search}` },
-      });
-    }
-    if (pathname === "/hub/vaults" || pathname.startsWith("/hub/vaults/")) {
-      const newPath = `/admin/vaults${pathname.slice("/hub/vaults".length)}`;
-      return new Response("", {
-        status: 301,
-        headers: { location: `${newPath}${url.search}` },
-      });
-    }
-    if (pathname === "/hub/permissions") {
-      return new Response("", {
-        status: 301,
-        headers: { location: `/admin/permissions${url.search}` },
-      });
-    }
-    if (pathname === "/hub/tokens") {
-      return new Response("", {
-        status: 301,
-        headers: { location: `/admin/tokens${url.search}` },
-      });
-    }
-    if (pathname === "/hub" || pathname === "/hub/") {
-      return new Response("", {
-        status: 301,
-        headers: { location: `/admin/vaults${url.search}` },
-      });
-    }
-
-    // Login surface rename: `/admin/login` and `/admin/logout` 301 to the
-    // canonical `/login` and `/logout`. The names were "admin" only by
-    // historical accident — the handlers serve every parachute auth flow
-    // (operator, OAuth user-redirect, future SPA sign-in). Renaming makes
-    // the surface name match its actual scope.
-    if (pathname === "/admin/login") {
-      return new Response("", {
-        status: 301,
-        headers: { location: `/login${url.search}` },
-      });
-    }
-    if (pathname === "/admin/logout") {
-      return new Response("", {
-        status: 301,
-        headers: { location: `/logout${url.search}` },
-      });
-    }
-
-    // Notes-as-app migration Phase 2 (parachute-app design doc §16).
-    // `/notes/*` 301-redirects to `/surface/notes/*` so legacy bookmarks land on
-    // the apps-hosted Notes. Default-on; operators on notes-as-module-only
-    // installs can opt out via `hub_settings.notes_redirect_disabled = true`
-    // (see hub-settings.ts). The opt-out exists so a legacy operator
-    // doesn't hit redirect → 404 in the deprecation window. Phase 3
-    // (parachute-notes v0.5) retires this redirect entirely.
-    //
-    // Method-agnostic — same shape as the other back-compat 301s above.
-    // The browser re-issues GET on the new URL per RFC 7231 (a POST won't
-    // round-trip its body, but no /notes/* path hosts a POST endpoint
-    // worth preserving — the Notes PWA is read-write against vault, not
-    // against the hub mount itself).
-    //
-    // Lazy DB read: only consult `getDb` when the path actually matches a
-    // legacy notes prefix — every non-notes request must NOT touch the DB
-    // here (some tests + the /health route assert getDb is never called).
-    if (isLegacyNotesPath(pathname)) {
-      const notesRedirect = maybeRedirectNotes(pathname, url.search, getDb?.());
-      if (notesRedirect !== undefined) {
-        logNotesRedirect(pathname, notesRedirect);
-        return new Response("", {
-          status: 301,
-          headers: { location: notesRedirect },
-        });
-      }
-    }
-
-    // CORS preflight for the public OAuth + discovery surface. Browsers
-    // issue OPTIONS before any non-simple cross-origin request — third-party
-    // SPAs hitting `/oauth/register` (RFC 7591 DCR), `/oauth/token`,
-    // `/.well-known/oauth-authorization-server`, etc. Handling this above
-    // the route table means an OPTIONS to e.g. `/oauth/register` doesn't
-    // hit the method-not-allowed branch in the handler — the preflight is a
-    // CORS-protocol artifact, not a "real" request to the endpoint. The
-    // single `isCorsAllowedRoute` predicate is the source of truth for
-    // which paths carry wildcard-CORS; see `src/cors.ts` for the rationale.
-    // Out-of-scope paths (`/api/*`, `/admin/*`, `/login`, `/account/*`,
-    // `/vault/*`, generic service proxy) fall through and OPTIONS reaches
-    // whatever default the downstream handler enforces (typically 405).
-    if (req.method === "OPTIONS" && isCorsAllowedRoute(pathname)) {
-      return corsPreflightResponse(req);
-    }
-
-    // Platform health check (Render, Fly, Kubernetes, etc.). Plain JSON,
-    // no DB required — the route reports liveness, not readiness. Anything
-    // more invasive (DB ping, schema check) would let a transient lock turn
-    // into a restart loop on the platform side. 200 always while the
-    // process is up.
-    if (pathname === "/health") {
-      return new Response(
-        JSON.stringify({ status: "ok", service: "parachute-hub", version: pkg.version }),
-        {
-          headers: {
-            "content-type": "application/json",
-            "cache-control": "no-store",
-          },
-        },
-      );
-    }
-
-    // Boot-readiness probe (hub#443). Used by the transient-state proxy
-    // error page's inline poll script to detect when a still-booting
-    // module has come up. Public + DB-free so it works during the pre-
-    // admin lockout (the page that polls it is itself served pre-auth).
-    if (pathname === "/api/ready") {
-      const readyDeps: Parameters<typeof handleApiReady>[1] = {};
-      if (deps?.supervisor !== undefined) readyDeps.supervisor = deps.supervisor;
-      return handleApiReady(req, readyDeps);
-    }
-
-    // First-boot setup wizard (hub#259). Three steps server-rendered:
-    //   GET  /admin/setup            — derive state, render the right step
-    //   POST /admin/setup/account    — create the admin row, set session
-    //   POST /admin/setup/vault      — provision the first vault
-    //
-    // The wizard owns the "should I 301 to /login now?" decision: setup is
-    // complete only when admin AND a vault entry both exist. A re-visit
-    // after partial setup picks up at the next step. See
-    // src/setup-wizard.ts for the renderer + handler internals.
-    if (pathname === "/admin/setup" || pathname.startsWith("/admin/setup/")) {
-      if (!getDb) return dbNotConfigured();
-      const wizardDeps: SetupWizardDeps = {
-        db: getDb(),
-        manifestPath,
-        configDir: CONFIG_DIR,
-        issuer: oauthDeps(req).issuer,
-        registry: getDefaultOperationsRegistry(),
-        // hub#576: a loopback peer (the on-box operator's own shell) is allowed
-        // to read the actual bootstrap token from the GET /admin/setup JSON
-        // probe. `layerOf` fails closed to non-loopback when peerAddr is
-        // unknown, so a header-less caller never gets the token.
-        requestIsLoopback: layerOf(req, peerAddr) === "loopback",
-      };
-      if (deps?.supervisor !== undefined) wizardDeps.supervisor = deps.supervisor;
-      if (pathname === "/admin/setup") {
-        if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
-        return handleSetupGet(req, wizardDeps);
-      }
-      if (pathname === "/admin/setup/account") {
-        if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
-        return handleSetupAccountPost(req, wizardDeps);
-      }
-      if (pathname === "/admin/setup/vault") {
-        if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
-        return handleSetupVaultPost(req, wizardDeps);
-      }
-      if (pathname === "/admin/setup/expose") {
-        if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
-        return handleSetupExposePost(req, wizardDeps);
-      }
-      // hub#272 Item B: post-wizard direct module-install POSTs from
-      // the done-screen "What's next?" tiles. Path shape is
-      // `/admin/setup/install/<short>`; the handler rejects on
-      // unknown shorts, on `vault` (the wizard's own step owns that),
-      // and on missing session/CSRF — same gates as the vault POST.
-      if (pathname.startsWith("/admin/setup/install/")) {
-        if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
-        const short = pathname.slice("/admin/setup/install/".length);
-        return handleSetupInstallPost(req, short, wizardDeps);
-      }
-      return new Response("not found", { status: 404 });
-    }
-
-    // Fresh-hub redirect: when the wizard still has work to do, the
-    // discovery page (`/`, `/hub.html`) funnels straight to it. Two
-    // wizard-mode conditions trigger the redirect:
-    //
-    //   1. No admin row exists (the original fresh-deploy case). The
-    //      static portal carries no usable signal — no installed
-    //      services to discover, no admin to sign in as.
-    //   2. Admin exists but no vault is installed (env-seed deploys
-    //      where the operator baked admin into env vars but hasn't
-    //      walked the wizard's vault step). Pre-fix, env-seeded
-    //      operators bounced past the wizard entirely and had to
-    //      hand-find /admin/modules + /admin/vaults; surface
-    //      "let me finish the wizard" instead.
-    //
-    // The wizard's GET handler already picks the right step
-    // (`deriveWizardState` resumes at vault step when admin exists +
-    // no vault), so we just need the redirect to fire.
-    //
-    // 302 (not 301) so the redirect disappears the moment the wizard
-    // finishes. Sits before the JSON-shaped 503 gate below because `/`
-    // is an HTML surface — a JSON 503 there would render as raw text
-    // in the operator's browser tab. The 503 gate handles API + admin
-    // SPA + OAuth callers that branch on the structured body.
-    if (getDb && (pathname === "/" || pathname === "/hub.html")) {
-      const db = getDb();
-      // Either condition triggers the wizard funnel:
-      //   - no admin row (the fresh-deploy case)
-      //   - admin row exists but no vault installed (env-seed case)
-      // Short-circuit the manifest read when `noAdmin` is true; the
-      // wizard's first step is admin creation regardless of vault state.
-      const needsWizard = userCount(db) === 0 || !hasVaultInstalled(manifestPath);
-      if (needsWizard) {
-        return new Response(null, {
-          status: 302,
-          headers: { location: "/admin/setup" },
-        });
-      }
-    }
-
-    // Pre-admin lockout. When the hub has booted with no admin row (the
-    // fresh-container case before PARACHUTE_INITIAL_ADMIN_* is set or
-    // /admin/setup is walked), every operator-facing surface that requires
-    // identity is meaningless — auth flows can't validate, the SPA can't
-    // mint a host-admin token, OAuth can't issue codes. Route those to a
-    // 503 that points at /admin/setup. Health, well-known, /admin/setup
-    // itself, OAuth third-party endpoints, and content proxies pass
-    // through; the fresh-hub `/` and `/hub.html` redirect above handled
-    // the discovery-page case.
-    //
-    // `shouldGateForSetup` runs first so non-gated paths (well-known, /,
-    // /health, /admin/setup) never touch getDb — keeping the
-    // existing OPTIONS-preflight contract that those routes are db-free.
-    if (getDb && shouldGateForSetup(pathname) && userCount(getDb()) === 0) {
+    // Self-heal-or-die wrapper (#594). Any DB throw that escapes a route
+    // handler lands here. A persistent-corruption error (disk I/O error /
+    // malformed image — the state-dir-deleted-under-a-running-hub class)
+    // triggers ONE reopen attempt via `onDbError`; if reopen fails the holder
+    // exits the process so the platform manager restarts with a fresh handle.
+    // The CALLER (this catch) shapes the HTTP response so the operator/CLI see
+    // a structured cause instead of a bare bodyless 500 ("HTTP 500 with no
+    // error detail"). A transient SQLITE_BUSY is classified non-fatal and just
+    // surfaces a 503 the next request clears — it never kills the hub.
+    try {
+      return await dispatch();
+    } catch (err) {
+      const klass = classifyDbError(err);
+      if (klass === "other") throw err; // not a DB-handle failure — let it propagate
+      const verdict = deps?.onDbError?.(err) ?? "ignored";
+      const detail = err instanceof Error ? err.message : String(err);
+      // 503 (not bare 500): the fault is transient-from-the-client's-view —
+      // either the handle was just reopened (`healed`) or it's a momentary
+      // lock (`ignored`/transient); a retry is the right next move. `exited` is
+      // only reachable in tests (production has exited the process). All carry
+      // a structured body so the CLI's `asErrorBody` prints the real cause
+      // instead of "HTTP 500 with no error detail" (#594 part 3).
       return new Response(
         JSON.stringify({
-          error: "setup_required",
+          error: "db_unavailable",
           error_description:
-            "no admin configured. Visit /admin/setup, or set PARACHUTE_INITIAL_ADMIN_USERNAME + PARACHUTE_INITIAL_ADMIN_PASSWORD and restart.",
-          setup_url: "/admin/setup",
+            verdict === "healed"
+              ? `hub database handle was reopened after a fault (${detail}); retry the request.`
+              : `hub database error (${klass}): ${detail}`,
         }),
         {
           status: 503,
-          headers: {
-            "content-type": "application/json",
-            "cache-control": "no-store",
-          },
+          headers: { "content-type": "application/json", "cache-control": "no-store" },
         },
       );
     }
 
-    if (pathname === "/" || pathname === "/hub.html") {
-      // When a DB is configured, render the discovery page dynamically so
-      // the header carries a "Signed in as <name>" affordance for the
-      // active session. Without a DB, fall back to the static disk file
-      // (signed-out shape) — the disk file is what `parachute expose`
-      // wrote out, used when the hub-server is running without state.
-      if (getDb) {
-        const db = getDb();
-        const session = findActiveSession(db, req);
-        let renderOpts: RenderHubOpts = {};
-        const headers: Record<string, string> = {
-          "content-type": "text/html; charset=utf-8",
-        };
-        if (session) {
-          const user = getUserById(db, session.userId);
-          if (user) {
-            const csrf = ensureCsrfToken(req);
-            renderOpts = {
-              session: { displayName: user.username, csrfToken: csrf.token },
-            };
-            if (csrf.setCookie) headers["set-cookie"] = csrf.setCookie;
+    async function dispatch(): Promise<Response> {
+      // 301 back-compat for the pre-hub#231 admin-SPA mounts:
+      //
+      //   `/vault`            → `/admin/vaults`
+      //   `/vault/new`        → `/admin/vaults/new`
+      //   `/hub/vaults*`      → `/admin/vaults*` (this redirect predates #231;
+      //                        it now retargets at the new admin mount instead
+      //                        of the interim `/vault` mount)
+      //   `/hub/permissions`  → `/admin/permissions`
+      //   `/hub/tokens`       → `/admin/tokens`
+      //   `/hub` (bare)       → `/admin/vaults`
+      //
+      // Permanent redirect so cached operator URLs keep working without
+      // leaving dangling SPA routes. Query string preserved; fragment is
+      // client-side and survives the redirect at the browser. Method-agnostic
+      // — even a misrouted POST gets the redirect; none of these paths host a
+      // POST endpoint to protect.
+      //
+      // `/vault/<name>/*` is INTENTIONALLY excluded — that's the per-vault
+      // content proxy (Notes PWA, etc.), not the admin SPA. Stays where it is.
+      if (pathname === "/vault" || pathname === "/vault/" || pathname === "/vault/new") {
+        const sub = pathname === "/vault/new" ? "/new" : "";
+        return new Response("", {
+          status: 301,
+          headers: { location: `/admin/vaults${sub}${url.search}` },
+        });
+      }
+      if (pathname === "/hub/vaults" || pathname.startsWith("/hub/vaults/")) {
+        const newPath = `/admin/vaults${pathname.slice("/hub/vaults".length)}`;
+        return new Response("", {
+          status: 301,
+          headers: { location: `${newPath}${url.search}` },
+        });
+      }
+      if (pathname === "/hub/permissions") {
+        return new Response("", {
+          status: 301,
+          headers: { location: `/admin/permissions${url.search}` },
+        });
+      }
+      if (pathname === "/hub/tokens") {
+        return new Response("", {
+          status: 301,
+          headers: { location: `/admin/tokens${url.search}` },
+        });
+      }
+      if (pathname === "/hub" || pathname === "/hub/") {
+        return new Response("", {
+          status: 301,
+          headers: { location: `/admin/vaults${url.search}` },
+        });
+      }
+
+      // Login surface rename: `/admin/login` and `/admin/logout` 301 to the
+      // canonical `/login` and `/logout`. The names were "admin" only by
+      // historical accident — the handlers serve every parachute auth flow
+      // (operator, OAuth user-redirect, future SPA sign-in). Renaming makes
+      // the surface name match its actual scope.
+      if (pathname === "/admin/login") {
+        return new Response("", {
+          status: 301,
+          headers: { location: `/login${url.search}` },
+        });
+      }
+      if (pathname === "/admin/logout") {
+        return new Response("", {
+          status: 301,
+          headers: { location: `/logout${url.search}` },
+        });
+      }
+
+      // Notes-as-app migration Phase 2 (parachute-app design doc §16).
+      // `/notes/*` 301-redirects to `/surface/notes/*` so legacy bookmarks land on
+      // the apps-hosted Notes. Default-on; operators on notes-as-module-only
+      // installs can opt out via `hub_settings.notes_redirect_disabled = true`
+      // (see hub-settings.ts). The opt-out exists so a legacy operator
+      // doesn't hit redirect → 404 in the deprecation window. Phase 3
+      // (parachute-notes v0.5) retires this redirect entirely.
+      //
+      // Method-agnostic — same shape as the other back-compat 301s above.
+      // The browser re-issues GET on the new URL per RFC 7231 (a POST won't
+      // round-trip its body, but no /notes/* path hosts a POST endpoint
+      // worth preserving — the Notes PWA is read-write against vault, not
+      // against the hub mount itself).
+      //
+      // Lazy DB read: only consult `getDb` when the path actually matches a
+      // legacy notes prefix — every non-notes request must NOT touch the DB
+      // here (some tests + the /health route assert getDb is never called).
+      if (isLegacyNotesPath(pathname)) {
+        const notesRedirect = maybeRedirectNotes(pathname, url.search, getDb?.());
+        if (notesRedirect !== undefined) {
+          logNotesRedirect(pathname, notesRedirect);
+          return new Response("", {
+            status: 301,
+            headers: { location: notesRedirect },
+          });
+        }
+      }
+
+      // CORS preflight for the public OAuth + discovery surface. Browsers
+      // issue OPTIONS before any non-simple cross-origin request — third-party
+      // SPAs hitting `/oauth/register` (RFC 7591 DCR), `/oauth/token`,
+      // `/.well-known/oauth-authorization-server`, etc. Handling this above
+      // the route table means an OPTIONS to e.g. `/oauth/register` doesn't
+      // hit the method-not-allowed branch in the handler — the preflight is a
+      // CORS-protocol artifact, not a "real" request to the endpoint. The
+      // single `isCorsAllowedRoute` predicate is the source of truth for
+      // which paths carry wildcard-CORS; see `src/cors.ts` for the rationale.
+      // Out-of-scope paths (`/api/*`, `/admin/*`, `/login`, `/account/*`,
+      // `/vault/*`, generic service proxy) fall through and OPTIONS reaches
+      // whatever default the downstream handler enforces (typically 405).
+      if (req.method === "OPTIONS" && isCorsAllowedRoute(pathname)) {
+        return corsPreflightResponse(req);
+      }
+
+      // Platform health check (Render, Fly, Kubernetes, etc.). Plain JSON.
+      // Always 200 while the process is up — the HTTP status reports process
+      // liveness, not DB readiness, so a transient DB blip never turns into a
+      // platform-side restart loop. The `db` field (#594) carries the cheap
+      // `SELECT 1` verdict ("ok" / "error: <class>") so monitoring, `parachute
+      // status`, and the #590/#591 adoption probe can distinguish "hub up" from
+      // "hub up but its database is gone" (the dead-handle field repro: green
+      // /health while every DB route 500s). The probe NEVER throws — a thrown
+      // probe would make /health itself 500, defeating the point.
+      if (pathname === "/health") {
+        let db: "ok" | string = "unconfigured";
+        if (getDb) {
+          try {
+            db = probeDbLiveness(getDb());
+          } catch {
+            // getDb() itself threw (e.g. openHubDb failed) — report it as an
+            // error class without letting /health 500.
+            db = "error: other";
           }
         }
-        return new Response(renderHub(renderOpts), { headers });
+        return new Response(
+          JSON.stringify({ status: "ok", service: "parachute-hub", version: pkg.version, db }),
+          {
+            headers: {
+              "content-type": "application/json",
+              "cache-control": "no-store",
+            },
+          },
+        );
       }
-      // No DB configured → fall back to static file (signed-out only).
-      if (!existsSync(hubHtmlPath)) {
-        return new Response("hub.html not found", { status: 404 });
-      }
-      return new Response(Bun.file(hubHtmlPath), {
-        headers: { "content-type": "text/html; charset=utf-8" },
-      });
-    }
 
-    if (pathname === "/.well-known/parachute.json") {
-      // The well-known doc is a public service-discovery manifest (no
-      // secrets, no PII), and Notes / future browser clients fetch it
-      // cross-origin from their own loopback port. Wildcard CORS is the
-      // shape it needs. Browsers send an OPTIONS preflight when the request
-      // adds non-simple headers; answer it with 204 + the same allow-list.
+      // Boot-readiness probe (hub#443). Used by the transient-state proxy
+      // error page's inline poll script to detect when a still-booting
+      // module has come up. Public + DB-free so it works during the pre-
+      // admin lockout (the page that polls it is itself served pre-auth).
+      if (pathname === "/api/ready") {
+        const readyDeps: Parameters<typeof handleApiReady>[1] = {};
+        if (deps?.supervisor !== undefined) readyDeps.supervisor = deps.supervisor;
+        return handleApiReady(req, readyDeps);
+      }
+
+      // First-boot setup wizard (hub#259). Three steps server-rendered:
+      //   GET  /admin/setup            — derive state, render the right step
+      //   POST /admin/setup/account    — create the admin row, set session
+      //   POST /admin/setup/vault      — provision the first vault
       //
-      // `cache-control: no-store` matters here: the discovery page (`/`)
-      // fetches this doc and renders Service tiles from it; without
-      // no-store, the browser's HTTP cache returns the stale services list
-      // the next time the operator navigates back to `/` after installing
-      // a module via the admin SPA. The doc is small and built per-request
-      // anyway, so giving up cacheability has no real cost (hub#268 Item 1).
-      const corsHeaders = {
-        "access-control-allow-origin": "*",
-        "access-control-allow-methods": "GET, OPTIONS",
-        "cache-control": "no-store",
-      };
-      if (req.method === "OPTIONS") {
-        return new Response(null, { status: 204, headers: corsHeaders });
-      }
-      // Built dynamically from services.json on every request — that's what
-      // makes `parachute vault create` show up here without re-running
-      // expose. canonicalOrigin reuses the OAuth issuer fallback: prefer the
-      // configured public origin (set by `--issuer https://<fqdn>`), else
-      // the request's own origin (fine for direct loopback hits).
-      try {
-        // Lenient — see hub#406.
-        const manifest = readManifestLenient(manifestPath);
-        // Same precedence as the OAuth issuer (hub#298): hub_settings →
-        // env → request origin. The well-known doc embeds this origin
-        // in service URLs + the issuer metadata link, so it must follow
-        // the same chain — otherwise a public-domain operator who set
-        // `hub_origin` would still see the Render-assigned URL on
-        // `/.well-known/parachute.json` while their JWTs carry the
-        // canonical URL, and discovery clients would split-brain on
-        // which one to trust.
-        const canonicalOrigin = resolveIssuer(
-          req,
-          getDb?.(),
-          configuredIssuer,
-          loadExposeHubOrigin,
-        );
-        const readManifestFn = deps?.readModuleManifest ?? defaultReadModuleManifest;
-        const [managementUrlByName, serviceUiMeta] = await Promise.all([
-          loadManagementUrls(manifest.services, readManifestFn),
-          loadServiceUiMetadata(manifest.services, readManifestFn),
-        ]);
-        const doc = buildWellKnown({
-          services: manifest.services,
-          canonicalOrigin,
-          managementUrlFor: (entry) => managementUrlByName.get(entry.name),
-          uiUrlFor: (entry) => serviceUiMeta.uiUrls.get(entry.name),
-          displayNameFor: (entry) => serviceUiMeta.displayNames.get(entry.name),
-        });
-        return new Response(JSON.stringify(doc), {
-          headers: { "content-type": "application/json", ...corsHeaders },
-        });
-      } catch (err) {
-        // ServicesManifestError lands here too — corrupt JSON or schema
-        // violation in services.json shouldn't crash the hub for everyone.
-        const msg = err instanceof Error ? err.message : String(err);
-        return new Response(JSON.stringify({ error: `well-known build failed: ${msg}` }), {
-          status: 500,
-          headers: { "content-type": "application/json", ...corsHeaders },
-        });
-      }
-    }
-
-    if (pathname === REVOCATION_LIST_MOUNT) {
-      // Revocation list (hub#212 Phase 1). Public — same CORS posture as
-      // jwks.json since resource servers (vault/scribe/agent) fetch it
-      // cross-origin on the 60s polling cadence wired in Phase 4.
-      const corsHeaders = {
-        "access-control-allow-origin": "*",
-        "access-control-allow-methods": "GET, OPTIONS",
-      };
-      if (req.method === "OPTIONS") {
-        return new Response(null, { status: 204, headers: corsHeaders });
-      }
-      if (!getDb) {
-        return new Response('{"error":"revocation list unavailable: db not configured"}', {
-          status: 503,
-          headers: { "content-type": "application/json", ...corsHeaders },
-        });
-      }
-      const resp = handleRevocationList(req, { db: getDb() });
-      // Layer the wildcard CORS over whatever cache-control the handler set.
-      const merged = new Headers(resp.headers);
-      for (const [k, v] of Object.entries(corsHeaders)) merged.set(k, v);
-      return new Response(resp.body, { status: resp.status, headers: merged });
-    }
-
-    if (pathname === "/.well-known/jwks.json") {
-      // JWKS is also a cross-origin fetch target (browser-side OAuth
-      // libraries pull this to verify access tokens). Same wildcard CORS
-      // shape as parachute.json — JWKS is public-by-design (only public
-      // keys leave the server).
-      const corsHeaders = {
-        "access-control-allow-origin": "*",
-        "access-control-allow-methods": "GET, OPTIONS",
-      };
-      if (req.method === "OPTIONS") {
-        return new Response(null, { status: 204, headers: corsHeaders });
-      }
-      if (!getDb) {
-        return new Response('{"error":"jwks unavailable: db not configured"}', {
-          status: 503,
-          headers: { "content-type": "application/json", ...corsHeaders },
-        });
-      }
-      try {
-        const db = getDb();
-        const keys = getAllPublicKeys(db).map((k) => pemToJwk(k.publicKeyPem, k.kid));
-        return new Response(JSON.stringify({ keys }), {
-          headers: { "content-type": "application/json", ...corsHeaders },
-        });
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        return new Response(JSON.stringify({ error: `jwks failed: ${msg}` }), {
-          status: 500,
-          headers: { "content-type": "application/json", ...corsHeaders },
-        });
-      }
-    }
-
-    if (pathname === "/.well-known/oauth-authorization-server") {
-      // Public discovery doc — clients pull this cross-origin to find the
-      // authorize/token endpoints. Same wildcard CORS shape as the JWKS
-      // and the parachute manifest.
-      const corsHeaders = {
-        "access-control-allow-origin": "*",
-        "access-control-allow-methods": "GET, OPTIONS",
-      };
-      if (req.method === "OPTIONS") {
-        return new Response(null, { status: 204, headers: corsHeaders });
-      }
-      const res = authorizationServerMetadata(oauthDeps(req));
-      // Fold CORS into the existing JSON response.
-      const merged = new Headers(res.headers);
-      for (const [k, v] of Object.entries(corsHeaders)) merged.set(k, v);
-      return new Response(res.body, { status: res.status, headers: merged });
-    }
-
-    if (pathname === "/.well-known/oauth-protected-resource") {
-      // RFC 9728 — companion to oauth-authorization-server. MCP clients
-      // (since 2025-06-18 spec) probe this to discover scopes + the
-      // authorization server. Same wildcard CORS shape. Closes hub#393.
-      const corsHeaders = {
-        "access-control-allow-origin": "*",
-        "access-control-allow-methods": "GET, OPTIONS",
-      };
-      if (req.method === "OPTIONS") {
-        return new Response(null, { status: 204, headers: corsHeaders });
-      }
-      const res = protectedResourceMetadata(oauthDeps(req));
-      const merged = new Headers(res.headers);
-      for (const [k, v] of Object.entries(corsHeaders)) merged.set(k, v);
-      return new Response(res.body, { status: res.status, headers: merged });
-    }
-
-    // OAuth surface — every handler return is wrapped in `applyCorsHeaders`
-    // so third-party SPAs can fetch these endpoints cross-origin (the entire
-    // point of OAuth DCR: arbitrary SPAs register → authorize → exchange
-    // tokens). Preflight OPTIONS already returned at the top of dispatch.
-    // See `src/cors.ts` for the wildcard-origin rationale.
-    if (pathname === "/oauth/authorize") {
-      if (!getDb) return applyCorsHeaders(req, dbNotConfigured());
-      // Per-request force-change-password gate (P0-1 / hub#469). CHOKE POINT 3:
-      // a signed-in pre-rotation user must NOT be able to ride the consent flow
-      // to an auth code → `/oauth/token` exchange → vault-scoped access token
-      // without rotating the temp password. Gating `/oauth/authorize` (the
-      // session-backed consent path) is sufficient — no code is issued without
-      // it, so `/oauth/token` (back-channel code exchange, no session cookie)
-      // is intentionally NOT gated (gating it would break the legitimate
-      // exchange). An UNAUTHENTICATED authorize request returns null from the
-      // gate and falls through to render the login form, unchanged.
-      const oauthGate = forceChangePasswordGate(getDb(), req);
-      if (oauthGate) return applyCorsHeaders(req, oauthGate);
-      if (req.method === "GET") {
-        // handleAuthorizeGet is sync (returns Response, not Promise<Response>).
-        // handleAuthorizePost is async — keep the await on POST only.
-        return applyCorsHeaders(req, handleAuthorizeGet(getDb(), req, oauthDeps(req)));
-      }
-      if (req.method === "POST") {
-        return applyCorsHeaders(req, await handleAuthorizePost(getDb(), req, oauthDeps(req)));
-      }
-      return applyCorsHeaders(req, new Response("method not allowed", { status: 405 }));
-    }
-
-    // Inline approve form for the operator-driven pending-client flow (#208).
-    // Receives `client_id` + `csrf_token` + `return_to` from the form rendered
-    // by handleAuthorizeGet when the operator hits a pending client. Three
-    // gates inside the handler: CSRF, active session, same-origin Origin.
-    if (pathname === "/oauth/authorize/approve") {
-      if (!getDb) return applyCorsHeaders(req, dbNotConfigured());
-      if (req.method !== "POST") {
-        return applyCorsHeaders(req, new Response("method not allowed", { status: 405 }));
-      }
-      return applyCorsHeaders(req, await handleApproveClientPost(getDb(), req, oauthDeps(req)));
-    }
-
-    if (pathname === "/oauth/token") {
-      if (!getDb) return applyCorsHeaders(req, dbNotConfigured());
-      if (req.method !== "POST") {
-        return applyCorsHeaders(req, new Response("method not allowed", { status: 405 }));
-      }
-      return applyCorsHeaders(req, await handleToken(getDb(), req, oauthDeps(req)));
-    }
-
-    if (pathname === "/oauth/register") {
-      if (!getDb) return applyCorsHeaders(req, dbNotConfigured());
-      if (req.method !== "POST") {
-        return applyCorsHeaders(req, new Response("method not allowed", { status: 405 }));
-      }
-      return applyCorsHeaders(req, await handleRegister(getDb(), req, oauthDeps(req)));
-    }
-
-    if (pathname === "/oauth/revoke") {
-      if (!getDb) return applyCorsHeaders(req, dbNotConfigured());
-      if (req.method !== "POST") {
-        return applyCorsHeaders(req, new Response("method not allowed", { status: 405 }));
-      }
-      return applyCorsHeaders(req, await handleRevoke(getDb(), req, oauthDeps(req)));
-    }
-
-    if (pathname === "/vaults") {
-      if (!getDb) return dbNotConfigured();
-      return handleCreateVault(req, {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-      });
-    }
-
-    // Note: the old `/hub/*` SPA mount has been retired. Known prefixes
-    // (`/hub`, `/hub/vaults*`, `/hub/permissions`, `/hub/tokens`) are
-    // 301-redirected at the top of dispatch. Any other `/hub/*` path falls
-    // through to the catch-all 404 — there's no admin surface left there.
-
-    if (pathname === "/admin/host-admin-token") {
-      if (!getDb) return dbNotConfigured();
-      return handleHostAdminToken(req, {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-      });
-    }
-
-    if (pathname.startsWith("/admin/vault-admin-token/")) {
-      if (!getDb) return dbNotConfigured();
-      const vaultName = decodeURIComponent(pathname.slice("/admin/vault-admin-token/".length));
-      // The vault name must correspond to an actual vault instance — same
-      // shape the well-known doc derives. Source from services.json so a
-      // freshly-created vault is mintable on the next request without a
-      // restart.
-      // Lenient — see hub#406.
-      const manifest = readManifestLenient(manifestPath);
-      const knownVaultNames = new Set<string>();
-      for (const s of manifest.services) {
-        if (!isVaultEntry(s)) continue;
-        for (const path of s.paths) knownVaultNames.add(vaultInstanceNameFor(s.name, path));
-      }
-      return handleVaultAdminToken(req, vaultName, {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-        knownVaultNames,
-      });
-    }
-
-    if (pathname === "/api/me") {
-      if (!getDb) return dbNotConfigured();
-      return handleApiMe(req, { db: getDb() });
-    }
-
-    // SPA-driven hub self-upgrade (design 2026-06-01 §5.3 / D4). Dedicated
-    // endpoint — the hub is NOT a supervised module (no /api/modules/hub/*),
-    // so it gets its own route. Checked BEFORE the `/api/hub` exact match
-    // below (and the `/api/modules/*` switch) so the more-specific path wins.
-    // Does NOT require a supervisor: the hub upgrades itself via a detached
-    // helper, not the supervisor. Host-admin gated inside the handler (reuses
-    // the same validateAccessToken + scope check the module-ops API uses); the
-    // channel param is a closed enum (rc|latest) — no injection surface.
-    if (pathname === "/api/hub/upgrade") {
-      if (!getDb) return dbNotConfigured();
-      return handleHubUpgrade(req, {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-        configDir: CONFIG_DIR,
-      });
-    }
-    if (pathname === "/api/hub/upgrade/status") {
-      if (!getDb) return dbNotConfigured();
-      return handleHubUpgradeStatus(req, {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-        configDir: CONFIG_DIR,
-      });
-    }
-
-    // Hub version + uptime + install-source — drives the admin SPA's
-    // version badge (hub#348). Bearer-gated on `parachute:host:admin`
-    // (same as the rest of the operator-only admin surface).
-    if (pathname === "/api/hub") {
-      if (!getDb) return dbNotConfigured();
-      return handleApiHub(req, {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-      });
-    }
-
-    if (pathname === "/api/modules") {
-      if (!getDb) return dbNotConfigured();
-      const od = oauthDeps(req);
-      const modulesDeps: Parameters<typeof handleApiModules>[1] = {
-        db: getDb(),
-        issuer: od.issuer,
-        // hub#516: validate the host-admin bearer's `iss` against the SET of
-        // origins the hub answers on (loopback ∪ expose-state ∪ env/platform ∪
-        // per-request issuer), so `parachute status` works on an exposed box
-        // where the operator token carries the public origin but the loopback
-        // request resolves the loopback issuer.
-        knownIssuers: od.hubBoundOrigins(),
-        manifestPath: deps?.manifestPath ?? SERVICES_MANIFEST_PATH,
-      };
-      if (deps?.supervisor !== undefined) modulesDeps.supervisor = deps.supervisor;
-      // hub#342: thread the test-injectable module-manifest reader
-      // through so `management_url` resolution can be exercised in
-      // unit tests without writing real install dirs.
-      if (deps?.readModuleManifest !== undefined)
-        modulesDeps.readModuleManifest = deps.readModuleManifest;
-      return handleApiModules(req, modulesDeps);
-    }
-
-    // Channel toggle (hub#275) — pre-empts the /api/modules/:short/*
-    // routes below so `/api/modules/channel` doesn't accidentally match
-    // `parseModulesPath` (which would reject it as a non-curated short
-    // anyway, but precedence makes the intent explicit).
-    if (pathname === "/api/modules/channel") {
-      if (!getDb) return dbNotConfigured();
-      return handleApiModulesChannel(req, {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-      });
-    }
-
-    // Canonical hub URL (hub#298). Admin SPA reads + writes the
-    // operator-set issuer override. The handler computes the resolved
-    // issuer + source here so it can surface them in the GET payload
-    // without re-walking the precedence chain inside the handler.
-    if (pathname === "/api/settings/hub-origin") {
-      if (!getDb) return dbNotConfigured();
-      const db = getDb();
-      return handleApiSettingsHubOrigin(req, {
-        db,
-        issuer: oauthDeps(req).issuer,
-        resolvedIssuer: resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin),
-        resolvedSource: resolveIssuerSource(db, configuredIssuer, loadExposeHubOrigin),
-      });
-    }
-
-    // Module operation poll surface — pre-empts the /api/modules/:short/*
-    // routes below so `/api/modules/operations/<uuid>` doesn't accidentally
-    // match a parseModulesPath("/operations") and fall through.
-    if (pathname.startsWith("/api/modules/operations/")) {
-      if (!getDb) return dbNotConfigured();
-      if (!deps?.supervisor) {
-        return new Response(
-          JSON.stringify({
-            error: "supervisor_unavailable",
-            error_description:
-              "module operations require `parachute serve` (supervisor mode); on-box CLI uses `parachute install/upgrade/restart`",
-          }),
-          { status: 503, headers: { "content-type": "application/json" } },
-        );
-      }
-      const opId = decodeURIComponent(pathname.slice("/api/modules/operations/".length));
-      if (!opId || opId.includes("/")) return new Response("not found", { status: 404 });
-      const od = oauthDeps(req);
-      return handleOperationGet(req, opId, {
-        db: getDb(),
-        issuer: od.issuer,
-        // hub#516: see the `/api/modules` deps note — the CLI polls async ops
-        // on loopback with the operator token (public `iss`).
-        knownIssuers: od.hubBoundOrigins(),
-        manifestPath: deps?.manifestPath ?? SERVICES_MANIFEST_PATH,
-        configDir: CONFIG_DIR,
-        supervisor: deps.supervisor,
-      });
-    }
-
-    // Per-module config surface (hub#260) — schema + values GET, values PUT.
-    // Sits ahead of the install/restart/upgrade/uninstall switch below so
-    // `/api/modules/<short>/config[/schema]` doesn't fall into the default-
-    // branch 404 (`parseModulesPath` only matches the action-suffix shape,
-    // not the `config` / `config/schema` shape).
-    //
-    // Diverges from the action endpoints in two ways: doesn't require a
-    // supervisor (we just proxy to the running module's HTTP surface, not
-    // spawn a child), and mints a `<short>:admin` token at proxy time so
-    // the upstream auth gate is satisfied without forcing the SPA bearer
-    // to carry per-module scopes.
-    {
-      const configMatch = parseModulesConfigPath(pathname);
-      if (configMatch) {
+      // The wizard owns the "should I 301 to /login now?" decision: setup is
+      // complete only when admin AND a vault entry both exist. A re-visit
+      // after partial setup picks up at the next step. See
+      // src/setup-wizard.ts for the renderer + handler internals.
+      if (pathname === "/admin/setup" || pathname.startsWith("/admin/setup/")) {
         if (!getDb) return dbNotConfigured();
-        return handleApiModulesConfig(req, configMatch, {
+        const wizardDeps: SetupWizardDeps = {
           db: getDb(),
+          manifestPath,
+          configDir: CONFIG_DIR,
           issuer: oauthDeps(req).issuer,
-          manifestPath: deps?.manifestPath ?? SERVICES_MANIFEST_PATH,
-        });
-      }
-    }
-
-    // Per-module action endpoints: /api/modules/:short/{install,restart,upgrade,uninstall}.
-    if (pathname.startsWith("/api/modules/")) {
-      if (!getDb) return dbNotConfigured();
-      if (!deps?.supervisor) {
-        return new Response(
-          JSON.stringify({
-            error: "supervisor_unavailable",
-            error_description:
-              "module operations require `parachute serve` (supervisor mode); on-box CLI uses `parachute install/upgrade/restart`",
-          }),
-          { status: 503, headers: { "content-type": "application/json" } },
-        );
-      }
-      const match = parseModulesPath(pathname);
-      if (!match) return new Response("not found", { status: 404 });
-      const od = oauthDeps(req);
-      const opsDeps = {
-        db: getDb(),
-        issuer: od.issuer,
-        // hub#516: the CLI drives start/stop/restart/install/upgrade/uninstall
-        // on loopback with the operator token, whose `iss` is the hub's public
-        // origin after `expose`. Validate against the hub's known-origin set.
-        knownIssuers: od.hubBoundOrigins(),
-        manifestPath: deps?.manifestPath ?? SERVICES_MANIFEST_PATH,
-        configDir: CONFIG_DIR,
-        supervisor: deps.supervisor,
-      };
-      switch (match.rest) {
-        case "install":
-          return handleInstall(req, match.short, opsDeps);
-        case "start":
-          return handleStart(req, match.short, opsDeps);
-        case "stop":
-          return handleStop(req, match.short, opsDeps);
-        case "restart":
-          return handleRestart(req, match.short, opsDeps);
-        case "logs":
-          return handleLogs(req, match.short, opsDeps);
-        case "upgrade":
-          return handleUpgrade(req, match.short, opsDeps);
-        case "uninstall":
-          return handleUninstall(req, match.short, opsDeps);
-        default:
-          return new Response("not found", { status: 404 });
-      }
-    }
-
-    if (pathname === "/api/auth/mint-token") {
-      if (!getDb) return dbNotConfigured();
-      // Derive the set of registered vault names so the handler can reject a
-      // `vault:<typo>:admin` mint (item D / hub#450) — same source + shape the
-      // session-cookie `/admin/vault-admin-token/<name>` path uses. Lenient
-      // read so a malformed manifest doesn't 500 the mint endpoint.
-      const mintManifest = readManifestLenient(manifestPath);
-      const mintKnownVaultNames = new Set<string>();
-      for (const s of mintManifest.services) {
-        if (!isVaultEntry(s)) continue;
-        for (const path of s.paths) mintKnownVaultNames.add(vaultInstanceNameFor(s.name, path));
-      }
-      return handleApiMintToken(req, {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-        knownVaultNames: mintKnownVaultNames,
-      });
-    }
-
-    if (pathname === "/api/auth/revoke-token") {
-      if (!getDb) return dbNotConfigured();
-      return handleApiRevokeToken(req, {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-      });
-    }
-
-    if (pathname === "/api/auth/tokens") {
-      if (!getDb) return dbNotConfigured();
-      return handleApiTokens(req, {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-      });
-    }
-
-    if (pathname === "/api/grants") {
-      if (!getDb) return dbNotConfigured();
-      return handleListGrants(req, {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-      });
-    }
-
-    if (pathname.startsWith("/api/grants/")) {
-      if (!getDb) return dbNotConfigured();
-      const clientId = decodeURIComponent(pathname.slice("/api/grants/".length));
-      if (!clientId || clientId.includes("/")) {
+          registry: getDefaultOperationsRegistry(),
+          // hub#576: a loopback peer (the on-box operator's own shell) is allowed
+          // to read the actual bootstrap token from the GET /admin/setup JSON
+          // probe. `layerOf` fails closed to non-loopback when peerAddr is
+          // unknown, so a header-less caller never gets the token.
+          requestIsLoopback: layerOf(req, peerAddr) === "loopback",
+        };
+        if (deps?.supervisor !== undefined) wizardDeps.supervisor = deps.supervisor;
+        if (pathname === "/admin/setup") {
+          if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
+          return handleSetupGet(req, wizardDeps);
+        }
+        if (pathname === "/admin/setup/account") {
+          if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+          return handleSetupAccountPost(req, wizardDeps);
+        }
+        if (pathname === "/admin/setup/vault") {
+          if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+          return handleSetupVaultPost(req, wizardDeps);
+        }
+        if (pathname === "/admin/setup/expose") {
+          if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+          return handleSetupExposePost(req, wizardDeps);
+        }
+        // hub#272 Item B: post-wizard direct module-install POSTs from
+        // the done-screen "What's next?" tiles. Path shape is
+        // `/admin/setup/install/<short>`; the handler rejects on
+        // unknown shorts, on `vault` (the wizard's own step owns that),
+        // and on missing session/CSRF — same gates as the vault POST.
+        if (pathname.startsWith("/admin/setup/install/")) {
+          if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+          const short = pathname.slice("/admin/setup/install/".length);
+          return handleSetupInstallPost(req, short, wizardDeps);
+        }
         return new Response("not found", { status: 404 });
       }
-      return handleRevokeGrant(req, clientId, {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-      });
-    }
 
-    // OAuth client lookup + approval. Both bearer-gated under host:admin.
-    // Two paths: `/api/oauth/clients/<id>` (GET, details) and
-    // `/api/oauth/clients/<id>/approve` (POST, flip to approved). The
-    // SPA approve-client deep link reads details from the first and
-    // submits approval to the second — keeps the surface easy to test
-    // and audit without overloading a single verb.
-    if (pathname.startsWith("/api/oauth/clients/")) {
-      if (!getDb) return dbNotConfigured();
-      const tail = pathname.slice("/api/oauth/clients/".length);
-      if (!tail) return new Response("not found", { status: 404 });
-      const approveSuffix = "/approve";
-      if (tail.endsWith(approveSuffix)) {
-        const clientId = decodeURIComponent(tail.slice(0, -approveSuffix.length));
+      // Fresh-hub redirect: when the wizard still has work to do, the
+      // discovery page (`/`, `/hub.html`) funnels straight to it. Two
+      // wizard-mode conditions trigger the redirect:
+      //
+      //   1. No admin row exists (the original fresh-deploy case). The
+      //      static portal carries no usable signal — no installed
+      //      services to discover, no admin to sign in as.
+      //   2. Admin exists but no vault is installed (env-seed deploys
+      //      where the operator baked admin into env vars but hasn't
+      //      walked the wizard's vault step). Pre-fix, env-seeded
+      //      operators bounced past the wizard entirely and had to
+      //      hand-find /admin/modules + /admin/vaults; surface
+      //      "let me finish the wizard" instead.
+      //
+      // The wizard's GET handler already picks the right step
+      // (`deriveWizardState` resumes at vault step when admin exists +
+      // no vault), so we just need the redirect to fire.
+      //
+      // 302 (not 301) so the redirect disappears the moment the wizard
+      // finishes. Sits before the JSON-shaped 503 gate below because `/`
+      // is an HTML surface — a JSON 503 there would render as raw text
+      // in the operator's browser tab. The 503 gate handles API + admin
+      // SPA + OAuth callers that branch on the structured body.
+      if (getDb && (pathname === "/" || pathname === "/hub.html")) {
+        const db = getDb();
+        // Either condition triggers the wizard funnel:
+        //   - no admin row (the fresh-deploy case)
+        //   - admin row exists but no vault installed (env-seed case)
+        // Short-circuit the manifest read when `noAdmin` is true; the
+        // wizard's first step is admin creation regardless of vault state.
+        const needsWizard = userCount(db) === 0 || !hasVaultInstalled(manifestPath);
+        if (needsWizard) {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "/admin/setup" },
+          });
+        }
+      }
+
+      // Pre-admin lockout. When the hub has booted with no admin row (the
+      // fresh-container case before PARACHUTE_INITIAL_ADMIN_* is set or
+      // /admin/setup is walked), every operator-facing surface that requires
+      // identity is meaningless — auth flows can't validate, the SPA can't
+      // mint a host-admin token, OAuth can't issue codes. Route those to a
+      // 503 that points at /admin/setup. Health, well-known, /admin/setup
+      // itself, OAuth third-party endpoints, and content proxies pass
+      // through; the fresh-hub `/` and `/hub.html` redirect above handled
+      // the discovery-page case.
+      //
+      // `shouldGateForSetup` runs first so non-gated paths (well-known, /,
+      // /health, /admin/setup) never touch getDb — keeping the
+      // existing OPTIONS-preflight contract that those routes are db-free.
+      if (getDb && shouldGateForSetup(pathname) && userCount(getDb()) === 0) {
+        return new Response(
+          JSON.stringify({
+            error: "setup_required",
+            error_description:
+              "no admin configured. Visit /admin/setup, or set PARACHUTE_INITIAL_ADMIN_USERNAME + PARACHUTE_INITIAL_ADMIN_PASSWORD and restart.",
+            setup_url: "/admin/setup",
+          }),
+          {
+            status: 503,
+            headers: {
+              "content-type": "application/json",
+              "cache-control": "no-store",
+            },
+          },
+        );
+      }
+
+      if (pathname === "/" || pathname === "/hub.html") {
+        // When a DB is configured, render the discovery page dynamically so
+        // the header carries a "Signed in as <name>" affordance for the
+        // active session. Without a DB, fall back to the static disk file
+        // (signed-out shape) — the disk file is what `parachute expose`
+        // wrote out, used when the hub-server is running without state.
+        if (getDb) {
+          const db = getDb();
+          const session = findActiveSession(db, req);
+          let renderOpts: RenderHubOpts = {};
+          const headers: Record<string, string> = {
+            "content-type": "text/html; charset=utf-8",
+          };
+          if (session) {
+            const user = getUserById(db, session.userId);
+            if (user) {
+              const csrf = ensureCsrfToken(req);
+              renderOpts = {
+                session: { displayName: user.username, csrfToken: csrf.token },
+              };
+              if (csrf.setCookie) headers["set-cookie"] = csrf.setCookie;
+            }
+          }
+          return new Response(renderHub(renderOpts), { headers });
+        }
+        // No DB configured → fall back to static file (signed-out only).
+        if (!existsSync(hubHtmlPath)) {
+          return new Response("hub.html not found", { status: 404 });
+        }
+        return new Response(Bun.file(hubHtmlPath), {
+          headers: { "content-type": "text/html; charset=utf-8" },
+        });
+      }
+
+      if (pathname === "/.well-known/parachute.json") {
+        // The well-known doc is a public service-discovery manifest (no
+        // secrets, no PII), and Notes / future browser clients fetch it
+        // cross-origin from their own loopback port. Wildcard CORS is the
+        // shape it needs. Browsers send an OPTIONS preflight when the request
+        // adds non-simple headers; answer it with 204 + the same allow-list.
+        //
+        // `cache-control: no-store` matters here: the discovery page (`/`)
+        // fetches this doc and renders Service tiles from it; without
+        // no-store, the browser's HTTP cache returns the stale services list
+        // the next time the operator navigates back to `/` after installing
+        // a module via the admin SPA. The doc is small and built per-request
+        // anyway, so giving up cacheability has no real cost (hub#268 Item 1).
+        const corsHeaders = {
+          "access-control-allow-origin": "*",
+          "access-control-allow-methods": "GET, OPTIONS",
+          "cache-control": "no-store",
+        };
+        if (req.method === "OPTIONS") {
+          return new Response(null, { status: 204, headers: corsHeaders });
+        }
+        // Built dynamically from services.json on every request — that's what
+        // makes `parachute vault create` show up here without re-running
+        // expose. canonicalOrigin reuses the OAuth issuer fallback: prefer the
+        // configured public origin (set by `--issuer https://<fqdn>`), else
+        // the request's own origin (fine for direct loopback hits).
+        try {
+          // Lenient — see hub#406.
+          const manifest = readManifestLenient(manifestPath);
+          // Same precedence as the OAuth issuer (hub#298): hub_settings →
+          // env → request origin. The well-known doc embeds this origin
+          // in service URLs + the issuer metadata link, so it must follow
+          // the same chain — otherwise a public-domain operator who set
+          // `hub_origin` would still see the Render-assigned URL on
+          // `/.well-known/parachute.json` while their JWTs carry the
+          // canonical URL, and discovery clients would split-brain on
+          // which one to trust.
+          const canonicalOrigin = resolveIssuer(
+            req,
+            getDb?.(),
+            configuredIssuer,
+            loadExposeHubOrigin,
+          );
+          const readManifestFn = deps?.readModuleManifest ?? defaultReadModuleManifest;
+          const [managementUrlByName, serviceUiMeta] = await Promise.all([
+            loadManagementUrls(manifest.services, readManifestFn),
+            loadServiceUiMetadata(manifest.services, readManifestFn),
+          ]);
+          const doc = buildWellKnown({
+            services: manifest.services,
+            canonicalOrigin,
+            managementUrlFor: (entry) => managementUrlByName.get(entry.name),
+            uiUrlFor: (entry) => serviceUiMeta.uiUrls.get(entry.name),
+            displayNameFor: (entry) => serviceUiMeta.displayNames.get(entry.name),
+          });
+          return new Response(JSON.stringify(doc), {
+            headers: { "content-type": "application/json", ...corsHeaders },
+          });
+        } catch (err) {
+          // ServicesManifestError lands here too — corrupt JSON or schema
+          // violation in services.json shouldn't crash the hub for everyone.
+          const msg = err instanceof Error ? err.message : String(err);
+          return new Response(JSON.stringify({ error: `well-known build failed: ${msg}` }), {
+            status: 500,
+            headers: { "content-type": "application/json", ...corsHeaders },
+          });
+        }
+      }
+
+      if (pathname === REVOCATION_LIST_MOUNT) {
+        // Revocation list (hub#212 Phase 1). Public — same CORS posture as
+        // jwks.json since resource servers (vault/scribe/agent) fetch it
+        // cross-origin on the 60s polling cadence wired in Phase 4.
+        const corsHeaders = {
+          "access-control-allow-origin": "*",
+          "access-control-allow-methods": "GET, OPTIONS",
+        };
+        if (req.method === "OPTIONS") {
+          return new Response(null, { status: 204, headers: corsHeaders });
+        }
+        if (!getDb) {
+          return new Response('{"error":"revocation list unavailable: db not configured"}', {
+            status: 503,
+            headers: { "content-type": "application/json", ...corsHeaders },
+          });
+        }
+        const resp = handleRevocationList(req, { db: getDb() });
+        // Layer the wildcard CORS over whatever cache-control the handler set.
+        const merged = new Headers(resp.headers);
+        for (const [k, v] of Object.entries(corsHeaders)) merged.set(k, v);
+        return new Response(resp.body, { status: resp.status, headers: merged });
+      }
+
+      if (pathname === "/.well-known/jwks.json") {
+        // JWKS is also a cross-origin fetch target (browser-side OAuth
+        // libraries pull this to verify access tokens). Same wildcard CORS
+        // shape as parachute.json — JWKS is public-by-design (only public
+        // keys leave the server).
+        const corsHeaders = {
+          "access-control-allow-origin": "*",
+          "access-control-allow-methods": "GET, OPTIONS",
+        };
+        if (req.method === "OPTIONS") {
+          return new Response(null, { status: 204, headers: corsHeaders });
+        }
+        if (!getDb) {
+          return new Response('{"error":"jwks unavailable: db not configured"}', {
+            status: 503,
+            headers: { "content-type": "application/json", ...corsHeaders },
+          });
+        }
+        try {
+          const db = getDb();
+          const keys = getAllPublicKeys(db).map((k) => pemToJwk(k.publicKeyPem, k.kid));
+          return new Response(JSON.stringify({ keys }), {
+            headers: { "content-type": "application/json", ...corsHeaders },
+          });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return new Response(JSON.stringify({ error: `jwks failed: ${msg}` }), {
+            status: 500,
+            headers: { "content-type": "application/json", ...corsHeaders },
+          });
+        }
+      }
+
+      if (pathname === "/.well-known/oauth-authorization-server") {
+        // Public discovery doc — clients pull this cross-origin to find the
+        // authorize/token endpoints. Same wildcard CORS shape as the JWKS
+        // and the parachute manifest.
+        const corsHeaders = {
+          "access-control-allow-origin": "*",
+          "access-control-allow-methods": "GET, OPTIONS",
+        };
+        if (req.method === "OPTIONS") {
+          return new Response(null, { status: 204, headers: corsHeaders });
+        }
+        const res = authorizationServerMetadata(oauthDeps(req));
+        // Fold CORS into the existing JSON response.
+        const merged = new Headers(res.headers);
+        for (const [k, v] of Object.entries(corsHeaders)) merged.set(k, v);
+        return new Response(res.body, { status: res.status, headers: merged });
+      }
+
+      if (pathname === "/.well-known/oauth-protected-resource") {
+        // RFC 9728 — companion to oauth-authorization-server. MCP clients
+        // (since 2025-06-18 spec) probe this to discover scopes + the
+        // authorization server. Same wildcard CORS shape. Closes hub#393.
+        const corsHeaders = {
+          "access-control-allow-origin": "*",
+          "access-control-allow-methods": "GET, OPTIONS",
+        };
+        if (req.method === "OPTIONS") {
+          return new Response(null, { status: 204, headers: corsHeaders });
+        }
+        const res = protectedResourceMetadata(oauthDeps(req));
+        const merged = new Headers(res.headers);
+        for (const [k, v] of Object.entries(corsHeaders)) merged.set(k, v);
+        return new Response(res.body, { status: res.status, headers: merged });
+      }
+
+      // OAuth surface — every handler return is wrapped in `applyCorsHeaders`
+      // so third-party SPAs can fetch these endpoints cross-origin (the entire
+      // point of OAuth DCR: arbitrary SPAs register → authorize → exchange
+      // tokens). Preflight OPTIONS already returned at the top of dispatch.
+      // See `src/cors.ts` for the wildcard-origin rationale.
+      if (pathname === "/oauth/authorize") {
+        if (!getDb) return applyCorsHeaders(req, dbNotConfigured());
+        // Per-request force-change-password gate (P0-1 / hub#469). CHOKE POINT 3:
+        // a signed-in pre-rotation user must NOT be able to ride the consent flow
+        // to an auth code → `/oauth/token` exchange → vault-scoped access token
+        // without rotating the temp password. Gating `/oauth/authorize` (the
+        // session-backed consent path) is sufficient — no code is issued without
+        // it, so `/oauth/token` (back-channel code exchange, no session cookie)
+        // is intentionally NOT gated (gating it would break the legitimate
+        // exchange). An UNAUTHENTICATED authorize request returns null from the
+        // gate and falls through to render the login form, unchanged.
+        const oauthGate = forceChangePasswordGate(getDb(), req);
+        if (oauthGate) return applyCorsHeaders(req, oauthGate);
+        if (req.method === "GET") {
+          // handleAuthorizeGet is sync (returns Response, not Promise<Response>).
+          // handleAuthorizePost is async — keep the await on POST only.
+          return applyCorsHeaders(req, handleAuthorizeGet(getDb(), req, oauthDeps(req)));
+        }
+        if (req.method === "POST") {
+          return applyCorsHeaders(req, await handleAuthorizePost(getDb(), req, oauthDeps(req)));
+        }
+        return applyCorsHeaders(req, new Response("method not allowed", { status: 405 }));
+      }
+
+      // Inline approve form for the operator-driven pending-client flow (#208).
+      // Receives `client_id` + `csrf_token` + `return_to` from the form rendered
+      // by handleAuthorizeGet when the operator hits a pending client. Three
+      // gates inside the handler: CSRF, active session, same-origin Origin.
+      if (pathname === "/oauth/authorize/approve") {
+        if (!getDb) return applyCorsHeaders(req, dbNotConfigured());
+        if (req.method !== "POST") {
+          return applyCorsHeaders(req, new Response("method not allowed", { status: 405 }));
+        }
+        return applyCorsHeaders(req, await handleApproveClientPost(getDb(), req, oauthDeps(req)));
+      }
+
+      if (pathname === "/oauth/token") {
+        if (!getDb) return applyCorsHeaders(req, dbNotConfigured());
+        if (req.method !== "POST") {
+          return applyCorsHeaders(req, new Response("method not allowed", { status: 405 }));
+        }
+        return applyCorsHeaders(req, await handleToken(getDb(), req, oauthDeps(req)));
+      }
+
+      if (pathname === "/oauth/register") {
+        if (!getDb) return applyCorsHeaders(req, dbNotConfigured());
+        if (req.method !== "POST") {
+          return applyCorsHeaders(req, new Response("method not allowed", { status: 405 }));
+        }
+        return applyCorsHeaders(req, await handleRegister(getDb(), req, oauthDeps(req)));
+      }
+
+      if (pathname === "/oauth/revoke") {
+        if (!getDb) return applyCorsHeaders(req, dbNotConfigured());
+        if (req.method !== "POST") {
+          return applyCorsHeaders(req, new Response("method not allowed", { status: 405 }));
+        }
+        return applyCorsHeaders(req, await handleRevoke(getDb(), req, oauthDeps(req)));
+      }
+
+      if (pathname === "/vaults") {
+        if (!getDb) return dbNotConfigured();
+        return handleCreateVault(req, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+        });
+      }
+
+      // Note: the old `/hub/*` SPA mount has been retired. Known prefixes
+      // (`/hub`, `/hub/vaults*`, `/hub/permissions`, `/hub/tokens`) are
+      // 301-redirected at the top of dispatch. Any other `/hub/*` path falls
+      // through to the catch-all 404 — there's no admin surface left there.
+
+      if (pathname === "/admin/host-admin-token") {
+        if (!getDb) return dbNotConfigured();
+        return handleHostAdminToken(req, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+        });
+      }
+
+      if (pathname.startsWith("/admin/vault-admin-token/")) {
+        if (!getDb) return dbNotConfigured();
+        const vaultName = decodeURIComponent(pathname.slice("/admin/vault-admin-token/".length));
+        // The vault name must correspond to an actual vault instance — same
+        // shape the well-known doc derives. Source from services.json so a
+        // freshly-created vault is mintable on the next request without a
+        // restart.
+        // Lenient — see hub#406.
+        const manifest = readManifestLenient(manifestPath);
+        const knownVaultNames = new Set<string>();
+        for (const s of manifest.services) {
+          if (!isVaultEntry(s)) continue;
+          for (const path of s.paths) knownVaultNames.add(vaultInstanceNameFor(s.name, path));
+        }
+        return handleVaultAdminToken(req, vaultName, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          knownVaultNames,
+        });
+      }
+
+      if (pathname === "/api/me") {
+        if (!getDb) return dbNotConfigured();
+        return handleApiMe(req, { db: getDb() });
+      }
+
+      // SPA-driven hub self-upgrade (design 2026-06-01 §5.3 / D4). Dedicated
+      // endpoint — the hub is NOT a supervised module (no /api/modules/hub/*),
+      // so it gets its own route. Checked BEFORE the `/api/hub` exact match
+      // below (and the `/api/modules/*` switch) so the more-specific path wins.
+      // Does NOT require a supervisor: the hub upgrades itself via a detached
+      // helper, not the supervisor. Host-admin gated inside the handler (reuses
+      // the same validateAccessToken + scope check the module-ops API uses); the
+      // channel param is a closed enum (rc|latest) — no injection surface.
+      if (pathname === "/api/hub/upgrade") {
+        if (!getDb) return dbNotConfigured();
+        return handleHubUpgrade(req, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          configDir: CONFIG_DIR,
+        });
+      }
+      if (pathname === "/api/hub/upgrade/status") {
+        if (!getDb) return dbNotConfigured();
+        return handleHubUpgradeStatus(req, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          configDir: CONFIG_DIR,
+        });
+      }
+
+      // Hub version + uptime + install-source — drives the admin SPA's
+      // version badge (hub#348). Bearer-gated on `parachute:host:admin`
+      // (same as the rest of the operator-only admin surface).
+      if (pathname === "/api/hub") {
+        if (!getDb) return dbNotConfigured();
+        return handleApiHub(req, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+        });
+      }
+
+      if (pathname === "/api/modules") {
+        if (!getDb) return dbNotConfigured();
+        const od = oauthDeps(req);
+        const modulesDeps: Parameters<typeof handleApiModules>[1] = {
+          db: getDb(),
+          issuer: od.issuer,
+          // hub#516: validate the host-admin bearer's `iss` against the SET of
+          // origins the hub answers on (loopback ∪ expose-state ∪ env/platform ∪
+          // per-request issuer), so `parachute status` works on an exposed box
+          // where the operator token carries the public origin but the loopback
+          // request resolves the loopback issuer.
+          knownIssuers: od.hubBoundOrigins(),
+          manifestPath: deps?.manifestPath ?? SERVICES_MANIFEST_PATH,
+        };
+        if (deps?.supervisor !== undefined) modulesDeps.supervisor = deps.supervisor;
+        // hub#342: thread the test-injectable module-manifest reader
+        // through so `management_url` resolution can be exercised in
+        // unit tests without writing real install dirs.
+        if (deps?.readModuleManifest !== undefined)
+          modulesDeps.readModuleManifest = deps.readModuleManifest;
+        return handleApiModules(req, modulesDeps);
+      }
+
+      // Channel toggle (hub#275) — pre-empts the /api/modules/:short/*
+      // routes below so `/api/modules/channel` doesn't accidentally match
+      // `parseModulesPath` (which would reject it as a non-curated short
+      // anyway, but precedence makes the intent explicit).
+      if (pathname === "/api/modules/channel") {
+        if (!getDb) return dbNotConfigured();
+        return handleApiModulesChannel(req, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+        });
+      }
+
+      // Canonical hub URL (hub#298). Admin SPA reads + writes the
+      // operator-set issuer override. The handler computes the resolved
+      // issuer + source here so it can surface them in the GET payload
+      // without re-walking the precedence chain inside the handler.
+      if (pathname === "/api/settings/hub-origin") {
+        if (!getDb) return dbNotConfigured();
+        const db = getDb();
+        return handleApiSettingsHubOrigin(req, {
+          db,
+          issuer: oauthDeps(req).issuer,
+          resolvedIssuer: resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin),
+          resolvedSource: resolveIssuerSource(db, configuredIssuer, loadExposeHubOrigin),
+        });
+      }
+
+      // Module operation poll surface — pre-empts the /api/modules/:short/*
+      // routes below so `/api/modules/operations/<uuid>` doesn't accidentally
+      // match a parseModulesPath("/operations") and fall through.
+      if (pathname.startsWith("/api/modules/operations/")) {
+        if (!getDb) return dbNotConfigured();
+        if (!deps?.supervisor) {
+          return new Response(
+            JSON.stringify({
+              error: "supervisor_unavailable",
+              error_description:
+                "module operations require `parachute serve` (supervisor mode); on-box CLI uses `parachute install/upgrade/restart`",
+            }),
+            { status: 503, headers: { "content-type": "application/json" } },
+          );
+        }
+        const opId = decodeURIComponent(pathname.slice("/api/modules/operations/".length));
+        if (!opId || opId.includes("/")) return new Response("not found", { status: 404 });
+        const od = oauthDeps(req);
+        return handleOperationGet(req, opId, {
+          db: getDb(),
+          issuer: od.issuer,
+          // hub#516: see the `/api/modules` deps note — the CLI polls async ops
+          // on loopback with the operator token (public `iss`).
+          knownIssuers: od.hubBoundOrigins(),
+          manifestPath: deps?.manifestPath ?? SERVICES_MANIFEST_PATH,
+          configDir: CONFIG_DIR,
+          supervisor: deps.supervisor,
+        });
+      }
+
+      // Per-module config surface (hub#260) — schema + values GET, values PUT.
+      // Sits ahead of the install/restart/upgrade/uninstall switch below so
+      // `/api/modules/<short>/config[/schema]` doesn't fall into the default-
+      // branch 404 (`parseModulesPath` only matches the action-suffix shape,
+      // not the `config` / `config/schema` shape).
+      //
+      // Diverges from the action endpoints in two ways: doesn't require a
+      // supervisor (we just proxy to the running module's HTTP surface, not
+      // spawn a child), and mints a `<short>:admin` token at proxy time so
+      // the upstream auth gate is satisfied without forcing the SPA bearer
+      // to carry per-module scopes.
+      {
+        const configMatch = parseModulesConfigPath(pathname);
+        if (configMatch) {
+          if (!getDb) return dbNotConfigured();
+          return handleApiModulesConfig(req, configMatch, {
+            db: getDb(),
+            issuer: oauthDeps(req).issuer,
+            manifestPath: deps?.manifestPath ?? SERVICES_MANIFEST_PATH,
+          });
+        }
+      }
+
+      // Per-module action endpoints: /api/modules/:short/{install,restart,upgrade,uninstall}.
+      if (pathname.startsWith("/api/modules/")) {
+        if (!getDb) return dbNotConfigured();
+        if (!deps?.supervisor) {
+          return new Response(
+            JSON.stringify({
+              error: "supervisor_unavailable",
+              error_description:
+                "module operations require `parachute serve` (supervisor mode); on-box CLI uses `parachute install/upgrade/restart`",
+            }),
+            { status: 503, headers: { "content-type": "application/json" } },
+          );
+        }
+        const match = parseModulesPath(pathname);
+        if (!match) return new Response("not found", { status: 404 });
+        const od = oauthDeps(req);
+        const opsDeps = {
+          db: getDb(),
+          issuer: od.issuer,
+          // hub#516: the CLI drives start/stop/restart/install/upgrade/uninstall
+          // on loopback with the operator token, whose `iss` is the hub's public
+          // origin after `expose`. Validate against the hub's known-origin set.
+          knownIssuers: od.hubBoundOrigins(),
+          manifestPath: deps?.manifestPath ?? SERVICES_MANIFEST_PATH,
+          configDir: CONFIG_DIR,
+          supervisor: deps.supervisor,
+        };
+        switch (match.rest) {
+          case "install":
+            return handleInstall(req, match.short, opsDeps);
+          case "start":
+            return handleStart(req, match.short, opsDeps);
+          case "stop":
+            return handleStop(req, match.short, opsDeps);
+          case "restart":
+            return handleRestart(req, match.short, opsDeps);
+          case "logs":
+            return handleLogs(req, match.short, opsDeps);
+          case "upgrade":
+            return handleUpgrade(req, match.short, opsDeps);
+          case "uninstall":
+            return handleUninstall(req, match.short, opsDeps);
+          default:
+            return new Response("not found", { status: 404 });
+        }
+      }
+
+      if (pathname === "/api/auth/mint-token") {
+        if (!getDb) return dbNotConfigured();
+        // Derive the set of registered vault names so the handler can reject a
+        // `vault:<typo>:admin` mint (item D / hub#450) — same source + shape the
+        // session-cookie `/admin/vault-admin-token/<name>` path uses. Lenient
+        // read so a malformed manifest doesn't 500 the mint endpoint.
+        const mintManifest = readManifestLenient(manifestPath);
+        const mintKnownVaultNames = new Set<string>();
+        for (const s of mintManifest.services) {
+          if (!isVaultEntry(s)) continue;
+          for (const path of s.paths) mintKnownVaultNames.add(vaultInstanceNameFor(s.name, path));
+        }
+        return handleApiMintToken(req, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          knownVaultNames: mintKnownVaultNames,
+        });
+      }
+
+      if (pathname === "/api/auth/revoke-token") {
+        if (!getDb) return dbNotConfigured();
+        return handleApiRevokeToken(req, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+        });
+      }
+
+      if (pathname === "/api/auth/tokens") {
+        if (!getDb) return dbNotConfigured();
+        return handleApiTokens(req, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+        });
+      }
+
+      if (pathname === "/api/grants") {
+        if (!getDb) return dbNotConfigured();
+        return handleListGrants(req, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+        });
+      }
+
+      if (pathname.startsWith("/api/grants/")) {
+        if (!getDb) return dbNotConfigured();
+        const clientId = decodeURIComponent(pathname.slice("/api/grants/".length));
         if (!clientId || clientId.includes("/")) {
           return new Response("not found", { status: 404 });
         }
-        return handleApproveClient(req, clientId, {
+        return handleRevokeGrant(req, clientId, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
         });
       }
-      const clientId = decodeURIComponent(tail);
-      if (!clientId || clientId.includes("/")) {
-        return new Response("not found", { status: 404 });
-      }
-      return handleGetClient(req, clientId, {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-      });
-    }
 
-    // Multi-user Phase 1 admin endpoints (hub#252, design 2026-05-20).
-    // `/api/users` collection (GET list / POST create) and
-    // `/api/users/vaults` for the assigned-vault picker. Per-id route
-    // `/api/users/:id` (DELETE only — Phase 1 doesn't ship edit) is
-    // handled by the `startsWith("/api/users/")` branch below, with the
-    // `/api/users/vaults` sub-path pre-empted *before* the catch-all so
-    // a literal `vaults` segment can't be mistaken for a user id.
-    if (pathname === "/api/users") {
-      if (!getDb) return dbNotConfigured();
-      const usersDeps = {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-        manifestPath,
-      };
-      if (req.method === "GET") return handleListUsers(req, usersDeps);
-      if (req.method === "POST") return handleCreateUser(req, usersDeps);
-      return new Response("method not allowed", { status: 405 });
-    }
-    if (pathname === "/api/users/vaults") {
-      if (!getDb) return dbNotConfigured();
-      return handleListVaults(req, {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-        manifestPath,
-      });
-    }
-    // Phase 2 PR 1 — `/api/users/:id/reset-password` (admin-initiated
-    // password reset for non-admin users). Routed BEFORE the per-id DELETE
-    // catch-all so the trailing `/reset-password` segment isn't mistaken
-    // for part of a user id. Same `host:admin` Bearer gate as the other
-    // /api/users surfaces.
-    {
-      const resetMatch = pathname.match(/^\/api\/users\/([^/]+)\/reset-password$/);
-      if (resetMatch) {
+      // OAuth client lookup + approval. Both bearer-gated under host:admin.
+      // Two paths: `/api/oauth/clients/<id>` (GET, details) and
+      // `/api/oauth/clients/<id>/approve` (POST, flip to approved). The
+      // SPA approve-client deep link reads details from the first and
+      // submits approval to the second — keeps the surface easy to test
+      // and audit without overloading a single verb.
+      if (pathname.startsWith("/api/oauth/clients/")) {
         if (!getDb) return dbNotConfigured();
-        const id = decodeURIComponent(resetMatch[1] ?? "");
-        if (!id) {
+        const tail = pathname.slice("/api/oauth/clients/".length);
+        if (!tail) return new Response("not found", { status: 404 });
+        const approveSuffix = "/approve";
+        if (tail.endsWith(approveSuffix)) {
+          const clientId = decodeURIComponent(tail.slice(0, -approveSuffix.length));
+          if (!clientId || clientId.includes("/")) {
+            return new Response("not found", { status: 404 });
+          }
+          return handleApproveClient(req, clientId, {
+            db: getDb(),
+            issuer: oauthDeps(req).issuer,
+          });
+        }
+        const clientId = decodeURIComponent(tail);
+        if (!clientId || clientId.includes("/")) {
           return new Response("not found", { status: 404 });
         }
-        return handleResetUserPassword(req, id, {
+        return handleGetClient(req, clientId, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+        });
+      }
+
+      // Multi-user Phase 1 admin endpoints (hub#252, design 2026-05-20).
+      // `/api/users` collection (GET list / POST create) and
+      // `/api/users/vaults` for the assigned-vault picker. Per-id route
+      // `/api/users/:id` (DELETE only — Phase 1 doesn't ship edit) is
+      // handled by the `startsWith("/api/users/")` branch below, with the
+      // `/api/users/vaults` sub-path pre-empted *before* the catch-all so
+      // a literal `vaults` segment can't be mistaken for a user id.
+      if (pathname === "/api/users") {
+        if (!getDb) return dbNotConfigured();
+        const usersDeps = {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          manifestPath,
+        };
+        if (req.method === "GET") return handleListUsers(req, usersDeps);
+        if (req.method === "POST") return handleCreateUser(req, usersDeps);
+        return new Response("method not allowed", { status: 405 });
+      }
+      if (pathname === "/api/users/vaults") {
+        if (!getDb) return dbNotConfigured();
+        return handleListVaults(req, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
           manifestPath,
         });
       }
-    }
-    // Phase 2 PR 2 — `/api/users/:id/vaults` (replace a user's vault
-    // assignments). Routed before the per-id DELETE catch-all so the
-    // trailing `/vaults` segment isn't mistaken for part of a user id.
-    {
-      const vaultsMatch = pathname.match(/^\/api\/users\/([^/]+)\/vaults$/);
-      if (vaultsMatch) {
+      // Phase 2 PR 1 — `/api/users/:id/reset-password` (admin-initiated
+      // password reset for non-admin users). Routed BEFORE the per-id DELETE
+      // catch-all so the trailing `/reset-password` segment isn't mistaken
+      // for part of a user id. Same `host:admin` Bearer gate as the other
+      // /api/users surfaces.
+      {
+        const resetMatch = pathname.match(/^\/api\/users\/([^/]+)\/reset-password$/);
+        if (resetMatch) {
+          if (!getDb) return dbNotConfigured();
+          const id = decodeURIComponent(resetMatch[1] ?? "");
+          if (!id) {
+            return new Response("not found", { status: 404 });
+          }
+          return handleResetUserPassword(req, id, {
+            db: getDb(),
+            issuer: oauthDeps(req).issuer,
+            manifestPath,
+          });
+        }
+      }
+      // Phase 2 PR 2 — `/api/users/:id/vaults` (replace a user's vault
+      // assignments). Routed before the per-id DELETE catch-all so the
+      // trailing `/vaults` segment isn't mistaken for part of a user id.
+      {
+        const vaultsMatch = pathname.match(/^\/api\/users\/([^/]+)\/vaults$/);
+        if (vaultsMatch) {
+          if (!getDb) return dbNotConfigured();
+          const id = decodeURIComponent(vaultsMatch[1] ?? "");
+          if (!id) {
+            return new Response("not found", { status: 404 });
+          }
+          return handleUpdateUserVaults(req, id, {
+            db: getDb(),
+            issuer: oauthDeps(req).issuer,
+            manifestPath,
+          });
+        }
+      }
+      if (pathname.startsWith("/api/users/")) {
         if (!getDb) return dbNotConfigured();
-        const id = decodeURIComponent(vaultsMatch[1] ?? "");
-        if (!id) {
+        const id = decodeURIComponent(pathname.slice("/api/users/".length));
+        if (!id || id.includes("/")) {
           return new Response("not found", { status: 404 });
         }
-        return handleUpdateUserVaults(req, id, {
+        return handleDeleteUser(req, id, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
           manifestPath,
         });
       }
-    }
-    if (pathname.startsWith("/api/users/")) {
-      if (!getDb) return dbNotConfigured();
-      const id = decodeURIComponent(pathname.slice("/api/users/".length));
-      if (!id || id.includes("/")) {
-        return new Response("not found", { status: 404 });
+
+      // One-time invite links (design §7). host:admin-gated, same gate flavor
+      // as /api/users. POST creates (returns the single-emit token + URL), GET
+      // lists (status-annotated), DELETE /:id revokes by sha256 hash.
+      if (pathname === "/api/invites") {
+        if (!getDb) return dbNotConfigured();
+        const invitesDeps = { db: getDb(), issuer: oauthDeps(req).issuer, manifestPath };
+        if (req.method === "GET") return handleListInvites(req, invitesDeps);
+        if (req.method === "POST") return handleCreateInvite(req, invitesDeps);
+        return new Response("method not allowed", { status: 405 });
       }
-      return handleDeleteUser(req, id, {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-        manifestPath,
-      });
-    }
-
-    // One-time invite links (design §7). host:admin-gated, same gate flavor
-    // as /api/users. POST creates (returns the single-emit token + URL), GET
-    // lists (status-annotated), DELETE /:id revokes by sha256 hash.
-    if (pathname === "/api/invites") {
-      if (!getDb) return dbNotConfigured();
-      const invitesDeps = { db: getDb(), issuer: oauthDeps(req).issuer, manifestPath };
-      if (req.method === "GET") return handleListInvites(req, invitesDeps);
-      if (req.method === "POST") return handleCreateInvite(req, invitesDeps);
-      return new Response("method not allowed", { status: 405 });
-    }
-    if (pathname.startsWith("/api/invites/")) {
-      if (!getDb) return dbNotConfigured();
-      const id = decodeURIComponent(pathname.slice("/api/invites/".length));
-      if (!id || id.includes("/")) {
-        return new Response("not found", { status: 404 });
-      }
-      return handleRevokeInvite(req, id, {
-        db: getDb(),
-        issuer: oauthDeps(req).issuer,
-        manifestPath,
-      });
-    }
-
-    // Canonical login/logout. The handlers themselves are unchanged from
-    // when they lived at /admin/login + /admin/logout; the rename surfaced
-    // via #231-followup so the URL reflects the surface's actual scope
-    // (entry point for ALL parachute auth — not admin-only). The
-    // /admin/login and /admin/logout paths 301 to here, dispatched at the
-    // top of this fn alongside the other back-compat redirects.
-    if (pathname === "/login") {
-      if (!getDb) return dbNotConfigured();
-      if (req.method === "GET") return handleAdminLoginGet(getDb(), req);
-      if (req.method === "POST") return handleAdminLoginPost(getDb(), req);
-      return new Response("method not allowed", { status: 405 });
-    }
-
-    // /login/2fa — second-factor step (hub#473). POST-only: reached only
-    // after a correct password POST for a 2FA-enrolled user handed back a
-    // pending-login cookie + rendered the challenge page. A bare GET (e.g.
-    // browser back button) has no form to render usefully, so 405 → the
-    // operator restarts at /login.
-    if (pathname === "/login/2fa") {
-      if (!getDb) return dbNotConfigured();
-      if (req.method === "POST") return handleAdminLoginTotpPost(getDb(), req);
-      return new Response("method not allowed", { status: 405 });
-    }
-
-    if (pathname === "/logout") {
-      if (!getDb) return dbNotConfigured();
-      if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
-      return handleAdminLogoutPost(getDb(), req);
-    }
-
-    // Invite redemption — `/account/setup/<token>` (design §7). Un-authed
-    // onboarding surface (the invitee has no session yet); routed BEFORE the
-    // per-request force-change choke point and the `/account/` matches below.
-    // GET renders the claim form; POST redeems → creates account + own vault,
-    // mints a session, 302 → /account/. The handler validates the invite
-    // (sha256 lookup, expiry/used/revoked), CSRF, and rate-limits on the
-    // /login IP bucket. The invite alone is the authorization — no host:admin.
-    if (pathname.startsWith("/account/setup/")) {
-      if (!getDb) return dbNotConfigured();
-      const rawToken = decodeURIComponent(pathname.slice("/account/setup/".length));
-      if (!rawToken || rawToken.includes("/")) {
-        return new Response("not found", { status: 404 });
-      }
-      const db = getDb();
-      const hubOrigin = resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin);
-      const setupDeps = { db, hubOrigin, manifestPath };
-      if (req.method === "GET") return handleAccountSetupGet(req, rawToken, setupDeps);
-      if (req.method === "POST") return handleAccountSetupPost(req, rawToken, setupDeps);
-      return new Response("method not allowed", { status: 405 });
-    }
-
-    // Multi-user Phase 1 PR 3 — user self-service change-password surface
-    // (hub#252, design §sign-in flow change). Both GET (render form) and
-    // POST (apply change) require a session cookie. The handler itself
-    // does the session check + 302 to /login when missing — same posture
-    // as the rest of /account/* will use as Phase 2 broadens this prefix.
-    //
-    // This route is intentionally NOT gated by `password_changed === false`
-    // — that's only the *redirect* path from /login. A signed-in user with
-    // `password_changed: true` can still navigate here to rotate their
-    // password (design §"Direct navigation").
-    if (pathname === "/account/change-password") {
-      if (!getDb) return dbNotConfigured();
-      // `now` deliberately omitted — handlers fall through to `new Date()` in
-      // production; the seam exists only so tests can advance the rate-limiter
-      // clock deterministically.
-      const accountDeps = { db: getDb() };
-      if (req.method === "GET") return handleAccountChangePasswordGet(req, accountDeps);
-      if (req.method === "POST") return handleAccountChangePasswordPost(req, accountDeps);
-      return new Response("method not allowed", { status: 405 });
-    }
-
-    // Per-request force-change-password gate (P0-1 / hub#469). CHOKE POINT 1:
-    // every `/account/*` route BELOW this line is gated. `/logout` and
-    // `/account/change-password` (the rotation/exit path) ran above and already
-    // returned, so they're never reached here — they stay reachable
-    // pre-rotation by construction. A signed-in user with
-    // `password_changed === false` is bounced (302 → change-password for
-    // browsers, 403 JSON for API clients) before any account surface
-    // (2fa, vault-token, vault-admin-token, account home) resolves. DRY: one
-    // gate for the whole `/account/*` family rather than per-route. The
-    // per-route mints in `account-vault-{token,admin-token}.ts` keep their own
-    // gate as defence-in-depth (they're also reachable in tests directly).
-    //
-    // The bare `/account` (no trailing slash) is matched explicitly too —
-    // otherwise it would slip past `startsWith("/account/")` to its 301 →
-    // `/account/` below, and a pre-rotation user wouldn't be gated until the
-    // second hop. Exact-match `/account` (not `startsWith("/account")`) so
-    // unrelated paths like `/accounts-something` aren't caught.
-    if (getDb && (pathname === "/account" || pathname.startsWith("/account/"))) {
-      const gate = forceChangePasswordGate(getDb(), req);
-      if (gate) return gate;
-    }
-
-    // /account/2fa — user self-service TOTP 2FA enroll / disenroll (hub#473).
-    // Both GET (render state) and POST (start/confirm/disable) require an
-    // active session; the handler does the session check + 302 to /login when
-    // missing, same posture as /account/change-password.
-    if (pathname === "/account/2fa") {
-      if (!getDb) return dbNotConfigured();
-      const twoFactorDeps = { db: getDb() };
-      if (req.method === "GET") return handleTwoFactorGet(req, twoFactorDeps);
-      if (req.method === "POST") return handleTwoFactorPost(req, twoFactorDeps);
-      return new Response("method not allowed", { status: 405 });
-    }
-
-    // /account/vault-admin-token/<name> — friend-facing vault ADMIN deep-link.
-    // POST-only, session-gated, assignment-capped to the `admin` verb: an
-    // assigned non-admin user mints a `vault:<name>:admin` bootstrap token and
-    // 303-redirects into the vault's own admin SPA (`#token=<jwt>`), where they
-    // can rotate vault tokens AND configure Git backup / mirror. The non-admin
-    // sibling of `/admin/vault-admin-token/<name>` (which is first-admin-gated
-    // and returns JSON for the hub SPA). The handler enforces session →
-    // assignment-grants-admin → CSRF → force-change-password (item F / #469)
-    // before minting. Must precede `/account/vault-token/` (it isn't a prefix
-    // of it, but keep the more-specific admin path first for clarity) and the
-    // `/account/` match below. See `account-vault-admin-token.ts`.
-    if (pathname.startsWith("/account/vault-admin-token/")) {
-      if (!getDb) return dbNotConfigured();
-      if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
-      const vaultName = decodeURIComponent(pathname.slice("/account/vault-admin-token/".length));
-      const db = getDb();
-      const hubOrigin = resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin);
-      // Resolve the vault's declared `managementUrl` at request time (same
-      // source the well-known doc reads — `installDir/.parachute/module.json`)
-      // so the deep-link lands on the vault admin SPA's real entry point. Quiet
-      // on a malformed/absent manifest: the handler defaults to `/admin/`
-      // (vault's canonical value), the same target the admin sibling uses.
-      const readManifestFn = deps?.readModuleManifest ?? defaultReadModuleManifest;
-      const manifest = readManifestLenient(manifestPath);
-      let managementUrl: string | undefined;
-      for (const s of manifest.services) {
-        if (!isVaultEntry(s) || !s.installDir) continue;
-        const instanceNames = new Set(s.paths.map((p) => vaultInstanceNameFor(s.name, p)));
-        if (!instanceNames.has(vaultName)) continue;
-        try {
-          const m = await readManifestFn(s.installDir);
-          if (m?.managementUrl) managementUrl = m.managementUrl;
-        } catch {
-          // Leave undefined → handler defaults to /admin/.
+      if (pathname.startsWith("/api/invites/")) {
+        if (!getDb) return dbNotConfigured();
+        const id = decodeURIComponent(pathname.slice("/api/invites/".length));
+        if (!id || id.includes("/")) {
+          return new Response("not found", { status: 404 });
         }
-        break;
+        return handleRevokeInvite(req, id, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          manifestPath,
+        });
       }
-      return handleAccountVaultAdminTokenPost(req, vaultName, {
-        db,
-        hubOrigin,
-        ...(managementUrl !== undefined ? { managementUrl } : {}),
-      });
-    }
 
-    // /account/vault-token/<name> — friend-facing scoped vault token mint.
-    // POST-only, session-gated, assignment-capped: a non-admin friend mints a
-    // `vault:<name>:read|write` bearer for a vault they're ASSIGNED to, for
-    // scripts / headless clients that can't do browser OAuth. The handler
-    // enforces session → assignment → scope-cap (never `:admin`, never a
-    // vault outside the assignment, never a broader verb than the role
-    // grants) + CSRF + per-user rate limit. Must precede the `/account/`
-    // match below (more specific prefix). See `account-vault-token.ts`.
-    if (pathname.startsWith("/account/vault-token/")) {
-      if (!getDb) return dbNotConfigured();
-      if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
-      const vaultName = decodeURIComponent(pathname.slice("/account/vault-token/".length));
-      const db = getDb();
-      const hubOrigin = resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin);
-      return handleAccountVaultTokenPost(req, vaultName, { db, hubOrigin });
-    }
-
-    // /account/ — friend-facing user home (multi-user Phase 1 follow-up).
-    // Companion to the first-admin gate on `/admin/host-admin-token`: a
-    // signed-in non-admin (friend) lands here instead of bouncing against
-    // a 403 wall on the admin SPA. Admin users also land here when they
-    // hit `/account/` directly, with a "you're the administrator → /admin/"
-    // exit ramp. Bare `/account` 301-redirects to `/account/` so links
-    // without the trailing slash work.
-    if (pathname === "/account" || pathname === "/account/") {
-      if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
-      if (pathname === "/account") {
-        return new Response(null, { status: 301, headers: { location: "/account/" } });
+      // Canonical login/logout. The handlers themselves are unchanged from
+      // when they lived at /admin/login + /admin/logout; the rename surfaced
+      // via #231-followup so the URL reflects the surface's actual scope
+      // (entry point for ALL parachute auth — not admin-only). The
+      // /admin/login and /admin/logout paths 301 to here, dispatched at the
+      // top of this fn alongside the other back-compat redirects.
+      if (pathname === "/login") {
+        if (!getDb) return dbNotConfigured();
+        if (req.method === "GET") return handleAdminLoginGet(getDb(), req);
+        if (req.method === "POST") return handleAdminLoginPost(getDb(), req);
+        return new Response("method not allowed", { status: 405 });
       }
-      if (!getDb) return dbNotConfigured();
-      const db = getDb();
-      const hubOrigin = resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin);
-      // Resolve each assigned vault's loopback port from services.json so the
-      // home can fetch per-vault usage. Read at request time (same dynamism as
-      // proxyToVault) — a vault created seconds ago surfaces a stat without a
-      // restart. Returns null for an unknown name → that tile skips the stat.
-      const resolveVaultPort = (vaultName: string): number | null => {
-        const services = readManifestLenient(manifestPath).services;
-        const match = findVaultUpstream(services, `/vault/${vaultName}`);
-        return match ? match.port : null;
-      };
-      return handleAccountHomeGet(req, { db, hubOrigin, resolveVaultPort });
-    }
 
-    // Legacy `/admin/config` (server-rendered module-config portal, #46)
-    // retired post-SPA-rework. 301 → the SPA home so any bookmark or stale
-    // post-login redirect lands somewhere useful. The route stays here in
-    // dispatch order (above the /admin/* SPA catch-all) so the redirect
-    // wins over a SPA shell render.
-    if (pathname === "/admin/config" || pathname.startsWith("/admin/config/")) {
-      return new Response(null, {
-        status: 301,
-        headers: { location: "/admin/vaults" },
-      });
-    }
+      // /login/2fa — second-factor step (hub#473). POST-only: reached only
+      // after a correct password POST for a 2FA-enrolled user handed back a
+      // pending-login cookie + rendered the challenge page. A bare GET (e.g.
+      // browser back button) has no form to render usefully, so 405 → the
+      // operator restarts at /login.
+      if (pathname === "/login/2fa") {
+        if (!getDb) return dbNotConfigured();
+        if (req.method === "POST") return handleAdminLoginTotpPost(getDb(), req);
+        return new Response("method not allowed", { status: 405 });
+      }
 
-    // /vault/<name>/* — per-vault content proxy. Stays as user-facing
-    // surface (the Notes PWA loads through here, etc.). The bare `/vault`
-    // and `/vault/new` paths were SPA routes pre-#231; they 301-redirect at
-    // the top of dispatch now. Multi-segment requests like
-    // `/vault/<unknown>/health` are vault-API shapes targeting a
-    // non-existent vault and 404 directly — there's no SPA-shell fallback
-    // here anymore (the SPA moved to /admin), so we can't accidentally
-    // mask a backend 404 with HTML.
-    if (pathname.startsWith("/vault/")) {
-      // Per-request force-change-password gate (P0-1 / hub#469). CHOKE POINT 2:
-      // a pre-rotation signed-in user can't reach a per-vault user surface
-      // (Notes PWA, MCP, vault API) on the un-rotated temp password — they're
-      // bounced to change-password (browser) / 403 (API). Same posture as the
-      // `/account/*` gate above. An UNAUTHENTICATED proxy request (no hub
-      // session — the common Notes/MCP case carrying its own bearer) passes the
-      // gate untouched (`forceChangePasswordGate` returns null with no session)
-      // and is handled by the vault's own auth downstream.
-      if (getDb) {
+      if (pathname === "/logout") {
+        if (!getDb) return dbNotConfigured();
+        if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+        return handleAdminLogoutPost(getDb(), req);
+      }
+
+      // Invite redemption — `/account/setup/<token>` (design §7). Un-authed
+      // onboarding surface (the invitee has no session yet); routed BEFORE the
+      // per-request force-change choke point and the `/account/` matches below.
+      // GET renders the claim form; POST redeems → creates account + own vault,
+      // mints a session, 302 → /account/. The handler validates the invite
+      // (sha256 lookup, expiry/used/revoked), CSRF, and rate-limits on the
+      // /login IP bucket. The invite alone is the authorization — no host:admin.
+      if (pathname.startsWith("/account/setup/")) {
+        if (!getDb) return dbNotConfigured();
+        const rawToken = decodeURIComponent(pathname.slice("/account/setup/".length));
+        if (!rawToken || rawToken.includes("/")) {
+          return new Response("not found", { status: 404 });
+        }
+        const db = getDb();
+        const hubOrigin = resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin);
+        const setupDeps = { db, hubOrigin, manifestPath };
+        if (req.method === "GET") return handleAccountSetupGet(req, rawToken, setupDeps);
+        if (req.method === "POST") return handleAccountSetupPost(req, rawToken, setupDeps);
+        return new Response("method not allowed", { status: 405 });
+      }
+
+      // Multi-user Phase 1 PR 3 — user self-service change-password surface
+      // (hub#252, design §sign-in flow change). Both GET (render form) and
+      // POST (apply change) require a session cookie. The handler itself
+      // does the session check + 302 to /login when missing — same posture
+      // as the rest of /account/* will use as Phase 2 broadens this prefix.
+      //
+      // This route is intentionally NOT gated by `password_changed === false`
+      // — that's only the *redirect* path from /login. A signed-in user with
+      // `password_changed: true` can still navigate here to rotate their
+      // password (design §"Direct navigation").
+      if (pathname === "/account/change-password") {
+        if (!getDb) return dbNotConfigured();
+        // `now` deliberately omitted — handlers fall through to `new Date()` in
+        // production; the seam exists only so tests can advance the rate-limiter
+        // clock deterministically.
+        const accountDeps = { db: getDb() };
+        if (req.method === "GET") return handleAccountChangePasswordGet(req, accountDeps);
+        if (req.method === "POST") return handleAccountChangePasswordPost(req, accountDeps);
+        return new Response("method not allowed", { status: 405 });
+      }
+
+      // Per-request force-change-password gate (P0-1 / hub#469). CHOKE POINT 1:
+      // every `/account/*` route BELOW this line is gated. `/logout` and
+      // `/account/change-password` (the rotation/exit path) ran above and already
+      // returned, so they're never reached here — they stay reachable
+      // pre-rotation by construction. A signed-in user with
+      // `password_changed === false` is bounced (302 → change-password for
+      // browsers, 403 JSON for API clients) before any account surface
+      // (2fa, vault-token, vault-admin-token, account home) resolves. DRY: one
+      // gate for the whole `/account/*` family rather than per-route. The
+      // per-route mints in `account-vault-{token,admin-token}.ts` keep their own
+      // gate as defence-in-depth (they're also reachable in tests directly).
+      //
+      // The bare `/account` (no trailing slash) is matched explicitly too —
+      // otherwise it would slip past `startsWith("/account/")` to its 301 →
+      // `/account/` below, and a pre-rotation user wouldn't be gated until the
+      // second hop. Exact-match `/account` (not `startsWith("/account")`) so
+      // unrelated paths like `/accounts-something` aren't caught.
+      if (getDb && (pathname === "/account" || pathname.startsWith("/account/"))) {
         const gate = forceChangePasswordGate(getDb(), req);
         if (gate) return gate;
       }
-      const proxied = await proxyToVault(req, manifestPath, deps?.supervisor, peerAddr);
+
+      // /account/2fa — user self-service TOTP 2FA enroll / disenroll (hub#473).
+      // Both GET (render state) and POST (start/confirm/disable) require an
+      // active session; the handler does the session check + 302 to /login when
+      // missing, same posture as /account/change-password.
+      if (pathname === "/account/2fa") {
+        if (!getDb) return dbNotConfigured();
+        const twoFactorDeps = { db: getDb() };
+        if (req.method === "GET") return handleTwoFactorGet(req, twoFactorDeps);
+        if (req.method === "POST") return handleTwoFactorPost(req, twoFactorDeps);
+        return new Response("method not allowed", { status: 405 });
+      }
+
+      // /account/vault-admin-token/<name> — friend-facing vault ADMIN deep-link.
+      // POST-only, session-gated, assignment-capped to the `admin` verb: an
+      // assigned non-admin user mints a `vault:<name>:admin` bootstrap token and
+      // 303-redirects into the vault's own admin SPA (`#token=<jwt>`), where they
+      // can rotate vault tokens AND configure Git backup / mirror. The non-admin
+      // sibling of `/admin/vault-admin-token/<name>` (which is first-admin-gated
+      // and returns JSON for the hub SPA). The handler enforces session →
+      // assignment-grants-admin → CSRF → force-change-password (item F / #469)
+      // before minting. Must precede `/account/vault-token/` (it isn't a prefix
+      // of it, but keep the more-specific admin path first for clarity) and the
+      // `/account/` match below. See `account-vault-admin-token.ts`.
+      if (pathname.startsWith("/account/vault-admin-token/")) {
+        if (!getDb) return dbNotConfigured();
+        if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+        const vaultName = decodeURIComponent(pathname.slice("/account/vault-admin-token/".length));
+        const db = getDb();
+        const hubOrigin = resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin);
+        // Resolve the vault's declared `managementUrl` at request time (same
+        // source the well-known doc reads — `installDir/.parachute/module.json`)
+        // so the deep-link lands on the vault admin SPA's real entry point. Quiet
+        // on a malformed/absent manifest: the handler defaults to `/admin/`
+        // (vault's canonical value), the same target the admin sibling uses.
+        const readManifestFn = deps?.readModuleManifest ?? defaultReadModuleManifest;
+        const manifest = readManifestLenient(manifestPath);
+        let managementUrl: string | undefined;
+        for (const s of manifest.services) {
+          if (!isVaultEntry(s) || !s.installDir) continue;
+          const instanceNames = new Set(s.paths.map((p) => vaultInstanceNameFor(s.name, p)));
+          if (!instanceNames.has(vaultName)) continue;
+          try {
+            const m = await readManifestFn(s.installDir);
+            if (m?.managementUrl) managementUrl = m.managementUrl;
+          } catch {
+            // Leave undefined → handler defaults to /admin/.
+          }
+          break;
+        }
+        return handleAccountVaultAdminTokenPost(req, vaultName, {
+          db,
+          hubOrigin,
+          ...(managementUrl !== undefined ? { managementUrl } : {}),
+        });
+      }
+
+      // /account/vault-token/<name> — friend-facing scoped vault token mint.
+      // POST-only, session-gated, assignment-capped: a non-admin friend mints a
+      // `vault:<name>:read|write` bearer for a vault they're ASSIGNED to, for
+      // scripts / headless clients that can't do browser OAuth. The handler
+      // enforces session → assignment → scope-cap (never `:admin`, never a
+      // vault outside the assignment, never a broader verb than the role
+      // grants) + CSRF + per-user rate limit. Must precede the `/account/`
+      // match below (more specific prefix). See `account-vault-token.ts`.
+      if (pathname.startsWith("/account/vault-token/")) {
+        if (!getDb) return dbNotConfigured();
+        if (req.method !== "POST") return new Response("method not allowed", { status: 405 });
+        const vaultName = decodeURIComponent(pathname.slice("/account/vault-token/".length));
+        const db = getDb();
+        const hubOrigin = resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin);
+        return handleAccountVaultTokenPost(req, vaultName, { db, hubOrigin });
+      }
+
+      // /account/ — friend-facing user home (multi-user Phase 1 follow-up).
+      // Companion to the first-admin gate on `/admin/host-admin-token`: a
+      // signed-in non-admin (friend) lands here instead of bouncing against
+      // a 403 wall on the admin SPA. Admin users also land here when they
+      // hit `/account/` directly, with a "you're the administrator → /admin/"
+      // exit ramp. Bare `/account` 301-redirects to `/account/` so links
+      // without the trailing slash work.
+      if (pathname === "/account" || pathname === "/account/") {
+        if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
+        if (pathname === "/account") {
+          return new Response(null, { status: 301, headers: { location: "/account/" } });
+        }
+        if (!getDb) return dbNotConfigured();
+        const db = getDb();
+        const hubOrigin = resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin);
+        // Resolve each assigned vault's loopback port from services.json so the
+        // home can fetch per-vault usage. Read at request time (same dynamism as
+        // proxyToVault) — a vault created seconds ago surfaces a stat without a
+        // restart. Returns null for an unknown name → that tile skips the stat.
+        const resolveVaultPort = (vaultName: string): number | null => {
+          const services = readManifestLenient(manifestPath).services;
+          const match = findVaultUpstream(services, `/vault/${vaultName}`);
+          return match ? match.port : null;
+        };
+        return handleAccountHomeGet(req, { db, hubOrigin, resolveVaultPort });
+      }
+
+      // Legacy `/admin/config` (server-rendered module-config portal, #46)
+      // retired post-SPA-rework. 301 → the SPA home so any bookmark or stale
+      // post-login redirect lands somewhere useful. The route stays here in
+      // dispatch order (above the /admin/* SPA catch-all) so the redirect
+      // wins over a SPA shell render.
+      if (pathname === "/admin/config" || pathname.startsWith("/admin/config/")) {
+        return new Response(null, {
+          status: 301,
+          headers: { location: "/admin/vaults" },
+        });
+      }
+
+      // /vault/<name>/* — per-vault content proxy. Stays as user-facing
+      // surface (the Notes PWA loads through here, etc.). The bare `/vault`
+      // and `/vault/new` paths were SPA routes pre-#231; they 301-redirect at
+      // the top of dispatch now. Multi-segment requests like
+      // `/vault/<unknown>/health` are vault-API shapes targeting a
+      // non-existent vault and 404 directly — there's no SPA-shell fallback
+      // here anymore (the SPA moved to /admin), so we can't accidentally
+      // mask a backend 404 with HTML.
+      if (pathname.startsWith("/vault/")) {
+        // Per-request force-change-password gate (P0-1 / hub#469). CHOKE POINT 2:
+        // a pre-rotation signed-in user can't reach a per-vault user surface
+        // (Notes PWA, MCP, vault API) on the un-rotated temp password — they're
+        // bounced to change-password (browser) / 403 (API). Same posture as the
+        // `/account/*` gate above. An UNAUTHENTICATED proxy request (no hub
+        // session — the common Notes/MCP case carrying its own bearer) passes the
+        // gate untouched (`forceChangePasswordGate` returns null with no session)
+        // and is handled by the vault's own auth downstream.
+        if (getDb) {
+          const gate = forceChangePasswordGate(getDb(), req);
+          if (gate) return gate;
+        }
+        const proxied = await proxyToVault(req, manifestPath, deps?.supervisor, peerAddr);
+        if (proxied) return decorateWithChrome(proxied, req, pathname, getDb);
+        return new Response("not found", { status: 404 });
+      }
+
+      // /admin/* SPA mount. All non-SPA admin handlers (host-admin-token,
+      // vault-admin-token, login, logout, config, api/auth/*, api/grants,
+      // grants/*) ran above and either matched or returned. Anything that
+      // makes it here under /admin/* is a SPA route or asset request; the
+      // SPA's own router renders the page and handles 404 client-side for
+      // unknown sub-paths.
+      if (pathname === "/admin" || pathname === "/admin/") {
+        // Unprefixed /admin → SPA shell pointed at the vault list (its home).
+        // The SPA's basename is /admin, so the router will land on / and
+        // render VaultsList.
+        if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
+        return serveSpa(spaDistDir, pathname, "/admin");
+      }
+      if (pathname.startsWith("/admin/")) {
+        if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
+        return serveSpa(spaDistDir, pathname, "/admin");
+      }
+
+      // Generic services.json-driven dispatch for non-vault modules. Reaches
+      // here only after every hub-owned prefix above has had its turn — so
+      // `/`, `/admin/*`, `/oauth/*`, `/.well-known/*`, `/hub/*`, `/vault/*`,
+      // `/api/*` are excluded by ordering, not by an explicit denylist (#182).
+      const proxied = await proxyToService(req, manifestPath, deps?.supervisor, peerAddr);
       if (proxied) return decorateWithChrome(proxied, req, pathname, getDb);
+
+      // Branded fall-through 404 (closes hub#392) — the operator who mistyped
+      // a URL sees a clear "not found" page with a path back home, not the
+      // browser's default empty-body chrome. Only HTML clients get the
+      // rendered page; non-HTML callers (curl, API probes) still see the
+      // shorter "not found" text so log noise stays low.
+      const wantsHtml = (req.headers.get("accept") ?? "").includes("text/html");
+      if (wantsHtml) {
+        return new Response(renderNotFoundPage(pathname), {
+          status: 404,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        });
+      }
       return new Response("not found", { status: 404 });
-    }
-
-    // /admin/* SPA mount. All non-SPA admin handlers (host-admin-token,
-    // vault-admin-token, login, logout, config, api/auth/*, api/grants,
-    // grants/*) ran above and either matched or returned. Anything that
-    // makes it here under /admin/* is a SPA route or asset request; the
-    // SPA's own router renders the page and handles 404 client-side for
-    // unknown sub-paths.
-    if (pathname === "/admin" || pathname === "/admin/") {
-      // Unprefixed /admin → SPA shell pointed at the vault list (its home).
-      // The SPA's basename is /admin, so the router will land on / and
-      // render VaultsList.
-      if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
-      return serveSpa(spaDistDir, pathname, "/admin");
-    }
-    if (pathname.startsWith("/admin/")) {
-      if (req.method !== "GET") return new Response("method not allowed", { status: 405 });
-      return serveSpa(spaDistDir, pathname, "/admin");
-    }
-
-    // Generic services.json-driven dispatch for non-vault modules. Reaches
-    // here only after every hub-owned prefix above has had its turn — so
-    // `/`, `/admin/*`, `/oauth/*`, `/.well-known/*`, `/hub/*`, `/vault/*`,
-    // `/api/*` are excluded by ordering, not by an explicit denylist (#182).
-    const proxied = await proxyToService(req, manifestPath, deps?.supervisor, peerAddr);
-    if (proxied) return decorateWithChrome(proxied, req, pathname, getDb);
-
-    // Branded fall-through 404 (closes hub#392) — the operator who mistyped
-    // a URL sees a clear "not found" page with a path back home, not the
-    // browser's default empty-body chrome. Only HTML clients get the
-    // rendered page; non-HTML callers (curl, API probes) still see the
-    // shorter "not found" text so log noise stays low.
-    const wantsHtml = (req.headers.get("accept") ?? "").includes("text/html");
-    if (wantsHtml) {
-      return new Response(renderNotFoundPage(pathname), {
-        status: 404,
-        headers: { "content-type": "text/html; charset=utf-8" },
-      });
-    }
-    return new Response("not found", { status: 404 });
+    } // end dispatch()
   };
 }
 
@@ -2701,11 +2765,18 @@ async function decorateWithChrome(
 
 if (import.meta.main) {
   const { port, hostname, wellKnownDir, dbPath, issuer } = parseArgs(process.argv.slice(2));
-  let cachedDb: Database | undefined;
+  // Self-heal-or-die DB holder (#594), opened lazily so a route that doesn't
+  // touch the DB still works before first open. Once opened, the holder owns
+  // reopen-once-or-exit on a persistent SQLite fault.
+  let holder: ReturnType<typeof createDbHolder> | undefined;
   const getDb = () => {
-    if (!cachedDb) cachedDb = openHubDb(dbPath);
-    return cachedDb;
+    if (!holder) {
+      holder = createDbHolder(openHubDb(dbPath), { reopen: () => openHubDb(dbPath) });
+    }
+    return holder.get();
   };
+  const onDbError = (err: unknown): "ignored" | "healed" | "exited" =>
+    holder ? holder.healOrExit(err) : "ignored";
   Bun.serve({
     port,
     hostname,
@@ -2721,7 +2792,7 @@ if (import.meta.main) {
     // Bun's equivalent is this. 255s comfortably exceeds Render's edge
     // pool TTL (community-observed ~120s). Closes hub#399.
     idleTimeout: 255,
-    fetch: hubFetch(wellKnownDir, { getDb, issuer, loopbackPort: port }),
+    fetch: hubFetch(wellKnownDir, { getDb, onDbError, issuer, loopbackPort: port }),
   });
   // Register PID + port from the running hub itself so any startup path
   // (spawn-via-`ensureHubRunning` or a direct `bun src/hub-server.ts` from

--- a/src/hub-unit.ts
+++ b/src/hub-unit.ts
@@ -85,7 +85,9 @@ export interface HubUnitDeps extends ManagedUnitDeps {
    * `null` when the hub doesn't answer at all (connection-refused / timeout).
    * Production uses a bounded `fetch`; tests inject a deterministic stub.
    */
-  probeHealthVersion: (port: number) => Promise<{ ok: boolean; version?: string } | null>;
+  probeHealthVersion: (
+    port: number,
+  ) => Promise<{ ok: boolean; version?: string; db?: string } | null>;
   /** TCP connect-probe for readiness polling (reuses `defaultPortListening`). */
   portListening: PortListeningFn;
   /** Sleep between readiness polls (tests pin to 0). */
@@ -118,25 +120,46 @@ async function defaultProbeHealth(port: number): Promise<boolean> {
  */
 async function defaultProbeHealthVersion(
   port: number,
-): Promise<{ ok: boolean; version?: string } | null> {
+): Promise<{ ok: boolean; version?: string; db?: string } | null> {
   try {
     const res = await fetch(`http://127.0.0.1:${port}/health`, {
       signal: AbortSignal.timeout(1500),
     });
     let version: string | undefined;
+    let db: string | undefined;
     try {
       const body = (await res.json()) as unknown;
-      if (body && typeof body === "object" && "version" in body) {
+      if (body && typeof body === "object") {
         const v = (body as { version?: unknown }).version;
         if (typeof v === "string" && v.length > 0) version = v;
+        // `db` liveness verdict (#594): "ok" / "error: <class>" / "unconfigured".
+        // Threaded through so the adoption probe can treat a db-error hub as
+        // needing a restart even when its version matches.
+        const d = (body as { db?: unknown }).db;
+        if (typeof d === "string" && d.length > 0) db = d;
       }
     } catch {
-      // Non-JSON body → no version. Leave `version` undefined (→ mismatch).
+      // Non-JSON body → no version/db. Leave undefined (→ mismatch / unknown db).
     }
-    return version !== undefined ? { ok: res.ok, version } : { ok: res.ok };
+    const out: { ok: boolean; version?: string; db?: string } = { ok: res.ok };
+    if (version !== undefined) out.version = version;
+    if (db !== undefined) out.db = db;
+    return out;
   } catch {
     return null;
   }
+}
+
+/**
+ * True when a `/health` `db` field reports a non-recoverable liveness fault
+ * (#594) — anything starting with "error:" (e.g. "error: fatal" from the
+ * dead-handle field repro). "ok" and "unconfigured" are not faults: a
+ * pre-wizard hub with no DB rows still reports a working handle. A missing
+ * `db` field (an older hub that predates #594) reads as "unknown → don't
+ * treat as a fault" so we never restart a hub merely for lacking the field.
+ */
+function healthReportsDbFault(db: string | undefined): boolean {
+  return typeof db === "string" && db.startsWith("error:");
 }
 
 export const defaultHubUnitDeps: HubUnitDeps = {
@@ -510,13 +533,22 @@ export async function ensureHubVersionMatches(
   }
 
   const runningVersion = probe.version;
-  if (runningVersion === installedVersion) {
-    // Exactly today's behavior — versions agree, no extra restart.
+  const dbFault = healthReportsDbFault(probe.db);
+  if (runningVersion === installedVersion && !dbFault) {
+    // Versions agree AND the DB handle is live — today's behavior, no restart.
     return { outcome: "match", runningVersion, installedVersion, messages: [] };
   }
 
-  // Mismatch (includes the no-`version`-field very-old-hub case → undefined).
-  const runningLabel = runningVersion ?? "an older version (no version field)";
+  // From here we know the running hub needs a restart: EITHER its version is
+  // stale (the #590 zombie-adoption case) OR it's reporting a dead DB handle
+  // (#594 — a hub that adopted-as-version-match but whose state dir was deleted
+  // under it; /health stays 200 while every DB route 500s). Both run through
+  // the same restart-once machinery. `runningLabel` describes whichever fault
+  // we're acting on so the operator sees an accurate reason.
+  const versionMismatch = runningVersion !== installedVersion;
+  const runningLabel = versionMismatch
+    ? (runningVersion ?? "an older version (no version field)")
+    : `${runningVersion} with a dead database handle (${probe.db})`;
 
   // Is this hub one we can restart through the manager? If there's no manager,
   // or no unit installed, the running hub is a legacy detached pid / a dev
@@ -556,45 +588,60 @@ export async function ensureHubVersionMatches(
     outcome: "restarted",
     runningVersion: v,
     installedVersion,
-    messages: [`✓ hub unit restarted; now running ${installedVersion}.`],
+    messages: [`✓ hub unit restarted; now running ${installedVersion} with a live database.`],
   });
-  const stillMismatchedResult = (last: string | undefined): EnsureHubVersionMatchesResult => {
-    const reports = last ? ` (reports ${last})` : "";
+  const stillMismatchedResult = (
+    last: { version?: string; db?: string } | undefined,
+  ): EnsureHubVersionMatchesResult => {
+    const lastVersion = last?.version;
+    const reports = lastVersion ? ` (reports ${lastVersion})` : "";
+    const dbStillBad = healthReportsDbFault(last?.db);
     return {
       outcome: "still-mismatched",
-      ...(last !== undefined ? { runningVersion: last } : {}),
+      ...(lastVersion !== undefined ? { runningVersion: lastVersion } : {}),
       installedVersion,
-      messages: [
-        `⚠ restarted the hub unit, but it is still not reporting ${installedVersion}${reports}.`,
-        "  This can happen with a bun-linked checkout on a feature branch whose package.json version trails the running code.",
-        `  Continuing — verify with \`parachute status\` / \`curl http://127.0.0.1:${port}/health\` if the hub should be on a specific version.`,
-      ],
+      messages: dbStillBad
+        ? [
+            `⚠ restarted the hub unit, but its database still reports a fault (${last?.db}).`,
+            "  The state directory may still be missing or the database file corrupted.",
+            `  Check it with \`curl http://127.0.0.1:${port}/health\` and ensure ~/.parachute exists.`,
+          ]
+        : [
+            `⚠ restarted the hub unit, but it is still not reporting ${installedVersion}${reports}.`,
+            "  This can happen with a bun-linked checkout on a feature branch whose package.json version trails the running code.",
+            `  Continuing — verify with \`parachute status\` / \`curl http://127.0.0.1:${port}/health\` if the hub should be on a specific version.`,
+          ],
     };
   };
 
-  // Re-probe `/health` until the running version matches the installed version
-  // or the readiness budget elapses. Restart-loop guard: we restart AT MOST
-  // once — if it still mismatches after this single restart (e.g. a bun-linked
-  // checkout on a branch), we warn + continue rather than looping.
+  // A re-probe counts as "healed" only when the version matches AND the DB
+  // handle is live — a restart that came back on the right version but with a
+  // still-dead handle hasn't actually fixed the #594 fault.
+  const probeHealed = (p: { version?: string; db?: string } | null): boolean =>
+    p !== null && p.version === installedVersion && !healthReportsDbFault(p.db);
+
+  // Re-probe `/health` until the hub is healed or the readiness budget elapses.
+  // Restart-loop guard: we restart AT MOST once — if it still mismatches /
+  // db-faults after this single restart (e.g. a bun-linked checkout on a
+  // branch, or a still-missing state dir), we warn + continue rather than loop.
   const deadline = Date.now() + readyTimeoutMs;
   for (;;) {
     const after = await deps.probeHealthVersion(port);
-    if (after !== null && after.version === installedVersion) {
+    if (probeHealed(after)) {
       return restartedResult(installedVersion);
     }
     if (Date.now() >= deadline) {
-      // Report the last-observed (still-stale) version if the hub came back.
-      return stillMismatchedResult(after?.version ?? runningVersion);
+      return stillMismatchedResult(after ?? { version: runningVersion });
     }
     if (readyPollMs > 0) await deps.sleep(readyPollMs);
     else break;
   }
   // readyPollMs === 0 fast-path: one more probe, then settle.
   const finalProbe = await deps.probeHealthVersion(port);
-  if (finalProbe !== null && finalProbe.version === installedVersion) {
+  if (probeHealed(finalProbe)) {
     return restartedResult(installedVersion);
   }
-  return stillMismatchedResult(finalProbe?.version ?? runningVersion);
+  return stillMismatchedResult(finalProbe ?? { version: runningVersion });
 }
 
 /**


### PR DESCRIPTION
Fixes #593
Fixes #594

Theme: stop trusting, start verifying — convert two field-reported silent failures into self-healing or loud, actionable errors. Both reproduced on Aaron's macOS laptop (hub 0.6.4-rc.10).

## #593 — `expose --cloudflare`: verify credentials + verify the connector actually connects

**Reuse-path credentials self-heal.** `findTunnelByName` only proves the tunnel exists *account-side*. The connector needs the *local* `~/.cloudflared/<uuid>.json` creds file (written at `tunnel create`) to authenticate, and that file gets lost on clean-slate flows (`rm -rf ~/.parachute`) while the account-side tunnel survives. Field repro: tunnel reused, "✓ tunnel up" printed, connector crash-looping on `credentials file … doesn't exist`, every public request → Cloudflare **error 1033**.

- When the creds file is missing on the reuse path: `cloudflared tunnel delete --force <name>` (force so a stale registered connector doesn't block the delete) then recreate, which re-writes a fresh creds file. `routeDns` already uses `--overwrite-dns`, so the hostname's CNAME repoints to the new UUID.
- **Recreate-vs-fail decision:** auto-recreate is preferred (the field case confirmed `tunnel delete` + re-run heals cleanly). If the delete itself fails, we print the exact recovery commands and return 1 — never a false "✓".

**Post-start connection verification.** Pid existing ≠ connected. After spawning/installing the connector, poll `cloudflared tunnel info` for a live edge connection (bounded, ~25s) before printing "✓ Cloudflare tunnel up". On timeout: fail loudly naming the connector log path + the crash-loop signature to grep for.

New `tunnel.ts` helpers: `deleteTunnel` (force), `tunnelConnectionCount` (defensive across the `conns`/`connections` JSON shapes; swallows CLI/parse errors → 0). New injectable `verifyConnection`/`verifyTimeoutMs`/`verifyPollMs`/`sleep` seams, defaulted to inert stubs for stub-spawner suites and the real bounded poll in production.

## #594 — hub self-heal on a dead SQLite handle + DB liveness in `/health`

Operator deleted `~/.parachute` under a running hub: the process keeps an fd to the unlinked `hub.db` inode → cached reads half-work, every write/WAL op throws `disk I/O error`. `/health` stayed 200 (never touched the DB) while every DB route 500'd indefinitely with "no error detail" — the worst possible failure shape (a crash-restart would have self-healed in seconds).

**Self-heal or die.** New `src/hub-db-liveness.ts`:
- `classifyDbError` — **fatal** persistent-corruption class (disk I/O error / malformed image / CORRUPT / NOTADB) vs **transient** `SQLITE_BUSY`/`LOCKED` (explicitly NON-fatal so momentary lock contention never kills the hub) vs **other** (propagates unchanged).
- `DbHolder` — mutable handle + `healOrExit`. The hub-server request loop's new top-level catch routes a fatal escaping throw to it: attempt **ONE** reopen (verified with `SELECT 1` on the fresh handle), swap on success; if reopen fails OR the reopened handle is also dead, log loudly + `exit(1)` so the platform manager restarts with a fresh handle.

**Reopen-vs-exit policy:** never exit on the first fatal error without the reopen attempt; exit only when the reopen can't produce a live handle (the dir/file is genuinely gone/corrupt) — the platform manager owns the durable fix. Transient errors never trigger either path.

**DB liveness in `/health`.** Adds a `db` field ("ok" / "error: <class>" / "unconfigured") via a cheap `SELECT 1` that never throws (a thrown probe would 500 /health). Status stays 200 always (process liveness, not readiness). Threaded into #591's `ensureHubVersionMatches` adoption probe: a hub reporting a db fault is treated as needing a restart (same restart-once machinery) even when its version matches — so adoption no longer adopts a broken-DB hub behind a green /health.

**Error detail.** DB throws escaping a handler are wrapped into the structured `{ error, error_description }` body (503 `db_unavailable`) so the CLI's `asErrorBody` prints the real cause instead of "HTTP 500 with no error detail".

### Live verification (#594)
Sandboxed `parachute serve` on a spare port (`PARACHUTE_HOME=/tmp/...`), deleted its home mid-run → next DB route returned a structured **503**, the holder logged `persistent SQLite failure (disk I/O error). Attempting one DB handle reopen… reopened successfully; continuing`, and subsequent requests returned **200** with `/health` `db:"ok"`. Live launchd hub on :1939 verified healthy after.

## Test plan
- `bun run typecheck` — clean.
- `bun test ./src` — **3095 pass, 1 skip, 0 fail** (3096 across 125 files).
- New behavior coverage:
  - #593: creds-missing→recreate; delete-fails→recovery-commands (no false success); connection-verify success + timeout branches; `defaultVerifyConnection` poll loop (connects / times out); direct `deleteTunnel` + `tunnelConnectionCount` unit tests. Existing reuse-path tests seed a fake creds file so they exercise plain reuse.
  - #594: `classifyDbError` fatal/transient/other; `probeDbLiveness` ok/error; `DbHolder` reopen-once-success / reopen-fail→exit / reopened-handle-dead→exit / transient-ignored (SQLITE_BUSY not fatal); `/health` db field ok + error states; fatal-throw→structured 503 + `onDbError` invoked; non-DB throw propagates; adoption probe restarts on db-fault, matches on healthy, db-specific still-mismatched message, no-db-field hub not treated as a fault.

All injectable: tests never touch real cloudflared, real launchctl/hub, or exit the test process.

## Notes
- No version bump (per RC-versioning discipline — bump+tag happen on ship signal).
- The branch carries one pre-existing doc-only commit (`3099355` changelog accuracy nits) that was on `ag-unforced-dev` but not yet on `main`; preserved via rebase rather than clobbered. It'll merge alongside these two fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)