### PR TITLE
release: v0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
0.7.0 → 0.7.1.

Aboard: surface-runtime substrate R1 #648, audience `surface` tier #651, connections claim/reconcile #653/#654, WS connection caps #655, supervised logs #656, pre-named invites #657.

Gates: `bun run typecheck` clean; `bun test ./src` — **3392 pass, 1 skip, 0 fail** (3393 tests across 134 files).

No CHANGELOG roll: the file has no `Unreleased` section — its newest entry is 0.6.4 (same posture as the v0.7.0 release PR #647; the 0.6.5-rc/0.7.0 gap predates this train).

Tag `v0.7.1` comes after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)