### PR TITLE
fix(serve): wire the WebSocket bridge into the production parachute serve listener

### DIFF
--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -8,11 +8,37 @@ import {
   formatBootstrapTokenBanner,
   formatListeningBanner,
   hubPortConflictMessage,
+  hubServeOptions,
   resolveStartupIssuer,
   seedInitialAdminIfNeeded,
 } from "../commands/serve.ts";
 import { openHubDb } from "../hub-db.ts";
 import { getUserByUsername, userCount } from "../users.ts";
+
+describe("hubServeOptions — the production listener wires the WS bridge", () => {
+  // Regression guard: the WS bridge handler was wired into hub-server.ts's
+  // Bun.serve but NOT this production `parachute serve` path, so module WS
+  // upgrades (the channel in-page terminal) 500'd through the hub
+  // ("set the websocket object in Bun.serve({})"). The listener MUST declare a
+  // websocket handler or `server.upgrade()` throws.
+  const fakeFetch = (() => new Response("ok")) as unknown as Parameters<typeof hubServeOptions>[0]["fetch"];
+
+  test("declares a websocket handler set (open/message/close)", () => {
+    const o = hubServeOptions({ port: 0, hostname: "127.0.0.1", fetch: fakeFetch });
+    expect(o.websocket).toBeDefined();
+    expect(typeof o.websocket.open).toBe("function");
+    expect(typeof o.websocket.message).toBe("function");
+    expect(typeof o.websocket.close).toBe("function");
+  });
+
+  test("preserves the port/hostname/idleTimeout + the passed fetch", () => {
+    const o = hubServeOptions({ port: 1939, hostname: "0.0.0.0", fetch: fakeFetch });
+    expect(o.port).toBe(1939);
+    expect(o.hostname).toBe("0.0.0.0");
+    expect(o.idleTimeout).toBe(255);
+    expect(o.fetch).toBe(fakeFetch);
+  });
+});
 
 describe("hubPortConflictMessage (hub#536)", () => {
   test("maps a port-in-use error to a clear duplicate-supervisor message", () => {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -38,12 +38,42 @@ import { createDbHolder, defaultStatInode, startDbPathLivenessTimer } from "../h
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { hubFetch } from "../hub-server.ts";
 import { writeHubFile } from "../hub.ts";
+import { createWsBridgeHandlers } from "../ws-bridge.ts";
 import { enrichedPath } from "../spawn-path.ts";
 import { Supervisor } from "../supervisor.ts";
 import { createUser, userCount } from "../users.ts";
 import { sanitizePublicOrigin } from "../vault-hub-origin-env.ts";
 import { WELL_KNOWN_DIR } from "../well-known.ts";
 import { bootSupervisedModules } from "./serve-boot.ts";
+
+/**
+ * Build the `Bun.serve` options for the hub listener. Extracted (pure) so the
+ * load-bearing wiring — crucially the `websocket` bridge handler — is unit-
+ * testable and can't silently drift from the other `Bun.serve` in
+ * `hub-server.ts`. That drift is exactly how the in-page-terminal WS upgrade
+ * started 500ing: the bridge was wired into hub-server.ts's serve but NOT this
+ * production `parachute serve` path, so `server.upgrade()` (in `hubFetch`'s
+ * `maybeUpgradeWebSocket`) threw "set the websocket object in Bun.serve({})".
+ */
+export function hubServeOptions(args: {
+  port: number;
+  hostname: string;
+  fetch: ReturnType<typeof hubFetch>;
+}) {
+  return {
+    port: args.port,
+    hostname: args.hostname,
+    // Hold idle keep-alive connections for Bun's maximum 255s so reverse-proxy
+    // edges (Render, Cloudflare, fly.io) don't race us reusing pooled
+    // connections (hub#399).
+    idleTimeout: 255,
+    fetch: args.fetch,
+    // The WebSocket upgrade bridge. `maybeUpgradeWebSocket` (in `hubFetch`) calls
+    // `server.upgrade()`, which THROWS unless the server declares this handler —
+    // so it MUST be present on every Bun.serve that runs `hubFetch`.
+    websocket: createWsBridgeHandlers(),
+  };
+}
 
 export interface ServeOpts {
   /** Override PORT (test-only). Real callers thread env via process.env. */
@@ -456,26 +486,22 @@ export async function serve(opts: ServeOpts = {}): Promise<{
   // fail fast and cleanly, leaving the live hub's children untouched.
   let server: ReturnType<typeof Bun.serve>;
   try {
-    server = Bun.serve({
-      port,
-      hostname,
-      // Hold idle keep-alive connections for Bun's maximum 255s so reverse-
-      // proxy edges (Render, Cloudflare, fly.io) don't race us when reusing
-      // pooled connections. See `src/hub-server.ts` for the full rationale —
-      // this is the active code path for `bun src/cli.ts serve` (the Docker
-      // CMD), so the fix has to land here too. Closes hub#399.
-      idleTimeout: 255,
-      fetch: hubFetch(WELL_KNOWN_DIR, {
-        getDb: () => dbHolder.get(),
-        onDbError: (err) => dbHolder.healOrExit(err),
-        // #610: /health's db check probes the path so monitoring + the #591
-        // adoption probe see a wipe instead of the ghost-fd lie.
-        probeDbPath: () => dbHolder.probePath(),
-        issuer,
-        loopbackPort: port,
-        supervisor,
+    server = Bun.serve(
+      hubServeOptions({
+        port,
+        hostname,
+        fetch: hubFetch(WELL_KNOWN_DIR, {
+          getDb: () => dbHolder.get(),
+          onDbError: (err) => dbHolder.healOrExit(err),
+          // #610: /health's db check probes the path so monitoring + the #591
+          // adoption probe see a wipe instead of the ghost-fd lie.
+          probeDbPath: () => dbHolder.probePath(),
+          issuer,
+          loopbackPort: port,
+          supervisor,
+        }),
       }),
-    });
+    );
   } catch (err) {
     const conflict = hubPortConflictMessage(err, port);
     if (conflict) throw new Error(conflict);


### PR DESCRIPTION
## The bug
Module WebSocket upgrades — the channel **in-page terminal** — 500'd through the hub with:
```
TypeError: To enable websocket support, set the "websocket" object in Bun.serve({})
```
The browser's terminal WS never reached 101 → endless **connecting↔reconnecting**. It worked daemon-direct, which masked it.

## Root cause
The WS bridge handler (`createWsBridgeHandlers()`, #648) was wired into **`hub-server.ts`'s** `Bun.serve` but **not** **`commands/serve.ts`'s** — and `serve.ts` is the **production** listener (`parachute serve`, the launchd/systemd/Docker path). So `server.upgrade()` (in `hubFetch`'s `maybeUpgradeWebSocket`) threw, and the proxied upgrade 500'd. Only the hub-proxied browser path hit it; daemon-direct tests (the channel daemon's own `Bun.serve` has its terminal handler) never did — which is why it took a real-browser test to find.

## Fix
Extract `hubServeOptions()` (pure, exported) that builds the `Bun.serve` config **including** `websocket: createWsBridgeHandlers()`, and have `serve()` use it. The extraction makes the wiring unit-testable and stops it drifting from the other `Bun.serve` again.

## Verification (Playwright, real browser)
Drove real chromium → hub → channel daemon → tmux: the terminal page holds **`● attached`** across 8 samples with **zero reconnect flaps**, xterm renders live pty output. Raw hub WS upgrade now returns **101** (was 500).

## Tests
`serve.test.ts`: `hubServeOptions` wires the websocket handler set + preserves port/hostname/idleTimeout/fetch. Hub suite **3400 pass, 0 fail**; typecheck clean.

Note: this is already live on the local box (bun-linked + hub restarted) to unblock terminal testing; this PR is the formal record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)