### PR TITLE
release: hub 0.6.5-rc.1 (expose + DB self-heal robustness #597)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.4",
+  "version": "0.6.5-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
First rc of the 0.6.5 line. Ships #597 (fixes #593 #594 — the last two silent-failure classes from Aaron's laptop field testing) atop 0.6.4 stable.

Tag v0.6.5-rc.1 → npm dist-tag `rc`. Stable @latest stays at 0.6.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)