### PR TITLE
fix(oauth): expand hub-served DCR redirect_uris across all known hub origins (surface#118)

### DIFF
--- a/src/__tests__/clients.test.ts
+++ b/src/__tests__/clients.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   InvalidRedirectUriError,
   approveClient,
+  expandRedirectUrisForHubOrigins,
   getClient,
   isValidRedirectUri,
   listClientsByStatus,
@@ -138,6 +139,96 @@ describe("requireRegisteredRedirectUri", () => {
       expect(() => requireRegisteredRedirectUri(r.client, "https://evil.com/cb")).toThrow(
         InvalidRedirectUriError,
       );
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("expandRedirectUrisForHubOrigins (surface#118 cross-hub-origin DCR expansion)", () => {
+  const LOOPBACK = "http://127.0.0.1:1939";
+  const PUBLIC = "https://box.taildf9ce2.ts.net";
+  const hubOrigins = [LOOPBACK, "http://localhost:1939", PUBLIC];
+
+  test("expands a loopback-rooted URI onto every other hub origin", () => {
+    const out = expandRedirectUrisForHubOrigins([`${LOOPBACK}/surface/notes/oauth/callback`], hubOrigins);
+    // Original is preserved + the public + localhost variants are added.
+    expect(out).toContain(`${LOOPBACK}/surface/notes/oauth/callback`);
+    expect(out).toContain(`${PUBLIC}/surface/notes/oauth/callback`);
+    expect(out).toContain("http://localhost:1939/surface/notes/oauth/callback");
+    // The submitted URI comes first (order-preserving).
+    expect(out[0]).toBe(`${LOOPBACK}/surface/notes/oauth/callback`);
+  });
+
+  test("INVARIANT: a foreign-origin URI is stored verbatim — not expanded, not dropped", () => {
+    const foreign = "https://my-vault-ui.example/oauth/callback";
+    const out = expandRedirectUrisForHubOrigins([foreign], hubOrigins);
+    // Stored exactly as submitted...
+    expect(out).toContain(foreign);
+    // ...and NOTHING was minted on any hub origin from it (no open redirect).
+    expect(out).toEqual([foreign]);
+    for (const o of hubOrigins) {
+      expect(out).not.toContain(`${o}/oauth/callback`);
+    }
+  });
+
+  test("mixed submit: hub-origin URI expands, foreign URI rides verbatim alongside", () => {
+    const foreign = "https://evil.example/cb";
+    const out = expandRedirectUrisForHubOrigins(
+      [`${LOOPBACK}/surface/notes/`, foreign],
+      hubOrigins,
+    );
+    // Hub-origin URI fanned out to the public origin.
+    expect(out).toContain(`${PUBLIC}/surface/notes/`);
+    // Foreign URI present, but no hub-origin variant of it exists.
+    expect(out).toContain(foreign);
+    for (const o of hubOrigins) {
+      expect(out).not.toContain(`${o}/cb`);
+    }
+  });
+
+  test("single known hub origin → no expansion (submitted set returned as-is)", () => {
+    const out = expandRedirectUrisForHubOrigins(
+      [`${LOOPBACK}/surface/notes/`],
+      [LOOPBACK],
+    );
+    expect(out).toEqual([`${LOOPBACK}/surface/notes/`]);
+  });
+
+  test("dedupes — already-public + loopback submit doesn't double-register", () => {
+    const out = expandRedirectUrisForHubOrigins(
+      [`${LOOPBACK}/surface/notes/`, `${PUBLIC}/surface/notes/`],
+      hubOrigins,
+    );
+    const publicCount = out.filter((u) => u === `${PUBLIC}/surface/notes/`).length;
+    expect(publicCount).toBe(1);
+  });
+
+  test("path + query + hash are preserved across origins", () => {
+    const out = expandRedirectUrisForHubOrigins(
+      [`${LOOPBACK}/surface/notes/oauth-callback?foo=bar`],
+      hubOrigins,
+    );
+    expect(out).toContain(`${PUBLIC}/surface/notes/oauth-callback?foo=bar`);
+  });
+
+  test("expanded URIs survive registerClient → requireRegisteredRedirectUri strict match", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const expanded = expandRedirectUrisForHubOrigins(
+        [`${LOOPBACK}/surface/notes/oauth/callback`],
+        hubOrigins,
+      );
+      const r = registerClient(db, { redirectUris: expanded });
+      // The public-origin variant now matches exactly at authorize time — the
+      // off-localhost sign-in that surface#118 broke.
+      expect(
+        requireRegisteredRedirectUri(r.client, `${PUBLIC}/surface/notes/oauth/callback`),
+      ).toBe(`${PUBLIC}/surface/notes/oauth/callback`);
+      // A truly-unregistered URI is still rejected — strict match unchanged.
+      expect(() =>
+        requireRegisteredRedirectUri(r.client, "https://evil.example/surface/notes/oauth/callback"),
+      ).toThrow(InvalidRedirectUriError);
     } finally {
       cleanup();
     }

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -3279,6 +3279,103 @@ describe("handleRegister — RFC 7591 DCR", () => {
   });
 });
 
+// surface#118 — a hub-served module (surface, notes) registers at install time
+// knowing only the loopback hub origin; once exposed, the browser computes its
+// redirect_uri from the PUBLIC hub origin, which strict authorize-time matching
+// would reject. handleRegister expands hub-origin-rooted redirect_uris onto
+// every known hub origin (via deps.hubBoundOrigins). Foreign-origin URIs stay
+// verbatim — never expanded onto hub origins, never dropped (open-redirect
+// guard). Authorize-time matching is unchanged (strict exact-match).
+describe("handleRegister — cross-hub-origin redirect_uri expansion (surface#118)", () => {
+  const PUBLIC = "https://box.taildf9ce2.ts.net";
+  const LOOPBACK = "http://127.0.0.1:1939";
+  const boundOrigins = () => [ISSUER, LOOPBACK, "http://localhost:1939", PUBLIC];
+
+  test("loopback-rooted URI is stored WITH the public-origin variant", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const req = new Request(`${ISSUER}/oauth/register`, {
+        method: "POST",
+        body: JSON.stringify({
+          redirect_uris: [`${LOOPBACK}/surface/notes/oauth/callback`],
+          scope: "vault:default:read",
+          client_name: "Notes",
+        }),
+        headers: { "content-type": "application/json" },
+      });
+      const res = await handleRegister(db, req, {
+        issuer: ISSUER,
+        hubBoundOrigins: boundOrigins,
+      });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as Record<string, unknown>;
+      const stored = body.redirect_uris as string[];
+      // The submitted loopback URI is preserved...
+      expect(stored).toContain(`${LOOPBACK}/surface/notes/oauth/callback`);
+      // ...and the public-origin variant is now registered — the fix.
+      expect(stored).toContain(`${PUBLIC}/surface/notes/oauth/callback`);
+
+      // The stored set drives authorize-time matching; confirm the public
+      // variant now matches via the real client record.
+      const stored2 = getClient(db, body.client_id as string);
+      expect(stored2?.redirectUris).toContain(`${PUBLIC}/surface/notes/oauth/callback`);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("INVARIANT: a foreign-origin redirect_uri is stored verbatim, NOT expanded onto hub origins", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const foreign = "https://my-vault-ui.example/oauth/callback";
+      const req = new Request(`${ISSUER}/oauth/register`, {
+        method: "POST",
+        body: JSON.stringify({
+          redirect_uris: [foreign],
+          scope: "vault:default:read",
+          client_name: "Off-origin surface",
+        }),
+        headers: { "content-type": "application/json" },
+      });
+      const res = await handleRegister(db, req, {
+        issuer: ISSUER,
+        hubBoundOrigins: boundOrigins,
+      });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as Record<string, unknown>;
+      const stored = body.redirect_uris as string[];
+      // Stored exactly as submitted — never dropped.
+      expect(stored).toEqual([foreign]);
+      // No hub-origin variant was minted from the foreign URI (open-redirect guard).
+      for (const o of [ISSUER, LOOPBACK, "http://localhost:1939", PUBLIC]) {
+        expect(stored).not.toContain(`${o}/oauth/callback`);
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("no expansion when only one hub origin is known (single-origin hub unaffected)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const req = new Request(`${ISSUER}/oauth/register`, {
+        method: "POST",
+        body: JSON.stringify({
+          redirect_uris: [`${ISSUER}/surface/notes/oauth/callback`],
+        }),
+        headers: { "content-type": "application/json" },
+      });
+      // hubBoundOrigins absent → resolveBoundOrigins falls back to [issuer].
+      const res = await handleRegister(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.redirect_uris).toEqual([`${ISSUER}/surface/notes/oauth/callback`]);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
 // closes #74 — DCR is now operator-gated. Self-served registrations land as
 // pending and cannot OAuth; operator-bearer (hub:admin) registrations land
 // as approved and can OAuth immediately. This block covers all four exposed

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -215,6 +215,94 @@ export function requireRegisteredRedirectUri(client: OAuthClient, candidate: str
   return candidate;
 }
 
+/**
+ * Cross-hub-origin redirect_uri expansion for hub-served DCR clients
+ * (surface#118; the "hub assist" half of the fix).
+ *
+ * THE PROBLEM. A hub-served module (surface-host, notes) registers its OAuth
+ * client at install time, when the only origin it knows is the loopback hub
+ * URL (`http://127.0.0.1:1939`). Once the operator runs `parachute expose`,
+ * the browser loads the surface from the PUBLIC hub origin and the
+ * surface-client runtime computes its `redirect_uri` from `window.location.
+ * origin` (the public one) — which was never registered. Authorize-time
+ * matching is deliberately strict exact-match (`requireRegisteredRedirectUri`,
+ * RFC 8252 anti-open-redirect), so the public-origin redirect_uri is rejected
+ * ("Redirect mismatch") and no off-localhost user can sign in.
+ *
+ * THE FIX. At DCR time, for each submitted redirect_uri WHOSE ORIGIN IS ONE
+ * OF THE HUB'S OWN KNOWN ORIGINS (issuer, expose-state hubOrigin, platform
+ * origin, loopback aliases — i.e. the same set `buildHubBoundOrigins`
+ * produces), ALSO register the same PATH on every OTHER known hub origin. A
+ * loopback-registered hub-served client thus becomes valid on the public hub
+ * origin too, without ever loosening the strict authorize-time match.
+ *
+ * THE INVARIANT (no open redirect). Expansion ONLY ever produces URIs rooted
+ * at the hub's OWN known origins. A submitted redirect_uri whose origin is
+ * FOREIGN — a separate-origin surface on its own domain (e.g. my-vault-ui at
+ * `https://notes.example`), a third-party app — is stored VERBATIM: not
+ * expanded onto any hub origin, and not dropped. Only hub-origin-rooted URIs
+ * receive the cross-origin fan-out. Because authorize-time matching stays
+ * strict exact-match against this stored set, an attacker who registers a
+ * foreign redirect_uri gets back exactly what they submitted (no hub-origin
+ * variant minted for them), and a hub-origin-rooted URI only ever fans out to
+ * other hub origins the operator already controls.
+ *
+ * Order-preserving + de-duplicated: the originally-submitted URIs come first
+ * (preserving caller order), with the synthesized hub-origin variants
+ * appended in a stable order; duplicates are collapsed.
+ */
+export function expandRedirectUrisForHubOrigins(
+  submitted: readonly string[],
+  hubOrigins: readonly string[],
+): string[] {
+  // Parse the hub's known origins into a Set for membership tests. Malformed
+  // entries are skipped — the function fails safe (no expansion) rather than
+  // throwing.
+  const hubOriginSet = new Set<string>();
+  for (const raw of hubOrigins) {
+    try {
+      hubOriginSet.add(new URL(raw).origin);
+    } catch {
+      // Skip malformed hub origin.
+    }
+  }
+
+  // Preserve submitted order + dedupe; append synthesized variants after.
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const push = (uri: string) => {
+    if (seen.has(uri)) return;
+    seen.add(uri);
+    out.push(uri);
+  };
+
+  // 1) Every submitted URI is stored as-is (foreign + hub-origin alike). This
+  //    is what guarantees a foreign redirect_uri is never dropped.
+  for (const uri of submitted) push(uri);
+
+  // 2) For each submitted URI rooted at a hub origin, synthesize the same path
+  //    on every OTHER hub origin. Foreign-origin URIs are skipped here — they
+  //    never spawn a hub-origin variant (the open-redirect guard).
+  if (hubOriginSet.size > 1) {
+    for (const uri of submitted) {
+      let parsed: URL;
+      try {
+        parsed = new URL(uri);
+      } catch {
+        continue;
+      }
+      if (!hubOriginSet.has(parsed.origin)) continue; // foreign → no expansion
+      const pathSuffix = `${parsed.pathname}${parsed.search}${parsed.hash}`;
+      for (const origin of hubOriginSet) {
+        if (origin === parsed.origin) continue;
+        push(`${origin}${pathSuffix}`);
+      }
+    }
+  }
+
+  return out;
+}
+
 export function verifyClientSecret(client: OAuthClient, presented: string): boolean {
   if (!client.clientSecretHash) return false;
   const presentedHash = createHash("sha256").update(presented).digest("hex");

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -38,6 +38,7 @@ import {
   type OAuthClient,
   type RegisteredClient,
   approveClient,
+  expandRedirectUrisForHubOrigins,
   getClient,
   isValidRedirectUri,
   registerClient,
@@ -2546,10 +2547,26 @@ export async function handleRegister(
   }
   const confidential = body.token_endpoint_auth_method === "client_secret_post";
   const scopes = (body.scope ?? "").split(" ").filter((s) => s.length > 0);
+  // Cross-hub-origin expansion (surface#118). A hub-served module (surface,
+  // notes) registers at install time knowing only the loopback hub origin;
+  // once exposed, the browser computes its redirect_uri from the PUBLIC hub
+  // origin, which strict authorize-time matching would reject. We expand each
+  // submitted URI rooted at one of THIS hub's known origins onto every other
+  // known hub origin, so a loopback-registered hub-served client is valid on
+  // the public origin too. FOREIGN-origin redirect_uris (a separate-origin
+  // surface on its own domain) are stored verbatim — never expanded onto hub
+  // origins, never dropped — preserving the strict anti-open-redirect
+  // invariant. Authorize-time matching stays exact-match
+  // (`requireRegisteredRedirectUri`); this only ever ADDS correct hub-origin
+  // URIs the operator already controls.
+  const expandedRedirectUris = expandRedirectUrisForHubOrigins(
+    redirectUris,
+    resolveBoundOrigins(deps),
+  );
   let registered: RegisteredClient;
   try {
     registered = registerClient(db, {
-      redirectUris,
+      redirectUris: expandedRedirectUris,
       scopes,
       clientName: body.client_name,
       confidential,


### PR DESCRIPTION
The hub-assist half of the launch-critical sign-in blocker **surface#118** — the centralized, load-bearing fix (fixes surface + Notes + every hub-served DCR client at once).

## Problem
A hub-served module (surface, notes) registers its OAuth client at install time knowing only the loopback hub origin (`http://127.0.0.1:1939`). Once the operator runs `parachute expose`, the browser loads the surface from the PUBLIC hub origin and surface-client computes its `redirect_uri` from `window.location.origin` (the public one) — which was never registered. Authorize-time matching is strict exact-match (`requireRegisteredRedirectUri`, RFC 8252 anti-open-redirect), so the public-origin `redirect_uri` is rejected ("Redirect mismatch") and no off-localhost user can sign in.

## Fix
At DCR time (`handleRegister`), for each submitted `redirect_uri` whose origin is one of **THIS hub's own known origins** (issuer, expose-state `hubOrigin`, platform origin, loopback aliases — the `buildHubBoundOrigins` set, threaded via `deps.hubBoundOrigins`), also register the same PATH on every other known hub origin. A loopback-registered hub-served client thus becomes valid on the public hub origin too — **without loosening the strict authorize-time match** (`requireRegisteredRedirectUri` is untouched).

- `clients.ts`: new `expandRedirectUrisForHubOrigins` (pure, order-preserving, deduped).
- `oauth-handlers.ts` `handleRegister`: expand via `resolveBoundOrigins(deps)` before `registerClient`. Single-origin hubs (deps without `hubBoundOrigins` → `[issuer]`) are unaffected (no expansion) — all existing DCR tests pass unchanged.

## No-open-redirect invariant (the security crux)
Expansion **only ever produces URIs rooted at the hub's own known origins**. A submitted `redirect_uri` whose origin is **FOREIGN** (a separate-origin surface like my-vault-ui on its own domain, a third-party app) is stored **verbatim — never expanded onto a hub origin, never dropped**. Only hub-origin-rooted URIs receive the cross-origin fan-out. Authorize-time matching stays strict exact-match, so an attacker registering a foreign `redirect_uri` gets back exactly what they submitted (no hub-origin variant minted for them).

Proof in tests:
- `clients.test.ts` › *INVARIANT: a foreign-origin URI is stored verbatim — not expanded, not dropped* (`expandRedirectUrisForHubOrigins([foreign], hubOrigins)` === `[foreign]`).
- `oauth-handlers.test.ts` › *INVARIANT: a foreign-origin redirect_uri is stored verbatim, NOT expanded onto hub origins* (end-to-end through `handleRegister` → `getClient`).
- `requireRegisteredRedirectUri` strict-match tests unchanged + a new test confirms an expanded public-origin URI matches while a truly-unregistered one still throws.

## Tests
- **hub: 3409 pass / 0 fail; typecheck clean.**

## Pairs with
ParachuteComputer/parachute-surface#122 (surface-side multi-origin registration + boot self-heal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)