### PR TITLE
feat(audience-gate): `surface` tier — backed surfaces own their own admission (H3 + Aaron's audience-options direction)

### DIFF
--- a/src/__tests__/audience-gate.test.ts
+++ b/src/__tests__/audience-gate.test.ts
@@ -284,6 +284,98 @@ describe("audience gate matrix (H3)", () => {
     }
   });
 
+  test("audience: surface — anon passes through on document, API, and WS-upgrade shapes (the surface self-auths)", async () => {
+    const upstream = startEchoUpstream();
+    try {
+      writeServices({
+        ...surfaceEntry(upstream.port, { audience: "surface" }),
+        websocket: true,
+      });
+      const f = fetcher();
+
+      // Anonymous document request — NO 302 to /login (this was the concrete
+      // blocker: capability-link invitees aren't hub users by design).
+      const anonDoc = await f(
+        req("/surface/notes/", { headers: { accept: "text/html" } }),
+        fakeServer("127.0.0.1"),
+      );
+      expect(anonDoc?.status).toBe(200);
+
+      // Anonymous API-shaped request — no 401; the surface decides.
+      const anonApi = await f(
+        req("/surface/notes/api/docs", { method: "POST" }),
+        fakeServer("127.0.0.1"),
+      );
+      expect(anonApi?.status).toBe(200);
+
+      // Anonymous WebSocket upgrade — passes the gate and upgrades (the
+      // docs editor's collab WS rides this; the surface auths the socket).
+      let upgradeCalls = 0;
+      const spy = {
+        requestIP: () => ({ address: "127.0.0.1" }),
+        upgrade: () => {
+          upgradeCalls++;
+          return true;
+        },
+      };
+      const ws = await f(
+        req("/surface/notes/ws", {
+          headers: { upgrade: "websocket", connection: "Upgrade" },
+        }),
+        spy,
+      );
+      expect(ws).toBeUndefined();
+      expect(upgradeCalls).toBe(1);
+    } finally {
+      upstream.stop();
+    }
+  });
+
+  test("audience: surface — passes on an ABSENT DB (stateless boot), like public", async () => {
+    // The surface self-auths every request — a hub-side deny on a missing
+    // identity store would break the surface for zero security gain (the
+    // hub's DB plays no part in the surface's admission decision). `public`
+    // passes on absent DB for the same structural reason; pin the parity.
+    const upstream = startEchoUpstream();
+    try {
+      writeServices(surfaceEntry(upstream.port, { audience: "surface" }));
+      const statelessFetcher = hubFetch(h.dir, {
+        // no getDb — the hub booted without a DB
+        manifestPath: h.manifestPath,
+        loadExposeHubOrigin: () => undefined,
+      });
+      const res = await statelessFetcher(req("/surface/notes/x"), fakeServer("127.0.0.1"));
+      expect(res?.status).toBe(200);
+
+      // Contrast: hub-users on the same stateless boot still fails closed.
+      writeServices(surfaceEntry(upstream.port, { audience: "hub-users" }));
+      const denied = await statelessFetcher(req("/surface/notes/x"), fakeServer("127.0.0.1"));
+      expect(denied?.status).toBe(401);
+    } finally {
+      upstream.stop();
+    }
+  });
+
+  test("audience: surface — the loopback cloak still wins (exposure is orthogonal to audience)", async () => {
+    const upstream = startEchoUpstream();
+    try {
+      writeServices({
+        ...surfaceEntry(upstream.port, { audience: "surface" }),
+        publicExposure: "loopback",
+      });
+      // Public-layer caller: a surface-audience mount on a loopback-only row
+      // is unreachable from funnel — same as public; the audience never
+      // bypasses the exposure layer.
+      const res = await fetcher()(
+        req("/surface/notes/x", { headers: { "cf-ray": "1" } }),
+        fakeServer("127.0.0.1"),
+      );
+      expect(res?.status).toBe(404);
+    } finally {
+      upstream.stop();
+    }
+  });
+
   test("absent audience defaults to hub-users (anon denied)", async () => {
     const upstream = startEchoUpstream();
     try {
@@ -502,6 +594,43 @@ describe("resolveUiMount", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // The fourth tier is a valid manifest value: validation accepts it and the
+  // validated write round-trips it (a backed surface registering
+  // `audience: "surface"` must survive a hub-side manifest rewrite).
+  test("manifest validation accepts audience: 'surface' and round-trips it", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pcli-uis-surface-roundtrip-"));
+    const p = join(dir, "services.json");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-surface",
+              port: 1946,
+              paths: ["/surface"],
+              health: "/surface/healthz",
+              version: "0.3.0",
+              uis: {
+                "docs-editor": {
+                  displayName: "Docs Editor",
+                  path: "/surface/docs",
+                  audience: "surface",
+                },
+              },
+            },
+          ],
+        },
+        p,
+      );
+      const raw = JSON.parse(require("node:fs").readFileSync(p, "utf8") as string) as {
+        services: { uis: Record<string, { audience?: string }> }[];
+      };
+      expect(raw.services[0]?.uis["docs-editor"]?.audience).toBe("surface");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ===========================================================================
@@ -563,6 +692,34 @@ describe("chrome strip × audience (H5)", () => {
       const html = await res?.text();
       expect(html).toContain("pc-chrome"); // identity chrome present
       expect(html).toContain("surface page");
+    } finally {
+      upstream.stop();
+    }
+  });
+
+  test("audience: surface → NO injected chrome (capability invitees aren't hub users — follows the public precedent)", async () => {
+    const upstream = startHtmlUpstream();
+    try {
+      // Mount OUTSIDE the static /surface/notes/ opt-out so the audience
+      // mechanism (not the legacy hardcoded prefix) is what's exercised.
+      writeServices({
+        name: "parachute-surface",
+        port: upstream.port,
+        paths: ["/surface"],
+        health: "/surface/healthz",
+        version: "0.3.0",
+        uis: {
+          docs: { displayName: "Docs Editor", path: "/surface/docs", audience: "surface" },
+        },
+      });
+      const res = await fetcher()(
+        req("/surface/docs/some-doc", { headers: { accept: "text/html" } }),
+        fakeServer("127.0.0.1"),
+      );
+      expect(res?.status).toBe(200);
+      const html = await res?.text();
+      expect(html).toContain("surface page"); // upstream body intact
+      expect(html).not.toContain("pc-chrome"); // identity chrome absent
     } finally {
       upstream.stop();
     }

--- a/src/audience-gate.ts
+++ b/src/audience-gate.ts
@@ -155,7 +155,8 @@ export function scopesSatisfyRequirement(
 }
 
 export interface AudienceGateDeps {
-  /** Hub DB — absent (stateless boot) denies every non-public audience. */
+  /** Hub DB — absent (stateless boot) denies every hub-gated audience
+   *  (`hub-users` / `operator`); `public` and `surface` pass without it. */
   db: Database | undefined;
   /**
    * The hub's bound-origin set for Bearer `iss` validation (the hub#516

--- a/src/audience-gate.ts
+++ b/src/audience-gate.ts
@@ -4,9 +4,9 @@
  *
  * A module's services.json row may carry a `uis{}` map of hosted UI
  * sub-units; each sub-unit now declares an `audience`
- * (`public | hub-users | operator`, default `hub-users`). The HUB PROXY
- * enforces it BEFORE forwarding — surface-host serves whatever the proxy
- * lets through, exactly like the publicExposure cloak.
+ * (`public | hub-users | operator | surface`, default `hub-users`). The HUB
+ * PROXY enforces it BEFORE forwarding — surface-host serves whatever the
+ * proxy lets through, exactly like the publicExposure cloak.
  *
  * Scope discipline: the gate covers the SURFACE UI MOUNTS specifically (the
  * uis sub-unit paths), not every module path — a module's own APIs keep
@@ -14,7 +14,7 @@
  * The gate also runs before WebSocket upgrades on a gated mount (threaded
  * into `maybeUpgradeWebSocket`).
  *
- * The three audiences:
+ * The four audiences:
  *
  *   public    — pass (and the chrome strip is disabled — H5: public readers
  *               aren't hub users).
@@ -29,16 +29,43 @@
  *   operator  — the first-admin session only. A Bearer never satisfies this
  *               tier (operator surfaces are interactive; the session is the
  *               operator's presence).
+ *   surface   — pass: the surface backend owns admission END-TO-END
+ *               (backed surfaces — parachute-surface runtime, surfaces with
+ *               their own server entry, kit-authenticated via
+ *               @openparachute/surface-server: hub JWTs / capability links /
+ *               anon, deny-by-default with a public conformance suite). The
+ *               hub gating these would add a SECOND auth layer that BLOCKS
+ *               the surface's own audience plane — e.g. the docs-editor's
+ *               capability-link invitees are NOT hub users by design, so a
+ *               hub-users gate would 302 them to /login before the surface's
+ *               own auth ever ran. Chrome strip follows the `public`
+ *               precedent (disabled — the visitors are mostly capability
+ *               invitees, not hub users), and WS upgrades pass through too
+ *               (the gate threads into `maybeUpgradeWebSocket`; null = no
+ *               deny = the upgrade proceeds to the capability check).
  *
  * Deny shape: document requests (GET + Accept: text/html, no session) get a
  * 302 to `/login?next=<path>`; everything else gets 401/403 JSON. A
  * signed-in-but-insufficient caller (non-admin on an operator surface, or a
  * Bearer missing the required scopes) gets 403, not a login redirect.
  *
+ * Exposure layers are ORTHOGONAL to the audience: the `publicExposure`
+ * cloak runs at the service-row level BEFORE this gate (dispatch skips the
+ * gate entirely on a cloaked row so the 404 stays indistinguishable from
+ * not-installed). A `surface`-audience mount on a loopback-only row is
+ * therefore still unreachable from tailnet/funnel — exactly like `public`.
+ *
  * Fail-closed posture: malformed `audience` metadata never reaches this
  * module — `services-manifest.ts` validation rejects the row and the lenient
  * read drops it (the mount 404s). An absent DB (hub booted stateless) denies
- * every non-public audience.
+ * every audience that needs an identity store: `hub-users` and `operator`.
+ * `public` and `surface` still pass — neither consults hub identity
+ * (`surface` self-auths every request; denying it on absent DB would break
+ * the surface for zero security gain). Version skew: a surface declaring
+ * `audience: "surface"` registered against an OLDER hub (pre-dating the
+ * value) gets its row rejected by manifest validation — the mount 404s
+ * until the hub upgrades; the surface-side meta-schema ships the value
+ * separately with a hub-version requirement note.
  */
 
 import type { Database } from "bun:sqlite";
@@ -171,8 +198,15 @@ export async function gateUiAudience(
 ): Promise<Response | null> {
   if (audience === "public") return null;
 
+  // `surface` — pass through unconditionally (incl. on an absent DB, below):
+  // the surface backend authenticates EVERY request itself (deny-by-default
+  // kit auth: hub JWTs / capability links / anon). A hub-side deny here
+  // would block the surface's own audience plane — its capability-link
+  // invitees are not hub users by design.
+  if (audience === "surface") return null;
+
   // Fail closed without a DB: no identity store, no way to admit anyone to
-  // a non-public surface.
+  // a hub-gated (`hub-users` / `operator`) surface.
   if (!deps.db) {
     return wantsDocument(req)
       ? loginRedirect(req)

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -1874,8 +1874,11 @@ export function hubFetch(
           readModuleManifestFn: deps?.readModuleManifest ?? defaultReadModuleManifest,
           // H3 — the audience gate runs BEFORE the upgrade, same posture as
           // the HTTP dispatch below: a WS endpoint under a hub-users surface
-          // never hands a socket to an anonymous caller. (The publicExposure
-          // cloak already ran inside maybeUpgradeWebSocket before this hook.)
+          // never hands a socket to an anonymous caller, while `surface`
+          // audiences pass through (the backed surface authenticates the
+          // socket itself — e.g. the docs editor's collab WS rides this).
+          // (The publicExposure cloak already ran inside
+          // maybeUpgradeWebSocket before this hook.)
           gateAudience: async (wsPathname) => {
             const wsUiMatch = resolveUiMount(
               readManifestLenient(manifestPath).services,
@@ -3339,13 +3342,17 @@ export function hubFetch(
       // H3 — per-UI audience gate. When the path falls under a declared UI
       // sub-unit (a `uis{}` entry on the matched service row — surface-hosted
       // UI mounts like /surface/<name>/*), the sub-unit's audience is
-      // enforced BEFORE forwarding: 'public' passes, 'hub-users' requires a
-      // session or a scope-satisfying Bearer, 'operator' requires the first
-      // admin. Module API paths outside any uis entry are NOT gated here —
-      // modules keep their own auth. Ordering nuance: when the row's
-      // publicExposure cloak would fire (loopback-only, non-loopback layer),
-      // the gate is SKIPPED so the 404 cloak stays indistinguishable from
-      // not-installed (a 401 here would leak the route's existence).
+      // enforced BEFORE forwarding: 'public' passes, 'surface' passes (the
+      // backed surface authenticates every request itself), 'hub-users'
+      // requires a session or a scope-satisfying Bearer, 'operator' requires
+      // the first admin. Module API paths outside any uis entry are NOT
+      // gated here — modules keep their own auth. Ordering nuance: when the
+      // row's publicExposure cloak would fire (loopback-only, non-loopback
+      // layer), the gate is SKIPPED so the 404 cloak stays indistinguishable
+      // from not-installed (a 401 here would leak the route's existence) —
+      // which also means a 'surface'/'public' mount on a loopback-only row
+      // stays unreachable from tailnet/funnel: exposure is orthogonal to
+      // audience.
       const uiMatch = resolveUiMount(readManifestLenient(manifestPath).services, pathname);
       if (uiMatch) {
         const cloaked =
@@ -3363,15 +3370,20 @@ export function hubFetch(
       if (proxied) {
         // H5 — chrome-strip rides the gate: where the audience resolved
         // `public`, the identity chrome is disabled for that mount (public
-        // readers aren't hub users). Reuses the per-path opt-out mechanism
-        // the /surface/notes/ precedent established, generalized to the
-        // declared audience.
+        // readers aren't hub users). `surface` follows the same precedent —
+        // a backed surface's visitors are mostly capability-link invitees,
+        // NOT hub users, so the "Signed in as…" chrome would be wrong for
+        // them (and the surface owns its whole page anyway). Reuses the
+        // per-path opt-out mechanism the /surface/notes/ precedent
+        // established, generalized to the declared audience.
         return decorateWithChrome(
           proxied,
           req,
           pathname,
           getDb,
-          uiMatch !== undefined && uiMatch.audience === "public" ? [uiMatch.mount] : undefined,
+          uiMatch !== undefined && (uiMatch.audience === "public" || uiMatch.audience === "surface")
+            ? [uiMatch.mount]
+            : undefined,
         );
       }
 
@@ -3403,7 +3415,8 @@ export function hubFetch(
  *
  * `extraOptOutPrefixes` (H5) generalizes the static opt-out list: the
  * dispatch passes the matched UI mount when the audience gate resolved
- * `public` — public readers aren't hub users, so the identity chrome
+ * `public` or `surface` — public readers (and a backed surface's
+ * capability-link invitees) aren't hub users, so the identity chrome
  * ("Signed in as…", Sign in link) must not ride their pages. Same
  * mechanism as the hardcoded `/surface/notes/` precedent, now driven by
  * the sub-unit's declared audience instead of a hub-side path list.

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -81,16 +81,27 @@ function normalizeUiSubUnitStatus(value: string): UiSubUnitStatus | undefined {
  *                 scopes satisfy the surface's `scopes_required` (the OR
  *                 keeps installed PWAs working). THE DEFAULT when absent.
  *   "operator"  — the first-admin session only.
+ *   "surface"   — the surface backend owns admission END-TO-END; the hub
+ *                 proxy passes every request through (backed surfaces —
+ *                 kit-authenticated via @openparachute/surface-server: hub
+ *                 JWTs / capability links / anon, deny-by-default). Chrome
+ *                 strip off like `public` — capability-link invitees are
+ *                 NOT hub users.
  *
  * Enforced at the hub proxy BEFORE forwarding (`src/audience-gate.ts`).
  * Legacy boolean `public` on the wire is accepted one alias window:
  * `public: true` → `"public"`, `public: false` → default. Fail-closed: an
  * unrecognized `audience` value rejects the row (the lenient manifest read
- * then drops it — unroutable beats accidentally public).
+ * then drops it — unroutable beats accidentally public). Version-skew
+ * corollary: a surface declaring `audience: "surface"` registered against a
+ * hub OLDER than this value's introduction gets its row rejected by that
+ * same fail-closed rule — the mount 404s until the hub is upgraded. The
+ * surface-side meta-schema ships the value with a hub-version requirement
+ * note for exactly this reason.
  */
-export type UiAudience = "public" | "hub-users" | "operator";
+export type UiAudience = "public" | "hub-users" | "operator" | "surface";
 
-const UI_AUDIENCE_VALUES: readonly UiAudience[] = ["public", "hub-users", "operator"];
+const UI_AUDIENCE_VALUES: readonly UiAudience[] = ["public", "hub-users", "operator", "surface"];
 
 /**
  * A sub-unit beneath a module — used today by parachute-app to surface each
@@ -467,7 +478,7 @@ function validateUiSubUnit(raw: unknown, where: string): UiSubUnit {
       !(UI_AUDIENCE_VALUES as readonly string[]).includes(u.audience)
     ) {
       throw new ServicesManifestError(
-        `${where}: "audience" must be "public" | "hub-users" | "operator" if present (got ${JSON.stringify(u.audience)})`,
+        `${where}: "audience" must be "public" | "hub-users" | "operator" | "surface" if present (got ${JSON.stringify(u.audience)})`,
       );
     }
     audience = u.audience as UiAudience;


### PR DESCRIPTION
## What

Adds the fourth audience value, `surface`, to the per-UI audience gate (H3, shipped in #648). Backed surfaces — parachute-surface runtime surfaces with their own server entry, kit-authenticated via `@openparachute/surface-server` (hub JWTs / capability links / anon, deny-by-default + public conformance suite) — own admission END-TO-END; the hub proxy passes through. Hub gating them adds a second auth layer that BLOCKS their own audience plane.

**Concrete blocker fixed:** the docs-editor's capability-link invitees (NOT hub users by design) currently get 302→/login at the proxy before the surface's own auth runs.

Per Aaron's direction (2026-06-10): audiences should have options — public surfaces, surfaces with their own auth layer, and hub-gated surfaces are all legitimate.

## The four tiers

| Audience | Who passes | Who decides |
|---|---|---|
| `public` | anyone | nobody — open |
| `hub-users` *(default)* | hub session OR scope-satisfying hub Bearer | hub |
| `operator` | first-admin session only | hub |
| `surface` *(new)* | everyone at the proxy — the surface authenticates every request itself | **the surface** |

## Gate behavior matrix

| Request shape | `public` | `hub-users` | `operator` | `surface` (new) |
|---|---|---|---|---|
| Document (GET + Accept: text/html), anon | pass | 302 → /login | 302 → /login | **pass** |
| API-shaped, anon | pass | 401 JSON | 401 JSON | **pass** |
| WS upgrade, anon | pass → capability check | 401, no socket | 401, no socket | **pass → capability check** (docs editor's collab WS rides this) |
| Stateless boot (absent DB) | pass | denied (fail-closed) | denied (fail-closed) | **pass** — the surface self-auths; denying on absent DB breaks it for zero security gain (the hub DB plays no part in its admission decision). Pinned by test. |

## Chrome + exposure interaction

- **Chrome strip (H5):** disabled for `surface` mounts, following the `public` precedent — the visitors are mostly capability-link invitees, not hub users, so the "Signed in as…" identity chrome would be wrong for them. Same per-path opt-out mechanism, driven by the declared audience. Pinned by test.
- **publicExposure cloak:** unchanged and orthogonal — the cloak runs at the service-row level BEFORE the gate (dispatch skips the gate on a cloaked row so the 404 stays indistinguishable from not-installed). A `surface`-audience mount on a loopback-only row is still unreachable from tailnet/funnel, exactly like `public`. Pinned by test.

## Version-skew note

A surface declaring `audience: "surface"` registered against an OLDER hub (pre-dating this value) gets its row rejected by manifest validation — fail-closed, the mount 404s until the hub upgrades. This is the intended posture (unroutable beats accidentally open). The surface-side meta-schema ships the value separately with a hub-version requirement note (different repo — handled there). Documented in the gate header and the `UiAudience` docstring.

## Deferred

Hub-side per-surface ACL tier ("user needs access to that surface", e.g. `audience: "granted-users"`) — Aaron wants it as an option eventually; filed as #650 with a sketch, not implemented here.

## Tests

New: surface × (anon document / API / WS-upgrade) pass-through; absent-DB parity with `public` (+ `hub-users` contrast on the same stateless fetcher); loopback cloak × surface; manifest validation acceptance + `writeManifest` round-trip; chrome-strip off for a surface mount outside the static opt-out list. Existing fail-closed test still pins unknown-value rejection.

## Gates

- `bun test ./src` → **3339 pass, 1 skip, 0 fail** (3340 tests across 133 files)
- `bun run typecheck` → clean
- `bunx biome check` on the 4 touched files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)