### PR TITLE
fix(supervisor): reconcile drifted fixed-port modules back to canonical (channel#41)

### DIFF
--- a/src/__tests__/api-modules-ops.test.ts
+++ b/src/__tests__/api-modules-ops.test.ts
@@ -1012,6 +1012,55 @@ describe("POST /api/modules/:short/start", () => {
     expect(spawns).toEqual([]);
     expect(calls).toEqual([]);
   });
+
+  test("channel#41: start reconciles a drifted services.json port back to canonical (API path)", async () => {
+    // The live signature: channel's row carried 19415 instead of canonical 1941.
+    // The API start path (admin SPA / `parachute start channel`) must apply the
+    // SAME reconcile the boot path does — otherwise an operator-triggered start
+    // re-strands the module on the dead port.
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-channel",
+        port: 19415,
+        paths: ["/channel"],
+        health: "/health",
+        version: "0.0.0-linked",
+      },
+    ]);
+    const { supervisor, spawns } = makeIdleSupervisor();
+    const logs: string[] = [];
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+
+    const res = await handleStart(
+      postReq("/api/modules/channel/start", { authorization: `Bearer ${bearer}` }),
+      "channel",
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        log: (l) => logs.push(l),
+      },
+    );
+
+    expect(res.status).toBe(200);
+    // The supervisor child gets PORT=1941 (canonical), not the drifted 19415 —
+    // so it binds + the readiness probe checks the right port.
+    expect(spawns.length).toBe(1);
+    expect(spawns[0]?.short).toBe("channel");
+    expect(spawns[0]?.env?.PORT).toBe("1941");
+    // services.json row is rewritten to 1941 → the reverse-proxy (which reads
+    // services.json) routes /channel/* to the live port.
+    const onDisk = JSON.parse(readFileSync(h.manifestPath, "utf8")) as {
+      services: { name: string; port: number }[];
+    };
+    expect(onDisk.services.find((s) => s.name === "parachute-channel")?.port).toBe(1941);
+    // The reconcile event logged on the API path too (deps.log wired — #41 review).
+    expect(
+      logs.some((l) => l.includes("reconciled") && l.includes("19415") && l.includes("1941")),
+    ).toBe(true);
+  });
 });
 
 describe("POST /api/modules/:short/stop", () => {

--- a/src/__tests__/serve-boot.test.ts
+++ b/src/__tests__/serve-boot.test.ts
@@ -2,8 +2,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { bootSupervisedModules, buildModuleSpawnRequest } from "../commands/serve-boot.ts";
-import { type ServiceEntry, writeManifest } from "../services-manifest.ts";
+import {
+  bootSupervisedModules,
+  buildModuleSpawnRequest,
+  reconcilePortToCanonical,
+} from "../commands/serve-boot.ts";
+import { type ServiceEntry, readManifestLenient, writeManifest } from "../services-manifest.ts";
 import { type SpawnRequest, type SupervisedProc, Supervisor } from "../supervisor.ts";
 
 interface Harness {
@@ -283,5 +287,132 @@ describe("bootSupervisedModules", () => {
     expect(results[0]?.reason).toBe("no-spec");
     expect(recorder.calls).toEqual([]);
     expect(logs.some((l) => l.includes("no startCmd resolvable"))).toBe(true);
+  });
+});
+
+// channel#41 — a transiently-wrong (drifted) services.json port for a
+// fixed-port first-party module self-perpetuates: the supervisor injects PORT /
+// probes / proxies from that row, so the wrong port strands the module forever.
+// The boot path snaps it back to canonical before spawn AND persists the fix so
+// the reverse-proxy (which reads services.json) routes correctly.
+describe("reconcilePortToCanonical (channel#41)", () => {
+  let h: Harness;
+  beforeEach(() => {
+    h = makeHarness();
+  });
+  afterEach(() => h.cleanup());
+
+  // The live-observed signature: channel's row carried 19415 instead of its
+  // canonical 1941.
+  const DRIFTED_CHANNEL: ServiceEntry = {
+    name: "parachute-channel",
+    port: 19415,
+    paths: ["/channel"],
+    health: "/health",
+    version: "0.1.0",
+  };
+
+  test("snaps a drifted fixed-port row back to canonical + persists it", () => {
+    writeManifest({ services: [DRIFTED_CHANNEL] }, h.manifestPath);
+    const logs: string[] = [];
+
+    const reconciled = reconcilePortToCanonical(DRIFTED_CHANNEL, h.manifestPath, (l) =>
+      logs.push(l),
+    );
+
+    // Returned entry carries canonical (channel → 1941).
+    expect(reconciled.port).toBe(1941);
+    // And it's PERSISTED — the proxy reads services.json, so the row itself must
+    // now point at 1941 or `/channel/*` keeps routing to the dead 19415.
+    const onDisk = readManifestLenient(h.manifestPath).services.find(
+      (s) => s.name === "parachute-channel",
+    );
+    expect(onDisk?.port).toBe(1941);
+    expect(
+      logs.some((l) => l.includes("reconciled") && l.includes("19415") && l.includes("1941")),
+    ).toBe(true);
+  });
+
+  test("no-op when the row already sits on its canonical port (vault/scribe/surface common path)", () => {
+    writeManifest({ services: [VAULT_ENTRY] }, h.manifestPath);
+    const out = reconcilePortToCanonical(VAULT_ENTRY, h.manifestPath);
+    expect(out).toBe(VAULT_ENTRY); // identity — untouched
+    expect(out.port).toBe(1940);
+  });
+
+  test("third-party module (no canonical) is never touched", () => {
+    const thirdParty: ServiceEntry = {
+      name: "third-party-thing",
+      port: 7777,
+      paths: ["/thing"],
+      health: "/thing/health",
+      version: "1.0.0",
+    };
+    writeManifest({ services: [thirdParty] }, h.manifestPath);
+    const out = reconcilePortToCanonical(thirdParty, h.manifestPath);
+    expect(out).toBe(thirdParty);
+    expect(out.port).toBe(7777);
+  });
+
+  test("does NOT steal the canonical port when another row already holds it", () => {
+    // Another row legitimately occupies 1941 — reconciling would trip the
+    // write-side duplicate-port guard and isn't channel's to take. Leave the
+    // drift; the supervisor's squatter detection surfaces it.
+    const squatter: ServiceEntry = {
+      name: "parachute-vault",
+      port: 1941, // unusual, but it owns this slot right now
+      paths: ["/vault/default"],
+      health: "/vault/default/health",
+      version: "0.4.5",
+    };
+    writeManifest({ services: [squatter, DRIFTED_CHANNEL] }, h.manifestPath);
+    const logs: string[] = [];
+
+    const out = reconcilePortToCanonical(DRIFTED_CHANNEL, h.manifestPath, (l) => logs.push(l));
+
+    expect(out.port).toBe(19415); // unchanged
+    const onDisk = readManifestLenient(h.manifestPath).services.find(
+      (s) => s.name === "parachute-channel",
+    );
+    expect(onDisk?.port).toBe(19415); // not rewritten
+    expect(logs.some((l) => l.includes("held by another row"))).toBe(true);
+  });
+
+  test("boot path injects PORT=canonical + persists the fix for a drifted channel row", async () => {
+    writeManifest({ services: [DRIFTED_CHANNEL] }, h.manifestPath);
+    const recorder = makeRecorder();
+    const sup = new Supervisor({ spawnFn: recorder.spawn });
+
+    await bootSupervisedModules(sup, {
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+    });
+
+    // The supervisor child gets PORT=1941 (so it binds + the readiness probe
+    // checks the right port), not the drifted 19415.
+    expect(recorder.calls[0]?.short).toBe("channel");
+    expect(recorder.calls[0]?.env?.PORT).toBe("1941");
+    // services.json row is reconciled → proxy routes /channel/* to 1941.
+    const onDisk = readManifestLenient(h.manifestPath).services.find(
+      (s) => s.name === "parachute-channel",
+    );
+    expect(onDisk?.port).toBe(1941);
+  });
+
+  test("boot path leaves a non-drifted vault row's port untouched", async () => {
+    writeManifest({ services: [VAULT_ENTRY] }, h.manifestPath);
+    const recorder = makeRecorder();
+    const sup = new Supervisor({ spawnFn: recorder.spawn });
+
+    await bootSupervisedModules(sup, {
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+    });
+
+    expect(recorder.calls[0]?.env?.PORT).toBe("1940");
+    const onDisk = readManifestLenient(h.manifestPath).services.find(
+      (s) => s.name === "parachute-vault",
+    );
+    expect(onDisk?.port).toBe(1940);
   });
 });

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -39,7 +39,7 @@ import { MissingDependencyError, type MissingDependencyWire } from "@openparachu
 import type { CuratedModuleShort } from "./api-modules.ts";
 import { isLinked as defaultIsLinked } from "./bun-link.ts";
 import { PARACHUTE_INSTALL_CHANNEL_ENV } from "./commands/install.ts";
-import { buildModuleSpawnRequest } from "./commands/serve-boot.ts";
+import { buildModuleSpawnRequest, reconcilePortToCanonical } from "./commands/serve-boot.ts";
 import { validateHostAdminToken } from "./host-admin-token-validation.ts";
 import { getModuleInstallChannel } from "./hub-settings.ts";
 import { readModuleManifest } from "./module-manifest.ts";
@@ -264,6 +264,15 @@ export interface ApiModulesOpsDeps {
    * per-request HTTP build stay aligned.
    */
   readModuleManifest?: Parameters<typeof regenerateWellKnown>[0]["readModuleManifest"];
+  /**
+   * Diagnostic log sink for spawn-path events that aren't tied to an op-log
+   * (e.g. the canonical-port reconcile in `resolveSpawnRequest`: a drift fixed,
+   * a held-canonical decline, or a persist failure). Without this, those events
+   * are swallowed on an operator-triggered start/restart while the boot path
+   * logs them. Defaults to `console.error` (stderr — same destination as the
+   * serve-boot path's logger). Tests inject a collector to assert the events.
+   */
+  log?: (line: string) => void;
 }
 
 interface PathMatch {
@@ -447,7 +456,14 @@ async function resolveSpawnRequest(
     if (resolved) spawnSpec = resolved;
   }
 
-  const cmd = spawnSpec.startCmd?.(entry);
+  // Snap a drifted fixed-port row back to canonical before deriving startCmd
+  // (notes' startCmd embeds the port) / PORT / probe / proxy from it
+  // (channel#41). No-op on the common path. Mirror of the serve-boot path so a
+  // module started from the admin SPA gets the same canonical-port reconciliation
+  // — including the same diagnostic logging (deps.log, default stderr).
+  const spawnEntry = reconcilePortToCanonical(entry, deps.manifestPath, deps.log ?? console.error);
+
+  const cmd = spawnSpec.startCmd?.(spawnEntry);
   if (!cmd || cmd.length === 0) {
     return {
       ok: false,
@@ -462,7 +478,7 @@ async function resolveSpawnRequest(
   // / live HUB_ORIGIN / enriched PATH). The test-seam / first-boot `spawnEnv`
   // rides the shared helper's `extraEnv` and wins last, matching
   // `spawnSupervised`'s precedence.
-  const req = buildModuleSpawnRequest(short, entry, cmd, {
+  const req = buildModuleSpawnRequest(short, spawnEntry, cmd, {
     configDir: deps.configDir,
     ...(deps.issuer ? { hubOrigin: deps.issuer } : {}),
     ...(deps.spawnEnv ? { extraEnv: deps.spawnEnv } : {}),

--- a/src/commands/serve-boot.ts
+++ b/src/commands/serve-boot.ts
@@ -22,11 +22,12 @@ import { HUB_ORIGIN_ENV } from "../hub-origin.ts";
 import { ModuleManifestError } from "../module-manifest.ts";
 import {
   type ServiceSpec,
+  canonicalPortForManifest,
   getSpec,
   getSpecFromInstallDir,
   shortNameForManifest,
 } from "../service-spec.ts";
-import { type ServiceEntry, readManifestLenient } from "../services-manifest.ts";
+import { type ServiceEntry, readManifestLenient, upsertService } from "../services-manifest.ts";
 import { enrichedPath } from "../spawn-path.ts";
 import type { Supervisor } from "../supervisor.ts";
 
@@ -67,6 +68,77 @@ export interface BuildSpawnRequestOpts {
    * boot path.
    */
   readonly extraEnv?: Record<string, string>;
+}
+
+/**
+ * Snap a fixed-port first-party module's services.json `port` back to its
+ * compiled-in canonical value when it has DRIFTED, and persist the correction.
+ * Returns the entry to spawn with — reconciled when a drift was repaired, the
+ * original otherwise.
+ *
+ * Why (channel#41): the hub is the port authority, and a first-party module
+ * with a compiled-in canonical port (`canonicalPortForManifest` ≠ undefined —
+ * vault / scribe / surface / channel / notes / runner) has exactly ONE correct
+ * port: its canonical one. The injected `PORT`, the supervisor's readiness
+ * probe, and the reverse-proxy target are ALL derived from the services.json
+ * row's `port`. So once a transiently-wrong port lands in that row (the channel
+ * row was observed live carrying `19415` instead of `1941`), it self-perpetuates:
+ * the supervisor probes/proxies the wrong port forever and `/channel/*` routes
+ * to a dead port. The canonical port is authoritative, so we reconcile the row
+ * before spawn rather than honoring the drift.
+ *
+ * Safety for the other fixed-port modules (vault / scribe / surface): the
+ * canonical value is exactly what each ALREADY self-registers, so on the
+ * common path `entry.port === canonical` and this is a no-op. There is no
+ * legitimate "first-party module intentionally on a non-canonical port" case —
+ * install-time `assignPort` only walks off canonical on a genuine collision,
+ * and that's a same-range fallback for a DIFFERENT module, never a steady state
+ * for the canonical owner. If another row genuinely already owns the canonical
+ * port we DON'T rewrite (it would trip the write-side duplicate-port guard and
+ * isn't ours to take) — we leave the drift in place and let the supervisor's
+ * port-squatter detection surface it. Third-party modules (no canonical) are
+ * never touched.
+ */
+export function reconcilePortToCanonical(
+  entry: ServiceEntry,
+  manifestPath: string,
+  log: (line: string) => void = () => {},
+): ServiceEntry {
+  const canonical = canonicalPortForManifest(entry.name);
+  if (canonical === undefined || entry.port === canonical) return entry;
+
+  // Don't steal a canonical port another row legitimately holds — that would
+  // trip `upsertService`'s duplicate-port guard. Re-read live so we see the
+  // current on-disk state (another module may have just registered).
+  const others = readManifestLenient(manifestPath).services.filter((s) => s.name !== entry.name);
+  if (others.some((s) => s.port === canonical)) {
+    log(
+      `[supervisor] ${entry.name}: services.json port ${entry.port} ≠ canonical ${canonical}, ` +
+        `but ${canonical} is held by another row — not reconciling; surfacing the drift.`,
+    );
+    return entry;
+  }
+
+  const reconciled: ServiceEntry = { ...entry, port: canonical };
+  try {
+    upsertService(reconciled, manifestPath);
+    log(
+      `[supervisor] ${entry.name}: reconciled drifted services.json port ${entry.port} → canonical ${canonical} (channel#41).`,
+    );
+    return reconciled;
+  } catch (err) {
+    // Best-effort: a failed reconcile must not block the boot. The write can
+    // fail for an I/O reason (permissions, races against an external writer) OR
+    // because `upsertService`'s duplicate-port guard tripped — e.g. another row
+    // raced onto the canonical port between the check above and this write.
+    // Either way, spawn with the canonical port in-memory so at least the child
+    // binds + the probe checks the right port this run; the proxy still reads
+    // the (stale) row until the next reconcile succeeds.
+    log(
+      `[supervisor] ${entry.name}: could not reconcile services.json port to canonical (${entry.port} → ${canonical}; write failed or canonical held): ${err} — spawning with canonical in-memory.`,
+    );
+    return reconciled;
+  }
 }
 
 /**
@@ -166,7 +238,12 @@ export async function bootSupervisedModules(
       continue;
     }
 
-    const cmd = spec.startCmd?.(entry);
+    // Snap a drifted fixed-port row back to canonical before we derive PORT /
+    // probe / proxy from it (channel#41). No-op on the common path where the
+    // module already sits on its canonical port.
+    const spawnEntry = reconcilePortToCanonical(entry, opts.manifestPath, log);
+
+    const cmd = spec.startCmd?.(spawnEntry);
     if (!cmd || cmd.length === 0) {
       log(`[supervisor] ${short}: spec resolved but no startCmd — skipping (CLI-only module).`);
       results.push({
@@ -182,7 +259,7 @@ export async function bootSupervisedModules(
     // .env merge, and PARACHUTE_HUB_ORIGIN propagation (hub#365) all live in the
     // shared `buildModuleSpawnRequest` so the `POST /api/modules/:short/start`
     // handler builds an identical request (design 2026-06-01 §3.3).
-    const req = buildModuleSpawnRequest(short, entry, cmd, {
+    const req = buildModuleSpawnRequest(short, spawnEntry, cmd, {
       configDir: opts.configDir,
       ...(opts.hubOrigin !== undefined ? { hubOrigin: opts.hubOrigin } : {}),
     });


### PR DESCRIPTION
A fixed-canonical-port module whose services.json port drifted now gets snapped back to canonical + persisted before spawn (both boot + API start paths), so a transiently-bad port can't permanently strand it (the proxy reads services.json). No-op for healthy modules; won't steal a held canonical port; third-party modules untouched. Closes the channel#41 hub side. Reviewer: MERGE. 3213 tests / typecheck clean. 🤖 Generated with [Claude Code](https://claude.com/claude-code)