### PR TITLE
fix(oauth): close authorize open-redirect (#570) + disable unauthorizable consent Approve (#431)

### DIFF
--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -8127,6 +8127,171 @@ describe("zero-vault non-admin privesc gate (hub#429 reviewer)", () => {
   });
 });
 
+// hub#431 — consent UX: a non-admin with zero assigned vaults requesting a
+// NAMED vault scope (`vault:<name>:read`) renders an enabled Approve button
+// pre-fix, even though the POST is correctly 400'd. (Unnamed `vault:read` was
+// already covered by the empty-picker disable; the gap was named scopes,
+// which carry no picker.) The fix disables Approve + shows explanatory copy.
+describe("handleAuthorizeGet — zero-vault non-admin named vault scope disables Approve (hub#431)", () => {
+  test("non-admin / zero vaults / named vault scope → Approve disabled + copy", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "admin-aaron", "pw");
+      const bob = await createUser(db, "bob", "pw", { allowMulti: true });
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          // NAMED vault scope — no picker, so pre-fix Approve stayed enabled.
+          scope: "vault:default:read",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("You have no assigned vaults");
+      expect(html).toMatch(/<button[^>]*name="approve"[^>]*value="yes"[^>]*disabled/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("admin / named vault scope → Approve enabled", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const admin = await createUser(db, "admin-aaron", "pw");
+      const session = createSession(db, { userId: admin.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          scope: "vault:default:read",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).not.toContain("You have no assigned vaults");
+      expect(html).not.toMatch(/<button[^>]*name="approve"[^>]*value="yes"[^>]*disabled/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("non-admin WITH an assigned vault / named vault scope → Approve enabled", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "admin-aaron", "pw");
+      const bob = await createUser(db, "bob", "pw", { allowMulti: true });
+      setUserVaults(db, bob.id, ["default"]);
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          scope: "vault:default:read",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).not.toContain("You have no assigned vaults");
+      expect(html).not.toMatch(/<button[^>]*name="approve"[^>]*value="yes"[^>]*disabled/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("non-admin / zero vaults / NON-vault scope → Approve enabled", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "admin-aaron", "pw");
+      const bob = await createUser(db, "bob", "pw", { allowMulti: true });
+      const session = createSession(db, { userId: bob.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          // Non-vault scope — the user can still consent without a vault.
+          scope: "scribe:transcribe",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, {
+        issuer: ISSUER,
+        loadServicesManifest: fixtureLoadServicesManifest,
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).not.toContain("You have no assigned vaults");
+      expect(html).not.toMatch(/<button[^>]*name="approve"[^>]*value="yes"[^>]*disabled/);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
 // RFC 8707 resource binding (fix #461). A friend connecting an MCP client to
 // ONE vault (`<origin>/vault/<name>/mcp`) must see ONLY that vault's scopes on
 // consent, and the minted token must carry the narrow, NAMED scope +

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -578,6 +578,176 @@ describe("handleAuthorizeGet", () => {
   });
 });
 
+// hub#570 — open-redirect: protocol errors (unsupported_response_type,
+// invalid_request for non-S256 PKCE) MUST NOT redirect to the supplied
+// redirect_uri until the (client_id, redirect_uri) pair is confirmed
+// registered. RFC 6749 §4.1.2.1: an unvalidated redirect_uri error is shown
+// to the user, never redirected. Pre-fix, an attacker with a valid client_id
+// + crafted redirect_uri + bad response_type got an error redirect to the
+// attacker-controlled URI.
+describe("handleAuthorizeGet — error redirects gated on redirect_uri validation (hub#570)", () => {
+  test("invalid response_type + UNREGISTERED redirect_uri → HTML error, no redirect", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          // Crafted attacker-controlled URI, NOT registered for this client.
+          redirect_uri: "https://evil.example/steal",
+          response_type: "token",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          state: "abc",
+        }),
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      // Must be the HTML "Redirect mismatch" error page, NOT a 302 to evil.
+      expect(res.status).toBe(400);
+      expect(res.headers.get("location")).toBeNull();
+      const body = await res.text();
+      expect(body).toContain("Redirect mismatch");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("invalid code_challenge_method + UNREGISTERED redirect_uri → HTML error, no redirect", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://evil.example/steal",
+          response_type: "code",
+          code_challenge: "challenge",
+          code_challenge_method: "plain",
+          state: "abc",
+        }),
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(400);
+      expect(res.headers.get("location")).toBeNull();
+      const body = await res.text();
+      expect(body).toContain("Redirect mismatch");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("invalid response_type + VALID registered redirect_uri → error redirect (spec-correct)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "token",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          state: "abc",
+        }),
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      // Pair is registered → redirecting the protocol error is RFC-correct.
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.get("location") ?? "");
+      expect(loc.origin + loc.pathname).toBe("https://app.example/cb");
+      expect(loc.searchParams.get("error")).toBe("unsupported_response_type");
+      expect(loc.searchParams.get("state")).toBe("abc");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("invalid code_challenge_method + VALID registered redirect_uri → error redirect (spec-correct)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: "challenge",
+          code_challenge_method: "plain",
+          state: "abc",
+        }),
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.get("location") ?? "");
+      expect(loc.origin + loc.pathname).toBe("https://app.example/cb");
+      expect(loc.searchParams.get("error")).toBe("invalid_request");
+      expect(loc.searchParams.get("state")).toBe("abc");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("unknown client_id + invalid response_type → HTML error, no redirect", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: "no-such-client",
+          redirect_uri: "https://evil.example/steal",
+          response_type: "token",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        }),
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(400);
+      expect(res.headers.get("location")).toBeNull();
+      const body = await res.text();
+      expect(body).toContain("Unknown application");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("valid full flow still reaches consent (regression guard)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "MyApp",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:read",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("Approve");
+      expect(html).toContain('name="__action" value="consent"');
+    } finally {
+      cleanup();
+    }
+  });
+});
+
 // Q1 of 2026-04-28-vault-config-and-scopes.md: an unnamed `vault:<verb>` is
 // ambiguous, so the consent screen forces the operator to pick a vault before
 // the JWT is minted. Picked vault rewrites the scope to `vault:<picked>:<verb>`

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -746,6 +746,128 @@ describe("handleAuthorizeGet — error redirects gated on redirect_uri validatio
       cleanup();
     }
   });
+
+  test("pending client + valid session + bad response_type → NOT promoted to approved, request rejected (#570 reviewer fold)", async () => {
+    // The pending-client auto-approve (`approveClient`) is a DB state
+    // mutation. It must not fire for a request we're about to reject — so
+    // redirect_uri validation (and, transitively, the protocol-error checks)
+    // gate it. A malformed `response_type` on a registered-but-pending
+    // client must leave the client `pending`, not silently promote it.
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "MyApp",
+        status: "pending",
+      });
+      // Sanity: the client starts pending.
+      expect(getClient(db, reg.client.clientId)?.status).toBe("pending");
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          // Valid REGISTERED redirect_uri — so the rejection is driven by the
+          // malformed response_type, not the redirect mismatch. This isolates
+          // the "mutation before full validation" class the fold closes.
+          redirect_uri: "https://app.example/cb",
+          response_type: "token",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          state: "pend-1",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      // Registered redirect_uri → the protocol error redirects (spec-correct).
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.get("location") ?? "");
+      expect(loc.searchParams.get("error")).toBe("unsupported_response_type");
+      // The crux: the client must STILL be pending — no silent promotion.
+      expect(getClient(db, reg.client.clientId)?.status).toBe("pending");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("pending client + valid session + UNREGISTERED redirect_uri → HTML error, not promoted (#570 reviewer fold)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "MyApp",
+        status: "pending",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://evil.example/steal",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(400);
+      expect(res.headers.get("location")).toBeNull();
+      expect(await res.text()).toContain("Redirect mismatch");
+      // Still pending — unregistered redirect_uri never promotes the client.
+      expect(getClient(db, reg.client.clientId)?.status).toBe("pending");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("pending client + valid session + valid request → auto-approved → consent (happy path preserved)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "MyApp",
+        status: "pending",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:read",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      // Valid client + valid uri + pending → auto-approve → consent render.
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain('name="__action" value="consent"');
+      // The valid request DID promote the client (auto-approve still works).
+      expect(getClient(db, reg.client.clientId)?.status).toBe("approved");
+    } finally {
+      cleanup();
+    }
+  });
 });
 
 // Q1 of 2026-04-28-vault-config-and-scopes.md: an unnamed `vault:<verb>` is

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -225,6 +225,33 @@ describe("renderConsent", () => {
     expect(html).toContain("no vaults exist");
     expect(html).toContain('value="yes" class="btn btn-primary" disabled');
   });
+
+  test("disables Approve + shows copy when user can't authorize (hub#431)", () => {
+    const html = renderConsent({
+      params: { ...PARAMS, scope: "vault:work:read" },
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:work:read"],
+      userCanAuthorizeRequest: false,
+    });
+    expect(html).toContain("You have no assigned vaults");
+    expect(html).toContain("ask the hub admin".replace("ask", "Ask"));
+    expect(html).toContain('value="yes" class="btn btn-primary" disabled');
+  });
+
+  test("leaves Approve enabled when userCanAuthorizeRequest is true (hub#431)", () => {
+    const html = renderConsent({
+      params: { ...PARAMS, scope: "vault:work:read" },
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:work:read"],
+      userCanAuthorizeRequest: true,
+    });
+    expect(html).not.toContain("You have no assigned vaults");
+    expect(html).not.toContain('value="yes" class="btn btn-primary" disabled');
+  });
 });
 
 describe("renderError", () => {

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -2584,6 +2584,23 @@ function consentProps(
 ) {
   const scopes = params.scope.split(" ").filter((s) => s.length > 0);
   const unnamedVerbs = unnamedVaultVerbs(scopes);
+  // Zero-vault non-admin can't authorize a vault-scoped request (hub#431).
+  // The POST handler already 400s this case ("No vaults assigned"); this
+  // flag lets the consent screen render Approve disabled + explain why,
+  // instead of showing an enabled button that lands the user on an error.
+  // Mirrors the vault-scope detection in `handleConsentSubmit`'s zero-vault
+  // gate. Non-vault scopes (`scribe:transcribe`, etc.) stay authorizable.
+  const requestsVaultScope = scopes.some((s) => {
+    if (s === "vault:read" || s === "vault:write" || s === "vault:admin") return true;
+    const parts = s.split(":");
+    return (
+      parts.length === 3 &&
+      parts[0] === "vault" &&
+      parts[2] !== undefined &&
+      VAULT_VERBS.has(parts[2])
+    );
+  });
+  const userCanAuthorizeRequest = userIsAdmin || assignedVaults.length > 0 || !requestsVaultScope;
   // Multi-user Phase 2 PR 2 stale-assignment branch (hub#284 generalized
   // from one vault to N). A non-admin user whose entire vault list has
   // been removed from services.json — admin removed / renamed the vaults
@@ -2709,6 +2726,7 @@ function consentProps(
     // verb against the stale assignment).
     blockApproveForStaleAssignment:
       staleAssignedVault !== undefined && (unnamedVerbs.length > 0 || hasNamedStaleVaultScope),
+    userCanAuthorizeRequest,
   };
 }
 

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -861,22 +861,14 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   if ("error" in parsed) {
     return htmlError("Invalid authorization request", parsed.error, 400);
   }
-  if (parsed.responseType !== "code") {
-    return oauthErrorRedirect(
-      parsed.redirectUri,
-      "unsupported_response_type",
-      "only response_type=code is supported",
-      parsed.state,
-    );
-  }
-  if (parsed.codeChallengeMethod !== "S256") {
-    return oauthErrorRedirect(
-      parsed.redirectUri,
-      "invalid_request",
-      "PKCE S256 is required",
-      parsed.state,
-    );
-  }
+  // NOTE: response_type / code_challenge_method validation is DELIBERATELY
+  // deferred until after the (client_id, redirect_uri) pair is confirmed
+  // registered (below, just past `requireRegisteredRedirectUri`). RFC 6749
+  // §4.1.2.1: when the redirect_uri can't be validated against the client,
+  // errors MUST be shown to the user — NOT redirected to the supplied URI.
+  // Redirecting here (pre-validation) on a crafted redirect_uri is an open
+  // redirect (hub#570). Once the pair is validated, redirecting these errors
+  // back to the now-trusted URI is spec-correct.
   let client = getClient(db, parsed.clientId);
   if (!client) {
     // Can't safely redirect — we don't trust the redirect_uri until we've
@@ -1002,6 +994,27 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
       "Redirect mismatch",
       "The redirect_uri does not match any URI registered for this app.",
       400,
+    );
+  }
+
+  // The (client_id, redirect_uri) pair is now confirmed registered, so it is
+  // spec-correct (RFC 6749 §4.1.2.1) to deliver these protocol errors by
+  // redirect to that trusted URI. Validating BEFORE these checks closes the
+  // pre-validation open-redirect on a crafted redirect_uri (hub#570).
+  if (parsed.responseType !== "code") {
+    return oauthErrorRedirect(
+      parsed.redirectUri,
+      "unsupported_response_type",
+      "only response_type=code is supported",
+      parsed.state,
+    );
+  }
+  if (parsed.codeChallengeMethod !== "S256") {
+    return oauthErrorRedirect(
+      parsed.redirectUri,
+      "invalid_request",
+      "PKCE S256 is required",
+      parsed.state,
     );
   }
 

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -920,6 +920,49 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
     url.searchParams.set("scope", parsed.scope);
   }
 
+  // Validate the FULL request BEFORE any state mutation (the pending-client
+  // auto-approve below calls `approveClient`). Two reasons, both #570:
+  //
+  //   1. RFC 6749 §4.1.2.1 — an unvalidated redirect_uri error is shown to
+  //      the user, never redirected. `requireRegisteredRedirectUri` first
+  //      confirms the (client_id, redirect_uri) pair is registered; only then
+  //      may we redirect the protocol errors (response_type / PKCE) to it.
+  //   2. We must not permanently promote a pending client to `approved` for a
+  //      request we're about to reject. Pre-fix the redirect-uri + protocol
+  //      checks sat BELOW the auto-approve block, so a malformed request
+  //      (bad response_type / PKCE) against a registered-but-pending client
+  //      mutated the DB before validation ever ran (#570 reviewer fold).
+  //
+  // So: redirect_uri registration → response_type → PKCE, all ahead of the
+  // pending-client auto-approve.
+  try {
+    requireRegisteredRedirectUri(client, parsed.redirectUri);
+  } catch {
+    return htmlError(
+      "Redirect mismatch",
+      "The redirect_uri does not match any URI registered for this app.",
+      400,
+    );
+  }
+  // The pair is confirmed registered, so redirecting these protocol errors to
+  // it is spec-correct (RFC 6749 §4.1.2.1).
+  if (parsed.responseType !== "code") {
+    return oauthErrorRedirect(
+      parsed.redirectUri,
+      "unsupported_response_type",
+      "only response_type=code is supported",
+      parsed.state,
+    );
+  }
+  if (parsed.codeChallengeMethod !== "S256") {
+    return oauthErrorRedirect(
+      parsed.redirectUri,
+      "invalid_request",
+      "PKCE S256 is required",
+      parsed.state,
+    );
+  }
+
   if (client.status !== "approved") {
     // Single-consent change (2026-05-29): the separate operator "approve this
     // client" gate is retired — the user's OAuth consent IS the authorization.
@@ -986,36 +1029,6 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
       return pendingClientResponse(db, req, client, url, deps);
     }
     client = refreshed;
-  }
-  try {
-    requireRegisteredRedirectUri(client, parsed.redirectUri);
-  } catch {
-    return htmlError(
-      "Redirect mismatch",
-      "The redirect_uri does not match any URI registered for this app.",
-      400,
-    );
-  }
-
-  // The (client_id, redirect_uri) pair is now confirmed registered, so it is
-  // spec-correct (RFC 6749 §4.1.2.1) to deliver these protocol errors by
-  // redirect to that trusted URI. Validating BEFORE these checks closes the
-  // pre-validation open-redirect on a crafted redirect_uri (hub#570).
-  if (parsed.responseType !== "code") {
-    return oauthErrorRedirect(
-      parsed.redirectUri,
-      "unsupported_response_type",
-      "only response_type=code is supported",
-      parsed.state,
-    );
-  }
-  if (parsed.codeChallengeMethod !== "S256") {
-    return oauthErrorRedirect(
-      parsed.redirectUri,
-      "invalid_request",
-      "PKCE S256 is required",
-      parsed.state,
-    );
   }
 
   // Operator-only scope gate (#96). Reject any request that names a scope

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -20,7 +20,7 @@
  *     module scopes that the hub doesn't know about) render verbatim.
  *   - **No JavaScript.** Entirely form-based. Submit is the only interaction.
  */
-import { brandMarkSvg, WORDMARK_TEXT } from "./brand.ts";
+import { WORDMARK_TEXT, brandMarkSvg } from "./brand.ts";
 import { renderCsrfHiddenInput } from "./csrf.ts";
 import { type ScopeExplanation, explainScope } from "./scope-explanations.ts";
 
@@ -138,6 +138,15 @@ export interface ConsentViewProps {
    * the user can still proceed.
    */
   blockApproveForStaleAssignment?: boolean;
+  /**
+   * Multi-user (hub#431): false when the signed-in user can't authorize this
+   * request at all — a non-admin with zero assigned vaults requesting a vault
+   * scope (named or unnamed). The POST handler already 400s this case ("No
+   * vaults assigned"); this flag lets the consent screen render Approve
+   * disabled + show explanatory copy instead of an enabled button that lands
+   * the user on an error page. Defaults to authorizable when omitted.
+   */
+  userCanAuthorizeRequest?: boolean;
 }
 
 export interface VaultPicker {
@@ -318,6 +327,7 @@ export function renderConsent(props: ConsentViewProps): string {
     displayVault,
     staleAssignedVault,
     blockApproveForStaleAssignment,
+    userCanAuthorizeRequest,
   } = props;
   // Substitute unnamed `vault:<verb>` rows with the resolved named form so
   // the operator sees the scope shape that will appear in the token. Raw
@@ -345,11 +355,16 @@ export function renderConsent(props: ConsentViewProps): string {
   // requested scope actually depends on a vault — non-vault flows (e.g.
   // `scribe:transcribe` only) keep Approve enabled so the user can still
   // proceed despite the informational banner.
+  // Zero-vault non-admin requesting a vault scope (hub#431): the POST handler
+  // refuses with 400 "No vaults assigned", so render Approve disabled rather
+  // than leading the user to click into an error page.
+  const cannotAuthorize = userCanAuthorizeRequest === false;
   const approveDisabled =
     (vaultPicker &&
       vaultPicker.lockedVault === undefined &&
       vaultPicker.availableVaults.length === 0) ||
-    blockApproveForStaleAssignment === true
+    blockApproveForStaleAssignment === true ||
+    cannotAuthorize
       ? " disabled"
       : "";
   // Banner copy (hub#284). Worded to the *user* — "ask the admin" framing
@@ -366,6 +381,16 @@ export function renderConsent(props: ConsentViewProps): string {
             again.
           </p>`
       : "";
+  // No-vaults-assigned banner (hub#431). Shown when a non-admin with zero
+  // assigned vaults requests a vault scope — Approve is disabled above, this
+  // explains why and points at admin remediation.
+  const noVaultsBanner = cannotAuthorize
+    ? `<p class="stale-assignment-banner" role="alert">
+            <strong>You have no assigned vaults.</strong>
+            Ask the hub admin to assign you a vault via <code>/admin/users</code>
+            before authorizing vault access.
+          </p>`
+    : "";
   const body = `
     <div class="card">
       <div class="card-header">
@@ -383,6 +408,7 @@ export function renderConsent(props: ConsentViewProps): string {
         </p>
       </div>
       ${staleBanner}
+      ${noVaultsBanner}
       <section class="scopes">
         <h2 class="scopes-title">Permissions requested</h2>
         <ul class="scope-list">${scopeRows}</ul>


### PR DESCRIPTION
Two OAuth fixes in `src/oauth-handlers.ts` / `src/oauth-ui.ts`, one commit each.

## #570 — open redirect on `/oauth/authorize` error paths (HIGH, security)

**The bug.** On `GET /oauth/authorize`, two error paths redirected to the **supplied** `redirect_uri` BEFORE the client was looked up and the `redirect_uri` validated against the client's registered URIs:
- `unsupported_response_type` (`response_type != code`)
- `invalid_request` (`code_challenge_method != S256`)

An attacker with a valid `client_id` + a crafted `redirect_uri=https://evil.example` + an invalid `response_type` got an error redirect to the attacker-controlled URI. Leak is low-value (error params only, no codes/tokens), but it's a genuine open redirect.

**RFC.** RFC 6749 §4.1.2.1: when the client identity / `redirect_uri` can't be validated, errors MUST be shown to the user, NOT redirected.

**Fix.** Moved the `response_type` / `code_challenge_method` checks to AFTER `getClient()` + `requireRegisteredRedirectUri()`. The `(client_id, redirect_uri)` pair is confirmed registered before any error redirect to that URI. Once validated, redirecting these protocol errors is spec-correct and still fires (regression-tested).

**Audit — every `oauthErrorRedirect(...)` call site, confirmed gated:**
| file:line | error | posture |
|---|---|---|
| `src/oauth-handlers.ts:865` (was) | `unsupported_response_type` | **was the bug** → moved past validation (now ~1017) |
| `src/oauth-handlers.ts:873` (was) | `invalid_request` (PKCE) | **was the bug** → moved past validation (now ~1025) |
| `src/oauth-handlers.ts:1015` | `invalid_scope` (operator-only) | already after `requireRegisteredRedirectUri` ✓ |
| `src/oauth-handlers.ts:1282` | `invalid_scope` (cap → empty) | inside `issueAuthCodeRedirect`, post-validation ✓ |
| `src/oauth-handlers.ts:1490` | `access_denied` (POST deny) | after `getClient` + `requireRegisteredRedirectUri` ✓ |
| `src/oauth-handlers.ts:1503` | `invalid_scope` (POST defense) | same, post-validation ✓ |

POST/consent-submit path was already safe (lookup + URI validation precede both its redirects).

## #431 — consent renders enabled Approve for vaults the user can't authorize (cosmetic)

Server already 400s the POST (`handleConsentSubmit`, "No vaults assigned" per hub#429). UI-only: a non-admin with zero assigned vaults requesting a vault scope saw an **enabled** Approve button → clicking it landed on an error page. The gap was **named** vault scopes (`vault:<name>:read`) — unnamed `vault:<verb>` already disabled Approve via the empty-picker path, but named scopes carry no picker.

**Fix.** `consentProps()` computes `userCanAuthorizeRequest` (false when not-admin AND zero assigned vaults AND request includes a vault scope), threaded to `renderConsent()`. When false: Approve renders `disabled` (matching the existing empty-picker / stale-assignment disable precedents) + a banner — "You have no assigned vaults — ask the hub admin to assign you a vault before authorizing vault access."

## Test plan

`bun test ./src`: **3109 pass, 1 skip, 0 fail** (35783 expect()).
`bun run typecheck`: clean.
Live hub `curl /health`: ok.

New tests:
- `oauth-handlers.test.ts` hub#570 block (6): unregistered redirect_uri + bad response_type/PKCE → HTML error no redirect (exploit case ×2); valid registered redirect_uri + bad response_type/PKCE → error redirect (spec-correct ×2); unknown client + bad response_type → HTML error; valid full flow → consent (regression).
- `oauth-handlers.test.ts` hub#431 block (4): non-admin/zero-vault/named-vault-scope → Approve disabled + copy; admin → enabled; non-admin with assigned vault → enabled; non-vault scope → enabled.
- `oauth-ui.test.ts` (2): `userCanAuthorizeRequest=false` → disabled + copy; `=true` → enabled.

## Out of scope
2 pre-existing biome lint findings in `src/oauth-handlers.ts:1773` (useTemplate / noUnusedTemplateLiteral on an unrelated `console.warn`) — present on `main`, untouched. No version bump (per instructions).

Fixes #570
Fixes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)