### PR TITLE
fix(wizard): poll vault provisioning over session-authed surface (#616)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.5-rc.5",
+  "version": "0.6.5-rc.6",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/wizard.test.ts
+++ b/src/__tests__/wizard.test.ts
@@ -9,7 +9,9 @@
  *      OK envelope.
  *   3. POST /admin/setup/vault (application/json) → 200 OK envelope
  *      with `op_id`.
- *   4. GET /api/modules/operations/<id> until terminal status.
+ *   4. GET /admin/setup?op=<id> until the `operation` envelope field
+ *      reaches a terminal status (hub#616 — session-authed poll surface,
+ *      NOT the Bearer-gated /api/modules/operations/:id the SPA uses).
  *   5. POST /admin/setup/expose (application/json) → 200 OK.
  *
  * The stub fetch in this file is a mini-router that mimics the
@@ -32,6 +34,8 @@ interface FakeHubState {
   importParams?: { remoteUrl: string; pat?: string; mode: string };
   exposeMode?: string;
   posted: Array<{ path: string; body: unknown }>;
+  /** hub#616: path+query of every op-poll GET, to assert the wizard polls the session surface. */
+  polled: string[];
   /** hub#576: when set, the fake GET /admin/setup reports requireBootstrapToken=true. */
   requireBootstrapToken?: boolean;
   /** hub#576: when set, the fake GET also returns it (loopback-probe behavior). */
@@ -52,6 +56,7 @@ function makeFakeHub(initialState?: Partial<FakeHubState>): {
     hasVault: false,
     hasExposeMode: false,
     posted: [],
+    polled: [],
     ...initialState,
   };
   // Synthesize a stable CSRF token + session token for the stub. The
@@ -81,12 +86,17 @@ function makeFakeHub(initialState?: Partial<FakeHubState>): {
     const body = init?.body;
     const bodyJson: unknown = body ? JSON.parse(String(body)) : null;
 
-    // GET /admin/setup
-    if (path === "/admin/setup" && method === "GET") {
+    // GET /admin/setup (incl. the `?op=<id>` poll surface — hub#616)
+    if (url.pathname === "/admin/setup" && method === "GET") {
       let step: "welcome" | "vault" | "expose" | "done" = "welcome";
       if (state.hasAdmin && state.hasVault && state.hasExposeMode) step = "done";
       else if (state.hasAdmin && state.hasVault) step = "expose";
       else if (state.hasAdmin) step = "vault";
+      // hub#616: the CLI wizard polls vault provisioning via this session-authed
+      // GET with `?op=<id>`; the op snapshot rides in the `operation` field.
+      const opId = url.searchParams.get("op");
+      if (opId) state.polled.push(path);
+      const op = opId ? ops.get(opId) : undefined;
       const respBody = JSON.stringify({
         step,
         hasAdmin: state.hasAdmin,
@@ -96,6 +106,7 @@ function makeFakeHub(initialState?: Partial<FakeHubState>): {
         csrfToken: csrf,
         // hub#576: a loopback probe carries the actual token value.
         ...(state.bootstrapToken ? { bootstrapToken: state.bootstrapToken } : {}),
+        ...(op ? { operation: op } : {}),
       });
       return new Response(respBody, {
         status: 200,
@@ -165,20 +176,18 @@ function makeFakeHub(initialState?: Partial<FakeHubState>): {
       });
     }
 
-    // GET /api/modules/operations/<id>
-    if (path.startsWith("/api/modules/operations/") && method === "GET") {
-      const id = path.slice("/api/modules/operations/".length);
-      const op = ops.get(id);
-      if (!op) {
-        return new Response(JSON.stringify({ error: "not found" }), {
-          status: 404,
-          headers: { "content-type": "application/json; charset=utf-8" },
-        });
-      }
-      return new Response(JSON.stringify(op), {
-        status: 200,
-        headers: { "content-type": "application/json; charset=utf-8" },
-      });
+    // GET /api/modules/operations/<id> — the Bearer-gated SPA/install-CLI poll
+    // surface. hub#616: the CLI wizard must NOT use it (it holds only a session
+    // cookie, not a host-admin Bearer). Mirror the real 401 so any regression
+    // back to this path fails the wizard poll loudly instead of silently.
+    if (url.pathname.startsWith("/api/modules/operations/") && method === "GET") {
+      return new Response(
+        JSON.stringify({
+          error: "unauthenticated",
+          error_description: "Authorization: Bearer required",
+        }),
+        { status: 401, headers: { "content-type": "application/json; charset=utf-8" } },
+      );
     }
 
     // POST /admin/setup/expose
@@ -287,6 +296,12 @@ describe("runCliWizard", () => {
     expect(vaultBody.mode).toBe("create");
     expect(vaultBody.vault_name).toBe("default");
     expect(state.exposeMode).toBe("localhost");
+    // hub#616: the vault-provisioning op is polled over the session-authed
+    // wizard surface, NOT the Bearer-gated /api/modules/operations/:id (which
+    // the fake 401s, mirroring the real gate). At least one poll must land on
+    // /admin/setup?op=, and every poll must use that path.
+    expect(state.polled.length).toBeGreaterThan(0);
+    for (const p of state.polled) expect(p.startsWith("/admin/setup?op=")).toBe(true);
   });
 
   test("loopback-probe bootstrap token is sent transparently (no prompt) — hub#576", async () => {

--- a/src/__tests__/wizard.test.ts
+++ b/src/__tests__/wizard.test.ts
@@ -36,6 +36,13 @@ interface FakeHubState {
   posted: Array<{ path: string; body: unknown }>;
   /** hub#616: path+query of every op-poll GET, to assert the wizard polls the session surface. */
   polled: string[];
+  /**
+   * hub#616: number of poll ticks the vault op reports `"running"` before
+   * flipping to `"succeeded"`. 0 (default) = succeeds immediately on the first
+   * poll. >0 exercises the multi-tick poll loop (the import-mode long-running
+   * provisioning path).
+   */
+  vaultProvisionTicks?: number;
   /** hub#576: when set, the fake GET /admin/setup reports requireBootstrapToken=true. */
   requireBootstrapToken?: boolean;
   /** hub#576: when set, the fake GET also returns it (loopback-probe behavior). */
@@ -74,6 +81,9 @@ function makeFakeHub(initialState?: Partial<FakeHubState>): {
       error?: string;
     }
   >();
+  // hub#616: per-op countdown of remaining `"running"` poll ticks before the
+  // op flips to `"succeeded"` (see FakeHubState.vaultProvisionTicks).
+  const opTicksRemaining = new Map<string, number>();
 
   const fetchImpl = async (
     input: string | URL | Request,
@@ -97,6 +107,17 @@ function makeFakeHub(initialState?: Partial<FakeHubState>): {
       const opId = url.searchParams.get("op");
       if (opId) state.polled.push(path);
       const op = opId ? ops.get(opId) : undefined;
+      // hub#616: drive a multi-tick op (running → succeeded) so the poll loop
+      // is exercised across more than one fetch when configured.
+      if (op && op.status === "running") {
+        const remaining = opTicksRemaining.get(op.id) ?? 0;
+        if (remaining <= 0) {
+          op.status = "succeeded";
+          state.hasVault = true;
+        } else {
+          opTicksRemaining.set(op.id, remaining - 1);
+        }
+      }
       const respBody = JSON.stringify({
         step,
         hasAdmin: state.hasAdmin,
@@ -166,10 +187,18 @@ function makeFakeHub(initialState?: Partial<FakeHubState>): {
           ...(b.pat ? { pat: b.pat } : {}),
         };
       }
-      // Create an op + drive it to succeeded immediately for the test.
+      // Create an op. By default it succeeds immediately on the first poll;
+      // when `vaultProvisionTicks` is set it reports `"running"` for that many
+      // poll ticks first (hub#616 — exercises the multi-tick poll loop).
       const opId = `op-test-${++opCount}`;
-      ops.set(opId, { id: opId, status: "succeeded", log: ["bun add -g", "spawned"] });
-      state.hasVault = true;
+      const ticks = state.vaultProvisionTicks ?? 0;
+      if (ticks > 0) {
+        ops.set(opId, { id: opId, status: "running", log: ["bun add -g"] });
+        opTicksRemaining.set(opId, ticks);
+      } else {
+        ops.set(opId, { id: opId, status: "succeeded", log: ["bun add -g", "spawned"] });
+        state.hasVault = true;
+      }
       return new Response(JSON.stringify({ op_id: opId, step: "vault", mode: b.mode }), {
         status: 200,
         headers: { "content-type": "application/json; charset=utf-8" },
@@ -302,6 +331,31 @@ describe("runCliWizard", () => {
     // /admin/setup?op=, and every poll must use that path.
     expect(state.polled.length).toBeGreaterThan(0);
     for (const p of state.polled) expect(p.startsWith("/admin/setup?op=")).toBe(true);
+  });
+
+  test("multi-tick vault op (running → succeeded) polls the session surface across ticks — hub#616", async () => {
+    // Models the import-mode long-running provisioning path: the op reports
+    // `running` for two poll ticks before flipping to `succeeded`.
+    const { state, fetchImpl } = makeFakeHub({ vaultProvisionTicks: 2 });
+    const logs: string[] = [];
+    const code = await runCliWizard({
+      hubUrl: "http://127.0.0.1:1939",
+      log: (l) => logs.push(l),
+      fetchImpl,
+      sleep: async () => {},
+      accountUsername: "admin",
+      accountPassword: "longpassword",
+      vaultMode: "create",
+      vaultName: "default",
+      exposeMode: "localhost",
+    });
+    expect(code).toBe(0);
+    // The loop ran more than once (2 running ticks + the terminal succeeded
+    // poll), and every tick used the session-authed surface — never the
+    // Bearer-gated /api/modules/operations/:id.
+    expect(state.polled.length).toBeGreaterThanOrEqual(3);
+    for (const p of state.polled) expect(p.startsWith("/admin/setup?op=")).toBe(true);
+    expect(state.exposeMode).toBe("localhost");
   });
 
   test("loopback-probe bootstrap token is sent transparently (no prompt) — hub#576", async () => {

--- a/src/commands/wizard.ts
+++ b/src/commands/wizard.ts
@@ -347,9 +347,15 @@ async function pollOperation(
   const start = Date.now();
   let lastLogIndex = 0;
   for (;;) {
+    // hub#616: poll over the session-authed wizard surface (`/admin/setup?op=`),
+    // mirroring the browser wizard's re-GET — NOT the Bearer-gated
+    // `/api/modules/operations/:id` the SPA + install CLI use. Mid-setup the
+    // wizard holds only a session cookie; the op endpoint demands a host-admin
+    // Bearer it doesn't have, so a direct poll 401s and the vault step dies.
+    // The op snapshot rides back in the envelope's `operation` field.
     const res = await setupFetch(
       hubUrl,
-      `/api/modules/operations/${encodeURIComponent(opId)}`,
+      `/admin/setup?op=${encodeURIComponent(opId)}`,
       jar,
       fetchImpl,
     );
@@ -358,10 +364,11 @@ async function pollOperation(
         `op-poll failed (${res.status}) for ${shortLabel} op ${opId}: ${res.bodyText.slice(0, 200)}`,
       );
     }
-    const body = res.json as Partial<OperationSnapshot> | undefined;
+    const envelope = res.json as { operation?: Partial<OperationSnapshot> } | undefined;
+    const body = envelope?.operation;
     if (!body || typeof body !== "object" || typeof body.id !== "string") {
       throw new Error(
-        `op-poll returned unexpected body for ${shortLabel} op ${opId}: ${res.bodyText.slice(0, 200)}`,
+        `op-poll returned no operation snapshot for ${shortLabel} op ${opId}: ${res.bodyText.slice(0, 200)}`,
       );
     }
     // Print any new log lines since the last tick so the operator sees

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -1640,6 +1640,12 @@ export function handleSetupGet(req: Request, deps: SetupWizardDeps): Response {
       requireBootstrapToken: boolean;
       csrfToken: string;
       bootstrapToken?: string;
+      operation?: {
+        id: string;
+        status: "pending" | "running" | "succeeded" | "failed";
+        log: readonly string[];
+        error?: string;
+      };
     } = {
       step: state.step,
       hasAdmin: state.hasAdmin,
@@ -1648,6 +1654,25 @@ export function handleSetupGet(req: Request, deps: SetupWizardDeps): Response {
       requireBootstrapToken: requireToken,
       csrfToken: csrf.token,
     };
+    // hub#616: the CLI wizard polls vault-provisioning over THIS session-authed
+    // surface (mirroring the browser wizard's `/admin/setup?op=<id>` re-GET),
+    // not the Bearer-gated `/api/modules/operations/:id` the SPA + install CLI
+    // use. The wizard holds only a session cookie mid-setup; the op endpoint
+    // requires a host-admin Bearer it doesn't have, so a direct poll 401s and
+    // the vault step dies. Threading the op snapshot into the envelope keeps the
+    // poll on the auth the wizard already carries.
+    const opId = url.searchParams.get("op");
+    if (opId) {
+      const op = deps.registry?.get(opId);
+      if (op) {
+        envelope.operation = {
+          id: op.id,
+          status: op.status,
+          log: op.log,
+          ...(op.error !== undefined ? { error: op.error } : {}),
+        };
+      }
+    }
     // hub#576: hand the actual token to a LOOPBACK caller only. The on-box
     // operator (`parachute init` → CLI wizard, or a curl from their own shell)
     // already proves box access by reaching loopback — same trust level as


### PR DESCRIPTION
## What

The CLI setup wizard's **vault step** 401'd polling vault-provisioning, killing `parachute init` on a fresh box right after "Step 2/3 — Vault".

## Root cause

`pollOperation` polled `GET /api/modules/operations/:id` — the **Bearer-gated** `/api/*` surface (`api-modules-ops.ts` `authorize()` requires a host-admin Bearer). Mid-setup the wizard holds only the **session cookie** minted by `/admin/setup/account`, so every poll returned:

```
op-poll failed (401) for vault op <id>: {"error":"unauthenticated","error_description":"Authorization: *** required"}
```

The **browser** wizard never hits that endpoint — it re-GETs the session-authed `/admin/setup?op=<id>` and reads op status from the re-rendered page. The CLI duplicated poll logic against the wrong surface.

## Fix

- `handleSetupGet` JSON envelope now carries an `operation` field when `?op=<id>` is present, read from the shared operations registry (the same default registry `handleSetupVaultPost` writes to).
- CLI `pollOperation` polls `/admin/setup?op=<id>` (session cookie) and reads `envelope.operation` — mirrors the browser flow exactly.

## Why it surfaced now

Hidden behind #607 (vault step silently skipped). #612 made the step actually run (rc.5), making this 401 reachable — a **chain-bug**. Found by the **Tier-1 systemd E2E harness** on a live `npm:rc` install, *not* unit tests: the wizard unit test mocked the op endpoint as 200, masking the auth mismatch.

## Regression guard

The wizard unit test's fake now **401s** `/api/modules/operations/` (mirroring the real gate) and asserts every poll lands on `/admin/setup?op=`. A regression to the Bearer path fails loudly.

## Gates

- `bun test ./src`: **3151 pass / 1 skip**
- `bun run typecheck`: clean
- `bunx biome check`: clean

Closes #616. Ships in hub 0.6.5-rc.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)