### PR TITLE
ci: bump actions/checkout + setup-node v4 → v6 (Node-20 migration #462)

### DIFF
--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3
@@ -102,11 +102,11 @@ jobs:
       # Required for npm provenance attestation.
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           # Node 24 ships npm 11.5+ which has Trusted Publishing OIDC
           # support built in. Node 20 LTS only has npm 10 and would
@@ -163,12 +163,12 @@ jobs:
         # install below).
         working-directory: packages/scope-guard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         # checkout has no working-directory option; runs from repo root.
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -212,12 +212,12 @@ jobs:
         # `working-directory: ${{ github.workspace }}`.
         working-directory: packages/depcheck
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         # checkout has no working-directory option; runs from repo root.
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -257,7 +257,7 @@ jobs:
       # Required for ghcr.io push via GITHUB_TOKEN.
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Bumps the bare `actions/checkout@v4` + `actions/setup-node@v4` aliases in `release.yml` (×8) and `container-smoke.yml` (×1) to `@v6`, ahead of GitHub's 2026-06-16 force-migration of Node-20 actions to Node 24. `@v6` natively targets Node 24 (matches parachute-surface, the ecosystem precedent) so this eliminates the deprecation rather than deferring it.

- `setup-bun@v2` left as-is (no deprecation warning; third-party cadence).
- A pre-existing `container-smoke.yml:75` SC2086 shellcheck warning is confirmed present on `origin/main` and left untouched (out of scope for a version bump).

yaml.safe_load + actionlint pass on both files (the only actionlint finding is the pre-existing SC2086). Part of #462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)