### PR TITLE
feat(boundary): hub wave 1 — registered connection mints, vault delete cascade, reserved-name consolidation, URL-semantics unification, /vault/admin route

### DIFF
--- a/src/__tests__/account-setup.test.ts
+++ b/src/__tests__/account-setup.test.ts
@@ -527,6 +527,40 @@ describe("POST /account/setup/<token> — vault-name validation (N1)", () => {
     // No account created.
     expect(getUserByUsernameCI(harness.db, "sam")).toBeNull();
   });
+
+  test("an invitee-chosen RESERVED vault name (list/new/assets/admin) → 400, never provisioned (B2h)", async () => {
+    // Pre-consolidation, the invite path's validator reserved only "list" —
+    // a non-admin invite redeemer could squat "admin" and capture the
+    // daemon-level /vault/admin mount. One consolidated set closes that.
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    for (const name of ["list", "new", "assets", "admin"]) {
+      // vault_name null → the redeemer names their own vault.
+      const { rawToken } = issueInvite(harness.db, { createdBy: admin.id });
+      const { token: csrfToken, cookieFragment } = csrfPair();
+      const stub = makeStubRunCommand();
+      const res = await handleAccountSetupPost(
+        postReq(
+          rawToken,
+          {
+            [CSRF_FIELD_NAME]: csrfToken,
+            username: "sam",
+            password: "sam-strong-password-12",
+            password_confirm: "sam-strong-password-12",
+            vault_name: name,
+          },
+          cookieFragment,
+        ),
+        rawToken,
+        deps(stub.run),
+      );
+      expect(res.status).toBe(400);
+      const html = await res.text();
+      expect(html).toContain("reserved");
+      // The vault CLI is never reached; no account created.
+      expect(stub.calls.length).toBe(0);
+      expect(getUserByUsernameCI(harness.db, "sam")).toBeNull();
+    }
+  });
 });
 
 describe("POST /account/setup/<token> — concurrent redeem (N2)", () => {

--- a/src/__tests__/account-vault-admin-token.test.ts
+++ b/src/__tests__/account-vault-admin-token.test.ts
@@ -128,7 +128,8 @@ describe("handleAccountVaultAdminTokenPost — happy path (assigned vault)", () 
     expect(res.status).toBe(303);
     expect(res.headers.get("cache-control")).toBe("no-store");
     const location = res.headers.get("location") ?? "";
-    // Default managementUrl is /admin/ → lands on the vault admin SPA home.
+    // Default managementUrl is the relative "admin/" (B4 per-instance form)
+    // → lands on the vault admin SPA home under the vault's mount.
     expect(location.startsWith(`${ISSUER}/vault/work/admin/#token=`)).toBe(true);
 
     const token = tokenFromLocation(location);
@@ -151,7 +152,21 @@ describe("handleAccountVaultAdminTokenPost — happy path (assigned vault)", () 
     expect(rows?.n).toBe(1);
   });
 
-  test("honors a vault-declared managementUrl (e.g. a custom admin path)", async () => {
+  test("honors a vault-declared RELATIVE managementUrl (B4 per-instance form)", async () => {
+    const { cookie, csrfToken } = await seedFriend(["work"]);
+    const res = await handleAccountVaultAdminTokenPost(
+      mintReq("work", { cookie, csrfToken }),
+      "work",
+      deps({ managementUrl: "manage/" }),
+    );
+    expect(res.status).toBe(303);
+    const location = res.headers.get("location") ?? "";
+    expect(location.startsWith(`${ISSUER}/vault/work/manage/#token=`)).toBe(true);
+  });
+
+  test("a LEADING-SLASH managementUrl resolves origin-absolute (B4 inverted pin)", async () => {
+    // Pre-B4 "/manage/" joined under the vault mount (/vault/work/manage/).
+    // Under the unified semantics a leading-"/" is origin-absolute.
     const { cookie, csrfToken } = await seedFriend(["work"]);
     const res = await handleAccountVaultAdminTokenPost(
       mintReq("work", { cookie, csrfToken }),
@@ -160,7 +175,24 @@ describe("handleAccountVaultAdminTokenPost — happy path (assigned vault)", () 
     );
     expect(res.status).toBe(303);
     const location = res.headers.get("location") ?? "";
-    expect(location.startsWith(`${ISSUER}/vault/work/manage/#token=`)).toBe(true);
+    expect(location.startsWith(`${ISSUER}/manage/#token=`)).toBe(true);
+  });
+
+  test('COMPAT SHIM: the literal legacy "/admin/" managementUrl still joins under the vault (one release)', async () => {
+    // Deployed vaults declare managementUrl "/admin/" — the OLD per-instance
+    // form. Origin-absolute resolution would deep-link the daemon-level
+    // /vault/admin mount instead of the instance SPA, so the literal
+    // "/admin"/"/admin/" keeps the old vault-join for one release with a
+    // deprecation log.
+    const { cookie, csrfToken } = await seedFriend(["work"]);
+    const res = await handleAccountVaultAdminTokenPost(
+      mintReq("work", { cookie, csrfToken }),
+      "work",
+      deps({ managementUrl: "/admin/" }),
+    );
+    expect(res.status).toBe(303);
+    const location = res.headers.get("location") ?? "";
+    expect(location.startsWith(`${ISSUER}/vault/work/admin/#token=`)).toBe(true);
   });
 
   test("a friend assigned to multiple vaults can deep-link each, never cross-vault", async () => {

--- a/src/__tests__/admin-connections.test.ts
+++ b/src/__tests__/admin-connections.test.ts
@@ -30,8 +30,9 @@ import {
   handleConnectionsCatalog,
   whenFromFilter,
 } from "../admin-connections.ts";
-import { readConnections } from "../connections-store.ts";
+import { putConnection, readConnections } from "../connections-store.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { findTokenRowByJti, listActiveRevocations } from "../jwt-sign.ts";
 import { type ModuleManifest, validateModuleManifest } from "../module-manifest.ts";
 import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
@@ -897,6 +898,170 @@ describe("DELETE /admin/connections/:id — teardown", () => {
       baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST)),
     );
     expect(res.status).toBe(404);
+  });
+});
+
+// ===========================================================================
+// B0 — registered connection mints (hub-module-boundary, registered-mint rule)
+// ===========================================================================
+
+describe("B0 — registered connection mints", () => {
+  /** Create the canonical channel-backed connection; return the long-lived jtis. */
+  async function createChannelConnection(
+    cookie: string,
+    deps: ConnectionsDeps,
+    calls: Array<{ method: string; url: string; bearer: string | null; body: unknown }>,
+  ): Promise<{ replyJti: string; webhookJti: string }> {
+    const res = await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections`, {
+        method: "POST",
+        headers: { cookie },
+        body: JSON.stringify({
+          source: { module: "vault", vault: "default", event: "note.created" },
+          sink: { module: "channel", action: "message.deliver", params: { channel: "eng" } },
+        }),
+      }),
+      "",
+      deps,
+    );
+    expect(res.status).toBe(200);
+    const cfgCall = calls.find((c) => c.url.endsWith("/api/channels"));
+    const replyToken = (cfgCall!.body as { config: { token: string } }).config.token;
+    const trigCall = calls.find((c) => c.url.endsWith("/vault/default/api/triggers"));
+    const webhookBearer = (trigCall!.body as { action: { auth: { bearer: string } } }).action.auth
+      .bearer;
+    return {
+      replyJti: (decodeJwt(replyToken) as { jti?: string }).jti!,
+      webhookJti: (decodeJwt(webhookBearer) as { jti?: string }).jti!,
+    };
+  }
+
+  test("long-lived mints get a connection_provision registry row; jtis persist on the record; short-lived provisioning mints stay unregistered", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({
+      "POST /api/channels": () => ok({ ok: true }),
+      "POST /vault/default/api/triggers": () => ok({ ok: true }),
+    });
+    const deps = baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, CHANNEL_MANIFEST));
+    const { replyJti, webhookJti } = await createChannelConnection(cookie, deps, calls);
+
+    // Both ~90d tokens are registered with the connection provenance + exact scopes.
+    const replyRow = findTokenRowByJti(harness.db, replyJti);
+    expect(replyRow).not.toBeNull();
+    expect(replyRow!.createdVia).toBe("connection_provision");
+    expect(replyRow!.scopes).toEqual(["vault:default:write"]);
+    expect(replyRow!.revokedAt).toBeNull();
+    const webhookRow = findTokenRowByJti(harness.db, webhookJti);
+    expect(webhookRow).not.toBeNull();
+    expect(webhookRow!.createdVia).toBe("connection_provision");
+    expect(webhookRow!.scopes).toEqual(["channel:send"]);
+
+    // The short-lived (60s) provisioning bearers — vault:<v>:admin on the
+    // trigger POST, channel:admin on the channel-config POST — ride to expiry
+    // by design (the documented ≤10-min unregistered bound). NOT registered.
+    const trigCall = calls.find((c) => c.url.endsWith("/vault/default/api/triggers"));
+    const cfgCall = calls.find((c) => c.url.endsWith("/api/channels"));
+    const trigAuthJti = (decodeJwt(trigCall!.bearer!) as { jti?: string }).jti!;
+    const cfgAuthJti = (decodeJwt(cfgCall!.bearer!) as { jti?: string }).jti!;
+    expect(findTokenRowByJti(harness.db, trigAuthJti)).toBeNull();
+    expect(findTokenRowByJti(harness.db, cfgAuthJti)).toBeNull();
+
+    // The jtis are persisted on the record's provisioned block for teardown.
+    const stored = readConnections(harness.storePath);
+    expect(stored).toHaveLength(1);
+    expect([...(stored[0]!.provisioned.mintedJtis ?? [])].sort()).toEqual(
+      [replyJti, webhookJti].sort(),
+    );
+  });
+
+  test("teardown revokes the registered jtis → they appear on the revocation list", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({
+      "POST /api/channels": () => ok({ ok: true }),
+      "POST /vault/default/api/triggers": () => ok({ ok: true }),
+      "DELETE /api/channels/eng": () => ok({ ok: true }),
+      "DELETE /vault/default/api/triggers/conn_channel-eng": () => ok({ ok: true }),
+    });
+    const deps = baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, CHANNEL_MANIFEST));
+    const { replyJti, webhookJti } = await createChannelConnection(cookie, deps, calls);
+
+    const res = await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections/channel-eng`, {
+        method: "DELETE",
+        headers: { cookie },
+      }),
+      "/channel-eng",
+      deps,
+    );
+    expect(res.status).toBe(200);
+
+    // Registry rows flipped to revoked…
+    expect(findTokenRowByJti(harness.db, replyJti)!.revokedAt).not.toBeNull();
+    expect(findTokenRowByJti(harness.db, webhookJti)!.revokedAt).not.toBeNull();
+    // …and the revocation list (what resource servers poll) advertises them.
+    const revoked = listActiveRevocations(harness.db, new Date());
+    expect(revoked).toContain(replyJti);
+    expect(revoked).toContain(webhookJti);
+  });
+
+  test("legacy records (pre-B0, no mintedJtis): teardown proceeds; list surfaces legacy: true", async () => {
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({
+      "POST /vault/default/api/triggers": () => ok({ ok: true }),
+      "DELETE /vault/default/api/triggers/conn_old1": () => ok({ ok: true }),
+    });
+    const deps = baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, WIDGET_MANIFEST));
+
+    // A record written before B0 — provisioned block has no mintedJtis.
+    putConnection(harness.storePath, {
+      id: "old1",
+      source: { module: "vault", vault: "default", event: "note.created" },
+      sink: { module: "widget", action: "thing.do" },
+      provisioned: { type: "vault-trigger", vault: "default", triggerName: "conn_old1" },
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    // And a new-style one created through the engine.
+    await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections`, {
+        method: "POST",
+        headers: { cookie },
+        body: JSON.stringify({
+          id: "w-new",
+          source: { module: "vault", vault: "default", event: "note.created" },
+          sink: { module: "widget", action: "thing.do" },
+        }),
+      }),
+      "",
+      deps,
+    );
+
+    // List: the legacy record is flagged, the new one is not.
+    const list = await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections`, { method: "GET", headers: { cookie } }),
+      "",
+      deps,
+    );
+    const out = (await list.json()) as { connections: Array<{ id: string; legacy?: boolean }> };
+    expect(out.connections.find((c) => c.id === "old1")!.legacy).toBe(true);
+    expect(out.connections.find((c) => c.id === "w-new")!.legacy).toBeUndefined();
+
+    // Teardown of the legacy record proceeds cleanly (no crash, no revocation
+    // step — its tokens were never registered and ride to expiry).
+    const res = await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections/old1`, {
+        method: "DELETE",
+        headers: { cookie },
+      }),
+      "/old1",
+      deps,
+    );
+    expect(res.status).toBe(200);
+    expect(
+      calls.some(
+        (c) => c.method === "DELETE" && c.url.endsWith("/vault/default/api/triggers/conn_old1"),
+      ),
+    ).toBe(true);
+    expect(readConnections(harness.storePath).find((r) => r.id === "old1")).toBeUndefined();
   });
 });
 

--- a/src/__tests__/admin-vaults.test.ts
+++ b/src/__tests__/admin-vaults.test.ts
@@ -301,6 +301,28 @@ describe("POST /vaults — body validation", () => {
       h.cleanup();
     }
   });
+
+  test('400 when name is "admin" (would shadow the /vault/admin daemon-level mount — B2h)', async () => {
+    // A vault named "admin" would capture `/vault/admin`, the daemon-level
+    // mount for vault's own multi-vault admin surface (B-route). The reserved
+    // set is now the consolidated RESERVED_VAULT_NAMES in vault-name.ts, so
+    // the wizard + invite redemption reject it too.
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const res = await call({ db, manifestPath: h.manifestPath, body: { name: "admin" } });
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as { error_description: string };
+        expect(body.error_description).toMatch(/reserved/i);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
 });
 
 describe("POST /vaults — orchestration", () => {

--- a/src/__tests__/admin-vaults.test.ts
+++ b/src/__tests__/admin-vaults.test.ts
@@ -721,3 +721,571 @@ describe("POST /vaults — method gating", () => {
     }
   });
 });
+
+// ===========================================================================
+// DELETE /vaults/<name> — the identity cascade (B1, hub-module-boundary)
+// ===========================================================================
+
+import { handleDeleteVault } from "../admin-vaults.ts";
+import { registerClient } from "../clients.ts";
+import { putConnection, readConnections } from "../connections-store.ts";
+import { findGrant, recordGrant } from "../grants.ts";
+import { findInviteByHash, issueInvite } from "../invites.ts";
+import { findTokenRowByJti, listActiveRevocations, recordTokenMint } from "../jwt-sign.ts";
+import { createUser, setUserVaults } from "../users.ts";
+
+const VAULT_ORIGIN = "http://127.0.0.1:19400";
+const CHANNEL_ORIGIN = "http://127.0.0.1:19410";
+
+/** Successful no-op runner — records the commands it was asked to run. */
+function stubRun(
+  exitCode = 0,
+  stderr = "",
+): {
+  run: (cmd: readonly string[]) => Promise<RunResult>;
+  calls: (readonly string[])[];
+} {
+  const calls: (readonly string[])[] = [];
+  return {
+    calls,
+    run: async (cmd) => {
+      calls.push(cmd);
+      return { exitCode, stdout: "", stderr };
+    },
+  };
+}
+
+/** Recording fetch mock keyed by `METHOD <pathname>` (mirrors admin-connections.test). */
+function mockFetch(routes: Record<string, () => Response>): {
+  fetchImpl: typeof fetch;
+  calls: { method: string; url: string }[];
+} {
+  const calls: { method: string; url: string }[] = [];
+  const fetchImpl = (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+    calls.push({ method, url });
+    const responder = routes[`${method} ${new URL(url).pathname}`];
+    if (!responder) return new Response("no route", { status: 599 });
+    return responder();
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function okJson(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+interface DeleteCallOpts {
+  name: string;
+  body?: unknown;
+  authHeader?: string | null;
+  db: ReturnType<typeof openHubDb>;
+  manifestPath: string;
+  connectionsStorePath: string;
+  runCommand?: (cmd: readonly string[]) => Promise<RunResult>;
+  restartVaultModule?: () => Promise<void>;
+  channelOrigin?: string | null;
+  fetchImpl?: typeof fetch;
+  resolveVaultOrigin?: (v: string) => string | null;
+}
+
+async function callDelete(opts: DeleteCallOpts): Promise<Response> {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (opts.authHeader === undefined) {
+    headers.set("authorization", `Bearer ${await adminToken(opts.db)}`);
+  } else if (opts.authHeader !== null) {
+    headers.set("authorization", opts.authHeader);
+  }
+  const req = new Request(`${ISSUER}/vaults/${opts.name}`, {
+    method: "DELETE",
+    headers,
+    body: JSON.stringify(opts.body ?? { confirm: opts.name }),
+  });
+  return handleDeleteVault(req, opts.name, {
+    db: opts.db,
+    issuer: ISSUER,
+    manifestPath: opts.manifestPath,
+    connectionsStorePath: opts.connectionsStorePath,
+    channelOrigin: opts.channelOrigin ?? null,
+    resolveVaultOrigin: opts.resolveVaultOrigin ?? (() => VAULT_ORIGIN),
+    runCommand: opts.runCommand ?? stubRun().run,
+    ...(opts.restartVaultModule ? { restartVaultModule: opts.restartVaultModule } : {}),
+    ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+  });
+}
+
+/** services.json with one multi-path vault row (the canonical Q5 shape). */
+function writeVaults(manifestPath: string, instanceNames: string[]): void {
+  writeManifest(
+    {
+      services: [
+        {
+          name: "parachute-vault",
+          port: 1940,
+          paths: instanceNames.map((n) => `/vault/${n}`),
+          health: `/vault/${instanceNames[0]}/health`,
+          version: "0.5.0",
+        },
+      ],
+    },
+    manifestPath,
+  );
+}
+
+function registryRow(db: ReturnType<typeof openHubDb>, jti: string, scopes: string[]): void {
+  recordTokenMint(db, {
+    jti,
+    createdVia: "cli_mint",
+    subject: "user-admin",
+    clientId: "test-client",
+    scopes,
+    expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+  });
+}
+
+describe("DELETE /vaults/<name> — gates", () => {
+  test("401 without a bearer; 403 without host:admin", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        writeVaults(h.manifestPath, ["default", "work"]);
+        const store = join(h.dir, "connections.json");
+        const noAuth = await callDelete({
+          name: "work",
+          db,
+          manifestPath: h.manifestPath,
+          connectionsStorePath: store,
+          authHeader: null,
+        });
+        expect(noAuth.status).toBe(401);
+        const readOnly = await callDelete({
+          name: "work",
+          db,
+          manifestPath: h.manifestPath,
+          connectionsStorePath: store,
+          authHeader: `Bearer ${await readOnlyToken(db)}`,
+        });
+        expect(readOnly.status).toBe(403);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("400 confirm_mismatch when the body doesn't retype the name (nothing revoked, CLI never runs)", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        writeVaults(h.manifestPath, ["default", "work"]);
+        registryRow(db, "jti-confirm-guard", ["vault:work:write"]);
+        const runner = stubRun();
+        for (const body of [{ confirm: "wrong" }, {}, { confirm: "" }]) {
+          const res = await callDelete({
+            name: "work",
+            body,
+            db,
+            manifestPath: h.manifestPath,
+            connectionsStorePath: join(h.dir, "connections.json"),
+            runCommand: runner.run,
+          });
+          expect(res.status).toBe(400);
+          expect(((await res.json()) as { error: string }).error).toBe("confirm_mismatch");
+        }
+        expect(runner.calls.length).toBe(0);
+        expect(findTokenRowByJti(db, "jti-confirm-guard")?.revokedAt).toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("404 on an unknown vault", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        writeVaults(h.manifestPath, ["default", "work"]);
+        const res = await callDelete({
+          name: "ghost",
+          db,
+          manifestPath: h.manifestPath,
+          connectionsStorePath: join(h.dir, "connections.json"),
+        });
+        expect(res.status).toBe(404);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("409 last_vault on the only remaining vault (CLI never runs)", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        writeVaults(h.manifestPath, ["default"]);
+        const runner = stubRun();
+        const res = await callDelete({
+          name: "default",
+          db,
+          manifestPath: h.manifestPath,
+          connectionsStorePath: join(h.dir, "connections.json"),
+          runCommand: runner.run,
+        });
+        expect(res.status).toBe(409);
+        const out = (await res.json()) as { error: string; error_description: string };
+        expect(out.error).toBe("last_vault");
+        // Guidance names the CLI escape hatch + the resurrection reason.
+        expect(out.error_description).toContain("parachute-vault remove");
+        expect(runner.calls.length).toBe(0);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("reserved names are deletable (a squatted `admin` vault can be removed)", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        // A vault squatted on "admin" BEFORE the B2h reservation existed.
+        writeVaults(h.manifestPath, ["default", "admin"]);
+        const runner = stubRun();
+        const res = await callDelete({
+          name: "admin",
+          db,
+          manifestPath: h.manifestPath,
+          connectionsStorePath: join(h.dir, "connections.json"),
+          runCommand: runner.run,
+        });
+        expect(res.status).toBe(200);
+        expect(runner.calls).toContainEqual(["parachute-vault", "remove", "admin", "--yes"]);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("DELETE /vaults/<name> — the identity cascade", () => {
+  test("full cascade: tokens, grants, user_vaults, invites, connections, mechanics, restart", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        writeVaults(h.manifestPath, ["default", "work"]);
+        const store = join(h.dir, "connections.json");
+
+        // 1. Registry rows: two naming "work" (one standalone + the
+        //    connection's registered mint below), one naming "default".
+        registryRow(db, "jti-work-1", ["vault:work:write"]);
+        registryRow(db, "jti-conn-1", ["channel:send"]); // connection webhook bearer (non-vault scope)
+        registryRow(db, "jti-default-1", ["vault:default:read"]);
+
+        // 2. Grants: one spanning both vaults (rewrite), one work-only (drop).
+        const alice = await createUser(db, "alice", "alice-passphrase-123");
+        const clientSpan = registerClient(db, { redirectUris: ["https://a.example/cb"] }).client
+          .clientId;
+        const clientWorkOnly = registerClient(db, { redirectUris: ["https://b.example/cb"] }).client
+          .clientId;
+        recordGrant(db, alice.id, clientSpan, [
+          "vault:work:read",
+          "vault:default:read",
+          "offline_access",
+        ]);
+        recordGrant(db, alice.id, clientWorkOnly, ["vault:work:admin"]);
+
+        // 3. user_vaults: alice assigned to both.
+        setUserVaults(db, alice.id, ["work", "default"]);
+
+        // 4. Invites: pending pinned to work (invalidate), pending pinned to
+        //    default (keep), already-redeemed work invite (terminal, keep).
+        const pendingWork = issueInvite(db, { createdBy: alice.id, vaultName: "work" });
+        const pendingDefault = issueInvite(db, { createdBy: alice.id, vaultName: "default" });
+        const redeemedWork = issueInvite(db, { createdBy: alice.id, vaultName: "work" });
+        db.prepare("UPDATE invites SET used_at = ?, redeemed_user_id = ? WHERE token = ?").run(
+          new Date().toISOString(),
+          alice.id,
+          redeemedWork.invite.tokenHash,
+        );
+
+        // 5. Connections: one sourced on work (torn down), one on default (kept).
+        putConnection(store, {
+          id: "conn-work",
+          source: { module: "vault", vault: "work", event: "note.created" },
+          sink: { module: "channel", action: "message.deliver", params: { channel: "eng" } },
+          provisioned: {
+            type: "vault-trigger",
+            vault: "work",
+            triggerName: "conn_conn-work",
+            mintedJtis: ["jti-conn-1"],
+          },
+          createdAt: new Date().toISOString(),
+        });
+        putConnection(store, {
+          id: "conn-default",
+          source: { module: "vault", vault: "default", event: "note.created" },
+          sink: { module: "channel", action: "message.deliver", params: { channel: "ops" } },
+          provisioned: { type: "vault-trigger", vault: "default", triggerName: "conn_d" },
+          createdAt: new Date().toISOString(),
+        });
+
+        const { fetchImpl, calls } = mockFetch({
+          "DELETE /vault/work/api/triggers/conn_conn-work": () => okJson({ ok: true }),
+          "DELETE /api/channels/eng": () => okJson({ ok: true }),
+          // Channel scan: one legacy vault-backed entry still references work.
+          "GET /api/channels": () =>
+            okJson({
+              channels: [
+                { name: "legacy-chan", transport: "vault", vault: "work" },
+                { name: "other-chan", transport: "vault", vault: "default" },
+                { name: "tg", transport: "telegram", vault: null },
+              ],
+            }),
+        });
+
+        const runner = stubRun();
+        let restarted = false;
+        const res = await callDelete({
+          name: "work",
+          db,
+          manifestPath: h.manifestPath,
+          connectionsStorePath: store,
+          runCommand: runner.run,
+          restartVaultModule: async () => {
+            restarted = true;
+          },
+          channelOrigin: CHANNEL_ORIGIN,
+          fetchImpl,
+          resolveVaultOrigin: (v) => (v === "work" ? VAULT_ORIGIN : null),
+        });
+        expect(res.status).toBe(200);
+        const out = (await res.json()) as {
+          ok: boolean;
+          name: string;
+          cascade: {
+            tokens_revoked: number;
+            grants_rewritten: number;
+            grants_dropped: number;
+            user_vaults_removed: number;
+            invites_invalidated: number;
+            connections_torn_down: number;
+            orphaned_channels: string[];
+            vault_removed: boolean;
+            module_restarted: boolean;
+          };
+        };
+        expect(out.ok).toBe(true);
+        expect(out.name).toBe("work");
+
+        // 1. Registry sweep: the work-scoped row revoked; default untouched.
+        //    The connection's webhook-bearer row (channel:send — names no
+        //    vault) is revoked by the CONNECTION teardown, not the sweep.
+        expect(out.cascade.tokens_revoked).toBe(1);
+        expect(findTokenRowByJti(db, "jti-work-1")?.revokedAt).not.toBeNull();
+        expect(findTokenRowByJti(db, "jti-conn-1")?.revokedAt).not.toBeNull();
+        expect(findTokenRowByJti(db, "jti-default-1")?.revokedAt).toBeNull();
+        expect(listActiveRevocations(db, new Date())).toContain("jti-work-1");
+
+        // 2. Grants: span-rewritten (kept, minus work scopes); work-only dropped.
+        expect(out.cascade.grants_rewritten).toBe(1);
+        expect(out.cascade.grants_dropped).toBe(1);
+        const span = findGrant(db, alice.id, clientSpan);
+        expect(span?.scopes.sort()).toEqual(["offline_access", "vault:default:read"]);
+        expect(findGrant(db, alice.id, clientWorkOnly)).toBeNull();
+
+        // 3. user_vaults: work row gone, default row stays.
+        expect(out.cascade.user_vaults_removed).toBe(1);
+        const remaining = db
+          .query<{ vault_name: string }, [string]>(
+            "SELECT vault_name FROM user_vaults WHERE user_id = ?",
+          )
+          .all(alice.id)
+          .map((r) => r.vault_name);
+        expect(remaining).toEqual(["default"]);
+
+        // 4. Invites: pending-work revoked; pending-default + redeemed-work untouched.
+        expect(out.cascade.invites_invalidated).toBe(1);
+        expect(findInviteByHash(db, pendingWork.invite.tokenHash)?.revokedAt).not.toBeNull();
+        expect(findInviteByHash(db, pendingDefault.invite.tokenHash)?.revokedAt).toBeNull();
+        expect(findInviteByHash(db, redeemedWork.invite.tokenHash)?.usedAt).not.toBeNull();
+        expect(findInviteByHash(db, redeemedWork.invite.tokenHash)?.revokedAt).toBeNull();
+
+        // 5. Connections: work connection torn down (trigger deregistered +
+        //    channel entry deleted + record removed); default connection kept.
+        expect(out.cascade.connections_torn_down).toBe(1);
+        expect(
+          calls.some(
+            (c) =>
+              c.method === "DELETE" && c.url.endsWith("/vault/work/api/triggers/conn_conn-work"),
+          ),
+        ).toBe(true);
+        expect(
+          calls.some((c) => c.method === "DELETE" && c.url.endsWith("/api/channels/eng")),
+        ).toBe(true);
+        const records = readConnections(store);
+        expect(records.map((r) => r.id)).toEqual(["conn-default"]);
+
+        // Channel scan: legacy entry surfaced, NOT deleted (report-only —
+        // no DELETE call for it), and the default-vault entry not flagged.
+        expect(out.cascade.orphaned_channels).toEqual(["legacy-chan"]);
+        expect(calls.some((c) => c.method === "DELETE" && c.url.includes("legacy-chan"))).toBe(
+          false,
+        );
+
+        // 6 + 7. Mechanics + eviction.
+        expect(runner.calls).toContainEqual(["parachute-vault", "remove", "work", "--yes"]);
+        expect(out.cascade.vault_removed).toBe(true);
+        expect(restarted).toBe(true);
+        expect(out.cascade.module_restarted).toBe(true);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("registry sweep is EXACT-match — `_` in vault names is not a LIKE wildcard", async () => {
+    // Vault `my_vault` must not revoke `myxvault` tokens: under SQL LIKE,
+    // `_` matches any single character, so a LIKE-based sweep for
+    // `%vault:my_vault:%` would catch `vault:myxvault:write` too. The sweep
+    // splits + exact-matches scope segments instead.
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        writeVaults(h.manifestPath, ["my_vault", "myxvault"]);
+        registryRow(db, "jti-underscore", ["vault:my_vault:write"]);
+        registryRow(db, "jti-lookalike", ["vault:myxvault:write"]);
+        const res = await callDelete({
+          name: "my_vault",
+          db,
+          manifestPath: h.manifestPath,
+          connectionsStorePath: join(h.dir, "connections.json"),
+        });
+        expect(res.status).toBe(200);
+        const out = (await res.json()) as { cascade: { tokens_revoked: number } };
+        expect(out.cascade.tokens_revoked).toBe(1);
+        expect(findTokenRowByJti(db, "jti-underscore")?.revokedAt).not.toBeNull();
+        // The lookalike vault's token is NOT revoked.
+        expect(findTokenRowByJti(db, "jti-lookalike")?.revokedAt).toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("a multi-vault grant is REWRITTEN, not dropped (dropping over-revokes)", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        writeVaults(h.manifestPath, ["default", "work"]);
+        const bob = await createUser(db, "bob", "bob-passphrase-12345");
+        const claude = registerClient(db, { redirectUris: ["https://c.example/cb"] }).client
+          .clientId;
+        recordGrant(db, bob.id, claude, ["vault:work:write", "vault:default:write"]);
+        const res = await callDelete({
+          name: "work",
+          db,
+          manifestPath: h.manifestPath,
+          connectionsStorePath: join(h.dir, "connections.json"),
+        });
+        expect(res.status).toBe(200);
+        const grant = findGrant(db, bob.id, claude);
+        // Row survives with the other vault's scope intact.
+        expect(grant).not.toBeNull();
+        expect(grant?.scopes).toEqual(["vault:default:write"]);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("mechanics failure → 500, identity artifacts stay revoked", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        writeVaults(h.manifestPath, ["default", "work"]);
+        registryRow(db, "jti-pre-fail", ["vault:work:write"]);
+        const res = await callDelete({
+          name: "work",
+          db,
+          manifestPath: h.manifestPath,
+          connectionsStorePath: join(h.dir, "connections.json"),
+          runCommand: stubRun(1, "disk on fire").run,
+        });
+        expect(res.status).toBe(500);
+        const out = (await res.json()) as { error: string; error_description: string };
+        expect(out.error).toBe("server_error");
+        expect(out.error_description).toContain("disk on fire");
+        // Revocation is the safe direction — the sweep is NOT rolled back.
+        expect(findTokenRowByJti(db, "jti-pre-fail")?.revokedAt).not.toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("no supervisor → 200 with a module_restart warning (not silent)", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        writeVaults(h.manifestPath, ["default", "work"]);
+        const res = await callDelete({
+          name: "work",
+          db,
+          manifestPath: h.manifestPath,
+          connectionsStorePath: join(h.dir, "connections.json"),
+        });
+        expect(res.status).toBe(200);
+        const out = (await res.json()) as {
+          cascade: { module_restarted: boolean };
+          warnings?: { step: string; detail: string }[];
+        };
+        expect(out.cascade.module_restarted).toBe(false);
+        expect(out.warnings?.some((w) => w.step === "module_restart")).toBe(true);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -527,10 +527,12 @@ describe("GET /api/modules", () => {
     expect(scribe?.supervisor_start_error).toBeNull();
   });
 
-  test("populates management_url from a relative managementUrl + module mount (hub#342)", async () => {
-    // Vault declares `managementUrl: "/admin"` in its module.json — hub
-    // resolves that against the entry's mount path (`/vault/default`)
-    // to produce the absolute admin URL the SPA's "Open" button targets.
+  test("populates management_url from a RELATIVE managementUrl + module mount (B4 per-instance form)", async () => {
+    // Vault's new manifest declares `managementUrl: "admin/"` — relative, no
+    // leading slash: the per-instance form under the B4 unified semantics
+    // (2026-06-09 hub-module-boundary). Hub joins it under the entry's mount
+    // path (`/vault/default`) to produce the absolute admin URL the SPA's
+    // "Open" button targets.
     writeManifest(h.manifestPath, [
       {
         name: "parachute-vault",
@@ -561,6 +563,55 @@ describe("GET /api/modules", () => {
             port: 1940,
             paths: ["/vault/default"],
             health: "/health",
+            managementUrl: "admin/",
+          } as unknown as Awaited<
+            ReturnType<typeof import("../module-manifest.ts").readModuleManifest>
+          >;
+        }
+        return null;
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      modules: Array<{ short: string; management_url: string | null }>;
+    };
+    const vault = body.modules.find((m) => m.short === "vault");
+    expect(vault?.management_url).toBe("/vault/default/admin/");
+  });
+
+  test('COMPAT SHIM: the literal legacy "/admin" on a VAULT entry still mount-joins (one release)', async () => {
+    // Deployed vaults still declare `managementUrl: "/admin"` — the OLD
+    // per-instance relative form. Under the new semantics a leading-"/" is
+    // origin-absolute (which would point at the daemon-level /vault/admin
+    // mount, not the instance), so the literal "/admin"/"/admin/" on a vault
+    // entry keeps the old mount-join behavior for one release, with a
+    // deprecation log. Remove the shim once vault's new manifest is @latest.
+    writeManifest(h.manifestPath, [
+      {
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/vault/default"],
+        health: "/vault/default/health",
+        version: "0.4.5",
+        installDir: "/install/dir/vault",
+      },
+    ]);
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: async () => null,
+      readModuleManifest: async (installDir) => {
+        if (installDir === "/install/dir/vault") {
+          return {
+            name: "parachute-vault",
+            manifestName: "parachute-vault",
+            displayName: "Vault",
+            tagline: "",
+            port: 1940,
+            paths: ["/vault/default"],
+            health: "/health",
             managementUrl: "/admin",
           } as unknown as Awaited<
             ReturnType<typeof import("../module-manifest.ts").readModuleManifest>
@@ -574,15 +625,16 @@ describe("GET /api/modules", () => {
       modules: Array<{ short: string; management_url: string | null }>;
     };
     const vault = body.modules.find((m) => m.short === "vault");
+    // Mount-joined (legacy behavior preserved), NOT origin-absolute "/admin".
     expect(vault?.management_url).toBe("/vault/default/admin");
   });
 
   test("populates config_ui_url from a module's configUiUrl (2026-06-09 modular-UI P3)", async () => {
     // Channel declares `configUiUrl: "/channel/admin"` (a single-instance,
-    // already-mount-prefixed path) + `uiUrl: "/channel/ui"`. The hub surfaces
+    // origin-absolute path) + `uiUrl: "/channel/ui"`. The hub surfaces
     // both: `config_ui_url` drives the Modules page Configure action,
     // `management_url` drives Open. configUiUrl resolves identically to
-    // managementUrl (same path-or-URL + mount-join rule).
+    // managementUrl (same B4 unified semantics).
     writeManifest(h.manifestPath, [
       {
         name: "channel",
@@ -627,7 +679,7 @@ describe("GET /api/modules", () => {
       }>;
     };
     const channel = body.modules.find((m) => m.short === "channel");
-    // Already mount-prefixed — must NOT double-prepend `/channel`.
+    // Origin-absolute — verbatim, never double-prepends `/channel`.
     expect(channel?.config_ui_url).toBe("/channel/admin");
     // uiUrl (no managementUrl) drives the Open action's management_url.
     expect(channel?.management_url).toBe("/channel/ui");
@@ -676,21 +728,14 @@ describe("GET /api/modules", () => {
     expect(vault?.config_ui_url).toBeNull();
   });
 
-  test("management_url does not double-prepend mount when managementUrl is already mount-prefixed (hub#380)", async () => {
-    // Audit caught 2026-05-25: surface declared `managementUrl: "/surface/admin/"`
-    // (full hub-origin path) and `paths: ["/surface", "/.parachute"]`. The
-    // SPA's Services dropdown was navigating to `/surface/surface/admin/`
-    // (404) because api-modules unconditionally prepended the mount onto
-    // the candidate. Fix: detect already-mount-prefixed paths and pass
-    // through.
-    //
-    // Single-instance modules conventionally declare the full path; only
-    // multi-instance modules (vault) use the per-instance relative form.
-    // Post 2026-05-27 CURATED trim the canonical single-instance example
-    // is scribe (when scribe ships a managementUrl — scribe#53). For now
-    // we exercise the same code path with vault declaring an
-    // already-mount-prefixed managementUrl: any module whose declared
-    // URL starts with its mount must pass through unchanged.
+  test("management_url passes a leading-slash path through verbatim (origin-absolute, B4)", async () => {
+    // Historical context (hub#380): surface declared `managementUrl:
+    // "/surface/admin/"` (full hub-origin path) and the resolver
+    // double-prepended the mount (`/surface/surface/admin/` → 404), patched
+    // then by an already-mount-prefixed heuristic. Under the B4 unified
+    // semantics the heuristic is gone: ANY leading-"/" path is
+    // ORIGIN-ABSOLUTE and passes through verbatim (except the vault "/admin"
+    // compat shim) — same result here, simpler rule.
     writeManifest(h.manifestPath, [
       {
         name: "parachute-vault",
@@ -717,8 +762,8 @@ describe("GET /api/modules", () => {
             port: 1940,
             paths: ["/vault/default"],
             health: "/vault/default/health",
-            // Already-mount-prefixed managementUrl — must NOT have the
-            // mount prepended again.
+            // Origin-absolute managementUrl — passes through verbatim,
+            // never gets the mount prepended.
             managementUrl: "/vault/default/admin/",
           } as unknown as Awaited<
             ReturnType<typeof import("../module-manifest.ts").readModuleManifest>
@@ -736,14 +781,12 @@ describe("GET /api/modules", () => {
     expect(vault?.management_url).toBe("/vault/default/admin/");
   });
 
-  test("management_url prefix-ish names don't collide (hub#380 — /app vs /app-foo)", async () => {
-    // The detection uses `tail.startsWith(\`${mount}/\`)` with the trailing
-    // slash specifically to avoid a false positive when a candidate
-    // path looks like a sibling name (e.g. `/app-foo/admin` shouldn't be
-    // treated as "already prefixed by /app"). Without the slash gate,
-    // a future module named `app-foo` would silently inherit the
-    // pass-through behavior and `/app` mount would skip its prepend.
-    // Tests the trailing-slash discriminator stays load-bearing.
+  test("management_url: a leading-slash path NOT under the mount is still origin-absolute (B4 inverts hub#380)", async () => {
+    // INVERTED PIN (B4). Pre-B4 the resolver prepended the mount onto any
+    // leading-"/" candidate that didn't look already-mount-prefixed:
+    // mount=/surface + "/app-foo/admin" → "/surface/app-foo/admin". Under
+    // the unified semantics a leading-"/" is ORIGIN-ABSOLUTE, verbatim —
+    // the module says exactly where its surface lives on the origin.
     writeManifest(h.manifestPath, [
       {
         name: "parachute-vault",
@@ -770,8 +813,8 @@ describe("GET /api/modules", () => {
             port: 1940,
             paths: ["/surface"],
             health: "/surface/health",
-            // candidate looks like a sibling-name prefix but is NOT a
-            // mount-prefix of /app — should still get prepended.
+            // Origin-absolute path outside this module's own mount —
+            // verbatim under B4 (pre-B4 this was mount-prepended).
             managementUrl: "/app-foo/admin",
           } as unknown as Awaited<
             ReturnType<typeof import("../module-manifest.ts").readModuleManifest>
@@ -785,14 +828,13 @@ describe("GET /api/modules", () => {
       modules: Array<{ short: string; management_url: string | null }>;
     };
     const vault = body.modules.find((m) => m.short === "vault");
-    // /surface + /app-foo/admin → /surface/app-foo/admin (prepend fires; not
-    // treated as already-mount-prefixed because /app-foo/ doesn't start with /surface/).
-    expect(vault?.management_url).toBe("/surface/app-foo/admin");
+    // Origin-absolute, verbatim — NOT /surface/app-foo/admin.
+    expect(vault?.management_url).toBe("/app-foo/admin");
   });
 
-  test("management_url equality edge: tail equals mount exactly (hub#380)", async () => {
-    // mount=/foo, candidate=/foo → tail === mount → pass through unchanged.
-    // Not a "real" config but pins the equality branch of the detection.
+  test("management_url equality edge: candidate equals mount exactly", async () => {
+    // mount=/foo, candidate=/foo → origin-absolute, verbatim — same output
+    // as the pre-B4 equality branch, simpler rule.
     writeManifest(h.manifestPath, [
       {
         name: "parachute-vault",

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -5253,6 +5253,50 @@ describe("force-change-password per-request gate (#469)", () => {
     }
   });
 
+  test("(a) pre-rotation browser GET /vault/admin/ is 302'd to change-password (B-route gate parity)", async () => {
+    // The daemon-level /vault/admin mount applies the SAME per-request
+    // force-change-password gate as the per-vault proxy — a pre-rotation
+    // session can't reach the multi-vault admin surface on an un-rotated
+    // temp password either.
+    const h = makeHarness();
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              // Canonical row name so findServiceByShort would resolve it if
+              // the request ever got past the gate.
+              name: "parachute-vault",
+              port: 1940,
+              paths: ["/vault/work"],
+              health: "/vault/work/health",
+              version: "0.5.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const { cookie } = await seedUser(h, db, {
+          passwordChanged: false,
+          assignedVaults: ["work"],
+        });
+        const res = await hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath })(
+          req("/vault/admin/", { headers: { cookie, accept: "text/html" } }),
+        );
+        // Gated BEFORE proxyToVaultAdmin ever runs — the gate's 302, not a
+        // proxy 404/502.
+        expect(res.status).toBe(302);
+        expect(res.headers.get("location")).toBe("/account/change-password");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("(b) pre-rotation user CAN still reach /account/change-password (GET)", async () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -4098,6 +4098,208 @@ describe("hubFetch publicExposure layer-gate (proxyToVault)", () => {
   });
 });
 
+describe("hubFetch /vault/admin daemon-level mount (B-route, hub-module-boundary)", () => {
+  // /vault/admin + /vault/admin/* route to the vault MODULE's daemon
+  // (resolved via findServiceByShort, not findVaultUpstream) — the
+  // daemon-level multi-vault admin surface, not an instance path. "admin"
+  // is a reserved vault name (B2h) so no instance can ever claim the mount.
+
+  /** Upstream that ECHOES the request path, so the tests can pin both which
+   * daemon got the request and that the FULL path was forwarded (vault's
+   * row declares no stripPrefix). */
+  function startEchoUpstream(tag: string): { port: number; stop: () => void } {
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: (r) =>
+        new Response(JSON.stringify({ tag, path: new URL(r.url).pathname }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    });
+    return { port: server.port as number, stop: () => server.stop(true) };
+  }
+
+  const fakeServer = (address: string) => ({ requestIP: () => ({ address }) });
+
+  test("/vault/admin and /vault/admin/* route to the vault module's daemon port with the FULL path", async () => {
+    const h = makeHarness();
+    const upstream = startEchoUpstream("vault-daemon");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              // The canonical self-registered row name — findServiceByShort
+              // resolves `parachute-vault` → short "vault".
+              name: "parachute-vault",
+              port: upstream.port,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.5.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      for (const path of ["/vault/admin", "/vault/admin/", "/vault/admin/assets/app.js"]) {
+        const res = await fetcher(req(path));
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { tag: string; path: string };
+        expect(body.tag).toBe("vault-daemon");
+        // Full path forwarded — no prefix strip (vault routes /vault/admin itself).
+        expect(body.path).toBe(path);
+      }
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("/vault/admin is NOT captured by a per-instance mount — daemon-level route wins", async () => {
+    // A pathological vault row mounted at the bare `/vault` would prefix-match
+    // `/vault/admin` in findVaultUpstream; the daemon-level branch runs FIRST
+    // so the per-vault proxy never sees the path (and no consumer can
+    // fabricate a phantom instance named "admin"). With distinct upstream
+    // ports we can tell exactly which one served the request.
+    const h = makeHarness();
+    const daemonUpstream = startEchoUpstream("vault-daemon");
+    const instanceUpstream = startEchoUpstream("vault-instance");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: daemonUpstream.port,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.5.0",
+            },
+            {
+              // Pathological-but-representable bare mount on a second row.
+              name: "parachute-vault-bare",
+              port: instanceUpstream.port,
+              paths: ["/vault"],
+              health: "/vault/health",
+              version: "0.5.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(req("/vault/admin/"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { tag: string };
+      expect(body.tag).toBe("vault-daemon");
+    } finally {
+      daemonUpstream.stop();
+      instanceUpstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test('a vault instance named "adminx" still routes per-instance (exact-segment match only)', async () => {
+    const h = makeHarness();
+    const upstream = startEchoUpstream("vault-daemon");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: upstream.port,
+              paths: ["/vault/adminx"],
+              health: "/vault/adminx/health",
+              version: "0.5.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      // Per-instance path — proxied through the per-vault dispatch (full
+      // path forwarded; vault rows don't strip).
+      const res = await fetcher(req("/vault/adminx/health"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { path: string };
+      expect(body.path).toBe("/vault/adminx/health");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("404 cleanly when no vault module is installed", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              // Some other module installed — must not capture /vault/admin.
+              name: "parachute-scribe",
+              port: 1942,
+              paths: ["/scribe"],
+              health: "/scribe/health",
+              version: "0.1.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(req("/vault/admin/"));
+      expect(res.status).toBe(404);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test('publicExposure: "loopback" on the vault row cloaks /vault/admin from tailnet/public (same gate as proxyToVault)', async () => {
+    const h = makeHarness();
+    const upstream = startEchoUpstream("vault-daemon");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: upstream.port,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.5.0",
+              publicExposure: "loopback",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      // Tailnet caller → cloaked.
+      const tailnet = await fetcher(
+        req("/vault/admin/", { headers: { "Tailscale-User-Login": "alice@example.com" } }),
+      );
+      expect(tailnet.status).toBe(404);
+      // Public caller → cloaked.
+      const pub = await fetcher(req("/vault/admin/", { headers: { "CF-Ray": "abc123" } }));
+      expect(pub.status).toBe(404);
+      // Header-absent NON-loopback peer (0.0.0.0 bind) → cloaked (#526 posture).
+      const direct = await fetcher(req("/vault/admin/"), fakeServer("198.51.100.4"));
+      expect(direct.status).toBe(404);
+      // Loopback peer → reaches the daemon.
+      const loop = await fetcher(req("/vault/admin/"), fakeServer("127.0.0.1"));
+      expect(loop.status).toBe(200);
+      expect(((await loop.json()) as { tag: string }).tag).toBe("vault-daemon");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+});
+
 /** Find a port that no one is listening on by binding briefly and releasing. */
 async function pickClosedPort(): Promise<number> {
   const s = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("x") });

--- a/src/__tests__/invites.test.ts
+++ b/src/__tests__/invites.test.ts
@@ -27,6 +27,7 @@ import {
   issueInvite,
   listInvites,
   revokeInvite,
+  revokeInvitesForVault,
 } from "../invites.ts";
 import { createUser } from "../users.ts";
 
@@ -177,6 +178,32 @@ describe("revokeInvite", () => {
       const b = issueInvite(db, { createdBy: adminId });
       consumeInvite(db, b.invite.tokenHash, adminId);
       expect(revokeInvite(db, b.invite.tokenHash)).toBe(false); // already used
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("revokeInvitesForVault (B1 cascade step)", () => {
+  test("a NULL-vault_name invite (redeemer-named flow) is NOT revoked by any vault's cascade", async () => {
+    // The cascade invalidates invites PINNED to the deleted vault — an
+    // unpinned invite (vault_name NULL: the redeemer names their own vault)
+    // can't resurrect a specific name, so it must survive every vault's
+    // delete. SQL `vault_name = ?` never matches NULL; pin that boundary.
+    const { db, adminId, cleanup } = await makeDb();
+    try {
+      const unpinned = issueInvite(db, { createdBy: adminId }); // vault_name NULL
+      const pinned = issueInvite(db, { createdBy: adminId, vaultName: "work" });
+
+      expect(revokeInvitesForVault(db, "work")).toBe(1);
+      // The pinned invite is revoked; the unpinned one rides on untouched.
+      expect(findInviteByRawToken(db, pinned.rawToken)?.revokedAt).not.toBeNull();
+      expect(findInviteByRawToken(db, unpinned.rawToken)?.revokedAt).toBeNull();
+
+      // A second sweep (or another vault's sweep) finds nothing more.
+      expect(revokeInvitesForVault(db, "work")).toBe(0);
+      expect(revokeInvitesForVault(db, "other")).toBe(0);
+      expect(findInviteByRawToken(db, unpinned.rawToken)?.revokedAt).toBeNull();
     } finally {
       cleanup();
     }

--- a/src/__tests__/module-manifest.test.ts
+++ b/src/__tests__/module-manifest.test.ts
@@ -127,7 +127,19 @@ describe("validateModuleManifest", () => {
     expect(m.managementUrl).toBe("https://admin.example.com/");
   });
 
-  test("managementUrl rejects empty / non-string / non-url-or-path", () => {
+  test("managementUrl accepts the relative (per-instance) form — B4", () => {
+    // Unified URL semantics (2026-06-09 hub-module-boundary, B4): a relative
+    // path (no leading slash) is the per-instance form resolvers join under
+    // the module's mount. Vault's new manifest declares `"admin/"`.
+    expect(validateModuleManifest({ ...VALID, managementUrl: "admin/" }, "x").managementUrl).toBe(
+      "admin/",
+    );
+    expect(
+      validateModuleManifest({ ...VALID, managementUrl: "deep/admin" }, "x").managementUrl,
+    ).toBe("deep/admin");
+  });
+
+  test("managementUrl rejects empty / non-string / bad-scheme / traversal", () => {
     expect(() => validateModuleManifest({ ...VALID, managementUrl: "" }, "x")).toThrow(
       /managementUrl/,
     );
@@ -135,11 +147,16 @@ describe("validateModuleManifest", () => {
       /managementUrl/,
     );
     expect(() =>
-      validateModuleManifest({ ...VALID, managementUrl: "no-leading-slash" }, "x"),
-    ).toThrow(/path starting with "\/" or a full http\(s\) URL/);
-    expect(() =>
       validateModuleManifest({ ...VALID, managementUrl: "ftp://example.com" }, "x"),
     ).toThrow(/http:.*https:/);
+    // Scheme-bearing non-URL strings must not smuggle through as "relative".
+    expect(() =>
+      validateModuleManifest({ ...VALID, managementUrl: "javascript:alert(1)" }, "x"),
+    ).toThrow(/managementUrl/);
+    // The relative form can only deepen its mount — no `..` traversal.
+    expect(() =>
+      validateModuleManifest({ ...VALID, managementUrl: "../other/admin" }, "x"),
+    ).toThrow(/\.\./);
   });
 
   // --- 2026-06-09 modular-UI architecture P1 fields: focus / configUiUrl /
@@ -156,7 +173,7 @@ describe("validateModuleManifest", () => {
     expect(() => validateModuleManifest({ ...VALID, focus: 1 }, "x")).toThrow(/focus/);
   });
 
-  test("configUiUrl follows the path-or-url shape", () => {
+  test("configUiUrl follows the path-or-url shape (incl. the B4 relative form)", () => {
     expect(
       validateModuleManifest({ ...VALID, configUiUrl: "/scribe/admin" }, "x").configUiUrl,
     ).toBe("/scribe/admin");
@@ -164,8 +181,9 @@ describe("validateModuleManifest", () => {
       validateModuleManifest({ ...VALID, configUiUrl: "https://cfg.example.com/" }, "x")
         .configUiUrl,
     ).toBe("https://cfg.example.com/");
-    expect(() => validateModuleManifest({ ...VALID, configUiUrl: "nope" }, "x")).toThrow(
-      /configUiUrl/,
+    // Relative = the per-instance mount-joined form (B4) — valid.
+    expect(validateModuleManifest({ ...VALID, configUiUrl: "admin/" }, "x").configUiUrl).toBe(
+      "admin/",
     );
     expect(() => validateModuleManifest({ ...VALID, configUiUrl: "//evil.com" }, "x")).toThrow(
       /configUiUrl/,
@@ -314,15 +332,17 @@ describe("validateModuleManifest", () => {
     expect(m.uiUrl).toBe("https://app.example.com/");
   });
 
-  test("uiUrl rejects empty / non-string / non-url-or-path (mirrors managementUrl)", () => {
+  test("uiUrl accepts the relative (per-instance) form — B4 (mirrors managementUrl)", () => {
+    expect(validateModuleManifest({ ...VALID, uiUrl: "admin/" }, "x").uiUrl).toBe("admin/");
+  });
+
+  test("uiUrl rejects empty / non-string / bad-scheme / traversal (mirrors managementUrl)", () => {
     expect(() => validateModuleManifest({ ...VALID, uiUrl: "" }, "x")).toThrow(/uiUrl/);
     expect(() => validateModuleManifest({ ...VALID, uiUrl: 7 }, "x")).toThrow(/uiUrl/);
-    expect(() => validateModuleManifest({ ...VALID, uiUrl: "no-slash" }, "x")).toThrow(
-      /path starting with "\/" or a full http\(s\) URL/,
-    );
     expect(() => validateModuleManifest({ ...VALID, uiUrl: "ftp://example.com" }, "x")).toThrow(
       /http:.*https:/,
     );
+    expect(() => validateModuleManifest({ ...VALID, uiUrl: "../sneaky" }, "x")).toThrow(/\.\./);
   });
 
   test("uiUrl absent stays absent", () => {

--- a/src/__tests__/module-manifest.test.ts
+++ b/src/__tests__/module-manifest.test.ts
@@ -157,6 +157,23 @@ describe("validateModuleManifest", () => {
     expect(() =>
       validateModuleManifest({ ...VALID, managementUrl: "../other/admin" }, "x"),
     ).toThrow(/\.\./);
+    // Backslash-traversal closure: WHATWG URL parsing treats `\` as `/` in
+    // http(s) schemes, so `a\..\b` would normalize to `a/../b` post-join and
+    // pop a segment past the `..`-segment check. Any backslash → invalid.
+    expect(() => validateModuleManifest({ ...VALID, managementUrl: "a\\..\\b" }, "x")).toThrow(
+      /backslash/,
+    );
+  });
+
+  test("percent-encoded ..%2f is inert in the relative form (URL base-join doesn't decode)", () => {
+    // The validator ACCEPTS `..%2f...` — it isn't a literal ".." segment and
+    // needs no guard, because `new URL()` does not decode percent-escapes
+    // during base-join: the segment stays the literal "..%2fadmin" and never
+    // traverses. Pin the resolution behavior the safety argument rests on.
+    const m = validateModuleManifest({ ...VALID, managementUrl: "..%2fadmin" }, "x");
+    expect(m.managementUrl).toBe("..%2fadmin");
+    const joined = new URL("/vault/default/..%2fadmin", "https://x.example/");
+    expect(joined.pathname).toBe("/vault/default/..%2fadmin"); // no segment popped
   });
 
   // --- 2026-06-09 modular-UI architecture P1 fields: focus / configUiUrl /

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -3158,6 +3158,54 @@ describe("typed vault name (hub#267)", () => {
     }
   });
 
+  test("vault POST rejects every consolidated reserved name (B2h: list, new, assets, admin)", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const { createSession } = await import("../sessions.ts");
+      const session = createSession(db, { userId: user.id });
+      const get = handleSetupGet(req("/admin/setup"), {
+        db,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
+        issuer: "https://hub.example",
+        registry: getDefaultOperationsRegistry(),
+      });
+      const csrf = setCookie(get, CSRF_COOKIE_NAME) ?? "";
+      for (const name of ["list", "new", "assets", "admin"]) {
+        const post = await handleSetupVaultPost(
+          req("/admin/setup/vault", {
+            method: "POST",
+            body: new URLSearchParams({
+              [CSRF_FIELD_NAME]: csrf,
+              vault_name: name,
+            }).toString(),
+            headers: {
+              "content-type": "application/x-www-form-urlencoded",
+              cookie: `${CSRF_COOKIE_NAME}=${csrf}; ${SESSION_COOKIE_NAME}=${session.id}`,
+            },
+          }),
+          {
+            db,
+            manifestPath: h.manifestPath,
+            configDir: h.dir,
+            readExposeStateFn: h.readExposeStateFn,
+            issuer: "https://hub.example",
+            supervisor: makeSupervisor(),
+            registry: getDefaultOperationsRegistry(),
+          },
+        );
+        expect(post.status).toBe(400);
+        const html = await post.text();
+        expect(html).toContain("reserved");
+        expect(getSetting(db, "setup_vault_name")).toBeUndefined();
+      }
+    } finally {
+      db.close();
+    }
+  });
+
   test("vault POST with empty name falls back to 'default' + omits the env override", async () => {
     const db = openHubDb(hubDbPath(h.dir));
     try {

--- a/src/__tests__/vault-name.test.ts
+++ b/src/__tests__/vault-name.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { DEFAULT_VAULT_NAME, validateVaultName } from "../vault-name.ts";
+import { DEFAULT_VAULT_NAME, RESERVED_VAULT_NAMES, validateVaultName } from "../vault-name.ts";
 
 describe("validateVaultName", () => {
   test("accepts lowercase alphanumeric + hyphens/underscores", () => {
@@ -64,10 +64,25 @@ describe("validateVaultName", () => {
     expect(validateVaultName("   ").ok).toBe(false);
   });
 
-  test("rejects the reserved name 'list' (matches vault's reservation)", () => {
-    const result = validateVaultName("list");
-    expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.error).toContain("reserved");
+  test("rejects every consolidated reserved name (B2h: list, new, assets, admin)", () => {
+    // One set for every hub edge — wizard, invite redemption, POST /vaults.
+    // `list` mirrors vault's CLI reservation; `new`/`assets` shadow SPA
+    // routes; `admin` shadows the daemon-level /vault/admin mount (B-route).
+    for (const name of ["list", "new", "assets", "admin"]) {
+      const result = validateVaultName(name);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("reserved");
+    }
+  });
+
+  test("near-miss names of the reserved set still pass (admins, listing, my-admin)", () => {
+    for (const name of ["admins", "listing", "my-admin", "assets2", "newer"]) {
+      expect(validateVaultName(name).ok).toBe(true);
+    }
+  });
+
+  test("RESERVED_VAULT_NAMES is the consolidated four-name set", () => {
+    expect([...RESERVED_VAULT_NAMES].sort()).toEqual(["admin", "assets", "list", "new"]);
   });
 
   test("DEFAULT_VAULT_NAME is 'default'", () => {

--- a/src/__tests__/well-known.test.ts
+++ b/src/__tests__/well-known.test.ts
@@ -361,21 +361,41 @@ describe("buildWellKnown", () => {
     expect(notesSvc?.uiUrl).toBe("https://x.example/notes");
   });
 
-  // Workstream C (patterns#96): vault declares `uiUrl: "/admin/"` as a
-  // per-instance path. buildWellKnown applies the per-instance mount-path
-  // prefix on emission, yielding one tile per vault instance pointing at
-  // `<origin>/vault/<name>/admin/`. Non-vault uiUrl behavior is unchanged.
-  test("vault uiUrl is prefixed with the per-instance mount path (single instance)", () => {
+  // B4 unified semantics (2026-06-09 hub-module-boundary): relative
+  // (no leading slash) = the per-instance form, mount-joined per vault
+  // instance; leading-"/" = origin-absolute pass-through. The literal legacy
+  // `"/admin/"` on a vault entry rides the one-release COMPAT SHIM
+  // (mount-join + deprecation log) because deployed vaults still declare it.
+  test("vault RELATIVE uiUrl mount-joins per instance (B4 per-instance form)", () => {
     const doc = buildWellKnown({
       services: [vault],
       canonicalOrigin: "https://x.example",
-      uiUrlFor: () => "/admin/",
+      uiUrlFor: () => "admin/",
     });
     const svc = doc.services.find((s) => s.name === "parachute-vault");
     expect(svc?.uiUrl).toBe("https://x.example/vault/default/admin/");
   });
 
-  test("vault uiUrl is prefixed per-instance for multi-path vault entries", () => {
+  test("vault RELATIVE uiUrl mount-joins per instance for multi-path vault entries", () => {
+    const multi: ServiceEntry = { ...vault, paths: ["/vault/default", "/vault/techne"] };
+    const doc = buildWellKnown({
+      services: [multi],
+      canonicalOrigin: "https://x.example",
+      uiUrlFor: () => "admin/",
+    });
+    const rows = doc.services.filter((s) => s.name === "parachute-vault");
+    expect(rows.length).toBe(2);
+    const uiUrls = rows.map((r) => r.uiUrl).sort();
+    expect(uiUrls[0]).toBe("https://x.example/vault/default/admin/");
+    expect(uiUrls[1]).toBe("https://x.example/vault/techne/admin/");
+  });
+
+  test('COMPAT SHIM: vault legacy "/admin/" uiUrl still mount-joins per instance (one release)', () => {
+    // Deployed vaults declare `uiUrl: "/admin/"` (the OLD per-instance form).
+    // Origin-absolute resolution would point every tile at the daemon-level
+    // /vault/admin mount — so the literal "/admin"/"/admin/" keeps the old
+    // mount-join for one release, with a deprecation log. Remove the shim
+    // once vault's new manifest ("admin/") reaches @latest.
     const multi: ServiceEntry = { ...vault, paths: ["/vault/default", "/vault/techne"] };
     const doc = buildWellKnown({
       services: [multi],
@@ -383,10 +403,26 @@ describe("buildWellKnown", () => {
       uiUrlFor: () => "/admin/",
     });
     const rows = doc.services.filter((s) => s.name === "parachute-vault");
-    expect(rows.length).toBe(2);
     const uiUrls = rows.map((r) => r.uiUrl).sort();
     expect(uiUrls[0]).toBe("https://x.example/vault/default/admin/");
     expect(uiUrls[1]).toBe("https://x.example/vault/techne/admin/");
+  });
+
+  test("vault LEADING-SLASH uiUrl (non-shim) is origin-absolute pass-through (B4)", () => {
+    // The daemon-level surface form: `/vault/admin/` resolves against the
+    // origin — NOT per-instance — so a multi-path vault emits the same
+    // daemon-level URL on each row.
+    const multi: ServiceEntry = { ...vault, paths: ["/vault/default", "/vault/techne"] };
+    const doc = buildWellKnown({
+      services: [multi],
+      canonicalOrigin: "https://x.example",
+      uiUrlFor: () => "/vault/admin/",
+    });
+    const rows = doc.services.filter((s) => s.name === "parachute-vault");
+    expect(rows.length).toBe(2);
+    for (const r of rows) {
+      expect(r.uiUrl).toBe("https://x.example/vault/admin/");
+    }
   });
 
   test("vault uiUrl absolute URL still passes through verbatim (no prefix)", () => {

--- a/src/account-vault-admin-token.ts
+++ b/src/account-vault-admin-token.ts
@@ -77,10 +77,12 @@ export interface AccountVaultAdminTokenDeps {
   hubOrigin: string;
   /**
    * The vault's declared `managementUrl` (from its `.parachute/module.json`),
-   * resolved by the route handler at request time. Either an absolute URL or a
-   * path relative to the vault's mounted URL. Defaults to `/admin/` (vault's
-   * canonical value) when the handler can't resolve one — that's where the
-   * admin sibling's deep-link lands too.
+   * resolved by the route handler at request time. Resolved per the B4
+   * unified semantics (http(s):// verbatim · leading-`/` origin-absolute ·
+   * relative joined under the vault's mounted URL; the literal legacy
+   * `"/admin/"` mount-joins via the one-release compat shim). Defaults to
+   * `"admin/"` (vault's canonical per-instance value) when the handler can't
+   * resolve one — that's where the admin sibling's deep-link lands too.
    */
   managementUrl?: string;
   /** Test seam for the clock (mint). */
@@ -94,17 +96,43 @@ function htmlResponse(body: string, status = 200, extra: Record<string, string> 
   });
 }
 
+/** One-time deprecation log for the legacy `"/admin/"` managementUrl (B4 compat shim). */
+let warnedLegacyManagementUrl = false;
+
 /**
  * Resolve a vault's `managementUrl` against the vault's hub-mounted URL.
- * Absolute URL → returned verbatim; path → joined onto the vault URL after
- * trimming a trailing slash. Mirrors `resolveManagementUrl` in the SPA's
- * `web/ui/src/lib/api.ts` so hub-server and SPA deep-links agree.
+ * Unified URL-resolution semantics (B4 of the 2026-06-09 hub-module-boundary
+ * migration) — mirrors `resolveManagementUrl` in the SPA's
+ * `web/ui/src/lib/api.ts` so hub-server and SPA deep-links agree:
+ *
+ *   - Absolute http(s) URL → verbatim.
+ *   - Leading-`/` path → ORIGIN-ABSOLUTE: resolved against the vault URL's
+ *     origin (not joined under the vault mount).
+ *   - Relative path (no leading slash, e.g. `"admin/"`) → the PER-INSTANCE
+ *     form: joined under the vault's mounted URL
+ *     (`<origin>/vault/<name>/admin/`).
+ *
+ * COMPAT SHIM (one release — remove once vault's new manifest reaches
+ * @latest): the literal legacy `"/admin"`/`"/admin/"` is the OLD per-instance
+ * relative declaration deployed vaults still ship; it joins under the vault
+ * URL (the pre-B4 behavior) with a one-time deprecation log.
  */
 function resolveManagementUrl(vaultUrl: string, managementUrl: string): string {
   if (/^https?:\/\//i.test(managementUrl)) return managementUrl;
   const base = vaultUrl.replace(/\/+$/, "");
-  const tail = managementUrl.startsWith("/") ? managementUrl : `/${managementUrl}`;
-  return `${base}${tail}`;
+  if (managementUrl === "/admin" || managementUrl === "/admin/") {
+    if (!warnedLegacyManagementUrl) {
+      warnedLegacyManagementUrl = true;
+      console.warn(
+        `account-vault-admin-token: vault declares the legacy per-instance managementUrl ${JSON.stringify(managementUrl)}; joining under the vault URL for one release. New semantics: relative ("admin/") = per-instance join, leading-"/" = origin-absolute. Upgrade the vault module to clear this.`,
+      );
+    }
+    return `${base}${managementUrl}`;
+  }
+  if (managementUrl.startsWith("/")) {
+    return new URL(managementUrl, `${base}/`).toString();
+  }
+  return `${base}/${managementUrl}`;
 }
 
 export async function handleAccountVaultAdminTokenPost(
@@ -224,14 +252,15 @@ export async function handleAccountVaultAdminTokenPost(
     ...(deps.now !== undefined ? { now: deps.now } : {}),
   });
 
-  // Build the redirect target: <vault-url><managementUrl>#token=<jwt>. The
+  // Build the redirect target: <vault-url>/<managementUrl>#token=<jwt>. The
   // vault URL is the hub-mounted path (`<hubOrigin>/vault/<name>`); the
-  // managementUrl (default `/admin/`) is the vault admin SPA entry point. The
-  // JWT rides the URL fragment — never sent to the server — exactly as the hub
-  // SPA's "Manage" button does (vault PR #219).
+  // managementUrl (default `"admin/"` — the per-instance relative form under
+  // the B4 semantics) is the vault admin SPA entry point. The JWT rides the
+  // URL fragment — never sent to the server — exactly as the hub SPA's
+  // "Manage" button does (vault PR #219).
   const trimmedOrigin = deps.hubOrigin.replace(/\/+$/, "");
   const vaultUrl = `${trimmedOrigin}/vault/${vaultName}`;
-  const target = resolveManagementUrl(vaultUrl, deps.managementUrl ?? "/admin/");
+  const target = resolveManagementUrl(vaultUrl, deps.managementUrl ?? "admin/");
   const sep = target.includes("#") ? "&" : "#";
   const location = `${target}${sep}token=${minted.token}`;
 

--- a/src/admin-connections.ts
+++ b/src/admin-connections.ts
@@ -554,7 +554,14 @@ async function prepareChannelSink(
 // DELETE — teardown
 // ---------------------------------------------------------------------------
 
-async function teardownConnection(
+/**
+ * Tear down one connection by id: deregister the vault trigger, delete the
+ * channel-config entry (channel sinks), revoke the registered long-lived
+ * mints (B0), remove the record. Exported for the vault-delete cascade (B1)
+ * — `admin-vaults.handleDeleteVault` reuses this per matching record so the
+ * cascade and the operator-facing DELETE behave identically.
+ */
+export async function teardownConnection(
   id: string,
   userId: string,
   deps: ConnectionsDeps,

--- a/src/admin-connections.ts
+++ b/src/admin-connections.ts
@@ -43,7 +43,7 @@ import {
   readConnections,
   removeConnection,
 } from "./connections-store.ts";
-import { signAccessToken } from "./jwt-sign.ts";
+import { recordTokenMint, revokeTokenByJti, signAccessToken } from "./jwt-sign.ts";
 import type { ModuleAction, ModuleEvent, ModuleManifest } from "./module-manifest.ts";
 import { findSession, parseSessionCookie } from "./sessions.ts";
 import { isFirstAdmin } from "./users.ts";
@@ -227,8 +227,17 @@ function listConnections(deps: ConnectionsDeps): Response {
     // Provenance (modular-UI R2). Records written before R2 carry no
     // `requestedBy`; project them as the default so the SPA grouping is total.
     requested_by: c.requestedBy ?? DEFAULT_REQUESTED_BY,
+    // Records provisioned before the registered-mint rule (B0) carry no
+    // mintedJtis — their long-lived tokens were never registered, so teardown
+    // can't revoke them (they ride to their original ~90d expiry).
+    ...(isLegacyRecord(c) ? { legacy: true } : {}),
   }));
   return json(200, { ok: true, connections });
+}
+
+/** A record minted before B0 — no registered jtis, tokens unrevocable. */
+function isLegacyRecord(c: ConnectionRecord): boolean {
+  return (c.provisioned?.mintedJtis?.length ?? 0) === 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -391,6 +400,10 @@ async function createConnection(
     return jsonError(400, "invalid_request", `connection id "${id}" is not a valid identifier`);
   }
 
+  // jtis of the long-lived tokens minted for this connection — persisted on
+  // the record so teardown can revoke them (registered-mint rule).
+  const mintedJtis: string[] = [];
+
   // --- Sink prerequisite (channel reply path), fenced to the channel sink. --
   // Everything below this is general; THIS block is the only sink-specific step.
   // The channel name comes from the action params (`sink.params.channel`) — it
@@ -405,20 +418,21 @@ async function createConnection(
       );
     }
     const prep = await prepareChannelSink(channelName, vault, vaultOrigin, userId, deps);
-    if (prep) return prep; // an error response
+    if (prep.error) return prep.error;
+    mintedJtis.push(prep.replyTokenJti);
   }
 
   // --- Mint the webhook bearer at the action's DECLARED scope. -------------
   let webhookBearer: string;
   try {
-    webhookBearer = (
-      await mint(deps, userId, {
-        scopes: [action.scope],
-        audience: audienceForScope(action.scope, sinkModule),
-        vaultScope: [],
-        ttlSeconds: WEBHOOK_BEARER_TTL_SECONDS,
-      })
-    ).token;
+    const signed = await mint(deps, userId, {
+      scopes: [action.scope],
+      audience: audienceForScope(action.scope, sinkModule),
+      vaultScope: [],
+      ttlSeconds: WEBHOOK_BEARER_TTL_SECONDS,
+    });
+    webhookBearer = signed.token;
+    mintedJtis.push(signed.jti);
   } catch (err) {
     return stepError("mint_webhook_bearer", err);
   }
@@ -457,7 +471,7 @@ async function createConnection(
     id,
     source: sourceRec,
     sink: sinkRec,
-    provisioned: { type: "vault-trigger", vault, triggerName },
+    provisioned: { type: "vault-trigger", vault, triggerName, mintedJtis },
     createdAt: (deps.now?.() ?? new Date()).toISOString(),
     requestedBy,
   };
@@ -481,7 +495,9 @@ async function createConnection(
  * `vault:<v>:write` for the channel + writes the `channels.json` entry on the
  * channel daemon so the session can reply. Fenced to `sink.module === "channel"`
  * — this is sink-specific config, not part of the general vault-trigger engine.
- * Returns an error Response on failure, or `null` on success.
+ * Returns `{ error }` on failure, or `{ error: null, replyTokenJti }` on
+ * success — the jti of the long-lived reply token, so the caller can persist
+ * it for teardown revocation.
  */
 async function prepareChannelSink(
   channelName: string,
@@ -489,20 +505,24 @@ async function prepareChannelSink(
   vaultOrigin: string,
   userId: string,
   deps: ConnectionsDeps,
-): Promise<Response | null> {
+): Promise<{ error: Response } | { error: null; replyTokenJti: string }> {
   if (deps.channelOrigin === null) {
-    return jsonError(503, "channel_unavailable", "the channel module is not installed on this hub");
+    return {
+      error: jsonError(
+        503,
+        "channel_unavailable",
+        "the channel module is not installed on this hub",
+      ),
+    };
   }
   const fetchImpl = deps.fetchImpl ?? fetch;
   try {
-    const vaultWriteToken = (
-      await mint(deps, userId, {
-        scopes: [`vault:${vault}:write`],
-        audience: `vault.${vault}`,
-        vaultScope: [vault],
-        ttlSeconds: WEBHOOK_BEARER_TTL_SECONDS, // channel keeps it for its lifetime
-      })
-    ).token;
+    const vaultWriteSigned = await mint(deps, userId, {
+      scopes: [`vault:${vault}:write`],
+      audience: `vault.${vault}`,
+      vaultScope: [vault],
+      ttlSeconds: WEBHOOK_BEARER_TTL_SECONDS, // channel keeps it for its lifetime
+    });
     const channelAdminToken = (
       await mint(deps, userId, {
         scopes: ["channel:admin"],
@@ -520,14 +540,14 @@ async function prepareChannelSink(
       body: JSON.stringify({
         name: channelName,
         transport: "vault",
-        config: { vault, vaultUrl: vaultOrigin, token: vaultWriteToken },
+        config: { vault, vaultUrl: vaultOrigin, token: vaultWriteSigned.token },
       }),
     });
-    if (!res.ok) return stepError("channel_config", await describeRemote(res));
+    if (!res.ok) return { error: stepError("channel_config", await describeRemote(res)) };
+    return { error: null, replyTokenJti: vaultWriteSigned.jti };
   } catch (err) {
-    return stepError("channel_config", err);
+    return { error: stepError("channel_config", err) };
   }
-  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -602,6 +622,29 @@ async function teardownConnection(
       }
     } catch (err) {
       errors.push({ step: "channel_config", detail: errMsg(err) });
+    }
+  }
+
+  // --- Revoke the registered long-lived mints (B0, registered-mint rule). ---
+  // Marks each tokens-registry row revoked → the revocation list at
+  // `/.well-known/parachute-revocation.json` advertises the jtis, and every
+  // resource server (vault, channel) rejects the credential from its next
+  // poll. Runs regardless of remote-teardown outcome — revocation is the safe
+  // direction. Legacy records (provisioned before B0) carry no jtis: teardown
+  // proceeds, but their tokens were never registered and ride to expiry.
+  const mintedJtis = record.provisioned?.mintedJtis ?? [];
+  if (mintedJtis.length === 0) {
+    console.warn(
+      `[connections] connection "${id}" predates registered mints — its provisioned tokens were never registered and ride to their original expiry`,
+    );
+  } else {
+    const now = deps.now?.() ?? new Date();
+    for (const jti of mintedJtis) {
+      try {
+        revokeTokenByJti(deps.db, jti, now);
+      } catch (err) {
+        errors.push({ step: "revoke_mints", detail: `jti ${jti}: ${errMsg(err)}` });
+      }
     }
   }
 
@@ -789,6 +832,17 @@ function sessionUser(req: Request, deps: ConnectionsDeps): { userId: string } {
 
 // --- Mint -------------------------------------------------------------------
 
+/**
+ * TTL boundary between "interactive" mints (used immediately, ride to expiry
+ * by design — the documented ≤10-min unregistered bound) and LONG-LIVED mints,
+ * which MUST be registered in the tokens table so they stay revocable
+ * (hub-module-boundary charter, registered-mint rule). The audit that produced
+ * the rule found this engine minting ~90-day tokens with no registry row — an
+ * unrevocable-by-construction credential (`api-revoke-token` 404s unknown
+ * jtis; the revocation list only carries registered jtis).
+ */
+const REGISTERED_MINT_TTL_THRESHOLD_SECONDS = 10 * 60;
+
 interface MintSpec {
   scopes: string[];
   audience: string;
@@ -798,7 +852,7 @@ interface MintSpec {
 
 async function mint(deps: ConnectionsDeps, userId: string, spec: MintSpec) {
   const sign = deps.signToken ?? signAccessToken;
-  return sign(deps.db, {
+  const signed = await sign(deps.db, {
     sub: userId,
     scopes: spec.scopes,
     audience: spec.audience,
@@ -808,6 +862,21 @@ async function mint(deps: ConnectionsDeps, userId: string, spec: MintSpec) {
     vaultScope: spec.vaultScope,
     ...(deps.now !== undefined ? { now: deps.now } : {}),
   });
+  // Register long-lived mints so they're revocable on teardown. Short-lived
+  // provisioning tokens (60s, consumed inline) stay unregistered by design.
+  if (spec.ttlSeconds > REGISTERED_MINT_TTL_THRESHOLD_SECONDS) {
+    recordTokenMint(deps.db, {
+      jti: signed.jti,
+      createdVia: "connection_provision",
+      subject: "connection",
+      userId,
+      clientId: PROVISION_CLIENT_ID,
+      scopes: spec.scopes,
+      expiresAt: signed.expiresAt,
+      ...(deps.now !== undefined ? { now: deps.now } : {}),
+    });
+  }
+  return signed;
 }
 
 // --- Response helpers -------------------------------------------------------

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -726,6 +726,16 @@ export async function handleDeleteVault(
   // --- 1. Registry sweep: revoke every tokens row naming the vault. --------
   summary.tokens_revoked = revokeTokensNamingVault(deps.db, name, now);
 
+  // NOTE on `auth_codes.scopes` — the one identity-artifact column from the
+  // charter's enumeration deliberately NOT swept here. Authorization codes
+  // are transient by construction: AUTH_CODE_TTL_SECONDS = 60 (auth-codes.ts)
+  // and single-use. A code naming the deleted vault either (a) expires
+  // unredeemed within the minute, or (b) redeems into tokens whose registry
+  // rows the sweep above already governs — and whose requests the evicted
+  // daemon no longer serves. Sweeping a 60-second-lived table adds a step
+  // with no security delta; same class as the documented ≤10-min
+  // unregistered interactive-mint bound.
+
   // --- 2. Grants rewrite (drop rows only when emptied). ---------------------
   const grants = rewriteGrantsRemovingVault(deps.db, name);
   summary.grants_rewritten = grants.rewritten;
@@ -783,6 +793,9 @@ export async function handleDeleteVault(
   if (deps.channelOrigin !== null) {
     try {
       const fetchImpl = deps.fetchImpl ?? fetch;
+      // Short-lived (60s) — stays below the registered-mint threshold by
+      // design (the documented ≤10-min interactive bound; see B0's
+      // REGISTERED_MINT_TTL_THRESHOLD_SECONDS in admin-connections.ts).
       const scanToken = (
         await signAccessToken(deps.db, {
           sub: adminSub,

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -60,27 +60,20 @@ import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./adm
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import { findService, type readManifest, readManifestLenient } from "./services-manifest.ts";
 import { enrichedPath } from "./spawn-path.ts";
-import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
+import { RESERVED_VAULT_NAMES, VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
 import { type WellKnownVaultEntry, isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
 
 /** Scope required to call POST /vaults. */
 export const HOST_ADMIN_SCOPE = "parachute:host:admin";
 
-/**
- * Mirror parachute-vault's `cmdCreate` validation rules, plus hub-only
- * reservations for SPA-route shadowing. `list` matches the CLI; `new` and
- * `assets` would collide with `/vault/new` (the SPA's create-vault route)
- * and `/vault/assets/*` (the SPA's static asset bundle) respectively, so
- * the hub rejects them at the API edge before a vault under those names
- * can register and capture the proxy path.
- */
 // Lowercase-only (item I) — single source of truth in vault-name.ts. Vault's
 // init enforces `[a-z0-9_-]`; a hub-side `[a-zA-Z0-9_-]` superset let an
 // uppercased name through that vault would then lowercase or reject, drifting
-// the hub's idea of the vault from vault's. The hub-only reservations (`new`,
-// `assets`) shadow SPA routes and stay on top of vault's `list`.
+// the hub's idea of the vault from vault's. The reserved set is the ONE
+// consolidated `RESERVED_VAULT_NAMES` from vault-name.ts (B2h) — this file
+// used to carry its own `{list, new, assets}` copy that drifted from the
+// `{list}`-only set gating the wizard + invite redemption.
 const VAULT_NAME_PATTERN = VAULT_NAME_CHARSET_RE;
-const RESERVED_VAULT_NAMES = new Set(["list", "new", "assets"]);
 
 export interface CreateVaultRequest {
   name: string;

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -1,5 +1,7 @@
 /**
  * `POST /vaults` — provision a new vault on the host.
+ * `DELETE /vaults/<name>` — destroy a vault WITH the identity cascade
+ * (B1, 2026-06-09 hub-module-boundary migration — see `handleDeleteVault`).
  *
  * The hub's first authenticated, mutating endpoint. Until now the hub has
  * been a pure issuer; Phase 1 of the vault-config-and-scopes design (D1)
@@ -57,9 +59,15 @@
  */
 import type { Database } from "bun:sqlite";
 import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
+import { type ConnectionsDeps, teardownConnection } from "./admin-connections.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
+import { readConnections } from "./connections-store.ts";
+import { rewriteGrantsRemovingVault } from "./grants.ts";
+import { revokeInvitesForVault } from "./invites.ts";
+import { revokeTokensNamingVault, signAccessToken } from "./jwt-sign.ts";
 import { findService, type readManifest, readManifestLenient } from "./services-manifest.ts";
 import { enrichedPath } from "./spawn-path.ts";
+import { removeVaultAssignments } from "./users.ts";
 import { RESERVED_VAULT_NAMES, VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
 import { type WellKnownVaultEntry, isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
 
@@ -496,4 +504,368 @@ export async function handleCreateVault(req: Request, deps: CreateVaultDeps): Pr
     status: 201,
     headers: { "content-type": "application/json" },
   });
+}
+
+// ===========================================================================
+// DELETE /vaults/<name> — the identity cascade (B1, 2026-06-09
+// hub-module-boundary migration: lifecycle symmetry)
+// ===========================================================================
+//
+// "Every provision flow must have a deprovision flow that cascades the
+// identity artifacts it created." Mechanics deletion without identity
+// cascade is a security hole: before B1, vault deletion was CLI-only
+// (`parachute-vault remove`) and left every hub-side identity artifact
+// naming the vault alive — scoped tokens, grants, user assignments, pinned
+// invites, connections. This handler enumerates the full artifact list and
+// handles every entry.
+//
+// Documented bound: short-lived (≤10-min) unregistered interactive mints
+// ride to expiry by design — the cascade revokes persisted registry rows
+// and publishes the revocation list; it does not claim instant revocation
+// of in-flight interactive JWTs.
+
+/** Client id stamped on the short-lived channel-scan mint. */
+const DELETE_VAULT_CLIENT_ID = "parachute-hub-spa";
+/** TTL for the cascade's interactive provisioning mints (channel scan). */
+const DELETE_VAULT_PROVISION_TTL_SECONDS = 60;
+
+export interface DeleteVaultDeps {
+  db: Database;
+  /** Hub origin — JWT `iss` validation + cascade mint issuer. */
+  issuer: string;
+  /** Override the services.json path. Defaults to `~/.parachute/services.json`. */
+  manifestPath?: string;
+  /** Absolute path to `connections.json` in the hub state dir. */
+  connectionsStorePath: string;
+  /** Loopback origin for the channel daemon, or `null` when not installed. */
+  channelOrigin: string | null;
+  /** Resolve a vault's loopback origin from services.json (trigger teardown). */
+  resolveVaultOrigin: (vaultName: string) => string | null;
+  /** Test seam: run `parachute-vault remove` — same Runner seam as create. */
+  runCommand?: CreateVaultDeps["runCommand"];
+  /**
+   * Supervisor-restart the vault module — the daemon-eviction cascade step.
+   * The running daemon caches open store handles, so rmSync alone leaves the
+   * deleted vault SERVING from the open fd; and vault's boot `selfRegister`
+   * rebuilds services.json paths from `listVaults()`, dropping the deleted
+   * path. Wired to the same supervisor machinery the lifecycle verbs use.
+   * Absent (no supervisor — CLI-mode hub, tests) → recorded as a warning in
+   * the response, not silently skipped. (The boundary-conformant per-daemon
+   * store-eviction endpoint is tracked as E9.)
+   */
+  restartVaultModule?: () => Promise<void>;
+  /** Test seam — `globalThis.fetch` in production. */
+  fetchImpl?: typeof fetch;
+  /** Test seam for the clock. */
+  now?: () => Date;
+}
+
+interface DeleteVaultBody {
+  confirm?: unknown;
+}
+
+/** Wire shape of the cascade summary in the 200/500 response. */
+interface CascadeSummary {
+  tokens_revoked: number;
+  grants_rewritten: number;
+  grants_dropped: number;
+  user_vaults_removed: number;
+  invites_invalidated: number;
+  connections_torn_down: number;
+  /**
+   * Vault-backed channel-daemon entries still referencing the deleted vault
+   * AFTER connection teardown (legacy pre-Connections wiring). Surfaced for
+   * the operator — the hub does NOT silently delete channel's config; remove
+   * them from channel's own UI.
+   */
+  orphaned_channels: string[];
+  vault_removed: boolean;
+  module_restarted: boolean;
+}
+
+function emptyCascadeSummary(): CascadeSummary {
+  return {
+    tokens_revoked: 0,
+    grants_rewritten: 0,
+    grants_dropped: 0,
+    user_vaults_removed: 0,
+    invites_invalidated: 0,
+    connections_torn_down: 0,
+    orphaned_channels: [],
+    vault_removed: false,
+    module_restarted: false,
+  };
+}
+
+/** Every vault instance name currently registered in services.json. */
+function listVaultInstanceNames(manifestPath: string): Set<string> {
+  const names = new Set<string>();
+  let manifest: ReturnType<typeof readManifest>;
+  try {
+    manifest = readManifestLenient(manifestPath);
+  } catch {
+    return names;
+  }
+  for (const svc of manifest.services) {
+    if (!isVaultEntry(svc)) continue;
+    if (svc.paths.length === 0) {
+      names.add(vaultInstanceNameFor(svc.name, undefined));
+      continue;
+    }
+    for (const path of svc.paths) names.add(vaultInstanceNameFor(svc.name, path));
+  }
+  return names;
+}
+
+/**
+ * `DELETE /vaults/<name>` — destroy a vault with the full identity cascade.
+ *
+ * Gate: Bearer `parachute:host:admin` (same gate as create). Body MUST carry
+ * `{"confirm": "<name>"}` — a deliberate retype-the-name guard against
+ * fat-finger disasters (mismatch → 400).
+ *
+ * Refusals:
+ *   - unknown vault → 404;
+ *   - LAST remaining vault → 409. Vault's boot auto-creates `default` at
+ *     zero vaults, so deleting the last one would silently resurrect a fresh
+ *     `default` (with a fresh global API key) — refusing sidesteps the
+ *     resurrection class entirely. The CLI (`parachute-vault remove`) is the
+ *     escape hatch for an operator who really means it.
+ *   - RESERVED names are deliberately ALLOWED (no reserved-name gate): a
+ *     squatted `admin`/`new`/`assets` vault created before the B2h
+ *     reservation must be removable through this endpoint.
+ *
+ * Cascade, in order (identity first, mechanics last — revocation is the safe
+ * direction if a later step fails):
+ *   1. tokens-registry sweep (exact scope-segment match — never SQL LIKE);
+ *   2. grants rewrite (drop `vault:<name>:*` entries; drop the row only when
+ *      it empties — a (user,client) grant can span multiple vaults);
+ *   3. `user_vaults` rows;
+ *   4. unredeemed invites pinned to the vault (redemption would resurrect
+ *      the name);
+ *   5. connections whose source/provisioned vault is the deleted vault
+ *      (via `teardownConnection`, which post-B0 also revokes the registered
+ *      long-lived mints) + a report-only scan of channel's `/api/channels`
+ *      for legacy vault-backed entries (`orphaned_channels`);
+ *   6. mechanics: shell to `parachute-vault remove <name> --yes` (the module
+ *      CLI stays the single source of truth for vault destruction,
+ *      mirroring create);
+ *   7. daemon eviction: supervisor-restart the vault module (open
+ *      store-handle eviction + `selfRegister` services.json path rebuild).
+ *
+ * Response: 200 with a structured per-step summary (counts +
+ * `orphaned_channels` + warnings). A mechanics failure responds 500 with
+ * the partial summary — the identity artifacts already revoked stay revoked.
+ */
+export async function handleDeleteVault(
+  req: Request,
+  rawName: string,
+  deps: DeleteVaultDeps,
+): Promise<Response> {
+  if (req.method !== "DELETE") {
+    return new Response("method not allowed", { status: 405 });
+  }
+  const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const runCommand = deps.runCommand ?? defaultRunCommand;
+  const now = deps.now?.() ?? new Date();
+
+  // Auth gate: parachute:host:admin — the same gate as POST /vaults.
+  let adminSub: string;
+  try {
+    const auth = await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    adminSub = auth.sub;
+  } catch (err) {
+    return adminAuthErrorResponse(err as AdminAuthError);
+  }
+
+  // Name shape guard. NOTE: no reserved-name check — see docstring.
+  const name = rawName.trim();
+  if (!VAULT_NAME_PATTERN.test(name)) {
+    return jsonError(
+      400,
+      "invalid_request",
+      "vault name must contain only lowercase letters, numbers, hyphens, and underscores",
+    );
+  }
+
+  // Confirm body — the retype-the-name guard.
+  let body: DeleteVaultBody;
+  try {
+    body = (await req.json()) as DeleteVaultBody;
+  } catch {
+    return jsonError(400, "confirm_mismatch", `body must be JSON: {"confirm": "${name}"}`);
+  }
+  if (!body || typeof body !== "object" || body.confirm !== name) {
+    return jsonError(
+      400,
+      "confirm_mismatch",
+      `deleting a vault requires the body {"confirm": "${name}"} (retype the vault name)`,
+    );
+  }
+
+  // Existence.
+  const existing = findExistingVault(manifestPath, name);
+  if (!existing) {
+    return jsonError(404, "not_found", `no vault named "${name}" on this hub`);
+  }
+
+  // Last-vault refusal (resurrection guard).
+  const instanceNames = listVaultInstanceNames(manifestPath);
+  instanceNames.delete(name);
+  if (instanceNames.size === 0) {
+    return jsonError(
+      409,
+      "last_vault",
+      `"${name}" is the last vault on this hub. Vault's boot auto-creates "default" at zero vaults, so deleting the last one would silently resurrect it with fresh credentials. Create another vault first, or use the CLI (parachute-vault remove ${name} --yes) if you really mean to empty the hub.`,
+    );
+  }
+
+  const summary = emptyCascadeSummary();
+  const warnings: { step: string; detail: string }[] = [];
+
+  // --- 1. Registry sweep: revoke every tokens row naming the vault. --------
+  summary.tokens_revoked = revokeTokensNamingVault(deps.db, name, now);
+
+  // --- 2. Grants rewrite (drop rows only when emptied). ---------------------
+  const grants = rewriteGrantsRemovingVault(deps.db, name);
+  summary.grants_rewritten = grants.rewritten;
+  summary.grants_dropped = grants.dropped;
+
+  // --- 3. user_vaults assignments. ------------------------------------------
+  summary.user_vaults_removed = removeVaultAssignments(deps.db, name);
+
+  // --- 4. Unredeemed invites pinned to the vault. ----------------------------
+  summary.invites_invalidated = revokeInvitesForVault(deps.db, name, now);
+
+  // --- 5. Connections teardown (+ legacy channel scan, report-only). --------
+  // Runs BEFORE the CLI remove so the vault daemon is still alive to accept
+  // the trigger-deregister calls.
+  const connectionsDeps: ConnectionsDeps = {
+    db: deps.db,
+    hubOrigin: deps.issuer,
+    modules: [], // teardown never consults the catalog
+    resolveVaultOrigin: deps.resolveVaultOrigin,
+    channelOrigin: deps.channelOrigin,
+    storePath: deps.connectionsStorePath,
+    ...(deps.fetchImpl !== undefined ? { fetchImpl: deps.fetchImpl } : {}),
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  };
+  const records = readConnections(deps.connectionsStorePath).filter(
+    (r) => r.source.vault === name || r.provisioned?.vault === name,
+  );
+  for (const record of records) {
+    try {
+      const res = await teardownConnection(record.id, adminSub, connectionsDeps);
+      if (res.status === 200) {
+        summary.connections_torn_down++;
+      } else {
+        // 207 partial — the record is removed + mints revoked; remote steps
+        // failed. Surface as warnings, count as torn down (the identity side
+        // is done; the operator can clean the remote residue).
+        summary.connections_torn_down++;
+        const out = (await res.json()) as { errors?: { step: string; detail: string }[] };
+        for (const e of out.errors ?? []) {
+          warnings.push({ step: `connection_${record.id}_${e.step}`, detail: e.detail });
+        }
+      }
+    } catch (err) {
+      warnings.push({
+        step: `connection_${record.id}`,
+        detail: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // Legacy channel scan — vault-backed channel entries still referencing the
+  // vault after connection teardown (pre-Connections wiring). REPORT ONLY:
+  // channel's config is the channel module's domain; the operator removes
+  // them from channel's own UI.
+  if (deps.channelOrigin !== null) {
+    try {
+      const fetchImpl = deps.fetchImpl ?? fetch;
+      const scanToken = (
+        await signAccessToken(deps.db, {
+          sub: adminSub,
+          scopes: ["channel:admin"],
+          audience: "channel",
+          clientId: DELETE_VAULT_CLIENT_ID,
+          issuer: deps.issuer,
+          ttlSeconds: DELETE_VAULT_PROVISION_TTL_SECONDS,
+          vaultScope: [],
+          ...(deps.now !== undefined ? { now: deps.now } : {}),
+        })
+      ).token;
+      const res = await fetchImpl(`${deps.channelOrigin}/api/channels`, {
+        headers: { authorization: `Bearer ${scanToken}`, accept: "application/json" },
+      });
+      if (res.ok) {
+        const listed = (await res.json()) as { channels?: unknown };
+        const rawList = Array.isArray(listed?.channels) ? listed.channels : [];
+        for (const c of rawList) {
+          const row = (c ?? {}) as Record<string, unknown>;
+          if (row.transport === "vault" && row.vault === name && typeof row.name === "string") {
+            summary.orphaned_channels.push(row.name);
+          }
+        }
+      } else {
+        warnings.push({ step: "channel_scan", detail: `channel list returned ${res.status}` });
+      }
+    } catch (err) {
+      warnings.push({
+        step: "channel_scan",
+        detail: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // --- 6. Mechanics: the module CLI is the source of truth for destruction. -
+  try {
+    const result = await runCommand(["parachute-vault", "remove", name, "--yes"]);
+    if (result.exitCode !== 0) {
+      const stderrTail = result.stderr.trim();
+      const tailSuffix = stderrTail ? `: ${stderrTail.slice(-500)}` : "";
+      return jsonError(
+        500,
+        "server_error",
+        `parachute-vault remove ${name} --yes exited with code ${result.exitCode}${tailSuffix} — identity artifacts already revoked (summary: ${JSON.stringify(summary)})`,
+      );
+    }
+    summary.vault_removed = true;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return jsonError(
+      500,
+      "server_error",
+      `orchestration failed: ${msg} — identity artifacts already revoked (summary: ${JSON.stringify(summary)})`,
+    );
+  }
+
+  // --- 7. Daemon eviction: supervisor-restart the vault module. -------------
+  if (deps.restartVaultModule) {
+    try {
+      await deps.restartVaultModule();
+      summary.module_restarted = true;
+    } catch (err) {
+      warnings.push({
+        step: "module_restart",
+        detail: `vault module restart failed: ${err instanceof Error ? err.message : String(err)} — the running daemon may still serve the deleted vault from its open store handle until restarted (parachute restart vault)`,
+      });
+    }
+  } else {
+    warnings.push({
+      step: "module_restart",
+      detail:
+        "no supervisor available — restart the vault module (parachute restart vault) to evict the deleted vault's open store handle and refresh services.json",
+    });
+  }
+
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      name,
+      cascade: summary,
+      ...(warnings.length > 0 ? { warnings } : {}),
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
 }

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -483,18 +483,20 @@ export async function handleApiModules(req: Request, deps: ApiModulesDeps): Prom
         if (!m) return;
         if (m.focus !== undefined) declaredFocusByShort.set(short, m.focus);
         // Resolution per the module-ui-declaration.md hierarchy:
-        // managementUrl > uiUrl. Both are EITHER an absolute
-        // http(s) URL OR a relative path. Relative paths are joined
-        // against the module's mount path (entry.paths[0]) since both
-        // surfaces conventionally live under it (vault's `/admin`,
-        // app's `/admin`). Absolute URLs pass through verbatim.
-        const resolvedManagement = resolveModuleUrl(m.managementUrl ?? m.uiUrl, value.mountPath);
+        // managementUrl > uiUrl. Unified semantics (B4): http(s):// verbatim ·
+        // leading-"/" = origin-absolute verbatim · relative = joined under the
+        // module's mount path (entry.paths[0]) — the per-instance form.
+        const resolvedManagement = resolveModuleUrl(
+          m.managementUrl ?? m.uiUrl,
+          value.mountPath,
+          short,
+        );
         if (resolvedManagement !== undefined) managementUrlByShort.set(short, resolvedManagement);
         // The config surface resolves with the SAME rule. A module may declare
         // `configUiUrl` independently of `managementUrl` — channel ships
-        // `configUiUrl: "/channel/admin"` (single-instance, already
-        // mount-prefixed) alongside a separate `uiUrl`.
-        const resolvedConfig = resolveModuleUrl(m.configUiUrl, value.mountPath);
+        // `configUiUrl: "/channel/admin"` (single-instance, origin-absolute)
+        // alongside a separate `uiUrl`.
+        const resolvedConfig = resolveModuleUrl(m.configUiUrl, value.mountPath, short);
         if (resolvedConfig !== undefined) configUiUrlByShort.set(short, resolvedConfig);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -724,23 +726,37 @@ function jsonError(status: number, code: string, description: string): Response 
 }
 
 /**
+ * The literal legacy per-instance candidates the COMPAT SHIM recognizes on a
+ * vault entry (see `resolveModuleUrl`). One-release shim — remove once vault's
+ * new manifest (`managementUrl: "admin/"`) reaches @latest.
+ */
+const LEGACY_VAULT_ADMIN_CANDIDATES = new Set(["/admin", "/admin/"]);
+let warnedLegacyVaultAdminCandidate = false;
+
+/**
  * Resolve a module-declared "path or http(s) URL" surface field (`managementUrl`,
  * `uiUrl`, `configUiUrl`) to a full hub-origin path the SPA can navigate to.
  *
+ * Unified URL-resolution semantics (B4 of the 2026-06-09 hub-module-boundary
+ * migration — same doctrine as `buildWellKnown`'s uiUrl branch and the
+ * `resolveManagementUrl` pair):
+ *
  *   - `undefined` candidate → `undefined` (the module didn't declare it).
  *   - Absolute http(s) URL → returned verbatim (off-origin escape hatch).
- *   - Relative path + no mount → `undefined` (can't resolve; the SPA renders
- *     the disabled/omitted state rather than guessing).
- *   - Relative path + mount → joined per the module-ui-declaration.md rule:
- *       · Multi-instance modules (vault) declare a per-instance relative path
- *         (`/admin/`); hub prepends the mount (`/vault/default` + `/admin/`
- *         → `/vault/default/admin/`).
- *       · Single-instance modules (surface, scribe, runner, channel) declare a
- *         full hub-origin path that ALREADY includes the mount (`/surface/admin/`,
- *         `/scribe/admin`, `/channel/admin`); the mount must NOT be prepended
- *         again or the result double-prefixes (the audit bug caught 2026-05-25
- *         on the SPA's Services dropdown). Detected by checking if the candidate
- *         is already mount-prefixed.
+ *   - Leading-`/` path → ORIGIN-ABSOLUTE, returned verbatim. Single-instance
+ *     modules (surface, scribe, runner, channel) declare their full hub-origin
+ *     path this way (`/surface/admin/`, `/scribe/admin`, `/channel/admin`);
+ *     vault's daemon-level surface is `/vault/admin/`.
+ *   - Relative path (no leading slash) → MOUNT-JOINED: the per-instance form
+ *     (`admin/` on a `/vault/default` mount → `/vault/default/admin/`). With
+ *     no mount to join → `undefined` (can't resolve; the SPA renders the
+ *     disabled/omitted state rather than guessing).
+ *
+ * COMPAT SHIM (one release): the literal legacy `"/admin"`/`"/admin/"` on a
+ * VAULT entry is the OLD per-instance relative declaration — deployed vaults
+ * still ship it until the vault wave's manifest lands — and mount-joins with
+ * a one-time deprecation log instead of resolving origin-absolute (which
+ * would point at the daemon-level `/vault/admin` mount, not the instance).
  *
  * Shared by `managementUrl`/`uiUrl` (the Open action) and `configUiUrl` (the
  * Configure action, 2026-06-09 modular-UI architecture P3) so the two resolve
@@ -749,13 +765,24 @@ function jsonError(status: number, code: string, description: string): Response 
 function resolveModuleUrl(
   candidate: string | undefined,
   mount: string | undefined,
+  short: string,
 ): string | undefined {
   if (candidate === undefined) return undefined;
   if (/^https?:\/\//i.test(candidate)) return candidate;
-  if (mount === undefined) return undefined;
-  const tail = candidate.startsWith("/") ? candidate : `/${candidate}`;
-  const alreadyMountPrefixed = tail === mount || tail.startsWith(`${mount}/`);
-  return alreadyMountPrefixed ? tail : `${mount}${tail}`;
+  const mountBase = mount?.replace(/\/+$/, "");
+  if (short === "vault" && LEGACY_VAULT_ADMIN_CANDIDATES.has(candidate)) {
+    if (!warnedLegacyVaultAdminCandidate) {
+      warnedLegacyVaultAdminCandidate = true;
+      console.warn(
+        `api-modules: vault declares the legacy per-instance form ${JSON.stringify(candidate)}; mount-joining for one release. New semantics: relative ("admin/") = per-instance mount-join, leading-"/" = origin-absolute. Upgrade the vault module to clear this.`,
+      );
+    }
+    if (mountBase === undefined) return undefined;
+    return `${mountBase}${candidate}`;
+  }
+  if (candidate.startsWith("/")) return candidate;
+  if (mountBase === undefined) return undefined;
+  return `${mountBase}/${candidate}`;
 }
 
 /**

--- a/src/api-tokens.ts
+++ b/src/api-tokens.ts
@@ -23,7 +23,7 @@
  *         "expires_at": "ISO-8601",
  *         "revoked_at": "ISO-8601" | null,
  *         "created_at": "ISO-8601",
- *         "created_via": "oauth_refresh" | "cli_mint" | "operator_mint",
+ *         "created_via": "oauth_refresh" | "cli_mint" | "operator_mint" | "connection_provision",
  *         "permissions": "<json-string>" | null
  *       }
  *     ],
@@ -45,8 +45,10 @@
  *   - `created_via=<value>` — narrow by mint provenance. One of
  *     `oauth_refresh` (OAuth refresh-token rotation), `operator_mint`
  *     (operator-token rotation via `parachute auth rotate-operator`),
- *     or `cli_mint` (CLI / `POST /api/auth/mint-token`). Powers the
- *     admin UI's "by source" filter pills (hub#212 Phase F).
+ *     `cli_mint` (CLI / `POST /api/auth/mint-token`), or
+ *     `connection_provision` (long-lived tokens the Connections engine
+ *     mints — see admin-connections.ts). Powers the admin UI's
+ *     "by source" filter pills (hub#212 Phase F).
  *
  * Why bearer-gated rather than session-cookie-gated: matches the rest
  * of `/api/auth/*` (mint-token, revoke-token), so an automation client
@@ -149,14 +151,15 @@ export async function handleApiTokens(req: Request, deps: ApiTokensDeps): Promis
   if (
     createdViaParam === "oauth_refresh" ||
     createdViaParam === "operator_mint" ||
-    createdViaParam === "cli_mint"
+    createdViaParam === "cli_mint" ||
+    createdViaParam === "connection_provision"
   ) {
     createdVia = createdViaParam;
   } else if (createdViaParam !== null) {
     return jsonError(
       400,
       "invalid_request",
-      "created_via must be one of: oauth_refresh | operator_mint | cli_mint",
+      "created_via must be one of: oauth_refresh | operator_mint | cli_mint | connection_provision",
     );
   }
   const cursor = url.searchParams.get("cursor");

--- a/src/connections-store.ts
+++ b/src/connections-store.ts
@@ -51,6 +51,17 @@ export interface ConnectionProvisioned {
   readonly vault?: string;
   /** The exact vault trigger name registered — DELETE removes this. */
   readonly triggerName?: string;
+  /**
+   * jtis of the LONG-LIVED tokens minted for this connection (the webhook
+   * bearer, and for a channel sink the vault-write reply token). Each is
+   * registered in the hub's tokens table (`created_via='connection_provision'`)
+   * at mint time so teardown can revoke them — an unregistered long-lived
+   * token is unrevocable by construction (hub-module-boundary charter,
+   * registered-mint rule). Records written before this field existed read back
+   * as `undefined`; their tokens were never registered and ride to expiry
+   * (surfaced as `legacy: true` in the list wire shape).
+   */
+  readonly mintedJtis?: readonly string[];
 }
 
 export interface ConnectionRecord {

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -26,6 +26,7 @@
  */
 
 import type { Database } from "bun:sqlite";
+import { vaultScopeName } from "./scope-explanations.ts";
 
 export interface Grant {
   userId: string;
@@ -323,4 +324,53 @@ export function revokeGrant(db: Database, userId: string, clientId: string): boo
     .prepare("DELETE FROM grants WHERE user_id = ? AND client_id = ?")
     .run(userId, clientId);
   return res.changes > 0;
+}
+
+/**
+ * Vault-delete cascade step (B1, 2026-06-09 hub-module-boundary): REWRITE
+ * every grant whose scope list names the deleted vault, removing the
+ * `vault:<name>:<verb>` entries; DROP the row only when the rewrite leaves
+ * it empty.
+ *
+ * Rewrite-not-drop matters: a grant row is keyed (user, client) and its
+ * scope set spans every vault the user ever approved for that client —
+ * dropping the whole row over a single vault would silently revoke the
+ * client's consent on the user's OTHER vaults (over-revocation).
+ *
+ * Matching is the exact `vaultScopeName` segment comparison (regex on the
+ * `vault:<name>:<read|write|admin>` shape), never SQL LIKE — `_` in a vault
+ * name is a LIKE wildcard. Unnamed scopes (`vault:read`) and non-vault
+ * scopes are preserved.
+ */
+export function rewriteGrantsRemovingVault(
+  db: Database,
+  vaultName: string,
+): { rewritten: number; dropped: number } {
+  return db.transaction(() => {
+    const rows = db
+      .prepare("SELECT user_id, client_id, scopes, granted_at FROM grants")
+      .all() as GrantRow[];
+    let rewritten = 0;
+    let dropped = 0;
+    for (const row of rows) {
+      const scopes = row.scopes.split(" ").filter((s) => s.length > 0);
+      const kept = scopes.filter((s) => vaultScopeName(s) !== vaultName);
+      if (kept.length === scopes.length) continue; // doesn't name the vault
+      if (kept.length === 0) {
+        db.prepare("DELETE FROM grants WHERE user_id = ? AND client_id = ?").run(
+          row.user_id,
+          row.client_id,
+        );
+        dropped++;
+      } else {
+        db.prepare("UPDATE grants SET scopes = ? WHERE user_id = ? AND client_id = ?").run(
+          kept.join(" "),
+          row.user_id,
+          row.client_id,
+        );
+        rewritten++;
+      }
+    }
+    return { rewritten, dropped };
+  })();
 }

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -43,6 +43,11 @@
  *
  *   # Admin API + bearer-mint surfaces (must precede /admin/* SPA mount).
  *   /vaults                       (POST)       → create vault
+ *   /vaults/<name>                (DELETE)     → destroy vault + identity cascade
+ *                                                 (B1: confirm body, host:admin,
+ *                                                 tokens/grants/user_vaults/invites/
+ *                                                 connections sweep, CLI remove,
+ *                                                 supervisor restart)
  *   /admin/host-admin-token       (GET)        → SPA bearer mint (cookie-gated)
  *   /admin/vault-admin-token/<n>  (GET)        → per-vault bearer mint (cookie-gated)
  *   /admin/channel-token          (GET)        → channel UI bearer mint (cookie-gated)
@@ -160,7 +165,7 @@ import {
 import { handleHostAdminToken } from "./admin-host-admin-token.ts";
 import { handleModuleToken } from "./admin-module-token.ts";
 import { handleVaultAdminToken } from "./admin-vault-admin-token.ts";
-import { handleCreateVault } from "./admin-vaults.ts";
+import { handleCreateVault, handleDeleteVault } from "./admin-vaults.ts";
 import {
   handleAccountChangePasswordGet,
   handleAccountChangePasswordPost,
@@ -2196,6 +2201,46 @@ export function hubFetch(
         return handleCreateVault(req, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+        });
+      }
+
+      // DELETE /vaults/<name> — destroy a vault with the full identity
+      // cascade (B1, 2026-06-09 hub-module-boundary: lifecycle symmetry).
+      // Bearer parachute:host:admin + {"confirm": "<name>"} body. See
+      // admin-vaults.handleDeleteVault for the enumerated cascade.
+      if (pathname.startsWith("/vaults/")) {
+        if (!getDb) return dbNotConfigured();
+        const name = decodeURIComponent(pathname.slice("/vaults/".length));
+        const services = readManifestLenient(manifestPath).services;
+        // Channel's row carries its MANIFEST name — resolve via
+        // findServiceByShort (see the /admin/channels note above).
+        const channelEntry = findServiceByShort(services, "channel");
+        const channelOrigin = channelEntry ? `http://127.0.0.1:${channelEntry.port}` : null;
+        const resolveVaultOrigin = (vaultName: string): string | null => {
+          const match = findVaultUpstream(
+            readManifestLenient(manifestPath).services,
+            `/vault/${vaultName}`,
+          );
+          return match ? `http://127.0.0.1:${match.port}` : null;
+        };
+        const supervisor = deps?.supervisor;
+        return handleDeleteVault(req, name, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          manifestPath,
+          connectionsStorePath: deps?.connectionsStorePath ?? join(CONFIG_DIR, "connections.json"),
+          channelOrigin,
+          resolveVaultOrigin,
+          // Daemon eviction — the same in-process supervisor the lifecycle
+          // verbs drive (module-ops API); restarting vault evicts the open
+          // store handle + re-runs selfRegister (services.json path rebuild).
+          ...(supervisor
+            ? {
+                restartVaultModule: async () => {
+                  await supervisor.restart("vault");
+                },
+              }
+            : {}),
         });
       }
 

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -101,6 +101,11 @@
  *   /admin/config*                             → 301 → /admin/vaults (legacy
  *                                                portal retired post-SPA-rework)
  *
+ *   # Vault MODULE daemon-level admin surface (B-route, 2026-06-09
+ *   # hub-module-boundary). Runs BEFORE the per-vault proxy; "admin" is a
+ *   # reserved vault name so no instance can claim the mount.
+ *   /vault/admin, /vault/admin/*               → proxy to the vault module's daemon
+ *
  *   # Per-vault content proxy (user-facing vault data: Notes PWA, MCP, etc.).
  *   /vault/<name>/*                            → proxy to the vault backend
  *
@@ -750,6 +755,50 @@ async function proxyToVault(
   // single-vault-per-hub model; if multi-vault-per-hub ever ships, the
   // classifier will need a per-instance key.
   return proxyRequest(req, match.port, "vault", "vault", supervisor, targetPath);
+}
+
+/**
+ * Reverse-proxy `/vault/admin` + `/vault/admin/*` to the vault MODULE's
+ * daemon — the daemon-level multi-vault admin surface (B-route, 2026-06-09
+ * hub-module-boundary migration), NOT a per-instance path.
+ *
+ * Resolution is via `findServiceByShort(services, "vault")` (the canonical
+ * self-registered `parachute-vault` row — same shape as the channelEntry
+ * lookup in the Connections deps), deliberately NOT `findVaultUpstream`:
+ * vault must NOT self-register `/vault/admin` in `paths[]`, because every
+ * consumer that derives instance names from paths (`vaultInstanceNameFor`,
+ * the well-known vaults[] fan-out, `findExistingVault`, the mint
+ * allowlists, the users vault-picker) would fabricate a phantom vault named
+ * "admin". The mount is hub-owned and gated on the B2h `admin` name
+ * reservation, so no real instance can ever claim it.
+ *
+ * Applies the SAME `publicExposure: "loopback"` 404-cloak as `proxyToVault`
+ * (the per-vault proxy's only layer-gate; "allowed"/"auth-required" pass
+ * through and the daemon self-gates). Vault's row declares no `stripPrefix`
+ * — the FULL path forwards, so the daemon's own `/vault/admin` routing
+ * branch (vault wave, B3) serves it.
+ *
+ * Returns `undefined` when no vault module is installed (caller 404s).
+ * NOTE: legacy per-instance rows named `parachute-vault-<name>` don't
+ * resolve through `findServiceByShort` (it only knows the canonical
+ * manifest name) — on such an install this surface 404s until vault's boot
+ * selfRegister rewrites the canonical row, which is the documented
+ * old-install degradation, not a routing hole.
+ */
+async function proxyToVaultAdmin(
+  req: Request,
+  manifestPath: string,
+  supervisor: Supervisor | undefined,
+  peerAddr: string | null,
+): Promise<Response | undefined> {
+  // Lenient — see hub#406 (same posture as proxyToVault).
+  const services = readManifestLenient(manifestPath).services;
+  const entry = findServiceByShort(services, "vault");
+  if (!entry) return undefined;
+  if (effectivePublicExposure(entry) === "loopback" && layerOf(req, peerAddr) !== "loopback") {
+    return new Response("not found", { status: 404 });
+  }
+  return proxyRequest(req, entry.port, "vault", "vault", supervisor);
 }
 
 /**
@@ -2850,6 +2899,27 @@ export function hubFetch(
           status: 301,
           headers: { location: "/admin/vaults" },
         });
+      }
+
+      // /vault/admin + /vault/admin/* — the vault MODULE's daemon-level
+      // admin surface (B-route, 2026-06-09 hub-module-boundary). MUST run
+      // BEFORE the per-vault proxy dispatch below: this is a module-level
+      // mount, not an instance path. "admin" is a reserved vault name (B2h)
+      // so no instance can claim it, and `findVaultUpstream` never sees it —
+      // no consumer fabricates a phantom vault named "admin". Exact-segment
+      // match only: a vault instance named e.g. "adminx" still routes
+      // per-instance through the branch below.
+      if (pathname === "/vault/admin" || pathname.startsWith("/vault/admin/")) {
+        // Same per-request force-change-password gate as the per-vault proxy
+        // (P0-1 / hub#469) — a pre-rotation signed-in user can't reach the
+        // multi-vault admin surface on an un-rotated temp password either.
+        if (getDb) {
+          const gate = forceChangePasswordGate(getDb(), req);
+          if (gate) return gate;
+        }
+        const proxied = await proxyToVaultAdmin(req, manifestPath, deps?.supervisor, peerAddr);
+        if (proxied) return decorateWithChrome(proxied, req, pathname, getDb);
+        return new Response("not found", { status: 404 });
       }
 
       // /vault/<name>/* — per-vault content proxy. Stays as user-facing

--- a/src/invites.ts
+++ b/src/invites.ts
@@ -289,3 +289,25 @@ export function revokeInvite(db: Database, tokenHash: string, now: Date = new Da
     .run(now.toISOString(), tokenHash);
   return res.changes > 0;
 }
+
+/**
+ * Vault-delete cascade step (B1, 2026-06-09 hub-module-boundary): invalidate
+ * every UNREDEEMED invite pinned to the deleted vault. An un-revoked pending
+ * invite carrying `vault_name = <deleted>` would re-provision (resurrect)
+ * the name on redemption — the cascade must close that door. Used/already-
+ * revoked invites are untouched (terminal states). `vault_name` is an exact
+ * `=` comparison — no pattern matching. Returns the number of invites
+ * newly revoked.
+ */
+export function revokeInvitesForVault(
+  db: Database,
+  vaultName: string,
+  now: Date = new Date(),
+): number {
+  const res = db
+    .prepare(
+      "UPDATE invites SET revoked_at = ? WHERE vault_name = ? AND used_at IS NULL AND revoked_at IS NULL",
+    )
+    .run(now.toISOString(), vaultName);
+  return Number(res.changes);
+}

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -135,8 +135,17 @@ export interface SignRefreshTokenOpts {
  * one table for refresh tokens, one for CLI-minted access tokens, one
  * for operator tokens. Different mint paths = different rows; revocation
  * lookup + revocation list are uniform across all of them.
+ *
+ * `connection_provision` — long-lived tokens the Connections engine mints
+ * when provisioning a connection (the webhook bearer + the channel reply
+ * token). Registered so connection teardown can revoke them
+ * (hub-module-boundary charter, registered-mint rule).
  */
-export type TokenCreatedVia = "oauth_refresh" | "cli_mint" | "operator_mint";
+export type TokenCreatedVia =
+  | "oauth_refresh"
+  | "cli_mint"
+  | "operator_mint"
+  | "connection_provision";
 
 export interface SignedRefreshToken {
   /** Opaque token to return to the client. NOT recoverable from the DB. */

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -27,6 +27,7 @@ import {
   importSPKI,
   jwtVerify,
 } from "jose";
+import { vaultScopeName } from "./scope-explanations.ts";
 import { getActiveSigningKey, getAllPublicKeys } from "./signing-keys.ts";
 
 export const ACCESS_TOKEN_TTL_SECONDS = 15 * 60;
@@ -274,6 +275,36 @@ export function revokeTokenByJti(db: Database, jti: string, now: Date): boolean 
     .prepare("UPDATE tokens SET revoked_at = ? WHERE jti = ? AND revoked_at IS NULL")
     .run(now.toISOString(), jti);
   return Number(res.changes) > 0;
+}
+
+/**
+ * Revoke every un-revoked tokens row whose recorded scopes NAME the given
+ * vault (`vault:<name>:<verb>`) — the B1 vault-delete registry sweep
+ * (2026-06-09 hub-module-boundary migration, lifecycle symmetry).
+ *
+ * Matching is EXACT scope-segment comparison via `vaultScopeName` — NEVER
+ * SQL `LIKE`: `_` in a vault name is a LIKE single-char wildcard, so a
+ * `LIKE '%vault:my_vault:%'` sweep for vault `my_vault` would also revoke
+ * `myxvault`-scoped tokens. We read candidate rows and match in JS instead.
+ * Unnamed scopes (`vault:read`) don't name an instance and are untouched.
+ *
+ * Returns the number of rows newly revoked. Idempotent (already-revoked
+ * rows are filtered by the WHERE and by `revokeTokenByJti`).
+ */
+export function revokeTokensNamingVault(db: Database, vaultName: string, now: Date): number {
+  const rows = db
+    .query<{ jti: string; scopes: string }, []>(
+      "SELECT jti, scopes FROM tokens WHERE revoked_at IS NULL",
+    )
+    .all();
+  let revoked = 0;
+  for (const row of rows) {
+    const scopes = row.scopes.split(" ").filter((s) => s.length > 0);
+    if (scopes.some((s) => vaultScopeName(s) === vaultName)) {
+      if (revokeTokenByJti(db, row.jti, now)) revoked++;
+    }
+  }
+  return revoked;
 }
 
 /**

--- a/src/module-manifest.ts
+++ b/src/module-manifest.ts
@@ -165,12 +165,18 @@ export interface ModuleManifest {
    * Where the module's admin UI lives. Hub renders a "Manage" link when set
    * (see `parachute-patterns/patterns/module-json-extensibility.md`).
    *
-   * Two shapes:
-   *   - A relative path (e.g. `"/admin"`) — hub resolves against the module's
-   *     mounted URL: `<module-url><managementUrl>`. Most first-party modules
-   *     take this path so the admin UI rides the same Tailscale Funnel cap.
-   *   - A full absolute URL — hub uses verbatim. Escape hatch for modules
-   *     whose admin UI is hosted off-origin.
+   * Three shapes (unified URL-resolution semantics — B4 of the 2026-06-09
+   * hub-module-boundary migration):
+   *   - A full http(s) URL — used verbatim. Escape hatch for modules whose
+   *     admin UI is hosted off-origin.
+   *   - A leading-`/` path (e.g. `"/scribe/admin"`) — ORIGIN-ABSOLUTE, used
+   *     verbatim against the hub origin.
+   *   - A relative path (e.g. `"admin/"`) — the PER-INSTANCE form; hub joins
+   *     it under the module's mounted URL: `<module-url>/<managementUrl>`.
+   *
+   * COMPAT SHIM (one release): the literal legacy `"/admin"`/`"/admin/"` on a
+   * vault entry is treated as the old per-instance relative form (mount-join)
+   * — deployed vaults still declare it until the vault wave ships.
    *
    * Absent = no link rendered (CLI-only management). Same back-compat rule
    * as `hasAuth` / `init` / `urlForEntry`.
@@ -633,33 +639,64 @@ function asUiUrl(v: unknown, where: string): string | undefined {
 }
 
 /**
- * Validate a "path or http(s) URL" field. Both `managementUrl` and `uiUrl`
- * follow the same shape per the module-json-extensibility pattern doc;
- * factored so the next URL-shaped field doesn't have to copy-paste.
+ * Validate a "path or http(s) URL" field. `managementUrl`, `uiUrl`, and
+ * `configUiUrl` follow the same shape per the module-json-extensibility
+ * pattern doc; factored so the next URL-shaped field doesn't have to
+ * copy-paste.
+ *
+ * Three valid shapes (unified URL-resolution semantics, B4 of the 2026-06-09
+ * hub-module-boundary migration):
+ *   - a full http(s) URL — resolvers use it verbatim;
+ *   - an origin-absolute path starting with a single "/" — resolvers use it
+ *     verbatim against the hub origin;
+ *   - a RELATIVE path (no leading slash, e.g. `"admin/"`) — the per-instance
+ *     form; resolvers join it under the module's mount. Constrained so it can
+ *     only deepen its mount: no `..` segments, no URL scheme.
+ *
+ * Rejected: protocol-relative forms like `"//evil.com"` — they start with "/"
+ * but `new URL("//evil.com", base)` resolves to the foreign origin, which
+ * would let a malicious module render an off-origin tile and turn the
+ * discovery page into an open-redirect surface.
  */
 function asPathOrUrl(v: unknown, where: string, field: string): string | undefined {
   if (v === undefined) return undefined;
   if (typeof v !== "string" || v.length === 0) {
     throw new ModuleManifestError(`${where}: "${field}" must be a non-empty string if present`);
   }
-  // Two valid shapes: an absolute path starting with a single "/" or a full
-  // http(s) URL. Reject protocol-relative forms like "//evil.com" — they
-  // start with "/" but `new URL("//evil.com", base)` resolves to the foreign
-  // origin, which would let a malicious module render an off-origin tile and
-  // turn the discovery page into an open-redirect surface.
-  if (v.startsWith("/") && !v.startsWith("//")) return v;
-  try {
-    const u = new URL(v);
-    if (u.protocol !== "http:" && u.protocol !== "https:") {
-      throw new ModuleManifestError(`${where}: "${field}" absolute form must use http: or https:`);
-    }
-    return v;
-  } catch (err) {
-    if (err instanceof ModuleManifestError) throw err;
+  if (v.startsWith("//")) {
     throw new ModuleManifestError(
-      `${where}: "${field}" must be a path starting with "/" or a full http(s) URL`,
+      `${where}: "${field}" must not be protocol-relative ("//..." resolves off-origin)`,
     );
   }
+  // Origin-absolute path — verbatim.
+  if (v.startsWith("/")) return v;
+  // Scheme-bearing string — must be a well-formed http(s) URL. Anything else
+  // ("ftp://...", "javascript:...") is rejected rather than smuggled through
+  // as a "relative path".
+  if (/^[a-z][a-z0-9+.-]*:/i.test(v)) {
+    try {
+      const u = new URL(v);
+      if (u.protocol !== "http:" && u.protocol !== "https:") {
+        throw new ModuleManifestError(
+          `${where}: "${field}" absolute form must use http: or https:`,
+        );
+      }
+      return v;
+    } catch (err) {
+      if (err instanceof ModuleManifestError) throw err;
+      throw new ModuleManifestError(
+        `${where}: "${field}" must be a relative path, a path starting with "/", or a full http(s) URL`,
+      );
+    }
+  }
+  // Relative (per-instance, mount-joined) form. Forbid `..` traversal so a
+  // declared value can only deepen the module's own mount, never escape it.
+  if (v.split("/").some((segment) => segment === "..")) {
+    throw new ModuleManifestError(
+      `${where}: "${field}" relative form must not contain ".." segments`,
+    );
+  }
+  return v;
 }
 
 /**

--- a/src/module-manifest.ts
+++ b/src/module-manifest.ts
@@ -696,6 +696,19 @@ function asPathOrUrl(v: unknown, where: string, field: string): string | undefin
       `${where}: "${field}" relative form must not contain ".." segments`,
     );
   }
+  // Forbid backslashes anywhere in the relative form — the simplest closure
+  // of the backslash-traversal quirk: WHATWG URL parsing treats `\` as `/`
+  // in special (http/https) schemes, so `a\..\b` joined under a mount would
+  // normalize to `a/../b` and pop a segment, escaping the `..`-segment check
+  // above. Percent-encoded forms (`..%2f`) need no equivalent guard:
+  // `new URL()` does NOT decode percent-escapes during base-join, so a
+  // `..%2f` stays a literal three-char segment and never traverses (pinned
+  // in module-manifest.test.ts).
+  if (v.includes("\\")) {
+    throw new ModuleManifestError(
+      `${where}: "${field}" relative form must not contain backslashes`,
+    );
+  }
   return v;
 }
 

--- a/src/users.ts
+++ b/src/users.ts
@@ -467,6 +467,17 @@ export function setUserVaults(
 }
 
 /**
+ * Vault-delete cascade step (B1, 2026-06-09 hub-module-boundary): drop every
+ * `user_vaults` assignment row for the deleted vault, across all users.
+ * Exact `=` comparison on `vault_name` — no pattern matching. Returns the
+ * number of rows deleted.
+ */
+export function removeVaultAssignments(db: Database, vaultName: string): number {
+  const res = db.prepare("DELETE FROM user_vaults WHERE vault_name = ?").run(vaultName);
+  return Number(res.changes);
+}
+
+/**
  * Updates the password for an existing user. Throws `UserNotFoundError` if
  * the id has no row. Single-user-mode flows look up by username first and
  * pass the resolved id here.

--- a/src/vault-name.ts
+++ b/src/vault-name.ts
@@ -10,7 +10,9 @@
  *
  *   * lowercase alphanumeric + hyphens or underscores
  *   * 2–32 chars
- *   * `list` is reserved
+ *   * `list` / `new` / `assets` / `admin` are reserved (see
+ *     `RESERVED_VAULT_NAMES` below — one consolidated set for every hub
+ *     edge, per the 2026-06-09 hub-module-boundary migration B2)
  *
  * If vault's validator changes (e.g. additional reserved name, length
  * relaxation), the two must move in lockstep — hub passing the typed
@@ -41,12 +43,30 @@ const VAULT_NAME_RE = VAULT_NAME_CHARSET_RE;
 const VAULT_NAME_MIN_LEN = 2;
 const VAULT_NAME_MAX_LEN = 32;
 
-const RESERVED_NAMES = new Set([
-  // Mirrors vault's reservation. Collides with the legacy `/vaults/list`
-  // discovery endpoint; the routes have moved under `/vault/<name>/` but
-  // vault's `cmdCreate` still rejects "list" and cross-repo consistency
-  // is cheap.
+/**
+ * THE reserved vault-name set — single source of truth for every hub edge
+ * that names a vault (B2h of the 2026-06-09 hub-module-boundary migration).
+ * Before the consolidation hub carried TWO drifted sets: this file held only
+ * `list` (gating the setup wizard + invite redemption via `validateVaultName`)
+ * while `admin-vaults.ts` held `{list, new, assets}` (gating POST /vaults
+ * only) — so a non-admin invite redeemer could squat names an admin couldn't.
+ *
+ *   - `list`   — mirrors vault's own `cmdCreate` reservation (legacy
+ *     `/vaults/list` discovery endpoint; cross-repo consistency is cheap).
+ *   - `new`    — collides with `/vault/new`, the SPA's create-vault route.
+ *   - `assets` — collides with `/vault/assets/*`, the SPA's static bundle.
+ *   - `admin`  — collides with `/vault/admin`, the daemon-level mount for
+ *     vault's own multi-vault admin surface (B-route). A vault named `admin`
+ *     would capture the mount.
+ *
+ * DELETE /vaults/<name> deliberately does NOT consult this set — a squatted
+ * reserved-name vault (created before the reservation) must be removable.
+ */
+export const RESERVED_VAULT_NAMES: ReadonlySet<string> = new Set([
   "list",
+  "new",
+  "assets",
+  "admin",
 ]);
 
 export type VaultNameValidation = { ok: true; name: string } | { ok: false; error: string };
@@ -73,7 +93,7 @@ export function validateVaultName(raw: string): VaultNameValidation {
       error: "vault names must be lowercase alphanumeric with hyphens or underscores.",
     };
   }
-  if (RESERVED_NAMES.has(name)) {
+  if (RESERVED_VAULT_NAMES.has(name)) {
     return { ok: false, error: `"${name}" is a reserved vault name.` };
   }
   return { ok: true, name };

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -227,6 +227,9 @@ function buildUisArray(uis: Record<string, UiSubUnit>, base: string): WellKnownU
   });
 }
 
+/** One-time deprecation log for the legacy vault `"/admin/"` uiUrl (B4 compat shim). */
+let warnedLegacyVaultUiUrl = false;
+
 export function buildWellKnown(opts: BuildWellKnownOpts): WellKnownDocument {
   const base = opts.canonicalOrigin.replace(/\/$/, "");
   const doc: WellKnownDocument = { vaults: [], services: [] };
@@ -257,43 +260,43 @@ export function buildWellKnown(opts: BuildWellKnownOpts): WellKnownDocument {
       // entry — no installDir round-trip needed since it's already
       // persisted server-side and reasonably stable across reboots.
       if (s.tagline !== undefined) entry.tagline = s.tagline;
-      // Resolve uiUrl. Three forms (per patterns#96
-      // `module-ui-declaration.md` §"Shape"):
+      // Resolve uiUrl. Unified URL-resolution semantics (B4 of the 2026-06-09
+      // hub-module-boundary migration — same doctrine as api-modules.ts
+      // `resolveModuleUrl` and the `resolveManagementUrl` pair):
       //   - Absolute http(s) URL → verbatim.
-      //   - Path on a non-vault entry → joined onto `base` directly.
-      //   - Path on a vault entry → joined onto `base` AFTER prefixing
-      //     with the per-instance mount path. Vault is the only
-      //     multi-instance service today; its declared `uiUrl: "/admin/"`
-      //     resolves to `<base>/vault/<name>/admin/` (one tile per
-      //     instance). The mount path is whichever `path` we're iterating
-      //     this loop turn (vault's `pathsToEmit` is its `paths[]`,
-      //     fanning one row per instance).
+      //   - Leading-`/` path → ORIGIN-ABSOLUTE: resolved against `base`
+      //     directly (`/scribe/admin` → `<base>/scribe/admin`; vault's
+      //     daemon-level `/vault/admin/` → `<base>/vault/admin/`, once,
+      //     NOT per instance).
+      //   - Relative path (no leading slash) → MOUNT-JOINED: the
+      //     per-instance form. Vault is the only multi-instance service
+      //     today; a declared `uiUrl: "admin/"` resolves to
+      //     `<base>/vault/<name>/admin/` (one tile per instance). The mount
+      //     is whichever `path` we're iterating this loop turn (vault's
+      //     `pathsToEmit` is its `paths[]`, fanning one row per instance).
       //
-      // Path concatenation: `path` is the canonical per-instance mount
-      // ("/vault/default", no trailing slash from services.json). `uiUrlRaw`
-      // starts with "/" per pattern rule. Direct concatenation yields the
-      // correct join ("/vault/default" + "/admin/" → "/vault/default/admin/").
+      // COMPAT SHIM (one release — remove once vault's new manifest reaches
+      // @latest): the literal legacy `"/admin"`/`"/admin/"` on a VAULT entry
+      // is the OLD per-instance relative declaration that deployed vaults
+      // still ship; it mount-joins (the pre-B4 behavior) with a deprecation
+      // log instead of resolving origin-absolute.
       const uiUrlRaw = opts.uiUrlFor?.(s);
       if (uiUrlRaw !== undefined) {
+        const mount = path.replace(/\/+$/, "");
         if (/^https?:\/\//i.test(uiUrlRaw)) {
           entry.uiUrl = uiUrlRaw;
-        } else if (isVault) {
-          // Defensive guard: vault uiUrl MUST start with "/" per the
-          // multi-instance pattern (see module-ui-declaration.md). A bare
-          // "admin/" (no leading slash) would concatenate into
-          // "/vault/defaultadmin/" — a silent malformed URL that 404s.
-          // Warn loudly instead of emitting garbage; the entry just
-          // omits its uiUrl rather than poisoning the well-known doc.
-          if (!uiUrlRaw.startsWith("/")) {
+        } else if (isVault && (uiUrlRaw === "/admin" || uiUrlRaw === "/admin/")) {
+          if (!warnedLegacyVaultUiUrl) {
+            warnedLegacyVaultUiUrl = true;
             console.warn(
-              `[well-known] vault entry "${s.name}" declares uiUrl=${JSON.stringify(uiUrlRaw)} without a leading slash; skipping uiUrl emission. Per module-ui-declaration.md, multi-instance uiUrl must be a path-form starting with "/".`,
+              `[well-known] vault entry "${s.name}" declares the legacy per-instance uiUrl ${JSON.stringify(uiUrlRaw)}; mount-joining for one release. New semantics: relative ("admin/") = per-instance mount-join, leading-"/" = origin-absolute. Upgrade the vault module to clear this.`,
             );
-          } else {
-            const mount = path.replace(/\/$/, "");
-            entry.uiUrl = new URL(`${mount}${uiUrlRaw}`, `${base}/`).toString();
           }
-        } else {
+          entry.uiUrl = new URL(`${mount}${uiUrlRaw}`, `${base}/`).toString();
+        } else if (uiUrlRaw.startsWith("/")) {
           entry.uiUrl = new URL(uiUrlRaw, `${base}/`).toString();
+        } else {
+          entry.uiUrl = new URL(`${mount}/${uiUrlRaw}`, `${base}/`).toString();
         }
       }
       // Hierarchical sub-units (hub#313 / parachute-app design doc §12). The

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -169,12 +169,17 @@ export interface BuildWellKnownOpts {
   /**
    * Optional resolver mapping a `ServiceEntry` to its `module.json:uiUrl`,
    * if any. Same shape as `managementUrlFor`. Returning `undefined` means
-   * "no user-facing UI" and discovery omits the Services tile. For vault
-   * entries, the declared `uiUrl` is the per-instance path (e.g. "/admin/")
-   * — `buildWellKnown` prefixes it with the per-instance mount path on
-   * emission, yielding one tile per vault instance pointing at
-   * `<origin>/vault/<name>/admin/`. See patterns#96
-   * `module-ui-declaration.md` §"Multi-instance services (vault)".
+   * "no user-facing UI" and discovery omits the Services tile.
+   *
+   * Resolution follows the B4 unified semantics (2026-06-09
+   * hub-module-boundary): http(s):// → verbatim; leading-`/` →
+   * ORIGIN-ABSOLUTE against the canonical origin (vault's daemon-level
+   * `/vault/admin/` emits as-is, once per row); RELATIVE (no leading slash,
+   * e.g. `"admin/"`) → the per-instance form, mount-joined per emitted path
+   * — for a multi-path vault entry that yields one tile per instance at
+   * `<origin>/vault/<name>/admin/`. The literal legacy `"/admin/"` on a
+   * vault entry rides the one-release compat shim (mount-join + deprecation
+   * log). See `buildWellKnown`'s uiUrl branch.
    */
   uiUrlFor?: (entry: ServiceEntry) => string | undefined;
   /**

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -561,15 +561,38 @@ describe("revokeGrant", () => {
 });
 
 describe("resolveManagementUrl", () => {
-  // Note: the manifest validator (`asManagementUrl` in module-manifest.ts)
-  // rejects paths that don't start with `/`, so the bare-relative branch
-  // inside `resolveManagementUrl` is defensive-only — never exercised by a
-  // valid managementUrl reaching the SPA. We don't test that branch here.
+  // B4 unified semantics (2026-06-09 hub-module-boundary): http(s)://
+  // verbatim · leading-"/" = origin-absolute · relative = joined under the
+  // vault's mounted URL (the per-instance form). The literal legacy
+  // "/admin"/"/admin/" rides the one-release COMPAT SHIM (vault-join +
+  // deprecation log) because deployed vaults still declare it.
 
-  it("joins a leading-slash path onto the vault URL after stripping trailing slash", async () => {
+  it("joins a RELATIVE path under the vault URL (B4 per-instance form)", async () => {
+    const api = await import("./api.ts");
+    expect(api.resolveManagementUrl("http://hub.local/vault/work/", "admin/")).toBe(
+      "http://hub.local/vault/work/admin/",
+    );
+    expect(api.resolveManagementUrl("http://hub.local/vault/work", "manage")).toBe(
+      "http://hub.local/vault/work/manage",
+    );
+  });
+
+  it('COMPAT SHIM: the literal legacy "/admin" still joins under the vault URL (one release)', async () => {
     const api = await import("./api.ts");
     expect(api.resolveManagementUrl("http://hub.local/vault/work/", "/admin")).toBe(
       "http://hub.local/vault/work/admin",
+    );
+    expect(api.resolveManagementUrl("http://hub.local/vault/work/", "/admin/")).toBe(
+      "http://hub.local/vault/work/admin/",
+    );
+  });
+
+  it("resolves a non-shim leading-slash path origin-absolute (B4 inverted pin)", async () => {
+    const api = await import("./api.ts");
+    // Pre-B4 this joined under the vault mount; under the unified semantics
+    // a leading-"/" names the full origin path verbatim.
+    expect(api.resolveManagementUrl("http://hub.local/vault/work/", "/vault/admin/")).toBe(
+      "http://hub.local/vault/admin/",
     );
   });
 

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -440,18 +440,44 @@ export async function signOut(csrfToken: string): Promise<void> {
   throw new HttpError(res.status, await readError(res));
 }
 
+/** One-time deprecation log for the legacy `"/admin/"` managementUrl (B4 compat shim). */
+let warnedLegacyManagementUrl = false;
+
 /**
  * Resolve a vault's `managementUrl` against the vault's mounted URL.
- * Absolute URL → returned verbatim. Path → joined onto `vaultUrl` after
- * stripping the trailing slash so we don't double-slash.
+ * Unified URL-resolution semantics (B4 of the 2026-06-09 hub-module-boundary
+ * migration) — mirrors `resolveManagementUrl` in the hub's
+ * `src/account-vault-admin-token.ts` so SPA and hub-server deep-links agree:
+ *
+ *   - Absolute http(s) URL → verbatim.
+ *   - Leading-`/` path → ORIGIN-ABSOLUTE: resolved against the vault URL's
+ *     origin (not joined under the vault mount).
+ *   - Relative path (no leading slash, e.g. `"admin/"`) → the PER-INSTANCE
+ *     form: joined onto `vaultUrl` after stripping the trailing slash.
+ *
+ * COMPAT SHIM (one release — remove once vault's new manifest reaches
+ * @latest): the literal legacy `"/admin"`/`"/admin/"` is the OLD per-instance
+ * relative declaration deployed vaults still ship; it joins under the vault
+ * URL (the pre-B4 behavior) with a one-time deprecation log.
  *
  * Exported for direct testing; `VaultsList` calls it before redirecting.
  */
 export function resolveManagementUrl(vaultUrl: string, managementUrl: string): string {
   if (/^https?:\/\//i.test(managementUrl)) return managementUrl;
   const base = vaultUrl.replace(/\/+$/, "");
-  const tail = managementUrl.startsWith("/") ? managementUrl : `/${managementUrl}`;
-  return `${base}${tail}`;
+  if (managementUrl === "/admin" || managementUrl === "/admin/") {
+    if (!warnedLegacyManagementUrl) {
+      warnedLegacyManagementUrl = true;
+      console.warn(
+        `resolveManagementUrl: vault declares the legacy per-instance managementUrl ${JSON.stringify(managementUrl)}; joining under the vault URL for one release. New semantics: relative ("admin/") = per-instance join, leading-"/" = origin-absolute.`,
+      );
+    }
+    return `${base}${managementUrl}`;
+  }
+  if (managementUrl.startsWith("/")) {
+    return new URL(managementUrl, `${base}/`).toString();
+  }
+  return `${base}/${managementUrl}`;
 }
 
 /**


### PR DESCRIPTION
Hub wave 1 of the **hub–module boundary migration** — spec:
[`parachute-patterns/migrations/2026-06-09-hub-module-boundary.md`](https://github.com/ParachuteComputer/parachute-patterns/blob/pattern/hub-module-boundary/migrations/2026-06-09-hub-module-boundary.md)
(charter: `patterns/hub-module-boundary.md`). Items **B0, B2h, B4, B-route, B1**, one commit each, in dependency order.

**Sequencing (hub-first):** this wave lands BEFORE the vault wave (B2v + B3 + manifest). Every hub-side semantic change here ships with a one-release compat shim for the old vault manifest, so deployed vaults keep working unchanged; old-hub + new-vault is the documented cosmetic-404 degradation (links only, no auth impact).

## Commit 1 — B0: register the connections engine's long-lived mints
The Connections engine minted two ~90-day tokens per channel-backed connection (vault-write reply token + webhook bearer) via `signAccessToken` with **no `recordTokenMint`** — unrevocable by construction (`api-revoke-token` 404s unknown jtis; the revocation list only carries registered jtis). Now: `mint()` registers every long-lived mint (`created_via: "connection_provision"`, new `TokenCreatedVia` member accepted by the `/api/auth/tokens` filter); jtis persist on the record's `provisioned.mintedJtis`; `teardownConnection` revokes them (registry → revocation list); legacy records tear down gracefully with a log + `legacy: true` on the list wire shape. **Live connections are NOT auto-rotated** (per the work brief — the migration file's "rotate/re-provision existing" line is deliberately not implemented; legacy mints ride to their original expiry, visibly flagged).

## Commit 2 — B2h: reserved-name consolidation
Two drifted validators (`admin-vaults.ts` `{list,new,assets}` on POST /vaults only; `vault-name.ts` `{list}` on the wizard + invite redemption) collapse to ONE exported set in `vault-name.ts`: **`{list, new, assets, admin}`**. `admin` was reserved nowhere — any creation path could squat the upcoming `/vault/admin` mount. All four names now rejected at every edge (wizard, invite redemption, POST /vaults); near-miss names still pass. DELETE (commit 5) deliberately skips the reserved gate so a squatted `admin` vault stays removable.

## Commit 3 — B4: URL-resolution unification + compat shim
One doctrine across **all resolver families**: `http(s)://` verbatim · leading-`/` = **origin-absolute** verbatim · relative = **mount-joined** (per-instance form).
- `api-modules.ts` `resolveModuleUrl` — both old-semantics test pins inverted as specified (`'/admin'`+mount now pins the new relative form + a separate shim pin; `/app-foo/admin` on `/surface` is now origin-absolute verbatim).
- `well-known.ts` `buildWellKnown` vault uiUrl branch — flipped: relative is the valid per-instance mount-joined form (was warn+skip); leading-`/` passes through (vault's daemon-level `/vault/admin/` emits as-is, not per-instance).
- `resolveManagementUrl` pair (`account-vault-admin-token.ts` + `web/ui/src/lib/api.ts`) — leading-`/` was vault-relative, now origin-absolute; fallback `"/admin/"` → `"admin/"` (same resolved target). Audited the other consumers named in the spec: `hub-server.ts` forwards raw declared values and `loadServiceUiMetadata` only collects strings — neither resolves, no change needed.
- **Enabler:** `module-manifest.ts` `asPathOrUrl` previously REJECTED non-leading-slash paths, making the relative form unreachable (and vault's upcoming `managementUrl: "admin/"` manifest invalid). It now accepts the relative form, constrained (no `..` segments, no smuggled schemes; protocol-relative `//…` still rejected).
- **COMPAT SHIM (one release, clearly commented at every site):** the literal legacy `"/admin"`/`"/admin/"` on a VAULT entry mount-joins with a one-time deprecation log. Remove once vault's new manifest reaches @latest.

## Commit 4 — B-route: the /vault/admin daemon-level mount
`/vault/admin` + `/vault/admin/*` route to the vault MODULE's daemon, resolved via `findServiceByShort(services, "vault")` (the #636 helper, channelEntry shape) → `http://127.0.0.1:<port>`, dispatched **before** `findVaultUpstream` so no consumer can fabricate a phantom `admin` instance. Same `publicExposure` loopback-cloak/trust-layer gating as `proxyToVault` + the same force-change-password gate; full path forwarded (no stripPrefix); 404 when vault isn't installed; exact-segment match (a vault named `adminx` routes per-instance). Gated on the B2h reservation.

## Commit 5 — B1: DELETE /vaults/<name> with the identity cascade
Lifecycle symmetry: host:admin Bearer + `{"confirm": "<name>"}` body; unknown → 404; **last vault → 409** (boot would auto-resurrect `default`; CLI is the escape hatch); reserved names deletable. Cascade in order: ① registry sweep (EXACT scope-segment match, **never SQL LIKE** — `my_vault` ≠ `myxvault`, pinned); ② grants **rewrite** (drop row only when emptied — multi-vault grants survive, pinned); ③ `user_vaults`; ④ unredeemed pinned invites invalidated; ⑤ connections torn down via the (now-exported) `teardownConnection` — revoking the B0-registered jtis — plus a **report-only** scan of channel's `/api/channels` surfaced as `orphaned_channels`; ⑥ mechanics via `parachute-vault remove <name> --yes` (same runner seam as create); ⑦ supervisor-restart of the vault module (open-store-handle eviction + `selfRegister` path rebuild; explicit warning when no supervisor). Structured per-step summary in the response. Identity-first ordering: a mechanics failure 500s with the partial summary and the revocations stay.

## Gates
- `bun test ./src`: **3246 pass / 1 skip / 0 fail** (130 files)
- `bun run typecheck` (tsc --noEmit): clean
- `web/ui` `bunx vitest run`: **276 pass** (18 files); `web/ui` typecheck clean
- `bun run build:spa`: ok (verify-base passes)
- No binary/NUL files in the diff (`git diff --stat` + `file` on every changed path)
- No version bumps (per instruction); no live services touched.

## Notes for the reviewer
- The spec's claim that an invite redeemer could create `new`/`assets` was slightly conservative — `provisionVault` (which the redeem path calls) already gated those two; **`admin` was genuinely open on every path**. The consolidation fixes both and removes the drift class.
- `findServiceByShort(services, "vault")` doesn't resolve legacy per-instance rows named `parachute-vault-<name>`; on such an install `/vault/admin` 404s until vault's boot selfRegister rewrites the canonical row (documented in the helper's docstring) — the spec'd resolution path, kept as specified.
- B0 follows the work brief's "do NOT auto-rotate live connections", which supersedes the migration file's "rotate/re-provision existing connections (one-time migration)" line; legacy records are flagged `legacy: true` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)