### PR TITLE
feat(invites): pre-named invites + verified read-role story (Adam/Jonathan scenario)

### DIFF
--- a/src/__tests__/account-setup.test.ts
+++ b/src/__tests__/account-setup.test.ts
@@ -21,11 +21,14 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { hasScope } from "../../packages/scope-guard/src/scope.ts";
 import { handleAccountSetupGet, handleAccountSetupPost } from "../account-setup.ts";
+import { handleAccountVaultTokenPost } from "../account-vault-token.ts";
 import type { RunResult } from "../admin-vaults.ts";
 import { CSRF_FIELD_NAME, buildCsrfCookie, generateCsrfToken } from "../csrf.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { consumeInvite, findInviteByRawToken, issueInvite, revokeInvite } from "../invites.ts";
+import { validateAccessToken } from "../jwt-sign.ts";
 import { __resetForTests } from "../rate-limit.ts";
 import { findActiveSession } from "../sessions.ts";
 import { createUser, getUserByUsernameCI, userCount, vaultVerbsForUserVault } from "../users.ts";
@@ -783,9 +786,10 @@ describe("POST /account/setup/<token> — cross-tenant: existing-vault rejection
     expect(userCount(harness.db) - before).toBe(1);
   });
 
-  test("shared-vault invite that slipped through (provision_vault=false + pinned name) → rejected at redeem", async () => {
-    // Defense in depth: the admin API rejects creating this shape, but if one
-    // exists in the DB the redeem must still refuse to assign the existing vault.
+  test("shared-vault invite (provision_vault=false + pinned EXISTING name) → assigns at the invite's role, NO provisioning", async () => {
+    // The supported shared-vault shape: host:admin minted this invite, the
+    // same authority that can assign any user to any vault via POST
+    // /api/users — the invite just packages that assignment as a link.
     await createUser(harness.db, "owner", "owner-strong-password-1", {
       assignedVaults: ["legacy"],
       role: "write",
@@ -798,6 +802,46 @@ describe("POST /account/setup/<token> — cross-tenant: existing-vault rejection
       createdBy: admin.id,
       vaultName: "legacy",
       provisionVault: false,
+      role: "write",
+    });
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const stub = makeStubRunCommand();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "guest",
+          password: "guest-strong-password-11",
+          password_confirm: "guest-strong-password-11",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    expect(res.status).toBe(302);
+    // NO provisioning shell-out — the vault already exists.
+    expect(stub.calls.length).toBe(0);
+    const user = getUserByUsernameCI(harness.db, "guest");
+    expect(user?.assignedVaults).toEqual(["legacy"]);
+    expect(vaultVerbsForUserVault(harness.db, user?.id ?? "", "legacy")).toEqual([
+      "read",
+      "write",
+      "admin",
+    ]);
+    expect(findInviteByRawToken(harness.db, rawToken)?.usedAt).not.toBeNull();
+  });
+
+  test("shared-vault invite whose vault VANISHED from services.json → 400, invite unconsumed", async () => {
+    // The vault-delete cascade revokes pending invites, so this is the
+    // defense-in-depth path (manual manifest edits / restored DB).
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, {
+      createdBy: admin.id,
+      vaultName: "ghost",
+      provisionVault: false,
+      role: "read",
     });
     const before = userCount(harness.db);
     const { token: csrfToken, cookieFragment } = csrfPair();
@@ -819,10 +863,192 @@ describe("POST /account/setup/<token> — cross-tenant: existing-vault rejection
     expect(res.status).toBe(400);
     expect(getUserByUsernameCI(harness.db, "wouldbe")).toBeNull();
     expect(userCount(harness.db) - before).toBe(0);
-    // No vault shell-out — rejected before provisioning.
     expect(stub.calls.length).toBe(0);
-    // Invite NOT consumed.
     expect(findInviteByRawToken(harness.db, rawToken)?.usedAt).toBeNull();
+  });
+});
+
+describe("POST /account/setup/<token> — the Adam/Jonathan read-only shared-vault e2e", () => {
+  test("redeem read-role shared invite → read mints, write/admin/cross-vault REFUSED, vault-side scope check refuses writes", async () => {
+    // End-to-end pin of the read-role enforcement chain:
+    //   invite(role=read, existing vault) → redeem → user_vaults row role=read
+    //   → /account/vault-token mint caps to vaultVerbsForRole ('read' only)
+    //   → the minted JWT carries vault:<name>:read + the vault_scope pin
+    //   → scope-guard (what the vault runs per request) refuses write/admin.
+    await createUser(harness.db, "adam", "adams-strong-password-1", {
+      assignedVaults: ["jonathan-vault", "adams-vault"],
+      role: "write",
+    });
+    seedExistingVault("jonathan-vault");
+    seedExistingVault("adams-vault");
+    const admin = getUserByUsernameCI(harness.db, "adam");
+    const { rawToken } = issueInvite(harness.db, {
+      createdBy: admin?.id ?? "",
+      vaultName: "jonathan-vault",
+      username: "jonathan",
+      provisionVault: false,
+      role: "read",
+    });
+
+    // Redeem (the form's username field is absent — pre-named).
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const stub = makeStubRunCommand();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          password: "jonathans-strong-pass-1",
+          password_confirm: "jonathans-strong-pass-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    expect(res.status).toBe(302);
+    const jonathan = getUserByUsernameCI(harness.db, "jonathan");
+    expect(jonathan).not.toBeNull();
+    // (1) The user_vaults row is read.
+    const row = harness.db
+      .query<{ role: string }, [string]>(
+        "SELECT role FROM user_vaults WHERE user_id = ? AND vault_name = 'jonathan-vault'",
+      )
+      .get(jonathan?.id ?? "");
+    expect(row?.role).toBe("read");
+    expect(vaultVerbsForUserVault(harness.db, jonathan?.id ?? "", "jonathan-vault")).toEqual([
+      "read",
+    ]);
+
+    // (2) Enforcement at the mint surface — drive the REAL /account mint
+    // handler with the session the redeem just created.
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    const sessionFragment = setCookie.split(";")[0] ?? "";
+    const { token: mintCsrf, cookieFragment: mintCsrfCookie } = csrfPair();
+    const cookie = `${sessionFragment}; ${mintCsrfCookie}`;
+    const mint = (vault: string, verb: string) =>
+      handleAccountVaultTokenPost(
+        new Request(`${ISSUER}/account/vault-token/${vault}`, {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded", cookie },
+          body: new URLSearchParams({ [CSRF_FIELD_NAME]: mintCsrf, verb }).toString(),
+        }),
+        vault,
+        { db: harness.db, hubOrigin: ISSUER },
+      );
+    expect((await mint("jonathan-vault", "write")).status).toBe(403);
+    expect((await mint("jonathan-vault", "admin")).status).toBe(403);
+    // (3) Cannot touch the OTHER vault at all.
+    expect((await mint("adams-vault", "read")).status).toBe(403);
+
+    const readRes = await mint("jonathan-vault", "read");
+    expect(readRes.status).toBe(200);
+    const html = await readRes.text();
+    const m = html.match(/data-testid="minted-token-value">([^<]+)</);
+    expect(m).not.toBeNull();
+    const validated = await validateAccessToken(harness.db, m?.[1] ?? "", ISSUER);
+    const scopes = ((validated.payload as { scope?: string }).scope ?? "").split(/\s+/);
+    expect(scopes).toEqual(["vault:jonathan-vault:read"]);
+    expect((validated.payload as { vault_scope?: string[] }).vault_scope).toEqual([
+      "jonathan-vault",
+    ]);
+
+    // (4) The resource-server side: scope-guard (what the vault runs) refuses
+    // writes for this token and refuses the other vault entirely. Hub never
+    // imports scope-guard at runtime (issuer vs validator boundary); the test
+    // crosses it deliberately to pin the cross-system contract.
+    expect(hasScope(scopes, "vault:jonathan-vault:write")).toBe(false);
+    expect(hasScope(scopes, "vault:jonathan-vault:admin")).toBe(false);
+    expect(hasScope(scopes, "vault:jonathan-vault:read")).toBe(true);
+    expect(hasScope(scopes, "vault:adams-vault:read")).toBe(false);
+  });
+});
+
+describe("POST /account/setup/<token> — pre-named username (ENFORCED)", () => {
+  test("the invite's username wins — a different submitted username is ignored", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, {
+      createdBy: admin.id,
+      username: "jonathan",
+      vaultName: "maya",
+    });
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const stub = makeStubRunCommand();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          // Submitted name must NOT be honored — the invite is a named deliverable.
+          username: "imposter",
+          password: "jonathans-strong-pass-1",
+          password_confirm: "jonathans-strong-pass-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    expect(res.status).toBe(302);
+    expect(getUserByUsernameCI(harness.db, "imposter")).toBeNull();
+    expect(getUserByUsernameCI(harness.db, "jonathan")).not.toBeNull();
+  });
+
+  test("pre-named username TAKEN at redeem time → 409 'ask your operator', invite stays re-usable", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, {
+      createdBy: admin.id,
+      username: "jonathan",
+      vaultName: "maya",
+    });
+    // Someone takes the name between mint and redeem.
+    await createUser(harness.db, "jonathan", "squatter-strong-pass-1", { allowMulti: true });
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const stub = makeStubRunCommand();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          password: "jonathans-strong-pass-1",
+          password_confirm: "jonathans-strong-pass-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    expect(res.status).toBe(409);
+    const html = await res.text();
+    expect(html).toContain("Ask your hub operator");
+    // No vault provisioned, invite NOT consumed — operator can revoke + re-mint.
+    expect(stub.calls.length).toBe(0);
+    expect(findInviteByRawToken(harness.db, rawToken)?.usedAt).toBeNull();
+  });
+
+  test("GET renders the pre-named username read-only (no editable username field)", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, {
+      createdBy: admin.id,
+      username: "jonathan",
+      vaultName: "shared",
+      provisionVault: false,
+      role: "read",
+    });
+    seedExistingVault("shared");
+    const res = handleAccountSetupGet(
+      new Request(`${ISSUER}/account/setup/${rawToken}`),
+      rawToken,
+      deps(),
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("jonathan");
+    expect(html).toContain("Your hub operator chose this username for you.");
+    // No editable username input on a pre-named form.
+    expect(html).not.toContain('name="username"');
+    // Shared-vault invites surface the role.
+    expect(html).toContain("read-only");
   });
 });
 

--- a/src/__tests__/account-setup.test.ts
+++ b/src/__tests__/account-setup.test.ts
@@ -299,11 +299,16 @@ describe("POST /account/setup/<token> — security invariants", () => {
     expect(firstId).not.toBe(id);
   });
 
-  test("a 'read' invite lands a read-only assignment", async () => {
+  test("a 'read' invite (shared-vault shape) lands a read-only assignment", async () => {
+    // read+provision is no longer a redeemable shape (a fresh vault's sole
+    // user must hold write — see the hand-edited-row guard test below), so
+    // the read role rides the shared-vault shape: assign an EXISTING vault.
     const admin = await createUser(harness.db, "operator", "operator-password-1");
+    seedExistingVault("shared");
     const { rawToken } = issueInvite(harness.db, {
       createdBy: admin.id,
       vaultName: "shared",
+      provisionVault: false,
       role: "read",
     });
     const { token: csrfToken, cookieFragment } = csrfPair();
@@ -324,6 +329,45 @@ describe("POST /account/setup/<token> — security invariants", () => {
     );
     const user = getUserByUsernameCI(harness.db, "guest");
     expect(vaultVerbsForUserVault(harness.db, user?.id ?? "", "shared")).toEqual(["read"]);
+  });
+
+  test("hand-edited provision_vault=1 + role='read' row → refused at redeem (no un-writable owner), invite unconsumed", async () => {
+    // The API refuses to MINT this shape (400 invalid_request); this row can
+    // only exist via a hand edit. The redeem-side guard must refuse it too —
+    // honoring it would provision a vault whose ONLY user can never write.
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, {
+      createdBy: admin.id,
+      vaultName: "deadend",
+      provisionVault: true,
+      role: "read",
+    });
+    const before = userCount(harness.db);
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const stub = makeStubRunCommand();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "guest",
+          password: "guest-strong-password-1",
+          password_confirm: "guest-strong-password-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    expect(res.status).toBe(400);
+    const html = await res.text();
+    expect(html).toContain("must have write access");
+    // No account, no vault shell-out, invite re-usable for the operator to
+    // revoke + re-mint correctly.
+    expect(getUserByUsernameCI(harness.db, "guest")).toBeNull();
+    expect(userCount(harness.db) - before).toBe(0);
+    expect(stub.calls.length).toBe(0);
+    expect(findInviteByRawToken(harness.db, rawToken)?.usedAt).toBeNull();
   });
 });
 

--- a/src/__tests__/api-invites.test.ts
+++ b/src/__tests__/api-invites.test.ts
@@ -68,6 +68,24 @@ function deps() {
   return { db: harness.db, issuer: ISSUER, manifestPath: harness.manifestPath };
 }
 
+/** Register an existing vault in the harness manifest (for shared-vault invites). */
+function seedVaultInManifest(name: string) {
+  writeFileSync(
+    harness.manifestPath,
+    JSON.stringify({
+      services: [
+        {
+          name: "parachute-vault",
+          port: 4101,
+          paths: [`/vault/${name}`],
+          health: "/health",
+          version: "0.0.0-test",
+        },
+      ],
+    }),
+  );
+}
+
 function withBearer(path: string, bearer: string, init: RequestInit = {}): Request {
   const headers = new Headers(init.headers ?? {});
   headers.set("authorization", `Bearer ${bearer}`);
@@ -121,23 +139,64 @@ describe("POST /api/invites", () => {
     expect(res.status).toBe(400);
   });
 
-  test("400 rejects a shared-vault invite (provision_vault=false + vault_name)", async () => {
-    // Defense in depth (FIX-1): assigning a redeemer to a PRE-EXISTING vault
-    // as owner-admin is a cross-tenant breach; shared-vault invites aren't
-    // supported yet, so the create handler refuses this combination outright.
+  test("shared-vault invite (provision_vault=false + EXISTING vault_name) → 201 at the given role", async () => {
+    // The Adam/Jonathan shape: read-only access to a vault the admin already
+    // built. Issuing is host:admin-gated — the same authority that can assign
+    // any user to any vault via POST /api/users.
+    seedVaultInManifest("jonathan-vault");
     const bearer = await makeAdminBearer();
     const res = await handleCreateInvite(
       withBearer("/api/invites", bearer, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ provision_vault: false, vault_name: "someoneelse" }),
+        body: JSON.stringify({
+          provision_vault: false,
+          vault_name: "jonathan-vault",
+          role: "read",
+        }),
+      }),
+      deps(),
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      invite: { vault_name: string | null; role: string; provision_vault: boolean };
+    };
+    expect(body.invite.vault_name).toBe("jonathan-vault");
+    expect(body.invite.role).toBe("read");
+    expect(body.invite.provision_vault).toBe(false);
+  });
+
+  test("400 vault_not_found when the shared vault doesn't exist on this hub", async () => {
+    // A pinned-but-nonexistent name is a typo, not a future reservation —
+    // fail at mint, not at the invitee's redeem.
+    const bearer = await makeAdminBearer();
+    const res = await handleCreateInvite(
+      withBearer("/api/invites", bearer, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ provision_vault: false, vault_name: "nosuchvault", role: "read" }),
+      }),
+      deps(),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("vault_not_found");
+  });
+
+  test("400 rejects role=read with provision_vault=true (sole user of a new vault must hold write)", async () => {
+    const bearer = await makeAdminBearer();
+    const res = await handleCreateInvite(
+      withBearer("/api/invites", bearer, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ provision_vault: true, role: "read" }),
       }),
       deps(),
     );
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string; error_description: string };
     expect(body.error).toBe("invalid_request");
-    expect(body.error_description).toContain("shared-vault");
+    expect(body.error_description).toContain("write");
   });
 
   test("account-only invite (provision_vault=false, NO vault_name) is still allowed", async () => {
@@ -156,6 +215,107 @@ describe("POST /api/invites", () => {
     };
     expect(body.invite.provision_vault).toBe(false);
     expect(body.invite.vault_name).toBeNull();
+  });
+});
+
+describe("POST /api/invites — pre-named username", () => {
+  test("201 carries the username in the wire shape", async () => {
+    seedVaultInManifest("jonathan-vault");
+    const bearer = await makeAdminBearer();
+    const res = await handleCreateInvite(
+      withBearer("/api/invites", bearer, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          username: "jonathan",
+          provision_vault: false,
+          vault_name: "jonathan-vault",
+          role: "read",
+        }),
+      }),
+      deps(),
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { invite: { username: string | null } };
+    expect(body.invite.username).toBe("jonathan");
+  });
+
+  test("400 invalid_username on a name outside the /api/users vocabulary", async () => {
+    const bearer = await makeAdminBearer();
+    for (const bad of ["A", "Has Spaces", "admin"]) {
+      const res = await handleCreateInvite(
+        withBearer("/api/invites", bearer, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ username: bad }),
+        }),
+        deps(),
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("invalid_username");
+    }
+  });
+
+  test("409 username_taken when an existing user holds the name (case-insensitive)", async () => {
+    const bearer = await makeAdminBearer(); // creates user "operator"
+    const res = await handleCreateInvite(
+      withBearer("/api/invites", bearer, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ username: "operator" }),
+      }),
+      deps(),
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("username_taken");
+  });
+
+  test("409 username_reserved when another PENDING invite pre-names the same username", async () => {
+    const bearer = await makeAdminBearer();
+    const make = () =>
+      handleCreateInvite(
+        withBearer("/api/invites", bearer, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ username: "jonathan" }),
+        }),
+        deps(),
+      );
+    const first = await make();
+    expect(first.status).toBe(201);
+    const second = await make();
+    expect(second.status).toBe(409);
+    const body = (await second.json()) as { error: string };
+    expect(body.error).toBe("username_reserved");
+  });
+
+  test("revoking the pending invite frees the reserved username", async () => {
+    const bearer = await makeAdminBearer();
+    const first = await handleCreateInvite(
+      withBearer("/api/invites", bearer, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ username: "jonathan" }),
+      }),
+      deps(),
+    );
+    const { invite } = (await first.json()) as { invite: { id: string } };
+    await handleRevokeInvite(
+      withBearer(`/api/invites/${invite.id}`, bearer, { method: "DELETE" }),
+      invite.id,
+      deps(),
+    );
+    const second = await handleCreateInvite(
+      withBearer("/api/invites", bearer, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ username: "jonathan" }),
+      }),
+      deps(),
+    );
+    expect(second.status).toBe(201);
   });
 });
 

--- a/src/__tests__/hub-db.test.ts
+++ b/src/__tests__/hub-db.test.ts
@@ -380,6 +380,42 @@ describe("openHubDb + migrate", () => {
     }
   });
 
+  test("v13 adds invites.username; pre-existing invite rows keep NULL (no backfill)", () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(h.dbPath);
+      try {
+        // Simulate a real v12 install: strip the v13 column, mark v13
+        // unapplied, and seed an invite row that pre-dates pre-naming.
+        db.exec(`
+          ALTER TABLE invites DROP COLUMN username;
+          INSERT INTO invites (token, created_by, vault_name, role, provision_vault,
+                               default_mirror, expires_at, created_at)
+          VALUES ('hash-v12', NULL, 'maya', 'write', 1, NULL,
+                  '2099-01-01T00:00:00.000Z', '2026-06-01T00:00:00.000Z');
+        `);
+        db.exec("DELETE FROM schema_version WHERE version = 13");
+        migrate(db);
+        const cols = db
+          .query<{ name: string }, []>("SELECT name FROM pragma_table_info('invites')")
+          .all()
+          .map((c) => c.name);
+        expect(cols).toContain("username");
+        // Grandfathered row → NULL (redeemer picks their own name).
+        const row = db
+          .query<{ username: string | null }, [string]>(
+            "SELECT username FROM invites WHERE token = ?",
+          )
+          .get("hash-v12");
+        expect(row?.username).toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("v10 FK cascade: deleting a user drops their user_vaults rows", () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/invites.test.ts
+++ b/src/__tests__/invites.test.ts
@@ -28,6 +28,7 @@ import {
   listInvites,
   revokeInvite,
   revokeInvitesForVault,
+  usernameReservedByPendingInvite,
 } from "../invites.ts";
 import { createUser } from "../users.ts";
 
@@ -68,7 +69,7 @@ describe("issueInvite", () => {
     }
   });
 
-  test("defaults: role=write, provision_vault=1, 7-day expiry", async () => {
+  test("defaults: role=write, provision_vault=1, 7-day expiry, no pre-named username", async () => {
     const { db, adminId, cleanup } = await makeDb();
     try {
       const now = new Date("2026-06-04T00:00:00Z");
@@ -76,8 +77,70 @@ describe("issueInvite", () => {
       expect(invite.role).toBe("write");
       expect(invite.provisionVault).toBe(true);
       expect(invite.vaultName).toBeNull();
+      expect(invite.username).toBeNull();
       const expiry = new Date(invite.expiresAt).getTime() - now.getTime();
       expect(Math.round(expiry / 1000)).toBe(DEFAULT_INVITE_TTL_SECONDS);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("pre-named username round-trips through the row", async () => {
+    const { db, adminId, cleanup } = await makeDb();
+    try {
+      const { rawToken, invite } = issueInvite(db, {
+        createdBy: adminId,
+        username: "jonathan",
+        vaultName: "shared",
+        provisionVault: false,
+        role: "read",
+      });
+      expect(invite.username).toBe("jonathan");
+      const found = findInviteByRawToken(db, rawToken);
+      expect(found?.username).toBe("jonathan");
+      expect(found?.vaultName).toBe("shared");
+      expect(found?.provisionVault).toBe(false);
+      expect(found?.role).toBe("read");
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("usernameReservedByPendingInvite", () => {
+  test("pending reserves; redeemed / revoked / expired / other-name do not", async () => {
+    const { db, adminId, cleanup } = await makeDb();
+    try {
+      const now = new Date("2026-06-10T00:00:00Z");
+      // Pending → reserved.
+      issueInvite(db, { createdBy: adminId, username: "pending-name", now: () => now });
+      expect(usernameReservedByPendingInvite(db, "pending-name", now)).toBe(true);
+      expect(usernameReservedByPendingInvite(db, "other-name", now)).toBe(false);
+      // Redeemed → free.
+      const redeemed = issueInvite(db, {
+        createdBy: adminId,
+        username: "used-name",
+        now: () => now,
+      });
+      consumeInvite(db, redeemed.invite.tokenHash, adminId, now);
+      expect(usernameReservedByPendingInvite(db, "used-name", now)).toBe(false);
+      // Revoked → free.
+      const revoked = issueInvite(db, {
+        createdBy: adminId,
+        username: "gone-name",
+        now: () => now,
+      });
+      revokeInvite(db, revoked.invite.tokenHash, now);
+      expect(usernameReservedByPendingInvite(db, "gone-name", now)).toBe(false);
+      // Expired → free.
+      issueInvite(db, {
+        createdBy: adminId,
+        username: "old-name",
+        expiresInSeconds: 60,
+        now: () => now,
+      });
+      const later = new Date(now.getTime() + 120_000);
+      expect(usernameReservedByPendingInvite(db, "old-name", later)).toBe(false);
     } finally {
       cleanup();
     }

--- a/src/account-setup.ts
+++ b/src/account-setup.ts
@@ -13,9 +13,20 @@
  *
  * Redeem ORDERING (the re-usability guarantee, mirroring the wizard):
  *   1. lookup + validate the invite (not-found/expired/used/revoked)
- *   2. validate username/password (+ vault name)
- *   3. provision the vault (must FRESHLY CREATE — reject a pre-existing name;
- *      attaching the new user to someone else's vault is a cross-tenant breach)
+ *   2. validate username/password (+ vault name). A pre-named invite
+ *      (invite.username set) ENFORCES the username — the form field is
+ *      ignored and the invite's name is used; if it's been taken since
+ *      mint, the invitee is told to ask the operator for a new link
+ *      (the invite stays unconsumed so the operator can revoke + re-mint).
+ *   3. resolve the vault:
+ *      - provision_vault=1 → provision (must FRESHLY CREATE — reject a
+ *        pre-existing name; silently attaching the new user to someone
+ *        else's vault would be a cross-tenant breach)
+ *      - provision_vault=0 + vault_name → SHARED-VAULT invite: assign the
+ *        admin's EXISTING vault at the invite's role (no provisioning).
+ *        The vault must still exist in services.json (the vault-delete
+ *        cascade revokes pending invites, so this re-check is defense in
+ *        depth against manual manifest edits).
  *   4. createUser (the commit point)
  *   5. consumeInvite — stamp used_at + redeemed_user_id ONLY AFTER (4) commits
  *   6. createSession + cookie + 302
@@ -25,15 +36,21 @@
  * invite re-usable — the invitee can simply retry. `consumeInvite`'s
  * `used_at IS NULL` guard makes the stamp itself single-use / race-free.
  *
- * What an invite pre-authorizes: EXACTLY one account + the one named/created
- * vault at the baked-in role — NEVER host:admin, NEVER another vault. The new
- * user gets `assignedVaults:[that vault]` with the invite's role; nothing
- * grants admin posture (the first-admin-by-earliest-row heuristic is
- * untouched — an invited user is never the earliest row).
+ * What an invite pre-authorizes: EXACTLY one account + the one named/created/
+ * shared vault at the baked-in role — NEVER host:admin, NEVER another vault.
+ * The new user gets `assignedVaults:[that vault]` with the invite's role;
+ * nothing grants admin posture (the first-admin-by-earliest-row heuristic is
+ * untouched — an invited user is never the earliest row). The shared-vault
+ * shape is admin-authorized by construction: only a host:admin bearer can
+ * mint an invite, and that same authority can already assign any user to any
+ * vault via POST /api/users. The role ('read' or 'write') is enforced at
+ * every mint chokepoint via `vaultVerbsForRole` and at the vault by
+ * scope-guard.
  */
 import type { Database } from "bun:sqlite";
 import { renderAdminError, renderInviteSetup } from "./admin-login-ui.ts";
 import { type RunResult, provisionVault } from "./admin-vaults.ts";
+import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
 import {
   InviteExpiredError,
@@ -55,6 +72,7 @@ import {
   validateUsername,
 } from "./users.ts";
 import { validateVaultName } from "./vault-name.ts";
+import { listVaultNamesFromPath } from "./vault-names.ts";
 
 export interface AccountSetupDeps {
   db: Database;
@@ -145,6 +163,8 @@ export function handleAccountSetupGet(
       token: rawToken,
       csrfToken: csrf.token,
       pinnedVaultName: invite.vaultName,
+      pinnedUsername: invite.username,
+      role: invite.role,
       provisionVault: invite.provisionVault,
     }),
     200,
@@ -196,7 +216,11 @@ export async function handleAccountSetupPost(
     );
   }
 
-  const username = String(form.get("username") ?? "").trim();
+  // Pre-named invite → the invite's username is ENFORCED (the form renders it
+  // read-only and any submitted value is ignored — server is the source of
+  // truth, same posture as the pinned vault name).
+  const username =
+    invite.username !== null ? invite.username : String(form.get("username") ?? "").trim();
   const password = String(form.get("password") ?? "");
   const confirm = String(form.get("password_confirm") ?? "");
 
@@ -209,6 +233,8 @@ export async function handleAccountSetupPost(
         token: rawToken,
         csrfToken: csrf.token,
         pinnedVaultName: invite.vaultName,
+        pinnedUsername: invite.username,
+        role: invite.role,
         provisionVault: invite.provisionVault,
         username,
         ...(vaultNameEcho !== undefined ? { vaultName: vaultNameEcho } : {}),
@@ -218,12 +244,16 @@ export async function handleAccountSetupPost(
       setCookie,
     );
 
-  // (2) Validate credentials with the SAME validators as /api/users.
+  // (2) Validate credentials with the SAME validators as /api/users. Runs for
+  // the pre-named case too — defense in depth against a hand-edited invites
+  // row carrying a name the vocabulary forbids.
   const u = validateUsername(username);
   if (!u.valid) {
     return rerender(
       400,
-      "Username must be 2–32 lowercase letters, digits, _ or - (and not a reserved word).",
+      invite.username !== null
+        ? "This invite's pre-set username is not valid. Ask your hub operator for a new invite."
+        : "Username must be 2–32 lowercase letters, digits, _ or - (and not a reserved word).",
     );
   }
   if (password.length > PASSWORD_MAX_LEN) {
@@ -236,9 +266,17 @@ export async function handleAccountSetupPost(
   if (password !== confirm) {
     return rerender(400, "The two passwords don't match.");
   }
-  // Case-insensitive uniqueness — same gate as /api/users.
+  // Case-insensitive uniqueness — same gate as /api/users. For a pre-named
+  // invite the name can't be changed by the invitee, so a collision (someone
+  // took the name between mint and redeem) needs the operator to revoke +
+  // re-mint; the invite stays unconsumed either way.
   if (getUserByUsernameCI(deps.db, username) !== null) {
-    return rerender(409, `The username "${username}" is already taken. Pick another.`);
+    return rerender(
+      409,
+      invite.username !== null
+        ? `The username "${username}" chosen for this invite is already taken. Ask your hub operator for a new invite.`
+        : `The username "${username}" is already taken. Pick another.`,
+    );
   }
 
   // Resolve the vault name: pinned by the invite, or chosen by the invitee.
@@ -268,16 +306,29 @@ export async function handleAccountSetupPost(
       vaultName = v.name;
     }
   } else if (invite.vaultName !== null) {
-    // UNSUPPORTED shared-vault case: an account-only invite (provision_vault
-    // =false) that pins an EXISTING vault would assign the new user owner-
-    // admin on a pre-existing vault — a cross-tenant breach, and the owner-
-    // vs-shared role split isn't built. The admin API rejects creating such
-    // an invite (defense in depth); reject here too in case one slipped
-    // through. The legit account-only invite (vaultName === null) is unaffected.
-    return rerender(
-      400,
-      "This invite is not supported (shared-vault invites aren't available yet). Ask your hub operator for a new one.",
-    );
+    // SHARED-VAULT invite: assign the redeemer to the admin's EXISTING vault
+    // at the invite's baked-in role ('read' or 'write') — no provisioning.
+    // Admin-authorized by construction: only a host:admin bearer can mint an
+    // invite, and that same authority can already assign any user to any
+    // vault via POST /api/users; the invite packages that assignment as a
+    // deliverable link. The role is enforced downstream at every mint
+    // chokepoint (`vaultVerbsForRole`: read → ["read"]) and at the vault by
+    // scope-guard — a read-role redeemer can never obtain a write-capable
+    // token for this (or any other) vault.
+    //
+    // The vault must still exist: the vault-delete cascade
+    // (`revokeInvitesForVault`) revokes pending invites pinned to a deleted
+    // vault, so this re-check is defense in depth (manual services.json
+    // edits, restored DB). The invite stays unconsumed on this rejection.
+    const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
+    const known = new Set(listVaultNamesFromPath(manifestPath));
+    if (!known.has(invite.vaultName)) {
+      return rerender(
+        400,
+        "The vault this invite shares no longer exists on this hub. Ask your hub operator for a new invite.",
+      );
+    }
+    vaultName = invite.vaultName;
   }
 
   // (3) Provision the vault — must FRESHLY CREATE it (see the security

--- a/src/account-setup.ts
+++ b/src/account-setup.ts
@@ -270,6 +270,14 @@ export async function handleAccountSetupPost(
   // invite the name can't be changed by the invitee, so a collision (someone
   // took the name between mint and redeem) needs the operator to revoke +
   // re-mint; the invite stays unconsumed either way.
+  //
+  // Username-existence oracle, accepted trade-off: a 409 here confirms to the
+  // bearer that a given name is taken. The probe is gated behind a single-use,
+  // unexpired invite token (256-bit, sha256-at-rest) — not an open endpoint —
+  // and for the pre-named case the probed name was chosen by the ADMIN at
+  // mint (where it was already validated against existing users), not
+  // attacker-supplied. The same disclosure already exists for the (more
+  // privileged) callers of /api/users and the setup wizard.
   if (getUserByUsernameCI(deps.db, username) !== null) {
     return rerender(
       409,
@@ -286,6 +294,18 @@ export async function handleAccountSetupPost(
   // at the vault CLI with a generic provision error.
   let vaultName: string | null = null;
   if (invite.provisionVault) {
+    // Defense in depth against a hand-edited invites row: the API refuses to
+    // MINT provision_vault=1 with role != 'write' (a fresh vault's SOLE user
+    // must hold write — a read-only owner would leave the new vault
+    // permanently un-writable). Honor the same invariant at redeem so a row
+    // that bypassed the API can't create that dead-end. The invite stays
+    // unconsumed; the operator re-mints a valid one.
+    if (invite.role !== "write") {
+      return rerender(
+        400,
+        "This invite is not valid (a new vault's owner must have write access). Ask your hub operator for a new invite.",
+      );
+    }
     if (invite.vaultName !== null) {
       vaultName = invite.vaultName;
     } else {

--- a/src/admin-login-ui.ts
+++ b/src/admin-login-ui.ts
@@ -161,8 +161,18 @@ export interface InviteSetupProps {
   /**
    * When the invite pins a vault name the redeemer can't choose one — we show
    * it read-only. When null the redeemer names their own vault (a text field).
+   * With `provisionVault: false` a pinned name is a SHARED-VAULT invite: the
+   * redeemer is being given `role` access to the operator's existing vault.
    */
   pinnedVaultName: string | null;
+  /**
+   * When the invite pre-names the account, the username is shown read-only
+   * and ENFORCED server-side (the redeem handler ignores the form field).
+   * Null = the redeemer picks their own.
+   */
+  pinnedUsername: string | null;
+  /** The `user_vaults` role redemption grants ('read' | 'write') — shown on the shared-vault row. */
+  role: string;
   /** Whether redemption provisions a vault at all (shows the vault row iff true). */
   provisionVault: boolean;
   username?: string;
@@ -177,15 +187,55 @@ export interface InviteSetupProps {
  * same `/account/setup/<token>` path. Reuses the shared login chrome.
  */
 export function renderInviteSetup(props: InviteSetupProps): string {
-  const { token, csrfToken, pinnedVaultName, provisionVault, username, vaultName, errorMessage } =
-    props;
+  const {
+    token,
+    csrfToken,
+    pinnedVaultName,
+    pinnedUsername,
+    role,
+    provisionVault,
+    username,
+    vaultName,
+    errorMessage,
+  } = props;
   const error = errorMessage ? `<p class="error-banner">${escapeHtml(errorMessage)}</p>` : "";
   const usernameAttr = username ? ` value="${escapeAttr(username)}"` : "";
 
-  // Vault row: shown only when the invite provisions a vault. Pinned → a
-  // read-only display of the name the admin chose (redeemer can't squat names).
-  // Unpinned → a text field the redeemer fills.
+  // Username row: pre-named → read-only display (the server ENFORCES the
+  // invite's username; the disabled input never submits and the handler
+  // ignores the field anyway). Unpinned → the normal pick-a-name field.
+  const usernameRow =
+    pinnedUsername !== null
+      ? `
+        <label class="field">
+          <span class="field-label">Username</span>
+          <input type="text" value="${escapeAttr(pinnedUsername)}" readonly disabled />
+          <span class="field-hint">Your hub operator chose this username for you.</span>
+        </label>`
+      : `
+        <label class="field">
+          <span class="field-label">Username</span>
+          <input type="text" name="username" id="username" autocomplete="username" autofocus
+            required minlength="2" maxlength="32"
+            pattern="[a-z0-9_-]+" title="lowercase letters, digits, _ - (2–32 chars)"
+            spellcheck="false" autocapitalize="off"${usernameAttr} />
+          <span class="field-hint">lowercase letters, digits, <code>_</code>, <code>-</code></span>
+        </label>`;
+
+  // Vault row. Provisioning invites show the new vault's name (pinned →
+  // read-only; unpinned → a text field the redeemer fills). A shared-vault
+  // invite (no provisioning + a pinned name) shows what the redeemer is
+  // being given access to, including the role.
   let vaultRow = "";
+  if (!provisionVault && pinnedVaultName !== null) {
+    const roleLabel = role === "read" ? "read-only" : "read &amp; write";
+    vaultRow = `
+        <label class="field">
+          <span class="field-label">Shared vault</span>
+          <input type="text" value="${escapeAttr(pinnedVaultName)}" readonly disabled />
+          <span class="field-hint">You're being given ${roleLabel} access to this existing vault.</span>
+        </label>`;
+  }
   if (provisionVault) {
     if (pinnedVaultName !== null) {
       vaultRow = `
@@ -240,21 +290,20 @@ export function renderInviteSetup(props: InviteSetupProps): string {
       <div class="card-header">
         ${header()}
         <h1>Claim your invite</h1>
-        <p class="subtitle">Pick a username and password to create your Parachute account${
-          provisionVault ? " and your own vault" : ""
+        <p class="subtitle">${
+          pinnedUsername !== null ? "Pick a password" : "Pick a username and password"
+        } to create your Parachute account${
+          provisionVault
+            ? " and your own vault"
+            : pinnedVaultName !== null
+              ? " with access to a shared vault"
+              : ""
         }.</p>
       </div>
       ${error}
       <form method="POST" action="/account/setup/${escapeAttr(token)}" class="auth-form">
         ${renderCsrfHiddenInput(csrfToken)}
-        <label class="field">
-          <span class="field-label">Username</span>
-          <input type="text" name="username" id="username" autocomplete="username" autofocus
-            required minlength="2" maxlength="32"
-            pattern="[a-z0-9_-]+" title="lowercase letters, digits, _ - (2–32 chars)"
-            spellcheck="false" autocapitalize="off"${usernameAttr} />
-          <span class="field-hint">lowercase letters, digits, <code>_</code>, <code>-</code></span>
-        </label>
+        ${usernameRow}
         <label class="field">
           <span class="field-label">Password</span>
           <input type="password" name="password" autocomplete="new-password"

--- a/src/api-invites.ts
+++ b/src/api-invites.ts
@@ -19,6 +19,7 @@
 import type { Database } from "bun:sqlite";
 import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
 import { HOST_ADMIN_SCOPE } from "./admin-vaults.ts";
+import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import {
   DEFAULT_INVITE_TTL_SECONDS,
   type Invite,
@@ -28,8 +29,11 @@ import {
   issueInvite,
   listInvites,
   revokeInvite,
+  usernameReservedByPendingInvite,
 } from "./invites.ts";
+import { getUserByUsernameCI, validateUsername } from "./users.ts";
 import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
+import { listVaultNamesFromPath } from "./vault-names.ts";
 
 export interface ApiInvitesDeps {
   db: Database;
@@ -49,6 +53,7 @@ interface InviteWireShape {
   id: string;
   status: InviteStatus;
   vault_name: string | null;
+  username: string | null;
   role: string;
   provision_vault: boolean;
   default_mirror: string | null;
@@ -64,6 +69,7 @@ function toWire(invite: Invite, status: InviteStatus): InviteWireShape {
     id: invite.tokenHash,
     status,
     vault_name: invite.vaultName,
+    username: invite.username,
     role: invite.role,
     provision_vault: invite.provisionVault,
     default_mirror: invite.defaultMirror,
@@ -89,6 +95,7 @@ function redeemUrl(issuer: string, rawToken: string): string {
 
 interface CreateInviteBody {
   vaultName: string | null;
+  username: string | null;
   role: string;
   provisionVault: boolean;
   defaultMirror: string | null;
@@ -160,6 +167,37 @@ async function parseCreateBody(
       };
     }
     vaultName = rawVault;
+  }
+
+  // username — optional. null/omitted = redeemer picks their own. Validated
+  // with the SAME vocabulary as /api/users (charset + length + reserved).
+  let username: string | null = null;
+  const rawUsername =
+    Object.hasOwn(obj, "username") && obj.username !== undefined ? obj.username : undefined;
+  if (rawUsername !== undefined && rawUsername !== null) {
+    if (typeof rawUsername !== "string" || rawUsername.length === 0) {
+      return {
+        ok: false,
+        status: 400,
+        error: "invalid_request",
+        description: '"username" must be a non-empty string or null',
+      };
+    }
+    const u = validateUsername(rawUsername);
+    if (!u.valid) {
+      return {
+        ok: false,
+        status: 400,
+        error: "invalid_username",
+        description:
+          u.reason === "length"
+            ? "username must be 2-32 characters long"
+            : u.reason === "reserved"
+              ? "username is reserved (admin, root, system, setup, parachute, hub)"
+              : "username must contain only lowercase letters, digits, hyphens, and underscores ([a-z0-9_-])",
+      };
+    }
+    username = u.name;
   }
 
   // role — default 'write' (owner).
@@ -245,7 +283,10 @@ async function parseCreateBody(
     expiresInSeconds = Math.floor(rawExpiry);
   }
 
-  return { ok: true, body: { vaultName, role, provisionVault, defaultMirror, expiresInSeconds } };
+  return {
+    ok: true,
+    body: { vaultName, username, role, provisionVault, defaultMirror, expiresInSeconds },
+  };
 }
 
 /** POST /api/invites — create an invite, return the single-emit URL + token. */
@@ -262,33 +303,72 @@ export async function handleCreateInvite(req: Request, deps: ApiInvitesDeps): Pr
   }
   const parsed = await parseCreateBody(req);
   if (!parsed.ok) return jsonError(parsed.status, parsed.error, parsed.description);
-  const { vaultName, role, provisionVault, defaultMirror, expiresInSeconds } = parsed.body;
+  const { vaultName, username, role, provisionVault, defaultMirror, expiresInSeconds } =
+    parsed.body;
+  const now = (deps.now ?? (() => new Date()))();
 
-  // SECURITY: a pinned vault_name with provision_vault=false would assign the
-  // redeeming user to a PRE-EXISTING vault as owner-admin — a cross-tenant
-  // breach, since the owner-vs-shared role split isn't built. Shared-vault
-  // invites aren't supported yet, so reject this combination outright (defense
-  // in depth — the redeem path rejects it too). The supported shapes are:
-  // provision_vault=true (+ optional pinned name → provisions THAT name), or
-  // provision_vault=false with NO name (account-only, assignedVaults=[]).
-  if (vaultName !== null && !provisionVault) {
+  // Shape gates over the three supported invite shapes:
+  //
+  //   1. provision_vault=true (+ optional pinned NEW name) — redemption
+  //      provisions a fresh vault for the redeemer. Role must be 'write':
+  //      the redeemer is the vault's ONLY user, so a read-only sole user
+  //      would leave the new vault permanently un-writable.
+  //   2. provision_vault=false + vault_name — SHARED-VAULT invite: redemption
+  //      assigns the redeemer to the admin's EXISTING vault at `role` ('read'
+  //      or 'write'). The vault must exist NOW (services.json) — pinning a
+  //      nonexistent name is a typo, not a future reservation. Issuing is
+  //      host:admin-gated, the same authority that can already assign any
+  //      user to any vault via POST /api/users — the invite only packages
+  //      that assignment as a deliverable link. The vault-delete cascade
+  //      (`revokeInvitesForVault`) revokes pending shared invites when the
+  //      pinned vault is deleted, and the redeem path re-checks existence.
+  //   3. provision_vault=false with NO name — account-only (assignedVaults=[]).
+  if (provisionVault && role !== "write") {
     return jsonError(
       400,
       "invalid_request",
-      "shared-vault invites (provision_vault=false with a vault_name) aren't supported yet — omit vault_name for an account-only invite, or set provision_vault=true to provision a new vault",
+      'a provisioned vault\'s sole user must hold write — use role "write", or share an existing vault (provision_vault=false + vault_name) for read-only access',
     );
+  }
+  if (vaultName !== null && !provisionVault) {
+    const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
+    const known = new Set(listVaultNamesFromPath(manifestPath));
+    if (!known.has(vaultName)) {
+      return jsonError(
+        400,
+        "vault_not_found",
+        `vault "${vaultName}" is not registered on this hub — shared-vault invites must name an existing vault`,
+      );
+    }
+  }
+
+  // Pre-named username: catch collisions at MINT time (the redeem-time check
+  // stays authoritative, but an enforced name that's already taken makes the
+  // link dead-on-arrival — fail fast for the admin instead).
+  if (username !== null) {
+    if (getUserByUsernameCI(deps.db, username) !== null) {
+      return jsonError(409, "username_taken", `username "${username}" is already in use`);
+    }
+    if (usernameReservedByPendingInvite(deps.db, username, now)) {
+      return jsonError(
+        409,
+        "username_reserved",
+        `username "${username}" is already reserved by another pending invite — revoke that invite first or pick a different name`,
+      );
+    }
   }
 
   const issued = issueInvite(deps.db, {
     createdBy: authUserId,
     vaultName,
+    username,
     role,
     provisionVault,
     defaultMirror,
     expiresInSeconds,
     ...(deps.now !== undefined ? { now: deps.now } : {}),
   });
-  const status = inviteStatus(issued.invite, (deps.now ?? (() => new Date()))());
+  const status = inviteStatus(issued.invite, now);
   return new Response(
     JSON.stringify({
       invite: toWire(issued.invite, status),

--- a/src/hub-db.ts
+++ b/src/hub-db.ts
@@ -4,7 +4,7 @@
  * issuer — signing keys (v1), users + opaque refresh tokens (v2), OAuth
  * clients + auth-codes + grants + browser sessions (v3), TOTP 2FA
  * enrollment on the users row (v11, hub#473), and one-time invite links
- * (v12, the `invites` table).
+ * (v12, the `invites` table; v13 adds the pre-named `username` column).
  *
  * Each open() runs `migrate()` to bring the schema up to date. A
  * `schema_version` table records every applied migration so re-opens are
@@ -424,6 +424,31 @@ const MIGRATIONS: readonly Migration[] = [
         created_at TEXT NOT NULL
       );
       CREATE INDEX invites_created_at ON invites (created_at);
+    `,
+  },
+  {
+    version: 13,
+    sql: `
+      -- Pre-named invites (Adam/Jonathan scenario). Adds an optional
+      -- \`username\` column to \`invites\`: when set, the invite pre-names
+      -- the account the redeemer gets — the redemption form shows the name
+      -- read-only and the redeem handler ENFORCES it (the form's username
+      -- field is ignored). NULL = the redeemer picks their own username
+      -- (every pre-v13 invite, and the default for new ones).
+      --
+      -- Enforced (not just pre-filled) because a pre-named invite is a
+      -- *named deliverable*: the admin mints "Jonathan's link" and hands it
+      -- to Jonathan; if the redeemer could pick a different name, the
+      -- link's identity binding would be decorative — the admin's audit
+      -- expectation ("this link = jonathan") and any vault assignment
+      -- story told against that name would silently break.
+      --
+      -- Stored as plain TEXT (already-validated lowercase [a-z0-9_-], the
+      -- users.username vocabulary). Mint-time validation rejects names
+      -- taken by an existing user or reserved by another pending invite;
+      -- the redeem path re-checks authoritatively. No backfill — every
+      -- existing invite predates pre-naming and keeps NULL.
+      ALTER TABLE invites ADD COLUMN username TEXT;
     `,
   },
 ];

--- a/src/invites.ts
+++ b/src/invites.ts
@@ -253,8 +253,19 @@ export function findInviteByHash(db: Database, tokenHash: string): Invite | null
  * unrevoked, not yet expired)? Two pending invites pre-naming the same
  * username would make the second one un-redeemable (the redeem path's
  * uniqueness check fails permanently for an enforced name), so mint-time
- * rejects the collision. Usernames are validator-pinned lowercase, so an
- * exact `=` comparison suffices.
+ * rejects the collision.
+ *
+ * Exact `=` comparison, deliberately NOT `COLLATE NOCASE` — an asymmetry
+ * with `getUserByUsernameCI` worth naming. The users-table CI lookup is
+ * defense in depth against legacy/hand-edited `users` rows that might carry
+ * mixed case from before the validator pinned lowercase. `invites.username`
+ * has no such legacy: the column is only ever written through the
+ * `validateUsername`-gated mint path (api-invites.ts), so every stored value
+ * is already lowercase, and the value compared against it went through the
+ * same validator. A hand-edited mixed-case invites row wouldn't reserve —
+ * but it also can't redeem: the redeem path re-runs `validateUsername` on
+ * the pre-named value and rejects it (the hand-edited-row backstop in
+ * account-setup.ts).
  */
 export function usernameReservedByPendingInvite(
   db: Database,

--- a/src/invites.ts
+++ b/src/invites.ts
@@ -19,6 +19,24 @@
  * the createUser-then-stamp ordering so a createUser failure leaves the
  * invite re-usable.
  *
+ * Two invite shapes carry that authorization (plus the account-only shape):
+ *   - provision_vault=1 — redemption provisions a NEW vault (optionally
+ *     pre-named via `vault_name`) and assigns the redeemer at `role`
+ *     (always 'write': the sole user of a fresh vault must hold write).
+ *   - provision_vault=0 + vault_name — a SHARED-VAULT invite: redemption
+ *     assigns the redeemer to the admin's EXISTING vault at `role`
+ *     ('read' or 'write'). Issuing is host:admin-gated — the same
+ *     authority that can already assign any user to any vault via
+ *     `POST /api/users` / `PATCH /api/users/:id/vaults` — so the invite
+ *     is a delivery mechanism for an admin-authorized assignment, not an
+ *     escalation. The read-only role is enforced end-to-end: every mint
+ *     path caps to `vaultVerbsForRole` (users.ts) and the vault's
+ *     scope-guard refuses writes for a `vault:<name>:read` token.
+ *
+ * An invite may also pre-name the redeemer's USERNAME (`username` column,
+ * v13): the redemption form shows it read-only and the redeem handler
+ * enforces it. NULL = redeemer picks their own.
+ *
  * Single-use is enforced by stamping `used_at` on redemption — a replay
  * attempt sees the row with `used_at` set and `redeemInvite` throws
  * `InviteUsedError`. Revocation is a separate `revoked_at` stamp the admin
@@ -41,6 +59,11 @@ export interface Invite {
   createdBy: string | null;
   /** Pinned vault name, or null when the redeemer names their own vault. */
   vaultName: string | null;
+  /**
+   * Pre-named username the redeemer's account gets (ENFORCED at redeem),
+   * or null when the redeemer picks their own. v13.
+   */
+  username: string | null;
   /** `user_vaults.role` granted on redemption (`'write'` = owner). */
   role: string;
   /** Whether redemption provisions a NEW vault for the redeemer. */
@@ -86,6 +109,7 @@ interface Row {
   token: string;
   created_by: string | null;
   vault_name: string | null;
+  username: string | null;
   role: string;
   provision_vault: number;
   default_mirror: string | null;
@@ -101,6 +125,7 @@ function rowToInvite(r: Row): Invite {
     tokenHash: r.token,
     createdBy: r.created_by,
     vaultName: r.vault_name,
+    username: r.username,
     role: r.role,
     provisionVault: r.provision_vault === 1,
     defaultMirror: r.default_mirror,
@@ -130,6 +155,11 @@ export interface IssueInviteOpts {
   createdBy: string;
   /** Pinned vault name; omit/null to let the redeemer name their own. */
   vaultName?: string | null;
+  /**
+   * Pre-named username (ENFORCED at redeem); omit/null to let the redeemer
+   * pick their own. Caller validates the vocabulary + uniqueness.
+   */
+  username?: string | null;
   /** `user_vaults` role granted on redemption. Default `'write'` (owner). */
   role?: string;
   /** Provision a new vault on redemption. Default `true` (the primary flow). */
@@ -165,18 +195,20 @@ export function issueInvite(db: Database, opts: IssueInviteOpts): IssuedInvite {
   const expiresAt = new Date(now.getTime() + ttl * 1000).toISOString();
   const role = opts.role ?? "write";
   const vaultName = opts.vaultName ?? null;
+  const username = opts.username ?? null;
   const provisionVault = opts.provisionVault ?? true;
   const defaultMirror = opts.defaultMirror ?? null;
 
   db.prepare(
     `INSERT INTO invites
-       (token, created_by, vault_name, role, provision_vault, default_mirror,
+       (token, created_by, vault_name, username, role, provision_vault, default_mirror,
         expires_at, used_at, redeemed_user_id, revoked_at, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?)`,
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?)`,
   ).run(
     tokenHash,
     opts.createdBy,
     vaultName,
+    username,
     role,
     provisionVault ? 1 : 0,
     defaultMirror,
@@ -190,6 +222,7 @@ export function issueInvite(db: Database, opts: IssueInviteOpts): IssuedInvite {
       tokenHash,
       createdBy: opts.createdBy,
       vaultName,
+      username,
       role,
       provisionVault,
       defaultMirror,
@@ -213,6 +246,29 @@ export function findInviteByRawToken(db: Database, rawToken: string): Invite | n
 export function findInviteByHash(db: Database, tokenHash: string): Invite | null {
   const row = db.query<Row, [string]>("SELECT * FROM invites WHERE token = ?").get(tokenHash);
   return row ? rowToInvite(row) : null;
+}
+
+/**
+ * Is `username` already reserved by a PENDING pre-named invite (unredeemed,
+ * unrevoked, not yet expired)? Two pending invites pre-naming the same
+ * username would make the second one un-redeemable (the redeem path's
+ * uniqueness check fails permanently for an enforced name), so mint-time
+ * rejects the collision. Usernames are validator-pinned lowercase, so an
+ * exact `=` comparison suffices.
+ */
+export function usernameReservedByPendingInvite(
+  db: Database,
+  username: string,
+  now: Date = new Date(),
+): boolean {
+  const row = db
+    .query<{ token: string }, [string, string]>(
+      `SELECT token FROM invites
+       WHERE username = ? AND used_at IS NULL AND revoked_at IS NULL AND expires_at > ?
+       LIMIT 1`,
+    )
+    .get(username, now.toISOString());
+  return row !== null;
 }
 
 /** List every invite, newest first, with derived status. */

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1200,6 +1200,8 @@ export interface InviteListing {
   id: string;
   status: InviteStatus;
   vault_name: string | null;
+  /** Pre-named username the redeemer's account gets (enforced), or null. */
+  username: string | null;
   role: string;
   provision_vault: boolean;
   default_mirror: string | null;
@@ -1213,6 +1215,9 @@ export interface InviteListing {
 /** Body for `POST /api/invites`. Every field is optional (server defaults apply). */
 export interface CreateInviteInput {
   vault_name?: string | null;
+  /** Pre-name the redeemer's username (enforced at redemption). */
+  username?: string | null;
+  /** `'write'` (owner) | `'read'` (read-only; shared-vault invites only). */
   role?: string;
   provision_vault?: boolean;
   default_mirror?: "internal" | "off" | null;

--- a/web/ui/src/routes/InvitesSection.test.tsx
+++ b/web/ui/src/routes/InvitesSection.test.tsx
@@ -213,10 +213,14 @@ describe("InvitesSection — prefiguration (what will this link do?)", () => {
     fireEvent.click(screen.getByRole("button", { name: /copy message/i }));
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
     const message = writeText.mock.calls[0]?.[0] as string;
-    expect(message).toContain("https://hub.example.com/account/setup/raw-token");
-    expect(message).toContain('Your username will be "jonathan".');
-    expect(message).toContain('read-only access to the vault "jonathan-vault"');
-    expect(message).toContain("expires");
+    // Full-content snapshot of the composed message — pins the pre-named
+    // username line, the access phrase, and the link in their exact shape.
+    // The expiry date renders via the same toLocaleDateString the component
+    // uses, so the assertion is locale-stable on any runner.
+    const expires = new Date("2026-06-20T00:00:00.000Z").toLocaleDateString();
+    expect(message).toBe(
+      `You're invited to my Parachute. Open this link to set your password and claim your account. Your username will be "jonathan". You'll get read-only access to the vault "jonathan-vault". The link works once and expires ${expires}: https://hub.example.com/account/setup/raw-token`,
+    );
   });
 });
 

--- a/web/ui/src/routes/InvitesSection.test.tsx
+++ b/web/ui/src/routes/InvitesSection.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * InvitesSection smoke tests — the invite-create form (pre-named username,
+ * provision-vs-share modes, role selector) + the single-emit URL banner and
+ * the list's access labels.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import { InvitesSection } from "./InvitesSection.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    listInvites: vi.fn(),
+    listUserVaults: vi.fn(),
+    createInvite: vi.fn(),
+    revokeInvite: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(api.listInvites).mockResolvedValue([]);
+  vi.mocked(api.listUserVaults).mockResolvedValue(["jonathan-vault", "work"]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function invite(overrides: Partial<api.InviteListing> = {}): api.InviteListing {
+  return {
+    id: "hash-1",
+    status: "pending",
+    vault_name: null,
+    username: null,
+    role: "write",
+    provision_vault: true,
+    default_mirror: null,
+    expires_at: "2026-06-20T00:00:00.000Z",
+    used_at: null,
+    redeemed_user_id: null,
+    revoked_at: null,
+    created_at: "2026-06-10T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function renderSection() {
+  return render(<InvitesSection hubOrigin="https://hub.example.com" />);
+}
+
+describe("InvitesSection — form modes", () => {
+  it("defaults to provision mode: new-vault name field, no role selector", async () => {
+    renderSection();
+    await waitFor(() => expect(screen.getByText(/no invites yet/i)).toBeInTheDocument());
+    expect(screen.getByText(/new vault name/i)).toBeInTheDocument();
+    expect(screen.queryByText("Role")).not.toBeInTheDocument();
+  });
+
+  it("share mode reveals the existing-vault picker + role selector", async () => {
+    renderSection();
+    await waitFor(() => expect(screen.getByText(/no invites yet/i)).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/vault access/i), { target: { value: "share" } });
+    expect(screen.getByText("Role")).toBeInTheDocument();
+    // The existing vaults populate the picker.
+    expect(screen.getByRole("option", { name: "jonathan-vault" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "work" })).toBeInTheDocument();
+    // New-vault name field is gone in share mode.
+    expect(screen.queryByText(/new vault name/i)).not.toBeInTheDocument();
+  });
+
+  it("submits a pre-named read-only shared-vault invite (the Adam/Jonathan shape)", async () => {
+    vi.mocked(api.createInvite).mockResolvedValue({
+      invite: invite({
+        username: "jonathan",
+        vault_name: "jonathan-vault",
+        role: "read",
+        provision_vault: false,
+      }),
+      token: "raw-token",
+      url: "https://hub.example.com/account/setup/raw-token",
+    });
+    renderSection();
+    await waitFor(() => expect(screen.getByText(/no invites yet/i)).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: "jonathan" } });
+    fireEvent.change(screen.getByLabelText(/vault access/i), { target: { value: "share" } });
+    fireEvent.change(screen.getByLabelText("Vault"), { target: { value: "jonathan-vault" } });
+    fireEvent.change(screen.getByLabelText("Role"), { target: { value: "read" } });
+    fireEvent.click(screen.getByRole("button", { name: /create invite/i }));
+
+    await waitFor(() => expect(api.createInvite).toHaveBeenCalledTimes(1));
+    expect(api.createInvite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        username: "jonathan",
+        vault_name: "jonathan-vault",
+        provision_vault: false,
+        role: "read",
+      }),
+    );
+    // Single-emit URL banner.
+    await waitFor(() =>
+      expect(
+        screen.getByText("https://hub.example.com/account/setup/raw-token"),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("share mode without a picked vault shows an inline error, no API call", async () => {
+    const { container } = renderSection();
+    await waitFor(() => expect(screen.getByText(/no invites yet/i)).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/vault access/i), { target: { value: "share" } });
+    // Dispatch submit directly: the picker is `required`, so a real browser's
+    // native validation already blocks the click path — this exercises the
+    // belt-and-suspenders inline guard behind it.
+    const form = container.querySelector("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/pick which existing vault to share before creating/i),
+      ).toBeInTheDocument(),
+    );
+    expect(api.createInvite).not.toHaveBeenCalled();
+  });
+
+  it("provision mode submits provision_vault=true with the optional pinned name", async () => {
+    vi.mocked(api.createInvite).mockResolvedValue({
+      invite: invite({ vault_name: "maya" }),
+      token: "raw-token-2",
+      url: "https://hub.example.com/account/setup/raw-token-2",
+    });
+    renderSection();
+    await waitFor(() => expect(screen.getByText(/no invites yet/i)).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/new vault name/i), { target: { value: "maya" } });
+    fireEvent.click(screen.getByRole("button", { name: /create invite/i }));
+    await waitFor(() => expect(api.createInvite).toHaveBeenCalledTimes(1));
+    expect(api.createInvite).toHaveBeenCalledWith(
+      expect.objectContaining({ vault_name: "maya", provision_vault: true }),
+    );
+    const call = vi.mocked(api.createInvite).mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call.role).toBeUndefined();
+    expect(call.username).toBeUndefined();
+  });
+
+  it("surfaces a createInvite server error in the banner", async () => {
+    vi.mocked(api.createInvite).mockRejectedValue(
+      new Error('username "jonathan" is already in use'),
+    );
+    renderSection();
+    await waitFor(() => expect(screen.getByText(/no invites yet/i)).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: "jonathan" } });
+    fireEvent.click(screen.getByRole("button", { name: /create invite/i }));
+    await waitFor(() => expect(screen.getByText(/already in use/i)).toBeInTheDocument());
+  });
+});
+
+describe("InvitesSection — prefiguration (what will this link do?)", () => {
+  it("shows a live preview that follows the form state", async () => {
+    renderSection();
+    await waitFor(() => expect(screen.getByText(/no invites yet/i)).toBeInTheDocument());
+    // Default: new account + self-named new vault.
+    expect(screen.getByTestId("invite-preview").textContent).toContain(
+      "Creates an account (they pick the username) + their own new vault (they name it), as owner.",
+    );
+    // Pre-name the user + share an existing vault read-only.
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: "jonathan" } });
+    fireEvent.change(screen.getByLabelText(/vault access/i), { target: { value: "share" } });
+    // Until a vault is picked the preview says what's missing.
+    expect(screen.getByTestId("invite-preview").textContent).toContain(
+      "Pick the existing vault to share",
+    );
+    fireEvent.change(screen.getByLabelText("Vault"), { target: { value: "jonathan-vault" } });
+    expect(screen.getByTestId("invite-preview").textContent).toContain(
+      'Creates an account for "jonathan" with read-only access to your existing vault "jonathan-vault".',
+    );
+  });
+
+  it("created banner shows the minted link's prefiguration + Copy message composes a paste-ready note", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    vi.mocked(api.createInvite).mockResolvedValue({
+      invite: invite({
+        username: "jonathan",
+        vault_name: "jonathan-vault",
+        role: "read",
+        provision_vault: false,
+      }),
+      token: "raw-token",
+      url: "https://hub.example.com/account/setup/raw-token",
+    });
+    renderSection();
+    await waitFor(() => expect(screen.getByText(/no invites yet/i)).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: "jonathan" } });
+    fireEvent.change(screen.getByLabelText(/vault access/i), { target: { value: "share" } });
+    fireEvent.change(screen.getByLabelText("Vault"), { target: { value: "jonathan-vault" } });
+    fireEvent.click(screen.getByRole("button", { name: /create invite/i }));
+
+    // Banner restates the prefiguration so "how did I send this?" has an answer.
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          /Creates an account for "jonathan" with read-only access to your existing vault "jonathan-vault"\./,
+        ),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /copy message/i }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const message = writeText.mock.calls[0]?.[0] as string;
+    expect(message).toContain("https://hub.example.com/account/setup/raw-token");
+    expect(message).toContain('Your username will be "jonathan".');
+    expect(message).toContain('read-only access to the vault "jonathan-vault"');
+    expect(message).toContain("expires");
+  });
+});
+
+describe("InvitesSection — list rendering", () => {
+  it("renders username + access labels per row", async () => {
+    vi.mocked(api.listInvites).mockResolvedValue([
+      invite({
+        id: "h1",
+        username: "jonathan",
+        vault_name: "jonathan-vault",
+        role: "read",
+        provision_vault: false,
+      }),
+      invite({ id: "h2", username: null, vault_name: null, role: "write", provision_vault: true }),
+    ]);
+    renderSection();
+    await waitFor(() => expect(screen.getByText("jonathan")).toBeInTheDocument());
+    expect(screen.getByText("read-only (shared)")).toBeInTheDocument();
+    expect(screen.getByText("owner (new vault)")).toBeInTheDocument();
+    expect(screen.getByText("they choose")).toBeInTheDocument();
+    expect(screen.getByText("redeemer chooses")).toBeInTheDocument();
+  });
+});

--- a/web/ui/src/routes/InvitesSection.tsx
+++ b/web/ui/src/routes/InvitesSection.tsx
@@ -1,12 +1,24 @@
 /**
- * Invite-links section for the Users admin view (design §7). An admin
- * generates a one-time, expiring link; the recipient opens it, creates an
- * account, and gets their OWN newly-provisioned vault as owner.
+ * Invite-links section for the Users admin view (design §7 + pre-named
+ * invites). An admin generates a one-time, expiring link; the recipient opens
+ * it, picks a password (and a username, unless the invite pre-names one), and
+ * gets vault access per the invite:
  *
- * Defaults to "provision a new vault for them" (the primary flow). The raw
- * token + URL come back ONCE on create — the hub stores only its sha256 — so
- * the create result is surfaced with a copy-URL affordance and is gone on the
- * next render. List rows show status + a revoke button for pending invites.
+ *   - "Create a new vault" (default) — the redeemer becomes owner of a
+ *     freshly-provisioned vault (optionally pre-named by the admin).
+ *   - "Share an existing vault" — the redeemer is assigned to one of this
+ *     hub's existing vaults at the chosen role (read-only or read & write).
+ *     This is the "give Jonathan read-only access to the vault I built for
+ *     him" flow.
+ *
+ * The optional username field pre-names the account: the redemption form
+ * shows it read-only and the server enforces it, so the link is a named
+ * deliverable ("Jonathan's link"), not a generic one.
+ *
+ * The raw token + URL come back ONCE on create — the hub stores only its
+ * sha256 — so the create result is surfaced with a copy-URL affordance and is
+ * gone on the next render. List rows show status + a revoke button for
+ * pending invites.
  *
  * Self-contained (own state, own load) so it doesn't thread through the big
  * Users component. Reuses the cached host-admin bearer (via the api client)
@@ -14,10 +26,12 @@
  */
 import { type FormEvent, useEffect, useState } from "react";
 import {
+  type CreateInviteInput,
   type CreatedInvite,
   type InviteListing,
   createInvite,
   listInvites,
+  listUserVaults,
   revokeInvite,
 } from "../lib/api";
 
@@ -34,22 +48,101 @@ type CreateState =
   | { kind: "created"; result: CreatedInvite }
   | { kind: "error"; message: string };
 
+type AccessMode = "provision" | "share";
+
+/** Human label for an invite row's access shape. */
+function accessLabel(inv: InviteListing): string {
+  if (inv.provision_vault) return "owner (new vault)";
+  if (inv.vault_name === null) return "account only";
+  return inv.role === "read" ? "read-only (shared)" : "read & write (shared)";
+}
+
+/** The fields that prefigure what a link does — shared by the live form preview and minted rows. */
+interface Prefiguration {
+  username: string | null;
+  vault_name: string | null;
+  role: string;
+  provision_vault: boolean;
+}
+
+/**
+ * Admin-facing, one-line answer to "what will this link do when clicked?" —
+ * the prefiguration summary. Shown live under the form (before mint), on the
+ * created banner (after mint), and reused for the paste-ready message.
+ */
+function prefigSummary(p: Prefiguration): string {
+  const who =
+    p.username !== null ? `an account for "${p.username}"` : "an account (they pick the username)";
+  if (p.provision_vault) {
+    const vault =
+      p.vault_name !== null
+        ? `their own new vault "${p.vault_name}"`
+        : "their own new vault (they name it)";
+    return `Creates ${who} + ${vault}, as owner.`;
+  }
+  if (p.vault_name === null) return `Creates ${who} with no vault access yet.`;
+  const access = p.role === "read" ? "read-only" : "read & write";
+  return `Creates ${who} with ${access} access to your existing vault "${p.vault_name}".`;
+}
+
+/**
+ * Recipient-facing, paste-ready message: what the link does + the link
+ * itself. The "Copy message" affordance — so how an invite was sent is never
+ * a mystery to either side.
+ */
+function inviteMessage(p: Prefiguration, url: string, expiresAt: string): string {
+  const who = p.username !== null ? ` Your username will be "${p.username}".` : "";
+  const access = p.provision_vault
+    ? p.vault_name !== null
+      ? ` You'll get your own new vault ("${p.vault_name}").`
+      : " You'll get your own new vault."
+    : p.vault_name !== null
+      ? ` You'll get ${p.role === "read" ? "read-only" : "read & write"} access to the vault "${p.vault_name}".`
+      : "";
+  const expires = new Date(expiresAt).toLocaleDateString();
+  return `You're invited to my Parachute. Open this link to set your password and claim your account.${who}${access} The link works once and expires ${expires}: ${url}`;
+}
+
 export function InvitesSection({ hubOrigin }: { hubOrigin: string }) {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
   const [reload, setReload] = useState(0);
+  const [username, setUsername] = useState("");
+  const [mode, setMode] = useState<AccessMode>("provision");
   const [vaultName, setVaultName] = useState("");
+  const [shareVault, setShareVault] = useState("");
+  const [shareRole, setShareRole] = useState<"read" | "write">("read");
+  const [knownVaults, setKnownVaults] = useState<string[]>([]);
   const [expiresDays, setExpiresDays] = useState("7");
   const [createSt, setCreateSt] = useState<CreateState>({ kind: "idle" });
-  const [copied, setCopied] = useState(false);
+  const [copied, setCopied] = useState<"link" | "message" | null>(null);
   const [revoking, setRevoking] = useState<string | null>(null);
+
+  // What the link being configured will do when clicked — recomputed live
+  // from the form state so the admin sees the prefiguration BEFORE minting.
+  const formPrefig: Prefiguration = {
+    username: username.trim() !== "" ? username.trim() : null,
+    vault_name:
+      mode === "share"
+        ? shareVault !== ""
+          ? shareVault
+          : null
+        : vaultName.trim() !== ""
+          ? vaultName.trim()
+          : null,
+    role: mode === "share" ? shareRole : "write",
+    provision_vault: mode === "provision",
+  };
 
   useEffect(() => {
     void reload;
     let cancelled = false;
     setState({ kind: "loading" });
-    listInvites()
-      .then((invites) => {
-        if (!cancelled) setState({ kind: "ok", invites });
+    Promise.all([listInvites(), listUserVaults()])
+      .then(([invites, vaults]) => {
+        if (!cancelled) {
+          setState({ kind: "ok", invites });
+          setKnownVaults(vaults);
+        }
       })
       .catch((err: unknown) => {
         if (!cancelled) {
@@ -64,19 +157,34 @@ export function InvitesSection({ hubOrigin }: { hubOrigin: string }) {
   async function onSubmit(e: FormEvent) {
     e.preventDefault();
     if (createSt.kind === "submitting") return;
-    setCreateSt({ kind: "submitting" });
-    setCopied(false);
-    const days = Number.parseInt(expiresDays, 10);
-    try {
-      const result = await createInvite({
-        // Pin the vault name when the admin typed one; otherwise the redeemer
-        // names their own vault at redeem time.
-        ...(vaultName.trim() !== "" ? { vault_name: vaultName.trim() } : {}),
-        provision_vault: true,
-        ...(Number.isFinite(days) && days > 0 ? { expires_in: days * DAY_SECONDS } : {}),
+    if (mode === "share" && shareVault === "") {
+      setCreateSt({
+        kind: "error",
+        message: "Pick which existing vault to share before creating the invite.",
       });
+      return;
+    }
+    setCreateSt({ kind: "submitting" });
+    setCopied(null);
+    const days = Number.parseInt(expiresDays, 10);
+    const input: CreateInviteInput = {
+      ...(username.trim() !== "" ? { username: username.trim() } : {}),
+      ...(Number.isFinite(days) && days > 0 ? { expires_in: days * DAY_SECONDS } : {}),
+      ...(mode === "share"
+        ? { vault_name: shareVault, provision_vault: false, role: shareRole }
+        : {
+            // Pin the vault name when the admin typed one; otherwise the
+            // redeemer names their own vault at redeem time.
+            ...(vaultName.trim() !== "" ? { vault_name: vaultName.trim() } : {}),
+            provision_vault: true,
+          }),
+    };
+    try {
+      const result = await createInvite(input);
       setCreateSt({ kind: "created", result });
+      setUsername("");
       setVaultName("");
+      setShareVault("");
       setReload((n) => n + 1);
     } catch (err: unknown) {
       setCreateSt({ kind: "error", message: err instanceof Error ? err.message : String(err) });
@@ -96,10 +204,10 @@ export function InvitesSection({ hubOrigin }: { hubOrigin: string }) {
     }
   }
 
-  function copyUrl(url: string) {
-    void navigator.clipboard?.writeText(url).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+  function copyText(text: string, which: "link" | "message") {
+    void navigator.clipboard?.writeText(text).then(() => {
+      setCopied(which);
+      setTimeout(() => setCopied(null), 2000);
     });
   }
 
@@ -109,25 +217,76 @@ export function InvitesSection({ hubOrigin }: { hubOrigin: string }) {
         <h2>Invite links</h2>
       </div>
       <p className="muted">
-        Generate a one-time, expiring link. The recipient opens it, picks a username and password,
-        and gets their own newly-provisioned vault (they become its owner). No admin-typed default
-        password. Leave the vault name blank to let them name it themselves.
+        Generate a one-time, expiring link. The recipient opens it and picks their password — no
+        admin-typed default password. Either provision them a new vault of their own, or share an
+        existing vault read-only or read &amp; write. Pre-naming the username makes the link a named
+        deliverable (the recipient can't change it).
       </p>
 
       <form onSubmit={(e) => void onSubmit(e)} style={{ marginBottom: "1rem" }}>
         <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap", alignItems: "flex-end" }}>
-          <label className="field" style={{ flex: "1 1 14rem" }}>
-            <span className="field-label">Vault name (optional)</span>
+          <label className="field" style={{ flex: "1 1 10rem" }}>
+            <span className="field-label">Username (optional)</span>
             <input
               type="text"
-              value={vaultName}
-              onChange={(e) => setVaultName(e.target.value)}
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
               placeholder="leave blank → they choose"
               pattern="[a-z0-9_-]*"
+              minLength={2}
+              maxLength={32}
               autoComplete="off"
               spellCheck={false}
             />
           </label>
+          <label className="field" style={{ flex: "0 0 14rem" }}>
+            <span className="field-label">Vault access</span>
+            <select
+              value={mode}
+              onChange={(e) => setMode(e.target.value === "share" ? "share" : "provision")}
+            >
+              <option value="provision">Create a new vault for them</option>
+              <option value="share">Share an existing vault</option>
+            </select>
+          </label>
+          {mode === "provision" ? (
+            <label className="field" style={{ flex: "1 1 12rem" }}>
+              <span className="field-label">New vault name (optional)</span>
+              <input
+                type="text"
+                value={vaultName}
+                onChange={(e) => setVaultName(e.target.value)}
+                placeholder="leave blank → they choose"
+                pattern="[a-z0-9_-]*"
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </label>
+          ) : (
+            <>
+              <label className="field" style={{ flex: "1 1 10rem" }}>
+                <span className="field-label">Vault</span>
+                <select value={shareVault} onChange={(e) => setShareVault(e.target.value)} required>
+                  <option value="">Pick a vault…</option>
+                  {knownVaults.map((v) => (
+                    <option key={v} value={v}>
+                      {v}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="field" style={{ flex: "0 0 9rem" }}>
+                <span className="field-label">Role</span>
+                <select
+                  value={shareRole}
+                  onChange={(e) => setShareRole(e.target.value === "write" ? "write" : "read")}
+                >
+                  <option value="read">Read-only</option>
+                  <option value="write">Read &amp; write</option>
+                </select>
+              </label>
+            </>
+          )}
           <label className="field" style={{ flex: "0 0 8rem" }}>
             <span className="field-label">Expires (days)</span>
             <input
@@ -142,6 +301,11 @@ export function InvitesSection({ hubOrigin }: { hubOrigin: string }) {
             {createSt.kind === "submitting" ? "Creating…" : "Create invite"}
           </button>
         </div>
+        <p className="muted" style={{ marginTop: "0.5rem" }} data-testid="invite-preview">
+          {mode === "share" && shareVault === ""
+            ? "Pick the existing vault to share to finish configuring this link."
+            : prefigSummary(formPrefig)}
+        </p>
       </form>
 
       {createSt.kind === "error" && (
@@ -152,8 +316,11 @@ export function InvitesSection({ hubOrigin }: { hubOrigin: string }) {
 
       {createSt.kind === "created" && (
         <output className="success-banner" style={{ display: "block", marginBottom: "1rem" }}>
-          <strong>Invite created.</strong> Copy this link now — it's shown only once and can't be
-          retrieved later. The hub stores only a hash.
+          <strong>Invite created.</strong> {prefigSummary(createSt.result.invite)}
+          <br />
+          Copy it now — the link is shown only once and can't be retrieved later (the hub stores
+          only a hash). "Copy message" includes a ready-to-send note telling the recipient what the
+          link does.
           <div
             style={{
               display: "flex",
@@ -167,9 +334,25 @@ export function InvitesSection({ hubOrigin }: { hubOrigin: string }) {
             <button
               type="button"
               className="secondary"
-              onClick={() => copyUrl(createSt.result.url)}
+              onClick={() => copyText(createSt.result.url, "link")}
             >
-              {copied ? "Copied!" : "Copy link"}
+              {copied === "link" ? "Copied!" : "Copy link"}
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() =>
+                copyText(
+                  inviteMessage(
+                    createSt.result.invite,
+                    createSt.result.url,
+                    createSt.result.invite.expires_at,
+                  ),
+                  "message",
+                )
+              }
+            >
+              {copied === "message" ? "Copied!" : "Copy message"}
             </button>
             <button
               type="button"
@@ -201,8 +384,9 @@ export function InvitesSection({ hubOrigin }: { hubOrigin: string }) {
           <table className="user-table">
             <thead>
               <tr>
+                <th>For</th>
                 <th>Vault</th>
-                <th>Role</th>
+                <th>Access</th>
                 <th>Status</th>
                 <th>Expires</th>
                 <th>Created</th>
@@ -212,8 +396,9 @@ export function InvitesSection({ hubOrigin }: { hubOrigin: string }) {
             <tbody>
               {state.invites.map((inv) => (
                 <tr key={inv.id}>
+                  <td>{inv.username ?? <span className="muted">they choose</span>}</td>
                   <td>{inv.vault_name ?? <span className="muted">redeemer chooses</span>}</td>
-                  <td>{inv.role === "write" ? "owner" : inv.role}</td>
+                  <td>{accessLabel(inv)}</td>
                   <td>
                     <span className={`status status-${inv.status}`}>{inv.status}</span>
                   </td>

--- a/web/ui/src/routes/Users.test.tsx
+++ b/web/ui/src/routes/Users.test.tsx
@@ -306,7 +306,9 @@ describe("Users — create form", () => {
     vi.mocked(api.listUserVaults).mockResolvedValue(["home", "work"]);
     renderRoute();
     fireEvent.click(await screen.findByRole("button", { name: /create user/i }));
-    expect(await screen.findByLabelText(/username/i)).toBeInTheDocument();
+    expect(
+      await screen.findByLabelText(/username/i, { selector: "#new-user-username" }),
+    ).toBeInTheDocument();
     const select = screen.getByLabelText(/assigned vaults/i) as HTMLSelectElement;
     expect(select.multiple).toBe(true);
     const optionTexts = Array.from(select.options).map((o) => o.text);
@@ -328,7 +330,9 @@ describe("Users — create form", () => {
     );
     renderRoute();
     fireEvent.click(await screen.findByRole("button", { name: /create user/i }));
-    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: "alice" } });
+    fireEvent.change(screen.getByLabelText(/username/i, { selector: "#new-user-username" }), {
+      target: { value: "alice" },
+    });
     fireEvent.change(screen.getByLabelText(/^password/i), {
       target: { value: "alice-strong-passphrase" },
     });
@@ -361,7 +365,9 @@ describe("Users — create form", () => {
     vi.mocked(api.listUserVaults).mockResolvedValue([]);
     renderRoute();
     fireEvent.click(await screen.findByRole("button", { name: /create user/i }));
-    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: "alice" } });
+    fireEvent.change(screen.getByLabelText(/username/i, { selector: "#new-user-username" }), {
+      target: { value: "alice" },
+    });
     // 11 chars — under the floor.
     fireEvent.change(screen.getByLabelText(/^password/i), { target: { value: "tooshortpw1" } });
     // Submit via form submit handler (the input minLength HTML attribute
@@ -381,7 +387,9 @@ describe("Users — create form", () => {
     );
     renderRoute();
     fireEvent.click(await screen.findByRole("button", { name: /create user/i }));
-    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: "alice" } });
+    fireEvent.change(screen.getByLabelText(/username/i, { selector: "#new-user-username" }), {
+      target: { value: "alice" },
+    });
     fireEvent.change(screen.getByLabelText(/^password/i), {
       target: { value: "alice-strong-passphrase" },
     });
@@ -519,7 +527,9 @@ describe("Users — sign-in handoff URL (onboarding discoverability)", () => {
     );
     renderRoute();
     fireEvent.click(await screen.findByRole("button", { name: /create user/i }));
-    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: "alice" } });
+    fireEvent.change(screen.getByLabelText(/username/i, { selector: "#new-user-username" }), {
+      target: { value: "alice" },
+    });
     fireEvent.change(screen.getByLabelText(/^password/i), {
       target: { value: "alice-strong-passphrase" },
     });
@@ -578,7 +588,9 @@ describe("Users — sign-in handoff URL (onboarding discoverability)", () => {
     vi.mocked(api.createUser).mockResolvedValue(user("alice", { password_changed: false }));
     renderRoute();
     fireEvent.click(await screen.findByRole("button", { name: /create user/i }));
-    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: "alice" } });
+    fireEvent.change(screen.getByLabelText(/username/i, { selector: "#new-user-username" }), {
+      target: { value: "alice" },
+    });
     fireEvent.change(screen.getByLabelText(/^password/i), {
       target: { value: "alice-strong-passphrase" },
     });


### PR DESCRIPTION
## Part A — live verification (sandboxed, 19/19 checks)

A real beta user (Adam) wants to give a new user (Jonathan) **read-only** access to an **existing** vault, used from Claude MCP + Notes. Verified against the production handlers in a fresh temp `PARACHUTE_HOME` + temp DB (no live hub touched):

**The story did NOT exist end-to-end before this PR:**
- Shared-vault invites (`provision_vault=false` + `vault_name`) were rejected at create (400) **and** redeem (defense in depth) — "aren't supported yet."
- The sneaky path (provision=true pinned to the existing name) is correctly refused at redeem (409, `created:false` guard).
- The manual path (`POST /api/users` + `assignedVaults`) works but hardwires **role `write` = full read/write/admin** (the 2026-05-30 any-assigned-user-gets-admin policy). `setUserVaults` also hardcodes `'write'`. **No surface anywhere could set `role='read'`** — only a hand SQL edit.
- **Enforcement of `read`, once set, is solid at every layer** (verified): `vaultVerbsForRole` (`users.ts` — the single role→verb source) → `/account/vault-token` mint gates (write/admin/cross-vault 403, read 200) → OAuth `capScopesToUserAuthority` chokepoint (`oauth-handlers.ts`) → token carries exactly `vault:<name>:read` + `vault_scope` pin → scope-guard (`hasScope` verb-rank) refuses writes at the vault. No enforcement gap — the gap was purely *settability/deliverability*.

## Part B — pre-named, prefigured invites

The fix for "I don't really know how I sent the invite links": every axis of what a link does is set — and visible — at mint time.

- **Migration v13**: `invites.username` (nullable, no backfill).
- **Pre-named username, ENFORCED at redemption** (not just pre-filled): the invite is a named deliverable — "Jonathan's link." The redemption form renders the name read-only; the server ignores the submitted field. If the redeemer could rename, the identity binding would be decorative and the admin's audit expectation would silently break. Collisions: mint-time 409 (`username_taken` vs existing user, `username_reserved` vs another pending invite); authoritative re-check at redeem leaves the invite unconsumed with "ask your hub operator" copy (operator revokes + re-mints).
- **Shared-vault invites now supported**: `provision_vault=false` + existing `vault_name` + role `read`|`write`. Authorization argument: minting requires `parachute:host:admin` — the same authority that can already assign any user to any vault via `POST /api/users`; the invite only packages that assignment as a one-time link. The vault must exist at mint (400 `vault_not_found`) and at redeem (defense in depth behind the existing `revokeInvitesForVault` delete-cascade). What an invite pre-authorizes is unchanged: exactly one account + the one vault at the baked role — never host:admin, never another vault.
- **`provision_vault=true` requires role `write`** (400 otherwise): a fresh vault whose sole user is read-only would be permanently un-writable.
- **Admin SPA** (`InvitesSection`): three prefiguration axes in one form — username (optional), vault access mode ("Create a new vault for them" — the explicit option, not a hidden default — vs "Share an existing vault" with vault picker + read/write role), expiry. A live **"what will this link do" preview** updates with the form. The created banner restates the minted link's prefiguration and adds **"Copy message"** — a paste-ready recipient note (what the link grants + username + expiry + URL) next to "Copy link." The invite list shows each link's prefiguration at a glance (For / Vault / Access).
- Redemption page: pre-named username shown read-only; shared-vault invites show "you're being given read-only access to this existing vault."

## Operator flow for Adam (post-merge)

Admin → Users → Invite links: username `jonathan` · "Share an existing vault" · pick the vault · role "Read-only" → Create invite → **Copy message** → send to Jonathan. He sets a password, lands signed in at `/account/` with exactly `read` on that one vault; Claude MCP / Notes OAuth and the token-mint tile are capped to read by the existing chokepoints.

## Tests

- **The Part-A pin, as a permanent e2e**: redeem a read-role shared invite → `user_vaults.role='read'` → write/admin/cross-vault mints 403, read mint 200 with scope exactly `vault:<name>:read` + `vault_scope` pin → scope-guard refuses write/admin/cross-vault, accepts read. (The test imports scope-guard deliberately to pin the issuer↔validator contract; runtime hub still never imports it.)
- Pre-named enforcement (submitted username ignored), taken-at-redeem 409 + invite re-usable, GET renders read-only name.
- Shared-vault: create 201 / vault_not_found 400 / provision+read 400 / vanished-vault redeem 400 + invite re-usable; the old "rejected at redeem" test rewritten to the supported behavior.
- v13 upgrade against a seeded v12 row (grandfathered NULL).
- SPA: 9 InvitesSection tests (modes, preview, copy-message composition, list labels); Users tests disambiguated (page now has two username fields).

## Gates (literal)

- hub `bun test ./src`: **3391 pass / 1 skip / 0 fail** (134 files)
- hub `bun run typecheck`: clean
- SPA `bun run test` (vitest): **284 pass / 0 fail**; SPA `tsc --noEmit`: clean
- biome: clean on all changed files

## Patterns check

- Migration follows the append-only `hub-db.ts` pattern (v13) with rationale docstring + upgrade test.
- No rc bump per current practice (bump+tag ride the ship signal).
- Hub-module boundary untouched: invites stay hub-owned identity issuance; vault lifecycle untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)