### PR TITLE
fix(connections): claim accepts the CLI-mint token shape (vault_scope [])

### DIFF
--- a/src/__tests__/admin-connections-credentials.test.ts
+++ b/src/__tests__/admin-connections-credentials.test.ts
@@ -800,6 +800,9 @@ async function mintDirectDelivered(opts: {
   tags?: string[];
   /** Skip the tokens-registry row (the unregistered-jti refusal case). */
   register?: boolean;
+  /** Mint the CLI shape: vault_scope [] — the pin rides scope + aud only
+   *  (the live surface#113 credentials; see the claim's vault_scope note). */
+  emptyVaultScope?: boolean;
   now?: () => Date;
 }): Promise<{ token: string; jti: string }> {
   const scope = `vault:${opts.vault}:${opts.verb}`;
@@ -811,7 +814,7 @@ async function mintDirectDelivered(opts: {
     clientId: "parachute-hub",
     issuer: HUB_ORIGIN,
     ttlSeconds: DIRECT_TTL_SECONDS,
-    vaultScope: [opts.vault],
+    vaultScope: opts.emptyVaultScope ? [] : [opts.vault],
     ...(tags.length > 0 ? { extraClaims: { permissions: { scoped_tags: tags } } } : {}),
     ...(opts.now ? { now: opts.now } : {}),
   });
@@ -1113,6 +1116,53 @@ describe("credential connection — claim/reconcile (surface#113)", () => {
     // only b) but NOT revoked: a's holder keeps a valid token. Pinned so a
     // future "cleanup" doesn't add revocation here and punish the holder.
     expect(findTokenRowByJti(harness.db, a.jti)!.revokedAt).toBeNull();
+  });
+
+  test("CLI-shape claim: vault_scope [] accepted when scope+aud pin the vault (the live surface#113 credentials)", async () => {
+    const { fetchImpl } = mockFetch({});
+    const deps = credDeps(fetchImpl, modulesOf(SURFACE_MANIFEST));
+    const cli = await mintDirectDelivered({ vault: "default", verb: "read", emptyVaultScope: true });
+    const res = await handleConnections(
+      claimReq(CLAIM_ID, SURFACE_CLAIM, cli.token),
+      `/${CLAIM_ID}/claim`,
+      deps,
+    );
+    expect(res.status).toBe(202);
+    const records = readConnections(harness.storePath);
+    expect(records.length).toBe(1);
+    expect(records[0]!.status).toBe("pending");
+  });
+
+  test("a NON-empty vault_scope that omits the claimed vault is still refused (pinned elsewhere)", async () => {
+    const { fetchImpl } = mockFetch({});
+    const deps = credDeps(fetchImpl, modulesOf(SURFACE_MANIFEST));
+    // Same scope/aud text would never pass for another vault, so forge the
+    // mismatch the only way it can occur: vault_scope pinning a different
+    // vault than scope/aud (defense-in-depth pin disagreement).
+    const signed = await signAccessToken(harness.db, {
+      sub: "operator-user",
+      scopes: ["vault:default:read"],
+      audience: "vault.default",
+      clientId: "parachute-hub",
+      issuer: HUB_ORIGIN,
+      ttlSeconds: DIRECT_TTL_SECONDS,
+      vaultScope: ["boulder"],
+    });
+    recordTokenMint(harness.db, {
+      jti: signed.jti,
+      createdVia: "cli_mint",
+      subject: "operator",
+      clientId: "parachute-hub",
+      scopes: ["vault:default:read"],
+      expiresAt: signed.expiresAt,
+    });
+    const res = await handleConnections(
+      claimReq(CLAIM_ID, SURFACE_CLAIM, signed.token),
+      `/${CLAIM_ID}/claim`,
+      deps,
+    );
+    expect(res.status).toBe(403);
+    expect(readConnections(harness.storePath).length).toBe(0);
   });
 
   test("no mutation without approval: a pending renewal attempt mints nothing, revokes nothing, rewrites nothing", async () => {

--- a/src/admin-connections.ts
+++ b/src/admin-connections.ts
@@ -1333,8 +1333,16 @@ async function claimCredentialConnection(
   const aud = payload.aud;
   const audOk = aud === `vault.${vault}` || (Array.isArray(aud) && aud.includes(`vault.${vault}`));
   if (!audOk) return reject(`token aud is not "vault.${vault}"`);
+  // vault_scope: connection-minted tokens pin the vault here; CLI-minted
+  // tokens (the very population claims reconcile — surface#113's live case)
+  // carry vault_scope: [] and pin the vault via scope + aud instead, both
+  // already exact-matched above. An EMPTY vault_scope is therefore accepted;
+  // a NON-empty one that omits this vault is a genuine mismatch (the token
+  // was pinned elsewhere) and is refused.
   const vaultScopePin = Array.isArray(payload.vault_scope) ? payload.vault_scope : [];
-  if (!vaultScopePin.includes(vault)) return reject(`token vault_scope does not pin "${vault}"`);
+  if (vaultScopePin.length > 0 && !vaultScopePin.includes(vault)) {
+    return reject(`token vault_scope does not pin "${vault}"`);
+  }
   if (!registryRow.scopes.includes(scope)) return reject("registry row scope mismatch");
 
   // Tags ride along verbatim from the SIGNED token (never request input) —


### PR DESCRIPTION
Live follow-up to #653: firing real claims for the two surface#113 credentials failed — `token vault_scope does not pin "<vault>"`. CLI-minted tokens (the exact population claims reconcile) carry `vault_scope: []` and pin the vault via `scope` + `aud`, both of which the claim already exact-matches. Fix: empty vault_scope accepted; a NON-empty pin that omits the vault stays refused (pin disagreement = genuine mismatch).

Tests: CLI-shape claim → 202 pending (fails pre-fix with the live rejection); forged pin-disagreement (vault_scope names a different vault than scope/aud) → 403, no record. Suite 31/0; hub `bun test ./src` + typecheck green (counts in thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)