### PR TITLE
harden(admin): same-origin belt on cookie-gated /admin/* JSON mutations (hub#632, boundary C1)

### DIFF
--- a/src/__tests__/admin-csrf-belt.test.ts
+++ b/src/__tests__/admin-csrf-belt.test.ts
@@ -1,0 +1,360 @@
+/**
+ * CSRF belt on cookie-gated /admin/* JSON mutation endpoints (hub#632,
+ * 2026-06-09 hub-module-boundary Phase C1).
+ *
+ * Two layers:
+ *
+ *   1. Unit — `assertSameOriginForCookieMutation` semantics: which requests
+ *      the belt gates (cookie-authed mutations), which it waves through
+ *      (reads, Bearer-authed, cookie-less), and the two rejection codes
+ *      (`csrf_origin_required` / `csrf_origin_mismatch`).
+ *   2. Integration — the wiring in hub-server.ts dispatch for
+ *      `/admin/connections` + `/admin/channels`: cross-origin cookie
+ *      mutations 403 BEFORE the operator gate; same-origin mutations reach
+ *      the handler; GETs are unaffected; Bearer-authed mutations skip the
+ *      belt and land on the endpoint's own gate.
+ *
+ * The canonical seam consumer is pinned here: channel's admin page POSTs
+ * `/admin/connections` as a same-origin `fetch()` with
+ * `credentials: "include"` (parachute-channel src/admin-ui.ts) — i.e.
+ * session cookie + browser-sent matching Origin. That shape must keep
+ * passing the belt without any token dance.
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { hubFetch } from "../hub-server.ts";
+import { assertSameOriginForCookieMutation } from "../origin-check.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
+import { createUser } from "../users.ts";
+
+const BOUND = ["https://hub.example", "http://localhost:1939", "http://127.0.0.1:1939"];
+const SESSION_COOKIE = "parachute_hub_session=abc123";
+
+function mutReq(opts: {
+  method?: string;
+  origin?: string;
+  cookie?: string;
+  authorization?: string;
+  url?: string;
+}): Request {
+  const headers: Record<string, string> = {};
+  if (opts.origin !== undefined) headers.origin = opts.origin;
+  if (opts.cookie !== undefined) headers.cookie = opts.cookie;
+  if (opts.authorization !== undefined) headers.authorization = opts.authorization;
+  return new Request(opts.url ?? "https://hub.example/admin/connections", {
+    method: opts.method ?? "POST",
+    headers,
+  });
+}
+
+async function errorCode(res: Response): Promise<string> {
+  const body = (await res.json()) as { error?: string };
+  return body.error ?? "";
+}
+
+describe("assertSameOriginForCookieMutation (unit)", () => {
+  test("cookie-authed POST with matching Origin passes", () => {
+    const res = mutReq({ cookie: SESSION_COOKIE, origin: "https://hub.example" });
+    expect(assertSameOriginForCookieMutation(res, BOUND)).toBeNull();
+  });
+
+  test("matching any bound origin passes (multi-origin hub: loopback alias)", () => {
+    const res = mutReq({
+      cookie: SESSION_COOKIE,
+      origin: "http://127.0.0.1:1939",
+      url: "http://127.0.0.1:1939/admin/connections",
+    });
+    expect(assertSameOriginForCookieMutation(res, BOUND)).toBeNull();
+  });
+
+  test("cookie-authed POST with cross-site Origin → 403 csrf_origin_mismatch", async () => {
+    const rejected = assertSameOriginForCookieMutation(
+      mutReq({ cookie: SESSION_COOKIE, origin: "https://evil.example" }),
+      BOUND,
+    );
+    expect(rejected).not.toBeNull();
+    expect(rejected?.status).toBe(403);
+    expect(await errorCode(rejected as Response)).toBe("csrf_origin_mismatch");
+  });
+
+  test("cookie-authed POST with NO Origin → 403 csrf_origin_required", async () => {
+    const rejected = assertSameOriginForCookieMutation(mutReq({ cookie: SESSION_COOKIE }), BOUND);
+    expect(rejected?.status).toBe(403);
+    expect(await errorCode(rejected as Response)).toBe("csrf_origin_required");
+  });
+
+  test("`Origin: null` (opaque origin) is a mismatch, NOT a pass — no Host fallback", async () => {
+    // The attacker form-post shape: referrer-policy no-referrer makes the
+    // browser send `Origin: null` on a navigation POST; Host always names
+    // the target. isSameOriginRequest's Host fallback would pass this —
+    // the belt must not (these JSON endpoints carry no double-submit token).
+    const rejected = assertSameOriginForCookieMutation(
+      mutReq({ cookie: SESSION_COOKIE, origin: "null" }),
+      BOUND,
+    );
+    expect(rejected?.status).toBe(403);
+    expect(await errorCode(rejected as Response)).toBe("csrf_origin_mismatch");
+  });
+
+  test("malformed Origin is a mismatch", async () => {
+    const rejected = assertSameOriginForCookieMutation(
+      mutReq({ cookie: SESSION_COOKIE, origin: "not a url" }),
+      BOUND,
+    );
+    expect(rejected?.status).toBe(403);
+    expect(await errorCode(rejected as Response)).toBe("csrf_origin_mismatch");
+  });
+
+  test("PUT / PATCH / DELETE are gated like POST", () => {
+    for (const method of ["PUT", "PATCH", "DELETE"]) {
+      const rejected = assertSameOriginForCookieMutation(
+        mutReq({ method, cookie: SESSION_COOKIE }),
+        BOUND,
+      );
+      expect(rejected?.status).toBe(403);
+    }
+  });
+
+  test("GET / HEAD / OPTIONS pass regardless of Origin", () => {
+    for (const method of ["GET", "HEAD", "OPTIONS"]) {
+      const res = mutReq({ method, cookie: SESSION_COOKIE, origin: "https://evil.example" });
+      expect(assertSameOriginForCookieMutation(res, BOUND)).toBeNull();
+    }
+  });
+
+  test("Bearer-authed mutation without Origin passes (API clients are CSRF-immune)", () => {
+    const res = mutReq({ authorization: "Bearer some-token" });
+    expect(assertSameOriginForCookieMutation(res, BOUND)).toBeNull();
+  });
+
+  test("Authorization present + cookie present passes — a custom header cannot ride a CSRF", () => {
+    // Cross-site pages cannot attach an Authorization header without a CORS
+    // preflight these routes never approve, so its presence proves this is
+    // not a browser-forged request. The endpoint's own gate still runs.
+    const res = mutReq({ authorization: "Bearer some-token", cookie: SESSION_COOKIE });
+    expect(assertSameOriginForCookieMutation(res, BOUND)).toBeNull();
+  });
+
+  test("no cookie + no Authorization passes through (endpoint's own 401 is the right answer)", () => {
+    const res = mutReq({});
+    expect(assertSameOriginForCookieMutation(res, BOUND)).toBeNull();
+  });
+
+  test("other cookies without the session cookie do not arm the belt", () => {
+    const res = mutReq({ cookie: "parachute_hub_csrf=tok; theme=dark" });
+    expect(assertSameOriginForCookieMutation(res, BOUND)).toBeNull();
+  });
+
+  test("empty bound-origin set fails closed for cookie-authed mutations", async () => {
+    const rejected = assertSameOriginForCookieMutation(
+      mutReq({ cookie: SESSION_COOKIE, origin: "https://hub.example" }),
+      [],
+    );
+    expect(rejected?.status).toBe(403);
+    expect(await errorCode(rejected as Response)).toBe("csrf_origin_mismatch");
+  });
+});
+
+// ===========================================================================
+// Integration — the dispatch wiring in hub-server.ts
+// ===========================================================================
+
+interface Harness {
+  dir: string;
+  db: Database;
+  cookie: string;
+  cleanup: () => void;
+}
+
+let h: Harness;
+
+beforeEach(async () => {
+  const dir = mkdtempSync(join(tmpdir(), "phub-csrf-belt-"));
+  const db = openHubDb(hubDbPath(dir));
+  const user = await createUser(db, "operator", "hunter2");
+  const session = createSession(db, { userId: user.id });
+  h = {
+    dir,
+    db,
+    cookie: buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000)),
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+});
+afterEach(() => h.cleanup());
+
+/** hubFetch with bound origins pinned to the request-derived issuer (no
+ * stored hub_origin, no configured issuer, no expose state). */
+function handler() {
+  return hubFetch(h.dir, {
+    getDb: () => h.db,
+    manifestPath: join(h.dir, "services.json"),
+    connectionsStorePath: join(h.dir, "connections.json"),
+    loadExposeHubOrigin: () => undefined,
+  });
+}
+
+const ORIGIN = "http://hub.test";
+
+function adminReq(
+  path: string,
+  opts: { method?: string; origin?: string; cookie?: string; auth?: string; body?: unknown } = {},
+): Request {
+  const headers: Record<string, string> = {};
+  if (opts.origin !== undefined) headers.origin = opts.origin;
+  if (opts.cookie !== undefined) headers.cookie = opts.cookie;
+  if (opts.auth !== undefined) headers.authorization = opts.auth;
+  if (opts.body !== undefined) headers["content-type"] = "application/json";
+  return new Request(`${ORIGIN}${path}`, {
+    method: opts.method ?? "POST",
+    headers,
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  });
+}
+
+describe("CSRF belt wiring — /admin/connections + /admin/channels", () => {
+  test("cross-origin cookie POST /admin/connections → 403 csrf_origin_mismatch (even with a valid admin session)", async () => {
+    const res = await handler()(
+      adminReq("/admin/connections", {
+        cookie: h.cookie,
+        origin: "https://evil.example",
+        body: {},
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect(await errorCode(res)).toBe("csrf_origin_mismatch");
+  });
+
+  test("missing-Origin cookie POST /admin/connections → 403 csrf_origin_required", async () => {
+    const res = await handler()(adminReq("/admin/connections", { cookie: h.cookie, body: {} }));
+    expect(res.status).toBe(403);
+    expect(await errorCode(res)).toBe("csrf_origin_required");
+  });
+
+  test("same-origin cookie POST /admin/connections passes the belt and reaches handler validation", async () => {
+    const res = await handler()(
+      adminReq("/admin/connections", { cookie: h.cookie, origin: ORIGIN, body: {} }),
+    );
+    // Past the belt: the handler's own body validation answers (400), not a
+    // csrf_* 403.
+    expect(res.status).toBe(400);
+    expect(await errorCode(res)).toBe("invalid_request");
+  });
+
+  test("seam pin — the channel link-vault shape (cookie + correct Origin, requestedBy: channel) passes the belt", async () => {
+    // parachute-channel/src/admin-ui.ts: fetch(window.location.origin +
+    // "/admin/connections", { method: "POST", credentials: "include" }) —
+    // same-origin fetch(), so the browser sends Origin = hub origin on the
+    // POST. With no modules installed in this harness the engine answers
+    // 400 unknown_module — i.e. the request cleared the belt AND the
+    // operator gate and reached catalog validation. The full provision flow
+    // is covered handler-level in admin-connections.test.ts.
+    const res = await handler()(
+      adminReq("/admin/connections", {
+        cookie: h.cookie,
+        origin: ORIGIN,
+        body: {
+          source: {
+            module: "vault",
+            vault: "main",
+            event: "note.created",
+            filter: { tags: ["channel-message/inbound"] },
+          },
+          sink: { module: "channel", action: "message.deliver", params: { channel: "tg" } },
+          requestedBy: "channel",
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(await errorCode(res)).toBe("unknown_module");
+  });
+
+  test("X-Forwarded-Proto public-origin case over the proxy passes", async () => {
+    // TLS terminates at the edge; hub sees plain http with
+    // X-Forwarded-Proto: https and the public Host preserved end-to-end.
+    // resolveIssuer derives https://<host> — the browser's Origin on a
+    // same-origin fetch is exactly that, so the belt matches.
+    const req = new Request("http://pub.example/admin/connections", {
+      method: "POST",
+      headers: {
+        cookie: h.cookie,
+        origin: "https://pub.example",
+        "x-forwarded-proto": "https",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+    const res = await handler()(req);
+    expect(res.status).toBe(400); // handler validation, not the belt's 403
+    expect(await errorCode(res)).toBe("invalid_request");
+  });
+
+  test("GET /admin/connections with cookie and no Origin is unaffected", async () => {
+    const res = await handler()(
+      adminReq("/admin/connections", { method: "GET", cookie: h.cookie }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; connections: unknown[] };
+    expect(body.ok).toBe(true);
+    expect(body.connections).toEqual([]);
+  });
+
+  test("Bearer-authed POST /admin/connections without Origin skips the belt; the endpoint's own gate answers", async () => {
+    const res = await handler()(
+      adminReq("/admin/connections", { auth: "Bearer junk-token", body: {} }),
+    );
+    // Cookie-gated endpoint: the operator gate 401s the Bearer-only caller.
+    // The point pinned here: NOT a 403 csrf_* rejection.
+    expect(res.status).toBe(401);
+    expect(await errorCode(res)).toBe("unauthenticated");
+  });
+
+  test("cross-origin cookie DELETE /admin/connections/<id> → 403 csrf_origin_mismatch", async () => {
+    const res = await handler()(
+      adminReq("/admin/connections/some-id", {
+        method: "DELETE",
+        cookie: h.cookie,
+        origin: "https://evil.example",
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect(await errorCode(res)).toBe("csrf_origin_mismatch");
+  });
+
+  test("cross-origin cookie POST /admin/channels → 403 csrf_origin_mismatch", async () => {
+    const res = await handler()(
+      adminReq("/admin/channels", {
+        cookie: h.cookie,
+        origin: "https://evil.example",
+        body: { channelName: "x", vault: "main" },
+      }),
+    );
+    expect(res.status).toBe(403);
+    expect(await errorCode(res)).toBe("csrf_origin_mismatch");
+  });
+
+  test("missing-Origin cookie DELETE /admin/channels/<name> → 403 csrf_origin_required", async () => {
+    const res = await handler()(
+      adminReq("/admin/channels/tg", { method: "DELETE", cookie: h.cookie }),
+    );
+    expect(res.status).toBe(403);
+    expect(await errorCode(res)).toBe("csrf_origin_required");
+  });
+
+  test("same-origin cookie DELETE /admin/channels/<name> passes the belt (handler answers)", async () => {
+    const res = await handler()(
+      adminReq("/admin/channels/tg", { method: "DELETE", cookie: h.cookie, origin: ORIGIN }),
+    );
+    // channel isn't installed in this harness — the handler (not the belt)
+    // answers with its own error, proving the belt passed it through.
+    expect(res.status).not.toBe(403);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error ?? "").not.toStartWith("csrf_");
+  });
+});

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -52,11 +52,15 @@
  *   /admin/vault-admin-token/<n>  (GET)        → per-vault bearer mint (cookie-gated)
  *   /admin/channel-token          (GET)        → channel UI bearer mint (cookie-gated)
  *   /admin/module-token/<short>   (GET)        → generic module config-UI bearer mint <short>:admin (cookie-gated)
- *   /admin/channels               (POST/GET)   → vault-channel provision/list (cookie-gated)
- *   /admin/channels/<name>        (DELETE)     → vault-channel teardown (cookie-gated)
+ *   /admin/channels               (POST/GET)   → vault-channel provision/list (cookie-gated; POST CSRF-belted)
+ *   /admin/channels/<name>        (DELETE)     → vault-channel teardown (cookie-gated; CSRF-belted)
  *   /api/connections/catalog      (GET)        → events/actions across installed modules (cookie-gated)
- *   /admin/connections            (POST/GET)   → connection provision/list (cookie-gated)
- *   /admin/connections/<id>       (DELETE)     → connection teardown (cookie-gated)
+ *   /admin/connections            (POST/GET)   → connection provision/list (cookie-gated; POST CSRF-belted)
+ *   /admin/connections/<id>       (DELETE)     → connection teardown (cookie-gated; CSRF-belted)
+ *
+ *   # "CSRF-belted" = strict same-origin Origin check on cookie-authed
+ *   # mutations (hub#632, boundary C1) — origin-check.ts
+ *   # `assertSameOriginForCookieMutation` carries the canonical enumeration.
  *   /api/me                       (GET)        → who-am-I (session+CSRF or hasSession:false)
  *   /api/hub                      (GET)        → hub version + uptime + install-source (host:admin)
  *   /api/hub/upgrade              (POST)       → SPA-driven hub self-upgrade → 202 + detached helper (host:admin, §5.3/D4)
@@ -235,7 +239,7 @@ import {
   protectedResourceMetadata,
 } from "./oauth-handlers.ts";
 import { renderNotFoundPage } from "./oauth-ui.ts";
-import { buildHubBoundOrigins } from "./origin-check.ts";
+import { assertSameOriginForCookieMutation, buildHubBoundOrigins } from "./origin-check.ts";
 import { clearPid, writePid } from "./process-state.ts";
 import { toResponse as proxyErrorToResponse, renderProxyError } from "./proxy-error-ui.ts";
 import { classifyUpstream } from "./proxy-state.ts";
@@ -2291,6 +2295,14 @@ export function hubFetch(
       // only for the webhook URL + the copy-paste connect lines.
       if (pathname === "/admin/channels" || pathname.startsWith("/admin/channels/")) {
         if (!getDb) return dbNotConfigured();
+        // CSRF belt (hub#632, boundary C1): cookie-authed POST/DELETE must
+        // carry a matching Origin. Same-origin pages (hub SPA + proxied
+        // module pages) pass automatically; see the enumeration in
+        // origin-check.ts `assertSameOriginForCookieMutation`.
+        {
+          const rejected = assertSameOriginForCookieMutation(req, oauthDeps(req).hubBoundOrigins());
+          if (rejected) return rejected;
+        }
         const subPath = pathname.slice("/admin/channels".length);
         const services = readManifestLenient(manifestPath).services;
         // Channel's services.json row carries its MANIFEST name (`parachute-channel`),
@@ -2353,6 +2365,16 @@ export function hubFetch(
         };
         if (pathname === "/api/connections/catalog") {
           return handleConnectionsCatalog(req, connectionsDeps);
+        }
+        // CSRF belt (hub#632, boundary C1): cookie-authed POST/DELETE must
+        // carry a matching Origin. The seam's canonical consumer — channel's
+        // admin page POSTing link-vault with `credentials: "include"` — is a
+        // same-origin fetch() and passes; see origin-check.ts
+        // `assertSameOriginForCookieMutation` for the belted-endpoint
+        // enumeration.
+        {
+          const rejected = assertSameOriginForCookieMutation(req, oauthDeps(req).hubBoundOrigins());
+          if (rejected) return rejected;
         }
         const subPath = pathname.slice("/admin/connections".length);
         return handleConnections(req, subPath, connectionsDeps);

--- a/src/origin-check.ts
+++ b/src/origin-check.ts
@@ -29,6 +29,7 @@
  * case. CSRF + session gates upstream are the real auth defense — this is
  * a belt for browser flows where the legitimate Origin/Referer got dropped.
  */
+import { parseSessionCookie } from "./sessions.ts";
 
 /**
  * Build the bound-origin set from the hub's configuration. Returns
@@ -160,4 +161,108 @@ export function isSameOriginRequest(req: Request, boundOrigins: readonly string[
     return boundHosts.has(host);
   }
   return false;
+}
+
+// ===========================================================================
+// CSRF belt for cookie-gated /admin/* JSON mutation endpoints (hub#632,
+// 2026-06-09 hub-module-boundary Phase C1)
+// ===========================================================================
+
+/** Methods the belt gates. GET/HEAD/OPTIONS are read-shaped and pass. */
+const MUTATION_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/**
+ * Strict same-origin belt for cookie-authenticated JSON mutations — the
+ * defense-in-depth layer over `SameSite=Lax` on the hub's cookie-gated JSON
+ * mutation endpoints (hub#632; hub-module-boundary charter, trust statement).
+ *
+ * BELTED ENDPOINTS (the explicit enumeration — every cookie-gated JSON
+ * mutation under `/admin/*`; keep this list in sync with the dispatch in
+ * `hub-server.ts`):
+ *
+ *   - `POST /admin/connections` + `DELETE /admin/connections/<id>`
+ *     (connection provision/teardown — the seam's canonical consumers are
+ *     channel's admin page and the hub SPA, both same-origin `fetch()` with
+ *     `credentials: "include"`)
+ *   - `POST /admin/channels` + `DELETE /admin/channels/<name>`
+ *     (legacy vault-channel provision/teardown, hub SPA)
+ *
+ * NOT belted, and why:
+ *   - GET/HEAD/OPTIONS — read-shaped; the mint GETs
+ *     (`/admin/host-admin-token`, `/admin/channel-token`,
+ *     `/admin/module-token/<short>`, `/admin/vault-admin-token/<name>`)
+ *     enforce GET-only with a 405 and their response bodies are unreadable
+ *     cross-origin (no CORS on these routes).
+ *   - Bearer-authed requests — a cross-site page cannot attach an
+ *     `Authorization` header without a CORS preflight these routes never
+ *     approve, so a request carrying one is not a browser CSRF. The
+ *     downstream auth gate still validates the credential; this belt sits
+ *     only on the cookie path.
+ *   - Server-rendered form posts (`/login`, `/logout`, `/admin/setup/*`,
+ *     `/oauth/authorize` approve) — already carry the double-submit CSRF
+ *     token (`csrf.ts`) and/or `isSameOriginRequest`; not double-gated here.
+ *   - `/vaults` (POST) + `/vaults/<name>` (DELETE) — Bearer
+ *     `parachute:host:admin` gated, CSRF-immune.
+ *   - `/api/*` — Bearer-gated. `/oauth/*` — spec-shaped, own protections.
+ *
+ * Stricter than `isSameOriginRequest` ON PURPOSE: no Referer fallback and —
+ * critically — no Host-header fallback. The Host fallback exists for
+ * server-rendered form flows where the double-submit token is the real
+ * defense and headers got proxy-stripped (#245). These JSON endpoints carry
+ * NO token, so a Host fallback would be a genuine bypass: an attacker form
+ * post under `referrer-policy: no-referrer` arrives with `Origin: null` and
+ * no Referer, and the Host header always names the target. Browsers send a
+ * real `Origin` on every non-GET `fetch()` (same-origin included — default
+ * `mode: "cors"` is exempt from referrer-policy Origin masking), so every
+ * legitimate consumer of these endpoints passes tier 1. `Origin: null` and
+ * malformed values are affirmative mismatches; a missing header on a
+ * cookie-authed mutation is rejected with its own error code
+ * (`csrf_origin_required`) naming the fix (send Origin, or use a Bearer).
+ *
+ * Returns `null` when the request may proceed, or a 403 JSON `Response`
+ * when the belt rejects. Rejections are logged (method, path, origin — no
+ * cookies, no tokens).
+ */
+export function assertSameOriginForCookieMutation(
+  req: Request,
+  boundOrigins: readonly string[],
+): Response | null {
+  if (!MUTATION_METHODS.has(req.method.toUpperCase())) return null;
+  // Authorization present → not a browser CSRF (custom headers require a
+  // CORS preflight no /admin/* route approves). The endpoint's own gate
+  // validates the credential — API clients with Bearers never see the belt.
+  if (req.headers.get("authorization")) return null;
+  // No session cookie → no ambient credential to ride; the endpoint's own
+  // gate returns its usual 401. Presence is enough here — a forged/stale
+  // session id fails downstream regardless of what the belt decides.
+  if (!parseSessionCookie(req.headers.get("cookie"))) return null;
+
+  const pathname = new URL(req.url).pathname;
+  const origin = req.headers.get("origin");
+  if (!origin) {
+    console.warn(`csrf belt: rejected cookie-authed ${req.method} ${pathname} — no Origin header`);
+    return csrfBeltError(
+      "csrf_origin_required",
+      "cookie-authenticated mutations require an Origin header matching the hub origin; browser fetch() sends it automatically — non-browser clients should authenticate with a Bearer token instead",
+    );
+  }
+  if (origin !== "null") {
+    try {
+      if (new Set(boundOrigins).has(new URL(origin).origin)) return null;
+    } catch {
+      // Malformed Origin — fall through to the mismatch rejection.
+    }
+  }
+  console.warn(`csrf belt: rejected cookie-authed ${req.method} ${pathname} — origin=${origin}`);
+  return csrfBeltError(
+    "csrf_origin_mismatch",
+    "request Origin does not match this hub's origin — cross-site mutations are not allowed on cookie-authenticated endpoints",
+  );
+}
+
+function csrfBeltError(code: string, description: string): Response {
+  return new Response(JSON.stringify({ error: code, error_description: description }), {
+    status: 403,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
 }


### PR DESCRIPTION
## What

Phase **C1** of the [2026-06-09 hub–module boundary migration](https://github.com/ParachuteComputer/parachute-patterns/blob/main/migrations/2026-06-09-hub-module-boundary.md): the CSRF belt on cookie-gated `/admin/*` JSON mutation endpoints. Closes #632.

The boundary charter's trust statement names this as in-progress hardening: module surfaces (same-origin under the hub proxy) drive cookie-gated hub identity APIs with `credentials: "include"`, and until now those JSON mutations relied solely on `SameSite=Lax` — no CSRF token, no Origin check.

## Belted endpoints (the explicit enumeration)

Every cookie-gated JSON mutation under `/admin/*` — wired at the two dispatch points in `hub-server.ts`, canonical list in `origin-check.ts` `assertSameOriginForCookieMutation`:

| Endpoint | Methods belted |
|---|---|
| `/admin/connections` | POST |
| `/admin/connections/<id>` | DELETE |
| `/admin/channels` | POST |
| `/admin/channels/<name>` | DELETE |

**Not belted, and why:** the four mint endpoints (`/admin/host-admin-token`, `/admin/channel-token`, `/admin/module-token/<short>`, `/admin/vault-admin-token/<name>`) are GET-only (405-enforced) and their bodies are unreadable cross-origin; `/login`, `/logout`, `/admin/setup/*`, `/oauth/authorize` approve already carry the double-submit token and/or `isSameOriginRequest` (unchanged — not double-gated, not weakened); `/vaults` POST + `/vaults/<name>` DELETE are Bearer `host:admin` (CSRF-immune); `/api/*` Bearer-gated; `/oauth/*` spec-shaped with its own protections.

## Semantics

For POST/PUT/PATCH/DELETE where a **session cookie** is the authorizing credential:

- `Origin` must parse and exact-match the hub's bound-origin set — the same per-request derivation the OAuth cookie-POST paths use (`oauthDeps(req).hubBoundOrigins()`: resolved issuer incl. Host/X-Forwarded-Proto request derivation, loopback aliases, expose-state hostname, platform origin). Multi-origin hubs (loopback + tailnet + funnel + custom domain) keep working.
- Missing `Origin` → **403 `csrf_origin_required`**; mismatched / `null` / malformed → **403 `csrf_origin_mismatch`**. Rejections logged (method + path + origin; no secrets).
- `Authorization` header present → belt passes (a cross-site page cannot attach one without a CORS preflight these routes never approve); the endpoint's own gate still validates the credential. **API clients with Bearers never see the belt.**
- No session cookie → belt passes; the endpoint's usual 401 answers.
- GET/HEAD/OPTIONS untouched.

**The seam needs no coordination:** same-origin `fetch()` sends a real `Origin` on every mutation (default `mode: "cors"` is exempt from referrer-policy Origin masking), so the hub SPA (`web/ui/src/lib/api.ts`) and proxied module pages pass automatically. Verified against the seam's canonical consumer — channel's link-vault page (`parachute-channel/src/admin-ui.ts`) POSTs `/admin/connections` via `fetch(window.location.origin + ..., { credentials: "include" })` — and pinned in the tests.

## Judgment calls

1. **Stricter than `isSameOriginRequest` on purpose — no Referer, no Host fallback.** The Host fallback (#245) exists for server-rendered form flows where the double-submit token is the real defense and a proxy stripped headers. These JSON endpoints carry **no token**, so a Host fallback would be a genuine bypass: an attacker form post under `referrer-policy: no-referrer` arrives with `Origin: null`, no Referer, and a Host that always names the target (and `text/plain` form bodies can smuggle near-JSON). Same reasoning rejects `Origin: null` outright. The existing `isSameOriginRequest` consumers (login/oauth forms) are untouched.
2. **Residual #245 risk accepted, made debuggable.** If some proxy in the wild strips `Origin` on *fetch* POSTs (never actually confirmed in #245 — the confirmed case was form-navigation `Origin: null`, which doesn't affect `fetch`), operators get a distinct, actionable error code (`csrf_origin_required`) naming the fix rather than a mystery 403.
3. **`Authorization`-presence (not validity) skips the belt.** Validity stays the downstream gate's job — duplicating token validation in the belt would double DB reads for zero CSRF value, since the CSRF property comes from "browsers can't attach custom headers cross-site without preflight," not from the token being good.
4. **Belt placed after the `/api/connections/catalog` early-return** so the read-only catalog route stays exactly as it was; the belt covers only the `/admin/*` mutation subtree per the issue scope.
5. **Belt runs before the operator gate** (dispatch-level), so a cross-site request is refused before any session/admin evaluation — and the rejection is observable in tests even with a valid admin session.

## Tests

24 new in `src/__tests__/admin-csrf-belt.test.ts`:
- unit semantics: matching/multi-origin pass; cross-origin, missing-Origin, `Origin: null`, malformed → 403; PUT/PATCH/DELETE gated; GET/HEAD/OPTIONS pass; Bearer (with and without cookie) passes; cookie-less passes; non-session cookies don't arm the belt; empty bound set fails closed
- dispatch wiring: cross-origin + missing-Origin 403 on both endpoint families; same-origin POST reaches handler validation; **X-Forwarded-Proto public-origin proxy case** passes; GET list unaffected (200); Bearer-without-Origin lands on the endpoint's own 401, not a csrf 403
- **seam pin:** the channel link-vault shape (session cookie + correct Origin + `requestedBy: "channel"` body) clears the belt and operator gate into catalog validation

## Gates

- `bun test ./src`: **3273 pass / 1 skip / 0 fail** (24 new)
- `bun run typecheck` (`tsc --noEmit`): clean
- `bunx biome check`: clean
- No version bump (per current RC policy — tag-time bumps only)
- web/ui untouched (browser fetch sends Origin automatically; no SPA change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)