### PR TITLE
fix(connections): resolve channel row by manifest name (fixes 'channel module is not installed' on vault-link)

### DIFF
--- a/src/__tests__/service-spec-discovery.test.ts
+++ b/src/__tests__/service-spec-discovery.test.ts
@@ -3,6 +3,7 @@ import {
   FIRST_PARTY_FALLBACKS,
   KNOWN_MODULES,
   discoverableShorts,
+  findServiceByShort,
   focusForShort,
   isKnownModuleShort,
 } from "../service-spec.ts";
@@ -69,5 +70,37 @@ describe("isKnownModuleShort", () => {
   test("false for the hub itself + genuinely third-party shorts", () => {
     expect(isKnownModuleShort("hub")).toBe(false);
     expect(isKnownModuleShort("random")).toBe(false);
+  });
+});
+
+// Regression: services.json rows carry the MANIFEST name (`parachute-channel`),
+// not the bare short (`channel`). The connection/channels wiring used to do
+// `services.find((s) => s.name === "channel")`, which never matched the on-disk
+// row → channelOrigin null → a spurious "channel module is not installed" when
+// linking a vault-backed channel. findServiceByShort resolves through the
+// short↔manifest map so the lookup hits the real row.
+describe("findServiceByShort", () => {
+  const services = [
+    { name: "parachute-vault-default", port: 1940 },
+    { name: "parachute-channel", port: 1941 },
+    { name: "parachute-scribe", port: 1943 },
+  ];
+
+  test("matches a row by its manifest name via the short↔manifest map", () => {
+    const found = findServiceByShort(services, "channel");
+    expect(found?.name).toBe("parachute-channel");
+    expect(found?.port).toBe(1941);
+  });
+
+  test("the naive `name === short` comparison would have missed it (the bug)", () => {
+    // The exact pre-fix predicate: a bare short never matches a manifest-named row.
+    expect(services.find((s) => s.name === "channel")).toBeUndefined();
+    // The fix finds it.
+    expect(findServiceByShort(services, "channel")).toBeDefined();
+  });
+
+  test("resolves scribe too, and returns undefined for an absent module", () => {
+    expect(findServiceByShort(services, "scribe")?.port).toBe(1943);
+    expect(findServiceByShort(services, "runner")).toBeUndefined();
   });
 });

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -234,6 +234,7 @@ import {
   FIRST_PARTY_FALLBACKS,
   KNOWN_MODULES,
   effectivePublicExposure,
+  findServiceByShort,
   shortNameForManifest,
 } from "./service-spec.ts";
 import { type ServiceEntry, readManifest, readManifestLenient } from "./services-manifest.ts";
@@ -2198,8 +2199,11 @@ export function hubFetch(
         if (!getDb) return dbNotConfigured();
         const subPath = pathname.slice("/admin/channels".length);
         const services = readManifestLenient(manifestPath).services;
-        // Channel's services.json row is `name: "channel"` on its loopback port.
-        const channelEntry = services.find((s) => s.name === "channel");
+        // Channel's services.json row carries its MANIFEST name (`parachute-channel`),
+        // not the bare short `channel` — resolve via findServiceByShort so the
+        // lookup matches the on-disk row. (A bare `s.name === "channel"` never
+        // matched, leaving channelOrigin null → "channel not installed".)
+        const channelEntry = findServiceByShort(services, "channel");
         const channelOrigin = channelEntry ? `http://127.0.0.1:${channelEntry.port}` : null;
         const resolveVaultOrigin = (vaultName: string): string | null => {
           const match = findVaultUpstream(
@@ -2232,7 +2236,9 @@ export function hubFetch(
       ) {
         if (!getDb) return dbNotConfigured();
         const services = readManifestLenient(manifestPath).services;
-        const channelEntry = services.find((s) => s.name === "channel");
+        // See the `/admin/channels` note above: match the manifest name via
+        // findServiceByShort, not the bare short `channel`.
+        const channelEntry = findServiceByShort(services, "channel");
         const channelOrigin = channelEntry ? `http://127.0.0.1:${channelEntry.port}` : null;
         const resolveVaultOrigin = (vaultName: string): string | null => {
           const match = findVaultUpstream(

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -834,6 +834,24 @@ export function shortNameForManifest(manifestName: string): string | undefined {
 }
 
 /**
+ * Find a services.json row by its SHORT name (e.g. `"channel"`), resolving each
+ * row's manifest name (`parachute-channel`) back through `shortNameForManifest`.
+ *
+ * services.json rows carry the MANIFEST name, not the bare short — so a direct
+ * `s.name === short` comparison silently misses every first-party module. That
+ * exact mismatch (`s.name === "channel"` vs a `parachute-channel` row) is what
+ * surfaced a spurious "channel module is not installed" when wiring the channel
+ * connection sink. Resolve through the short↔manifest map instead. Returns the
+ * first match, or undefined when no installed row maps to `short`.
+ */
+export function findServiceByShort<T extends { name: string }>(
+  services: readonly T[],
+  short: string,
+): T | undefined {
+  return services.find((s) => shortNameForManifest(s.name) === short);
+}
+
+/**
  * Compose a `ServiceSpec` from a `KNOWN_MODULES` entry plus the static
  * manifest data the caller has on hand (typically read from
  * `<installDir>/.parachute/module.json`).

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -843,6 +843,12 @@ export function shortNameForManifest(manifestName: string): string | undefined {
  * surfaced a spurious "channel module is not installed" when wiring the channel
  * connection sink. Resolve through the short↔manifest map instead. Returns the
  * first match, or undefined when no installed row maps to `short`.
+ *
+ * NOTE: multi-instance vault rows (`parachute-vault-<name>`) are NOT resolvable
+ * here — `shortNameForManifest` only knows the canonical `parachute-vault`, so
+ * `findServiceByShort(services, "vault")` returns undefined even when a vault is
+ * installed. Vault rows are resolved by mount path via `findVaultUpstream`; this
+ * helper is for single-instance modules (channel / scribe / runner / surface).
  */
 export function findServiceByShort<T extends { name: string }>(
   services: readonly T[],


### PR DESCRIPTION
## Symptom (Aaron, using the deployed channel admin)

> "When I selected vault and then clicked link I got this: **Link failed. the channel module is not installed on this hub**"

— even though channel is installed, supervised, and healthy (`/channel/health` → 200).

## Root cause

The `/admin/channels` and `/admin/connections` wiring in `hub-server.ts` resolved the channel daemon's loopback origin with:

```ts
const channelEntry = services.find((s) => s.name === "channel");
```

But services.json rows carry the **manifest name** (`parachute-channel`), not the bare short (`channel`). The `find` never matched → `channelOrigin = null` → `prepareChannelSink` returned `503 channel_unavailable` ("the channel module is not installed on this hub").

The handler logic was correct and well-tested — but the handler takes `channelOrigin` as an *injected dep*, so the existing handler tests (which pass it directly) never exercised the manifest resolution. The bug lived entirely in the un-tested wiring glue.

## Fix

- Add `findServiceByShort(services, short)` to `service-spec.ts` — resolves each row's manifest name back through `shortNameForManifest`, so a short like `channel` matches a `parachute-channel` row.
- Use it at both `hub-server.ts` call sites (replacing the bare `s.name === "channel"`).
- Regression tests in `service-spec-discovery.test.ts`: the manifest-named row resolves; the old bare-short `find` provably misses.

## Verification

Against the **real** live `services.json`:
```
OLD predicate (s.name==="channel"): NULL → channel not installed
NEW findServiceByShort: parachute-channel port 1941 → channelOrigin http://127.0.0.1:1941
```

Gates: `bun test ./src` **3216 pass / 0 fail**; `bun run typecheck` clean; no NUL/binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)