### PR TITLE
fix(wizard): present vault step on init'd box + start the vault on create (#607, #608)

### DIFF
--- a/e2e/stages.sh
+++ b/e2e/stages.sh
@@ -213,7 +213,7 @@ note "vault '${VAULT_NAME}' is up (auth-gated health, hub#423 semantics)"
 # status table reports it active without any manual start having been issued.
 STATUS_LOG=/tmp/parachute-status.log
 parachute status >"$STATUS_LOG" 2>&1 || true
-cat "$STATUS_LOG" | head -30
+head -30 "$STATUS_LOG"
 if ! grep -qiE 'vault.*(active|running)' "$STATUS_LOG"; then
   die "stage1-vault" \
     "parachute status does not show vault active right after the wizard (hub#608 regression — vault inactive until restart)"

--- a/e2e/stages.sh
+++ b/e2e/stages.sh
@@ -156,15 +156,19 @@ record "stage1-init" "PASS" "systemd unit active, /health db:ok, channel=${PARAC
 # transparently (#576). `parachute setup-wizard` drives the SAME endpoints the
 # browser wizard hits (Account → Vault → Expose), fully non-interactive.
 #
-# FIELD NOTE (rc 0.6.5-rc.4): `parachute init` pre-seeds the vault MODULE into
+# hub#607 + hub#608 (fixed): `parachute init` pre-seeds the vault MODULE into
 # services.json (a `default` placeholder, version 0.0.0-linked) under hub#168
-# Cut 1. `deriveWizardState.hasVault` keys off `findService("parachute-vault")`,
-# which the placeholder satisfies — so the wizard SKIPS its vault step on an
-# init'd box. The wizard's real job in this sequence is the account + expose
-# decisions; the vault is provisioned separately (below). We therefore drive
-# the wizard for account+expose, then create the named '${VAULT_NAME}' vault
-# the way an operator who wants a named vault does: `parachute vault create`.
-note "Driving the setup wizard over loopback (admin account + expose mode)…"
+# Cut 1. Pre-fix, `deriveWizardState.hasVault` matched that placeholder, so the
+# wizard SILENTLY SKIPPED its vault step on an init'd box — the operator
+# finished setup with no vault, and the harness had to work around it with an
+# explicit `parachute vault create` + a manual start/restart. With hub#607,
+# `hasVault` discriminates the SEED_VERSION placeholder from a real instance,
+# so the wizard PRESENTS its create/import/skip step and creates the named
+# vault itself (`--vault-mode create --vault-name`). With hub#608, the create
+# path drives the supervisor to START the new vault, so it is ACTIVE
+# immediately — no `parachute vault create`, no manual start, no hub restart.
+# This stage now asserts that fixed end-to-end behavior directly.
+note "Driving the setup wizard over loopback (account → create vault '${VAULT_NAME}' → expose)…"
 WIZ_LOG=/tmp/parachute-wizard.log
 if ! parachute setup-wizard \
       --hub-url "${HUB}" \
@@ -179,27 +183,19 @@ fi
 cat "$WIZ_LOG"
 grep -qi "Setup complete" "$WIZ_LOG" || die "stage1-wizard" "wizard did not report 'Setup complete'"
 grep -qi "admin account created" "$WIZ_LOG" || die "stage1-wizard" "wizard did not create the admin account"
-note "wizard created admin '${ADMIN_USER}' + set expose mode (vault step skipped — pre-seeded module)"
-record "stage1-wizard" "PASS" "admin '${ADMIN_USER}' created + expose=localhost via wizard"
+# hub#607: the wizard must actually walk its vault step (not skip it). The CLI
+# wizard logs "Vault ready" once the create op succeeds; a skipped step never
+# would. This guards against a regression back to the silent-skip behavior.
+grep -qi "Vault ready" "$WIZ_LOG" || die "stage1-wizard" \
+  "wizard did not run its vault step (hub#607 regression — vault step silently skipped on the init'd box)"
+note "wizard created admin '${ADMIN_USER}' + created vault '${VAULT_NAME}' + set expose mode"
+record "stage1-wizard" "PASS" "admin + vault '${VAULT_NAME}' created via wizard (hub#607); expose=localhost"
 
-# --- create the named vault ---
-# `parachute vault create <name>` is the operator path to a named vault.
-note "Creating the named vault '${VAULT_NAME}' (parachute vault create)…"
-VC_LOG=/tmp/parachute-vault-create.log
-if ! parachute vault create "${VAULT_NAME}" >"$VC_LOG" 2>&1; then
-  cat "$VC_LOG" >&2
-  die "stage1-vault" "parachute vault create ${VAULT_NAME} failed"
-fi
-cat "$VC_LOG"
-# The supervisor mounts the new vault on its next boot; nudge it (an operator
-# would `parachute restart` or the next reboot does it). `parachute start vault`
-# ensures the vault child is running under the supervisor.
-parachute start vault >/dev/null 2>&1 || true
-systemctl restart parachute-hub.service || true
-if ! wait_for "hub healthy after vault-mount restart" 30 "curl -fsS ${HUB}/health | grep -q '\"db\":\"ok\"'"; then
-  die "stage1-vault" "hub did not come back healthy after mounting vault '${VAULT_NAME}'"
-fi
-
+# --- vault is live immediately after the wizard (hub#608) ---
+# No `parachute vault create`, no `parachute start vault`, no hub restart: the
+# wizard's create path drove the supervisor to start the vault child, so it is
+# already serving. Assert it WITHOUT any manual nudge.
+note "Asserting vault '${VAULT_NAME}' is active right after the wizard (hub#608 — no manual start)…"
 # vault running + auth-gated (401 = healthy per hub#423 semantics)
 if ! wait_for "vault ${VAULT_NAME} health 401" 60 "test \"\$(curl -s -o /dev/null -w '%{http_code}' ${HUB}/vault/${VAULT_NAME}/health)\" = 401"; then
   code="$(curl -s -o /dev/null -w '%{http_code}' "${HUB}/vault/${VAULT_NAME}/health" || true)"
@@ -211,8 +207,19 @@ if ! wait_for "vault ${VAULT_NAME} health 401" 60 "test \"\$(curl -s -o /dev/nul
   esac
 fi
 note "vault '${VAULT_NAME}' is up (auth-gated health, hub#423 semantics)"
-parachute status 2>&1 | head -30 || true
-record "stage1-vault" "PASS" "vault '${VAULT_NAME}' created + served (401 health)"
+# hub#608: `parachute status` must show the vault as active (the issue's
+# operator-visible symptom was a freshly-created vault stuck `inactive` until a
+# restart). The supervisor child is named by the short `vault`; assert the
+# status table reports it active without any manual start having been issued.
+STATUS_LOG=/tmp/parachute-status.log
+parachute status >"$STATUS_LOG" 2>&1 || true
+cat "$STATUS_LOG" | head -30
+if ! grep -qiE 'vault.*(active|running)' "$STATUS_LOG"; then
+  die "stage1-vault" \
+    "parachute status does not show vault active right after the wizard (hub#608 regression — vault inactive until restart)"
+fi
+note "parachute status reports vault active (hub#608 — live without a manual start)"
+record "stage1-vault" "PASS" "vault '${VAULT_NAME}' created by wizard + active + served (401 health); hub#607/#608"
 
 # --- MCP handshake — full OAuth dance + round-trip ---
 note "Running the full OAuth dance + MCP round-trip (mcp-probe.ts)…"

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -179,6 +179,46 @@ describe("deriveWizardState", () => {
     }
   });
 
+  test("vault step when admin exists and only the SEED placeholder vault row is present (hub#607)", async () => {
+    // `parachute init` seeds a `parachute-vault` placeholder into
+    // services.json at SEED_VERSION ("0.0.0-linked") under hub#168 Cut 1
+    // (`noCreate`): the MODULE is installed, but no instance exists yet.
+    // Pre-#607, `hasVault` keyed off a bare `findService(...) !== undefined`
+    // check, which the placeholder satisfied — so the wizard silently
+    // skipped its vault step on EVERY init'd box and the operator finished
+    // setup with no vault. The placeholder must NOT count as a real vault.
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      await createUser(db, "owner", "pw");
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              version: "0.0.0-linked",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/health",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        readExposeStateFn: h.readExposeStateFn,
+      });
+      // The placeholder is module-installed-but-no-instance, so the wizard
+      // still owns vault creation: it presents the create/import/skip step.
+      expect(s.step).toBe("vault");
+      expect(s.hasAdmin).toBe(true);
+      expect(s.hasVault).toBe(false);
+    } finally {
+      db.close();
+    }
+  });
+
   test("expose step when admin + vault exist but expose mode not set yet (hub#268 Item 2)", async () => {
     const db = openHubDb(hubDbPath(h.dir));
     try {
@@ -1501,6 +1541,105 @@ describe("handleSetupVaultPost", () => {
       const op = getDefaultOperationsRegistry().get(opId);
       expect(op?.status).toBe("succeeded");
       expect(op?.log.join("\n")).toContain("already supervised");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("create on a SEED-placeholder box: does NOT short-circuit + drives the supervisor to start vault (hub#607 + hub#608)", async () => {
+    // hub#607 + hub#608 coupled fresh-operator flow. On an init'd box,
+    // services.json already carries a `parachute-vault` placeholder at
+    // SEED_VERSION ("0.0.0-linked") — the MODULE is installed, no instance
+    // exists. With the hub#607 `hasVault` discrimination, the wizard's vault
+    // step still appears (the placeholder isn't a real vault), so a
+    // `mode=create` POST must NOT be treated as "already provisioned" and
+    // short-circuit to expose. It runs `runInstall`, which seeds/stamps the
+    // row and — the hub#608 fix — drives `supervisor.start(...)` so the
+    // freshly-created vault is ACTIVE immediately, not inactive-until-
+    // restart. We assert both: the install op fired (no short-circuit) AND
+    // the supervisor now reports a live vault child.
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const { createSession, SESSION_COOKIE_NAME: SC } = await import("../sessions.ts");
+      const session = createSession(db, { userId: user.id });
+      // Simulate `parachute init`: the vault MODULE is seeded as a
+      // placeholder, no supervisor entry yet (init ran with noStart).
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              version: "0.0.0-linked",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/health",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const get = handleSetupGet(req("/admin/setup"), {
+        db,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
+        issuer: "https://hub.example",
+        registry: getDefaultOperationsRegistry(),
+      });
+      const csrf = setCookie(get, CSRF_COOKIE_NAME) ?? "";
+      const supervisor = makeSupervisor();
+      // Sanity: no vault child before the wizard create.
+      expect(supervisor.get("vault")).toBeUndefined();
+      const runCalls: string[][] = [];
+      const stubbedRun = async (cmd: readonly string[]) => {
+        runCalls.push([...cmd]);
+        return 0;
+      };
+      const post = await handleSetupVaultPost(
+        req("/admin/setup/vault", {
+          method: "POST",
+          body: new URLSearchParams({
+            [CSRF_FIELD_NAME]: csrf,
+            mode: "create",
+            vault_name: "myvault",
+            scribe_provider: "none",
+          }).toString(),
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            cookie: `${CSRF_COOKIE_NAME}=${csrf}; ${SC}=${session.id}`,
+          },
+        }),
+        {
+          db,
+          manifestPath: h.manifestPath,
+          configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
+          issuer: "https://hub.example",
+          supervisor,
+          registry: getDefaultOperationsRegistry(),
+          run: stubbedRun,
+          isLinked: () => false,
+        },
+      );
+      // Not short-circuited: the placeholder is not a real vault, so the
+      // POST enqueues an install op rather than redirecting to expose.
+      expect(post.status).toBe(303);
+      const location = post.headers.get("location") ?? "";
+      expect(location).toMatch(/^\/admin\/setup\?op=/);
+      // Let the background runInstall promise reach the runner + supervisor.
+      await new Promise((r) => setTimeout(r, 50));
+      // #607 proof: the install actually ran (not the "already provisioned"
+      // short-circuit, which fires no `bun add`).
+      expect(runCalls.some((c) => c.join(" ").includes("bun add -g @openparachute/vault"))).toBe(
+        true,
+      );
+      // #608 proof: the supervisor was driven to start the vault child, so
+      // the vault is live immediately after the wizard create — no manual
+      // `parachute start vault` / hub restart needed.
+      const vaultState = supervisor.get("vault");
+      expect(vaultState).toBeDefined();
+      expect(["starting", "running", "restarting"]).toContain(vaultState?.status ?? "");
     } finally {
       db.close();
     }

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -75,6 +75,7 @@ import {
   readOperatorTokenFile,
 } from "./operator-token.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
+import { SEED_VERSION } from "./service-spec.ts";
 import { findService, readManifestLenient } from "./services-manifest.ts";
 import {
   SESSION_TTL_MS,
@@ -274,13 +275,29 @@ export function deriveWizardState(deps: {
   // which maps to `parachute-vault` in services.json.
   const vaultSpec = specFor(FIRST_VAULT_SHORT);
   const vaultEntry = findService(vaultSpec.manifestName, deps.manifestPath);
+  // hub#607: distinguish the SEED placeholder from a real vault instance.
+  // `parachute init` installs the vault MODULE without creating an instance
+  // (hub#168 Cut 1: `noCreate`), seeding a services.json entry at
+  // SEED_VERSION ("0.0.0-linked") with the canonical `/vault/default` mount.
+  // Vault's own first-boot overwrites that entry with the real instance once
+  // a vault is actually created. A bare `findService(...) !== undefined`
+  // check matches the placeholder, so on EVERY init'd box the wizard treated
+  // the vault step as already-done and skipped straight to expose — the
+  // operator finished setup with no vault and no prompt. Treat a
+  // SEED_VERSION row as "module installed, no instance" so the wizard still
+  // presents its create / import / skip step. This is the SAME
+  // discrimination `buildWellKnown` gained in hub#577 (it suppresses the
+  // phantom `vaults[]` row at SEED_VERSION); both surfaces must agree that a
+  // placeholder is not a real vault.
+  const vaultIsPlaceholder = vaultEntry !== undefined && vaultEntry.version === SEED_VERSION;
+  const hasRealVault = vaultEntry !== undefined && !vaultIsPlaceholder;
   // hub#168 Cut 2: `setup_vault_skipped === "true"` advances the wizard
   // past the vault step even when no vault row exists. The operator
   // explicitly chose Skip; the module is installed (Cut 1) but no
   // instance was provisioned. Treat as "vault step is done" for the
   // purposes of state-derivation so the wizard moves to expose.
   const vaultSkipped = getSetting(deps.db, "setup_vault_skipped") === "true";
-  const hasVault = vaultEntry !== undefined || vaultSkipped;
+  const hasVault = hasRealVault || vaultSkipped;
   // Expose-mode is the operator's "how will this hub be reached?" answer
   // (hub#268 Item 2). Stored as a hub_setting; the wizard's expose step
   // sets it; absence means we should still ask. EXCEPT — if we're


### PR DESCRIPTION
Fixes #607
Fixes #608

Two coupled fresh-operator bugs in the `init → wizard → vault-setup` flow, found by the Tier-1 E2E harness (#606). The harness worked around both with an explicit `parachute vault create` + a manual start/restart — a real operator wouldn't know to do that.

## #607 — wizard silently skipped its vault step on an init'd box

`parachute init` seeds a `parachute-vault` placeholder into `services.json` (hub#168 Cut 1, `noCreate`) at the `SEED_VERSION` sentinel (`"0.0.0-linked"`): the vault MODULE is installed, but no instance exists. `deriveWizardState.hasVault` keyed off a bare `findService("parachute-vault") !== undefined`, which the placeholder satisfied — so on **every** init'd box the wizard treated the vault step as already-done and skipped straight to expose. Net: the operator finished the wizard with no vault, and `--vault-name` was inert.

**Fix:** `hasVault` now discriminates the `SEED_VERSION` placeholder from a real instance — the **same** discrimination `buildWellKnown` gained in #577 (which suppresses a phantom `vaults[]` row at `SEED_VERSION`). With a placeholder-only manifest, the wizard presents its create / import / skip step. A real vault row (`version != SEED_VERSION`) still advances past the step — no regression.

```ts
const vaultIsPlaceholder = vaultEntry !== undefined && vaultEntry.version === SEED_VERSION;
const hasRealVault = vaultEntry !== undefined && !vaultIsPlaceholder;
const hasVault = hasRealVault || vaultSkipped;
```

## #608 — freshly-created vault was `inactive` until a restart

With the vault step now reachable, the wizard's create path runs `runInstall` (`api-modules-ops.ts`), which seeds/stamps the `services.json` row and then drives `spawnSupervised` → `supervisor.start(...)`. So the freshly-created vault comes up **active immediately** — no `parachute start vault`, no hub restart. After init (`noStart`) the supervisor has no vault child, so the idempotent short-circuit in `handleSetupVaultPost` (which only fires for an already running/starting/restarting child) is correctly bypassed, and the start is driven exactly once.

The two are coupled: **#607 makes the wizard create the vault; #608 makes that vault come up.** Both the browser wizard and the CLI wizard (`parachute setup-wizard` / `commands/wizard.ts`) share the same `handleSetupVaultPost` backend, so both surfaces are fixed.

## Placeholder-vs-real discrimination

`SEED_VERSION` (`"0.0.0-linked"`, from `service-spec.ts`) telegraphs "module installed, daemon hasn't booted + registered a real row yet." Vault's own first boot overwrites the placeholder with its real version. `well-known.ts` already used `s.version === SEED_VERSION` to skip phantom vault rows (#577); this PR applies the identical check in `deriveWizardState` so the wizard and well-known agree that a placeholder is not a real vault.

## Start-after-create wiring

Unchanged and already correct in `runInstall`: seed `services.json` (skipped if the placeholder already exists) → stamp `installDir` → re-resolve spawn spec from `module.json` → `spawnSupervised` → `supervisor.start(req)`. The #607 fix is what makes this path reachable from the wizard on an init'd box.

## Test plan

- `bun test ./src` — **3132 pass, 1 skip, 0 fail** (35867 expect calls). +2 tests vs base.
- `bun run typecheck` — clean (`tsc --noEmit`).
- Live hub `/health` after the suite — `{"status":"ok",...,"db":"ok"}` (still up).

New unit tests (`src/__tests__/setup-wizard.test.ts`):
1. `deriveWizardState` returns the **vault** step when only the `SEED_VERSION` placeholder row exists (hub#607).
2. (existing, unchanged) `deriveWizardState` returns the **expose** step when a real vault row (`0.1.0`) exists — don't-regress guard.
3. A `mode=create` POST on a placeholder box does **not** short-circuit (asserts `bun add -g @openparachute/vault` ran) **and** leaves the supervisor with a started vault child (`get("vault").status` ∈ starting/running/restarting) — proves #607 + #608 together.

## E2E assertion update (`e2e/stages.sh` Stage 1)

Dropped the `parachute vault create` + manual `parachute start vault` + `systemctl restart` workaround. Stage 1 now asserts the **fixed** behavior:
- the wizard runs its vault step (greps the CLI wizard's `Vault ready` line — a silently-skipped step never emits it; guards the #607 regression),
- vault is reachable (auth-gated 401 health) with **no** manual create/start/restart, and
- `parachute status` shows vault **active** right after the wizard (the #608 operator-visible symptom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)