### PR TITLE
feat(channels): one-action vault-channel provisioning + Channels admin UI (frictionless setup)

### DIFF
--- a/src/__tests__/admin-channels.test.ts
+++ b/src/__tests__/admin-channels.test.ts
@@ -286,6 +286,69 @@ describe("POST /admin/channels — provision", () => {
     expect((decodeJwt(cfgBody.config.token) as { sub?: string }).sub).toBe(userId);
   });
 
+  test("mixed-case channelName is canonicalized to lowercase EVERYWHERE", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({
+      "POST /api/channels": () => ok({ ok: true, name: "eng", transport: "vault", live: true }),
+      "GET /.parachute/config": () => ok({ channels: [], triggerTemplate: TRIGGER_TEMPLATE }),
+      "POST /vault/default/api/triggers": () => ok({ ok: true, name: "channel_inbound_eng" }),
+    });
+    const req = new Request(`${HUB_ORIGIN}/admin/channels`, {
+      method: "POST",
+      headers: { cookie },
+      // Mixed-case input — accepted (the `i`-flag regex passes), then lowercased.
+      body: JSON.stringify({ channelName: "Eng", vault: "default" }),
+    });
+    const res = await handleChannels(req, "", baseDeps(fetchImpl));
+    expect(res.status).toBe(200);
+    const out = (await res.json()) as {
+      channel: string;
+      connect: { mcpAdd: string; launch: string };
+    };
+    // Response channel is lowercased.
+    expect(out.channel).toBe("eng");
+    // Connect lines use the lowercased name.
+    expect(out.connect.mcpAdd).toContain("channel-eng");
+    expect(out.connect.mcpAdd).not.toContain("Eng");
+    expect(out.connect.launch).toContain("server:channel-eng");
+    expect(out.connect.launch).not.toContain("Eng");
+
+    // Channel-config POST writes the lowercased name.
+    const cfgCall = calls.find((c) => c.method === "POST" && c.url.endsWith("/api/channels"));
+    expect((cfgCall!.body as { name: string }).name).toBe("eng");
+
+    // Trigger name is lowercased — so a later DELETE (which reconstructs
+    // `channel_inbound_<lowercased>`) targets exactly this trigger.
+    const trigCall = calls.find(
+      (c) => c.method === "POST" && c.url.endsWith("/vault/default/api/triggers"),
+    );
+    expect((trigCall!.body as { name: string }).name).toBe("channel_inbound_eng");
+  });
+
+  test("mixed-case DELETE targets the lowercased trigger name", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({
+      "GET /api/channels": () =>
+        ok({ channels: [{ name: "eng", transport: "vault", vault: "default" }] }),
+      "DELETE /api/channels/eng": () => ok({ ok: true }),
+      "DELETE /vault/default/api/triggers/channel_inbound_eng": () => ok({ ok: true }),
+    });
+    // Caller passes mixed-case "Eng" in the URL segment.
+    const req = new Request(`${HUB_ORIGIN}/admin/channels/Eng`, {
+      method: "DELETE",
+      headers: { cookie },
+    });
+    const res = await handleChannels(req, "/Eng", baseDeps(fetchImpl));
+    expect(res.status).toBe(200);
+    // The channel DELETE + the trigger DELETE both hit the lowercased name.
+    expect(calls.some((c) => c.url.endsWith("/api/channels/eng"))).toBe(true);
+    expect(
+      calls.some((c) =>
+        c.url.endsWith("/vault/default/api/triggers/channel_inbound_eng"),
+      ),
+    ).toBe(true);
+  });
+
   test("unknown vault → 400", async () => {
     const { cookie } = await adminCookie();
     const { fetchImpl, calls } = mockFetch({});
@@ -381,7 +444,7 @@ describe("POST /admin/channels — provision", () => {
 // ---------------------------------------------------------------------------
 
 describe("GET /admin/channels — list", () => {
-  test("proxies the channel listing; never tokens", async () => {
+  test("returns the flat projected listing; never tokens", async () => {
     const { cookie } = await adminCookie();
     const { fetchImpl, calls } = mockFetch({
       "GET /api/channels": () =>
@@ -393,13 +456,68 @@ describe("GET /admin/channels — list", () => {
     });
     const res = await handleChannels(req, "", baseDeps(fetchImpl));
     expect(res.status).toBe(200);
-    const out = (await res.json()) as { ok: boolean; channels: { channels: unknown[] } };
+    // Flat shape: `{ ok, channels: [{name,transport,vault}] }`.
+    const out = (await res.json()) as {
+      ok: boolean;
+      channels: { name: string; transport: string; vault: string }[];
+    };
     expect(out.ok).toBe(true);
+    expect(out.channels).toEqual([{ name: "eng", transport: "vault", vault: "default" }]);
     // The list bearer is channel:admin; the channel GET never returns secrets.
     const getCall = calls.find((c) => c.method === "GET" && c.url.endsWith("/api/channels"));
     expect(scopeOf(getCall!.bearer!)).toEqual(["channel:admin"]);
     expect(JSON.stringify(out)).not.toContain("token");
     expect(JSON.stringify(out)).not.toContain("webhookSecret");
+  });
+
+  test("hub-layer projection strips any extra/secret field a future channel might add", async () => {
+    const { cookie } = await adminCookie();
+    // A hypothetical future channel version leaks a token + webhookSecret in its
+    // list response. The hub must project them OUT before reaching the SPA.
+    const { fetchImpl } = mockFetch({
+      "GET /api/channels": () =>
+        ok({
+          channels: [
+            {
+              name: "eng",
+              transport: "vault",
+              vault: "default",
+              token: "LEAKED-WRITE-JWT",
+              config: { webhookSecret: "LEAKED-SECRET", token: "ALSO-LEAKED" },
+            },
+          ],
+        }),
+    });
+    const req = new Request(`${HUB_ORIGIN}/admin/channels`, {
+      method: "GET",
+      headers: { cookie },
+    });
+    const res = await handleChannels(req, "", baseDeps(fetchImpl));
+    expect(res.status).toBe(200);
+    const out = (await res.json()) as {
+      channels: Record<string, unknown>[];
+    };
+    // Only the three projected keys survive.
+    expect(Object.keys(out.channels[0]!).sort()).toEqual(["name", "transport", "vault"]);
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain("LEAKED-WRITE-JWT");
+    expect(serialized).not.toContain("LEAKED-SECRET");
+    expect(serialized).not.toContain("ALSO-LEAKED");
+    expect(serialized).not.toContain("webhookSecret");
+  });
+
+  test("mintAdminListToken carries the operator's session userId as sub", async () => {
+    const { cookie, userId } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({
+      "GET /api/channels": () => ok({ channels: [] }),
+    });
+    const req = new Request(`${HUB_ORIGIN}/admin/channels`, {
+      method: "GET",
+      headers: { cookie },
+    });
+    await handleChannels(req, "", baseDeps(fetchImpl));
+    const getCall = calls.find((c) => c.method === "GET" && c.url.endsWith("/api/channels"));
+    expect((decodeJwt(getCall!.bearer!) as { sub?: string }).sub).toBe(userId);
   });
 });
 
@@ -507,5 +625,49 @@ describe("substituteTrigger", () => {
     expect(out.action.send).toBe("json");
     // when-clause is preserved untouched (no placeholders in it here).
     expect(out.when.tags).toEqual(["#channel-message/inbound"]);
+  });
+
+  test("an adversarial template with a __proto__ key does NOT pollute Object.prototype, and the pinned action survives", async () => {
+    const before = ({} as Record<string, unknown>).polluted;
+    expect(before).toBeUndefined();
+
+    // A template carrying a `__proto__` key (both at the top level and nested
+    // inside `action`) that, with a naive `out[k] = ...` over a `{}` object,
+    // would invoke the prototype setter and pollute Object.prototype globally.
+    const adversarial = JSON.parse(
+      JSON.stringify({
+        name: "channel_inbound_<channel>",
+        events: ["created"],
+        when: { tags: ["x"] },
+        action: {
+          webhook: "<hub-origin>/evil",
+          __proto__: { polluted: "yes" },
+        },
+        __proto__: { polluted: "yes" },
+      }),
+      // reviver keeps `__proto__` as an OWN enumerable key (JSON.parse otherwise
+      // also has its own __proto__ handling) — build it explicitly to be safe.
+    ) as Record<string, unknown>;
+    // Force an explicit own `__proto__` data property regardless of parser.
+    Object.defineProperty(adversarial, "__proto__", {
+      value: { polluted: "yes" },
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+
+    const out = substituteTrigger(
+      adversarial as never,
+      "eng",
+      HUB_ORIGIN,
+      "SEND_BEARER",
+    );
+
+    // No global pollution — a fresh object still has no `polluted` key.
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    // The hub still pins the webhook + bearer regardless of the malicious input.
+    expect(out.action.webhook).toBe(`${HUB_ORIGIN}/channel/api/vault/inbound`);
+    expect(out.action.auth?.bearer).toBe("SEND_BEARER");
+    expect(out.name).toBe("channel_inbound_eng");
   });
 });

--- a/src/__tests__/admin-channels.test.ts
+++ b/src/__tests__/admin-channels.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Tests for `POST/GET/DELETE /admin/channels` — one-action vault-channel
+ * provisioning (frictionless channel setup PR 3).
+ *
+ * The channel + vault HTTP calls are mocked via an injectable `fetchImpl` that
+ * records every request (method, URL, decoded Authorization bearer, parsed
+ * JSON body) and returns scripted responses. Tokens are real (minted by the
+ * actual `signAccessToken` against a real signing key), so we can decode the
+ * JWT claims (scope/aud/vault_scope) the way channel/vault would.
+ *
+ * Coverage:
+ *   - 401 with no/invalid session cookie (operator gate).
+ *   - 403 for a signed-in non-first-admin (friend).
+ *   - happy path provisions all three: asserts the channel-config POST body, the
+ *     trigger POST body (incl. action.auth.bearer + substituted webhook URL +
+ *     substituted name), and the returned connect lines.
+ *   - unknown vault → 400.
+ *   - a failing downstream step → clear `provision_failed` error naming the step.
+ *   - idempotent re-POST (channel replace + trigger upsert succeed again).
+ *   - GET lists (never tokens).
+ *   - DELETE tears down both sides.
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { decodeJwt } from "jose";
+import { type ChannelsDeps, handleChannels, substituteTrigger } from "../admin-channels.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+
+const HUB_ORIGIN = "https://hub.test";
+const CHANNEL_ORIGIN = "http://127.0.0.1:1941";
+const VAULT_ORIGIN = "http://127.0.0.1:1940";
+
+interface Harness {
+  db: Database;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-admin-channels-"));
+  const db = openHubDb(hubDbPath(dir));
+  rotateSigningKey(db);
+  return {
+    db,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+async function adminCookie(): Promise<{ cookie: string; userId: string }> {
+  const user = await createUser(harness.db, "operator", "hunter2");
+  const session = createSession(harness.db, { userId: user.id });
+  return {
+    cookie: buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000)),
+    userId: user.id,
+  };
+}
+
+async function friendCookie(): Promise<string> {
+  await createUser(harness.db, "admin", "admin-passphrase");
+  const friend = await createUser(harness.db, "alice", "alice-passphrase", { allowMulti: true });
+  const session = createSession(harness.db, { userId: friend.id });
+  return buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+}
+
+// ---------------------------------------------------------------------------
+// Mock fetch — records requests, returns scripted responses by (method, path).
+// ---------------------------------------------------------------------------
+
+interface RecordedReq {
+  method: string;
+  url: string;
+  bearer: string | null;
+  body: unknown;
+}
+
+type Responder = (req: RecordedReq) => Response;
+
+function mockFetch(routes: Record<string, Responder>): {
+  fetchImpl: typeof fetch;
+  calls: RecordedReq[];
+} {
+  const calls: RecordedReq[] = [];
+  const fetchImpl = (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+    const auth =
+      (init?.headers as Record<string, string> | undefined)?.authorization ??
+      (init?.headers as Record<string, string> | undefined)?.Authorization ??
+      null;
+    const bearer = auth ? auth.replace(/^Bearer\s+/i, "") : null;
+    let body: unknown = undefined;
+    if (typeof init?.body === "string") {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    }
+    const path = new URL(url).pathname;
+    const rec: RecordedReq = { method, url, bearer, body };
+    calls.push(rec);
+    const key = `${method} ${path}`;
+    const responder = routes[key];
+    if (!responder) return new Response("no route", { status: 599 });
+    return responder(rec);
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function ok(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** The channel's prescribed trigger template (mirrors CHANNEL_VAULT_TRIGGER_TEMPLATE). */
+const TRIGGER_TEMPLATE = {
+  name: "channel_inbound_<channel>",
+  events: ["created"],
+  when: {
+    tags: ["#channel-message/inbound"],
+    has_metadata: ["channel"],
+    missing_metadata: ["channel_inbound_rendered_at"],
+  },
+  action: {
+    webhook: "<hub-origin>/channel/api/vault/inbound",
+    send: "json",
+  },
+};
+
+function baseDeps(fetchImpl: typeof fetch): ChannelsDeps {
+  return {
+    db: harness.db,
+    hubOrigin: HUB_ORIGIN,
+    channelOrigin: CHANNEL_ORIGIN,
+    resolveVaultOrigin: (v) => (v === "default" ? VAULT_ORIGIN : null),
+    fetchImpl,
+  };
+}
+
+function scopeOf(jwt: string): string[] {
+  const claims = decodeJwt(jwt) as { scope?: string };
+  return (claims.scope ?? "").split(/\s+/).filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
+// Operator gate
+// ---------------------------------------------------------------------------
+
+describe("operator gate", () => {
+  test("401 when no session cookie is present", async () => {
+    const { fetchImpl } = mockFetch({});
+    const req = new Request(`${HUB_ORIGIN}/admin/channels`, {
+      method: "POST",
+      body: JSON.stringify({ channelName: "eng", vault: "default" }),
+    });
+    const res = await handleChannels(req, "", baseDeps(fetchImpl));
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error: string }).error).toBe("unauthenticated");
+  });
+
+  test("401 when the cookie is garbage (no matching session)", async () => {
+    const { fetchImpl } = mockFetch({});
+    const req = new Request(`${HUB_ORIGIN}/admin/channels`, {
+      method: "POST",
+      headers: { cookie: "parachute_hub_session=nope" },
+      body: JSON.stringify({ channelName: "eng", vault: "default" }),
+    });
+    const res = await handleChannels(req, "", baseDeps(fetchImpl));
+    expect(res.status).toBe(401);
+  });
+
+  test("403 for a signed-in non-first-admin (friend)", async () => {
+    const cookie = await friendCookie();
+    const { fetchImpl } = mockFetch({});
+    const req = new Request(`${HUB_ORIGIN}/admin/channels`, {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify({ channelName: "eng", vault: "default" }),
+    });
+    const res = await handleChannels(req, "", baseDeps(fetchImpl));
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe("not_admin");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST — happy path
+// ---------------------------------------------------------------------------
+
+describe("POST /admin/channels — provision", () => {
+  test("provisions all three: channel config body, trigger body, connect lines", async () => {
+    const { cookie, userId } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({
+      "POST /api/channels": () => ok({ ok: true, name: "eng", transport: "vault", live: true }),
+      "GET /.parachute/config": () => ok({ channels: [], triggerTemplate: TRIGGER_TEMPLATE }),
+      "POST /vault/default/api/triggers": () => ok({ ok: true, name: "channel_inbound_eng" }),
+    });
+    const req = new Request(`${HUB_ORIGIN}/admin/channels`, {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify({ channelName: "eng", vault: "default" }),
+    });
+    const res = await handleChannels(req, "", baseDeps(fetchImpl));
+    expect(res.status).toBe(200);
+    const out = (await res.json()) as {
+      ok: boolean;
+      channel: string;
+      vault: string;
+      connect: { mcpAdd: string; launch: string };
+    };
+    expect(out.ok).toBe(true);
+    expect(out.channel).toBe("eng");
+    expect(out.vault).toBe("default");
+    // Connect lines use the PUBLIC origin + the channel-prefixed MCP name.
+    expect(out.connect.mcpAdd).toBe(
+      `claude mcp add --transport http --scope user channel-eng ${HUB_ORIGIN}/channel/mcp/eng`,
+    );
+    expect(out.connect.launch).toBe(
+      "claude --dangerously-load-development-channels=server:channel-eng --dangerously-skip-permissions",
+    );
+
+    // --- Channel config POST body: vault transport, loopback vaultUrl, a real
+    // vault:default:write token, NO webhookSecret.
+    const cfgCall = calls.find((c) => c.method === "POST" && c.url.endsWith("/api/channels"));
+    expect(cfgCall).toBeDefined();
+    const cfgBody = cfgCall!.body as {
+      name: string;
+      transport: string;
+      config: { vault: string; vaultUrl: string; token: string; webhookSecret?: string };
+    };
+    expect(cfgBody.name).toBe("eng");
+    expect(cfgBody.transport).toBe("vault");
+    expect(cfgBody.config.vault).toBe("default");
+    expect(cfgBody.config.vaultUrl).toBe(VAULT_ORIGIN);
+    expect(cfgBody.config).not.toHaveProperty("webhookSecret");
+    // The config-write bearer carries channel:admin.
+    expect(scopeOf(cfgCall!.bearer!)).toEqual(["channel:admin"]);
+    // The embedded write token is a real vault:default:write JWT.
+    expect(scopeOf(cfgBody.config.token)).toEqual(["vault:default:write"]);
+    expect((decodeJwt(cfgBody.config.token) as { aud?: string }).aud).toBe("vault.default");
+
+    // --- Trigger POST body: substituted name, substituted webhook, the
+    // channel:send bearer in action.auth.bearer.
+    const trigCall = calls.find(
+      (c) => c.method === "POST" && c.url.endsWith("/vault/default/api/triggers"),
+    );
+    expect(trigCall).toBeDefined();
+    const trig = trigCall!.body as {
+      name: string;
+      when: Record<string, unknown>;
+      action: { webhook: string; send?: string; auth?: { bearer?: string } };
+    };
+    expect(trig.name).toBe("channel_inbound_eng");
+    expect(trig.action.webhook).toBe(`${HUB_ORIGIN}/channel/api/vault/inbound`);
+    expect(trig.action.send).toBe("json"); // template field preserved
+    expect(trig.action.auth?.bearer).toBeDefined();
+    expect(scopeOf(trig.action.auth!.bearer!)).toEqual(["channel:send"]);
+    expect((decodeJwt(trig.action.auth!.bearer!) as { aud?: string }).aud).toBe("channel");
+    // The trigger-register bearer (Authorization header) carries vault:default:admin.
+    expect(scopeOf(trigCall!.bearer!)).toEqual(["vault:default:admin"]);
+
+    // Minted tokens are NEVER echoed in the response.
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain(cfgBody.config.token);
+    expect(serialized).not.toContain(trig.action.auth!.bearer);
+
+    // sub = the operator.
+    expect((decodeJwt(cfgBody.config.token) as { sub?: string }).sub).toBe(userId);
+  });
+
+  test("unknown vault → 400", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({});
+    const req = new Request(`${HUB_ORIGIN}/admin/channels`, {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify({ channelName: "eng", vault: "ghost" }),
+    });
+    const res = await handleChannels(req, "", baseDeps(fetchImpl));
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("unknown_vault");
+    // No downstream calls when the vault doesn't exist.
+    expect(calls.length).toBe(0);
+  });
+
+  test("a failing downstream step → clear provision_failed naming the step", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl } = mockFetch({
+      "POST /api/channels": () => new Response("boom", { status: 500 }),
+    });
+    const req = new Request(`${HUB_ORIGIN}/admin/channels`, {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify({ channelName: "eng", vault: "default" }),
+    });
+    const res = await handleChannels(req, "", baseDeps(fetchImpl));
+    expect(res.status).toBe(502);
+    const out = (await res.json()) as { error: string; step: string; error_description: string };
+    expect(out.error).toBe("provision_failed");
+    expect(out.step).toBe("channel_config");
+    expect(out.error_description).toContain("channel_config");
+  });
+
+  test("invalid channelName → 400 before any downstream call", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({});
+    const req = new Request(`${HUB_ORIGIN}/admin/channels`, {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify({ channelName: "bad name!", vault: "default" }),
+    });
+    const res = await handleChannels(req, "", baseDeps(fetchImpl));
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("invalid_request");
+    expect(calls.length).toBe(0);
+  });
+
+  test("idempotent re-POST completes again (channel replace + trigger upsert)", async () => {
+    const { cookie } = await adminCookie();
+    let channelPosts = 0;
+    let triggerPosts = 0;
+    const { fetchImpl } = mockFetch({
+      "POST /api/channels": () => {
+        channelPosts += 1;
+        return ok({ ok: true, name: "eng", transport: "vault", live: true });
+      },
+      "GET /.parachute/config": () => ok({ channels: [], triggerTemplate: TRIGGER_TEMPLATE }),
+      "POST /vault/default/api/triggers": () => {
+        triggerPosts += 1;
+        return ok({ ok: true, name: "channel_inbound_eng" });
+      },
+    });
+    const deps = baseDeps(fetchImpl);
+    const mkReq = () =>
+      new Request(`${HUB_ORIGIN}/admin/channels`, {
+        method: "POST",
+        headers: { cookie },
+        body: JSON.stringify({ channelName: "eng", vault: "default" }),
+      });
+    expect((await handleChannels(mkReq(), "", deps)).status).toBe(200);
+    expect((await handleChannels(mkReq(), "", deps)).status).toBe(200);
+    expect(channelPosts).toBe(2);
+    expect(triggerPosts).toBe(2);
+  });
+
+  test("503 when the channel module is not installed", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl } = mockFetch({});
+    const deps = { ...baseDeps(fetchImpl), channelOrigin: null };
+    const req = new Request(`${HUB_ORIGIN}/admin/channels`, {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify({ channelName: "eng", vault: "default" }),
+    });
+    const res = await handleChannels(req, "", deps);
+    expect(res.status).toBe(503);
+    expect(((await res.json()) as { error: string }).error).toBe("channel_unavailable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET — list
+// ---------------------------------------------------------------------------
+
+describe("GET /admin/channels — list", () => {
+  test("proxies the channel listing; never tokens", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({
+      "GET /api/channels": () =>
+        ok({ channels: [{ name: "eng", transport: "vault", vault: "default" }] }),
+    });
+    const req = new Request(`${HUB_ORIGIN}/admin/channels`, {
+      method: "GET",
+      headers: { cookie },
+    });
+    const res = await handleChannels(req, "", baseDeps(fetchImpl));
+    expect(res.status).toBe(200);
+    const out = (await res.json()) as { ok: boolean; channels: { channels: unknown[] } };
+    expect(out.ok).toBe(true);
+    // The list bearer is channel:admin; the channel GET never returns secrets.
+    const getCall = calls.find((c) => c.method === "GET" && c.url.endsWith("/api/channels"));
+    expect(scopeOf(getCall!.bearer!)).toEqual(["channel:admin"]);
+    expect(JSON.stringify(out)).not.toContain("token");
+    expect(JSON.stringify(out)).not.toContain("webhookSecret");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE — teardown
+// ---------------------------------------------------------------------------
+
+describe("DELETE /admin/channels/:name — teardown", () => {
+  test("tears down both the channel and the vault trigger", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({
+      // resolveChannelVault reads the listing to learn the bound vault.
+      "GET /api/channels": () =>
+        ok({ channels: [{ name: "eng", transport: "vault", vault: "default" }] }),
+      "DELETE /api/channels/eng": () => ok({ ok: true }),
+      "DELETE /vault/default/api/triggers/channel_inbound_eng": () => ok({ ok: true }),
+    });
+    const req = new Request(`${HUB_ORIGIN}/admin/channels/eng`, {
+      method: "DELETE",
+      headers: { cookie },
+    });
+    const res = await handleChannels(req, "/eng", baseDeps(fetchImpl));
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { ok: boolean }).ok).toBe(true);
+
+    const chanDel = calls.find((c) => c.method === "DELETE" && c.url.endsWith("/api/channels/eng"));
+    expect(chanDel).toBeDefined();
+    expect(scopeOf(chanDel!.bearer!)).toEqual(["channel:admin"]);
+
+    const trigDel = calls.find(
+      (c) =>
+        c.method === "DELETE" && c.url.endsWith("/vault/default/api/triggers/channel_inbound_eng"),
+    );
+    expect(trigDel).toBeDefined();
+    expect(scopeOf(trigDel!.bearer!)).toEqual(["vault:default:admin"]);
+  });
+
+  test("partial failure (vault trigger DELETE errors) → 207 with the failing step named", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl } = mockFetch({
+      "GET /api/channels": () =>
+        ok({ channels: [{ name: "eng", transport: "vault", vault: "default" }] }),
+      "DELETE /api/channels/eng": () => ok({ ok: true }),
+      "DELETE /vault/default/api/triggers/channel_inbound_eng": () =>
+        new Response("nope", { status: 500 }),
+    });
+    const req = new Request(`${HUB_ORIGIN}/admin/channels/eng`, {
+      method: "DELETE",
+      headers: { cookie },
+    });
+    const res = await handleChannels(req, "/eng", baseDeps(fetchImpl));
+    expect(res.status).toBe(207);
+    const out = (await res.json()) as { ok: boolean; partial: boolean; errors: { step: string }[] };
+    expect(out.ok).toBe(false);
+    expect(out.partial).toBe(true);
+    expect(out.errors.some((e) => e.step === "vault_trigger")).toBe(true);
+  });
+
+  test("404 from the channel DELETE is treated as already-gone (idempotent)", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl } = mockFetch({
+      "GET /api/channels": () => ok({ channels: [] }), // not listed → vault unknown
+      "DELETE /api/channels/eng": () => new Response("not found", { status: 404 }),
+    });
+    const req = new Request(`${HUB_ORIGIN}/admin/channels/eng`, {
+      method: "DELETE",
+      headers: { cookie },
+    });
+    const res = await handleChannels(req, "/eng", baseDeps(fetchImpl));
+    // Channel side is fine (404 = gone); vault side can't resolve the bound
+    // vault from an empty listing → reported as a partial.
+    expect(res.status).toBe(207);
+    const out = (await res.json()) as { errors: { step: string }[] };
+    expect(out.errors.some((e) => e.step === "vault_trigger")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Method guard
+// ---------------------------------------------------------------------------
+
+describe("method guard", () => {
+  test("405 on PUT /admin/channels", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl } = mockFetch({});
+    const req = new Request(`${HUB_ORIGIN}/admin/channels`, {
+      method: "PUT",
+      headers: { cookie },
+    });
+    const res = await handleChannels(req, "", baseDeps(fetchImpl));
+    expect(res.status).toBe(405);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// substituteTrigger — unit
+// ---------------------------------------------------------------------------
+
+describe("substituteTrigger", () => {
+  test("substitutes <channel>/<hub-origin>, fills webhook + auth.bearer, trims origin slash", async () => {
+    const out = substituteTrigger(TRIGGER_TEMPLATE, "eng", `${HUB_ORIGIN}/`, "SEND_BEARER");
+    expect(out.name).toBe("channel_inbound_eng");
+    expect(out.action.webhook).toBe(`${HUB_ORIGIN}/channel/api/vault/inbound`);
+    expect(out.action.auth?.bearer).toBe("SEND_BEARER");
+    expect(out.action.send).toBe("json");
+    // when-clause is preserved untouched (no placeholders in it here).
+    expect(out.when.tags).toEqual(["#channel-message/inbound"]);
+  });
+});

--- a/src/admin-channels.ts
+++ b/src/admin-channels.ts
@@ -1,0 +1,551 @@
+/**
+ * `POST/GET/DELETE /admin/channels` — one-action vault-channel provisioning.
+ *
+ * The backend half of "frictionless channel setup": make "add a vault-backed
+ * channel" ONE hub action that provisions everything, leaning on the hub's
+ * existing token-minting + operator session so the human never mints tokens,
+ * invents secrets, or edits YAML.
+ *
+ * Gated EXACTLY like `/admin/channel-token` + `/admin/vault-admin-token`: a
+ * cookie-gated operator session pinned to the first admin (`isFirstAdmin`).
+ * Friends pinned to a vault use the OAuth flow for their assigned scopes; they
+ * don't provision channels through this endpoint.
+ *
+ * The hub is the JWT issuer — every token here is minted off the operator's
+ * session via `signAccessToken` (the same machinery `admin-channel-token.ts` +
+ * `admin-vault-admin-token.ts` use). NO secrets are invented (the channel runs
+ * JWT-only — no `webhookSecret`).
+ *
+ * ## POST /admin/channels — body `{ channelName, vault }`
+ *
+ * All steps are server-to-server over loopback (the hub knows the channel's +
+ * vault's loopback ports from services.json). The PUBLIC origin (`hubOrigin`) is
+ * used only for the webhook URL the vault calls back on + the copy-paste connect
+ * lines the UI shows; the internal vault/channel calls use loopback.
+ *
+ *   1. Validate `vault` exists in services.json → 400 if not.
+ *   2. Mint `vault:<vault>:write` — the channel writes replies + ensureSchema.
+ *   3. Mint `channel:admin` (call the channel config API) + `channel:send` (the
+ *      trigger's `action.auth.bearer`).
+ *   4. POST `<channel>/api/channels` (Bearer channel:admin) — write channels.json
+ *      + hot-add the channel. JWT-only (NO webhookSecret).
+ *   5. GET `<channel>/.parachute/config` → take `triggerTemplate`; substitute the
+ *      channel name into `name`/`when`, set `action.webhook` to the hub-proxied
+ *      inbound URL, and set `action.auth.bearer = <channel:send>`.
+ *   6. Mint `vault:<vault>:admin`; POST `<vault>/vault/<vault>/api/triggers`
+ *      (Bearer vault:admin) with the substituted trigger.
+ *   7. Return `{ ok, channel, vault, connect: { mcpAdd, launch } }`.
+ *
+ * Idempotent / re-runnable: every downstream step is an upsert (channel config
+ * replace, trigger upsert), so re-POSTing the same channel completes a partial
+ * provision rather than erroring. A failing step returns a clear error naming
+ * the step.
+ *
+ * ## GET /admin/channels — proxy the channel config API list. Never tokens.
+ *
+ * ## DELETE /admin/channels/:name — tear down both sides (best-effort):
+ *   - DELETE `<channel>/api/channels/:name`
+ *   - DELETE `<vault>/vault/<vault>/api/triggers/channel_inbound_<name>`
+ *   reports partial failures.
+ */
+import type { Database } from "bun:sqlite";
+import { signAccessToken } from "./jwt-sign.ts";
+import { findSession, parseSessionCookie } from "./sessions.ts";
+import { isFirstAdmin } from "./users.ts";
+import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
+
+/** Short TTL — these tokens are used immediately for the provisioning calls. */
+const PROVISION_TOKEN_TTL_SECONDS = 60;
+/**
+ * The channel:send token is the trigger's persisted `action.auth.bearer` — it
+ * must outlive the request (the vault re-presents it on every inbound webhook).
+ * Long-lived to match the daemon's headless-credential posture (~90d).
+ */
+const TRIGGER_BEARER_TTL_SECONDS = 90 * 24 * 60 * 60;
+const CHANNEL_AUDIENCE = "channel";
+const PROVISION_CLIENT_ID = "parachute-hub-spa";
+
+/**
+ * Channel + trigger name charset. The channel name lands in a services.json
+ * key, a vault trigger name (`channel_inbound_<name>`), a URL path segment, and
+ * an MCP server name — keep it to a conservative slug to close injection across
+ * all of them. Mirrors the slug shape the channel launcher enforces.
+ */
+const CHANNEL_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/i;
+
+export interface ChannelsDeps {
+  db: Database;
+  /** Public hub origin — webhook URL + connect lines + minted-token `iss`. */
+  hubOrigin: string;
+  /** Loopback origin for the channel daemon, e.g. `http://127.0.0.1:1941`, or null when channel isn't installed. */
+  channelOrigin: string | null;
+  /**
+   * Resolve a vault's loopback origin (e.g. `http://127.0.0.1:1940`) from
+   * services.json, or `null` when no vault by that name is installed. Read at
+   * request time so a freshly-created vault provisions without a hub restart.
+   */
+  resolveVaultOrigin: (vaultName: string) => string | null;
+  /** Test seam — `globalThis.fetch` in production. */
+  fetchImpl?: typeof fetch;
+  /** Test seam — defaults to the real `signAccessToken`. */
+  signToken?: typeof signAccessToken;
+  /** Test seam for the clock. */
+  now?: () => Date;
+}
+
+/** Shape of the prescribed trigger the channel serves at `/.parachute/config`. */
+interface TriggerTemplate {
+  name: string;
+  events: string[];
+  when: Record<string, unknown>;
+  action: {
+    webhook: string;
+    send?: string;
+    auth?: { bearer?: string };
+    [k: string]: unknown;
+  };
+  [k: string]: unknown;
+}
+
+export async function handleChannels(
+  req: Request,
+  /** Path after `/admin/channels` — `""` for the collection, `/<name>` for an item. */
+  subPath: string,
+  deps: ChannelsDeps,
+): Promise<Response> {
+  // --- Operator gate (mirrors admin-channel-token / admin-vault-admin-token).
+  const sid = parseSessionCookie(req.headers.get("cookie"));
+  const session = sid ? findSession(deps.db, sid) : null;
+  if (!session) {
+    return jsonError(401, "unauthenticated", "no admin session — sign in at /login first");
+  }
+  if (!isFirstAdmin(deps.db, session.userId)) {
+    return jsonError(
+      403,
+      "not_admin",
+      "channel provisioning is restricted to the hub admin — your account home is at /account/",
+    );
+  }
+
+  if (deps.channelOrigin === null) {
+    return jsonError(
+      503,
+      "channel_unavailable",
+      "the channel module is not installed on this hub",
+    );
+  }
+
+  const method = req.method;
+  const itemName = subPath.startsWith("/") ? decodeURIComponent(subPath.slice(1)) : "";
+
+  if (itemName === "" && method === "GET") {
+    return listChannels(deps);
+  }
+  if (itemName === "" && method === "POST") {
+    return provisionChannel(req, session.userId, deps);
+  }
+  if (itemName !== "" && method === "DELETE") {
+    return teardownChannel(itemName, session.userId, deps);
+  }
+  return jsonError(405, "method_not_allowed", "use POST/GET on /admin/channels or DELETE on /admin/channels/:name");
+}
+
+// ---------------------------------------------------------------------------
+// POST — provision
+// ---------------------------------------------------------------------------
+
+async function provisionChannel(
+  req: Request,
+  userId: string,
+  deps: ChannelsDeps,
+): Promise<Response> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const channelOrigin = deps.channelOrigin as string; // null-checked by caller
+
+  let body: { channelName?: unknown; vault?: unknown };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return jsonError(400, "invalid_request", "request body must be JSON");
+  }
+  const channelName = typeof body.channelName === "string" ? body.channelName.trim() : "";
+  const vault = typeof body.vault === "string" ? body.vault.trim() : "";
+
+  if (!CHANNEL_NAME_RE.test(channelName)) {
+    return jsonError(400, "invalid_request", `channelName "${channelName}" is not a valid identifier`);
+  }
+  if (!VAULT_NAME_CHARSET_RE.test(vault)) {
+    return jsonError(400, "invalid_request", `vault "${vault}" is not a valid identifier`);
+  }
+
+  // Step 1 — vault must exist in services.json.
+  const vaultOrigin = deps.resolveVaultOrigin(vault);
+  if (vaultOrigin === null) {
+    return jsonError(400, "unknown_vault", `no vault named "${vault}" in this hub`);
+  }
+
+  // Steps 2–3 — mint the three tokens off the operator's session.
+  let vaultWriteToken: string;
+  let channelAdminToken: string;
+  let channelSendToken: string;
+  try {
+    vaultWriteToken = (await mint(deps, userId, {
+      scopes: [`vault:${vault}:write`],
+      audience: `vault.${vault}`,
+      vaultScope: [vault],
+      ttlSeconds: TRIGGER_BEARER_TTL_SECONDS, // the channel keeps this for its lifetime
+    })).token;
+    channelAdminToken = (await mint(deps, userId, {
+      scopes: ["channel:admin"],
+      audience: CHANNEL_AUDIENCE,
+      vaultScope: [],
+      ttlSeconds: PROVISION_TOKEN_TTL_SECONDS,
+    })).token;
+    channelSendToken = (await mint(deps, userId, {
+      scopes: ["channel:send"],
+      audience: CHANNEL_AUDIENCE,
+      vaultScope: [],
+      ttlSeconds: TRIGGER_BEARER_TTL_SECONDS, // persisted as the trigger bearer
+    })).token;
+  } catch (err) {
+    return stepError("mint_tokens", err);
+  }
+
+  // Step 4 — write the channel (upsert: POST replaces an existing entry). NO
+  // webhookSecret — JWT-only.
+  try {
+    const res = await fetchImpl(`${channelOrigin}/api/channels`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${channelAdminToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        name: channelName,
+        transport: "vault",
+        config: { vault, vaultUrl: vaultOrigin, token: vaultWriteToken },
+      }),
+    });
+    if (!res.ok) {
+      return stepError("channel_config", await describeRemote(res));
+    }
+  } catch (err) {
+    return stepError("channel_config", err);
+  }
+
+  // Step 5 — fetch the channel's prescribed trigger template + substitute.
+  let trigger: TriggerTemplate;
+  try {
+    const res = await fetchImpl(`${channelOrigin}/.parachute/config`, {
+      headers: { accept: "application/json" },
+    });
+    if (!res.ok) {
+      return stepError("channel_config_fetch", await describeRemote(res));
+    }
+    const cfg = (await res.json()) as { triggerTemplate?: TriggerTemplate };
+    if (!cfg.triggerTemplate || typeof cfg.triggerTemplate !== "object") {
+      return stepError(
+        "channel_config_fetch",
+        new Error("channel /.parachute/config returned no triggerTemplate"),
+      );
+    }
+    trigger = substituteTrigger(cfg.triggerTemplate, channelName, deps.hubOrigin, channelSendToken);
+  } catch (err) {
+    return stepError("channel_config_fetch", err);
+  }
+
+  // Step 6 — register the trigger on the vault (upsert: POST replaces by name).
+  try {
+    const vaultAdminToken = (await mint(deps, userId, {
+      scopes: [`vault:${vault}:admin`],
+      audience: `vault.${vault}`,
+      vaultScope: [vault],
+      ttlSeconds: PROVISION_TOKEN_TTL_SECONDS,
+    })).token;
+    const res = await fetchImpl(`${vaultOrigin}/vault/${vault}/api/triggers`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${vaultAdminToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(trigger),
+    });
+    if (!res.ok) {
+      return stepError("vault_trigger", await describeRemote(res));
+    }
+  } catch (err) {
+    return stepError("vault_trigger", err);
+  }
+
+  // Step 7 — connect lines for the UI. Built from the PUBLIC origin so the
+  // copy-paste one-liners work over the expose, not just loopback.
+  const origin = deps.hubOrigin.replace(/\/+$/, "");
+  return json(200, {
+    ok: true,
+    channel: channelName,
+    vault,
+    connect: {
+      mcpAdd: `claude mcp add --transport http --scope user channel-${channelName} ${origin}/channel/mcp/${channelName}`,
+      launch: `claude --dangerously-load-development-channels=server:channel-${channelName} --dangerously-skip-permissions`,
+    },
+  });
+}
+
+/**
+ * Substitute the channel name + hub origin + send-bearer into the channel's
+ * prescribed trigger template. The template carries `<channel>` placeholders in
+ * `name`/`when` and `<hub-origin>` in `action.webhook`, plus an (empty/absent)
+ * `action.auth.bearer` for the hub to fill.
+ */
+export function substituteTrigger(
+  template: TriggerTemplate,
+  channelName: string,
+  hubOrigin: string,
+  sendBearer: string,
+): TriggerTemplate {
+  const origin = hubOrigin.replace(/\/+$/, "");
+  const replace = (s: string): string =>
+    s.replace(/<channel>/g, channelName).replace(/<hub-origin>/g, origin);
+
+  // Deep-walk strings, substituting placeholders. Keeps the channel as the
+  // owner of the trigger SHAPE — the hub only fills the placeholders + bearer.
+  const walk = (v: unknown): unknown => {
+    if (typeof v === "string") return replace(v);
+    if (Array.isArray(v)) return v.map(walk);
+    if (v && typeof v === "object") {
+      const out: Record<string, unknown> = {};
+      for (const [k, val] of Object.entries(v as Record<string, unknown>)) out[k] = walk(val);
+      return out;
+    }
+    return v;
+  };
+
+  const substituted = walk(template) as TriggerTemplate;
+  // Fill the inbound webhook URL with the hub-proxied path + the channel:send
+  // bearer the vault re-presents on each inbound callback.
+  substituted.action = {
+    ...substituted.action,
+    webhook: `${origin}/channel/api/vault/inbound`,
+    auth: { ...(substituted.action.auth ?? {}), bearer: sendBearer },
+  };
+  return substituted;
+}
+
+// ---------------------------------------------------------------------------
+// GET — list (proxy channel config API; never tokens)
+// ---------------------------------------------------------------------------
+
+async function listChannels(deps: ChannelsDeps): Promise<Response> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const channelOrigin = deps.channelOrigin as string;
+  // List is operator-only metadata; mint a short channel:admin to read it.
+  // (The channel GET /api/channels gates on channel:admin and never returns
+  // secrets — see parachute-channel daemon-config-api.)
+  let adminToken: string;
+  try {
+    adminToken = (await mintAdminListToken(deps)).token;
+  } catch (err) {
+    return stepError("mint_tokens", err);
+  }
+  try {
+    const res = await fetchImpl(`${channelOrigin}/api/channels`, {
+      headers: { authorization: `Bearer ${adminToken}`, accept: "application/json" },
+    });
+    if (!res.ok) {
+      return stepError("channel_config", await describeRemote(res));
+    }
+    const listed = (await res.json()) as unknown;
+    return json(200, { ok: true, channels: listed });
+  } catch (err) {
+    return stepError("channel_config", err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DELETE — teardown both sides (best-effort)
+// ---------------------------------------------------------------------------
+
+async function teardownChannel(
+  channelName: string,
+  userId: string,
+  deps: ChannelsDeps,
+): Promise<Response> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const channelOrigin = deps.channelOrigin as string;
+
+  if (!CHANNEL_NAME_RE.test(channelName)) {
+    return jsonError(400, "invalid_request", `channel name "${channelName}" is not a valid identifier`);
+  }
+
+  const errors: { step: string; detail: string }[] = [];
+
+  // Channel side — DELETE the channel config entry.
+  try {
+    const adminToken = (await mint(deps, userId, {
+      scopes: ["channel:admin"],
+      audience: CHANNEL_AUDIENCE,
+      vaultScope: [],
+      ttlSeconds: PROVISION_TOKEN_TTL_SECONDS,
+    })).token;
+    const res = await fetchImpl(`${channelOrigin}/api/channels/${encodeURIComponent(channelName)}`, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    // 404 = already gone → treat as success (idempotent teardown).
+    if (!res.ok && res.status !== 404) {
+      errors.push({ step: "channel_config", detail: await remoteDetail(res) });
+    }
+  } catch (err) {
+    errors.push({ step: "channel_config", detail: errMsg(err) });
+  }
+
+  // Vault side — DELETE the inbound trigger. We don't know which vault the
+  // channel was bound to from the name alone, so derive it from the channel
+  // listing (best-effort) and delete `channel_inbound_<name>` on that vault.
+  const vault = await resolveChannelVault(channelName, deps).catch(() => null);
+  if (vault) {
+    const vaultOrigin = deps.resolveVaultOrigin(vault);
+    if (vaultOrigin) {
+      try {
+        const vaultAdminToken = (await mint(deps, userId, {
+          scopes: [`vault:${vault}:admin`],
+          audience: `vault.${vault}`,
+          vaultScope: [vault],
+          ttlSeconds: PROVISION_TOKEN_TTL_SECONDS,
+        })).token;
+        const triggerName = `channel_inbound_${channelName}`;
+        const res = await fetchImpl(
+          `${vaultOrigin}/vault/${vault}/api/triggers/${encodeURIComponent(triggerName)}`,
+          { method: "DELETE", headers: { authorization: `Bearer ${vaultAdminToken}` } },
+        );
+        if (!res.ok && res.status !== 404) {
+          errors.push({ step: "vault_trigger", detail: await remoteDetail(res) });
+        }
+      } catch (err) {
+        errors.push({ step: "vault_trigger", detail: errMsg(err) });
+      }
+    } else {
+      errors.push({ step: "vault_trigger", detail: `vault "${vault}" no longer installed` });
+    }
+  } else {
+    // Couldn't determine the bound vault — the channel side is torn down, but
+    // the trigger may linger. Surface it as a partial failure, not a hard error.
+    errors.push({
+      step: "vault_trigger",
+      detail: "could not determine the bound vault — its inbound trigger may need manual removal",
+    });
+  }
+
+  if (errors.length > 0) {
+    return json(207, { ok: false, channel: channelName, partial: true, errors });
+  }
+  return json(200, { ok: true, channel: channelName });
+}
+
+/**
+ * Best-effort: read the channel listing to find which vault `channelName` is
+ * bound to. Returns null when the channel isn't listed or carries no vault.
+ */
+async function resolveChannelVault(channelName: string, deps: ChannelsDeps): Promise<string | null> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const channelOrigin = deps.channelOrigin as string;
+  const adminToken = (await mintAdminListToken(deps)).token;
+  const res = await fetchImpl(`${channelOrigin}/api/channels`, {
+    headers: { authorization: `Bearer ${adminToken}`, accept: "application/json" },
+  });
+  if (!res.ok) return null;
+  const parsed = (await res.json()) as { channels?: Array<{ name?: string; vault?: string }> };
+  const list = Array.isArray(parsed?.channels) ? parsed.channels : [];
+  const match = list.find((c) => c?.name === channelName);
+  return match && typeof match.vault === "string" ? match.vault : null;
+}
+
+// ---------------------------------------------------------------------------
+// Mint helpers
+// ---------------------------------------------------------------------------
+
+interface MintSpec {
+  scopes: string[];
+  audience: string;
+  vaultScope: string[];
+  ttlSeconds: number;
+}
+
+async function mint(deps: ChannelsDeps, userId: string, spec: MintSpec) {
+  const sign = deps.signToken ?? signAccessToken;
+  return sign(deps.db, {
+    sub: userId,
+    scopes: spec.scopes,
+    audience: spec.audience,
+    clientId: PROVISION_CLIENT_ID,
+    issuer: deps.hubOrigin,
+    ttlSeconds: spec.ttlSeconds,
+    vaultScope: spec.vaultScope,
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  });
+}
+
+/** A short channel:admin token, used for the read-only list/lookup paths. */
+async function mintAdminListToken(deps: ChannelsDeps) {
+  const sign = deps.signToken ?? signAccessToken;
+  // List/lookup happens with no per-request user in scope beyond the gate; use
+  // a fixed operator subject. The session gate already authorized the caller.
+  return sign(deps.db, {
+    sub: "operator",
+    scopes: ["channel:admin"],
+    audience: CHANNEL_AUDIENCE,
+    clientId: PROVISION_CLIENT_ID,
+    issuer: deps.hubOrigin,
+    ttlSeconds: PROVISION_TOKEN_TTL_SECONDS,
+    vaultScope: [],
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Response helpers
+// ---------------------------------------------------------------------------
+
+function json(status: number, payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+/** A clear "step X failed" error so a partial provision never returns ambiguously. */
+function stepError(step: string, cause: unknown): Response {
+  return json(502, {
+    error: "provision_failed",
+    step,
+    error_description: `provisioning failed at step "${step}": ${errMsg(cause)}`,
+  });
+}
+
+function errMsg(cause: unknown): string {
+  if (cause instanceof Error) return cause.message;
+  if (typeof cause === "string") return cause;
+  return String(cause);
+}
+
+/** Build an Error describing a non-ok downstream response (status + short body). */
+async function describeRemote(res: Response): Promise<Error> {
+  return new Error(await remoteDetail(res));
+}
+
+async function remoteDetail(res: Response): Promise<string> {
+  let text = "";
+  try {
+    text = (await res.text()).slice(0, 300);
+  } catch {
+    // ignore — status alone is informative enough
+  }
+  return `downstream ${res.status}${text ? `: ${text}` : ""}`;
+}

--- a/src/admin-channels.ts
+++ b/src/admin-channels.ts
@@ -139,7 +139,7 @@ export async function handleChannels(
   const itemName = subPath.startsWith("/") ? decodeURIComponent(subPath.slice(1)) : "";
 
   if (itemName === "" && method === "GET") {
-    return listChannels(deps);
+    return listChannels(deps, session.userId);
   }
   if (itemName === "" && method === "POST") {
     return provisionChannel(req, session.userId, deps);
@@ -168,15 +168,26 @@ async function provisionChannel(
   } catch {
     return jsonError(400, "invalid_request", "request body must be JSON");
   }
-  const channelName = typeof body.channelName === "string" ? body.channelName.trim() : "";
+  const rawChannelName = typeof body.channelName === "string" ? body.channelName.trim() : "";
   const vault = typeof body.vault === "string" ? body.vault.trim() : "";
 
-  if (!CHANNEL_NAME_RE.test(channelName)) {
-    return jsonError(400, "invalid_request", `channelName "${channelName}" is not a valid identifier`);
+  if (!CHANNEL_NAME_RE.test(rawChannelName)) {
+    return jsonError(
+      400,
+      "invalid_request",
+      `channelName "${rawChannelName}" is not a valid identifier`,
+    );
   }
   if (!VAULT_NAME_CHARSET_RE.test(vault)) {
     return jsonError(400, "invalid_request", `vault "${vault}" is not a valid identifier`);
   }
+  // Canonicalize to lowercase AFTER validation. `CHANNEL_NAME_RE` carries the
+  // `i` flag, so mixed-case input is accepted — but the name then becomes a
+  // services.json key, the `channel_inbound_<name>` trigger name, an MCP server
+  // name, and a DELETE-path segment. Case-drift there ("Eng" created, "eng"
+  // deleted) silently desyncs create/delete/connect. Lowercasing once here and
+  // using the normalized value EVERYWHERE keeps all four in lockstep.
+  const channelName = rawChannelName.toLowerCase();
 
   // Step 1 — vault must exist in services.json.
   const vaultOrigin = deps.resolveVaultOrigin(vault);
@@ -309,11 +320,15 @@ export function substituteTrigger(
 
   // Deep-walk strings, substituting placeholders. Keeps the channel as the
   // owner of the trigger SHAPE — the hub only fills the placeholders + bearer.
+  // Constructed objects use a null prototype (`Object.create(null)`) so an
+  // adversarial template carrying a `"__proto__"` (or `"constructor"`) key sets
+  // it as a plain own property rather than invoking the prototype setter — no
+  // prototype pollution even though the channel is currently trusted local code.
   const walk = (v: unknown): unknown => {
     if (typeof v === "string") return replace(v);
     if (Array.isArray(v)) return v.map(walk);
     if (v && typeof v === "object") {
-      const out: Record<string, unknown> = {};
+      const out: Record<string, unknown> = Object.create(null);
       for (const [k, val] of Object.entries(v as Record<string, unknown>)) out[k] = walk(val);
       return out;
     }
@@ -322,12 +337,13 @@ export function substituteTrigger(
 
   const substituted = walk(template) as TriggerTemplate;
   // Fill the inbound webhook URL with the hub-proxied path + the channel:send
-  // bearer the vault re-presents on each inbound callback.
-  substituted.action = {
-    ...substituted.action,
+  // bearer the vault re-presents on each inbound callback. Rebuild `action` on a
+  // null prototype too (same anti-pollution posture) before pinning the two
+  // hub-owned fields.
+  substituted.action = Object.assign(Object.create(null), substituted.action, {
     webhook: `${origin}/channel/api/vault/inbound`,
-    auth: { ...(substituted.action.auth ?? {}), bearer: sendBearer },
-  };
+    auth: Object.assign(Object.create(null), substituted.action.auth ?? {}, { bearer: sendBearer }),
+  });
   return substituted;
 }
 
@@ -335,7 +351,7 @@ export function substituteTrigger(
 // GET — list (proxy channel config API; never tokens)
 // ---------------------------------------------------------------------------
 
-async function listChannels(deps: ChannelsDeps): Promise<Response> {
+async function listChannels(deps: ChannelsDeps, userId: string): Promise<Response> {
   const fetchImpl = deps.fetchImpl ?? fetch;
   const channelOrigin = deps.channelOrigin as string;
   // List is operator-only metadata; mint a short channel:admin to read it.
@@ -343,7 +359,7 @@ async function listChannels(deps: ChannelsDeps): Promise<Response> {
   // secrets — see parachute-channel daemon-config-api.)
   let adminToken: string;
   try {
-    adminToken = (await mintAdminListToken(deps)).token;
+    adminToken = (await mintAdminListToken(deps, userId)).token;
   } catch (err) {
     return stepError("mint_tokens", err);
   }
@@ -354,8 +370,22 @@ async function listChannels(deps: ChannelsDeps): Promise<Response> {
     if (!res.ok) {
       return stepError("channel_config", await describeRemote(res));
     }
-    const listed = (await res.json()) as unknown;
-    return json(200, { ok: true, channels: listed });
+    const listed = (await res.json()) as { channels?: unknown };
+    // Belt-and-suspenders projection at the HUB layer: re-shape every listed
+    // channel to ONLY {name, transport, vault}, so a future channel version that
+    // adds a token/secret field to its list response can NEVER be proxied to the
+    // SPA. The channel today never returns secrets here — this guards against a
+    // downstream regression independent of the SPA-side filtering.
+    const rawList = Array.isArray(listed?.channels) ? listed.channels : [];
+    const channels = rawList.map((c) => {
+      const row = (c ?? {}) as Record<string, unknown>;
+      return {
+        name: typeof row.name === "string" ? row.name : null,
+        transport: typeof row.transport === "string" ? row.transport : null,
+        vault: typeof row.vault === "string" ? row.vault : null,
+      };
+    });
+    return json(200, { ok: true, channels });
   } catch (err) {
     return stepError("channel_config", err);
   }
@@ -366,16 +396,24 @@ async function listChannels(deps: ChannelsDeps): Promise<Response> {
 // ---------------------------------------------------------------------------
 
 async function teardownChannel(
-  channelName: string,
+  rawChannelName: string,
   userId: string,
   deps: ChannelsDeps,
 ): Promise<Response> {
   const fetchImpl = deps.fetchImpl ?? fetch;
   const channelOrigin = deps.channelOrigin as string;
 
-  if (!CHANNEL_NAME_RE.test(channelName)) {
-    return jsonError(400, "invalid_request", `channel name "${channelName}" is not a valid identifier`);
+  if (!CHANNEL_NAME_RE.test(rawChannelName)) {
+    return jsonError(
+      400,
+      "invalid_request",
+      `channel name "${rawChannelName}" is not a valid identifier`,
+    );
   }
+  // Canonicalize to lowercase — matches the create-side normalization so the
+  // `channel_inbound_<name>` trigger formula + the channel-config key target
+  // exactly what provisioning wrote, regardless of the casing the caller used.
+  const channelName = rawChannelName.toLowerCase();
 
   const errors: { step: string; detail: string }[] = [];
 
@@ -402,7 +440,7 @@ async function teardownChannel(
   // Vault side — DELETE the inbound trigger. We don't know which vault the
   // channel was bound to from the name alone, so derive it from the channel
   // listing (best-effort) and delete `channel_inbound_<name>` on that vault.
-  const vault = await resolveChannelVault(channelName, deps).catch(() => null);
+  const vault = await resolveChannelVault(channelName, deps, userId).catch(() => null);
   if (vault) {
     const vaultOrigin = deps.resolveVaultOrigin(vault);
     if (vaultOrigin) {
@@ -446,10 +484,14 @@ async function teardownChannel(
  * Best-effort: read the channel listing to find which vault `channelName` is
  * bound to. Returns null when the channel isn't listed or carries no vault.
  */
-async function resolveChannelVault(channelName: string, deps: ChannelsDeps): Promise<string | null> {
+async function resolveChannelVault(
+  channelName: string,
+  deps: ChannelsDeps,
+  userId: string,
+): Promise<string | null> {
   const fetchImpl = deps.fetchImpl ?? fetch;
   const channelOrigin = deps.channelOrigin as string;
-  const adminToken = (await mintAdminListToken(deps)).token;
+  const adminToken = (await mintAdminListToken(deps, userId)).token;
   const res = await fetchImpl(`${channelOrigin}/api/channels`, {
     headers: { authorization: `Bearer ${adminToken}`, accept: "application/json" },
   });
@@ -485,13 +527,16 @@ async function mint(deps: ChannelsDeps, userId: string, spec: MintSpec) {
   });
 }
 
-/** A short channel:admin token, used for the read-only list/lookup paths. */
-async function mintAdminListToken(deps: ChannelsDeps) {
+/**
+ * A short channel:admin token for the read-only list/lookup paths. `sub` is the
+ * operator's session userId — same subject the POST/DELETE mints use, so every
+ * token this endpoint issues attributes back to the authenticated operator in
+ * the registry (rather than a synthetic "operator" subject).
+ */
+async function mintAdminListToken(deps: ChannelsDeps, userId: string) {
   const sign = deps.signToken ?? signAccessToken;
-  // List/lookup happens with no per-request user in scope beyond the gate; use
-  // a fixed operator subject. The session gate already authorized the caller.
   return sign(deps.db, {
-    sub: "operator",
+    sub: userId,
     scopes: ["channel:admin"],
     audience: CHANNEL_AUDIENCE,
     clientId: PROVISION_CLIENT_ID,

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -46,6 +46,8 @@
  *   /admin/host-admin-token       (GET)        → SPA bearer mint (cookie-gated)
  *   /admin/vault-admin-token/<n>  (GET)        → per-vault bearer mint (cookie-gated)
  *   /admin/channel-token          (GET)        → channel UI bearer mint (cookie-gated)
+ *   /admin/channels               (POST/GET)   → vault-channel provision/list (cookie-gated)
+ *   /admin/channels/<name>        (DELETE)     → vault-channel teardown (cookie-gated)
  *   /api/me                       (GET)        → who-am-I (session+CSRF or hasSession:false)
  *   /api/hub                      (GET)        → hub version + uptime + install-source (host:admin)
  *   /api/hub/upgrade              (POST)       → SPA-driven hub self-upgrade → 202 + detached helper (host:admin, §5.3/D4)
@@ -140,6 +142,7 @@ import {
   handleAdminLogoutPost,
 } from "./admin-handlers.ts";
 import { handleChannelToken } from "./admin-channel-token.ts";
+import { handleChannels } from "./admin-channels.ts";
 import { handleHostAdminToken } from "./admin-host-admin-token.ts";
 import { handleVaultAdminToken } from "./admin-vault-admin-token.ts";
 import { handleCreateVault } from "./admin-vaults.ts";
@@ -2083,6 +2086,37 @@ export function hubFetch(
         return handleChannelToken(req, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+        });
+      }
+
+      // /admin/channels — one-action vault-channel provisioning (frictionless
+      // channel setup PR 3). Cookie-gated operator session (first-admin),
+      // exactly like /admin/channel-token above. POST provisions everything
+      // (mint vault:write + channel:admin + channel:send, write the channel
+      // config, register the vault inbound trigger); GET lists; DELETE tears
+      // down both sides. Internal channel/vault calls go over loopback (origins
+      // resolved from services.json at request time); the public origin is used
+      // only for the webhook URL + the copy-paste connect lines.
+      if (pathname === "/admin/channels" || pathname.startsWith("/admin/channels/")) {
+        if (!getDb) return dbNotConfigured();
+        const subPath = pathname.slice("/admin/channels".length);
+        const services = readManifestLenient(manifestPath).services;
+        // Channel's services.json row is `name: "channel"` on its loopback port.
+        const channelEntry = services.find((s) => s.name === "channel");
+        const channelOrigin = channelEntry ? `http://127.0.0.1:${channelEntry.port}` : null;
+        const resolveVaultOrigin = (vaultName: string): string | null => {
+          const match = findVaultUpstream(
+            readManifestLenient(manifestPath).services,
+            `/vault/${vaultName}`,
+          );
+          return match ? `http://127.0.0.1:${match.port}` : null;
+        };
+        return handleChannels(req, subPath, {
+          db: getDb(),
+          // Public origin — webhook URL + connect lines + minted-token `iss`.
+          hubOrigin: oauthDeps(req).issuer,
+          channelOrigin,
+          resolveVaultOrigin,
         });
       }
 

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -82,7 +82,7 @@ describe("App — brand subtitle (route-derived)", () => {
 });
 
 describe("App — nav structure", () => {
-  it("renders all nav links in order: brand, Vaults, Modules, Users, Permissions, Tokens, Settings, Discovery (signed-out)", async () => {
+  it("renders all nav links in order: brand, Vaults, Modules, Users, Channels, Permissions, Tokens, Settings, Discovery (signed-out)", async () => {
     renderAt("/vaults");
     // Wait for /api/me to resolve so AuthIndicator's "Sign in" link
     // appears in the nav before we snapshot the link order.
@@ -101,6 +101,7 @@ describe("App — nav structure", () => {
       "Vaults",
       "Modules",
       "Users",
+      "Channels",
       "Permissions",
       "Tokens",
       "Settings",

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -27,6 +27,7 @@ import { BrandMark, WORDMARK_TEXT } from "./components/BrandMark.tsx";
 import { HubVersionBadge } from "./components/HubVersionBadge.tsx";
 import { type MeResponse, type ModuleListing, getMe, listModules, signOut } from "./lib/api.ts";
 import { ApproveClient } from "./routes/ApproveClient.tsx";
+import { Channels } from "./routes/Channels.tsx";
 import { ModuleConfig } from "./routes/ModuleConfig.tsx";
 import { Modules } from "./routes/Modules.tsx";
 import { NewVault } from "./routes/NewVault.tsx";
@@ -57,6 +58,9 @@ function subtitleFor(pathname: string): string {
   }
   if (pathname === "/users" || pathname.startsWith("/users/")) {
     return "users";
+  }
+  if (pathname === "/channels" || pathname.startsWith("/channels/")) {
+    return "channels";
   }
   if (pathname === "/settings" || pathname.startsWith("/settings/")) {
     return "settings";
@@ -172,6 +176,7 @@ export function App() {
         <NavSection to="/modules" label="Modules" />
         <InstalledServicesDropdown services={installedServices} />
         <NavSection to="/users" label="Users" />
+        <NavSection to="/channels" label="Channels" />
         <NavSection to="/permissions" label="Permissions" />
         <NavSection to="/tokens" label="Tokens" />
         <NavSection to="/settings" label="Settings" />
@@ -188,6 +193,7 @@ export function App() {
         <Route path="/modules" element={<Modules />} />
         <Route path="/modules/:short/config" element={<ModuleConfig />} />
         <Route path="/users" element={<Users />} />
+        <Route path="/channels" element={<Channels />} />
         <Route path="/permissions" element={<Permissions />} />
         <Route path="/tokens" element={<Tokens />} />
         <Route path="/settings" element={<Settings />} />

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1589,6 +1589,173 @@ export async function getHubUpgradeStatus(): Promise<HubUpgradeStatus | null> {
   return (await res.json()) as HubUpgradeStatus;
 }
 
+// ---------------------------------------------------------------------------
+// Channels (vault-backed chat channels). cookie-gated `/admin/channels`
+// orchestration endpoint (src/admin-channels.ts) — provisions a channel +
+// vault trigger + tokens in one POST. First-admin only, same operator-session
+// gate as the vault-admin-token mint, so these go through the session cookie
+// rather than the host-admin Bearer.
+// ---------------------------------------------------------------------------
+
+/** One row from `GET /admin/channels` — the operator-visible channel metadata (never tokens). */
+export interface ChannelListing {
+  name: string;
+  /** Channel transport — `vault` for a vault-backed channel. */
+  transport: string;
+  /** Vault the channel is bound to. */
+  vault: string;
+}
+
+/**
+ * Copy-paste connect lines returned by `POST /admin/channels`. The operator
+ * runs these where their Claude Code session will live; the launch line is
+ * the one-shot that joins the freshly-provisioned channel.
+ */
+export interface ChannelConnect {
+  mcpAdd: string;
+  launch: string;
+}
+
+/** `POST /admin/channels` success body. */
+export interface ProvisionedChannel {
+  channel: string;
+  vault: string;
+  connect: ChannelConnect;
+}
+
+/**
+ * GET /admin/channels — list provisioned channels. The hub wraps the channel
+ * daemon's own listing as `{ ok, channels: <proxied> }`, and the proxied body
+ * is itself `{ channels: [...] }` — so the rows live at `body.channels.channels`.
+ * We unwrap defensively (tolerate either nesting) and drop any malformed entry.
+ *
+ * Unlike the `/api/*` admin endpoints, this is session-cookie-gated (no Bearer);
+ * a 401 means the operator's session is gone — we redirect to login and hang the
+ * promise, same shape as `mintVaultAdminToken`.
+ */
+export async function listChannels(): Promise<ChannelListing[]> {
+  const res = await fetch("/admin/channels", {
+    method: "GET",
+    headers: { accept: "application/json" },
+    credentials: "same-origin",
+  });
+  if (res.status === 401) {
+    return redirectToLoginAndHang<ChannelListing[]>();
+  }
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  const body = (await res.json()) as {
+    channels?: unknown;
+  };
+  // Unwrap the proxied nesting: hub returns `{ ok, channels: { channels: [...] } }`,
+  // but tolerate a flat `{ channels: [...] }` too.
+  const outer = body.channels;
+  let rows: unknown[] = [];
+  if (Array.isArray(outer)) {
+    rows = outer;
+  } else if (
+    outer &&
+    typeof outer === "object" &&
+    Array.isArray((outer as { channels?: unknown }).channels)
+  ) {
+    rows = (outer as { channels: unknown[] }).channels;
+  }
+  return rows.flatMap((row) => {
+    if (!row || typeof row !== "object") return [];
+    const r = row as { name?: unknown; transport?: unknown; vault?: unknown };
+    if (typeof r.name !== "string" || typeof r.vault !== "string") return [];
+    return [
+      {
+        name: r.name,
+        transport: typeof r.transport === "string" ? r.transport : "vault",
+        vault: r.vault,
+      } satisfies ChannelListing,
+    ];
+  });
+}
+
+/**
+ * POST /admin/channels — provision a vault-backed channel. The hub mints every
+ * token, writes the channel config, and registers the vault trigger; the
+ * response carries the copy-paste connect lines (never the tokens themselves).
+ *
+ * Session-cookie-gated like `listChannels`. A 4xx surfaces the server's
+ * `error_description` verbatim (unknown vault, invalid name, provision step
+ * failure) so the form can render it; 401 redirects to login.
+ */
+export async function provisionChannel(input: {
+  channelName: string;
+  vault: string;
+}): Promise<ProvisionedChannel> {
+  const res = await fetch("/admin/channels", {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json" },
+    credentials: "same-origin",
+    body: JSON.stringify(input),
+  });
+  if (res.status === 401) {
+    return redirectToLoginAndHang<ProvisionedChannel>();
+  }
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+  const body = (await res.json()) as {
+    channel?: string;
+    vault?: string;
+    connect?: { mcpAdd?: string; launch?: string };
+  };
+  if (
+    typeof body.channel !== "string" ||
+    typeof body.vault !== "string" ||
+    !body.connect ||
+    typeof body.connect.mcpAdd !== "string" ||
+    typeof body.connect.launch !== "string"
+  ) {
+    throw new HttpError(500, "/admin/channels returned a malformed provision body");
+  }
+  return {
+    channel: body.channel,
+    vault: body.vault,
+    connect: { mcpAdd: body.connect.mcpAdd, launch: body.connect.launch },
+  };
+}
+
+/**
+ * DELETE /admin/channels/:name — tear down a channel (best-effort, both the
+ * channel config + the vault trigger). The hub returns 207 with `partial: true`
+ * when one side fails; we surface that as an HttpError so the caller can show
+ * the operator the residue needs manual cleanup. 401 redirects to login.
+ */
+export async function deleteChannel(name: string): Promise<void> {
+  const res = await fetch(`/admin/channels/${encodeURIComponent(name)}`, {
+    method: "DELETE",
+    headers: { accept: "application/json" },
+    credentials: "same-origin",
+  });
+  if (res.status === 401) {
+    await redirectToLoginAndHang<void>();
+    return;
+  }
+  // 207 (multi-status) = partial teardown; treat as an error so the caller
+  // can surface which side lingered. The body carries `errors[]`.
+  if (res.status === 207) {
+    let detail = "channel teardown partially failed";
+    try {
+      const body = (await res.json()) as { errors?: Array<{ step?: string; detail?: string }> };
+      if (Array.isArray(body.errors) && body.errors.length > 0) {
+        detail = body.errors.map((e) => `${e.step ?? "step"}: ${e.detail ?? "failed"}`).join("; ");
+      }
+    } catch {
+      // not JSON — keep the generic message
+    }
+    throw new HttpError(207, detail);
+  }
+  if (!res.ok) {
+    throw new HttpError(res.status, await readError(res));
+  }
+}
+
 async function readError(res: Response): Promise<string> {
   try {
     const text = await res.text();

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1624,10 +1624,13 @@ export interface ProvisionedChannel {
 }
 
 /**
- * GET /admin/channels — list provisioned channels. The hub wraps the channel
- * daemon's own listing as `{ ok, channels: <proxied> }`, and the proxied body
- * is itself `{ channels: [...] }` — so the rows live at `body.channels.channels`.
- * We unwrap defensively (tolerate either nesting) and drop any malformed entry.
+ * GET /admin/channels — list provisioned channels. The hub now PROJECTS each
+ * channel to only `{name, transport, vault}` at its own layer and returns the
+ * flat `{ ok, channels: [...] }` shape (hub-layer field projection — a future
+ * channel version that leaks a token/secret in its list can never be proxied
+ * through). We still unwrap defensively (tolerating the older
+ * `{ channels: { channels: [...] } }` nesting) and drop any malformed entry,
+ * so an SPA built against either hub version keeps working.
  *
  * Unlike the `/api/*` admin endpoints, this is session-cookie-gated (no Bearer);
  * a 401 means the operator's session is gone — we redirect to login and hang the

--- a/web/ui/src/routes/Channels.test.tsx
+++ b/web/ui/src/routes/Channels.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * Channels route tests — loading, list rendering, empty state, the add-form
+ * happy path (POST /admin/channels → connect lines rendered), the add-form
+ * error path, and the remove confirm-then-DELETE flow.
+ *
+ * Same shape as Users.test.tsx: mock `lib/api.ts` so the route's fetch helpers
+ * are stubbed and we assert on the rendered DOM + the calls the route makes.
+ */
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import { Channels } from "./Channels.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    listChannels: vi.fn(),
+    listVaults: vi.fn(),
+    provisionChannel: vi.fn(),
+    deleteChannel: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderRoute() {
+  return render(
+    <MemoryRouter>
+      <Channels />
+    </MemoryRouter>,
+  );
+}
+
+function channel(name: string, vault = "default"): api.ChannelListing {
+  return { name, transport: "vault", vault };
+}
+
+function vaultsResult(...names: string[]): api.VaultsListResult {
+  return {
+    moduleInstalled: names.length > 0,
+    vaults: names.map((name) => ({
+      name,
+      url: `https://hub.example.com/vault/${name}`,
+      version: "0.5.0",
+      path: `/vault/${name}`,
+    })),
+  };
+}
+
+describe("Channels — list rendering", () => {
+  it("shows a loading state on first paint", () => {
+    vi.mocked(api.listChannels).mockImplementation(() => new Promise(() => {}));
+    vi.mocked(api.listVaults).mockImplementation(() => new Promise(() => {}));
+    renderRoute();
+    expect(screen.getByText(/loading channels/i)).toBeInTheDocument();
+  });
+
+  it("renders the empty state when no channels exist", async () => {
+    vi.mocked(api.listChannels).mockResolvedValue([]);
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/no channels yet/i)).toBeInTheDocument());
+    expect(
+      screen.getByText(/add one below to chat with a claude code session/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders one row per channel with name + vault", async () => {
+    vi.mocked(api.listChannels).mockResolvedValue([
+      channel("eng", "default"),
+      channel("ops", "work"),
+    ]);
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default", "work"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("eng")).toBeInTheDocument());
+    expect(screen.getByText("ops")).toBeInTheDocument();
+    // Each channel's bound vault renders in its row.
+    const engRow = screen.getByText("eng").closest("tr")!;
+    expect(within(engRow).getByText("default")).toBeInTheDocument();
+    const opsRow = screen.getByText("ops").closest("tr")!;
+    expect(within(opsRow).getByText("work")).toBeInTheDocument();
+  });
+
+  it("renders the error banner + retry on listChannels failure", async () => {
+    vi.mocked(api.listChannels).mockRejectedValue(new Error("network down"));
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/couldn't load channels/i)).toBeInTheDocument());
+    expect(screen.getByText("network down")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+});
+
+describe("Channels — add a channel", () => {
+  it("submits to provisionChannel and renders the connect lines on success", async () => {
+    vi.mocked(api.listChannels).mockResolvedValue([]);
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    vi.mocked(api.provisionChannel).mockResolvedValue({
+      channel: "eng",
+      vault: "default",
+      connect: {
+        mcpAdd:
+          "claude mcp add --transport http --scope user channel-eng https://hub.example.com/channel/mcp/eng",
+        launch:
+          "claude --dangerously-load-development-channels=server:channel-eng --dangerously-skip-permissions",
+      },
+    });
+    renderRoute();
+
+    await waitFor(() => expect(screen.getByLabelText(/channel name/i)).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/channel name/i), { target: { value: "eng" } });
+    fireEvent.click(screen.getByRole("button", { name: /add channel/i }));
+
+    await waitFor(() => expect(screen.getByTestId("channel-connect-panel")).toBeInTheDocument());
+    expect(vi.mocked(api.provisionChannel)).toHaveBeenCalledWith({
+      channelName: "eng",
+      vault: "default",
+    });
+    // The two connect lines are rendered in copy-able code boxes.
+    expect(screen.getByTestId("channel-mcp-add")).toHaveTextContent(
+      "claude mcp add --transport http --scope user channel-eng",
+    );
+    expect(screen.getByTestId("channel-launch")).toHaveTextContent(
+      "--dangerously-load-development-channels=server:channel-eng",
+    );
+  });
+
+  it("shows the server error message when provisioning fails", async () => {
+    vi.mocked(api.listChannels).mockResolvedValue([]);
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    vi.mocked(api.provisionChannel).mockRejectedValue(
+      new api.HttpError(400, 'no vault named "default" in this hub'),
+    );
+    renderRoute();
+
+    await waitFor(() => expect(screen.getByLabelText(/channel name/i)).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/channel name/i), { target: { value: "eng" } });
+    fireEvent.click(screen.getByRole("button", { name: /add channel/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/no vault named "default" in this hub/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("channel-connect-panel")).not.toBeInTheDocument();
+  });
+
+  it("client-validates the channel name before calling the server", async () => {
+    vi.mocked(api.listChannels).mockResolvedValue([]);
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    renderRoute();
+
+    const input = (await screen.findByLabelText(/channel name/i)) as HTMLInputElement;
+    // A trailing-space name passes once trimmed but the leading char of the
+    // raw value is fine — set a value the JS validator rejects (a leading
+    // hyphen fails `^[a-z0-9]`), then submit the form directly so we exercise
+    // the JS guard rather than the native HTML `pattern` gate.
+    fireEvent.change(input, { target: { value: "-eng" } });
+    fireEvent.submit(input.closest("form")!);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/channel name must start with a letter or digit/i),
+      ).toBeInTheDocument(),
+    );
+    expect(vi.mocked(api.provisionChannel)).not.toHaveBeenCalled();
+  });
+
+  it("tells the operator to create a vault first when none exist", async () => {
+    vi.mocked(api.listChannels).mockResolvedValue([]);
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult());
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/create a vault first/i)).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: /add channel/i })).not.toBeInTheDocument();
+  });
+});
+
+describe("Channels — remove a channel", () => {
+  it("confirms then calls deleteChannel and reloads the list", async () => {
+    vi.mocked(api.listChannels)
+      .mockResolvedValueOnce([channel("eng", "default")])
+      .mockResolvedValueOnce([]);
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    vi.mocked(api.deleteChannel).mockResolvedValue(undefined);
+    renderRoute();
+
+    await waitFor(() => expect(screen.getByText("eng")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /remove eng/i }));
+
+    // Confirm dialog appears.
+    const dialog = await screen.findByRole("dialog", { name: /confirm remove eng/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: /^remove$/i }));
+
+    await waitFor(() => expect(vi.mocked(api.deleteChannel)).toHaveBeenCalledWith("eng"));
+    // After the reload (second listChannels returns []), the empty state shows.
+    await waitFor(() => expect(screen.getByText(/no channels yet/i)).toBeInTheDocument());
+  });
+
+  it("surfaces a row-level error when teardown fails", async () => {
+    vi.mocked(api.listChannels).mockResolvedValue([channel("eng", "default")]);
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    vi.mocked(api.deleteChannel).mockRejectedValue(
+      new api.HttpError(207, "vault_trigger: downstream 500"),
+    );
+    renderRoute();
+
+    await waitFor(() => expect(screen.getByText("eng")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /remove eng/i }));
+    const dialog = await screen.findByRole("dialog", { name: /confirm remove eng/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: /^remove$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/vault_trigger: downstream 500/i)).toBeInTheDocument(),
+    );
+  });
+});

--- a/web/ui/src/routes/Channels.test.tsx
+++ b/web/ui/src/routes/Channels.test.tsx
@@ -132,6 +132,14 @@ describe("Channels — add a channel", () => {
     expect(screen.getByTestId("channel-launch")).toHaveTextContent(
       "--dangerously-load-development-channels=server:channel-eng",
     );
+    // The launch line carries `--dangerously-skip-permissions`, so a caution
+    // note must render alongside it warning the operator about unrestricted
+    // tool access.
+    const warning = screen.getByTestId("channel-launch-warning");
+    expect(warning).toBeInTheDocument();
+    expect(warning).toHaveTextContent(/unrestricted tool access/i);
+    expect(warning).toHaveTextContent(/--dangerously-skip-permissions/);
+    expect(warning).toHaveTextContent(/trust/i);
   });
 
   it("shows the server error message when provisioning fails", async () => {

--- a/web/ui/src/routes/Channels.tsx
+++ b/web/ui/src/routes/Channels.tsx
@@ -463,6 +463,11 @@ function ConnectPanel({
           <code data-testid="channel-launch">{result.connect.launch}</code>
           <CopyButton value={result.connect.launch} />
         </div>
+        <p className="muted" data-testid="channel-launch-warning" style={{ marginTop: "0.4rem" }}>
+          ⚠ This launches Claude Code with unrestricted tool access (
+          <code>--dangerously-skip-permissions</code>) — run it only on a machine/environment you
+          trust for that session.
+        </p>
       </div>
 
       <div style={{ marginTop: "0.75rem" }}>

--- a/web/ui/src/routes/Channels.tsx
+++ b/web/ui/src/routes/Channels.tsx
@@ -1,0 +1,475 @@
+/**
+ * /admin/channels — vault-backed channel provisioning (the front door).
+ *
+ * Most users never touch the CLI, so setting up a channel — "chat with a
+ * Claude Code session through your vault" — has to be a UI action. This view
+ * drives the cookie-gated `/admin/channels` orchestration endpoint
+ * (src/admin-channels.ts): one POST provisions everything (vault token,
+ * channel config, vault trigger) and hands back the copy-paste connect lines.
+ *
+ * Surface (modeled on Users.tsx + McpConnectCard.tsx):
+ *
+ *   1. **Channels list.** Name · Vault · Remove (confirm-then-DELETE inline,
+ *      mirroring the Users delete dialog).
+ *   2. **Add a channel.** A vault picker (sourced from `listVaults()`, the same
+ *      well-known doc the rest of the SPA reads) + a channel-name input → one
+ *      "Add channel" button. On success, a "Connect a session" panel renders the
+ *      returned `connect.mcpAdd` + `connect.launch` lines, each in a
+ *      copy-to-clipboard code block (the `.token-box` shape from McpConnectCard).
+ *   3. **Empty state** when no channels exist yet.
+ *
+ * Auth: `/admin/channels` is session-cookie-gated (first-admin only) — not the
+ * `/api/*` host-admin Bearer path. The `lib/api.ts` helpers redirect to login
+ * on 401; errors surface the server's `error_description` verbatim.
+ */
+import { type FormEvent, useEffect, useState } from "react";
+import {
+  type ChannelListing,
+  HttpError,
+  type ProvisionedChannel,
+  type VaultListing,
+  deleteChannel,
+  listChannels,
+  listVaults,
+  provisionChannel,
+} from "../lib/api.ts";
+
+/**
+ * Channel-name charset. Mirrors `CHANNEL_NAME_RE` in src/admin-channels.ts —
+ * the name lands in a services.json key, a vault trigger name, a URL path
+ * segment, and an MCP server name, so it stays a conservative slug. Server is
+ * authoritative; this is fast-feedback only.
+ */
+const CHANNEL_NAME_REGEX = /^[a-z0-9][a-z0-9_-]*$/i;
+
+interface ChannelsData {
+  channels: ChannelListing[];
+  vaults: VaultListing[];
+}
+
+type ListState =
+  | { kind: "loading" }
+  | { kind: "ok"; data: ChannelsData }
+  | { kind: "error"; message: string };
+
+type AddState =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "provisioned"; result: ProvisionedChannel }
+  | { kind: "error"; message: string };
+
+type RemoveState =
+  | { kind: "idle" }
+  | { kind: "confirming"; channel: ChannelListing }
+  | { kind: "removing"; name: string }
+  | { kind: "error"; name: string; message: string };
+
+function errMessage(err: unknown, verb: string): string {
+  if (err instanceof HttpError) return `${verb} failed (${err.status}): ${err.message}`;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/**
+ * Copy-to-clipboard button that flips its label to "Copied ✓" for 2s.
+ * Mirrors `McpConnectCard.tsx`'s CopyButton — same copy affordance vocabulary
+ * across the SPA. Clipboard is unavailable in insecure contexts; we no-op
+ * gracefully (the command is still selectable in the `.token-box` codebox).
+ */
+function CopyButton({ value, label = "Copy" }: { value: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      className="secondary"
+      onClick={() => {
+        if (typeof navigator === "undefined" || !navigator.clipboard) return;
+        void navigator.clipboard.writeText(value).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        });
+      }}
+    >
+      {copied ? "Copied ✓" : label}
+    </button>
+  );
+}
+
+export function Channels() {
+  const [state, setState] = useState<ListState>({ kind: "loading" });
+  const [reload, setReload] = useState(0);
+  const [channelName, setChannelName] = useState("");
+  const [vault, setVault] = useState("");
+  const [addState, setAddState] = useState<AddState>({ kind: "idle" });
+  const [removeSt, setRemoveSt] = useState<RemoveState>({ kind: "idle" });
+
+  useEffect(() => {
+    void reload;
+    let cancelled = false;
+    setState({ kind: "loading" });
+    Promise.all([listChannels(), listVaults()])
+      .then(([channels, vaultsResult]) => {
+        if (cancelled) return;
+        setState({ kind: "ok", data: { channels, vaults: vaultsResult.vaults } });
+        // Pre-select the first vault so the picker isn't a blank required field
+        // on a single-vault hub (the common case). Only seed when nothing's
+        // chosen yet, so a reload after an add doesn't stomp the operator's pick.
+        setVault((cur) => cur || vaultsResult.vaults[0]?.name || "");
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setState({ kind: "error", message: err instanceof Error ? err.message : String(err) });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reload]);
+
+  async function onSubmitAdd(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    const name = channelName.trim();
+    if (!CHANNEL_NAME_REGEX.test(name)) {
+      setAddState({
+        kind: "error",
+        message:
+          "Channel name must start with a letter or digit and contain only letters, digits, hyphens, and underscores.",
+      });
+      return;
+    }
+    if (!vault) {
+      setAddState({ kind: "error", message: "Pick a vault to back this channel." });
+      return;
+    }
+    setAddState({ kind: "submitting" });
+    try {
+      const result = await provisionChannel({ channelName: name, vault });
+      setAddState({ kind: "provisioned", result });
+      setChannelName("");
+      // Refresh the list so the new channel appears (the POST doesn't return
+      // the full row; the well-known/list is the source of truth).
+      setReload((n) => n + 1);
+    } catch (err) {
+      setAddState({ kind: "error", message: errMessage(err, "Add") });
+    }
+  }
+
+  async function onConfirmRemove(channel: ChannelListing): Promise<void> {
+    setRemoveSt({ kind: "removing", name: channel.name });
+    try {
+      await deleteChannel(channel.name);
+      setRemoveSt({ kind: "idle" });
+      setReload((n) => n + 1);
+    } catch (err) {
+      setRemoveSt({ kind: "error", name: channel.name, message: errMessage(err, "Remove") });
+    }
+  }
+
+  return (
+    <div data-route-content="true">
+      <div className="list-header">
+        <h1>Channels</h1>
+      </div>
+
+      <p className="muted">
+        A channel lets you chat with a Claude Code session <em>through</em> a vault — messages land
+        as notes, and the session replies the same way. Adding one provisions everything (a scoped
+        vault token, the channel config, and the vault trigger) in a single step — no tokens to
+        mint, no YAML to edit.
+      </p>
+
+      {renderList(state, removeSt, setRemoveSt, onConfirmRemove, () => setReload((n) => n + 1))}
+
+      {state.kind === "ok" && (
+        <AddChannelSection
+          vaults={state.data.vaults}
+          channelName={channelName}
+          setChannelName={setChannelName}
+          vault={vault}
+          setVault={setVault}
+          addState={addState}
+          setAddState={setAddState}
+          onSubmit={onSubmitAdd}
+        />
+      )}
+    </div>
+  );
+}
+
+function renderList(
+  state: ListState,
+  removeSt: RemoveState,
+  setRemoveSt: (s: RemoveState) => void,
+  onConfirmRemove: (channel: ChannelListing) => Promise<void>,
+  onRetry: () => void,
+): React.ReactNode {
+  if (state.kind === "loading") {
+    return <p className="muted">Loading channels…</p>;
+  }
+  if (state.kind === "error") {
+    return (
+      <>
+        <div className="error-banner">
+          Couldn't load channels: <code>{state.message}</code>
+        </div>
+        <button type="button" onClick={onRetry} className="secondary">
+          Retry
+        </button>
+      </>
+    );
+  }
+  const { channels } = state.data;
+  if (channels.length === 0) {
+    return (
+      <div className="empty empty-rich">
+        <p className="empty-headline">No channels yet.</p>
+        <p className="muted">
+          Add one below to chat with a Claude Code session through your vault.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <ChannelTable
+      channels={channels}
+      removeSt={removeSt}
+      setRemoveSt={setRemoveSt}
+      onConfirmRemove={onConfirmRemove}
+    />
+  );
+}
+
+function ChannelTable({
+  channels,
+  removeSt,
+  setRemoveSt,
+  onConfirmRemove,
+}: {
+  channels: ChannelListing[];
+  removeSt: RemoveState;
+  setRemoveSt: (s: RemoveState) => void;
+  onConfirmRemove: (channel: ChannelListing) => Promise<void>;
+}): React.ReactNode {
+  return (
+    <div className="channel-list" style={{ marginTop: "1rem" }}>
+      <div className="table-scroll">
+        <table className="channel-table">
+          <thead>
+            <tr>
+              <th scope="col">Channel</th>
+              <th scope="col">Vault</th>
+              <th scope="col">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {channels.map((c) => {
+              const isConfirming =
+                removeSt.kind === "confirming" && removeSt.channel.name === c.name;
+              const isRemoving = removeSt.kind === "removing" && removeSt.name === c.name;
+              const rowError =
+                removeSt.kind === "error" && removeSt.name === c.name ? removeSt.message : null;
+              return (
+                <tr key={c.name} data-channel-name={c.name}>
+                  <td>
+                    <code>{c.name}</code>
+                  </td>
+                  <td>
+                    <code>{c.vault}</code>
+                  </td>
+                  <td>
+                    {isConfirming ? (
+                      <dialog
+                        open
+                        className="error-banner"
+                        style={{ marginTop: "0.25rem", background: "var(--bg-warn, #fffbe6)" }}
+                        aria-label={`Confirm remove ${c.name}`}
+                      >
+                        <p>
+                          Remove channel <code>{c.name}</code>? This tears down the channel config
+                          and the vault's inbound trigger. Existing notes stay; new messages stop
+                          flowing.
+                        </p>
+                        <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.5rem" }}>
+                          <button
+                            type="button"
+                            className="destructive"
+                            onClick={() => {
+                              void onConfirmRemove(c);
+                            }}
+                            disabled={isRemoving}
+                          >
+                            {isRemoving ? "Removing…" : "Remove"}
+                          </button>
+                          <button
+                            type="button"
+                            className="secondary"
+                            onClick={() => setRemoveSt({ kind: "idle" })}
+                            disabled={isRemoving}
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </dialog>
+                    ) : (
+                      <button
+                        type="button"
+                        className="secondary"
+                        disabled={isRemoving}
+                        onClick={() => setRemoveSt({ kind: "confirming", channel: c })}
+                        aria-label={`Remove ${c.name}`}
+                      >
+                        {isRemoving ? "Removing…" : "Remove"}
+                      </button>
+                    )}
+                    {rowError && (
+                      <div className="error-banner" style={{ marginTop: "0.25rem" }}>
+                        <code>{rowError}</code>
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function AddChannelSection({
+  vaults,
+  channelName,
+  setChannelName,
+  vault,
+  setVault,
+  addState,
+  setAddState,
+  onSubmit,
+}: {
+  vaults: VaultListing[];
+  channelName: string;
+  setChannelName: (s: string) => void;
+  vault: string;
+  setVault: (s: string) => void;
+  addState: AddState;
+  setAddState: (s: AddState) => void;
+  onSubmit: (e: FormEvent) => Promise<void>;
+}): React.ReactNode {
+  const submitting = addState.kind === "submitting";
+  const noVaults = vaults.length === 0;
+  return (
+    <section style={{ marginTop: "1.5rem" }}>
+      <form onSubmit={(e) => void onSubmit(e)} aria-label="Add a channel">
+        <h3>Add a channel</h3>
+
+        {noVaults ? (
+          <p className="muted">
+            No vaults on this hub yet. Create a vault first — a channel has to be backed by one.
+          </p>
+        ) : (
+          <>
+            <p>
+              <label htmlFor="new-channel-vault">Vault</label>
+              <br />
+              <select
+                id="new-channel-vault"
+                value={vault}
+                onChange={(e) => setVault(e.target.value)}
+                disabled={submitting}
+                style={{ minWidth: "12rem" }}
+              >
+                {vaults.map((v) => (
+                  <option key={v.name} value={v.name}>
+                    {v.name}
+                  </option>
+                ))}
+              </select>
+            </p>
+            <p>
+              <label htmlFor="new-channel-name">
+                Channel name <span className="muted">(letters, digits, hyphens, underscores)</span>
+              </label>
+              <br />
+              <input
+                id="new-channel-name"
+                type="text"
+                required
+                autoComplete="off"
+                placeholder="eng"
+                value={channelName}
+                pattern="[A-Za-z0-9][A-Za-z0-9_\-]*"
+                onChange={(e) => setChannelName(e.target.value)}
+                disabled={submitting}
+              />
+            </p>
+
+            {addState.kind === "error" && (
+              <div className="error-banner">
+                <code>{addState.message}</code>
+              </div>
+            )}
+
+            <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.5rem" }}>
+              <button type="submit" disabled={submitting}>
+                {submitting ? "Adding…" : "Add channel"}
+              </button>
+            </div>
+          </>
+        )}
+      </form>
+
+      {addState.kind === "provisioned" && (
+        <ConnectPanel result={addState.result} onDismiss={() => setAddState({ kind: "idle" })} />
+      )}
+    </section>
+  );
+}
+
+/**
+ * "Connect a session" panel shown after a successful provision. Reuses the
+ * `.mcp-connect-card` + `.token-box` chrome from McpConnectCard so the
+ * copy-to-clipboard code blocks read identically to the vault MCP-connect card.
+ */
+function ConnectPanel({
+  result,
+  onDismiss,
+}: {
+  result: ProvisionedChannel;
+  onDismiss: () => void;
+}): React.ReactNode {
+  return (
+    <div
+      className="mcp-connect-card"
+      style={{ marginTop: "1rem" }}
+      data-testid="channel-connect-panel"
+    >
+      <h3>Connect a session</h3>
+      <p className="muted">
+        Channel <code>{result.channel}</code> is live on the <code>{result.vault}</code> vault. Run
+        these where your Claude Code session will live; authorize in the browser when prompted.
+      </p>
+
+      <div className="mcp-field">
+        <span className="mcp-field-label">1 · Register the channel (MCP)</span>
+        <div className="token-box">
+          <code data-testid="channel-mcp-add">{result.connect.mcpAdd}</code>
+          <CopyButton value={result.connect.mcpAdd} />
+        </div>
+      </div>
+
+      <div className="mcp-field">
+        <span className="mcp-field-label">2 · Launch a session on the channel</span>
+        <div className="token-box">
+          <code data-testid="channel-launch">{result.connect.launch}</code>
+          <CopyButton value={result.connect.launch} />
+        </div>
+      </div>
+
+      <div style={{ marginTop: "0.75rem" }}>
+        <button type="button" className="secondary" onClick={onDismiss}>
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -372,11 +372,13 @@ h2 {
  * (lines ~799) so the visual language is consistent across SPA list
  * shapes (rows of cards AND rows of cells). */
 .user-table tbody tr,
-.tokens-table tbody tr {
+.tokens-table tbody tr,
+.channel-table tbody tr {
   transition: background-color 0.12s ease;
 }
 .user-table tbody tr:hover,
-.tokens-table tbody tr:hover {
+.tokens-table tbody tr:hover,
+.channel-table tbody tr:hover {
   background: var(--bg-soft);
 }
 


### PR DESCRIPTION
## What (PR 3 of frictionless-channel-setup — the front door)

Setting up a vault-backed channel becomes **one hub action** — no minted tokens, no shared secret, no hand-edited YAML. Leans entirely on the hub's existing token-minting + operator session.

**Backend** — cookie-gated (first-admin) `POST/GET/DELETE /admin/channels`:
- `POST {channelName, vault}` provisions everything by minting 4 scoped JWTs off the operator session and making server-to-server calls: `vault:<v>:write` (channel's config token) · `channel:admin` (calls the channel config API) · `channel:send` (the trigger's `action.auth.bearer`) · `vault:<v>:admin` (registers the inbound trigger). Reads the channel's prescribed `triggerTemplate`, **pins the webhook URL + bearer hub-side** (the channel can't redirect or inject), registers it in the vault. Returns copy-paste `claude mcp add` + launch connect lines. Idempotent.
- `GET` lists channels (hub-layer field-projected to `{name,transport,vault}` — never proxies a token). `DELETE` tears down both the channel config and the vault trigger.

**UI** — a native **Channels** admin-SPA view (modeled on Users + the vault MCP-connect card): pick a vault, name it, one button → provisioned, then a "Connect a session" panel with copy-to-clipboard connect lines (and a caution note on `--dangerously-skip-permissions`).

## Review
Reviewer (committed-core, security-first): **MERGE**, no must-fixes — session gate, token scope/aud/TTL, and the `substituteTrigger` webhook+bearer overwrite all verified correct. 5 hardening nits folded: `Object.create(null)` prototype-pollution safety in the template walk, hub-layer field projection, lowercase channel-name normalization, mint-subject consistency, the UI safety warning.

Gates: `bun test ./src` 3180/0 · SPA vitest 280/0 · both typechecks clean · no binary files. Additive; version untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)