### PR TITLE
fix(login): friendly finish-setup page on a no-admin box instead of JSON 503 (closes #644)

### DIFF
--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -1576,8 +1576,10 @@ describe("hubFetch routing", () => {
   });
 
   // Pre-admin lockout (hub#258). When no admin row exists, operator-
-  // facing surfaces (admin/api/login) 503 with a JSON body pointing at
-  // /admin/setup. Public surfaces (health, well-known, /, oauth, vault,
+  // facing API surfaces (admin/api) 503 with a JSON body pointing at
+  // /admin/setup. The browser-facing `/login` GET 302s to the wizard
+  // instead (hub#644) — a JSON 503 there would render as raw text in the
+  // visitor's tab. Public surfaces (health, well-known, /, oauth, vault,
   // /admin/setup itself) stay open so the container is reachable and
   // OAuth third parties aren't held hostage by admin onboarding.
   test("pre-admin lockout: /admin/vaults returns 503 setup_required", async () => {
@@ -1615,7 +1617,7 @@ describe("hubFetch routing", () => {
     }
   });
 
-  test("pre-admin lockout: /login is gated, /admin/setup + /health + well-known stay open, / funnels to /admin/setup", async () => {
+  test("pre-admin lockout: /login GET funnels to /admin/setup, /admin/setup + /health + well-known stay open, / funnels to /admin/setup", async () => {
     const h = makeHarness();
     try {
       writeFileSync(join(h.dir, "hub.html"), "<html>discovery</html>");
@@ -1623,9 +1625,11 @@ describe("hubFetch routing", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         const handler = hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath });
-        // /login gated
+        // /login GET funnels to the wizard (hub#644) — the browser-facing
+        // sign-in surface 302s to /admin/setup instead of a raw JSON 503.
         const loginRes = await handler(req("/login"));
-        expect(loginRes.status).toBe(503);
+        expect(loginRes.status).toBe(302);
+        expect(loginRes.headers.get("location")).toBe("/admin/setup");
         // /admin/setup open
         const setupRes = await handler(req("/admin/setup"));
         expect(setupRes.status).toBe(200);

--- a/src/__tests__/setup-gate.test.ts
+++ b/src/__tests__/setup-gate.test.ts
@@ -4,8 +4,15 @@
  * with `{error: "setup_required", setup_url: "/admin/setup"}` so
  * callers can branch on the shape rather than scrape an HTML page.
  *
- * Gated routes (require an admin to be useful): `/login`, `/logout`,
- * `/admin/*` (except `/admin/setup`), `/api/*`.
+ * Exception (hub#644): the browser-facing `/login` GET is a server-
+ * rendered HTML surface (the sign-in form), so on a no-admin box it
+ * 302s to `/admin/setup` rather than emitting a raw JSON 503 the
+ * browser would render as text. A `/login` POST still 503s (no account
+ * to authenticate — the right shape for a stray non-browser caller).
+ *
+ * Gated routes (require an admin to be useful): `/login` (GET → 302
+ * wizard; POST → 503), `/logout`, `/admin/*` (except `/admin/setup`),
+ * `/api/*`.
  *
  * Routes that pass through (platform health, public discovery, OAuth
  * third-party flows, content proxies, the setup page itself):
@@ -70,10 +77,33 @@ describe("setup gate (no admin yet)", () => {
     }
   });
 
-  test("503s /login when no admin exists", async () => {
+  // hub#644: `/login` GET is a browser-facing HTML surface (the sign-in
+  // form). On a no-admin box a JSON 503 would render as raw text in the
+  // visitor's tab — exactly what a visitor sees after clicking the "Sign in"
+  // banner on an open module surface. Funnel the GET to the wizard instead,
+  // mirroring the `/` + `/hub.html` redirect.
+  test("/login GET 302s to /admin/setup when no admin exists (hub#644)", async () => {
     const db = openHubDb(hubDbPath(h.dir));
     try {
       const res = await hubFetch(h.dir, { getDb: () => db })(req("/login"));
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/admin/setup");
+      // Never a JSON body on the HTML sign-in surface.
+      expect(res.headers.get("content-type") ?? "").not.toContain("application/json");
+    } finally {
+      db.close();
+    }
+  });
+
+  // A POST to `/login` pre-admin has no account to authenticate, so it falls
+  // through to the JSON-503 gate — the right shape for a stray non-browser
+  // caller. Only the browser GET is funneled to the wizard.
+  test("/login POST still 503s setup_required when no admin exists (hub#644)", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const res = await hubFetch(h.dir, { getDb: () => db })(
+        req("/login", { method: "POST" }),
+      );
       expect(res.status).toBe(503);
       const body = (await res.json()) as Record<string, unknown>;
       expect(body.error).toBe("setup_required");
@@ -194,6 +224,25 @@ describe("setup gate (admin exists)", () => {
         req("/oauth/token", { method: "GET" }),
       );
       expect(res.status).toBe(405);
+    } finally {
+      db.close();
+    }
+  });
+
+  // hub#644 guard: the no-admin `/login` funnel must NOT fire once an admin
+  // exists — the normal server-rendered sign-in form takes over so operators
+  // (and invited members) can actually sign in.
+  test("/login GET renders the sign-in form (not the setup funnel) once an admin exists (hub#644)", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      await createUser(db, "owner", "pw");
+      const res = await hubFetch(h.dir, { getDb: () => db })(req("/login"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
+      const html = await res.text();
+      // The actual sign-in form, posting back to /login.
+      expect(html).toContain('action="/login"');
+      expect(html).toContain('name="password"');
     } finally {
       db.close();
     }

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -2332,6 +2332,16 @@ export function hubFetch(
       // (env-seed deploys). Only GET is funneled — a POST to `/login`
       // pre-admin has no account to authenticate and falls through to the
       // JSON-503 gate, the right shape for a stray non-browser caller.
+      //
+      // The `?next=<surface>` param is intentionally dropped: there's no
+      // account yet to return the visitor to, and the open surface they came
+      // from likely can't function until setup completes. They land on the
+      // wizard, not back on that surface.
+      //
+      // `cache-control: no-store` (the `/` + `/hub.html` funnel above omits
+      // it) — this 302 reflects transient pre-setup state that flips the
+      // moment an admin is created, so it must never be cached by a CDN or
+      // bfcache and serve a stale "go finish setup" to a now-set-up hub.
       if (getDb && pathname === "/login" && req.method === "GET" && userCount(getDb()) === 0) {
         return new Response(null, {
           status: 302,

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -2314,6 +2314,31 @@ export function hubFetch(
         }
       }
 
+      // Fresh-hub `/login` funnel (hub#644). `/login` is a browser-facing,
+      // server-rendered HTML surface (the sign-in form) — but on a no-admin
+      // box there is no account to sign in as, so the JSON-503 gate below
+      // would render as raw `{"error":"setup_required",...}` text in the
+      // visitor's tab. This is exactly the path a visitor takes when they
+      // load an open module surface (e.g. /vault/admin/) and click its
+      // "Sign in" banner, which links to `/login?next=<surface>`. Funnel the
+      // GET to the wizard instead, mirroring the `/` + `/hub.html` redirect
+      // above (same shape, same justification: never emit a JSON body on an
+      // HTML surface). 302 (not 301) so it disappears the moment setup
+      // completes and the real sign-in form takes over.
+      //
+      // Scoped to `userCount === 0` (the true no-admin state), NOT the
+      // broader `needsWizard`: once an admin exists, that operator must be
+      // able to reach the sign-in form even if no vault is installed yet
+      // (env-seed deploys). Only GET is funneled — a POST to `/login`
+      // pre-admin has no account to authenticate and falls through to the
+      // JSON-503 gate, the right shape for a stray non-browser caller.
+      if (getDb && pathname === "/login" && req.method === "GET" && userCount(getDb()) === 0) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "/admin/setup", "cache-control": "no-store" },
+        });
+      }
+
       // Pre-admin lockout. When the hub has booted with no admin row (the
       // fresh-container case before PARACHUTE_INITIAL_ADMIN_* is set or
       // /admin/setup is walked), every operator-facing surface that requires


### PR DESCRIPTION
## Problem (hub#644, p0 launch-readiness)

On a fresh box with no admin user yet, a visitor who loads an open module surface (e.g. `/vault/admin/`) and clicks its **Sign in** banner lands on `/login?next=<surface>`. `/login` is gated by the pre-admin setup lockout (`shouldGateForSetup("/login") === true` + `userCount === 0`), which returned a raw **JSON 503 `setup_required`** — rendered as literal `{"error":"setup_required",...}` text in the visitor's browser tab instead of guiding them to finish setup.

## Fix — 302 to the wizard (not a new HTML page)

`/login` is a browser-facing, server-rendered HTML surface (the sign-in form, per the hub's own architecture table). On a no-admin box the GET now **302s to `/admin/setup`** (the setup wizard), mirroring the existing `/` + `/hub.html` fresh-hub funnel a few lines above — same shape, same justification: *never emit a JSON body on an HTML surface*. The wizard's GET (`deriveWizardState`) resumes at the right step.

**Why 302 over a bespoke HTML page:** the issue offers either; the 302 reuses the exact precedent already in `hub-server.ts` for `/` and `/hub.html`, funnels straight into the live wizard (no second "finish setup" page to maintain or drift), and is the minimal change. The visitor lands on the actual onboarding flow rather than a static link page.

### Scope / safety
- **Scoped to `userCount === 0`** (true no-admin), NOT the broader `needsWizard` — once an admin exists, that operator must still reach the sign-in form even if no vault is installed yet (env-seed deploys). The normal admin-exists `/login` form path is unchanged.
- **GET only.** A POST to `/login` pre-admin has no account to authenticate, so it still falls through to the JSON-503 gate — the right shape for a stray non-browser caller.
- **No JSON consumer of `/login` exists** to preserve: every SPA reference is a browser navigation (`<a href>` / `window.location.replace`), never a `fetch` that parses a body — verified across `web/ui/src`. No `Accept`-based content negotiation needed.
- Auth logic untouched — this only changes the unauthenticated pre-setup empty-state response.

## Tests
In `src/__tests__/setup-gate.test.ts` + `src/__tests__/hub-server.test.ts`:
- `/login` GET 302s to `/admin/setup` with no admin (replaces the old "503s /login" assertion in both files), and carries no JSON content-type.
- `/login` POST still 503s `setup_required` with no admin.
- `/login` GET renders the real sign-in form (`action="/login"`, password field) once an admin exists.

**Gate:** `bun test ./src` → **3411 pass, 1 skip, 0 fail** (hub-only). `bun run typecheck` → clean (no new errors).

closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)