### PR TITLE
fix(upgrade): rc channel resolves best-of rc/latest above installed — no more stranding below stable (closes #659)

### DIFF
--- a/src/__tests__/upgrade.test.ts
+++ b/src/__tests__/upgrade.test.ts
@@ -1219,6 +1219,282 @@ describe("parachute upgrade", () => {
     }
   });
 
+  // -------------------------------------------------------------------------
+  // hub#659 — rc channel resolves best-of @rc / @latest above installed.
+  // The rc channel is a canary: it must stay ahead when a newer rc exists, but
+  // CONVERGE to stable when a train shipped stable-direct (no rc cut) and the
+  // box would otherwise strand below @latest with no visible path forward.
+  // -------------------------------------------------------------------------
+
+  test("rc channel, newer rc exists → takes @rc (canary stays ahead, #332 unchanged)", async () => {
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.6.5-rc.8" });
+
+      const seenCmd: string[][] = [];
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          seenCmd.push([...cmd]);
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.6.5-rc.9" });
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      const logs: string[] = [];
+      const code = await upgrade("hub", {
+        supervisor: okHubUnitSupervisor,
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        restartFn: async () => 0,
+        // A newer rc (rc.9) exists AND @latest moved (0.7.1) — the canary wins.
+        resolveChannelVersion: async (_pkg, channel) => (channel === "rc" ? "0.6.5-rc.9" : "0.7.1"),
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
+      expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@rc"]);
+      // No "converging to stable" line — we stayed on the canary.
+      expect(logs.join("\n")).not.toMatch(/converging to stable/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("THE hub#659 pin: rc channel, NO newer rc but @latest is higher → converges to @latest with a loud line", async () => {
+    // The live stranding case: friends.parachute.computer on 0.6.5-rc.8. The
+    // @rc dist-tag never advanced (every train since shipped stable-direct), so
+    // pre-fix `parachute upgrade hub` followed @rc and NO-OPPED — the box sat
+    // below @latest (0.7.1) with no visible path. Post-fix: converge to the
+    // concrete stable, pinned, with a loud log naming the channel + the version.
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.6.5-rc.8" });
+
+      const seenCmd: string[][] = [];
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          seenCmd.push([...cmd]);
+          // Honest registry simulation: `bun add -g @…@rc` resolves to the
+          // installed rc.8 (no change → the pre-fix no-op); only the converged
+          // stable pin rewrites the package.json. This is what makes the test
+          // fail PRE-FIX — pre-fix the verb only ever asks for @rc and no-ops.
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            const spec = cmd[3] ?? "";
+            if (spec.endsWith("@0.7.1") || spec.endsWith("@latest")) {
+              writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.7.1" });
+            }
+            // spec ending in @rc → resolves to installed 0.6.5-rc.8, no rewrite.
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      const logs: string[] = [];
+      let restartedShort: string | undefined;
+      const code = await upgrade("hub", {
+        supervisor: okHubUnitSupervisor,
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        restartFn: async (svc) => {
+          restartedShort = svc;
+          return 0;
+        },
+        // @rc stuck at the installed version (no newer rc); @latest moved ahead.
+        resolveChannelVersion: async (_pkg, channel) => (channel === "rc" ? "0.6.5-rc.8" : "0.7.1"),
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      // Converged: pinned to the CONCRETE stable version (not @latest dist-tag),
+      // so a moving tag can't race the resolution.
+      const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
+      expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@0.7.1"]);
+      // Phase 5b: hub restarts via the manager (okHubUnitSupervisor); the verb
+      // still reaches the restart leg because the version changed.
+      const joined = logs.join("\n");
+      // The LOUD convergence line — names the rc channel, the installed version,
+      // the stable target, and the "next rc" reassurance.
+      expect(joined).toMatch(/the rc channel has nothing newer than 0\.6\.5-rc\.8/);
+      expect(joined).toMatch(/converging to stable 0\.7\.1/);
+      expect(joined).toMatch(/pick up the next rc/);
+      // It actually moved (the no-op would NOT have).
+      expect(joined).toMatch(/0\.6\.5-rc\.8 → 0\.7\.1/);
+      void restartedShort; // hub restarts via the manager seam, not restartFn
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("rc channel, @rc and @latest both ≤ installed → up-to-date no-op (names both)", async () => {
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.7.2-rc.1" });
+
+      const seenCmd: string[][] = [];
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          seenCmd.push([...cmd]);
+          // bun add -g @rc resolves to the same installed version → no rewrite.
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      const logs: string[] = [];
+      let restartCalled = false;
+      const code = await upgrade("hub", {
+        supervisor: okHubUnitSupervisor,
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        restartFn: async () => {
+          restartCalled = true;
+          return 0;
+        },
+        // Nothing newer anywhere: @rc == installed, @latest below installed.
+        resolveChannelVersion: async (_pkg, channel) => (channel === "rc" ? "0.7.2-rc.1" : "0.7.1"),
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      expect(restartCalled).toBe(false);
+      // Stays on @rc (no convergence); the post-install no-op fires.
+      const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
+      expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@rc"]);
+      const joined = logs.join("\n");
+      expect(joined).toMatch(/@rc \(0\.7\.2-rc\.1\) and @latest \(0\.7\.1\) are both at or below/);
+      expect(joined).toMatch(/already at 0\.7\.2-rc\.1/);
+      expect(joined).not.toMatch(/converging to stable/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("latest channel is unchanged: stable install never reaches for @rc (hub#659 scoped to rc)", async () => {
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.7.1" });
+
+      const seenCmd: string[][] = [];
+      let rcProbed = false;
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          seenCmd.push([...cmd]);
+          if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g") {
+            writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.7.2" });
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      const code = await upgrade("hub", {
+        supervisor: okHubUnitSupervisor,
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        restartFn: async () => 0,
+        // Track whether the rc tag is ever probed — it must NOT be on the
+        // stable channel (best-of resolution is scoped to rc).
+        resolveChannelVersion: async (_pkg, channel) => {
+          if (channel === "rc") rcProbed = true;
+          return channel === "latest" ? "0.7.2" : "0.8.0-rc.1";
+        },
+        log: () => {},
+      });
+      expect(code).toBe(0);
+      const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
+      expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@latest"]);
+      // The stable channel never reaches across to @rc.
+      expect(rcProbed).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("rc channel converge still respects the downgrade guard (no @latest below installed sneaks through)", async () => {
+    // Defensive: if @rc is stuck AND @latest is somehow BELOW installed (an
+    // operator on a hand-pinned newer rc than the latest stable), we neither
+    // converge nor downgrade — we stay on @rc and no-op.
+    const h = makeHarness();
+    try {
+      const hubInstallDir = join(h.installRoot, "hub");
+      writePackageJson(hubInstallDir, { name: "@openparachute/hub", version: "0.8.0-rc.1" });
+
+      const seenCmd: string[][] = [];
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          seenCmd.push([...cmd]);
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 128, stdout: "" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      const logs: string[] = [];
+      const code = await upgrade("hub", {
+        supervisor: okHubUnitSupervisor,
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: (pkg) =>
+          pkg === "@openparachute/hub" ? join(hubInstallDir, "package.json") : null,
+        restartFn: async () => 0,
+        // @rc == installed (no newer rc); @latest is a PRIOR stable, below us.
+        resolveChannelVersion: async (_pkg, channel) => (channel === "rc" ? "0.8.0-rc.1" : "0.7.1"),
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(0);
+      // Stayed on @rc — no convergence to a lower stable.
+      const addCall = seenCmd.find((c) => c[0] === "bun" && c[1] === "add");
+      expect(addCall).toEqual(["bun", "add", "-g", "@openparachute/hub@rc"]);
+      expect(logs.join("\n")).not.toMatch(/converging to stable/);
+      expect(logs.join("\n")).not.toMatch(/refusing to downgrade/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("--tag still overrides everything (back-compat for programmatic pin)", async () => {
     const h = makeHarness();
     try {

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -44,6 +44,26 @@
  * downgrades: if `npm view <pkg>@<channel> version` resolves to something
  * lower than what's installed, we abort with an actionable message
  * (override with `--allow-downgrade`).
+ *
+ * RC-channel best-of resolution (hub#659). Channel preservation (#332) made
+ * the rc channel sticky — `parachute upgrade` follows `@rc`. But the rc
+ * channel is a *canary*: when a train ships stable-direct without cutting an
+ * rc (the common case under the post-#332 governance where trains start at
+ * stable), `@rc` doesn't advance and the box strands BELOW `@latest` with no
+ * visible path forward (the live case: friends.parachute.computer pinned at
+ * 0.6.5-rc.8 while @latest moved to 0.7.1). The fix: on the rc channel we
+ * resolve the target to the HIGHEST version above installed across BOTH `@rc`
+ * AND `@latest`.
+ *   - mid-chain (a newer rc exists) → take the rc; the canary stays ahead
+ *     (UNCHANGED — this is the #332 behavior).
+ *   - end-of-chain / skipped-rc train (no newer rc, but @latest > installed)
+ *     → CONVERGE to @latest, with a loud log line. The operator stays ON the
+ *     rc channel (the install/config notion of channel is unchanged) — only
+ *     the resolved VERSION changes; they pick up the next rc when it ships.
+ *   - nothing newer anywhere → the existing up-to-date no-op.
+ * The `@latest` (stable) channel path is UNCHANGED — stable never reaches for
+ * `@rc`. `--channel rc|latest` explicit overrides and `--allow-downgrade`
+ * keep working.
  */
 
 import { existsSync, readFileSync, realpathSync } from "node:fs";
@@ -689,10 +709,99 @@ function pickChannel(installedVersion: string | null, r: Resolved): string {
   return "latest";
 }
 
+/**
+ * The dist-tag / version `upgradeNpm` will hand to `bun add -g`, after the
+ * rc-channel best-of resolution (hub#659). `installSpec` is what follows the
+ * `@` in `bun add -g <pkg>@<installSpec>` — usually a dist-tag (`rc` /
+ * `latest`), but a pinned concrete version when we converge an rc-channel box
+ * onto stable (so a moving `@latest` can't race the resolution). `channel` is
+ * the dist-tag we resolved against, used by the downgrade-guard messaging.
+ */
+interface ResolvedNpmTarget {
+  installSpec: string;
+  channel: string;
+}
+
+/**
+ * Resolve which version the rc channel should actually move to (hub#659).
+ *
+ * Channel preservation (#332) keeps an rc operator following `@rc`. But `@rc`
+ * is a canary that only advances when a train cuts an rc; a stable-direct
+ * train leaves it stranded below `@latest`. So on the rc channel we look at
+ * BOTH dist-tags and take the highest one that's actually ABOVE installed:
+ *   - a newer `@rc` exists → stay on rc (mid-chain canary; UNCHANGED).
+ *   - no newer rc but `@latest` > installed → converge to `@latest`, pinned to
+ *     the concrete resolved version, with a LOUD log. The operator stays ON
+ *     the rc channel; only this upgrade's resolved version changes.
+ *   - neither tag is above installed → fall through to the rc tag and let the
+ *     normal "already at <v>" no-op fire after `bun add -g`.
+ *
+ * Returns the original `{ installSpec: "rc" }` unchanged whenever we can't read
+ * the installed version or can't resolve a higher stable (fail-open: never
+ * block a legitimate `@rc` upgrade on a flaky probe).
+ */
+async function resolveRcBestOf(
+  target: ResolvedTarget,
+  beforeVersion: string | null,
+  r: Resolved,
+): Promise<ResolvedNpmTarget> {
+  const rcTarget: ResolvedNpmTarget = { installSpec: "rc", channel: "rc" };
+  if (!beforeVersion) return rcTarget;
+
+  const [rcVersion, latestVersion] = await Promise.all([
+    r.resolveChannelVersion(target.packageName, "rc"),
+    r.resolveChannelVersion(target.packageName, "latest"),
+  ]);
+
+  const rcAbove = rcVersion !== null && (compareVersions(rcVersion, beforeVersion) ?? -1) > 0;
+  if (rcAbove) {
+    // A newer rc exists — the canary stays ahead (the #332 mid-chain path).
+    return rcTarget;
+  }
+
+  const latestAbove =
+    latestVersion !== null && (compareVersions(latestVersion, beforeVersion) ?? -1) > 0;
+  if (latestAbove && latestVersion) {
+    // End-of-chain / skipped-rc train: nothing newer on @rc, but stable moved
+    // ahead. Converge to @latest — pinned to the concrete version so a moving
+    // dist-tag can't race us — and say so LOUDLY (the hub#659 stranding fix).
+    r.log(
+      `${target.short}: the rc channel has nothing newer than ${beforeVersion}; ` +
+        `converging to stable ${latestVersion} — you'll pick up the next rc when it ships.`,
+    );
+    return { installSpec: latestVersion, channel: "latest" };
+  }
+
+  // Neither tag is above installed — stay on @rc and let the post-install
+  // "already at <v>" no-op fire (handled in upgradeNpm). When both probes
+  // resolved and both are ≤ installed, name that explicitly.
+  if (rcVersion !== null && latestVersion !== null) {
+    r.log(
+      `${target.short}: on the rc channel — @rc (${rcVersion}) and @latest (${latestVersion}) ` +
+        `are both at or below installed ${beforeVersion}.`,
+    );
+  }
+  return rcTarget;
+}
+
 async function upgradeNpm(target: ResolvedTarget, sourceDir: string, r: Resolved): Promise<number> {
   r.log(`${target.short}: npm-installed (${sourceDir})`);
   const beforeVersion = readPackageVersion(join(sourceDir, "package.json"));
-  const channel = pickChannel(beforeVersion, r);
+  const pickedChannel = pickChannel(beforeVersion, r);
+
+  // RC-channel best-of resolution (hub#659). On the rc channel, resolve to the
+  // highest version above installed across @rc AND @latest — so an end-of-chain
+  // box converges to stable instead of stranding below it. The stable channel
+  // and explicit programmatic `--tag` are UNCHANGED: only an *auto-detected or
+  // --channel-rc* resolution reaches for stable. `r.tag` (programmatic pin) and
+  // an explicit `--channel latest` both leave the rc best-of untouched.
+  let installSpec = pickedChannel;
+  let channel = pickedChannel;
+  if (pickedChannel === "rc" && !r.tag) {
+    const resolved = await resolveRcBestOf(target, beforeVersion, r);
+    installSpec = resolved.installSpec;
+    channel = resolved.channel;
+  }
 
   // Downgrade guard: refuse to silently move backward. Only applies when
   // we can read both sides — beforeVersion from disk, targetVersion via
@@ -700,6 +809,10 @@ async function upgradeNpm(target: ResolvedTarget, sourceDir: string, r: Resolved
   // behavior: just run `bun add -g`). This is the load-bearing fix for
   // hub#332 — Aaron got `0.5.13-rc.13` → `0.5.10` because the implicit
   // `@latest` resolved to a prior stable while he was on the rc chain.
+  //
+  // After hub#659's best-of resolution `channel` is already the tag we're
+  // actually shipping (rc on the canary path, latest on the converge path), so
+  // the guard checks the version we'll really install.
   if (beforeVersion && !r.allowDowngrade) {
     const targetVersion = await r.resolveChannelVersion(target.packageName, channel);
     if (targetVersion) {
@@ -725,7 +838,7 @@ async function upgradeNpm(target: ResolvedTarget, sourceDir: string, r: Resolved
     }
   }
 
-  const spec = `${target.packageName}@${channel}`;
+  const spec = `${target.packageName}@${installSpec}`;
   r.log(`${target.short}: bun add -g ${spec}`);
   const code = await r.runner.run(["bun", "add", "-g", spec]);
   if (code !== 0) {

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -761,6 +761,8 @@ async function resolveRcBestOf(
 
   const latestAbove =
     latestVersion !== null && (compareVersions(latestVersion, beforeVersion) ?? -1) > 0;
+  // (`latestVersion !== null` already guaranteed by `latestAbove`; the second
+  // term only narrows it for TS.)
   if (latestAbove && latestVersion) {
     // End-of-chain / skipped-rc train: nothing newer on @rc, but stable moved
     // ahead. Converge to @latest — pinned to the concrete version so a moving
@@ -793,8 +795,9 @@ async function upgradeNpm(target: ResolvedTarget, sourceDir: string, r: Resolved
   // highest version above installed across @rc AND @latest — so an end-of-chain
   // box converges to stable instead of stranding below it. The stable channel
   // and explicit programmatic `--tag` are UNCHANGED: only an *auto-detected or
-  // --channel-rc* resolution reaches for stable. `r.tag` (programmatic pin) and
-  // an explicit `--channel latest` both leave the rc best-of untouched.
+  // --channel-rc* resolution reaches for stable. An explicit `--channel rc`
+  // ALSO flows through best-of (a deliberate rc operator still gets converge);
+  // `r.tag` (programmatic pin) and `--channel latest` both leave it untouched.
   let installSpec = pickedChannel;
   let channel = pickedChannel;
   if (pickedChannel === "rc" && !r.tag) {


### PR DESCRIPTION
## The bug (live)

`friends.parachute.computer` is installed on the **rc channel** at `0.6.5-rc.8`. `parachute upgrade hub` correctly preserves the rc channel (hub#332) and follows `@rc` — but `@rc` never advanced (three trains since shipped stable-direct, no rc cut), so the box **strands below `@latest` (0.7.1) with no visible path forward**: the upgrade just silently no-ops.

The rc channel is a *canary*. Under the post-#332 governance where trains start at stable, `@rc` only moves when a train actually cuts an rc — so an end-of-chain / skipped-rc box gets stuck below stable.

This is the client-side, token-free mechanical guarantee that backs rc-first governance: rc operators always converge upward to the newest shipped code.

## The fix — best-of resolution

On the **rc channel** (auto-detected from the `-rc` suffix OR explicit `--channel rc`), resolve the target to the **highest version ABOVE installed across BOTH `@rc` and `@latest`** (`npm view <pkg>@rc version` + `@latest version`), then upgrade to that:

- **mid-chain** (a newer rc exists) → take the rc; the canary stays ahead. **UNCHANGED #332 behavior.**
- **end-of-chain / skipped-rc train** (no newer rc, but `@latest` > installed) → **converge to `@latest`**, pinned to the concrete resolved version (so a moving dist-tag can't race the resolution), with a **loud log line**: `the rc channel has nothing newer than X; converging to stable Y — you'll pick up the next rc when it ships`. This is the stranding fix.
- **nothing newer anywhere** → the existing up-to-date no-op (now also names both tags when both resolved ≤ installed).

The operator **stays ON the rc channel** — the install/config notion of channel is unchanged; only which *version* the rc channel resolves to changes. They pick up the next rc automatically when one ships.

**Unchanged surfaces:** the `@latest` (stable) channel path (stable never reaches for `@rc`); explicit programmatic `--tag`; `--channel rc|latest` overrides; `--allow-downgrade`; the downgrade guard (it now checks the version we'll really install). Semver comparison uses the existing `compareVersions` helper — no hand-rolled compare.

The whole change lives in `src/commands/upgrade.ts:upgradeNpm` (+ a new `resolveRcBestOf` helper). No CLI surface change, no HTTP-endpoint change, no version bump.

## Fails-pre-fix evidence

THE #659 pin test — rc channel, `@rc` stuck at installed `0.6.5-rc.8`, `@latest` at `0.7.1`:

- **Pre-fix:** the verb only ever asks for `@rc`, which resolves to the installed rc.8 → no-op. The test asserts `bun add -g @openparachute/hub@0.7.1`; pre-fix it gets `@openparachute/hub@rc` → **FAIL** (verified by stashing the `upgrade.ts` change and running the test).
- **Post-fix:** converges to the concrete `@0.7.1`, emits the loud convergence line, version moves `0.6.5-rc.8 → 0.7.1` → **PASS**.

## Tests added (5)

- rc channel, newer rc exists → takes `@rc` (canary stays ahead)
- **THE #659 pin**: rc channel, no newer rc but `@latest` higher → converges to `@latest` + loud log asserted
- rc channel, `@rc` and `@latest` both ≤ installed → up-to-date no-op (names both)
- latest channel unchanged: stable install never probes `@rc`
- rc converge respects the downgrade guard (a prior-stable `@latest` below installed neither converges nor downgrades)

## Gates

- `bun test ./src` (hub-only canonical): **3397 pass, 1 skip, 0 fail** (was 3392 pre-PR; +5 new tests)
- `bun run typecheck`: clean
- `biome check`: clean on touched files

## Operator note

`friends.parachute.computer` (old hub, pre-fix) needs a **one-time** `parachute upgrade hub --channel latest` to reach a fixed hub. After that the convergence is automatic — once running fixed code, plain `parachute upgrade hub` will best-of-resolve on its own and pick up future rcs when they ship.

Patterns check: touches the `parachute upgrade` channel-resolution behavior (governance rule 2 / RC versioning). Conforms — rc operators stay on the rc channel; this strengthens the channel-preservation contract rather than changing it. Establishes the "rc converges upward to best-of rc/latest" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)