### PR TITLE
feat(connections): record + surface provenance (module-initiated connections)

### DIFF
--- a/src/__tests__/admin-connections.test.ts
+++ b/src/__tests__/admin-connections.test.ts
@@ -560,6 +560,95 @@ describe("POST /admin/connections — general vault-trigger provision", () => {
 });
 
 // ===========================================================================
+// POST — provenance (modular-UI R2, module-initiated connections)
+// ===========================================================================
+
+describe("POST /admin/connections — provenance (R2)", () => {
+  test("records the requestedBy label a module-owned UI supplies, returns it on GET", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl } = mockFetch({
+      "POST /vault/default/api/triggers": () => ok({ ok: true }),
+    });
+    const deps = baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, WIDGET_MANIFEST));
+    const res = await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections`, {
+        method: "POST",
+        headers: { cookie },
+        body: JSON.stringify({
+          id: "w1",
+          requestedBy: "channel",
+          source: { module: "vault", vault: "default", event: "note.created" },
+          sink: { module: "widget", action: "thing.do" },
+        }),
+      }),
+      "",
+      deps,
+    );
+    expect(res.status).toBe(200);
+    // Persisted on the record.
+    const stored = readConnections(harness.storePath);
+    expect(stored[0]!.requestedBy).toBe("channel");
+    // Returned (snake_case) on the GET wire shape.
+    const list = await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections`, { method: "GET", headers: { cookie } }),
+      "",
+      deps,
+    );
+    const out = (await list.json()) as { connections: Array<{ requested_by?: string }> };
+    expect(out.connections[0]!.requested_by).toBe("channel");
+  });
+
+  test("defaults requestedBy to custom when the body omits it", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl } = mockFetch({
+      "POST /vault/default/api/triggers": () => ok({ ok: true }),
+    });
+    const deps = baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, WIDGET_MANIFEST));
+    await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections`, {
+        method: "POST",
+        headers: { cookie },
+        body: JSON.stringify({
+          id: "w2",
+          source: { module: "vault", vault: "default", event: "note.created" },
+          sink: { module: "widget", action: "thing.do" },
+        }),
+      }),
+      "",
+      deps,
+    );
+    expect(readConnections(harness.storePath)[0]!.requestedBy).toBe("custom");
+  });
+
+  test("rejects a non-slug requestedBy with 400 before provisioning", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({
+      "POST /vault/default/api/triggers": () => ok({ ok: true }),
+    });
+    const deps = baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, WIDGET_MANIFEST));
+    const res = await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections`, {
+        method: "POST",
+        headers: { cookie },
+        body: JSON.stringify({
+          id: "w3",
+          requestedBy: "<script>",
+          source: { module: "vault", vault: "default", event: "note.created" },
+          sink: { module: "widget", action: "thing.do" },
+        }),
+      }),
+      "",
+      deps,
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("invalid_request");
+    // Nothing provisioned, nothing persisted.
+    expect(calls.length).toBe(0);
+    expect(readConnections(harness.storePath)).toHaveLength(0);
+  });
+});
+
+// ===========================================================================
 // POST — channel-backed connection (parity with hub#624)
 // ===========================================================================
 

--- a/src/admin-connections.ts
+++ b/src/admin-connections.ts
@@ -72,6 +72,15 @@ const CONNECTION_ID_RE = /^[a-z0-9][a-z0-9_-]*$/i;
  */
 const CHANNEL_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/i;
 
+/**
+ * Provenance label charset (modular-UI R2). `requestedBy` is an operator-/module-
+ * supplied label that lands in the Connections SPA as a grouping key — keep it a
+ * conservative slug so it can't carry markup or odd characters into the view.
+ * Defaults to `"custom"` (the hub's own builder) when omitted.
+ */
+const REQUESTED_BY_RE = /^[a-z0-9][a-z0-9_-]*$/i;
+const DEFAULT_REQUESTED_BY = "custom";
+
 /** A module installed on this hub, with its manifest + resolved mount path. */
 export interface InstalledModuleInfo {
   /** Module short name (the catalog/wire key). */
@@ -215,6 +224,9 @@ function listConnections(deps: ConnectionsDeps): Response {
     sink: c.sink,
     provisioned: c.provisioned,
     created_at: c.createdAt,
+    // Provenance (modular-UI R2). Records written before R2 carry no
+    // `requestedBy`; project them as the default so the SPA grouping is total.
+    requested_by: c.requestedBy ?? DEFAULT_REQUESTED_BY,
   }));
   return json(200, { ok: true, connections });
 }
@@ -237,6 +249,12 @@ interface CreateBody {
   };
   /** Optional operator-supplied id; otherwise derived from source/sink. */
   id?: unknown;
+  /**
+   * Provenance — WHO requested this connection (modular-UI R2). A module-owned
+   * config UI calling this endpoint on the operator's behalf labels itself (e.g.
+   * `"channel"`); the hub's own builder omits it and falls back to `"custom"`.
+   */
+  requestedBy?: unknown;
 }
 
 async function createConnection(
@@ -255,6 +273,19 @@ async function createConnection(
   const sourceEvent = str(body.source?.event);
   const sinkModule = str(body.sink?.module);
   const sinkAction = str(body.sink?.action);
+
+  // Provenance label (modular-UI R2). Default to the hub's own builder; a
+  // module-owned config UI that POSTs on the operator's behalf labels itself.
+  // Validated to a slug so a bad value can't poison the SPA grouping.
+  const requestedByRaw = str(body.requestedBy);
+  const requestedBy = requestedByRaw === "" ? DEFAULT_REQUESTED_BY : requestedByRaw.toLowerCase();
+  if (!REQUESTED_BY_RE.test(requestedBy)) {
+    return jsonError(
+      400,
+      "invalid_request",
+      `requestedBy "${requestedByRaw}" is not a valid label (letters, numbers, dash, underscore)`,
+    );
+  }
   if (!sourceModule || !sourceEvent || !sinkModule || !sinkAction) {
     return jsonError(
       400,
@@ -428,6 +459,7 @@ async function createConnection(
     sink: sinkRec,
     provisioned: { type: "vault-trigger", vault, triggerName },
     createdAt: (deps.now?.() ?? new Date()).toISOString(),
+    requestedBy,
   };
   putConnection(deps.storePath, record);
 

--- a/src/connections-store.ts
+++ b/src/connections-store.ts
@@ -59,6 +59,17 @@ export interface ConnectionRecord {
   readonly sink: ConnectionSink;
   readonly provisioned: ConnectionProvisioned;
   readonly createdAt: string;
+  /**
+   * Provenance — WHO requested this connection (modular-UI R2, module-initiated
+   * connections). A module-owned config UI that creates a connection on the
+   * operator's behalf (e.g. the channel admin page's "link to a vault" flow)
+   * labels itself here (e.g. `"channel"`); a connection built by hand in the
+   * hub's own Connections builder is `"custom"`. Lets the operator see which
+   * connections a module initiated vs which they wired themselves. Optional for
+   * back-compat: records written before R2 read back as `undefined`, which the
+   * SPA treats as `"custom"`.
+   */
+  readonly requestedBy?: string;
 }
 
 interface ConnectionsFile {

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1705,6 +1705,14 @@ export interface ConnectionListing {
   };
   provisioned: { type: string; vault?: string; triggerName?: string };
   created_at: string;
+  /**
+   * Provenance — WHO requested this connection (modular-UI R2). `"custom"` for a
+   * connection built by hand in this builder; a module short name (e.g.
+   * `"channel"`) when a module-owned config UI created it on the operator's
+   * behalf. Always present on the GET wire shape (the server defaults pre-R2
+   * records to `"custom"`); optional here for resilience to older responses.
+   */
+  requested_by?: string;
 }
 
 /** Connect lines returned when the sink is a channel-deliver action. */

--- a/web/ui/src/routes/Connections.test.tsx
+++ b/web/ui/src/routes/Connections.test.tsx
@@ -106,6 +106,51 @@ describe("Connections — list rendering", () => {
     expect(screen.getByText(/vault\.note\.created/)).toBeInTheDocument();
     expect(screen.getByText(/channel\.message\.deliver/)).toBeInTheDocument();
   });
+
+  it("groups connections by provenance — module-initiated vs custom (R2)", async () => {
+    const fromChannel: api.ConnectionListing = {
+      ...connection("channel-eng"),
+      requested_by: "channel",
+    };
+    const custom: api.ConnectionListing = { ...connection("custom-one"), requested_by: "custom" };
+    vi.mocked(api.listConnections).mockResolvedValue([custom, fromChannel]);
+    vi.mocked(api.getConnectionsCatalog).mockResolvedValue(catalog());
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("channel-eng")).toBeInTheDocument());
+
+    // Two labeled groups appear: "Added from channel" and "Custom (built here)".
+    expect(screen.getByText(/added from channel/i)).toBeInTheDocument();
+    expect(screen.getByText(/custom \(built here\)/i)).toBeInTheDocument();
+
+    // The channel-initiated connection carries a provenance badge; the
+    // hand-built one does not (it shows the muted "custom" marker instead).
+    const channelRow = document.querySelector('[data-connection-id="channel-eng"]');
+    expect(channelRow?.getAttribute("data-requested-by")).toBe("channel");
+    expect(within(channelRow as HTMLElement).getByTestId("provenance-badge").textContent).toBe(
+      "channel",
+    );
+    const customRow = document.querySelector('[data-connection-id="custom-one"]');
+    expect(customRow?.getAttribute("data-requested-by")).toBe("custom");
+    expect(within(customRow as HTMLElement).queryByTestId("provenance-badge")).toBeNull();
+
+    // The module-initiated group sorts before custom (custom sorts last).
+    const groups = Array.from(document.querySelectorAll("[data-provenance-group]")).map((g) =>
+      g.getAttribute("data-provenance-group"),
+    );
+    expect(groups).toEqual(["channel", "custom"]);
+  });
+
+  it("treats a connection with no requested_by as custom (pre-R2 back-compat)", async () => {
+    vi.mocked(api.listConnections).mockResolvedValue([connection("legacy")]);
+    vi.mocked(api.getConnectionsCatalog).mockResolvedValue(catalog());
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("legacy")).toBeInTheDocument());
+    expect(screen.getByText(/custom \(built here\)/i)).toBeInTheDocument();
+    const row = document.querySelector('[data-connection-id="legacy"]');
+    expect(row?.getAttribute("data-requested-by")).toBe("custom");
+  });
 });
 
 describe("Connections — builder", () => {

--- a/web/ui/src/routes/Connections.tsx
+++ b/web/ui/src/routes/Connections.tsx
@@ -281,6 +281,39 @@ function renderList(
   );
 }
 
+/**
+ * Provenance label for the group header (modular-UI R2). `"custom"` →
+ * connections wired by hand in this builder; any module short name →
+ * connections a module-owned config UI initiated on the operator's behalf.
+ */
+function provenanceOf(c: ConnectionListing): string {
+  return c.requested_by && c.requested_by.length > 0 ? c.requested_by : "custom";
+}
+
+function provenanceHeading(provenance: string): string {
+  return provenance === "custom" ? "Custom (built here)" : `Added from ${provenance}`;
+}
+
+/**
+ * Group connections by provenance for display. "custom" sorts last so
+ * module-initiated connections lead; within a group, insertion order is kept.
+ */
+function groupByProvenance(connections: ConnectionListing[]): [string, ConnectionListing[]][] {
+  const groups = new Map<string, ConnectionListing[]>();
+  for (const c of connections) {
+    const key = provenanceOf(c);
+    const bucket = groups.get(key);
+    if (bucket) bucket.push(c);
+    else groups.set(key, [c]);
+  }
+  return Array.from(groups.entries()).sort(([a], [b]) => {
+    if (a === b) return 0;
+    if (a === "custom") return 1;
+    if (b === "custom") return -1;
+    return a.localeCompare(b);
+  });
+}
+
 function ConnectionsTable({
   connections,
   removeSt,
@@ -292,96 +325,124 @@ function ConnectionsTable({
   setRemoveSt: (s: RemoveState) => void;
   onConfirmRemove: (id: string) => Promise<void>;
 }): React.ReactNode {
+  const groups = groupByProvenance(connections);
   return (
-    <div className="channel-list" style={{ marginTop: "1rem" }}>
-      <div className="table-scroll">
-        <table className="channel-table">
-          <thead>
-            <tr>
-              <th scope="col">Connection</th>
-              <th scope="col">When</th>
-              <th scope="col">Do</th>
-              <th scope="col">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {connections.map((c) => {
-              const isConfirming = removeSt.kind === "confirming" && removeSt.id === c.id;
-              const isRemoving = removeSt.kind === "removing" && removeSt.id === c.id;
-              const rowError =
-                removeSt.kind === "error" && removeSt.id === c.id ? removeSt.message : null;
-              const when = `${c.source.module}.${c.source.event}${
-                c.source.vault ? ` (${c.source.vault})` : ""
-              }`;
-              const doStr = `${c.sink.module}.${c.sink.action}`;
-              return (
-                <tr key={c.id} data-connection-id={c.id}>
-                  <td>
-                    <code>{c.id}</code>
-                  </td>
-                  <td>
-                    <code>{when}</code>
-                  </td>
-                  <td>
-                    <code>{doStr}</code>
-                  </td>
-                  <td>
-                    {isConfirming ? (
-                      <dialog
-                        open
-                        className="error-banner"
-                        style={{ marginTop: "0.25rem", background: "var(--bg-warn, #fffbe6)" }}
-                        aria-label={`Confirm remove ${c.id}`}
-                      >
-                        <p>
-                          Remove connection <code>{c.id}</code>? This tears down the provisioned
-                          trigger (and channel config, if any).
-                        </p>
-                        <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.5rem" }}>
-                          <button
-                            type="button"
-                            className="destructive"
-                            onClick={() => {
-                              void onConfirmRemove(c.id);
-                            }}
-                            disabled={isRemoving}
-                          >
-                            {isRemoving ? "Removing…" : "Remove"}
-                          </button>
-                          <button
-                            type="button"
-                            className="secondary"
-                            onClick={() => setRemoveSt({ kind: "idle" })}
-                            disabled={isRemoving}
-                          >
-                            Cancel
-                          </button>
-                        </div>
-                      </dialog>
-                    ) : (
-                      <button
-                        type="button"
-                        className="secondary"
-                        disabled={isRemoving}
-                        onClick={() => setRemoveSt({ kind: "confirming", id: c.id })}
-                        aria-label={`Remove ${c.id}`}
-                      >
-                        {isRemoving ? "Removing…" : "Remove"}
-                      </button>
-                    )}
-                    {rowError && (
-                      <div className="error-banner" style={{ marginTop: "0.25rem" }}>
-                        <code>{rowError}</code>
-                      </div>
-                    )}
-                  </td>
+    <>
+      {groups.map(([provenance, rows]) => (
+        <div
+          key={provenance}
+          className="channel-list"
+          style={{ marginTop: "1rem" }}
+          data-provenance-group={provenance}
+        >
+          <h3 style={{ marginBottom: "0.25rem" }}>{provenanceHeading(provenance)}</h3>
+          <div className="table-scroll">
+            <table className="channel-table">
+              <thead>
+                <tr>
+                  <th scope="col">Connection</th>
+                  <th scope="col">When</th>
+                  <th scope="col">Do</th>
+                  <th scope="col">Source</th>
+                  <th scope="col">Actions</th>
                 </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-    </div>
+              </thead>
+              <tbody>
+                {rows.map((c) => renderConnectionRow(c, removeSt, setRemoveSt, onConfirmRemove))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+function renderConnectionRow(
+  c: ConnectionListing,
+  removeSt: RemoveState,
+  setRemoveSt: (s: RemoveState) => void,
+  onConfirmRemove: (id: string) => Promise<void>,
+): React.ReactNode {
+  const isConfirming = removeSt.kind === "confirming" && removeSt.id === c.id;
+  const isRemoving = removeSt.kind === "removing" && removeSt.id === c.id;
+  const rowError = removeSt.kind === "error" && removeSt.id === c.id ? removeSt.message : null;
+  const when = `${c.source.module}.${c.source.event}${
+    c.source.vault ? ` (${c.source.vault})` : ""
+  }`;
+  const doStr = `${c.sink.module}.${c.sink.action}`;
+  const provenance = provenanceOf(c);
+  return (
+    <tr key={c.id} data-connection-id={c.id} data-requested-by={provenance}>
+      <td>
+        <code>{c.id}</code>
+      </td>
+      <td>
+        <code>{when}</code>
+      </td>
+      <td>
+        <code>{doStr}</code>
+      </td>
+      <td>
+        {provenance === "custom" ? (
+          <span className="muted">custom</span>
+        ) : (
+          <span className="tag" data-testid="provenance-badge">
+            {provenance}
+          </span>
+        )}
+      </td>
+      <td>
+        {isConfirming ? (
+          <dialog
+            open
+            className="error-banner"
+            style={{ marginTop: "0.25rem", background: "var(--bg-warn, #fffbe6)" }}
+            aria-label={`Confirm remove ${c.id}`}
+          >
+            <p>
+              Remove connection <code>{c.id}</code>? This tears down the provisioned trigger (and
+              channel config, if any).
+            </p>
+            <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.5rem" }}>
+              <button
+                type="button"
+                className="destructive"
+                onClick={() => {
+                  void onConfirmRemove(c.id);
+                }}
+                disabled={isRemoving}
+              >
+                {isRemoving ? "Removing…" : "Remove"}
+              </button>
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => setRemoveSt({ kind: "idle" })}
+                disabled={isRemoving}
+              >
+                Cancel
+              </button>
+            </div>
+          </dialog>
+        ) : (
+          <button
+            type="button"
+            className="secondary"
+            disabled={isRemoving}
+            onClick={() => setRemoveSt({ kind: "confirming", id: c.id })}
+            aria-label={`Remove ${c.id}`}
+          >
+            {isRemoving ? "Removing…" : "Remove"}
+          </button>
+        )}
+        {rowError && (
+          <div className="error-banner" style={{ marginTop: "0.25rem" }}>
+            <code>{rowError}</code>
+          </div>
+        )}
+      </td>
+    </tr>
   );
 }
 


### PR DESCRIPTION
R2 (hub side). Connections now record requestedBy (slug-validated, defaults 'custom', back-compat for pre-R2 records) so module-initiated connections are distinguishable; the Connections SPA groups them ('Added from channel' vs 'Custom (built here)'). Enables the channel 'Link to a vault' flow. Reviewer: MERGE (CSRF posture sound — SameSite=Lax blocks cross-site forged POSTs; requestedBy is descriptive-only, no authz role). Gates: hub 3206/0 · SPA 261/0 · typechecks clean. 🤖 Generated with [Claude Code](https://claude.com/claude-code)