### PR TITLE
fix(home): de-dup Vault — move all-vaults to Vault module card, drop from Administer

### DIFF
--- a/web/ui/src/routes/Home.test.tsx
+++ b/web/ui/src/routes/Home.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * Home route tests — Administer group (no /vaults card), Modules group
+ * (vault card = in-shell Link to /vaults; non-vault module = off-shell <a>),
+ * loading / error / empty states.
+ */
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import { Home } from "./Home.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    listModules: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/** Build a full ModuleListing; tests override only what they need. */
+function makeModule(short: string, overrides: Partial<api.ModuleListing> = {}): api.ModuleListing {
+  return {
+    short,
+    package: `@openparachute/${short}`,
+    display_name: short.charAt(0).toUpperCase() + short.slice(1),
+    tagline: `the ${short} module`,
+    focus: "core",
+    available: true,
+    installed: true,
+    installed_version: "1.0.0",
+    latest_version: "1.0.0",
+    supervisor_status: "running",
+    pid: 1234,
+    install_dir: `/home/.parachute/${short}`,
+    uis: [],
+    management_url: null,
+    config_ui_url: null,
+    ...overrides,
+  };
+}
+
+/** Build a catalog wrapping the given module list. */
+function makeCatalog(modules: api.ModuleListing[]): api.ModulesCatalog {
+  return {
+    modules,
+    supervisor_available: true,
+    module_install_channel: "latest",
+  };
+}
+
+function renderRoute() {
+  return render(
+    <MemoryRouter>
+      <Home />
+    </MemoryRouter>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Administer group
+// ---------------------------------------------------------------------------
+
+describe("Administer group", () => {
+  it("renders without a /vaults card", async () => {
+    vi.mocked(api.listModules).mockResolvedValue(makeCatalog([]));
+    renderRoute();
+
+    const administer = await screen.findByTestId("home-administer");
+    // The Administer group must NOT contain a card linking to /vaults.
+    const vaultsCard = administer.querySelector<HTMLElement>("[data-section='/vaults']");
+    expect(vaultsCard).toBeNull();
+  });
+
+  it("renders the expected hub-native section cards", async () => {
+    vi.mocked(api.listModules).mockResolvedValue(makeCatalog([]));
+    renderRoute();
+
+    const administer = await screen.findByTestId("home-administer");
+    // These six sections should be present; /vaults should not.
+    for (const path of ["/connections", "/modules", "/users", "/tokens", "/permissions", "/settings"]) {
+      expect(administer.querySelector(`[data-section='${path}']`)).not.toBeNull();
+    }
+    expect(administer.querySelector("[data-section='/vaults']")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Modules group — vault card (in-shell)
+// ---------------------------------------------------------------------------
+
+describe("Modules group — vault card", () => {
+  it("renders the vault module card as an in-shell <Link> to /vaults (not an <a>)", async () => {
+    vi.mocked(api.listModules).mockResolvedValue(
+      makeCatalog([makeModule("vault", { management_url: "http://vault.example.com/manage" })]),
+    );
+    renderRoute();
+
+    await screen.findByTestId("home-modules");
+    const card = screen.getByTestId("home-module-vault");
+
+    // Must be rendered as a <a> by react-router's Link (not a bare <a href>
+    // pointing at an external URL). The Link renders as an <a> with an
+    // href derived from the router basename — here "/vaults".
+    expect(card.tagName).toBe("A");
+    expect(card).toHaveAttribute("href", "/vaults");
+  });
+
+  it("vault card does NOT carry the external ↗ mark", async () => {
+    vi.mocked(api.listModules).mockResolvedValue(
+      makeCatalog([makeModule("vault")]),
+    );
+    renderRoute();
+
+    await screen.findByTestId("home-modules");
+    const card = screen.getByTestId("home-module-vault");
+    expect(card.querySelector(".ext-mark")).toBeNull();
+  });
+
+  it("vault card shows the in-shell caption", async () => {
+    vi.mocked(api.listModules).mockResolvedValue(
+      makeCatalog([makeModule("vault")]),
+    );
+    renderRoute();
+
+    await screen.findByTestId("home-modules");
+    const card = screen.getByTestId("home-module-vault");
+    expect(card.textContent).toContain("manage all vaults");
+    expect(card.textContent).toContain("opens here");
+  });
+
+  it("vault card opens /vaults even when management_url is null", async () => {
+    // Vault has no management_url but we still link in-shell.
+    vi.mocked(api.listModules).mockResolvedValue(
+      makeCatalog([makeModule("vault", { management_url: null })]),
+    );
+    renderRoute();
+
+    await screen.findByTestId("home-modules");
+    const card = screen.getByTestId("home-module-vault");
+    expect(card).toHaveAttribute("href", "/vaults");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Modules group — non-vault module cards (off-shell)
+// ---------------------------------------------------------------------------
+
+describe("Modules group — non-vault module cards", () => {
+  it("renders a non-vault module with a config_ui_url as an off-shell <a>", async () => {
+    vi.mocked(api.listModules).mockResolvedValue(
+      makeCatalog([
+        makeModule("scribe", { config_ui_url: "http://hub.example.com/scribe/admin" }),
+      ]),
+    );
+    renderRoute();
+
+    await screen.findByTestId("home-modules");
+    const card = screen.getByTestId("home-module-scribe");
+
+    // Should be a plain <a> pointing at the external config URL.
+    expect(card.tagName).toBe("A");
+    expect(card).toHaveAttribute("href", "http://hub.example.com/scribe/admin");
+  });
+
+  it("non-vault card carries the ↗ external mark", async () => {
+    vi.mocked(api.listModules).mockResolvedValue(
+      makeCatalog([
+        makeModule("scribe", { management_url: "http://hub.example.com/scribe/manage" }),
+      ]),
+    );
+    renderRoute();
+
+    await screen.findByTestId("home-modules");
+    const card = screen.getByTestId("home-module-scribe");
+    expect(card.querySelector(".ext-mark")).not.toBeNull();
+  });
+
+  it("non-vault module with no URL renders as disabled card (not a link)", async () => {
+    vi.mocked(api.listModules).mockResolvedValue(
+      makeCatalog([makeModule("runner", { management_url: null, config_ui_url: null })]),
+    );
+    renderRoute();
+
+    await screen.findByTestId("home-modules");
+    const card = screen.getByTestId("home-module-runner");
+    expect(card.tagName).toBe("DIV");
+    expect(card).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("falls back to management_url when config_ui_url is null", async () => {
+    vi.mocked(api.listModules).mockResolvedValue(
+      makeCatalog([
+        makeModule("channel", {
+          config_ui_url: null,
+          management_url: "http://hub.example.com/channel/manage",
+        }),
+      ]),
+    );
+    renderRoute();
+
+    await screen.findByTestId("home-modules");
+    const card = screen.getByTestId("home-module-channel");
+    expect(card).toHaveAttribute("href", "http://hub.example.com/channel/manage");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Loading / error / empty states
+// ---------------------------------------------------------------------------
+
+describe("loading / error / empty states", () => {
+  it("shows loading state before fetch resolves", () => {
+    vi.mocked(api.listModules).mockImplementation(() => new Promise(() => {}));
+    renderRoute();
+
+    expect(screen.getByTestId("home-administer")).toBeDefined();
+    expect(document.querySelector("[data-loading]")).not.toBeNull();
+  });
+
+  it("shows error state when listModules rejects", async () => {
+    vi.mocked(api.listModules).mockRejectedValue(new Error("network error"));
+    renderRoute();
+
+    await screen.findByTestId("home-modules-error");
+  });
+
+  it("shows empty state when no modules are installed", async () => {
+    vi.mocked(api.listModules).mockResolvedValue(
+      makeCatalog([makeModule("vault", { installed: false })]),
+    );
+    renderRoute();
+
+    // The Home component filters to installed only.
+    await screen.findByTestId("home-modules-empty");
+  });
+});

--- a/web/ui/src/routes/Home.tsx
+++ b/web/ui/src/routes/Home.tsx
@@ -148,11 +148,12 @@ export function Home() {
         </div>
       </section>
 
-      {/* 2. Modules — each opens the MODULE's OWN admin/config UI (off-shell). */}
+      {/* 2. Modules — most open the MODULE's OWN admin/config UI (off-shell);
+          vault is the exception (hub-rendered, opens /vaults in-shell). */}
       <section className="home-group" data-testid="home-modules">
         <div className="home-group-head">
           <h2>Modules</h2>
-          <span className="home-group-tag home-group-tag-module">module-owned</span>
+          <span className="home-group-tag home-group-tag-module">modules</span>
         </div>
         <p className="muted home-group-sub">
           Installed modules. Vault opens here in the shell; other modules open their own admin

--- a/web/ui/src/routes/Home.tsx
+++ b/web/ui/src/routes/Home.tsx
@@ -12,25 +12,27 @@
  * page's content into three clearly-separated groups:
  *
  *   1. **Administer (hub)** — in-shell links to every hub-native section
- *      (Connections, Modules, Users, Vaults, Tokens, Settings). These open
+ *      (Connections, Modules, Users, Tokens, Permissions, Settings). These open
  *      WITHIN the admin shell (react-router `<Link>`), so the persistent nav
- *      stays put and you never lose your place.
+ *      stays put and you never lose your place. Vault management lives under
+ *      the Vault module card below — not here — because the hub-rendered vault
+ *      list IS the vault module's admin surface.
  *
- *   2. **Modules** — one card per installed module, opening the MODULE's OWN
- *      admin / config UI (`config_ui_url` ?? `management_url`). Explicitly
- *      labeled "opens <module>'s own admin ↗" with an external affordance so
- *      the hub-vs-module boundary is obvious — clicking leaves the shell into
- *      a surface the module owns. Modules without either URL render disabled
- *      with a "no admin UI yet" note (never a dead 404 click).
+ *   2. **Modules** — one card per installed module. Vault is special: it has no
+ *      separate admin SPA of its own — the hub SPA is vault's admin — so its
+ *      card opens `/vaults` in-shell (no `↗`). All other modules open their own
+ *      admin/config UI off-shell (full-page `<a href>`, explicit `↗` mark +
+ *      "opens <module>'s own admin" caption). Modules without any URL render
+ *      disabled with a "no admin UI yet" note (never a dead 404 click).
  *
  *   3. **Your surfaces** — the user-facing module UIs (Notes etc.) sourced from
  *      each installed module's hosted-UI sub-units (`uis[]`). These are the
  *      `uiUrl` tiles that lived on the old discovery page; kept reachable here
  *      so an operator can jump straight into "browse my content" from the shell.
  *
- * The visual through-line: hub-native sections read as in-shell cards (no
- * external arrow); module-owned + user surfaces carry the `↗` external mark and
- * a "opens <module>'s own surface" caption. That contrast IS the clarity fix.
+ * The visual through-line: hub-native sections (including the Vault card) read
+ * as in-shell cards (no external arrow); module-owned + user surfaces carry the
+ * `↗` external mark. That contrast IS the clarity fix.
  *
  * Data: a single `/api/modules` round-trip drives both the Modules and Your
  * surfaces groups (it already carries `config_ui_url` / `management_url` and the
@@ -64,7 +66,6 @@ const HUB_SECTIONS: readonly HubSection[] = [
   },
   { to: "/modules", label: "Modules", desc: "Install, upgrade, and manage modules." },
   { to: "/users", label: "Users", desc: "Manage operators and invite members." },
-  { to: "/vaults", label: "Vaults", desc: "Create and manage vaults on this hub." },
   { to: "/tokens", label: "Tokens", desc: "Mint and revoke access tokens." },
   { to: "/permissions", label: "Permissions", desc: "OAuth consent grants per app." },
   { to: "/settings", label: "Settings", desc: "Canonical URL, install channel, more." },
@@ -154,8 +155,9 @@ export function Home() {
           <span className="home-group-tag home-group-tag-module">module-owned</span>
         </div>
         <p className="muted home-group-sub">
-          Installed modules. Each card opens the module's own admin surface — outside the hub shell.
-          Manage install / upgrade / restart from <Link to="/modules">Modules</Link>.
+          Installed modules. Vault opens here in the shell; other modules open their own admin
+          surface outside the hub shell. Manage install / upgrade / restart from{" "}
+          <Link to="/modules">Modules</Link>.
         </p>
         {state.kind === "loading" ? (
           <p className="muted" data-loading="true">
@@ -212,17 +214,39 @@ export function Home() {
 }
 
 /**
- * One installed-module card on the Home overview. Links to the module's OWN
- * admin/config UI (`config_ui_url` first — that's the module's dedicated config
- * surface — falling back to `management_url`). Full-page `<a href>` (NOT a
- * react-router `<Link>`) because we're LEAVING the shell into a surface the
- * module owns; the `↗` mark + owner caption make that boundary explicit.
+ * One installed-module card on the Home overview.
  *
- * A module that declares neither URL (scribe, runner today) renders as a
- * disabled card with a "no admin UI yet" note rather than a dead click —
+ * **Vault is special**: the hub SPA *is* vault's admin — there is no separate
+ * vault admin SPA. So vault's card opens `/vaults` in-shell via a react-router
+ * `<Link>` (no `↗` mark, `home-card-hub` treatment). The "all vaults + click
+ * through to each" experience lives there.
+ *
+ * **All other modules** link to the module's OWN admin/config UI
+ * (`config_ui_url` first — the module's dedicated config surface — falling back
+ * to `management_url`). Full-page `<a href>` (NOT a react-router `<Link>`)
+ * because we're LEAVING the shell; the `↗` mark + owner caption make that
+ * boundary explicit.
+ *
+ * A non-vault module that declares neither URL (scribe, runner today) renders
+ * as a disabled card with a "no admin UI yet" note rather than a dead click —
  * the operator still sees it's installed.
  */
 function ModuleAdminCard({ module: m }: { module: ModuleListing }) {
+  // Vault: hub-native admin lives at /vaults — open in-shell, no external mark.
+  if (m.short === "vault") {
+    return (
+      <Link
+        to="/vaults"
+        className="home-card home-card-hub"
+        data-testid={`home-module-${m.short}`}
+      >
+        <span className="home-card-title">{m.display_name}</span>
+        {m.tagline ? <span className="home-card-desc">{m.tagline}</span> : null}
+        <span className="home-card-owner">manage all vaults — opens here</span>
+      </Link>
+    );
+  }
+
   const adminUrl = m.config_ui_url ?? m.management_url;
   if (!adminUrl) {
     return (


### PR DESCRIPTION
## What and why

Aaron's feedback (verbatim):
> "From Home, Vault is listed in the administer section, but also in the modules section. The module section just goes to manage for /vault/default, whereas the administer section lists all of them. I think ideally we see all of them and can click through but this should probably be in the Vault module not in the administer bit."

Before this PR, Vault appeared in two places on the Home overview:
- **Administer section**: a `/vaults` card ("Create and manage vaults on this hub")
- **Modules section**: a `ModuleAdminCard` for vault — but it pointed at `/vault/default`'s manage page (a single vault), not the full list

Aaron's ask: the "see ALL vaults and click through" experience belongs under the **Vault module card**, and the duplicate `/vaults` entry should go away from Administer.

## What changed

**`HUB_SECTIONS`** — removed the `/vaults` entry. Administer now has 6 cards: Connections, Modules, Users, Tokens, Permissions, Settings.

**`ModuleAdminCard`** — special-cased `m.short === "vault"`:
- Renders a react-router `<Link to="/vaults">` (in-shell) with `home-card-hub` styling
- No `↗` external mark (it stays in the shell)
- Caption: "manage all vaults — opens here"
- `VaultsList` at `/vaults` already lists ALL vaults and click-through to each — that's exactly the experience Aaron asked for; no new route needed

All other module cards are unchanged: off-shell `<a href>`, `↗` mark, "opens X's own admin" caption.

**`Home.test.tsx`** (new file) — covers:
- Administer group has no `/vaults` card
- Vault module card is an in-shell `<Link>` to `/vaults`, no `↗`, correct caption
- Vault card works regardless of whether `management_url` is set (vault's admin isn't via that field)
- Non-vault modules render off-shell `<a>` with `↗`
- Disabled state (no URL)
- Loading / error / empty states

## Styling judgment call

Vault's card gets `home-card-hub` (same class as the Administer cards) rather than `home-card-module`. Rationale: `home-card-module` + `↗` is the visual grammar for "leaves the shell"; vault's admin doesn't leave the shell. Using `home-card-hub` makes vault read as "opens here" — which matches the semantic reality. The Modules section description copy is updated to explain the mix: "Vault opens here in the shell; other modules open their own admin surface outside the hub shell."

## Gates

- `bun run typecheck`: clean
- `bun run test` (vitest): **274/274 passed** (18 test files, including the new Home.test.tsx with 13 tests)
- `bun run build`: build succeeded, verify-base ✓

## Files changed

- `web/ui/src/routes/Home.tsx` — remove `/vaults` from HUB_SECTIONS, special-case vault in ModuleAdminCard, update doc comment and Modules section description
- `web/ui/src/routes/Home.test.tsx` — new, 13 tests covering the above