### PR TITLE
fix(db-liveness): exit on a wiped state dir instead of healing in-place (#621)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.5-rc.7",
+  "version": "0.6.5-rc.8",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-db-liveness.test.ts
+++ b/src/__tests__/hub-db-liveness.test.ts
@@ -214,18 +214,23 @@ describe("DbHolder.probePath (#610 proactive detection)", () => {
     h.cleanup();
   });
 
-  test("path GONE (ENOENT) → reopen attempted; reopen verify fails → exit(1)", () => {
-    // Reopen returns a closed handle (the dir is still gone) → SELECT 1 throws
-    // → exit. This is the genuine `rm -rf ~/.parachute` field shape.
-    const dead = new Database(":memory:");
-    dead.close();
+  test("path GONE (ENOENT) → exit(1) directly, NO reopen (#619 follow-up)", () => {
+    // The genuine `rm -rf ~/.parachute` field shape. We must NOT reopen here:
+    // reopen is openHubDb, which mkdir-recursive's the dir back + opens a fresh
+    // EMPTY db, so its SELECT-1 verify would PASS and the hub would "heal" into a
+    // half-recovered state (empty db, stale in-memory state, wiped well-known,
+    // un-respawned modules). A full wipe must exit so the platform manager does a
+    // clean restart that re-bootstraps everything. `onReopen` throws to PROVE the
+    // reopen path is never taken — if it were, this test would surface the throw.
     const h = makeHolder({
       initialInode: INODE_A,
       statInode: () => undefined, // ENOENT
-      onReopen: () => dead,
+      onReopen: () => {
+        throw new Error("reopen must NOT be called on a gone verdict");
+      },
     });
     expect(h.holder.probePath()).toBe("gone");
-    expect(h.stats().reopens).toBe(1);
+    expect(h.stats().reopens).toBe(0);
     expect(h.stats().exits).toBe(1);
     expect(h.stats().exitCode).toBe(1);
     h.cleanup();

--- a/src/hub-db-liveness.ts
+++ b/src/hub-db-liveness.ts
@@ -383,25 +383,41 @@ export function createDbHolder(initial: Database, deps: DbHolderDeps): DbHolder 
       const verdict = classifyPathLiveness({ expected: currentInode, current: pathInode });
       if (verdict === "ok" || verdict === "unknown") return verdict;
 
-      // Genuine wipe signal: the on-disk DB the handle points at is gone
-      // ("gone") or was replaced underneath us ("replaced"). Trigger the SAME
-      // reopen-or-exit machinery. When the path is gone, reopen's SELECT-1
-      // verify fails → exit → platform manager restarts with a fresh on-disk
-      // handle (seconds, not "never"). When replaced, we adopt the fresh inode.
+      if (verdict === "gone") {
+        // The whole state dir was wiped under the running hub (`rm -rf
+        // ~/.parachute`). We must NOT reopen-in-place here: `reopen` is
+        // `openHubDb`, which `mkdirSync`'s the dir back + opens a fresh EMPTY db,
+        // so its SELECT-1 verify would PASS and we'd "heal" into a half-recovered
+        // hub — empty db, but stale in-memory state, wiped well-known files, and
+        // supervised modules whose own state dirs are gone yet never re-spawned
+        // (#619 follow-up). The correct recovery for a full wipe is a clean
+        // process exit so the platform manager (systemd / launchd / container)
+        // restarts `parachute serve`, which re-bootstraps everything (well-known,
+        // admin seed, supervisor re-spawn). This restores the #610 design intent
+        // ("we exit, letting the platform manager restart") that the shared
+        // reopen-or-exit path silently defeated via openHubDb's mkdir-recursive.
+        log(
+          `parachute hub: db path ${deps.dbPath} no longer exists (state dir wiped under a running hub, #610); exiting so the platform manager restarts the hub with a freshly bootstrapped state dir.`,
+        );
+        exit(1);
+        return verdict;
+      }
+
+      // "replaced": the db FILE was swapped underneath us (e.g. a restore copied
+      // a new file over the same path) while the rest of the state dir is intact.
+      // Adopting the fresh inode in-place via reopen-or-exit is correct here — a
+      // process restart would be heavier than needed.
       //
-      // ONE-TICK /health ANOMALY (intentional): on a "replaced" verdict the
-      // reopenOrExit below heals SYNCHRONOUSLY, but we still RETURN "replaced"
-      // for this one call — so the /health request that drove this probe reports
-      // `db:"error: path-replaced"` even though the handle is now healthy; the
-      // very next request reads `ok`. We don't mask it (returning "ok" here would
-      // hide that a heal just happened, which is exactly what monitoring wants to
-      // see). It's safe because #591's adoption probe checks only HTTP 200
-      // (`res.ok`), not the specific `db` string, so a single transient error
-      // string can't cascade.
+      // ONE-TICK /health ANOMALY (intentional): the reopenOrExit below heals
+      // SYNCHRONOUSLY, but we still RETURN "replaced" for this one call — so the
+      // /health request that drove this probe reports `db:"error: path-replaced"`
+      // even though the handle is now healthy; the very next request reads `ok`.
+      // We don't mask it (returning "ok" here would hide that a heal just
+      // happened, which is exactly what monitoring wants to see). It's safe
+      // because #591's adoption probe checks only HTTP 200 (`res.ok`), not the
+      // specific `db` string, so a single transient error string can't cascade.
       reopenOrExit(
-        verdict === "gone"
-          ? `db path ${deps.dbPath} no longer exists (state dir wiped under a running hub, #610)`
-          : `db path ${deps.dbPath} now resolves to a different inode (DB file replaced underneath the open handle, #610)`,
+        `db path ${deps.dbPath} now resolves to a different inode (DB file replaced underneath the open handle, #610)`,
       );
       return verdict;
     },

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -1627,8 +1627,11 @@ export function hubFetch(
             // succeeding, so `probeDbLiveness` alone would report `db:"ok"` on a
             // database that's gone from disk (the /health lie the issue calls
             // out). `probeDbPath` stat()s the path + compares inodes; on a
-            // gone/replaced verdict it ALSO self-heals (reopen-or-exit) and we
-            // surface the fault so the #591 adoption probe + monitoring see it.
+            // "replaced" verdict it self-heals in-place (reopen-or-exit, adopt
+            // the new inode); on a "gone" verdict it exits the process directly
+            // (#621 — a full wipe needs a clean platform-manager restart, not an
+            // empty-db reopen). Either way we surface the fault so the #591
+            // adoption probe + monitoring see it.
             const pathVerdict = deps?.probeDbPath?.();
             if (pathVerdict === "gone" || pathVerdict === "replaced") {
               // One-request anomaly on "replaced": probeDbPath already healed the


### PR DESCRIPTION
## What

After #619 wired the #610 ghost-fd watchdog into the real `parachute serve` path, stage-4 wipe-recovery E2E revealed the watchdog now **fires** but heals **in-process** (same PID, fresh empty db) instead of exiting for a clean restart:

```
stage4-wipe-recovery — hub did not self-recover (health=db:ok,
  on-disk hub.db=present, MainPID 557→557, ghost-fd seen=1)
```

## Root cause

`probePath`'s **"gone"** verdict routed through the shared `reopenOrExit`, whose `reopen` is `openHubDb` — which does `mkdirSync(dirname, { recursive: true })`. So after `rm -rf ~/.parachute` it **recreates the dir + a fresh empty db**, the SELECT-1 verify PASSES, and the hub "heals" in-place. The #610 module docstring explicitly assumed the opposite ("reopen's SELECT-1 verify fails → exit") — `openHubDb`'s mkdir-recursive silently defeated it.

In-place reopen is **incomplete recovery** for a full wipe: empty db, but stale in-memory state, wiped well-known files, and supervised modules whose own state dirs are gone yet never re-spawned. Only a clean process restart re-bootstraps everything.

## Fix

On a **"gone"** verdict, `probePath` now logs loudly + `exit(1)` **directly** (no reopen) so the platform manager (systemd / launchd / container) restarts `parachute serve` and re-bootstraps the whole state dir. The **"replaced"** verdict (a file swap with the rest of the dir intact) still uses reopen-or-exit to adopt the new inode in-place — correct lighter recovery there.

This **restores the #610 design intent**.

## Tests

Updated the gone-verdict unit test: it now asserts exit-without-reopen, with `onReopen` throwing to **prove** reopen is never taken on a gone path. Stage-4 E2E (asserts PID change + fresh on-disk db) is the integration guard.

- `bun test ./src`: **3154 pass / 1 skip**
- `bun run typecheck`: clean
- `bunx biome check`: clean

Closes #621. Ships in hub 0.6.5-rc.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)