### PR TITLE
release: v0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.6.5-rc.8",
+  "version": "0.7.0",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Version bump for the stable push (Aaron's ship call, 2026-06-09 — post-boundary-arc). Promotes everything since 0.6.4: the 0.6.5-rc hardening chain (expose+DB self-heal, OAuth open-redirect fix, supervisor port-reclaim, PR-time CI) PLUS the hub-module boundary arc (DELETE /vaults identity cascade, registered connection mints, /vault/admin route, URL-semantics unification + compat shim, Origin belt, SPA slim, /admin/channels retired, mint re-gate). Minor bump for the architecture shift. Tag v0.7.0 follows merge; CI publishes to npm @latest on the tag push. 🤖 Generated with [Claude Code](https://claude.com/claude-code)