### PR TITLE
feat(hub): /admin/channel-token — session→bearer mint for the channel UI

### DIFF
--- a/src/__tests__/admin-channel-token.test.ts
+++ b/src/__tests__/admin-channel-token.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for the channel UI session→bearer mint endpoint. Mirrors
+ * `admin-host-admin-token.test.ts` shape (channel has a single bare audience,
+ * no per-vault name). Covers:
+ *   - 401 when no admin session cookie is present.
+ *   - 401 when the cookie names a deleted session.
+ *   - 405 on POST.
+ *   - 200 + JWT carrying `aud: "channel"` and `channel:read channel:send`.
+ *   - First-admin gate: 403 for a signed-in non-first-admin (friend); the
+ *     admin's happy path still mints when a friend exists alongside.
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CHANNEL_TOKEN_TTL_SECONDS, handleChannelToken } from "../admin-channel-token.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { validateAccessToken } from "../jwt-sign.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession, deleteSession } from "../sessions.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "https://hub.test";
+
+interface Harness {
+  db: Database;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-channel-token-"));
+  const db = openHubDb(hubDbPath(dir));
+  return {
+    db,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+async function withSession(): Promise<{ cookie: string; userId: string }> {
+  const user = await createUser(harness.db, "operator", "hunter2");
+  const session = createSession(harness.db, { userId: user.id });
+  const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+  return { cookie, userId: user.id };
+}
+
+/**
+ * Seed an admin (first-created user) + a second non-admin "friend" account,
+ * return cookies + ids for both. Used by the first-admin-gate tests.
+ */
+async function withAdminAndFriend(): Promise<{
+  adminCookie: string;
+  adminId: string;
+  friendCookie: string;
+  friendId: string;
+}> {
+  const admin = await createUser(harness.db, "admin", "admin-passphrase");
+  const friend = await createUser(harness.db, "alice", "alice-passphrase", {
+    allowMulti: true,
+  });
+  const adminSession = createSession(harness.db, { userId: admin.id });
+  const friendSession = createSession(harness.db, { userId: friend.id });
+  return {
+    adminCookie: buildSessionCookie(adminSession.id, Math.floor(SESSION_TTL_MS / 1000)),
+    adminId: admin.id,
+    friendCookie: buildSessionCookie(friendSession.id, Math.floor(SESSION_TTL_MS / 1000)),
+    friendId: friend.id,
+  };
+}
+
+describe("handleChannelToken", () => {
+  test("401 when no session cookie is present", async () => {
+    const req = new Request(`${ISSUER}/admin/channel-token`);
+    const res = await handleChannelToken(req, { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("unauthenticated");
+  });
+
+  test("401 when the cookie names a deleted session", async () => {
+    const { cookie } = await withSession();
+    const sid = cookie.match(/parachute_hub_session=([^;]+)/)?.[1] ?? "";
+    deleteSession(harness.db, sid);
+    const req = new Request(`${ISSUER}/admin/channel-token`, { headers: { cookie } });
+    const res = await handleChannelToken(req, { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(401);
+  });
+
+  test("405 on POST", async () => {
+    const { cookie } = await withSession();
+    const req = new Request(`${ISSUER}/admin/channel-token`, {
+      method: "POST",
+      headers: { cookie },
+    });
+    const res = await handleChannelToken(req, { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(405);
+  });
+
+  test("200 mints a JWT carrying aud:channel + channel:read channel:send", async () => {
+    const { cookie, userId } = await withSession();
+    rotateSigningKey(harness.db);
+    const req = new Request(`${ISSUER}/admin/channel-token`, { headers: { cookie } });
+    const res = await handleChannelToken(req, { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+
+    const body = (await res.json()) as { token: string; expires_at: string; scopes: string[] };
+    // `channel:send` (post) + `channel:read` (SSE replies). Deliberately NOT
+    // `channel:write` — that's the session-reply scope a UI token must not hold.
+    expect(body.scopes).toEqual(["channel:read", "channel:send"]);
+    expect(body.scopes).not.toContain("channel:write");
+    expect(body.token.length).toBeGreaterThan(20);
+
+    const expMs = new Date(body.expires_at).getTime();
+    const skew = expMs - Date.now();
+    expect(skew).toBeGreaterThan((CHANNEL_TOKEN_TTL_SECONDS - 30) * 1000);
+    expect(skew).toBeLessThan((CHANNEL_TOKEN_TTL_SECONDS + 30) * 1000);
+
+    const validated = await validateAccessToken(harness.db, body.token, ISSUER);
+    expect(validated.payload.sub).toBe(userId);
+    expect(validated.payload.iss).toBe(ISSUER);
+    // Bare service audience — channel validates `aud === "channel"`
+    // (parachute-channel src/hub-jwt.ts CHANNEL_AUDIENCE).
+    expect(validated.payload.aud).toBe("channel");
+    const scopeClaim = (validated.payload as { scope?: string }).scope ?? "";
+    const scopes = scopeClaim.split(/\s+/);
+    expect(scopes).toContain("channel:read");
+    expect(scopes).toContain("channel:send");
+    expect(scopes).not.toContain("channel:write");
+  });
+
+  test("403 not_admin when a signed-in non-first-admin (friend) hits the endpoint", async () => {
+    // Privesc closure (mirrors host/vault-admin-token). The friend's session
+    // is valid; the endpoint must refuse because session.userId isn't the
+    // first-admin row.
+    const { friendCookie } = await withAdminAndFriend();
+    rotateSigningKey(harness.db);
+    const req = new Request(`${ISSUER}/admin/channel-token`, {
+      headers: { cookie: friendCookie },
+    });
+    const res = await handleChannelToken(req, { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("not_admin");
+    expect(body.error_description).toContain("/account/");
+  });
+
+  test("first-admin path still succeeds when a friend exists alongside", async () => {
+    const { adminCookie, adminId } = await withAdminAndFriend();
+    rotateSigningKey(harness.db);
+    const req = new Request(`${ISSUER}/admin/channel-token`, {
+      headers: { cookie: adminCookie },
+    });
+    const res = await handleChannelToken(req, { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string };
+    const validated = await validateAccessToken(harness.db, body.token, ISSUER);
+    expect(validated.payload.sub).toBe(adminId);
+  });
+});

--- a/src/admin-channel-token.ts
+++ b/src/admin-channel-token.ts
@@ -1,0 +1,116 @@
+/**
+ * `GET /admin/channel-token` — exchange a valid admin session cookie for a
+ * short-lived JWT carrying `channel:read channel:send`.
+ *
+ * Why this exists: the Channel chat UI (served behind hub's proxy to a
+ * logged-in portal operator) needs a Bearer to talk to channel's API the
+ * same way the vault-management and scribe-config SPAs do — receive replies
+ * over SSE (`channel:read`) and post a message (`channel:send`). This local
+ * session-cookie mint path is the UI's way to acquire that Bearer without
+ * running the public `/oauth/authorize` flow.
+ *
+ * Scope choice — `channel:read channel:send`, deliberately NOT `channel:write`:
+ *   - `channel:read`  — receive replies over SSE.
+ *   - `channel:send`  — post a message into the channel.
+ *   - `channel:write` is the *session-reply* scope (a connected Claude Code
+ *     session replying on a channel). A UI token must not be able to
+ *     impersonate a session, so we never mint `channel:write` here.
+ *
+ * Audience: `channel` (the bare service prefix). Channel validates the JWT's
+ * `aud` claim against the literal string `"channel"` (parachute-channel
+ * `src/hub-jwt.ts` `CHANNEL_AUDIENCE`), the same shape `inferAudience` in
+ * oauth-handlers.ts stamps for the public OAuth flow — so hub-minted and
+ * OAuth-minted channel tokens are indistinguishable to channel. Unlike the
+ * per-vault admin token (`vault.<name>`), channel has a single bare audience.
+ *
+ * Multi-user Phase 1 gate: the session must belong to the first admin (the
+ * single hub admin under the Phase 1 model — see `users.ts:isFirstAdmin`),
+ * mirroring host-admin-token and vault-admin-token. Friends pinned to a vault
+ * use the OAuth flow for their assigned scopes; they don't get a channel
+ * Bearer via this endpoint.
+ *
+ * Tokens minted here are short-lived (10 min — matches host/vault admin
+ * tokens); the UI re-fetches on near-expiry.
+ */
+import type { Database } from "bun:sqlite";
+import { signAccessToken } from "./jwt-sign.ts";
+import { findSession, parseSessionCookie } from "./sessions.ts";
+import { isFirstAdmin } from "./users.ts";
+
+/** Short TTL — matches host/vault admin-token. UI re-fetches on near-expiry. */
+export const CHANNEL_TOKEN_TTL_SECONDS = 10 * 60;
+const CHANNEL_AUDIENCE = "channel";
+const CHANNEL_CLIENT_ID = "parachute-hub-spa";
+/**
+ * `channel:read` (SSE replies) + `channel:send` (post a message). Deliberately
+ * NOT `channel:write` — that's the session-reply scope, and a UI token must
+ * not be able to impersonate a connected session.
+ */
+export const CHANNEL_TOKEN_SCOPES = ["channel:read", "channel:send"] as const;
+
+export interface MintChannelTokenDeps {
+  db: Database;
+  /** Hub origin — written into JWT `iss`. */
+  issuer: string;
+}
+
+export async function handleChannelToken(
+  req: Request,
+  deps: MintChannelTokenDeps,
+): Promise<Response> {
+  if (req.method !== "GET") {
+    return jsonError(405, "method_not_allowed", "use GET");
+  }
+  const sid = parseSessionCookie(req.headers.get("cookie"));
+  const session = sid ? findSession(deps.db, sid) : null;
+  if (!session) {
+    return jsonError(401, "unauthenticated", "no admin session — sign in at /login first");
+  }
+  // First-admin gate (mirrors host/vault-admin-token). A friend account
+  // (non-first-admin user created via `/api/users`) holds a valid session but
+  // must not mint a channel Bearer. Without this check, any signed-in friend
+  // hitting `GET /admin/channel-token` would walk away with a token carrying
+  // `channel:read channel:send`.
+  if (!isFirstAdmin(deps.db, session.userId)) {
+    return jsonError(
+      403,
+      "not_admin",
+      "channel token mint is restricted to the hub admin — your account home is at /account/",
+    );
+  }
+  const minted = await signAccessToken(deps.db, {
+    sub: session.userId,
+    scopes: [...CHANNEL_TOKEN_SCOPES],
+    audience: CHANNEL_AUDIENCE,
+    clientId: CHANNEL_CLIENT_ID,
+    issuer: deps.issuer,
+    ttlSeconds: CHANNEL_TOKEN_TTL_SECONDS,
+    // Channel tokens carry no per-user vault pin — the UI Bearer talks to a
+    // channel-scoped endpoint, not to a single vault. Empty `vault_scope` is
+    // the "no per-user restriction" sentinel matching host-admin tokens.
+    vaultScope: [],
+  });
+  return new Response(
+    JSON.stringify({
+      token: minted.token,
+      expires_at: minted.expiresAt,
+      scopes: CHANNEL_TOKEN_SCOPES,
+    }),
+    {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+        // No browser cache — token rotates per-fetch, and a stale 200 from a
+        // back/forward navigation could hand the UI a long-expired JWT.
+        "cache-control": "no-store",
+      },
+    },
+  );
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -45,6 +45,7 @@
  *   /vaults                       (POST)       → create vault
  *   /admin/host-admin-token       (GET)        → SPA bearer mint (cookie-gated)
  *   /admin/vault-admin-token/<n>  (GET)        → per-vault bearer mint (cookie-gated)
+ *   /admin/channel-token          (GET)        → channel UI bearer mint (cookie-gated)
  *   /api/me                       (GET)        → who-am-I (session+CSRF or hasSession:false)
  *   /api/hub                      (GET)        → hub version + uptime + install-source (host:admin)
  *   /api/hub/upgrade              (POST)       → SPA-driven hub self-upgrade → 202 + detached helper (host:admin, §5.3/D4)
@@ -138,6 +139,7 @@ import {
   handleAdminLoginTotpPost,
   handleAdminLogoutPost,
 } from "./admin-handlers.ts";
+import { handleChannelToken } from "./admin-channel-token.ts";
 import { handleHostAdminToken } from "./admin-host-admin-token.ts";
 import { handleVaultAdminToken } from "./admin-vault-admin-token.ts";
 import { handleCreateVault } from "./admin-vaults.ts";
@@ -2071,6 +2073,14 @@ export function hubFetch(
       if (pathname === "/admin/host-admin-token") {
         if (!getDb) return dbNotConfigured();
         return handleHostAdminToken(req, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+        });
+      }
+
+      if (pathname === "/admin/channel-token") {
+        if (!getDb) return dbNotConfigured();
+        return handleChannelToken(req, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
         });


### PR DESCRIPTION
## Mint a short-lived channel token from the portal session

Adds `GET /admin/channel-token`, a faithful mirror of the existing `/admin/vault-admin-token` / `/admin/host-admin-token`. It lets the **channel chat UI** (served behind hub's proxy to a logged-in portal operator) obtain a short-lived hub-minted token — the same hub-management auth path scribe-config and vault-management already use.

**Pairs with parachute-channel PR #24** (which validates these tokens on the chat-UI endpoints). The channel daemon should only be redeployed to enforce UI auth *after* this is live (hub restarted), so the chat UI can fetch a token.

### What's in it
- **`src/admin-channel-token.ts`** (new) — cookie-gated (same `parseSessionCookie`/`findSession` + first-admin gate as the vault token), mints a JWT with `audience: "channel"`, scope `"channel:read channel:send"` (deliberately **not** `channel:write` — that's the session-reply scope, so a UI token can't impersonate a session), TTL **10 min** (matches `VAULT_ADMIN_TOKEN_TTL_SECONDS`). Returns `{ token, expires_at, scopes }` (`no-store`).
- **`src/hub-server.ts`** — registers `GET /admin/channel-token` next to the other admin-token routes.

### Notes
- Admin-mint goes through `signAccessToken` (no declared-scope gate — same as `vault:<name>:admin`), so this needs no change to channel's `module.json` to mint `channel:send`. (`channel:send` is already a first-party scope in `scope-explanations.ts`.)
- Single bare `aud:"channel"` (channel is one resource, unlike vault's per-instance `vault.<name>`), so no name-validation path — closer to host-admin-token's shape.

### Testing
`bun run typecheck` clean. Targeted: `bun test src/__tests__/admin-channel-token.test.ts admin-host-admin-token.test.ts admin-vault-admin-token.test.ts` → **23 pass / 0 fail** (6 new: no/expired cookie → 401, POST → 405, friend → 403, valid first-admin → 200 with `aud:channel` + correct scopes + TTL + JWT-validates, admin-mints-with-friend-present). Full suite not run (lifecycle tests can boot the real launchd unit — known hazard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)