### PR TITLE
fix: three issue-sweep papercuts (notes-serve idleTimeout, hub.html regen, depcheck dist build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   },
   "scripts": {
     "start": "bun src/cli.ts",
+    "build:depcheck": "[ ! -f packages/depcheck/package.json ] || [ -f packages/depcheck/dist/index.js ] || bun run --cwd packages/depcheck build",
+    "prepare": "bun run build:depcheck",
+    "pretest": "bun run build:depcheck",
     "test": "bun test ./src",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/src/__tests__/hub.test.ts
+++ b/src/__tests__/hub.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { renderHub, writeHubFile } from "../hub.ts";
@@ -296,6 +296,32 @@ describe("writeHubFile", () => {
       expect(written).toBe(path);
       expect(existsSync(path)).toBe(true);
       const content = readFileSync(path, "utf8");
+      expect(content).toBe(renderHub());
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // hub#171: serve regenerates hub.html on EVERY start (the `!existsSync`
+  // guard in commands/serve.ts was dropped), so writeHubFile must be safe to
+  // call when the file already exists and must overwrite stale content with
+  // a fresh render from current code — otherwise an upgrade serves the old
+  // page until an unrelated `parachute expose` re-runs.
+  test("overwrites a pre-existing stale hub.html with a fresh render (hub#171)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pcli-hub-"));
+    try {
+      const path = join(dir, "well-known", "hub.html");
+      // First write creates the well-known dir + a real file; then plant
+      // stale content to simulate an old hub.html left over from a prior code
+      // version after `git pull` + `parachute restart hub`.
+      writeHubFile(path);
+      writeFileSync(path, "<!-- stale pre-upgrade hub.html -->");
+      expect(readFileSync(path, "utf8")).toContain("stale");
+
+      const written = writeHubFile(path);
+      expect(written).toBe(path);
+      const content = readFileSync(path, "utf8");
+      expect(content).not.toContain("stale");
       expect(content).toBe(renderHub());
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/src/__tests__/notes-serve.test.ts
+++ b/src/__tests__/notes-serve.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeMount,
   notesDistCandidates,
   notesFetch,
+  notesServeOptions,
   resolveNotesDistFrom,
 } from "../notes-serve.ts";
 
@@ -25,6 +26,15 @@ function makeHarness(): Harness {
 function req(path: string): Request {
   return new Request(`http://127.0.0.1${path}`);
 }
+
+describe("notesServeOptions (hub#399 residual)", () => {
+  test("sets idleTimeout: 255 to outlast edge keep-alive pools, matching hub-server.ts", () => {
+    const opts = notesServeOptions(5173, "/tmp/dist", "/notes");
+    expect(opts.idleTimeout).toBe(255);
+    expect(opts.port).toBe(5173);
+    expect(typeof opts.fetch).toBe("function");
+  });
+});
 
 describe("normalizeMount", () => {
   test("strips trailing slashes", () => {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -337,13 +337,22 @@ export async function serve(opts: ServeOpts = {}): Promise<{
   // hatch for setups that want loopback-only inside a sidecar.
   const hostname = env.PARACHUTE_BIND_HOST || "0.0.0.0";
 
-  // Ensure the well-known dir exists, and seed a static hub.html so `/`
+  // Ensure the well-known dir exists, and (re)write the static hub.html so `/`
   // serves something coherent on a fresh disk (the dynamic path through
   // `hubFetch` takes over once a DB row exists; the disk file is the
   // signed-out fallback).
+  //
+  // Regenerate on EVERY serve start, not just when the file is absent (#171):
+  // hub.html is a served artifact built from current code, and code ships via
+  // `git pull` + `parachute restart hub`. Guarding on `!existsSync` left the
+  // stale post-upgrade file on disk until an unrelated `parachute expose`
+  // re-ran — so operators saw old hub.html after an upgrade. The write is a
+  // cheap, deterministic, atomic (tmp+rename) render of static signed-out
+  // HTML with no expose-state or DB dependency, so it's safe to call every
+  // start.
   if (!existsSync(WELL_KNOWN_DIR)) mkdirSync(WELL_KNOWN_DIR, { recursive: true });
   const hubHtmlPath = join(WELL_KNOWN_DIR, "hub.html");
-  if (!existsSync(hubHtmlPath)) writeHubFile(hubHtmlPath);
+  writeHubFile(hubHtmlPath);
 
   const dbPath = hubDbPath();
   // Self-heal-or-die DB holder (#594). The handle lives behind a mutable

--- a/src/notes-serve.ts
+++ b/src/notes-serve.ts
@@ -176,6 +176,29 @@ export function notesFetch(dist: string, mount: string): (req: Request) => Respo
   };
 }
 
+/**
+ * Build the `Bun.serve` config for the notes static server.
+ *
+ * `idleTimeout: 255` matches hub-server.ts. When this static-serve sits behind
+ * an edge proxy that pools keep-alive connections (Render, Cloudflare, fly
+ * proxy), the edge's idle timeout outlasts Bun's default — the proxy reuses a
+ * connection we just closed and returns a "random" 502. 255s comfortably
+ * exceeds Render's community-observed ~120s edge pool TTL. Closes the hub#399
+ * residual on the second serve entrypoint (the Notes PWA path). Exported so a
+ * test can assert the option is set without booting a server.
+ */
+export function notesServeOptions(
+  port: number,
+  dist: string,
+  mount: string,
+): { port: number; idleTimeout: number; fetch: (req: Request) => Response } {
+  return {
+    port,
+    idleTimeout: 255,
+    fetch: notesFetch(dist, mount),
+  };
+}
+
 if (import.meta.main) {
   const { port, dist: distArg, mount } = parseArgs(process.argv.slice(2));
 
@@ -187,10 +210,7 @@ if (import.meta.main) {
     process.exit(1);
   }
 
-  Bun.serve({
-    port,
-    fetch: notesFetch(dist, mount),
-  });
+  Bun.serve(notesServeOptions(port, dist, mount));
 
   console.log(`notes static-serve listening on :${port} (dist=${dist}, mount=${mount || "/"})`);
 }


### PR DESCRIPTION
Three confirmed-real papercuts found in an issue sweep, one logical commit each. Each item's described state was verified to still exist before changing.

## 1. notes-serve missing idleTimeout — closes the #399 residual

PR #400 gave the main hub server `Bun.serve({ idleTimeout: 255 })` to defeat the Render edge keep-alive 502 race, but the **second** serve entrypoint — `src/notes-serve.ts`, the Notes PWA static-serve shim — never got it, so the same race persisted behind a reverse proxy on the notes path. Extracted an exported `notesServeOptions(port, dist, mount)` carrying `idleTimeout: 255` (matching hub-server.ts's value + comment shape); a test asserts the option is set without booting a server. #399 is already closed, so this references it rather than auto-closing.

## 2. hub.html regen on every serve start — `Fixes #171`

`commands/serve.ts` only wrote `hub.html` when `!existsSync(hubHtmlPath)`, so after an upgrade (`git pull` + `parachute restart hub`) the hub kept serving the OLD hub.html until an unrelated `parachute expose` re-ran. Dropped the existence guard so `writeHubFile` runs on every start. Verified safe to call unconditionally: it renders static signed-out HTML from code with **no expose-state or DB dependency** and writes atomically (tmp + rename). Nothing depends on the file persisting across restarts — the dynamic session-aware `/` path takes over whenever a DB row exists; the disk file is only the signed-out fallback. Added a unit test asserting it overwrites a pre-existing stale file with a fresh render.

## 3. depcheck dist not built on fresh clone — `Fixes #505`

`@openparachute/depcheck`'s `exports` point at `./dist/index.js` (dist gitignored, no `bun`→src condition), so a fresh clone/worktree symlinks the package but lacks its dist → any depcheck import fails with "Cannot find module" (`0 pass / 1 fail / 1 error`). CI already builds it (release.yml), so this only bit local dev / worktrees; two reviewers hit it independently.

**Approach chosen (option a):** a guarded `build:depcheck` script wired to both `prepare` (runs on `bun install`, including `--frozen-lockfile` — verified) and `pretest` (runs before `bun run test`). The guard builds **only** when the workspace source is present and dist is missing, so it's a no-op on the published-package install path and idempotent on repeat runs. `prepare` was preferred over `pretest`-alone because it also fixes the fresh-clone **runtime** import path (depcheck is imported in `src/cli.ts`, `supervisor.ts`, etc., not just tests); `pretest` is added so `bun run test` self-heals even in an odd worktree.

**Verified by the mechanism, not faked:** removing dist and running a depcheck-importing test directly reproduced `Cannot find module` (`0 pass / 1 fail / 1 error`); running `build:depcheck` first made the same file pass (63 pass).

**Larger follow-up (out of scope):** removing the gitignore-of-dist or restructuring the export conditions so no build step is needed at all — noted for a future issue rather than expanded here.

## Gates

- `bun test ./src`: **3130 pass, 1 skip, 0 fail** (3131 across 126 files)
- `bun run typecheck`: clean (exit 0)
- Live hub `/health` after: `{"status":"ok",...,"db":"ok"}`
- biome: the one package.json error is pre-existing (baseline `workspaces`/`files` array formatting), untouched by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)