### PR TITLE
feat(ws-bridge): per-IP + total connection caps — the hub#649 public-surface gate

### DIFF
--- a/src/__tests__/ws-connection-caps.test.ts
+++ b/src/__tests__/ws-connection-caps.test.ts
@@ -1,0 +1,456 @@
+/**
+ * Tests for hub#649 — per-client-IP + total WebSocket connection caps at the
+ * upgrade gate (`maybeUpgradeWebSocket` via the fetch fn), with release
+ * riding the ws-bridge close path.
+ *
+ * Three tiers:
+ *   - UNIT (fetch fn + spy upgrade): per-IP cap refusal (the HEADLINE test —
+ *     it FAILED pre-fix with all 40 upgrades accepted), global cap refusal,
+ *     generic 429 body, forwarded-header trust (spoofed XFF on an untrusted
+ *     layer can't escape its bucket), release on a failed `server.upgrade`,
+ *     env-configurable caps.
+ *   - UNIT (pure): `wsCapBucketKey` derivation + `WsConnectionTracker`
+ *     accounting (double-release latch, key eviction at zero).
+ *   - INTEGRATION (real Bun.serve hub + real WS echo upstream): a churn of
+ *     open/close cycles returns the counters to zero — including the
+ *     unreachable-upstream teardown path, where the bridge (not the client)
+ *     initiates the close.
+ *
+ * Every test injects its OWN tracker via `HubFetchDeps.wsConnectionTracker`
+ * so nothing here consumes (or depends on) the process-wide default
+ * tracker's counters.
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WS_CAP_SHARED_BUCKET, hubFetch, wsCapBucketKey } from "../hub-server.ts";
+import { type ServiceEntry, writeManifest } from "../services-manifest.ts";
+import { type WsBridgeData, createWsBridgeHandlers } from "../ws-bridge.ts";
+import {
+  DEFAULT_WS_MAX_PER_IP,
+  DEFAULT_WS_MAX_TOTAL,
+  WsConnectionTracker,
+  wsCapsFromEnv,
+} from "../ws-connection-caps.ts";
+
+interface Harness {
+  dir: string;
+  manifestPath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "pcli-ws-caps-"));
+  return {
+    dir,
+    manifestPath: join(dir, "services.json"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+function wsEntry(port: number, extra: Partial<ServiceEntry> = {}): ServiceEntry {
+  return {
+    name: "wsmod",
+    port,
+    paths: ["/wsmod"],
+    health: "/wsmod/health",
+    version: "0.1.0",
+    websocket: true,
+    ...extra,
+  };
+}
+
+function upgradeReq(path: string, headers: Record<string, string> = {}): Request {
+  return new Request(`http://127.0.0.1${path}`, {
+    headers: { upgrade: "websocket", connection: "Upgrade", ...headers },
+  });
+}
+
+interface UpgradeSpy {
+  requestIP: () => { address: string };
+  upgrade: (req: Request, options: { data: WsBridgeData }) => boolean;
+  calls: { data: WsBridgeData }[];
+}
+
+function upgradeSpy(address: string, accept = true): UpgradeSpy {
+  const calls: { data: WsBridgeData }[] = [];
+  return {
+    requestIP: () => ({ address }),
+    upgrade: (_req, options) => {
+      calls.push(options);
+      return accept;
+    },
+    calls,
+  };
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error("waitFor timed out");
+    await Bun.sleep(10);
+  }
+}
+
+// ===========================================================================
+// Unit — cap refusal at the upgrade gate
+// ===========================================================================
+
+describe("WS connection caps — upgrade-gate refusal (hub#649)", () => {
+  test("HEADLINE: a same-IP upgrade flood is refused past the default per-IP cap (429), not accepted unboundedly", async () => {
+    // Pre-fix evidence: run against the unmodified tree (with the default
+    // tracker), this expressed-behavior test failed with accepted=40 — the
+    // hub had NO connection bound at all.
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [wsEntry(12345)] }, h.manifestPath);
+      const spy = upgradeSpy("127.0.0.1");
+      const tracker = new WsConnectionTracker(); // built-in defaults: 32 / 512
+      const fetcher = hubFetch(h.dir, {
+        manifestPath: h.manifestPath,
+        wsConnectionTracker: tracker,
+      });
+
+      let accepted = 0;
+      const refusals: Response[] = [];
+      for (let i = 0; i < 40; i++) {
+        // Loopback peer = trusted forwarder (tailscale serve / funnel
+        // shape) — all 40 attempts attribute to ONE public client IP.
+        const res = await fetcher(
+          upgradeReq("/wsmod/ws", { "x-forwarded-for": "198.51.100.7" }),
+          spy,
+        );
+        if (res === undefined) accepted++;
+        else refusals.push(res);
+      }
+
+      expect(accepted).toBe(DEFAULT_WS_MAX_PER_IP); // 32
+      expect(refusals.length).toBe(8);
+      expect(spy.calls.length).toBe(DEFAULT_WS_MAX_PER_IP); // upgrade never attempted over-cap
+      for (const res of refusals) expect(res.status).toBe(429);
+
+      // The refusal is generic: no counts, no cap identity, no numbers.
+      const body = (await refusals[0]!.json()) as { error: string; error_description: string };
+      expect(body.error).toBe("too_many_connections");
+      expect(JSON.stringify(body)).not.toMatch(/\d/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("global cap: distinct client IPs are refused once the total is saturated", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [wsEntry(12345)] }, h.manifestPath);
+      const spy = upgradeSpy("127.0.0.1");
+      const tracker = new WsConnectionTracker(10, 3); // per-IP generous, total=3
+      const fetcher = hubFetch(h.dir, {
+        manifestPath: h.manifestPath,
+        wsConnectionTracker: tracker,
+      });
+
+      for (let i = 0; i < 3; i++) {
+        const res = await fetcher(
+          upgradeReq("/wsmod/ws", { "x-forwarded-for": `198.51.100.${i}` }),
+          spy,
+        );
+        expect(res).toBeUndefined(); // upgraded
+      }
+      const res = await fetcher(
+        upgradeReq("/wsmod/ws", { "x-forwarded-for": "198.51.100.99" }),
+        spy,
+      );
+      expect(res?.status).toBe(429);
+      expect(spy.calls.length).toBe(3);
+      expect(tracker.totalCount).toBe(3);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("forwarded-header trust: spoofed XFF from a direct (non-loopback) peer does NOT escape the peer's bucket", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [wsEntry(12345)] }, h.manifestPath);
+      // Direct public peer — its XFF is attacker-controlled and must be ignored.
+      const spy = upgradeSpy("203.0.113.50");
+      const tracker = new WsConnectionTracker(2, 100);
+      const fetcher = hubFetch(h.dir, {
+        manifestPath: h.manifestPath,
+        wsConnectionTracker: tracker,
+      });
+
+      const r1 = await fetcher(upgradeReq("/wsmod/ws", { "x-forwarded-for": "1.1.1.1" }), spy);
+      const r2 = await fetcher(upgradeReq("/wsmod/ws", { "x-forwarded-for": "2.2.2.2" }), spy);
+      const r3 = await fetcher(upgradeReq("/wsmod/ws", { "x-forwarded-for": "3.3.3.3" }), spy);
+      expect(r1).toBeUndefined();
+      expect(r2).toBeUndefined();
+      expect(r3?.status).toBe(429); // rotating XFF minted no fresh buckets
+      expect(tracker.countFor("203.0.113.50")).toBe(2);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("forwarded-header trust: XFF from a loopback (trusted forwarder) peer DOES key distinct buckets", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [wsEntry(12345)] }, h.manifestPath);
+      const spy = upgradeSpy("127.0.0.1");
+      const tracker = new WsConnectionTracker(2, 100);
+      const fetcher = hubFetch(h.dir, {
+        manifestPath: h.manifestPath,
+        wsConnectionTracker: tracker,
+      });
+
+      // Two different real clients behind the on-box forwarder: each gets
+      // its own per-IP allotment.
+      for (const ip of ["198.51.100.1", "198.51.100.1", "198.51.100.2", "198.51.100.2"]) {
+        const res = await fetcher(upgradeReq("/wsmod/ws", { "x-forwarded-for": ip }), spy);
+        expect(res).toBeUndefined();
+      }
+      expect(tracker.countFor("198.51.100.1")).toBe(2);
+      expect(tracker.countFor("198.51.100.2")).toBe(2);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("a failed server.upgrade releases the slot (no leak without a socket)", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [wsEntry(12345)] }, h.manifestPath);
+      const spy = upgradeSpy("127.0.0.1", false); // handshake malformed → upgrade() = false
+      const tracker = new WsConnectionTracker(1, 1);
+      const fetcher = hubFetch(h.dir, {
+        manifestPath: h.manifestPath,
+        wsConnectionTracker: tracker,
+      });
+
+      const r1 = await fetcher(upgradeReq("/wsmod/ws"), spy);
+      expect(r1?.status).toBe(400);
+      expect(tracker.totalCount).toBe(0); // released inline
+      // The (1,1)-capped tracker still admits the next attempt.
+      const r2 = await fetcher(upgradeReq("/wsmod/ws"), spy);
+      expect(r2?.status).toBe(400);
+      expect(tracker.totalCount).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("caps are configurable: an env-built tracker enforces the overridden values", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [wsEntry(12345)] }, h.manifestPath);
+      const caps = wsCapsFromEnv({
+        PARACHUTE_WS_MAX_PER_IP: "2",
+        PARACHUTE_WS_MAX_TOTAL: "50",
+      } as NodeJS.ProcessEnv);
+      const tracker = new WsConnectionTracker(caps.maxPerIp, caps.maxTotal);
+      const spy = upgradeSpy("127.0.0.1");
+      const fetcher = hubFetch(h.dir, {
+        manifestPath: h.manifestPath,
+        wsConnectionTracker: tracker,
+      });
+
+      const headers = { "x-forwarded-for": "198.51.100.7" };
+      expect(await fetcher(upgradeReq("/wsmod/ws", headers), spy)).toBeUndefined();
+      expect(await fetcher(upgradeReq("/wsmod/ws", headers), spy)).toBeUndefined();
+      const res = await fetcher(upgradeReq("/wsmod/ws", headers), spy);
+      expect(res?.status).toBe(429);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// ===========================================================================
+// Unit — env parsing, bucket-key derivation, tracker accounting
+// ===========================================================================
+
+describe("wsCapsFromEnv", () => {
+  test("absent env → defaults", () => {
+    expect(wsCapsFromEnv({} as NodeJS.ProcessEnv)).toEqual({
+      maxPerIp: DEFAULT_WS_MAX_PER_IP,
+      maxTotal: DEFAULT_WS_MAX_TOTAL,
+    });
+  });
+
+  test("valid positive integers are honored", () => {
+    expect(
+      wsCapsFromEnv({
+        PARACHUTE_WS_MAX_PER_IP: "8",
+        PARACHUTE_WS_MAX_TOTAL: "1024",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({ maxPerIp: 8, maxTotal: 1024 });
+  });
+
+  test("malformed / non-positive values fall back to the defaults, never to unlimited", () => {
+    for (const bad of ["", "abc", "0", "-3", "12.5", "1e3", "32x"]) {
+      const caps = wsCapsFromEnv({
+        PARACHUTE_WS_MAX_PER_IP: bad,
+        PARACHUTE_WS_MAX_TOTAL: bad,
+      } as NodeJS.ProcessEnv);
+      expect(caps).toEqual({ maxPerIp: DEFAULT_WS_MAX_PER_IP, maxTotal: DEFAULT_WS_MAX_TOTAL });
+    }
+  });
+});
+
+describe("wsCapBucketKey — trust-model keying", () => {
+  const req = (headers: Record<string, string> = {}) =>
+    new Request("http://127.0.0.1/wsmod/ws", { headers });
+
+  test("loopback peer: CF-Connecting-IP wins, then XFF first hop, then the peer itself", () => {
+    expect(
+      wsCapBucketKey(
+        req({ "cf-connecting-ip": "198.51.100.9", "x-forwarded-for": "10.0.0.1" }),
+        "127.0.0.1",
+      ),
+    ).toBe("198.51.100.9");
+    expect(wsCapBucketKey(req({ "x-forwarded-for": "198.51.100.7, 10.0.0.1" }), "127.0.0.1")).toBe(
+      "198.51.100.7",
+    );
+    expect(wsCapBucketKey(req(), "::1")).toBe("::1");
+  });
+
+  test("non-loopback peer: keyed by peer address, injected headers ignored", () => {
+    expect(
+      wsCapBucketKey(
+        req({ "cf-connecting-ip": "1.2.3.4", "x-forwarded-for": "5.6.7.8" }),
+        "203.0.113.50",
+      ),
+    ).toBe("203.0.113.50");
+  });
+
+  test("underivable (no peer) → the shared fail-closed bucket, headers still ignored", () => {
+    expect(wsCapBucketKey(req({ "x-forwarded-for": "5.6.7.8" }), null)).toBe(WS_CAP_SHARED_BUCKET);
+    expect(wsCapBucketKey(req(), "   ")).toBe(WS_CAP_SHARED_BUCKET);
+  });
+});
+
+describe("WsConnectionTracker accounting", () => {
+  test("release is latched: double-release decrements once, never below zero", () => {
+    const tracker = new WsConnectionTracker(2, 2);
+    const a = tracker.tryAcquire("k");
+    const b = tracker.tryAcquire("k");
+    if (!a.ok || !b.ok) throw new Error("expected both acquires to succeed");
+    a.release();
+    a.release(); // latched no-op
+    expect(tracker.totalCount).toBe(1);
+    expect(tracker.countFor("k")).toBe(1);
+    b.release();
+    b.release();
+    expect(tracker.totalCount).toBe(0);
+    expect(tracker.countFor("k")).toBe(0);
+    expect(tracker.keyCount).toBe(0); // bucket evicted at zero — no map growth
+  });
+
+  test("refusals don't mutate counts", () => {
+    const tracker = new WsConnectionTracker(1, 10);
+    const a = tracker.tryAcquire("k");
+    if (!a.ok) throw new Error("expected acquire to succeed");
+    const refused = tracker.tryAcquire("k");
+    expect(refused.ok).toBe(false);
+    if (!refused.ok) expect(refused.reason).toBe("per_ip_cap");
+    expect(tracker.totalCount).toBe(1);
+    a.release();
+    expect(tracker.totalCount).toBe(0);
+  });
+});
+
+// ===========================================================================
+// Integration — real sockets: churn returns the counters to zero
+// ===========================================================================
+
+function startWsEchoUpstream(): { port: number; stop: () => void } {
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req, srv) {
+      if (srv.upgrade(req)) return undefined as unknown as Response;
+      return new Response("expected websocket", { status: 400 });
+    },
+    websocket: {
+      message(ws, msg) {
+        ws.send(typeof msg === "string" ? `echo:${msg}` : msg);
+      },
+    },
+  });
+  return { port: server.port as number, stop: () => server.stop(true) };
+}
+
+function startHub(h: Harness, tracker: WsConnectionTracker): { port: number; stop: () => void } {
+  const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath, wsConnectionTracker: tracker });
+  const server = Bun.serve<WsBridgeData>({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch: (req, srv) => fetcher(req, srv),
+    websocket: createWsBridgeHandlers(),
+  });
+  return { port: server.port as number, stop: () => server.stop(true) };
+}
+
+describe("WS connection caps — integration (real sockets, churn to zero)", () => {
+  test("open/close churn returns per-IP + total counters to zero every cycle", async () => {
+    const h = makeHarness();
+    const upstream = startWsEchoUpstream();
+    let hub: { port: number; stop: () => void } | undefined;
+    try {
+      writeManifest({ services: [wsEntry(upstream.port)] }, h.manifestPath);
+      const tracker = new WsConnectionTracker(); // defaults — churn never nears them
+      hub = startHub(h, tracker);
+
+      for (let cycle = 0; cycle < 3; cycle++) {
+        const clients: WebSocket[] = [];
+        for (let i = 0; i < 3; i++) {
+          const ws = new WebSocket(`ws://127.0.0.1:${hub.port}/wsmod/ws`);
+          const opened = new Promise<void>((resolve, reject) => {
+            ws.addEventListener("open", () => resolve());
+            ws.addEventListener("error", () => reject(new Error("client failed to connect")));
+          });
+          clients.push(ws);
+          await opened;
+        }
+        // Slots held while the sockets live (all test clients are direct
+        // loopback peers → one shared bucket).
+        expect(tracker.totalCount).toBe(3);
+        expect(tracker.countFor("127.0.0.1")).toBe(3);
+
+        for (const ws of clients) ws.close(1000, "done");
+        await waitFor(() => tracker.totalCount === 0);
+        expect(tracker.keyCount).toBe(0); // bucket map fully drained — no leak
+      }
+    } finally {
+      hub?.stop();
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("bridge-initiated teardown (unreachable upstream) also releases the slot", async () => {
+    const h = makeHarness();
+    // Bind a port + release it so the upstream connect gets ECONNREFUSED.
+    const probe = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("") });
+    const deadPort = probe.port as number;
+    probe.stop(true);
+    let hub: { port: number; stop: () => void } | undefined;
+    try {
+      writeManifest({ services: [wsEntry(deadPort)] }, h.manifestPath);
+      const tracker = new WsConnectionTracker();
+      hub = startHub(h, tracker);
+
+      const ws = new WebSocket(`ws://127.0.0.1:${hub.port}/wsmod/ws`);
+      const closed = new Promise<number>((resolve) => {
+        ws.addEventListener("close", (ev) => resolve(ev.code));
+      });
+      expect(await closed).toBe(1011);
+      await waitFor(() => tracker.totalCount === 0);
+      expect(tracker.keyCount).toBe(0);
+    } finally {
+      hub?.stop();
+      h.cleanup();
+    }
+  });
+});

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -1802,7 +1802,7 @@ async function maybeUpgradeWebSocket(
     // generic (no counts, no cap identity).
     console.warn(
       `[ws-caps] refused upgrade for ${url.pathname}: ${
-        acquired.reason === "per_ip_cap" ? `per-IP cap (ip=${capKey})` : "total cap"
+        acquired.reason === "per_ip_cap" ? `per-IP cap (ip=${capKey})` : `total cap (ip=${capKey})`
       }; total=${deps.wsConnectionTracker.totalCount} ip_count=${deps.wsConnectionTracker.countFor(
         capKey,
       )}`,

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -279,6 +279,7 @@ import {
   vaultInstanceNameFor,
 } from "./well-known.ts";
 import { type WsBridgeData, createWsBridgeHandlers } from "./ws-bridge.ts";
+import { type WsConnectionTracker, defaultWsConnectionTracker } from "./ws-connection-caps.ts";
 
 interface Args {
   port: number;
@@ -659,6 +660,54 @@ export function stampSubstrateTrustHeaders(
   headers.set(PARACHUTE_LAYER_HEADER, layerOf(req, peerAddr));
   const clientIp = resolveClientIp(req, peerAddr);
   if (clientIp) headers.set(PARACHUTE_CLIENT_IP_HEADER, clientIp);
+}
+
+/**
+ * Shared bucket for connections whose client IP cannot be derived at all
+ * (no forwarder headers AND no peer address). Fail-closed: they all contend
+ * for one per-IP allotment rather than each minting a fresh bucket — the
+ * same posture as rate-limit.ts's UNKNOWN_IP_SENTINEL.
+ */
+export const WS_CAP_SHARED_BUCKET = "unknown";
+
+/**
+ * Derive the connection-cap bucket key for a WS upgrade (hub#649).
+ *
+ * STRICTER than {@link resolveClientIp} on purpose. The H2 attribution stamp
+ * tolerates a direct caller misattributing itself (documented limitation —
+ * the LAYER stays truthful, only the attribution string is best-effort). A
+ * cap key cannot afford that tolerance: if a direct peer's forged
+ * X-Forwarded-For were believed, rotating the header would mint a fresh
+ * bucket per connection and the per-IP cap would never trip. So forwarded
+ * IP headers are believed ONLY when the peer is loopback — the hub's actual
+ * forwarder topology (cloudflared, tailscale serve/funnel) runs on-box and
+ * dials 127.0.0.1; nothing else legitimately presents those headers from
+ * loopback, and a remote attacker can't BE loopback.
+ *
+ *   - loopback peer:  CF-Connecting-IP → X-Forwarded-For first hop → the
+ *     loopback address itself (direct local callers share one bucket —
+ *     owner-operated, and the cap is configurable).
+ *   - non-loopback peer: the peer address, regardless of injected headers
+ *     (spoofed XFF on an untrusted layer lands in the spoofer's own bucket).
+ *   - no peer derivable: {@link WS_CAP_SHARED_BUCKET} (fail closed).
+ *
+ * Known limitation, container deploys (Render / Fly): the platform edge
+ * dials from a private non-loopback address, so all public clients share
+ * the edge peer's bucket there — the per-IP cap degrades to a coarse shared
+ * cap and the global cap is the operative bound. Raise
+ * PARACHUTE_WS_MAX_PER_IP on such deploys; a trusted-proxy allowlist can
+ * refine this when a cloud WS surface actually ships.
+ */
+export function wsCapBucketKey(req: Request, peerAddr: string | null): string {
+  const peer = peerAddr?.trim() || null;
+  if (peer && isLoopbackPeer(peer)) {
+    const cf = req.headers.get("cf-connecting-ip")?.trim();
+    if (cf) return cf;
+    const xff = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+    if (xff) return xff;
+    return peer;
+  }
+  return peer ?? WS_CAP_SHARED_BUCKET;
 }
 
 /**
@@ -1148,6 +1197,15 @@ export interface HubFetchDeps {
    * CLI commands directly.
    */
   supervisor?: Supervisor;
+  /**
+   * WebSocket connection-cap accounting (hub#649). Production uses the
+   * process-wide {@link defaultWsConnectionTracker} (caps from env at boot);
+   * tests inject their own tracker so they neither consume nor depend on the
+   * shared counters. Release pairing is structural — the acquire site stashes
+   * the release closure on the upgraded socket's `data`, so a mismatched
+   * tracker between fetch fn and bridge handlers is impossible.
+   */
+  wsConnectionTracker?: WsConnectionTracker;
 }
 
 /**
@@ -1629,7 +1687,15 @@ type WsUpgradeVerdict =
  *      `.parachute/module.json`. No declaration → 426 (the route exists but
  *      doesn't speak WebSocket; the fetch-based proxy can't forward upgrades
  *      and the daemon never sees the request).
- *   4. `server.upgrade(req, { data })` with the upstream URL + headers
+ *   4. Connection caps (hub#649): per-client-IP + total concurrent caps,
+ *      checked-and-acquired in the same synchronous block as the upgrade
+ *      (no await between check and commit). Over-cap → generic 429 (no
+ *      count leakage; the hub log carries which cap + bucket), refused
+ *      BEFORE `server.upgrade()` commits a socket or the bridge dials the
+ *      upstream. Keying + trust model: {@link wsCapBucketKey}; defaults +
+ *      env overrides: `ws-connection-caps.ts`. Release rides the bridge's
+ *      close handler via `data.releaseCap`.
+ *   5. `server.upgrade(req, { data })` with the upstream URL + headers
  *      (client headers minus hop-by-hop/handshake, plus the H2 substrate
  *      trust stamps). The ws-bridge handlers take over from there.
  */
@@ -1642,6 +1708,8 @@ async function maybeUpgradeWebSocket(
     readModuleManifestFn: (installDir: string) => Promise<ModuleManifest | null>;
     /** H3 — gate the upgrade on the mount's audience BEFORE upgrading. */
     gateAudience?: (pathname: string) => Promise<Response | null>;
+    /** hub#649 — per-IP + total connection-cap accounting. */
+    wsConnectionTracker: WsConnectionTracker;
   },
 ): Promise<WsUpgradeVerdict> {
   const services = readManifestLenient(deps.manifestPath).services;
@@ -1719,10 +1787,46 @@ async function maybeUpgradeWebSocket(
     upstreamHeaders[key] = value;
   });
 
+  // Connection caps (hub#649) — the LAST gate, synchronous with the upgrade
+  // itself (everything between here and `server.upgrade` must stay
+  // await-free so the check can't race the commit). Last on purpose: the
+  // earlier refusals keep their precise statuses (the 404 cloak stays
+  // indistinguishable from not-installed even under cap pressure), and the
+  // counters only ever hold slots for connections that would actually
+  // bridge.
+  const capKey = wsCapBucketKey(req, deps.peerAddr);
+  const acquired = deps.wsConnectionTracker.tryAcquire(capKey);
+  if (!acquired.ok) {
+    // Operator-facing pressure signal: which cap, which bucket, how full.
+    // None of this reaches the client — the 429 body is deliberately
+    // generic (no counts, no cap identity).
+    console.warn(
+      `[ws-caps] refused upgrade for ${url.pathname}: ${
+        acquired.reason === "per_ip_cap" ? `per-IP cap (ip=${capKey})` : "total cap"
+      }; total=${deps.wsConnectionTracker.totalCount} ip_count=${deps.wsConnectionTracker.countFor(
+        capKey,
+      )}`,
+    );
+    return {
+      kind: "response",
+      response: new Response(
+        JSON.stringify({
+          error: "too_many_connections",
+          error_description: "WebSocket connection limit reached; try again later",
+        }),
+        { status: 429, headers: { "content-type": "application/json" } },
+      ),
+    };
+  }
+
   const upgraded = server.upgrade(req, {
-    data: { upstreamUrl, upstreamHeaders },
+    data: { upstreamUrl, upstreamHeaders, releaseCap: acquired.release },
   });
   if (upgraded) return { kind: "upgraded" };
+  // No socket was created, so the bridge's close handler will never fire —
+  // release the slot inline (the closure latches, so this can't double-count
+  // against a later close).
+  acquired.release();
   return {
     kind: "response",
     response: new Response(
@@ -1875,6 +1979,7 @@ export function hubFetch(
           manifestPath,
           peerAddr,
           readModuleManifestFn: deps?.readModuleManifest ?? defaultReadModuleManifest,
+          wsConnectionTracker: deps?.wsConnectionTracker ?? defaultWsConnectionTracker,
           // H3 — the audience gate runs BEFORE the upgrade, same posture as
           // the HTTP dispatch below: a WS endpoint under a hub-users surface
           // never hands a socket to an anonymous caller, while `surface`

--- a/src/ws-bridge.ts
+++ b/src/ws-bridge.ts
@@ -28,6 +28,15 @@
  *     buffered amount exceeds {@link DEFAULT_MAX_BUFFERED_BYTES}, the bridge
  *     closes BOTH sides (1011). A slow consumer should reconnect rather than
  *     let the hub buffer unboundedly.
+ *   - Admission control is upstream of this module (hub#649): the gate in
+ *     `maybeUpgradeWebSocket` enforces per-client-IP + total connection caps
+ *     (defaults 32 / 512, env-overridable via PARACHUTE_WS_MAX_PER_IP /
+ *     PARACHUTE_WS_MAX_TOTAL — see `ws-connection-caps.ts`) BEFORE
+ *     `server.upgrade()`. The bridge's part of the contract is release: the
+ *     `close` handler below is the single funnel every accepted socket
+ *     passes through, so it invokes {@link WsBridgeData.releaseCap} first
+ *     thing — whatever the teardown reason — and the counters churn back to
+ *     zero with the sockets.
  *
  * Lifecycle: either side closing tears down the other (close code + reason
  * propagated where the RFC 6455 rules allow), and an upstream connect failure
@@ -59,6 +68,14 @@ export interface WsBridgeData {
    * plus the H2 substrate trust stamps.
    */
   upstreamHeaders: Record<string, string>;
+  /**
+   * Releases this connection's slot in the connection-cap accounting
+   * (hub#649) — attached by the acquire site in `maybeUpgradeWebSocket`,
+   * invoked by the `close` handler. Self-disarming (safe to call more than
+   * once). Optional so handler-level unit tests that fake `ws.data` don't
+   * have to care about caps.
+   */
+  releaseCap?: () => void;
   /** Internal bridge state — attached by `open()`, owned by this module. */
   _bridge?: BridgeState;
 }
@@ -219,6 +236,12 @@ export function createWsBridgeHandlers(opts: WsBridgeOptions = {}): WebSocketHan
     },
 
     close(ws, code, reason) {
+      // Connection-cap release FIRST (hub#649) — before the bridge-state
+      // early-returns, because this callback fires even for sockets whose
+      // upstream connect threw in open() (no `_bridge` attached) and is the
+      // one teardown funnel every accepted socket passes through. The
+      // closure latches, so re-entry is harmless.
+      ws.data.releaseCap?.();
       // Client → upstream close propagation. Note: Bun's server-side close
       // callback delivers the client's close CODE but an empty `reason`
       // (verified on Bun 1.3.13), so only the code propagates upstream in

--- a/src/ws-connection-caps.ts
+++ b/src/ws-connection-caps.ts
@@ -1,0 +1,170 @@
+/**
+ * WebSocket connection caps for the upgrade bridge (hub#649) — the gate
+ * before any backed surface goes public-facing.
+ *
+ * The H1 bridge (`ws-bridge.ts`) holds one client socket + one upstream
+ * socket per connection, and the only per-connection bound before this
+ * module was the 8 MiB buffered-byte backpressure cap — a public client
+ * could hold upgrade slots open indefinitely at near-zero send rate and
+ * exhaust daemon memory at ~KB/connection. With the `surface` audience tier
+ * (H3, hub#651) anonymous WS is REACHABLE BY DESIGN on surface-audience
+ * mounts, so admission control can't lean on auth: the hub needs a blunt
+ * concurrent-connection bound of its own.
+ *
+ * Enforcement lives in `maybeUpgradeWebSocket` (hub-server.ts), which calls
+ * {@link WsConnectionTracker.tryAcquire} synchronously right before
+ * `server.upgrade()` — over-cap upgrades are refused with a clean HTTP 429
+ * (the upgrade never happens, so a normal Response is the correct refusal
+ * shape in Bun) BEFORE the proxy commits any socket or upstream-dial
+ * resources. The refusal body is generic: it never reveals counts, caps, or
+ * which cap tripped (the hub log carries the specifics for the operator).
+ *
+ * Release rides the bridge's socket lifecycle: the acquire site threads a
+ * self-disarming release closure into `ws.data` ({@link
+ * WsBridgeData.releaseCap}), and the bridge's Bun-level `close` handler —
+ * the single funnel every accepted socket passes through, whatever the
+ * teardown reason (client close, upstream close, backpressure, connect
+ * failure) — invokes it first thing. A failed `server.upgrade()` releases
+ * inline (no socket ⇒ no close callback). The closure latches, so a stray
+ * double-close can't corrupt the counters.
+ *
+ * Defaults (overridable via env, the hub's config precedent —
+ * `PARACHUTE_HUB_ORIGIN` et al.):
+ *
+ *   - {@link DEFAULT_WS_MAX_PER_IP} = 32 per client IP
+ *     (`PARACHUTE_WS_MAX_PER_IP`). An owner-operated box realistically
+ *     serves a handful of humans; a collab surface opens a socket or two
+ *     per tab, so 32 covers a small team behind one NAT egress IP with
+ *     headroom, while turning a single-source flood into a rotate-IPs
+ *     problem.
+ *   - {@link DEFAULT_WS_MAX_TOTAL} = 512 total (`PARACHUTE_WS_MAX_TOTAL`).
+ *     Bounds worst-case hub memory under a distributed flood (512 bridged
+ *     pairs ≈ low MBs idle) at a ceiling far above any realistic legitimate
+ *     concurrent load for a single-operator hub.
+ *
+ * Keying: callers derive the bucket key with `wsCapBucketKey`
+ * (hub-server.ts), which follows the hub's substrate trust model — forwarded
+ * IP headers are only believed when the peer is an on-box (loopback)
+ * forwarder; direct network peers key by their socket address no matter
+ * what headers they inject; an underivable IP lands in one shared bucket
+ * (fail closed, same posture as rate-limit.ts's UNKNOWN_IP_SENTINEL).
+ */
+
+/** Default cap on concurrent bridged WS connections per client-IP bucket. */
+export const DEFAULT_WS_MAX_PER_IP = 32;
+/** Default cap on concurrent bridged WS connections across all clients. */
+export const DEFAULT_WS_MAX_TOTAL = 512;
+
+/** Env var overriding {@link DEFAULT_WS_MAX_PER_IP}. */
+export const WS_MAX_PER_IP_ENV = "PARACHUTE_WS_MAX_PER_IP";
+/** Env var overriding {@link DEFAULT_WS_MAX_TOTAL}. */
+export const WS_MAX_TOTAL_ENV = "PARACHUTE_WS_MAX_TOTAL";
+
+export interface WsCaps {
+  maxPerIp: number;
+  maxTotal: number;
+}
+
+/**
+ * Parse the cap overrides from an env bag. Only positive integers are
+ * honored; absent / malformed / non-positive values fall back to the
+ * defaults (an operator typo must not silently disable the gate — fail to
+ * the safe defaults, never to "unlimited").
+ */
+export function wsCapsFromEnv(env: NodeJS.ProcessEnv = process.env): WsCaps {
+  return {
+    maxPerIp: parseCap(env[WS_MAX_PER_IP_ENV], DEFAULT_WS_MAX_PER_IP),
+    maxTotal: parseCap(env[WS_MAX_TOTAL_ENV], DEFAULT_WS_MAX_TOTAL),
+  };
+}
+
+function parseCap(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) return fallback;
+  const n = Number.parseInt(raw.trim(), 10);
+  if (!Number.isSafeInteger(n) || n <= 0 || String(n) !== raw.trim()) return fallback;
+  return n;
+}
+
+/** The verdict of {@link WsConnectionTracker.tryAcquire}. */
+export type WsAcquireResult =
+  | { ok: true; release: () => void }
+  | { ok: false; reason: "per_ip_cap" | "total_cap" };
+
+/**
+ * Concurrent-connection accounting: a per-key map + a global counter.
+ *
+ * Acquire and release are synchronous and O(1); `tryAcquire` is called in
+ * the same synchronous block as `server.upgrade()` (no await between check
+ * and commit), so the counters can't race the admission decision.
+ *
+ * The returned `release` closure is latched — calling it twice decrements
+ * once. That makes leaks structurally hard: the caller doesn't need to know
+ * which teardown paths can double-fire; any number of invocations after the
+ * first are no-ops, and a key's bucket entry is deleted at zero so an
+ * attacker cycling keys can't grow the map without also holding sockets.
+ */
+export class WsConnectionTracker {
+  private readonly perKey = new Map<string, number>();
+  private total = 0;
+
+  constructor(
+    private readonly maxPerKey: number = DEFAULT_WS_MAX_PER_IP,
+    private readonly maxTotal: number = DEFAULT_WS_MAX_TOTAL,
+  ) {}
+
+  /**
+   * Admit-or-refuse a would-be connection for `key`. On admission the slot
+   * is counted immediately and the caller MUST either hand the returned
+   * `release` to the socket's close path or invoke it inline when the
+   * upgrade fails to complete.
+   */
+  tryAcquire(key: string): WsAcquireResult {
+    if (this.total >= this.maxTotal) return { ok: false, reason: "total_cap" };
+    const current = this.perKey.get(key) ?? 0;
+    if (current >= this.maxPerKey) return { ok: false, reason: "per_ip_cap" };
+    this.perKey.set(key, current + 1);
+    this.total += 1;
+
+    let released = false;
+    return {
+      ok: true,
+      release: () => {
+        if (released) return;
+        released = true;
+        const n = this.perKey.get(key) ?? 0;
+        if (n <= 1) this.perKey.delete(key);
+        else this.perKey.set(key, n - 1);
+        if (this.total > 0) this.total -= 1;
+      },
+    };
+  }
+
+  /** Current global connection count (observability + tests). */
+  get totalCount(): number {
+    return this.total;
+  }
+
+  /** Current count for one key (observability + tests). 0 when absent. */
+  countFor(key: string): number {
+    return this.perKey.get(key) ?? 0;
+  }
+
+  /** Number of distinct keys currently holding connections (leak probe). */
+  get keyCount(): number {
+    return this.perKey.size;
+  }
+}
+
+/**
+ * The production tracker — one per hub process, shared by every upgrade.
+ * Caps come from the env at module load (the hub reads its config once at
+ * boot; changing the env requires a restart, same as every other
+ * `PARACHUTE_*` knob). Tests construct their own trackers and inject them
+ * via `HubFetchDeps.wsConnectionTracker` so they never consume (or depend
+ * on) the shared process-level counters.
+ */
+const bootCaps = wsCapsFromEnv();
+export const defaultWsConnectionTracker = new WsConnectionTracker(
+  bootCaps.maxPerIp,
+  bootCaps.maxTotal,
+);


### PR DESCRIPTION
Closes #649 — the gate before any backed surface goes public-facing. From the #648 transport review: the WS upgrade bridge had no per-IP or aggregate connection limit, and the only existing bound was the 8MiB buffered-byte backpressure cap — a public client could hold upgrade slots open indefinitely at near-zero send rate. With the `surface` audience tier (#651) making anonymous WS reachable by design on surface-audience mounts, admission control can't lean on auth.

## What ships

**Enforcement at upgrade time, before resources commit.** `maybeUpgradeWebSocket` now check-and-acquires a connection slot in the same synchronous block as `server.upgrade()` (no await between check and commit — the counters can't race the admission decision). Over-cap upgrades are refused with a clean HTTP 429: since the upgrade never happens, returning a normal `Response` from the fetch handler is the correct refusal shape in Bun. The cap check runs **last** in the gate chain so the loopback-exposure 404 cloak stays indistinguishable from not-installed even under cap pressure, and counters only ever hold slots for connections that would actually bridge.

**Refusal is generic.** The 429 body (`too_many_connections`) carries no counts, no cap values, and doesn't distinguish per-IP from global — the test asserts the body contains no digits at all. Operator observability rides the hub log instead: every refusal logs which cap tripped, the bucket, and the current pressure (`[ws-caps] refused upgrade for /path: per-IP cap (ip=…); total=N ip_count=M`).

**Accounting that's structurally hard to leak.** `WsConnectionTracker` (new `src/ws-connection-caps.ts`) keeps a per-key map + global counter. The acquire site threads a **self-disarming release closure** into `ws.data`, so the tracker pairing between the fetch fn and the bridge handlers can't be mismatched, and a double-fire decrements exactly once. The bridge's Bun-level `close` handler — the single teardown funnel every accepted socket passes through (client close, upstream close, backpressure trip, upstream connect failure) — invokes it before its bridge-state early-returns. A failed `server.upgrade()` (no socket ⇒ no close callback) releases inline. Key buckets are evicted at zero, so the map can't grow without held sockets behind it.

## Trust-model note (client IP derivation)

`wsCapBucketKey` is deliberately **stricter** than the H2 attribution stamp's `resolveClientIp`. The H2 stamp tolerates a direct caller misattributing itself (documented limitation — the layer stays truthful). A cap key can't afford that: a believed forged `X-Forwarded-For` would mint a fresh bucket per connection and the per-IP cap would never trip. So:

- **Loopback peer** (the hub's actual forwarder topology — cloudflared, tailscale serve/funnel all run on-box and dial 127.0.0.1): `CF-Connecting-IP` → XFF first hop → the loopback address itself.
- **Direct non-loopback peer**: keyed by its socket address, injected headers ignored — spoofed XFF lands in the spoofer's own bucket (test-proven).
- **Underivable IP** (no headers, no peer): one shared bucket — fail closed, same posture as `rate-limit.ts`'s `UNKNOWN_IP_SENTINEL`.

Known limitation (documented in the jsdoc): on container deploys where a platform edge dials from a private non-loopback address (Render/Fly), public clients share the edge peer's bucket — per-IP degrades to a coarse shared cap and the global cap is the operative bound. Raise the per-IP env on such deploys; a trusted-proxy allowlist can refine this when a cloud WS surface actually ships.

## Defaults + config

- `PARACHUTE_WS_MAX_PER_IP` — default **32**. An owner-operated box serves a handful of humans; a collab surface opens a socket or two per tab, so 32 covers a small team behind one NAT egress with headroom while turning a single-source flood into a rotate-IPs problem.
- `PARACHUTE_WS_MAX_TOTAL` — default **512**. Bounds worst-case hub memory under a distributed flood (~low MBs idle for 512 bridged pairs) far above realistic legitimate load.
- Env follows the hub's existing config precedent (`PARACHUTE_*`, read at boot). Positive integers only — malformed values fall back to the **defaults, never to unlimited**.

## Fails-pre-fix evidence

The headline test (40 same-IP upgrade attempts → expect 32 accepted / 8 refused 429) was written against pre-fix exports and run on the unmodified tree first:

```
error: expect(received).toBe(expected)
Expected: 32
Received: 40
(fail) hub#649 headline — per-IP WS connection cap > a same-IP upgrade flood is refused past the cap (429), not accepted unboundedly
```

i.e. all 40 upgrades accepted — no bound existed.

## Tests (16 new)

Per-IP cap refusal (headline) · global cap refusal · generic-429-body (no digits) · spoofed-XFF-on-untrusted-layer containment · loopback-XFF distinct buckets · release on failed `server.upgrade` · env-configured caps enforced · `wsCapsFromEnv` parsing (valid / malformed→defaults) · `wsCapBucketKey` derivation (loopback CF/XFF/peer, non-loopback peer, shared bucket) · tracker double-release latch + key eviction · **integration churn-to-zero** (real `Bun.serve` hub + real WS upstream, 3 open/close cycles, counters provably return to 0 with the bucket map empty) · bridge-initiated teardown (unreachable upstream) also releases.

## Gates

- `bun test ./src`: **3367 pass / 1 skip / 0 fail** (134 files)
- `bun run typecheck` (`tsc --noEmit`): clean
- `bunx biome check` on the 4 touched files: clean

## Patterns check

- Extends the rate-limit precedent (fail-closed shared bucket for underivable actors; layer-independent enforcement) from HTTP to the WS analog at the hub layer, per the #649 framing.
- No rc bump in this PR per current practice (bump+tag together on ship signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)