### PR TITLE
feat(connections): claim/reconcile path — modules backfill the hub-side record for directly-delivered credentials (surface#113)

### DIFF
--- a/src/__tests__/admin-connections-credentials.test.ts
+++ b/src/__tests__/admin-connections-credentials.test.ts
@@ -20,9 +20,15 @@ import {
   buildCatalog,
   handleConnections,
 } from "../admin-connections.ts";
-import { readConnections } from "../connections-store.ts";
+import { putConnection, readConnections } from "../connections-store.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
-import { findTokenRowByJti, listActiveRevocations } from "../jwt-sign.ts";
+import {
+  findTokenRowByJti,
+  listActiveRevocations,
+  recordTokenMint,
+  revokeTokenByJti,
+  signAccessToken,
+} from "../jwt-sign.ts";
 import {
   type ModuleManifest,
   ModuleManifestError,
@@ -773,5 +779,488 @@ describe("credential connection — catalog", () => {
     );
     expect(validated.credentials?.length).toBe(1);
     expect(validated.credentials?.[0]?.scope).toBe("vault:{vault}:read");
+  });
+});
+
+// ===========================================================================
+// Claim / reconcile (surface#113)
+// ===========================================================================
+
+/**
+ * The live-incident shape (surface#113): a credential minted via the CLI
+ * (`parachute auth mint-token` → created_via "cli_mint") and POSTed straight
+ * to the module's delivery endpoint. Valid, REGISTERED, held by the module —
+ * but no ConnectionRecord exists, so jti-bound renewal 404s.
+ */
+const DIRECT_TTL_SECONDS = 90 * 24 * 60 * 60;
+
+async function mintDirectDelivered(opts: {
+  vault: string;
+  verb: "read" | "write";
+  tags?: string[];
+  /** Skip the tokens-registry row (the unregistered-jti refusal case). */
+  register?: boolean;
+  now?: () => Date;
+}): Promise<{ token: string; jti: string }> {
+  const scope = `vault:${opts.vault}:${opts.verb}`;
+  const tags = opts.tags ?? [];
+  const signed = await signAccessToken(harness.db, {
+    sub: "operator-user",
+    scopes: [scope],
+    audience: `vault.${opts.vault}`,
+    clientId: "parachute-hub",
+    issuer: HUB_ORIGIN,
+    ttlSeconds: DIRECT_TTL_SECONDS,
+    vaultScope: [opts.vault],
+    ...(tags.length > 0 ? { extraClaims: { permissions: { scoped_tags: tags } } } : {}),
+    ...(opts.now ? { now: opts.now } : {}),
+  });
+  if (opts.register !== false) {
+    recordTokenMint(harness.db, {
+      jti: signed.jti,
+      createdVia: "cli_mint",
+      subject: "operator",
+      clientId: "parachute-hub",
+      scopes: [scope],
+      expiresAt: signed.expiresAt,
+      ...(tags.length > 0 ? { permissions: JSON.stringify({ scoped_tags: tags }) } : {}),
+      ...(opts.now ? { now: opts.now } : {}),
+    });
+  }
+  return { token: signed.token, jti: signed.jti };
+}
+
+function claimReq(id: string, body: Record<string, unknown>, bearer?: string): Request {
+  return new Request(`http://127.0.0.1/admin/connections/${id}/claim`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(bearer ? { authorization: `Bearer ${bearer}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function approveReq(id: string, cookie?: string): Request {
+  return new Request(`http://127.0.0.1/admin/connections/${id}/approve`, {
+    method: "POST",
+    headers: cookie ? { cookie } : {},
+  });
+}
+
+const SURFACE_CLAIM = { module: "surface", key: "vault", vault: "default" };
+const CLAIM_ID = "cred-surface-vault-default";
+
+describe("credential connection — claim/reconcile (surface#113)", () => {
+  test("headline: directly-delivered credential has no record → renewal 404s (the pre-fix bug); claim → pending → approve → renewal succeeds", async () => {
+    const { fetchImpl } = mockFetch({});
+    const deps = credDeps(fetchImpl, modulesOf(SURFACE_MANIFEST));
+    const direct = await mintDirectDelivered({ vault: "default", verb: "read", tags: ["boulder"] });
+
+    // PRE-FIX pin (extends the "unknown connection id → 404" pin above): the
+    // credential is valid + registered, but with no hub-side record the
+    // jti-bound renewal 404s — exactly the surface#113 live failure.
+    const before = await handleConnections(
+      renewReq(CLAIM_ID, direct.token),
+      `/${CLAIM_ID}/renew`,
+      deps,
+    );
+    expect(before.status).toBe(404);
+
+    // Claim by proof of possession → 202 + a PENDING record derived from the
+    // SIGNED token (scope/tags) + the module's declaration (endpoint).
+    const claim = await handleConnections(
+      claimReq(CLAIM_ID, SURFACE_CLAIM, direct.token),
+      `/${CLAIM_ID}/claim`,
+      deps,
+    );
+    expect(claim.status).toBe(202);
+    const claimBody = (await claim.json()) as {
+      ok: boolean;
+      status: string;
+      connection_id: string;
+    };
+    expect(claimBody.ok).toBe(true);
+    expect(claimBody.status).toBe("pending");
+    expect(claimBody.connection_id).toBe(CLAIM_ID);
+
+    const rec = readConnections(harness.storePath)[0]!;
+    expect(rec.status).toBe("pending");
+    expect(rec.kind).toBe("credential");
+    expect(rec.provisioned.mintedJtis).toEqual([direct.jti]);
+    expect(rec.provisioned.scope).toBe("vault:default:read");
+    expect(rec.provisioned.scopedTags).toEqual(["boulder"]);
+    expect(rec.provisioned.credentialKey).toBe("vault");
+    expect(rec.provisioned.endpoint).toBe("/api/credential");
+    expect(rec.requestedBy).toBe("surface");
+
+    // A claim grants nothing: renewal still refused while pending (the
+    // pending state is revealed only after the possession proof).
+    const pendingRenew = await handleConnections(
+      renewReq(CLAIM_ID, direct.token),
+      `/${CLAIM_ID}/renew`,
+      deps,
+    );
+    expect(pendingRenew.status).toBe(403);
+    expect(((await pendingRenew.json()) as { error: string }).error).toBe("pending_approval");
+
+    // Approval is operator-gated: no session → 401, record stays pending.
+    const noSession = await handleConnections(approveReq(CLAIM_ID), `/${CLAIM_ID}/approve`, deps);
+    expect(noSession.status).toBe(401);
+    expect(readConnections(harness.storePath)[0]!.status).toBe("pending");
+
+    const { cookie } = await adminCookie();
+    const approved = await handleConnections(
+      approveReq(CLAIM_ID, cookie),
+      `/${CLAIM_ID}/approve`,
+      deps,
+    );
+    expect(approved.status).toBe(200);
+    expect(((await approved.json()) as { status: string }).status).toBe("active");
+    expect(readConnections(harness.storePath)[0]!.status).toBeUndefined();
+
+    // Renewal now proceeds through the UNCHANGED flow: same scope + tags
+    // re-minted, old jti revoked, record updated.
+    const renew = await handleConnections(
+      renewReq(CLAIM_ID, direct.token),
+      `/${CLAIM_ID}/renew`,
+      deps,
+    );
+    expect(renew.status).toBe(200);
+    const out = (await renew.json()) as { ok: boolean; credential: DeliveredCredential };
+    expect(out.credential.op).toBe("renewed");
+    expect(out.credential.scope).toBe("vault:default:read");
+    expect(out.credential.scoped_tags).toEqual(["boulder"]);
+    expect(out.credential.jti).not.toBe(direct.jti);
+    expect(findTokenRowByJti(harness.db, direct.jti)!.revokedAt).not.toBeNull();
+    expect(readConnections(harness.storePath)[0]!.provisioned.mintedJtis).toEqual([
+      out.credential.jti!,
+    ]);
+  });
+
+  test("the live docs shape: an UNTAGGED write credential is claimable verbatim (create's write-requires-tags guards NEW grants; the operator's approve sanctions the existing shape)", async () => {
+    const { fetchImpl } = mockFetch({});
+    const deps = credDeps(fetchImpl, modulesOf(SURFACE_MANIFEST));
+    const id = "cred-surface-vault-write-default";
+    const direct = await mintDirectDelivered({ vault: "default", verb: "write" });
+
+    const claim = await handleConnections(
+      claimReq(id, { module: "surface", key: "vault-write", vault: "default" }, direct.token),
+      `/${id}/claim`,
+      deps,
+    );
+    expect(claim.status).toBe(202);
+    const rec = readConnections(harness.storePath)[0]!;
+    expect(rec.provisioned.scope).toBe("vault:default:write");
+    expect(rec.provisioned.scopedTags).toEqual([]);
+
+    const { cookie } = await adminCookie();
+    await handleConnections(approveReq(id, cookie), `/${id}/approve`, deps);
+    const renew = await handleConnections(renewReq(id, direct.token), `/${id}/renew`, deps);
+    expect(renew.status).toBe(200);
+    const out = (await renew.json()) as { credential: DeliveredCredential };
+    expect(out.credential.scope).toBe("vault:default:write");
+    expect(out.credential.scoped_tags).toEqual([]);
+    const claims = decodeJwt(out.credential.token!) as { scope?: string; permissions?: unknown };
+    expect(claims.scope).toBe("vault:default:write");
+    expect(claims.permissions).toBeUndefined();
+  });
+
+  test("refusals are GENERIC and identical across causes — no oracle on registry contents", async () => {
+    const { fetchImpl } = mockFetch({});
+    const deps = credDeps(fetchImpl, modulesOf(SURFACE_MANIFEST));
+    const readCred = await mintDirectDelivered({ vault: "default", verb: "read" });
+    const unregistered = await mintDirectDelivered({
+      vault: "default",
+      verb: "read",
+      register: false,
+    });
+
+    const cases: { name: string; req: Request; subPath: string }[] = [
+      {
+        name: "unregistered jti",
+        req: claimReq(CLAIM_ID, SURFACE_CLAIM, unregistered.token),
+        subPath: `/${CLAIM_ID}/claim`,
+      },
+      {
+        name: "verb/scope mismatch (read token against the write key)",
+        req: claimReq(
+          "cred-surface-vault-write-default",
+          { module: "surface", key: "vault-write", vault: "default" },
+          readCred.token,
+        ),
+        subPath: "/cred-surface-vault-write-default/claim",
+      },
+      {
+        name: "id does not match module/key/vault",
+        req: claimReq("cred-surface-vault-other", SURFACE_CLAIM, readCred.token),
+        subPath: "/cred-surface-vault-other/claim",
+      },
+      {
+        name: "unknown module",
+        req: claimReq(
+          "cred-ghost-vault-default",
+          { ...SURFACE_CLAIM, module: "ghost" },
+          readCred.token,
+        ),
+        subPath: "/cred-ghost-vault-default/claim",
+      },
+      {
+        name: "undeclared credential key",
+        req: claimReq(
+          "cred-surface-nope-default",
+          { ...SURFACE_CLAIM, key: "nope" },
+          readCred.token,
+        ),
+        subPath: "/cred-surface-nope-default/claim",
+      },
+      {
+        name: "unknown vault",
+        req: claimReq(
+          "cred-surface-vault-ghost",
+          { ...SURFACE_CLAIM, vault: "ghost" },
+          readCred.token,
+        ),
+        subPath: "/cred-surface-vault-ghost/claim",
+      },
+    ];
+
+    const bodies: string[] = [];
+    for (const c of cases) {
+      const res = await handleConnections(c.req, c.subPath, deps);
+      expect(res.status).toBe(403);
+      bodies.push(await res.text());
+    }
+    // One indistinguishable refusal across every cause.
+    expect(new Set(bodies).size).toBe(1);
+    expect(JSON.parse(bodies[0]!)).toEqual({
+      error: "claim_rejected",
+      error_description: "the presented credential does not match a claimable connection",
+    });
+    // And no record was ever written.
+    expect(readConnections(harness.storePath).length).toBe(0);
+  });
+
+  test("expired or revoked credentials cannot be claimed — 401, no record written (re-link is the path)", async () => {
+    const { fetchImpl } = mockFetch({});
+    const deps = credDeps(fetchImpl, modulesOf(SURFACE_MANIFEST));
+
+    const past = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000);
+    const expired = await mintDirectDelivered({ vault: "default", verb: "read", now: () => past });
+    const expiredRes = await handleConnections(
+      claimReq(CLAIM_ID, SURFACE_CLAIM, expired.token),
+      `/${CLAIM_ID}/claim`,
+      deps,
+    );
+    expect(expiredRes.status).toBe(401);
+    expect(((await expiredRes.json()) as { error: string }).error).toBe("invalid_credential");
+
+    const revoked = await mintDirectDelivered({ vault: "default", verb: "read" });
+    revokeTokenByJti(harness.db, revoked.jti, new Date());
+    const revokedRes = await handleConnections(
+      claimReq(CLAIM_ID, SURFACE_CLAIM, revoked.token),
+      `/${CLAIM_ID}/claim`,
+      deps,
+    );
+    expect(revokedRes.status).toBe(401);
+
+    const noBearer = await handleConnections(
+      claimReq(CLAIM_ID, SURFACE_CLAIM),
+      `/${CLAIM_ID}/claim`,
+      deps,
+    );
+    expect(noBearer.status).toBe(401);
+
+    expect(readConnections(harness.storePath).length).toBe(0);
+  });
+
+  test("idempotent re-claim → same single pending record, no dupes; a different valid credential supersedes the unapproved claim", async () => {
+    const { fetchImpl } = mockFetch({});
+    const deps = credDeps(fetchImpl, modulesOf(SURFACE_MANIFEST));
+    const a = await mintDirectDelivered({ vault: "default", verb: "read", tags: ["x"] });
+
+    const first = await handleConnections(
+      claimReq(CLAIM_ID, SURFACE_CLAIM, a.token),
+      `/${CLAIM_ID}/claim`,
+      deps,
+    );
+    expect(first.status).toBe(202);
+    const again = await handleConnections(
+      claimReq(CLAIM_ID, SURFACE_CLAIM, a.token),
+      `/${CLAIM_ID}/claim`,
+      deps,
+    );
+    expect(again.status).toBe(202);
+    let records = readConnections(harness.storePath);
+    expect(records.length).toBe(1);
+    expect(records[0]!.provisioned.mintedJtis).toEqual([a.jti]);
+
+    // PENDING grants nothing, so a second fully-validated credential may
+    // supersede it (last writer wins until the operator approves).
+    const b = await mintDirectDelivered({ vault: "default", verb: "read", tags: ["y"] });
+    const supersede = await handleConnections(
+      claimReq(CLAIM_ID, SURFACE_CLAIM, b.token),
+      `/${CLAIM_ID}/claim`,
+      deps,
+    );
+    expect(supersede.status).toBe(202);
+    records = readConnections(harness.storePath);
+    expect(records.length).toBe(1);
+    expect(records[0]!.status).toBe("pending");
+    expect(records[0]!.provisioned.mintedJtis).toEqual([b.jti]);
+    expect(records[0]!.provisioned.scopedTags).toEqual(["y"]);
+  });
+
+  test("no mutation without approval: a pending renewal attempt mints nothing, revokes nothing, rewrites nothing", async () => {
+    const { fetchImpl } = mockFetch({});
+    const deps = credDeps(fetchImpl, modulesOf(SURFACE_MANIFEST));
+    const direct = await mintDirectDelivered({ vault: "default", verb: "read", tags: ["t"] });
+    await handleConnections(
+      claimReq(CLAIM_ID, SURFACE_CLAIM, direct.token),
+      `/${CLAIM_ID}/claim`,
+      deps,
+    );
+
+    const tokenCount = () =>
+      (harness.db.query("SELECT COUNT(*) AS c FROM tokens").get() as { c: number }).c;
+    const before = tokenCount();
+    const recordBefore = JSON.stringify(readConnections(harness.storePath));
+
+    const renew = await handleConnections(
+      renewReq(CLAIM_ID, direct.token),
+      `/${CLAIM_ID}/renew`,
+      deps,
+    );
+    expect(renew.status).toBe(403);
+
+    expect(tokenCount()).toBe(before); // no new mint registered
+    expect(findTokenRowByJti(harness.db, direct.jti)!.revokedAt).toBeNull(); // not revoked
+    expect(JSON.stringify(readConnections(harness.storePath))).toBe(recordBefore); // record untouched
+  });
+
+  test("claiming an ACTIVE connection: the current holder learns 'active'; any other credential is refused and the record untouched", async () => {
+    const { fetchImpl, calls } = mockFetch({ "POST /api/credential": () => ok({ ok: true }) });
+    const deps = credDeps(fetchImpl, modulesOf(SURFACE_MANIFEST));
+    const { cookie } = await adminCookie();
+    const res = await postCredential(
+      cookie,
+      { credential: { module: "surface", key: "vault", vault: "default", tags: ["t"] } },
+      deps,
+    );
+    expect(res.status).toBe(200);
+    const cred = calls.find((c) => c.url === `${SURFACE_ORIGIN}/api/credential`)!
+      .body as DeliveredCredential;
+
+    // Current holder re-claims → "active", record unchanged (no pending flip).
+    const holder = await handleConnections(
+      claimReq(CLAIM_ID, SURFACE_CLAIM, cred.token),
+      `/${CLAIM_ID}/claim`,
+      deps,
+    );
+    expect(holder.status).toBe(200);
+    expect(((await holder.json()) as { status: string }).status).toBe("active");
+    expect(readConnections(harness.storePath)[0]!.status).toBeUndefined();
+
+    // A DIFFERENT valid registered credential cannot claim over it.
+    const other = await mintDirectDelivered({ vault: "default", verb: "read", tags: ["t"] });
+    const refused = await handleConnections(
+      claimReq(CLAIM_ID, SURFACE_CLAIM, other.token),
+      `/${CLAIM_ID}/claim`,
+      deps,
+    );
+    expect(refused.status).toBe(403);
+    expect(((await refused.json()) as { error: string }).error).toBe("claim_rejected");
+    expect(readConnections(harness.storePath)[0]!.provisioned.mintedJtis).toEqual([cred.jti!]);
+  });
+
+  test("claim against an existing event→action connection id is refused generically", async () => {
+    const { fetchImpl } = mockFetch({});
+    const deps = credDeps(fetchImpl, modulesOf(SURFACE_MANIFEST));
+    putConnection(harness.storePath, {
+      id: CLAIM_ID,
+      source: { module: "vault", vault: "default", event: "note.created" },
+      sink: { module: "channel", action: "message.deliver" },
+      provisioned: { type: "vault-trigger", vault: "default", triggerName: "t", mintedJtis: [] },
+      createdAt: new Date().toISOString(),
+    });
+    const direct = await mintDirectDelivered({ vault: "default", verb: "read" });
+    const res = await handleConnections(
+      claimReq(CLAIM_ID, SURFACE_CLAIM, direct.token),
+      `/${CLAIM_ID}/claim`,
+      deps,
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe("claim_rejected");
+    // The event→action record is untouched.
+    expect(readConnections(harness.storePath)[0]!.kind).toBeUndefined();
+  });
+
+  test("approve: unknown id → 404; non-credential record → 400; re-approve is idempotent", async () => {
+    const { fetchImpl } = mockFetch({});
+    const deps = credDeps(fetchImpl, modulesOf(SURFACE_MANIFEST));
+    const { cookie } = await adminCookie();
+
+    const unknown = await handleConnections(approveReq("ghost", cookie), "/ghost/approve", deps);
+    expect(unknown.status).toBe(404);
+
+    putConnection(harness.storePath, {
+      id: "ev-conn",
+      source: { module: "vault", vault: "default", event: "note.created" },
+      sink: { module: "channel", action: "message.deliver" },
+      provisioned: { type: "vault-trigger", vault: "default", triggerName: "t", mintedJtis: [] },
+      createdAt: new Date().toISOString(),
+    });
+    const nonCred = await handleConnections(
+      approveReq("ev-conn", cookie),
+      "/ev-conn/approve",
+      deps,
+    );
+    expect(nonCred.status).toBe(400);
+
+    const direct = await mintDirectDelivered({ vault: "default", verb: "read" });
+    await handleConnections(
+      claimReq(CLAIM_ID, SURFACE_CLAIM, direct.token),
+      `/${CLAIM_ID}/claim`,
+      deps,
+    );
+    const once = await handleConnections(
+      approveReq(CLAIM_ID, cookie),
+      `/${CLAIM_ID}/approve`,
+      deps,
+    );
+    expect(once.status).toBe(200);
+    const twice = await handleConnections(
+      approveReq(CLAIM_ID, cookie),
+      `/${CLAIM_ID}/approve`,
+      deps,
+    );
+    expect(twice.status).toBe(200);
+    expect(((await twice.json()) as { status: string }).status).toBe("active");
+  });
+
+  test("list projects status: 'pending' on claimed records (the SPA's approve affordance)", async () => {
+    const { fetchImpl } = mockFetch({});
+    const deps = credDeps(fetchImpl, modulesOf(SURFACE_MANIFEST));
+    const { cookie } = await adminCookie();
+    const direct = await mintDirectDelivered({ vault: "default", verb: "read" });
+    await handleConnections(
+      claimReq(CLAIM_ID, SURFACE_CLAIM, direct.token),
+      `/${CLAIM_ID}/claim`,
+      deps,
+    );
+
+    const list = await handleConnections(
+      new Request("http://127.0.0.1/admin/connections", { method: "GET", headers: { cookie } }),
+      "",
+      deps,
+    );
+    expect(list.status).toBe(200);
+    const body = (await list.json()) as {
+      connections: { id: string; kind?: string; status?: string; requested_by?: string }[];
+    };
+    const row = body.connections.find((c) => c.id === CLAIM_ID)!;
+    expect(row.kind).toBe("credential");
+    expect(row.status).toBe("pending");
+    expect(row.requested_by).toBe("surface");
   });
 });

--- a/src/__tests__/admin-connections-credentials.test.ts
+++ b/src/__tests__/admin-connections-credentials.test.ts
@@ -1109,6 +1109,10 @@ describe("credential connection — claim/reconcile (surface#113)", () => {
     expect(records[0]!.status).toBe("pending");
     expect(records[0]!.provisioned.mintedJtis).toEqual([b.jti]);
     expect(records[0]!.provisioned.scopedTags).toEqual(["y"]);
+    // The displaced jti is orphaned (can no longer renew — the record names
+    // only b) but NOT revoked: a's holder keeps a valid token. Pinned so a
+    // future "cleanup" doesn't add revocation here and punish the holder.
+    expect(findTokenRowByJti(harness.db, a.jti)!.revokedAt).toBeNull();
   });
 
   test("no mutation without approval: a pending renewal attempt mints nothing, revokes nothing, rewrites nothing", async () => {

--- a/src/admin-connections.ts
+++ b/src/admin-connections.ts
@@ -1294,6 +1294,11 @@ async function claimCredentialConnection(
   // unrevocable by construction and not reconcilable here).
   const registryRow = findTokenRowByJti(deps.db, jti);
   if (!registryRow) return reject("jti is not in the token registry");
+  // NOTE: created_via is deliberately NOT filtered here. A claim grandfathers
+  // a token that already exists and is already registered — provenance
+  // (cli_mint, connection_credential, …) adds no authority either way, and
+  // a connection_credential jti with an active record is already refused by
+  // the existing-record check below.
 
   // Declaration half — the same checks create performs, so a claim can't
   // smuggle past anything the operator-initiated path would refuse.

--- a/src/admin-connections.ts
+++ b/src/admin-connections.ts
@@ -33,11 +33,12 @@
  *
  * AUTH. Same gate as the admin-token mints: a cookie-gated operator session
  * pinned to the first admin. The catalog (`/api/connections/catalog`) is
- * operator-only metadata; it uses the same session gate. ONE exception:
- * `POST /admin/connections/:id/renew` (H4 credential renewal) authenticates
- * by PROOF OF POSSESSION of the connection's current still-valid credential
- * as Bearer — no operator click; an expired credential cannot renew itself
- * (the operator re-approves in the UI).
+ * operator-only metadata; it uses the same session gate. TWO exceptions:
+ * `POST /admin/connections/:id/renew` (H4 credential renewal) and
+ * `POST /admin/connections/:id/claim` (surface#113 claim/reconcile) both
+ * authenticate by PROOF OF POSSESSION of the connection's current
+ * still-valid credential as Bearer — no operator click; an expired
+ * credential can neither renew nor claim (the operator re-links in the UI).
  *
  * THE SECOND KIND — `kind: "credential"` (H4, surface-runtime design). A
  * module declares `credentials` in module.json (scope TEMPLATE
@@ -52,6 +53,23 @@
  * payload. Tags are REQUIRED for write scopes (tags are the sharing scope);
  * read may be tag-scoped or vault-wide per the operator's choice (the
  * approval UI defaults to tag-scoped).
+ *
+ * CLAIM / RECONCILE (surface#113). A credential delivered to a module
+ * OUTSIDE this engine (e.g. minted via the CLI and POSTed straight to the
+ * module's delivery endpoint) leaves no ConnectionRecord, so jti-bound
+ * renewal 404s at the pre-expiry window. `POST /admin/connections/:id/claim`
+ * lets the module backfill the record: it presents the credential it ALREADY
+ * holds as Bearer (the renew endpoint's proof-of-possession posture), and
+ * the hub — after verifying the jti is REGISTERED in the tokens table and
+ * that the token's scope/aud/vault_scope match what the claimed connection
+ * id implies — writes the record in `status: "pending"`. A claim grants
+ * NOTHING: renewal refuses pending records; only the operator-gated
+ * `POST /admin/connections/:id/approve` flips it active, after which the
+ * existing renewal flow proceeds unchanged. Expired/revoked/unregistered/
+ * mismatched claims are refused with ONE generic error (no oracle on
+ * registry contents); re-linking through the operator flow is the recovery
+ * path. Rejecting a claim = DELETE on the pending record (which revokes the
+ * claimed jti — the safe direction).
  */
 import type { Database } from "bun:sqlite";
 import {
@@ -63,6 +81,7 @@ import {
   removeConnection,
 } from "./connections-store.ts";
 import {
+  findTokenRowByJti,
   recordTokenMint,
   revokeTokenByJti,
   signAccessToken,
@@ -329,11 +348,31 @@ export async function handleConnections(
     return renewCredentialConnection(req, segments[0] ?? "", deps);
   }
 
+  // surface#113 — claim/reconcile. Same auth class as renew (proof of
+  // possession of the credential as Bearer, no operator session), so it's
+  // routed before the gate too. A successful claim only writes a PENDING
+  // record — the operator-gated approve below is what activates it.
+  if (segments.length === 2 && segments[1] === "claim") {
+    if (method !== "POST") {
+      return jsonError(405, "method_not_allowed", "use POST on /admin/connections/:id/claim");
+    }
+    return claimCredentialConnection(req, segments[0] ?? "", deps);
+  }
+
   const gate = operatorGate(req, deps);
   if (gate) return gate;
   const { userId } = sessionUser(req, deps);
 
   const itemId = segments.length === 1 ? (segments[0] ?? "") : "";
+
+  // surface#113 — operator approval of a pending claim. Cookie-gated like
+  // create/teardown (and CSRF-belted by the dispatch in hub-server.ts).
+  if (segments.length === 2 && segments[1] === "approve") {
+    if (method !== "POST") {
+      return jsonError(405, "method_not_allowed", "use POST on /admin/connections/:id/approve");
+    }
+    return approveCredentialConnection(segments[0] ?? "", deps);
+  }
 
   if (segments.length === 0 && method === "GET") return listConnections(deps);
   if (segments.length === 0 && method === "POST") return createConnection(req, userId, deps);
@@ -341,7 +380,7 @@ export async function handleConnections(
   return jsonError(
     405,
     "method_not_allowed",
-    "use GET/POST on /admin/connections, DELETE on /admin/connections/:id, or POST on /admin/connections/:id/renew",
+    "use GET/POST on /admin/connections, DELETE on /admin/connections/:id, or POST on /admin/connections/:id/renew, /claim, /approve",
   );
 }
 
@@ -359,6 +398,10 @@ function listConnections(deps: ConnectionsDeps): Response {
     // standing module credential. Projected so the SPA can render the two
     // shapes distinctly.
     ...(c.kind !== undefined ? { kind: c.kind } : {}),
+    // Approval state (surface#113): "pending" = a module-initiated claim
+    // awaiting the operator's one-click approve in the Connections view.
+    // Absent = active.
+    ...(c.status !== undefined ? { status: c.status } : {}),
     source: c.source,
     sink: c.sink,
     provisioned: c.provisioned,
@@ -1070,6 +1113,17 @@ async function renewCredentialConnection(
     );
   }
 
+  // surface#113 — a CLAIMED record grants nothing until the operator
+  // approves. Checked AFTER the possession proof so the pending state is
+  // revealed only to the actual credential holder (the claimant itself).
+  if (record.status === "pending") {
+    return jsonError(
+      403,
+      "pending_approval",
+      "this connection's claim awaits operator approval in the hub admin Connections view — renewal is enabled after approval",
+    );
+  }
+
   const vault = record.provisioned?.vault ?? "";
   const scope = record.provisioned?.scope ?? "";
   const scopedTags = record.provisioned?.scopedTags ?? [];
@@ -1128,6 +1182,253 @@ async function renewCredentialConnection(
     renew_path: `/admin/connections/${id}/renew`,
   };
   return json(200, { ok: true, credential: payload });
+}
+
+/**
+ * POST /admin/connections/:id/claim — backfill the hub-side record for a
+ * credential that was delivered to a module OUTSIDE this engine (surface#113:
+ * CLI-minted + POSTed straight to the module's delivery endpoint), so the
+ * existing jti-bound renewal flow can find a record instead of 404ing.
+ *
+ * AUTH mirrors renew: proof of possession — the module presents the
+ * credential it ALREADY holds as Bearer; the jti is derived from the
+ * validated token, never from request input. The claim grants NOTHING:
+ *
+ *   - the presented token must verify (signature / expiry / revocation —
+ *     an expired or revoked credential cannot be claimed; re-link via the
+ *     operator flow is the path);
+ *   - its jti must be REGISTERED in the tokens table (the registered-mint
+ *     rule is the precondition for renewal anyway), with the registry row
+ *     recording the same scope;
+ *   - the token's scope / aud / vault_scope must carry EXACTLY the grant the
+ *     claimed connection id implies (`cred-<module>-<key>-<vault>` +
+ *     the module's DECLARED credential template — same declaration checks
+ *     as create);
+ *   - the record is written `status: "pending"`: renewal refuses it until
+ *     the operator's one-click approve in the Connections view.
+ *
+ * So the only thing a claim can ever enable — and only after explicit
+ * operator approval — is renewal of a token the module already holds, at the
+ * scope/tags already baked into that token. NOTE the deliberate asymmetry
+ * with create: a claim ACCEPTS the existing token's shape verbatim,
+ * including an untagged write (create refuses those for NEW grants) — the
+ * operator already granted that shape when they minted + delivered it, and
+ * the approve click is the explicit sanction of carrying it forward.
+ *
+ * All post-authentication mismatches refuse with ONE generic error so the
+ * endpoint is not an oracle on registry contents; the specific reason is
+ * logged server-side (no token material).
+ *
+ * Idempotency: re-claiming with the same credential returns the same pending
+ * record (no dupes). A pending record's claim may be superseded by another
+ * fully-valid claim for the same id (pending grants nothing — last writer
+ * wins until approval). An ACTIVE record is never touched: claiming it with
+ * its own current credential reports "active" (renewal already works);
+ * anything else is refused.
+ */
+async function claimCredentialConnection(
+  req: Request,
+  id: string,
+  deps: ConnectionsDeps,
+): Promise<Response> {
+  if (!CONNECTION_ID_RE.test(id)) {
+    return jsonError(400, "invalid_request", `connection id "${id}" is not a valid identifier`);
+  }
+  let body: { module?: unknown; key?: unknown; vault?: unknown };
+  try {
+    body = (await req.json()) as { module?: unknown; key?: unknown; vault?: unknown };
+  } catch {
+    return jsonError(400, "invalid_request", "request body must be JSON");
+  }
+  const moduleShort = str(body.module);
+  const key = str(body.key);
+  const vault = str(body.vault);
+  if (!moduleShort || !key || !vault) {
+    return jsonError(400, "invalid_request", "module, key, vault are all required");
+  }
+  if (!VAULT_NAME_CHARSET_RE.test(vault)) {
+    return jsonError(400, "invalid_request", `vault "${vault}" is not a valid identifier`);
+  }
+
+  const auth = req.headers.get("authorization");
+  if (!auth || !auth.startsWith("Bearer ")) {
+    return jsonError(
+      401,
+      "unauthenticated",
+      "a claim requires the delivered credential as Authorization: Bearer",
+    );
+  }
+  const bearer = auth.slice("Bearer ".length).trim();
+  let payload: Record<string, unknown>;
+  try {
+    // Same validation posture as renew (and the same deliberate absence of
+    // an issuer pin — see renewCredentialConnection): signature proves local
+    // issuance; the registry + claim-shape binding below does the rest.
+    payload = (await validateAccessToken(deps.db, bearer)).payload as Record<string, unknown>;
+  } catch (err) {
+    // Signature/expiry/revocation failure — an expired or revoked credential
+    // cannot be claimed; the operator re-links through the module's flow.
+    return jsonError(
+      401,
+      "invalid_credential",
+      `credential is not valid (expired or revoked credentials cannot be claimed — re-link via the operator flow): ${errMsg(err)}`,
+    );
+  }
+
+  // Every post-authentication mismatch refuses identically (no oracle on
+  // registry contents); the reason is logged server-side, token-free.
+  const reject = (reason: string): Response => {
+    console.warn(`[connections] claim for "${id}" rejected: ${reason}`);
+    return jsonError(
+      403,
+      "claim_rejected",
+      "the presented credential does not match a claimable connection",
+    );
+  };
+
+  const jti = typeof payload.jti === "string" ? payload.jti : "";
+  if (!jti) return reject("token carries no jti");
+
+  // Registry half: the jti must be a REGISTERED mint (renewal's revocation
+  // lifecycle depends on the row; an unregistered long-lived token is
+  // unrevocable by construction and not reconcilable here).
+  const registryRow = findTokenRowByJti(deps.db, jti);
+  if (!registryRow) return reject("jti is not in the token registry");
+
+  // Declaration half — the same checks create performs, so a claim can't
+  // smuggle past anything the operator-initiated path would refuse.
+  const mod = deps.modules.find((m) => m.short === moduleShort);
+  if (!mod) return reject(`no installed module "${moduleShort}"`);
+  const decl = findCredentialDecl(mod.manifest, key);
+  if (!decl) return reject(`module "${moduleShort}" declares no credential "${key}"`);
+  if (!CREDENTIAL_SCOPE_TEMPLATE_RE.test(decl.scope)) {
+    return reject(`declared scope template "${decl.scope}" is not grantable`);
+  }
+  if (!decl.endpoint || !decl.endpoint.startsWith("/")) {
+    return reject(`credential "${moduleShort}.${key}" declares no delivery endpoint`);
+  }
+  if (deps.resolveVaultOrigin(vault) === null) return reject(`no vault named "${vault}"`);
+
+  // Identity half: the claimed id must be EXACTLY the id the hub derives for
+  // this module/key/vault (the same derivation create uses by default) — the
+  // id alone is ambiguous to parse (keys may contain dashes), so the body
+  // names the parts and the derivation closes the loop.
+  const impliedId = `cred-${moduleShort}-${key}-${vault}`.toLowerCase();
+  if (id !== impliedId)
+    return reject(`id does not match module/key/vault (implies "${impliedId}")`);
+
+  // Token-shape half: the presented credential must carry EXACTLY the grant
+  // the connection implies — scope at the declared verb, audience-bound and
+  // vault_scope-pinned to the vault (what makes it usable there at all).
+  const verb = decl.scope.endsWith(":write") ? "write" : "read";
+  const scope = `vault:${vault}:${verb}`;
+  const tokenScopes =
+    typeof payload.scope === "string" ? payload.scope.split(" ").filter((s) => s.length > 0) : [];
+  if (!tokenScopes.includes(scope)) return reject(`token scope does not include "${scope}"`);
+  const aud = payload.aud;
+  const audOk = aud === `vault.${vault}` || (Array.isArray(aud) && aud.includes(`vault.${vault}`));
+  if (!audOk) return reject(`token aud is not "vault.${vault}"`);
+  const vaultScopePin = Array.isArray(payload.vault_scope) ? payload.vault_scope : [];
+  if (!vaultScopePin.includes(vault)) return reject(`token vault_scope does not pin "${vault}"`);
+  if (!registryRow.scopes.includes(scope)) return reject("registry row scope mismatch");
+
+  // Tags ride along verbatim from the SIGNED token (never request input) —
+  // renewal will re-mint exactly this shape.
+  const scopedTags = readScopedTagsClaim(payload);
+
+  const nowIso = (deps.now?.() ?? new Date()).toISOString();
+  const pendingRecord: ConnectionRecord = {
+    id,
+    kind: "credential",
+    status: "pending",
+    source: { module: "vault", vault, event: "credential" },
+    sink: {
+      module: moduleShort,
+      action: `credential.${key}`,
+      ...(scopedTags.length > 0 ? { params: { tags: scopedTags } } : {}),
+    },
+    provisioned: {
+      type: "credential",
+      vault,
+      mintedJtis: [jti],
+      scope,
+      scopedTags,
+      credentialKey: key,
+      endpoint: decl.endpoint,
+    },
+    createdAt: nowIso,
+    requestedBy: moduleShort,
+  };
+
+  const existing = readConnections(deps.storePath).find((r) => r.id === id);
+  if (existing) {
+    if (existing.kind !== "credential") {
+      return reject("id names an existing non-credential connection");
+    }
+    const holdsCurrent = (existing.provisioned?.mintedJtis ?? []).includes(jti);
+    if (existing.status !== "pending") {
+      // ACTIVE record: never mutated by a claim. The current holder learns
+      // renewal already works; anything else is refused generically.
+      if (holdsCurrent) {
+        return json(200, { ok: true, connection_id: id, status: "active" });
+      }
+      return reject("an active connection already exists for this id");
+    }
+    if (holdsCurrent) {
+      // Idempotent re-claim — same pending record, no dupes, no rewrite.
+      return json(202, claimPendingBody(id));
+    }
+    // A different fully-validated credential supersedes the unapproved claim
+    // (pending grants nothing; last writer wins until the operator approves).
+  }
+
+  putConnection(deps.storePath, pendingRecord);
+  return json(202, claimPendingBody(id));
+}
+
+function claimPendingBody(id: string): Record<string, unknown> {
+  return {
+    ok: true,
+    connection_id: id,
+    status: "pending",
+    detail:
+      "claim recorded — awaiting operator approval in the hub admin Connections view; renewal is enabled after approval",
+  };
+}
+
+/** `permissions.scoped_tags` from a validated token payload (strings only). */
+function readScopedTagsClaim(payload: Record<string, unknown>): string[] {
+  const permissions = payload.permissions;
+  if (!permissions || typeof permissions !== "object" || Array.isArray(permissions)) return [];
+  const tags = (permissions as Record<string, unknown>).scoped_tags;
+  if (!Array.isArray(tags)) return [];
+  return tags.filter((t): t is string => typeof t === "string" && t.trim().length > 0);
+}
+
+/**
+ * POST /admin/connections/:id/approve — the operator's one-click activation
+ * of a pending claim (surface#113). Operator-gated by the caller (same
+ * session gate as create/teardown, CSRF-belted in hub-server.ts). Flips
+ * `status: "pending"` → active by dropping the field; mints NOTHING and
+ * delivers NOTHING — the module already holds the credential, approval only
+ * lets the existing renewal flow find the record. Idempotent: approving an
+ * already-active credential record reports active without rewriting it.
+ */
+function approveCredentialConnection(id: string, deps: ConnectionsDeps): Response {
+  if (!CONNECTION_ID_RE.test(id)) {
+    return jsonError(400, "invalid_request", `connection id "${id}" is not a valid identifier`);
+  }
+  const record = readConnections(deps.storePath).find((r) => r.id === id);
+  if (!record) return jsonError(404, "not_found", `no connection "${id}"`);
+  if (record.kind !== "credential") {
+    return jsonError(400, "not_claimable", `connection "${id}" is not a credential connection`);
+  }
+  if (record.status !== "pending") {
+    return json(200, { ok: true, id, status: "active" });
+  }
+  const { status: _pending, ...approved } = record;
+  putConnection(deps.storePath, approved);
+  return json(200, { ok: true, id, status: "active" });
 }
 
 function findCredentialDecl(m: ModuleManifest, key: string): ModuleCredential | undefined {

--- a/src/connections-store.ts
+++ b/src/connections-store.ts
@@ -87,6 +87,15 @@ export interface ConnectionRecord {
    * module). Optional for back-compat: pre-H4 records read back undefined.
    */
   readonly kind?: "credential";
+  /**
+   * Approval state (surface#113 claim/reconcile). Absent = active (every
+   * operator-provisioned record, and pre-claim records, read back undefined
+   * = active). `"pending"` = a module-initiated CLAIM for a directly-delivered
+   * credential, awaiting operator approval in the hub admin Connections view.
+   * A pending record grants nothing: renewal refuses it, and only the
+   * operator-gated approve endpoint flips it to active.
+   */
+  readonly status?: "pending";
   readonly source: ConnectionSource;
   readonly sink: ConnectionSink;
   readonly provisioned: ConnectionProvisioned;

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -56,6 +56,9 @@
  *   /api/connections/catalog      (GET)        → events/actions across installed modules (cookie-gated)
  *   /admin/connections            (POST/GET)   → connection provision/list (cookie-gated; POST CSRF-belted)
  *   /admin/connections/<id>       (DELETE)     → connection teardown (cookie-gated; CSRF-belted)
+ *   /admin/connections/<id>/renew (POST)       → credential renewal (H4; Bearer = the credential itself, proof of possession)
+ *   /admin/connections/<id>/claim (POST)       → claim/reconcile a directly-delivered credential → pending record (surface#113; Bearer = the credential itself)
+ *   /admin/connections/<id>/approve (POST)     → operator approval of a pending claim (cookie-gated; CSRF-belted)
  *
  *   # "CSRF-belted" = strict same-origin Origin check on cookie-authed
  *   # mutations (hub#632, boundary C1) — origin-check.ts

--- a/src/origin-check.ts
+++ b/src/origin-check.ts
@@ -180,10 +180,13 @@ const MUTATION_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
  * mutation under `/admin/*`; keep this list in sync with the dispatch in
  * `hub-server.ts`):
  *
- *   - `POST /admin/connections` + `DELETE /admin/connections/<id>`
- *     (connection provision/teardown — the seam's canonical consumers are
- *     channel's admin page and the hub SPA, both same-origin `fetch()` with
- *     `credentials: "include"`)
+ *   - `POST /admin/connections` + `DELETE /admin/connections/<id>` +
+ *     `POST /admin/connections/<id>/approve`
+ *     (connection provision/teardown/claim-approval — the seam's canonical
+ *     consumers are channel's admin page and the hub SPA, both same-origin
+ *     `fetch()` with `credentials: "include"`. The Bearer-authed
+ *     `/<id>/renew` + `/<id>/claim` siblings pass the belt via the
+ *     Authorization carve-out below.)
  *
  * (The legacy `POST/DELETE /admin/channels` pair was belted here until
  * boundary D1 retired the endpoint — superseded by `/admin/connections`.)

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1493,6 +1493,14 @@ export interface ConnectionsCatalog {
 /** A provisioned connection (the list/wire shape from `/admin/connections`). */
 export interface ConnectionListing {
   id: string;
+  /** `"credential"` = a standing module credential (H4); absent = event→action. */
+  kind?: string;
+  /**
+   * Approval state (surface#113 claim/reconcile). `"pending"` = a
+   * module-initiated claim for a directly-delivered credential awaiting the
+   * operator's one-click approve; absent = active.
+   */
+  status?: string;
   source: {
     module: string;
     vault?: string;
@@ -1504,7 +1512,7 @@ export interface ConnectionListing {
     action: string;
     params?: Record<string, unknown>;
   };
-  provisioned: { type: string; vault?: string; triggerName?: string };
+  provisioned: { type: string; vault?: string; triggerName?: string; scope?: string };
   created_at: string;
   /**
    * Provenance — WHO requested this connection (modular-UI R2). `"custom"` for a
@@ -1580,6 +1588,24 @@ export async function createConnection(input: {
     throw new HttpError(500, "/admin/connections returned a malformed connection body");
   }
   return { connection: body.connection, ...(body.connect ? { connect: body.connect } : {}) };
+}
+
+/**
+ * POST /admin/connections/:id/approve — activate a pending credential claim
+ * (surface#113). Mints and delivers nothing; the module already holds the
+ * credential — approval only enables its renewal.
+ */
+export async function approveConnection(id: string): Promise<void> {
+  const res = await fetch(`/admin/connections/${encodeURIComponent(id)}/approve`, {
+    method: "POST",
+    headers: { accept: "application/json" },
+    credentials: "same-origin",
+  });
+  if (res.status === 401) {
+    await redirectToLoginAndHang<void>();
+    return;
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
 }
 
 /** DELETE /admin/connections/:id — tear a connection down (best-effort). */

--- a/web/ui/src/routes/Connections.test.tsx
+++ b/web/ui/src/routes/Connections.test.tsx
@@ -23,6 +23,7 @@ vi.mock("../lib/api.ts", async (orig) => {
     listVaults: vi.fn(),
     createConnection: vi.fn(),
     deleteConnection: vi.fn(),
+    approveConnection: vi.fn(),
   };
 });
 
@@ -306,5 +307,69 @@ describe("Connections — remove", () => {
     // Confirm dialog → Remove.
     fireEvent.click(screen.getByRole("button", { name: /^remove$/i }));
     await waitFor(() => expect(api.deleteConnection).toHaveBeenCalledWith("channel-eng"));
+  });
+});
+
+describe("Connections — pending credential claims (surface#113)", () => {
+  /** A claimed-but-unapproved credential connection, as the wire projects it. */
+  function pendingCredential(id: string): api.ConnectionListing {
+    return {
+      id,
+      kind: "credential",
+      status: "pending",
+      source: { module: "vault", vault: "default", event: "credential" },
+      sink: { module: "surface", action: "credential.vault" },
+      provisioned: { type: "credential", vault: "default", scope: "vault:default:read" },
+      created_at: "2026-06-10T00:00:00.000Z",
+      requested_by: "surface",
+    };
+  }
+
+  it("renders the pending badge + one-click Approve, which POSTs approve and reloads", async () => {
+    const pending = pendingCredential("cred-surface-vault-default");
+    const { status: _pendingFlag, ...approved } = pending;
+    vi.mocked(api.listConnections)
+      .mockResolvedValueOnce([pending])
+      .mockResolvedValueOnce([approved]);
+    vi.mocked(api.getConnectionsCatalog).mockResolvedValue(catalog());
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    vi.mocked(api.approveConnection).mockResolvedValue(undefined);
+    renderRoute();
+
+    await waitFor(() => expect(screen.getByText("cred-surface-vault-default")).toBeInTheDocument());
+    expect(screen.getByTestId("pending-badge")).toHaveTextContent(/pending approval/i);
+
+    fireEvent.click(screen.getByRole("button", { name: /approve cred-surface-vault-default/i }));
+    await waitFor(() =>
+      expect(api.approveConnection).toHaveBeenCalledWith("cred-surface-vault-default"),
+    );
+    // The reload renders the now-active record: badge + Approve gone.
+    await waitFor(() => expect(screen.queryByTestId("pending-badge")).toBeNull());
+    expect(screen.queryByTestId("approve-connection")).toBeNull();
+  });
+
+  it("active connections render no Approve affordance", async () => {
+    vi.mocked(api.listConnections).mockResolvedValue([connection("channel-eng")]);
+    vi.mocked(api.getConnectionsCatalog).mockResolvedValue(catalog());
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("channel-eng")).toBeInTheDocument());
+    expect(screen.queryByTestId("approve-connection")).toBeNull();
+    expect(screen.queryByTestId("pending-badge")).toBeNull();
+  });
+
+  it("surfaces an approve failure on the row", async () => {
+    vi.mocked(api.listConnections).mockResolvedValue([
+      pendingCredential("cred-surface-vault-default"),
+    ]);
+    vi.mocked(api.getConnectionsCatalog).mockResolvedValue(catalog());
+    vi.mocked(api.listVaults).mockResolvedValue(vaultsResult("default"));
+    vi.mocked(api.approveConnection).mockRejectedValue(new api.HttpError(404, "no connection"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("approve-connection")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("approve-connection"));
+    await waitFor(() => expect(screen.getByText(/approve failed \(404\)/i)).toBeInTheDocument());
+    // The pending row is still there — nothing was reloaded away.
+    expect(screen.getByTestId("pending-badge")).toBeInTheDocument();
   });
 });

--- a/web/ui/src/routes/Connections.tsx
+++ b/web/ui/src/routes/Connections.tsx
@@ -28,6 +28,7 @@ import {
   type ConnectionsCatalog,
   HttpError,
   type VaultListing,
+  approveConnection,
   createConnection,
   deleteConnection,
   getConnectionsCatalog,
@@ -75,6 +76,16 @@ type RemoveState =
   | { kind: "removing"; id: string }
   | { kind: "error"; id: string; message: string };
 
+/**
+ * Per-row approve state for pending credential claims (surface#113). One
+ * click — approval mints nothing, it only lets the module's existing
+ * credential renew, so no confirm dialog (Remove stays the destructive path).
+ */
+type ApproveState =
+  | { kind: "idle" }
+  | { kind: "approving"; id: string }
+  | { kind: "error"; id: string; message: string };
+
 function errMessage(err: unknown, verb: string): string {
   if (err instanceof HttpError) return `${verb} failed (${err.status}): ${err.message}`;
   if (err instanceof Error) return err.message;
@@ -106,6 +117,7 @@ export function Connections() {
   const [reload, setReload] = useState(0);
   const [createSt, setCreateSt] = useState<CreateState>({ kind: "idle" });
   const [removeSt, setRemoveSt] = useState<RemoveState>({ kind: "idle" });
+  const [approveSt, setApproveSt] = useState<ApproveState>({ kind: "idle" });
 
   // Builder form fields.
   const [sourceModule, setSourceModule] = useState("");
@@ -201,6 +213,18 @@ export function Connections() {
     }
   }
 
+  async function onApprove(id: string): Promise<void> {
+    if (approveSt.kind === "approving") return;
+    setApproveSt({ kind: "approving", id });
+    try {
+      await approveConnection(id);
+      setApproveSt({ kind: "idle" });
+      setReload((n) => n + 1);
+    } catch (err) {
+      setApproveSt({ kind: "error", id, message: errMessage(err, "Approve") });
+    }
+  }
+
   return (
     <div data-route-content="true">
       <div className="list-header">
@@ -213,7 +237,9 @@ export function Connections() {
         — pick one below to pre-fill the builder.
       </p>
 
-      {renderList(state, removeSt, setRemoveSt, onConfirmRemove, () => setReload((n) => n + 1))}
+      {renderList(state, removeSt, setRemoveSt, onConfirmRemove, approveSt, onApprove, () =>
+        setReload((n) => n + 1),
+      )}
 
       {state.kind === "ok" && (
         <BuilderSection
@@ -248,6 +274,8 @@ function renderList(
   removeSt: RemoveState,
   setRemoveSt: (s: RemoveState) => void,
   onConfirmRemove: (id: string) => Promise<void>,
+  approveSt: ApproveState,
+  onApprove: (id: string) => Promise<void>,
   onRetry: () => void,
 ): React.ReactNode {
   if (state.kind === "loading") return <p className="muted">Loading connections…</p>;
@@ -278,6 +306,8 @@ function renderList(
       removeSt={removeSt}
       setRemoveSt={setRemoveSt}
       onConfirmRemove={onConfirmRemove}
+      approveSt={approveSt}
+      onApprove={onApprove}
     />
   );
 }
@@ -320,11 +350,15 @@ function ConnectionsTable({
   removeSt,
   setRemoveSt,
   onConfirmRemove,
+  approveSt,
+  onApprove,
 }: {
   connections: ConnectionListing[];
   removeSt: RemoveState;
   setRemoveSt: (s: RemoveState) => void;
   onConfirmRemove: (id: string) => Promise<void>;
+  approveSt: ApproveState;
+  onApprove: (id: string) => Promise<void>;
 }): React.ReactNode {
   const groups = groupByProvenance(connections);
   return (
@@ -349,7 +383,16 @@ function ConnectionsTable({
                 </tr>
               </thead>
               <tbody>
-                {rows.map((c) => renderConnectionRow(c, removeSt, setRemoveSt, onConfirmRemove))}
+                {rows.map((c) =>
+                  renderConnectionRow(
+                    c,
+                    removeSt,
+                    setRemoveSt,
+                    onConfirmRemove,
+                    approveSt,
+                    onApprove,
+                  ),
+                )}
               </tbody>
             </table>
           </div>
@@ -364,10 +407,16 @@ function renderConnectionRow(
   removeSt: RemoveState,
   setRemoveSt: (s: RemoveState) => void,
   onConfirmRemove: (id: string) => Promise<void>,
+  approveSt: ApproveState,
+  onApprove: (id: string) => Promise<void>,
 ): React.ReactNode {
   const isConfirming = removeSt.kind === "confirming" && removeSt.id === c.id;
   const isRemoving = removeSt.kind === "removing" && removeSt.id === c.id;
   const rowError = removeSt.kind === "error" && removeSt.id === c.id ? removeSt.message : null;
+  const isPending = c.status === "pending";
+  const isApproving = approveSt.kind === "approving" && approveSt.id === c.id;
+  const approveError =
+    approveSt.kind === "error" && approveSt.id === c.id ? approveSt.message : null;
   const when = `${c.source.module}.${c.source.event}${
     c.source.vault ? ` (${c.source.vault})` : ""
   }`;
@@ -377,6 +426,20 @@ function renderConnectionRow(
     <tr key={c.id} data-connection-id={c.id} data-requested-by={provenance}>
       <td>
         <code>{c.id}</code>
+        {isPending && (
+          <>
+            {" "}
+            <span
+              className="tag"
+              data-testid="pending-badge"
+              title={`A module claimed a credential it already holds${
+                c.provisioned.scope ? ` (${c.provisioned.scope})` : ""
+              } — approving lets it renew before expiry. Nothing new is granted.`}
+            >
+              pending approval
+            </span>
+          </>
+        )}
       </td>
       <td>
         <code>{when}</code>
@@ -394,6 +457,18 @@ function renderConnectionRow(
         )}
       </td>
       <td>
+        {isPending && (
+          <button
+            type="button"
+            disabled={isApproving}
+            onClick={() => void onApprove(c.id)}
+            aria-label={`Approve ${c.id}`}
+            data-testid="approve-connection"
+            style={{ marginRight: "0.5rem" }}
+          >
+            {isApproving ? "Approving…" : "Approve"}
+          </button>
+        )}
         {isConfirming ? (
           <dialog
             open
@@ -440,6 +515,11 @@ function renderConnectionRow(
         {rowError && (
           <div className="error-banner" style={{ marginTop: "0.25rem" }}>
             <code>{rowError}</code>
+          </div>
+        )}
+        {approveError && (
+          <div className="error-banner" style={{ marginTop: "0.25rem" }}>
+            <code>{approveError}</code>
           </div>
         )}
       </td>


### PR DESCRIPTION
Fixes the hub side of [parachute-surface#113](https://github.com/ParachuteComputer/parachute-surface/issues/113): both live surfaces (woven-boulder `vault:boulder:read`, docs `vault:default:write`) hold valid, **registered** credentials that were delivered straight to surface-host's delivery endpoint under hub-derived connection ids — but no `ConnectionRecord` exists, so the jti-bound `POST /admin/connections/:id/renew` 404s at the ~7-day pre-expiry window (~2026-09-01/09).

## What lands

**`POST /admin/connections/:id/claim`** — module-initiated backfill. Same auth class as renew: proof of possession, the credential the module *already holds* as Bearer; the jti is derived from the validated token, never request input. Body names `{ module, key, vault }`. The hub verifies, in order:

1. token validity (signature / expiry / revocation — `validateAccessToken`, same no-issuer-pin rationale as renew);
2. the jti is **registered** in the tokens table, with the registry row recording the same scope;
3. the module is installed and **declares** the credential key with a grantable `vault:{vault}:read|write` template + delivery endpoint (the exact checks create performs);
4. the claimed id equals the hub's own derivation `cred-<module>-<key>-<vault>` (the id alone is ambiguous to parse — keys may contain dashes — so the body names the parts and the derivation closes the loop);
5. the token's `scope` / `aud` / `vault_scope` carry exactly the grant that id implies.

Then it writes the record with **`status: "pending"`**. Tags ride along verbatim from the *signed* token's `permissions.scoped_tags`.

**`POST /admin/connections/:id/approve`** — the operator's one-click activation: cookie-gated like create/teardown, CSRF-belted, idempotent. Flips pending → active by dropping the field. **Mints nothing, delivers nothing.**

**Renewal gate** — a pending record refuses renewal with `pending_approval` (403), checked *after* the possession proof so the pending state is revealed only to the credential holder. After approval the existing renewal flow proceeds completely unchanged.

**SPA** — the Connections list already rendered credential records generically; this adds a `pending approval` badge (scope in the tooltip) + an Approve button on the existing row. No parallel UI.

## Trust argument — no new authority

A claim grants nothing. It can only ever enable — and only after explicit operator approval — **renewal of a token the module already holds**, at the scope/tags already baked into that token by a prior operator mint. Pending records are inert: renewal refuses them, approval is first-admin-session-only, and DELETE on a pending record is the reject path (it revokes the claimed jti — the safe direction).

One deliberate asymmetry, flagged for review: a claim accepts the existing token's shape **verbatim, including an untagged write** (the live docs credential is exactly that). Create's write-requires-tags rule guards *new* grants; the operator already granted this shape when they minted + delivered it, and the approve click is the explicit sanction of carrying it forward. Pinned by test.

## Refusal semantics

- Expired / revoked / unsigned credential → 401 `invalid_credential`, **no record written** — an expired credential cannot claim itself; re-link via the operator flow is the path.
- *Every* post-authentication mismatch (unregistered jti, scope/verb/vault/aud mismatch, unknown module/key/vault, id mismatch, collision with an existing record) → **one byte-identical generic 403** `claim_rejected` — no oracle on registry contents. Specific reasons go to the server log, token-free. Pinned by a test asserting all six refusal bodies are identical.
- Idempotent re-claim → same single pending record, no dupes. A different fully-validated credential may supersede an *unapproved* claim (pending grants nothing; last writer wins until approval). An **active** record is never mutated by a claim.

## Tests (+10 hub, +3 web/ui)

- **Headline E2E** (extends the existing `unknown connection id → 404` pin): a registered `cli_mint`-provenance token with no record → renewal **404s** → claim → 202 pending → renewal 403 `pending_approval` → approve (sessionless 401 first) → renewal 200, same scope/tags re-minted, old jti revoked, record updated. **Verified failing pre-fix**: with the source stashed, the 404 assertions pass and the claim step fails (endpoint absent).
- Live docs shape: untagged `vault:default:write` claim → approve → renewal re-mints untagged write.
- Generic-refusal identity across six causes; expired/revoked/no-Bearer 401s with no record written.
- Idempotent re-claim + pending supersede; **no mutation without approval** (pending renewal attempt: zero new registry rows, nothing revoked, record byte-identical).
- Active-record safety (current holder told `active`; others refused, record untouched); claim against an event→action id refused; approve edge cases (404 / non-credential 400 / idempotent re-approve).
- SPA: pending badge + one-click approve → POST + reload; no affordance on active rows; row-level error surface.
- Existing delivery/renewal/teardown tests untouched and green (regression).

## Live rollout (after merge + restart)

The live ids and module declarations line up exactly: `cred-surface-vault-boulder` ⇒ `{module:"surface", key:"vault", vault:"boulder"}`, `cred-surface-vault-write-default` ⇒ `{module:"surface", key:"vault-write", vault:"default"}`. The stored credential files at `~/.parachute/surface/credentials/*.credential.json` carry connection_id/key/vault/token — a manual claim is two curl POSTs + two approve clicks in `/admin/connections`. **No daemon was restarted in this session.**

## Surface-side follow-up (other repo, optional)

surface-host's renewal sweep (`packages/surface-host/src/credential-renewal.ts`) currently treats a renew 404 as a *transient* failure and retries forever. A natural follow-up in parachute-surface: on 404, auto-POST the claim from the stored record's fields, and treat `pending_approval` (403) as a distinct awaiting-operator status rather than transient. Not required to resolve #113 — manual claim via the existing stored files suffices for the two live credentials, and the hub-side record then makes the existing sweep work unchanged.

## Gates (literal)

- `bun test ./src`: **3349 pass, 1 skip, 0 fail** (3350 tests, 133 files) — main baseline 3340 tests, 0 fail (+10 new)
- `web/ui` vitest: **275 passed (275)**, 17 files (+3 new); `tsc --noEmit` clean in both root and web/ui
- `bunx biome check` on all 8 touched files: clean
- No version bump (RC discipline — tag at ship time)

Patterns check: extends the hub#648 H4 credential-connections engine inside the hub-module-boundary charter (identity transactions are substrate; registered-mint rule is now also the claim precondition). No pattern files change; no new scopes; module.json shape untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)