### PR TITLE
fix(logs): supervised modules read the hub log's [svc]-prefixed stream (#652)

### DIFF
--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, openSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, openSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -678,9 +678,36 @@ describe("group-aware kill / liveness (hub#88)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// `parachute logs <svc>` — unchanged by Phase 5b. Reads the per-service logfile
-// keyed by short name (the readers §7.5 keeps). Includes the internal `hub`.
+// `parachute logs <svc>`. Under hub-as-supervisor (Phase 5b) a module's output
+// is multiplexed into the HUB log with a `[<svc>] ` line prefix, so `logs <svc>`
+// reads that stream filtered to the service (hub#652). The per-service logfile
+// keyed by short name (the readers §7.5 keeps) survives as the legacy source
+// when it's fresher than the hub log (pre-supervised installs). `logs hub`
+// reads the hub log unfiltered.
 // ---------------------------------------------------------------------------
+
+/** The supervisor's multiplexed hub-log shape (supervisor.ts pipeOutput). */
+const INTERLEAVED_HUB_LOG =
+  "[vault] vault boot\n" +
+  "[scribe] scribe boot\n" +
+  "[vault] GET /vault/default/api/notes 200 7ms\n" +
+  "[surface] [app-dcr] client registered\n" +
+  "[vaultx] not vault's line\n" +
+  "[vault] sync ok\n";
+
+const VAULT_LINES_STRIPPED = ["vault boot", "GET /vault/default/api/notes 200 7ms", "sync ok"];
+
+function writeHubLog(configDir: string, content: string): string {
+  const path = ensureLogPath("hub", configDir);
+  writeFileSync(path, content);
+  return path;
+}
+
+/** Backdate a file's mtime so freshness comparisons are deterministic. */
+function backdate(path: string, secondsAgo: number): void {
+  const t = new Date(Date.now() - secondsAgo * 1000);
+  utimesSync(path, t, t);
+}
 
 describe("parachute logs", () => {
   test("hint when no log file exists", async () => {
@@ -825,6 +852,214 @@ describe("parachute logs", () => {
       });
       expect(code).toBe(0);
       expect(log).toEqual(["hub line one", "hub line two"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // ---- hub#652: supervised modules read the hub log's [svc]-prefixed stream ----
+
+  test("supervised module: reads the hub log filtered to its prefix, stripped (hub#652)", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writeHubLog(h.configDir, INTERLEAVED_HUB_LOG);
+      // No per-service vault.log — the supervised steady state.
+      const log: string[] = [];
+      const code = await logs("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      // Exact-prefix match: `[vaultx]` noise excluded; `[vault] ` stripped.
+      expect(log).toEqual(VAULT_LINES_STRIPPED);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("stale per-service file + fresher hub log: the hub stream wins (the live hub#652 shape)", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const legacy = ensureLogPath("vault", h.configDir);
+      writeFileSync(legacy, "stale pre-cutover line\n");
+      backdate(legacy, 3600);
+      writeHubLog(h.configDir, INTERLEAVED_HUB_LOG);
+      const log: string[] = [];
+      const code = await logs("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(log).toEqual(VAULT_LINES_STRIPPED);
+      expect(log.join("\n")).not.toContain("stale pre-cutover line");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("per-service file fresher than the hub log: legacy file wins (pre-supervised install)", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const hubLog = writeHubLog(h.configDir, "[vault] old supervised line\n");
+      backdate(hubLog, 3600);
+      const legacy = ensureLogPath("vault", h.configDir);
+      writeFileSync(legacy, "live detached line\n");
+      const log: string[] = [];
+      const code = await logs("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(log).toEqual(["live detached line"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("lines cap applies to the FILTERED set, not raw hub-log lines", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writeHubLog(h.configDir, INTERLEAVED_HUB_LOG);
+      const log: string[] = [];
+      const code = await logs("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        lines: 2,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(log).toEqual(VAULT_LINES_STRIPPED.slice(-2));
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("hub log has no lines for the service + no per-service file: start hint", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writeHubLog(h.configDir, "[scribe] scribe boot\n");
+      const log: string[] = [];
+      const code = await logs("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(log.join("\n")).toMatch(/no logs yet for vault/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("hub log has no lines for the service + per-service file exists: legacy shown with a note", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const legacy = ensureLogPath("vault", h.configDir);
+      writeFileSync(legacy, "old detached line\n");
+      backdate(legacy, 3600);
+      writeHubLog(h.configDir, "[scribe] scribe boot\n");
+      const log: string[] = [];
+      const code = await logs("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      // The note distinguishes the stale per-service file from the live
+      // stream — the exact "stale logs presented as current" trap in hub#652.
+      expect(log[0]).toMatch(/no vault lines in the hub log/);
+      expect(log).toContain("old detached line");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("follow mode filters the hub stream and strips the prefix (hub#652)", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      writeHubLog(h.configDir, INTERLEAVED_HUB_LOG);
+      const encoder = new TextEncoder();
+      let streamedPath: string | undefined;
+      const followStream = (path: string): ReadableStream<Uint8Array> => {
+        streamedPath = path;
+        return new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode("[vault] live one\n[scribe] noise\n"));
+            // Split a line across chunks to exercise the line buffer.
+            controller.enqueue(encoder.encode("[vault] live "));
+            controller.enqueue(encoder.encode("two\n"));
+            controller.close();
+          },
+        });
+      };
+      const log: string[] = [];
+      const code = await logs("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        follow: true,
+        followStream,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(streamedPath).toContain("hub.log");
+      expect(log).toEqual([...VAULT_LINES_STRIPPED, "live one", "live two"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("follow mode with a fresher per-service file tails THAT file via tail -f", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const hubLog = writeHubLog(h.configDir, "[vault] old supervised line\n");
+      backdate(hubLog, 3600);
+      const legacy = ensureLogPath("vault", h.configDir);
+      writeFileSync(legacy, "live detached line\n");
+      const spawned: string[][] = [];
+      const code = await logs("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        follow: true,
+        tailSpawner: {
+          spawn(cmd) {
+            spawned.push([...cmd]);
+            return 12345;
+          },
+        },
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      expect(spawned).toHaveLength(1);
+      expect(spawned[0]?.[0]).toBe("tail");
+      expect(spawned[0]?.at(-1)).toBe(legacy);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("logs hub: stays unfiltered — module-prefixed lines included", async () => {
+    const h = makeHarness();
+    try {
+      writeHubLog(h.configDir, INTERLEAVED_HUB_LOG);
+      const log: string[] = [];
+      const code = await logs("hub", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+      });
+      expect(code).toBe(0);
+      expect(log).toEqual(INTERLEAVED_HUB_LOG.replace(/\n$/, "").split("\n"));
     } finally {
       h.cleanup();
     }

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -821,6 +821,9 @@ export async function logs(svc: string, opts: LogsOpts = {}): Promise<number> {
     // Print the filtered backlog above, then follow new hub-log lines through
     // the same filter. Runs until the tail is killed (Ctrl-C takes down the
     // whole foreground process group); in tests the injected stream closes.
+    if (matched.length === 0) {
+      log(`(no prior ${svc} lines — waiting for new output…)`);
+    }
     const source = opts.followStream ?? defaultFollowStream;
     await pumpFilteredLines(source(hubLogPath), prefix, log);
   }

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { rethrowIfMissing } from "@openparachute/depcheck";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
@@ -609,6 +609,74 @@ export interface LogsOpts {
    * Defaults to the group-aware `defaultAlive` (hub#88).
    */
   alive?: AliveFn;
+  /**
+   * Filtered-follow source seam (hub#652) — the byte stream of lines appended
+   * to the hub log from attach onward. The production default spawns
+   * `tail -n 0 -f <hub.log>` with piped stdout so the `[<svc>] ` filter runs
+   * in-process; tests inject a deterministic stream.
+   */
+  followStream?: (path: string) => ReadableStream<Uint8Array>;
+}
+
+/** Default `followStream`: tail the file from its end, stdout piped to us. */
+function defaultFollowStream(path: string): ReadableStream<Uint8Array> {
+  try {
+    // Inherit env so `tail` sees PATH, etc. Bun.spawn defaults to empty
+    // env — see api-modules-ops.ts:defaultRun.
+    const proc = Bun.spawn(["tail", "-n", "0", "-f", path], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "inherit",
+      env: process.env,
+    });
+    return proc.stdout;
+  } catch (err) {
+    // A missing `tail` (minimal container without coreutils) surfaces the
+    // friendly install UX instead of a raw spawn throw (cli.ts top-level
+    // catch renders the MissingDependencyError).
+    rethrowIfMissing(err, "tail");
+    throw err;
+  }
+}
+
+/**
+ * Pump a byte stream line-by-line, emitting only lines that carry `prefix`
+ * (stripped). Line-buffered the same way the supervisor's `pumpLines` is, so
+ * chunk boundaries inside a line don't drop or split matches.
+ */
+async function pumpFilteredLines(
+  stream: ReadableStream<Uint8Array>,
+  prefix: string,
+  output: (line: string) => void,
+): Promise<void> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  const emit = (line: string): void => {
+    if (line.startsWith(prefix)) output(line.slice(prefix.length));
+  };
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let nl = buf.indexOf("\n");
+      while (nl !== -1) {
+        emit(buf.slice(0, nl));
+        buf = buf.slice(nl + 1);
+        nl = buf.indexOf("\n");
+      }
+    }
+    if (buf.length > 0) emit(buf);
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/** Split a log file's content into lines, dropping the trailing newline. */
+function splitLogLines(content: string): string[] {
+  const trimmed = content.replace(/\n$/, "");
+  return trimmed === "" ? [] : trimmed.split("\n");
 }
 
 export async function logs(svc: string, opts: LogsOpts = {}): Promise<number> {
@@ -620,11 +688,12 @@ export async function logs(svc: string, opts: LogsOpts = {}): Promise<number> {
   const alive = opts.alive ?? defaultAlive;
 
   // logs only needs a valid short name to find the log file. First-party
-  // wins via the spec lookup; third-party rows match by `entry.name`; the
-  // internal hub is a known short outside of services.json. installDir is
-  // irrelevant here — the log file is keyed by short name and exists once
-  // the service has run, regardless of how it was registered. We just need
-  // to confirm the name maps to something the CLI manages.
+  // wins via the spec lookup; third-party rows match by `entry.name` (the
+  // same token the supervisor uses as its log prefix); the internal hub is
+  // a known short outside of services.json. installDir is irrelevant here —
+  // the log file is keyed by short name and exists once the service has
+  // run, regardless of how it was registered. We just need to confirm the
+  // name maps to something the CLI manages.
   const isFirstParty = getSpec(svc) !== undefined;
   if (!isFirstParty && svc !== HUB_SVC) {
     const entry = readManifest(manifestPath).services.find((s) => s.name === svc);
@@ -634,19 +703,111 @@ export async function logs(svc: string, opts: LogsOpts = {}): Promise<number> {
     }
   }
 
-  const path = logPathFor(svc, configDir);
-  if (!existsSync(path)) {
-    // Distinguish "daemon never started" from "daemon is running but the
-    // log file is missing" (hub#335). The latter shape surfaces when a
-    // module self-registers + spawns its own logger without going through
-    // `parachute start <svc>` (no hub-managed log file), or when an
-    // operator deletes the log mid-run. Previously both shapes printed the
-    // same `parachute start ${svc}` hint, leading operators to think their
-    // running daemon hadn't started.
+  // Per-file plain reader (the pre-#652 behavior): tail/print one log file.
+  const readPlain = async (path: string): Promise<number> => {
+    if (follow) {
+      const spawner = opts.tailSpawner ?? {
+        spawn(cmd) {
+          // Inherit env so `tail` sees PATH, etc. Bun.spawn defaults to empty
+          // env — see api-modules-ops.ts:defaultRun.
+          try {
+            const proc = Bun.spawn([...cmd], {
+              stdio: ["ignore", "inherit", "inherit"],
+              env: process.env,
+            });
+            return proc.pid;
+          } catch (err) {
+            // A missing `tail` (minimal container without coreutils) surfaces
+            // the friendly install UX instead of a raw spawn throw. The CLI
+            // top-level catch in cli.ts renders the MissingDependencyError.
+            rethrowIfMissing(err, "tail");
+            throw err;
+          }
+        },
+      };
+      spawner.spawn(["tail", "-n", String(lines), "-f", path], path);
+      // tail runs until user Ctrl-C; block this process until it exits.
+      // When called from the real CLI, process.exit wraps us; in tests a
+      // stub spawner returns immediately and we fall through.
+      return 0;
+    }
+    // Non-follow path: read last N lines synchronously for a clean one-shot.
+    const tail = splitLogLines(await Bun.file(path).text()).slice(-lines);
+    for (const line of tail) log(line);
+    return 0;
+  };
+
+  const legacyPath = logPathFor(svc, configDir);
+  const hubLogPath = logPathFor(HUB_SVC, configDir);
+  const legacyExists = svc !== HUB_SVC && existsSync(legacyPath);
+  const hubLogExists = existsSync(hubLogPath);
+
+  // Source selection (hub#652): under hub-as-supervisor (Phase 5b) a module's
+  // stdout/stderr is multiplexed into the HUB log with a `[<svc>] ` line
+  // prefix (supervisor.ts pipeOutput) — the per-service file stops advancing
+  // at the cutover. Prefer whichever file is fresher: a pre-supervised
+  // install is still actively writing the per-service file (it wins); on a
+  // supervised box the hub log is the live stream and the per-service file
+  // is a stale remnant (it loses). `logs hub` always reads the hub log
+  // unfiltered — the interleaved prefixed stream IS the hub's own log.
+  const useHubStream =
+    svc !== HUB_SVC &&
+    hubLogExists &&
+    (!legacyExists || statSync(hubLogPath).mtimeMs >= statSync(legacyPath).mtimeMs);
+
+  if (!useHubStream) {
+    if (!existsSync(legacyPath)) {
+      // Distinguish "daemon never started" from "daemon is running but the
+      // log file is missing" (hub#335). The latter shape surfaces when a
+      // module self-registers + spawns its own logger without going through
+      // the hub (no hub-managed log file), or when an operator deletes the
+      // log mid-run. Previously both shapes printed the same
+      // `parachute start ${svc}` hint, leading operators to think their
+      // running daemon hadn't started.
+      const state = processState(svc, configDir, alive);
+      if (state.status === "running") {
+        const whereabouts =
+          svc === HUB_SVC
+            ? `no log file at ${legacyPath}`
+            : `no log file at ${legacyPath} and no hub log at ${hubLogPath}`;
+        log(
+          `${svc} is running (pid ${state.pid}) but ${whereabouts}. The daemon may be writing logs elsewhere — check its stdout/stderr or its own log destination.`,
+        );
+        return 0;
+      }
+      log(`no logs yet for ${svc}. \`parachute start ${svc}\` to begin.`);
+      return 0;
+    }
+    return readPlain(legacyPath);
+  }
+
+  // Supervised path (hub#652): the service's lines in the hub log, prefix
+  // stripped. Stripped rather than kept: every line would otherwise repeat
+  // the name the operator just typed, while the module's own output shape
+  // (e.g. surface's `[app-dcr]` sub-prefixes) stays intact — the same shape
+  // its per-service file had pre-cutover.
+  const prefix = `[${svc}] `;
+  const matched = splitLogLines(await Bun.file(hubLogPath).text())
+    .filter((l) => l.startsWith(prefix))
+    .map((l) => l.slice(prefix.length));
+
+  if (matched.length === 0 && !follow) {
+    if (legacyExists) {
+      // Transitional shape: nothing for this service in the hub log, but a
+      // (staler) per-service file exists — e.g. the module last ran detached,
+      // pre-cutover. Show it, with a note so a stale file isn't mistaken for
+      // the live stream (the exact hub#652 trap).
+      log(
+        `note: no ${svc} lines in the hub log (${hubLogPath}); showing the per-service log at ${legacyPath}.`,
+      );
+      return readPlain(legacyPath);
+    }
+    // Keep the hub#335 shapes coherent with the hub-stream source: a live
+    // pidfile here means a daemon the hub isn't logging for.
     const state = processState(svc, configDir, alive);
     if (state.status === "running") {
       log(
-        `${svc} is running (pid ${state.pid}) but no log file at ${path}. The daemon may be writing logs elsewhere — check its stdout/stderr or its own log destination.`,
+        `${svc} is running (pid ${state.pid}) but has no lines in the hub log (${hubLogPath}) and no log file at ${legacyPath}. The daemon may be writing logs elsewhere — check its stdout/stderr or its own log destination.`,
       );
       return 0;
     }
@@ -654,38 +815,14 @@ export async function logs(svc: string, opts: LogsOpts = {}): Promise<number> {
     return 0;
   }
 
-  if (follow) {
-    const spawner = opts.tailSpawner ?? {
-      spawn(cmd) {
-        // Inherit env so `tail` sees PATH, etc. Bun.spawn defaults to empty
-        // env — see api-modules-ops.ts:defaultRun.
-        try {
-          const proc = Bun.spawn([...cmd], {
-            stdio: ["ignore", "inherit", "inherit"],
-            env: process.env,
-          });
-          return proc.pid;
-        } catch (err) {
-          // A missing `tail` (minimal container without coreutils) surfaces
-          // the friendly install UX instead of a raw spawn throw. The CLI
-          // top-level catch in cli.ts renders the MissingDependencyError.
-          rethrowIfMissing(err, "tail");
-          throw err;
-        }
-      },
-    };
-    spawner.spawn(["tail", "-n", String(lines), "-f", path], path);
-    // tail runs until user Ctrl-C; block this process until it exits.
-    // When called from the real CLI, process.exit wraps us; in tests a
-    // stub spawner returns immediately and we fall through.
-    return 0;
-  }
+  for (const line of matched.slice(-lines)) log(line);
 
-  // Non-follow path: read last N lines synchronously for a clean one-shot.
-  const content = await Bun.file(path).text();
-  const trimmed = content.replace(/\n$/, "");
-  const allLines = trimmed === "" ? [] : trimmed.split("\n");
-  const tail = allLines.slice(-lines);
-  for (const line of tail) log(line);
+  if (follow) {
+    // Print the filtered backlog above, then follow new hub-log lines through
+    // the same filter. Runs until the tail is killed (Ctrl-C takes down the
+    // whole foreground process group); in tests the injected stream closes.
+    const source = opts.followStream ?? defaultFollowStream;
+    await pumpFilteredLines(source(hubLogPath), prefix, log);
+  }
   return 0;
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -583,12 +583,18 @@ export function logsHelp(): string {
 Usage:
   parachute logs <service>          print the last 200 lines
   parachute logs <service> -f       tail the log (like \`tail -f\`)
-  parachute logs hub                logs for the internal hub
+  parachute logs hub                the full hub log (every module interleaved)
 
-Log file:
-  ~/.parachute/<service>/logs/<service>.log
+Where logs live:
+  Supervised modules (the normal shape — hub-as-supervisor) write through
+  the hub: the supervisor multiplexes each child's output into
+  ~/.parachute/hub/logs/hub.log with a \`[<service>]\` line prefix.
+  \`parachute logs <service>\` reads that stream filtered to the service's
+  lines, prefix stripped. A legacy per-service file
+  (~/.parachute/<service>/logs/<service>.log) is read instead when it is
+  fresher than the hub log — the pre-supervised install shape.
 
-If no log file exists yet, prints a hint to \`parachute start <service>\`.
+If no log lines exist yet, prints a hint to \`parachute start <service>\`.
 `;
 }
 

--- a/src/help.ts
+++ b/src/help.ts
@@ -590,7 +590,8 @@ Where logs live:
   the hub: the supervisor multiplexes each child's output into
   ~/.parachute/hub/logs/hub.log with a \`[<service>]\` line prefix.
   \`parachute logs <service>\` reads that stream filtered to the service's
-  lines, prefix stripped. A legacy per-service file
+  lines, prefix stripped (-n caps the MATCHING lines, not raw hub-log
+  lines; \`logs hub\` is unfiltered). A legacy per-service file
   (~/.parachute/<service>/logs/<service>.log) is read instead when it is
   fresher than the hub log — the pre-supervised install shape.
 


### PR DESCRIPTION
Closes #652.

## Problem

Under hub-as-supervisor (Phase 5b), a module's stdout/stderr is multiplexed into `~/.parachute/hub/logs/hub.log` with a `[<svc>] ` line prefix (`supervisor.ts` `pipeOutput` — verified the exact format, also live: `[vault] GET /vault/default/api/notes 200 7ms`). The per-service file `~/.parachute/<svc>/logs/<svc>.log` stops advancing at the cutover, but `parachute logs <svc>` still read it. Live symptom: `parachute logs surface` showed Jun-2 pre-rename lines while diagnosing on Jun-10 — the first diagnostic an operator reaches for was blind.

## Fix

`logs <svc>` now picks its source by freshness:

- **Supervised (hub log fresher or only source):** reads/follows the hub log filtered to the service's `[<svc>] ` lines, **prefix stripped**. Stripped rather than kept: every line would otherwise repeat the name the operator just typed, while the module's *own* output shape (e.g. surface's `[app-dcr]` sub-prefixes) stays intact — the same shape its per-service file had pre-cutover, so output is consistent across both sources.
- **`-f` follow:** prints the filtered backlog, then follows via `tail -n 0 -f <hub.log>` piped through the same in-process line-buffered filter (new injectable `followStream` seam; chunk-split lines handled). Blocks until the tail dies (Ctrl-C takes the process group).
- **Legacy fallback:** when the per-service file exists and is *fresher* than the hub log (pre-supervised installs still actively writing it), the pre-#652 behavior is unchanged. When the hub log has no `[<svc>]` lines but a staler per-service file exists, that file is shown **with an explicit note** — so stale output can't masquerade as the live stream (the exact #652 trap).
- **hub#335 diagnostics kept coherent:** the running-but-no-logfile message now names both candidate sources (per-service file + hub log); the "no logs yet → `parachute start <svc>`" hint is unchanged, and a new running-but-nothing-in-hub-log variant covers the supervised-source shapes.
- **`logs hub`** keeps reading hub.log unfiltered (the interleaved prefixed stream IS the hub's own log). Unknown-service handling unchanged. `logsHelp()` updated.

Third-party rows are covered too: the supervisor's prefix short for them is `entry.name` (`serve-boot.ts`), the same token `logs` validates.

## Proof the headline failed pre-fix

New tests run against pre-fix `logs()`: 5 fail —
- "supervised module: reads the hub log filtered…" → printed `no logs yet for vault` (supervised lines invisible)
- "stale per-service file + fresher hub log…" → printed the stale pre-cutover line (the live shape)
- plus filtered-lines-cap, note-on-stale-fallback, follow-mode filtering.

## Live verification (read-only — hub NOT restarted)

- `bun src/cli.ts logs surface` now shows the current supervised stream (was: Jun-2 stale file)
- `bun src/cli.ts logs hub` unchanged, unfiltered
- `bun src/cli.ts logs vault -f`: 200-line filtered backlog, then a mid-follow loopback `GET /vault/default/health` appeared live, filtered + stripped

## Tests

Nine new cases in `lifecycle.test.ts`: multi-service interleaved fixture (exact-prefix match — `[vaultx]` doesn't leak into `logs vault`), stale-legacy vs fresh-hub, fresher-legacy fallback, filtered `lines` cap, no-lines hints (with/without legacy), follow-mode filtering across chunk-split lines, legacy follow still via `tail`, `logs hub` unfiltered. All pre-existing logs tests pass unmodified.

## Gates (literal)

- `bun test ./src`: **3376 pass, 1 skip, 0 fail** (3377 tests across 134 files)
- `bun run typecheck` (`tsc --noEmit`): clean
- `bunx biome check` on the 3 touched files: clean

No version bump per governance (bump+tag together on ship call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)