### PR TITLE
release: hub 0.6.5-rc.3 (supervisor reclaims squatted ports #601)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.5-rc.2",
+  "version": "0.6.5-rc.3",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Bumps to 0.6.5-rc.3, bundling #601 (fixes #522 #582 #519). Tag → npm `rc`. Stable @latest stays 0.6.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)