### PR TITLE
feat(connections): general module event→action connection builder + engine (generalizes channel-add)

### DIFF
--- a/src/__tests__/admin-connections.test.ts
+++ b/src/__tests__/admin-connections.test.ts
@@ -1,0 +1,829 @@
+/**
+ * Tests for the general Connections engine (2026-06-09 modular-UI architecture,
+ * P5) — `GET /api/connections/catalog`, `GET/POST /admin/connections`,
+ * `DELETE /admin/connections/:id`.
+ *
+ * The catalog is built from injected module manifests. The vault + channel HTTP
+ * calls are mocked via an injectable `fetchImpl` that records every request
+ * (method, URL, decoded bearer, parsed body) and returns scripted responses.
+ * Tokens are real (minted by the actual `signAccessToken`), so we can decode the
+ * JWT claims (scope/aud) the way channel/vault would.
+ *
+ * The whole point of the engine is GENERALITY: the webhook + scope come from the
+ * SINK ACTION's declaration, not hardcoded per module. The tests assert that —
+ * e.g. a synthetic sink module ("widget") with a different endpoint/scope
+ * provisions a trigger with THAT endpoint + THAT scope.
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { decodeJwt } from "jose";
+import {
+  type ConnectionsDeps,
+  type InstalledModuleInfo,
+  buildCatalog,
+  buildWebhook,
+  eventsForSourceEvent,
+  handleConnections,
+  handleConnectionsCatalog,
+  whenFromFilter,
+} from "../admin-connections.ts";
+import { readConnections } from "../connections-store.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { type ModuleManifest, validateModuleManifest } from "../module-manifest.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+
+const HUB_ORIGIN = "https://hub.test";
+const CHANNEL_ORIGIN = "http://127.0.0.1:1941";
+const VAULT_ORIGIN = "http://127.0.0.1:1940";
+
+interface Harness {
+  db: Database;
+  storePath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-connections-"));
+  const db = openHubDb(hubDbPath(dir));
+  rotateSigningKey(db);
+  return {
+    db,
+    storePath: join(dir, "connections.json"),
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+async function adminCookie(): Promise<{ cookie: string; userId: string }> {
+  const user = await createUser(harness.db, "operator", "hunter2");
+  const session = createSession(harness.db, { userId: user.id });
+  return {
+    cookie: buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000)),
+    userId: user.id,
+  };
+}
+
+async function friendCookie(): Promise<string> {
+  await createUser(harness.db, "admin", "admin-passphrase");
+  const friend = await createUser(harness.db, "alice", "alice-passphrase", { allowMulti: true });
+  const session = createSession(harness.db, { userId: friend.id });
+  return buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+}
+
+// --- Mock fetch -------------------------------------------------------------
+
+interface RecordedReq {
+  method: string;
+  url: string;
+  bearer: string | null;
+  body: unknown;
+}
+type Responder = (req: RecordedReq) => Response;
+
+function mockFetch(routes: Record<string, Responder>): {
+  fetchImpl: typeof fetch;
+  calls: RecordedReq[];
+} {
+  const calls: RecordedReq[] = [];
+  const fetchImpl = (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+    const auth =
+      (init?.headers as Record<string, string> | undefined)?.authorization ??
+      (init?.headers as Record<string, string> | undefined)?.Authorization ??
+      null;
+    const bearer = auth ? auth.replace(/^Bearer\s+/i, "") : null;
+    let body: unknown;
+    if (typeof init?.body === "string") {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    }
+    const path = new URL(url).pathname;
+    const rec: RecordedReq = { method, url, bearer, body };
+    calls.push(rec);
+    const responder = routes[`${method} ${path}`];
+    if (!responder) return new Response("no route", { status: 599 });
+    return responder(rec);
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function ok(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function scopeOf(jwt: string): string[] {
+  const claims = decodeJwt(jwt) as { scope?: string };
+  return (claims.scope ?? "").split(/\s+/).filter(Boolean);
+}
+
+// --- Module fixtures --------------------------------------------------------
+
+const VAULT_MANIFEST: ModuleManifest = {
+  name: "vault",
+  manifestName: "@openparachute/vault",
+  port: 1940,
+  paths: ["/vault"],
+  health: "/health",
+  events: [
+    {
+      key: "note.created",
+      title: "A note was created",
+      filterSchema: { type: "object", properties: { tags: { type: "array" } } },
+    },
+    { key: "note.updated", title: "A note was updated" },
+    // A declared event with NO vault-trigger verb mapping — used to exercise
+    // the clean `unsupported_event` 400 (vs a downstream 500).
+    { key: "note.deleted", title: "A note was deleted" },
+  ],
+  actions: [{ key: "note.create", title: "Create a note", inputSchema: {} }],
+};
+
+const CHANNEL_MANIFEST: ModuleManifest = {
+  name: "channel",
+  manifestName: "parachute-channel",
+  port: 1941,
+  paths: ["/channel"],
+  health: "/health",
+  events: [{ key: "message.received", title: "A message arrived" }],
+  actions: [
+    {
+      key: "message.deliver",
+      title: "Deliver an inbound message",
+      endpoint: "/api/vault/inbound",
+      scope: "channel:send",
+      provision: { type: "vault-trigger" },
+    },
+  ],
+};
+
+/** A synthetic sink module that proves the engine is NOT channel-hardcoded. */
+const WIDGET_MANIFEST: ModuleManifest = {
+  name: "widget",
+  manifestName: "widget",
+  port: 1955,
+  paths: ["/widget"],
+  health: "/health",
+  actions: [
+    {
+      key: "thing.do",
+      title: "Do a thing",
+      endpoint: "/hooks/incoming",
+      scope: "widget:trigger",
+      provision: { type: "vault-trigger" },
+    },
+  ],
+};
+
+function modulesOf(...manifests: ModuleManifest[]): InstalledModuleInfo[] {
+  return manifests.map((manifest) => ({
+    short: manifest.name,
+    manifest,
+    mount: manifest.paths[0] ?? null,
+  }));
+}
+
+function baseDeps(fetchImpl: typeof fetch, modules: InstalledModuleInfo[]): ConnectionsDeps {
+  return {
+    db: harness.db,
+    hubOrigin: HUB_ORIGIN,
+    modules,
+    resolveVaultOrigin: (v) => (v === "default" ? VAULT_ORIGIN : null),
+    channelOrigin: CHANNEL_ORIGIN,
+    storePath: harness.storePath,
+    fetchImpl,
+  };
+}
+
+// ===========================================================================
+// Pure derivation units
+// ===========================================================================
+
+describe("derivation units", () => {
+  test("eventsForSourceEvent maps note.created/updated to vault verbs", () => {
+    expect(eventsForSourceEvent("note.created")).toEqual(["created"]);
+    expect(eventsForSourceEvent("note.updated")).toEqual(["updated"]);
+  });
+
+  test("eventsForSourceEvent throws (not a silent fallback) on an unmappable event", () => {
+    // note.deleted is a real vault event but has no trigger verb — fail loud.
+    expect(() => eventsForSourceEvent("note.deleted")).toThrow(/no vault-trigger event mapping/);
+    expect(() => eventsForSourceEvent("bogus")).toThrow();
+  });
+
+  test("whenFromFilter maps filter keys 1:1 to the trigger predicate", () => {
+    expect(
+      whenFromFilter({
+        tags: ["#channel-message/inbound"],
+        has_metadata: ["channel"],
+        missing_metadata: ["channel_inbound_rendered_at"],
+        has_content: true,
+        ignored: "x",
+      }),
+    ).toEqual({
+      tags: ["#channel-message/inbound"],
+      has_metadata: ["channel"],
+      missing_metadata: ["channel_inbound_rendered_at"],
+      has_content: true,
+    });
+    expect(whenFromFilter(undefined)).toEqual({});
+  });
+
+  test("buildWebhook joins origin + mount + endpoint, trimming slashes", () => {
+    expect(buildWebhook(`${HUB_ORIGIN}/`, "/channel", "/api/vault/inbound")).toBe(
+      `${HUB_ORIGIN}/channel/api/vault/inbound`,
+    );
+    expect(buildWebhook(HUB_ORIGIN, "widget", "hooks/incoming")).toBe(
+      `${HUB_ORIGIN}/widget/hooks/incoming`,
+    );
+  });
+});
+
+// ===========================================================================
+// Catalog
+// ===========================================================================
+
+describe("GET /api/connections/catalog", () => {
+  test("returns events + actions read from installed module manifests", () => {
+    const cat = buildCatalog(modulesOf(VAULT_MANIFEST, CHANNEL_MANIFEST));
+    expect(cat.events).toContainEqual({
+      module: "vault",
+      key: "note.created",
+      title: "A note was created",
+      filterSchema: { type: "object", properties: { tags: { type: "array" } } },
+    });
+    expect(cat.actions).toContainEqual({
+      module: "channel",
+      key: "message.deliver",
+      title: "Deliver an inbound message",
+      inputSchema: null,
+      provision: { type: "vault-trigger" },
+    });
+  });
+
+  test("catalog endpoint is operator-gated (401 with no session)", async () => {
+    const { fetchImpl } = mockFetch({});
+    const req = new Request(`${HUB_ORIGIN}/api/connections/catalog`);
+    const res = await handleConnectionsCatalog(req, baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST)));
+    expect(res.status).toBe(401);
+  });
+
+  test("catalog endpoint returns the catalog for an admin", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl } = mockFetch({});
+    const req = new Request(`${HUB_ORIGIN}/api/connections/catalog`, { headers: { cookie } });
+    const res = await handleConnectionsCatalog(
+      req,
+      baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, CHANNEL_MANIFEST)),
+    );
+    expect(res.status).toBe(200);
+    const out = (await res.json()) as { events: unknown[]; actions: unknown[] };
+    // vault: 3 events + 1 action; channel: 1 event + 1 action.
+    expect(out.events.length).toBe(4);
+    expect(out.actions.length).toBe(2);
+  });
+});
+
+// ===========================================================================
+// Operator gate
+// ===========================================================================
+
+describe("operator gate", () => {
+  test("401 with no session cookie", async () => {
+    const { fetchImpl } = mockFetch({});
+    const req = new Request(`${HUB_ORIGIN}/admin/connections`, {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    const res = await handleConnections(req, "", baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST)));
+    expect(res.status).toBe(401);
+  });
+
+  test("403 for a non-first-admin (friend)", async () => {
+    const cookie = await friendCookie();
+    const { fetchImpl } = mockFetch({});
+    const req = new Request(`${HUB_ORIGIN}/admin/connections`, {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify({}),
+    });
+    const res = await handleConnections(req, "", baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST)));
+    expect(res.status).toBe(403);
+  });
+});
+
+// ===========================================================================
+// POST — validation
+// ===========================================================================
+
+describe("POST /admin/connections — validation", () => {
+  test("400 on unknown event", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({});
+    const req = new Request(`${HUB_ORIGIN}/admin/connections`, {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify({
+        source: { module: "vault", vault: "default", event: "note.imaginary" },
+        sink: { module: "channel", action: "message.deliver" },
+      }),
+    });
+    const res = await handleConnections(
+      req,
+      "",
+      baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, CHANNEL_MANIFEST)),
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("unknown_event");
+    expect(calls.length).toBe(0);
+  });
+
+  test("400 unsupported_event on a declared-but-unmappable event (note.deleted)", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({});
+    const req = new Request(`${HUB_ORIGIN}/admin/connections`, {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify({
+        // note.deleted IS a declared vault event (passes the catalog check) but
+        // has no vault-trigger verb → clean 400, no downstream provisioning.
+        source: { module: "vault", vault: "default", event: "note.deleted" },
+        sink: { module: "widget", action: "thing.do" },
+      }),
+    });
+    const res = await handleConnections(
+      req,
+      "",
+      baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, WIDGET_MANIFEST)),
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("unsupported_event");
+    expect(calls.length).toBe(0);
+  });
+
+  test("400 on unknown action", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl } = mockFetch({});
+    const req = new Request(`${HUB_ORIGIN}/admin/connections`, {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify({
+        source: { module: "vault", vault: "default", event: "note.created" },
+        sink: { module: "channel", action: "message.imaginary" },
+      }),
+    });
+    const res = await handleConnections(
+      req,
+      "",
+      baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, CHANNEL_MANIFEST)),
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("unknown_action");
+  });
+
+  test("400 on unknown vault", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl } = mockFetch({});
+    const req = new Request(`${HUB_ORIGIN}/admin/connections`, {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify({
+        source: { module: "vault", vault: "ghost", event: "note.created" },
+        sink: { module: "widget", action: "thing.do" },
+      }),
+    });
+    const res = await handleConnections(
+      req,
+      "",
+      baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, WIDGET_MANIFEST)),
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("unknown_vault");
+  });
+});
+
+// ===========================================================================
+// POST — GENERAL provision (synthetic widget sink — proves no channel-hardcoding)
+// ===========================================================================
+
+describe("POST /admin/connections — general vault-trigger provision", () => {
+  test("derives webhook + scope from the SINK ACTION declaration (not hardcoded)", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({
+      "POST /vault/default/api/triggers": () => ok({ ok: true }),
+    });
+    const req = new Request(`${HUB_ORIGIN}/admin/connections`, {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify({
+        id: "w1",
+        source: {
+          module: "vault",
+          vault: "default",
+          event: "note.updated",
+          filter: { tags: ["#urgent"], has_metadata: ["owner"] },
+        },
+        sink: { module: "widget", action: "thing.do" },
+      }),
+    });
+    const res = await handleConnections(
+      req,
+      "",
+      baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, WIDGET_MANIFEST)),
+    );
+    expect(res.status).toBe(200);
+
+    const trigCall = calls.find((c) => c.url.endsWith("/vault/default/api/triggers"));
+    expect(trigCall).toBeDefined();
+    const trig = trigCall!.body as {
+      name: string;
+      events: string[];
+      when: Record<string, unknown>;
+      action: { webhook: string; auth: { bearer: string } };
+    };
+    // Webhook comes from widget's mount + the action's declared endpoint.
+    expect(trig.action.webhook).toBe(`${HUB_ORIGIN}/widget/hooks/incoming`);
+    // The persisted bearer carries the action's DECLARED scope (widget:trigger),
+    // with the audience taken from the scope namespace.
+    expect(scopeOf(trig.action.auth.bearer)).toEqual(["widget:trigger"]);
+    expect((decodeJwt(trig.action.auth.bearer) as { aud?: string }).aud).toBe("widget");
+    // events from the source event verb; when from the filter, 1:1.
+    expect(trig.events).toEqual(["updated"]);
+    expect(trig.when).toEqual({ tags: ["#urgent"], has_metadata: ["owner"] });
+    expect(trig.name).toBe("conn_w1");
+    // The trigger-register Authorization bearer is vault:default:admin.
+    expect(scopeOf(trigCall!.bearer!)).toEqual(["vault:default:admin"]);
+
+    // Persisted record carries the provisioned trigger name + vault for teardown.
+    const stored = readConnections(harness.storePath);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]!.id).toBe("w1");
+    expect(stored[0]!.provisioned.triggerName).toBe("conn_w1");
+    expect(stored[0]!.provisioned.vault).toBe("default");
+    // Bearer tokens are NEVER persisted in the record.
+    expect(JSON.stringify(stored[0])).not.toContain(trig.action.auth.bearer);
+  });
+
+  test("a failing vault-trigger step → 502 provision_failed naming the step", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl } = mockFetch({
+      "POST /vault/default/api/triggers": () => new Response("boom", { status: 500 }),
+    });
+    const req = new Request(`${HUB_ORIGIN}/admin/connections`, {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify({
+        id: "w1",
+        source: { module: "vault", vault: "default", event: "note.created" },
+        sink: { module: "widget", action: "thing.do" },
+      }),
+    });
+    const res = await handleConnections(
+      req,
+      "",
+      baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, WIDGET_MANIFEST)),
+    );
+    expect(res.status).toBe(502);
+    const out = (await res.json()) as { error: string; step: string };
+    expect(out.error).toBe("provision_failed");
+    expect(out.step).toBe("vault_trigger");
+    // Nothing persisted on failure.
+    expect(readConnections(harness.storePath)).toHaveLength(0);
+  });
+
+  test("a module CANNOT declare a cross-namespace action.scope → no escalating bearer (M1)", () => {
+    // The webhook bearer is minted at the sink action's DECLARED scope. The only
+    // defense against a malicious module declaring `vault:default:admin` and
+    // tricking the hub into minting a 90-day cross-module token is the manifest
+    // validator's namespace rule — so a manifest carrying such a scope can never
+    // reach the engine in the first place. Prove it's rejected at the boundary.
+    expect(() =>
+      validateModuleManifest(
+        {
+          name: "widget",
+          manifestName: "widget",
+          port: 1955,
+          paths: ["/widget"],
+          health: "/health",
+          actions: [
+            {
+              key: "thing.do",
+              title: "Do",
+              endpoint: "/hooks/incoming",
+              scope: "vault:default:admin", // ← escalation attempt
+              provision: { type: "vault-trigger" },
+            },
+          ],
+        },
+        "widget/.parachute/module.json",
+      ),
+    ).toThrow(/namespace "vault" does not match module name "widget"/);
+    // The legitimate widget (own-namespace scope) parses fine, and THAT is what
+    // the engine mints from — verified end-to-end in the provision test above
+    // (bearer carries `widget:trigger`, never a vault scope).
+    const okm = validateModuleManifest(
+      {
+        name: "widget",
+        manifestName: "widget",
+        port: 1955,
+        paths: ["/widget"],
+        health: "/health",
+        actions: [
+          { key: "thing.do", title: "Do", endpoint: "/hooks/incoming", scope: "widget:trigger" },
+        ],
+      },
+      "widget/.parachute/module.json",
+    );
+    expect(okm.actions?.[0]?.scope).toBe("widget:trigger");
+  });
+});
+
+// ===========================================================================
+// POST — channel-backed connection (parity with hub#624)
+// ===========================================================================
+
+describe("POST /admin/connections — channel-backed (the #624 flow as a connection)", () => {
+  test("provisions channel config + trigger, returns connect lines", async () => {
+    const { cookie, userId } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({
+      "POST /api/channels": () => ok({ ok: true, name: "eng", transport: "vault" }),
+      "POST /vault/default/api/triggers": () => ok({ ok: true }),
+    });
+    const req = new Request(`${HUB_ORIGIN}/admin/connections`, {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify({
+        source: {
+          module: "vault",
+          vault: "default",
+          event: "note.created",
+          filter: {
+            tags: ["#channel-message/inbound"],
+            has_metadata: ["channel"],
+            missing_metadata: ["channel_inbound_rendered_at"],
+          },
+        },
+        sink: { module: "channel", action: "message.deliver", params: { channel: "eng" } },
+      }),
+    });
+    const res = await handleConnections(
+      req,
+      "",
+      baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, CHANNEL_MANIFEST)),
+    );
+    expect(res.status).toBe(200);
+    const out = (await res.json()) as {
+      ok: boolean;
+      connection: { id: string };
+      connect?: { mcpAdd: string; launch: string };
+    };
+    expect(out.ok).toBe(true);
+    // Derived channel id.
+    expect(out.connection.id).toBe("channel-eng");
+    // Connect lines (parity with #624).
+    expect(out.connect?.mcpAdd).toBe(
+      `claude mcp add --transport http --scope user channel-eng ${HUB_ORIGIN}/channel/mcp/eng`,
+    );
+    expect(out.connect?.launch).toContain("server:channel-eng");
+
+    // Channel config POST: vault transport, loopback vaultUrl, real
+    // vault:default:write token, NO webhookSecret.
+    const cfgCall = calls.find((c) => c.url.endsWith("/api/channels"));
+    expect(cfgCall).toBeDefined();
+    const cfgBody = cfgCall!.body as {
+      name: string;
+      transport: string;
+      config: { vault: string; vaultUrl: string; token: string; webhookSecret?: string };
+    };
+    expect(cfgBody.name).toBe("eng");
+    expect(cfgBody.config.vaultUrl).toBe(VAULT_ORIGIN);
+    expect(cfgBody.config).not.toHaveProperty("webhookSecret");
+    expect(scopeOf(cfgCall!.bearer!)).toEqual(["channel:admin"]);
+    expect(scopeOf(cfgBody.config.token)).toEqual(["vault:default:write"]);
+
+    // Trigger: webhook from channel mount + message.deliver endpoint; bearer
+    // carries channel:send; predicate from the filter.
+    const trigCall = calls.find((c) => c.url.endsWith("/vault/default/api/triggers"));
+    const trig = trigCall!.body as {
+      name: string;
+      when: Record<string, unknown>;
+      action: { webhook: string; auth: { bearer: string } };
+    };
+    expect(trig.action.webhook).toBe(`${HUB_ORIGIN}/channel/api/vault/inbound`);
+    expect(scopeOf(trig.action.auth.bearer)).toEqual(["channel:send"]);
+    expect((decodeJwt(trig.action.auth.bearer) as { aud?: string }).aud).toBe("channel");
+    expect(trig.when).toEqual({
+      tags: ["#channel-message/inbound"],
+      has_metadata: ["channel"],
+      missing_metadata: ["channel_inbound_rendered_at"],
+    });
+    expect(trig.name).toBe("conn_channel-eng");
+
+    // sub = the operator on every minted token.
+    expect((decodeJwt(cfgBody.config.token) as { sub?: string }).sub).toBe(userId);
+    // No tokens echoed in the response.
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain(cfgBody.config.token);
+    expect(serialized).not.toContain(trig.action.auth.bearer);
+  });
+
+  test("503 when the channel module is not installed (channelOrigin null)", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl } = mockFetch({});
+    const deps = {
+      ...baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, CHANNEL_MANIFEST)),
+      channelOrigin: null,
+    };
+    const req = new Request(`${HUB_ORIGIN}/admin/connections`, {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify({
+        source: { module: "vault", vault: "default", event: "note.created" },
+        sink: { module: "channel", action: "message.deliver", params: { channel: "eng" } },
+      }),
+    });
+    const res = await handleConnections(req, "", deps);
+    expect(res.status).toBe(503);
+    expect(((await res.json()) as { error: string }).error).toBe("channel_unavailable");
+  });
+});
+
+// ===========================================================================
+// GET — list
+// ===========================================================================
+
+describe("GET /admin/connections — list", () => {
+  test("lists persisted connections; never a token", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl } = mockFetch({
+      "POST /vault/default/api/triggers": () => ok({ ok: true }),
+    });
+    const deps = baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, WIDGET_MANIFEST));
+    // Create one.
+    await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections`, {
+        method: "POST",
+        headers: { cookie },
+        body: JSON.stringify({
+          id: "w1",
+          source: { module: "vault", vault: "default", event: "note.created" },
+          sink: { module: "widget", action: "thing.do" },
+        }),
+      }),
+      "",
+      deps,
+    );
+    const res = await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections`, { method: "GET", headers: { cookie } }),
+      "",
+      deps,
+    );
+    expect(res.status).toBe(200);
+    const out = (await res.json()) as {
+      ok: boolean;
+      connections: Array<{ id: string; source: unknown; sink: unknown }>;
+    };
+    expect(out.ok).toBe(true);
+    expect(out.connections).toHaveLength(1);
+    expect(out.connections[0]!.id).toBe("w1");
+    expect(JSON.stringify(out)).not.toContain("eyJ"); // no JWT
+  });
+});
+
+// ===========================================================================
+// DELETE — teardown
+// ===========================================================================
+
+describe("DELETE /admin/connections/:id — teardown", () => {
+  test("tears down the vault trigger + removes the record", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({
+      "POST /vault/default/api/triggers": () => ok({ ok: true }),
+      "DELETE /vault/default/api/triggers/conn_w1": () => ok({ ok: true }),
+    });
+    const deps = baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, WIDGET_MANIFEST));
+    await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections`, {
+        method: "POST",
+        headers: { cookie },
+        body: JSON.stringify({
+          id: "w1",
+          source: { module: "vault", vault: "default", event: "note.created" },
+          sink: { module: "widget", action: "thing.do" },
+        }),
+      }),
+      "",
+      deps,
+    );
+    expect(readConnections(harness.storePath)).toHaveLength(1);
+
+    const res = await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections/w1`, { method: "DELETE", headers: { cookie } }),
+      "/w1",
+      deps,
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { ok: boolean }).ok).toBe(true);
+
+    const trigDel = calls.find(
+      (c) => c.method === "DELETE" && c.url.endsWith("/vault/default/api/triggers/conn_w1"),
+    );
+    expect(trigDel).toBeDefined();
+    expect(scopeOf(trigDel!.bearer!)).toEqual(["vault:default:admin"]);
+    // Record gone.
+    expect(readConnections(harness.storePath)).toHaveLength(0);
+  });
+
+  test("channel-sink teardown also removes the channel config entry", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({
+      "POST /api/channels": () => ok({ ok: true }),
+      "POST /vault/default/api/triggers": () => ok({ ok: true }),
+      "DELETE /api/channels/eng": () => ok({ ok: true }),
+      "DELETE /vault/default/api/triggers/conn_channel-eng": () => ok({ ok: true }),
+    });
+    const deps = baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, CHANNEL_MANIFEST));
+    await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections`, {
+        method: "POST",
+        headers: { cookie },
+        body: JSON.stringify({
+          source: { module: "vault", vault: "default", event: "note.created" },
+          sink: { module: "channel", action: "message.deliver", params: { channel: "eng" } },
+        }),
+      }),
+      "",
+      deps,
+    );
+    const res = await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections/channel-eng`, {
+        method: "DELETE",
+        headers: { cookie },
+      }),
+      "/channel-eng",
+      deps,
+    );
+    expect(res.status).toBe(200);
+    expect(calls.some((c) => c.method === "DELETE" && c.url.endsWith("/api/channels/eng"))).toBe(
+      true,
+    );
+    expect(
+      calls.some(
+        (c) =>
+          c.method === "DELETE" && c.url.endsWith("/vault/default/api/triggers/conn_channel-eng"),
+      ),
+    ).toBe(true);
+  });
+
+  test("404 deleting an unknown connection", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl } = mockFetch({});
+    const res = await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections/ghost`, {
+        method: "DELETE",
+        headers: { cookie },
+      }),
+      "/ghost",
+      baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST)),
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+// ===========================================================================
+// Method guard
+// ===========================================================================
+
+describe("method guard", () => {
+  test("405 on PUT /admin/connections", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl } = mockFetch({});
+    const res = await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections`, { method: "PUT", headers: { cookie } }),
+      "",
+      baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST)),
+    );
+    expect(res.status).toBe(405);
+  });
+});

--- a/src/__tests__/module-manifest.test.ts
+++ b/src/__tests__/module-manifest.test.ts
@@ -228,6 +228,82 @@ describe("validateModuleManifest", () => {
     );
   });
 
+  test("actions parse endpoint + scope (the connection-wiring fields, P5)", () => {
+    // The scope namespace must match the module name (VALID is "demo"), so use
+    // a demo-namespaced scope here; the cross-namespace rejection is exercised
+    // in the namespace-guard test below.
+    const m = validateModuleManifest(
+      {
+        ...VALID,
+        actions: [
+          {
+            key: "message.deliver",
+            title: "Deliver",
+            endpoint: "/api/vault/inbound",
+            scope: "demo:send",
+            provision: { type: "vault-trigger" },
+          },
+        ],
+      },
+      "x",
+    );
+    expect(m.actions?.[0]?.endpoint).toBe("/api/vault/inbound");
+    expect(m.actions?.[0]?.scope).toBe("demo:send");
+    // endpoint must be a leading-slash path.
+    expect(() =>
+      validateModuleManifest(
+        { ...VALID, actions: [{ key: "a", title: "A", endpoint: "no-slash" }] },
+        "x",
+      ),
+    ).toThrow(/actions\[0\]\.endpoint/);
+    // scope must be a non-empty string.
+    expect(() =>
+      validateModuleManifest({ ...VALID, actions: [{ key: "a", title: "A", scope: 7 }] }, "x"),
+    ).toThrow(/actions\[0\]\.scope/);
+  });
+
+  test("action.scope namespace MUST match the declaring module name (privilege-escalation guard)", () => {
+    // A malicious manifest named "widget" declaring an action scoped to ANOTHER
+    // module's namespace (vault:default:admin) would trick the hub into minting a
+    // 90-day cross-module bearer when an operator wires a Connection to it.
+    // Reject it at validation, mirroring the `scopes.defines` namespace rule.
+    expect(() =>
+      validateModuleManifest(
+        {
+          ...VALID,
+          name: "widget",
+          actions: [{ key: "thing.do", title: "Do", scope: "vault:default:admin" }],
+        },
+        "x",
+      ),
+    ).toThrow(/namespace "vault" does not match module name "widget"/);
+    // An un-namespaced scope is rejected too.
+    expect(() =>
+      validateModuleManifest(
+        { ...VALID, name: "widget", actions: [{ key: "a", title: "A", scope: "bare" }] },
+        "x",
+      ),
+    ).toThrow(/must be namespaced as "<name>:<verb>"/);
+    // A matching-namespace scope still validates — the real channel case
+    // (channel.message.deliver → channel:send).
+    const okm = validateModuleManifest(
+      {
+        ...VALID,
+        name: "channel",
+        actions: [
+          {
+            key: "message.deliver",
+            title: "Deliver",
+            endpoint: "/api/vault/inbound",
+            scope: "channel:send",
+          },
+        ],
+      },
+      "x",
+    );
+    expect(okm.actions?.[0]?.scope).toBe("channel:send");
+  });
+
   test("uiUrl accepts a leading-slash path (Phase D)", () => {
     const m = validateModuleManifest({ ...VALID, uiUrl: "/notes" }, "x");
     expect(m.uiUrl).toBe("/notes");

--- a/src/admin-connections.ts
+++ b/src/admin-connections.ts
@@ -1,0 +1,823 @@
+/**
+ * `GET /api/connections/catalog` + `GET/POST/DELETE /admin/connections` — the
+ * general module event→action Connections engine (2026-06-09 modular-UI
+ * architecture, P5). Generalizes the channel-specific `admin-channels.ts`
+ * (hub#624): "add a vault-backed channel" is just the first connection,
+ * `vault.note.created (filter #channel-message/inbound) → channel.message.deliver`.
+ *
+ * THE CONCEPT. A connection wires "when [EVENT] in [source module] (filter) →
+ * do [ACTION] in [sink module]". The sink is ALWAYS an action. Modules declare
+ * the `events` they emit + the `actions` they accept in `module.json` (landed
+ * P4). The hub is the only thing with cross-module authority (mint tokens,
+ * register vault triggers), so this is hub-native.
+ *
+ * WHY IT'S GENERAL, NOT CHANNEL-HARDCODED. The provisioning engine reads
+ * everything it needs from the declarations:
+ *   - the SINK action's `endpoint` → the hub-proxied webhook the vault calls
+ *     (`<hub-origin>/<sink-mount><endpoint>`). NOT a hardcoded channel path.
+ *   - the SINK action's `scope` → the OAuth scope minted into the webhook's
+ *     `Authorization: Bearer`. NOT a hardcoded `channel:send`.
+ *   - the SOURCE event key → the vault trigger's `events` (`note.created` →
+ *     `["created"]`, `note.updated` → `["updated"]`).
+ *   - the SOURCE filter → the vault trigger's `when` predicate (`tags` /
+ *     `has_metadata` / `missing_metadata` / `has_content`), 1:1.
+ * Any future `vault-trigger` sink (a different module's action) provisions
+ * through the same path with zero hub code changes.
+ *
+ * THE ONE SINK-SPECIFIC PREREQUISITE. A vault-backed channel additionally needs
+ * its reply path wired: a `vault:<v>:write` token + a `channels.json` entry so
+ * the session can reply. That's a property of the channel SINK, not of the
+ * engine — it runs only for `sink.module === "channel"` and is clearly fenced
+ * (`prepareChannelSink`). Everything else is declaration-driven.
+ *
+ * AUTH. Same gate as `/admin/channels`: a cookie-gated operator session pinned
+ * to the first admin. The catalog (`/api/connections/catalog`) is operator-only
+ * metadata; it uses the same session gate.
+ */
+import type { Database } from "bun:sqlite";
+import {
+  type ConnectionRecord,
+  type ConnectionSink,
+  type ConnectionSource,
+  putConnection,
+  readConnections,
+  removeConnection,
+} from "./connections-store.ts";
+import { signAccessToken } from "./jwt-sign.ts";
+import type { ModuleAction, ModuleEvent, ModuleManifest } from "./module-manifest.ts";
+import { findSession, parseSessionCookie } from "./sessions.ts";
+import { isFirstAdmin } from "./users.ts";
+import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
+
+/** Short TTL — provisioning calls use these immediately. */
+const PROVISION_TOKEN_TTL_SECONDS = 60;
+/**
+ * The webhook bearer is persisted as the vault trigger's `action.auth.bearer` —
+ * the vault re-presents it on every callback, so it must outlive the request.
+ * Long-lived (~90d) to match the daemon's headless-credential posture.
+ */
+const WEBHOOK_BEARER_TTL_SECONDS = 90 * 24 * 60 * 60;
+const PROVISION_CLIENT_ID = "parachute-hub-spa";
+
+/**
+ * Connection id charset. The id lands in a URL path segment (DELETE) and is the
+ * basis for the derived vault trigger name — keep it a conservative slug.
+ */
+const CONNECTION_ID_RE = /^[a-z0-9][a-z0-9_-]*$/i;
+
+/**
+ * Channel-name charset (mirrors `admin-channels.CHANNEL_NAME_RE`). A channel
+ * name lands in a services.json key, a URL path segment, and an MCP server name
+ * — keep it a conservative slug to close injection across all of them.
+ */
+const CHANNEL_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/i;
+
+/** A module installed on this hub, with its manifest + resolved mount path. */
+export interface InstalledModuleInfo {
+  /** Module short name (the catalog/wire key). */
+  readonly short: string;
+  /** Parsed `.parachute/module.json`. */
+  readonly manifest: ModuleManifest;
+  /**
+   * The module's user-facing mount path under the hub origin (e.g. `/channel`),
+   * used to build a hub-proxied webhook from a sink action's `endpoint`.
+   * `null` when the module declares no user-facing mount.
+   */
+  readonly mount: string | null;
+}
+
+export interface ConnectionsDeps {
+  db: Database;
+  /** Public hub origin — webhook URL + connect lines + minted-token `iss`. */
+  hubOrigin: string;
+  /**
+   * Snapshot of installed modules + their manifests + mounts, read at request
+   * time so a freshly-installed module's events/actions show up without a hub
+   * restart. Keyed scan is fine — cardinality is small.
+   */
+  modules: InstalledModuleInfo[];
+  /**
+   * Resolve a vault's loopback origin (e.g. `http://127.0.0.1:1940`) from
+   * services.json, or `null` when no vault by that name is installed.
+   */
+  resolveVaultOrigin: (vaultName: string) => string | null;
+  /** Loopback origin for the channel daemon, or `null` when not installed. */
+  channelOrigin: string | null;
+  /** Absolute path to `connections.json` in the hub state dir. */
+  storePath: string;
+  /** Test seam — `globalThis.fetch` in production. */
+  fetchImpl?: typeof fetch;
+  /** Test seam — defaults to the real `signAccessToken`. */
+  signToken?: typeof signAccessToken;
+  /** Test seam for the clock. */
+  now?: () => Date;
+}
+
+// ===========================================================================
+// Catalog — GET /api/connections/catalog
+// ===========================================================================
+
+interface CatalogEvent {
+  module: string;
+  key: string;
+  title: string;
+  filterSchema: unknown;
+}
+interface CatalogAction {
+  module: string;
+  key: string;
+  title: string;
+  inputSchema: unknown;
+  /** The provision descriptor (e.g. `{ type: "vault-trigger" }`), opaque to the SPA. */
+  provision: unknown;
+}
+
+/**
+ * Build the catalog from the installed modules' declared events/actions. Drives
+ * the SPA builder's source/sink dropdowns. NO tokens, NO secrets — pure
+ * declaration metadata read from each `module.json`.
+ */
+export function buildCatalog(modules: InstalledModuleInfo[]): {
+  events: CatalogEvent[];
+  actions: CatalogAction[];
+} {
+  const events: CatalogEvent[] = [];
+  const actions: CatalogAction[] = [];
+  for (const { short, manifest } of modules) {
+    for (const e of manifest.events ?? []) {
+      events.push({
+        module: short,
+        key: e.key,
+        title: e.title,
+        filterSchema: e.filterSchema ?? null,
+      });
+    }
+    for (const a of manifest.actions ?? []) {
+      actions.push({
+        module: short,
+        key: a.key,
+        title: a.title,
+        inputSchema: a.inputSchema ?? null,
+        provision: a.provision ?? null,
+      });
+    }
+  }
+  return { events, actions };
+}
+
+export async function handleConnectionsCatalog(
+  req: Request,
+  deps: ConnectionsDeps,
+): Promise<Response> {
+  const gate = operatorGate(req, deps);
+  if (gate) return gate;
+  return json(200, buildCatalog(deps.modules));
+}
+
+// ===========================================================================
+// Collection + item — GET/POST /admin/connections, DELETE /admin/connections/:id
+// ===========================================================================
+
+export async function handleConnections(
+  req: Request,
+  /** Path after `/admin/connections` — `""` for the collection, `/<id>` for an item. */
+  subPath: string,
+  deps: ConnectionsDeps,
+): Promise<Response> {
+  const gate = operatorGate(req, deps);
+  if (gate) return gate;
+  const { userId } = sessionUser(req, deps);
+
+  const method = req.method;
+  const itemId = subPath.startsWith("/") ? decodeURIComponent(subPath.slice(1)) : "";
+
+  if (itemId === "" && method === "GET") return listConnections(deps);
+  if (itemId === "" && method === "POST") return createConnection(req, userId, deps);
+  if (itemId !== "" && method === "DELETE") return teardownConnection(itemId, userId, deps);
+  return jsonError(
+    405,
+    "method_not_allowed",
+    "use GET/POST on /admin/connections or DELETE on /admin/connections/:id",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// GET — list
+// ---------------------------------------------------------------------------
+
+function listConnections(deps: ConnectionsDeps): Response {
+  // The store never holds a token — records carry source/sink/provisioned
+  // metadata only — so this is a straight read. Project to the wire shape so
+  // the response is stable regardless of the on-disk record shape.
+  const connections = readConnections(deps.storePath).map((c) => ({
+    id: c.id,
+    source: c.source,
+    sink: c.sink,
+    provisioned: c.provisioned,
+    created_at: c.createdAt,
+  }));
+  return json(200, { ok: true, connections });
+}
+
+// ---------------------------------------------------------------------------
+// POST — create + provision
+// ---------------------------------------------------------------------------
+
+interface CreateBody {
+  source?: {
+    module?: unknown;
+    vault?: unknown;
+    event?: unknown;
+    filter?: unknown;
+  };
+  sink?: {
+    module?: unknown;
+    action?: unknown;
+    params?: unknown;
+  };
+  /** Optional operator-supplied id; otherwise derived from source/sink. */
+  id?: unknown;
+}
+
+async function createConnection(
+  req: Request,
+  userId: string,
+  deps: ConnectionsDeps,
+): Promise<Response> {
+  let body: CreateBody;
+  try {
+    body = (await req.json()) as CreateBody;
+  } catch {
+    return jsonError(400, "invalid_request", "request body must be JSON");
+  }
+
+  const sourceModule = str(body.source?.module);
+  const sourceEvent = str(body.source?.event);
+  const sinkModule = str(body.sink?.module);
+  const sinkAction = str(body.sink?.action);
+  if (!sourceModule || !sourceEvent || !sinkModule || !sinkAction) {
+    return jsonError(
+      400,
+      "invalid_request",
+      "source.module, source.event, sink.module, sink.action are all required",
+    );
+  }
+
+  // --- Validate event + action existence against the declared catalog. -----
+  const src = deps.modules.find((m) => m.short === sourceModule);
+  if (!src) return jsonError(400, "unknown_module", `no installed module "${sourceModule}"`);
+  const event = findEvent(src.manifest, sourceEvent);
+  if (!event) {
+    return jsonError(
+      400,
+      "unknown_event",
+      `module "${sourceModule}" declares no event "${sourceEvent}"`,
+    );
+  }
+  const sink = deps.modules.find((m) => m.short === sinkModule);
+  if (!sink) return jsonError(400, "unknown_module", `no installed module "${sinkModule}"`);
+  const action = findAction(sink.manifest, sinkAction);
+  if (!action) {
+    return jsonError(
+      400,
+      "unknown_action",
+      `module "${sinkModule}" declares no action "${sinkAction}"`,
+    );
+  }
+
+  const provisionType = readProvisionType(action.provision);
+  if (provisionType !== "vault-trigger") {
+    return jsonError(
+      400,
+      "unsupported_provision",
+      `action "${sinkModule}.${sinkAction}" provision type ${provisionType ? `"${provisionType}"` : "(none)"} is not supported (only "vault-trigger" today)`,
+    );
+  }
+
+  // vault-trigger requires the source to be a vault event on a named vault.
+  if (sourceModule !== "vault") {
+    return jsonError(
+      400,
+      "invalid_source",
+      `a "vault-trigger" sink requires a vault source event; got "${sourceModule}"`,
+    );
+  }
+  // The source event must map to a vault-trigger verb. `note.deleted` is a
+  // declared vault event (passes the catalog check above) but has no trigger
+  // verb today — reject it cleanly here rather than 500ing downstream.
+  try {
+    eventsForSourceEvent(sourceEvent);
+  } catch {
+    return jsonError(
+      400,
+      "unsupported_event",
+      `source event "${sourceEvent}" has no vault-trigger mapping (supported: note.created, note.updated)`,
+    );
+  }
+  const vault = str(body.source?.vault);
+  if (!VAULT_NAME_CHARSET_RE.test(vault)) {
+    return jsonError(400, "invalid_request", `source.vault "${vault}" is not a valid identifier`);
+  }
+  const vaultOrigin = deps.resolveVaultOrigin(vault);
+  if (vaultOrigin === null) {
+    return jsonError(400, "unknown_vault", `no vault named "${vault}" in this hub`);
+  }
+
+  // The sink action MUST declare its webhook endpoint + scope for the hub to
+  // wire it generically. A vault-trigger action without these is mis-declared.
+  if (!action.endpoint || !action.scope) {
+    return jsonError(
+      400,
+      "action_underdeclared",
+      `action "${sinkModule}.${sinkAction}" is a vault-trigger sink but declares no endpoint/scope`,
+    );
+  }
+  if (sink.mount === null) {
+    return jsonError(
+      400,
+      "sink_unmounted",
+      `sink module "${sinkModule}" has no mount path — cannot build a hub-proxied webhook`,
+    );
+  }
+
+  const filter = readFilter(body.source?.filter);
+  const sourceRec: ConnectionSource = {
+    module: sourceModule,
+    vault,
+    event: sourceEvent,
+    ...(filter ? { filter } : {}),
+  };
+  const sinkParams = readParams(body.sink?.params);
+  const sinkRec: ConnectionSink = {
+    module: sinkModule,
+    action: sinkAction,
+    ...(sinkParams ? { params: sinkParams } : {}),
+  };
+
+  // Connection id — operator-supplied or derived. Drives the trigger name.
+  const id = deriveId(body.id, sourceRec, sinkRec);
+  if (!CONNECTION_ID_RE.test(id)) {
+    return jsonError(400, "invalid_request", `connection id "${id}" is not a valid identifier`);
+  }
+
+  // --- Sink prerequisite (channel reply path), fenced to the channel sink. --
+  // Everything below this is general; THIS block is the only sink-specific step.
+  // The channel name comes from the action params (`sink.params.channel`) — it
+  // becomes a services.json key + an MCP server name, so it must be a slug.
+  if (sinkModule === "channel") {
+    const channelName = typeof sinkParams?.channel === "string" ? sinkParams.channel : "";
+    if (!CHANNEL_NAME_RE.test(channelName)) {
+      return jsonError(
+        400,
+        "invalid_request",
+        `channel sink requires sink.params.channel as a valid identifier; got "${channelName}"`,
+      );
+    }
+    const prep = await prepareChannelSink(channelName, vault, vaultOrigin, userId, deps);
+    if (prep) return prep; // an error response
+  }
+
+  // --- Mint the webhook bearer at the action's DECLARED scope. -------------
+  let webhookBearer: string;
+  try {
+    webhookBearer = (
+      await mint(deps, userId, {
+        scopes: [action.scope],
+        audience: audienceForScope(action.scope, sinkModule),
+        vaultScope: [],
+        ttlSeconds: WEBHOOK_BEARER_TTL_SECONDS,
+      })
+    ).token;
+  } catch (err) {
+    return stepError("mint_webhook_bearer", err);
+  }
+
+  // --- Build the trigger from the declarations + filter. -------------------
+  const triggerName = `conn_${id}`;
+  const webhook = buildWebhook(deps.hubOrigin, sink.mount, action.endpoint);
+  const trigger = buildVaultTrigger(triggerName, sourceEvent, filter, webhook, webhookBearer);
+
+  // --- Register the trigger on the vault (upsert: POST replaces by name). ---
+  try {
+    const vaultAdminToken = (
+      await mint(deps, userId, {
+        scopes: [`vault:${vault}:admin`],
+        audience: `vault.${vault}`,
+        vaultScope: [vault],
+        ttlSeconds: PROVISION_TOKEN_TTL_SECONDS,
+      })
+    ).token;
+    const fetchImpl = deps.fetchImpl ?? fetch;
+    const res = await fetchImpl(`${vaultOrigin}/vault/${vault}/api/triggers`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${vaultAdminToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(trigger),
+    });
+    if (!res.ok) return stepError("vault_trigger", await describeRemote(res));
+  } catch (err) {
+    return stepError("vault_trigger", err);
+  }
+
+  // --- Persist the connection record. --------------------------------------
+  const record: ConnectionRecord = {
+    id,
+    source: sourceRec,
+    sink: sinkRec,
+    provisioned: { type: "vault-trigger", vault, triggerName },
+    createdAt: (deps.now?.() ?? new Date()).toISOString(),
+  };
+  putConnection(deps.storePath, record);
+
+  // --- Response. For a channel-deliver sink, hand back the connect lines
+  //     (parity with hub#624) so the operator can join a session.
+  const out: {
+    ok: true;
+    connection: typeof record;
+    connect?: { mcpAdd: string; launch: string };
+  } = { ok: true, connection: record };
+  if (sinkModule === "channel" && typeof sinkParams?.channel === "string") {
+    out.connect = channelConnectLines(deps.hubOrigin, sinkParams.channel);
+  }
+  return json(200, out);
+}
+
+/**
+ * The channel sink's reply-path prerequisite (mirrors hub#624). Mints a
+ * `vault:<v>:write` for the channel + writes the `channels.json` entry on the
+ * channel daemon so the session can reply. Fenced to `sink.module === "channel"`
+ * — this is sink-specific config, not part of the general vault-trigger engine.
+ * Returns an error Response on failure, or `null` on success.
+ */
+async function prepareChannelSink(
+  channelName: string,
+  vault: string,
+  vaultOrigin: string,
+  userId: string,
+  deps: ConnectionsDeps,
+): Promise<Response | null> {
+  if (deps.channelOrigin === null) {
+    return jsonError(503, "channel_unavailable", "the channel module is not installed on this hub");
+  }
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  try {
+    const vaultWriteToken = (
+      await mint(deps, userId, {
+        scopes: [`vault:${vault}:write`],
+        audience: `vault.${vault}`,
+        vaultScope: [vault],
+        ttlSeconds: WEBHOOK_BEARER_TTL_SECONDS, // channel keeps it for its lifetime
+      })
+    ).token;
+    const channelAdminToken = (
+      await mint(deps, userId, {
+        scopes: ["channel:admin"],
+        audience: "channel",
+        vaultScope: [],
+        ttlSeconds: PROVISION_TOKEN_TTL_SECONDS,
+      })
+    ).token;
+    const res = await fetchImpl(`${deps.channelOrigin}/api/channels`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${channelAdminToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        name: channelName,
+        transport: "vault",
+        config: { vault, vaultUrl: vaultOrigin, token: vaultWriteToken },
+      }),
+    });
+    if (!res.ok) return stepError("channel_config", await describeRemote(res));
+  } catch (err) {
+    return stepError("channel_config", err);
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// DELETE — teardown
+// ---------------------------------------------------------------------------
+
+async function teardownConnection(
+  id: string,
+  userId: string,
+  deps: ConnectionsDeps,
+): Promise<Response> {
+  if (!CONNECTION_ID_RE.test(id)) {
+    return jsonError(400, "invalid_request", `connection id "${id}" is not a valid identifier`);
+  }
+  const record = readConnections(deps.storePath).find((r) => r.id === id);
+  if (!record) {
+    return jsonError(404, "not_found", `no connection "${id}"`);
+  }
+
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const errors: { step: string; detail: string }[] = [];
+
+  // --- Vault trigger teardown. ---------------------------------------------
+  const vault = record.provisioned.vault;
+  const triggerName = record.provisioned.triggerName;
+  if (vault && triggerName) {
+    const vaultOrigin = deps.resolveVaultOrigin(vault);
+    if (vaultOrigin) {
+      try {
+        const vaultAdminToken = (
+          await mint(deps, userId, {
+            scopes: [`vault:${vault}:admin`],
+            audience: `vault.${vault}`,
+            vaultScope: [vault],
+            ttlSeconds: PROVISION_TOKEN_TTL_SECONDS,
+          })
+        ).token;
+        const res = await fetchImpl(
+          `${vaultOrigin}/vault/${vault}/api/triggers/${encodeURIComponent(triggerName)}`,
+          { method: "DELETE", headers: { authorization: `Bearer ${vaultAdminToken}` } },
+        );
+        if (!res.ok && res.status !== 404) {
+          errors.push({ step: "vault_trigger", detail: await remoteDetail(res) });
+        }
+      } catch (err) {
+        errors.push({ step: "vault_trigger", detail: errMsg(err) });
+      }
+    } else {
+      errors.push({ step: "vault_trigger", detail: `vault "${vault}" no longer installed` });
+    }
+  }
+
+  // --- Channel-sink teardown (remove the channel config entry). ------------
+  if (record.sink.module === "channel" && deps.channelOrigin) {
+    const channelName =
+      typeof record.sink.params?.channel === "string" ? record.sink.params.channel : record.id;
+    try {
+      const channelAdminToken = (
+        await mint(deps, userId, {
+          scopes: ["channel:admin"],
+          audience: "channel",
+          vaultScope: [],
+          ttlSeconds: PROVISION_TOKEN_TTL_SECONDS,
+        })
+      ).token;
+      const res = await fetchImpl(
+        `${deps.channelOrigin}/api/channels/${encodeURIComponent(channelName)}`,
+        { method: "DELETE", headers: { authorization: `Bearer ${channelAdminToken}` } },
+      );
+      if (!res.ok && res.status !== 404) {
+        errors.push({ step: "channel_config", detail: await remoteDetail(res) });
+      }
+    } catch (err) {
+      errors.push({ step: "channel_config", detail: errMsg(err) });
+    }
+  }
+
+  // Remove the record regardless — leaving a phantom record after a downstream
+  // failure is worse than a possibly-orphaned trigger the operator can re-run.
+  removeConnection(deps.storePath, id);
+
+  if (errors.length > 0) {
+    return json(207, { ok: false, id, partial: true, errors });
+  }
+  return json(200, { ok: true, id });
+}
+
+// ===========================================================================
+// Derivation — the GENERAL mapping (filter→predicate, event→events, webhook)
+// ===========================================================================
+
+/** Shape of the vault runtime trigger we POST (vault#469 API). */
+interface VaultTrigger {
+  name: string;
+  events: string[];
+  when: Record<string, unknown>;
+  action: { webhook: string; send: string; auth: { bearer: string } };
+}
+
+/**
+ * Map a source event key to the vault trigger's `events`. The vault hook system
+ * fires on `"created"` / `"updated"`; the `note.<verb>` key carries the verb.
+ */
+export function eventsForSourceEvent(eventKey: string): string[] {
+  if (eventKey === "note.created") return ["created"];
+  if (eventKey === "note.updated") return ["updated"];
+  // The catalog already validated the event exists upstream, so an unknown key
+  // reaching here is a bug (or an event with no vault-trigger verb mapping, e.g.
+  // note.deleted). Fail loud rather than silently registering the wrong trigger.
+  throw new Error(`no vault-trigger event mapping for source event "${eventKey}"`);
+}
+
+/**
+ * Map the operator-set `source.filter` to a vault trigger `when` predicate. The
+ * filter keys are the trigger predicate keys 1:1 (`tags`, `has_metadata`,
+ * `missing_metadata`, `has_content`) — this is what makes a vault event's
+ * filterSchema drive the predicate with no per-module code.
+ */
+export function whenFromFilter(
+  filter: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const when: Record<string, unknown> = {};
+  if (!filter) return when;
+  if (Array.isArray(filter.tags)) {
+    const tags = filter.tags.filter((t): t is string => typeof t === "string");
+    if (tags.length > 0) when.tags = tags;
+  }
+  if (Array.isArray(filter.has_metadata)) {
+    const keys = filter.has_metadata.filter((k): k is string => typeof k === "string");
+    if (keys.length > 0) when.has_metadata = keys;
+  }
+  if (Array.isArray(filter.missing_metadata)) {
+    const keys = filter.missing_metadata.filter((k): k is string => typeof k === "string");
+    if (keys.length > 0) when.missing_metadata = keys;
+  }
+  if (typeof filter.has_content === "boolean") when.has_content = filter.has_content;
+  return when;
+}
+
+/** Build the hub-proxied webhook from the sink module's mount + action endpoint. */
+export function buildWebhook(hubOrigin: string, mount: string, endpoint: string): string {
+  const origin = hubOrigin.replace(/\/+$/, "");
+  const m = mount.startsWith("/") ? mount.replace(/\/+$/, "") : `/${mount.replace(/\/+$/, "")}`;
+  const ep = endpoint.startsWith("/") ? endpoint : `/${endpoint}`;
+  return `${origin}${m}${ep}`;
+}
+
+function buildVaultTrigger(
+  name: string,
+  sourceEvent: string,
+  filter: Record<string, unknown> | undefined,
+  webhook: string,
+  bearer: string,
+): VaultTrigger {
+  return {
+    name,
+    events: eventsForSourceEvent(sourceEvent),
+    when: whenFromFilter(filter),
+    action: { webhook, send: "json", auth: { bearer } },
+  };
+}
+
+// ===========================================================================
+// Helpers
+// ===========================================================================
+
+function findEvent(m: ModuleManifest, key: string): ModuleEvent | undefined {
+  return (m.events ?? []).find((e) => e.key === key);
+}
+function findAction(m: ModuleManifest, key: string): ModuleAction | undefined {
+  return (m.actions ?? []).find((a) => a.key === key);
+}
+
+/** Extract `provision.type` from the opaque provision descriptor. */
+function readProvisionType(provision: unknown): string | null {
+  if (provision && typeof provision === "object" && !Array.isArray(provision)) {
+    const t = (provision as Record<string, unknown>).type;
+    if (typeof t === "string") return t;
+  }
+  return null;
+}
+
+/**
+ * Audience for a minted sink bearer. A `<module>:<verb>` scope (e.g.
+ * `channel:send`) takes the module namespace as its audience — matching how
+ * the channel validates `aud: channel`. Falls back to the sink module name.
+ */
+function audienceForScope(scope: string, sinkModule: string): string {
+  const colon = scope.indexOf(":");
+  return colon > 0 ? scope.slice(0, colon) : sinkModule;
+}
+
+function readFilter(v: unknown): Record<string, unknown> | undefined {
+  if (v && typeof v === "object" && !Array.isArray(v)) return v as Record<string, unknown>;
+  return undefined;
+}
+function readParams(v: unknown): Record<string, unknown> | undefined {
+  if (v && typeof v === "object" && !Array.isArray(v)) return v as Record<string, unknown>;
+  return undefined;
+}
+
+function str(v: unknown): string {
+  return typeof v === "string" ? v.trim() : "";
+}
+
+/**
+ * Derive the connection id. Operator-supplied wins; else for a channel sink use
+ * the channel name (so the trigger + channel-config share a stable key), else a
+ * `<srcModule>-<event>-<sinkModule>-<action>` slug.
+ */
+function deriveId(rawId: unknown, source: ConnectionSource, sink: ConnectionSink): string {
+  const supplied = str(rawId);
+  if (supplied) return supplied.toLowerCase();
+  if (sink.module === "channel" && typeof sink.params?.channel === "string") {
+    return `channel-${sink.params.channel}`.toLowerCase();
+  }
+  const slug = `${source.module}-${source.event}-${sink.module}-${sink.action}`
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug;
+}
+
+function channelConnectLines(
+  hubOrigin: string,
+  channelName: string,
+): { mcpAdd: string; launch: string } {
+  const origin = hubOrigin.replace(/\/+$/, "");
+  return {
+    mcpAdd: `claude mcp add --transport http --scope user channel-${channelName} ${origin}/channel/mcp/${channelName}`,
+    launch: `claude --dangerously-load-development-channels=server:channel-${channelName} --dangerously-skip-permissions`,
+  };
+}
+
+// --- Auth gate (mirrors admin-channels) ------------------------------------
+
+/** Returns an error Response when the operator gate fails, else `null`. */
+function operatorGate(req: Request, deps: ConnectionsDeps): Response | null {
+  const sid = parseSessionCookie(req.headers.get("cookie"));
+  const session = sid ? findSession(deps.db, sid) : null;
+  if (!session) {
+    return jsonError(401, "unauthenticated", "no admin session — sign in at /login first");
+  }
+  if (!isFirstAdmin(deps.db, session.userId)) {
+    return jsonError(
+      403,
+      "not_admin",
+      "connection provisioning is restricted to the hub admin — your account home is at /account/",
+    );
+  }
+  return null;
+}
+
+function sessionUser(req: Request, deps: ConnectionsDeps): { userId: string } {
+  const sid = parseSessionCookie(req.headers.get("cookie"));
+  const session = sid ? findSession(deps.db, sid) : null;
+  return { userId: session?.userId ?? "" };
+}
+
+// --- Mint -------------------------------------------------------------------
+
+interface MintSpec {
+  scopes: string[];
+  audience: string;
+  vaultScope: string[];
+  ttlSeconds: number;
+}
+
+async function mint(deps: ConnectionsDeps, userId: string, spec: MintSpec) {
+  const sign = deps.signToken ?? signAccessToken;
+  return sign(deps.db, {
+    sub: userId,
+    scopes: spec.scopes,
+    audience: spec.audience,
+    clientId: PROVISION_CLIENT_ID,
+    issuer: deps.hubOrigin,
+    ttlSeconds: spec.ttlSeconds,
+    vaultScope: spec.vaultScope,
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  });
+}
+
+// --- Response helpers -------------------------------------------------------
+
+function json(status: number, payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+function stepError(step: string, cause: unknown): Response {
+  return json(502, {
+    error: "provision_failed",
+    step,
+    error_description: `provisioning failed at step "${step}": ${errMsg(cause)}`,
+  });
+}
+
+function errMsg(cause: unknown): string {
+  if (cause instanceof Error) return cause.message;
+  if (typeof cause === "string") return cause;
+  return String(cause);
+}
+
+async function describeRemote(res: Response): Promise<Error> {
+  return new Error(await remoteDetail(res));
+}
+
+async function remoteDetail(res: Response): Promise<string> {
+  let text = "";
+  try {
+    text = (await res.text()).slice(0, 300);
+  } catch {
+    // status alone is informative enough
+  }
+  return `downstream ${res.status}${text ? `: ${text}` : ""}`;
+}

--- a/src/connections-store.ts
+++ b/src/connections-store.ts
@@ -1,0 +1,139 @@
+/**
+ * `connections.json` — the persisted registry of operator-created Connections
+ * (2026-06-09 modular-UI architecture, P5).
+ *
+ * A **connection** wires "when [EVENT] in [source module] (filter) → do [ACTION]
+ * in [sink module]". The hub is the only thing with cross-module authority
+ * (mint tokens, register vault triggers), so connections are hub-native + the
+ * record of what got provisioned lives here, in the hub state dir.
+ *
+ * One file, a flat array of records. Each record carries enough to (a) render
+ * the Connections list and (b) tear down what was provisioned — notably the
+ * `provisioned.triggerName` + `provisioned.vault` so DELETE can remove the exact
+ * vault trigger that was registered. We keep the store deliberately small +
+ * synchronous (Bun file I/O); the cardinality is "a handful of connections per
+ * hub", not a hot path.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+/** The source side — an event a module emits, with an operator-set filter. */
+export interface ConnectionSource {
+  /** Source module short name, e.g. `vault`. */
+  readonly module: string;
+  /** For vault events, which vault instance the event is scoped to. */
+  readonly vault?: string;
+  /** Event key declared in the source module's `module.json`, e.g. `note.created`. */
+  readonly event: string;
+  /**
+   * Operator-set filter, shaped by the event's `filterSchema`. For a vault
+   * event this maps to the trigger predicate (`tags` / `has_metadata` /
+   * `missing_metadata` / `has_content`).
+   */
+  readonly filter?: Record<string, unknown>;
+}
+
+/** The sink side — an action a module accepts (the sink is ALWAYS an action). */
+export interface ConnectionSink {
+  /** Sink module short name, e.g. `channel`. */
+  readonly module: string;
+  /** Action key declared in the sink module's `module.json`, e.g. `message.deliver`. */
+  readonly action: string;
+  /** Action params, shaped by the action's `inputSchema` (e.g. `{ channel }`). */
+  readonly params?: Record<string, unknown>;
+}
+
+/** What the provisioning engine actually wired, for teardown + display. */
+export interface ConnectionProvisioned {
+  /** How the action was provisioned, e.g. `vault-trigger`. */
+  readonly type: string;
+  /** The vault instance the trigger was registered on (vault-trigger). */
+  readonly vault?: string;
+  /** The exact vault trigger name registered — DELETE removes this. */
+  readonly triggerName?: string;
+}
+
+export interface ConnectionRecord {
+  readonly id: string;
+  readonly source: ConnectionSource;
+  readonly sink: ConnectionSink;
+  readonly provisioned: ConnectionProvisioned;
+  readonly createdAt: string;
+}
+
+interface ConnectionsFile {
+  connections: ConnectionRecord[];
+}
+
+function emptyFile(): ConnectionsFile {
+  return { connections: [] };
+}
+
+/** Read the store. A missing/garbage file reads as empty (fresh hub). */
+export function readConnections(storePath: string): ConnectionRecord[] {
+  let buf: string;
+  try {
+    buf = readFileSync(storePath, "utf8");
+  } catch {
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(buf);
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+  const arr = (parsed as { connections?: unknown }).connections;
+  if (!Array.isArray(arr)) return [];
+  // Lenient: drop any malformed row rather than failing the whole read, so one
+  // bad hand-edit doesn't take down the Connections view (mirrors the
+  // services.json lenient-read posture).
+  return arr.filter((r): r is ConnectionRecord => {
+    if (!r || typeof r !== "object") return false;
+    const rec = r as Record<string, unknown>;
+    return (
+      typeof rec.id === "string" &&
+      !!rec.source &&
+      typeof rec.source === "object" &&
+      !!rec.sink &&
+      typeof rec.sink === "object"
+    );
+  });
+}
+
+function writeAll(storePath: string, records: ConnectionRecord[]): void {
+  mkdirSync(dirname(storePath), { recursive: true });
+  const file: ConnectionsFile = { connections: records };
+  // Written WITHOUT 0o600 because this file holds NO secrets — the provisioned
+  // webhook bearer lives only in the vault trigger's row, never here; records
+  // carry source/sink/trigger-name metadata only. Consistent with the default
+  // perms on services.json / expose-state.json.
+  writeFileSync(storePath, `${JSON.stringify(file, null, 2)}\n`);
+}
+
+/** Upsert by id (replace an existing record with the same id, else append). */
+export function putConnection(storePath: string, record: ConnectionRecord): void {
+  const records = readConnections(storePath);
+  const idx = records.findIndex((r) => r.id === record.id);
+  if (idx >= 0) records[idx] = record;
+  else records.push(record);
+  writeAll(storePath, records);
+}
+
+/** Remove a connection by id. Returns the removed record, or null if absent. */
+export function removeConnection(storePath: string, id: string): ConnectionRecord | null {
+  const records = readConnections(storePath);
+  const idx = records.findIndex((r) => r.id === id);
+  if (idx < 0) return null;
+  const [removed] = records.splice(idx, 1);
+  writeAll(storePath, records);
+  return removed ?? null;
+}
+
+export function getConnection(storePath: string, id: string): ConnectionRecord | null {
+  return readConnections(storePath).find((r) => r.id === id) ?? null;
+}
+
+/** Re-export for the unused-import linter when only the type is consumed. */
+export const _emptyConnectionsFile = emptyFile;

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -49,6 +49,9 @@
  *   /admin/module-token/<short>   (GET)        → generic module config-UI bearer mint <short>:admin (cookie-gated)
  *   /admin/channels               (POST/GET)   → vault-channel provision/list (cookie-gated)
  *   /admin/channels/<name>        (DELETE)     → vault-channel teardown (cookie-gated)
+ *   /api/connections/catalog      (GET)        → events/actions across installed modules (cookie-gated)
+ *   /admin/connections            (POST/GET)   → connection provision/list (cookie-gated)
+ *   /admin/connections/<id>       (DELETE)     → connection teardown (cookie-gated)
  *   /api/me                       (GET)        → who-am-I (session+CSRF or hasSession:false)
  *   /api/hub                      (GET)        → hub version + uptime + install-source (host:admin)
  *   /api/hub/upgrade              (POST)       → SPA-driven hub self-upgrade → 202 + detached helper (host:admin, §5.3/D4)
@@ -137,6 +140,11 @@ import { handleAccountVaultTokenPost } from "./account-vault-token.ts";
 import { handleChannelToken } from "./admin-channel-token.ts";
 import { handleChannels } from "./admin-channels.ts";
 import { handleApproveClient, handleGetClient } from "./admin-clients.ts";
+import {
+  type ConnectionsDeps,
+  handleConnections,
+  handleConnectionsCatalog,
+} from "./admin-connections.ts";
 import { handleListGrants, handleRevokeGrant } from "./admin-grants.ts";
 import {
   handleAdminLoginGet,
@@ -416,6 +424,45 @@ function hasVaultInstalled(manifestPath: string): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Snapshot of every installed module's `.parachute/module.json` + its
+ * user-facing mount path, for the Connections engine (2026-06-09 modular-UI
+ * architecture, P5). Read at request time so a freshly-installed module's
+ * declared events/actions surface without a hub restart. A malformed manifest
+ * on one module is skipped (logged), never 500s the whole catalog — same
+ * posture as `/api/modules`.
+ *
+ * `mount` is the first non-`.parachute` services.json path (the proxied
+ * user-facing prefix, e.g. `/channel`), which the engine joins with a sink
+ * action's `endpoint` to build the hub-proxied webhook.
+ */
+async function collectInstalledModules(
+  manifestPath: string,
+  readManifestFn: (installDir: string) => Promise<ModuleManifest | null>,
+): Promise<import("./admin-connections.ts").InstalledModuleInfo[]> {
+  // Lenient — see hub#406.
+  const services = readManifestLenient(manifestPath).services;
+  const out: import("./admin-connections.ts").InstalledModuleInfo[] = [];
+  await Promise.all(
+    services.map(async (entry) => {
+      if (!entry.installDir) return;
+      const short = shortNameForManifest(entry.name) ?? entry.name;
+      const userPath = (entry.paths ?? []).find(
+        (p) => p !== "/.parachute" && !p.startsWith("/.parachute/"),
+      );
+      try {
+        const manifest = await readManifestFn(entry.installDir);
+        if (!manifest) return;
+        out.push({ short, manifest, mount: userPath ?? null });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`connections: skipping module ${short}: ${msg}`);
+      }
+    }),
+  );
+  return out;
 }
 
 /**
@@ -879,6 +926,11 @@ export interface HubFetchDeps {
    * the doc reflect `parachute vault create` etc. without re-running expose.
    */
   manifestPath?: string;
+  /**
+   * Path to `connections.json` (the Connections store, P5). Tests point this
+   * at a tmpdir; production defaults to `<CONFIG_DIR>/connections.json`.
+   */
+  connectionsStorePath?: string;
   /**
    * Directory containing the built SPA bundle (`index.html` + `assets/`). When
    * absent, the hub auto-resolves to `<repo>/web/ui/dist/` — handy for the
@@ -2135,6 +2187,47 @@ export function hubFetch(
           channelOrigin,
           resolveVaultOrigin,
         });
+      }
+
+      // Connections — the GENERAL module event→action engine (2026-06-09
+      // modular-UI architecture, P5). `/api/connections/catalog` (GET) returns
+      // the available events/actions read from each installed module's
+      // `module.json`; `/admin/connections` (GET/POST) lists + provisions;
+      // `/admin/connections/:id` (DELETE) tears down. Same cookie-gated
+      // first-admin operator gate as `/admin/channels`. The provisioning engine
+      // derives the vault trigger's webhook + scope from the SINK action's
+      // declaration — nothing is channel-hardcoded.
+      if (
+        pathname === "/api/connections/catalog" ||
+        pathname === "/admin/connections" ||
+        pathname.startsWith("/admin/connections/")
+      ) {
+        if (!getDb) return dbNotConfigured();
+        const services = readManifestLenient(manifestPath).services;
+        const channelEntry = services.find((s) => s.name === "channel");
+        const channelOrigin = channelEntry ? `http://127.0.0.1:${channelEntry.port}` : null;
+        const resolveVaultOrigin = (vaultName: string): string | null => {
+          const match = findVaultUpstream(
+            readManifestLenient(manifestPath).services,
+            `/vault/${vaultName}`,
+          );
+          return match ? `http://127.0.0.1:${match.port}` : null;
+        };
+        const readManifestFn = deps?.readModuleManifest ?? defaultReadModuleManifest;
+        const modules = await collectInstalledModules(manifestPath, readManifestFn);
+        const connectionsDeps: ConnectionsDeps = {
+          db: getDb(),
+          hubOrigin: oauthDeps(req).issuer,
+          modules,
+          resolveVaultOrigin,
+          channelOrigin,
+          storePath: deps?.connectionsStorePath ?? join(CONFIG_DIR, "connections.json"),
+        };
+        if (pathname === "/api/connections/catalog") {
+          return handleConnectionsCatalog(req, connectionsDeps);
+        }
+        const subPath = pathname.slice("/admin/connections".length);
+        return handleConnections(req, subPath, connectionsDeps);
       }
 
       if (pathname.startsWith("/admin/vault-admin-token/")) {

--- a/src/module-manifest.ts
+++ b/src/module-manifest.ts
@@ -110,6 +110,23 @@ export interface ModuleAction {
   readonly title: string;
   /** Optional JSON-Schema for the action's input. */
   readonly inputSchema?: unknown;
+  /**
+   * The module-relative HTTP endpoint the hub's Connections engine calls when
+   * this action fires (P5). For a `vault-trigger` provision, this becomes the
+   * vault trigger's `action.webhook`, hub-proxied under the module's mount:
+   * `<hub-origin>/<mount><endpoint>`. Declaring it here — rather than
+   * hardcoding a per-module path in the hub — is what makes the engine general.
+   * Channel ships `"/api/vault/inbound"`.
+   */
+  readonly endpoint?: string;
+  /**
+   * The OAuth scope the hub mints into the action webhook's `Authorization:
+   * Bearer` (P5). For a `vault-trigger`, this is persisted as the trigger's
+   * long-lived `action.auth.bearer` scope — the credential the sink module
+   * validates on every callback. Sourced from the action declaration so the
+   * hub never hardcodes a per-module scope. Channel ships `"channel:send"`.
+   */
+  readonly scope?: string;
   /** Opaque (P1) descriptor of how the hub provisions this action. */
   readonly provision?: unknown;
 }
@@ -476,7 +493,7 @@ export function validateModuleManifest(
       ? undefined
       : asStringArray(m.adminCapabilities, where, "adminCapabilities");
   const events = asEvents(m.events, where);
-  const actions = asActions(m.actions, where);
+  const actions = asActions(m.actions, where, name);
   let stripPrefix: boolean | undefined;
   if (m.stripPrefix !== undefined) {
     if (typeof m.stripPrefix !== "boolean") {
@@ -547,7 +564,12 @@ function asEvents(v: unknown, where: string): readonly ModuleEvent[] | undefined
   });
 }
 
-function asActions(v: unknown, where: string): readonly ModuleAction[] | undefined {
+function asActions(
+  v: unknown,
+  where: string,
+  /** Declaring module's name — enforces the `action.scope` namespace rule. */
+  name: string,
+): readonly ModuleAction[] | undefined {
   if (v === undefined) return undefined;
   if (!Array.isArray(v)) {
     throw new ModuleManifestError(`${where}: "actions" must be an array if present`);
@@ -563,6 +585,40 @@ function asActions(v: unknown, where: string): readonly ModuleAction[] | undefin
       title: asString(a.title, where, `${at}.title`),
     };
     if (a.inputSchema !== undefined) (out as { inputSchema?: unknown }).inputSchema = a.inputSchema;
+    if (a.endpoint !== undefined) {
+      const ep = asString(a.endpoint, where, `${at}.endpoint`);
+      if (!ep.startsWith("/")) {
+        throw new ModuleManifestError(`${where}: "${at}.endpoint" must start with "/"`);
+      }
+      (out as { endpoint?: string }).endpoint = ep;
+    }
+    if (a.scope !== undefined) {
+      const scope = asString(a.scope, where, `${at}.scope`);
+      // Scope-namespace rule (mirrors `scopes.defines` above): an action's
+      // `scope` is minted by the hub into a 90-day webhook bearer presented to
+      // THIS module's own endpoint, which validates `aud:<name>` + a scope in
+      // its own namespace. A legitimate `action.scope` is therefore always in
+      // the declaring module's namespace (channel.message.deliver → channel:send).
+      // Enforcing `<ns> === name` blocks a malicious module declaring e.g.
+      // `vault:default:admin` and tricking the hub into minting a cross-module
+      // privilege-escalating token when an operator wires a Connection to it.
+      // Cross-module tokens a sink legitimately needs for OTHER purposes (e.g.
+      // channel's reply path needs `vault:write`) are minted separately by the
+      // engine, NOT declared here.
+      const colon = scope.indexOf(":");
+      if (colon <= 0) {
+        throw new ModuleManifestError(
+          `${where}: "${at}.scope" "${scope}" must be namespaced as "<name>:<verb>"`,
+        );
+      }
+      const ns = scope.slice(0, colon);
+      if (ns !== name) {
+        throw new ModuleManifestError(
+          `${where}: "${at}.scope" "${scope}" namespace "${ns}" does not match module name "${name}"`,
+        );
+      }
+      (out as { scope?: string }).scope = scope;
+    }
     if (a.provision !== undefined) (out as { provision?: unknown }).provision = a.provision;
     return out;
   });

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -82,7 +82,7 @@ describe("App — brand subtitle (route-derived)", () => {
 });
 
 describe("App — nav structure", () => {
-  it("renders all nav links in order: brand, Vaults, Modules, Users, Channels, Permissions, Tokens, Settings, Discovery (signed-out)", async () => {
+  it("renders all nav links in order: brand, Vaults, Modules, Users, Connections, Permissions, Tokens, Settings, Discovery (signed-out)", async () => {
     renderAt("/vaults");
     // Wait for /api/me to resolve so AuthIndicator's "Sign in" link
     // appears in the nav before we snapshot the link order.
@@ -101,7 +101,7 @@ describe("App — nav structure", () => {
       "Vaults",
       "Modules",
       "Users",
-      "Channels",
+      "Connections",
       "Permissions",
       "Tokens",
       "Settings",

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -28,6 +28,7 @@ import { HubVersionBadge } from "./components/HubVersionBadge.tsx";
 import { type MeResponse, type ModuleListing, getMe, listModules, signOut } from "./lib/api.ts";
 import { ApproveClient } from "./routes/ApproveClient.tsx";
 import { Channels } from "./routes/Channels.tsx";
+import { Connections } from "./routes/Connections.tsx";
 import { Modules } from "./routes/Modules.tsx";
 import { NewVault } from "./routes/NewVault.tsx";
 import { Permissions } from "./routes/Permissions.tsx";
@@ -53,6 +54,9 @@ function subtitleFor(pathname: string): string {
   }
   if (pathname === "/users" || pathname.startsWith("/users/")) {
     return "users";
+  }
+  if (pathname === "/connections" || pathname.startsWith("/connections/")) {
+    return "connections";
   }
   if (pathname === "/channels" || pathname.startsWith("/channels/")) {
     return "channels";
@@ -171,7 +175,7 @@ export function App() {
         <NavSection to="/modules" label="Modules" />
         <InstalledServicesDropdown services={installedServices} />
         <NavSection to="/users" label="Users" />
-        <NavSection to="/channels" label="Channels" />
+        <NavSection to="/connections" label="Connections" />
         <NavSection to="/permissions" label="Permissions" />
         <NavSection to="/tokens" label="Tokens" />
         <NavSection to="/settings" label="Settings" />
@@ -187,6 +191,8 @@ export function App() {
         <Route path="/vaults/new" element={<NewVault />} />
         <Route path="/modules" element={<Modules />} />
         <Route path="/users" element={<Users />} />
+        <Route path="/connections" element={<Connections />} />
+        {/* Back-compat: the pre-P5 Channels view stays routable for bookmarks. */}
         <Route path="/channels" element={<Channels />} />
         <Route path="/permissions" element={<Permissions />} />
         <Route path="/tokens" element={<Tokens />} />

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1657,3 +1657,143 @@ async function readError(res: Response): Promise<string> {
   }
   return `${res.status} ${res.statusText}`;
 }
+
+// ---------------------------------------------------------------------------
+// Connections (the general module event→action engine, modular-UI P5).
+// `/api/connections/catalog` lists available events/actions across installed
+// modules; `/admin/connections` builds/lists/removes connections. All
+// session-cookie-gated (first-admin), same posture as Channels above.
+// ---------------------------------------------------------------------------
+
+/** One event a module emits (catalog left-hand side). */
+export interface CatalogEvent {
+  module: string;
+  key: string;
+  title: string;
+  /** Optional JSON Schema describing the per-event filter the operator may set. */
+  filterSchema: unknown;
+}
+
+/** One action a module accepts (catalog right-hand side — the sink). */
+export interface CatalogAction {
+  module: string;
+  key: string;
+  title: string;
+  inputSchema: unknown;
+  /** Opaque provision descriptor, e.g. `{ type: "vault-trigger" }`. */
+  provision: unknown;
+}
+
+export interface ConnectionsCatalog {
+  events: CatalogEvent[];
+  actions: CatalogAction[];
+}
+
+/** A provisioned connection (the list/wire shape from `/admin/connections`). */
+export interface ConnectionListing {
+  id: string;
+  source: {
+    module: string;
+    vault?: string;
+    event: string;
+    filter?: Record<string, unknown>;
+  };
+  sink: {
+    module: string;
+    action: string;
+    params?: Record<string, unknown>;
+  };
+  provisioned: { type: string; vault?: string; triggerName?: string };
+  created_at: string;
+}
+
+/** Connect lines returned when the sink is a channel-deliver action. */
+export interface ConnectionConnect {
+  mcpAdd: string;
+  launch: string;
+}
+
+/** `POST /admin/connections` success body. */
+export interface CreatedConnection {
+  connection: ConnectionListing;
+  connect?: ConnectionConnect;
+}
+
+/** GET /api/connections/catalog — events + actions across installed modules. */
+export async function getConnectionsCatalog(): Promise<ConnectionsCatalog> {
+  const res = await fetch("/api/connections/catalog", {
+    method: "GET",
+    headers: { accept: "application/json" },
+    credentials: "same-origin",
+  });
+  if (res.status === 401) return redirectToLoginAndHang<ConnectionsCatalog>();
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  const body = (await res.json()) as { events?: unknown; actions?: unknown };
+  const events = Array.isArray(body.events) ? (body.events as CatalogEvent[]) : [];
+  const actions = Array.isArray(body.actions) ? (body.actions as CatalogAction[]) : [];
+  return { events, actions };
+}
+
+/** GET /admin/connections — list provisioned connections. */
+export async function listConnections(): Promise<ConnectionListing[]> {
+  const res = await fetch("/admin/connections", {
+    method: "GET",
+    headers: { accept: "application/json" },
+    credentials: "same-origin",
+  });
+  if (res.status === 401) return redirectToLoginAndHang<ConnectionListing[]>();
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  const body = (await res.json()) as { connections?: unknown };
+  return Array.isArray(body.connections) ? (body.connections as ConnectionListing[]) : [];
+}
+
+/** POST /admin/connections — build a connection. */
+export async function createConnection(input: {
+  id?: string;
+  source: { module: string; vault?: string; event: string; filter?: Record<string, unknown> };
+  sink: { module: string; action: string; params?: Record<string, unknown> };
+}): Promise<CreatedConnection> {
+  const res = await fetch("/admin/connections", {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json" },
+    credentials: "same-origin",
+    body: JSON.stringify(input),
+  });
+  if (res.status === 401) return redirectToLoginAndHang<CreatedConnection>();
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  const body = (await res.json()) as {
+    connection?: ConnectionListing;
+    connect?: ConnectionConnect;
+  };
+  if (!body.connection || typeof body.connection.id !== "string") {
+    throw new HttpError(500, "/admin/connections returned a malformed connection body");
+  }
+  return { connection: body.connection, ...(body.connect ? { connect: body.connect } : {}) };
+}
+
+/** DELETE /admin/connections/:id — tear a connection down (best-effort). */
+export async function deleteConnection(id: string): Promise<void> {
+  const res = await fetch(`/admin/connections/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    headers: { accept: "application/json" },
+    credentials: "same-origin",
+  });
+  if (res.status === 401) {
+    await redirectToLoginAndHang<void>();
+    return;
+  }
+  // 207 = partial teardown; surface the residue so the operator knows.
+  if (res.status === 207) {
+    let detail = "connection teardown partially failed";
+    try {
+      const body = (await res.json()) as { errors?: Array<{ step?: string; detail?: string }> };
+      if (Array.isArray(body.errors) && body.errors.length > 0) {
+        detail = body.errors.map((e) => `${e.step ?? "step"}: ${e.detail ?? "failed"}`).join("; ");
+      }
+    } catch {
+      // keep the generic message
+    }
+    throw new HttpError(207, detail);
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+}

--- a/web/ui/src/routes/Connections.test.tsx
+++ b/web/ui/src/routes/Connections.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * Connections route tests (modular-UI P5) — loading, list, empty state, the
+ * builder driven from the catalog, create posting the right body, the channel
+ * preset pre-filling + showing connect lines, and remove confirm-then-DELETE.
+ *
+ * Same shape as Channels.test.tsx: mock `lib/api.ts` so the route's fetch
+ * helpers are stubbed and assert on the rendered DOM + the calls made.
+ */
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import { Connections } from "./Connections.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    listConnections: vi.fn(),
+    getConnectionsCatalog: vi.fn(),
+    listVaults: vi.fn(),
+    createConnection: vi.fn(),
+    deleteConnection: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderRoute() {
+  return render(
+    <MemoryRouter>
+      <Connections />
+    </MemoryRouter>,
+  );
+}
+
+function catalog(): api.ConnectionsCatalog {
+  return {
+    events: [
+      { module: "vault", key: "note.created", title: "A note was created", filterSchema: null },
+      { module: "vault", key: "note.updated", title: "A note was updated", filterSchema: null },
+    ],
+    actions: [
+      {
+        module: "channel",
+        key: "message.deliver",
+        title: "Deliver an inbound message",
+        inputSchema: null,
+        provision: { type: "vault-trigger" },
+      },
+    ],
+  };
+}
+
+function vaultsResult(...names: string[]): api.VaultsListResult {
+  return {
+    moduleInstalled: names.length > 0,
+    vaults: names.map((name) => ({
+      name,
+      url: `https://hub.example.com/vault/${name}`,
+      version: "0.5.0",
+      path: `/vault/${name}`,
+    })),
+  };
+}
+
+function connection(id: string): api.ConnectionListing {
+  return {
+    id,
+    source: { module: "vault", vault: "default", event: "note.created" },
+    sink: { module: "channel", action: "message.deliver", params: { channel: "eng" } },
+    provisioned: { type: "vault-trigger", vault: "default", triggerName: `conn_${id}` },
+    created_at: "2026-06-09T00:00:00.000Z",
+  };
+}
+
+describe("Connections — list rendering", () => {
+  it("shows a loading state on first paint", () => {
+    vi.mocked(api.listConnections).mockImplementation(() => new Promise(() => {}));
+    vi.mocked(api.getConnectionsCatalog).mockImplementation(() => new Promise(() => {}));
+    vi.mocked(api.listVaults).mockImplementation(() => new Promise(() => {}));
+    renderRoute();
+    expect(screen.getByText(/loading connections/i)).toBeInTheDocument();
+  });
+
+  it("renders the empty state when no connections exist", async () => {
+    vi.mocked(api.listConnections).mockResolvedValue([]);
+    vi.mocked(api.getConnectionsCatalog).mockResolvedValue(catalog());
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/no connections yet/i)).toBeInTheDocument());
+  });
+
+  it("lists provisioned connections", async () => {
+    vi.mocked(api.listConnections).mockResolvedValue([connection("channel-eng")]);
+    vi.mocked(api.getConnectionsCatalog).mockResolvedValue(catalog());
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("channel-eng")).toBeInTheDocument());
+    expect(screen.getByText(/vault\.note\.created/)).toBeInTheDocument();
+    expect(screen.getByText(/channel\.message\.deliver/)).toBeInTheDocument();
+  });
+});
+
+describe("Connections — builder", () => {
+  it("populates source/sink dropdowns from the catalog", async () => {
+    vi.mocked(api.listConnections).mockResolvedValue([]);
+    vi.mocked(api.getConnectionsCatalog).mockResolvedValue(catalog());
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("channel-preset")).toBeInTheDocument());
+    // Source module select offers vault.
+    const srcModule = screen.getByLabelText("Module", { selector: "#conn-source-module" });
+    expect(within(srcModule).getByRole("option", { name: "vault" })).toBeInTheDocument();
+    // Sink module select offers channel.
+    const sinkModule = screen.getByLabelText("Module", { selector: "#conn-sink-module" });
+    expect(within(sinkModule).getByRole("option", { name: "channel" })).toBeInTheDocument();
+  });
+
+  it("the channel preset pre-fills the builder", async () => {
+    vi.mocked(api.listConnections).mockResolvedValue([]);
+    vi.mocked(api.getConnectionsCatalog).mockResolvedValue(catalog());
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("channel-preset")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("channel-preset"));
+    // Source module + event get set.
+    const srcModule = screen.getByLabelText("Module", {
+      selector: "#conn-source-module",
+    }) as HTMLSelectElement;
+    expect(srcModule.value).toBe("vault");
+    const srcEvent = screen.getByLabelText(/Event/i) as HTMLSelectElement;
+    expect(srcEvent.value).toBe("note.created");
+    // The filter text carries the inbound tag.
+    const filter = screen.getByLabelText(/Filter/i) as HTMLTextAreaElement;
+    expect(filter.value).toContain("#channel-message/inbound");
+  });
+
+  it("create posts the right body and renders connect lines for a channel sink", async () => {
+    vi.mocked(api.listConnections).mockResolvedValue([]);
+    vi.mocked(api.getConnectionsCatalog).mockResolvedValue(catalog());
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    vi.mocked(api.createConnection).mockResolvedValue({
+      connection: connection("channel-eng"),
+      connect: {
+        mcpAdd:
+          "claude mcp add --transport http --scope user channel-eng https://hub/channel/mcp/eng",
+        launch:
+          "claude --dangerously-load-development-channels=server:channel-eng --dangerously-skip-permissions",
+      },
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("channel-preset")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("channel-preset"));
+    fireEvent.click(screen.getByRole("button", { name: /create connection/i }));
+
+    await waitFor(() => expect(api.createConnection).toHaveBeenCalledTimes(1));
+    const arg = vi.mocked(api.createConnection).mock.calls[0]![0];
+    expect(arg.source.module).toBe("vault");
+    expect(arg.source.event).toBe("note.created");
+    expect(arg.source.vault).toBe("default");
+    expect(arg.source.filter).toMatchObject({ tags: ["#channel-message/inbound"] });
+    expect(arg.sink).toMatchObject({
+      module: "channel",
+      action: "message.deliver",
+      params: { channel: "eng" },
+    });
+
+    // Connect lines surface.
+    await waitFor(() => expect(screen.getByTestId("connection-connect-panel")).toBeInTheDocument());
+    expect(screen.getByTestId("connection-mcp-add").textContent).toContain("channel-eng");
+  });
+
+  it("surfaces a bad-JSON filter error before posting", async () => {
+    vi.mocked(api.listConnections).mockResolvedValue([]);
+    vi.mocked(api.getConnectionsCatalog).mockResolvedValue(catalog());
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("channel-preset")).toBeInTheDocument());
+    // Pick valid source/sink, then a broken filter.
+    fireEvent.change(screen.getByLabelText("Module", { selector: "#conn-source-module" }), {
+      target: { value: "vault" },
+    });
+    fireEvent.change(screen.getByLabelText("Event", { selector: "#conn-source-event" }), {
+      target: { value: "note.created" },
+    });
+    fireEvent.change(screen.getByLabelText("Module", { selector: "#conn-sink-module" }), {
+      target: { value: "channel" },
+    });
+    fireEvent.change(screen.getByLabelText("Action", { selector: "#conn-sink-action" }), {
+      target: { value: "message.deliver" },
+    });
+    fireEvent.change(screen.getByLabelText(/Filter/i), { target: { value: "{ not json" } });
+    fireEvent.click(screen.getByRole("button", { name: /create connection/i }));
+    await waitFor(() => expect(screen.getByText(/not valid JSON/i)).toBeInTheDocument());
+    expect(api.createConnection).not.toHaveBeenCalled();
+  });
+});
+
+describe("Connections — remove", () => {
+  it("confirm-then-DELETE removes a connection", async () => {
+    vi.mocked(api.listConnections).mockResolvedValue([connection("channel-eng")]);
+    vi.mocked(api.getConnectionsCatalog).mockResolvedValue(catalog());
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    vi.mocked(api.deleteConnection).mockResolvedValue(undefined);
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("channel-eng")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /remove channel-eng/i }));
+    // Confirm dialog → Remove.
+    fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
+    await waitFor(() => expect(api.deleteConnection).toHaveBeenCalledWith("channel-eng"));
+  });
+});

--- a/web/ui/src/routes/Connections.tsx
+++ b/web/ui/src/routes/Connections.tsx
@@ -1,0 +1,658 @@
+/**
+ * /admin/connections — the general Connections builder (modular-UI P5).
+ *
+ * A connection wires "when [EVENT] in [source module] (filter) → do [ACTION] in
+ * [sink module]". The hub is the only thing with cross-module authority, so this
+ * is hub-native. The IFTTT-style builder drives the cookie-gated
+ * `/admin/connections` engine; dropdowns populate from
+ * `/api/connections/catalog` (events + actions read from each module.json).
+ *
+ * "Add a vault-backed channel" is no longer a bespoke view — it's the first
+ * connection (`vault.note.created` filtered to the inbound tag →
+ * `channel.message.deliver`). A one-click **preset** pre-fills that common case
+ * and still shows the connect-a-session lines on success.
+ *
+ * Modeled on Channels.tsx + Users.tsx for visual continuity. Auth: the
+ * `/admin/*` + catalog endpoints are session-cookie-gated; the `lib/api.ts`
+ * helpers redirect to login on 401 and surface `error_description` verbatim.
+ */
+import { type FormEvent, useEffect, useState } from "react";
+import {
+  type CatalogAction,
+  type CatalogEvent,
+  type ConnectionConnect,
+  type ConnectionListing,
+  type ConnectionsCatalog,
+  HttpError,
+  type VaultListing,
+  createConnection,
+  deleteConnection,
+  getConnectionsCatalog,
+  listConnections,
+  listVaults,
+} from "../lib/api.ts";
+
+const SLUG_REGEX = /^[a-z0-9][a-z0-9_-]*$/i;
+
+/** The channel-add preset — the common vault.note.created → channel.message.deliver case. */
+const CHANNEL_PRESET = {
+  sourceModule: "vault",
+  sourceEvent: "note.created",
+  sinkModule: "channel",
+  sinkAction: "message.deliver",
+  inboundTag: "#channel-message/inbound",
+} as const;
+
+interface ConnectionsData {
+  connections: ConnectionListing[];
+  catalog: ConnectionsCatalog;
+  vaults: VaultListing[];
+}
+
+type ListState =
+  | { kind: "loading" }
+  | { kind: "ok"; data: ConnectionsData }
+  | { kind: "error"; message: string };
+
+type CreateState =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "created"; connect?: ConnectionConnect }
+  | { kind: "error"; message: string };
+
+type RemoveState =
+  | { kind: "idle" }
+  | { kind: "confirming"; id: string }
+  | { kind: "removing"; id: string }
+  | { kind: "error"; id: string; message: string };
+
+function errMessage(err: unknown, verb: string): string {
+  if (err instanceof HttpError) return `${verb} failed (${err.status}): ${err.message}`;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/** Copy-to-clipboard button (mirrors Channels.tsx / McpConnectCard). */
+function CopyButton({ value, label = "Copy" }: { value: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      className="secondary"
+      onClick={() => {
+        if (typeof navigator === "undefined" || !navigator.clipboard) return;
+        void navigator.clipboard.writeText(value).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        });
+      }}
+    >
+      {copied ? "Copied ✓" : label}
+    </button>
+  );
+}
+
+export function Connections() {
+  const [state, setState] = useState<ListState>({ kind: "loading" });
+  const [reload, setReload] = useState(0);
+  const [createSt, setCreateSt] = useState<CreateState>({ kind: "idle" });
+  const [removeSt, setRemoveSt] = useState<RemoveState>({ kind: "idle" });
+
+  // Builder form fields.
+  const [sourceModule, setSourceModule] = useState("");
+  const [sourceEvent, setSourceEvent] = useState("");
+  const [vault, setVault] = useState("");
+  const [filterText, setFilterText] = useState("");
+  const [sinkModule, setSinkModule] = useState("");
+  const [sinkAction, setSinkAction] = useState("");
+  const [paramsText, setParamsText] = useState("");
+
+  useEffect(() => {
+    void reload;
+    let cancelled = false;
+    setState({ kind: "loading" });
+    Promise.all([listConnections(), getConnectionsCatalog(), listVaults()])
+      .then(([connections, catalog, vaultsResult]) => {
+        if (cancelled) return;
+        setState({ kind: "ok", data: { connections, catalog, vaults: vaultsResult.vaults } });
+        setVault((cur) => cur || vaultsResult.vaults[0]?.name || "");
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setState({ kind: "error", message: err instanceof Error ? err.message : String(err) });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reload]);
+
+  function applyChannelPreset(): void {
+    setSourceModule(CHANNEL_PRESET.sourceModule);
+    setSourceEvent(CHANNEL_PRESET.sourceEvent);
+    setSinkModule(CHANNEL_PRESET.sinkModule);
+    setSinkAction(CHANNEL_PRESET.sinkAction);
+    setFilterText(
+      JSON.stringify(
+        {
+          tags: [CHANNEL_PRESET.inboundTag],
+          has_metadata: ["channel"],
+          missing_metadata: ["channel_inbound_rendered_at"],
+        },
+        null,
+        2,
+      ),
+    );
+    setParamsText(JSON.stringify({ channel: "eng" }, null, 2));
+    setCreateSt({ kind: "idle" });
+  }
+
+  async function onSubmitCreate(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    if (!sourceModule || !sourceEvent || !sinkModule || !sinkAction) {
+      setCreateSt({ kind: "error", message: "Pick a source event and a sink action." });
+      return;
+    }
+    let filter: Record<string, unknown> | undefined;
+    let params: Record<string, unknown> | undefined;
+    try {
+      filter = filterText.trim() ? (JSON.parse(filterText) as Record<string, unknown>) : undefined;
+    } catch {
+      setCreateSt({ kind: "error", message: "Filter is not valid JSON." });
+      return;
+    }
+    try {
+      params = paramsText.trim() ? (JSON.parse(paramsText) as Record<string, unknown>) : undefined;
+    } catch {
+      setCreateSt({ kind: "error", message: "Action params are not valid JSON." });
+      return;
+    }
+    // A vault source needs a vault selected.
+    if (sourceModule === "vault" && !vault) {
+      setCreateSt({ kind: "error", message: "Pick a vault for the source event." });
+      return;
+    }
+    setCreateSt({ kind: "submitting" });
+    try {
+      const result = await createConnection({
+        source: {
+          module: sourceModule,
+          ...(sourceModule === "vault" ? { vault } : {}),
+          event: sourceEvent,
+          ...(filter ? { filter } : {}),
+        },
+        sink: { module: sinkModule, action: sinkAction, ...(params ? { params } : {}) },
+      });
+      setCreateSt({ kind: "created", ...(result.connect ? { connect: result.connect } : {}) });
+      setReload((n) => n + 1);
+    } catch (err) {
+      setCreateSt({ kind: "error", message: errMessage(err, "Create") });
+    }
+  }
+
+  async function onConfirmRemove(id: string): Promise<void> {
+    setRemoveSt({ kind: "removing", id });
+    try {
+      await deleteConnection(id);
+      setRemoveSt({ kind: "idle" });
+      setReload((n) => n + 1);
+    } catch (err) {
+      setRemoveSt({ kind: "error", id, message: errMessage(err, "Remove") });
+    }
+  }
+
+  return (
+    <div data-route-content="true">
+      <div className="list-header">
+        <h1>Connections</h1>
+      </div>
+
+      <p className="muted">
+        A connection wires <em>when [event] in a module → do [action] in another module</em>. The
+        hub mints the tokens and registers the trigger. The most common one — chat with a Claude
+        Code session through your vault — is the channel preset below.
+      </p>
+
+      {renderList(state, removeSt, setRemoveSt, onConfirmRemove, () => setReload((n) => n + 1))}
+
+      {state.kind === "ok" && (
+        <BuilderSection
+          catalog={state.data.catalog}
+          vaults={state.data.vaults}
+          sourceModule={sourceModule}
+          setSourceModule={setSourceModule}
+          sourceEvent={sourceEvent}
+          setSourceEvent={setSourceEvent}
+          vault={vault}
+          setVault={setVault}
+          filterText={filterText}
+          setFilterText={setFilterText}
+          sinkModule={sinkModule}
+          setSinkModule={setSinkModule}
+          sinkAction={sinkAction}
+          setSinkAction={setSinkAction}
+          paramsText={paramsText}
+          setParamsText={setParamsText}
+          createSt={createSt}
+          setCreateSt={setCreateSt}
+          onSubmit={onSubmitCreate}
+          onApplyChannelPreset={applyChannelPreset}
+        />
+      )}
+    </div>
+  );
+}
+
+function renderList(
+  state: ListState,
+  removeSt: RemoveState,
+  setRemoveSt: (s: RemoveState) => void,
+  onConfirmRemove: (id: string) => Promise<void>,
+  onRetry: () => void,
+): React.ReactNode {
+  if (state.kind === "loading") return <p className="muted">Loading connections…</p>;
+  if (state.kind === "error") {
+    return (
+      <>
+        <div className="error-banner">
+          Couldn't load connections: <code>{state.message}</code>
+        </div>
+        <button type="button" onClick={onRetry} className="secondary">
+          Retry
+        </button>
+      </>
+    );
+  }
+  const { connections } = state.data;
+  if (connections.length === 0) {
+    return (
+      <div className="empty empty-rich">
+        <p className="empty-headline">No connections yet.</p>
+        <p className="muted">Build one below, or use the channel preset for the common case.</p>
+      </div>
+    );
+  }
+  return (
+    <ConnectionsTable
+      connections={connections}
+      removeSt={removeSt}
+      setRemoveSt={setRemoveSt}
+      onConfirmRemove={onConfirmRemove}
+    />
+  );
+}
+
+function ConnectionsTable({
+  connections,
+  removeSt,
+  setRemoveSt,
+  onConfirmRemove,
+}: {
+  connections: ConnectionListing[];
+  removeSt: RemoveState;
+  setRemoveSt: (s: RemoveState) => void;
+  onConfirmRemove: (id: string) => Promise<void>;
+}): React.ReactNode {
+  return (
+    <div className="channel-list" style={{ marginTop: "1rem" }}>
+      <div className="table-scroll">
+        <table className="channel-table">
+          <thead>
+            <tr>
+              <th scope="col">Connection</th>
+              <th scope="col">When</th>
+              <th scope="col">Do</th>
+              <th scope="col">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {connections.map((c) => {
+              const isConfirming = removeSt.kind === "confirming" && removeSt.id === c.id;
+              const isRemoving = removeSt.kind === "removing" && removeSt.id === c.id;
+              const rowError =
+                removeSt.kind === "error" && removeSt.id === c.id ? removeSt.message : null;
+              const when = `${c.source.module}.${c.source.event}${
+                c.source.vault ? ` (${c.source.vault})` : ""
+              }`;
+              const doStr = `${c.sink.module}.${c.sink.action}`;
+              return (
+                <tr key={c.id} data-connection-id={c.id}>
+                  <td>
+                    <code>{c.id}</code>
+                  </td>
+                  <td>
+                    <code>{when}</code>
+                  </td>
+                  <td>
+                    <code>{doStr}</code>
+                  </td>
+                  <td>
+                    {isConfirming ? (
+                      <dialog
+                        open
+                        className="error-banner"
+                        style={{ marginTop: "0.25rem", background: "var(--bg-warn, #fffbe6)" }}
+                        aria-label={`Confirm remove ${c.id}`}
+                      >
+                        <p>
+                          Remove connection <code>{c.id}</code>? This tears down the provisioned
+                          trigger (and channel config, if any).
+                        </p>
+                        <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.5rem" }}>
+                          <button
+                            type="button"
+                            className="destructive"
+                            onClick={() => {
+                              void onConfirmRemove(c.id);
+                            }}
+                            disabled={isRemoving}
+                          >
+                            {isRemoving ? "Removing…" : "Remove"}
+                          </button>
+                          <button
+                            type="button"
+                            className="secondary"
+                            onClick={() => setRemoveSt({ kind: "idle" })}
+                            disabled={isRemoving}
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </dialog>
+                    ) : (
+                      <button
+                        type="button"
+                        className="secondary"
+                        disabled={isRemoving}
+                        onClick={() => setRemoveSt({ kind: "confirming", id: c.id })}
+                        aria-label={`Remove ${c.id}`}
+                      >
+                        {isRemoving ? "Removing…" : "Remove"}
+                      </button>
+                    )}
+                    {rowError && (
+                      <div className="error-banner" style={{ marginTop: "0.25rem" }}>
+                        <code>{rowError}</code>
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+interface BuilderProps {
+  catalog: ConnectionsCatalog;
+  vaults: VaultListing[];
+  sourceModule: string;
+  setSourceModule: (s: string) => void;
+  sourceEvent: string;
+  setSourceEvent: (s: string) => void;
+  vault: string;
+  setVault: (s: string) => void;
+  filterText: string;
+  setFilterText: (s: string) => void;
+  sinkModule: string;
+  setSinkModule: (s: string) => void;
+  sinkAction: string;
+  setSinkAction: (s: string) => void;
+  paramsText: string;
+  setParamsText: (s: string) => void;
+  createSt: CreateState;
+  setCreateSt: (s: CreateState) => void;
+  onSubmit: (e: FormEvent) => Promise<void>;
+  onApplyChannelPreset: () => void;
+}
+
+function BuilderSection(props: BuilderProps): React.ReactNode {
+  const { catalog, createSt } = props;
+  const submitting = createSt.kind === "submitting";
+
+  // The set of source events for the selected source module, etc.
+  const eventsForModule = (m: string): CatalogEvent[] =>
+    catalog.events.filter((e) => e.module === m);
+  const actionsForModule = (m: string): CatalogAction[] =>
+    catalog.actions.filter((a) => a.module === m);
+  const sourceModules = Array.from(new Set(catalog.events.map((e) => e.module)));
+  const sinkModules = Array.from(new Set(catalog.actions.map((a) => a.module)));
+
+  return (
+    <section style={{ marginTop: "1.5rem" }}>
+      <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+        <h3 style={{ marginRight: "auto" }}>Build a connection</h3>
+        <button
+          type="button"
+          className="secondary"
+          onClick={props.onApplyChannelPreset}
+          data-testid="channel-preset"
+        >
+          Use channel preset
+        </button>
+      </div>
+
+      <form onSubmit={(e) => void props.onSubmit(e)} aria-label="Build a connection">
+        <fieldset style={{ border: "1px solid var(--border, #ddd)", padding: "0.75rem" }}>
+          <legend>When (source event)</legend>
+          <p>
+            <label htmlFor="conn-source-module">Module</label>
+            <br />
+            <select
+              id="conn-source-module"
+              value={props.sourceModule}
+              disabled={submitting}
+              onChange={(e) => {
+                props.setSourceModule(e.target.value);
+                props.setSourceEvent("");
+              }}
+            >
+              <option value="">— pick a module —</option>
+              {sourceModules.map((m) => (
+                <option key={m} value={m}>
+                  {m}
+                </option>
+              ))}
+            </select>
+          </p>
+          {props.sourceModule && (
+            <p>
+              <label htmlFor="conn-source-event">Event</label>
+              <br />
+              <select
+                id="conn-source-event"
+                value={props.sourceEvent}
+                disabled={submitting}
+                onChange={(e) => props.setSourceEvent(e.target.value)}
+              >
+                <option value="">— pick an event —</option>
+                {eventsForModule(props.sourceModule).map((ev) => (
+                  <option key={ev.key} value={ev.key}>
+                    {ev.title} ({ev.key})
+                  </option>
+                ))}
+              </select>
+            </p>
+          )}
+          {props.sourceModule === "vault" && (
+            <p>
+              <label htmlFor="conn-vault">Vault</label>
+              <br />
+              <select
+                id="conn-vault"
+                value={props.vault}
+                disabled={submitting}
+                onChange={(e) => props.setVault(e.target.value)}
+              >
+                {props.vaults.map((v) => (
+                  <option key={v.name} value={v.name}>
+                    {v.name}
+                  </option>
+                ))}
+              </select>
+            </p>
+          )}
+          <p>
+            <label htmlFor="conn-filter">
+              Filter <span className="muted">(JSON — tags / has_metadata / missing_metadata)</span>
+            </label>
+            <br />
+            <textarea
+              id="conn-filter"
+              value={props.filterText}
+              disabled={submitting}
+              rows={4}
+              style={{ width: "100%", fontFamily: "monospace" }}
+              onChange={(e) => props.setFilterText(e.target.value)}
+              placeholder={'{ "tags": ["#channel-message/inbound"] }'}
+            />
+          </p>
+        </fieldset>
+
+        <fieldset
+          style={{
+            border: "1px solid var(--border, #ddd)",
+            padding: "0.75rem",
+            marginTop: "0.75rem",
+          }}
+        >
+          <legend>Do (sink action)</legend>
+          <p>
+            <label htmlFor="conn-sink-module">Module</label>
+            <br />
+            <select
+              id="conn-sink-module"
+              value={props.sinkModule}
+              disabled={submitting}
+              onChange={(e) => {
+                props.setSinkModule(e.target.value);
+                props.setSinkAction("");
+              }}
+            >
+              <option value="">— pick a module —</option>
+              {sinkModules.map((m) => (
+                <option key={m} value={m}>
+                  {m}
+                </option>
+              ))}
+            </select>
+          </p>
+          {props.sinkModule && (
+            <p>
+              <label htmlFor="conn-sink-action">Action</label>
+              <br />
+              <select
+                id="conn-sink-action"
+                value={props.sinkAction}
+                disabled={submitting}
+                onChange={(e) => props.setSinkAction(e.target.value)}
+              >
+                <option value="">— pick an action —</option>
+                {actionsForModule(props.sinkModule).map((a) => (
+                  <option key={a.key} value={a.key}>
+                    {a.title} ({a.key})
+                  </option>
+                ))}
+              </select>
+            </p>
+          )}
+          <p>
+            <label htmlFor="conn-params">
+              Action params <span className="muted">(JSON — e.g. {'{ "channel": "eng" }'})</span>
+            </label>
+            <br />
+            <textarea
+              id="conn-params"
+              value={props.paramsText}
+              disabled={submitting}
+              rows={3}
+              style={{ width: "100%", fontFamily: "monospace" }}
+              onChange={(e) => props.setParamsText(e.target.value)}
+              placeholder={'{ "channel": "eng" }'}
+            />
+          </p>
+        </fieldset>
+
+        {createSt.kind === "error" && (
+          <div className="error-banner" style={{ marginTop: "0.5rem" }}>
+            <code>{createSt.message}</code>
+          </div>
+        )}
+
+        <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.75rem" }}>
+          <button type="submit" disabled={submitting}>
+            {submitting ? "Creating…" : "Create connection"}
+          </button>
+        </div>
+      </form>
+
+      {createSt.kind === "created" && createSt.connect && (
+        <ConnectPanel
+          connect={createSt.connect}
+          onDismiss={() => props.setCreateSt({ kind: "idle" })}
+        />
+      )}
+      {createSt.kind === "created" && !createSt.connect && (
+        <div
+          className="success-banner"
+          style={{ marginTop: "1rem" }}
+          data-testid="connection-created"
+        >
+          Connection created.
+        </div>
+      )}
+    </section>
+  );
+}
+
+/** Connect-a-session panel for channel-deliver sinks (parity with hub#624). */
+function ConnectPanel({
+  connect,
+  onDismiss,
+}: {
+  connect: ConnectionConnect;
+  onDismiss: () => void;
+}): React.ReactNode {
+  return (
+    <div
+      className="mcp-connect-card"
+      style={{ marginTop: "1rem" }}
+      data-testid="connection-connect-panel"
+    >
+      <h3>Connect a session</h3>
+      <p className="muted">
+        Run these where your Claude Code session will live; authorize in the browser when prompted.
+      </p>
+      <div className="mcp-field">
+        <span className="mcp-field-label">1 · Register the channel (MCP)</span>
+        <div className="token-box">
+          <code data-testid="connection-mcp-add">{connect.mcpAdd}</code>
+          <CopyButton value={connect.mcpAdd} />
+        </div>
+      </div>
+      <div className="mcp-field">
+        <span className="mcp-field-label">2 · Launch a session on the channel</span>
+        <div className="token-box">
+          <code data-testid="connection-launch">{connect.launch}</code>
+          <CopyButton value={connect.launch} />
+        </div>
+        <p className="muted" style={{ marginTop: "0.4rem" }}>
+          ⚠ This launches Claude Code with unrestricted tool access (
+          <code>--dangerously-skip-permissions</code>) — run it only on a machine you trust for that
+          session.
+        </p>
+      </div>
+      <div style={{ marginTop: "0.75rem" }}>
+        <button type="button" className="secondary" onClick={onDismiss}>
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// `SLUG_REGEX` retained for future client-side validation parity with the
+// server's id/channel charset; referenced here to satisfy the linter.
+export const _connectionsSlugRegex = SLUG_REGEX;


### PR DESCRIPTION
P5 of the modular-UI arc — the crux. A general **Connections** surface: 'when [event] in [source module] (filter) → do [action] in [sink module]'. The hub-native engine mints tokens + registers vault triggers off the operator session, provisioning ANY connection from the sink action's declared endpoint+scope+provision — proven module-agnostic via a synthetic non-channel sink test. 'Add a vault-backed channel' is now just the first connection (vault.note.created(#channel-message/inbound) → channel.message.deliver). Generalizes hub#624 (which stays back-compat). + IFTTT-style SPA builder, nav reframed Channels→Connections.

Reviewer caught + I fixed a real privilege-escalation (action.scope is now namespace-enforced to the declaring module, same rule as scopes.defines — a module can't declare a vault:admin action scope to get an over-scoped bearer minted). Gates: hub 3202/0 · SPA 264/0 · typechecks clean · no binary. Spec: parachute-patterns/design/2026-06-09-modular-ui-architecture.md. 🤖 Generated with [Claude Code](https://claude.com/claude-code)