### PR TITLE
release: hub 0.6.5-rc.2 (OAuth open-redirect fix + consent UX #599)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.5-rc.1",
+  "version": "0.6.5-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Bumps to 0.6.5-rc.2, bundling #599 (fixes #570 HIGH open-redirect + #431) atop rc.1's #593/#594 robustness.

Tag v0.6.5-rc.2 → npm dist-tag `rc`. Stable @latest stays at 0.6.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)