### PR TITLE
feat(hub): optional idle screen-lock PIN for the admin UI

### DIFF
--- a/design/2026-06-17-admin-ui-lock.md
+++ b/design/2026-06-17-admin-ui-lock.md
@@ -1,0 +1,168 @@
+# Optional idle screen-lock PIN for the hub admin UI
+
+**Status:** implemented · **Date:** 2026-06-17 · **Scope:** `@openparachute/hub`
+
+A phone-style screen lock for the hub admin UI: an **optional** operator PIN
+that locks the **whole** admin surface, **auto-locks after idle** (and on a
+fresh load), and unlocks with the PIN into a frictionless working window that
+activity keeps alive. Off by default — absent PIN = today's behavior, exactly.
+
+This is the **hub-layer realization of channel issue #80** (step-up /
+protection for a sensitive surface). Surfaces (notes-ui, my-vault-ui, etc.) can
+add their own PIN independently; this guards the hub's own admin portal.
+
+## Threat model — what this guards, and what it deliberately doesn't
+
+The hub admin UI is reachable remotely once `parachute expose` is up (Tailscale
+/ Cloudflare). The password-login session cookie lasts 24h, so an **unattended
+or grabbed browser session is a standing admin console** — vault provisioning,
+token minting, user management, module config, all one click away. That is the
+risk this closes: a left-logged-in or shoulder-surfed remote admin session.
+
+**Honest limit — this is a web/UI-layer guard for the EXPOSED portal.** It does
+**NOT** protect against someone with a **shell** on the box. A shell user reads
+`~/.parachute/operator.token` or the vault DB directly and bypasses the hub
+entirely. That's an OS concern: disk encryption, a locked OS screen, SSH-key
+hygiene. The lock shuts the **portal** door — the one the internet can reach —
+which is the point. We state this in the Settings UI copy too, so operators
+don't mistake it for at-rest protection.
+
+## The single chokepoint (why the lock cascades for free)
+
+The admin SPA and **every** module config UI obtain their working Bearer from
+one of four cookie-gated mint endpoints, all sharing the identical
+`parseSessionCookie → findSession → [isFirstAdmin] → signAccessToken` shape:
+
+| Endpoint | Bearer for |
+|---|---|
+| `GET /admin/host-admin-token` | the admin SPA itself (`parachute:host:admin/auth`) |
+| `GET /admin/channel-token` | channel chat + config UIs |
+| `GET /admin/vault-admin-token/<name>` | per-vault admin SPA (`vault:<name>:admin`) |
+| `GET /admin/module-token/<short>` | generic module config UI (`<short>:admin`) |
+
+Inserting **one gate** — `admin-lock.ts:requireUnlocked(db, sessionId)` — into
+each handler makes the lock cascade to the **entire admin surface with no
+per-module changes**. When the session is locked, every mint returns **`423
+Locked`**; the SPA shows the lock screen, and every module admin API fails
+closed (no Bearer). This is why a single lock over the whole surface is both
+simpler AND safer than per-action gating — per-action would friction-up
+configuration, which is exactly the dangerous stuff we most want behind one
+gate.
+
+## CRITICAL boundary — the OAuth issuer is untouched
+
+The lock gates **only** the admin-token mint path. It must NOT — and does not —
+affect the OAuth flow for third-party clients (surfaces, claude.ai connectors,
+etc.). `/oauth/authorize`, `/oauth/token`, `/oauth/register`, `/oauth/revoke`,
+`/.well-known/*`, JWKS, the services catalog, and all third-party token
+issuance work **unchanged while the admin UI is locked**. A surface OAuth'ing
+in never hits a `/admin/*-token` endpoint, so it never sees the lock.
+
+Proof: `src/__tests__/admin-lock.test.ts` →
+*"a third-party client completes authorize→token while the admin session is
+locked"* sets a PIN, asserts `GET /admin/host-admin-token` returns 423, then
+runs a full PKCE `authorize → token` flow that succeeds and yields a valid
+`vault:default:read` JWT.
+
+### Also untouched: friend `/account/*` surfaces
+
+The lock is the **first admin's** screen lock for the **admin console**, keyed
+per-session. The four gated mints are all `isFirstAdmin`-gated, so the lock only
+ever affects the admin's own session. The assigned-user (friend) path —
+`POST /account/vault-admin-token/<name>` and `/account/vault-token/<name>` — is
+a different principal on the `/account/*` home and is **not** gated: the admin's
+idle lock must not lock another user out of their own assigned vault (they never
+set that PIN). Intentional scoping, not an oversight.
+
+## Unlock state — per-session, in-memory, "unlocked-until"
+
+The simplest workable model (chosen over a client-held unlock token — no signing
+/ replay surface to manage, and a hub restart naturally re-locks):
+
+- A successful PIN unlock records `unlockedUntil = now + idle` for the session
+  id (the cookie value) in a **process-local Map** (`src/admin-lock.ts`).
+- A session is **unlocked** iff a future `unlockedUntil` exists. Genuine **user
+  activity** — the SPA's debounced `/heartbeat`, fired on pointer/key/scroll —
+  **slides** the window forward by the idle interval. Token mints are a pure
+  check and do **not** slide it: the SPA polls some endpoints in the background
+  (e.g. the version badge every 30s), each re-minting a Bearer, so an
+  extend-on-mint window would never let an idle-but-open tab lock. The heartbeat
+  is the one signal that means "a human is here."
+- **Locked** when: no PIN set (feature off — always allowed); PIN set + no
+  unlock recorded (fresh load / first visit); PIN set + the window is in the
+  past (idle-expired); a hub restart wiped the Map (re-lock — a feature).
+- The unlock state is **never persisted** and **never in the cookie**. A stolen
+  cookie alone can't carry an unlocked window; the attacker still needs the PIN.
+
+Default idle window: **15 minutes** (operator-configurable 1 min – 24 h, clamped).
+
+## PIN storage
+
+- **argon2id** hash (`@node-rs/argon2` — the same family the hub already uses
+  for passwords + TOTP backup codes), stored in `hub_settings` under
+  `admin_lock_pin_hash`. **Never plaintext, never in the session/cookie.** The
+  hash sits at the same operator-local trust boundary as the password hashes +
+  signing keys already in `hub.db`.
+- **Absent row = feature OFF = today's behavior exactly.** No lock, nothing
+  changes. No DB migration needed — `hub_settings` is a generic KV table; the
+  feature only adds two keys (`admin_lock_pin_hash`, `admin_lock_idle_seconds`).
+- PIN format: 4–12 digits (a phone-lock affordance). The real defense is the
+  idle window + a brute-force limiter, not PIN entropy — the session is already
+  password-authenticated; this is a second, idle-bounded, convenience-grade gate.
+
+## Set / change / remove (the chicken-and-egg)
+
+All under `/api/admin-lock*`, session-cookie-gated to the **first admin**
+(same audience as the token mints) + CSRF-belted (double-submit `__csrf` token
+**and** the same-origin Origin belt the `/admin/connections` mutations use).
+These manage the lock itself, so they are **not** behind the lock gate — you
+must be able to unlock + set the PIN even when the surface is locked.
+
+| Route (POST unless noted) | Behavior |
+|---|---|
+| `GET /api/admin-lock` | status: `{ configured, locked, idle_seconds, unlock_seconds_remaining }` |
+| `/set` | set the **first** PIN — allowed when none configured; `409` if one exists |
+| `/change` | rotate PIN — requires the **current PIN** OR an already-unlocked session |
+| `/remove` | turn the feature **off** — same authorization as `/change` |
+| `/unlock` | verify PIN → open an unlock window (brute-force limited) |
+| `/lock` | "Lock now" — drop this session's unlock window |
+| `/heartbeat` | slide the idle window forward on activity (no-op if locked) |
+
+Setting the first PIN is the authenticated-admin path (logged in, no PIN yet).
+Change/remove require proving the current PIN OR an unlocked session (the
+operator just unlocked, so they hold it — re-typing is friction). Unlock + the
+current-PIN path on change/remove run through a **5-attempts / 5-min** per-session
+limiter (keyed by session id, same posture as `/account/change-password`) BEFORE
+the argon2id verify, so a stolen cookie can't grind PINs unbounded.
+
+## Idle-lock UX (client side)
+
+`web/ui/src/lib/useAdminLock.ts` + `web/ui/src/components/LockScreen.tsx`:
+
+- On mount (when signed in) fetch lock status; a fresh load with a PIN set + no
+  unlock window = locked → render `LockScreen` **instead of** the admin shell
+  (one lock over everything).
+- A local idle timer (the server's idle interval) flips to locked on expiry —
+  promptly, instead of waiting for the next failed API call. Activity
+  (pointer / key / scroll) re-arms it and debounces a `/heartbeat` that slides
+  the server window forward. Re-check on tab refocus.
+- **"Lock now"** button in the nav (shown only when a PIN is configured).
+- The lock screen is a single PIN field → Unlock. On the `423` reality the
+  server enforces, the SPA also drops its cached host-admin Bearer so a clean
+  re-mint (and a clean lock screen) happens rather than riding a stale token.
+
+## Files
+
+- `src/admin-lock.ts` — PIN hash storage, in-memory unlock state, the
+  `requireUnlocked` gate, the unlock limiter.
+- `src/api-admin-lock.ts` — the `/api/admin-lock*` management router.
+- `src/admin-{host-admin,channel,vault-admin,module}-token.ts` — the gate
+  inserted into all four mint chokepoints.
+- `src/hub-server.ts` — route wiring + CSRF belt.
+- `src/hub-settings.ts` — the two new KV keys.
+- `web/ui/src/components/LockScreen.tsx`, `lib/useAdminLock.ts`,
+  `routes/Settings.tsx` (the manage-PIN section), `App.tsx` (lock-screen render
+  + "Lock now"), `lib/api.ts` (client helpers).
+- Tests: `src/__tests__/admin-lock.test.ts` (server, incl. the OAuth-unaffected
+  proof), `web/ui/src/components/LockScreen.test.tsx`, `web/ui/src/App.test.tsx`
+  (lock integration).

--- a/src/__tests__/admin-lock.test.ts
+++ b/src/__tests__/admin-lock.test.ts
@@ -1,0 +1,600 @@
+/**
+ * Tests for the optional admin-UI screen-lock (admin-lock.ts +
+ * api-admin-lock.ts) and the lock gate's cascade through the four
+ * admin-token mint chokepoints.
+ *
+ * Coverage map (from the feature brief):
+ *   - PIN set / verify / change / remove.
+ *   - The gate: locked → host-admin-token mint refused (423); unlocked → mint
+ *     works; idle-expired → locked again; cascade to channel/vault/module mints.
+ *   - **OAuth path works while the admin session is locked** (the critical
+ *     boundary — a surface OAuth'ing in never hits the lock).
+ *   - Optional: no PIN → no lock, the mint works exactly as today.
+ *   - argon2 hash is never stored plaintext / never in the cookie.
+ *   - Brute-force limiter on unlock.
+ *   - "Lock now" + heartbeat (idle window slide).
+ *   - First-PIN chicken-and-egg + change/remove authorization.
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createHash, randomBytes } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleChannelToken } from "../admin-channel-token.ts";
+import { handleHostAdminToken } from "../admin-host-admin-token.ts";
+import {
+  DEFAULT_ADMIN_LOCK_IDLE_SECONDS,
+  _resetUnlockStateForTest,
+  clearPin,
+  getIdleSeconds,
+  isLockConfigured,
+  isSessionUnlocked,
+  recordUnlock,
+  refreshActivity,
+  requireUnlocked,
+  setIdleSeconds,
+  setPin,
+  unlockLimiter,
+  validatePin,
+  verifyPin,
+} from "../admin-lock.ts";
+import { handleModuleToken } from "../admin-module-token.ts";
+import { handleVaultAdminToken } from "../admin-vault-admin-token.ts";
+import { handleAdminLock } from "../api-admin-lock.ts";
+import { registerClient } from "../clients.ts";
+import { CSRF_COOKIE_NAME } from "../csrf.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { getSetting } from "../hub-settings.ts";
+import { validateAccessToken } from "../jwt-sign.ts";
+import { handleAuthorizePost, handleToken } from "../oauth-handlers.ts";
+import type { ServicesManifest } from "../services-manifest.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "https://hub.test";
+const TEST_CSRF = "csrf-test-token";
+const CSRF_COOKIE = `${CSRF_COOKIE_NAME}=${TEST_CSRF}`;
+const ORIGIN_HEADERS = { "content-type": "application/json", origin: ISSUER };
+
+interface Harness {
+  db: Database;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-admin-lock-"));
+  const db = openHubDb(hubDbPath(dir));
+  return {
+    db,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+  _resetUnlockStateForTest();
+  unlockLimiter.reset();
+});
+afterEach(() => {
+  harness.cleanup();
+  _resetUnlockStateForTest();
+  unlockLimiter.reset();
+});
+
+/** Create the first admin + a session, return { cookie, sessionId, userId }. */
+async function withAdmin(): Promise<{ cookie: string; sessionId: string; userId: string }> {
+  const user = await createUser(harness.db, "operator", "admin-passphrase");
+  const session = createSession(harness.db, { userId: user.id });
+  const cookie = `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`;
+  return { cookie, sessionId: session.id, userId: user.id };
+}
+
+function lockReq(subpath: string, cookie: string, body: Record<string, unknown>): Request {
+  return new Request(`${ISSUER}/api/admin-lock${subpath}`, {
+    method: "POST",
+    headers: { ...ORIGIN_HEADERS, cookie },
+    body: JSON.stringify({ __csrf: TEST_CSRF, ...body }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Pure module: validate / hash / verify / idle.
+// ---------------------------------------------------------------------------
+
+describe("admin-lock pure helpers", () => {
+  test("validatePin accepts 4–12 digits, rejects others", () => {
+    expect(validatePin("1234").valid).toBe(true);
+    expect(validatePin("123456789012").valid).toBe(true);
+    expect(validatePin("123").valid).toBe(false); // too short
+    expect(validatePin("1234567890123").valid).toBe(false); // too long
+    expect(validatePin("12a4").valid).toBe(false); // non-digit
+    expect(validatePin("").valid).toBe(false);
+  });
+
+  test("setPin stores an argon2id hash — NOT plaintext", async () => {
+    await setPin(harness.db, "4827");
+    const stored = getSetting(harness.db, "admin_lock_pin_hash");
+    expect(stored).toBeDefined();
+    expect(stored).not.toBe("4827");
+    expect(stored).not.toContain("4827");
+    // argon2id hashes carry the canonical $argon2id$ prefix.
+    expect(stored?.startsWith("$argon2id$")).toBe(true);
+  });
+
+  test("verifyPin matches the set PIN and rejects wrong ones", async () => {
+    await setPin(harness.db, "4827");
+    expect(await verifyPin(harness.db, "4827")).toBe(true);
+    expect(await verifyPin(harness.db, "0000")).toBe(false);
+  });
+
+  test("verifyPin returns false when no PIN configured", async () => {
+    expect(await verifyPin(harness.db, "anything")).toBe(false);
+  });
+
+  test("isLockConfigured tracks set/clear", async () => {
+    expect(isLockConfigured(harness.db)).toBe(false);
+    await setPin(harness.db, "4827");
+    expect(isLockConfigured(harness.db)).toBe(true);
+    clearPin(harness.db);
+    expect(isLockConfigured(harness.db)).toBe(false);
+  });
+
+  test("idle seconds default + clamp", () => {
+    expect(getIdleSeconds(harness.db)).toBe(DEFAULT_ADMIN_LOCK_IDLE_SECONDS);
+    setIdleSeconds(harness.db, 5); // below min → clamped to 60
+    expect(getIdleSeconds(harness.db)).toBe(60);
+    setIdleSeconds(harness.db, 999_999); // above max → clamped to 24h
+    expect(getIdleSeconds(harness.db)).toBe(24 * 60 * 60);
+    setIdleSeconds(harness.db, 1200);
+    expect(getIdleSeconds(harness.db)).toBe(1200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requireUnlocked — the gate logic itself (clock-injected).
+// ---------------------------------------------------------------------------
+
+describe("requireUnlocked gate", () => {
+  test("feature OFF (no PIN) → always allowed", () => {
+    expect(requireUnlocked(harness.db, "sid-1", 1000).ok).toBe(true);
+  });
+
+  test("PIN set + no unlock → locked", async () => {
+    await setPin(harness.db, "4827");
+    expect(requireUnlocked(harness.db, "sid-1", 1000).ok).toBe(false);
+  });
+
+  test("PIN set + fresh unlock → allowed; the mint is a PURE CHECK (does NOT slide)", async () => {
+    await setPin(harness.db, "4827");
+    setIdleSeconds(harness.db, 60);
+    const t0 = 1_000_000;
+    recordUnlock("sid-1", 60, t0);
+    const at30s = t0 + 30_000;
+    // A mint at 30s is allowed but must NOT extend the window — only genuine
+    // USER activity (the heartbeat) slides it; a background poll's mint shouldn't
+    // keep an idle tab alive forever.
+    expect(requireUnlocked(harness.db, "sid-1", at30s).ok).toBe(true);
+    // Original window was t0 + 60s. The mint didn't move it, so at t0 + 61s it's
+    // expired/locked.
+    expect(isSessionUnlocked("sid-1", t0 + 61_000)).toBe(false);
+  });
+
+  test("refreshActivity (heartbeat) DOES slide the window for an unlocked session", async () => {
+    await setPin(harness.db, "4827");
+    setIdleSeconds(harness.db, 60);
+    const t0 = 1_000_000;
+    recordUnlock("sid-1", 60, t0);
+    // A heartbeat at 30s re-anchors to 30s + 60s = t0 + 90s.
+    refreshActivity("sid-1", 60, t0 + 30_000);
+    expect(isSessionUnlocked("sid-1", t0 + 80_000)).toBe(true);
+  });
+
+  test("refreshActivity does NOT unlock a locked session (activity ≠ unlock)", async () => {
+    await setPin(harness.db, "4827");
+    // No unlock recorded → locked. A heartbeat must not create a window.
+    refreshActivity("sid-1", 60, 1_000_000);
+    expect(isSessionUnlocked("sid-1", 1_000_000)).toBe(false);
+  });
+
+  test("PIN set + idle-expired → locked again", async () => {
+    await setPin(harness.db, "4827");
+    setIdleSeconds(harness.db, 60);
+    const t0 = 1_000_000;
+    recordUnlock("sid-1", 60, t0);
+    // 61s later, with no intervening activity → expired → locked.
+    expect(requireUnlocked(harness.db, "sid-1", t0 + 61_000).ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The cascade: a locked session refuses ALL four admin-token mints.
+// ---------------------------------------------------------------------------
+
+describe("lock cascade through the four admin-token mints", () => {
+  test("host-admin-token: 200 when no PIN, 423 when locked, 200 after unlock", async () => {
+    const { cookie, sessionId } = await withAdmin();
+    rotateSigningKey(harness.db);
+    const mk = () => new Request(`${ISSUER}/admin/host-admin-token`, { headers: { cookie } });
+
+    // No PIN → today's behavior (200).
+    expect((await handleHostAdminToken(mk(), { db: harness.db, issuer: ISSUER })).status).toBe(200);
+
+    // Set a PIN → locked → 423.
+    await setPin(harness.db, "4827");
+    const lockedRes = await handleHostAdminToken(mk(), { db: harness.db, issuer: ISSUER });
+    expect(lockedRes.status).toBe(423);
+    expect(((await lockedRes.json()) as { error: string }).error).toBe("locked");
+
+    // Unlock → 200.
+    recordUnlock(sessionId, getIdleSeconds(harness.db));
+    expect((await handleHostAdminToken(mk(), { db: harness.db, issuer: ISSUER })).status).toBe(200);
+  });
+
+  test("channel-token cascades (423 when locked)", async () => {
+    const { cookie } = await withAdmin();
+    rotateSigningKey(harness.db);
+    await setPin(harness.db, "4827");
+    const res = await handleChannelToken(
+      new Request(`${ISSUER}/admin/channel-token`, { headers: { cookie } }),
+      { db: harness.db, issuer: ISSUER },
+    );
+    expect(res.status).toBe(423);
+  });
+
+  test("vault-admin-token cascades (423 when locked)", async () => {
+    const { cookie } = await withAdmin();
+    rotateSigningKey(harness.db);
+    await setPin(harness.db, "4827");
+    const res = await handleVaultAdminToken(
+      new Request(`${ISSUER}/admin/vault-admin-token/default`, { headers: { cookie } }),
+      "default",
+      { db: harness.db, issuer: ISSUER, knownVaultNames: new Set(["default"]) },
+    );
+    expect(res.status).toBe(423);
+  });
+
+  test("module-token cascades (423 when locked)", async () => {
+    const { cookie } = await withAdmin();
+    rotateSigningKey(harness.db);
+    await setPin(harness.db, "4827");
+    const res = await handleModuleToken(
+      new Request(`${ISSUER}/admin/module-token/scribe`, { headers: { cookie } }),
+      "scribe",
+      {
+        db: harness.db,
+        issuer: ISSUER,
+        // scribe is a KNOWN bootstrap short — no module.json read needed.
+        readServices: () => [],
+      },
+    );
+    expect(res.status).toBe(423);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// THE CRITICAL BOUNDARY: OAuth issuance works while the admin UI is locked.
+// ---------------------------------------------------------------------------
+
+const FIXTURE_MANIFEST: ServicesManifest = {
+  services: [
+    {
+      name: "parachute-vault",
+      port: 1940,
+      paths: ["/vault/default"],
+      health: "/health",
+      version: "0.3.0",
+    },
+  ],
+};
+function fixtureLoadServicesManifest(): ServicesManifest {
+  return FIXTURE_MANIFEST;
+}
+function makePkce() {
+  const verifier = randomBytes(32).toString("base64url");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  return { verifier, challenge };
+}
+
+describe("OAuth issuer is unaffected by the admin lock", () => {
+  test("a third-party client completes authorize→token while the admin session is locked", async () => {
+    const { db } = harness;
+    rotateSigningKey(db);
+    const user = await createUser(db, "owner", "owner-passphrase");
+    const session = createSession(db, { userId: user.id });
+
+    // Lock the admin surface: set a PIN, leave the admin session locked.
+    await setPin(db, "4827");
+    // Sanity: the admin token mint IS locked right now.
+    const adminMint = await handleHostAdminToken(
+      new Request(`${ISSUER}/admin/host-admin-token`, {
+        headers: { cookie: buildSessionCookie(session.id, 86400) },
+      }),
+      { db, issuer: ISSUER },
+    );
+    expect(adminMint.status).toBe(423);
+
+    // Now run a full OAuth authorization-code + PKCE flow. This must succeed —
+    // the lock lives only on the `/admin/*-token` mints, never on `/oauth/*`.
+    const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+    const { verifier, challenge } = makePkce();
+    const consentForm = new URLSearchParams({
+      __action: "consent",
+      __csrf: TEST_CSRF,
+      approve: "yes",
+      client_id: reg.client.clientId,
+      redirect_uri: "https://app.example/cb",
+      response_type: "code",
+      scope: "vault:read",
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+      vault_pick: "default",
+    });
+    const consentRes = await handleAuthorizePost(
+      db,
+      new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: consentForm,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, 86400)}`,
+        },
+      }),
+      { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+    );
+    expect(consentRes.status).toBe(302);
+    const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+    expect(code).toBeTruthy();
+
+    const tokenForm = new URLSearchParams({
+      grant_type: "authorization_code",
+      code: code ?? "",
+      client_id: reg.client.clientId,
+      redirect_uri: "https://app.example/cb",
+      code_verifier: verifier,
+    });
+    const tokenRes = await handleToken(
+      db,
+      new Request(`${ISSUER}/oauth/token`, {
+        method: "POST",
+        body: tokenForm,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+      { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+    );
+    // The OAuth token endpoint issues normally despite the locked admin UI.
+    expect(tokenRes.status).toBe(200);
+    const body = (await tokenRes.json()) as { access_token: string; scope: string };
+    expect(body.scope).toBe("vault:default:read");
+    const { payload } = await validateAccessToken(db, body.access_token, ISSUER);
+    expect(payload.aud).toBe("vault.default");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The management API: status, set/change/remove/unlock/lock/heartbeat.
+// ---------------------------------------------------------------------------
+
+describe("admin-lock management API", () => {
+  test("GET status reflects unconfigured → configured → locked/unlocked", async () => {
+    const { cookie, sessionId } = await withAdmin();
+    const statusReq = () =>
+      new Request(`${ISSUER}/api/admin-lock`, { method: "GET", headers: { cookie } });
+
+    let res = await handleAdminLock(statusReq(), "", { db: harness.db });
+    expect(res.status).toBe(200);
+    let body = (await res.json()) as { configured: boolean; locked: boolean };
+    expect(body).toMatchObject({ configured: false, locked: false });
+
+    await setPin(harness.db, "4827");
+    res = await handleAdminLock(statusReq(), "", { db: harness.db });
+    body = (await res.json()) as { configured: boolean; locked: boolean };
+    expect(body).toMatchObject({ configured: true, locked: true });
+
+    recordUnlock(sessionId, getIdleSeconds(harness.db));
+    res = await handleAdminLock(statusReq(), "", { db: harness.db });
+    body = (await res.json()) as { configured: boolean; locked: boolean };
+    expect(body).toMatchObject({ configured: true, locked: false });
+  });
+
+  test("set first PIN → 201; setting again → 409", async () => {
+    const { cookie } = await withAdmin();
+    const ok = await handleAdminLock(lockReq("/set", cookie, { pin: "4827" }), "/set", {
+      db: harness.db,
+    });
+    expect(ok.status).toBe(201);
+    expect(isLockConfigured(harness.db)).toBe(true);
+    // hash is not the plaintext.
+    expect(getSetting(harness.db, "admin_lock_pin_hash")).not.toContain("4827");
+
+    const again = await handleAdminLock(lockReq("/set", cookie, { pin: "1111" }), "/set", {
+      db: harness.db,
+    });
+    expect(again.status).toBe(409);
+  });
+
+  test("set rejects a bad PIN format with 400", async () => {
+    const { cookie } = await withAdmin();
+    const res = await handleAdminLock(lockReq("/set", cookie, { pin: "ab" }), "/set", {
+      db: harness.db,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("unlock with correct PIN opens the window; wrong PIN → 401", async () => {
+    const { cookie, sessionId } = await withAdmin();
+    await setPin(harness.db, "4827");
+
+    const bad = await handleAdminLock(lockReq("/unlock", cookie, { pin: "0000" }), "/unlock", {
+      db: harness.db,
+    });
+    expect(bad.status).toBe(401);
+    expect(isSessionUnlocked(sessionId)).toBe(false);
+
+    const good = await handleAdminLock(lockReq("/unlock", cookie, { pin: "4827" }), "/unlock", {
+      db: harness.db,
+    });
+    expect(good.status).toBe(200);
+    expect(isSessionUnlocked(sessionId)).toBe(true);
+  });
+
+  test("change requires current PIN (or unlocked session)", async () => {
+    const { cookie, sessionId } = await withAdmin();
+    await setPin(harness.db, "4827");
+
+    // Locked + wrong current_pin → 401.
+    const wrong = await handleAdminLock(
+      lockReq("/change", cookie, { current_pin: "0000", new_pin: "1111" }),
+      "/change",
+      { db: harness.db },
+    );
+    expect(wrong.status).toBe(401);
+
+    // Correct current_pin → 200, and the new PIN verifies.
+    const ok = await handleAdminLock(
+      lockReq("/change", cookie, { current_pin: "4827", new_pin: "1111" }),
+      "/change",
+      { db: harness.db },
+    );
+    expect(ok.status).toBe(200);
+    expect(await verifyPin(harness.db, "1111")).toBe(true);
+    expect(await verifyPin(harness.db, "4827")).toBe(false);
+    // Changing re-opens the window for this session.
+    expect(isSessionUnlocked(sessionId)).toBe(true);
+  });
+
+  test("change works from an already-unlocked session without current_pin", async () => {
+    const { cookie, sessionId } = await withAdmin();
+    await setPin(harness.db, "4827");
+    recordUnlock(sessionId, getIdleSeconds(harness.db));
+    const ok = await handleAdminLock(lockReq("/change", cookie, { new_pin: "1111" }), "/change", {
+      db: harness.db,
+    });
+    expect(ok.status).toBe(200);
+    expect(await verifyPin(harness.db, "1111")).toBe(true);
+  });
+
+  test("remove requires current PIN; turns the feature OFF", async () => {
+    const { cookie } = await withAdmin();
+    await setPin(harness.db, "4827");
+
+    const wrong = await handleAdminLock(
+      lockReq("/remove", cookie, { current_pin: "0000" }),
+      "/remove",
+      { db: harness.db },
+    );
+    expect(wrong.status).toBe(401);
+    expect(isLockConfigured(harness.db)).toBe(true);
+
+    const ok = await handleAdminLock(
+      lockReq("/remove", cookie, { current_pin: "4827" }),
+      "/remove",
+      { db: harness.db },
+    );
+    expect(ok.status).toBe(200);
+    expect(isLockConfigured(harness.db)).toBe(false);
+  });
+
+  test("lock-now drops the unlock window", async () => {
+    const { cookie, sessionId } = await withAdmin();
+    await setPin(harness.db, "4827");
+    recordUnlock(sessionId, getIdleSeconds(harness.db));
+    expect(isSessionUnlocked(sessionId)).toBe(true);
+
+    const res = await handleAdminLock(lockReq("/lock", cookie, {}), "/lock", { db: harness.db });
+    expect(res.status).toBe(200);
+    expect(isSessionUnlocked(sessionId)).toBe(false);
+  });
+
+  test("heartbeat slides the window but does NOT unlock a locked session", async () => {
+    const { cookie, sessionId } = await withAdmin();
+    await setPin(harness.db, "4827");
+    // Locked: heartbeat must not unlock.
+    const r1 = await handleAdminLock(lockReq("/heartbeat", cookie, {}), "/heartbeat", {
+      db: harness.db,
+    });
+    expect(r1.status).toBe(200);
+    expect(((await r1.json()) as { locked: boolean }).locked).toBe(true);
+    expect(isSessionUnlocked(sessionId)).toBe(false);
+
+    // Unlocked: heartbeat keeps it alive.
+    recordUnlock(sessionId, getIdleSeconds(harness.db));
+    const r2 = await handleAdminLock(lockReq("/heartbeat", cookie, {}), "/heartbeat", {
+      db: harness.db,
+    });
+    expect(((await r2.json()) as { locked: boolean }).locked).toBe(false);
+  });
+
+  test("unlock brute-force limiter: 6th attempt is 429", async () => {
+    const { cookie } = await withAdmin();
+    await setPin(harness.db, "4827");
+    // 5 wrong attempts are allowed (and fail 401), the 6th is rate-limited.
+    for (let i = 0; i < 5; i++) {
+      const res = await handleAdminLock(lockReq("/unlock", cookie, { pin: "0000" }), "/unlock", {
+        db: harness.db,
+      });
+      expect(res.status).toBe(401);
+    }
+    const limited = await handleAdminLock(lockReq("/unlock", cookie, { pin: "0000" }), "/unlock", {
+      db: harness.db,
+    });
+    expect(limited.status).toBe(429);
+    expect(limited.headers.get("retry-after")).toBeTruthy();
+  });
+
+  test("management endpoints require an admin session (401) and the first-admin (403)", async () => {
+    // No session.
+    const noSession = await handleAdminLock(
+      new Request(`${ISSUER}/api/admin-lock`, { method: "GET" }),
+      "",
+      { db: harness.db },
+    );
+    expect(noSession.status).toBe(401);
+
+    // A non-first-admin friend is 403.
+    await createUser(harness.db, "operator", "admin-passphrase");
+    const friend = await createUser(harness.db, "alice", "alice-passphrase", { allowMulti: true });
+    const friendSession = createSession(harness.db, { userId: friend.id });
+    const friendCookie = `${CSRF_COOKIE}; ${buildSessionCookie(friendSession.id, 86400)}`;
+    const res = await handleAdminLock(
+      new Request(`${ISSUER}/api/admin-lock`, { method: "GET", headers: { cookie: friendCookie } }),
+      "",
+      { db: harness.db },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("POST without a CSRF token is rejected (403)", async () => {
+    const { cookie } = await withAdmin();
+    const res = await handleAdminLock(
+      new Request(`${ISSUER}/api/admin-lock/set`, {
+        method: "POST",
+        headers: { ...ORIGIN_HEADERS, cookie },
+        body: JSON.stringify({ pin: "4827" }), // no __csrf
+      }),
+      "/set",
+      { db: harness.db },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("the PIN hash never appears in any Set-Cookie header", async () => {
+    const { cookie } = await withAdmin();
+    const setRes = await handleAdminLock(lockReq("/set", cookie, { pin: "4827" }), "/set", {
+      db: harness.db,
+    });
+    // No cookie is set by lock management at all, and certainly not the hash.
+    const hash = getSetting(harness.db, "admin_lock_pin_hash") ?? "";
+    expect(setRes.headers.get("set-cookie")).toBeNull();
+    expect(JSON.stringify([...setRes.headers.entries()])).not.toContain(hash);
+    // And the response body never echoes the hash or the PIN.
+    const text = await setRes.text();
+    expect(text).not.toContain("4827");
+    expect(text).not.toContain(hash);
+  });
+});

--- a/src/admin-channel-token.ts
+++ b/src/admin-channel-token.ts
@@ -48,6 +48,7 @@
  * tokens); the UI re-fetches on near-expiry.
  */
 import type { Database } from "bun:sqlite";
+import { lockedResponse, requireUnlocked } from "./admin-lock.ts";
 import { signAccessToken } from "./jwt-sign.ts";
 import { findSession, parseSessionCookie } from "./sessions.ts";
 import { isFirstAdmin } from "./users.ts";
@@ -82,7 +83,7 @@ export async function handleChannelToken(
   }
   const sid = parseSessionCookie(req.headers.get("cookie"));
   const session = sid ? findSession(deps.db, sid) : null;
-  if (!session) {
+  if (!session || !sid) {
     return jsonError(401, "unauthenticated", "no admin session — sign in at /login first");
   }
   // First-admin gate (mirrors host/vault-admin-token). A friend account
@@ -96,6 +97,12 @@ export async function handleChannelToken(
       "not_admin",
       "channel token mint is restricted to the hub admin — your account home is at /account/",
     );
+  }
+  // Admin screen-lock gate (see admin-host-admin-token.ts). A locked admin
+  // session can't mint a channel Bearer, so channel's config + chat UIs show
+  // the lock screen / fail closed until the operator unlocks. Off by default.
+  if (!requireUnlocked(deps.db, sid).ok) {
+    return lockedResponse();
   }
   const minted = await signAccessToken(deps.db, {
     sub: session.userId,

--- a/src/admin-host-admin-token.ts
+++ b/src/admin-host-admin-token.ts
@@ -47,6 +47,7 @@
  * in line with the admin scope-set semantics from hub#214 / #222.
  */
 import type { Database } from "bun:sqlite";
+import { lockedResponse, requireUnlocked } from "./admin-lock.ts";
 import { signAccessToken } from "./jwt-sign.ts";
 import { findSession, parseSessionCookie } from "./sessions.ts";
 import { isFirstAdmin } from "./users.ts";
@@ -72,7 +73,7 @@ export async function handleHostAdminToken(
   }
   const sid = parseSessionCookie(req.headers.get("cookie"));
   const session = sid ? findSession(deps.db, sid) : null;
-  if (!session) {
+  if (!session || !sid) {
     return jsonError(401, "unauthenticated", "no admin session — sign in at /login first");
   }
   // First-admin gate. A friend account (non-first-admin user created via
@@ -88,6 +89,15 @@ export async function handleHostAdminToken(
       "not_admin",
       "host-admin token mint is restricted to the hub admin — your account home is at /account/",
     );
+  }
+  // Admin screen-lock gate (optional, off by default). When a lock PIN is set
+  // AND this session isn't within an unlock window, refuse to mint — the SPA
+  // shows the lock screen on the 423. No PIN configured → always allowed
+  // (today's behavior). A successful mint slides the idle window forward.
+  // The OAuth issuer (`/oauth/*`) never reaches this endpoint, so it's
+  // unaffected by the lock.
+  if (!requireUnlocked(deps.db, sid).ok) {
+    return lockedResponse();
   }
   const minted = await signAccessToken(deps.db, {
     sub: session.userId,

--- a/src/admin-host-admin-token.ts
+++ b/src/admin-host-admin-token.ts
@@ -93,7 +93,10 @@ export async function handleHostAdminToken(
   // Admin screen-lock gate (optional, off by default). When a lock PIN is set
   // AND this session isn't within an unlock window, refuse to mint — the SPA
   // shows the lock screen on the 423. No PIN configured → always allowed
-  // (today's behavior). A successful mint slides the idle window forward.
+  // (today's behavior). This mint is a PURE CHECK — it does NOT slide the idle
+  // window; sliding is driven only by genuine user activity (the SPA's debounced
+  // `/heartbeat`), so a background re-mint (e.g. the 30s version-badge poll) can't
+  // keep an idle tab unlocked. See the `requireUnlocked` docblock in admin-lock.ts.
   // The OAuth issuer (`/oauth/*`) never reaches this endpoint, so it's
   // unaffected by the lock.
   if (!requireUnlocked(deps.db, sid).ok) {

--- a/src/admin-lock.ts
+++ b/src/admin-lock.ts
@@ -1,0 +1,281 @@
+/**
+ * Optional idle screen-lock for the hub ADMIN UI (phone-style lock).
+ *
+ * ## What this guards (and what it deliberately doesn't)
+ *
+ * The hub admin UI is reachable remotely once `parachute expose` is up
+ * (Tailscale / Cloudflare). A grabbed or left-logged-in admin browser session
+ * is a real risk: the password-login session cookie lasts 24h, so an
+ * unattended tab is a standing admin console. This adds an OPTIONAL operator
+ * PIN that LOCKS THE WHOLE ADMIN SURFACE — one lock over everything, not
+ * per-action gating (per-action would friction-up configuration, which is the
+ * dangerous stuff we most want behind the lock anyway). Unlock with the PIN →
+ * a frictionless working window; admin activity refreshes it; idle re-locks.
+ *
+ * THREAT MODEL: this is a WEB/UI-layer guard for the EXPOSED admin portal. It
+ * does NOT protect against someone with a SHELL on the box — they read
+ * `~/.parachute/operator.token` / the vault DB directly and bypass the hub
+ * entirely. That's an OS concern (disk encryption, a locked OS screen, SSH-key
+ * hygiene). The lock shuts the *portal* door — the one the internet can reach —
+ * which is the point.
+ *
+ * ## The single chokepoint
+ *
+ * The admin SPA + every module config UI get their working Bearer from one of
+ * the cookie-gated mint endpoints:
+ *   - `GET /admin/host-admin-token`        (the SPA's own Bearer)
+ *   - `GET /admin/channel-token`           (channel chat + config UIs)
+ *   - `GET /admin/vault-admin-token/<name>`(per-vault admin SPA)
+ *   - `GET /admin/module-token/<short>`    (generic module config UI Bearer)
+ *
+ * All four share the exact `parseSessionCookie → findSession → [isFirstAdmin]
+ * → signAccessToken` shape. Inserting {@link requireUnlocked} into each makes
+ * the lock cascade to EVERY admin surface with no per-module changes: when
+ * locked, the mint returns 423 and the relevant UI shows the lock screen / its
+ * admin calls fail closed (no Bearer). A surface OAuth'ing in via `/oauth/*`
+ * never touches these endpoints, so the OAuth issuer is untouched — see the
+ * design note (`design/2026-06-17-admin-ui-lock.md`).
+ *
+ * ## Unlock state — per-session, in-memory, "unlocked-until"
+ *
+ * Simplest workable model. A successful PIN unlock records `unlockedUntil` for
+ * the session id (the cookie value) in a process-local Map. The session is
+ * UNLOCKED iff a future `unlockedUntil` exists; genuine USER activity (the SPA's
+ * debounced `/heartbeat`, fired on pointer/key/scroll) slides it forward by the
+ * idle window. Token mints do NOT slide it — the SPA polls some endpoints in the
+ * background, and letting a poll's re-mint extend the window would keep an
+ * idle-but-open tab unlocked forever. LOCKED when:
+ *   - no PIN is set → feature OFF, never locked (today's behavior);
+ *   - PIN set + no unlock recorded (fresh load / first visit);
+ *   - PIN set + the recorded unlock is in the past (idle-expired);
+ *   - a hub restart wipes the Map → re-lock (a feature, not a bug).
+ *
+ * The unlock state is NEVER persisted and NEVER put in the cookie — a stolen
+ * cookie alone can't carry an unlocked window; the attacker still needs the
+ * PIN. (The cookie already authenticates the password session; the PIN is the
+ * second, idle-bounded gate on top.)
+ */
+import type { Database } from "bun:sqlite";
+import { hash as argonHash, verify as argonVerify } from "@node-rs/argon2";
+import { deleteSetting, getSetting, setSetting } from "./hub-settings.ts";
+import { RateLimiter } from "./rate-limit.ts";
+
+/** Default idle window before a session re-locks. Phone-lock territory. */
+export const DEFAULT_ADMIN_LOCK_IDLE_SECONDS = 15 * 60;
+
+/** Clamp on the operator-configurable idle window: 1 min … 24h. */
+export const MIN_ADMIN_LOCK_IDLE_SECONDS = 60;
+export const MAX_ADMIN_LOCK_IDLE_SECONDS = 24 * 60 * 60;
+
+/**
+ * PIN format: 4–12 digits. A numeric PIN is the phone-lock affordance the
+ * feature is named for; the real defense is the idle window + brute-force
+ * limiter, not PIN entropy (the session is already password-authenticated —
+ * this is a second, convenience-grade gate). Operators wanting a full secret
+ * use the OS lock / a strong account password; this is the "don't leave the
+ * console open on the train" guard.
+ */
+export const ADMIN_LOCK_PIN_RE = /^[0-9]{4,12}$/;
+
+export type ValidatePinResult = { valid: true } | { valid: false; reason: "format" };
+
+export function validatePin(pin: string): ValidatePinResult {
+  return ADMIN_LOCK_PIN_RE.test(pin) ? { valid: true } : { valid: false, reason: "format" };
+}
+
+// --- PIN storage (argon2id hash in hub_settings) ---------------------------
+
+/** True iff an admin-lock PIN is configured (feature is ON). */
+export function isLockConfigured(db: Database): boolean {
+  const h = getSetting(db, "admin_lock_pin_hash");
+  return typeof h === "string" && h.length > 0;
+}
+
+/**
+ * Store (or rotate) the PIN. Hashes with argon2id — the same family the hub
+ * already uses for passwords + TOTP backup codes (`@node-rs/argon2`). The
+ * caller MUST have validated the PIN format first; this trusts its input.
+ */
+export async function setPin(db: Database, pin: string): Promise<void> {
+  const h = await argonHash(pin);
+  setSetting(db, "admin_lock_pin_hash", h);
+}
+
+/** Remove the PIN (turn the feature OFF). Idempotent. Also clears idle config. */
+export function clearPin(db: Database): void {
+  deleteSetting(db, "admin_lock_pin_hash");
+  deleteSetting(db, "admin_lock_idle_seconds");
+}
+
+/**
+ * Verify a submitted PIN against the stored hash. Returns false when no PIN is
+ * configured (defensive — callers gate on {@link isLockConfigured} first) or
+ * the hash is malformed.
+ */
+export async function verifyPin(db: Database, pin: string): Promise<boolean> {
+  const h = getSetting(db, "admin_lock_pin_hash");
+  if (typeof h !== "string" || h.length === 0) return false;
+  try {
+    return await argonVerify(h, pin);
+  } catch {
+    // Corrupt/unparseable hash — fail closed.
+    return false;
+  }
+}
+
+// --- idle window config ----------------------------------------------------
+
+/** Read the configured idle window (clamped). Falls back to the default. */
+export function getIdleSeconds(db: Database): number {
+  const raw = getSetting(db, "admin_lock_idle_seconds");
+  if (typeof raw !== "string") return DEFAULT_ADMIN_LOCK_IDLE_SECONDS;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n)) return DEFAULT_ADMIN_LOCK_IDLE_SECONDS;
+  return clampIdleSeconds(n);
+}
+
+export function clampIdleSeconds(n: number): number {
+  if (n < MIN_ADMIN_LOCK_IDLE_SECONDS) return MIN_ADMIN_LOCK_IDLE_SECONDS;
+  if (n > MAX_ADMIN_LOCK_IDLE_SECONDS) return MAX_ADMIN_LOCK_IDLE_SECONDS;
+  return Math.floor(n);
+}
+
+/** Persist the operator's idle-window choice (clamped). */
+export function setIdleSeconds(db: Database, seconds: number): void {
+  setSetting(db, "admin_lock_idle_seconds", String(clampIdleSeconds(seconds)));
+}
+
+// --- per-session unlock state (in-memory, never persisted) -----------------
+
+/**
+ * sessionId → unlockedUntil epoch ms. Process-local; a restart wipes it (which
+ * is the re-lock-on-fresh-process behavior we want). Bounded by an
+ * opportunistic prune of expired rows on every touch, so an attacker churning
+ * session ids can't grow it unboundedly.
+ */
+const unlockedUntil = new Map<string, number>();
+
+function pruneExpired(now: number): void {
+  for (const [sid, until] of unlockedUntil) {
+    if (until <= now) unlockedUntil.delete(sid);
+  }
+}
+
+/**
+ * Record a fresh unlock for `sessionId`, valid for `idleSeconds` from now.
+ * Called after a successful PIN verify.
+ */
+export function recordUnlock(
+  sessionId: string,
+  idleSeconds: number,
+  now: number = Date.now(),
+): void {
+  pruneExpired(now);
+  unlockedUntil.set(sessionId, now + idleSeconds * 1000);
+}
+
+/**
+ * Slide the unlock window forward by `idleSeconds` IF the session is currently
+ * unlocked. Called on admin activity (heartbeat + every successful mint) so an
+ * actively-used console doesn't lock mid-work. Does NOT create an unlock for a
+ * locked session — only an explicit PIN entry can do that.
+ */
+export function refreshActivity(
+  sessionId: string,
+  idleSeconds: number,
+  now: number = Date.now(),
+): void {
+  const until = unlockedUntil.get(sessionId);
+  if (until === undefined || until <= now) return; // locked — activity doesn't unlock
+  unlockedUntil.set(sessionId, now + idleSeconds * 1000);
+}
+
+/** Is this session currently within an unlock window? */
+export function isSessionUnlocked(sessionId: string, now: number = Date.now()): boolean {
+  const until = unlockedUntil.get(sessionId);
+  return until !== undefined && until > now;
+}
+
+/** Force-lock a session immediately ("Lock now"). Idempotent. */
+export function lockSession(sessionId: string): void {
+  unlockedUntil.delete(sessionId);
+}
+
+/** Remaining unlock seconds for a session (0 when locked). For status UI. */
+export function unlockSecondsRemaining(sessionId: string, now: number = Date.now()): number {
+  const until = unlockedUntil.get(sessionId);
+  if (until === undefined || until <= now) return 0;
+  return Math.ceil((until - now) / 1000);
+}
+
+/** Test seam: wipe all in-memory unlock state. */
+export function _resetUnlockStateForTest(): void {
+  unlockedUntil.clear();
+}
+
+// --- the gate the four token-mint chokepoints call -------------------------
+
+/**
+ * The single lock gate. Returns whether the mint may proceed.
+ *
+ *   - feature OFF (no PIN) → ALWAYS allow (today's behavior, byte-for-byte).
+ *   - feature ON + session unlocked → allow.
+ *   - feature ON + session locked → DENY (the caller returns 423 Locked).
+ *
+ * Deliberately a PURE CHECK — it does NOT slide the idle window. Sliding is
+ * driven exclusively by genuine USER activity (the SPA's debounced
+ * `/heartbeat`, fired on pointer/key/scroll), NOT by token mints. The SPA polls
+ * some endpoints in the background (e.g. the version badge every 30s), and each
+ * such poll re-mints a host-admin Bearer; if a mint extended the window, a
+ * left-open-but-idle tab would never lock — defeating the whole feature. The
+ * heartbeat is the one thing that means "a human is here."
+ *
+ * `now` is injectable for tests.
+ */
+export function requireUnlocked(
+  db: Database,
+  sessionId: string,
+  now: number = Date.now(),
+): { ok: true } | { ok: false; reason: "locked" } {
+  if (!isLockConfigured(db)) return { ok: true };
+  if (isSessionUnlocked(sessionId, now)) {
+    return { ok: true };
+  }
+  return { ok: false, reason: "locked" };
+}
+
+/** RFC-shaped 423 the mint chokepoints return when locked. */
+export function lockedResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: "locked",
+      error_description:
+        "the admin UI is locked — enter your PIN to unlock (POST /api/admin-lock/unlock)",
+    }),
+    {
+      status: 423,
+      headers: {
+        "content-type": "application/json",
+        "cache-control": "no-store",
+      },
+    },
+  );
+}
+
+// --- unlock brute-force limiter --------------------------------------------
+
+/**
+ * Per-session unlock-attempt limiter. The unlock endpoint is session-gated, so
+ * the threat is a compromised session (stolen cookie) grinding argon2id PIN
+ * verifications without bound — keyed by session id, same posture as
+ * `/account/change-password` (keyed by user). 5 wrong PINs / 5 min is the
+ * floor; the idle window + the limiter together are the real defense (the PIN
+ * itself is convenience-grade — see the module header).
+ */
+export const ADMIN_LOCK_UNLOCK_MAX_ATTEMPTS = 5;
+export const ADMIN_LOCK_UNLOCK_WINDOW_MS = 5 * 60 * 1000;
+
+export const unlockLimiter = new RateLimiter(
+  ADMIN_LOCK_UNLOCK_MAX_ATTEMPTS,
+  ADMIN_LOCK_UNLOCK_WINDOW_MS,
+);

--- a/src/admin-module-token.ts
+++ b/src/admin-module-token.ts
@@ -39,6 +39,7 @@
  * config UI re-fetches on near-expiry.
  */
 import type { Database } from "bun:sqlite";
+import { lockedResponse, requireUnlocked } from "./admin-lock.ts";
 import { signAccessToken } from "./jwt-sign.ts";
 import {
   type ModuleManifest,
@@ -143,7 +144,7 @@ export async function handleModuleToken(
   }
   const sid = parseSessionCookie(req.headers.get("cookie"));
   const session = sid ? findSession(deps.db, sid) : null;
-  if (!session) {
+  if (!session || !sid) {
     return jsonError(401, "unauthenticated", "no admin session — sign in at /login first");
   }
   // First-admin gate (mirrors host/vault/channel-admin-token). A friend account
@@ -155,6 +156,13 @@ export async function handleModuleToken(
       "not_admin",
       "module admin token mint is restricted to the hub admin — your account home is at /account/",
     );
+  }
+  // Admin screen-lock gate (see admin-host-admin-token.ts). A locked admin
+  // session can't mint a module admin Bearer, so every module-owned config UI
+  // fails closed until the operator unlocks. This is what makes the lock
+  // cascade to ALL modules with zero per-module changes. Off by default.
+  if (!requireUnlocked(deps.db, sid).ok) {
+    return lockedResponse();
   }
   const scope = `${short}:admin`;
   const minted = await signAccessToken(deps.db, {

--- a/src/admin-vault-admin-token.ts
+++ b/src/admin-vault-admin-token.ts
@@ -25,6 +25,7 @@
  * for their assigned vault; they don't get vault admin via this endpoint.
  */
 import type { Database } from "bun:sqlite";
+import { lockedResponse, requireUnlocked } from "./admin-lock.ts";
 import { signAccessToken } from "./jwt-sign.ts";
 import { findSession, parseSessionCookie } from "./sessions.ts";
 import { isFirstAdmin } from "./users.ts";
@@ -66,7 +67,7 @@ export async function handleVaultAdminToken(
   }
   const sid = parseSessionCookie(req.headers.get("cookie"));
   const session = sid ? findSession(deps.db, sid) : null;
-  if (!session) {
+  if (!session || !sid) {
     return jsonError(401, "unauthenticated", "no admin session — sign in at /login first");
   }
   // Multi-user Phase 1 privesc gate (mirrors host-admin-token). vault:<name>:admin
@@ -79,6 +80,12 @@ export async function handleVaultAdminToken(
       "not_admin",
       "vault admin token mint is restricted to the hub admin — your account home is at /account/",
     );
+  }
+  // Admin screen-lock gate (see admin-host-admin-token.ts). A locked admin
+  // session can't mint a vault admin Bearer, so the vault admin SPA fails
+  // closed until the operator unlocks. Off by default.
+  if (!requireUnlocked(deps.db, sid).ok) {
+    return lockedResponse();
   }
   const scope = `vault:${vaultName}:admin`;
   // Per-vault audience: vault validates the JWT's `aud` claim against

--- a/src/api-admin-lock.ts
+++ b/src/api-admin-lock.ts
@@ -1,0 +1,335 @@
+/**
+ * Admin screen-lock management API (hub admin-lock feature).
+ *
+ * All endpoints are session-cookie-gated to the first admin — the same gate
+ * the admin-token mints use (`isFirstAdmin`). These manage the lock itself, so
+ * they are NOT behind the lock gate (you must be able to unlock + set the PIN
+ * even when the surface is locked).
+ *
+ *   GET  /api/admin-lock           → status { configured, locked, idle_seconds, unlock_seconds_remaining }
+ *   POST /api/admin-lock/set       → set the FIRST PIN (no PIN configured yet)
+ *   POST /api/admin-lock/change    → rotate PIN (requires current PIN or unlocked session)
+ *   POST /api/admin-lock/remove    → turn the feature OFF (requires current PIN or unlocked session)
+ *   POST /api/admin-lock/unlock    → verify PIN, open an unlock window
+ *   POST /api/admin-lock/lock      → "Lock now" — drop the session's unlock window
+ *   POST /api/admin-lock/heartbeat → slide the idle window forward on activity
+ *
+ * The chicken-and-egg: setting the FIRST PIN is an authenticated admin action
+ * (logged-in session, no PIN yet → allowed). Once a PIN exists, change/remove
+ * require proving knowledge of the current PIN OR an already-unlocked session
+ * (the operator just unlocked, so they hold the PIN — re-typing would be
+ * friction). Setting over an existing PIN is rejected (use change).
+ *
+ * State-changing POSTs additionally require a CSRF token (`__csrf`) — these
+ * are JSON endpoints on the same origin as the cookie, and SameSite=Lax alone
+ * doesn't stop same-site CSRF (see src/csrf.ts). The SPA sources the token
+ * from `/api/me`.
+ */
+import type { Database } from "bun:sqlite";
+import {
+  clampIdleSeconds,
+  clearPin,
+  getIdleSeconds,
+  isLockConfigured,
+  isSessionUnlocked,
+  lockSession,
+  recordUnlock,
+  refreshActivity,
+  setIdleSeconds,
+  setPin,
+  unlockLimiter,
+  unlockSecondsRemaining,
+  validatePin,
+  verifyPin,
+} from "./admin-lock.ts";
+import { verifyCsrfToken } from "./csrf.ts";
+import { findSession, parseSessionCookie } from "./sessions.ts";
+import { isFirstAdmin } from "./users.ts";
+
+export interface AdminLockDeps {
+  db: Database;
+  /** Injectable clock for tests. */
+  now?: () => Date;
+}
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+function err(status: number, error: string, description: string): Response {
+  return json(status, { error, error_description: description });
+}
+
+/**
+ * Resolve the first-admin session for this request, or an error Response.
+ * Mirrors the gate the token-mint endpoints apply, so the lock-management
+ * surface has the same audience.
+ */
+function requireAdminSession(
+  db: Database,
+  req: Request,
+): { ok: true; sessionId: string; userId: string } | { ok: false; res: Response } {
+  const sid = parseSessionCookie(req.headers.get("cookie"));
+  const session = sid ? findSession(db, sid) : null;
+  if (!session || !sid) {
+    return {
+      ok: false,
+      res: err(401, "unauthenticated", "no admin session — sign in at /login first"),
+    };
+  }
+  if (!isFirstAdmin(db, session.userId)) {
+    return {
+      ok: false,
+      res: err(
+        403,
+        "not_admin",
+        "admin lock management is restricted to the hub admin — your account home is at /account/",
+      ),
+    };
+  }
+  return { ok: true, sessionId: sid, userId: session.userId };
+}
+
+async function readJsonBody(req: Request): Promise<Record<string, unknown>> {
+  try {
+    const body = (await req.json()) as unknown;
+    return body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function checkCsrf(req: Request, body: Record<string, unknown>): boolean {
+  const token = typeof body.__csrf === "string" ? body.__csrf : null;
+  return verifyCsrfToken(req, token);
+}
+
+/**
+ * The lock-management router. `subpath` is the path AFTER `/api/admin-lock`
+ * (e.g. "" for status, "/unlock", "/set"). The hub-server dispatcher slices it.
+ */
+export async function handleAdminLock(
+  req: Request,
+  subpath: string,
+  deps: AdminLockDeps,
+): Promise<Response> {
+  const { db } = deps;
+  const now = deps.now ?? (() => new Date());
+
+  // GET status (no body, no CSRF — read-only).
+  if (subpath === "" || subpath === "/") {
+    if (req.method !== "GET") return err(405, "method_not_allowed", "use GET");
+    const gate = requireAdminSession(db, req);
+    if (!gate.ok) return gate.res;
+    const configured = isLockConfigured(db);
+    const nowMs = now().getTime();
+    const locked = configured && !isSessionUnlocked(gate.sessionId, nowMs);
+    return json(200, {
+      configured,
+      locked,
+      idle_seconds: getIdleSeconds(db),
+      unlock_seconds_remaining: configured ? unlockSecondsRemaining(gate.sessionId, nowMs) : 0,
+    });
+  }
+
+  // Everything below is a POST.
+  if (req.method !== "POST") return err(405, "method_not_allowed", "use POST");
+  const gate = requireAdminSession(db, req);
+  if (!gate.ok) return gate.res;
+  const body = await readJsonBody(req);
+  if (!checkCsrf(req, body)) {
+    return err(403, "csrf_failed", "missing or invalid CSRF token");
+  }
+
+  switch (subpath) {
+    case "/set":
+      return handleSet(db, gate.sessionId, body);
+    case "/change":
+      return handleChange(db, gate.sessionId, body, now);
+    case "/remove":
+      return handleRemove(db, gate.sessionId, body, now);
+    case "/unlock":
+      return handleUnlock(db, gate.sessionId, gate.userId, body, now);
+    case "/lock":
+      lockSession(gate.sessionId);
+      return json(200, { locked: true });
+    case "/heartbeat":
+      // Slide the idle window forward if (and only if) currently unlocked.
+      refreshActivity(gate.sessionId, getIdleSeconds(db), now().getTime());
+      return json(200, {
+        locked: isLockConfigured(db) && !isSessionUnlocked(gate.sessionId, now().getTime()),
+        unlock_seconds_remaining: unlockSecondsRemaining(gate.sessionId, now().getTime()),
+      });
+    default:
+      return err(404, "not_found", `no admin-lock route at /api/admin-lock${subpath}`);
+  }
+}
+
+/** Optional idle-seconds override from a request body field. Clamped; undefined when absent/invalid. */
+function readIdleSeconds(body: Record<string, unknown>): number | undefined {
+  const raw = body.idle_seconds;
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return undefined;
+  return clampIdleSeconds(raw);
+}
+
+async function handleSet(
+  db: Database,
+  sessionId: string,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  // Setting the FIRST PIN — refuse if one already exists (use /change).
+  if (isLockConfigured(db)) {
+    return err(409, "already_configured", "a PIN is already set — use /api/admin-lock/change");
+  }
+  const pin = typeof body.pin === "string" ? body.pin : "";
+  if (!validatePin(pin).valid) {
+    return err(400, "invalid_pin", "PIN must be 4–12 digits");
+  }
+  const idle = readIdleSeconds(body);
+  if (idle !== undefined) setIdleSeconds(db, idle);
+  await setPin(db, pin);
+  // Setting the PIN immediately opens an unlock window for this session — the
+  // operator who just typed it isn't locked out of their own current session.
+  recordUnlock(sessionId, getIdleSeconds(db));
+  return json(201, { configured: true, locked: false, idle_seconds: getIdleSeconds(db) });
+}
+
+async function handleChange(
+  db: Database,
+  sessionId: string,
+  body: Record<string, unknown>,
+  now: () => Date,
+): Promise<Response> {
+  if (!isLockConfigured(db)) {
+    return err(409, "not_configured", "no PIN is set — use /api/admin-lock/set");
+  }
+  const newPin = typeof body.new_pin === "string" ? body.new_pin : "";
+  if (!validatePin(newPin).valid) {
+    return err(400, "invalid_pin", "new PIN must be 4–12 digits");
+  }
+  // Authorize the change: an already-unlocked session OR a correct current PIN.
+  const authorized = await authorizeMutation(db, sessionId, body, now);
+  if (!authorized.ok) return authorized.res;
+  const idle = readIdleSeconds(body);
+  if (idle !== undefined) setIdleSeconds(db, idle);
+  await setPin(db, newPin);
+  // Re-open the unlock window for this session under the new PIN.
+  recordUnlock(sessionId, getIdleSeconds(db), now().getTime());
+  return json(200, { configured: true, locked: false, idle_seconds: getIdleSeconds(db) });
+}
+
+async function handleRemove(
+  db: Database,
+  sessionId: string,
+  body: Record<string, unknown>,
+  now: () => Date,
+): Promise<Response> {
+  if (!isLockConfigured(db)) {
+    // Idempotent — already off.
+    return json(200, { configured: false, locked: false });
+  }
+  const authorized = await authorizeMutation(db, sessionId, body, now);
+  if (!authorized.ok) return authorized.res;
+  clearPin(db);
+  // Feature is off now — drop any unlock window (it no longer means anything).
+  lockSession(sessionId);
+  return json(200, { configured: false, locked: false });
+}
+
+/**
+ * Shared authorization for change/remove: succeed when the session is already
+ * unlocked, OR a correct `current_pin` is supplied. The current-PIN path runs
+ * through the same brute-force limiter as /unlock.
+ */
+async function authorizeMutation(
+  db: Database,
+  sessionId: string,
+  body: Record<string, unknown>,
+  now: () => Date,
+): Promise<{ ok: true } | { ok: false; res: Response }> {
+  if (isSessionUnlocked(sessionId, now().getTime())) return { ok: true };
+  const currentPin = typeof body.current_pin === "string" ? body.current_pin : "";
+  if (!currentPin) {
+    return {
+      ok: false,
+      res: err(
+        401,
+        "pin_required",
+        "this session is locked — supply current_pin (or unlock first)",
+      ),
+    };
+  }
+  // Rate-limit BEFORE the argon2id verify (a stolen cookie shouldn't grind).
+  const rl = unlockLimiter.checkAndRecord(sessionId, now());
+  if (!rl.allowed) {
+    return {
+      ok: false,
+      res: new Response(
+        JSON.stringify({
+          error: "too_many_attempts",
+          error_description: `too many PIN attempts — retry in ${rl.retryAfterSeconds}s`,
+        }),
+        {
+          status: 429,
+          headers: {
+            "content-type": "application/json",
+            "cache-control": "no-store",
+            "retry-after": String(rl.retryAfterSeconds ?? 60),
+          },
+        },
+      ),
+    };
+  }
+  const ok = await verifyPin(db, currentPin);
+  if (!ok) return { ok: false, res: err(401, "wrong_pin", "incorrect PIN") };
+  return { ok: true };
+}
+
+async function handleUnlock(
+  db: Database,
+  sessionId: string,
+  _userId: string,
+  body: Record<string, unknown>,
+  now: () => Date,
+): Promise<Response> {
+  if (!isLockConfigured(db)) {
+    // No PIN → nothing to unlock; treat as already-open so the SPA proceeds.
+    return json(200, { unlocked: true, configured: false, idle_seconds: getIdleSeconds(db) });
+  }
+  const pin = typeof body.pin === "string" ? body.pin : "";
+  // Rate-limit BEFORE the argon2id verify — keyed by session (the session
+  // already identifies the actor; a stolen cookie shouldn't get fresh buckets
+  // across IPs). The denied attempt still counts toward the bucket so a wrong
+  // PIN can't be retried infinitely.
+  const rl = unlockLimiter.checkAndRecord(sessionId, now());
+  if (!rl.allowed) {
+    return new Response(
+      JSON.stringify({
+        error: "too_many_attempts",
+        error_description: `too many PIN attempts — retry in ${rl.retryAfterSeconds}s`,
+      }),
+      {
+        status: 429,
+        headers: {
+          "content-type": "application/json",
+          "cache-control": "no-store",
+          "retry-after": String(rl.retryAfterSeconds ?? 60),
+        },
+      },
+    );
+  }
+  const ok = await verifyPin(db, pin);
+  if (!ok) {
+    return err(401, "wrong_pin", "incorrect PIN");
+  }
+  recordUnlock(sessionId, getIdleSeconds(db), now().getTime());
+  return json(200, {
+    unlocked: true,
+    configured: true,
+    idle_seconds: getIdleSeconds(db),
+    unlock_seconds_remaining: unlockSecondsRemaining(sessionId, now().getTime()),
+  });
+}

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -64,6 +64,8 @@
  *   # mutations (hub#632, boundary C1) — origin-check.ts
  *   # `assertSameOriginForCookieMutation` carries the canonical enumeration.
  *   /api/me                       (GET)        → who-am-I (session+CSRF or hasSession:false)
+ *   /api/admin-lock               (GET)        → screen-lock status (cookie-gated; first-admin)
+ *   /api/admin-lock/{set,change,remove,unlock,lock,heartbeat} (POST) → manage the optional admin idle PIN lock (cookie-gated; CSRF)
  *   /api/hub                      (GET)        → hub version + uptime + install-source (host:admin)
  *   /api/hub/upgrade              (POST)       → SPA-driven hub self-upgrade → 202 + detached helper (host:admin, §5.3/D4)
  *   /api/hub/upgrade/status       (GET)        → poll the on-disk hub-upgrade status (host:admin)
@@ -176,6 +178,7 @@ import {
   handleAccountChangePasswordPost,
   handleAccountHomeGet,
 } from "./api-account.ts";
+import { handleAdminLock } from "./api-admin-lock.ts";
 import { handleHubUpgrade, handleHubUpgradeStatus } from "./api-hub-upgrade.ts";
 import { handleApiHub } from "./api-hub.ts";
 import { handleCreateInvite, handleListInvites, handleRevokeInvite } from "./api-invites.ts";
@@ -2846,6 +2849,25 @@ export function hubFetch(
       if (pathname === "/api/me") {
         if (!getDb) return dbNotConfigured();
         return handleApiMe(req, { db: getDb() });
+      }
+
+      // Admin screen-lock management (optional idle PIN lock for the admin
+      // UI). Session-cookie-gated to the first admin; these manage the lock
+      // itself so they are NOT behind the lock gate. The lock GATE lives in
+      // the four `/admin/*-token` mint handlers (admin-lock.ts:requireUnlocked)
+      // — it does NOT touch `/oauth/*`, so the OAuth issuer is unaffected.
+      if (pathname === "/api/admin-lock" || pathname.startsWith("/api/admin-lock/")) {
+        if (!getDb) return dbNotConfigured();
+        // CSRF belt (same posture as /admin/connections): these are
+        // cookie-authed JSON mutations. The handler ALSO checks a double-
+        // submit `__csrf` token; the Origin belt is defense-in-depth on the
+        // POST paths (GET status is read-shaped and skips it).
+        {
+          const rejected = assertSameOriginForCookieMutation(req, oauthDeps(req).hubBoundOrigins());
+          if (rejected) return rejected;
+        }
+        const subpath = pathname.slice("/api/admin-lock".length);
+        return handleAdminLock(req, subpath, { db: getDb() });
       }
 
       // SPA-driven hub self-upgrade (design 2026-06-01 §5.3 / D4). Dedicated

--- a/src/hub-settings.ts
+++ b/src/hub-settings.ts
@@ -91,7 +91,21 @@ export type HubSettingKey =
   // the deprecation window. Stored as the literal string "true" /
   // "false"; any other value parses as "redirect on" (the migration
   // default — operators must opt out, not opt in).
-  | "notes_redirect_disabled";
+  | "notes_redirect_disabled"
+  // Admin-UI screen-lock PIN (hub admin-lock feature). The argon2id hash of
+  // the operator's lock PIN. Absent row = lock feature OFF (today's behavior
+  // exactly — the admin UI is gated only by the password-login session). When
+  // set, the admin token-mint chokepoints refuse to mint while the operator's
+  // session is "locked" (no fresh unlock, or idle-expired). NEVER plaintext;
+  // the hash sits at the same operator-local trust boundary as the password
+  // hashes + signing keys already in hub.db (see migration v11's note on
+  // at-rest encryption). The "unlocked-until" state is per-session + in-memory
+  // (admin-lock.ts) — never persisted, never in the cookie.
+  | "admin_lock_pin_hash"
+  // Idle timeout for the admin screen-lock, in seconds. Optional override of
+  // the built-in default (DEFAULT_ADMIN_LOCK_IDLE_SECONDS). Stored as a
+  // stringified integer; absent / unparseable falls back to the default.
+  | "admin_lock_idle_seconds";
 
 export type SetupExposeMode = "localhost" | "tailnet" | "public";
 

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -34,6 +34,28 @@ vi.mock("./lib/api.ts", async (orig) => {
     // than racing on a real fetch. Per-test overrides via mockResolvedValue.
     getMe: vi.fn().mockResolvedValue({ hasSession: false }),
     signOut: vi.fn().mockResolvedValue(undefined),
+    // useAdminLock hits getAdminLockStatus when signed in. Default = no PIN
+    // configured (feature off), so the lock screen never appears in the
+    // existing route tests. The dedicated lock tests override per-case.
+    getAdminLockStatus: vi.fn().mockResolvedValue({
+      configured: false,
+      locked: false,
+      idle_seconds: 900,
+      unlock_seconds_remaining: 0,
+    }),
+    adminLockHeartbeat: vi.fn().mockResolvedValue({
+      configured: false,
+      locked: false,
+      idle_seconds: 900,
+      unlock_seconds_remaining: 0,
+    }),
+    lockAdminNow: vi.fn().mockResolvedValue(undefined),
+    unlockAdmin: vi.fn().mockResolvedValue({
+      configured: true,
+      locked: false,
+      idle_seconds: 900,
+      unlock_seconds_remaining: 900,
+    }),
   };
 });
 
@@ -444,5 +466,89 @@ describe("App — route rendering", () => {
     expect(empty).not.toBeNull();
     const backLink = within(empty as HTMLElement).getByRole("link", { name: /home/i });
     expect(backLink).toHaveAttribute("href", "/");
+  });
+});
+
+describe("App — admin screen lock", () => {
+  it("renders the lock screen (not the admin shell) when the session is locked", async () => {
+    vi.mocked(api.getMe).mockResolvedValue({
+      hasSession: true,
+      user: { id: "u1", displayName: "Op" },
+      csrf: "csrf-1",
+    });
+    vi.mocked(api.getAdminLockStatus).mockResolvedValue({
+      configured: true,
+      locked: true,
+      idle_seconds: 900,
+      unlock_seconds_remaining: 0,
+    });
+    renderAt("/");
+    // The lock screen is shown; the nav (admin shell) is hidden.
+    expect(await screen.findByTestId("admin-lock-screen")).toBeInTheDocument();
+    expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
+  });
+
+  it("shows the admin shell + a 'Lock now' button when configured but unlocked", async () => {
+    vi.mocked(api.getMe).mockResolvedValue({
+      hasSession: true,
+      user: { id: "u1", displayName: "Op" },
+      csrf: "csrf-1",
+    });
+    vi.mocked(api.getAdminLockStatus).mockResolvedValue({
+      configured: true,
+      locked: false,
+      idle_seconds: 900,
+      unlock_seconds_remaining: 900,
+    });
+    renderAt("/");
+    expect(await screen.findByTestId("admin-lock-now")).toBeInTheDocument();
+    // No lock screen — the shell is usable.
+    expect(screen.queryByTestId("admin-lock-screen")).not.toBeInTheDocument();
+  });
+
+  it("does NOT show 'Lock now' when no PIN is configured (feature off)", async () => {
+    vi.mocked(api.getMe).mockResolvedValue({
+      hasSession: true,
+      user: { id: "u1", displayName: "Op" },
+      csrf: "csrf-1",
+    });
+    vi.mocked(api.getAdminLockStatus).mockResolvedValue({
+      configured: false,
+      locked: false,
+      idle_seconds: 900,
+      unlock_seconds_remaining: 0,
+    });
+    renderAt("/");
+    await screen.findByRole("heading", { name: /^hub$/i });
+    expect(screen.queryByTestId("admin-lock-now")).not.toBeInTheDocument();
+  });
+
+  it("unlocking from the lock screen reveals the admin shell", async () => {
+    vi.mocked(api.getMe).mockResolvedValue({
+      hasSession: true,
+      user: { id: "u1", displayName: "Op" },
+      csrf: "csrf-1",
+    });
+    // First call: locked. After unlock, refresh() re-reads → unlocked.
+    vi.mocked(api.getAdminLockStatus)
+      .mockResolvedValueOnce({
+        configured: true,
+        locked: true,
+        idle_seconds: 900,
+        unlock_seconds_remaining: 0,
+      })
+      .mockResolvedValue({
+        configured: true,
+        locked: false,
+        idle_seconds: 900,
+        unlock_seconds_remaining: 900,
+      });
+    renderAt("/");
+    const input = await screen.findByTestId("admin-lock-pin-input");
+    fireEvent.change(input, { target: { value: "4827" } });
+    fireEvent.click(screen.getByTestId("admin-lock-unlock"));
+    await waitFor(() => expect(api.unlockAdmin).toHaveBeenCalledWith("csrf-1", "4827"));
+    // The shell returns (nav present, lock screen gone).
+    await waitFor(() => expect(screen.queryByTestId("admin-lock-screen")).not.toBeInTheDocument());
   });
 });

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -31,7 +31,17 @@ import { type ReactNode, useEffect, useState } from "react";
 import { Link, Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { BrandMark, WORDMARK_TEXT } from "./components/BrandMark.tsx";
 import { HubVersionBadge } from "./components/HubVersionBadge.tsx";
-import { type MeResponse, type ModuleListing, getMe, listModules, signOut } from "./lib/api.ts";
+import { LockScreen } from "./components/LockScreen.tsx";
+import {
+  type MeResponse,
+  type ModuleListing,
+  getMe,
+  listModules,
+  lockAdminNow,
+  signOut,
+} from "./lib/api.ts";
+import { clearCachedToken } from "./lib/auth.ts";
+import { useAdminLock } from "./lib/useAdminLock.ts";
 import { ApproveClient } from "./routes/ApproveClient.tsx";
 import { Connections } from "./routes/Connections.tsx";
 import { Home } from "./routes/Home.tsx";
@@ -108,6 +118,11 @@ export function App() {
   // just doesn't render).
   const [installedServices, setInstalledServices] = useState<ModuleListing[]>([]);
 
+  // Optional admin screen-lock. Only meaningful once we have a session +
+  // its CSRF token (lock APIs are session-cookie-gated, CSRF-belted).
+  const csrf = me?.hasSession ? me.csrf : null;
+  const lock = useAdminLock(csrf, Boolean(me?.hasSession));
+
   useEffect(() => {
     let cancelled = false;
     getMe()
@@ -151,6 +166,24 @@ export function App() {
     };
   }, [me]);
 
+  // When the surface locks, drop the cached host-admin Bearer so the next
+  // admin call re-mints from scratch (and gets a clean 423) rather than
+  // riding a still-valid in-memory token from before the lock.
+  useEffect(() => {
+    if (lock.locked) clearCachedToken();
+  }, [lock.locked]);
+
+  async function onLockNow(): Promise<void> {
+    if (!csrf) return;
+    try {
+      await lockAdminNow(csrf);
+    } catch {
+      // Even if the POST fails, refresh below pulls the real state.
+    }
+    clearCachedToken();
+    lock.refresh();
+  }
+
   async function onSignOut(csrf: string): Promise<void> {
     setSigningOut(true);
     try {
@@ -166,6 +199,15 @@ export function App() {
       // down, both of which a reload will resolve.
       setSigningOut(false);
     }
+  }
+
+  // Locked → render ONLY the lock screen (one lock over the whole admin
+  // surface, not per-action gating). The admin content + nav are hidden until
+  // the operator unlocks. Requires the CSRF token to unlock; if somehow absent
+  // we fall through to the normal shell (the server still fails admin calls
+  // closed).
+  if (lock.locked && csrf) {
+    return <LockScreen csrf={csrf} onUnlocked={lock.refresh} />;
   }
 
   return (
@@ -186,6 +228,20 @@ export function App() {
           <span className="sub">{subtitle}</span>
         </Link>
         <AuthIndicator me={me} signingOut={signingOut} onSignOut={onSignOut} />
+        {/* "Lock now" — only when an admin-lock PIN is configured. One click
+            re-locks the whole admin surface (phone-style); the idle timer does
+            the same automatically. Configure the PIN under Settings. */}
+        {me?.hasSession && lock.configured ? (
+          <button
+            type="button"
+            className="auth-spa-signout"
+            data-testid="admin-lock-now"
+            title="Lock the admin console now"
+            onClick={() => void onLockNow()}
+          >
+            Lock now
+          </button>
+        ) : null}
         {/* Hub-native sections — open in-shell. Home first, then the cross-
             cutting host-admin surfaces. "Vaults" left this group in B5
             (2026-06-09 hub-module-boundary): vault lifecycle UX is module-

--- a/web/ui/src/components/LockScreen.test.tsx
+++ b/web/ui/src/components/LockScreen.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * LockScreen — unit coverage for the PIN-entry surface.
+ *   - Unlock calls `unlockAdmin(csrf, pin)` and fires `onUnlocked` on success.
+ *   - A wrong PIN (HttpError 401) shows an error and clears the field.
+ *   - A rate-limit (429) shows the wait message.
+ *   - The Unlock button is disabled until the PIN is at least 4 digits.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as api from "../lib/api.ts";
+import { LockScreen } from "./LockScreen.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return { ...actual, unlockAdmin: vi.fn() };
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("LockScreen", () => {
+  it("unlocks on a correct PIN and calls onUnlocked", async () => {
+    vi.mocked(api.unlockAdmin).mockResolvedValue({
+      configured: true,
+      locked: false,
+      idle_seconds: 900,
+      unlock_seconds_remaining: 900,
+    });
+    const onUnlocked = vi.fn();
+    render(<LockScreen csrf="csrf-1" onUnlocked={onUnlocked} />);
+    fireEvent.change(screen.getByTestId("admin-lock-pin-input"), { target: { value: "4827" } });
+    fireEvent.click(screen.getByTestId("admin-lock-unlock"));
+    await waitFor(() => expect(api.unlockAdmin).toHaveBeenCalledWith("csrf-1", "4827"));
+    await waitFor(() => expect(onUnlocked).toHaveBeenCalled());
+  });
+
+  it("shows 'Incorrect PIN.' on a 401 and clears the field", async () => {
+    vi.mocked(api.unlockAdmin).mockRejectedValue(new api.HttpError(401, "incorrect PIN"));
+    const onUnlocked = vi.fn();
+    render(<LockScreen csrf="csrf-1" onUnlocked={onUnlocked} />);
+    const input = screen.getByTestId("admin-lock-pin-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "0000" } });
+    fireEvent.click(screen.getByTestId("admin-lock-unlock"));
+    expect(await screen.findByTestId("admin-lock-error")).toHaveTextContent(/incorrect pin/i);
+    expect(input.value).toBe("");
+    expect(onUnlocked).not.toHaveBeenCalled();
+  });
+
+  it("shows the wait message on a 429 rate-limit", async () => {
+    vi.mocked(api.unlockAdmin).mockRejectedValue(new api.HttpError(429, "too many"));
+    render(<LockScreen csrf="csrf-1" onUnlocked={vi.fn()} />);
+    fireEvent.change(screen.getByTestId("admin-lock-pin-input"), { target: { value: "0000" } });
+    fireEvent.click(screen.getByTestId("admin-lock-unlock"));
+    expect(await screen.findByTestId("admin-lock-error")).toHaveTextContent(/too many attempts/i);
+  });
+
+  it("disables Unlock until the PIN is at least 4 digits", () => {
+    render(<LockScreen csrf="csrf-1" onUnlocked={vi.fn()} />);
+    const btn = screen.getByTestId("admin-lock-unlock");
+    expect(btn).toBeDisabled();
+    fireEvent.change(screen.getByTestId("admin-lock-pin-input"), { target: { value: "12" } });
+    expect(btn).toBeDisabled();
+    fireEvent.change(screen.getByTestId("admin-lock-pin-input"), { target: { value: "1234" } });
+    expect(btn).not.toBeDisabled();
+  });
+
+  it("strips non-digit characters from input", () => {
+    render(<LockScreen csrf="csrf-1" onUnlocked={vi.fn()} />);
+    const input = screen.getByTestId("admin-lock-pin-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "12ab34" } });
+    expect(input.value).toBe("1234");
+  });
+});

--- a/web/ui/src/components/LockScreen.tsx
+++ b/web/ui/src/components/LockScreen.tsx
@@ -1,0 +1,102 @@
+/**
+ * Full-surface lock screen for the admin SPA (optional idle PIN lock).
+ *
+ * Rendered by `App` INSTEAD of the admin content when the operator's session is
+ * locked (a PIN is configured + no fresh unlock). Phone-style: one PIN field,
+ * Unlock → the whole admin surface is usable again. The server is the source of
+ * truth — this is the visible half of the `/admin/*-token` mint refusing to
+ * mint while locked (every admin API would fail closed anyway; this turns that
+ * into a clean "enter your PIN" instead of a wall of errors).
+ */
+import { type FormEvent, useEffect, useRef, useState } from "react";
+import { HttpError, unlockAdmin } from "../lib/api.ts";
+import { BrandMark, WORDMARK_TEXT } from "./BrandMark.tsx";
+
+interface LockScreenProps {
+  /** CSRF token from /api/me — required for the unlock POST. */
+  csrf: string;
+  /** Called after a successful unlock so the parent re-renders the admin shell. */
+  onUnlocked: () => void;
+}
+
+export function LockScreen({ csrf, onUnlocked }: LockScreenProps) {
+  const [pin, setPin] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await unlockAdmin(csrf, pin);
+      setPin("");
+      onUnlocked();
+    } catch (err) {
+      // 401 wrong PIN, 429 rate-limited — surface the server's message.
+      const msg =
+        err instanceof HttpError
+          ? err.status === 429
+            ? "Too many attempts — wait a moment and try again."
+            : "Incorrect PIN."
+          : err instanceof Error
+            ? err.message
+            : "Unlock failed.";
+      setError(msg);
+      setPin("");
+      inputRef.current?.focus();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    // The lock screen REPLACES the whole admin shell (it's not a modal layered
+    // over live content), so it's the page's main landmark rather than a
+    // role="dialog". `aria-label` names it for assistive tech.
+    <main className="lock-screen" data-testid="admin-lock-screen" aria-label="Admin console locked">
+      <div className="lock-card">
+        <BrandMark size={32} idSuffix="lock" className="lock-brand-mark" />
+        <h1 className="lock-title">{WORDMARK_TEXT} is locked</h1>
+        <p className="muted lock-sub">Enter your PIN to unlock the admin console.</p>
+        <form onSubmit={(e) => void onSubmit(e)} className="lock-form">
+          <label htmlFor="admin-lock-pin" className="visually-hidden">
+            PIN
+          </label>
+          <input
+            id="admin-lock-pin"
+            ref={inputRef}
+            type="password"
+            inputMode="numeric"
+            autoComplete="off"
+            // Digits only, matching the server's 4–12 digit rule. The pattern
+            // is a UX nudge; the server is authoritative.
+            pattern="[0-9]*"
+            maxLength={12}
+            placeholder="••••"
+            value={pin}
+            disabled={busy}
+            onChange={(e) => setPin(e.target.value.replace(/[^0-9]/g, ""))}
+            className="lock-pin-input"
+            data-testid="admin-lock-pin-input"
+            aria-invalid={error ? "true" : undefined}
+          />
+          <button type="submit" disabled={busy || pin.length < 4} data-testid="admin-lock-unlock">
+            {busy ? "Unlocking…" : "Unlock"}
+          </button>
+        </form>
+        {error && (
+          <div className="error lock-error" role="alert" data-testid="admin-lock-error">
+            {error}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1418,6 +1418,108 @@ export async function getHubUpgradeStatus(): Promise<HubUpgradeStatus | null> {
 // against the bespoke `/admin/channels` endpoint — were retired in boundary D1
 // along with the endpoint; the Connections helpers below are the successor.)
 
+// ---------------------------------------------------------------------------
+// Admin screen-lock (optional idle PIN lock for the admin UI).
+//
+// These talk to `/api/admin-lock*` with the session cookie directly (NOT the
+// host-admin Bearer) — the Bearer mint is exactly what the lock blocks, so the
+// lock-management surface must not depend on it. The POSTs carry the CSRF token
+// from `/api/me` and an Origin header (the browser adds it automatically) to
+// pass the server's same-origin belt.
+// ---------------------------------------------------------------------------
+
+/** Status from `GET /api/admin-lock`. */
+export interface AdminLockStatus {
+  /** True when a PIN is set (feature ON). False = today's behavior, no lock. */
+  configured: boolean;
+  /** True when configured AND this session isn't within an unlock window. */
+  locked: boolean;
+  /** Idle window before re-lock, in seconds. */
+  idle_seconds: number;
+  /** Seconds left in the current unlock window (0 when locked). */
+  unlock_seconds_remaining: number;
+}
+
+/** GET /api/admin-lock — read lock state for this session. Session-cookie auth. */
+export async function getAdminLockStatus(): Promise<AdminLockStatus> {
+  const res = await fetch("/api/admin-lock", {
+    method: "GET",
+    headers: { accept: "application/json" },
+    credentials: "same-origin",
+  });
+  if (res.status === 401) return redirectToLoginAndHang<AdminLockStatus>();
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as AdminLockStatus;
+}
+
+async function postAdminLock(
+  subpath: string,
+  csrf: string,
+  body: Record<string, unknown> = {},
+): Promise<Response> {
+  return await fetch(`/api/admin-lock${subpath}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json" },
+    credentials: "same-origin",
+    body: JSON.stringify({ __csrf: csrf, ...body }),
+  });
+}
+
+/** POST /api/admin-lock/unlock — verify the PIN, open an unlock window. */
+export async function unlockAdmin(csrf: string, pin: string): Promise<AdminLockStatus> {
+  const res = await postAdminLock("/unlock", csrf, { pin });
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  await res.json().catch(() => ({}));
+  return getAdminLockStatus();
+}
+
+/** POST /api/admin-lock/lock — "Lock now". */
+export async function lockAdminNow(csrf: string): Promise<void> {
+  const res = await postAdminLock("/lock", csrf);
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+}
+
+/** POST /api/admin-lock/heartbeat — slide the idle window forward on activity. */
+export async function adminLockHeartbeat(csrf: string): Promise<AdminLockStatus> {
+  const res = await postAdminLock("/heartbeat", csrf);
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as AdminLockStatus;
+}
+
+/** POST /api/admin-lock/set — set the FIRST PIN (no PIN configured yet). */
+export async function setAdminLockPin(
+  csrf: string,
+  pin: string,
+  idleSeconds?: number,
+): Promise<void> {
+  const body: Record<string, unknown> = { pin };
+  if (idleSeconds !== undefined) body.idle_seconds = idleSeconds;
+  const res = await postAdminLock("/set", csrf, body);
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+}
+
+/** POST /api/admin-lock/change — rotate the PIN (current PIN or unlocked session). */
+export async function changeAdminLockPin(
+  csrf: string,
+  newPin: string,
+  currentPin?: string,
+  idleSeconds?: number,
+): Promise<void> {
+  const body: Record<string, unknown> = { new_pin: newPin };
+  if (currentPin) body.current_pin = currentPin;
+  if (idleSeconds !== undefined) body.idle_seconds = idleSeconds;
+  const res = await postAdminLock("/change", csrf, body);
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+}
+
+/** POST /api/admin-lock/remove — turn the feature OFF (current PIN or unlocked session). */
+export async function removeAdminLockPin(csrf: string, currentPin?: string): Promise<void> {
+  const body: Record<string, unknown> = {};
+  if (currentPin) body.current_pin = currentPin;
+  const res = await postAdminLock("/remove", csrf, body);
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+}
+
 async function readError(res: Response): Promise<string> {
   try {
     const text = await res.text();

--- a/web/ui/src/lib/useAdminLock.ts
+++ b/web/ui/src/lib/useAdminLock.ts
@@ -1,0 +1,137 @@
+/**
+ * React hook driving the admin screen-lock client behavior.
+ *
+ * Responsibilities:
+ *   - On mount (and when signed in), fetch the lock status. A fresh load while
+ *     a PIN is set + no unlock window = locked (the "lock on fresh load" rule).
+ *   - Detect inactivity client-side: an idle timer set to the server's idle
+ *     window. On expiry, flip to locked (the server will already refuse mints
+ *     by then — this just shows the lock screen promptly instead of waiting for
+ *     the next failed API call).
+ *   - On activity (pointer / key / scroll), debounce a heartbeat that slides
+ *     the server-side window forward AND restarts the local idle timer.
+ *   - Re-check on tab refocus (a session left in another tab may have locked).
+ *
+ * The server is always authoritative; this hook is the UX layer that turns the
+ * server's "423 Locked" reality into a clean lock screen with no thrash.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { type AdminLockStatus, adminLockHeartbeat, getAdminLockStatus } from "./api.ts";
+
+export interface UseAdminLock {
+  /** True while the initial status fetch is in flight. */
+  loading: boolean;
+  /** True when a PIN is configured AND this session isn't unlocked. */
+  locked: boolean;
+  /** True when a PIN is configured (feature ON). */
+  configured: boolean;
+  /** Call after a successful unlock (or set) to refresh + clear the lock. */
+  refresh: () => void;
+}
+
+/** Debounce window for the activity → heartbeat call. */
+const HEARTBEAT_DEBOUNCE_MS = 30_000;
+
+export function useAdminLock(csrf: string | null, enabled: boolean): UseAdminLock {
+  const [loading, setLoading] = useState(true);
+  const [locked, setLocked] = useState(false);
+  const [configured, setConfigured] = useState(false);
+
+  // Timers + bookkeeping kept in refs so the activity listener (a stable
+  // closure) can reach the latest values without re-subscribing on every render.
+  const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastHeartbeat = useRef(0);
+  const idleSeconds = useRef(15 * 60);
+  const csrfRef = useRef<string | null>(csrf);
+  const lockedRef = useRef(false);
+  csrfRef.current = csrf;
+  lockedRef.current = locked;
+
+  const clearIdleTimer = useCallback(() => {
+    if (idleTimer.current) {
+      clearTimeout(idleTimer.current);
+      idleTimer.current = null;
+    }
+  }, []);
+
+  const armIdleTimer = useCallback(() => {
+    clearIdleTimer();
+    // Local idle expiry → show the lock screen. The server window is the same
+    // length, so by the time this fires the next mint would 423 anyway.
+    idleTimer.current = setTimeout(() => setLocked(true), Math.max(1, idleSeconds.current) * 1000);
+  }, [clearIdleTimer]);
+
+  const applyStatus = useCallback(
+    (s: AdminLockStatus) => {
+      setConfigured(s.configured);
+      setLocked(s.locked);
+      idleSeconds.current = s.idle_seconds;
+      if (s.configured && !s.locked) {
+        armIdleTimer();
+      } else {
+        clearIdleTimer();
+      }
+    },
+    [armIdleTimer, clearIdleTimer],
+  );
+
+  const refresh = useCallback(() => {
+    if (!enabled) return;
+    getAdminLockStatus()
+      .then(applyStatus)
+      .catch(() => {
+        // Network hiccup — leave current state; a later activity/refocus retries.
+      })
+      .finally(() => setLoading(false));
+  }, [enabled, applyStatus]);
+
+  // Initial + sign-in status fetch.
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      return;
+    }
+    refresh();
+  }, [enabled, refresh]);
+
+  // Activity listeners: debounced heartbeat (slides the server window) +
+  // re-arm the local idle timer. Only active while unlocked + configured.
+  useEffect(() => {
+    if (!enabled || !configured) return;
+
+    function onActivity() {
+      if (lockedRef.current) return; // locked — activity shouldn't extend anything
+      armIdleTimer();
+      const now = Date.now();
+      if (now - lastHeartbeat.current < HEARTBEAT_DEBOUNCE_MS) return;
+      lastHeartbeat.current = now;
+      const token = csrfRef.current;
+      if (!token) return;
+      adminLockHeartbeat(token)
+        .then((s) => {
+          // The server may report a lock that drifted (e.g. another tab locked).
+          if (s.locked) setLocked(true);
+          else idleSeconds.current = s.idle_seconds;
+        })
+        .catch(() => {
+          // Ignore — the idle timer + next mint failure are the backstop.
+        });
+    }
+
+    const events: Array<keyof WindowEventMap> = ["pointerdown", "keydown", "scroll", "mousemove"];
+    for (const ev of events) window.addEventListener(ev, onActivity, { passive: true });
+    // Re-check on tab refocus — a session may have locked while backgrounded.
+    function onFocus() {
+      refresh();
+    }
+    window.addEventListener("focus", onFocus);
+    return () => {
+      for (const ev of events) window.removeEventListener(ev, onActivity);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [enabled, configured, armIdleTimer, refresh]);
+
+  useEffect(() => () => clearIdleTimer(), [clearIdleTimer]);
+
+  return { loading, locked, configured, refresh };
+}

--- a/web/ui/src/routes/Settings.tsx
+++ b/web/ui/src/routes/Settings.tsx
@@ -31,9 +31,15 @@
  */
 import { type FormEvent, useCallback, useEffect, useState } from "react";
 import {
+  type AdminLockStatus,
   type HubOriginSetting,
   type IssuerSource,
+  changeAdminLockPin,
+  getAdminLockStatus,
   getHubOriginSetting,
+  getMe,
+  removeAdminLockPin,
+  setAdminLockPin,
   setHubOriginSetting,
 } from "../lib/api.ts";
 
@@ -190,6 +196,288 @@ export function Settings() {
           )}
         </form>
       </section>
+
+      <AdminLockSection />
+    </section>
+  );
+}
+
+/**
+ * Admin screen-lock settings (optional idle PIN lock).
+ *
+ * Off by default. Setting the first PIN is an authenticated admin action;
+ * changing / removing requires the current PIN (or an already-unlocked
+ * session — but this form always asks for it to keep the flow uniform and
+ * safe regardless of unlock state). The PIN locks the WHOLE admin surface
+ * after the idle window; "Lock now" lives in the nav.
+ */
+function AdminLockSection() {
+  const [status, setStatus] = useState<AdminLockStatus | null>(null);
+  const [csrf, setCsrf] = useState<string | null>(null);
+  const [loadErr, setLoadErr] = useState<string | null>(null);
+
+  // Form state.
+  const [pin, setPin] = useState("");
+  const [pin2, setPin2] = useState("");
+  const [currentPin, setCurrentPin] = useState("");
+  const [idleMinutes, setIdleMinutes] = useState("15");
+  const [busy, setBusy] = useState(false);
+  const [formErr, setFormErr] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const [s, me] = await Promise.all([getAdminLockStatus(), getMe()]);
+      setStatus(s);
+      setCsrf(me.hasSession ? me.csrf : null);
+      setIdleMinutes(String(Math.round(s.idle_seconds / 60)));
+      setLoadErr(null);
+    } catch (err) {
+      setLoadErr(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  function idleSecondsFromForm(): number | undefined {
+    const m = Number.parseInt(idleMinutes, 10);
+    if (!Number.isFinite(m)) return undefined;
+    return Math.max(1, m) * 60;
+  }
+
+  async function onSet(e: FormEvent) {
+    e.preventDefault();
+    if (busy || !csrf) return;
+    setFormErr(null);
+    setNotice(null);
+    if (!/^[0-9]{4,12}$/.test(pin)) {
+      setFormErr("PIN must be 4–12 digits.");
+      return;
+    }
+    if (pin !== pin2) {
+      setFormErr("PINs don't match.");
+      return;
+    }
+    setBusy(true);
+    try {
+      await setAdminLockPin(csrf, pin, idleSecondsFromForm());
+      setPin("");
+      setPin2("");
+      setNotice("Screen lock enabled.");
+      await refresh();
+    } catch (err) {
+      setFormErr(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onChange(e: FormEvent) {
+    e.preventDefault();
+    if (busy || !csrf) return;
+    setFormErr(null);
+    setNotice(null);
+    if (!/^[0-9]{4,12}$/.test(pin)) {
+      setFormErr("New PIN must be 4–12 digits.");
+      return;
+    }
+    if (pin !== pin2) {
+      setFormErr("PINs don't match.");
+      return;
+    }
+    setBusy(true);
+    try {
+      await changeAdminLockPin(csrf, pin, currentPin || undefined, idleSecondsFromForm());
+      setPin("");
+      setPin2("");
+      setCurrentPin("");
+      setNotice("PIN updated.");
+      await refresh();
+    } catch (err) {
+      setFormErr(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onRemove() {
+    if (busy || !csrf) return;
+    setFormErr(null);
+    setNotice(null);
+    setBusy(true);
+    try {
+      await removeAdminLockPin(csrf, currentPin || undefined);
+      setCurrentPin("");
+      setNotice("Screen lock disabled.");
+      await refresh();
+    } catch (err) {
+      setFormErr(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const configured = status?.configured ?? false;
+
+  return (
+    <section
+      className="settings-block"
+      aria-labelledby="admin-lock-heading"
+      data-testid="admin-lock-settings"
+    >
+      <h2 id="admin-lock-heading">Admin screen lock</h2>
+      <p className="muted">
+        An optional PIN that locks the whole admin console after a period of inactivity — a
+        phone-style lock for a remotely-exposed hub. Off by default; the OAuth flow for your
+        connected apps is never affected. <strong>Note:</strong> this guards the exposed web portal
+        only — anyone with shell access to the box bypasses it (that's an OS / disk-encryption
+        concern).
+      </p>
+
+      {loadErr ? (
+        <div className="error" data-testid="admin-lock-load-error">
+          Failed to load lock status: {loadErr}.{" "}
+          <button type="button" onClick={() => void refresh()}>
+            Retry
+          </button>
+        </div>
+      ) : (
+        <>
+          <p>
+            Status:{" "}
+            <span
+              className={`lock-status-pill ${configured ? "lock-status-on" : "lock-status-off"}`}
+              data-testid="admin-lock-status-pill"
+            >
+              {configured ? "Enabled" : "Off"}
+            </span>
+          </p>
+
+          {!configured ? (
+            <form onSubmit={(e) => void onSet(e)} className="lock-settings-form">
+              <label>
+                PIN (4–12 digits)
+                <input
+                  type="password"
+                  inputMode="numeric"
+                  autoComplete="off"
+                  value={pin}
+                  disabled={busy}
+                  onChange={(e) => setPin(e.target.value.replace(/[^0-9]/g, ""))}
+                  data-testid="admin-lock-set-pin"
+                />
+              </label>
+              <label>
+                Confirm PIN
+                <input
+                  type="password"
+                  inputMode="numeric"
+                  autoComplete="off"
+                  value={pin2}
+                  disabled={busy}
+                  onChange={(e) => setPin2(e.target.value.replace(/[^0-9]/g, ""))}
+                  data-testid="admin-lock-set-pin2"
+                />
+              </label>
+              <label>
+                Lock after (minutes idle)
+                <input
+                  type="number"
+                  min={1}
+                  max={1440}
+                  value={idleMinutes}
+                  disabled={busy}
+                  onChange={(e) => setIdleMinutes(e.target.value)}
+                  data-testid="admin-lock-idle"
+                />
+              </label>
+              <div className="actions">
+                <button type="submit" disabled={busy} data-testid="admin-lock-enable">
+                  {busy ? "Saving…" : "Enable screen lock"}
+                </button>
+              </div>
+            </form>
+          ) : (
+            <form onSubmit={(e) => void onChange(e)} className="lock-settings-form">
+              <label>
+                Current PIN
+                <input
+                  type="password"
+                  inputMode="numeric"
+                  autoComplete="off"
+                  value={currentPin}
+                  disabled={busy}
+                  onChange={(e) => setCurrentPin(e.target.value.replace(/[^0-9]/g, ""))}
+                  data-testid="admin-lock-current-pin"
+                />
+              </label>
+              <label>
+                New PIN (4–12 digits)
+                <input
+                  type="password"
+                  inputMode="numeric"
+                  autoComplete="off"
+                  value={pin}
+                  disabled={busy}
+                  onChange={(e) => setPin(e.target.value.replace(/[^0-9]/g, ""))}
+                  data-testid="admin-lock-new-pin"
+                />
+              </label>
+              <label>
+                Confirm new PIN
+                <input
+                  type="password"
+                  inputMode="numeric"
+                  autoComplete="off"
+                  value={pin2}
+                  disabled={busy}
+                  onChange={(e) => setPin2(e.target.value.replace(/[^0-9]/g, ""))}
+                  data-testid="admin-lock-new-pin2"
+                />
+              </label>
+              <label>
+                Lock after (minutes idle)
+                <input
+                  type="number"
+                  min={1}
+                  max={1440}
+                  value={idleMinutes}
+                  disabled={busy}
+                  onChange={(e) => setIdleMinutes(e.target.value)}
+                  data-testid="admin-lock-idle"
+                />
+              </label>
+              <div className="actions">
+                <button type="submit" disabled={busy} data-testid="admin-lock-change">
+                  {busy ? "Saving…" : "Update PIN"}
+                </button>
+                <button
+                  type="button"
+                  className="destructive"
+                  disabled={busy}
+                  onClick={() => void onRemove()}
+                  data-testid="admin-lock-remove"
+                >
+                  Remove lock
+                </button>
+              </div>
+            </form>
+          )}
+
+          {formErr && (
+            <div className="error" data-testid="admin-lock-form-error">
+              {formErr}
+            </div>
+          )}
+          {notice && (
+            <p className="muted" data-testid="admin-lock-notice">
+              {notice}
+            </p>
+          )}
+        </>
+      )}
     </section>
   );
 }

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -1375,3 +1375,125 @@ a.btn:hover {
   color: var(--accent);
   font-weight: 600;
 }
+
+/* -------------------------------------------------------------------------
+ * Admin screen-lock (optional idle PIN lock).
+ *
+ * The lock screen replaces the whole admin shell when the session is locked —
+ * a single lock over everything (phone-style), not per-action gating. Tokens
+ * are lifted from the brand palette so it stays continuous with the login →
+ * consent → admin flow the operator just walked through.
+ * ---------------------------------------------------------------------------*/
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.lock-screen {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  padding: 1.5rem;
+}
+
+.lock-card {
+  width: 100%;
+  max-width: 22rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.35rem;
+  padding: 2rem 1.75rem;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+}
+
+.lock-brand-mark {
+  margin-bottom: 0.4rem;
+}
+
+.lock-title {
+  font-size: 1.2rem;
+  margin: 0;
+}
+
+.lock-sub {
+  margin: 0 0 0.6rem;
+  font-size: 0.9rem;
+}
+
+.lock-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  width: 100%;
+}
+
+.lock-pin-input {
+  width: 100%;
+  text-align: center;
+  letter-spacing: 0.45em;
+  font-size: 1.3rem;
+  padding: 0.7rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+.lock-pin-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.lock-error {
+  margin-top: 0.6rem;
+  color: var(--error);
+  font-size: 0.88rem;
+}
+
+/* Settings: admin-lock block. */
+.lock-settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  max-width: 28rem;
+}
+
+.lock-settings-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.9rem;
+}
+
+.lock-status-pill {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 500;
+}
+
+.lock-status-on {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.lock-status-off {
+  background: var(--bg-soft);
+  color: var(--fg-muted);
+}


### PR DESCRIPTION
## What

A phone-style screen lock for the hub admin UI. An **optional** operator PIN that locks the **whole** admin surface, **auto-locks after idle** (and on a fresh load), and unlocks with the PIN into a frictionless working window that genuine activity keeps alive. **Off by default — absent PIN = today's behavior, exactly.**

Guards the risk of a **grabbed / left-logged-in remote admin session**: the admin UI is reachable once `parachute expose` is up (Tailscale / Cloudflare), and the password-login cookie lasts 24h, so an unattended tab is a standing admin console (vault provisioning, token minting, user + module config).

Hub-layer realization of **channel #80** (step-up / protection). Surfaces can add their own PIN independently. Design note: [`design/2026-06-17-admin-ui-lock.md`](../blob/ag-hub-admin-lock/design/2026-06-17-admin-ui-lock.md).

## Gate chokepoint

The admin SPA + every module config UI get their working Bearer from one of four cookie-gated mint endpoints, all sharing the same `parseSessionCookie → findSession → [isFirstAdmin] → signAccessToken` shape:

- `GET /admin/host-admin-token`
- `GET /admin/channel-token`
- `GET /admin/vault-admin-token/<name>`
- `GET /admin/module-token/<short>`

Inserting **one** gate — `admin-lock.ts:requireUnlocked(db, sessionId)` — into each makes the lock **cascade to the entire admin surface with zero per-module changes**. When locked, every mint returns **`423 Locked`**; the SPA shows the lock screen and every module admin API fails closed (no Bearer). One lock over everything, not per-action gating (per-action would friction-up configuration — the dangerous stuff).

## CRITICAL boundary — OAuth issuer unaffected

The lock touches **only** the `/admin/*-token` mints, never `/oauth/*`. `/oauth/{authorize,token,register,revoke}`, `/.well-known/*`, JWKS, the services catalog, and all third-party token issuance work **unchanged while the admin UI is locked** — a surface OAuth'ing in never hits a `/admin/*-token` endpoint.

**Proof test** (`src/__tests__/admin-lock.test.ts` → *"a third-party client completes authorize→token while the admin session is locked"*): sets a PIN, asserts `GET /admin/host-admin-token` returns 423, then runs a full PKCE `authorize → token` flow that **succeeds** and yields a valid `vault:default:read` JWT.

## Unlock-state mechanism

Per-session, in-memory **"unlocked-until"** (keyed by the session cookie value), never persisted, never in the cookie — a stolen cookie alone can't carry an unlocked window. Default idle **15 min** (operator-configurable 1 min–24h, clamped). Hub restart wipes the map → re-lock.

Token mints are a **pure check** (do not slide the window); only the SPA's debounced, activity-driven `/heartbeat` slides it — otherwise the version-badge's 30s background poll (which re-mints a Bearer) would keep an idle-but-open tab unlocked forever.

## PIN storage + set/change/remove

- **argon2id** hash (`@node-rs/argon2`, same family as passwords/TOTP) in `hub_settings` (`admin_lock_pin_hash`). **Never plaintext, never in the session/cookie.** No DB migration — `hub_settings` is generic KV.
- **`/api/admin-lock*`**, first-admin gated + CSRF-belted (double-submit `__csrf` + the same-origin Origin belt `/admin/connections` uses). These manage the lock so they're **not** behind the gate.
- **Set first PIN** = authenticated admin action (no PIN yet; `409` if one exists). **Change/remove** require the **current PIN** OR an already-unlocked session. **Unlock** + the current-PIN paths are brute-force limited (5 / 5 min per session) before the argon2id verify.
- Friend `/account/*` vault-admin paths are a different principal and are **not** gated (the admin's PIN must not lock another user out of their own assigned vault).

## Honest limit (in the design note)

This is a **web/UI-layer guard for the exposed portal**. It does **NOT** protect against someone with a **shell** on the box — they read `operator.token` / the vault DB directly, bypassing the hub. That's an OS concern (disk encryption, OS screen lock, SSH-key hygiene). The lock shuts the *portal* door — the one the internet can reach. Stated in the threat model + the Settings UI copy.

## UX

`LockScreen` (PIN entry) renders **instead of** the admin shell when locked. Idle auto-lock + activity heartbeat in `useAdminLock`. **"Lock now"** button in the nav (when a PIN is configured). Set / change / remove + idle window under **Settings**.

## Gates

- `bun test ./src` — **3441 pass / 1 skip / 0 fail**
- `web/ui` vitest — **293 pass**
- `bun run typecheck` (hub + SPA) clean; `bunx biome check` clean on all changed files (introduces zero new lint errors)
- SPA `bun run build` clean (verify-base passes)
- **No version bump** (rc bump + tag happens on the operator's ship call).

## Do not merge

Hub is the operator's merge domain — leaving this for foreground review + operator merge.